### PR TITLE
fix(spice): lower parser MOS source squares

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS instance `NRS` values before lowering
+  valid source diffusion square counts.
 - Reject negative and non-finite MOS instance `NRD` values before lowering
   valid drain diffusion square counts.
 - Reject MOS model-card `LD` values that are non-finite, negative, or leave a

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1329,6 +1329,10 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             not math.isfinite(instance_params["NRD"]) or instance_params["NRD"] < 0.0
         ):
             raise NetlistParseError("MOSFET NRD must be finite and non-negative")
+        if "NRS" in instance_params and (
+            not math.isfinite(instance_params["NRS"]) or instance_params["NRS"] < 0.0
+        ):
+            raise NetlistParseError("MOSFET NRS must be finite and non-negative")
         return Mosfet(
             name,
             fields[1],

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -981,6 +981,28 @@ def test_lowers_valid_mosfet_instance_drain_squares(
     assert expected == mosfet.model.model.params.NRD
 
 
+@pytest.mark.parametrize("source_squares", ["-1", "1e999"])
+def test_rejects_invalid_mosfet_instance_source_squares(source_squares: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="MOSFET NRS must be finite and non-negative"
+    ):
+        parse_netlist(
+            f".model nfast NMOS\nM1 d g s b nfast NRS={source_squares}\n"
+        )
+
+
+@pytest.mark.parametrize(("source_squares", "expected"), [("0", 0.0), ("3.5", 3.5)])
+def test_lowers_valid_mosfet_instance_source_squares(
+    source_squares: str, expected: float
+) -> None:
+    parsed = parse_netlist(
+        f".model nfast NMOS\nM1 d g s b nfast NRS={source_squares}\n"
+    )
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert expected == mosfet.model.model.params.NRS
+
+
 def test_parse_pwl_and_sin_source_waveforms() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS instance `NRS` values and lower valid
+  source diffusion square counts instead of silently dropping them.
 - Reject negative and non-finite MOS instance `NRD` values and lower valid
   drain diffusion square counts instead of silently dropping them.
 - Reject MOS model-card `LD` values that are non-finite, negative, or leave a

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1371,6 +1371,7 @@ function isMosfetParam(name: keyof MosfetLevel1Params): boolean {
     "RS",
     "RSH",
     "NRD",
+    "NRS",
     "IS",
     "N_SUB",
     "T_NOM",
@@ -1599,6 +1600,13 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
     const drainSquares = instanceParams.get("NRD");
     if (drainSquares !== undefined && (!Number.isFinite(drainSquares) || drainSquares < 0.0)) {
       throw new NetlistParseError("MOSFET NRD must be finite and non-negative");
+    }
+    const sourceSquares = instanceParams.get("NRS");
+    if (
+      sourceSquares !== undefined &&
+      (!Number.isFinite(sourceSquares) || sourceSquares < 0.0)
+    ) {
+      throw new NetlistParseError("MOSFET NRS must be finite and non-negative");
     }
     return mosfet(
       name,

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -971,6 +971,26 @@ Mp out gate vdd vdd pfast W=3u L=250n
     expect(element.params.NRD).toBe(expected);
   });
 
+  it.each(["-1", "1e999"])(
+    "rejects invalid MOSFET instance NRS=%s",
+    (sourceSquares) => {
+      expect(() =>
+        parseNetlist(`.model nfast NMOS\nM1 d g s b nfast NRS=${sourceSquares}\n`),
+      ).toThrow("MOSFET NRS must be finite and non-negative");
+    },
+  );
+
+  it.each([
+    ["0", 0.0],
+    ["3.5", 3.5],
+  ])("lowers valid MOSFET instance NRS=%s", (sourceSquares, expected) => {
+    const parsed = parseNetlist(`.model nfast NMOS\nM1 d g s b nfast NRS=${sourceSquares}\n`);
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.NRS).toBe(expected);
+  });
+
   it("parses PWL and SIN source waveforms", () => {
     const parsed = parseNetlist(`
 V1 in 0 PWL(0 0, 1n 1.8, 2n 0)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4219,11 +4219,17 @@ the Rust, Python, and TypeScript surfaces together.
      effective channel length, are rejected with the shared diagnostic while
      valid lateral diffusion lengths lower into Level-1 parameters.
 
+384. Python and TypeScript Berkeley SPICE MOS drain-squares parity.
+   - Status: completed in PR 9662.
+   - Negative and non-finite instance `NRD` values are rejected with the shared
+     diagnostic while zero and positive drain-square counts lower into Level-1
+     parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
-   - TypeScript still needs canonical lowering for `NRD`, `NRS`, `AD`, `AS`,
-     `PD`, `PS`, `CJ`, `CJSW`, `JS`, `PB`, `MJ`,
+   - TypeScript still needs canonical lowering for `NRS`, `AD`, `AS`, `PD`,
+     `PS`, `CJ`, `CJSW`, `JS`, `PB`, `MJ`,
      `MJSW`, `FC`, `KF`, and `AF`; Python already lowers these canonical fields
      but still needs matching facade validation coverage.
    - Align the `CJS` and `CJD` aliases with canonical `CBS` and `CBD` in both


### PR DESCRIPTION
## Summary
- validate MOS instance `NRS` as finite and non-negative in Python and TypeScript
- lower valid TypeScript source diffusion square counts into Level-1 parameters
- record the merged drain-squares slice and advance the prioritized SPICE backlog

## Verification
- Python spice-netlist-parser: 156 tests passed, 88.33% coverage
- Python Ruff: clean
- TypeScript spice-engine: build passed
- TypeScript spice-netlist-parser: build passed, 149 tests passed
- TypeScript spice-netlist-parser coverage: 84.63% lines