### PR TITLE
fix(spice): lower parser MOS drain squares

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS instance `NRD` values before lowering
+  valid drain diffusion square counts.
 - Reject MOS model-card `LD` values that are non-finite, negative, or leave a
   non-positive effective Level-1 channel length.
 - Reject negative and non-finite MOS model-card `RSH` values before lowering

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1325,6 +1325,10 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
                 f"model {model.name!r} has kind {model.kind!r}, expected 'NMOS' or 'PMOS'"
             )
         instance_params = _parse_element_params(fields[6:], "MOSFET")
+        if "NRD" in instance_params and (
+            not math.isfinite(instance_params["NRD"]) or instance_params["NRD"] < 0.0
+        ):
+            raise NetlistParseError("MOSFET NRD must be finite and non-negative")
         return Mosfet(
             name,
             fields[1],

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -959,6 +959,28 @@ Mp out gate vdd vdd pfast W=3u L=250n
     assert isclose(mosfet.model.model.params.L, 250.0e-9)
 
 
+@pytest.mark.parametrize("drain_squares", ["-1", "1e999"])
+def test_rejects_invalid_mosfet_instance_drain_squares(drain_squares: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="MOSFET NRD must be finite and non-negative"
+    ):
+        parse_netlist(
+            f".model nfast NMOS\nM1 d g s b nfast NRD={drain_squares}\n"
+        )
+
+
+@pytest.mark.parametrize(("drain_squares", "expected"), [("0", 0.0), ("2.5", 2.5)])
+def test_lowers_valid_mosfet_instance_drain_squares(
+    drain_squares: str, expected: float
+) -> None:
+    parsed = parse_netlist(
+        f".model nfast NMOS\nM1 d g s b nfast NRD={drain_squares}\n"
+    )
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert expected == mosfet.model.model.params.NRD
+
+
 def test_parse_pwl_and_sin_source_waveforms() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS instance `NRD` values and lower valid
+  drain diffusion square counts instead of silently dropping them.
 - Reject MOS model-card `LD` values that are non-finite, negative, or leave a
   non-positive effective Level-1 channel length, and lower valid values.
 - Reject negative and non-finite MOS model-card `RSH` values and lower valid

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1370,6 +1370,7 @@ function isMosfetParam(name: keyof MosfetLevel1Params): boolean {
     "RD",
     "RS",
     "RSH",
+    "NRD",
     "IS",
     "N_SUB",
     "T_NOM",
@@ -1594,6 +1595,11 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
         `model ${JSON.stringify(model.name)} has kind ${JSON.stringify(model.kind)}, expected "NMOS" or "PMOS"`,
       );
     }
+    const instanceParams = parseElementParams(fields.slice(6), "MOSFET");
+    const drainSquares = instanceParams.get("NRD");
+    if (drainSquares !== undefined && (!Number.isFinite(drainSquares) || drainSquares < 0.0)) {
+      throw new NetlistParseError("MOSFET NRD must be finite and non-negative");
+    }
     return mosfet(
       name,
       fields[1],
@@ -1601,7 +1607,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       fields[3],
       fields[4],
       model.kind,
-      mosfetParams(model, parseElementParams(fields.slice(6), "MOSFET")),
+      mosfetParams(model, instanceParams),
     );
   }
   if (prefix === "G") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -951,6 +951,26 @@ Mp out gate vdd vdd pfast W=3u L=250n
     expect(element.params.L).toBeCloseTo(250.0e-9, 12);
   });
 
+  it.each(["-1", "1e999"])(
+    "rejects invalid MOSFET instance NRD=%s",
+    (drainSquares) => {
+      expect(() =>
+        parseNetlist(`.model nfast NMOS\nM1 d g s b nfast NRD=${drainSquares}\n`),
+      ).toThrow("MOSFET NRD must be finite and non-negative");
+    },
+  );
+
+  it.each([
+    ["0", 0.0],
+    ["2.5", 2.5],
+  ])("lowers valid MOSFET instance NRD=%s", (drainSquares, expected) => {
+    const parsed = parseNetlist(`.model nfast NMOS\nM1 d g s b nfast NRD=${drainSquares}\n`);
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.NRD).toBe(expected);
+  });
+
   it("parses PWL and SIN source waveforms", () => {
     const parsed = parseNetlist(`
 V1 in 0 PWL(0 0, 1n 1.8, 2n 0)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4213,11 +4213,17 @@ the Rust, Python, and TypeScript surfaces together.
      diagnostic while zero and positive sheet resistances lower into Level-1
      parameters.
 
+383. Python and TypeScript Berkeley SPICE MOS lateral-diffusion parity.
+   - Status: completed in PR 9656.
+   - Non-finite and negative `LD` values, plus values that leave a non-positive
+     effective channel length, are rejected with the shared diagnostic while
+     valid lateral diffusion lengths lower into Level-1 parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
-   - TypeScript still needs canonical lowering for `LD`,
-     `NRD`, `NRS`, `AD`, `AS`, `PD`, `PS`, `CJ`, `CJSW`, `JS`, `PB`, `MJ`,
+   - TypeScript still needs canonical lowering for `NRD`, `NRS`, `AD`, `AS`,
+     `PD`, `PS`, `CJ`, `CJSW`, `JS`, `PB`, `MJ`,
      `MJSW`, `FC`, `KF`, and `AF`; Python already lowers these canonical fields
      but still needs matching facade validation coverage.
    - Align the `CJS` and `CJD` aliases with canonical `CBS` and `CBD` in both


### PR DESCRIPTION
## Summary
- validate MOS instance `NRD` as finite and non-negative in Python and TypeScript
- lower valid TypeScript drain diffusion square counts into Level-1 parameters
- record the merged lateral-diffusion slice and advance the prioritized SPICE backlog

## Verification
- Python spice-netlist-parser: 152 tests passed, 88.31% coverage
- Python Ruff: clean
- TypeScript spice-engine: build passed
- TypeScript spice-netlist-parser: build passed, 145 tests passed
- TypeScript spice-netlist-parser coverage: 84.58% lines