### PR TITLE
fix(human-languages): clean Marathi book warnings

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -71,9 +71,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-G03 | Complete (#9646) | Generate Spanish Chapters 4–6 from their canonical schema-v2 lesson ASTs after HL-S02. | All six generated chapters now share lesson hashes with Language Ladder; Markdown tables retain their structure in print. |
 | HL-V02 | Complete (#9653) | Validate learner-facing target-language prompts against block-level knowledge declarations and prerequisite closure. | Schema-v2 production and recall blocks cannot ask for an undeclared form or a form absent from the lesson's transitive knowledge frontier. |
 | HL-V03 | Queued | Compile individual prompt, answer, accepted-variant, feedback, and response-time contracts from typed activity blocks. | Every compiled activity names a non-empty subset of its block's assessed atoms and resolves all answer variants without scraping prose. |
-| HL-B04 | Complete in this PR | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
-| HL-B05 | Next | Remove Marathi's duplicate practice labels and Unicode bookmark warnings. | The six-chapter build reports four repeated `lesson:practice` labels, 32 Hyperref PDF-string warnings, and three underfull boxes; the clean-build signal is zero of each. |
-| HL-B06 | Queued | Publish Gujarati Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
+| HL-B04 | Complete (#9661) | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
+| HL-B05 | Complete in this PR | Remove Marathi's duplicate practice labels and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Devanagari, natural page bottoms, and explicit static-font shapes make the forced six-chapter build warning-free. |
+| HL-B06 | Next | Publish Gujarati Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
 | HL-B07 | Queued | Remove Gujarati's missing punctuation glyphs and LaTeX layout/bookmark warnings. | A forced build succeeds but reports four missing punctuation glyphs, one overfull box, four underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B08 | Queued | Publish Punjabi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
 | HL-B09 | Queued | Remove Punjabi's LaTeX layout, duplicate-label, and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs but reports one overfull box, four underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
@@ -297,9 +297,27 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   boxes. The generated pages preserve Devanagari shaping, width-aware tables,
   box titles, and recall prompts without clipping; one new underfull page joins
   the older warning debt recorded in HL-B05.
-- HL-B05 remains the next bounded item because the older five handwritten
-  chapters still carry duplicate practice labels, Unicode bookmark warnings,
-  and underfull boxes that should not be confused with generated-chapter drift.
+- HL-B05 records the bounded cleanup for the older handwritten chapters so its
+  presentation warnings are not confused with generated-chapter drift.
+
+## Findings from HL-B05
+
+- Each handwritten recap now uses its canonical lesson id (`MR-C01-practice`
+  through `MR-C05-practice`) instead of five copies of `lesson:practice`.
+- Hyperref's PDF-string fallback strips only the `\mr` / `\marathifont`
+  presentation wrapper. The inspected outline keeps readable Devanagari and
+  romanization in all handwritten section bookmarks, while the generated
+  chapter keeps its intentionally Latin short titles.
+- `\raggedbottom` lets pages around unbreakable lesson callouts end naturally
+  instead of stretching vertical glue. Visual inspection of the three formerly
+  underfull pages plus the final recall page found no clipping, collision, or
+  awkward box spacing.
+- The vendored static Devanagari file is now explicitly selected for regular,
+  bold, italic, and bold-italic requests. This matches the old fallback's glyph
+  appearance while avoiding misleading unavailable-shape warnings.
+- The forced 31-page XeLaTeX build now reports zero package or LaTeX warnings,
+  missing glyphs, overfull boxes, underfull boxes, and duplicate destinations.
+  HL-B06 is next: publish Gujarati Chapter 6 through the same canonical pipeline.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/marathi/CHANGELOG.md
+++ b/code/learning/human-languages/marathi/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Warning-clean six-chapter book — 2026-08-03
+
+- Gave the five handwritten recap sections stable canonical lesson labels rather
+  than five copies of `lesson:practice`.
+- Kept Devanagari text in PDF bookmarks while removing font-only commands from
+  Hyperref strings, and let pages around unbreakable callouts end naturally.
+- Declared the vendored static Devanagari file for every requested font shape.
+  The forced 31-page build now has zero LaTeX/package warnings, missing glyphs,
+  overfull or underfull boxes, and duplicate destinations.
+
 ## Generated Chapter 6 — 2026-08-03
 
 - Migrated both numbers 1–5 lessons to the strict schema-v2 contract with stable

--- a/code/learning/human-languages/marathi/README.md
+++ b/code/learning/human-languages/marathi/README.md
@@ -43,6 +43,8 @@ first five chapters retain their authored long-form narrative during migration.
 
 Compiles with XeLaTeX using the **vendored** Noto Sans Devanagari font
 (`../../_fonts/`) — the same font as the Hindi track. `latexmk -xelatex book.tex`.
+The six-chapter build is warning-clean, and its PDF outline preserves readable
+Devanagari while generated non-Latin sections use bookmark-safe romanization.
 
 ## Files
 

--- a/code/learning/human-languages/marathi/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch01-greetings.tex
@@ -119,7 +119,7 @@ every verb.
 \end{grammarlens}
 
 \section{Recap}
-\label{lesson:practice}
+\label{lesson:MR-C01-practice}
 
 \begin{center}
 \begin{tabular}{@{}lll@{}}

--- a/code/learning/human-languages/marathi/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch02-introductions.tex
@@ -138,7 +138,7 @@ Chapter~4's \emph{punh\=a bhe\d{t}\=u}.
 \end{cousinweb}
 
 \section{The whole exchange}
-\label{lesson:practice}
+\label{lesson:MR-C02-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/marathi/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch03-responding.tex
@@ -82,7 +82,7 @@ sultanates. An Indo-European negative wrapped around an Arabic noun.
 \end{cousinweb}
 
 \section{The whole exchange}
-\label{lesson:practice}
+\label{lesson:MR-C03-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/marathi/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch04-farewells.tex
@@ -79,7 +79,7 @@ The respectful \mr{घ्या} (\emph{ghy\=a}) matches \emph{tumh\=\i}; to a f
 \end{cousinweb}
 
 \section{The farewells}
-\label{lesson:practice}
+\label{lesson:MR-C04-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/marathi/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch05-first-verbs.tex
@@ -75,7 +75,7 @@ k\=am karto/karte} (``I work'').
 \end{cousinweb}
 
 \section{Sentences about yourself}
-\label{lesson:practice}
+\label{lesson:MR-C05-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/marathi/book/preamble.tex
+++ b/code/learning/human-languages/marathi/book/preamble.tex
@@ -30,7 +30,13 @@
 % Vendored Devanagari font (../../_fonts/ from <lang>/book/); \mr{...} = inline
 % Marathi snippet. Rendered font-only via Script=Devanagari (no polyglossia
 % Marathi module needed).
-\newfontfamily\marathifont[Path=../../_fonts/, Script=Devanagari]{NotoSansDevanagari-Static.ttf}
+\newfontfamily\marathifont[
+  Path=../../_fonts/,
+  Script=Devanagari,
+  BoldFont=NotoSansDevanagari-Static.ttf,
+  ItalicFont=NotoSansDevanagari-Static.ttf,
+  BoldItalicFont=NotoSansDevanagari-Static.ttf
+]{NotoSansDevanagari-Static.ttf}
 \newcommand{\mr}[1]{{\marathifont #1}}
 
 \hypersetup{
@@ -39,6 +45,14 @@
   pdfsubject={Etymology-driven Marathi curriculum},
   pdfkeywords={Marathi, Sanskrit, Devanagari, language learning}
 }
+\pdfstringdefDisableCommands{%
+  \def\mr#1{#1}% Keep Devanagari text while dropping font-only presentation.
+  \def\marathifont{}%
+}
+
+% Lesson callouts are deliberately kept together when they fit. Let short pages
+% end naturally instead of stretching their vertical glue around those boxes.
+\raggedbottom
 
 \newtcolorbox{cousinweb}{
   breakable, skin=enhanced, colback=yellow!8, colframe=yellow!45!black,


### PR DESCRIPTION
## Summary

- replace five duplicate handwritten recap labels with their canonical Marathi lesson IDs
- preserve Devanagari in PDF bookmarks while stripping font-only commands from Hyperref strings
- let pages around unbreakable lesson callouts end naturally instead of producing underfull vboxes
- explicitly map all requested Marathi font shapes to the vendored static Devanagari file
- mark HL-B05 complete and prioritize Gujarati Chapter 6 next

## Validation

- forced 31-page XeLaTeX build
- zero LaTeX warnings and zero package warnings
- zero missing glyphs, overfull boxes, underfull boxes, and duplicate destinations
- extracted PDF outline retains readable Devanagari plus romanization in handwritten section bookmarks
- visually inspected all three formerly underfull pages and the final recall page; no clipping, collisions, or awkward box spacing
- human-language-data build and deterministic book drift check pass
- git diff --check