### PR TITLE
fix(html-parser): diagnose implied-shell end tags

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Stray paragraph end tags before the parser has implied the document body now
+  reuse the existing pre-body diagnostic, closing 4 previously silent malformed
+  corpus cases without changing DOM recovery.
 - The after-after-frameset insertion mode now reports unexpected character,
   start-tag, and end-tag tokens, closing 8 previously silent malformed corpus
   cases without changing DOM recovery.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -25,8 +25,8 @@ The 2026-08-02 upstream audit covered all 1,934 WPT tree-construction cases and
 all 6,806 html5lib tokenizer cases with zero missing signatures and zero
 normalized skips. DOM output is complete, but diagnostic coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the after-after-frameset diagnostic slice, 1,794 of those cases emit at
-least one lexer or parser diagnostic and 389 remain uncovered. Another 139
+After the implied-shell end-tag diagnostic slice, 1,798 of those cases emit at
+least one lexer or parser diagnostic and 385 remain uncovered. Another 139
 cases emit diagnostics despite having no legacy `#errors` rows. These are
 reviewed rather than automatically removed: 89 are full-document inputs for
 which the legacy fixtures omit the Standard-required missing-doctype error,
@@ -40,10 +40,10 @@ Prioritized work items:
    start-tag diagnostics, body/html end tags with disallowed open elements,
    full-document in-body EOF diagnostics, unexpected-token recovery in the
    after-body and after-after-body modes, and the implied-shell `</body>`
-   transition, and after-after-frameset unexpected-token diagnostics are
-   complete. The fresh 389-case inventory identifies stray end tags before an
-   implied root or body and rejected frameset starts as the remaining concrete
-   shell slices, in that order.
+   transition and after-after-frameset unexpected-token diagnostics are
+   complete. Stray paragraph end tags before an implied root or body are also
+   covered. The fresh 385-case inventory identifies rejected frameset starts
+   as the remaining concrete shell slice.
 2. **Fragment EOF diagnostics.** Audit the current in-body EOF rule against
    fragment parsing. Legacy fragment fixtures omit many EOF error rows, so add
    explicit current-WHATWG evidence before extending the full-document

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -6801,7 +6801,13 @@ impl HtmlParser {
             "p" if !self.has_open_element("p")
                 && !self.has_open_element("body")
                 && !self.document_has_body_element()
-                && !self.body_has_non_whitespace_child() => {}
+                && !self.body_has_non_whitespace_child() =>
+            {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-p-end-tag-before-body",
+                    "end tag `</p>` before body content was ignored",
+                ));
+            }
             "p" if self.current_parent_has_element_ancestor("button")
                 && !self.current_parent_has_element_in_button_scope("p") =>
             {
@@ -32939,6 +32945,21 @@ mod tests {
                 "end tag `</p>` before body content was ignored"
             )]
         );
+
+        for source in [
+            "<!doctype html><html></p><!--foo-->",
+            "<!doctype html><head></head></p><!--foo-->",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "unexpected-p-end-tag-before-body",
+                    "end tag `</p>` before body content was ignored"
+                )],
+                "source {source:?}"
+            );
+        }
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 389);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1794);
+    assert_eq!(missing_diagnostic_cases, 385);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1798);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report the existing pre-body parse diagnostic for stray `</p>` tokens before an implied document body
- preserve the established ignored-token DOM recovery and comment placement
- update the executable diagnostic ratchet and reprioritized conformance backlog

## Evidence
- preserves all 2,637 checked tree-construction DOM outputs
- reduces declared-error cases without diagnostics from 389 to 385
- raises covered declared-error cases from 1,794 to 1,798 while undeclared-diagnostic cases remain 139
- live upstream audit covers 1,934/1,934 WPT tree signatures and 6,806/6,806 html5lib tokenizer signatures with zero normalized skips

## Validation
- `cargo test -p coding-adventures-html-parser --test tree_construction_test`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- parser audit manifest, Rust-test, and coverage checks
- generated HTML fixture and README inventory checks
- live upstream WPT/html5lib coverage audit
- `git diff --check`
