### PR TITLE
fix(html-parser): diagnose rejected frameset starts

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Rejected `frameset` start tags after an explicit body or body-incompatible
+  content now report the Standard's in-body parse error without changing DOM
+  recovery, closing 39 previously silent malformed corpus cases.
 - Stray paragraph end tags before the parser has implied the document body now
   reuse the existing pre-body diagnostic, closing 4 previously silent malformed
   corpus cases without changing DOM recovery.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -1,6 +1,6 @@
 # HTML Parser Conformance Backlog
 
-Last audited: 2026-08-02
+Last audited: 2026-08-03
 
 ## Completion Boundary
 
@@ -21,49 +21,47 @@ exact upstream commits used for the latest completed audit.
 
 ## Prioritized Queue
 
-The 2026-08-02 upstream audit covered all 1,934 WPT tree-construction cases and
-all 6,806 html5lib tokenizer cases with zero missing signatures and zero
-normalized skips. DOM output is complete, but diagnostic coverage is not:
+The 2026-08-03 upstream audit at WPT
+`d6c801946a63a6c5fec07c3d476b8b021e5eca34` and html5lib-tests
+`224991ec10db04f056a89eed8b0bd8695fd2950e` covered all 1,934 WPT
+tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
+signatures and zero normalized skips. DOM output is complete, but diagnostic
+coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the implied-shell end-tag diagnostic slice, 1,798 of those cases emit at
-least one lexer or parser diagnostic and 385 remain uncovered. Another 139
+After the rejected-frameset diagnostic slice, 1,837 of those cases emit at
+least one lexer or parser diagnostic and 346 remain uncovered. Another 139
 cases emit diagnostics despite having no legacy `#errors` rows. These are
 reviewed rather than automatically removed: 89 are full-document inputs for
 which the legacy fixtures omit the Standard-required missing-doctype error,
 including the current processing-instruction cases.
 
+The concrete document-shell insertion-mode inventory is complete: missing and
+nonconforming doctypes, duplicate shell tags, body/html boundary errors,
+after-body and frameset modes, implied-shell paragraph end tags, and rejected
+frameset starts all report their current-Standard parse errors.
+
 Prioritized work items:
 
-1. **Document shell insertion modes.** Emit the remaining parse errors around
-   explicit and implied `html`, `head`, and `body` creation. Missing-doctype
-   handling, nonconforming initial-doctype diagnostics, duplicate shell
-   start-tag diagnostics, body/html end tags with disallowed open elements,
-   full-document in-body EOF diagnostics, unexpected-token recovery in the
-   after-body and after-after-body modes, and the implied-shell `</body>`
-   transition and after-after-frameset unexpected-token diagnostics are
-   complete. Stray paragraph end tags before an implied root or body are also
-   covered. The fresh 385-case inventory identifies rejected frameset starts
-   as the remaining concrete shell slice.
-2. **Fragment EOF diagnostics.** Audit the current in-body EOF rule against
+1. **Fragment EOF diagnostics.** Audit the current in-body EOF rule against
    fragment parsing. Legacy fragment fixtures omit many EOF error rows, so add
    explicit current-WHATWG evidence before extending the full-document
    diagnostic into fragments.
-3. **In-body and text insertion modes.** Cover scope failures, implied-end-tag
+2. **In-body and text insertion modes.** Cover scope failures, implied-end-tag
    recovery, formatting reconstruction, stray start/end tags, and the large
    executable cluster of unclosed script/style/title/noframes text-mode EOF
    diagnostics.
-4. **Table, select, and template insertion modes.** Cover foster parenting,
+3. **Table, select, and template insertion modes.** Cover foster parenting,
    table scopes, select recovery, and template mode-stack errors.
-5. **Adoption agency and active formatting.** Cover malformed formatting cases
+4. **Adoption agency and active formatting.** Cover malformed formatting cases
    without changing their now-conforming DOM output.
-6. **Foreign content and fragment parsing.** Cover SVG/MathML integration
+5. **Foreign content and fragment parsing.** Cover SVG/MathML integration
    boundaries and context-sensitive fragment errors.
-7. **Diagnostic positions and error taxonomy.** Carry source positions into
+6. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.
-8. **Input boundary review.** Document the Unicode-code-point parser boundary
+7. **Input boundary review.** Document the Unicode-code-point parser boundary
    and either add or explicitly separate byte decoding and encoding sniffing.
-9. **Algorithm and differential audit.** Map implemented states/modes to the
+8. **Algorithm and differential audit.** Map implemented states/modes to the
    current HTML Standard and add deterministic differential/fuzz coverage for
    branches not exercised by the upstream corpora.
 

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5193,6 +5193,10 @@ impl HtmlParser {
                 || self.document_has_non_frameset_compatible_body_content())
             && self.has_open_element("body")
         {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-frameset-start-tag",
+                "start tag `<frameset>` was ignored after body content",
+            ));
             return;
         }
 
@@ -31782,6 +31786,28 @@ mod tests {
         assert_eq!(nested_frameset.name, "frameset");
         assert_eq!(element(&nested_frameset.children[0]).name, "frame");
         assert_eq!(element(&frameset.children[2]).name, "noframes");
+    }
+
+    #[test]
+    fn reports_frameset_start_tags_rejected_after_body_content() {
+        for source in [
+            "<!doctype html><body><frameset>",
+            "<!doctype html><input><frameset>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "unexpected-frameset-start-tag",
+                    "start tag `<frameset>` was ignored after body content"
+                )],
+                "source {source:?}"
+            );
+            assert!(body(&output.document)
+                .children
+                .iter()
+                .all(|node| !matches!(node, Node::Element(element) if element.name == "frameset")));
+        }
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 385);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1798);
+    assert_eq!(missing_diagnostic_cases, 346);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1837);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- emit the current Standard's in-body parse error when a `frameset` start tag is rejected after an explicit body or body-incompatible content
- keep existing DOM recovery unchanged and add focused explicit-body/body-content regressions
- reduce silent malformed tree cases from 385 to 346 and promote fragment EOF evidence to the top of the conformance backlog

## Evidence
- live WPT `d6c801946a63a6c5fec07c3d476b8b021e5eca34`: 1,934/1,934 tree-construction signatures, zero missing
- live html5lib-tests `224991ec10db04f056a89eed8b0bd8695fd2950e`: 6,806/6,806 tokenizer signatures, zero missing and zero normalized skips
- all 2,637 checked DOM outputs remain conforming
- declared-error cases with a diagnostic increase from 1,798 to 1,837; undeclared-diagnostic cases remain 139

## Validation
- `cargo test -p coding-adventures-html-parser --test tree_construction_test`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- parser audit manifest, Rust-test, and coverage checks
- generated HTML fixture and README inventory checks
- `git diff --check`
