### PR TITLE
feat(chief): add secure host channel kernel

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -751,6 +751,7 @@ members = [
     "chief-of-staff-channel-crypto",
     "chief-of-staff-channel-store",
     "chief-of-staff-channel-endpoints",
+    "chief-of-staff-secure-host-channel",
     "chief-of-staff-service-registry",
     "chief-of-staff-tool-api",
     "chief-of-staff-host-runtime",

--- a/code/packages/rust/chief-of-staff-secure-host-channel/BUILD
+++ b/code/packages/rust/chief-of-staff-secure-host-channel/BUILD
@@ -1,0 +1,1 @@
+cargo test -p chief-of-staff-secure-host-channel -- --nocapture

--- a/code/packages/rust/chief-of-staff-secure-host-channel/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-secure-host-channel/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Add fresh per-spawn X3DH bootstrap offers and authenticated child hellos.
+- Add strict bounded `D18O`, `D18H`, and `D18F` wire decoders.
+- Bind host, UUID-v7 session, direction, and exact sequence into frame AAD.
+- Close ratchet state after authentication failure or sequence exhaustion.

--- a/code/packages/rust/chief-of-staff-secure-host-channel/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-secure-host-channel/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "chief-of-staff-secure-host-channel"
+version = "0.1.0"
+edition = "2021"
+description = "Bounded authenticated host-channel bootstrap and wire protocol for D18 Chief"
+license = "MIT"
+
+[dependencies]
+coding_adventures_vault_secure_channel = { path = "../vault-secure-channel" }
+coding_adventures_x3dh = { path = "../x3dh" }

--- a/code/packages/rust/chief-of-staff-secure-host-channel/README.md
+++ b/code/packages/rust/chief-of-staff-secure-host-channel/README.md
@@ -1,0 +1,25 @@
+# chief-of-staff-secure-host-channel
+
+`chief-of-staff-secure-host-channel` is the transport-independent security
+kernel for D18 Chief host processes. It turns an unlocked orchestrator identity
+into a fresh per-spawn X3DH offer, lets the child answer with an authenticated
+hello, and wraps subsequent Vault Double Ratchet messages in strict bounded
+`D18F` records.
+
+The crate owns no file descriptors and performs no process, filesystem, or
+network I/O. A supervisor carries `BootstrapOffer`, `ClientHello`, and encrypted
+frame bytes over an inherited pipe, stdio, a Unix socket, or a Windows named
+pipe. Host ID, UUID-v7 session ID, direction, and exact sequence are bound into
+AEAD additional authenticated data on every frame.
+
+Malformed structures are rejected before ratchet state advances. An AEAD
+authentication failure permanently closes the channel because the underlying
+ratchet may consume receive state while authenticating.
+
+## Validation
+
+```sh
+cargo test -p chief-of-staff-secure-host-channel -- --nocapture
+cargo clippy -p chief-of-staff-secure-host-channel --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-secure-host-channel --no-deps
+```

--- a/code/packages/rust/chief-of-staff-secure-host-channel/required_capabilities.json
+++ b/code/packages/rust/chief-of-staff-secure-host-channel/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/chief-of-staff-secure-host-channel",
+  "capabilities": [],
+  "justification": "Pure bounded protocol and cryptographic orchestration over caller-provided bytes and identity material. Fresh key generation is delegated to the existing X3DH dependency; this package directly performs no filesystem, network, process, environment, clock, or stream access."
+}

--- a/code/packages/rust/chief-of-staff-secure-host-channel/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-secure-host-channel/src/lib.rs
@@ -1,0 +1,1079 @@
+//! Bounded authenticated host-channel bootstrap and records for D18 Chief.
+//!
+//! This crate is a pure byte-oriented protocol kernel. Supervisors provide an
+//! unlocked orchestrator identity and carry the returned bytes over a transport;
+//! the crate itself opens no files, streams, sockets, or processes.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use core::fmt::{self, Display, Formatter};
+
+use coding_adventures_vault_secure_channel::{
+    Channel, ChannelInitiator, ChannelResponder, FirstMessage,
+};
+use coding_adventures_x3dh::{
+    create_prekey_bundle, generate_identity_keypair, generate_prekey_pair, IdentityKeyPair,
+    PreKeyBundle, PreKeyPair,
+};
+
+const OFFER_MAGIC: &[u8; 4] = b"D18O";
+const HELLO_MAGIC: &[u8; 4] = b"D18H";
+const FRAME_MAGIC: &[u8; 4] = b"D18F";
+const VERSION: u8 = 1;
+const MAX_HOST_ID_BYTES: usize = 64;
+const MAX_FIRST_MESSAGE_BYTES: usize = 4 * 1024;
+const MAX_FRAME_BYTES: usize = 1024 * 1024;
+const FRAME_HEADER_BYTES: usize = 4 + 1 + 1 + 16 + 8 + 4;
+const VAULT_NEXT_MESSAGE_OVERHEAD: usize = 2 + 40 + 4 + 16;
+const MAX_VAULT_CIPHERTEXT_BYTES: usize = MAX_FRAME_BYTES - FRAME_HEADER_BYTES;
+const MAX_PLAINTEXT_BYTES: usize = MAX_VAULT_CIPHERTEXT_BYTES - VAULT_NEXT_MESSAGE_OVERHEAD;
+// The child consumes one inner ratchet counter during ClientHello, so close one
+// record before the u32 limit. This is conservative for the orchestrator too.
+const SEQUENCE_EXHAUSTION_LIMIT: u64 = (u32::MAX as u64) - 1;
+const MAX_OFFER_BYTES: usize = 4 + 1 + 1 + MAX_HOST_ID_BYTES + 16 + 32 + 32 + 4 + 32 + 64;
+const MAX_HELLO_BYTES: usize =
+    4 + 1 + 1 + MAX_HOST_ID_BYTES + 16 + 32 + 4 + MAX_FIRST_MESSAGE_BYTES;
+const FRAME_DOMAIN: &[u8] = b"chief-secure-host-channel-v1";
+const BOOTSTRAP_DOMAIN: &[u8] = b"chief-secure-host-bootstrap-v1";
+const BOOTSTRAP_PLAINTEXT: &[u8] = b"D18 secure host channel hello v1";
+
+/// Stable lowercase host identifier bound into every encrypted message.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct HostId(String);
+
+impl HostId {
+    /// Validate the D18 host-name grammar.
+    pub fn new(value: impl Into<String>) -> Result<Self, ChannelError> {
+        let value = value.into();
+        let bytes = value.as_bytes();
+        if bytes.len() < 2
+            || bytes.len() > MAX_HOST_ID_BYTES
+            || !bytes[0].is_ascii_lowercase()
+            || !bytes
+                .iter()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || *byte == b'-')
+        {
+            return Err(ChannelError::InvalidHostId);
+        }
+        Ok(Self(value))
+    }
+
+    /// Borrow the validated identifier.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for HostId {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// Canonical binary UUID-v7 session identifier.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SessionId([u8; 16]);
+
+impl SessionId {
+    /// Validate UUID-v7 version and RFC 4122 variant bits.
+    pub fn new(bytes: [u8; 16]) -> Result<Self, ChannelError> {
+        if bytes[6] >> 4 != 7 || bytes[8] & 0xc0 != 0x80 {
+            return Err(ChannelError::InvalidSessionId);
+        }
+        Ok(Self(bytes))
+    }
+
+    /// Return the canonical binary UUID bytes.
+    pub fn as_bytes(self) -> [u8; 16] {
+        self.0
+    }
+}
+
+/// The local endpoint's role in a host channel.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChannelRole {
+    /// Parent orchestrator, which publishes the X3DH prekey bundle.
+    Orchestrator,
+    /// Spawned child host, which initiates X3DH.
+    Child,
+}
+
+impl ChannelRole {
+    fn wire_tag(self) -> u8 {
+        match self {
+            Self::Orchestrator => 1,
+            Self::Child => 2,
+        }
+    }
+
+    fn peer(self) -> Self {
+        match self {
+            Self::Orchestrator => Self::Child,
+            Self::Child => Self::Orchestrator,
+        }
+    }
+}
+
+/// Bounded versioned orchestrator-to-child X3DH bootstrap bytes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BootstrapOffer(Vec<u8>);
+
+impl BootstrapOffer {
+    /// Validate and retain received offer bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ChannelError> {
+        decode_offer(bytes)?;
+        Ok(Self(bytes.to_vec()))
+    }
+
+    /// Borrow the encoded offer for transport.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Consume the wrapper and return transport bytes.
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+/// Bounded versioned child-to-orchestrator X3DH response bytes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ClientHello(Vec<u8>);
+
+impl ClientHello {
+    /// Validate and retain received hello bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ChannelError> {
+        decode_hello(bytes)?;
+        Ok(Self(bytes.to_vec()))
+    }
+
+    /// Borrow the encoded hello for transport.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Consume the wrapper and return transport bytes.
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+/// Orchestrator-side single-use X3DH bootstrap state.
+pub struct OrchestratorBootstrap<'a> {
+    identity: &'a IdentityKeyPair,
+    signed_prekey: PreKeyPair,
+    bundle: PreKeyBundle,
+    host: HostId,
+    session: SessionId,
+}
+
+impl<'a> OrchestratorBootstrap<'a> {
+    /// Create a fresh per-spawn signed prekey around an unlocked identity.
+    pub fn new(
+        identity: &'a IdentityKeyPair,
+        host: HostId,
+        session: SessionId,
+    ) -> Result<Self, ChannelError> {
+        let signed_prekey = generate_prekey_pair();
+        let session_prefix = [session.0[0], session.0[1], session.0[2], session.0[3]];
+        let prekey_id = u32::from_be_bytes(session_prefix);
+        let bundle = create_prekey_bundle(identity, &signed_prekey, prekey_id, None);
+        Ok(Self {
+            identity,
+            signed_prekey,
+            bundle,
+            host,
+            session,
+        })
+    }
+
+    /// Encode the public bundle and channel identity for the child.
+    pub fn offer(&self) -> Result<BootstrapOffer, ChannelError> {
+        Ok(BootstrapOffer(encode_offer(
+            &self.host,
+            self.session,
+            &self.bundle,
+        )))
+    }
+
+    /// Authenticate a child hello and consume this single-use bootstrap.
+    pub fn accept(self, hello: &ClientHello) -> Result<SecureHostChannel, ChannelError> {
+        let decoded = decode_hello(hello.as_bytes())?;
+        if decoded.host != self.host {
+            return Err(ChannelError::WrongHost);
+        }
+        if decoded.session != self.session {
+            return Err(ChannelError::WrongSession);
+        }
+        let aad = bootstrap_aad(&self.host, self.session);
+        let first = FirstMessage(decoded.first_message.to_vec());
+        let (channel, plaintext) = ChannelResponder::accept(
+            &first,
+            self.identity,
+            &self.signed_prekey,
+            None,
+            &decoded.child_identity,
+            &aad,
+        )
+        .map_err(|_| ChannelError::Crypto)?;
+        if plaintext != BOOTSTRAP_PLAINTEXT {
+            return Err(ChannelError::Crypto);
+        }
+        Ok(SecureHostChannel::new(
+            channel,
+            ChannelRole::Orchestrator,
+            self.host,
+            self.session,
+        ))
+    }
+}
+
+/// Child-side single-use bootstrap entry point.
+pub struct ChildBootstrap;
+
+impl ChildBootstrap {
+    /// Authenticate an offer and return the live child channel plus its hello.
+    pub fn open(offer: &BootstrapOffer) -> Result<(SecureHostChannel, ClientHello), ChannelError> {
+        let decoded = decode_offer(offer.as_bytes())?;
+        let child_identity = generate_identity_keypair();
+        let aad = bootstrap_aad(&decoded.host, decoded.session);
+        let (channel, first) =
+            ChannelInitiator::open(&child_identity, &decoded.bundle, BOOTSTRAP_PLAINTEXT, &aad)
+                .map_err(|_| ChannelError::Crypto)?;
+        if first.0.len() > MAX_FIRST_MESSAGE_BYTES {
+            return Err(ChannelError::FrameTooLarge);
+        }
+        let hello = ClientHello(encode_hello(
+            &decoded.host,
+            decoded.session,
+            &child_identity.x25519_public,
+            &first.0,
+        ));
+        Ok((
+            SecureHostChannel::new(channel, ChannelRole::Child, decoded.host, decoded.session),
+            hello,
+        ))
+    }
+}
+
+/// Live authenticated channel with exact per-direction stream sequencing.
+pub struct SecureHostChannel {
+    channel: Channel,
+    role: ChannelRole,
+    host: HostId,
+    session: SessionId,
+    send_sequence: u64,
+    receive_sequence: u64,
+    closed: bool,
+}
+
+impl SecureHostChannel {
+    fn new(channel: Channel, role: ChannelRole, host: HostId, session: SessionId) -> Self {
+        Self {
+            channel,
+            role,
+            host,
+            session,
+            send_sequence: 0,
+            receive_sequence: 0,
+            closed: false,
+        }
+    }
+
+    /// Encrypt one bounded plaintext and return a complete `D18F` record.
+    pub fn send(&mut self, plaintext: &[u8]) -> Result<Vec<u8>, ChannelError> {
+        self.ensure_open()?;
+        if plaintext.len() > MAX_PLAINTEXT_BYTES {
+            return Err(ChannelError::FrameTooLarge);
+        }
+        if self.send_sequence == SEQUENCE_EXHAUSTION_LIMIT {
+            self.closed = true;
+            return Err(ChannelError::SequenceExhausted);
+        }
+        let aad = frame_aad(&self.host, self.session, self.role, self.send_sequence);
+        let ciphertext = match self.channel.send(plaintext, &aad) {
+            Ok(ciphertext) => ciphertext,
+            Err(_) => {
+                self.closed = true;
+                return Err(ChannelError::Crypto);
+            }
+        };
+        if ciphertext.len() > MAX_VAULT_CIPHERTEXT_BYTES {
+            self.closed = true;
+            return Err(ChannelError::FrameTooLarge);
+        }
+        let frame = encode_frame(self.role, self.session, self.send_sequence, &ciphertext);
+        self.send_sequence += 1;
+        Ok(frame)
+    }
+
+    /// Validate, authenticate, and decrypt the exact next peer `D18F` record.
+    pub fn receive(&mut self, frame: &[u8]) -> Result<Vec<u8>, ChannelError> {
+        self.ensure_open()?;
+        if self.receive_sequence == SEQUENCE_EXHAUSTION_LIMIT {
+            self.closed = true;
+            return Err(ChannelError::SequenceExhausted);
+        }
+        let decoded = decode_frame(frame)?;
+        if decoded.session != self.session {
+            return Err(ChannelError::WrongSession);
+        }
+        let expected_role = self.role.peer();
+        if decoded.direction != expected_role {
+            return Err(ChannelError::WrongDirection);
+        }
+        if decoded.sequence != self.receive_sequence {
+            return Err(ChannelError::UnexpectedSequence);
+        }
+        let aad = frame_aad(
+            &self.host,
+            self.session,
+            expected_role,
+            self.receive_sequence,
+        );
+        let plaintext = match self.channel.receive(decoded.ciphertext, &aad) {
+            Ok(plaintext) => plaintext,
+            Err(_) => {
+                self.closed = true;
+                return Err(ChannelError::Crypto);
+            }
+        };
+        if plaintext.len() > MAX_PLAINTEXT_BYTES {
+            self.closed = true;
+            return Err(ChannelError::FrameTooLarge);
+        }
+        self.receive_sequence += 1;
+        Ok(plaintext)
+    }
+
+    /// Return this endpoint's channel role.
+    pub fn role(&self) -> ChannelRole {
+        self.role
+    }
+
+    /// Borrow the host identity bound into AAD.
+    pub fn host_id(&self) -> &HostId {
+        &self.host
+    }
+
+    /// Return the UUID-v7 session identity bound into AAD.
+    pub fn session_id(&self) -> SessionId {
+        self.session
+    }
+
+    /// Report whether a cryptographic failure or sequence exhaustion closed the channel.
+    pub fn is_closed(&self) -> bool {
+        self.closed
+    }
+
+    fn ensure_open(&self) -> Result<(), ChannelError> {
+        if self.closed {
+            Err(ChannelError::Closed)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Bounded protocol failures with input-independent display text.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChannelError {
+    /// Host identifier did not satisfy the stable D18 grammar.
+    InvalidHostId,
+    /// Session bytes were not a canonical UUID-v7 value.
+    InvalidSessionId,
+    /// Offer or hello structure was malformed, truncated, or padded.
+    MalformedBootstrap,
+    /// Encrypted frame structure was malformed, truncated, or padded.
+    MalformedFrame,
+    /// A structurally valid record used an unsupported wire version.
+    UnsupportedVersion,
+    /// A declared or produced record exceeded its protocol bound.
+    FrameTooLarge,
+    /// Child hello identified a different host.
+    WrongHost,
+    /// Record identified a different session.
+    WrongSession,
+    /// Record was sent in the wrong channel direction.
+    WrongDirection,
+    /// Ordered stream record did not contain the exact next sequence.
+    UnexpectedSequence,
+    /// A sequence counter reached its non-wrapping terminal value.
+    SequenceExhausted,
+    /// X3DH, ratchet, signature, or AEAD authentication failed.
+    Crypto,
+    /// Channel was permanently closed after a terminal failure.
+    Closed,
+}
+
+impl Display for ChannelError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidHostId => "secure-host-channel: invalid host id",
+            Self::InvalidSessionId => "secure-host-channel: invalid UUID-v7 session id",
+            Self::MalformedBootstrap => "secure-host-channel: malformed bootstrap record",
+            Self::MalformedFrame => "secure-host-channel: malformed encrypted frame",
+            Self::UnsupportedVersion => "secure-host-channel: unsupported wire version",
+            Self::FrameTooLarge => "secure-host-channel: record exceeds bounded frame size",
+            Self::WrongHost => "secure-host-channel: bootstrap host mismatch",
+            Self::WrongSession => "secure-host-channel: session mismatch",
+            Self::WrongDirection => "secure-host-channel: direction mismatch",
+            Self::UnexpectedSequence => "secure-host-channel: unexpected stream sequence",
+            Self::SequenceExhausted => "secure-host-channel: sequence exhausted",
+            Self::Crypto => "secure-host-channel: cryptographic operation failed",
+            Self::Closed => "secure-host-channel: channel is closed",
+        })
+    }
+}
+
+impl std::error::Error for ChannelError {}
+
+struct DecodedOffer {
+    host: HostId,
+    session: SessionId,
+    bundle: PreKeyBundle,
+}
+
+fn encode_offer(host: &HostId, session: SessionId, bundle: &PreKeyBundle) -> Vec<u8> {
+    let mut output = Vec::with_capacity(MAX_OFFER_BYTES);
+    output.extend_from_slice(OFFER_MAGIC);
+    output.push(VERSION);
+    encode_host_session(&mut output, host, session);
+    output.extend_from_slice(&bundle.identity_key);
+    output.extend_from_slice(&bundle.identity_key_sign);
+    output.extend_from_slice(&bundle.signed_prekey_id.to_be_bytes());
+    output.extend_from_slice(&bundle.signed_prekey);
+    output.extend_from_slice(&bundle.signed_prekey_sig);
+    output
+}
+
+fn decode_offer(bytes: &[u8]) -> Result<DecodedOffer, ChannelError> {
+    if bytes.len() > MAX_OFFER_BYTES {
+        return Err(ChannelError::FrameTooLarge);
+    }
+    let mut position = 0;
+    expect_magic(
+        bytes,
+        &mut position,
+        OFFER_MAGIC,
+        ChannelError::MalformedBootstrap,
+    )?;
+    expect_version(bytes, &mut position, ChannelError::MalformedBootstrap)?;
+    let (host, session) = decode_host_session(bytes, &mut position)?;
+    let identity_key = take_array(bytes, &mut position, ChannelError::MalformedBootstrap)?;
+    let identity_key_sign = take_array(bytes, &mut position, ChannelError::MalformedBootstrap)?;
+    let signed_prekey_id = u32::from_be_bytes(take_array(
+        bytes,
+        &mut position,
+        ChannelError::MalformedBootstrap,
+    )?);
+    let signed_prekey = take_array(bytes, &mut position, ChannelError::MalformedBootstrap)?;
+    let signed_prekey_sig = take_array(bytes, &mut position, ChannelError::MalformedBootstrap)?;
+    ensure_end(bytes, position, ChannelError::MalformedBootstrap)?;
+    Ok(DecodedOffer {
+        host,
+        session,
+        bundle: PreKeyBundle {
+            identity_key,
+            identity_key_sign,
+            signed_prekey_id,
+            signed_prekey,
+            signed_prekey_sig,
+            one_time_prekey_id: None,
+            one_time_prekey: None,
+        },
+    })
+}
+
+struct DecodedHello<'a> {
+    host: HostId,
+    session: SessionId,
+    child_identity: [u8; 32],
+    first_message: &'a [u8],
+}
+
+fn encode_hello(
+    host: &HostId,
+    session: SessionId,
+    child_identity: &[u8; 32],
+    first_message: &[u8],
+) -> Vec<u8> {
+    let mut output = Vec::with_capacity(MAX_HELLO_BYTES);
+    output.extend_from_slice(HELLO_MAGIC);
+    output.push(VERSION);
+    encode_host_session(&mut output, host, session);
+    output.extend_from_slice(child_identity);
+    output.extend_from_slice(&(first_message.len() as u32).to_be_bytes());
+    output.extend_from_slice(first_message);
+    output
+}
+
+fn decode_hello(bytes: &[u8]) -> Result<DecodedHello<'_>, ChannelError> {
+    if bytes.len() > MAX_HELLO_BYTES {
+        return Err(ChannelError::FrameTooLarge);
+    }
+    let mut position = 0;
+    expect_magic(
+        bytes,
+        &mut position,
+        HELLO_MAGIC,
+        ChannelError::MalformedBootstrap,
+    )?;
+    expect_version(bytes, &mut position, ChannelError::MalformedBootstrap)?;
+    let (host, session) = decode_host_session(bytes, &mut position)?;
+    let child_identity = take_array(bytes, &mut position, ChannelError::MalformedBootstrap)?;
+    let declared = u32::from_be_bytes(take_array(
+        bytes,
+        &mut position,
+        ChannelError::MalformedBootstrap,
+    )?) as usize;
+    if declared > MAX_FIRST_MESSAGE_BYTES {
+        return Err(ChannelError::FrameTooLarge);
+    }
+    let first_message = take(
+        bytes,
+        &mut position,
+        declared,
+        ChannelError::MalformedBootstrap,
+    )?;
+    ensure_end(bytes, position, ChannelError::MalformedBootstrap)?;
+    Ok(DecodedHello {
+        host,
+        session,
+        child_identity,
+        first_message,
+    })
+}
+
+struct DecodedFrame<'a> {
+    direction: ChannelRole,
+    session: SessionId,
+    sequence: u64,
+    ciphertext: &'a [u8],
+}
+
+fn encode_frame(
+    direction: ChannelRole,
+    session: SessionId,
+    sequence: u64,
+    ciphertext: &[u8],
+) -> Vec<u8> {
+    let mut output = Vec::with_capacity(FRAME_HEADER_BYTES + ciphertext.len());
+    output.extend_from_slice(FRAME_MAGIC);
+    output.push(VERSION);
+    output.push(direction.wire_tag());
+    output.extend_from_slice(&session.0);
+    output.extend_from_slice(&sequence.to_be_bytes());
+    output.extend_from_slice(&(ciphertext.len() as u32).to_be_bytes());
+    output.extend_from_slice(ciphertext);
+    output
+}
+
+fn decode_frame(bytes: &[u8]) -> Result<DecodedFrame<'_>, ChannelError> {
+    if bytes.len() > MAX_FRAME_BYTES {
+        return Err(ChannelError::FrameTooLarge);
+    }
+    let mut position = 0;
+    expect_magic(
+        bytes,
+        &mut position,
+        FRAME_MAGIC,
+        ChannelError::MalformedFrame,
+    )?;
+    expect_version(bytes, &mut position, ChannelError::MalformedFrame)?;
+    let direction = match take(bytes, &mut position, 1, ChannelError::MalformedFrame)?[0] {
+        1 => ChannelRole::Orchestrator,
+        2 => ChannelRole::Child,
+        _ => return Err(ChannelError::MalformedFrame),
+    };
+    let session = SessionId::new(take_array(
+        bytes,
+        &mut position,
+        ChannelError::MalformedFrame,
+    )?)?;
+    let sequence = u64::from_be_bytes(take_array(
+        bytes,
+        &mut position,
+        ChannelError::MalformedFrame,
+    )?);
+    let declared = u32::from_be_bytes(take_array(
+        bytes,
+        &mut position,
+        ChannelError::MalformedFrame,
+    )?) as usize;
+    if declared > MAX_VAULT_CIPHERTEXT_BYTES {
+        return Err(ChannelError::FrameTooLarge);
+    }
+    let ciphertext = take(bytes, &mut position, declared, ChannelError::MalformedFrame)?;
+    ensure_end(bytes, position, ChannelError::MalformedFrame)?;
+    Ok(DecodedFrame {
+        direction,
+        session,
+        sequence,
+        ciphertext,
+    })
+}
+
+fn encode_host_session(output: &mut Vec<u8>, host: &HostId, session: SessionId) {
+    output.push(host.0.len() as u8);
+    output.extend_from_slice(host.0.as_bytes());
+    output.extend_from_slice(&session.0);
+}
+
+fn decode_host_session(
+    bytes: &[u8],
+    position: &mut usize,
+) -> Result<(HostId, SessionId), ChannelError> {
+    let host_length = take(bytes, position, 1, ChannelError::MalformedBootstrap)?[0] as usize;
+    if host_length > MAX_HOST_ID_BYTES {
+        return Err(ChannelError::InvalidHostId);
+    }
+    let host_bytes = take(
+        bytes,
+        position,
+        host_length,
+        ChannelError::MalformedBootstrap,
+    )?;
+    let host_text = core::str::from_utf8(host_bytes).map_err(|_| ChannelError::InvalidHostId)?;
+    let host = HostId::new(host_text)?;
+    let session = SessionId::new(take_array(
+        bytes,
+        position,
+        ChannelError::MalformedBootstrap,
+    )?)?;
+    Ok((host, session))
+}
+
+fn expect_magic(
+    bytes: &[u8],
+    position: &mut usize,
+    expected: &[u8; 4],
+    malformed: ChannelError,
+) -> Result<(), ChannelError> {
+    if take(bytes, position, 4, malformed)? != expected {
+        return Err(malformed);
+    }
+    Ok(())
+}
+
+fn expect_version(
+    bytes: &[u8],
+    position: &mut usize,
+    malformed: ChannelError,
+) -> Result<(), ChannelError> {
+    let version = take(bytes, position, 1, malformed)?[0];
+    if version != VERSION {
+        return Err(ChannelError::UnsupportedVersion);
+    }
+    Ok(())
+}
+
+fn take<'a>(
+    bytes: &'a [u8],
+    position: &mut usize,
+    length: usize,
+    malformed: ChannelError,
+) -> Result<&'a [u8], ChannelError> {
+    let end = position.checked_add(length).ok_or(malformed)?;
+    let value = bytes.get(*position..end).ok_or(malformed)?;
+    *position = end;
+    Ok(value)
+}
+
+fn take_array<const N: usize>(
+    bytes: &[u8],
+    position: &mut usize,
+    malformed: ChannelError,
+) -> Result<[u8; N], ChannelError> {
+    take(bytes, position, N, malformed)?
+        .try_into()
+        .map_err(|_| malformed)
+}
+
+fn ensure_end(bytes: &[u8], position: usize, malformed: ChannelError) -> Result<(), ChannelError> {
+    if position == bytes.len() {
+        Ok(())
+    } else {
+        Err(malformed)
+    }
+}
+
+fn bootstrap_aad(host: &HostId, session: SessionId) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(2 + BOOTSTRAP_DOMAIN.len() + 2 + host.0.len() + 16);
+    append_length_prefixed(&mut aad, BOOTSTRAP_DOMAIN);
+    append_length_prefixed(&mut aad, host.0.as_bytes());
+    aad.extend_from_slice(&session.0);
+    aad
+}
+
+fn frame_aad(host: &HostId, session: SessionId, direction: ChannelRole, sequence: u64) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(2 + FRAME_DOMAIN.len() + 2 + host.0.len() + 16 + 1 + 8);
+    append_length_prefixed(&mut aad, FRAME_DOMAIN);
+    append_length_prefixed(&mut aad, host.0.as_bytes());
+    aad.extend_from_slice(&session.0);
+    aad.push(direction.wire_tag());
+    aad.extend_from_slice(&sequence.to_be_bytes());
+    aad
+}
+
+fn append_length_prefixed(output: &mut Vec<u8>, value: &[u8]) {
+    output.extend_from_slice(&(value.len() as u16).to_be_bytes());
+    output.extend_from_slice(value);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn host(value: &str) -> HostId {
+        HostId::new(value).unwrap()
+    }
+
+    fn session(last: u8) -> SessionId {
+        let mut bytes = [0u8; 16];
+        bytes[0..6].copy_from_slice(&[1, 2, 3, 4, 5, 6]);
+        bytes[6] = 0x70;
+        bytes[8] = 0x80;
+        bytes[15] = last;
+        SessionId::new(bytes).unwrap()
+    }
+
+    fn pending_handshake<'a>(
+        identity: &'a IdentityKeyPair,
+        host_id: &str,
+        session_id: SessionId,
+    ) -> (OrchestratorBootstrap<'a>, SecureHostChannel, ClientHello) {
+        let bootstrap = OrchestratorBootstrap::new(identity, host(host_id), session_id).unwrap();
+        let offer = bootstrap.offer().unwrap();
+        let (child, hello) = ChildBootstrap::open(&offer).unwrap();
+        (bootstrap, child, hello)
+    }
+
+    fn channel_pair() -> (SecureHostChannel, SecureHostChannel) {
+        let identity = generate_identity_keypair();
+        let (bootstrap, child, hello) = pending_handshake(&identity, "host-a", session(1));
+        let orchestrator = bootstrap.accept(&hello).unwrap();
+        (orchestrator, child)
+    }
+
+    #[test]
+    fn validates_host_and_session_identifiers() {
+        assert_eq!(host("host-7").as_str(), "host-7");
+        assert_eq!(host("host-7").to_string(), "host-7");
+        for invalid in ["", "a", "7host", "Host", "host_name"] {
+            assert_eq!(HostId::new(invalid), Err(ChannelError::InvalidHostId));
+        }
+        assert_eq!(
+            HostId::new("a".repeat(MAX_HOST_ID_BYTES + 1)),
+            Err(ChannelError::InvalidHostId)
+        );
+        let id = session(9);
+        assert_eq!(id.as_bytes()[15], 9);
+        let mut bad_version = id.as_bytes();
+        bad_version[6] = 0x60;
+        assert_eq!(
+            SessionId::new(bad_version),
+            Err(ChannelError::InvalidSessionId)
+        );
+        let mut bad_variant = id.as_bytes();
+        bad_variant[8] = 0x40;
+        assert_eq!(
+            SessionId::new(bad_variant),
+            Err(ChannelError::InvalidSessionId)
+        );
+    }
+
+    #[test]
+    fn offer_codec_is_bounded_and_strict() {
+        let identity = generate_identity_keypair();
+        let bootstrap = OrchestratorBootstrap::new(&identity, host("host-a"), session(1)).unwrap();
+        let offer = bootstrap.offer().unwrap();
+        let parsed = BootstrapOffer::from_bytes(offer.as_bytes()).unwrap();
+        assert_eq!(parsed.as_bytes(), offer.as_bytes());
+        assert_eq!(parsed.clone().into_bytes(), offer.as_bytes());
+        for end in 0..offer.as_bytes().len() {
+            assert!(BootstrapOffer::from_bytes(&offer.as_bytes()[..end]).is_err());
+        }
+        let mut trailing = offer.as_bytes().to_vec();
+        trailing.push(0);
+        assert_eq!(
+            BootstrapOffer::from_bytes(&trailing),
+            Err(ChannelError::MalformedBootstrap)
+        );
+        let mut wrong_version = offer.as_bytes().to_vec();
+        wrong_version[4] = 2;
+        assert_eq!(
+            BootstrapOffer::from_bytes(&wrong_version),
+            Err(ChannelError::UnsupportedVersion)
+        );
+        assert_eq!(
+            BootstrapOffer::from_bytes(&vec![0; MAX_OFFER_BYTES + 1]),
+            Err(ChannelError::FrameTooLarge)
+        );
+    }
+
+    #[test]
+    fn offer_rejects_invalid_host_and_session_fields() {
+        let identity = generate_identity_keypair();
+        let bootstrap = OrchestratorBootstrap::new(&identity, host("host-a"), session(1)).unwrap();
+        let offer = bootstrap.offer().unwrap();
+        let mut invalid_utf8 = offer.as_bytes().to_vec();
+        invalid_utf8[6] = 0xff;
+        assert_eq!(
+            BootstrapOffer::from_bytes(&invalid_utf8),
+            Err(ChannelError::InvalidHostId)
+        );
+        let mut invalid_session = offer.as_bytes().to_vec();
+        let session_start = 6 + "host-a".len();
+        invalid_session[session_start + 6] = 0x60;
+        assert_eq!(
+            BootstrapOffer::from_bytes(&invalid_session),
+            Err(ChannelError::InvalidSessionId)
+        );
+        let mut zero_host = offer.as_bytes().to_vec();
+        zero_host[5] = 0;
+        assert_eq!(
+            BootstrapOffer::from_bytes(&zero_host),
+            Err(ChannelError::InvalidHostId)
+        );
+    }
+
+    #[test]
+    fn tampered_bundle_signature_fails_child_bootstrap() {
+        let identity = generate_identity_keypair();
+        let bootstrap = OrchestratorBootstrap::new(&identity, host("host-a"), session(1)).unwrap();
+        let offer = bootstrap.offer().unwrap();
+        let mut bytes = offer.into_bytes();
+        *bytes.last_mut().unwrap() ^= 1;
+        let tampered = BootstrapOffer::from_bytes(&bytes).unwrap();
+        assert!(matches!(
+            ChildBootstrap::open(&tampered),
+            Err(ChannelError::Crypto)
+        ));
+    }
+
+    #[test]
+    fn hello_codec_is_bounded_and_strict() {
+        let identity = generate_identity_keypair();
+        let (_, _, hello) = pending_handshake(&identity, "host-a", session(1));
+        let parsed = ClientHello::from_bytes(hello.as_bytes()).unwrap();
+        assert_eq!(parsed.as_bytes(), hello.as_bytes());
+        assert_eq!(parsed.clone().into_bytes(), hello.as_bytes());
+        for end in 0..hello.as_bytes().len() {
+            assert!(ClientHello::from_bytes(&hello.as_bytes()[..end]).is_err());
+        }
+        let mut trailing = hello.as_bytes().to_vec();
+        trailing.push(0);
+        assert_eq!(
+            ClientHello::from_bytes(&trailing),
+            Err(ChannelError::MalformedBootstrap)
+        );
+        let mut too_large = hello.as_bytes().to_vec();
+        let length_offset = 4 + 1 + 1 + "host-a".len() + 16 + 32;
+        too_large[length_offset..length_offset + 4]
+            .copy_from_slice(&((MAX_FIRST_MESSAGE_BYTES as u32) + 1).to_be_bytes());
+        assert_eq!(
+            ClientHello::from_bytes(&too_large),
+            Err(ChannelError::FrameTooLarge)
+        );
+        assert_eq!(
+            ClientHello::from_bytes(&vec![0; MAX_HELLO_BYTES + 1]),
+            Err(ChannelError::FrameTooLarge)
+        );
+    }
+
+    #[test]
+    fn handshake_binds_host_and_session() {
+        let identity = generate_identity_keypair();
+        let (bootstrap, _, hello) = pending_handshake(&identity, "host-a", session(1));
+        let mut wrong_host = hello.into_bytes();
+        let host_start = 6;
+        wrong_host[host_start..host_start + 6].copy_from_slice(b"host-b");
+        let wrong_host = ClientHello::from_bytes(&wrong_host).unwrap();
+        assert!(matches!(
+            bootstrap.accept(&wrong_host),
+            Err(ChannelError::WrongHost)
+        ));
+
+        let (bootstrap, _, hello) = pending_handshake(&identity, "host-a", session(1));
+        let mut wrong_session = hello.into_bytes();
+        let session_start = 6 + "host-a".len();
+        wrong_session[session_start + 15] ^= 1;
+        let wrong_session = ClientHello::from_bytes(&wrong_session).unwrap();
+        assert!(matches!(
+            bootstrap.accept(&wrong_session),
+            Err(ChannelError::WrongSession)
+        ));
+    }
+
+    #[test]
+    fn bidirectional_messages_round_trip_with_identity_accessors() {
+        let (mut orchestrator, mut child) = channel_pair();
+        assert_eq!(orchestrator.role(), ChannelRole::Orchestrator);
+        assert_eq!(child.role(), ChannelRole::Child);
+        assert_eq!(child.host_id(), &host("host-a"));
+        assert_eq!(child.session_id(), session(1));
+        assert!(!child.is_closed());
+        for index in 0..64u8 {
+            let child_message = vec![index; usize::from(index) + 1];
+            let frame = child.send(&child_message).unwrap();
+            assert_eq!(orchestrator.receive(&frame).unwrap(), child_message);
+            let response = vec![255 - index; usize::from(index) + 2];
+            let frame = orchestrator.send(&response).unwrap();
+            assert_eq!(child.receive(&frame).unwrap(), response);
+        }
+    }
+
+    #[test]
+    fn every_truncated_frame_and_trailing_byte_is_rejected() {
+        let (mut orchestrator, mut child) = channel_pair();
+        let frame = child.send(b"complete").unwrap();
+        for end in 0..frame.len() {
+            assert!(decode_frame(&frame[..end]).is_err());
+        }
+        let mut trailing = frame.clone();
+        trailing.push(0);
+        assert_eq!(
+            orchestrator.receive(&trailing),
+            Err(ChannelError::MalformedFrame)
+        );
+        assert_eq!(orchestrator.receive(&frame).unwrap(), b"complete");
+    }
+
+    #[test]
+    fn structural_rejections_do_not_advance_receive_state() {
+        let (mut orchestrator, mut child) = channel_pair();
+        let frame = child.send(b"expected").unwrap();
+
+        let mut wrong_direction = frame.clone();
+        wrong_direction[5] = ChannelRole::Orchestrator.wire_tag();
+        assert_eq!(
+            orchestrator.receive(&wrong_direction),
+            Err(ChannelError::WrongDirection)
+        );
+
+        let mut wrong_session = frame.clone();
+        wrong_session[6 + 15] ^= 1;
+        assert_eq!(
+            orchestrator.receive(&wrong_session),
+            Err(ChannelError::WrongSession)
+        );
+
+        let mut wrong_sequence = frame.clone();
+        wrong_sequence[22..30].copy_from_slice(&7u64.to_be_bytes());
+        assert_eq!(
+            orchestrator.receive(&wrong_sequence),
+            Err(ChannelError::UnexpectedSequence)
+        );
+        assert_eq!(orchestrator.receive(&frame).unwrap(), b"expected");
+        assert_eq!(
+            orchestrator.receive(&frame),
+            Err(ChannelError::UnexpectedSequence)
+        );
+    }
+
+    #[test]
+    fn malformed_frame_fields_are_rejected_before_decryption() {
+        let (mut orchestrator, mut child) = channel_pair();
+        let frame = child.send(b"expected").unwrap();
+
+        let mut wrong_magic = frame.clone();
+        wrong_magic[0] = b'X';
+        assert_eq!(
+            orchestrator.receive(&wrong_magic),
+            Err(ChannelError::MalformedFrame)
+        );
+        let mut wrong_version = frame.clone();
+        wrong_version[4] = 2;
+        assert_eq!(
+            orchestrator.receive(&wrong_version),
+            Err(ChannelError::UnsupportedVersion)
+        );
+        let mut bad_direction = frame.clone();
+        bad_direction[5] = 7;
+        assert_eq!(
+            orchestrator.receive(&bad_direction),
+            Err(ChannelError::MalformedFrame)
+        );
+        let mut invalid_session = frame.clone();
+        invalid_session[6 + 6] = 0x60;
+        assert_eq!(
+            orchestrator.receive(&invalid_session),
+            Err(ChannelError::InvalidSessionId)
+        );
+        let mut oversized = frame.clone();
+        oversized[30..34].copy_from_slice(&((MAX_VAULT_CIPHERTEXT_BYTES as u32) + 1).to_be_bytes());
+        assert_eq!(
+            orchestrator.receive(&oversized),
+            Err(ChannelError::FrameTooLarge)
+        );
+        assert_eq!(
+            orchestrator.receive(&vec![0; MAX_FRAME_BYTES + 1]),
+            Err(ChannelError::FrameTooLarge)
+        );
+        assert_eq!(orchestrator.receive(&frame).unwrap(), b"expected");
+    }
+
+    #[test]
+    fn authentication_failure_permanently_closes_channel() {
+        let (mut orchestrator, mut child) = channel_pair();
+        let mut frame = child.send(b"authentic").unwrap();
+        *frame.last_mut().unwrap() ^= 1;
+        assert_eq!(orchestrator.receive(&frame), Err(ChannelError::Crypto));
+        assert!(orchestrator.is_closed());
+        assert_eq!(orchestrator.send(b"after"), Err(ChannelError::Closed));
+        assert_eq!(orchestrator.receive(&frame), Err(ChannelError::Closed));
+    }
+
+    #[test]
+    fn host_is_bound_into_frame_aad() {
+        let (mut orchestrator, mut child) = channel_pair();
+        let frame = child.send(b"bound").unwrap();
+        orchestrator.host = host("host-b");
+        assert_eq!(orchestrator.receive(&frame), Err(ChannelError::Crypto));
+    }
+
+    #[test]
+    fn plaintext_and_sequence_bounds_fail_closed_as_specified() {
+        let (mut orchestrator, mut child) = channel_pair();
+        assert_eq!(
+            child.send(&vec![0; MAX_PLAINTEXT_BYTES + 1]),
+            Err(ChannelError::FrameTooLarge)
+        );
+        assert!(!child.is_closed());
+        child.send_sequence = SEQUENCE_EXHAUSTION_LIMIT;
+        assert_eq!(child.send(b"never"), Err(ChannelError::SequenceExhausted));
+        assert!(child.is_closed());
+
+        orchestrator.receive_sequence = SEQUENCE_EXHAUSTION_LIMIT;
+        assert_eq!(
+            orchestrator.receive(b"never"),
+            Err(ChannelError::SequenceExhausted)
+        );
+        assert!(orchestrator.is_closed());
+    }
+
+    #[test]
+    fn error_messages_are_literal_and_safe() {
+        let errors = [
+            ChannelError::InvalidHostId,
+            ChannelError::InvalidSessionId,
+            ChannelError::MalformedBootstrap,
+            ChannelError::MalformedFrame,
+            ChannelError::UnsupportedVersion,
+            ChannelError::FrameTooLarge,
+            ChannelError::WrongHost,
+            ChannelError::WrongSession,
+            ChannelError::WrongDirection,
+            ChannelError::UnexpectedSequence,
+            ChannelError::SequenceExhausted,
+            ChannelError::Crypto,
+            ChannelError::Closed,
+        ];
+        for error in errors {
+            assert!(error.to_string().starts_with("secure-host-channel:"));
+            assert!(std::error::Error::source(&error).is_none());
+        }
+    }
+}

--- a/code/specs/secure-host-channel.md
+++ b/code/specs/secure-host-channel.md
@@ -244,6 +244,9 @@ increasing big-endian `u64` per direction. Length-prefixing variable fields
 prevents concatenation ambiguity. Including direction in AAD prevents an
 attacker from replaying a child's request as if it came from the
 orchestrator. Sequence exhaustion closes the channel rather than wrapping.
+Although the host record reserves a `u64`, V1 closes at the underlying Double
+Ratchet's `u32` message-counter limit; later versions may use the remaining wire
+range only if the cryptographic primitive can do so without an inner wrap.
 
 The Double Ratchet's internal counters and DH ratchet steps are managed by
 `vault-secure-channel`; this spec does not override them.
@@ -647,7 +650,7 @@ Rust implementation, matching the existing vault crates.
 // Channel handle (used by both orchestrator and child sides)
 // ─────────────────────────────────────────────────────────────────
 
-pub struct OrchestratorBootstrap { /* OIK + per-spawn OSPK */ }
+pub struct OrchestratorBootstrap<'a> { /* borrowed OIK + per-spawn OSPK */ }
 pub struct ChildBootstrap { /* per-spawn CIK */ }
 pub struct BootstrapOffer(Vec<u8>);
 pub struct ClientHello(Vec<u8>);
@@ -656,8 +659,8 @@ pub struct SecureHostChannel {
     /* opaque ratchet, role, host/session identity, and counters */
 }
 
-impl OrchestratorBootstrap {
-    pub fn new(identity: IdentityKeyPair, host: HostId, session: SessionId)
+impl<'a> OrchestratorBootstrap<'a> {
+    pub fn new(identity: &'a IdentityKeyPair, host: HostId, session: SessionId)
         -> Result<Self, ChannelError>;
     pub fn offer(&self) -> Result<BootstrapOffer, ChannelError>;
     pub fn accept(self, hello: &ClientHello)

--- a/code/specs/secure-host-channel.md
+++ b/code/specs/secure-host-channel.md
@@ -148,39 +148,44 @@ established before any Host Protocol message flows:
 ORCHESTRATOR                                          CHILD HOST PROCESS
 ────────────                                          ──────────────────
 
-(holds long-term identity key OIK from vault-key-custody)
-generate per-spawn ephemeral X25519 key OEK
-publish PreKeyBundle{OIK_pub, OEK_pub, signature}
-to a fresh in-memory location
+(holds long-term identity key OIK after vault-key-custody unlock)
+generate a fresh per-spawn signed X25519 prekey OSPK
+build the standard X3DH PreKeyBundle
+  { OIK_x25519_pub, OIK_ed25519_pub,
+    OSPK_pub, OIK_signature(OSPK_pub) }
 
 spawn child process with:
   - argv: <path to host package>
   - env:  CHANNEL_BOOTSTRAP_FD=3  (the fd carrying bootstrap)
   - fd 3: read end of pipe carrying:
-          { protocol_version: "1.0",
-            orch_prekey_bundle: { OIK_pub, OEK_pub, sig },
-            child_session_id:   uuid,
-            channel_aad_prefix: "host://<child_id>/<session_id>" }
+          a bounded, versioned BootstrapOffer containing:
+          { host_id, canonical UUID-v7 session_id,
+            orch_prekey_bundle }
                                                        │
                                                        ▼
                                                  read bootstrap from fd 3
                                                  generate child identity key CIK
-                                                 generate child ephemeral key CEK
+                                                 (X3DH generates a single-use
+                                                  child ephemeral key CEK)
 
                                                  ChannelInitiator::open(
                                                    identity = CIK,
-                                                   bundle   = OIK+OEK,
+                                                   bundle   = OIK+OSPK,
                                                    payload  = "hello",
-                                                   aad      = channel_aad_prefix)
+                                                   aad      = bootstrap_aad(
+                                                                host_id,
+                                                                session_id))
                                                  produces first wire message
 
-                                                 send first wire message to
+                                                 send ClientHello containing
+                                                 CIK_x25519_pub and the first
+                                                 vault-channel wire message to
                                                  orchestrator over the bidirectional
                                                  transport (e.g., stdin/stdout)
 
-orch reads first wire message
+orch reads ClientHello
 ChannelResponder::accept(...)
-recovers child's ephemeral key CEK_pub
+uses CIK_x25519_pub plus the embedded CEK_pub
 both sides now share a ratchet root
                                                        ◄── ratcheted from here on ──►
 
@@ -198,10 +203,10 @@ Properties this gives us:
    identity key from the moment of spawn, the attacker cannot impersonate
    the orchestrator to other children.
 
-2. The orchestrator's per-spawn ephemeral key OEK is rotated on every
-   spawn. If a child is compromised and exfiltrates OEK_pub plus its own
+2. The orchestrator's per-spawn signed prekey OSPK is rotated on every
+   spawn. If a child is compromised and exfiltrates OSPK_pub plus its own
    state, the attacker still cannot read other children's traffic; their
-   X3DH used a different OEK.
+   X3DH used a different OSPK.
 
 3. The bootstrap travels over a fresh pipe fd known only to the parent and
    the immediate child. It does not pass through stdin/stdout (which a
@@ -209,10 +214,18 @@ Properties this gives us:
    environment variables (which could be inspected by a sibling process
    on a non-sandboxed system).
 
-4. The channel AAD prefix binds every encrypted message to the specific
-   child and session. A captured ciphertext from one session cannot be
-   replayed into another — the AEAD verification fails because the AAD
-   does not match.
+4. The AAD is derived internally from the protocol domain, host id,
+   session id, direction, and sequence. Callers cannot accidentally omit
+   or vary one of those fields. A captured ciphertext from one session
+   cannot be replayed into another — the AEAD verification fails because
+   the AAD does not match.
+
+The protocol kernel does not open file descriptors or choose a transport.
+It encodes/decodes the offer and hello and turns plaintext into bounded wire
+frames. The process supervisor is responsible for carrying those byte strings
+over an inherited pipe, stdio, a Unix socket, or a named pipe. Keeping I/O
+behind that boundary makes the cryptographic state machine deterministic and
+portable across all three CI operating systems.
 
 ### Per-Message Encryption
 
@@ -221,17 +234,25 @@ chunk — passes through the channel as an AEAD ciphertext:
 
 ```
 plaintext  = utf-8 json (a single Host Protocol message)
-aad        = channel_aad_prefix || ":" || direction || ":" || sequence
+aad        = len(domain) || domain || len(host_id) || host_id
+             || session_id || direction_tag || sequence_be_u64
 ciphertext = vault_secure_channel.send(plaintext, aad)
 ```
 
-The `direction` is `"orch"` or `"child"`; the `sequence` is a monotonically
-increasing per-direction counter. Including direction in AAD prevents an
+The direction is an unambiguous one-byte tag and the sequence is a monotonically
+increasing big-endian `u64` per direction. Length-prefixing variable fields
+prevents concatenation ambiguity. Including direction in AAD prevents an
 attacker from replaying a child's request as if it came from the
-orchestrator.
+orchestrator. Sequence exhaustion closes the channel rather than wrapping.
 
 The Double Ratchet's internal counters and DH ratchet steps are managed by
 `vault-secure-channel`; this spec does not override them.
+
+If AEAD authentication fails, the protocol kernel permanently closes that
+channel instance. The underlying ratchet consumes key material while attempting
+decryption, so retrying after an authentication failure would operate from an
+ambiguous state. Structural frame errors are rejected before invoking the
+ratchet and do not advance the receive sequence.
 
 ### Key Rotation Schedule
 
@@ -554,22 +575,31 @@ ones. A replay window of 10,000 IDs is maintained per origin.
 
 ## Wire Format
 
-Every encrypted frame on the wire:
+Bootstrap and encrypted records use separate magic values and one common
+version. Every encrypted data frame on the wire is:
 
 ```
 ┌──────────────┬────────────────────────────────────────────────┐
-│ length: u32  │ ciphertext: vault-secure-channel format         │
-│ big-endian   │   First message:  "C1" || ek_pub(32) || dr_hdr  │
-│ (payload     │                       (40) || ct_len(4) || ct   │
-│  size)       │   Subsequent:     "CN" || dr_hdr(40) ||         │
-│              │                       ct_len(4) || ct           │
+│ "D18F"       │ version │ direction │ session UUID │ sequence  │
+├──────────────┼─────────┴───────────┴──────────────┴───────────┤
+│ length: u32  │ vault-secure-channel ciphertext                │
+│ big-endian   │ ("CN" || DR header || inner length || AEAD)     │
 └──────────────┴────────────────────────────────────────────────┘
 ```
 
-The outer length prefix is identical across transports (stdio,
-Unix socket, named pipe). The inner payload is exactly what
-`vault-secure-channel` produces — no double-wrapping, no extra
-header.
+The host frame header is authenticated indirectly because its direction,
+session, and sequence fields are reconstructed as AEAD AAD. The receiver
+validates magic, version, direction, canonical UUID-v7 bits, expected sequence,
+and the declared ciphertext length before copying or decrypting ciphertext.
+Unknown versions, truncated records, padded records, wrong-session records,
+wrong-direction records, oversized lengths, and trailing bytes fail closed.
+
+`BootstrapOffer` uses magic `D18O`; `ClientHello` uses magic `D18H`. Both carry
+the same version, bounded host id, and canonical UUID-v7 session id as the data
+frame. The offer additionally carries the orchestrator X3DH public bundle. The
+hello additionally carries the child's X25519 identity public key and a bounded
+vault `FirstMessage`. Each decoder validates every declared length before
+copying the corresponding bytes and requires exact end-of-record consumption.
 
 For stdio transport, the line-delimited JSON format from
 `host-protocol.md` is **replaced** by length-prefixed framing once the
@@ -582,10 +612,10 @@ frames).
 without decryption. Streaming large payloads is done with multiple
 chunked frames (as defined in `host-protocol.md`).
 
-**Replay window:** The Double Ratchet inherently handles in-order
-delivery; out-of-order frames within a small window (default 16) are
-buffered and processed when the gap fills. Frames more than 16 sequence
-numbers behind the highest seen are rejected as replays.
+**Replay policy:** V1 supervisor transports are ordered byte streams, so the
+protocol kernel requires the exact next sequence. Replays and gaps fail before
+decryption. A future datagram adapter may add a bounded reorder window outside
+the cryptographic state machine; it must not weaken the in-order stream mode.
 
 ---
 
@@ -617,36 +647,34 @@ Rust implementation, matching the existing vault crates.
 // Channel handle (used by both orchestrator and child sides)
 // ─────────────────────────────────────────────────────────────────
 
+pub struct OrchestratorBootstrap { /* OIK + per-spawn OSPK */ }
+pub struct ChildBootstrap { /* per-spawn CIK */ }
+pub struct BootstrapOffer(Vec<u8>);
+pub struct ClientHello(Vec<u8>);
+
 pub struct SecureHostChannel {
-    /* opaque internals: ratchet, queues, window, circuit */
+    /* opaque ratchet, role, host/session identity, and counters */
+}
+
+impl OrchestratorBootstrap {
+    pub fn new(identity: IdentityKeyPair, host: HostId, session: SessionId)
+        -> Result<Self, ChannelError>;
+    pub fn offer(&self) -> Result<BootstrapOffer, ChannelError>;
+    pub fn accept(self, hello: &ClientHello)
+        -> Result<SecureHostChannel, ChannelError>;
+}
+
+impl ChildBootstrap {
+    pub fn open(offer: &BootstrapOffer)
+        -> Result<(SecureHostChannel, ClientHello), ChannelError>;
 }
 
 impl SecureHostChannel {
-    /// Bootstrap as the orchestrator side.
-    pub fn open_orchestrator(
-        identity:       &IdentityKey,
-        per_spawn:      EphemeralKey,
-        child_session:  SessionId,
-        transport:      Box<dyn Transport>,
-    ) -> Result<Self, ChannelError>;
-
-    /// Bootstrap as the child side. Reads bootstrap from the fd
-    /// the parent supplied, then completes X3DH.
-    pub fn open_child(
-        bootstrap_fd:   RawFd,
-        transport:      Box<dyn Transport>,
-    ) -> Result<Self, ChannelError>;
-
-    /// Send a Host Protocol message. Returns once the message is
-    /// queued; flow-control backpressure may apply.
-    pub fn send(&mut self, msg: HostProtocolMessage) -> Result<(), SendError>;
-
-    /// Receive the next decrypted message. Blocks until one is available
-    /// or the channel is closed.
-    pub fn recv(&mut self) -> Result<HostProtocolMessage, RecvError>;
-
-    /// Close the channel cleanly. Zeroizes keys.
-    pub fn close(self) -> Result<(), ChannelError>;
+    pub fn send(&mut self, plaintext: &[u8]) -> Result<Vec<u8>, ChannelError>;
+    pub fn receive(&mut self, frame: &[u8]) -> Result<Vec<u8>, ChannelError>;
+    pub fn role(&self) -> ChannelRole;
+    pub fn host_id(&self) -> &HostId;
+    pub fn session_id(&self) -> SessionId;
 }
 
 // ─────────────────────────────────────────────────────────────────
@@ -654,24 +682,18 @@ impl SecureHostChannel {
 // ─────────────────────────────────────────────────────────────────
 
 pub enum ChannelError {
-    BootstrapFailed(String),
-    Crypto(CryptoError),
-    Transport(io::Error),
-    PolicyViolation,
-}
-
-pub enum SendError {
-    Backpressure,           // channel queue full; try again later
-    CircuitOpen,            // child's circuit breaker is open
+    InvalidHostId,
+    InvalidSessionId,
+    MalformedBootstrap,
+    MalformedFrame,
+    UnsupportedVersion,
+    FrameTooLarge,
+    WrongSession,
+    WrongDirection,
+    UnexpectedSequence,
+    SequenceExhausted,
+    Crypto,
     Closed,
-    Crypto(CryptoError),
-}
-
-pub enum RecvError {
-    Decryption,             // AEAD verification failed
-    InvalidFrame,           // malformed wire format
-    Closed,
-    PolicyViolation,        // rate limit, oversize frame, etc.
 }
 
 // ─────────────────────────────────────────────────────────────────
@@ -686,7 +708,6 @@ pub struct ChannelPolicy {
     pub ssthresh:              u32,
     pub max_cwnd:              u32,
     pub max_frame_size:        u32,
-    pub replay_window:         u32,
     pub circuit_failure_threshold: u32,
     pub circuit_cooldown:      Duration,
     pub idle_dh_rotation:      Duration,
@@ -703,7 +724,6 @@ impl Default for ChannelPolicy {
             ssthresh:              64,
             max_cwnd:              256,
             max_frame_size:        1 * 1024 * 1024,
-            replay_window:         16,
             circuit_failure_threshold: 10,
             circuit_cooldown:      Duration::from_secs(30),
             idle_dh_rotation:      Duration::from_secs(60),
@@ -713,6 +733,15 @@ impl Default for ChannelPolicy {
 }
 ```
 
+The first implementation slice is the transport-independent protocol kernel:
+X3DH bootstrap, strict offer/hello/frame codecs, AAD construction, authenticated
+encryption, exact stream sequencing, and fail-closed state transitions. Queueing,
+token buckets, AIMD, circuit breakers, timers, process termination, and panic
+broadcast remain supervisor/transport layers. They retain the acceptance tests
+below and are not silently approximated inside the cryptographic kernel. A
+future datagram adapter may define its own bounded reorder policy; the base
+`ChannelPolicy` deliberately has no replay-window field.
+
 ---
 
 ## Test Strategy
@@ -720,7 +749,7 @@ impl Default for ChannelPolicy {
 ### Unit Tests
 
 1. **Bootstrap correctness.** Orchestrator and child complete the X3DH
-   handshake; both derive the same ratchet root.
+   handshake and exchange authenticated application messages.
 2. **Per-message encryption / decryption round-trip.** Send 1000 messages
    in each direction; every one decrypts correctly with the right AAD.
 3. **Forward secrecy.** Snapshot the channel state at message N. Modify
@@ -732,72 +761,78 @@ impl Default for ChannelPolicy {
 5. **Per-child isolation.** Bootstrap two children with the same
    orchestrator. Snapshot child A's keys. Verify they cannot decrypt
    child B's traffic.
-6. **AAD binding.** Tamper with channel AAD prefix; verify AEAD rejects.
-7. **Replay rejection.** Re-send a captured ciphertext; verify rejected
-   by the replay window.
-8. **Wire format.** Malformed frame headers (length too large, length
-   too small, truncated payload) are rejected without decryption attempt.
+6. **AAD binding.** Reuse a frame with a different host, session, direction,
+   or sequence; verify it is rejected.
+7. **Replay rejection.** Re-send a captured ciphertext; verify the exact-next
+   sequence policy rejects it before decryption.
+8. **Strict wire format.** Every truncated prefix of an offer, hello, and frame
+   is rejected. Unknown versions, invalid host/session values, wrong direction,
+   gaps, oversized declared lengths, padding, and trailing bytes are rejected.
+9. **State transitions.** A structural rejection does not advance the receive
+   sequence, so the valid expected frame still succeeds. An AEAD authentication
+   failure closes the channel and all subsequent operations return `Closed`.
+10. **Sequence exhaustion.** Sending or receiving never wraps a `u64` sequence.
 
 ### DOS Protection Tests
 
-9. **Token bucket.** A child sending at 2x its budget receives
+11. **Token bucket.** A child sending at 2x its budget receives
    `RateLimited` for the excess. Tokens refill at the configured rate.
-10. **AIMD slow start.** With cwnd=4 and ssthresh=64, after 4 successful
+12. **AIMD slow start.** With cwnd=4 and ssthresh=64, after 4 successful
     round-trips cwnd reaches 64.
-11. **AIMD multiplicative decrease.** Inject a congestion signal at
+13. **AIMD multiplicative decrease.** Inject a congestion signal at
     cwnd=128; verify cwnd halves to 64 and growth resumes linearly.
-12. **Mailbox saturation.** Drive a child's inbound rate above the
+14. **Mailbox saturation.** Drive a child's inbound rate above the
     orchestrator's drain rate; verify queue depth triggers cwnd
     reduction.
-13. **Circuit open.** Trigger 10 consecutive `RateLimited` responses;
+15. **Circuit open.** Trigger 10 consecutive `RateLimited` responses;
     verify circuit opens, all subsequent inbound messages dropped
     without decryption.
-14. **Circuit half-open.** After the cooldown, one probe is permitted.
+16. **Circuit half-open.** After the cooldown, one probe is permitted.
     Success closes the circuit; failure re-opens with reset timer.
-15. **Priority starvation.** A child sending many `system.log`
+17. **Priority starvation.** A child sending many `system.log`
     notifications cannot delay another child's `network.fetch` requests.
-16. **No cross-child impact.** A misbehaving child A (max rate, max
+18. **No cross-child impact.** A misbehaving child A (max rate, max
     queue depth, circuit thrashing) does not affect throughput or
     latency for child B.
 
 ### Panic Broadcast Tests
 
-17. **Panic on circuit open.** Trigger a circuit open; verify a
+19. **Panic on circuit open.** Trigger a circuit open; verify a
     PanicSignal with severity Warn is emitted on the parent panic
     channel within 100 ms.
-18. **Panic escalation.** Open two circuits within 60 seconds; verify
+20. **Panic escalation.** Open two circuits within 60 seconds; verify
     severity escalates to Alert.
-19. **Brutal kill on panic.** Parent receives a panic signal naming a
+21. **Brutal kill on panic.** Parent receives a panic signal naming a
     child; verify the child process is killed within 100 ms without a
     graceful shutdown attempt.
-20. **Quarantine.** A killed child is marked quarantined; the
+22. **Quarantine.** A killed child is marked quarantined; the
     supervisor refuses to restart it for the cooldown period; after
     cooldown a single trial restart is permitted; a fresh panic doubles
     the cooldown.
-21. **Threshold tightening on siblings.** A panic in subtree X causes
+23. **Threshold tightening on siblings.** A panic in subtree X causes
     siblings of X to halve their bucket and cwnd; thresholds restore
     after 60 seconds of quiet.
-22. **Panic forging defense.** A child attempting to send a forged
+24. **Panic forging defense.** A child attempting to send a forged
     panic about its sibling cannot — the panic channel keys are not
     available to children, only to orchestrators.
-23. **Panic replay rejection.** Re-sending a captured panic signal is
+25. **Panic replay rejection.** Re-sending a captured panic signal is
     rejected by the per-origin replay window.
-24. **Tree-wide quarantine.** Five distinct alerts within 60 seconds
+26. **Tree-wide quarantine.** Five distinct alerts within 60 seconds
     across the tree triggers tree-wide quarantine at the root: no new
     spawns, no manifest installs, human paged.
 
 ### Integration Tests
 
-17. **End-to-end with two real children.** Spawn two child host
+27. **End-to-end with two real children.** Spawn two child host
     processes, exchange thousands of Host Protocol calls in parallel,
     verify all complete correctly.
-18. **Child crash mid-channel.** Kill a child while it has outstanding
+28. **Child crash mid-channel.** Kill a child while it has outstanding
     requests. Orchestrator detects via transport EOF, zeroizes keys,
     notifies supervisor.
-19. **Forced re-handshake.** Run a channel for 24 hours simulated time;
+29. **Forced re-handshake.** Run a channel for 24 hours simulated time;
     verify the full re-handshake fires and the new keys differ from the
     old.
-20. **Compromise simulation.** Capture a snapshot of one child's
+30. **Compromise simulation.** Capture a snapshot of one child's
     ratchet state. Continue running for one ratchet step. Verify the
     snapshot can no longer decrypt new messages.
 


### PR DESCRIPTION
## Summary

- add a transport-independent X3DH bootstrap for orchestrator-to-host channels
- add strict bounded D18O, D18H, and D18F codecs with exact stream sequencing
- bind host, UUID-v7 session, direction, and sequence into AEAD AAD
- fail closed on authentication failure and before the underlying ratchet counter can wrap
- update the secure-host-channel spec to separate this kernel from supervisor transport and flow control

This is the prioritized secure host-channel prerequisite for issue #128. It does not close the umbrella issue; registry reconciliation and supervisor integration remain next.

## Security

- borrow the unlocked long-term orchestrator identity and generate a fresh per-spawn signed prekey
- validate declared lengths before copying or decrypting
- reject truncation, padding, trailing bytes, wrong versions, sessions, directions, and sequences
- perform no filesystem, process, network, environment, clock, stdin, or stdout access

## Validation

- cargo test -p chief-of-staff-secure-host-channel --no-fail-fast
- cargo clippy -p chief-of-staff-secure-host-channel --all-targets -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc -p chief-of-staff-secure-host-channel --no-deps
- standalone BUILD and cargo metadata
- repository build-tool: 16 of 16 affected packages built with clippy enabled
- cargo-tarpaulin: 341/350 source lines, 97.43% coverage
- git diff --check

Issue: #128