### PR TITLE
fix(spice): lower parser MOS sheet resistance

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS model-card `RSH` values before lowering
+  Level-1 sheet resistance.
 - Reject negative and non-finite MOS model-card `RS` values before lowering
   Level-1 source resistance.
 - Reject negative and non-finite MOS model-card `RD` values before lowering

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1930,6 +1930,10 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(params["RS"]) or params["RS"] < 0.0
         ):
             raise NetlistParseError("MOSFET RS must be finite and non-negative")
+        if "RSH" in params and (
+            not math.isfinite(params["RSH"]) or params["RSH"] < 0.0
+        ):
+            raise NetlistParseError("MOSFET RSH must be finite and non-negative")
         nominal_temperature = params.get("T_NOM", params.get("TNOM"))
         if nominal_temperature is not None and (
             not math.isfinite(nominal_temperature) or nominal_temperature <= 0.0

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1638,6 +1638,31 @@ def test_lowers_valid_mosfet_model_source_resistance(
     assert float(source_resistance) == mosfet.model.model.params.RS
 
 
+@pytest.mark.parametrize("sheet_resistance", ["-1", "1e999"])
+def test_rejects_invalid_mosfet_model_sheet_resistance(
+    sheet_resistance: str,
+) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="MOSFET RSH must be finite and non-negative",
+    ):
+        parse_netlist(
+            f".model nfast NMOS(RSH={sheet_resistance})\nM1 d g s b nfast\n"
+        )
+
+
+@pytest.mark.parametrize("sheet_resistance", ["0", "42.5"])
+def test_lowers_valid_mosfet_model_sheet_resistance(
+    sheet_resistance: str,
+) -> None:
+    parsed = parse_netlist(
+        f".model nfast NMOS(RSH={sheet_resistance})\nM1 d g s b nfast\n"
+    )
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert float(sheet_resistance) == mosfet.model.model.params.RSH
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS model-card `RSH` values and lower valid
+  Level-1 sheet resistance instead of silently dropping it.
 - Reject negative and non-finite MOS model-card `RS` values and lower valid
   Level-1 source resistance instead of silently dropping it.
 - Reject negative and non-finite MOS model-card `RD` values and lower valid

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1253,6 +1253,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET RS must be finite and non-negative");
   }
+  const sheetResistance = params.get("RSH");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    sheetResistance !== undefined &&
+    (!Number.isFinite(sheetResistance) || sheetResistance < 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET RSH must be finite and non-negative");
+  }
   const nominalTemperature = params.get("T_NOM") ?? params.get("TNOM");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1345,6 +1353,7 @@ function isMosfetParam(name: keyof MosfetLevel1Params): boolean {
     "U0",
     "RD",
     "RS",
+    "RSH",
     "IS",
     "N_SUB",
     "T_NOM",

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1547,6 +1547,22 @@ Xright c d load
     expect(element.params.RS).toBe(Number(sourceResistance));
   });
 
+  it.each(["-1", "1e999"])("rejects invalid MOSFET model RSH=%s", (sheetResistance) => {
+    expect(() =>
+      parseNetlist(`.model nfast NMOS(RSH=${sheetResistance})\nM1 d g s b nfast\n`),
+    ).toThrow("MOSFET RSH must be finite and non-negative");
+  });
+
+  it.each(["0", "42.5"])("lowers valid MOSFET model RSH=%s", (sheetResistance) => {
+    const parsed = parseNetlist(
+      `.model nfast NMOS(RSH=${sheetResistance})\nM1 d g s b nfast\n`,
+    );
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.RSH).toBe(Number(sheetResistance));
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4201,10 +4201,16 @@ the Rust, Python, and TypeScript surfaces together.
      diagnostic while zero and positive drain resistances lower into Level-1
      parameters.
 
+381. Python and TypeScript Berkeley SPICE MOS source-resistance parity.
+   - Status: completed in PR 9645.
+   - Negative and non-finite `RS` values are rejected with the shared
+     diagnostic while zero and positive source resistances lower into Level-1
+     parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
-   - TypeScript still needs canonical lowering for `RS`, `RSH`, `LD`,
+   - TypeScript still needs canonical lowering for `RSH`, `LD`,
      `NRD`, `NRS`, `AD`, `AS`, `PD`, `PS`, `CJ`, `CJSW`, `JS`, `PB`, `MJ`,
      `MJSW`, `FC`, `KF`, and `AF`; Python already lowers these canonical fields
      but still needs matching facade validation coverage.


### PR DESCRIPTION
## Summary
- reject negative and non-finite MOS model-card `RSH` values in the Python and TypeScript parsers
- lower valid TypeScript sheet resistance instead of silently dropping it
- record the merged source-resistance parity slice and advance the audited backlog

## Verification
- Python spice-netlist-parser: 143 tests passed; 88.24% coverage
- Python spice-netlist-parser: `ruff check src tests`
- TypeScript spice-engine: `npm run build`
- TypeScript spice-netlist-parser: `npm run build`
- TypeScript spice-netlist-parser: 136 tests passed with coverage