### PR TITLE
fix(spice): lower parser MOS lateral diffusion

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject MOS model-card `LD` values that are non-finite, negative, or leave a
+  non-positive effective Level-1 channel length.
 - Reject negative and non-finite MOS model-card `RSH` values before lowering
   Level-1 sheet resistance.
 - Reject negative and non-finite MOS model-card `RS` values before lowering

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1918,6 +1918,17 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(params["L"]) or params["L"] <= 0.0
         ):
             raise NetlistParseError("MOSFET L must be finite and positive")
+        if "LD" in params:
+            length = params.get("L", Level1Params().L)
+            lateral_diffusion = params["LD"]
+            if (
+                not math.isfinite(lateral_diffusion)
+                or lateral_diffusion < 0.0
+                or length - 2.0 * lateral_diffusion <= 0.0
+            ):
+                raise NetlistParseError(
+                    "MOSFET LD must be finite and non-negative with L - 2*LD > 0"
+                )
         if "IS" in params and (
             not math.isfinite(params["IS"]) or params["IS"] <= 0.0
         ):

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1554,6 +1554,27 @@ def test_lowers_positive_mosfet_model_length() -> None:
     assert isclose(mosfet.model.model.params.L, 2.0e-6)
 
 
+@pytest.mark.parametrize("parameters", ["LD=-1n", "LD=1e999", "L=100n LD=50n"])
+def test_rejects_invalid_mosfet_model_lateral_diffusion(parameters: str) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match=r"MOSFET LD must be finite and non-negative with L - 2\*LD > 0",
+    ):
+        parse_netlist(f".model nfast NMOS({parameters})\nM1 d g s b nfast\n")
+
+
+@pytest.mark.parametrize("lateral_diffusion", ["0", "10n"])
+def test_lowers_valid_mosfet_model_lateral_diffusion(
+    lateral_diffusion: str,
+) -> None:
+    parsed = parse_netlist(
+        f".model nfast NMOS(L=180n LD={lateral_diffusion})\nM1 d g s b nfast\n"
+    )
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(mosfet.model.model.params.LD, parse_value(lateral_diffusion))
+
+
 @pytest.mark.parametrize("saturation_current", ["0", "-1p", "1e999"])
 def test_rejects_invalid_mosfet_model_saturation_current(
     saturation_current: str,

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject MOS model-card `LD` values that are non-finite, negative, or leave a
+  non-positive effective Level-1 channel length, and lower valid values.
 - Reject negative and non-finite MOS model-card `RSH` values and lower valid
   Level-1 sheet resistance instead of silently dropping it.
 - Reject negative and non-finite MOS model-card `RS` values and lower valid

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -15,6 +15,7 @@ import {
   acSweep,
   dcOp,
   dcSweep,
+  defaultMosfetLevel1Params,
   inductorWithInitialCurrent,
   jfet,
   mosfet,
@@ -1229,6 +1230,20 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET L must be finite and positive");
   }
+  const lateralDiffusion = params.get("LD");
+  if (kind === "NMOS" || kind === "PMOS") {
+    const effectiveLength = length ?? defaultMosfetLevel1Params().L;
+    if (
+      lateralDiffusion !== undefined &&
+      (!Number.isFinite(lateralDiffusion) ||
+        lateralDiffusion < 0.0 ||
+        effectiveLength - 2.0 * lateralDiffusion <= 0.0)
+    ) {
+      throw new NetlistParseError(
+        "MOSFET LD must be finite and non-negative with L - 2*LD > 0",
+      );
+    }
+  }
   const saturationCurrent = params.get("IS");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1349,6 +1364,7 @@ function isMosfetParam(name: keyof MosfetLevel1Params): boolean {
     "PHI",
     "W",
     "L",
+    "LD",
     "TOX",
     "U0",
     "RD",

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1485,6 +1485,28 @@ Xright c d load
     expect(element.params.L).toBeCloseTo(2.0e-6, 15);
   });
 
+  it.each(["LD=-1n", "LD=1e999", "L=100n LD=50n"])(
+    "rejects invalid MOSFET model lateral diffusion %s",
+    (parameters) => {
+      expect(() =>
+        parseNetlist(`.model nfast NMOS(${parameters})\nM1 d g s b nfast\n`),
+      ).toThrow("MOSFET LD must be finite and non-negative with L - 2*LD > 0");
+    },
+  );
+
+  it.each([
+    ["0", 0.0],
+    ["10n", 10.0e-9],
+  ])("lowers valid MOSFET model LD=%s", (lateralDiffusion, expected) => {
+    const parsed = parseNetlist(
+      `.model nfast NMOS(L=180n LD=${lateralDiffusion})\nM1 d g s b nfast\n`,
+    );
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.LD).toBeCloseTo(expected, 15);
+  });
+
   it.each(["0", "-1p", "1e999"])(
     "rejects invalid MOSFET model IS=%s",
     (saturationCurrent) => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4207,10 +4207,16 @@ the Rust, Python, and TypeScript surfaces together.
      diagnostic while zero and positive source resistances lower into Level-1
      parameters.
 
+382. Python and TypeScript Berkeley SPICE MOS sheet-resistance parity.
+   - Status: completed in PR 9652.
+   - Negative and non-finite `RSH` values are rejected with the shared
+     diagnostic while zero and positive sheet resistances lower into Level-1
+     parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
-   - TypeScript still needs canonical lowering for `RSH`, `LD`,
+   - TypeScript still needs canonical lowering for `LD`,
      `NRD`, `NRS`, `AD`, `AS`, `PD`, `PS`, `CJ`, `CJSW`, `JS`, `PB`, `MJ`,
      `MJSW`, `FC`, `KF`, and `AF`; Python already lowers these canonical fields
      but still needs matching facade validation coverage.


### PR DESCRIPTION
## Summary
- validate MOS model-card `LD` against the shared finite, non-negative, positive-effective-length contract
- lower valid TypeScript lateral diffusion instead of silently dropping it
- record the merged sheet-resistance parity slice and advance the audited backlog

## Verification
- Python spice-netlist-parser: 148 tests passed; 88.29% coverage
- Python spice-netlist-parser: `ruff check src tests`
- TypeScript spice-engine: `npm run build`
- TypeScript spice-netlist-parser: `npm run build`
- TypeScript spice-netlist-parser: 141 tests passed with coverage