### PR TITLE
feat(human-languages): validate block knowledge closure

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,13 +5,13 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after Spanish Chapters 4–6
-canonical generation: 20 registered tracks, 1,065 Markdown lessons, 20
-downloadable LaTeX books, and zero duration violations. HL-V01 keeps the
-remaining migration debt reproducible in both JSON and human-readable reports;
-the first 51 Spanish lessons now prove one typed source across Language Ladder
-and six generated book chapters, and the completed HL-D01 tranches prove
-duration remediation without discarding deep content.
+Last prioritized: 2026-08-03. Current baseline after schema-v2 block-boundary
+validation: 20 registered tracks, 1,065 Markdown lessons, 20 downloadable LaTeX
+books, and zero duration violations. HL-V01 keeps the remaining migration debt
+reproducible in both JSON and human-readable reports; the first 51 Spanish
+lessons now prove one typed, knowledge-closed source across Language Ladder and
+six generated book chapters, and the completed HL-D01 tranches prove duration
+remediation without discarding deep content.
 
 ## Priority rules
 
@@ -68,9 +68,10 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-D01R | Complete (#9624) | Remove all fifty-five remaining sub-five-minute violations from the Spanish track. | The report measures zero Spanish violations; twelve new prerequisite-ordered lessons preserve the grammar, etymology, usage, writing, and practice depth from the genuinely long lessons. |
 | HL-D01 | Complete (#9624) | Split or rewrite every lesson whose computed duration is at least 300 seconds. | The deterministic report now reaches zero effective-duration violations across all twenty tracks. |
 | HL-S02 | Complete (#9634) | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | All 27 lessons have typed blocks, unique sequence, transitive knowledge closure, and sub-five-minute duration guarantees. |
-| HL-G03 | Complete in this PR | Generate Spanish Chapters 4–6 from their canonical schema-v2 lesson ASTs after HL-S02. | All six generated chapters now share lesson hashes with Language Ladder; Markdown tables retain their structure in print. |
-| HL-V02 | Next | Validate learner-facing target-language prompts against block-level knowledge declarations and prerequisite closure. | Schema-v2 production and recall blocks cannot ask for an undeclared form or a form absent from the lesson's transitive knowledge frontier. |
-| HL-B04 | Queued | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
+| HL-G03 | Complete (#9646) | Generate Spanish Chapters 4–6 from their canonical schema-v2 lesson ASTs after HL-S02. | All six generated chapters now share lesson hashes with Language Ladder; Markdown tables retain their structure in print. |
+| HL-V02 | Complete in this PR | Validate learner-facing target-language prompts against block-level knowledge declarations and prerequisite closure. | Schema-v2 production and recall blocks cannot ask for an undeclared form or a form absent from the lesson's transitive knowledge frontier. |
+| HL-V03 | Queued | Compile individual prompt, answer, accepted-variant, feedback, and response-time contracts from typed activity blocks. | Every compiled activity names a non-empty subset of its block's assessed atoms and resolves all answer variants without scraping prose. |
+| HL-B04 | Next | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
 | HL-B05 | Queued | Remove Marathi's duplicate practice labels and Unicode bookmark warnings. | A forced build succeeds but reports four repeated `lesson:practice` labels, 32 Hyperref PDF-string warnings, and two underfull boxes; the clean-build signal is zero of each. |
 | HL-B06 | Queued | Publish Gujarati Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
 | HL-B07 | Queued | Remove Gujarati's missing punctuation glyphs and LaTeX layout/bookmark warnings. | A forced build succeeds but reports four missing punctuation glyphs, one overfull box, four underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
@@ -214,6 +215,27 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   explicit in HL-B37. HL-V02 is next because the HL-S02 editorial audit showed
   that lesson-level atom closure alone cannot detect undeclared target-language
   tokens inside learner production and recall prompts.
+
+## Findings from HL-V02
+
+- All 51 schema-v2 Spanish lessons now declare introductions and assessments at
+  every one of their typed body boundaries. Production and recall blocks require
+  non-empty assessment declarations, and all other blocks retain explicit empty
+  lists when they change no knowledge state.
+- Validation follows rendered order: assessed atoms must already belong to the
+  lesson's transitive prerequisite frontier or an earlier block, block
+  introductions must account exactly for `introduces.knowledge`, and assessed
+  atoms must be declared in `practises.knowledge`.
+- The editorial migration removed premature *muy bien*, *¿y usted?*, *el gusto
+  es mío*, *ojalá*, and next-chapter question-form production. It promoted *te
+  llamas* and *gusto* to explicit atoms and completed grammar, script,
+  etymology, and phrase practice declarations exposed by the boundary audit.
+- Block metadata changes the shared canonical hashes but not learner copy. The
+  six generated Spanish chapters omit the directives, and Language Ladder now
+  explicitly filters them from its lightweight Markdown view.
+- Individual prompt/answer/variant/feedback records remain prose rather than a
+  compiled activity schema. HL-V03 records that next validation layer; HL-B04
+  is the next bounded learner-visible publication gap.
 
 ## Findings from HL-D01A
 

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -5,7 +5,7 @@
     {
       "language": "spanish",
       "chapter": 1,
-      "sourceHash": "fnv1a64:746d660c5f9ec3cd",
+      "sourceHash": "fnv1a64:ad881fd61b3c4d60",
       "lessonIds": [
         "ES-C01-hola",
         "ES-C01-bien",
@@ -20,7 +20,7 @@
     {
       "language": "spanish",
       "chapter": 2,
-      "sourceHash": "fnv1a64:25b110167a9b669e",
+      "sourceHash": "fnv1a64:462a506683c04c7f",
       "lessonIds": [
         "ES-C02-tarde",
         "ES-C02-buenas-tardes",
@@ -33,7 +33,7 @@
     {
       "language": "spanish",
       "chapter": 3,
-      "sourceHash": "fnv1a64:394498f9947f7389",
+      "sourceHash": "fnv1a64:11a05b47aeca6e6d",
       "lessonIds": [
         "ES-C03-me",
         "ES-C03-llamar",
@@ -53,7 +53,7 @@
     {
       "language": "spanish",
       "chapter": 4,
-      "sourceHash": "fnv1a64:a8f2ef77f4c94859",
+      "sourceHash": "fnv1a64:d12c066ed597921d",
       "lessonIds": [
         "ES-C04-gracias",
         "ES-C04-de-nada",
@@ -74,7 +74,7 @@
     {
       "language": "spanish",
       "chapter": 5,
-      "sourceHash": "fnv1a64:3008dfa4a25b0bd2",
+      "sourceHash": "fnv1a64:6b08d82baacfa774",
       "lessonIds": [
         "ES-C05-adios",
         "ES-C05-hasta",
@@ -89,7 +89,7 @@
     {
       "language": "spanish",
       "chapter": 6,
-      "sourceHash": "fnv1a64:081983e1f50e4d6c",
+      "sourceHash": "fnv1a64:57e2a578e9dbb2a1",
       "lessonIds": [
         "ES-C06-cafe",
         "ES-C06-por-favor",

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Chapters 1–6 — block-boundary prompt closure
+
+- Declared introductions and assessments at every typed block boundary across
+  all 51 schema-v2 lessons. Guided production and recall now fail validation if
+  they ask for an atom outside the lesson's transitive knowledge frontier.
+- Made the boundary order executable: a block is checked before its own
+  introductions become available, and every lesson-level introduction and
+  practice atom must be accounted for by the body AST.
+- Removed early production of *muy bien*, *¿y usted?*, *el gusto es mío*, and
+  later preview forms; promoted *te llamas* and *gusto* to explicit atoms; and
+  completed the practice declarations found by the editorial pass.
+- Regenerated all six chapter fingerprints without exposing metadata comments
+  in the printed book or Language Ladder lesson copy.
+
 ## Chapters 4–6 — canonical book generation
 
 - Replaced three handwritten LaTeX chapters with deterministic output from all

--- a/code/learning/human-languages/spanish/book/chapters/ch01-first-words.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch01-first-words.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:746d660c5f9ec3cd
+% canonical-source-hash: fnv1a64:ad881fd61b3c4d60
 % canonical-lessons: ES-C01-hola, ES-C01-bien, ES-C01-el-la, ES-C01-genero-gramatical, ES-C01-dia, ES-C01-buenos-dias, ES-C01-practice
 
 \chapter{Hola and Buenos Días}
@@ -99,7 +99,6 @@ So \emph{bien} is the Spanish member of the \emph{bene-} family you've owned in 
 \raggedright
   \item "\emph{¿Cómo estás?}" (how are you?) $\to$ "\textbf{Bien.}" — "Well." / "I'm good." Done.
   \item As agreement, when someone suggests something $\to$ "\textbf{Bien.}" — "Okay / fine."
-  \item Stack it: "\textbf{muy bien}" — "very well / very good."
 \end{itemize}
 \end{cousinweb}
 
@@ -117,7 +116,6 @@ So \emph{bien} is the Spanish member of the \emph{bene-} family you've owned in 
 \begin{itemize}
 \raggedright
   \item {[}YOU SAY: "bien" as the answer to "how are you"{]}
-  \item {[}YOU SAY: "muy bien"{]}
   \item {[}YOU SAY: "bueno" then "buena" — the adjective, masculine then feminine{]}
 \end{itemize}
 
@@ -177,7 +175,7 @@ Over centuries the pointing force faded and the initial \emph{i-} dropped: \emph
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
-{[}PAUSE 3s{]} Which form is labelled masculine? (\emph{el}.) Which is labelled feminine? (\emph{la}.) Both come from Latin words meaning what? ("That one" — \emph{ille} / \emph{illa}.) What accented twins share their root? (\emph{él} / \emph{ella}.)
+{[}PAUSE 3s{]} Which form is labelled masculine? (\emph{el}.) Which is labelled feminine? (\emph{la}.) Both come from Latin words meaning what? ("That one" — \emph{ille} / \emph{illa}.)
 \end{tcolorbox}
 \section[el / la + noun]{Grammatical gender — the two noun classes behind \emph{el} and \emph{la}}
 
@@ -370,7 +368,7 @@ In four short lessons you went from nothing to two full greetings and the first 
   \item {[}YOU SAY: greet a friend casually — \emph{hola}{]}
   \item {[}YOU SAY: greet someone warmly in the morning — \emph{buenos días}{]}
   \item {[}YOU SAY: stack them — \emph{hola, buenos días}{]}
-  \item {[}YOU SAY: answer "how are you" with one word — \emph{bien}; then \emph{muy bien}{]}
+  \item {[}YOU SAY: answer "how are you" with one word — \emph{bien}{]}
   \item {[}YOU SAY: the four shapes of "good" — \emph{bueno, buena, buenos, buenas} — and for each, is it masculine/feminine, singular/plural?{]}
 \end{itemize}
 

--- a/code/learning/human-languages/spanish/book/chapters/ch02-greetings.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch02-greetings.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:25b110167a9b669e
+% canonical-source-hash: fnv1a64:462a506683c04c7f
 % canonical-lessons: ES-C02-tarde, ES-C02-buenas-tardes, ES-C02-noche, ES-C02-buenas-noches, ES-C02-practice
 
 \chapter{The Rest of the Greetings}

--- a/code/learning/human-languages/spanish/book/chapters/ch03-introductions.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch03-introductions.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:394498f9947f7389
+% canonical-source-hash: fnv1a64:11a05b47aeca6e6d
 % canonical-lessons: ES-C03-me, ES-C03-llamar, ES-C03-me-llamo, ES-C03-tu-usted, ES-C03-usted-origin, ES-C03-como, ES-C03-familia-qu, ES-C03-se-llama, ES-C03-como-se-llama, ES-C03-mucho, ES-C03-gusto, ES-C03-practice
 
 \chapter{Introducing Yourself}
@@ -420,10 +420,8 @@ Literally: \textbf{"How do you call yourself?"} Spanish asks \emph{how}, not \em
 You already have the answer from the \emph{me llamo} lesson: \textbf{Me llamo \_\_\_.}
 
 \begin{quote}
-— ¿Cómo se llama usted? — \textbf{Me llamo David.} ¿Y usted?
+— ¿Cómo se llama usted? — \textbf{Me llamo David.}
 \end{quote}
-
-(\emph{¿Y usted?} — "And you?" — bounces the same question back; \emph{y} = "and," a whole lesson's worth of its own soon, but usable now.)
 
 \subsection*{Guided Practice}
 {[}PAUSE 1s{]}
@@ -513,7 +511,7 @@ False friend to flag: a \emph{gust} of wind is \textbf{not} related — that one
 \end{cousinweb}
 
 \begin{culture}
-Spanish greets a new acquaintance by naming the \emph{pleasure} of it — "much pleasure" — where English names the \emph{person} ("pleased to meet \textbf{you}"). There's a stock reply that volleys it back: \textbf{"El gusto es mío"} — "the pleasure is mine."
+Spanish greets a new acquaintance by naming the \emph{pleasure} of it — "much pleasure" — where English names the \emph{person} ("pleased to meet \textbf{you}"). The phrase works by itself, so this first exchange needs no extra reply formula.
 \end{culture}
 
 \subsection*{Guided Practice}
@@ -523,7 +521,6 @@ Spanish greets a new acquaintance by naming the \emph{pleasure} of it — "much 
 \raggedright
   \item {[}YOU SAY: "gusto" then "gusto" (English), "disgust", "gustatory"{]}
   \item {[}YOU SAY: "mucho gusto" — on meeting someone{]}
-  \item {[}YOU SAY: the reply — "el gusto es mío"{]}
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
@@ -543,7 +540,7 @@ Spanish greets a new acquaintance by naming the \emph{pleasure} of it — "much 
 \textbf{Formal} (a stranger, an elder, a customer):
 
 \begin{quote}
-— Buenos días. Me llamo Susana. \textbf{¿Cómo se llama usted?} — Me llamo David. \textbf{Mucho gusto.} — El gusto es mío.
+— Buenos días. Me llamo Susana. \textbf{¿Cómo se llama usted?} — Me llamo David. \textbf{Mucho gusto.}
 \end{quote}
 
 \textbf{Informal} (a friend, a peer): only two words change, and they're the ones that carry the whole social difference:
@@ -575,5 +572,5 @@ Spanish greets a new acquaintance by naming the \emph{pleasure} of it — "much 
 {[}REPEAT x2{]} Run the formal version start to finish without stopping.
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
-{[}PAUSE 3s{]} Which two words change between the formal and informal introduction? (\emph{se llama usted} $\to$ \emph{te llamas}.) Next chapter: they answer your \emph{"¿cómo está usted?"} — "how are you?" — and you learn to say how you're doing.
+{[}PAUSE 3s{]} Which two words change between the formal and informal introduction? (\emph{se llama usted} $\to$ \emph{te llamas}.) Next chapter, you will learn how to ask how someone is doing.
 \end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/chapters/ch04-how-are-you.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch04-how-are-you.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:a8f2ef77f4c94859
+% canonical-source-hash: fnv1a64:d12c066ed597921d
 % canonical-lessons: ES-C04-gracias, ES-C04-de-nada, ES-C04-estar, ES-C04-como-esta, ES-C04-como-estas-register, ES-C04-regular, ES-C04-y, ES-W01-acento, ES-W01-tilde-diacritica, ES-W02-enye, ES-W03-inverted, ES-W03-question-span, ES-C04-practice
 
 \chapter{How Are You?}

--- a/code/learning/human-languages/spanish/book/chapters/ch05-farewells.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch05-farewells.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:3008dfa4a25b0bd2
+% canonical-source-hash: fnv1a64:6b08d82baacfa774
 % canonical-lessons: ES-C05-adios, ES-C05-hasta, ES-C05-hasta-limits, ES-C05-hasta-luego, ES-C05-hasta-manana, ES-C05-hasta-pronto, ES-C05-practice
 
 \chapter{Farewells}
@@ -107,7 +107,7 @@ But \textbf{hasta} is rare and special: it is a \textbf{function word} — a pre
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
-{[}PAUSE 3s{]} What language is \emph{hasta} from, and what does it mean? (Arabic \emph{ḥattā} — "until.") Why is it remarkable that Spanish borrowed it? (It's a \emph{function word} / preposition — languages almost never borrow those; it shows how deep the Arabic centuries went.) How do you spot many Arabic nouns in Spanish? (The frozen \emph{al-} article: \emph{almohada, azúcar, álgebra}.) Which \textbf{other} Arabic function word will return in Chapter 18? (\emph{\textbf{Ojalá}}, a word that triggers a grammatical mood.)
+{[}PAUSE 3s{]} What language is \emph{hasta} from, and what does it mean? (Arabic \emph{ḥattā} — "until.") Why is it remarkable that Spanish borrowed it? (It's a \emph{function word} / preposition — languages almost never borrow those; it shows how deep the Arabic centuries went.) How do you spot many Arabic nouns in Spanish? (The frozen \emph{al-} article: \emph{almohada, azúcar, álgebra}.)
 \end{tcolorbox}
 \section[hasta aquí / hasta la noche]{hasta aquí / hasta la noche — point to the limit}
 

--- a/code/learning/human-languages/spanish/book/chapters/ch06-first-verbs.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch06-first-verbs.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:081983e1f50e4d6c
+% canonical-source-hash: fnv1a64:57e2a578e9dbb2a1
 % canonical-lessons: ES-C06-cafe, ES-C06-por-favor, ES-C06-hablar, ES-C06-trabajar, ES-C06-estudiar, ES-C06-espanol, ES-C06-practice
 
 \chapter{The First Verbs}
@@ -376,5 +376,5 @@ Same three endings (\textbf{-o / -as / -a}) every time — that's the whole regu
 {[}REPEAT x2{]} Ask and answer “¿Hablas español? — Hablo español.”
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
-{[}PAUSE 3s{]} What are the three singular \emph{-ar} endings? (\emph{-o / -as / -a}.) Give the “I” form of all three verbs. (\emph{Hablo, trabajo, estudio}.) Why does \emph{Hablo español} need no separate subject word? (The \emph{-o} carries “I.”) You can now generate sentences — the course stops handing you phrases and starts handing you \emph{rules}. Next chapter: the \emph{-er/-ir} verbs, and questions with \emph{qué / dónde}.
+{[}PAUSE 3s{]} What are the three singular \emph{-ar} endings? (\emph{-o / -as / -a}.) Give the “I” form of all three verbs. (\emph{Hablo, trabajo, estudio}.) Why does \emph{Hablo español} need no separate subject word? (The \emph{-o} carries “I.”) You can now generate sentences — the course stops handing you phrases and starts handing you \emph{rules}. Next chapter adds the \emph{-er/-ir} verb families.
 \end{tcolorbox}

--- a/code/learning/human-languages/spanish/lessons/ES-C01-bien.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C01-bien.md
@@ -30,6 +30,7 @@ reviews_of: [ES-C01-hola]
 # bien — "well," a whole answer in one word
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You have *hola*. Now the word that carries half of everyday small
 talk: *bien*. It answers "how are you," it agrees to a plan, it stands
@@ -37,17 +38,20 @@ completely on its own — and it opens a family of English words you already
 use.
 
 ## You'll want to know first
+<!-- hl-knowledge: introduces=[ES-LEX-BIEN]; assesses=[] -->
 
 - [hola](./ES-C01-hola.md) — your first word; *bien* is
   what you say back when someone asks how you are.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - `diphthong-ie` — **ie** is a quick *YEH*: *bien* is said *byen*, one
   syllable. → [reference](../pronunciation-reference.md)
 - `v-b` — the **b** is soft, halfway to a *v*.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 **bien** — "well." Root: Latin **bene** ("well"). That *bene* is the piece
 hiding in a shelf of English words, every one about something being *good* or
@@ -65,9 +69,9 @@ your whole life.
 
 - "*¿Cómo estás?*" (how are you?) → "**Bien.**" — "Well." / "I'm good." Done.
 - As agreement, when someone suggests something → "**Bien.**" — "Okay / fine."
-- Stack it: "**muy bien**" — "very well / very good."
 
 ## The adjective sibling: *bueno* / *buena*
+<!-- hl-knowledge: introduces=[ES-MORPH-BUENO-BUENA]; assesses=[] -->
 
 *bien* is an **adverb** — it describes *how* something is done ("you speak
 *well*"). When you want the **adjective** — to describe a *thing* as "good" —
@@ -84,13 +88,14 @@ and Spanish kept both. The Latin-descended English cousins of *bueno* are
 > **bien = well, bueno/buena = good.**
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HOLA, ES-LEX-BIEN, ES-MORPH-BUENO-BUENA] -->
 
 [PAUSE 1s]
 - [YOU SAY: "bien" as the answer to "how are you"]
-- [YOU SAY: "muy bien"]
 - [YOU SAY: "bueno" then "buena" — the adjective, masculine then feminine]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HOLA, ES-LEX-BIEN, ES-MORPH-BUENO-BUENA] -->
 
 [PAUSE 3s] Which is the adverb ("well") and which is the adjective ("good")?
 (*bien* / *bueno*–*buena*.) And name an English *bene-* cousin of *bien*.

--- a/code/learning/human-languages/spanish/lessons/ES-C01-buenos-dias.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C01-buenos-dias.md
@@ -18,7 +18,7 @@ requires:
 introduces:
   knowledge: [ES-LEX-BUENOS-DIAS, ES-GRAMMAR-AGREEMENT-MASCULINE-PLURAL]
 practises:
-  knowledge: [ES-LEX-BUENOS-DIAS, ES-LEX-BIEN, ES-LEX-DIA]
+  knowledge: [ES-LEX-BUENOS-DIAS, ES-LEX-BIEN, ES-LEX-DIA, ES-MORPH-BUENO-BUENA, ES-GRAMMAR-AGREEMENT-MASCULINE-PLURAL]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
@@ -30,6 +30,7 @@ reviews_of: [ES-C01-bien, ES-C01-dia]
 # buenos días — assembled from two words you already have
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Now watch two lessons snap together. You have *bueno* ("good,"
 from the *bien* lesson) and *días* ("days," from the *día* lesson). Put them side by side and
@@ -37,17 +38,20 @@ you build the greeting everyone knows — and, for the first time, you'll know
 *why it's shaped the way it is*.
 
 ## You'll want to know first
+<!-- hl-knowledge: introduces=[ES-LEX-BUENOS-DIAS]; assesses=[] -->
 
 - [bien / bueno](./ES-C01-bien.md) — the adjective *bueno*.
 - [día](./ES-C01-dia.md) — the noun *días*, and that it's
   masculine.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - `diphthong-ue` — **ue** is a quick *WEH*: *bueno* is *BWEH-no*.
 - `accent-i` — *días* keeps its stress on the *í*: *DEE-as*.
 
 ## The word, taken apart — by assembling it
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 **buenos días** = **bueno** ("good") + **días** ("days") = literally **"good
 days."**
@@ -56,6 +60,7 @@ But look closely: it's *buen**os***, not *bueno*. Why? Because of the one new
 grammar rule of this lesson.
 
 ## Grammar Lens: agreement
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-AGREEMENT-MASCULINE-PLURAL]; assesses=[] -->
 
 An adjective in Spanish **agrees** with its noun — it copies the noun's
 gender and number. *días* is **masculine** (the *día* lesson's flagged
@@ -77,6 +82,7 @@ hundred. Spanish makes the adjective echo the noun. That echo is *why* it's
 *buenos días* and not *bueno días*.
 
 ## Why it's said this way
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 So why "good **days**," plural at all? Because *buenos días* is a **fossil** —
 the worn-down stub of a blessing: **"Buenos días os dé Dios,"** *"may God give
@@ -87,6 +93,7 @@ casual. It is, almost literally, a small *bene*diction (the *bien* lesson's word
 widely-accepted account; exact history debated.)*
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-BUENOS-DIAS, ES-LEX-BIEN, ES-LEX-DIA, ES-MORPH-BUENO-BUENA, ES-GRAMMAR-AGREEMENT-MASCULINE-PLURAL] -->
 
 [PAUSE 1s]
 - [YOU SAY: build it slowly — "bueno" … "días" … "buenos días"]
@@ -94,6 +101,7 @@ widely-accepted account; exact history debated.)*
 - [YOU SAY: why is it *buenos*, not *bueno*? (out loud, in your own words)]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-BUENOS-DIAS, ES-LEX-BIEN, ES-LEX-DIA, ES-MORPH-BUENO-BUENA, ES-GRAMMAR-AGREEMENT-MASCULINE-PLURAL] -->
 
 [PAUSE 3s] Two things: why is it *buenos* and not *bueno*? (Agreement — *días*
 is masculine plural.) And what blessing was *buenos días* shortened from?

--- a/code/learning/human-languages/spanish/lessons/ES-C01-dia.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C01-dia.md
@@ -30,22 +30,26 @@ reviews_of: [ES-C01-el-la]
 # día — your first noun
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You just learned how Spanish tags gender with *el* / *la*. Now put
 it to work on your very first noun — *día*, "day."
 
 ## You'll want to know first
+<!-- hl-knowledge: introduces=[ES-LEX-DIA]; assesses=[] -->
 
 - [el / la](./ES-C01-el-la.md) — grammatical gender and the two "the"s;
   *día* is where you apply them.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[ES-SOUND-WRITTEN-ACCENT]; assesses=[] -->
 
 - `accent-i` — the accent sits on the **í**: *día* is *DEE-a*, two beats. →
   [reference](../pronunciation-reference.md)
 - `d-soft` — the **d** between vowels is soft, toward the *th* in *this*.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 **el día** — "the day." Root: Latin **dies** ("day"). The family fans across
 English, mostly through French:
@@ -57,6 +61,7 @@ English, mostly through French:
   (*dies mali*, "evil days").
 
 ## Its two tags: gender and number
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-NOUN-NUMBER]; assesses=[] -->
 
 You already know gender from the last lesson; here's how *día* wears it.
 
@@ -71,6 +76,7 @@ the word, not guessed from the ending — and it's the first of several
 días* ("days"). (Consonant endings take *-es* — later.)
 
 ## Grammar Lens: why the gender matters next
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 Gender isn't a passive label — it *forces* the words around the noun to match.
 The very next lesson, *buenos días*, turns *bueno* ("good") into *buen**os***
@@ -78,6 +84,7 @@ precisely because *día* is masculine and plural. So the gender you just
 attached to *día* is about to earn its keep.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-DIA, ES-GRAMMAR-DEFINITE-ARTICLES, ES-GRAMMAR-NOUN-GENDER] -->
 
 [PAUSE 1s]
 - [YOU SAY: "el día" — with its masculine "the"]
@@ -86,6 +93,7 @@ attached to *día* is about to earn its keep.
   *dies*, despite the *-a*)]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-DIA, ES-GRAMMAR-DEFINITE-ARTICLES, ES-GRAMMAR-NOUN-GENDER] -->
 
 [PAUSE 3s] Which "the" goes with *día*, and why? (*el* — masculine, inherited
 from Latin *dies*, despite the *-a* ending.) How do you make it plural?

--- a/code/learning/human-languages/spanish/lessons/ES-C01-el-la.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C01-el-la.md
@@ -30,22 +30,26 @@ reviews_of: [ES-C01-bien]
 # el and la — "the," and the gender it carries
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Before your first noun, meet two of the smallest, most frequent
 words in Spanish: *el* and *la*. Both mean "the." Your job here is simply to
 recognize the pair and connect each form to its label.
 
 ## You'll want to know first
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - [bien / bueno](./ES-C01-bien.md) — you saw *bueno* change to *buena*; this
   lesson explains the gender that made it happen.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - `vowel-e`, `vowel-a` — two clean vowels: *el* (*ehl*), *la* (*lah*). →
   [reference](../pronunciation-reference.md)
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[ES-ETYMON-ILLE-ILLA]; assesses=[] -->
 
 **el** — "the" (masculine). **la** — "the" (feminine). English has one word,
 "the"; Spanish makes this two-way distinction.
@@ -68,19 +72,22 @@ the accent. (English "the," by contrast, is Germanic and *unrelated* — a
 shared job, not a shared root.)
 
 ## What you've built
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-DEFINITE-ARTICLES]; assesses=[] -->
 
 *el* and *la* are **articles**: little words that mark "the." Keep them apart
 from their accented relatives *él* and *ella*, the pronouns "he" and "she."
 The next micro-lesson explains why Spanish needs two article forms.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-DEFINITE-ARTICLES, ES-ETYMON-ILLE-ILLA] -->
 
 [PAUSE 1s]
 - [YOU SAY: "el" then "la" — the two "the"s]
 - [YOU SAY: which article goes with a masculine noun? with a feminine one?]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-DEFINITE-ARTICLES, ES-ETYMON-ILLE-ILLA] -->
 
 [PAUSE 3s] Which form is labelled masculine? (*el*.) Which is labelled
 feminine? (*la*.) Both come from Latin words meaning what? ("That one" —
-*ille* / *illa*.) What accented twins share their root? (*él* / *ella*.)
+*ille* / *illa*.)

--- a/code/learning/human-languages/spanish/lessons/ES-C01-genero-gramatical.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C01-genero-gramatical.md
@@ -29,15 +29,18 @@ reviews_of: [ES-C01-el-la]
 # Grammatical gender — the two noun classes behind *el* and *la*
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You know that *el* and *la* both mean "the." Now give their two
 labels: *el* is masculine; *la* is feminine.
 
 ## You'll want to know first
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - [el / la](./ES-C01-el-la.md) — the two definite articles.
 
 ## Grammar Lens: grammatical gender
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-NOUN-GENDER]; assesses=[] -->
 
 Every Spanish noun belongs to one of two **grammatical classes**, traditionally
 called masculine and feminine. This is not a claim about biological sex. It is
@@ -51,6 +54,7 @@ You cannot always predict a noun's class from its ending. Learn each new noun
 with its article, as one small unit: *el + noun* or *la + noun*.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-DEFINITE-ARTICLES, ES-GRAMMAR-NOUN-GENDER] -->
 
 [PAUSE 1s]
 - [YOU SAY: the article for a noun labelled masculine]
@@ -58,6 +62,7 @@ with its article, as one small unit: *el + noun* or *la + noun*.
 - [YOU SAY: what grammatical gender classifies — nouns, not people]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-DEFINITE-ARTICLES, ES-GRAMMAR-NOUN-GENDER] -->
 
 [PAUSE 3s] How many noun classes did Latin have? (Three.) How many does
 Spanish keep? (Two.) What should travel with every new noun you learn? (Its

--- a/code/learning/human-languages/spanish/lessons/ES-C01-hola.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C01-hola.md
@@ -30,11 +30,13 @@ reviews_of: []
 # hola — hello
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The very first word, and the easiest to say — but there's already
 one trap hiding in it, and one small mystery.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[ES-SOUND-H-SILENT]; assesses=[] -->
 
 - `silent-h` — the **h is silent**. *hola* is said *OH-la*, never *HOH-la*.
   The letter is written but makes no sound at all. This is true of every
@@ -42,6 +44,7 @@ one trap hiding in it, and one small mystery.
 - `vowel-o`, `vowel-a` — two pure vowels: *OH*, *AH*. No glide, no drift.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[ES-LEX-HOLA]; assesses=[] -->
 
 **hola** — hello / hi.
 
@@ -64,6 +67,7 @@ words sound alike by pure coincidence, not shared ancestry.
 > strangers who happen to look alike.
 
 ## Why it's said this way
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 *hola* is **informal**. It's the "hi" you'd say to a friend, a kid, a
 shopkeeper you know. It carries no time of day and no deference — which is
@@ -75,12 +79,14 @@ Note the written form: an exclamation gets an **upside-down mark** at the
 front — *¡hola!* — so you know the tone before you start reading it aloud.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HOLA, ES-SOUND-H-SILENT] -->
 
 [PAUSE 1s]
 - [YOU SAY: "hola" — *OH-la*, silent h]
 - [YOU SAY: "¡hola!" to an imagined friend — light, informal]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HOLA, ES-SOUND-H-SILENT] -->
 
 [PAUSE 3s] Two things to lock in: what sound does the *h* make? (None.) And
 is *hola* actually related to English *hello*? (No — a coincidence, a false

--- a/code/learning/human-languages/spanish/lessons/ES-C01-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C01-practice.md
@@ -18,7 +18,7 @@ requires:
 introduces:
   knowledge: []
 practises:
-  knowledge: [ES-LEX-HOLA, ES-LEX-BIEN, ES-LEX-DIA, ES-LEX-BUENOS-DIAS]
+  knowledge: [ES-LEX-HOLA, ES-LEX-BIEN, ES-LEX-DIA, ES-LEX-BUENOS-DIAS, ES-MORPH-BUENO-BUENA, ES-GRAMMAR-NOUN-GENDER, ES-GRAMMAR-NOUN-NUMBER, ES-GRAMMAR-AGREEMENT-MASCULINE-PLURAL]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus, fluency]
@@ -30,11 +30,13 @@ reviews_of: [ES-C01-hola, ES-C01-bien, ES-C01-dia, ES-C01-buenos-dias]
 # Practice — hola and buenos días
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] End of the chapter. No new words — just the four you have, turned
 over until they're automatic.
 
 ## What you've built
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 In four short lessons you went from nothing to two full greetings and the
 first two rules of Spanish grammar:
@@ -47,13 +49,14 @@ first two rules of Spanish grammar:
   turning *bueno* into *buenos* to match.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HOLA, ES-LEX-BIEN, ES-LEX-DIA, ES-LEX-BUENOS-DIAS, ES-MORPH-BUENO-BUENA, ES-GRAMMAR-NOUN-GENDER, ES-GRAMMAR-NOUN-NUMBER, ES-GRAMMAR-AGREEMENT-MASCULINE-PLURAL] -->
 
 [PAUSE 1s] Say each out loud; don't just read.
 
 - [YOU SAY: greet a friend casually — *hola*]
 - [YOU SAY: greet someone warmly in the morning — *buenos días*]
 - [YOU SAY: stack them — *hola, buenos días*]
-- [YOU SAY: answer "how are you" with one word — *bien*; then *muy bien*]
+- [YOU SAY: answer "how are you" with one word — *bien*]
 - [YOU SAY: the four shapes of "good" — *bueno, buena, buenos, buenas* — and
   for each, is it masculine/feminine, singular/plural?]
 
@@ -62,6 +65,7 @@ masculine-plural *días* → *buenos días*. Do it until the "why" feels obvious
 not memorized.
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HOLA, ES-LEX-BIEN, ES-LEX-DIA, ES-LEX-BUENOS-DIAS, ES-MORPH-BUENO-BUENA, ES-GRAMMAR-NOUN-GENDER, ES-GRAMMAR-NOUN-NUMBER, ES-GRAMMAR-AGREEMENT-MASCULINE-PLURAL] -->
 
 [PAUSE 3s] You can now greet two ways and give a one-word positive answer.
 The very next question is the one that opens a real conversation: when

--- a/code/learning/human-languages/spanish/lessons/ES-C02-buenas-noches.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C02-buenas-noches.md
@@ -18,7 +18,7 @@ requires:
 introduces:
   knowledge: [ES-LEX-BUENAS-NOCHES]
 practises:
-  knowledge: [ES-LEX-BUENAS-TARDES, ES-LEX-NOCHE, ES-LEX-BUENAS-NOCHES]
+  knowledge: [ES-LEX-BUENAS-TARDES, ES-LEX-NOCHE, ES-LEX-BUENAS-NOCHES, ES-GRAMMAR-NOUN-GENDER, ES-GRAMMAR-AGREEMENT-FEMININE-PLURAL]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
@@ -30,17 +30,20 @@ reviews_of: [ES-C01-bien, ES-C02-noche]
 # buenas noches — good evening *and* good night
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The fourth greeting, assembled the way you now expect — and it has
 one quirk the others don't: it works both coming and going.
 
 ## You'll want to know first
+<!-- hl-knowledge: introduces=[ES-LEX-BUENAS-NOCHES]; assesses=[] -->
 
 - [buenas tardes](./ES-C02-buenas-tardes.md) — feminine
   agreement (*buenas*); *noche* is feminine too, so the same shape applies.
 - [noche](./ES-C02-noche.md) — the noun *noches*.
 
 ## The word, taken apart — by assembling it
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 **buenas noches** = **buena** ("good") + **noches** ("nights"). *noche* is
 **feminine** (*la noche*), plural here, so — exactly like *tardes* — the
@@ -49,6 +52,7 @@ agreement you learned two lessons ago: masculine *días* → *buenos*, feminine
 *tardes*/*noches* → *buenas*.
 
 ## Why it's said this way
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 The same amputated blessing (*"Buenas noches os dé Dios"*) — but with a
 twist. *buenas noches* is both a **greeting** and a **farewell**:
@@ -61,6 +65,7 @@ tell you the direction. The blessing doesn't care which way you're going —
 you're wishing good hours either way.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-BUENAS-TARDES, ES-LEX-NOCHE, ES-LEX-BUENAS-NOCHES, ES-GRAMMAR-NOUN-GENDER, ES-GRAMMAR-AGREEMENT-FEMININE-PLURAL] -->
 
 [PAUSE 1s]
 - [YOU SAY: "buenas noches" arriving somewhere]
@@ -69,6 +74,7 @@ you're wishing good hours either way.
   noches" — and notice which take *buenos* vs *buenas* and why]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-BUENAS-TARDES, ES-LEX-NOCHE, ES-LEX-BUENAS-NOCHES, ES-GRAMMAR-NOUN-GENDER, ES-GRAMMAR-AGREEMENT-FEMININE-PLURAL] -->
 
 [PAUSE 3s] What's unusual about when you can use *buenas noches*? (Both hello
 and goodbye.) And why *buenas*, not *buenos*? (*noche* is feminine.)

--- a/code/learning/human-languages/spanish/lessons/ES-C02-buenas-tardes.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C02-buenas-tardes.md
@@ -18,7 +18,7 @@ requires:
 introduces:
   knowledge: [ES-LEX-BUENAS-TARDES, ES-GRAMMAR-AGREEMENT-FEMININE-PLURAL]
 practises:
-  knowledge: [ES-LEX-BUENAS-TARDES, ES-LEX-BUENOS-DIAS]
+  knowledge: [ES-LEX-BUENAS-TARDES, ES-LEX-BUENOS-DIAS, ES-GRAMMAR-NOUN-GENDER, ES-GRAMMAR-AGREEMENT-FEMININE-PLURAL]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
@@ -30,23 +30,27 @@ reviews_of: [ES-C01-bien, ES-C01-buenos-dias, ES-C02-tarde]
 # buenas tardes — assembled, and now the *feminine* side of agreement
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Same move as *buenos días*: take "good" and "afternoon" and snap
 them together. But watch the ending — this time it comes out *buen**as***,
 and that difference teaches you the other half of the agreement rule.
 
 ## You'll want to know first
+<!-- hl-knowledge: introduces=[ES-LEX-BUENAS-TARDES]; assesses=[] -->
 
 - [bien / bueno](./ES-C01-bien.md) — the adjective *bueno*
   and its four shapes.
 - [tarde](./ES-C02-tarde.md) — the noun *tardes*.
 
 ## The word, taken apart — by assembling it
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 **buenas tardes** = **buena** ("good") + **tardes** ("afternoons") =
 literally "good afternoons."
 
 ## Grammar Lens: agreement, the feminine case
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-AGREEMENT-FEMININE-PLURAL]; assesses=[] -->
 
 Back in *buenos días*, *bueno* became *buenos* — **masculine** plural,
 because *día* is masculine. Now: **tarde is a feminine noun** (*la tarde*).
@@ -61,6 +65,7 @@ adjective reporting the gender of the noun it's attached to. You now control
 all four shapes in the wild: *bueno, buena, buenos, buenas*.
 
 ## Why it's said this way
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 Same fossil blessing as the morning greeting: *buenas tardes* is short for
 *"Buenas tardes os dé Dios."* One cultural note on timing — *tardes* runs
@@ -69,6 +74,7 @@ Spanish-speaking world is late. Spanish follows the daylight, not the clock;
 there's no fixed "12:00 = afternoon" line.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-BUENAS-TARDES, ES-LEX-BUENOS-DIAS, ES-GRAMMAR-NOUN-GENDER, ES-GRAMMAR-AGREEMENT-FEMININE-PLURAL] -->
 
 [PAUSE 1s]
 - [YOU SAY: "buenas tardes" — *BWEH-nas TAR-des*]
@@ -76,6 +82,7 @@ there's no fixed "12:00 = afternoon" line.
 - [YOU SAY: why *buenas* and not *buenos*? (out loud, your own words)]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-BUENAS-TARDES, ES-LEX-BUENOS-DIAS, ES-GRAMMAR-NOUN-GENDER, ES-GRAMMAR-AGREEMENT-FEMININE-PLURAL] -->
 
 [PAUSE 3s] Why is it *buenas tardes* but *buenos días*? (*tarde* is feminine,
 *día* is masculine — the adjective agrees with each.)

--- a/code/learning/human-languages/spanish/lessons/ES-C02-noche.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C02-noche.md
@@ -18,7 +18,7 @@ requires:
 introduces:
   knowledge: [ES-LEX-NOCHE, ES-SOUND-LATIN-CLUSTER-TO-CH]
 practises:
-  knowledge: [ES-LEX-TARDE, ES-LEX-NOCHE, ES-GRAMMAR-NOUN-GENDER]
+  knowledge: [ES-LEX-TARDE, ES-LEX-NOCHE, ES-GRAMMAR-NOUN-GENDER, ES-GRAMMAR-NOUN-NUMBER, ES-SOUND-LATIN-CLUSTER-TO-CH]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
@@ -30,22 +30,26 @@ reviews_of: [ES-C02-tarde, ES-C02-buenas-tardes]
 # noche — "night," and a Latin sound-change you can now spot
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The last time-of-day word before the evening greeting. *noche* —
 "night" — and it shows off a spelling pattern that will help you decode
 dozens of Spanish words later.
 
 ## You'll want to know first
+<!-- hl-knowledge: introduces=[ES-LEX-NOCHE]; assesses=[] -->
 
 - [tarde](./ES-C02-tarde.md) — same build ahead: word first,
   then *buenas* + it.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[ES-SOUND-LATIN-CLUSTER-TO-CH]; assesses=[] -->
 
 - `soft-c` — the **ch** in *noche* is the *ch* of English *church*:
   *NO-cheh*. → [reference](../pronunciation-reference.md)
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 **la noche** (feminine) — "night / evening." Root: Latin **nox**, stem
 **noct-** — which was itself *feminine* in Latin, and *la noche* inherited
@@ -64,6 +68,7 @@ Latin). That *noct-* runs all through English:
 (and its English cousins) behind a Spanish *-ch-* word on sight.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-TARDE, ES-LEX-NOCHE, ES-GRAMMAR-NOUN-GENDER, ES-GRAMMAR-NOUN-NUMBER, ES-SOUND-LATIN-CLUSTER-TO-CH] -->
 
 [PAUSE 1s]
 - [YOU SAY: "noche" — *NO-cheh*]
@@ -71,6 +76,7 @@ Latin). That *noct-* runs all through English:
 - [YOU SAY: "noches" — plural, vowel + *-s*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-TARDE, ES-LEX-NOCHE, ES-GRAMMAR-NOUN-GENDER, ES-GRAMMAR-NOUN-NUMBER, ES-SOUND-LATIN-CLUSTER-TO-CH] -->
 
 [PAUSE 3s] What English word is *equi-* + *noche*'s root? (*Equinox*, "equal
 night.") And what Latin sound did the *-ch-* in *noche* come from? (*-ct-*,

--- a/code/learning/human-languages/spanish/lessons/ES-C02-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C02-practice.md
@@ -18,7 +18,7 @@ requires:
 introduces:
   knowledge: []
 practises:
-  knowledge: [ES-LEX-HOLA, ES-LEX-BUENOS-DIAS, ES-LEX-BUENAS-TARDES, ES-LEX-BUENAS-NOCHES]
+  knowledge: [ES-LEX-HOLA, ES-LEX-BUENOS-DIAS, ES-LEX-BUENAS-TARDES, ES-LEX-BUENAS-NOCHES, ES-GRAMMAR-NOUN-GENDER, ES-GRAMMAR-AGREEMENT-MASCULINE-PLURAL, ES-GRAMMAR-AGREEMENT-FEMININE-PLURAL]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus, fluency]
@@ -30,11 +30,13 @@ reviews_of: [ES-C01-hola, ES-C01-buenos-dias, ES-C02-buenas-tardes, ES-C02-buena
 # Practice — the four greetings
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You can now greet at any hour of the day. Let's make the choice —
 and the grammar behind it — automatic.
 
 ## What you've built
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - **hola** — any time, casual.
 - **buenos días** — morning (*días* masculine → *buenos*).
@@ -46,6 +48,7 @@ word copies the gender of the time-of-day word. That's why it's *buen**os**
 días* but *buen**as** tardes* and *buen**as** noches*.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HOLA, ES-LEX-BUENOS-DIAS, ES-LEX-BUENAS-TARDES, ES-LEX-BUENAS-NOCHES, ES-GRAMMAR-NOUN-GENDER, ES-GRAMMAR-AGREEMENT-MASCULINE-PLURAL, ES-GRAMMAR-AGREEMENT-FEMININE-PLURAL] -->
 
 [PAUSE 1s]
 - [YOU SAY: greet for the actual current time of day, correctly]
@@ -57,6 +60,7 @@ días* but *buen**as** tardes* and *buen**as** noches*.
 *buenos* vs *buenas*.
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HOLA, ES-LEX-BUENOS-DIAS, ES-LEX-BUENAS-TARDES, ES-LEX-BUENAS-NOCHES, ES-GRAMMAR-NOUN-GENDER, ES-GRAMMAR-AGREEMENT-MASCULINE-PLURAL, ES-GRAMMAR-AGREEMENT-FEMININE-PLURAL] -->
 
 [PAUSE 3s] Quick: is it *buenos* or *buenas* noches, and why? (*buenas* —
 *noche* is feminine.) Next chapter, someone finally greets *you* back — and

--- a/code/learning/human-languages/spanish/lessons/ES-C02-tarde.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C02-tarde.md
@@ -18,7 +18,7 @@ requires:
 introduces:
   knowledge: [ES-LEX-TARDE]
 practises:
-  knowledge: [ES-LEX-DIA, ES-LEX-BUENOS-DIAS, ES-LEX-TARDE]
+  knowledge: [ES-LEX-DIA, ES-LEX-BUENOS-DIAS, ES-LEX-TARDE, ES-GRAMMAR-NOUN-NUMBER]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
@@ -30,17 +30,20 @@ reviews_of: [ES-C01-buenos-dias]
 # tarde — "afternoon," and the "late" hiding inside it
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You built *buenos días*. The afternoon greeting is coming, but
 first its key word on its own — *tarde* — and it's secretly a word you
 already know from English.
 
 ## You'll want to know first
+<!-- hl-knowledge: introduces=[ES-LEX-TARDE]; assesses=[] -->
 
 - [buenos días](./ES-C01-buenos-dias.md) — you'll pair
   *tarde* with *buena* the same way you paired *días* with *bueno*.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - Regular stress: *TAR-de* — ends in a vowel, so the stress falls on the
   second-to-last syllable. → [reference](../pronunciation-reference.md)
@@ -66,6 +69,7 @@ isn't reliably guessable — and it will decide the shape of every word that
 describes the noun, starting next lesson.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-DIA, ES-LEX-BUENOS-DIAS, ES-LEX-TARDE, ES-GRAMMAR-NOUN-NUMBER] -->
 
 [PAUSE 1s]
 - [YOU SAY: "tarde" — *TAR-de*]
@@ -73,6 +77,7 @@ describes the noun, starting next lesson.
 - [YOU SAY: "tardes" — plural, add *-s* (vowel ending), just like *día → días*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-DIA, ES-LEX-BUENOS-DIAS, ES-LEX-TARDE, ES-GRAMMAR-NOUN-NUMBER] -->
 
 [PAUSE 3s] What did Latin *tardus* originally mean, before "afternoon"?
 (Slow, late — as in *tardy*, *retard*.) And how do you make *tarde* plural?

--- a/code/learning/human-languages/spanish/lessons/ES-C03-como-se-llama.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-como-se-llama.md
@@ -14,11 +14,11 @@ roots: []
 duration:
   max_seconds: 240
 requires:
-  knowledge: [ES-LEX-COMO, ES-SCRIPT-INVERTED-QUESTION, ES-LEX-SE-LLAMA, ES-LEX-USTED]
+  knowledge: [ES-LEX-COMO, ES-SCRIPT-INVERTED-QUESTION, ES-LEX-SE-LLAMA, ES-LEX-TE-LLAMAS, ES-LEX-USTED]
 introduces:
   knowledge: [ES-LEX-COMO-SE-LLAMA]
 practises:
-  knowledge: [ES-LEX-COMO, ES-LEX-SE-LLAMA, ES-LEX-USTED, ES-LEX-COMO-SE-LLAMA]
+  knowledge: [ES-LEX-COMO, ES-LEX-SE-LLAMA, ES-LEX-TE-LLAMAS, ES-LEX-USTED, ES-LEX-COMO-SE-LLAMA, ES-LEX-ME-LLAMO]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
@@ -30,17 +30,20 @@ reviews_of: [ES-C03-me-llamo, ES-C03-como, ES-C03-se-llama]
 # ¿cómo se llama usted? — assembling the question, and answering it
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Everything you built this chapter clicks into one sentence: how to
 ask a stranger their name, and how to answer back. This is your first real
 two-way exchange.
 
 ## You'll want to know first
+<!-- hl-knowledge: introduces=[ES-LEX-COMO-SE-LLAMA]; assesses=[] -->
 
 - [cómo](./ES-C03-como.md) · [se llama](./ES-C03-se-llama.md)
   · [usted](./ES-C03-tu-usted.md)
 
 ## The word, taken apart — by assembling it
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 **¿Cómo se llama usted?** = *cómo* ("how") + *se llama* ("do you-formal call
 yourself") + *usted* ("you," formal).
@@ -57,16 +60,15 @@ real sentence:
 - To a friend, a child, a peer → *¿Cómo te llamas?*
 
 ## How to answer
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-COMO, ES-LEX-SE-LLAMA, ES-LEX-TE-LLAMAS, ES-LEX-USTED, ES-LEX-COMO-SE-LLAMA, ES-LEX-ME-LLAMO] -->
 
 You already have the answer from the *me llamo* lesson: **Me llamo ___.**
 
 > — ¿Cómo se llama usted?
-> — **Me llamo David.** ¿Y usted?
-
-(*¿Y usted?* — "And you?" — bounces the same question back; *y* = "and," a
-whole lesson's worth of its own soon, but usable now.)
+> — **Me llamo David.**
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-COMO, ES-LEX-SE-LLAMA, ES-LEX-TE-LLAMAS, ES-LEX-USTED, ES-LEX-COMO-SE-LLAMA, ES-LEX-ME-LLAMO] -->
 
 [PAUSE 1s]
 - [YOU SAY: ask a stranger their name — *¿cómo se llama usted?*]
@@ -74,6 +76,7 @@ whole lesson's worth of its own soon, but usable now.)
 - [YOU SAY: the whole mini-exchange — ask, then answer with *me llamo ___*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-COMO, ES-LEX-SE-LLAMA, ES-LEX-TE-LLAMAS, ES-LEX-USTED, ES-LEX-COMO-SE-LLAMA, ES-LEX-ME-LLAMO] -->
 
 [PAUSE 3s] Formal vs. informal "what's your name"? (*¿Cómo se llama usted?* /
 *¿Cómo te llamas?*) Does Spanish literally ask "what" or "how" is your name?

--- a/code/learning/human-languages/spanish/lessons/ES-C03-como.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-como.md
@@ -30,12 +30,14 @@ reviews_of: [ES-C01-dia]
 # cómo — "how," your first question word
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] To ask someone's name or how they are, you need this word first.
 *cómo* — "how" — and it carries a little word for "manner" you already own in
 English.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[ES-SCRIPT-INVERTED-QUESTION]; assesses=[] -->
 
 - `inverted-marks` — Spanish questions open with an upside-down **¿** so you
   see the question coming: *¿cómo…?*
@@ -43,6 +45,7 @@ English.
   question word (see below): *CÓ-mo*.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[ES-LEX-COMO, ES-ETYMON-QUOMODO]; assesses=[] -->
 
 **cómo** — "how." Root: Latin **quomodo** — a fused little phrase, *quo modo*,
 "in what **manner**."
@@ -67,6 +70,7 @@ river. The same erosion gave Italian *come*, Portuguese *como*, French
 to mark the question (vs. accent-less *como*, "like / as").
 
 ## Grammar Lens: the accent that marks a question
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-QUESTION-ACCENT]; assesses=[] -->
 
 Watch the accent mark do real work. **cómo** (with the accent) = "how?", the
 question word. **como** (no accent) = "like / as," or "I eat." Same letters,
@@ -80,12 +84,14 @@ puts a visible flag on the question word. Every question word you'll learn
 (*qué, dónde, cuándo, quién…*) carries this accent for the same reason.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-COMO, ES-SCRIPT-INVERTED-QUESTION, ES-GRAMMAR-QUESTION-ACCENT] -->
 
 [PAUSE 1s]
 - [YOU SAY: "¿cómo?" — with question intonation]
 - [YOU SAY: "cómo" then English "mode", "model" — the *modo* root]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-COMO, ES-SCRIPT-INVERTED-QUESTION, ES-GRAMMAR-QUESTION-ACCENT] -->
 
 [PAUSE 3s] Walk the erosion: *quomodo* → ? → *cómo* (*quomo* → *como*, then
 the question-accent). What changes when the accent disappears? (*como* is no

--- a/code/learning/human-languages/spanish/lessons/ES-C03-familia-qu.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-familia-qu.md
@@ -29,15 +29,18 @@ reviews_of: [ES-C03-como]
 # The *qu-* question family — one ancient pattern, many clues
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You traced *cómo* back to Latin *quomodo*. Focus now on its first
 piece, *qu-*, without trying to use a whole set of new question words yet.
 
 ## You'll want to know first
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - [cómo](./ES-C03-como.md) — "how," from Latin *quomodo*.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[ES-ETYMON-QUESTION-QU]; assesses=[] -->
 
 Latin used a recurring *qu-* stem in questions. Spanish preserves that family,
 although centuries of sound change gave the modern forms different shapes:
@@ -57,6 +60,7 @@ continue the same Latin pattern. *Dónde*, "where," is an exception from Latin
 *de unde*, "from where."
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-COMO, ES-ETYMON-QUOMODO, ES-ETYMON-QUESTION-QU] -->
 
 [PAUSE 1s]
 - [YOU SAY: the Latin source of *cómo*]
@@ -64,6 +68,7 @@ continue the same Latin pattern. *Dónde*, "where," is an exception from Latin
 - [YOU SAY: whether the table is today's production list or a preview]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-COMO, ES-ETYMON-QUOMODO, ES-ETYMON-QUESTION-QU] -->
 
 [PAUSE 3s] Which old stem connects *qué, quién, cuándo,* and *cómo*? (*qu-*.)
 Which word in the preview is the exception? (*Dónde*.)

--- a/code/learning/human-languages/spanish/lessons/ES-C03-gusto.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-gusto.md
@@ -16,9 +16,9 @@ duration:
 requires:
   knowledge: [ES-LEX-MUCHO, ES-LEX-COMO-SE-LLAMA]
 introduces:
-  knowledge: [ES-LEX-MUCHO-GUSTO]
+  knowledge: [ES-LEX-GUSTO, ES-LEX-MUCHO-GUSTO]
 practises:
-  knowledge: [ES-LEX-MUCHO, ES-LEX-MUCHO-GUSTO, ES-LEX-COMO-SE-LLAMA]
+  knowledge: [ES-LEX-MUCHO, ES-LEX-GUSTO, ES-LEX-MUCHO-GUSTO, ES-LEX-COMO-SE-LLAMA]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
@@ -30,16 +30,19 @@ reviews_of: [ES-C03-como-se-llama, ES-C03-mucho]
 # gusto → mucho gusto — "much pleasure"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The line you say when you shake someone's hand. First the noun
 *gusto*, then snap *mucho* onto it, and you've got it.
 
 ## You'll want to know first
+<!-- hl-knowledge: introduces=[ES-LEX-GUSTO, ES-LEX-MUCHO-GUSTO]; assesses=[] -->
 
 - [mucho](./ES-C03-mucho.md) — "much," about to modify
   *gusto*.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 **el gusto** (masculine) — "taste; pleasure, liking." Root: Latin **gustus**
 ("a tasting, a taste"). The English cousins:
@@ -57,20 +60,21 @@ masculine (*el gusto*), and *mucho* is in its plain masculine form to match
 it: another quiet piece of the agreement you've been building.
 
 ## Why it's said this way
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 Spanish greets a new acquaintance by naming the *pleasure* of it — "much
 pleasure" — where English names the *person* ("pleased to meet **you**").
-There's a stock reply that volleys it back: **"El gusto es mío"** — "the
-pleasure is mine."
+The phrase works by itself, so this first exchange needs no extra reply formula.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-MUCHO, ES-LEX-GUSTO, ES-LEX-MUCHO-GUSTO, ES-LEX-COMO-SE-LLAMA] -->
 
 [PAUSE 1s]
 - [YOU SAY: "gusto" then "gusto" (English), "disgust", "gustatory"]
 - [YOU SAY: "mucho gusto" — on meeting someone]
-- [YOU SAY: the reply — "el gusto es mío"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-MUCHO, ES-LEX-GUSTO, ES-LEX-MUCHO-GUSTO, ES-LEX-COMO-SE-LLAMA] -->
 
 [PAUSE 3s] What does *mucho gusto* literally mean? ("Much pleasure.") Is *el
 gusto* masculine or feminine? (Masculine.) And the English cousin of *gusto*

--- a/code/learning/human-languages/spanish/lessons/ES-C03-llamar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-llamar.md
@@ -30,22 +30,26 @@ reviews_of: [ES-C03-me]
 # llamo — "I call," from a root that shouts
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The verb inside "my name is." On its own it means "to call" — and
 its Latin root literally means *to shout*, which is why it echoes through a
 whole family of English words.
 
 ## You'll want to know first
+<!-- hl-knowledge: introduces=[ES-LEX-LLAMO, ES-GRAMMAR-FIRST-PERSON-VERB]; assesses=[] -->
 
 - [me](./ES-C03-me.md) — you'll bolt *me* onto *llamo* next
   lesson.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - `ll-y` — **ll** sounds like English **y**: *llamo* is *YA-mo*, not *LA-mo*.
   → [reference](../pronunciation-reference.md)
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 **llamo** — "I call." The dictionary form (the infinitive) is **llamar**,
 "to call." Root: Latin **clamare**, "to cry out, to shout." That *clam-*
@@ -63,6 +67,7 @@ shouts all through English:
 English cousin usually kept the original cluster (*clamor*, *flame*, *pluvial*).
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ME, ES-LEX-LLAMO, ES-GRAMMAR-FIRST-PERSON-VERB] -->
 
 [PAUSE 1s]
 - [YOU SAY: "llamo" — *YA-mo*]
@@ -70,6 +75,7 @@ English cousin usually kept the original cluster (*clamor*, *flame*, *pluvial*).
 - [YOU SAY: "llamar" (to call), "llave" (key) — both from Latin *cl-*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ME, ES-LEX-LLAMO, ES-GRAMMAR-FIRST-PERSON-VERB] -->
 
 [PAUSE 3s] What does the root *clamare* mean? (To shout / cry out.) Latin
 *cl-* becomes which two letters in Spanish? (*ll-* — *clamare → llamar*.)

--- a/code/learning/human-languages/spanish/lessons/ES-C03-me-llamo.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-me-llamo.md
@@ -18,7 +18,7 @@ requires:
 introduces:
   knowledge: [ES-LEX-ME-LLAMO, ES-GRAMMAR-REFLEXIVE-FIRST-PERSON]
 practises:
-  knowledge: [ES-LEX-ME, ES-LEX-LLAMO, ES-LEX-ME-LLAMO]
+  knowledge: [ES-LEX-ME, ES-LEX-LLAMO, ES-LEX-ME-LLAMO, ES-GRAMMAR-REFLEXIVE-FIRST-PERSON]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
@@ -30,20 +30,24 @@ reviews_of: [ES-C03-me, ES-C03-llamar]
 # me llamo — "I call myself"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Snap the last two lessons together — *me* + *llamo* — and you can
 introduce yourself. But notice Spanish doesn't say "my name is" at all.
 
 ## You'll want to know first
+<!-- hl-knowledge: introduces=[ES-LEX-ME-LLAMO]; assesses=[] -->
 
 - [me](./ES-C03-me.md) · [llamo](./ES-C03-llamar.md)
 
 ## The word, taken apart — by assembling it
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 **me llamo** = **me** ("myself") + **llamo** ("I call") = literally **"I call
 myself."** Then the name: *Me llamo Susana* — "I call myself Susan."
 
 ## Grammar Lens: reflexive verbs
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-REFLEXIVE-FIRST-PERSON]; assesses=[] -->
 
 When the action loops back onto the person doing it — you call *yourself* —
 the verb is **reflexive**, and Spanish marks it with that little pronoun in
@@ -58,12 +62,14 @@ call myself) → *te* llamas (you-informal call yourself) → *se* llama
 lessons; for now, lock in *me llamo* for yourself.
 
 ## Why it's said this way
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 Spanish presents your name not as a thing you *have* ("my name is") but as
 what you *do* — what you call yourself. It's subtly more active, and it's the
 completely standard, neutral way to introduce yourself.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ME, ES-LEX-LLAMO, ES-LEX-ME-LLAMO, ES-GRAMMAR-REFLEXIVE-FIRST-PERSON] -->
 
 [PAUSE 1s]
 - [YOU SAY: "me llamo" + your own name]
@@ -71,6 +77,7 @@ completely standard, neutral way to introduce yourself.
 - [YOU SAY: what does *me llamo* literally mean, word for word?]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ME, ES-LEX-LLAMO, ES-LEX-ME-LLAMO, ES-GRAMMAR-REFLEXIVE-FIRST-PERSON] -->
 
 [PAUSE 3s] Literally, what is *me llamo*? ("I call myself.") What makes it
 reflexive? (The *me* — the action loops back on you.)

--- a/code/learning/human-languages/spanish/lessons/ES-C03-me.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-me.md
@@ -30,16 +30,19 @@ reviews_of: []
 # me — your first pronoun, and a *real* English twin
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] A tiny word doing big work. *me* is your first **pronoun** — and
 unlike *hola*, its English look-alike is the real thing: a true cousin, not
 a coincidence.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - `vowel-e` — one clean syllable, *meh* (the *e* of *bed*).
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[ES-LEX-ME]; assesses=[] -->
 
 **me** — "me / myself." Root: Latin **me** (the object form of *ego*, "I").
 
@@ -52,6 +55,7 @@ resemblance is real, and you can lean on it hard. Spanish *me* = English
 *me*, all the way down.
 
 ## Grammar Lens: what a pronoun is
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-OBJECT-PRONOUN]; assesses=[] -->
 
 A **pronoun** is a stand-in word that points to a person or thing without
 naming them — *I, you, he, me, it*. *me* specifically is an **object**
@@ -61,12 +65,14 @@ lesson in *me llamo*, literally "myself I-call." For now, just hold *me* =
 "me / myself."
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ME, ES-GRAMMAR-OBJECT-PRONOUN] -->
 
 [PAUSE 1s]
 - [YOU SAY: "me" — *meh*]
 - [YOU SAY: "me" then English "me", "my", "mine" — all one family]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ME, ES-GRAMMAR-OBJECT-PRONOUN] -->
 
 [PAUSE 3s] Is Spanish *me* a true cousin of English *me*, or a coincidence
 like *hola*/*hello*? (A true cousin — both from the same ancient root.) What

--- a/code/learning/human-languages/spanish/lessons/ES-C03-mucho.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-mucho.md
@@ -30,16 +30,19 @@ reviews_of: [ES-C03-se-llama]
 # mucho — "much," and a sound-change you've already seen
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] One more word before "pleased to meet you." *mucho* — "much, a
 lot" — and it hides the same Latin-to-Spanish sound trick you spotted in
 *noche*.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - `soft-c` — the **ch** is the *ch* of *church*: *MOO-cho*.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[ES-LEX-MUCHO]; assesses=[] -->
 
 **mucho** — "much, a lot." Root: Latin **multus** ("much, many"). The English
 cousins keep the original *-lt-*:
@@ -54,6 +57,7 @@ to a Latin *-ct-* or *-lt-* root — and the English cousin usually preserves
 it (*noct*urnal, *mult*iple).
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-MUCHO] -->
 
 [PAUSE 1s]
 - [YOU SAY: "mucho" — *MOO-cho*]
@@ -62,6 +66,7 @@ it (*noct*urnal, *mult*iple).
   cluster]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-MUCHO] -->
 
 [PAUSE 3s] *mucho* comes from Latin *multus* — what English words keep the
 *-lt-*? (multiple, multitude, multiply.) What Latin cluster melted into the

--- a/code/learning/human-languages/spanish/lessons/ES-C03-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-practice.md
@@ -8,17 +8,17 @@ type: practice-mix
 headword: (practice)
 gloss: a full introduction, formal and informal
 concept_tag: CH3-PRACTICE
-prerequisites: [ES-C03-me-llamo, ES-C03-tu-usted, ES-C03-como-se-llama, ES-C03-gusto]
+prerequisites: [ES-C02-practice, ES-C03-me-llamo, ES-C03-tu-usted, ES-C03-como-se-llama, ES-C03-gusto]
 sounds: []
 roots: []
 duration:
   max_seconds: 240
 requires:
-  knowledge: [ES-LEX-ME-LLAMO, ES-REGISTER-TU-USTED, ES-LEX-COMO-SE-LLAMA, ES-LEX-MUCHO-GUSTO]
+  knowledge: [ES-LEX-ME-LLAMO, ES-REGISTER-TU-USTED, ES-LEX-COMO-SE-LLAMA, ES-LEX-TE-LLAMAS, ES-LEX-MUCHO-GUSTO]
 introduces:
   knowledge: []
 practises:
-  knowledge: [ES-LEX-ME-LLAMO, ES-LEX-TU, ES-LEX-USTED, ES-LEX-COMO-SE-LLAMA, ES-LEX-MUCHO-GUSTO]
+  knowledge: [ES-LEX-HOLA, ES-LEX-BUENOS-DIAS, ES-LEX-ME-LLAMO, ES-LEX-TU, ES-LEX-USTED, ES-LEX-COMO-SE-LLAMA, ES-LEX-TE-LLAMAS, ES-LEX-MUCHO-GUSTO]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal, presentational]
 strands: [meaning-input, meaning-output, language-focus, fluency]
@@ -30,18 +30,19 @@ reviews_of: [ES-C03-me-llamo, ES-C03-tu-usted, ES-C03-como-se-llama, ES-C03-gust
 # Practice — introducing yourself
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Ten lessons of atoms now assemble into a real conversation. No new
 words — just the exchange, run both formally and informally until the *tú* /
 *usted* choice is automatic.
 
 ## The exchange
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 **Formal** (a stranger, an elder, a customer):
 
 > — Buenos días. Me llamo Susana. **¿Cómo se llama usted?**
 > — Me llamo David. **Mucho gusto.**
-> — El gusto es mío.
 
 **Informal** (a friend, a peer): only two words change, and they're the ones
 that carry the whole social difference:
@@ -50,6 +51,7 @@ that carry the whole social difference:
 > — Me llamo David. Mucho gusto.
 
 ## What you've built
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - **me llamo** — introduce yourself ("I call myself").
 - **tú / usted** — the informal vs. formal "you," and *why* (the retired
@@ -59,6 +61,7 @@ that carry the whole social difference:
 - **mucho gusto** — "much pleasure," pleased to meet you.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HOLA, ES-LEX-BUENOS-DIAS, ES-LEX-ME-LLAMO, ES-LEX-TU, ES-LEX-USTED, ES-LEX-COMO-SE-LLAMA, ES-LEX-TE-LLAMAS, ES-LEX-MUCHO-GUSTO] -->
 
 [PAUSE 1s]
 - [YOU SAY: the full *formal* exchange, both parts]
@@ -70,8 +73,8 @@ that carry the whole social difference:
 [REPEAT x2] Run the formal version start to finish without stopping.
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HOLA, ES-LEX-BUENOS-DIAS, ES-LEX-ME-LLAMO, ES-LEX-TU, ES-LEX-USTED, ES-LEX-COMO-SE-LLAMA, ES-LEX-TE-LLAMAS, ES-LEX-MUCHO-GUSTO] -->
 
 [PAUSE 3s] Which two words change between the formal and informal
-introduction? (*se llama usted* → *te llamas*.) Next chapter: they answer
-your *"¿cómo está usted?"* — "how are you?" — and you learn to say how you're
-doing.
+introduction? (*se llama usted* → *te llamas*.) Next chapter, you will learn
+how to ask how someone is doing.

--- a/code/learning/human-languages/spanish/lessons/ES-C03-se-llama.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-se-llama.md
@@ -16,9 +16,9 @@ duration:
 requires:
   knowledge: [ES-LEX-ME-LLAMO, ES-LEX-USTED, ES-GRAMMAR-USTED-THIRD-PERSON, ES-ETYMON-VUESTRA-MERCED]
 introduces:
-  knowledge: [ES-LEX-SE-LLAMA, ES-GRAMMAR-REFLEXIVE-THIRD-PERSON]
+  knowledge: [ES-LEX-SE-LLAMA, ES-LEX-TE-LLAMAS, ES-GRAMMAR-REFLEXIVE-THIRD-PERSON]
 practises:
-  knowledge: [ES-LEX-ME-LLAMO, ES-LEX-USTED, ES-LEX-SE-LLAMA]
+  knowledge: [ES-LEX-ME-LLAMO, ES-LEX-USTED, ES-LEX-SE-LLAMA, ES-LEX-TE-LLAMAS, ES-GRAMMAR-REFLEXIVE-THIRD-PERSON]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
@@ -30,12 +30,14 @@ reviews_of: [ES-C03-me-llamo, ES-C03-tu-usted]
 # se llama — the reflexive that fits *usted*
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You can say *me llamo* ("I call myself"). To ask someone *else*
 their name — especially formally, with *usted* — you need the version that
 loops back on *them*: *se llama*.
 
 ## You'll want to know first
+<!-- hl-knowledge: introduces=[ES-LEX-SE-LLAMA]; assesses=[] -->
 
 - [me llamo](./ES-C03-me-llamo.md) — the reflexive "I call
   myself."
@@ -43,6 +45,7 @@ loops back on *them*: *se llama*.
   *usted* takes *he/she* verb forms.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 **se llama** = **se** ("himself / herself / yourself-formal") + **llama**
 ("calls"). So *se llama* = "he/she calls himself," or — because *usted* uses
@@ -61,6 +64,7 @@ Every one is something turned in on itself or set apart — the same idea as a
 reflexive looping the action back on the doer.
 
 ## Grammar Lens: the reflexive pronoun changes with the person
+<!-- hl-knowledge: introduces=[ES-LEX-TE-LLAMAS, ES-GRAMMAR-REFLEXIVE-THIRD-PERSON]; assesses=[] -->
 
 The verb *llamar* stays, but the little reflexive word in front shifts to
 match *who* is doing the calling:
@@ -74,6 +78,7 @@ formal "what's your name?" is *¿cómo **se** llama usted?* — *usted*, born fr
 "your grace," politely takes the *he/she* shape.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ME-LLAMO, ES-LEX-USTED, ES-LEX-SE-LLAMA, ES-LEX-TE-LLAMAS, ES-GRAMMAR-REFLEXIVE-THIRD-PERSON] -->
 
 [PAUSE 1s]
 - [YOU SAY: "se llama" — *seh YA-ma*]
@@ -81,6 +86,7 @@ formal "what's your name?" is *¿cómo **se** llama usted?* — *usted*, born fr
 - [YOU SAY: "se" then "secede", "seclude", "separate" — the set-apart root]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ME-LLAMO, ES-LEX-USTED, ES-LEX-SE-LLAMA, ES-LEX-TE-LLAMAS, ES-GRAMMAR-REFLEXIVE-THIRD-PERSON] -->
 
 [PAUSE 3s] Which reflexive goes with *usted* — *te* or *se*? (*se* — because
 *usted* takes third-person forms.) What's the "self/apart" root inside

--- a/code/learning/human-languages/spanish/lessons/ES-C03-tu-usted.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-tu-usted.md
@@ -30,12 +30,14 @@ reviews_of: [ES-C03-me-llamo]
 # tú and usted — two words for "you," and why you must choose
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] English has one word for "you." Spanish has two, and picking the
 wrong one can send the wrong social signal. This lesson gives you both and
 shows the everyday choice. The remarkable history of *usted* comes next.
 
 ## The two words
+<!-- hl-knowledge: introduces=[ES-LEX-TU, ES-LEX-USTED, ES-ETYMON-TU-THOU]; assesses=[] -->
 
 **tú** — "you," **informal**. For friends, family, children, peers, anyone
 you're on easy terms with.
@@ -50,6 +52,7 @@ you're on easy terms with.
 anyone you're showing respect or keeping distance with.
 
 ## Grammar Lens: the choice English lost
+<!-- hl-knowledge: introduces=[ES-REGISTER-TU-USTED, ES-GRAMMAR-USTED-THIRD-PERSON]; assesses=[] -->
 
 Both are **subject pronouns** — the "doer" word, like *yo* ("I"). But they
 carry a second layer English dropped when *thou* died: **social register**.
@@ -64,6 +67,7 @@ and not *te llamas*. The next micro-lesson explains the history behind that
 third-person pattern.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-TU, ES-LEX-USTED, ES-REGISTER-TU-USTED, ES-GRAMMAR-USTED-THIRD-PERSON] -->
 
 [PAUSE 1s]
 - [YOU SAY: "tú" — for a close friend]
@@ -71,6 +75,7 @@ third-person pattern.
 - [YOU SAY: "tú" then English "thou" — the retired twin]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-TU, ES-LEX-USTED, ES-REGISTER-TU-USTED, ES-GRAMMAR-USTED-THIRD-PERSON] -->
 
 [PAUSE 3s] Which is formal, *tú* or *usted*? (*usted*.) What English pronoun
 is the lost twin of *tú*? (*Thou*.) Which verb pattern does *usted* take?

--- a/code/learning/human-languages/spanish/lessons/ES-C03-usted-origin.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-usted-origin.md
@@ -29,15 +29,18 @@ reviews_of: [ES-C03-tu-usted]
 # *vuestra merced* → *usted* — respect compressed into one word
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You use *usted* for respectful "you," and it takes the same verb
 form as "he" or "she." That surprising grammar preserves the word's history.
 
 ## You'll want to know first
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - [tú / usted](./ES-C03-tu-usted.md) — the informal and formal choices.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[ES-ETYMON-VUESTRA-MERCED]; assesses=[] -->
 
 *usted* wore down from **vuestra merced**, "your grace" or "your mercy."
 *Vuestra* comes from Latin *vestra*, "your." *Merced* comes from Latin
@@ -49,12 +52,14 @@ compressed into one pronoun. Its older abbreviation **Vd.** still preserves
 the *v* of *vuestra*.
 
 ## Why it's said this way
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 A title like "your grace" refers to a respected person in the third person.
 That is why modern *usted* still takes the he/she verb form even while it means
 "you." The social history remains visible in the grammar.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-USTED, ES-GRAMMAR-USTED-THIRD-PERSON, ES-ETYMON-VUESTRA-MERCED] -->
 
 [PAUSE 1s]
 - [YOU SAY: the two-word title that became *usted*]
@@ -62,6 +67,7 @@ That is why modern *usted* still takes the he/she verb form even while it means
 - [YOU SAY: which verb pattern *usted* takes]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-USTED, ES-GRAMMAR-USTED-THIRD-PERSON, ES-ETYMON-VUESTRA-MERCED] -->
 
 [PAUSE 3s] What did *vuestra merced* mean? ("Your grace" or "your mercy.")
 Why does *usted* take the he/she verb form? (It began as a third-person title.)

--- a/code/learning/human-languages/spanish/lessons/ES-C04-como-esta.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-como-esta.md
@@ -19,7 +19,7 @@ requires:
 introduces:
   knowledge: [ES-LEX-COMO-ESTA-USTED]
 practises:
-  knowledge: [ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO, ES-LEX-USTED]
+  knowledge: [ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO, ES-LEX-USTED, ES-LEX-ESTAR, ES-GRAMMAR-STATE-LOCATION-ESTAR]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
@@ -31,12 +31,14 @@ reviews_of: [ES-C04-estar, ES-C03-como, ES-C03-tu-usted]
 # ¿cómo está usted? — "how are you?"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Everything you've built this chapter now snaps together into one
 question. You already met **cómo** ("how") and the **tú / usted** choice back in
 Chapter 3; you just learned **estar**. Assemble them.
 
 ## The word, taken apart — assembling the phrase
+<!-- hl-knowledge: introduces=[ES-LEX-COMO-ESTA-USTED]; assesses=[] -->
 
 > **¿Cómo está usted?** = "How are you?" (formal)
 > literally: **"In what manner are you standing?"**
@@ -50,12 +52,14 @@ the melody is coming before you start reading aloud. (We take that mark apart in
 a dedicated writing lesson.)
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO, ES-LEX-USTED, ES-LEX-ESTAR, ES-GRAMMAR-STATE-LOCATION-ESTAR] -->
 
 [PAUSE 1s]
 - [YOU SAY: "¿Cómo está usted?" — formal, for a stranger]
 - [YOU SAY: the pieces — "cómo + está + usted"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO, ES-LEX-USTED, ES-LEX-ESTAR, ES-GRAMMAR-STATE-LOCATION-ESTAR] -->
 
 [PAUSE 3s] Which be-verb does "how are you?" use — *ser* or *estar*, and why?
 (*estar* — it's about your current state.) What changes between formal and

--- a/code/learning/human-languages/spanish/lessons/ES-C04-como-estas-register.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-como-estas-register.md
@@ -30,11 +30,13 @@ reviews_of: [ES-C04-como-esta, ES-C03-tu-usted]
 # ¿cómo está usted? / ¿cómo estás? — choose the register
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You can already ask a stranger **¿Cómo está usted?** Now change
 only the relationship: ask the same question of a friend.
 
 ## Grammar Lens: one question, two relationships
+<!-- hl-knowledge: introduces=[ES-LEX-COMO-ESTAS, ES-GRAMMAR-ESTAR-REGISTER-CONTRAST]; assesses=[] -->
 
 | register | question |
 |---|---|
@@ -47,6 +49,7 @@ This is the same relationship contrast you drilled with **se llama / te
 llamas**.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO-ESTAS, ES-GRAMMAR-ESTAR-REGISTER-CONTRAST] -->
 
 [PAUSE 1s]
 - [YOU SAY: to a doctor you just met — "¿Cómo está usted?"]
@@ -56,6 +59,7 @@ llamas**.
 [REPEAT x2] Ask both versions until the ending swap is automatic.
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO-ESTAS, ES-GRAMMAR-ESTAR-REGISTER-CONTRAST] -->
 
 [PAUSE 3s] Which version fits a stranger? (**¿Cómo está usted?**)
 Which fits a friend? (**¿Cómo estás?**) What two things change?

--- a/code/learning/human-languages/spanish/lessons/ES-C04-de-nada.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-de-nada.md
@@ -19,7 +19,7 @@ requires:
 introduces:
   knowledge: [ES-LEX-DE-NADA, ES-ETYMON-NATA]
 practises:
-  knowledge: [ES-LEX-GRACIAS, ES-LEX-DE-NADA]
+  knowledge: [ES-LEX-GRACIAS, ES-LEX-DE-NADA, ES-ETYMON-NATA]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
@@ -31,6 +31,7 @@ reviews_of: [ES-C04-gracias]
 # de nada — "you're welcome," or "it was nothing"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Someone says **gracias**. You need the reply that closes the loop:
 **de nada** — literally *"of nothing."* You're waving the favour off as no
@@ -38,12 +39,14 @@ trouble at all — the same move English makes with *"it's nothing"* / *"no
 problem."*
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - `d-soft` — the *d* in *nada* is soft, almost the *th* of *this* (**NAH-thah**),
   not a hard English *d*. Spanish *d* between vowels always softens.
 - `vowel-a` — three clean *ah* sounds: *deh NAH-thah*.
 
 ## The word, taken apart — the phrase
+<!-- hl-knowledge: introduces=[ES-LEX-DE-NADA, ES-ETYMON-NATA]; assesses=[] -->
 
 - **de** = "of / from" (Latin **dē**) — the same *de* hiding in English
   **de**part, **de**duct, **de**scend.
@@ -62,17 +65,20 @@ all." French did the identical trick with **rien** ("nothing") — which is Lati
 into the word for *nothing*.
 
 ## Grammar Lens: the courtesy pair
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 *gracias* → *de nada* is a fixed **adjacency pair**: one turn expects the other.
 Learn them as a unit, the way English glues *thank you* → *you're welcome*.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-GRACIAS, ES-LEX-DE-NADA, ES-ETYMON-NATA] -->
 
 [PAUSE 1s]
 - [YOU SAY: "gracias" … "de nada" — the full exchange, both voices]
 - [YOU SAY: "de nada" then English "native, nature, natal" — nada's true family]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-GRACIAS, ES-LEX-DE-NADA, ES-ETYMON-NATA] -->
 
 [PAUSE 3s] *nada* ("nothing") started life as the Latin word for a *born* —
 what? (A *thing* — *rēs nāta*, a born thing.) What English words share that

--- a/code/learning/human-languages/spanish/lessons/ES-C04-estar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-estar.md
@@ -31,12 +31,14 @@ reviews_of: [ES-C04-gracias]
 # estar — "to be," the *standing* kind
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] To ask *how are you?* Spanish needs a verb for **being**. Today:
 **estar** — the verb used for how someone is right now and where someone is.
 Spanish has another identity verb later; you do not need it yet.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - `st-no-e` — Spanish never starts a word with a bare *st-*; it props it up with
   an *e*: *es-TAR*. (That reflex is why Spanish speakers say *e-Spain*,
@@ -44,6 +46,7 @@ Spanish has another identity verb later; you do not need it yet.
 - `r-tap` — the final *r* is one soft tap: *es-TAR*.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[ES-LEX-ESTAR, ES-ETYMON-STARE]; assesses=[] -->
 
 **estar** comes straight from Latin **stāre**, *"to stand."* And "to stand" is
 exactly the right picture for the *temporary* be-verb: how you are *standing* at
@@ -63,6 +66,7 @@ So *¿cómo estás?* is, at the root, **"how are you standing?"** — a snapshot
 right now.
 
 ## Grammar Lens: state and location use estar
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-ESTAR-ESTA-ESTAS, ES-GRAMMAR-STATE-LOCATION-ESTAR]; assesses=[] -->
 
 Use **estar** for a current state or location. “How are you?” asks about a
 current state, so it takes **estar**. The other Spanish be-verb handles
@@ -75,6 +79,7 @@ You only need two forms of it this chapter:
 - **está** — "you are" (formal *usted*) / "he/she is"
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ESTAR, ES-GRAMMAR-ESTAR-ESTA-ESTAS, ES-GRAMMAR-STATE-LOCATION-ESTAR] -->
 
 [PAUSE 1s]
 - [YOU SAY: "estar" — *es-TAR*, with the little propping *e*]
@@ -82,6 +87,7 @@ You only need two forms of it this chapter:
 - [YOU SAY: "estar" then English "stay, state, status, stable" — all *standing*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ESTAR, ES-GRAMMAR-ESTAR-ESTA-ESTAS, ES-GRAMMAR-STATE-LOCATION-ESTAR] -->
 
 [PAUSE 3s] Which Latin verb is *estar* — “to be” or “to stand”? (To *stand* —
 *stāre*.) Which verb do you use for how you feel right now? (*estar*.) Next

--- a/code/learning/human-languages/spanish/lessons/ES-C04-gracias.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-gracias.md
@@ -31,12 +31,14 @@ reviews_of: [ES-C03-practice]
 # gracias — "thank you," and a whole family of English words
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You can now introduce yourself. The next exchange is *how are you?* —
 but every answer ends the same polite way, so we learn the courtesy word first:
 **gracias**.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - `vowel-a` — the clean *ah* of *father*, twice.
 - `r-tap` — a single flicked *r* (not the English one, and not yet the rolled
@@ -45,6 +47,7 @@ but every answer ends the same polite way, so we learn the courtesy word first:
   soft *th* in most of Spain (**GRAH-thyahs**). Either is correct — pick one.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[ES-LEX-GRACIAS, ES-ETYMON-GRATIA]; assesses=[] -->
 
 **gracias** is the plural of **gracia** ("grace, favour"), from Latin **grātia**
 — *favour freely given*. Saying *gracias* literally offers someone "graces,"
@@ -65,12 +68,14 @@ So *gracias* is not a word to memorize cold: it is **grace**, made plural and
 handed to another person.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-GRACIAS, ES-ETYMON-GRATIA] -->
 
 [PAUSE 1s]
 - [YOU SAY: "gracias" — *GRAH-syahs*, one soft tap on the *r*]
 - [YOU SAY: "gracias" then English "grace, grateful, gratitude" — one family]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-GRACIAS, ES-ETYMON-GRATIA] -->
 
 [PAUSE 3s] What everyday English word is *gracias* the plural of, at the root?
 (*Grace*.) So when you thank someone in Spanish, you are literally handing them

--- a/code/learning/human-languages/spanish/lessons/ES-C04-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-practice.md
@@ -14,11 +14,11 @@ roots: []
 duration:
   max_seconds: 280
 requires:
-  knowledge: [ES-LEX-GRACIAS, ES-LEX-DE-NADA, ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO-ESTAS, ES-LEX-BIEN, ES-LEX-REGULAR, ES-LEX-MAS-O-MENOS, ES-LEX-Y, ES-ORTHOGRAPHY-PUNCTUATION-SPAN]
+  knowledge: [ES-LEX-GRACIAS, ES-LEX-DE-NADA, ES-LEX-ESTAR, ES-GRAMMAR-STATE-LOCATION-ESTAR, ES-GRAMMAR-ESTAR-REGISTER-CONTRAST, ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO-ESTAS, ES-LEX-BIEN, ES-LEX-REGULAR, ES-LEX-MAS-O-MENOS, ES-LEX-Y, ES-LEX-ME-LLAMO, ES-ORTHOGRAPHY-PUNCTUATION-SPAN]
 introduces:
   knowledge: []
 practises:
-  knowledge: [ES-LEX-GRACIAS, ES-LEX-DE-NADA, ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO-ESTAS, ES-LEX-BIEN, ES-LEX-REGULAR, ES-LEX-MAS-O-MENOS, ES-PRAGMATICS-AND-YOU]
+  knowledge: [ES-LEX-GRACIAS, ES-LEX-DE-NADA, ES-LEX-ESTAR, ES-GRAMMAR-STATE-LOCATION-ESTAR, ES-GRAMMAR-ESTAR-REGISTER-CONTRAST, ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO-ESTAS, ES-LEX-BIEN, ES-LEX-REGULAR, ES-LEX-MAS-O-MENOS, ES-PRAGMATICS-AND-YOU, ES-LEX-ME-LLAMO]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal, presentational]
 strands: [meaning-input, meaning-output, language-focus, fluency]
@@ -30,6 +30,7 @@ reviews_of: [ES-C04-gracias, ES-C04-de-nada, ES-C04-como-estas-register, ES-C04-
 # Practice — "how are you?", start to finish
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] No new words. This chapter's atoms — *gracias, de nada, estar, ¿cómo
 está?, regular* — now assemble into a real exchange, run formally and informally
@@ -37,6 +38,7 @@ until the register swap is automatic. It picks up right where the Chapter 3
 introduction left off.
 
 ## The exchange
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 **Formal** (a stranger, an elder, a customer):
 
@@ -55,6 +57,7 @@ The glue pattern you just secured is **¿y usted? / ¿y tú?** — “and you?�
 It bounces the question back without repeating the whole sentence.
 
 ## What you've built this chapter
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - **gracias** — thank you (← *grātia*, "grace").
 - **de nada** — you're welcome (← "of a born-thing" → "of nothing").
@@ -63,6 +66,7 @@ It bounces the question back without repeating the whole sentence.
 - **bien / regular / más o menos** — well / so-so / more-or-less.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-GRACIAS, ES-LEX-DE-NADA, ES-LEX-ESTAR, ES-GRAMMAR-STATE-LOCATION-ESTAR, ES-GRAMMAR-ESTAR-REGISTER-CONTRAST, ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO-ESTAS, ES-LEX-BIEN, ES-LEX-REGULAR, ES-LEX-MAS-O-MENOS, ES-PRAGMATICS-AND-YOU, ES-LEX-ME-LLAMO] -->
 
 [PAUSE 1s]
 - [YOU SAY: the full *formal* exchange, both voices]
@@ -73,6 +77,7 @@ It bounces the question back without repeating the whole sentence.
 [REPEAT x2] Run the formal exchange, greeting to answer, without stopping.
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-GRACIAS, ES-LEX-DE-NADA, ES-LEX-ESTAR, ES-GRAMMAR-STATE-LOCATION-ESTAR, ES-GRAMMAR-ESTAR-REGISTER-CONTRAST, ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO-ESTAS, ES-LEX-BIEN, ES-LEX-REGULAR, ES-LEX-MAS-O-MENOS, ES-PRAGMATICS-AND-YOU, ES-LEX-ME-LLAMO] -->
 
 [PAUSE 3s] Which be-verb carries "how are you?" and why? (*estar* — current
 state.) Two words swap between formal and informal — which? (*está → estás*, and

--- a/code/learning/human-languages/spanish/lessons/ES-C04-regular.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-regular.md
@@ -19,7 +19,7 @@ requires:
 introduces:
   knowledge: [ES-LEX-REGULAR, ES-LEX-MAS-O-MENOS, ES-ETYMON-REGULA]
 practises:
-  knowledge: [ES-LEX-REGULAR, ES-LEX-MAS-O-MENOS, ES-LEX-BIEN, ES-LEX-COMO-ESTAS]
+  knowledge: [ES-LEX-REGULAR, ES-LEX-MAS-O-MENOS, ES-LEX-BIEN, ES-LEX-COMO-ESTAS, ES-ETYMON-REGULA]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
@@ -31,18 +31,21 @@ reviews_of: [ES-C01-bien, ES-C04-como-estas-register, ES-C04-como-esta]
 # regular / más o menos — the honest "so-so"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You asked *¿cómo estás?* Now you can answer three ways: great,
 middling, or a wave of the hand. You already have **bien** ("well," Chapter 1).
 Today, the *middling* answers — because nobody is *bien* every day.
 
 ## You'll want to know first
+<!-- hl-knowledge: introduces=[ES-LEX-REGULAR, ES-LEX-MAS-O-MENOS]; assesses=[] -->
 
 [PAUSE 2s] Recall from Chapter 1: **bien** — "well." Root? (Latin *bene*, "well"
 — same as *bene*fit, *bene*volent.) So *estoy bien* = "I'm well." Now the answer
 for when you're *not* quite bien.
 
 ## The word, taken apart — two answers
+<!-- hl-knowledge: introduces=[ES-ETYMON-REGULA]; assesses=[] -->
 
 **regular** — as an answer to "how are you?", it means **"so-so, average, not
 great."** (A famous false-friend trap: it does **not** mean English "regular /
@@ -65,6 +68,7 @@ So *más o menos* is literally **"more or less"** — the exact phrase, root for
 root, that English uses for the same shrug.
 
 ## Grammar Lens: a small answer set
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 You now have a scale to answer *¿cómo estás?*:
 
@@ -75,6 +79,7 @@ You now have a scale to answer *¿cómo estás?*:
 | **más o menos** | more or less / meh |
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-REGULAR, ES-LEX-MAS-O-MENOS, ES-LEX-BIEN, ES-LEX-COMO-ESTAS, ES-ETYMON-REGULA] -->
 
 [PAUSE 1s]
 - [YOU SAY: "regular" — *reh-goo-LAR*, soft tap on both *r*'s]
@@ -82,6 +87,7 @@ You now have a scale to answer *¿cómo estás?*:
 - [YOU SAY: answer "¿cómo estás?" three ways — bien / regular / más o menos]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-REGULAR, ES-LEX-MAS-O-MENOS, ES-LEX-BIEN, ES-LEX-COMO-ESTAS, ES-ETYMON-REGULA] -->
 
 [PAUSE 3s] As an answer, does *regular* mean "normal" or "so-so"? (So-so — the
 false-friend trap.) What straight-rod Latin word is it from, and what English

--- a/code/learning/human-languages/spanish/lessons/ES-C04-y.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-y.md
@@ -19,7 +19,7 @@ requires:
 introduces:
   knowledge: [ES-LEX-Y, ES-PRAGMATICS-AND-YOU, ES-ETYMON-ET]
 practises:
-  knowledge: [ES-LEX-Y, ES-PRAGMATICS-AND-YOU, ES-LEX-TU, ES-LEX-USTED]
+  knowledge: [ES-LEX-Y, ES-PRAGMATICS-AND-YOU, ES-LEX-TU, ES-LEX-USTED, ES-ETYMON-ET]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
@@ -31,17 +31,20 @@ reviews_of: [ES-C04-como-estas-register, ES-C03-tu-usted]
 # y / ¿y tú? — pass the question back
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You can ask how someone is and answer. One tiny connector turns
 that exchange around so the other person gets a turn too.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[ES-LEX-Y, ES-ETYMON-ET]; assesses=[] -->
 
 **Y** means **and** and sounds like Spanish **i**: *ee*. It continues Latin
 **et**, also “and.” English borrowed that Latin word intact inside **et
 cetera**, literally “and the rest.”
 
 ## Grammar Lens: the shortest return question
+<!-- hl-knowledge: introduces=[ES-PRAGMATICS-AND-YOU]; assesses=[] -->
 
 Put **y** before a person you already know:
 
@@ -52,6 +55,7 @@ Nothing else needs repeating. The little question hands the previous topic
 back to the other person.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-Y, ES-PRAGMATICS-AND-YOU, ES-LEX-TU, ES-LEX-USTED, ES-ETYMON-ET] -->
 
 [PAUSE 1s]
 - [YOU SAY: “Bien. ¿Y tú?” to a friend]
@@ -59,6 +63,7 @@ back to the other person.
 - [YOU SAY: “y” — one clear *ee* sound]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-Y, ES-PRAGMATICS-AND-YOU, ES-LEX-TU, ES-LEX-USTED, ES-ETYMON-ET] -->
 
 [PAUSE 3s] What does **y** mean? (**And.**) How do you hand a question back
 to a friend? (**¿Y tú?**) To a stranger? (**¿Y usted?**) Which Latin word

--- a/code/learning/human-languages/spanish/lessons/ES-C05-adios.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-adios.md
@@ -19,7 +19,7 @@ requires:
 introduces:
   knowledge: [ES-LEX-ADIOS, ES-PRAGMATICS-FINAL-FAREWELL, ES-ETYMON-A-DIOS]
 practises:
-  knowledge: [ES-LEX-ADIOS, ES-PRAGMATICS-FINAL-FAREWELL]
+  knowledge: [ES-LEX-ADIOS, ES-PRAGMATICS-FINAL-FAREWELL, ES-ETYMON-A-DIOS]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
@@ -31,17 +31,20 @@ reviews_of: [ES-C04-practice]
 # adiós — "goodbye," or "to God"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You can greet, introduce yourself, and ask how someone is. Time to
 leave gracefully. The final, plainest parting is **adiós** — and, like the
 English *goodbye*, it's a tiny prayer worn smooth.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - `diphthong-io` — the *-iós* is one glide, *ee-OHS*: *ah-DYOHS*, stress on the
   end (that's what the accent on *ó* marks — remember the acute-accent lesson).
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[ES-LEX-ADIOS, ES-ETYMON-A-DIOS]; assesses=[] -->
 
 **adiós** is **a + Dios** — "**to God**." It's the front half of an old blessing,
 *a Dios te encomiendo*, "I commend you **to God**" — said to someone setting off,
@@ -64,12 +67,14 @@ same sentence — a blessing for the road.
   *adieu*, and (via Greek *Zeus*, same root) the whole sky-god family.
 
 ## Grammar Lens: adiós is a *final* goodbye
+<!-- hl-knowledge: introduces=[ES-PRAGMATICS-FINAL-FAREWELL]; assesses=[] -->
 
 *adiós* leans toward a **longer** parting — you won't see them soon, or it's the
 end of the day. For "see you later / tomorrow," Spanish reaches for **hasta …**,
 which the rest of this chapter is about — and *hasta* has a surprising origin.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ADIOS, ES-PRAGMATICS-FINAL-FAREWELL, ES-ETYMON-A-DIOS] -->
 
 [PAUSE 1s]
 - [YOU SAY: "adiós" — *ah-DYOHS*, stress the end]
@@ -77,6 +82,7 @@ which the rest of this chapter is about — and *hasta* has a surprising origin.
 - [YOU SAY: English "goodbye" = "God be with ye" — the same prayer]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ADIOS, ES-PRAGMATICS-FINAL-FAREWELL, ES-ETYMON-A-DIOS] -->
 
 [PAUSE 3s] What two words hide inside *adiós*? (*a* + *Dios* — "to God.") What
 English goodbye is built the same way? (*Goodbye* ← "God be with ye.") Is *adiós*

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta-limits.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta-limits.md
@@ -30,11 +30,13 @@ reviews_of: [ES-C05-hasta, ES-C05-adios]
 # hasta aquí / hasta la noche — point to the limit
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You know **hasta** means “until” or “up to.” Give that small word
 one spatial endpoint and one temporal endpoint, using only one new word.
 
 ## Grammar Lens: endpoints in space and time
+<!-- hl-knowledge: introduces=[ES-LEX-AQUI, ES-GRAMMAR-HASTA-ENDPOINT]; assesses=[] -->
 
 **Aquí** means **here**. Put it after **hasta**:
 
@@ -48,6 +50,7 @@ The same preposition points to a place or the end of a stretch of time.
 The next lessons will place new time words after it one at a time.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HASTA, ES-LEX-AQUI, ES-LEX-NOCHE, ES-GRAMMAR-HASTA-ENDPOINT] -->
 
 [PAUSE 1s]
 - [YOU SAY: “aquí” — here]
@@ -55,6 +58,7 @@ The next lessons will place new time words after it one at a time.
 - [YOU SAY: “hasta la noche” — until tonight]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HASTA, ES-LEX-AQUI, ES-LEX-NOCHE, ES-GRAMMAR-HASTA-ENDPOINT] -->
 
 [PAUSE 3s] What does **hasta** point to? (**An endpoint.**) Give one spatial
 and one temporal example. (**Hasta aquí; hasta la noche.**) What is the only

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta-luego.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta-luego.md
@@ -19,7 +19,7 @@ requires:
 introduces:
   knowledge: [ES-LEX-LUEGO, ES-LEX-HASTA-LUEGO, ES-ETYMON-LOCUS]
 practises:
-  knowledge: [ES-LEX-HASTA, ES-LEX-LUEGO, ES-LEX-HASTA-LUEGO]
+  knowledge: [ES-LEX-HASTA, ES-LEX-LUEGO, ES-LEX-HASTA-LUEGO, ES-ETYMON-LOCUS]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
@@ -31,17 +31,20 @@ reviews_of: [ES-C05-hasta-limits, ES-C05-hasta, ES-C05-adios]
 # hasta luego — the everyday "see you later"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] This is the goodbye you'll actually use most — friendly, casual,
 open-ended. **hasta luego**: "until later." You already own **hasta** ("until");
 today you add **luego** ("later"), and it has a very Latin backstory.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - `diphthong-ue` — **luego** = *LWEH-goh*: the *ue* is a *w*-glide, *lweh-*.
 - The whole phrase: *AHS-tah LWEH-goh*.
 
 ## The word, taken apart — the phrase
+<!-- hl-knowledge: introduces=[ES-LEX-LUEGO, ES-LEX-HASTA-LUEGO, ES-ETYMON-LOCUS]; assesses=[] -->
 
 > **hasta luego** = "until later" → "see you later."
 
@@ -56,6 +59,7 @@ A nice contrast: **hasta luego** fuses an **Arabic** word and a **Latin** word i
 three syllables — the two great layers of Spanish, shaking hands as you leave.
 
 ## Grammar Lens: the "hasta …" family
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 *hasta* + a time word is Spanish's whole toolkit of soft goodbyes. You'll build
 the other two this chapter:
@@ -67,6 +71,7 @@ the other two this chapter:
 | **hasta pronto** | soon | you expect to meet again shortly |
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HASTA, ES-LEX-LUEGO, ES-LEX-HASTA-LUEGO, ES-ETYMON-LOCUS] -->
 
 [PAUSE 1s]
 - [YOU SAY: "hasta luego" — *AHS-tah LWEH-goh*]
@@ -74,6 +79,7 @@ the other two this chapter:
 - [YOU SAY: "¡Adiós! … no — ¡hasta luego!" — feel the difference: final vs. soon]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HASTA, ES-LEX-LUEGO, ES-LEX-HASTA-LUEGO, ES-ETYMON-LOCUS] -->
 
 [PAUSE 3s] What does *hasta luego* literally mean? ("Until later.") What did
 *luego*'s Latin root *loco* first mean, and what English words keep it? (Place —

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta-manana.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta-manana.md
@@ -19,7 +19,7 @@ requires:
 introduces:
   knowledge: [ES-LEX-MANANA, ES-LEX-HASTA-MANANA, ES-ETYMON-MANEANA]
 practises:
-  knowledge: [ES-LEX-HASTA, ES-LEX-MANANA, ES-LEX-HASTA-MANANA, ES-SCRIPT-ENYE]
+  knowledge: [ES-LEX-HASTA, ES-LEX-MANANA, ES-LEX-HASTA-MANANA, ES-SCRIPT-ENYE, ES-ETYMON-MANEANA]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
@@ -31,18 +31,21 @@ reviews_of: [ES-C05-hasta-luego, ES-W02-enye]
 # hasta mañana — "see you tomorrow" (and the ñ returns)
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Leaving for the day? **hasta mañana** — "until tomorrow." It brings
 back a letter you studied in the writing lessons: the **ñ**. Here it is, living
 in a word you'll say every evening.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - `enye-ny` — **mañana** = *mah-NYAH-nah*: the **ñ** is the squished *ny* of
   "canyon" (your ñ writing lesson — the tilde is a tiny second *n*, remember).
   Three soft *ah*'s: *ma-**ÑA**-na*.
 
 ## The word, taken apart — the phrase
+<!-- hl-knowledge: introduces=[ES-LEX-MANANA, ES-LEX-HASTA-MANANA, ES-ETYMON-MANEANA]; assesses=[] -->
 
 > **hasta mañana** = "until tomorrow" → "see you tomorrow."
 
@@ -58,11 +61,13 @@ scribe's shorthand for a doubled *n*. *mañana* comes from Latin *maneana*, whos
 little historical fossil sitting in the middle of "tomorrow."
 
 ## Grammar Lens: same word, two meanings — context decides
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 *mañana* means "morning" **or** "tomorrow"; the sentence tells you which. Paired
 with *hasta*, it's always **tomorrow**: *hasta mañana*, "until tomorrow."
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HASTA, ES-LEX-MANANA, ES-LEX-HASTA-MANANA, ES-SCRIPT-ENYE, ES-ETYMON-MANEANA] -->
 
 [PAUSE 1s]
 - [YOU SAY: "mañana" — *mah-NYAH-nah*, squished *ñ*]
@@ -70,6 +75,7 @@ with *hasta*, it's always **tomorrow**: *hasta mañana*, "until tomorrow."
 - [YOU SAY: “mañana” once as “morning,” then once as “tomorrow” — context decides]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HASTA, ES-LEX-MANANA, ES-LEX-HASTA-MANANA, ES-SCRIPT-ENYE, ES-ETYMON-MANEANA] -->
 
 [PAUSE 3s] What two meanings does *mañana* carry? (Morning; tomorrow.) With
 *hasta*, which one? (Tomorrow.) What sound is the *ñ*, and what is its tilde,

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta-pronto.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta-pronto.md
@@ -19,7 +19,7 @@ requires:
 introduces:
   knowledge: [ES-LEX-PRONTO, ES-LEX-HASTA-PRONTO, ES-ETYMON-PROMPTUS]
 practises:
-  knowledge: [ES-LEX-HASTA, ES-LEX-PRONTO, ES-LEX-HASTA-PRONTO]
+  knowledge: [ES-LEX-HASTA, ES-LEX-PRONTO, ES-LEX-HASTA-PRONTO, ES-ETYMON-PROMPTUS]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
@@ -31,16 +31,19 @@ reviews_of: [ES-C05-hasta-luego, ES-C05-hasta-manana]
 # hasta pronto — "see you soon"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The last of the "hasta …" trio: **hasta pronto**, "until soon" — for
 when you genuinely expect to meet again shortly. One new word, **pronto**, and
 it's hiding in plain sight in English.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - **hasta pronto** = *AHS-tah PRON-toh* — a clean *pr*, a pure *o*.
 
 ## The word, taken apart — the phrase
+<!-- hl-knowledge: introduces=[ES-LEX-PRONTO, ES-LEX-HASTA-PRONTO, ES-ETYMON-PROMPTUS]; assesses=[] -->
 
 > **hasta pronto** = "until soon" → "see you soon."
 
@@ -55,6 +58,7 @@ for input). Italian borrowed *pronto* too — it's what Italians say when they p
 up the phone (*"Pronto!"* = "Ready!").
 
 ## Grammar Lens: the "hasta …" trio, complete
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 You now have Spanish's three soft goodbyes, sharpest to vaguest in time:
 
@@ -67,6 +71,7 @@ You now have Spanish's three soft goodbyes, sharpest to vaguest in time:
 …and **adiós** for the long or final goodbye.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HASTA, ES-LEX-PRONTO, ES-LEX-HASTA-PRONTO, ES-ETYMON-PROMPTUS] -->
 
 [PAUSE 1s]
 - [YOU SAY: "hasta pronto" — *AHS-tah PRON-toh*]
@@ -74,6 +79,7 @@ You now have Spanish's three soft goodbyes, sharpest to vaguest in time:
 - [YOU SAY: the trio — hasta pronto / hasta luego / hasta mañana]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HASTA, ES-LEX-PRONTO, ES-LEX-HASTA-PRONTO, ES-ETYMON-PROMPTUS] -->
 
 [PAUSE 3s] What does *hasta pronto* mean, and *pronto*'s English twin? ("Until
 soon"; *prompt*.) What Latin word is it from, and its literal sense? (*promptus*,

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta.md
@@ -19,7 +19,7 @@ requires:
 introduces:
   knowledge: [ES-LEX-HASTA, ES-ETYMON-HATTA, ES-HISTORY-AL-ANDALUS-LOANS]
 practises:
-  knowledge: [ES-LEX-HASTA, ES-ETYMON-HATTA]
+  knowledge: [ES-LEX-HASTA, ES-ETYMON-HATTA, ES-HISTORY-AL-ANDALUS-LOANS]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
@@ -31,6 +31,7 @@ reviews_of: [ES-C05-adios]
 # hasta — "until," and Spain's Arabic centuries
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Spanish says "see you later" as **hasta luego** — literally "**until**
 later." So the key word is **hasta**, "until." And *hasta* carries the single
@@ -38,11 +39,13 @@ most important fact about Spanish's history: **for nearly 800 years, much of
 Spain spoke Arabic.**
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - `silent-h` — Spanish **h is always silent**: **hasta** = *AHS-tah* (no breath
   on the *h* at all). Stress the front.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[ES-LEX-HASTA, ES-ETYMON-HATTA, ES-HISTORY-AL-ANDALUS-LOANS]; assesses=[] -->
 
 **hasta** comes from Arabic **ḥattā**, “until, up to.” From **711 CE**,
 Muslim armies ruled much of the Iberian Peninsula — *al-Andalus* — and Arabic was
@@ -65,17 +68,17 @@ deep, how *intimate*, those centuries of contact were. (Its Latin rival *ad*
 say goodbye.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HASTA, ES-ETYMON-HATTA, ES-HISTORY-AL-ANDALUS-LOANS] -->
 
 [PAUSE 1s]
 - [YOU SAY: "hasta" — *AHS-tah*, silent h]
 - [YOU SAY: "hasta" then Arabic *ḥattā* — the same word, 1,300 years apart]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HASTA, ES-ETYMON-HATTA, ES-HISTORY-AL-ANDALUS-LOANS] -->
 
 [PAUSE 3s] What language is *hasta* from, and what does it mean? (Arabic *ḥattā*
 — "until.") Why is it remarkable that Spanish borrowed it? (It's a *function
 word* / preposition — languages almost never borrow those; it shows how deep the
 Arabic centuries went.) How do you spot many Arabic nouns in Spanish? (The frozen
-*al-* article: *almohada, azúcar, álgebra*.) Which **other** Arabic function word
-will return in Chapter 18? (***Ojalá***, a word that triggers a grammatical
-mood.)
+*al-* article: *almohada, azúcar, álgebra*.)

--- a/code/learning/human-languages/spanish/lessons/ES-C05-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-practice.md
@@ -18,7 +18,7 @@ requires:
 introduces:
   knowledge: []
 practises:
-  knowledge: [ES-LEX-ADIOS, ES-LEX-HASTA-LUEGO, ES-LEX-HASTA-MANANA, ES-LEX-HASTA-PRONTO, ES-LEX-HOLA, ES-LEX-COMO-ESTA-USTED]
+  knowledge: [ES-LEX-ADIOS, ES-LEX-HASTA, ES-LEX-HASTA-LUEGO, ES-LEX-HASTA-MANANA, ES-LEX-HASTA-PRONTO, ES-LEX-HOLA, ES-LEX-COMO-ESTA-USTED]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal, presentational]
 strands: [meaning-input, meaning-output, language-focus, fluency]
@@ -30,12 +30,14 @@ reviews_of: [ES-C05-adios, ES-C05-hasta-limits, ES-C05-hasta, ES-C05-hasta-luego
 # Practice — saying goodbye
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] No new words. This chapter's farewells — *adiós* and the three *hasta
 …* goodbyes — now close a real conversation, and fold back into the whole arc
 you've built since *hola*.
 
 ## Grammar Lens: choosing the right goodbye
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 The choice is about **when you'll meet again**:
 
@@ -47,6 +49,7 @@ The choice is about **when you'll meet again**:
 | leaving for the day | **Hasta mañana.** |
 
 ## The exchange — start to finish
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 Everything from Chapters 1–5, in one conversation:
 
@@ -58,6 +61,7 @@ Everything from Chapters 1–5, in one conversation:
 > — **Hasta mañana**, Ana. **¡Adiós!**
 
 ## What you've built this chapter
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - **adiós** — the plain/final goodbye ("to God"; twin of *goodbye*).
 - **hasta** — "until," Spain's everyday Arabic word (← *ḥattā*).
@@ -65,6 +69,7 @@ Everything from Chapters 1–5, in one conversation:
   Arabic + Latin handshake.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ADIOS, ES-LEX-HASTA, ES-LEX-HASTA-LUEGO, ES-LEX-HASTA-MANANA, ES-LEX-HASTA-PRONTO, ES-LEX-HOLA, ES-LEX-COMO-ESTA-USTED] -->
 
 [PAUSE 1s]
 - [YOU SAY: the full conversation above, both voices — greeting to goodbye]
@@ -74,6 +79,7 @@ Everything from Chapters 1–5, in one conversation:
 [REPEAT x2] Run the whole exchange, *hola* to *adiós*, without stopping.
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ADIOS, ES-LEX-HASTA, ES-LEX-HASTA-LUEGO, ES-LEX-HASTA-MANANA, ES-LEX-HASTA-PRONTO, ES-LEX-HOLA, ES-LEX-COMO-ESTA-USTED] -->
 
 [PAUSE 3s] Which goodbye for someone you won't see for a long time? (*Adiós*.)
 Which everyday word for "until" did Spanish take from Arabic? (*hasta*.) You can

--- a/code/learning/human-languages/spanish/lessons/ES-C06-cafe.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-cafe.md
@@ -19,7 +19,7 @@ requires:
 introduces:
   knowledge: [ES-LEX-CAFE, ES-ETYMON-QAHWA, ES-GRAMMAR-CAFE-MASCULINE]
 practises:
-  knowledge: [ES-LEX-CAFE, ES-SCRIPT-ACUTE-ACCENT]
+  knowledge: [ES-LEX-CAFE, ES-SCRIPT-ACUTE-ACCENT, ES-ETYMON-QAHWA, ES-GRAMMAR-CAFE-MASCULINE]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
@@ -31,17 +31,20 @@ reviews_of: [ES-W01-acento, ES-C05-hasta]
 # café — coffee, and a place to drink it
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Before you can make a polite request, you need one small thing to
 request. **Café** gives you a useful noun and lets the written accent do a job
 you already understand.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 Say **ca-FÉ**. A vowel-final word would normally stress the second-to-last
 syllable, so the acute accent records the unexpected final stress.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[ES-LEX-CAFE, ES-ETYMON-QAHWA, ES-GRAMMAR-CAFE-MASCULINE]; assesses=[] -->
 
 Spanish **café** came through Italian **caffè** and Turkish **kahve** from
 Arabic **qahwah**. English **coffee** reached the same travelling word by a
@@ -51,6 +54,7 @@ different European route. The drink and the word both crossed languages.
 **café** divide those jobs. It is masculine: **el café**.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CAFE, ES-SCRIPT-ACUTE-ACCENT, ES-ETYMON-QAHWA, ES-GRAMMAR-CAFE-MASCULINE] -->
 
 [PAUSE 1s]
 - [YOU SAY: “café” — final stress]
@@ -58,6 +62,7 @@ different European route. The drink and the word both crossed languages.
 - [YOU SAY: the route — “qahwah → kahve → caffè → café”]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CAFE, ES-SCRIPT-ACUTE-ACCENT, ES-ETYMON-QAHWA, ES-GRAMMAR-CAFE-MASCULINE] -->
 
 [PAUSE 3s] Where does the stress fall? (**On the final é.**) Why is the
 accent written? (**It overrides the usual vowel-final stress.**) What route

--- a/code/learning/human-languages/spanish/lessons/ES-C06-espanol.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-espanol.md
@@ -19,7 +19,7 @@ requires:
 introduces:
   knowledge: [ES-LEX-ESPANOL, ES-LEX-HABLO-ESPANOL, ES-GRAMMAR-BARE-LANGUAGE, ES-ETYMON-HISPANIA]
 practises:
-  knowledge: [ES-LEX-HABLO-ESPANOL, ES-LEX-TRABAJAR, ES-LEX-ESTUDIAR, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-GRAMMAR-PRO-DROP, ES-SCRIPT-ENYE]
+  knowledge: [ES-LEX-ESPANOL, ES-LEX-HABLO-ESPANOL, ES-LEX-TRABAJAR, ES-LEX-ESTUDIAR, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-GRAMMAR-PRO-DROP, ES-GRAMMAR-BARE-LANGUAGE, ES-SCRIPT-ENYE, ES-ETYMON-HISPANIA]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal, presentational]
 strands: [meaning-input, meaning-output, language-focus]
@@ -31,12 +31,14 @@ reviews_of: [ES-C06-hablar, ES-W02-enye]
 # Hablo español — your first real sentence
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] This is the moment the course has been building to: you take a **verb**
 you conjugated and a **noun**, and make a sentence **nobody handed you
 pre-assembled**. *Hablo español* — "I speak Spanish."
 
 ## The word, taken apart — español
+<!-- hl-knowledge: introduces=[ES-LEX-ESPANOL, ES-LEX-HABLO-ESPANOL, ES-ETYMON-HISPANIA]; assesses=[] -->
 
 **español** = "Spanish" (the language, and a Spaniard), from **Hispania**, the
 Roman name for the Iberian peninsula. The path *Hispania → hispaniolus → español*
@@ -49,6 +51,7 @@ fittingly, *español* itself may trace back through Latin to a **Phoenician** na
 for the coast, "land of hyraxes / rabbits.")
 
 ## What you've built — the sentence assembled
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-BARE-LANGUAGE]; assesses=[] -->
 
 Snap two things you already own together:
 
@@ -68,6 +71,7 @@ Now swap the pieces and watch it generate:
   writing lesson).
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ESPANOL, ES-LEX-HABLO-ESPANOL, ES-LEX-TRABAJAR, ES-LEX-ESTUDIAR, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-GRAMMAR-PRO-DROP, ES-GRAMMAR-BARE-LANGUAGE, ES-SCRIPT-ENYE, ES-ETYMON-HISPANIA] -->
 
 [PAUSE 1s]
 - [YOU SAY: "Hablo español" — *AH-bloh es-pa-NYOL*]
@@ -75,6 +79,7 @@ Now swap the pieces and watch it generate:
 - [YOU SAY: ask it — "¿Hablas español?" (raise the pitch, ¿ opens the question)]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ESPANOL, ES-LEX-HABLO-ESPANOL, ES-LEX-TRABAJAR, ES-LEX-ESTUDIAR, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-GRAMMAR-PRO-DROP, ES-GRAMMAR-BARE-LANGUAGE, ES-SCRIPT-ENYE, ES-ETYMON-HISPANIA] -->
 
 [PAUSE 3s] Where does *español* come from, and what letter does its ending bring
 back? (*Hispania*; the *ñ*.) In *Hablo español*, why is there no separate subject

--- a/code/learning/human-languages/spanish/lessons/ES-C06-estudiar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-estudiar.md
@@ -19,7 +19,7 @@ requires:
 introduces:
   knowledge: [ES-LEX-ESTUDIAR, ES-ETYMON-STUDERE]
 practises:
-  knowledge: [ES-LEX-ESTUDIAR, ES-GRAMMAR-AR-PRESENT-SINGULAR]
+  knowledge: [ES-LEX-ESTUDIAR, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-ETYMON-STUDERE]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal, presentational]
 strands: [meaning-input, meaning-output, language-focus]
@@ -31,18 +31,21 @@ reviews_of: [ES-C06-trabajar]
 # estudiar — "to study," and the eagerness inside it
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Your third **-ar** verb. By now the pattern should feel automatic —
 that's exactly what we want. *estudiar* also hides a nicer feeling than the
 classroom suggests: at root it means **eagerness.**
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - `st-no-e` — Spanish props up *st-* with an *e*: **es-tudiar** (the same reflex
   behind *estar*, *España*, *escuela*). *es-too-DYAR*.
 - `diphthong-io` — the *-iar* glides: *es-too-**DYAR***.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[ES-LEX-ESTUDIAR, ES-ETYMON-STUDERE]; assesses=[] -->
 
 **estudiar** comes from Latin **studēre**, *"to be eager, to apply oneself
 zealously."* A *studium* was **zeal, enthusiasm, devotion** — only later "study."
@@ -58,6 +61,7 @@ So *Estudio español* is "I *devote myself eagerly* to Spanish" — a nicer pict
 than mere schoolwork.
 
 ## Grammar Lens: the template holds
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 Drop **-ar**, add the ending — for the third time:
 
@@ -71,6 +75,7 @@ Three verbs, one pattern: *hablo, trabajo, estudio*. The singular regular
 **-ar** present is now reusable rather than memorized verb by verb.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ESTUDIAR, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-ETYMON-STUDERE] -->
 
 [PAUSE 1s]
 - [YOU SAY: "estudiar" — *es-too-DYAR*]
@@ -78,6 +83,7 @@ Three verbs, one pattern: *hablo, trabajo, estudio*. The singular regular
 - [YOU SAY: "estudiar" then English "student, studio" — the *studēre* "eagerness"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ESTUDIAR, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-ETYMON-STUDERE] -->
 
 [PAUSE 3s] What did *studēre* originally mean? ("To be eager / apply oneself.")
 Its English cousins? (Student, studio, studious.) Say "I study" — and notice it

--- a/code/learning/human-languages/spanish/lessons/ES-C06-hablar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-hablar.md
@@ -19,7 +19,7 @@ requires:
 introduces:
   knowledge: [ES-LEX-HABLAR, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-GRAMMAR-PRO-DROP, ES-SOUND-F-TO-H, ES-ETYMON-FABULARI]
 practises:
-  knowledge: [ES-LEX-HABLAR, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-GRAMMAR-PRO-DROP, ES-SOUND-F-TO-H]
+  knowledge: [ES-LEX-HABLAR, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-GRAMMAR-PRO-DROP, ES-SOUND-F-TO-H, ES-ETYMON-FABULARI]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal, presentational]
 strands: [meaning-input, meaning-output, language-focus]
@@ -31,18 +31,21 @@ reviews_of: [ES-C06-por-favor]
 # hablar — "to speak," and the engine of Spanish sentences
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Fixed phrases got you this far. **Hablar** (“to speak”) gives you a
 reusable singular **-ar** pattern. One ending swap says “I speak,” asks a
 friend, or addresses someone formally.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[ES-SOUND-F-TO-H]; assesses=[] -->
 
 - `silent-h` — the **h is completely silent**: *hablar* = *ah-BLAR*. (Spanish *h*
   never makes a sound.)
 - `v-b` — the *b* is a soft *b*; *hablo* = *AH-bloh*.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[ES-LEX-HABLAR, ES-ETYMON-FABULARI]; assesses=[] -->
 
 **hablar** comes from Latin **fābulārī**, *"to chat, to tell tales"* — from
 **fābula**, "a story." So to *speak*, in Spanish, is at root to *tell stories*.
@@ -55,6 +58,7 @@ is **fābulārī → hablar**; later words will let you test how broadly the sam
 historical pattern reaches.
 
 ## Grammar Lens: the -ar present tense (the big one)
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-GRAMMAR-PRO-DROP]; assesses=[] -->
 
 **Hablar** belongs to the **-ar** family. To conjugate the three singular
 forms you need now, **drop -ar** and add the ending for the person:
@@ -72,6 +76,7 @@ pronoun unstated. That is **pro-drop**: *hablo* is a complete “I speak.”
 verbs straight into it.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HABLAR, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-GRAMMAR-PRO-DROP, ES-SOUND-F-TO-H, ES-ETYMON-FABULARI] -->
 
 [PAUSE 1s]
 - [YOU SAY: "hablar" — *ah-BLAR*, silent *h*]
@@ -79,6 +84,7 @@ verbs straight into it.
 - [YOU SAY: "hablar" then English "fable, fabulous, ineffable" — the *fābula* root]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HABLAR, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-GRAMMAR-PRO-DROP, ES-SOUND-F-TO-H, ES-ETYMON-FABULARI] -->
 
 [PAUSE 3s] What Latin word is *hablar* from, and what English word shares it?
 (*fābulārī* ← *fābula* — fable.) What happened to its initial Latin *f-*?

--- a/code/learning/human-languages/spanish/lessons/ES-C06-por-favor.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-por-favor.md
@@ -19,7 +19,7 @@ requires:
 introduces:
   knowledge: [ES-LEX-POR-FAVOR, ES-PRAGMATICS-POLITE-REQUEST, ES-ETYMON-PRO-FAVOR]
 practises:
-  knowledge: [ES-LEX-CAFE, ES-LEX-POR-FAVOR, ES-LEX-GRACIAS, ES-LEX-DE-NADA]
+  knowledge: [ES-LEX-CAFE, ES-LEX-POR-FAVOR, ES-LEX-GRACIAS, ES-LEX-DE-NADA, ES-PRAGMATICS-POLITE-REQUEST, ES-ETYMON-PRO-FAVOR]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
@@ -31,12 +31,14 @@ reviews_of: [ES-C04-gracias, ES-C04-de-nada]
 # por favor — "please," i.e. "for a favour"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You can already thank (*gracias*) and reply (*de nada*). The third
 courtesy completes the set: **por favor**, "please" — literally *"for [a]
 favour."* You're asking someone to do you a kindness.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - `r-tap` — one soft tapped *r* in *por* and *favor*.
 - `v-b` — Spanish *v* and *b* sound **identical** (a soft *b*): *favor* ≈
@@ -44,6 +46,7 @@ favour."* You're asking someone to do you a kindness.
   like the *b* you'd hear in "harbour.")
 
 ## The word, taken apart — the phrase
+<!-- hl-knowledge: introduces=[ES-LEX-POR-FAVOR, ES-ETYMON-PRO-FAVOR]; assesses=[] -->
 
 - **por** = "for / through / by," from Latin **prō** ("for, on behalf of") — the
   same *pro-* in English **pro**noun, **pro**pose, **pro**tect.
@@ -56,6 +59,7 @@ to me.* English **favour**, **favorite**, and **favorable** keep the same
 Latin family visible without asking you to learn another language's formula.
 
 ## Grammar Lens: the courtesy set is complete
+<!-- hl-knowledge: introduces=[ES-PRAGMATICS-POLITE-REQUEST]; assesses=[] -->
 
 You now hold the three pillars of politeness:
 
@@ -64,6 +68,7 @@ You now hold the three pillars of politeness:
 - **de nada** — you're welcome (replying).
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CAFE, ES-LEX-POR-FAVOR, ES-LEX-GRACIAS, ES-LEX-DE-NADA, ES-PRAGMATICS-POLITE-REQUEST, ES-ETYMON-PRO-FAVOR] -->
 
 [PAUSE 1s]
 - [YOU SAY: "por favor" — *por fah-BOR*, soft *v/b*]
@@ -71,6 +76,7 @@ You now hold the three pillars of politeness:
 - [YOU SAY: "favor" then English "favour, favorite" — one family]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CAFE, ES-LEX-POR-FAVOR, ES-LEX-GRACIAS, ES-LEX-DE-NADA, ES-PRAGMATICS-POLITE-REQUEST, ES-ETYMON-PRO-FAVOR] -->
 
 [PAUSE 3s] What does *por favor* literally mean? ("For a favour.") What Latin
 verb is *favor* from, and its English cousins? (*favēre* — favour, favorite,

--- a/code/learning/human-languages/spanish/lessons/ES-C06-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-practice.md
@@ -18,7 +18,7 @@ requires:
 introduces:
   knowledge: []
 practises:
-  knowledge: [ES-LEX-CAFE, ES-LEX-POR-FAVOR, ES-LEX-HABLAR, ES-LEX-TRABAJAR, ES-LEX-ESTUDIAR, ES-LEX-HABLO-ESPANOL, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-GRAMMAR-PRO-DROP, ES-LEX-GRACIAS, ES-LEX-DE-NADA]
+  knowledge: [ES-LEX-CAFE, ES-LEX-POR-FAVOR, ES-LEX-HABLAR, ES-LEX-TRABAJAR, ES-LEX-ESTUDIAR, ES-LEX-ESPANOL, ES-LEX-HABLO-ESPANOL, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-GRAMMAR-PRO-DROP, ES-LEX-GRACIAS, ES-LEX-DE-NADA]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal, presentational]
 strands: [meaning-input, meaning-output, language-focus, fluency]
@@ -30,12 +30,14 @@ reviews_of: [ES-C06-hablar, ES-C06-trabajar, ES-C06-estudiar, ES-C06-espanol, ES
 # Practice — making sentences with -ar verbs
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] A milestone chapter: for the first time you're not reciting fixed
 phrases, you're **building sentences from a pattern**. Drill the three verbs
 through the endings until *hablo / hablas / habla* is automatic.
 
 ## Grammar Lens: conjugate on command
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 1s] Run each verb through the three singular jobs you know: the ending
 alone for **I** → **tú** → **usted**:
@@ -48,12 +50,14 @@ Same three endings (**-o / -as / -a**) every time — that's the whole regular
 **-ar** present, singular.
 
 ## The exchange — say something real
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 > — ¿**Hablas** español? — **Hablo español.**
 > — ¿**Estudias** español? — **Estudio español.**
 > — **Café, por favor.** — ¡Gracias! — De nada.
 
 ## What you've built this chapter
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - **por favor** — please (← "for a favour"), completing gracias / de nada / por
   favor.
@@ -64,6 +68,7 @@ Same three endings (**-o / -as / -a**) every time — that's the whole regular
 - **Hablo español** — your first self-assembled sentence (pro-drop, no article).
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CAFE, ES-LEX-POR-FAVOR, ES-LEX-HABLAR, ES-LEX-TRABAJAR, ES-LEX-ESTUDIAR, ES-LEX-ESPANOL, ES-LEX-HABLO-ESPANOL, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-GRAMMAR-PRO-DROP, ES-LEX-GRACIAS, ES-LEX-DE-NADA] -->
 
 [PAUSE 1s]
 - [YOU SAY: conjugate all three verbs for I / tú / usted, without stopping]
@@ -73,10 +78,11 @@ Same three endings (**-o / -as / -a**) every time — that's the whole regular
 [REPEAT x2] Ask and answer “¿Hablas español? — Hablo español.”
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CAFE, ES-LEX-POR-FAVOR, ES-LEX-HABLAR, ES-LEX-TRABAJAR, ES-LEX-ESTUDIAR, ES-LEX-ESPANOL, ES-LEX-HABLO-ESPANOL, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-GRAMMAR-PRO-DROP, ES-LEX-GRACIAS, ES-LEX-DE-NADA] -->
 
 [PAUSE 3s] What are the three singular *-ar* endings? (*-o / -as / -a*.) Give the
 “I” form of all three verbs. (*Hablo, trabajo, estudio*.) Why does *Hablo
 español* need no separate subject word? (The *-o* carries “I.”) You can now
 generate sentences — the course stops
-handing you phrases and starts handing you *rules*. Next chapter: the *-er/-ir*
-verbs, and questions with *qué / dónde*.
+handing you phrases and starts handing you *rules*. Next chapter adds the
+*-er/-ir* verb families.

--- a/code/learning/human-languages/spanish/lessons/ES-C06-trabajar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-trabajar.md
@@ -19,7 +19,7 @@ requires:
 introduces:
   knowledge: [ES-LEX-TRABAJAR, ES-ETYMON-TRIPALIUM]
 practises:
-  knowledge: [ES-LEX-TRABAJAR, ES-GRAMMAR-AR-PRESENT-SINGULAR]
+  knowledge: [ES-LEX-TRABAJAR, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-ETYMON-TRIPALIUM]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal, presentational]
 strands: [meaning-input, meaning-output, language-focus]
@@ -31,18 +31,21 @@ reviews_of: [ES-C06-hablar]
 # trabajar — "to work," and it once meant *torture*
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] A second **-ar** verb — snap it into the exact template you just
 learned. And *trabajar* has the darkest, best etymology in this chapter: it began
 as a word for **torture**, and it's the secret origin of English **travel**.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 - `j-jota` — the **j** is a raspy *h*-from-the-throat (the *jota*): *trabajar* =
   *tra-ba-**HAR***.
 - `r-tap`, `b-soft` — tapped *r*, soft *b*.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[ES-LEX-TRABAJAR, ES-ETYMON-TRIPALIUM]; assesses=[] -->
 
 **trabajar** comes from Vulgar Latin **tripaliāre**, *"to torture"* — from
 **tripalium**, a Roman instrument of torture made of **three stakes** (*tri-*
@@ -61,6 +64,7 @@ So even plain **trabajo**, “I work,” hides the old idea of toil as torment �
 dark little joke inside an everyday verb.
 
 ## Grammar Lens: same -ar template
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 Drop **-ar**, add the ending — identical to *hablar*:
 
@@ -74,6 +78,7 @@ Notice you didn't learn a new ending — that's the point. **One template, every
 regular -ar verb.**
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-TRABAJAR, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-ETYMON-TRIPALIUM] -->
 
 [PAUSE 1s]
 - [YOU SAY: "trabajar" — *tra-ba-HAR*, raspy *j*]
@@ -81,6 +86,7 @@ regular -ar verb.**
 - [YOU SAY: "trabajar" → travail → travel — torture became a journey]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-TRABAJAR, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-ETYMON-TRIPALIUM] -->
 
 [PAUSE 3s] What did *trabajar* originally mean, and from what device? ("To
 torture," ← *tripalium*, a three-stake tool.) What two English words come from

--- a/code/learning/human-languages/spanish/lessons/ES-W01-acento.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W01-acento.md
@@ -29,6 +29,7 @@ reviews_of: [ES-C03-como, ES-C04-regular]
 # á é í ó ú — the acute accent, and the two jobs it does
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You've been reading accented words since your very first noun —
 **dí**a, **có**mo, es**tá**, **má**s. Time to make that little stroke make
@@ -37,6 +38,7 @@ sense. Spanish uses one mark to write exceptional stress — the *acute* accent,
 stress job now; the next lesson adds its grammar-label job.
 
 ## Script — shape and stroke
+<!-- hl-knowledge: introduces=[ES-SCRIPT-ACUTE-ACCENT]; assesses=[] -->
 
 A short stroke rising **left-to-right**, sitting on top of a vowel:
 **á é í ó ú**. (On the *í*, it replaces the dot.) One clean up-stroke — the
@@ -44,6 +46,7 @@ opposite lean from the French *grave* accent `à`. Spanish never uses grave or
 circumflex; if it leans the wrong way, it isn't Spanish.
 
 ## Grammar Lens: the mark records exceptional stress
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-DEFAULT-STRESS, ES-GRAMMAR-STRESS-EXCEPTION]; assesses=[] -->
 
 Spanish stress is regular, so most words need **no** mark. The default:
 
@@ -59,6 +62,7 @@ is stressed *CÓ-mo*, so it gets the mark. The accent is a **spoken stress you
 can see** — it never changes the vowel's sound, only which syllable you hit.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-SCRIPT-ACUTE-ACCENT, ES-GRAMMAR-DEFAULT-STRESS, ES-GRAMMAR-STRESS-EXCEPTION] -->
 
 [PAUSE 1s]
 - [YOU SAY: “hola, llamo, gusto” — second-to-last stress]
@@ -66,6 +70,7 @@ can see** — it never changes the vowel's sound, only which syllable you hit.
 - [YOU SAY: "está, cómo" — the accent overrides the default]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-SCRIPT-ACUTE-ACCENT, ES-GRAMMAR-DEFAULT-STRESS, ES-GRAMMAR-STRESS-EXCEPTION] -->
 
 [PAUSE 3s] How many accent marks does Spanish have, and which way does it lean?
 (One — the acute, `´`, rising left-to-right.) Its two jobs? (Mark irregular

--- a/code/learning/human-languages/spanish/lessons/ES-W01-tilde-diacritica.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W01-tilde-diacritica.md
@@ -29,11 +29,13 @@ reviews_of: [ES-W01-acento, ES-C03-como, ES-C03-tu-usted]
 # el or él? — the accent as a meaning label
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You know **el** as the article “the.” Add one acute accent and the
 same two letters do a different job.
 
 ## Grammar Lens: one mark, two grammatical jobs
+<!-- hl-knowledge: introduces=[ES-LEX-EL-PRONOUN, ES-GRAMMAR-DIACRITIC-ACCENT]; assesses=[] -->
 
 The **tilde diacrítica** separates words that otherwise look alike:
 
@@ -46,6 +48,7 @@ labels meaning and grammar. Other pairs will arrive only when you know both
 words, so this lesson asks you to hold one contrast, not memorize a list.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-DEFINITE-ARTICLES, ES-LEX-EL-PRONOUN, ES-GRAMMAR-DIACRITIC-ACCENT] -->
 
 [PAUSE 1s]
 - [YOU SAY: “el” — the]
@@ -53,6 +56,7 @@ words, so this lesson asks you to hold one contrast, not memorize a list.
 - [YOU WRITE: **el / él**, adding the meaning-label accent only to the pronoun]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-DEFINITE-ARTICLES, ES-LEX-EL-PRONOUN, ES-GRAMMAR-DIACRITIC-ACCENT] -->
 
 [PAUSE 3s] What is the accent's second job? (**Separate look-alike words.**)
 Which means “the”? (**El**, no accent.) Which means “he”? (**Él**, with the

--- a/code/learning/human-languages/spanish/lessons/ES-W02-enye.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W02-enye.md
@@ -29,6 +29,7 @@ reviews_of: [ES-W01-tilde-diacritica, ES-W01-acento]
 # ñ — the letter that remembers a doubled n
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] **ñ** is the one letter English doesn't have — and it has the best
 origin story in the alphabet. That wavy hat (`~`, a *tilde*) is not decoration.
@@ -36,6 +37,7 @@ It is **a tiny second *n*, written on top to save space.** Once you know that,
 you know both how to write it *and* why it sounds the way it does.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[ES-SOUND-ENYE]; assesses=[] -->
 
 **ñ** = the *ny* in "ca**ny**on" or "o**ni**on" — one squished sound, tongue
 flat against the roof of the mouth. English *canyon* is, in fact, Spanish
@@ -43,6 +45,7 @@ flat against the roof of the mouth. English *canyon* is, in fact, Spanish
 that's ñ.
 
 ## Script — how to write it, and where the hat came from
+<!-- hl-knowledge: introduces=[ES-SCRIPT-ENYE, ES-FORM-MANANA, ES-FORM-ESPANOL, ES-ETYMON-DOUBLE-N]; assesses=[] -->
 
 Write a normal **n**, then a small wavy **~** floating above it. That wave is a
 **medieval shorthand**. Scribes copying Latin were forever writing double
@@ -66,6 +69,7 @@ shortcut.
 > is not optional flourish, it's a distinct letter of the alphabet.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-SCRIPT-ENYE, ES-SOUND-ENYE, ES-FORM-MANANA, ES-FORM-ESPANOL] -->
 
 [PAUSE 1s]
 - [YOU SAY: "año" — *AH-nyo*, one squished *ny*; then English "annual" — same
@@ -73,6 +77,7 @@ shortcut.
 - [YOU SAY: “año, mañana, español” — the ñ in three forms from this lesson]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-SCRIPT-ENYE, ES-SOUND-ENYE, ES-FORM-MANANA, ES-FORM-ESPANOL] -->
 
 [PAUSE 3s] What is the tilde on *ñ*, really? (A tiny second *n* — a scribe's
 shorthand for a doubled *nn*.) What Latin word gives *año*, and what English

--- a/code/learning/human-languages/spanish/lessons/ES-W03-inverted.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W03-inverted.md
@@ -29,6 +29,7 @@ reviews_of: [ES-C04-como-estas-register, ES-C04-como-esta, ES-W01-acento]
 # ¿ ¡ — the marks that open a question
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You've been writing them since *¿cómo está usted?* Spanish is the one
 major language that puts an **upside-down** question or exclamation mark at the
@@ -36,6 +37,7 @@ major language that puts an **upside-down** question or exclamation mark at the
 the reason is purely practical.
 
 ## Script — the two opening marks
+<!-- hl-knowledge: introduces=[ES-SCRIPT-INVERTED-EXCLAMATION, ES-ORTHOGRAPHY-OPENING-PUNCTUATION]; assesses=[] -->
 
 - **¿ … ?** wraps a question: *¿Cómo estás?*
 - **¡ … !** wraps an exclamation: *¡Hola!* *¡Gracias!*
@@ -45,6 +47,7 @@ The opening mark is just the closing mark **flipped 180°** — turned upside do
 the hook ends up at the bottom, the dot on top.
 
 ## Why it's said this way — the opening mark is an early cue
+<!-- hl-knowledge: introduces=[ES-HISTORY-RAE-INVERTED-MARKS]; assesses=[] -->
 
 English lets you read most of a sentence before the final **?** reveals it was a
 question — fine, because English usually flags a question early with word order
@@ -59,6 +62,7 @@ same instinct as the written accent marking stress you can't otherwise see. For
 a language read aloud, it's genuinely useful.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-SCRIPT-INVERTED-QUESTION, ES-SCRIPT-INVERTED-EXCLAMATION, ES-ORTHOGRAPHY-OPENING-PUNCTUATION] -->
 
 [PAUSE 1s]
 - [YOU SAY: read "¿Cómo estás?" — start the rising *question* melody from the
@@ -66,6 +70,7 @@ a language read aloud, it's genuinely useful.
 - [YOU SAY: "¡Hola!" — the ¡ warns you to begin with exclamation energy]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-SCRIPT-INVERTED-QUESTION, ES-SCRIPT-INVERTED-EXCLAMATION, ES-ORTHOGRAPHY-OPENING-PUNCTUATION] -->
 
 [PAUSE 3s] Why does Spanish open a question with **¿**? (Because word order often
 doesn't change, so the reader needs an early warning to use question

--- a/code/learning/human-languages/spanish/lessons/ES-W03-question-span.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W03-question-span.md
@@ -29,11 +29,13 @@ reviews_of: [ES-W03-inverted, ES-W01-tilde-diacritica]
 # Where does ¿ begin? — bracket the spoken span
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You can open a whole question with **¿**. Now place that mark
 inside a larger sentence, exactly where the questioning voice begins.
 
 ## Script — bracket the spoken span
+<!-- hl-knowledge: introduces=[ES-ORTHOGRAPHY-PUNCTUATION-SPAN]; assesses=[] -->
 
 The opening mark goes where the **question** begins, even if the sentence
 started earlier:
@@ -49,6 +51,7 @@ This is why the opening mark is more than decoration. It tells the reader
 exactly where to begin and end a change in spoken melody.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-ORTHOGRAPHY-PUNCTUATION-SPAN, ES-SCRIPT-INVERTED-QUESTION, ES-SCRIPT-INVERTED-EXCLAMATION] -->
 
 [PAUSE 1s]
 - [YOU WRITE: “María, ¿cómo estás?”]
@@ -56,6 +59,7 @@ exactly where to begin and end a change in spoken melody.
 - [YOU SAY: begin the new melody at ¿ or ¡, not at the first capital]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-ORTHOGRAPHY-PUNCTUATION-SPAN, ES-SCRIPT-INVERTED-QUESTION, ES-SCRIPT-INVERTED-EXCLAMATION] -->
 
 [PAUSE 3s] In **Roberto, ¿cómo estás?**, is **Roberto** inside the
 question? (**No.**) Where does the inverted mark go? (**At the start of the

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added — block-boundary knowledge closure
+
+- Parse canonical `hl-knowledge` directives beside every schema-v2 body block
+  while excluding the metadata from learner-facing Markdown.
+- Validate introductions and assessments in rendered order, reject undeclared or
+  unavailable prompt knowledge, and require production and recall blocks to name
+  what they assess.
+- Migrate all 51 Spanish Chapters 1–6 lessons to the fail-closed block contract
+  and refresh their shared app/book source hashes.
+
 ### Added — canonical LaTeX chapter generation
 
 - Added deterministic lesson-AST fingerprints and a pure Markdown-block to

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -105,7 +105,11 @@ For a lesson declaring `schema_version: 2`, `validateCurriculum()` additionally
 enforces its canonical spine node, unique per-language sequence, 1–299 second
 declared and computed duration, stable typed body sections, explicit
 skill/mode/strand/register/variety metadata, same-language prerequisites, and
-transitive knowledge closure. Schema-v1 tracks remain readable during migration.
+transitive knowledge closure. Each typed block must also author an
+`hl-knowledge` directive. Block introductions must exactly account for the
+lesson's introduced atoms; production and recall assessments must be declared by
+the lesson and available from transitive prerequisites or an earlier block.
+Schema-v1 tracks remain readable during migration.
 
 ## Scope note
 

--- a/code/packages/typescript/human-language-data/src/curriculum.ts
+++ b/code/packages/typescript/human-language-data/src/curriculum.ts
@@ -370,6 +370,92 @@ export function validateCurriculum(input: CurriculumValidationInput): Issue[] {
         );
       }
     }
+
+    const lessonIntroduces = new Set(stringList(lesson.frontmatter["introduces.knowledge"]));
+    const lessonPractises = new Set(stringList(lesson.frontmatter["practises.knowledge"]));
+    const blockFrontier = new Set(known);
+    const introducedInBlocks = new Set<string>();
+    const assessedInBlocks = new Set<string>();
+    for (const block of lesson.blocks) {
+      if (block.knowledgeDirectiveError) {
+        error(
+          "schema-v2-invalid-block-knowledge",
+          `${id}: block '${block.title}' ${block.knowledgeDirectiveError}`,
+        );
+        continue;
+      }
+      if (!block.knowledge) {
+        error(
+          "schema-v2-missing-block-knowledge",
+          `${id}: block '${block.title}' must declare block-boundary knowledge`,
+        );
+        continue;
+      }
+      for (const atom of [...block.knowledge.introduces, ...block.knowledge.assesses]) {
+        if (!KNOWLEDGE_ATOM.test(atom)) {
+          error(
+            "schema-v2-invalid-block-knowledge-atom",
+            `${id}: block '${block.title}' contains invalid knowledge atom '${atom}'`,
+          );
+        }
+      }
+      for (const atom of block.knowledge.assesses) {
+        assessedInBlocks.add(atom);
+        if (!lessonPractises.has(atom)) {
+          error(
+            "schema-v2-block-undeclared-assessment",
+            `${id}: block '${block.title}' assesses '${atom}' without declaring it in practises.knowledge`,
+          );
+        }
+        if (!blockFrontier.has(atom)) {
+          error(
+            "schema-v2-block-knowledge-not-closed",
+            `${id}: block '${block.title}' assesses '${atom}' before it is available`,
+          );
+        }
+      }
+      if (
+        (block.type === "guided-production" || block.type === "recall") &&
+        block.knowledge.assesses.length === 0
+      ) {
+        error(
+          "schema-v2-empty-block-assessment",
+          `${id}: ${block.type} block '${block.title}' must declare assessed knowledge`,
+        );
+      }
+      for (const atom of block.knowledge.introduces) {
+        if (!lessonIntroduces.has(atom)) {
+          error(
+            "schema-v2-block-undeclared-introduction",
+            `${id}: block '${block.title}' introduces '${atom}' without declaring it in introduces.knowledge`,
+          );
+        }
+        if (introducedInBlocks.has(atom)) {
+          error(
+            "schema-v2-duplicate-block-introduction",
+            `${id}: '${atom}' is introduced by more than one body block`,
+          );
+        }
+        introducedInBlocks.add(atom);
+        blockFrontier.add(atom);
+      }
+    }
+    for (const atom of lessonIntroduces) {
+      if (!introducedInBlocks.has(atom)) {
+        error(
+          "schema-v2-block-introduction-missing",
+          `${id}: introduced atom '${atom}' has no body-block introduction`,
+        );
+      }
+    }
+    for (const atom of lessonPractises) {
+      if (!assessedInBlocks.has(atom)) {
+        error(
+          "schema-v2-block-assessment-missing",
+          `${id}: practised atom '${atom}' is not assessed by any body block`,
+        );
+      }
+    }
   }
 
   const spineConcepts = new Set(conceptOwner.keys());

--- a/code/packages/typescript/human-language-data/src/parse.ts
+++ b/code/packages/typescript/human-language-data/src/parse.ts
@@ -11,6 +11,7 @@ import type {
   Dataset,
   Gender,
   LessonBodyBlock,
+  LessonBlockKnowledge,
   LessonBlockType,
   Realization,
   Script,
@@ -65,6 +66,49 @@ function classifyBlock(title: string): LessonBlockType {
   return "unknown";
 }
 
+const KNOWLEDGE_DIRECTIVE =
+  /^<!--\s*hl-knowledge:\s*introduces=\[([^\]]*)\];\s*assesses=\[([^\]]*)\]\s*-->$/;
+
+function directiveList(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item !== "");
+}
+
+function parseBlockKnowledge(markdown: string): {
+  markdown: string;
+  knowledge?: LessonBlockKnowledge;
+  knowledgeDirectiveError?: string;
+} {
+  const lines = markdown.split("\n");
+  const directiveIndexes = lines
+    .map((line, index) => (line.includes("hl-knowledge") ? index : -1))
+    .filter((index) => index >= 0);
+  if (directiveIndexes.length === 0) return { markdown };
+
+  const firstContent = lines.findIndex((line) => line.trim() !== "");
+  const directiveIndex = directiveIndexes[0] ?? -1;
+  const directive = lines[directiveIndex]?.trim() ?? "";
+  const match = KNOWLEDGE_DIRECTIVE.exec(directive);
+  if (directiveIndexes.length !== 1 || directiveIndex !== firstContent || !match) {
+    return {
+      markdown,
+      knowledgeDirectiveError:
+        "expected one first-line '<!-- hl-knowledge: introduces=[...]; assesses=[...] -->' directive",
+    };
+  }
+
+  lines.splice(directiveIndex, 1);
+  return {
+    markdown: lines.join("\n").replace(/^\n|\n$/g, ""),
+    knowledge: {
+      introduces: directiveList(match[1] ?? ""),
+      assesses: directiveList(match[2] ?? ""),
+    },
+  };
+}
+
 /** Parse level-two lesson sections into the stable HL04 body-block vocabulary. */
 export function parseBodyBlocks(body: string): {
   preamble: string;
@@ -77,7 +121,14 @@ export function parseBodyBlocks(body: string): {
   const blockLines: string[] = [];
   const finish = (): void => {
     if (!current) return;
-    current.markdown = blockLines.join("\n").replace(/^\n|\n$/g, "");
+    const parsedKnowledge = parseBlockKnowledge(
+      blockLines.join("\n").replace(/^\n|\n$/g, ""),
+    );
+    current.markdown = parsedKnowledge.markdown;
+    current.knowledge = parsedKnowledge.knowledge;
+    current.knowledgeDirectiveError = parsedKnowledge.knowledgeDirectiveError;
+    if (current.knowledge === undefined) delete current.knowledge;
+    if (current.knowledgeDirectiveError === undefined) delete current.knowledgeDirectiveError;
     blocks.push(current);
     blockLines.length = 0;
   };

--- a/code/packages/typescript/human-language-data/src/types.ts
+++ b/code/packages/typescript/human-language-data/src/types.ts
@@ -150,12 +150,29 @@ export type LessonBlockType =
   | "recall"
   | "unknown";
 
+/**
+ * Knowledge made available or assessed at one lesson-body boundary.
+ *
+ * Schema-v2 authors place this metadata in the first line after a level-two
+ * heading. Keeping it beside the prose lets the validator follow the same
+ * order that the book and app render instead of treating every lesson-level
+ * introduction as if it were available from the opening sentence.
+ */
+export interface LessonBlockKnowledge {
+  introduces: string[];
+  assesses: string[];
+}
+
 export interface LessonBodyBlock {
   type: LessonBlockType;
   /** Original level-two heading, kept for book/app presentation. */
   title: string;
-  /** Lossless Markdown between this heading and the next typed block. */
+  /** Display Markdown between headings, excluding the parsed metadata directive. */
   markdown: string;
+  /** Authored `hl-knowledge` directive, omitted by legacy lesson bodies. */
+  knowledge?: LessonBlockKnowledge;
+  /** Present when an author attempted a directive whose shape is invalid. */
+  knowledgeDirectiveError?: string;
 }
 
 // ---- Script / character-breakdown data (data/scripts/<script>.json) ----

--- a/code/packages/typescript/human-language-data/tests/curriculum.test.ts
+++ b/code/packages/typescript/human-language-data/tests/curriculum.test.ts
@@ -68,14 +68,22 @@ reviews_of: []
 # A real body
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 Recall what you know.
 
+## You'll want to know
+<!-- hl-knowledge: introduces=[${introduces.join(", ")}]; assesses=[] -->
+
+Meet the new material.
+
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[${practises.join(", ")}] -->
 
 Say hello.
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[${practises.join(", ")}] -->
 
 Say hello once.
 `;
@@ -145,6 +153,108 @@ describe("schema-v2 lesson validation", () => {
     const codes = validateCurriculum({ registry, taxonomy, spine, lessons }).map((issue) => issue.code);
     expect(codes).toContain("schema-v2-knowledge-not-closed");
     expect(codes).toContain("schema-v2-practice-before-introduction");
+  });
+
+  it("rejects block assessments before their atoms reach the block frontier", () => {
+    const premature = sourceV2(
+      "A",
+      10,
+      [],
+      [],
+      ["TEST-LEX-HELLO"],
+      ["TEST-LEX-HELLO"],
+    ).replace(
+      "<!-- hl-knowledge: introduces=[]; assesses=[] -->",
+      "<!-- hl-knowledge: introduces=[]; assesses=[TEST-LEX-HELLO] -->",
+    );
+    const codes = validateCurriculum({
+      registry,
+      taxonomy,
+      spine,
+      lessons: [parseLesson(premature, "test")],
+    }).map((issue) => issue.code);
+    expect(codes).toContain("schema-v2-block-knowledge-not-closed");
+  });
+
+  it("rejects assessed atoms omitted from lesson-level practice declarations", () => {
+    const undeclared = sourceV2("A", 10, [], [], ["TEST-LEX-HELLO"], ["TEST-LEX-HELLO"])
+      .replace(
+        "assesses=[TEST-LEX-HELLO]",
+        "assesses=[TEST-LEX-HELLO, TEST-LEX-UNDECLARED]",
+      );
+    const codes = validateCurriculum({
+      registry,
+      taxonomy,
+      spine,
+      lessons: [parseLesson(undeclared, "test")],
+    }).map((issue) => issue.code);
+    expect(codes).toContain("schema-v2-block-undeclared-assessment");
+    expect(codes).toContain("schema-v2-block-knowledge-not-closed");
+  });
+
+  it("requires every schema-v2 body block to declare its knowledge boundary", () => {
+    const missing = sourceV2("A", 10, [], [], ["TEST-LEX-HELLO"], ["TEST-LEX-HELLO"])
+      .replace("<!-- hl-knowledge: introduces=[]; assesses=[] -->\n", "");
+    expect(validateCurriculum({
+      registry,
+      taxonomy,
+      spine,
+      lessons: [parseLesson(missing, "test")],
+    }).map((issue) => issue.code)).toContain("schema-v2-missing-block-knowledge");
+  });
+
+  it("requires production and recall blocks to name what they assess", () => {
+    const empty = sourceV2("A", 10, [], [], ["TEST-LEX-HELLO"], ["TEST-LEX-HELLO"])
+      .replaceAll("assesses=[TEST-LEX-HELLO]", "assesses=[]");
+    const codes = validateCurriculum({
+      registry,
+      taxonomy,
+      spine,
+      lessons: [parseLesson(empty, "test")],
+    }).map((issue) => issue.code);
+    expect(codes).toContain("schema-v2-empty-block-assessment");
+    expect(codes).toContain("schema-v2-block-assessment-missing");
+  });
+
+  it("requires block introductions to exactly account for lesson introductions", () => {
+    const base = sourceV2("A", 10, [], [], ["TEST-LEX-HELLO"], ["TEST-LEX-HELLO"]);
+    const missing = base.replace(
+      "introduces=[TEST-LEX-HELLO]",
+      "introduces=[]",
+    );
+    expect(validateCurriculum({
+      registry,
+      taxonomy,
+      spine,
+      lessons: [parseLesson(missing, "test")],
+    }).map((issue) => issue.code)).toContain("schema-v2-block-introduction-missing");
+
+    const undeclaredAndDuplicate = base.replace(
+      "introduces=[]; assesses=[]",
+      "introduces=[TEST-LEX-HELLO, TEST-LEX-UNDECLARED]; assesses=[]",
+    );
+    const codes = validateCurriculum({
+      registry,
+      taxonomy,
+      spine,
+      lessons: [parseLesson(undeclaredAndDuplicate, "test")],
+    }).map((issue) => issue.code);
+    expect(codes).toContain("schema-v2-block-undeclared-introduction");
+    expect(codes).toContain("schema-v2-duplicate-block-introduction");
+  });
+
+  it("rejects a malformed authored block-knowledge directive", () => {
+    const malformed = sourceV2("A", 10, [], [], ["TEST-LEX-HELLO"], ["TEST-LEX-HELLO"])
+      .replace(
+        "<!-- hl-knowledge: introduces=[]; assesses=[] -->",
+        "<!-- hl-knowledge: assesses=[] -->",
+      );
+    expect(validateCurriculum({
+      registry,
+      taxonomy,
+      spine,
+      lessons: [parseLesson(malformed, "test")],
+    }).map((issue) => issue.code)).toContain("schema-v2-invalid-block-knowledge");
   });
 
   it("rejects malformed duration, coverage, sequence, and body blocks", () => {

--- a/code/packages/typescript/human-language-data/tests/parse.test.ts
+++ b/code/packages/typescript/human-language-data/tests/parse.test.ts
@@ -103,6 +103,35 @@ describe("parseLesson", () => {
       { type: "unknown", title: "A surprising section", markdown: "Keep me." },
     ]);
   });
+
+  it("parses block-boundary knowledge without rendering the directive", () => {
+    const parsed = parseBodyBlocks([
+      "## Guided Practice",
+      "<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HOLA, ES-SOUND-H-SILENT] -->",
+      "",
+      "Say *hola*.",
+    ].join("\n"));
+    expect(parsed.blocks).toEqual([{
+      type: "guided-production",
+      title: "Guided Practice",
+      markdown: "Say *hola*.",
+      knowledge: {
+        introduces: [],
+        assesses: ["ES-LEX-HOLA", "ES-SOUND-H-SILENT"],
+      },
+    }]);
+  });
+
+  it("preserves and flags a malformed or misplaced block knowledge directive", () => {
+    const [block] = parseBodyBlocks([
+      "## Guided Practice",
+      "Say *hola*.",
+      "<!-- hl-knowledge: assesses=[ES-LEX-HOLA] -->",
+    ].join("\n")).blocks;
+    expect(block?.knowledge).toBeUndefined();
+    expect(block?.knowledgeDirectiveError).toMatch(/expected one first-line/);
+    expect(block?.markdown).toContain("hl-knowledge");
+  });
 });
 
 describe("buildDataset", () => {

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased — schema-v2 lesson compatibility
 
+- Hide canonical `hl-knowledge` comments from learner-facing lesson sections;
+  the shared parser and source hash still retain their block-boundary meaning.
 - Keep the browser's lightweight dataset adapter compatible with the canonical
   typed lesson AST.
 - Derive the lesson-card minute label from schema-v2 `duration.max_seconds`,

--- a/code/programs/typescript/language-ladder/src/lessonbody.ts
+++ b/code/programs/typescript/language-ladder/src/lessonbody.ts
@@ -33,6 +33,7 @@ export function lessonSections(markdown: string): LessonSection[] {
   for (const raw of markdown.replace(/\r\n/g, "\n").split("\n")) {
     const line = raw.trim();
     if (/^#\s+/.test(line)) continue; // card already displays the lesson title
+    if (/^<!--\s*hl-knowledge:/.test(line)) continue; // canonical AST metadata, not learner copy
     const heading = /^##\s+(.+)$/.exec(line);
     if (heading) {
       flushSection();

--- a/code/programs/typescript/language-ladder/tests/lessonbody.test.ts
+++ b/code/programs/typescript/language-ladder/tests/lessonbody.test.ts
@@ -7,4 +7,15 @@ describe("lessonSections", () => {
       { title: "Notice", blocks: ["Read سلام.", "• Say salâm."] },
     ]);
   });
+
+  it("keeps block-boundary knowledge metadata out of learner copy", () => {
+    expect(lessonSections(`# Title
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HOLA] -->
+
+Say *hola*.`)).toEqual([
+      { title: "Guided Practice", blocks: ["Say hola."] },
+    ]);
+  });
 });

--- a/code/specs/HL04-shared-spine-and-content-pipeline.md
+++ b/code/specs/HL04-shared-spine-and-content-pipeline.md
@@ -211,11 +211,31 @@ sources: [rae-gracias, dle-gracia, de-vries-gratia]
 ---
 ```
 
+Each level-two body block begins with a compact metadata comment. The comment is
+part of the canonical AST and source hash, but renderers omit it from learner
+copy:
+
+```markdown
+## The word, taken apart
+<!-- hl-knowledge: introduces=[ES-LEX-GRACIAS-PRODUCTIVE]; assesses=[] -->
+
+**gracias** is the everyday way to say "thank you."
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-GRACIAS-PRODUCTIVE] -->
+
+- [YOU SAY: "gracias"]
+```
+
 The body is parsed into stable, named blocks: `warmup`, `input`, `notice`,
 `pronunciation`, `script`, `etymology`, `grammar`, `culture-pragmatics`,
 `guided-production`, `comprehension`, `fluency`, and `recall`. A block may declare
 prompts, accepted answers, feedback, and response time. The app and book render the
 same block; medium-specific presentation belongs in renderers, not a second copy.
+Every schema-v2 block authors both lists, including explicit empty lists. The
+union of block introductions must equal `introduces.knowledge`; every assessed
+atom must be declared in `practises.knowledge`; and guided-production and recall
+blocks must name at least one assessed atom.
 
 ### Knowledge closure
 
@@ -224,10 +244,13 @@ introduced by a transitive prerequisite. During the lesson, assessed material ma
 use only previously introduced atoms, atoms introduced earlier in this lesson, and
 transparent English instructions.
 
-The validator computes this set at every block boundary. Unknown atoms, cycles,
-forward references, and assessed undeclared forms are errors. Runtime scheduling
-fails closed and reports a curriculum defect; it never unlocks everything as a
-fallback.
+The validator computes this set at every block boundary. It checks assessments
+before adding that block's introductions, so a form must be established by a
+prerequisite or by an earlier block rather than introduced and tested in one
+opaque step. Unknown atoms, cycles, forward references, missing or malformed
+directives, undeclared assessments, and assessed unavailable forms are errors.
+Runtime scheduling fails closed and reports a curriculum defect; it never unlocks
+everything as a fallback.
 
 ### Five-minute contract
 


### PR DESCRIPTION
## Summary

- add canonical per-block `hl-knowledge` introduction and assessment declarations
- validate every schema-v2 block against the transitive knowledge frontier in rendered order
- migrate all 51 Spanish Chapters 1–6 lessons and remove early learner-facing forms found by the audit
- keep metadata out of generated LaTeX and Language Ladder learner copy
- record the next prompt-compilation and publication items in the shared backlog

## Validation

- human-language-data: 77 tests; 93.45% line coverage; generated-book drift check passes
- Language Ladder: 282 tests; 98.37% line coverage; production build passes (1,115 modules)
- curriculum report: 20 tracks, 1,065 lessons, 20 books, zero duration violations, zero unknown prerequisites
- Spanish XeLaTeX: 158 pages; changed-page render audit clean; generated Chapters 1–6 have no overfull or Hyperref warnings
- `git diff --check` passes