### PR TITLE
feat(smart-home): add verified Reolink recording control

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Expose the `camera_set_recording` D23 command label.
 - Expose labels for typed non-credential device-configuration commands.
 
 - Added explicit labels and argument conversion for D23 media playback,

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -90181,6 +90181,9 @@ fn parse_command_type(label: &str) -> Result<CommandType, ToolCallError> {
         "device_set_correction_profile" => Ok(CommandType::DeviceControl(
             DeviceControlCommandType::SetCorrectionProfile,
         )),
+        "camera_set_recording" => Ok(CommandType::DeviceControl(
+            DeviceControlCommandType::SetCameraRecording,
+        )),
         _ => Err(validation_error(format!("unknown command_type `{label}`"))),
     }
 }
@@ -92589,6 +92592,9 @@ fn command_type_label(command_type: CommandType) -> &'static str {
         }
         CommandType::DeviceControl(DeviceControlCommandType::SetCorrectionProfile) => {
             "device_set_correction_profile"
+        }
+        CommandType::DeviceControl(DeviceControlCommandType::SetCameraRecording) => {
+            "camera_set_recording"
         }
     }
 }
@@ -121539,6 +121545,10 @@ mod tests {
             (
                 "device_set_correction_profile",
                 DeviceControlCommandType::SetCorrectionProfile,
+            ),
+            (
+                "camera_set_recording",
+                DeviceControlCommandType::SetCameraRecording,
             ),
         ];
         for (label, device_command) in commands {

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Add a reusable `camera.recording` capability and typed recording-control
+  command with a human-approval policy tier.
 - Add a reusable device-configuration capability and typed commands for display
   standards, baseline/learning settings, self-test, and correction profiles.
 

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -34,13 +34,15 @@ Current scope:
 - capability-surface summaries for describe-capabilities tools
 - inventory summaries for bridge/device health and entity state coverage
 - canonical capability catalog entries for light, scene, lock, climate, media,
-  device indicator/display/configuration, sensor, calibration, and input families
+  camera recording, device indicator/display/configuration, sensor, calibration,
+  and input families
 - typed media playback, volume, grouping, and queue operations inside the
   existing authorized device-command envelope
 - typed device indicator/display and sensor-calibration operations with
   command-capability and policy-tier mappings
 - typed non-credential device configuration operations for display standards,
   learning settings, self-tests, and correction profiles
+- typed camera recording control with an explicit human-approval boundary
 - canonical integration descriptors for Hue, Zigbee, Z-Wave, Thread, Matter,
   and MQTT bootstrap families
 - compact integration catalog summaries for runtime, discovery, pairing, and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -352,6 +352,14 @@ impl Capability {
         )
     }
 
+    pub fn camera_recording() -> Self {
+        Self::new(
+            CapabilityId::trusted("camera.recording"),
+            CapabilityMode::ObserveAndCommand,
+            ValueKind::Boolean,
+        )
+    }
+
     pub fn sensor_calibration() -> Self {
         Self::new(
             CapabilityId::trusted("sensor.calibration"),
@@ -437,6 +445,7 @@ pub fn canonical_capability_catalog() -> Vec<Capability> {
         Capability::device_indicator(),
         Capability::device_display(),
         Capability::device_configuration(),
+        Capability::camera_recording(),
         Capability::sensor_calibration(),
         Capability::sensor_occupancy(),
         Capability::sensor_contact(),
@@ -1321,6 +1330,7 @@ pub enum DeviceControlCommandType {
     SetCompensatedDisplay,
     TestIndicator,
     SetCorrectionProfile,
+    SetCameraRecording,
 }
 
 impl CommandType {
@@ -1370,6 +1380,7 @@ impl DeviceControlCommandType {
             | Self::SetGasLearningOffsets
             | Self::SetCompensatedDisplay
             | Self::SetCorrectionProfile => CapabilityId::trusted("device.configuration"),
+            Self::SetCameraRecording => CapabilityId::trusted("camera.recording"),
         }
     }
 }
@@ -1430,7 +1441,8 @@ pub fn tier_for_command(command_type: CommandType) -> PrivilegeTier {
         | CommandType::DeviceControl(DeviceControlCommandType::CalibrateSensor)
         | CommandType::DeviceControl(DeviceControlCommandType::SetAutomaticCo2BaselineDays)
         | CommandType::DeviceControl(DeviceControlCommandType::SetGasLearningOffsets)
-        | CommandType::DeviceControl(DeviceControlCommandType::SetCorrectionProfile) => {
+        | CommandType::DeviceControl(DeviceControlCommandType::SetCorrectionProfile)
+        | CommandType::DeviceControl(DeviceControlCommandType::SetCameraRecording) => {
             PrivilegeTier::HumanApproval
         }
         CommandType::TurnOn
@@ -4293,7 +4305,7 @@ mod tests {
             .map(|capability| capability.capability_id.as_str())
             .collect::<Vec<_>>();
 
-        assert_eq!(catalog.len(), 22);
+        assert_eq!(catalog.len(), 23);
         assert_eq!(ids[0], "light.on_off");
         assert!(ids.contains(&"light.color"));
         assert!(ids.contains(&"scene.recall"));
@@ -4306,6 +4318,7 @@ mod tests {
         assert!(ids.contains(&"device.indicator"));
         assert!(ids.contains(&"device.display"));
         assert!(ids.contains(&"device.configuration"));
+        assert!(ids.contains(&"camera.recording"));
         assert!(ids.contains(&"sensor.calibration"));
         assert!(ids.contains(&"sensor.contact"));
         assert!(ids.contains(&"sensor.temperature"));
@@ -4365,6 +4378,7 @@ mod tests {
             CommandType::DeviceControl(DeviceControlCommandType::SetCompensatedDisplay),
             CommandType::DeviceControl(DeviceControlCommandType::TestIndicator),
             CommandType::DeviceControl(DeviceControlCommandType::SetCorrectionProfile),
+            CommandType::DeviceControl(DeviceControlCommandType::SetCameraRecording),
         ];
 
         for command_type in command_types {

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Upgrade Reolink with capability-probed recording state and authorized,
+  readback-verified recording enable/disable over the authenticated CGI host.
+
 - Record AirGradient's typed non-credential configuration entity and validated
   correction-profile surface.
 

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -45204,14 +45204,14 @@ pub fn first_party_catalog() -> Vec<IntegrationCatalogEntry> {
         base_entry(
             "reolink",
             "Reolink",
-            "Authenticated local Reolink camera and NVR device, channel, and motion inspection.",
+            "Authenticated local Reolink camera and NVR inspection plus verified recording control.",
             IntegrationCategory::CameraMedia,
             ConnectivityClass::LocalPolling,
             ImplementationStatus::FirstPartyRuntime,
             3,
             "reolink",
         )
-        .with_capabilities(&["smart_home.read"])
+        .with_capabilities(&["smart_home.read", "smart_home.command.device"])
         .with_entities(&[EntityKind::Camera, EntityKind::Sensor])
         .with_discovery(&[DiscoveryMechanism::Manual])
         .with_auth(&[AuthMode::UsernamePassword])
@@ -45225,7 +45225,8 @@ pub fn first_party_catalog() -> Vec<IntegrationCatalogEntry> {
             PrimitiveFamily::Supervision,
         ])
         .with_notes(&[
-            "This runtime slice covers authenticated CGI status and motion inspection; media transfer, recording, PTZ, and push events remain separate work.",
+            "Supported channels expose GetRecV20 state and authorized SetRecV20 recording enable/disable with readback verification.",
+            "Recording search/download, media transfer, PTZ, and push events remain separate work.",
         ]),
         base_entry(
             "roku",
@@ -80943,6 +80944,9 @@ mod tests {
             vec![ProtocolFamily::Vendor("reolink_cgi".to_string())]
         );
         assert_eq!(reolink.auth_modes, vec![AuthMode::UsernamePassword]);
+        assert!(reolink
+            .required_capabilities
+            .contains(&CapabilityId::trusted("smart_home.command.device")));
         assert!(reolink.target_entity_kinds.contains(&EntityKind::Camera));
         assert!(reolink.target_entity_kinds.contains(&EntityKind::Sensor));
         assert!(reolink

--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Add the stable `camera_set_recording` local API command label.
 - Add stable local API labels for typed device-configuration commands.
 
 - Added round-trippable local API labels for D23 media playback, volume,

--- a/code/packages/rust/smart-home-platform-http/src/lib.rs
+++ b/code/packages/rust/smart-home-platform-http/src/lib.rs
@@ -10302,6 +10302,9 @@ fn command_type_label(command_type: CommandType) -> &'static str {
         CommandType::DeviceControl(DeviceControlCommandType::SetCorrectionProfile) => {
             "device_set_correction_profile"
         }
+        CommandType::DeviceControl(DeviceControlCommandType::SetCameraRecording) => {
+            "camera_set_recording"
+        }
     }
 }
 
@@ -10357,6 +10360,9 @@ fn command_type_from_label(command_type: &str) -> Result<CommandType, ApiError> 
         )),
         "device_set_correction_profile" => Ok(CommandType::DeviceControl(
             DeviceControlCommandType::SetCorrectionProfile,
+        )),
+        "camera_set_recording" => Ok(CommandType::DeviceControl(
+            DeviceControlCommandType::SetCameraRecording,
         )),
         other => Err(ApiError::bad_request(format!(
             "unsupported command_type `{other}`"
@@ -13882,6 +13888,10 @@ mod tests {
             (
                 "device_set_correction_profile",
                 DeviceControlCommandType::SetCorrectionProfile,
+            ),
+            (
+                "camera_set_recording",
+                DeviceControlCommandType::SetCameraRecording,
             ),
         ];
         for (label, device_command) in commands {

--- a/code/packages/rust/smart-home-reolink-integration/CHANGELOG.md
+++ b/code/packages/rust/smart-home-reolink-integration/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.0
+
+- Added capability-probed Reolink `GetRecV20` state and D23-authorized
+  `SetRecV20` recording enable/disable with authenticated readback verification
+  and a real loopback HTTP proof.
+
 ## 0.1.0
 
 - Added authenticated Reolink CGI login-token lifecycle, device and channel

--- a/code/packages/rust/smart-home-reolink-integration/Cargo.toml
+++ b/code/packages/rust/smart-home-reolink-integration/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "smart-home-reolink-integration"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "Authenticated Reolink camera and NVR CGI integration for the smart-home runtime"
+description = "Authenticated Reolink camera and NVR CGI inspection and recording control for the smart-home runtime"
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/smart-home-reolink-integration/README.md
+++ b/code/packages/rust/smart-home-reolink-integration/README.md
@@ -6,14 +6,17 @@ local HTTP/HTTPS CGI API:
 - manual fixed-endpoint discovery after authenticated inspection;
 - bounded login-token, device-information, channel-status, motion-state, and
   logout exchanges;
-- normalized camera-channel and motion-sensor entities; and
+- normalized camera-channel and motion-sensor entities;
+- capability-probed `GetRecV20` state plus authorized `SetRecV20` recording
+  enable/disable with exact readback verification; and
 - D23 read authorization before credentials or network I/O are used.
 
 Credentials are zeroized after use and are represented in D23 only by a
 `VaultRef`. Session tokens are redacted and never enter normalized state.
 
-This slice does not claim RTSP media transfer, recording, PTZ control, webhook
-events, or ONVIF PullPoint events. Those remain separate transport/runtime work.
+This slice controls whether supported channels record, but it does not claim
+recording search/download, RTSP media transfer, PTZ control, webhook events, or
+ONVIF PullPoint events. Those remain separate transport/runtime work.
 
 Set `REOLINK_USERNAME`, `REOLINK_PASSWORD`, and `REOLINK_CREDENTIAL_REF`, then
 run `cargo run -p smart-home-reolink-integration -- inspect <base-url>` to emit

--- a/code/packages/rust/smart-home-reolink-integration/src/lib.rs
+++ b/code/packages/rust/smart-home-reolink-integration/src/lib.rs
@@ -8,14 +8,15 @@ use http_core::BodyKind;
 use serde_json::{json, Value as JsonValue};
 use smart_home_core::{
     AgentId, Bridge, BridgeId, BridgeTransport, Capability, CapabilityId, CapabilityMode, Device,
-    DeviceId, Entity, EntityId, EntityKind, Health, IntegrationId, Metadata, ProtocolFamily,
-    ProtocolIdentifier, SmartHomeTool, StateConfidence, StateSnapshot, StateSource, Value,
-    ValueKind, VaultRef,
+    CommandResult, CommandType, DeviceControlCommandType, DeviceId, Entity, EntityId, EntityKind,
+    Health, IntegrationId, Metadata, ProtocolFamily, ProtocolIdentifier, SmartHomeTool,
+    StateConfidence, StateSnapshot, StateSource, Value, ValueKind, VaultRef,
 };
 use smart_home_discovery::{
     DiscoveryConfidence, DiscoveryRecord, DiscoverySource, PairingRequirement,
 };
-use smart_home_runtime::{RuntimeError, SmartHomeRuntime};
+use smart_home_runtime::{RuntimeCommandToolRequest, RuntimeError, SmartHomeRuntime};
+use std::collections::BTreeMap;
 use std::fmt;
 use std::io::{self, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
@@ -23,7 +24,7 @@ use std::time::Duration;
 use tls_platform::{default_connector, TlsConfig, TlsConnector};
 use url_parser::{Url, UrlError};
 
-pub const VERSION: &str = "0.1.0";
+pub const VERSION: &str = "0.2.0";
 pub const INTEGRATION_ID: &str = "reolink";
 pub const PROTOCOL_ID: &str = "reolink_cgi";
 pub const DEFAULT_MAX_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
@@ -54,6 +55,17 @@ pub enum ReolinkError {
         field: &'static str,
     },
     NoChannels,
+    UnknownEntity(EntityId),
+    UnsupportedCommand(CommandType),
+    InvalidCommandArguments {
+        command_type: CommandType,
+        expected: &'static str,
+    },
+    VerificationFailed {
+        channel: u32,
+        expected: bool,
+        actual: bool,
+    },
     Runtime(RuntimeError),
 }
 
@@ -90,6 +102,27 @@ impl fmt::Display for ReolinkError {
                 write!(formatter, "Reolink command {command} is missing {field}")
             }
             Self::NoChannels => formatter.write_str("Reolink device returned no camera channels"),
+            Self::UnknownEntity(entity_id) => {
+                write!(formatter, "unknown Reolink entity {}", entity_id.as_str())
+            }
+            Self::UnsupportedCommand(command_type) => {
+                write!(formatter, "unsupported Reolink command {command_type:?}")
+            }
+            Self::InvalidCommandArguments {
+                command_type,
+                expected,
+            } => write!(
+                formatter,
+                "invalid arguments for Reolink command {command_type:?}; expected {expected}"
+            ),
+            Self::VerificationFailed {
+                channel,
+                expected,
+                actual,
+            } => write!(
+                formatter,
+                "Reolink channel {channel} recording readback was {actual}, expected {expected}"
+            ),
             Self::Runtime(error) => error.fmt(formatter),
         }
     }
@@ -198,6 +231,7 @@ pub struct ReolinkChannelStatus {
     pub online: bool,
     pub sleeping: bool,
     pub motion: Option<bool>,
+    pub recording_enabled: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -361,8 +395,59 @@ impl<T: ReolinkTransport> ReolinkClient<T> {
                 Err(ReolinkError::Api { .. }) => None,
                 Err(error) => return Err(error),
             };
+            let value = self.command(
+                "GetRecV20",
+                Some(session),
+                json!({"channel": channel.channel}),
+            );
+            channel.recording_enabled = match value {
+                Ok(value) => Some(parse_recording_enabled(&value)?),
+                Err(ReolinkError::Api { .. }) => None,
+                Err(error) => return Err(error),
+            };
         }
         Ok(ReolinkSnapshot { device, channels })
+    }
+
+    pub fn set_recording_and_verify(
+        &mut self,
+        channel: u32,
+        enabled: bool,
+    ) -> Result<(), ReolinkError> {
+        let session = self.login()?;
+        let result = self.set_recording_session(&session, channel, enabled);
+        let logout = self.logout(&session);
+        match (result, logout) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(error), _) => Err(error),
+            (Ok(()), Err(error)) => Err(error),
+        }
+    }
+
+    fn set_recording_session(
+        &mut self,
+        session: &ReolinkSession,
+        channel: u32,
+        enabled: bool,
+    ) -> Result<(), ReolinkError> {
+        self.command(
+            "SetRecV20",
+            Some(session),
+            json!({"Rec": {"channel": channel, "enable": enabled as u8}}),
+        )?;
+        let confirmed = parse_recording_enabled(&self.command(
+            "GetRecV20",
+            Some(session),
+            json!({"channel": channel}),
+        )?)?;
+        if confirmed != enabled {
+            return Err(ReolinkError::VerificationFailed {
+                channel,
+                expected: enabled,
+                actual: confirmed,
+            });
+        }
+        Ok(())
     }
 
     fn login(&mut self) -> Result<ReolinkSession, ReolinkError> {
@@ -427,16 +512,21 @@ pub struct InstalledReolinkDevice {
     pub bridge_id: BridgeId,
     pub device_ids: Vec<DeviceId>,
     pub camera_entity_ids: Vec<EntityId>,
+    pub recording_entity_ids: Vec<EntityId>,
     pub motion_entity_ids: Vec<EntityId>,
 }
 
 pub struct ReolinkRuntimeIntegration<T> {
     client: ReolinkClient<T>,
+    recording_channels: BTreeMap<EntityId, u32>,
 }
 
 impl<T: ReolinkTransport> ReolinkRuntimeIntegration<T> {
     pub fn new(client: ReolinkClient<T>) -> Self {
-        Self { client }
+        Self {
+            client,
+            recording_channels: BTreeMap::new(),
+        }
     }
 
     pub fn client(&self) -> &ReolinkClient<T> {
@@ -462,7 +552,60 @@ impl<T: ReolinkTransport> ReolinkRuntimeIntegration<T> {
             }));
         }
         let snapshot = self.client.inspect()?;
-        install_snapshot(runtime, &self.client.config, &snapshot, observed_at_ms)
+        let installed = install_snapshot(runtime, &self.client.config, &snapshot, observed_at_ms)?;
+        self.recording_channels = snapshot
+            .channels
+            .iter()
+            .filter(|channel| channel.recording_enabled.is_some())
+            .map(|channel| {
+                (
+                    camera_entity_id(&snapshot.device.serial, channel.channel),
+                    channel.channel,
+                )
+            })
+            .collect();
+        Ok(installed)
+    }
+
+    pub fn dispatch_command_authorized(
+        &mut self,
+        runtime: &mut SmartHomeRuntime,
+        principal_id: AgentId,
+        request: RuntimeCommandToolRequest,
+        now_ms: u64,
+    ) -> Result<CommandResult, ReolinkError> {
+        let channel = self
+            .recording_channels
+            .get(&request.entity_id)
+            .copied()
+            .ok_or_else(|| ReolinkError::UnknownEntity(request.entity_id.clone()))?;
+        if request.command_type
+            != CommandType::DeviceControl(DeviceControlCommandType::SetCameraRecording)
+        {
+            return Err(ReolinkError::UnsupportedCommand(request.command_type));
+        }
+        let Value::Bool(enabled) = request.arguments else {
+            return Err(ReolinkError::InvalidCommandArguments {
+                command_type: request.command_type,
+                expected: "a recording-enabled boolean",
+            });
+        };
+        let entity_id = request.entity_id.clone();
+        let command = runtime.authorize_command_tool(principal_id, request, now_ms)?;
+        let mut result = runtime.submit_command(command, now_ms)?;
+        self.client.set_recording_and_verify(channel, enabled)?;
+        let mut entity = runtime
+            .registry()
+            .entity(&entity_id)
+            .cloned()
+            .ok_or_else(|| ReolinkError::UnknownEntity(entity_id.clone()))?;
+        entity.state = Some(confirmed_recording_state(entity_id, entity.state, enabled, now_ms));
+        runtime.upsert_entity(entity)?;
+        result.message = Some(format!(
+            "Reolink confirmed channel {channel} recording {}",
+            if enabled { "enabled" } else { "disabled" }
+        ));
+        Ok(result)
     }
 }
 
@@ -524,12 +667,13 @@ pub fn install_snapshot(
         bridge_id: config.bridge_id.clone(),
         device_ids: Vec::new(),
         camera_entity_ids: Vec::new(),
+        recording_entity_ids: Vec::new(),
         motion_entity_ids: Vec::new(),
     };
     for channel in &snapshot.channels {
         let channel_id = format!("{native_id}:ch{}", channel.channel);
         let device_id = DeviceId::trusted(format!("reolink:{channel_id}"));
-        let camera_id = EntityId::trusted(format!("reolink:{channel_id}:camera"));
+        let camera_id = camera_entity_id(&snapshot.device.serial, channel.channel);
         let motion_id = EntityId::trusted(format!("reolink:{channel_id}:motion"));
         let mut entity_ids = vec![camera_id.clone()];
         if channel.motion.is_some() {
@@ -557,16 +701,21 @@ pub fn install_snapshot(
             health,
             metadata: vec![Metadata::new("reolink.protocol", PROTOCOL_ID)],
         })?;
+        let mut camera_capabilities = vec![Capability::new(
+            CapabilityId::trusted("camera.channel_status"),
+            CapabilityMode::Observe,
+            ValueKind::Object,
+        )];
+        if channel.recording_enabled.is_some() {
+            camera_capabilities.push(Capability::camera_recording());
+            installed.recording_entity_ids.push(camera_id.clone());
+        }
         runtime.upsert_entity(Entity {
             entity_id: camera_id.clone(),
             device_id: device_id.clone(),
             kind: EntityKind::Camera,
             name: channel.name.clone(),
-            capabilities: vec![Capability::new(
-                CapabilityId::trusted("camera.channel_status"),
-                CapabilityMode::Observe,
-                ValueKind::Object,
-            )],
+            capabilities: camera_capabilities,
             state: Some(StateSnapshot {
                 entity_id: camera_id.clone(),
                 value: channel_state(channel),
@@ -694,6 +843,7 @@ fn parse_channels(value: &JsonValue) -> Result<Vec<ReolinkChannelStatus>, Reolin
                 online: boolean(status.get("online")).unwrap_or(false),
                 sleeping: boolean(status.get("sleep")).unwrap_or(false),
                 motion: None,
+                recording_enabled: None,
             })
         })
         .collect()
@@ -701,6 +851,13 @@ fn parse_channels(value: &JsonValue) -> Result<Vec<ReolinkChannelStatus>, Reolin
 
 fn parse_motion(value: &JsonValue) -> Option<bool> {
     boolean(value.get("state"))
+}
+
+fn parse_recording_enabled(value: &JsonValue) -> Result<bool, ReolinkError> {
+    boolean(value.pointer("/Rec/enable")).ok_or(ReolinkError::MissingField {
+        command: "GetRecV20",
+        field: "value.Rec.enable",
+    })
 }
 
 fn boolean(value: Option<&JsonValue>) -> Option<bool> {
@@ -736,7 +893,49 @@ fn channel_state(channel: &ReolinkChannelStatus) -> Value {
     if let Some(motion) = channel.motion {
         fields.push(("motion".to_string(), Value::Bool(motion)));
     }
+    if let Some(recording_enabled) = channel.recording_enabled {
+        fields.push((
+            "recording_enabled".to_string(),
+            Value::Bool(recording_enabled),
+        ));
+    }
     Value::Object(fields)
+}
+
+fn camera_entity_id(serial: &str, channel: u32) -> EntityId {
+    EntityId::trusted(format!(
+        "reolink:{}:ch{channel}:camera",
+        stable_component(serial)
+    ))
+}
+
+fn confirmed_recording_state(
+    entity_id: EntityId,
+    previous: Option<StateSnapshot>,
+    enabled: bool,
+    observed_at_ms: u64,
+) -> StateSnapshot {
+    let mut fields = match previous.map(|state| state.value) {
+        Some(Value::Object(fields)) => fields,
+        _ => Vec::new(),
+    };
+    if let Some((_, value)) = fields
+        .iter_mut()
+        .find(|(field, _)| field == "recording_enabled")
+    {
+        *value = Value::Bool(enabled);
+    } else {
+        fields.push(("recording_enabled".to_string(), Value::Bool(enabled)));
+    }
+    StateSnapshot {
+        entity_id,
+        value: Value::Object(fields),
+        source: StateSource::Poll,
+        observed_at_ms,
+        received_at_ms: observed_at_ms,
+        expires_at_ms: None,
+        confidence: StateConfidence::Confirmed,
+    }
 }
 
 fn api_endpoint(
@@ -962,7 +1161,7 @@ mod tests {
     }
 
     #[test]
-    fn real_http_login_inspect_motion_logout_and_install() {
+    fn real_http_inspection_and_authorized_recording_control_are_verified() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let address = listener.local_addr().unwrap();
         let captured = Arc::new(Mutex::new(Vec::new()));
@@ -973,6 +1172,11 @@ mod tests {
                 json!([{"cmd":"GetDevInfo","code":0,"value":{"DevInfo":{"name":"Front NVR","model":"RLN8-410","serial":"ABC123","firmVer":"v3.5.0","hardVer":"N7MB01"}}}]),
                 json!([{"cmd":"GetChannelstatus","code":0,"value":{"status":[{"channel":0,"name":"Porch","online":1,"sleep":0},{"channel":1,"name":"Garage","online":0,"sleep":0}]}}]),
                 json!([{"cmd":"GetMdState","code":0,"value":{"state":1}}]),
+                json!([{"cmd":"GetRecV20","code":0,"value":{"Rec":{"enable":0}}}]),
+                json!([{"cmd":"Logout","code":0,"value":{}}]),
+                json!([{"cmd":"Login","code":0,"value":{"Token":{"name":"token456","leaseTime":3600}}}]),
+                json!([{"cmd":"SetRecV20","code":0,"value":{"rspCode":200}}]),
+                json!([{"cmd":"GetRecV20","code":0,"value":{"Rec":{"enable":1}}}]),
                 json!([{"cmd":"Logout","code":0,"value":{}}]),
             ];
             for response_value in responses {
@@ -1024,13 +1228,35 @@ mod tests {
         let mut runtime = SmartHomeRuntime::new();
         grant(&mut runtime, &principal);
         let installed = integration
-            .inspect_and_install_authorized(&mut runtime, principal, 5_000)
+            .inspect_and_install_authorized(&mut runtime, principal.clone(), 5_000)
+            .unwrap();
+        let request = RuntimeCommandToolRequest::new(
+            installed.recording_entity_ids[0].clone(),
+            CommandType::DeviceControl(DeviceControlCommandType::SetCameraRecording),
+            Value::Bool(true),
+        );
+        assert!(matches!(
+            integration.dispatch_command_authorized(
+                &mut runtime,
+                AgentId::trusted("agent:reolink-denied"),
+                request.clone(),
+                5_500,
+            ),
+            Err(ReolinkError::Runtime(_))
+        ));
+        let result = integration
+            .dispatch_command_authorized(&mut runtime, principal, request, 6_000)
             .unwrap();
         handle.join().unwrap();
 
         assert_eq!(installed.device_ids.len(), 2);
         assert_eq!(installed.camera_entity_ids.len(), 2);
+        assert_eq!(installed.recording_entity_ids.len(), 1);
         assert_eq!(installed.motion_entity_ids.len(), 1);
+        assert!(result
+            .message
+            .as_deref()
+            .is_some_and(|message| message.contains("recording enabled")));
         assert_eq!(
             runtime
                 .registry()
@@ -1039,6 +1265,17 @@ mod tests {
                 .value,
             Value::Bool(true)
         );
+        let camera_state = &runtime
+            .registry()
+            .state(&installed.recording_entity_ids[0])
+            .unwrap()
+            .value;
+        assert!(matches!(
+            camera_state,
+            Value::Object(fields)
+                if fields.iter().any(|(field, value)|
+                    field == "recording_enabled" && *value == Value::Bool(true))
+        ));
         let bridge = runtime.registry().bridge(&installed.bridge_id).unwrap();
         assert_eq!(
             bridge.auth_ref.as_ref().unwrap().as_str(),
@@ -1049,7 +1286,7 @@ mod tests {
         assert!(!serialized_runtime.contains("token123"));
 
         let requests = captured.lock().unwrap();
-        assert_eq!(requests.len(), 5);
+        assert_eq!(requests.len(), 10);
         let request_text = requests
             .iter()
             .map(|request| String::from_utf8_lossy(request).to_string())
@@ -1058,7 +1295,13 @@ mod tests {
         assert!(request_text[0].contains("\"password\":\"secret\""));
         assert!(request_text[1].contains("cmd=GetDevInfo&token=token123"));
         assert!(request_text[3].contains("cmd=GetMdState&token=token123"));
-        assert!(request_text[4].contains("cmd=Logout&token=token123"));
+        assert!(request_text[4].contains("cmd=GetRecV20&token=token123"));
+        assert!(request_text[4].contains("\"channel\":0"));
+        assert!(request_text[5].contains("cmd=Logout&token=token123"));
+        assert!(request_text[7].contains("cmd=SetRecV20&token=token456"));
+        assert!(request_text[7].contains("\"Rec\":{\"channel\":0,\"enable\":1}"));
+        assert!(request_text[8].contains("cmd=GetRecV20&token=token456"));
+        assert!(request_text[9].contains("cmd=Logout&token=token456"));
     }
 
     #[derive(Debug)]
@@ -1123,6 +1366,7 @@ mod tests {
                 online: true,
                 sleeping: false,
                 motion: Some(false),
+                recording_enabled: Some(true),
             }],
         };
         let record = discovery_record(&config, &snapshot, 9_000).unwrap();

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Keep camera recording changes non-optimistic until a native integration
+  confirms device readback.
 - Keep typed device-configuration and self-test commands non-optimistic until
   integrations return native confirmation.
 

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -6477,7 +6477,8 @@ fn optimistic_snapshot_for_command(command: &DeviceCommand, now_ms: u64) -> Opti
             | DeviceControlCommandType::SetGasLearningOffsets
             | DeviceControlCommandType::SetCompensatedDisplay
             | DeviceControlCommandType::TestIndicator
-            | DeviceControlCommandType::SetCorrectionProfile,
+            | DeviceControlCommandType::SetCorrectionProfile
+            | DeviceControlCommandType::SetCameraRecording,
         ) => return None,
     };
 

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -869,6 +869,22 @@ non-credential settings while keeping configuration values strongly typed:
 - A real loopback HTTP test proves all seven native setting transfers and
   readbacks, while malformed correction-profile tests stop before transport.
 
+## Current Reolink Recording Control Slice
+
+This slice extends the authenticated Reolink CGI inspection host with one
+bounded camera/NVR control that the current transport can verify:
+
+- D23 exposes a reusable boolean `camera.recording` capability and typed
+  recording command with a human-approval policy tier.
+- Online channels probe `GetRecV20`; only channels that return native recording
+  state advertise the commandable capability.
+- Authorized `SetRecV20` changes use the existing login-token lifecycle and are
+  followed by an exact `GetRecV20` readback before runtime state is confirmed.
+- Malformed, unsupported, and unauthorized commands fail before credentials or
+  transport I/O. Recording changes remain non-optimistic until device readback.
+- A real loopback HTTP test proves inspection, capability detection, denial,
+  native recording control, readback verification, logout, and D23 state update.
+
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
@@ -880,23 +896,27 @@ and then by prerequisite readiness:
    credential-bearing values use Vault leasing and destination validation.
 3. Add authenticated HEOS source browsing and queue insertion only after the
    account/session and Vault-leasing prerequisites are concrete.
-4. Extend authenticated Reolink CGI support with concrete camera/NVR control,
-   media, recording, and push-event operations supported by the current host.
-5. Add another vendor-specific camera or NVR integration where authenticated
+4. Add capability-probed Reolink PTZ preset and bounded movement controls over
+   the existing authenticated CGI host.
+5. Add Reolink snapshot, recording search/download, and playback operations only
+   through the existing camera-media lease and a concrete media executor.
+6. Add Reolink push events only after a concrete webhook or event-stream host
+   and subscription lifecycle exist.
+7. Add another vendor-specific camera or NVR integration where authenticated
    protocol and transport primitives are concrete.
-6. Add authenticated KLAP/Tapo devices and other broader-device families only
+8. Add authenticated KLAP/Tapo devices and other broader-device families only
    after their authentication and session prerequisites are concrete.
-7. Add ONVIF PullPoint events once a concrete event host and subscription
+9. Add ONVIF PullPoint events once a concrete event host and subscription
    lifecycle exist.
-8. Add RTSP media transfer and recording once concrete media transfer and
+10. Add RTSP media transfer and recording once concrete media transfer and
    recorder host primitives exist.
-9. Add a production Matter commissioning, secure-session, and network host only
+11. Add a production Matter commissioning, secure-session, and network host only
    after certificate, fabric, Interaction Model encoding, subscription, and
    transport prerequisites exist.
-10. Add a Thread border-router host only after an actual host transport exists.
-11. Add a production Zigbee coordinator, join, and security host only after
+12. Add a Thread border-router host only after an actual host transport exists.
+13. Add a production Zigbee coordinator, join, and security host only after
     concrete coordinator transport and security primitives exist.
-12. Add production Z-Wave inclusion and S2 only after concrete host transport
+14. Add production Z-Wave inclusion and S2 only after concrete host transport
     and security primitives exist.
 
 ## End-To-End Definition


### PR DESCRIPTION
## Summary
- add a reusable D23 `camera.recording` capability and typed human-approval command across core, Chief tools, local HTTP, and runtime boundaries
- capability-probe Reolink channels with authenticated `GetRecV20`, expose recording control only where supported, and execute `SetRecV20` with exact readback verification
- preserve authorization and non-optimistic state semantics, add real loopback HTTP proof, and reprioritize the remaining Smart Home backlog with concrete Reolink follow-ups

## Validation
- `cargo clippy -p smart-home-core -p smart-home-runtime -p smart-home-reolink-integration -p smart-home-integration-catalog -p chief-of-staff-smart-home-tools -p smart-home-platform-http -p matter-core --all-targets -- -D warnings`
- `bash smart-home-core/BUILD`
- `bash smart-home-runtime/BUILD`
- `bash smart-home-reolink-integration/BUILD`
- `bash chief-of-staff-smart-home-tools/BUILD`
- `bash smart-home-platform-http/BUILD`
- `bash matter-core/BUILD`
- `bash smart-home-integration-catalog/BUILD` (327 tests)

All gates were repeated after rebasing onto live `origin/main`. Generated `code/packages/rust/Cargo.lock` was removed.
