### PR TITLE
feat(human-languages): generate Marathi chapter six

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -69,10 +69,10 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-D01 | Complete (#9624) | Split or rewrite every lesson whose computed duration is at least 300 seconds. | The deterministic report now reaches zero effective-duration violations across all twenty tracks. |
 | HL-S02 | Complete (#9634) | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | All 27 lessons have typed blocks, unique sequence, transitive knowledge closure, and sub-five-minute duration guarantees. |
 | HL-G03 | Complete (#9646) | Generate Spanish Chapters 4–6 from their canonical schema-v2 lesson ASTs after HL-S02. | All six generated chapters now share lesson hashes with Language Ladder; Markdown tables retain their structure in print. |
-| HL-V02 | Complete in this PR | Validate learner-facing target-language prompts against block-level knowledge declarations and prerequisite closure. | Schema-v2 production and recall blocks cannot ask for an undeclared form or a form absent from the lesson's transitive knowledge frontier. |
+| HL-V02 | Complete (#9653) | Validate learner-facing target-language prompts against block-level knowledge declarations and prerequisite closure. | Schema-v2 production and recall blocks cannot ask for an undeclared form or a form absent from the lesson's transitive knowledge frontier. |
 | HL-V03 | Queued | Compile individual prompt, answer, accepted-variant, feedback, and response-time contracts from typed activity blocks. | Every compiled activity names a non-empty subset of its block's assessed atoms and resolves all answer variants without scraping prose. |
-| HL-B04 | Next | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
-| HL-B05 | Queued | Remove Marathi's duplicate practice labels and Unicode bookmark warnings. | A forced build succeeds but reports four repeated `lesson:practice` labels, 32 Hyperref PDF-string warnings, and two underfull boxes; the clean-build signal is zero of each. |
+| HL-B04 | Complete in this PR | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
+| HL-B05 | Next | Remove Marathi's duplicate practice labels and Unicode bookmark warnings. | The six-chapter build reports four repeated `lesson:practice` labels, 32 Hyperref PDF-string warnings, and three underfull boxes; the clean-build signal is zero of each. |
 | HL-B06 | Queued | Publish Gujarati Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
 | HL-B07 | Queued | Remove Gujarati's missing punctuation glyphs and LaTeX layout/bookmark warnings. | A forced build succeeds but reports four missing punctuation glyphs, one overfull box, four underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B08 | Queued | Publish Punjabi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
@@ -276,6 +276,30 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - Gujarati's nine violations are now the smallest remaining track-sized set,
   ahead of Punjabi's and Sanskrit's ten each. HL-D01C is therefore next after
   this PR merges.
+
+## Findings from HL-B04
+
+- Marathi Chapter 6 now comes from its two canonical schema-v2 lessons. The
+  generator manifest and Language Ladder independently combine the same ordered
+  lesson hashes, so an app/book edit can no longer drift silently.
+- The strict migration adds the first shared `SPINE-COUNT-ONE-TO-FIVE` can-do
+  node. Marathi keeps its local Devanagari, pronunciation, and historical
+  extensions while later number chapters can reuse the communicative spine.
+- Generated non-Latin chapters exposed a reusable pipeline need: each target may
+  name a Unicode Script property and its book's existing LaTeX font command.
+  Devanagari runs are wrapped automatically; Latin prose and bookmark-safe
+  romanization remain in the main font.
+- The deterministic report still measures 1,065 lessons, 20 books, zero duration
+  violations, and zero unknown prerequisites. Publishing this chapter reduces
+  the lesson-to-book chapter gap from 257 to 256 and moves Marathi from legacy
+  to mixed schema status.
+- The forced 31-page XeLaTeX build has zero missing glyphs and zero overfull
+  boxes. The generated pages preserve Devanagari shaping, width-aware tables,
+  box titles, and recall prompts without clipping; one new underfull page joins
+  the older warning debt recorded in HL-B05.
+- HL-B05 remains the next bounded item because the older five handwritten
+  chapters still carry duplicate practice labels, Unicode bookmark warnings,
+  and underfull boxes that should not be confused with generated-chapter drift.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -65,7 +65,7 @@ edition is authored.
 | [Portuguese](./portuguese/README.md) | Romance / Latin | Chapter 1 (Greetings) authored (lessons + book) |
 | [Arabic](./arabic/README.md) | Semitic / Arabic (vendored font) | Chapters 1-2 authored (script inline) |
 | [Hindi](./hindi/README.md) | Indo-Aryan / Devanagari | Chapters 1-2 authored (lessons + book) |
-| [Marathi](./marathi/README.md) | Indo-Aryan / Devanagari | Chapters 1-5 authored (lessons + book) |
+| [Marathi](./marathi/README.md) | Indo-Aryan / Devanagari | Chapters 1-6 authored (lessons + book) |
 | [Punjabi](./punjabi/README.md) | Indo-Aryan / Gurmukhi (vendored font) | Chapter 1 (Greetings) authored (lessons + book) |
 | [Bengali](./bengali/README.md) | Indo-Aryan / Bengali (vendored font) | Chapter 1 (Greetings) authored (lessons + book) |
 | [Gujarati](./gujarati/README.md) | Indo-Aryan / Gujarati (vendored font) | Chapters 1-5 authored (new track, script inline) |

--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -160,6 +160,13 @@
     "TIME-AFTERNOON": { "family": "TIME", "gloss": "afternoon (noun)", "core": false, "retires": ["TARDE"] },
     "TIME-EVENING": { "family": "TIME", "gloss": "evening (noun)", "core": false, "retires": ["ABEND", "SOIR"] },
 
+    "NUMBER-ONE-TO-FIVE": {
+      "family": "NUMBER",
+      "gloss": "the cardinal numbers one through five",
+      "core": false,
+      "notes": "A shared retrieval ability whose language-specific realizations may add script, sound-change, agreement, classifier, or etymology extensions."
+    },
+
     "WORD-GOOD": { "family": "WORD", "gloss": "good (adjective)", "core": false, "retires": ["BON", "GOOD", "GUT"] },
     "WORD-WELL": { "family": "WORD", "gloss": "well / fine (adverb)", "core": false, "retires": ["BIEN"] },
     "WORD-NAME": { "family": "WORD", "gloss": "name (noun)", "core": false, "retires": ["NAME"] },

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -42,6 +42,15 @@
       "title": "The First Verbs",
       "label": "ch:first-verbs",
       "output": "spanish/book/chapters/ch06-first-verbs.tex"
+    },
+    {
+      "language": "marathi",
+      "chapter": 6,
+      "title": "Numbers One to Five",
+      "label": "ch:numbers-one-to-five",
+      "output": "marathi/book/chapters/ch06-numbers-1-5.tex",
+      "unicodeScript": "Devanagari",
+      "scriptCommand": "mr"
     }
   ]
 }

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -3,6 +3,16 @@
   "algorithm": "fnv1a64",
   "chapters": [
     {
+      "language": "marathi",
+      "chapter": 6,
+      "sourceHash": "fnv1a64:d0addd66aaedf900",
+      "lessonIds": [
+        "MR-C06-numbers-1-5",
+        "MR-C06-number-differences"
+      ],
+      "tex": "marathi/book/chapters/ch06-numbers-1-5.tex"
+    },
+    {
       "language": "spanish",
       "chapter": 1,
       "sourceHash": "fnv1a64:ad881fd61b3c4d60",

--- a/code/learning/human-languages/core/spine.json
+++ b/code/learning/human-languages/core/spine.json
@@ -81,6 +81,14 @@
       "prerequisites": ["SPINE-EXCHANGE-NAMES"],
       "core": false,
       "concepts": ["GRAMMAR-THE"]
+    },
+    {
+      "id": "SPINE-COUNT-ONE-TO-FIVE",
+      "stage": "A1",
+      "canDo": "I can understand and produce the cardinal numbers one through five.",
+      "prerequisites": ["SPINE-RESPOND-BASIC"],
+      "core": false,
+      "concepts": ["NUMBER-ONE-TO-FIVE"]
     }
   ]
 }

--- a/code/learning/human-languages/marathi/CHANGELOG.md
+++ b/code/learning/human-languages/marathi/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Generated Chapter 6 — 2026-08-03
+
+- Migrated both numbers 1–5 lessons to the strict schema-v2 contract with stable
+  sequence, sub-five-minute duration budgets, typed blocks, and block-level
+  knowledge closure.
+- Added the shared `SPINE-COUNT-ONE-TO-FIVE` can-do node while keeping Marathi's
+  local Devanagari, *don / tīn* analogy, nasal-retention, and *chār / tsār*
+  extensions explicit.
+- Generated the new LaTeX chapter from the same canonical lesson AST consumed by
+  Language Ladder and committed its combined source hash for independent parity
+  checks.
+
 ## Sub-five-minute remediation — 2026-08-02
 
 - Corrected seven declared five-minute estimates whose computed durations were

--- a/code/learning/human-languages/marathi/README.md
+++ b/code/learning/human-languages/marathi/README.md
@@ -35,9 +35,9 @@ book.
   *don* copied *tīn*, why Hindi retains *pāṁch*'s nasal, and why written *chār*
   sounds nearer *tsār* in Marathi.
 
-Chapters 1–5 are in the book. Chapter 6 is canonical app-ready lesson content;
-its one-source book publication remains explicitly tracked in the shared
-backlog.
+Chapters 1–6 are in the book. Chapter 6 is generated from the same canonical
+schema-v2 lesson AST and source hashes that Language Ladder loads, while the
+first five chapters retain their authored long-form narrative during migration.
 
 ## Book / fonts
 

--- a/code/learning/human-languages/marathi/book/book.tex
+++ b/code/learning/human-languages/marathi/book/book.tex
@@ -72,4 +72,6 @@ Released under CC~BY-SA~4.0.
 
 \input{chapters/ch05-first-verbs}
 
+\input{chapters/ch06-numbers-1-5}
+
 \end{document}

--- a/code/learning/human-languages/marathi/book/chapters/ch06-numbers-1-5.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch06-numbers-1-5.tex
@@ -1,0 +1,106 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:d0addd66aaedf900
+% canonical-lessons: MR-C06-numbers-1-5, MR-C06-number-differences
+
+\chapter{Numbers One to Five}
+\label{ch:numbers-one-to-five}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[ek don tīn chār pāch]{\mr{एक}, \mr{दोन}, \mr{तीन}, \mr{चार}, \mr{पाच} — one to five}
+
+\label{lesson:MR-C06-numbers-1-5}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Marathi and Hindi both use Devanagari and both descend from Sanskrit, so their numbers look almost identical. \textbf{Almost} is where the interest is.
+\end{quote}
+
+\subsection*{You'll want to know: the five}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{Marathi} & \textbf{said} \\
+\midrule
+1 & \textbf{\mr{एक}} & \emph{ek} \\
+2 & \textbf{\mr{दोन}} & \emph{don} \\
+3 & \textbf{\mr{तीन}} & \emph{tīn} \\
+4 & \textbf{\mr{चार}} & \emph{chār} — but see below \\
+5 & \textbf{\mr{पाच}} & \emph{pāch} \\
+\bottomrule
+\end{tabularx}
+
+\begin{grammarlens}[title={What you've built: three Marathi tells}]
+Set them against Hindi. Two differences are visible and one is audible:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{number} & \textbf{Hindi} & \textbf{Marathi} \\
+\midrule
+2 & \mr{दो} \emph{do} & \textbf{\mr{दोन}} \emph{don}: final \emph{n} \\
+5 & \mr{पाँच} \emph{pāṁch} & \textbf{\mr{पाच}} \emph{pāch}: no nasal mark \\
+4 & \mr{चार} \emph{chār} & \textbf{\mr{चार}} \emph{tsār}: same spelling, different sound \\
+\bottomrule
+\end{tabularx}
+
+Do not explain all three histories yet. First make the five forms automatic; the next lesson earns the deeper comparison.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "ek, don, tīn, tsār, pāch"{]}
+  \item {[}YOU SAY: the visible tells — \emph{don} has \emph{n}; \emph{pāch} has no nasal mark{]}
+  \item {[}YOU SAY: the audible tell — written \emph{chār}, Marathi \emph{tsār}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Count to five in Marathi. (\emph{Ek, don, tīn, tsār, pāch}.) Where does Marathi add a letter compared with Hindi? (\textbf{\mr{दोन}}, \emph{don}.) Which form drops a nasal mark? (\textbf{\mr{पाच}}, \emph{pāch}.) What differs in \textbf{\mr{चार}} without differing in spelling? (Marathi's \textbf{\mr{च}} is nearer \textbf{ts} before \emph{ā}.) Next: explain where those differences came from.
+\end{tcolorbox}
+\section[don · tīn · pāch · chār]{Why Marathi \emph{two} rhymes with \emph{three}}
+
+\label{lesson:MR-C06-number-differences}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Count once: \emph{ek, don, tīn, tsār, pāch}. Which two words end in \emph{n}? (\emph{Don} and \emph{tīn}.)
+\end{quote}
+
+\begin{cousinweb}
+The tempting guess is that Marathi \textbf{\mr{दोन}} \emph{don} kept something Hindi \textbf{\mr{दो}} \emph{do} lost. It did not.
+
+Sanskrit's neuter word for three, \textbf{\mr{त्रीणि}} \emph{trī́ṇi}, became Prakrit \emph{\textbf{tiṇṇi}}. In \emph{three}, the \textbf{ṇ} genuinely belongs to the word. The doubled consonant is a Prakrit trade for the lost \emph{r}.
+
+The word for two was then reshaped to match its neighbour: Prakrit \emph{\textbf{doṇṇi}} copied the shape of \emph{\textbf{tiṇṇi}}. Marathi \emph{don}'s final \emph{n} is therefore an \textbf{innovation}, a rhyme borrowed from the number next door. Hindi \emph{do} simply never took it.
+
+English numbers did this too: \emph{four} acquired its initial \emph{f-} by analogy with \emph{five}. Familiar sequences pull neighbouring words toward one another.
+\end{cousinweb}
+
+\begin{grammarlens}[title={What you've built: \mr{पाच} and the nasal Hindi kept}]
+Marathi \textbf{\mr{पाच}} \emph{pāch} and Hindi \textbf{\mr{पाँच}} \emph{pāṁch} tell the opposite story. Hindi's chandrabindu \textbf{\mr{ँ}} records the nasal of Sanskrit \emph{\textbf{pañca}}; Marathi's spelling drops it.
+
+So neither language is simply “older.” Marathi innovated in \emph{don}, while Hindi retained an older feature in \emph{pāṁch}. Comparing both descendants reveals the history that either one alone could hide.
+\end{grammarlens}
+
+\begin{sounds}
+Both write \textbf{\mr{चार}}, but Marathi pronounces \textbf{\mr{च}} before \emph{ā} nearer \textbf{ts}: \emph{tsār}. The letters stayed aligned while the sound moved.
+\end{sounds}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the borrowed rhyme — \emph{tiṇṇi … doṇṇi}{]}
+  \item {[}YOU SAY: innovation — Marathi \emph{don}'s final \emph{n}{]}
+  \item {[}YOU SAY: retention — Hindi \emph{pāṁch}'s nasal{]}
+  \item {[}YOU SAY: same spelling, shifted sound — \emph{chār / tsār}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Did Marathi \emph{don} preserve an ancient ending? (No: \emph{two} copied \emph{three}.) Which language retains Sanskrit \emph{pañca}'s nasal in writing? (Hindi.) Why can neither daughter be called simply older? (Each changed or retained a different feature.) What does Marathi change without respelling \textbf{\mr{चार}}? (\emph{Ch} shifts toward \emph{ts} before \emph{ā}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/marathi/book/preamble.tex
+++ b/code/learning/human-languages/marathi/book/preamble.tex
@@ -19,6 +19,7 @@
 \tcbuselibrary{skins,breakable}
 \usepackage{booktabs}
 \usepackage{longtable}
+\usepackage{tabularx}
 \usepackage{array}
 \usepackage[hidelinks]{hyperref}
 \usepackage{titlesec}
@@ -49,10 +50,10 @@
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
   fonttitle=\bfseries, title={Why it's said this way}
 }
-\newtcolorbox{grammarlens}{
+\newtcolorbox{grammarlens}[1][]{
   breakable, skin=enhanced, colback=blue!5, colframe=blue!35!black,
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
-  fonttitle=\bfseries, title={Grammar Lens}
+  fonttitle=\bfseries, title={Grammar Lens}, #1
 }
 \newtcolorbox{sounds}{
   breakable, skin=enhanced, colback=green!6, colframe=green!30!black,

--- a/code/learning/human-languages/marathi/lessons/MR-C06-number-differences.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C06-number-differences.md
@@ -1,25 +1,43 @@
 ---
+schema_version: 2
 id: MR-C06-number-differences
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 350
 chapter: 6
 type: etymology
 headword: दोन · तीन · पाच · चार
+romanization: don · tīn · pāch · chār
 gloss: why Marathi two rhymes with three, and why Hindi preserves a different piece of five
 prerequisites: [MR-C06-numbers-1-5]
 sounds: [matra-aa, matra-i, inherent-a]
 roots: [sanskrit-dvi, sanskrit-panca]
 etymology_hook: "Marathi don's final n is an innovation copied from tin, while Hindi paanch preserves Sanskrit pancha's nasal; neither daughter is simply older"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [MR-LEX-NUMBERS-ONE-TO-FIVE, MR-SCRIPT-DON-FINAL-N, MR-SCRIPT-PAACH-NONNASAL, MR-SOUND-CHA-TSAA]
+introduces:
+  knowledge: [MR-ETYMON-DON-ANALOGY, MR-ETYMON-PAACH-NASAL-RETENTION, MR-HISTORY-SELECTIVE-RETENTION]
+practises:
+  knowledge: [MR-LEX-NUMBERS-ONE-TO-FIVE, MR-SCRIPT-DON-FINAL-N, MR-SCRIPT-PAACH-NONNASAL, MR-SOUND-CHA-TSAA, MR-ETYMON-DON-ANALOGY, MR-ETYMON-PAACH-NASAL-RETENTION, MR-HISTORY-SELECTIVE-RETENTION]
+skills: [listening, speaking, reading]
+modes: [interpretive, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [MR-C06-numbers-1-5]
 ---
 
 # Why Marathi *two* rhymes with *three*
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MR-LEX-NUMBERS-ONE-TO-FIVE, MR-SCRIPT-DON-FINAL-N] -->
 
 [PAUSE 2s] Count once: *ek, don, tīn, tsār, pāch*. Which two words end in *n*?
 (*Don* and *tīn*.)
 
-## दोन — an ending borrowed from “three”
+## The word, taken apart — दोन borrowed from “three”
+<!-- hl-knowledge: introduces=[MR-ETYMON-DON-ANALOGY]; assesses=[] -->
 
 The tempting guess is that Marathi **दोन** *don* kept something Hindi **दो**
 *do* lost. It did not.
@@ -36,7 +54,8 @@ therefore an **innovation**, a rhyme borrowed from the number next door. Hindi
 English numbers did this too: *four* acquired its initial *f-* by analogy with
 *five*. Familiar sequences pull neighbouring words toward one another.
 
-## पाच — the nasal Hindi kept
+## What you've built: पाच and the nasal Hindi kept
+<!-- hl-knowledge: introduces=[MR-ETYMON-PAACH-NASAL-RETENTION, MR-HISTORY-SELECTIVE-RETENTION]; assesses=[] -->
 
 Marathi **पाच** *pāch* and Hindi **पाँच** *pāṁch* tell the opposite story.
 Hindi's chandrabindu **ँ** records the nasal of Sanskrit ***pañca***; Marathi's
@@ -46,12 +65,14 @@ So neither language is simply “older.” Marathi innovated in *don*, while Hin
 retained an older feature in *pāṁch*. Comparing both descendants reveals the
 history that either one alone could hide.
 
-## चार — a change the spelling hides
+## Sounds you'll need: चार and the change its spelling hides
+<!-- hl-knowledge: introduces=[]; assesses=[MR-SOUND-CHA-TSAA] -->
 
 Both write **चार**, but Marathi pronounces **च** before *ā* nearer **ts**:
 *tsār*. The letters stayed aligned while the sound moved.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[MR-LEX-NUMBERS-ONE-TO-FIVE, MR-SCRIPT-DON-FINAL-N, MR-SCRIPT-PAACH-NONNASAL, MR-SOUND-CHA-TSAA, MR-ETYMON-DON-ANALOGY, MR-ETYMON-PAACH-NASAL-RETENTION, MR-HISTORY-SELECTIVE-RETENTION] -->
 
 [PAUSE 1s]
 - [YOU SAY: the borrowed rhyme — *tiṇṇi … doṇṇi*]
@@ -60,6 +81,7 @@ Both write **चार**, but Marathi pronounces **च** before *ā* nearer **ts
 - [YOU SAY: same spelling, shifted sound — *chār / tsār*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[MR-LEX-NUMBERS-ONE-TO-FIVE, MR-SCRIPT-DON-FINAL-N, MR-SCRIPT-PAACH-NONNASAL, MR-SOUND-CHA-TSAA, MR-ETYMON-DON-ANALOGY, MR-ETYMON-PAACH-NASAL-RETENTION, MR-HISTORY-SELECTIVE-RETENTION] -->
 
 [PAUSE 3s] Did Marathi *don* preserve an ancient ending? (No: *two* copied
 *three*.) Which language retains Sanskrit *pañca*'s nasal in writing? (Hindi.)

--- a/code/learning/human-languages/marathi/lessons/MR-C06-numbers-1-5.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C06-numbers-1-5.md
@@ -1,26 +1,44 @@
 ---
+schema_version: 2
 id: MR-C06-numbers-1-5
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 340
 chapter: 6
 type: word
 headword: एक दोन तीन चार पाच
+romanization: ek don tīn chār pāch
 gloss: one to five — nearly Hindi's, with two tells in the spelling and one in the sound
 concept_tag: MR-NUMBERS-1-5
 prerequisites: [MR-C01-namaskar]
 sounds: [matra-aa, matra-i, inherent-a]
 roots: [sanskrit-dvi, sanskrit-panca]
-etymology_hook: "Marathi don rhymes with tin, paach drops Hindi's written nasal, and chaar is pronounced nearer tsaar; the next short lesson explains why"
-est_minutes: 3
+etymology_hook: "don rhymes with tīn, pāch drops Hindi's written nasal, and chār sounds nearer tsār; the next lesson explains why"
+duration:
+  max_seconds: 180
+requires:
+  knowledge: []
+introduces:
+  knowledge: [MR-LEX-NUMBERS-ONE-TO-FIVE, MR-SCRIPT-DON-FINAL-N, MR-SCRIPT-PAACH-NONNASAL, MR-SOUND-CHA-TSAA]
+practises:
+  knowledge: [MR-LEX-NUMBERS-ONE-TO-FIVE, MR-SCRIPT-DON-FINAL-N, MR-SCRIPT-PAACH-NONNASAL, MR-SOUND-CHA-TSAA]
+skills: [listening, speaking, reading]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [MR-C01-namaskar]
 ---
 
 # एक, दोन, तीन, चार, पाच — one to five
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Marathi and Hindi both use Devanagari and both descend from Sanskrit,
 so their numbers look almost identical. **Almost** is where the interest is.
 
-## The five
+## You'll want to know: the five
+<!-- hl-knowledge: introduces=[MR-LEX-NUMBERS-ONE-TO-FIVE]; assesses=[] -->
 
 | | Marathi | said |
 |---|---|---|
@@ -30,7 +48,8 @@ so their numbers look almost identical. **Almost** is where the interest is.
 | 4 | **चार** | *chār* — but see below |
 | 5 | **पाच** | *pāch* |
 
-## Three Marathi tells
+## What you've built: three Marathi tells
+<!-- hl-knowledge: introduces=[MR-SCRIPT-DON-FINAL-N, MR-SCRIPT-PAACH-NONNASAL, MR-SOUND-CHA-TSAA]; assesses=[] -->
 
 Set them against Hindi. Two differences are visible and one is audible:
 
@@ -44,6 +63,7 @@ Do not explain all three histories yet. First make the five forms automatic;
 the next lesson earns the deeper comparison.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[MR-LEX-NUMBERS-ONE-TO-FIVE, MR-SCRIPT-DON-FINAL-N, MR-SCRIPT-PAACH-NONNASAL, MR-SOUND-CHA-TSAA] -->
 
 [PAUSE 1s]
 - [YOU SAY: "ek, don, tīn, tsār, pāch"]
@@ -51,6 +71,7 @@ the next lesson earns the deeper comparison.
 - [YOU SAY: the audible tell — written *chār*, Marathi *tsār*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[MR-LEX-NUMBERS-ONE-TO-FIVE, MR-SCRIPT-DON-FINAL-N, MR-SCRIPT-PAACH-NONNASAL, MR-SOUND-CHA-TSAA] -->
 
 [PAUSE 3s] Count to five in Marathi. (*Ek, don, tīn, tsār, pāch*.) Where does
 Marathi add a letter compared with Hindi? (**दोन**, *don*.) Which form drops a

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added — non-Latin canonical book chapters
+
+- Let a generated-book target declare a Unicode Script property and its existing
+  LaTeX font command, wrapping only target-script runs while keeping surrounding
+  prose in the book's main font.
+- Use authored romanization for non-Latin section bookmarks and fail closed when
+  only half of the script-rendering configuration is present.
+- Generate Marathi Chapter 6 from its two strict canonical lessons and expose the
+  same ordered source hash to Language Ladder.
+
 ### Added — block-boundary knowledge closure
 
 - Parse canonical `hl-knowledge` directives beside every schema-v2 body block

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -62,6 +62,9 @@ npm run check:books
 orders schema-v2 lessons by `sequence`, writes the LaTeX chapter, and records a
 stable FNV-1a fingerprint in `core/generated-book-hashes.json`. The fingerprint
 detects drift between book and app inputs; it is not a security hash.
+Non-Latin targets also declare `unicodeScript` and `scriptCommand`; the renderer
+wraps matching Unicode runs in the book's existing font macro and uses each
+lesson's `romanization` for a PDF-bookmark-safe short title.
 
 The duration estimator uses instructional word count, explicit pauses, repeat
 cues, learner-response prompts, and a safety margin. Its effective duration is

--- a/code/packages/typescript/human-language-data/src/book.ts
+++ b/code/packages/typescript/human-language-data/src/book.ts
@@ -8,6 +8,15 @@ export interface BookGenerationTarget {
   title: string;
   label: string;
   output: string;
+  /** Unicode Script property whose runs need the book's dedicated font command. */
+  unicodeScript?: string;
+  /** LaTeX command name, without the leading backslash, used for those runs. */
+  scriptCommand?: string;
+}
+
+export interface InlineRenderOptions {
+  unicodeScript: string;
+  scriptCommand: string;
 }
 
 export interface GeneratedBookChapter {
@@ -41,10 +50,25 @@ function escapeLatexCharacter(character: string): string {
   return escaped[character] ?? character;
 }
 
+function scriptMatcher(options: InlineRenderOptions | undefined): RegExp | undefined {
+  if (!options) return undefined;
+  if (!/^[A-Za-z_]+$/.test(options.unicodeScript)) {
+    throw new Error(`invalid Unicode script '${options.unicodeScript}'`);
+  }
+  if (!/^[A-Za-z@]+$/.test(options.scriptCommand)) {
+    throw new Error(`invalid LaTeX script command '${options.scriptCommand}'`);
+  }
+  return new RegExp(`^\\p{Script_Extensions=${options.unicodeScript}}$`, "u");
+}
+
 /** Render the deliberately small inline subset used by schema-v2 lessons. */
-export function renderInlineMarkdown(markdown: string): string {
+export function renderInlineMarkdown(
+  markdown: string,
+  options?: InlineRenderOptions,
+): string {
   const output: string[] = [];
   const emphasis: Array<"italic" | "bold"> = [];
+  const script = scriptMatcher(options);
   let cursor = 0;
   const open = (kind: "italic" | "bold"): void => {
     output.push(kind === "italic" ? "\\emph{" : "\\textbf{");
@@ -55,6 +79,20 @@ export function renderInlineMarkdown(markdown: string): string {
     emphasis.pop();
   };
   while (cursor < markdown.length) {
+    const codePoint = markdown.codePointAt(cursor);
+    const character = codePoint === undefined ? "" : String.fromCodePoint(codePoint);
+    if (script?.test(character)) {
+      const run: string[] = [];
+      while (cursor < markdown.length) {
+        const nextCodePoint = markdown.codePointAt(cursor);
+        const next = nextCodePoint === undefined ? "" : String.fromCodePoint(nextCodePoint);
+        if (!script.test(next)) break;
+        run.push(escapeLatexCharacter(next));
+        cursor += next.length;
+      }
+      output.push(`\\${options!.scriptCommand}{${run.join("")}}`);
+      continue;
+    }
     if (markdown[cursor] === "`") {
       const end = markdown.indexOf("`", cursor + 1);
       if (end !== -1) {
@@ -72,7 +110,7 @@ export function renderInlineMarkdown(markdown: string): string {
       const labelEnd = markdown.indexOf("](", cursor + 1);
       const destinationEnd = labelEnd === -1 ? -1 : markdown.indexOf(")", labelEnd + 2);
       if (labelEnd !== -1 && destinationEnd !== -1) {
-        output.push(renderInlineMarkdown(markdown.slice(cursor + 1, labelEnd)));
+        output.push(renderInlineMarkdown(markdown.slice(cursor + 1, labelEnd), options));
         cursor = destinationEnd + 1;
         continue;
       }
@@ -109,7 +147,7 @@ export function renderInlineMarkdown(markdown: string): string {
   return output.join("");
 }
 
-function renderMarkdown(markdown: string): string {
+function renderMarkdown(markdown: string, options?: InlineRenderOptions): string {
   const output: string[] = [];
   const paragraph: string[] = [];
   const quote: string[] = [];
@@ -119,17 +157,22 @@ function renderMarkdown(markdown: string): string {
 
   const flushParagraph = (): void => {
     if (paragraph.length === 0) return;
-    output.push(renderInlineMarkdown(paragraph.join(" ")), "");
+    output.push(renderInlineMarkdown(paragraph.join(" "), options), "");
     paragraph.length = 0;
   };
   const flushQuote = (): void => {
     if (quote.length === 0) return;
-    output.push("\\begin{quote}", renderInlineMarkdown(quote.join(" ")), "\\end{quote}", "");
+    output.push(
+      "\\begin{quote}",
+      renderInlineMarkdown(quote.join(" "), options),
+      "\\end{quote}",
+      "",
+    );
     quote.length = 0;
   };
   const flushListItem = (): void => {
     if (listItem.length === 0) return;
-    output.push(`  \\item ${renderInlineMarkdown(listItem.join(" "))}`);
+    output.push(`  \\item ${renderInlineMarkdown(listItem.join(" "), options)}`);
     listItem = [];
   };
   const closeList = (): void => {
@@ -147,7 +190,10 @@ function renderMarkdown(markdown: string): string {
       separator.every((cell) => /^:?-{3,}:?$/.test(cell));
     if (!isSeparator || header.length === 0) {
       output.push(
-        ...tableRows.flatMap((row) => [renderInlineMarkdown(`| ${row.join(" | ")} |`), ""]),
+        ...tableRows.flatMap((row) => [
+          renderInlineMarkdown(`| ${row.join(" | ")} |`, options),
+          "",
+        ]),
       );
       tableRows.length = 0;
       return;
@@ -157,7 +203,9 @@ function renderMarkdown(markdown: string): string {
       () => ">{\\raggedright\\arraybackslash}X",
     ).join("");
     const cells = (row: string[]): string[] =>
-      Array.from({ length: header.length }, (_, index) => renderInlineMarkdown(row[index] ?? ""));
+      Array.from({ length: header.length }, (_, index) =>
+        renderInlineMarkdown(row[index] ?? "", options),
+      );
     output.push(
       `\\begin{tabularx}{\\linewidth}{@{}${columns}@{}}`,
       "\\toprule",
@@ -229,9 +277,9 @@ function renderMarkdown(markdown: string): string {
   return output.join("\n").trimEnd();
 }
 
-function renderBlock(block: LessonBodyBlock): string {
-  const content = renderMarkdown(block.markdown);
-  const title = renderInlineMarkdown(block.title);
+function renderBlock(block: LessonBodyBlock, options?: InlineRenderOptions): string {
+  const content = renderMarkdown(block.markdown, options);
+  const title = renderInlineMarkdown(block.title, options);
   if (block.type === "pronunciation") return `\\begin{sounds}\n${content}\n\\end{sounds}`;
   if (block.type === "etymology") return `\\begin{cousinweb}\n${content}\n\\end{cousinweb}`;
   if (block.type === "grammar" || block.type === "notice") {
@@ -260,13 +308,26 @@ function lessonSequence(lesson: ParsedLesson): number {
   return Number(stringValue(lesson.frontmatter.sequence));
 }
 
-function sectionShortTitle(lesson: ParsedLesson): string {
+function sectionShortTitle(lesson: ParsedLesson, options?: InlineRenderOptions): string {
   const title = lesson.realization.type.startsWith("practice")
     ? "Practice"
-    : lesson.realization.headword;
+    : options && stringValue(lesson.frontmatter.romanization).trim() !== ""
+      ? stringValue(lesson.frontmatter.romanization)
+      : lesson.realization.headword;
   return renderInlineMarkdown(
     title.replaceAll("←", " from ").replaceAll("→", " to ").replace(/\s+/g, " ").trim(),
+    options,
   );
+}
+
+function targetRenderOptions(target: BookGenerationTarget): InlineRenderOptions | undefined {
+  if (target.unicodeScript === undefined && target.scriptCommand === undefined) return undefined;
+  if (target.unicodeScript === undefined || target.scriptCommand === undefined) {
+    throw new Error(
+      `${target.language} chapter ${target.chapter}: unicodeScript and scriptCommand must be declared together`,
+    );
+  }
+  return { unicodeScript: target.unicodeScript, scriptCommand: target.scriptCommand };
 }
 
 /** Render one configured chapter from the same typed lesson AST the app receives. */
@@ -274,6 +335,7 @@ export function renderBookChapter(
   target: BookGenerationTarget,
   allLessons: ParsedLesson[],
 ): GeneratedBookChapter {
+  const renderOptions = targetRenderOptions(target);
   const lessons = allLessons
     .filter(
       (lesson) =>
@@ -301,10 +363,10 @@ export function renderBookChapter(
   const sections = lessons.map((lesson) => {
     const id = lesson.realization.lessonId;
     return [
-      `\\section[${sectionShortTitle(lesson)}]{${renderInlineMarkdown(lessonTitle(lesson))}}`,
+      `\\section[${sectionShortTitle(lesson, renderOptions)}]{${renderInlineMarkdown(lessonTitle(lesson), renderOptions)}}`,
       `\\label{lesson:${id}}`,
       "",
-      ...lesson.blocks.map(renderBlock),
+      ...lesson.blocks.map((block) => renderBlock(block, renderOptions)),
     ].join("\n\n");
   });
   const tex = [
@@ -312,7 +374,7 @@ export function renderBookChapter(
     `% canonical-source-hash: ${sourceHash}`,
     `% canonical-lessons: ${lessons.map((lesson) => lesson.realization.lessonId).join(", ")}`,
     "",
-    `\\chapter{${renderInlineMarkdown(target.title)}}`,
+    `\\chapter{${renderInlineMarkdown(target.title, renderOptions)}}`,
     `\\label{${target.label}}`,
     "",
     "This chapter is generated from the canonical micro-lessons used by Language Ladder.",

--- a/code/packages/typescript/human-language-data/tests/book.test.ts
+++ b/code/packages/typescript/human-language-data/tests/book.test.ts
@@ -97,6 +97,32 @@ describe("canonical LaTeX chapter rendering", () => {
     );
   });
 
+  it("wraps configured Unicode-script runs in the book's dedicated font command", () => {
+    const options = { unicodeScript: "Devanagari", scriptCommand: "mr" };
+    expect(renderInlineMarkdown("**दोन** and पाच.", options)).toBe(
+      "\\textbf{\\mr{दोन}} and \\mr{पाच}.",
+    );
+  });
+
+  it("uses authored romanization for a non-Latin section bookmark", () => {
+    const lesson = parseLesson(
+      source("A", 10, "दोन").replace("gloss: दोन", "gloss: two\nromanization: don"),
+      "test",
+    );
+    const generated = renderBookChapter(
+      { ...target, unicodeScript: "Devanagari", scriptCommand: "mr" },
+      [lesson],
+    );
+    expect(generated.tex).toContain("\\section[don]{\\emph{\\mr{दोन}} — lesson}");
+  });
+
+  it("requires both script-rendering options when either is configured", () => {
+    const lesson = parseLesson(source("A", 10, "hello"), "test");
+    expect(() => renderBookChapter({ ...target, unicodeScript: "Devanagari" }, [lesson])).toThrow(
+      /unicodeScript and scriptCommand must be declared together/,
+    );
+  });
+
   it("fails closed when a target includes a legacy lesson", () => {
     const legacy = parseLesson(source("A", 10, "hello").replace("schema_version: 2\n", ""), "test");
     expect(() => renderBookChapter(target, [legacy])).toThrow(/schema version 2/);

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -10,7 +10,9 @@
   while retaining `est_minutes` for unmigrated tracks.
 - Independently combine loaded lesson fingerprints and show `book synced` for a
   generated chapter only when the app AST matches the committed book manifest;
-  Spanish Chapters 1–6 now verify all 51 migrated lessons this way.
+  Spanish Chapters 1–6 now verify all 51 migrated lessons this way, and Marathi
+  Chapter 6 verifies both of its canonical lessons independently of the book
+  generator.
 
 ## 0.25.0 — the same syllable in its sister scripts (syllabary, PR 9)
 

--- a/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
@@ -18,6 +18,14 @@ describe("generated book source hashes", () => {
     expect(bookHashStatus(lessons, "spanish", chapter)).toBe("synced");
   });
 
+  it("matches the browser-loaded Marathi Chapter 6 AST across both lessons", () => {
+    const lessons = loadLessons();
+    const expected = expectedBookHash("marathi", 6);
+    expect(expected?.lessonIds).toHaveLength(2);
+    expect(actualChapterHash(lessons, "marathi", 6)).toBe(expected?.sourceHash);
+    expect(bookHashStatus(lessons, "marathi", 6)).toBe("synced");
+  });
+
   it("reports a generated chapter stale when one canonical lesson changes", () => {
     const lessons = loadLessons();
     const changed = lessons.map((lesson) =>


### PR DESCRIPTION
## Summary

- migrate both Marathi Chapter 6 lessons to the strict schema-v2 contract with block-level knowledge closure
- add the shared count-one-to-five spine node while preserving Marathi-specific script, sound, and etymology extensions
- generate the LaTeX chapter from the canonical lesson AST and verify the same source hash in Language Ladder
- add reusable Unicode-script font wrapping and bookmark-safe romanization for future non-Latin generated chapters
- load the Marathi preamble support required by generated tables and dynamic grammar-box titles

## Validation

- human-language-data: build, 80 tests, 93.42% line coverage, deterministic generate/check
- curriculum report: 1,065 lessons, 20 books, zero duration violations, zero unknown prerequisites, 256 chapter gaps
- Language Ladder: 283 tests, 98.37% line coverage, production build (1,115 modules)
- Marathi PDF: forced XeLaTeX build, 31 pages, zero missing glyphs, zero overfull boxes
- visually inspected all three generated pages for Devanagari shaping, tables, callout titles, clipping, and recall layout
- git diff --check

## Follow-up

HL-B05 remains next for the pre-existing handwritten-chapter warnings: four duplicate practice labels, 32 Hyperref bookmark warnings, and three underfull boxes.