### PR TITLE
feat(sir-c): Hash non-block methods (Collections slice 6)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 0.27.0 — Collections slice 6: Hash non-block methods
+
+No new `Feature`.
+
+- New methods: `keys`/`values` (fresh arrays in INSERTION order, matching how
+  a map already prints), `fetch(k)` (like `h[k]` but RAISES `KeyError` out of
+  range instead of nil — `Array#fetch` already raises `IndexError` the same
+  way), `to_a` (a fresh array of `[k, v]` pairs; `to_a`/`fetch` both widen
+  their existing Array-only arms to also accept a Hash receiver), `to_h`
+  (identity, mirroring `Array#to_a`'s self-identity), `dig(k0, k1, ...)`
+  (looks up `k0` then recurses into the result for each remaining key if it's
+  itself a Hash or Array, else nil — lenient rather than Ruby's `TypeError`
+  on a non-diggable intermediate; polymorphic over the STARTING receiver too,
+  so `Array#dig` comes for free), `merge(other)` (a fresh map, `other`'s
+  entries win on a shared key, never mutates the receiver), `invert` (a fresh
+  map with keys/values swapped; a later duplicate value overwrites the
+  earlier one, matching Ruby).
+- `delete(k)`/`clear` are the FIRST Hash methods that mutate the receiver:
+  `delete` removes an entry (shifting later entries down by one, mirroring
+  `Array#shift`'s in-place style — no reallocation) and returns its value
+  (nil if absent); `clear` resets `len` to 0 in place (the backing array is
+  never freed, matching `Array#pop`) and returns the (now-empty) receiver.
+  Both mutate the EXISTING `SirMap` box, like `MapSet` — every binding
+  sharing the map sees the change.
+- No block-taking Hash method exists yet (that's slice 7), so none of these
+  helpers invoke a closure mid-loop — the length/mutation security discipline
+  slice 4 established for Array's block helpers doesn't yet apply here, but
+  slice 7 must apply the same len+entries-pointer snapshot pattern once it
+  lands (a block-taking Hash helper running while `delete`/`clear` mutates
+  the SAME map would face the identical class of bug slice 4 found and fixed).
+
+**Anti-RCE preserved:** the method name is a compiler-emitted quoted C literal
+used only as a `strcmp` target — never reflection.
+
 ## 0.26.0 — Collections slice 4: Array mutation + 1-arg query methods
 
 `push`/`pop`/`shift` are the FIRST Array methods that mutate the receiver

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -175,7 +175,13 @@ array's length AND its items pointer once before its loop/allocation instead
 of re-reading either — length alone isn't enough, since `push` reallocates
 relative to the CURRENT length, which can be smaller than an outer snapshot
 after a `pop`/`shift` — the same "iterate a snapshot" convention
-`_sir_seq_iter`'s `ForEach` already uses.  A
+`_sir_seq_iter`'s `ForEach` already uses; **slice 6** (Hash non-block
+methods): `keys`/`values`/`to_a`/`to_h`/`dig`/`merge`/`invert` (all
+non-mutating), plus `delete`/`clear` — the FIRST Hash methods that mutate
+the receiver (`delete` shifts later entries down like `Array#shift`;
+`clear` resets `len` in place like `Array#pop`).  `fetch`/`to_a` widen to
+accept a Hash receiver alongside their Array forms; `dig` is polymorphic
+over Hash/Array from the start.  A
 wrong-type receiver or argument raises `NoMethodError`; a built-in method not
 lowered yet is still rejected cleanly.
 

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -1766,9 +1766,12 @@ fn variadic_helper(name: &str) -> Option<&'static str> {
 /// `reduce`/`inject`; `count` also widens to accept its block form); slice 4
 /// = Array mutation (`push`/`pop`/`shift`) + 1-arg query methods (`fetch`/
 /// `values_at`/`rotate`/`zip`; `include?`/`index` widen to accept an Array
-/// receiver alongside their slice-2 String arms). The dispatcher raises
-/// `NoMethodError` on an unsupported receiver type or a malformed call
-/// (missing/extra args, a non-closure block position), matching Ruby.
+/// receiver alongside their slice-2 String arms); slice 6 = Hash non-block
+/// methods (`keys`/`values`/`to_h`/`dig`/`merge`/`delete`/`clear`/`invert`;
+/// `fetch`/`to_a` widen to accept a Hash receiver alongside their Array
+/// forms). The dispatcher raises `NoMethodError` on an unsupported receiver
+/// type or a malformed call (missing/extra args, a non-closure block
+/// position), matching Ruby.
 fn is_builtin_method(name: &str) -> bool {
     matches!(
         name,
@@ -1784,6 +1787,8 @@ fn is_builtin_method(name: &str) -> bool {
         | "sort_by" | "each_with_index" | "reduce" | "inject"
         // slice 4 — Array mutation + 1-arg query methods
         | "push" | "pop" | "shift" | "fetch" | "values_at" | "rotate" | "zip"
+        // slice 6 — Hash non-block methods
+        | "keys" | "values" | "to_h" | "dig" | "merge" | "delete" | "clear" | "invert"
     )
 }
 

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -783,6 +783,11 @@ SirValue _sir_map_set(SirValue map, SirValue key, SirValue val) {
     return val;
 }
 
+static SirValue _sir_map_wrap(SirMap *m) {
+    SirValue v; v.tag = SIR_MAP; v.as.map = m;
+    return v;
+}
+
 SirValue _sir_is_null(SirValue v)   { return _sir_bool(v.tag == SIR_NIL); }
 SirValue _sir_is_pair(SirValue v)   { return _sir_bool(v.tag == SIR_PAIR); }
 SirValue _sir_is_number(SirValue v) { return _sir_bool(_sir_is_num(v)); }
@@ -1830,6 +1835,102 @@ static SirValue _sir_array_zip(SirSeq *s, int argc, SirValue *args) {
     return _sir_seq_wrap(r);
 }
 
+/* ---- Collections slice 6: Hash non-block methods ---------------------------
+ *
+ * `keys`/`values`/`to_a` walk `m->entries` in INSERTION order (the same
+ * order `_sir_fmt_map`/iteration already use), so they agree with how a map
+ * prints. None of these take a block (that's slice 7), so — unlike the
+ * Array block helpers — there is no closure call mid-loop that could mutate
+ * the receiver; no snapshot retrofit is needed here. */
+
+static SirValue _sir_hash_keys(SirMap *m) {
+    SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    r->len = m->len;
+    r->items = (m->len > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)m->len) : NULL;
+    for (int64_t i = 0; i < m->len; i++) r->items[i] = m->entries[i].key;
+    return _sir_seq_wrap(r);
+}
+static SirValue _sir_hash_values(SirMap *m) {
+    SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    r->len = m->len;
+    r->items = (m->len > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)m->len) : NULL;
+    for (int64_t i = 0; i < m->len; i++) r->items[i] = m->entries[i].val;
+    return _sir_seq_wrap(r);
+}
+/* `fetch(k)` — like `h[k]` but RAISES `KeyError` on a missing key instead of
+ * returning nil (matching Ruby's `Hash#fetch`, and this backend's
+ * `Array#fetch`, which raises `IndexError` the same way). */
+static SirValue _sir_hash_fetch(SirMap *m, SirValue key) {
+    int64_t at = _sir_map_find(m, key);
+    if (at < 0) return _sir_raise(_sir_error("KeyError", _sir_str("key not found")));
+    return m->entries[at].val;
+}
+static SirValue _sir_hash_to_a(SirMap *m) {
+    SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    r->len = m->len;
+    r->items = (m->len > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)m->len) : NULL;
+    for (int64_t i = 0; i < m->len; i++) r->items[i] = _sir_seq_lit(2, m->entries[i].key, m->entries[i].val);
+    return _sir_seq_wrap(r);
+}
+/* `dig(k0, k1, ...)` — looks up `k0`, then recurses INTO the result for each
+ * remaining key if it is itself diggable (a Hash or an Array); anything else
+ * (including running out of structure early) yields nil — the same lenient
+ * OOB-is-nil convention `_sir_seq_index`/`_sir_map_get` already use, rather
+ * than real Ruby's `TypeError` on a non-diggable intermediate. Polymorphic
+ * over the STARTING receiver too, so it doubles as `Array#dig`. */
+static SirValue _sir_dig(SirValue recv, int argc, SirValue *args) {
+    SirValue cur = recv;
+    for (int i = 0; i < argc; i++) {
+        if (cur.tag == SIR_MAP) cur = _sir_map_get(cur, args[i]);
+        else if (cur.tag == SIR_SEQ) cur = _sir_seq_index(cur, args[i]);
+        else return _sir_nil();
+    }
+    return cur;
+}
+/* `merge(other)` — a FRESH map with `self`'s entries, then `other`'s entries
+ * put on top (a shared key takes `other`'s value, matching Ruby's no-block
+ * `Hash#merge`); a non-Hash `other` is ignored (lenient, mirroring
+ * `Array#zip`'s treatment of a non-Array `other` elsewhere in this file). */
+static SirValue _sir_hash_merge(SirMap *m, SirValue other) {
+    int64_t other_len = (other.tag == SIR_MAP) ? other.as.map->len : 0;
+    SirMap *r = _sir_map_new(m->len + other_len);
+    for (int64_t i = 0; i < m->len; i++) _sir_map_put(r, m->entries[i].key, m->entries[i].val);
+    for (int64_t i = 0; i < other_len; i++) {
+        _sir_map_put(r, other.as.map->entries[i].key, other.as.map->entries[i].val);
+    }
+    return _sir_map_wrap(r);
+}
+/* `delete(k)` — the FIRST Hash method that mutates the receiver: removes the
+ * entry (shifting later entries down by one, matching `Array#shift`'s
+ * in-place style — no reallocation) and returns its value, or nil if `k`
+ * wasn't present. No block-taking Hash helper exists yet (slice 7), so no
+ * mid-iteration mutation is reachable here — but slice 7 must apply the
+ * same len+entries-pointer snapshot discipline slice 4 established for
+ * Array once it lands. */
+static SirValue _sir_hash_delete(SirMap *m, SirValue key) {
+    int64_t at = _sir_map_find(m, key);
+    if (at < 0) return _sir_nil();
+    SirValue v = m->entries[at].val;
+    for (int64_t i = at + 1; i < m->len; i++) m->entries[i - 1] = m->entries[i];
+    m->len--;
+    return v;
+}
+/* `clear` — removes every entry IN PLACE (just resets `len`; the backing
+ * array is never freed, matching `Array#pop`'s style) and returns the
+ * (now-empty) receiver, matching Ruby. */
+static SirValue _sir_hash_clear(SirMap *m) {
+    m->len = 0;
+    return _sir_map_wrap(m);
+}
+/* `invert` — a FRESH map with keys and values swapped; a later duplicate
+ * (by resulting key, i.e. an earlier VALUE) overwrites the earlier one via
+ * `_sir_map_put`, matching Ruby (last entry in insertion order wins). */
+static SirValue _sir_hash_invert(SirMap *m) {
+    SirMap *r = _sir_map_new(m->len);
+    for (int64_t i = 0; i < m->len; i++) _sir_map_put(r, m->entries[i].val, m->entries[i].key);
+    return _sir_map_wrap(r);
+}
+
 /* ---- Collections slice 1: built-in String methods --------------------------
  *
  * A `__method__` dispatch whose name is a KNOWN built-in method — and which the
@@ -1911,6 +2012,7 @@ static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, Si
         if (recv.tag == SIR_SEQ) return _sir_array_flatten(recv);
     } else if (strcmp(m, "to_a") == 0) {
         if (recv.tag == SIR_SEQ) return recv;  /* Array#to_a is the array itself */
+        if (recv.tag == SIR_MAP) return _sir_hash_to_a(recv.as.map);
     }
     /* Collections slice 5: Array block methods. Each requires exactly the
        trailing-block shape the frontend emits (`argc==1`, a closure) except
@@ -1960,6 +2062,7 @@ static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, Si
         if (recv.tag == SIR_SEQ && argc == 0) return _sir_array_shift(recv.as.seq);
     } else if (strcmp(m, "fetch") == 0) {
         if (recv.tag == SIR_SEQ && argc == 1) return _sir_array_fetch(recv.as.seq, args[0]);
+        if (recv.tag == SIR_MAP && argc == 1) return _sir_hash_fetch(recv.as.map, args[0]);
     } else if (strcmp(m, "values_at") == 0) {
         if (recv.tag == SIR_SEQ) return _sir_array_values_at(recv.as.seq, argc, args);
     } else if (strcmp(m, "rotate") == 0) {
@@ -1969,6 +2072,25 @@ static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, Si
         }
     } else if (strcmp(m, "zip") == 0) {
         if (recv.tag == SIR_SEQ) return _sir_array_zip(recv.as.seq, argc, args);
+    }
+    /* Collections slice 6: Hash non-block methods. */
+    else if (strcmp(m, "keys") == 0) {
+        if (recv.tag == SIR_MAP) return _sir_hash_keys(recv.as.map);
+    } else if (strcmp(m, "values") == 0) {
+        if (recv.tag == SIR_MAP) return _sir_hash_values(recv.as.map);
+    } else if (strcmp(m, "to_h") == 0) {
+        if (recv.tag == SIR_MAP) return recv;  /* Hash#to_h is the hash itself */
+    } else if (strcmp(m, "dig") == 0) {
+        if ((recv.tag == SIR_MAP || recv.tag == SIR_SEQ) && argc >= 1)
+            return _sir_dig(recv, argc, args);
+    } else if (strcmp(m, "merge") == 0) {
+        if (recv.tag == SIR_MAP && argc >= 1) return _sir_hash_merge(recv.as.map, args[0]);
+    } else if (strcmp(m, "delete") == 0) {
+        if (recv.tag == SIR_MAP && argc == 1) return _sir_hash_delete(recv.as.map, args[0]);
+    } else if (strcmp(m, "clear") == 0) {
+        if (recv.tag == SIR_MAP && argc == 0) return _sir_hash_clear(recv.as.map);
+    } else if (strcmp(m, "invert") == 0) {
+        if (recv.tag == SIR_MAP && argc == 0) return _sir_hash_invert(recv.as.map);
     }
     /* Collections slice 2: 1-arg String queries (arg is a String); slice 4
        widens `include?`/`index` to accept an Array receiver too. */

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_hash_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_hash_methods.rs
@@ -1,0 +1,146 @@
+//! Execution proof for Collections slice 6 (Hash non-block methods) on the C
+//! backend — lower REAL Ruby source, emit C, compile with a real cc, run,
+//! assert stdout. Skips gracefully when no `cc` is present.
+
+use std::process::Command;
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    ["cc", "clang", "gcc"]
+        .iter()
+        .find(|c| {
+            Command::new(c)
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        })
+        .map(|s| s.to_string())
+}
+
+fn run_ruby(src: &str) -> Option<String> {
+    let cc = find_cc()?;
+    let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
+    let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
+    let dir = std::env::temp_dir();
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    src.hash(&mut hasher);
+    let stem = format!("sirc_hashm_{}_{}", std::process::id(), hasher.finish());
+    let cpath = dir.join(format!("{stem}.c"));
+    let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::write(&cpath, &art.source).expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        art.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "program exited non-zero");
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn hash_keys_and_values_in_insertion_order() {
+    match run_ruby("h = {1 => \"a\", 2 => \"b\", 3 => \"c\"}\nputs h.keys\nputs h.values\n") {
+        Some(out) => assert_eq!(out, "[1, 2, 3]\n[a, b, c]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn hash_fetch_present_and_missing_raises() {
+    match run_ruby(
+        "h = {1 => 10}\nputs h.fetch(1)\nbegin\n  h.fetch(9)\nrescue KeyError => e\n  puts \"caught\"\nend\n",
+    ) {
+        Some(out) => assert_eq!(out, "10\ncaught\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn hash_to_a_and_to_h() {
+    match run_ruby("h = {1 => 10, 2 => 20}\nputs h.to_a\nputs h.to_h.keys\n") {
+        Some(out) => assert_eq!(out, "[[1, 10], [2, 20]]\n[1, 2]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn hash_dig_single_and_nested() {
+    match run_ruby(
+        "h = {1 => {2 => \"deep\"}}\nputs h.dig(1, 2)\nputs h.dig(1)\nputs h.dig(9, 2)\nputs h.dig(9)\n",
+    ) {
+        Some(out) => assert_eq!(out, "deep\n{2: deep}\nnil\nnil\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn hash_merge_prefers_other_and_does_not_mutate_receiver() {
+    match run_ruby(
+        "a = {1 => \"a\", 2 => \"b\"}\nb = {2 => \"B\", 3 => \"c\"}\nputs a.merge(b)\nputs a\n",
+    ) {
+        Some(out) => assert_eq!(out, "{1: a, 2: B, 3: c}\n{1: a, 2: b}\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn hash_delete_removes_and_returns_the_value() {
+    match run_ruby("h = {1 => \"a\", 2 => \"b\", 3 => \"c\"}\nputs h.delete(2)\nputs h\nputs h.delete(9)\n") {
+        Some(out) => assert_eq!(out, "b\n{1: a, 3: c}\nnil\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn hash_delete_mutates_a_shared_binding() {
+    match run_ruby("a = {1 => \"a\"}\nb = a\na.delete(1)\nputs b.keys\n") {
+        Some(out) => assert_eq!(out, "[]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn hash_clear_empties_and_returns_the_receiver() {
+    match run_ruby("h = {1 => \"a\", 2 => \"b\"}\nputs h.clear.keys\nputs h.empty?\n") {
+        Some(out) => assert_eq!(out, "[]\n#t\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn hash_invert_swaps_keys_and_values() {
+    match run_ruby("h = {1 => \"a\", 2 => \"b\"}\nputs h.invert\n") {
+        Some(out) => assert_eq!(out, "{a: 1, b: 2}\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn hash_invert_duplicate_values_last_one_wins() {
+    match run_ruby("h = {1 => \"x\", 2 => \"x\"}\nputs h.invert\n") {
+        Some(out) => assert_eq!(out, "{x: 2}\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_dig_reuses_the_same_polymorphic_helper() {
+    match run_ruby("a = [[1, 2], [3, 4]]\nputs a.dig(1, 0)\n") {
+        Some(out) => assert_eq!(out, "3\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}


### PR DESCRIPTION
## Summary
- New Hash (`SirMap`) methods: `keys`/`values` (fresh arrays, insertion order), `fetch(k)` (raises `KeyError` OOB), `to_a` (fresh array of `[k,v]` pairs), `to_h` (identity), `dig(k0, k1, ...)` (polymorphic over Hash/Array — `Array#dig` comes for free), `merge(other)` (fresh map, `other` wins on conflict), `invert` (fresh map, keys/values swapped).
- `delete(k)`/`clear` are the FIRST Hash methods that mutate the receiver: `delete` shifts later entries down in place (mirroring `Array#shift`); `clear` resets `len` in place (mirroring `Array#pop`). `fetch`/`to_a` widen their existing Array-only arms to accept a Hash receiver too.
- No block-taking Hash method exists yet (that's slice 7), so none of these invoke a closure mid-loop — the snapshot discipline slice 4 established for Array's block helpers isn't needed yet, but is noted as required once slice 7 lands.

## Test plan
- [x] `cargo test -p semantic-ir-to-c` — full suite green (11 new tests + all existing)
- [x] `cargo clippy -p semantic-ir-to-c --all-targets` — clean
- [x] Security review — PASSED (specifically checked for the same class of aliasing/mutation-during-iteration bug found in the Array mutation PR; confirmed not reachable here since nothing in this slice invokes a callback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>