### PR TITLE
feat(venture): add Flutter live page bridge

### DIFF
--- a/code/packages/rust/mosaic-emit-flutter/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-flutter/CHANGELOG.md
@@ -5,6 +5,13 @@ this file.
 
 ## [Unreleased]
 
+### Added - host-driven prop refresh callback
+
+Generated Flutter shells register a prop-change handler on `MosaicHost` and
+reapply the host's current props when native content-surface input changes
+browser state. The default generated host keeps a no-op implementation, so
+existing injected hosts remain source-compatible.
+
 ### Fixed - native form state and generated-shell interaction acceptance
 
 Slot-backed `HostButton.disabled` and `HostInput.read-only` values now reach

--- a/code/packages/rust/mosaic-emit-flutter/README.md
+++ b/code/packages/rust/mosaic-emit-flutter/README.md
@@ -119,7 +119,9 @@ helpers.
 Flutter's native button and text-field contracts. Project shells expose a
 `MosaicApp(mosaicHost: ...)` injection seam so direct widget acceptance can
 drive those controls and verify host response hydration against the exact
-generated component.
+generated component. Hosts can also register a prop-change handler; native
+surface interactions use it to ask the generated shell to reproject current
+Mosaic props without creating a backend-specific state store.
 
 ## What works in v0.1 / what's deferred
 

--- a/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
@@ -358,6 +358,8 @@ fn build_main_dart(component_name: &str, slots: &[SlotDecl]) -> String {
             "  void initState() {{\n",
             "    super.initState();\n",
             "    _mosaicHost = widget.mosaicHost ?? MosaicHost.load();\n",
+            "    _mosaicHost?.setPropsChangedHandler(() =>\n",
+            "        _queueMosaicResponse(_mosaicHost.props()));\n",
             "    _queueMosaicResponse(_mosaicHost?.props());\n",
             "  }}\n\n",
             "  @override\n",
@@ -542,6 +544,7 @@ fn build_mosaic_host_dart() -> String {
     out.push_str(
         "  FutureOr<Map<String, Object?>?> handleEvent(Map<String, Object?> event) => null;\n\n",
     );
+    out.push_str("  void setPropsChangedHandler(void Function()? handler) {}\n\n");
     out.push_str("  void dispose() {}\n");
     out.push_str("}\n");
     out
@@ -5243,6 +5246,12 @@ mod tests {
             "main.dart must hydrate initial props through the Mosaic host"
         );
         assert!(
+            proj.main_dart.contains(
+                "_mosaicHost?.setPropsChangedHandler(() =>\n        _queueMosaicResponse(_mosaicHost.props()))"
+            ),
+            "main.dart must subscribe to host-owned page interaction updates"
+        );
+        assert!(
             proj.main_dart
                 .contains("final response = _mosaicHost?.handleEvent(event.mosaicEnvelope);"),
             "main.dart must forward Mosaic event envelopes to the host"
@@ -5265,6 +5274,11 @@ mod tests {
             proj.mosaic_host_dart
                 .contains("FutureOr<Map<String, Object?>?> handleEvent"),
             "default mosaic_host.dart must allow async host responses"
+        );
+        assert!(
+            proj.mosaic_host_dart
+                .contains("void setPropsChangedHandler(void Function()? handler) {}"),
+            "default mosaic_host.dart must expose optional prop-change notifications"
         );
     }
 

--- a/code/packages/rust/venture-browser-qt/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-qt/CHANGELOG.md
@@ -9,5 +9,8 @@
   mounted QML surface, and non-empty Cairo frame on provisioned Qt hosts.
 - Promote the generated-project gate to real address, history, wheel, hover,
   and link interaction acceptance through the package-owned Qt adapter.
+- Export Flutter-named C ABI wrappers over the same host-neutral controller and
+  Cairo renderer so Venture's generated Flutter shell can share the live page
+  implementation.
 - Accept either CMake's plain macOS executable or an application-bundle shell
   when launching the generated project.

--- a/code/packages/rust/venture-browser-qt/README.md
+++ b/code/packages/rust/venture-browser-qt/README.md
@@ -6,6 +6,10 @@ browser chrome; this library projects the shared `BrowserHostController`
 through a C ABI and renders the retained page to RGBA pixels with Cairo for a
 `QQuickPaintedItem` host surface.
 
+The crate also exports Flutter-named wrappers over that exact controller and
+Cairo session. Venture's Dart FFI host uses those wrappers to consume RGBA
+frames and native input without introducing a second browser implementation.
+
 The package-owned C++ adapter dynamically loads this library, registers the
 surface as a QML type, and forwards generated Mosaic events and native surface
 input to the same Rust session. Its direct-launch test emits and builds the

--- a/code/packages/rust/venture-browser-qt/src/lib.rs
+++ b/code/packages/rust/venture-browser-qt/src/lib.rs
@@ -434,6 +434,109 @@ mod ffi {
             drop(CString::from_raw(value));
         }
     }
+
+    // Flutter and Qt both consume the same Cairo RGBA bridge. Keep a
+    // backend-named ABI for each generated host while sharing the exact Rust
+    // browser implementation above.
+    #[no_mangle]
+    pub extern "C" fn venture_browser_flutter_new(
+        start_url: *const c_char,
+        width: f64,
+        height: f64,
+    ) -> *mut QtBrowserHost {
+        venture_browser_qt_new(start_url, width, height)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_flutter_free(host: *mut QtBrowserHost) {
+        unsafe { venture_browser_qt_free(host) }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_flutter_apply_props(
+        host: *mut QtBrowserHost,
+    ) -> *mut c_char {
+        unsafe { venture_browser_qt_apply_props(host) }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_flutter_handle_event(
+        host: *mut QtBrowserHost,
+        name: *const c_char,
+        value: *const c_char,
+    ) -> *mut c_char {
+        unsafe { venture_browser_qt_handle_event(host, name, value) }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_flutter_scroll(
+        host: *mut QtBrowserHost,
+        delta_y: f64,
+    ) -> u8 {
+        unsafe { venture_browser_qt_scroll(host, delta_y) }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_flutter_activate_link(
+        host: *mut QtBrowserHost,
+        x: f64,
+        y: f64,
+    ) -> u8 {
+        unsafe { venture_browser_qt_activate_link(host, x, y) }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_flutter_update_hover(
+        host: *mut QtBrowserHost,
+        x: f64,
+        y: f64,
+    ) -> u8 {
+        unsafe { venture_browser_qt_update_hover(host, x, y) }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_flutter_scroll_metrics(
+        host: *mut QtBrowserHost,
+        offset_y: *mut f64,
+        viewport_height: *mut f64,
+        content_height: *mut f64,
+        max_offset_y: *mut f64,
+    ) -> u8 {
+        unsafe {
+            venture_browser_qt_scroll_metrics(
+                host,
+                offset_y,
+                viewport_height,
+                content_height,
+                max_offset_y,
+            )
+        }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_flutter_resize(
+        host: *mut QtBrowserHost,
+        width: f64,
+        height: f64,
+    ) -> u8 {
+        unsafe { venture_browser_qt_resize(host, width, height) }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_flutter_render_rgba(
+        host: *mut QtBrowserHost,
+        output: *mut u8,
+        capacity: usize,
+        width: *mut u32,
+        height: *mut u32,
+    ) -> usize {
+        unsafe { venture_browser_qt_render_rgba(host, output, capacity, width, height) }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_flutter_string_free(value: *mut c_char) {
+        unsafe { venture_browser_qt_string_free(value) }
+    }
 }
 
 fn finite_positive_or(value: f64, fallback: f64) -> f64 {

--- a/code/programs/mosaic/venture-browser/ACCEPTANCE-BACKLOG.md
+++ b/code/programs/mosaic/venture-browser/ACCEPTANCE-BACKLOG.md
@@ -20,8 +20,13 @@ cross-platform proving application. Items are ordered by risk and dependency.
   - [x] Qt live interaction promotion: drive the generated address and history
     controls plus native scroll/link input through the real bridge, replacing
     the recording host as the authoritative Qt interaction gate.
-  - [ ] Flutter live page bridge and direct acceptance.
+  - [x] Flutter live page bridge and direct acceptance.
   - [ ] Compose Desktop live page bridge and direct acceptance.
+- [ ] **P2 architecture — backend-neutral Cairo bridge ownership.** Flutter now
+  reuses the exact controller and renderer currently packaged by the
+  Qt-named bridge crate. Extract that shared C ABI implementation into a
+  backend-neutral package before further native consumers make the ownership
+  boundary harder to change; keep thin Qt and Flutter exports over one session.
 - [ ] **P2 — Qt native-control style compatibility.** The macOS-native Qt
   Quick Controls style rejects custom `background` items emitted from Mosaic
   MSL. Define a native-compatible palette/appearance lowering (or an explicit

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -9,6 +9,14 @@
 
 ### Added
 
+- Add a package-owned Flutter `MosaicHost` that loads the shared Rust browser
+  session through Dart FFI, mounts Cairo-rendered RGBA pixels as a native
+  Flutter `RawImage`, and forwards wheel, hover, and tap input without
+  duplicating the Mosaic-authored chrome.
+- Replace Flutter's recording-only interaction gate with deterministic live
+  HTTP navigation, native address and history controls, shared viewport
+  scrolling, link hover projection, pointer activation, and rendered-pixel
+  acceptance. The backend matrix now builds and supplies the native bridge.
 - Add the package-owned Qt `MosaicHost.cpp/.h` and Cairo-backed
   `venture-browser-qt` bridge, reusing the shared native host controller for
   live page rendering, navigation, scrolling, hover, link activation, and

--- a/code/programs/mosaic/venture-browser/README.md
+++ b/code/programs/mosaic/venture-browser/README.md
@@ -56,6 +56,12 @@ recreating the surrounding chrome in backend-specific UI code.
   Its direct generated-app gate edits the Mosaic-emitted address field, drives
   Back and Forward with native key input, scrolls the real painted item, and
   activates a live HTML link through Qt hover and pointer events.
+- The Flutter project receives a package-owned `MosaicHost` adapter that loads
+  the shared Rust/Cairo bridge through Dart FFI, hydrates the generated native
+  controls from `BrowserHostController`, and mounts live RGBA page pixels as a
+  `RawImage`. Pointer wheel, hover, and tap input stay in Flutter's native
+  element tree while navigation and browser state remain in the shared Rust
+  session.
 - The native content surfaces are keyboard focus targets. Arrow, Page,
   Space/Shift-Space, Home, and End keys use the exact semantic scroll-command
   contract owned by `venture-browser-core`; Command-Left/Right on macOS and
@@ -100,9 +106,11 @@ interaction gate against their shared generated renderer, covering disabled
 controls, address editing, Return, Go, and host-driven prop refresh. The
 HTML/Web Component gate drives each target's real host runtime, including
 disabled dispatch suppression, node-slot mounting, Return, Go, and
-`mosaic-host-ready` refresh. The Flutter gate additionally pumps the emitted `MosaicApp`
-with a recording host and drives the generated native controls, including
-disabled buttons, address editing, Return, Go, and host-driven prop refresh.
+`mosaic-host-ready` refresh. The Flutter gate builds the shared Rust/Cairo
+bridge and pumps the emitted `MosaicApp` against deterministic HTTP pages. It
+requires live page pixels and drives the generated address field, Back/Forward
+controls, pointer scrolling, link hover projection, and link activation
+through the package-owned FFI host.
 The Qt gate runs the same chrome contract through Qt Quick Test against the
 emitted part-backed native controls and a recording `mosaicHost` seam as a
 fast emitter-contract test. On Linux and macOS with Qt and CMake available,
@@ -142,6 +150,10 @@ interaction gate required. Other workspace test environments may skip that one n
 launch test when CMake or Qt6 is unavailable; the package matrix does not.
 Repository CI provisions those Qt6 dependencies on its Linux Venture lane so
 the generated project build and direct launch are mandatory there.
+
+On Flutter-capable macOS and Linux hosts, the matrix builds the same Cairo page
+bridge, copies it beside the generated Flutter project, runs the live widget
+interaction gate, and then builds the native Flutter runner for that host.
 
 The macOS and Windows Rust package tests are the authoritative direct-launch
 gates. Each test builds its platform bridge in an isolated temporary target

--- a/code/programs/mosaic/venture-browser/host/flutter/mosaic_host.dart
+++ b/code/programs/mosaic/venture-browser/host/flutter/mosaic_host.dart
@@ -1,0 +1,499 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:ffi';
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+typedef _CreateNative = Pointer<Void> Function(Pointer<Char>, Double, Double);
+typedef _CreateDart = Pointer<Void> Function(Pointer<Char>, double, double);
+typedef _FreeNative = Void Function(Pointer<Void>);
+typedef _FreeDart = void Function(Pointer<Void>);
+typedef _PropsNative = Pointer<Char> Function(Pointer<Void>);
+typedef _PropsDart = Pointer<Char> Function(Pointer<Void>);
+typedef _EventNative =
+    Pointer<Char> Function(Pointer<Void>, Pointer<Char>, Pointer<Char>);
+typedef _EventDart =
+    Pointer<Char> Function(Pointer<Void>, Pointer<Char>, Pointer<Char>);
+typedef _PointNative = Uint8 Function(Pointer<Void>, Double, Double);
+typedef _PointDart = int Function(Pointer<Void>, double, double);
+typedef _ScalarNative = Uint8 Function(Pointer<Void>, Double);
+typedef _ScalarDart = int Function(Pointer<Void>, double);
+typedef _MetricsNative =
+    Uint8 Function(
+      Pointer<Void>,
+      Pointer<Double>,
+      Pointer<Double>,
+      Pointer<Double>,
+      Pointer<Double>,
+    );
+typedef _MetricsDart =
+    int Function(
+      Pointer<Void>,
+      Pointer<Double>,
+      Pointer<Double>,
+      Pointer<Double>,
+      Pointer<Double>,
+    );
+typedef _RenderNative =
+    IntPtr Function(
+      Pointer<Void>,
+      Pointer<Uint8>,
+      IntPtr,
+      Pointer<Uint32>,
+      Pointer<Uint32>,
+    );
+typedef _RenderDart =
+    int Function(
+      Pointer<Void>,
+      Pointer<Uint8>,
+      int,
+      Pointer<Uint32>,
+      Pointer<Uint32>,
+    );
+typedef _StringFreeNative = Void Function(Pointer<Char>);
+typedef _StringFreeDart = void Function(Pointer<Char>);
+typedef _MallocNative = Pointer<Void> Function(IntPtr);
+typedef _MallocDart = Pointer<Void> Function(int);
+typedef _SystemFreeNative = Void Function(Pointer<Void>);
+typedef _SystemFreeDart = void Function(Pointer<Void>);
+
+class _NativeMemory {
+  _NativeMemory() {
+    final library = Platform.isWindows
+        ? DynamicLibrary.open('msvcrt.dll')
+        : DynamicLibrary.process();
+    malloc = library.lookupFunction<_MallocNative, _MallocDart>('malloc');
+    free = library.lookupFunction<_SystemFreeNative, _SystemFreeDart>('free');
+  }
+
+  late final _MallocDart malloc;
+  late final _SystemFreeDart free;
+
+  Pointer<T> allocate<T extends NativeType>(int bytes) {
+    final pointer = malloc(bytes).cast<T>();
+    if (pointer == nullptr) {
+      throw StateError('native allocation of $bytes bytes failed');
+    }
+    return pointer;
+  }
+}
+
+final _NativeMemory _memory = _NativeMemory();
+
+class _NativeString {
+  _NativeString(String value) {
+    final bytes = utf8.encode(value);
+    pointer = _memory.allocate<Uint8>(bytes.length + 1).cast<Char>();
+    final view = pointer.cast<Uint8>().asTypedList(bytes.length + 1);
+    view.setRange(0, bytes.length, bytes);
+    view[bytes.length] = 0;
+  }
+
+  late final Pointer<Char> pointer;
+
+  void dispose() => _memory.free(pointer.cast<Void>());
+}
+
+class _VentureBindings {
+  _VentureBindings(DynamicLibrary library)
+    : create = library.lookupFunction<_CreateNative, _CreateDart>(
+        'venture_browser_flutter_new',
+      ),
+      free = library.lookupFunction<_FreeNative, _FreeDart>(
+        'venture_browser_flutter_free',
+      ),
+      props = library.lookupFunction<_PropsNative, _PropsDart>(
+        'venture_browser_flutter_apply_props',
+      ),
+      event = library.lookupFunction<_EventNative, _EventDart>(
+        'venture_browser_flutter_handle_event',
+      ),
+      scroll = library.lookupFunction<_ScalarNative, _ScalarDart>(
+        'venture_browser_flutter_scroll',
+      ),
+      activateLink = library.lookupFunction<_PointNative, _PointDart>(
+        'venture_browser_flutter_activate_link',
+      ),
+      updateHover = library.lookupFunction<_PointNative, _PointDart>(
+        'venture_browser_flutter_update_hover',
+      ),
+      metrics = library.lookupFunction<_MetricsNative, _MetricsDart>(
+        'venture_browser_flutter_scroll_metrics',
+      ),
+      resize = library.lookupFunction<_PointNative, _PointDart>(
+        'venture_browser_flutter_resize',
+      ),
+      render = library.lookupFunction<_RenderNative, _RenderDart>(
+        'venture_browser_flutter_render_rgba',
+      ),
+      stringFree = library.lookupFunction<_StringFreeNative, _StringFreeDart>(
+        'venture_browser_flutter_string_free',
+      );
+
+  final _CreateDart create;
+  final _FreeDart free;
+  final _PropsDart props;
+  final _EventDart event;
+  final _ScalarDart scroll;
+  final _PointDart activateLink;
+  final _PointDart updateHover;
+  final _MetricsDart metrics;
+  final _PointDart resize;
+  final _RenderDart render;
+  final _StringFreeDart stringFree;
+}
+
+class _RgbaFrame {
+  const _RgbaFrame(this.width, this.height, this.pixels);
+
+  final int width;
+  final int height;
+  final Uint8List pixels;
+
+  Future<ui.Image> decode() async {
+    final buffer = await ui.ImmutableBuffer.fromUint8List(pixels);
+    final descriptor = ui.ImageDescriptor.raw(
+      buffer,
+      width: width,
+      height: height,
+      rowBytes: width * 4,
+      pixelFormat: ui.PixelFormat.rgba8888,
+    );
+    final codec = await descriptor.instantiateCodec();
+    final frame = await codec.getNextFrame();
+    codec.dispose();
+    descriptor.dispose();
+    buffer.dispose();
+    return frame.image;
+  }
+}
+
+class MosaicHost {
+  MosaicHost._(this._bindings, this._host) {
+    _contentSurface = VentureContentSurface(
+      key: const Key('venture-content-surface'),
+      host: this,
+    );
+  }
+
+  static const double viewportWidth = 1024;
+  static const double viewportHeight = 640;
+
+  static MosaicHost? load() {
+    final libraryPath =
+        Platform.environment['VENTURE_BROWSER_FLUTTER_LIBRARY'] ??
+        _defaultLibraryName();
+    final startUrl =
+        Platform.environment['VENTURE_BROWSER_START_URL'] ??
+        'http://info.cern.ch/';
+    try {
+      return open(libraryPath: libraryPath, startUrl: startUrl);
+    } on Object catch (error) {
+      debugPrint('Venture Flutter host unavailable: $error');
+      return null;
+    }
+  }
+
+  static MosaicHost open({
+    required String libraryPath,
+    required String startUrl,
+  }) {
+    final bindings = _VentureBindings(DynamicLibrary.open(libraryPath));
+    final url = _NativeString(startUrl);
+    try {
+      final host = bindings.create(url.pointer, viewportWidth, viewportHeight);
+      if (host == nullptr) {
+        throw StateError(
+          'shared Venture browser session failed to load $startUrl',
+        );
+      }
+      return MosaicHost._(bindings, host);
+    } finally {
+      url.dispose();
+    }
+  }
+
+  static String _defaultLibraryName() {
+    if (Platform.isMacOS) return 'libventure_browser_flutter.dylib';
+    if (Platform.isWindows) return 'venture_browser_flutter.dll';
+    return 'libventure_browser_flutter.so';
+  }
+
+  final _VentureBindings _bindings;
+  final Pointer<Void> _host;
+  final ValueNotifier<int> _surfaceRevision = ValueNotifier<int>(0);
+  Completer<void> _surfaceReady = Completer<void>();
+  late final Widget _contentSurface;
+  void Function()? _propsChangedHandler;
+  bool _disposed = false;
+
+  FutureOr<Map<String, Object?>?> props() {
+    return _decorate(_decodeResponse(_bindings.props(_host)));
+  }
+
+  FutureOr<Map<String, Object?>?> handleEvent(Map<String, Object?> event) {
+    final name = _NativeString(event['event']?.toString() ?? '');
+    final value = _NativeString(event['value']?.toString() ?? '');
+    try {
+      final response = _decorate(
+        _decodeResponse(_bindings.event(_host, name.pointer, value.pointer)),
+      );
+      _surfaceChanged();
+      return response;
+    } finally {
+      value.dispose();
+      name.dispose();
+    }
+  }
+
+  void setPropsChangedHandler(void Function()? handler) {
+    _propsChangedHandler = handler;
+  }
+
+  Future<void> get surfaceReady => _surfaceReady.future;
+
+  Map<String, double>? get scrollMetrics {
+    final values = List<Pointer<Double>>.generate(
+      4,
+      (_) => _memory.allocate<Double>(sizeOf<Double>()),
+    );
+    try {
+      if (_bindings.metrics(
+            _host,
+            values[0],
+            values[1],
+            values[2],
+            values[3],
+          ) ==
+          0) {
+        return null;
+      }
+      return <String, double>{
+        'offset': values[0].value,
+        'viewport': values[1].value,
+        'content': values[2].value,
+        'max': values[3].value,
+      };
+    } finally {
+      for (final value in values) {
+        _memory.free(value.cast<Void>());
+      }
+    }
+  }
+
+  String get statusText {
+    final response = _decorate(_decodeResponse(_bindings.props(_host)));
+    final props = response['props'];
+    if (props is Map) return props['status-text']?.toString() ?? '';
+    return '';
+  }
+
+  void scrollBy(double deltaY) {
+    if (_bindings.scroll(_host, deltaY) != 0) _surfaceChanged();
+  }
+
+  void updateHover(double x, double y) {
+    if (_bindings.updateHover(_host, x, y) != 0) _surfaceChanged();
+  }
+
+  void activateLink(double x, double y) {
+    if (_bindings.activateLink(_host, x, y) != 0) _surfaceChanged();
+  }
+
+  void resize(double width, double height) {
+    if (_bindings.resize(_host, width, height) != 0) _surfaceChanged();
+  }
+
+  _RgbaFrame renderFrame() {
+    final width = _memory.allocate<Uint32>(sizeOf<Uint32>());
+    final height = _memory.allocate<Uint32>(sizeOf<Uint32>());
+    try {
+      final length = _bindings.render(
+        _host,
+        nullptr.cast<Uint8>(),
+        0,
+        width,
+        height,
+      );
+      if (length <= 0 || width.value == 0 || height.value == 0) {
+        throw StateError('shared Venture Cairo renderer returned no pixels');
+      }
+      final output = _memory.allocate<Uint8>(length);
+      try {
+        final written = _bindings.render(_host, output, length, width, height);
+        if (written != length) {
+          throw StateError(
+            'shared Venture Cairo render changed size during copy',
+          );
+        }
+        return _RgbaFrame(
+          width.value,
+          height.value,
+          Uint8List.fromList(output.asTypedList(length)),
+        );
+      } finally {
+        _memory.free(output.cast<Void>());
+      }
+    } finally {
+      _memory.free(height.cast<Void>());
+      _memory.free(width.cast<Void>());
+    }
+  }
+
+  Map<String, Object?> _decodeResponse(Pointer<Char> value) {
+    if (value == nullptr) {
+      throw StateError('shared Venture host returned a null response');
+    }
+    try {
+      var length = 0;
+      while (value.cast<Uint8>()[length] != 0) {
+        length += 1;
+      }
+      final decoded = jsonDecode(
+        utf8.decode(value.cast<Uint8>().asTypedList(length)),
+      );
+      return Map<String, Object?>.from(decoded as Map);
+    } finally {
+      _bindings.stringFree(value);
+    }
+  }
+
+  Map<String, Object?> _decorate(Map<String, Object?> response) {
+    final props = Map<String, Object?>.from(
+      (response['props'] as Map?) ?? const <String, Object?>{},
+    );
+    props['content-surface'] = _contentSurface;
+    return <String, Object?>{...response, 'props': props};
+  }
+
+  void _surfaceChanged() {
+    if (_surfaceReady.isCompleted) {
+      _surfaceReady = Completer<void>();
+    }
+    _surfaceRevision.value += 1;
+    _propsChangedHandler?.call();
+  }
+
+  void _surfaceRendered() {
+    if (!_surfaceReady.isCompleted) {
+      _surfaceReady.complete();
+    }
+  }
+
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _propsChangedHandler = null;
+    _bindings.free(_host);
+    _surfaceRevision.dispose();
+  }
+}
+
+class VentureContentSurface extends StatefulWidget {
+  const VentureContentSurface({super.key, required this.host});
+
+  final MosaicHost host;
+
+  @override
+  State<VentureContentSurface> createState() => _VentureContentSurfaceState();
+}
+
+class _VentureContentSurfaceState extends State<VentureContentSurface> {
+  ui.Image? _image;
+  bool _linkHover = false;
+  int _renderGeneration = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.host._surfaceRevision.addListener(_scheduleRefresh);
+    unawaited(_refresh());
+  }
+
+  @override
+  void didUpdateWidget(VentureContentSurface oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.host != widget.host) {
+      oldWidget.host._surfaceRevision.removeListener(_scheduleRefresh);
+      widget.host._surfaceRevision.addListener(_scheduleRefresh);
+      unawaited(_refresh());
+    }
+  }
+
+  void _scheduleRefresh() => unawaited(_refresh());
+
+  Future<void> _refresh() async {
+    final generation = ++_renderGeneration;
+    final rendered = widget.host.renderFrame();
+    final nextImage = await rendered.decode();
+    if (!mounted || generation != _renderGeneration) {
+      nextImage.dispose();
+      return;
+    }
+    final previous = _image;
+    setState(() {
+      _image = nextImage;
+      _linkHover = widget.host.statusText.isNotEmpty;
+    });
+    previous?.dispose();
+    widget.host._surfaceRendered();
+  }
+
+  void _handleHover(PointerHoverEvent event) {
+    widget.host.updateHover(event.localPosition.dx, event.localPosition.dy);
+    final linkHover = widget.host.statusText.isNotEmpty;
+    if (linkHover != _linkHover && mounted) {
+      setState(() => _linkHover = linkHover);
+    }
+  }
+
+  void _handlePointerSignal(PointerSignalEvent event) {
+    if (event is PointerScrollEvent) {
+      widget.host.scrollBy(event.scrollDelta.dy);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: MosaicHost.viewportWidth,
+      height: MosaicHost.viewportHeight,
+      child: MouseRegion(
+        cursor: _linkHover
+            ? SystemMouseCursors.click
+            : SystemMouseCursors.basic,
+        onHover: _handleHover,
+        child: Listener(
+          behavior: HitTestBehavior.opaque,
+          onPointerSignal: _handlePointerSignal,
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTapUp: (details) => widget.host.activateLink(
+              details.localPosition.dx,
+              details.localPosition.dy,
+            ),
+            child: _image == null
+                ? const ColoredBox(color: Colors.white)
+                : RawImage(
+                    key: const Key('venture-content-image'),
+                    image: _image,
+                    fit: BoxFit.fill,
+                  ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    widget.host._surfaceRevision.removeListener(_scheduleRefresh);
+    _renderGeneration += 1;
+    _image?.dispose();
+    super.dispose();
+  }
+}

--- a/code/programs/mosaic/venture-browser/host/flutter/venture_chrome_interaction_test.dart
+++ b/code/programs/mosaic/venture-browser/host/flutter/venture_chrome_interaction_test.dart
@@ -1,105 +1,162 @@
-import 'dart:async';
+import 'dart:convert';
+import 'dart:ffi' show DynamicLibrary;
+import 'dart:io';
+import 'dart:isolate';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mosaic_venture_chrome/main.dart';
 import 'package:mosaic_venture_chrome/mosaic_host.dart';
 
-class RecordingMosaicHost extends MosaicHost {
-  RecordingMosaicHost({required this.navigationDisabled});
-
-  final bool navigationDisabled;
-  final List<Map<String, Object?>> events = <Map<String, Object?>>[];
-
-  @override
-  FutureOr<Map<String, Object?>?> props() => <String, Object?>{
-    'props': <String, Object?>{
-      'address': 'http://venture.test/start',
-      'page-title': 'Venture Flutter Acceptance',
-      'status-text': 'Ready',
-      'back-disabled': true,
-      'forward-disabled': true,
-      'navigation-disabled': navigationDisabled,
-      'content-surface': const Text('Flutter host surface'),
-    },
-  };
-
-  @override
-  FutureOr<Map<String, Object?>?> handleEvent(Map<String, Object?> event) {
-    events.add(Map<String, Object?>.from(event));
-    if (event['event'] == 'onNavigate') {
-      return <String, Object?>{
-        'props': <String, Object?>{
-          'address': 'http://venture.test/next',
-          'page-title': 'Venture Flutter Acceptance',
-          'status-text': 'Navigated through MosaicHost',
-          'back-disabled': false,
-          'forward-disabled': true,
-          'navigation-disabled': false,
-          'content-surface': const Text('Flutter host surface'),
-        },
-      };
+Future<void> _servePages(SendPort port) async {
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  port.send(server.port);
+  await for (final request in server) {
+    print('flutter-live-server-request=${request.uri.path}');
+    request.response.headers.contentType = ContentType.html;
+    request.response.persistentConnection = false;
+    late final String body;
+    switch (request.uri.path) {
+      case '/start':
+        body =
+            '''
+          <html><head><title>Flutter Start</title></head><body>
+          <a href="/link">Open the Flutter link target</a>
+          ${List<String>.generate(80, (index) => '<p>scroll row $index</p>').join()}
+          </body></html>
+        ''';
+        break;
+      case '/target':
+        body =
+            '<html><head><title>Flutter Address Target</title></head>'
+            '<body>address navigation reached the shared browser</body></html>';
+        break;
+      case '/link':
+        body =
+            '<html><head><title>Flutter Link Target</title></head>'
+            '<body>native Flutter pointer activation reached Cairo</body></html>';
+        break;
+      default:
+        request.response.statusCode = HttpStatus.notFound;
+        body = 'missing page';
     }
-    return null;
+    request.response.contentLength = utf8.encode(body).length;
+    request.response.write(body);
+    await request.response.close();
   }
 }
 
-Future<void> pumpVentureShell(
-  WidgetTester tester,
-  RecordingMosaicHost host,
-) async {
-  await tester.binding.setSurfaceSize(const Size(1400, 900));
-  addTearDown(() => tester.binding.setSurfaceSize(null));
+Future<(Isolate, int)> _startPageServer() async {
+  final receivePort = ReceivePort();
+  final isolate = await Isolate.spawn(_servePages, receivePort.sendPort);
+  final port = await receivePort.first as int;
+  receivePort.close();
+  return (isolate, port);
+}
+
+Future<void> _pumpLiveVentureShell(WidgetTester tester, MosaicHost host) async {
   await tester.pumpWidget(MosaicApp(mosaicHost: host));
+  await _settleSurface(tester, host);
+  expect(find.text('Flutter Start'), findsOneWidget);
+  expect(find.byKey(const Key('venture-content-image')), findsOneWidget);
+}
+
+Future<void> _settleSurface(WidgetTester tester, MosaicHost host) async {
+  await tester.pump();
+  await tester.runAsync(
+    () => host.surfaceReady.timeout(const Duration(seconds: 10)),
+  );
   await tester.pumpAndSettle();
-  expect(find.text('Venture Flutter Acceptance'), findsOneWidget);
-  expect(find.text('Flutter host surface'), findsOneWidget);
 }
 
 void main() {
-  testWidgets('disabled native controls suppress Mosaic dispatch', (
-    WidgetTester tester,
-  ) async {
-    final host = RecordingMosaicHost(navigationDisabled: true);
-    await pumpVentureShell(tester, host);
-
-    expect(tester.widget<TextField>(find.byType(TextField)).readOnly, isTrue);
-    for (final label in <String>['Back', 'Forward', 'Reload', 'Go']) {
-      final button = tester.widget<ElevatedButton>(
-        find.widgetWithText(ElevatedButton, label),
+  testWidgets(
+    'package-owned Flutter shell drives the live shared browser and Cairo page',
+    (WidgetTester tester) async {
+      final libraryPath =
+          Platform.environment['VENTURE_BROWSER_FLUTTER_LIBRARY'];
+      expect(
+        libraryPath,
+        isNotNull,
+        reason: 'the direct Flutter gate requires the shared Rust bridge',
       );
-      expect(button.onPressed, isNull, reason: '$label must be disabled');
-      await tester.tap(find.text(label));
-    }
-    await tester.pump();
-    expect(host.events, isEmpty);
-  });
+      await tester.binding.setSurfaceSize(const Size(1400, 960));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      DynamicLibrary.open(libraryPath!);
+      final setup = await tester.runAsync(() async {
+        final (serverIsolate, port) = await _startPageServer();
+        debugPrint('flutter-live-stage=server-ready port=$port');
+        final startUrl = 'http://127.0.0.1:$port/start';
+        final host = MosaicHost.open(
+          libraryPath: libraryPath,
+          startUrl: startUrl,
+        );
+        return (serverIsolate, port, host);
+      });
+      final (serverIsolate, port, host) = setup!;
+      addTearDown(() => serverIsolate.kill(priority: Isolate.immediate));
+      addTearDown(host.dispose);
+      final targetUrl = 'http://127.0.0.1:$port/target';
+      final linkUrl = 'http://127.0.0.1:$port/link';
+      debugPrint('flutter-live-stage=host-open');
+      await _pumpLiveVentureShell(tester, host);
+      debugPrint('flutter-live-stage=shell-pumped');
 
-  testWidgets('address edit, Return, and Go cross the Mosaic host seam', (
-    WidgetTester tester,
-  ) async {
-    final host = RecordingMosaicHost(navigationDisabled: false);
-    await pumpVentureShell(tester, host);
+      final input = find.byType(TextField);
+      await tester.enterText(input, targetUrl);
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+      expect(find.text('Flutter Address Target'), findsOneWidget);
+      debugPrint('flutter-live-stage=address-navigation');
+      expect(
+        tester
+            .widget<ElevatedButton>(find.widgetWithText(ElevatedButton, 'Back'))
+            .onPressed,
+        isNotNull,
+      );
 
-    final input = find.byType(TextField);
-    expect(tester.widget<TextField>(input).readOnly, isFalse);
-    await tester.enterText(input, 'http://venture.test/next');
-    await tester.pump();
-    expect(host.events.last, <String, Object?>{
-      'event': 'onAddressChange',
-      'value': 'http://venture.test/next',
-    });
+      await tester.tap(find.text('Back'));
+      await tester.pumpAndSettle();
+      debugPrint('flutter-live-stage=history');
+      expect(find.text('Flutter Start'), findsOneWidget);
+      await tester.tap(find.text('Forward'));
+      await tester.pumpAndSettle();
+      expect(find.text('Flutter Address Target'), findsOneWidget);
+      await tester.tap(find.text('Back'));
+      await tester.pumpAndSettle();
 
-    await tester.testTextInput.receiveAction(TextInputAction.done);
-    await tester.pumpAndSettle();
-    expect(host.events.last['event'], 'onNavigate');
-    expect(find.text('Navigated through MosaicHost'), findsOneWidget);
+      final surface = find.byKey(const Key('venture-content-surface'));
+      final center = tester.getCenter(surface);
+      final beforeScroll = host.scrollMetrics!;
+      expect(beforeScroll['max'], greaterThan(0));
+      await tester.sendEventToBinding(
+        PointerScrollEvent(position: center, scrollDelta: const Offset(0, 320)),
+      );
+      await tester.pumpAndSettle();
+      expect(host.scrollMetrics!['offset'], greaterThan(0));
+      await tester.sendEventToBinding(
+        PointerScrollEvent(
+          position: center,
+          scrollDelta: const Offset(0, -10000),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(host.scrollMetrics!['offset'], 0);
+      debugPrint('flutter-live-stage=scroll');
 
-    await tester.tap(find.text('Go'));
-    await tester.pumpAndSettle();
-    expect(
-      host.events.where((event) => event['event'] == 'onNavigate').length,
-      2,
-    );
-  });
+      final linkPoint = tester.getTopLeft(surface) + const Offset(32, 26);
+      await tester.sendEventToBinding(PointerHoverEvent(position: linkPoint));
+      await tester.pumpAndSettle();
+      expect(find.text(linkUrl), findsOneWidget);
+      debugPrint('flutter-live-stage=hover');
+
+      await tester.tapAt(linkPoint);
+      await tester.pumpAndSettle();
+      expect(find.text('Flutter Link Target'), findsOneWidget);
+      expect(tester.widget<TextField>(input).controller!.text, linkUrl);
+      expect(find.byKey(const Key('venture-content-image')), findsOneWidget);
+      debugPrint('flutter-live-stage=link');
+    },
+  );
 }

--- a/code/programs/mosaic/venture-browser/mosaic-package.toml
+++ b/code/programs/mosaic/venture-browser/mosaic-package.toml
@@ -11,6 +11,7 @@ exports = ["VentureChrome"]
 files = [
   { backend = "swiftui", source = "host/swiftui/MosaicHost.swift", target = "Sources/App/MosaicHost.swift" },
   { backend = "xaml", source = "host/xaml/MosaicHost.cs", target = "MosaicHost.cs" },
+  { backend = "flutter", source = "host/flutter/mosaic_host.dart", target = "lib/mosaic_host.dart" },
   { backend = "flutter", source = "host/flutter/venture_chrome_interaction_test.dart", target = "test/venture_chrome_interaction_test.dart" },
   { backend = "qt", source = "host/qt/MosaicHost.cpp", target = "MosaicHost.cpp" },
   { backend = "qt", source = "host/qt/MosaicHost.h", target = "MosaicHost.h" },

--- a/code/programs/mosaic/venture-browser/scripts/build-all.ps1
+++ b/code/programs/mosaic/venture-browser/scripts/build-all.ps1
@@ -281,9 +281,42 @@ if ($isWindows -and (Test-Command "dotnet")) {
 
 $flutterPlatform = if ($isMacOS) { "macos" } elseif ($isWindows) { "windows" } elseif ($isLinux) { "linux" } else { $null }
 if ($null -ne $flutterPlatform -and (Test-Command "flutter")) {
+    Write-Host "==> Building Venture Flutter native bridge"
+    $flutterBridgeArgs = @("build", "-p", "venture-browser-qt")
+    $flutterBridgeProfile = "debug"
+    if ($Release) {
+        $flutterBridgeArgs += "--release"
+        $flutterBridgeProfile = "release"
+    }
+    Push-Location $rustWorkspace
+    try {
+        Invoke-Checked -Command "cargo" -Arguments $flutterBridgeArgs
+    } finally {
+        Pop-Location
+    }
+    $flutterBridgeSource = if ($isWindows) {
+        "venture_browser_qt.dll"
+    } elseif ($isMacOS) {
+        "libventure_browser_qt.dylib"
+    } else {
+        "libventure_browser_qt.so"
+    }
+    $flutterBridgeName = if ($isWindows) {
+        "venture_browser_flutter.dll"
+    } elseif ($isMacOS) {
+        "libventure_browser_flutter.dylib"
+    } else {
+        "libventure_browser_flutter.so"
+    }
+    $flutterBridgePath = Join-Path $outputRoot "flutter/$flutterBridgeName"
+    Copy-Item -Force `
+        (Join-Path $rustWorkspace "target/$flutterBridgeProfile/$flutterBridgeSource") `
+        $flutterBridgePath
     Write-Host "==> Building flutter ($flutterPlatform)"
     Push-Location (Join-Path $outputRoot "flutter")
+    $previousFlutterLibrary = $env:VENTURE_BROWSER_FLUTTER_LIBRARY
     try {
+        $env:VENTURE_BROWSER_FLUTTER_LIBRARY = $flutterBridgePath
         Invoke-Checked -Command "flutter" -Arguments @("pub", "get")
         Invoke-Checked -Command "flutter" -Arguments @("analyze", "lib")
         Invoke-Checked -Command "flutter" -Arguments @("test", "test/venture_chrome_interaction_test.dart")
@@ -292,6 +325,7 @@ if ($null -ne $flutterPlatform -and (Test-Command "flutter")) {
         }
         Invoke-Checked -Command "flutter" -Arguments @("build", $flutterPlatform)
     } finally {
+        $env:VENTURE_BROWSER_FLUTTER_LIBRARY = $previousFlutterLibrary
         Pop-Location
     }
 } elseif ($null -eq $flutterPlatform) {

--- a/code/programs/mosaic/venture-browser/scripts/build-all.sh
+++ b/code/programs/mosaic/venture-browser/scripts/build-all.sh
@@ -237,12 +237,37 @@ case "$host_os" in
 esac
 
 if [[ -n "$flutter_platform" ]] && has_command flutter; then
+  echo "==> Building Venture Flutter native bridge"
+  flutter_bridge_args=(build -p venture-browser-qt)
+  flutter_bridge_profile=debug
+  if ((release)); then
+    flutter_bridge_args+=(--release)
+    flutter_bridge_profile=release
+  fi
+  (cd "$rust_workspace" && cargo "${flutter_bridge_args[@]}")
+  case "$host_os" in
+    Darwin)
+      flutter_bridge_source=libventure_browser_qt.dylib
+      flutter_bridge_name=libventure_browser_flutter.dylib
+      ;;
+    Linux)
+      flutter_bridge_source=libventure_browser_qt.so
+      flutter_bridge_name=libventure_browser_flutter.so
+      ;;
+    *)
+      flutter_bridge_source=venture_browser_qt.dll
+      flutter_bridge_name=venture_browser_flutter.dll
+      ;;
+  esac
+  cp "$rust_workspace/target/$flutter_bridge_profile/$flutter_bridge_source" \
+    "$output_root/flutter/$flutter_bridge_name"
   echo "==> Building flutter ($flutter_platform)"
   (
     cd "$output_root/flutter"
     flutter pub get
     flutter analyze lib
-    flutter test test/venture_chrome_interaction_test.dart
+    VENTURE_BROWSER_FLUTTER_LIBRARY="$output_root/flutter/$flutter_bridge_name" \
+      flutter test test/venture_chrome_interaction_test.dart
     if [[ ! -d "$flutter_platform" ]]; then
       flutter create "--platforms=$flutter_platform" .
     fi

--- a/code/programs/mosaic/venture-browser/tests/package_compiles.rs
+++ b/code/programs/mosaic/venture-browser/tests/package_compiles.rs
@@ -89,7 +89,7 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
     let package = mosaic_package_manifest::parse(&manifest).expect("parse manifest");
     assert_eq!(package.package.name, "venture-browser");
     assert_eq!(package.components.exports, ["VentureChrome"]);
-    assert_eq!(package.host_assets.files.len(), 13);
+    assert_eq!(package.host_assets.files.len(), 14);
     assert_eq!(package.host_assets.files[0].backend, "swiftui");
     assert_eq!(
         package.host_assets.files[0].target,
@@ -104,40 +104,46 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
     assert_eq!(package.host_assets.files[2].backend, "flutter");
     assert_eq!(
         package.host_assets.files[2].source,
+        "host/flutter/mosaic_host.dart"
+    );
+    assert_eq!(package.host_assets.files[2].target, "lib/mosaic_host.dart");
+    assert_eq!(package.host_assets.files[3].backend, "flutter");
+    assert_eq!(
+        package.host_assets.files[3].source,
         "host/flutter/venture_chrome_interaction_test.dart"
     );
     assert_eq!(
-        package.host_assets.files[2].target,
+        package.host_assets.files[3].target,
         "test/venture_chrome_interaction_test.dart"
     );
-    assert_eq!(package.host_assets.files[3].backend, "qt");
+    assert_eq!(package.host_assets.files[4].backend, "qt");
     assert_eq!(
-        package.host_assets.files[3].source,
+        package.host_assets.files[4].source,
         "host/qt/MosaicHost.cpp"
     );
-    assert_eq!(package.host_assets.files[3].target, "MosaicHost.cpp");
-    assert_eq!(package.host_assets.files[4].backend, "qt");
-    assert_eq!(package.host_assets.files[4].source, "host/qt/MosaicHost.h");
-    assert_eq!(package.host_assets.files[4].target, "MosaicHost.h");
+    assert_eq!(package.host_assets.files[4].target, "MosaicHost.cpp");
     assert_eq!(package.host_assets.files[5].backend, "qt");
+    assert_eq!(package.host_assets.files[5].source, "host/qt/MosaicHost.h");
+    assert_eq!(package.host_assets.files[5].target, "MosaicHost.h");
+    assert_eq!(package.host_assets.files[6].backend, "qt");
     assert_eq!(
-        package.host_assets.files[5].source,
+        package.host_assets.files[6].source,
         "host/qt/tst_venture_chrome.qml"
     );
     assert_eq!(
-        package.host_assets.files[5].target,
+        package.host_assets.files[6].target,
         "test/tst_venture_chrome.qml"
     );
-    assert_eq!(package.host_assets.files[6].backend, "compose");
+    assert_eq!(package.host_assets.files[7].backend, "compose");
     assert_eq!(
-        package.host_assets.files[6].source,
+        package.host_assets.files[7].source,
         "host/compose/VentureChromeInteractionTest.kt"
     );
     assert_eq!(
-        package.host_assets.files[6].target,
+        package.host_assets.files[7].target,
         "src/test/kotlin/VentureChromeInteractionTest.kt"
     );
-    for index in [7, 8] {
+    for index in [8, 9] {
         assert_eq!(
             package.host_assets.files[index].source,
             "host/react/VentureChromeInteraction.test.tsx"
@@ -147,16 +153,16 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
             "src/VentureChromeInteraction.test.tsx"
         );
     }
-    assert_eq!(package.host_assets.files[7].backend, "react");
-    assert_eq!(package.host_assets.files[8].backend, "electron");
-    for index in [9, 11] {
+    assert_eq!(package.host_assets.files[8].backend, "react");
+    assert_eq!(package.host_assets.files[9].backend, "electron");
+    for index in [10, 12] {
         assert_eq!(
             package.host_assets.files[index].source,
             "host/web/package.json"
         );
         assert_eq!(package.host_assets.files[index].target, "package.json");
     }
-    for index in [10, 12] {
+    for index in [11, 13] {
         assert_eq!(
             package.host_assets.files[index].source,
             "host/web/VentureChromeInteraction.test.js"
@@ -166,10 +172,10 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
             "test/VentureChromeInteraction.test.js"
         );
     }
-    assert_eq!(package.host_assets.files[9].backend, "html");
     assert_eq!(package.host_assets.files[10].backend, "html");
-    assert_eq!(package.host_assets.files[11].backend, "webcomponent");
+    assert_eq!(package.host_assets.files[11].backend, "html");
     assert_eq!(package.host_assets.files[12].backend, "webcomponent");
+    assert_eq!(package.host_assets.files[13].backend, "webcomponent");
 
     let host = read_package_file("host/swiftui/MosaicHost.swift");
     for symbol in [
@@ -305,13 +311,33 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
         );
     }
 
+    let flutter_host = read_package_file("host/flutter/mosaic_host.dart");
+    for symbol in [
+        "venture_browser_flutter_new",
+        "venture_browser_flutter_handle_event",
+        "venture_browser_flutter_render_rgba",
+        "VentureContentSurface",
+        "PointerScrollEvent",
+        "activateLink",
+        "updateHover",
+        "setPropsChangedHandler",
+        "RawImage",
+    ] {
+        assert!(
+            flutter_host.contains(symbol),
+            "Flutter live host omits {symbol}"
+        );
+    }
+
     let flutter_acceptance = read_package_file("host/flutter/venture_chrome_interaction_test.dart");
     for symbol in [
         "MosaicApp(mosaicHost: host)",
-        "disabled native controls suppress Mosaic dispatch",
-        "address edit, Return, and Go cross the Mosaic host seam",
+        "package-owned Flutter shell drives the live shared browser and Cairo page",
+        "MosaicHost.open",
         "tester.testTextInput.receiveAction(TextInputAction.done)",
-        "Navigated through MosaicHost",
+        "PointerScrollEvent",
+        "PointerHoverEvent",
+        "Flutter Link Target",
     ] {
         assert!(
             flutter_acceptance.contains(symbol),


### PR DESCRIPTION
## Summary
- add a package-owned Dart FFI host that mounts the shared Rust/Cairo Venture page in generated Flutter chrome
- drive address navigation, history, scrolling, hover status, link activation, and rendered pixels through a live generated-app test
- make the POSIX and Windows package matrices build and supply the shared native bridge
- record the backend-neutral Cairo bridge extraction as prioritized follow-up debt

## Validation
- cargo test -p mosaic-emit-flutter -p venture-browser-qt
- cargo clippy -p mosaic-emit-flutter -p venture-browser-qt --all-targets -- -D warnings
- cargo test (Venture Mosaic package)
- all nine Venture backends emit successfully
- full package build entry point: React, Electron, HTML, Web Components, SwiftUI, Qt, and Flutter green locally; WinUI deferred to Windows; Compose deferred locally because JDK 21 is unavailable
- Flutter analyze, live interaction test, and macOS application build
- HTML parser checked audit: tree 1934 upstream / 2637 local / 0 missing; tokenizer 6806 upstream / 7015 raw / 7242 normalized / 0 skipped / 0 missing

This does not claim full browser conformance; parser, browser wiring, and direct platform acceptance remain separately gated.