### PR TITLE
fix(build-tool): declare Ruby Starlark runtime closure

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,12 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": {
+    "item_id": "build-tool-ruby-starlark-runtime-closure",
+    "number": 9660,
+    "url": "https://github.com/adhithyan15/coding-adventures/pull/9660",
+    "branch": "codex/build-tool-ruby-starlark-runtime-closure"
+  },
   "last_inventory": {
     "revision": "2c740cd5f41f57d014c28ae7260c7c71668efa6e",
     "schema_version": 3,
@@ -388,11 +393,11 @@
     {
       "id": "build-tool-ruby-starlark-runtime-closure",
       "title": "Make the Ruby build tool declare and load its Starlark runtime closure",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-ruby-engine-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-ruby-starlark-runtime-closure",
-      "pr_number": null,
-      "notes": "Selected after merged PR #9648 and the collision-clean b3a6616a inventory. The build tool lazily required coding_adventures_starlark_interpreter whenever a Starlark BUILD file was present, but its Gemfile declared only progress_bar and test gems; a clean source-tree invocation therefore aborted with LoadError until every Ruby package lib directory was injected through RUBYLIB. The implementation imports the interpreter's authoritative repository-local Gemfile closure, makes the existing evaluator integration test mandatory, and proves a clean Bundler subprocess resolves the exact repository feature with RUBYLIB and RUBYOPT removed and network proxies pointed at a dead loopback endpoint. Exact-base validation on 2c740cd5 passed 297 Ruby runs/589 assertions with one existing Windows platform skip and 87.91% line/72.05% branch coverage; 38 interpreter runs/60 assertions; Ruby syntax, changed-file Lint/Security RuboCop, and zero-advisory bundle audit; canonical Go test/vet/trimpath build and a 300-package Ruby plan; 17 schema and 40 runner conformance tests plus the valid 37-case/56-file corpus; and a real 258-Lua-package source-tree plan with zero LoadErrors. The plan also reproduced all 44 separately owned canonical Starlark parse fallbacks without widening this runtime-closure slice. Collision, diff, state, and credential checks are clean. The post-merge dependency/leverage pass ranked this ahead of Haskell and Elixir UTF-8 because Ruby 3.4.9 is already validated locally, the fix is the narrowest unblocked build-tool boundary, and it unlocks the dependent 44-case canonical BUILD compatibility repair."
+      "pr_number": 9660,
+      "notes": "Selected after merged PR #9648 and the collision-clean b3a6616a inventory. The build tool lazily required coding_adventures_starlark_interpreter whenever a Starlark BUILD file was present, but its Gemfile declared only progress_bar and test gems; a clean source-tree invocation therefore aborted with LoadError until every Ruby package lib directory was injected through RUBYLIB. The implementation imports the interpreter's authoritative repository-local Gemfile closure, makes the existing evaluator integration test mandatory, and proves a clean Bundler subprocess resolves the exact repository feature with RUBYLIB and RUBYOPT removed and network proxies pointed at a dead loopback endpoint. Exact-base validation on 2c740cd5 passed 297 Ruby runs/589 assertions with one existing Windows platform skip and 87.91% line/72.05% branch coverage; 38 interpreter runs/60 assertions; Ruby syntax, changed-file Lint/Security RuboCop, and zero-advisory bundle audit; canonical Go test/vet/trimpath build and a 300-package Ruby plan; 17 schema and 40 runner conformance tests plus the valid 37-case/56-file corpus; and a real 258-Lua-package source-tree plan with zero LoadErrors. The plan also reproduced all 44 separately owned canonical Starlark parse fallbacks without widening this runtime-closure slice. Collision, diff, state, and credential checks are clean. The post-merge dependency/leverage pass ranked this ahead of Haskell and Elixir UTF-8 because Ruby 3.4.9 is already validated locally, the fix is the narrowest unblocked build-tool boundary, and it unlocks the dependent 44-case canonical BUILD compatibility repair. Ready PR #9660 opened at exact pushed head 15d4a5cc55d910c713e5a6a157b9e24992bd3636."
     },
     {
       "id": "build-tool-ruby-starlark-canonical-build-compatibility",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,23 +11,18 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": {
-    "item_id": "build-tool-ruby-engine-rockspec-utf8-conformance",
-    "number": 9648,
-    "url": "https://github.com/adhithyan15/coding-adventures/pull/9648",
-    "branch": "codex/build-tool-ruby-rockspec-utf8"
-  },
+  "active_pr": null,
   "last_inventory": {
-    "revision": "816bd31f41bd21ce5bda30c1dfaac8b8b5102de0",
+    "revision": "b3a6616a14718cec150d82e87bdc9a2d35d30670",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1225,
-    "implementation_package_slots": 4373,
+    "implementation_identities": 1226,
+    "implementation_package_slots": 4374,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 271,
-    "singleton_packages": 775,
-    "singleton_missing_slots": 10850,
-    "rust_singletons": 580,
+    "singleton_packages": 776,
+    "singleton_missing_slots": 10864,
+    "rust_singletons": 581,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -366,11 +361,11 @@
     {
       "id": "build-tool-ruby-engine-rockspec-utf8-conformance",
       "title": "Make the Ruby build tool enforce strict UTF-8 rockspec metadata",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-perl-engine-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-ruby-rockspec-utf8",
       "pr_number": 9648,
-      "notes": "Selected after merged PR #9632 and the collision-clean 46d95281 inventory. Ruby currently reads rockspec text through the process locale/default external encoding. Consume the exact shared valid and invalid fixtures, decode raw bytes as strict UTF-8 before parsing, preserve exact dependency edges, raise a typed METADATA_INVALID_UTF8 failure with package and repository-relative manifest identity, and prove real CLI exit 2 plus stable root-redacted stderr. The quick post-merge leverage pass ranked Ruby before Haskell and Elixir because Ruby 3.4.9 and Bundler 2.6.9 are locally available, its direct read is the narrowest remaining boundary, and six merged implementations pin the behavior without the broader lazy-I/O or regex-position audit. After conflict-free rebases through 816bd31f, exact-head validation passes 296 Ruby runs/585 assertions with 87.41% line and 72.05% branch coverage, syntax, changed-file Lint/Security RuboCop, zero-advisory bundle audit, current dependencies, canonical Go test/vet/build and 300-package Ruby validation, 57 conformance tests, the 37-case/56-file corpus, a real 258-Lua-package/382-edge plan, and the collision-clean inventory. Full-repository validation separately discovered the undeclared Starlark runtime dependency and 44 canonical BUILD parse fallbacks; both have dedicated pending owners below and do not expand this UTF-8 slice."
+      "notes": "Merged PR #9648 as 6bf73aa418a62ddee66c1382f51205ca4774511e on 2026-08-03 after 17 exact-head checks were terminal: two detects, two fixture consumers, two Ubuntu builds, macOS, Windows, two CI gates, CodeQL detection, and Ruby analysis passed; four irrelevant analyzers skipped and the CodeQL aggregate was neutral. Ruby now strictly decodes raw rockspec bytes, emits typed METADATA_INVALID_UTF8 with package and repository-relative manifest identity, preserves exact success edges, accepts literal U+FFFD, rejects five malformed-sequence classes, and maps the real CLI to exit 2 without checkout-root leakage. Local validation passed 296 Ruby runs/585 assertions with 87.41% line and 72.05% branch coverage, syntax, changed-file Lint/Security RuboCop, zero-advisory bundle audit, current dependencies, canonical Go test/vet/build and 300-package Ruby validation, 57 conformance tests, the 37-case/56-file corpus, a real 258-Lua-package/382-edge plan, collision inventory, diff, state, and credential scans. Full-repository validation separately discovered the undeclared Starlark runtime dependency and 44 canonical BUILD parse fallbacks; both have dedicated owners below."
     },
     {
       "id": "build-tool-haskell-engine-rockspec-utf8-conformance",
@@ -393,11 +388,11 @@
     {
       "id": "build-tool-ruby-starlark-runtime-closure",
       "title": "Make the Ruby build tool declare and load its Starlark runtime closure",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-ruby-engine-rockspec-utf8-conformance"],
-      "branch": null,
+      "branch": "codex/build-tool-ruby-starlark-runtime-closure",
       "pr_number": null,
-      "notes": "Discovered while running the real full-repository Lua plan for the Ruby UTF-8 slice. The build tool lazily requires coding_adventures_starlark_interpreter whenever a Starlark BUILD file is present, but its Gemfile declares only progress_bar and test gems; a clean source-tree invocation therefore aborts with LoadError until every Ruby package lib directory is injected through RUBYLIB. Declare a repository-local runtime closure or a supported bootstrap path, exercise it from a clean environment on Windows and Unix, and preserve the tool's zero-network build execution policy."
+      "notes": "Selected after merged PR #9648 and the collision-clean b3a6616a inventory. The build tool lazily requires coding_adventures_starlark_interpreter whenever a Starlark BUILD file is present, but its Gemfile declares only progress_bar and test gems; a clean source-tree invocation therefore aborts with LoadError until every Ruby package lib directory is injected through RUBYLIB. Declare a repository-local runtime closure or a supported bootstrap path, exercise it from a clean environment on Windows and Unix, and preserve the tool's zero-network build execution policy. The post-merge dependency/leverage pass ranked this ahead of Haskell and Elixir UTF-8 because Ruby 3.4.9 is already validated locally, the fix is the narrowest unblocked build-tool boundary, and it unlocks the dependent 44-case canonical BUILD compatibility repair."
     },
     {
       "id": "build-tool-ruby-starlark-canonical-build-compatibility",
@@ -919,6 +914,15 @@
       "branch": null,
       "pr_number": null,
       "notes": "Discovered in the collision-clean 9bb12864 inventory after PR #9640 added Rust-only chief-of-staff-channel-store. Define language-neutral fixtures for two-phase CAS sequence reservation, exact pending-header recovery, nonce-safe abandoned gaps, idempotent encrypted-message and sealed-grant persistence, ordered pagination, monotonic per-receiver acknowledgements, conflict/retry ceilings, corrupt-record rejection, and stable repository-owned storage keys/errors. Expand the authority-free orchestration over injected StorageBackend and channel-crypto contracts after the cryptographic vectors land; backend I/O, filesystem durability, key custody, entropy, and actor routing remain separately injected or native and are not part of this portable package."
+    },
+    {
+      "id": "chief-channel-endpoints-portable-conformance",
+      "title": "Fixture and expand the portable Chief authorized channel endpoints",
+      "status": "pending",
+      "depends_on": ["chief-channel-store-portable-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-clean b3a6616a inventory after PR #9649 added Rust-only chief-of-staff-channel-endpoints. Define language-neutral fixtures for bounded identities, one-originator/nonempty-unique-receiver definitions, role and key authorization, monotonic active-to-destroyed lifecycle, injected UUIDv7/timestamp metadata, publish/grant/read/acknowledge orchestration, current-session delivery receipts, stable record identities, corrupt-definition rejection, and normalized authorization failures. Expand only the zero-capability deterministic core over the channel-store, channel-crypto, and injected StorageBackend contracts; backend I/O, filesystem durability, clocks, randomness, key custody, and actor routing remain injected or native."
     },
     {
       "id": "venture-browser-qt-portable-bridge-and-native-host",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -18,16 +18,16 @@
     "branch": "codex/build-tool-ruby-starlark-runtime-closure"
   },
   "last_inventory": {
-    "revision": "2c740cd5f41f57d014c28ae7260c7c71668efa6e",
+    "revision": "bce05ed6abe668df1339c4169e63fa1ed3c8d666",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1226,
-    "implementation_package_slots": 4374,
+    "implementation_identities": 1227,
+    "implementation_package_slots": 4375,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 271,
-    "singleton_packages": 776,
-    "singleton_missing_slots": 10864,
-    "rust_singletons": 581,
+    "singleton_packages": 777,
+    "singleton_missing_slots": 10878,
+    "rust_singletons": 582,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -397,7 +397,7 @@
       "depends_on": ["build-tool-ruby-engine-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-ruby-starlark-runtime-closure",
       "pr_number": 9660,
-      "notes": "Selected after merged PR #9648 and the collision-clean b3a6616a inventory. The build tool lazily required coding_adventures_starlark_interpreter whenever a Starlark BUILD file was present, but its Gemfile declared only progress_bar and test gems; a clean source-tree invocation therefore aborted with LoadError until every Ruby package lib directory was injected through RUBYLIB. The implementation imports the interpreter's authoritative repository-local Gemfile closure, makes the existing evaluator integration test mandatory, and proves a clean Bundler subprocess resolves the exact repository feature with RUBYLIB and RUBYOPT removed and network proxies pointed at a dead loopback endpoint. Exact-base validation on 2c740cd5 passed 297 Ruby runs/589 assertions with one existing Windows platform skip and 87.91% line/72.05% branch coverage; 38 interpreter runs/60 assertions; Ruby syntax, changed-file Lint/Security RuboCop, and zero-advisory bundle audit; canonical Go test/vet/trimpath build and a 300-package Ruby plan; 17 schema and 40 runner conformance tests plus the valid 37-case/56-file corpus; and a real 258-Lua-package source-tree plan with zero LoadErrors. The plan also reproduced all 44 separately owned canonical Starlark parse fallbacks without widening this runtime-closure slice. Collision, diff, state, and credential checks are clean. The post-merge dependency/leverage pass ranked this ahead of Haskell and Elixir UTF-8 because Ruby 3.4.9 is already validated locally, the fix is the narrowest unblocked build-tool boundary, and it unlocks the dependent 44-case canonical BUILD compatibility repair. Ready PR #9660 opened at exact pushed head 15d4a5cc55d910c713e5a6a157b9e24992bd3636."
+      "notes": "Selected after merged PR #9648 and the collision-clean b3a6616a inventory. The build tool lazily required coding_adventures_starlark_interpreter whenever a Starlark BUILD file was present, but its Gemfile declared only progress_bar and test gems; a clean source-tree invocation therefore aborted with LoadError until every Ruby package lib directory was injected through RUBYLIB. The implementation imports the interpreter's authoritative repository-local Gemfile closure, makes the existing evaluator integration test mandatory, and proves a clean Bundler subprocess resolves the exact repository feature with RUBYLIB and RUBYOPT removed and network proxies pointed at a dead loopback endpoint. Exact-base validation on bce05ed6 passed 297 Ruby runs/589 assertions with one existing Windows platform skip and 87.91% line/72.05% branch coverage; 38 interpreter runs/60 assertions; Ruby syntax, changed-file Lint/Security RuboCop, and zero-advisory bundle audit; canonical Go test/vet/trimpath build and a 300-package Ruby plan; 17 schema and 40 runner conformance tests plus the valid 37-case/56-file corpus; and a real 258-Lua-package source-tree plan with zero LoadErrors. The plan also reproduced all 44 separately owned canonical Starlark parse fallbacks without widening this runtime-closure slice. Collision, diff, state, and credential checks are clean. The post-merge dependency/leverage pass ranked this ahead of Haskell and Elixir UTF-8 because Ruby 3.4.9 is already validated locally, the fix is the narrowest unblocked build-tool boundary, and it unlocks the dependent 44-case canonical BUILD compatibility repair. Ready PR #9660 reached 17 terminal green/skipped/neutral checks at c3863989fbdbf747df85f4cc4bced59e86c64021, but GitHub rejected auto-complete because main moved during the request. The branch then rebased conflict-free onto bce05ed6, refreshed the inventory, classified the new Chief service-registry singleton, and reran the complete exact-base suite before the lease-guarded update."
     },
     {
       "id": "build-tool-ruby-starlark-canonical-build-compatibility",
@@ -928,6 +928,15 @@
       "branch": null,
       "pr_number": null,
       "notes": "Discovered in the collision-clean b3a6616a inventory after PR #9649 added Rust-only chief-of-staff-channel-endpoints. Define language-neutral fixtures for bounded identities, one-originator/nonempty-unique-receiver definitions, role and key authorization, monotonic active-to-destroyed lifecycle, injected UUIDv7/timestamp metadata, publish/grant/read/acknowledge orchestration, current-session delivery receipts, stable record identities, corrupt-definition rejection, and normalized authorization failures. Expand only the zero-capability deterministic core over the channel-store, channel-crypto, and injected StorageBackend contracts; backend I/O, filesystem durability, clocks, randomness, key custody, and actor routing remain injected or native."
+    },
+    {
+      "id": "chief-service-registry-portable-conformance",
+      "title": "Fixture and expand the portable Chief service registry",
+      "status": "pending",
+      "depends_on": ["chief-channel-crypto-portable-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-clean bce05ed6 inventory after PR #9655 added Rust-only chief-of-staff-service-registry. Define language-neutral fixtures for bounded host names and package paths, versioned host-record codecs, restart/desired-state/status invariants, stable namespaced keys and host-name ordering, immutable package registration, idempotent create-if-absent, revision-CAS update/delete, corrupt-record rejection, and restart recovery over an injected StorageBackend. Depend on the channel-crypto vectors for the shared ChannelId contract. Backend and filesystem durability, process liveness and supervision, trusted clocks, spawning, reconciliation effects, and secure-channel handshakes remain injected or native."
     },
     {
       "id": "venture-browser-qt-portable-bridge-and-native-host",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -13,7 +13,7 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "b3a6616a14718cec150d82e87bdc9a2d35d30670",
+    "revision": "2c740cd5f41f57d014c28ae7260c7c71668efa6e",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1226,
@@ -392,7 +392,7 @@
       "depends_on": ["build-tool-ruby-engine-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-ruby-starlark-runtime-closure",
       "pr_number": null,
-      "notes": "Selected after merged PR #9648 and the collision-clean b3a6616a inventory. The build tool lazily requires coding_adventures_starlark_interpreter whenever a Starlark BUILD file is present, but its Gemfile declares only progress_bar and test gems; a clean source-tree invocation therefore aborts with LoadError until every Ruby package lib directory is injected through RUBYLIB. Declare a repository-local runtime closure or a supported bootstrap path, exercise it from a clean environment on Windows and Unix, and preserve the tool's zero-network build execution policy. The post-merge dependency/leverage pass ranked this ahead of Haskell and Elixir UTF-8 because Ruby 3.4.9 is already validated locally, the fix is the narrowest unblocked build-tool boundary, and it unlocks the dependent 44-case canonical BUILD compatibility repair."
+      "notes": "Selected after merged PR #9648 and the collision-clean b3a6616a inventory. The build tool lazily required coding_adventures_starlark_interpreter whenever a Starlark BUILD file was present, but its Gemfile declared only progress_bar and test gems; a clean source-tree invocation therefore aborted with LoadError until every Ruby package lib directory was injected through RUBYLIB. The implementation imports the interpreter's authoritative repository-local Gemfile closure, makes the existing evaluator integration test mandatory, and proves a clean Bundler subprocess resolves the exact repository feature with RUBYLIB and RUBYOPT removed and network proxies pointed at a dead loopback endpoint. Exact-base validation on 2c740cd5 passed 297 Ruby runs/589 assertions with one existing Windows platform skip and 87.91% line/72.05% branch coverage; 38 interpreter runs/60 assertions; Ruby syntax, changed-file Lint/Security RuboCop, and zero-advisory bundle audit; canonical Go test/vet/trimpath build and a 300-package Ruby plan; 17 schema and 40 runner conformance tests plus the valid 37-case/56-file corpus; and a real 258-Lua-package source-tree plan with zero LoadErrors. The plan also reproduced all 44 separately owned canonical Starlark parse fallbacks without widening this runtime-closure slice. Collision, diff, state, and credential checks are clean. The post-merge dependency/leverage pass ranked this ahead of Haskell and Elixir UTF-8 because Ruby 3.4.9 is already validated locally, the fix is the narrowest unblocked build-tool boundary, and it unlocks the dependent 44-case canonical BUILD compatibility repair."
     },
     {
       "id": "build-tool-ruby-starlark-canonical-build-compatibility",

--- a/code/programs/ruby/build-tool/CHANGELOG.md
+++ b/code/programs/ruby/build-tool/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to the Ruby build tool are documented in this file.
 
 ### Changed
 
+- The build-tool Gemfile now imports the repository-owned Starlark
+  interpreter's authoritative dependency closure. Clean `bundle exec` source-
+  tree runs load the evaluator without manual `RUBYLIB`, and tests no longer
+  skip when that runtime is unavailable.
 - Lua rockspecs are decoded from raw bytes as strict UTF-8 before dependency
   parsing. Malformed metadata raises a typed `METADATA_INVALID_UTF8` error with
   stable package and repository-relative manifest identity.

--- a/code/programs/ruby/build-tool/Gemfile
+++ b/code/programs/ruby/build-tool/Gemfile
@@ -2,12 +2,13 @@
 
 source "https://rubygems.org"
 
-# We keep dependencies minimal. The build tool itself uses only the Ruby
-# standard library (json, digest, open3, pathname, optparse, set).
-# These gems are for development and testing only.
+# Keep third-party dependencies minimal. Starlark evaluation and progress
+# reporting use repository-local gems so a source-tree build never resolves
+# runtime code from the network.
 
-# Optional runtime dependency: progress bar for build output.
+# Repository-local runtime dependencies.
 gem "coding_adventures_progress_bar", path: "../../../packages/ruby/progress_bar"
+eval_gemfile "../../../packages/ruby/starlark_interpreter/Gemfile"
 
 group :test do
   gem "minitest", "~> 5.0"

--- a/code/programs/ruby/build-tool/README.md
+++ b/code/programs/ruby/build-tool/README.md
@@ -53,11 +53,24 @@ bundle exec rake test
 The `test/test_resolution_utf8.rb` coverage exercises the shared
 language-neutral valid and invalid fixtures, representative malformed sequence
 classes, and the real CLI subprocess. The full Rake suite enforces the
-whole-program coverage threshold.
+whole-program coverage threshold. Starlark evaluator tests are mandatory: the
+suite removes ambient `RUBYLIB` and `RUBYOPT` injection in a subprocess and
+proves that the repository-local interpreter loads through the build tool's
+declared bundle rather than skipping when it is unavailable.
 
 ## Dependencies
 
-Zero runtime gem dependencies -- uses only Ruby standard library modules:
+The build tool has no third-party runtime gems. Its source-tree runtime closure
+is repository-owned:
+
+- `coding_adventures_progress_bar` provides progress reporting.
+- `coding_adventures_starlark_interpreter` and its transitive repository gems
+  are imported from the interpreter's authoritative Gemfile.
+
+After `bundle install`, `bundle exec ruby build.rb ...` loads that closure with
+no manual Ruby search path and performs no network resolution during build
+execution. The remaining runtime modules come from the Ruby standard library:
+
 - `json` for cache serialization
 - `digest/sha2` for file hashing
 - `open3` for subprocess execution
@@ -65,4 +78,4 @@ Zero runtime gem dependencies -- uses only Ruby standard library modules:
 - `optparse` for CLI argument parsing
 - `set` for efficient set operations
 
-Dev dependencies: minitest, rake, simplecov.
+Development dependencies: minitest, rake, simplecov.

--- a/code/programs/ruby/build-tool/test/test_starlark_evaluator.rb
+++ b/code/programs/ruby/build-tool/test/test_starlark_evaluator.rb
@@ -16,6 +16,8 @@
 
 require_relative "test_helper"
 require_relative "../lib/build_tool/starlark_evaluator"
+require "open3"
+require "rbconfig"
 
 class TestStarlarkEvaluator < Minitest::Test
   include TestHelper
@@ -484,9 +486,37 @@ class TestStarlarkEvaluator < Minitest::Test
   # evaluate_build_file tests
   # ==========================================================================
   #
-  # These tests require the starlark_interpreter gem. We test with simple
-  # Starlark source that sets _targets directly, avoiding the need for
-  # load() and complex rule definitions.
+  # These tests require the repository-local starlark_interpreter runtime.
+  # We test with simple Starlark source that sets _targets directly, avoiding
+  # the need for load() and complex rule definitions.
+
+  def test_bundle_loads_repository_starlark_runtime_without_rubylib
+    gemfile = Pathname(__dir__).parent / "Gemfile"
+    env = {
+      "BUNDLE_GEMFILE" => gemfile.to_s,
+      "HTTP_PROXY" => "http://127.0.0.1:9",
+      "HTTPS_PROXY" => "http://127.0.0.1:9",
+      "RUBYLIB" => nil,
+      "RUBYOPT" => nil
+    }
+    script = 'require "coding_adventures_starlark_interpreter"; ' \
+             'feature = $LOADED_FEATURES.find { |path| ' \
+             'File.basename(path) == "coding_adventures_starlark_interpreter.rb" }; ' \
+             'abort "interpreter feature path missing" unless feature; print feature'
+
+    stdout, stderr, status = Open3.capture3(
+      env,
+      "bundle", "exec", RbConfig.ruby, "-e", script,
+      chdir: gemfile.dirname.to_s
+    )
+
+    assert status.success?, "clean bundle load failed: #{stderr}"
+    expected = (
+      gemfile.dirname / "../../../packages/ruby/starlark_interpreter" /
+      "lib/coding_adventures_starlark_interpreter.rb"
+    ).expand_path
+    assert_equal expected.to_s.tr("\\", "/"), stdout.tr("\\", "/")
+  end
 
   def test_evaluate_build_file_raises_for_missing_file
     assert_raises(RuntimeError) do
@@ -497,15 +527,6 @@ class TestStarlarkEvaluator < Minitest::Test
   end
 
   def test_evaluate_build_file_returns_empty_when_no_targets
-    # This test requires the starlark_interpreter gem. If it's not
-    # installed, we skip rather than fail -- the gem is only available
-    # when the full dependency chain is set up.
-    begin
-      require "coding_adventures_starlark_interpreter"
-    rescue LoadError
-      skip "starlark_interpreter gem not available"
-    end
-
     dir = create_temp_dir
     build_file = dir / "BUILD"
     # A valid Starlark file that doesn't declare any targets.

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -345,6 +345,12 @@ Final parity requires:
 Starlark evaluation MUST NOT read undeclared host files, environment variables,
 network resources, clocks, random sources, or process APIs.
 
+An executable front door that delegates evaluation to repository packages MUST
+declare its complete repository-local runtime closure through its supported
+dependency or bootstrap manifest. A clean source-tree test MUST remove ambient
+language search-path injection, load the evaluator without skipping, and prove
+that build execution does not need network resolution.
+
 ### 7. Build-plan v1
 
 `build-plan-v1.md` remains the interchange schema. Fixtures require:

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -122,7 +122,7 @@ The loop must not start by attempting 10,864 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`b3a6616a14718cec150d82e87bdc9a2d35d30670` is collision-clean at 1,226
+`2c740cd5f41f57d014c28ae7260c7c71668efa6e` is collision-clean at 1,226
 normalized implementation identities, 4,374 implementation slots, 172
 high-consensus packages, 271 high-consensus missing slots, 776 singletons, 581
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
@@ -282,7 +282,16 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   closure and canonical BUILD compatibility are separate children so the
   metadata-decoding slice stays behaviorally narrow. The post-#9648 leverage
   pass selected runtime closure first because it is the narrowest unblocked
-  fix and unlocks the dependent 44-case compatibility repair;
+  fix and unlocks the dependent 44-case compatibility repair. The selected
+  implementation now imports the interpreter's authoritative repository-local
+  Gemfile closure and proves the exact repository feature loads from a clean
+  Bundler subprocess with ambient Ruby load paths removed and network proxies
+  blocked. Exact-base validation passed 297 Ruby runs/589 assertions with
+  87.91% line and 72.05% branch coverage, 38 downstream interpreter runs,
+  canonical Go test/vet/build and a 300-package Ruby plan, the 17+40
+  conformance suites and 37-case/56-file corpus, and a real 258-package Ruby-
+  engine plan with zero LoadErrors while preserving all 44 separately owned
+  canonical Starlark parse fallbacks;
 - make the TypeScript build-tool git-diff suite portable on Windows. The strict-
   UTF-8 validation run found two hard-coded `/bin/sh` invocations and five
   POSIX-only `/repo` path fixtures. Merged PR #9592 is the completed slice: it

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -116,15 +116,15 @@ package slots and found zero canonical collisions or unknown language buckets:
 | Present in 10-15 languages | 172 | 271 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 776 | 10,864 |
+| Present in one language | 777 | 10,878 |
 
-The loop must not start by attempting 10,864 singleton ports. It should finish
+The loop must not start by attempting 10,878 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`2c740cd5f41f57d014c28ae7260c7c71668efa6e` is collision-clean at 1,226
-normalized implementation identities, 4,374 implementation slots, 172
-high-consensus packages, 271 high-consensus missing slots, 776 singletons, 581
+`bce05ed6abe668df1339c4169e63fa1ed3c8d666` is collision-clean at 1,227
+normalized implementation identities, 4,375 implementation slots, 172
+high-consensus packages, 271 high-consensus missing slots, 777 singletons, 582
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
 The seventeen newest mixed Rust identities are `smart-home-camera-media`,
 `smart-home-onvif-integration`, `smart-home-shelly-integration`,
@@ -200,6 +200,16 @@ receipts, and publish/grant/read/acknowledge orchestration are portable fixture
 candidates. Storage I/O, durability, clocks, randomness, key custody, and actor
 routing stay injected or native. Its dedicated backlog owner depends on the
 channel-store contract and therefore cannot bypass the crypto/store sequence.
+
+The `bce05ed6` refresh added `chief-of-staff-service-registry`, a zero-
+capability deterministic registry over an injected `StorageBackend`. Its
+bounded versioned host-record codec, identity and lifecycle invariants, stable
+keys and ordering, idempotent registration, revision-CAS updates/deletes,
+corrupt-record rejection, and restart-recovery plans are portable fixture
+candidates. Filesystem durability, process liveness and supervision, trusted
+clocks, spawning, effectful reconciliation, and secure-channel handshakes stay
+injected or native. Its dedicated backlog owner depends on the shared channel-
+crypto identifier vectors and cannot bypass that prerequisite.
 
 This loop delivers only deterministic, authority-free package contracts and
 implementations. DNS/UDP/TCP/TLS, endpoint review, credentials and Vault,

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,9 +106,9 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-working inventory was regenerated on August 2, 2026 from `816bd31f` after the
-Ruby build-tool branch was rebased onto current `origin/main`. The inventory
-contains 1,225 normalized implementation identities across 4,373 established-lane
+working inventory was regenerated on August 3, 2026 from `b3a6616a` after
+Ruby build-tool PR #9648 merged. The inventory contains 1,226 normalized
+implementation identities across 4,374 established-lane
 package slots and found zero canonical collisions or unknown language buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
@@ -116,15 +116,15 @@ package slots and found zero canonical collisions or unknown language buckets:
 | Present in 10-15 languages | 172 | 271 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 775 | 10,850 |
+| Present in one language | 776 | 10,864 |
 
-The loop must not start by attempting 10,850 singleton ports. It should finish
+The loop must not start by attempting 10,864 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`816bd31f41bd21ce5bda30c1dfaac8b8b5102de0` is collision-clean at 1,225
-normalized implementation identities, 4,373 implementation slots, 172
-high-consensus packages, 271 high-consensus missing slots, 775 singletons, 580
+`b3a6616a14718cec150d82e87bdc9a2d35d30670` is collision-clean at 1,226
+normalized implementation identities, 4,374 implementation slots, 172
+high-consensus packages, 271 high-consensus missing slots, 776 singletons, 581
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
 The seventeen newest mixed Rust identities are `smart-home-camera-media`,
 `smart-home-onvif-integration`, `smart-home-shelly-integration`,
@@ -192,6 +192,14 @@ and stable record errors are portable fixture candidates. Backend I/O,
 filesystem durability, key custody, entropy, and actor routing remain injected
 or native. A dedicated backlog owner depends on the channel-crypto vectors, so
 the new singleton is classified but is not eligible to preempt that dependency.
+
+The `b3a6616a` refresh added `chief-of-staff-channel-endpoints`, another
+zero-capability deterministic layer. Bounded identities, durable membership,
+role/key authorization, lifecycle, injected message metadata, delivery-session
+receipts, and publish/grant/read/acknowledge orchestration are portable fixture
+candidates. Storage I/O, durability, clocks, randomness, key custody, and actor
+routing stay injected or native. Its dedicated backlog owner depends on the
+channel-store contract and therefore cannot bypass the crypto/store sequence.
 
 This loop delivers only deterministic, authority-free package contracts and
 implementations. DNS/UDP/TCP/TLS, endpoint review, credentials and Vault,
@@ -262,17 +270,19 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   also discovered that the Perl build tool's `5.026` runtime floor and
   version-free core-module declarations do not produce an auditable clean
   dependency floor; that compatibility-policy review is logged as a separate
-  pending child instead of expanding the UTF-8 behavior slice. Ready-for-review
-  PR #9648 owns the Ruby child with strict byte decoding, typed stable
-  diagnostics, the exact shared fixtures, and real CLI exit 2. Haskell and
-  Elixir remain pending until that sole active parity PR merges;
+  pending child instead of expanding the UTF-8 behavior slice. Merged PR #9648
+  completed Ruby with strict byte decoding, typed stable diagnostics, the exact
+  shared fixtures, real CLI exit 2, and green Ubuntu, macOS, Windows, fixture,
+  CI-gate, and Ruby CodeQL checks. Haskell and Elixir remain pending;
 - close the Ruby build tool's Starlark source-tree execution gaps. The Ruby
   UTF-8 validation found that a clean real plan cannot load the undeclared
   `coding_adventures_starlark_interpreter` runtime until repository library
   paths are injected, after which 44 canonical Elixir, Go, and Rust
   BUILD suffixes still produce parse warnings and raw-command fallback. Runtime
-  closure and canonical BUILD compatibility are separate pending children so
-  the metadata-decoding slice stays behaviorally narrow;
+  closure and canonical BUILD compatibility are separate children so the
+  metadata-decoding slice stays behaviorally narrow. The post-#9648 leverage
+  pass selected runtime closure first because it is the narrowest unblocked
+  fix and unlocks the dependent 44-case compatibility repair;
 - make the TypeScript build-tool git-diff suite portable on Windows. The strict-
   UTF-8 validation run found two hard-coded `/bin/sh` invocations and five
   POSIX-only `/repo` path fixtures. Merged PR #9592 is the completed slice: it

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -291,7 +291,8 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   canonical Go test/vet/build and a 300-package Ruby plan, the 17+40
   conformance suites and 37-case/56-file corpus, and a real 258-package Ruby-
   engine plan with zero LoadErrors while preserving all 44 separately owned
-  canonical Starlark parse fallbacks;
+  canonical Starlark parse fallbacks. Ready PR #9660 is the sole active parity
+  PR;
 - make the TypeScript build-tool git-diff suite portable on Windows. The strict-
   UTF-8 validation run found two hard-coded `/bin/sh` invocations and five
   POSIX-only `/repo` path fixtures. Merged PR #9592 is the completed slice: it


### PR DESCRIPTION
## Summary
- require build-tool front doors that delegate Starlark evaluation to declare their complete repository-local runtime closure
- import the Ruby interpreter's authoritative Gemfile closure instead of relying on ambient RUBYLIB injection
- make Starlark integration mandatory and prove a clean Bundler subprocess loads the exact repository feature with RUBYLIB/RUBYOPT removed and dead HTTP(S) proxies
- record the separately owned 44 canonical BUILD parse fallbacks without expanding this runtime-closure slice

## Validation
- `bundle exec rake test`: 297 runs, 589 assertions, 0 failures/errors, 1 existing Windows platform skip; 87.91% line and 72.05% branch coverage
- downstream `starlark_interpreter`: 38 runs, 60 assertions, 0 failures/errors/skips
- Ruby syntax; changed-file Lint/Security RuboCop; `bundle audit check`; `bundle outdated --strict`
- canonical Go `go test ./...`, `go vet ./...`, trimpath build, and 300-package Ruby dry-run
- build-tool conformance: 17 schema tests, 40 runner tests, valid 37-case/56-file corpus across 16 implementations and 12 front doors
- real Ruby-engine Lua plan: 258 packages, zero LoadErrors, 44 separately backlogged Starlark evaluation fallbacks
- package parity: 10 report tests; 1,227 identities/4,375 slots; zero canonical collisions and zero unknown language buckets
- build-file validation, state graph, credential scan, and `git diff --check`

Exact local base: `bce05ed6abe668df1339c4169e63fa1ed3c8d666`
Exact pushed head: `07b928c719e13cfc055d5c8472b60b8db0c77a28`