### PR TITLE
feat(sir-c): Hash block methods + fix in-place-shift/delete aliasing (Collections slice 7)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -36,6 +36,19 @@ No new `Feature`.
   and (retroactively) Array test suites: `each` deleting/shifting from its
   own receiver mid-iteration now correctly sees every ORIGINAL element
   exactly once.
+- **Security fix, round 2 (found by re-review of the round-1 fix)**: the
+  reallocation `delete` gained above introduced a NEW bug — it resized
+  `m->entries` without also updating `m->cap`, the field `_sir_map_put`'s
+  `if (m->len == m->cap)` amortized-growth check relies on (`SirMap`, unlike
+  `SirSeq`, tracks spare capacity). A stale, too-large `cap` after `delete`
+  makes a LATER `put` skip growing and write one past the end of the freshly
+  tightly-sized buffer — a genuine heap out-of-bounds write reachable by
+  entirely ordinary code (`h.delete(k); h[new_key] = v`), not an edge case.
+  `delete` now sets `m->cap = new_len` alongside `m->entries`/`m->len`.
+  Pinned by a new hand-built-IR regression test (bracket-index assignment,
+  `h[k] = v`, has no Ruby source syntax yet — a separate, pre-existing
+  frontend gap, tracked on the backlog) that deletes then inserts twice,
+  crossing the grow-triggering `len == cap` boundary on the second insert.
 
 **Anti-RCE preserved:** the method name is a compiler-emitted quoted C literal
 used only as a `strcmp` target — never reflection.

--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 0.28.0 — Collections slice 7: Hash block methods
+
+No new `Feature`.
+
+- New methods taking a trailing BLOCK argument, called with `(key, value)`
+  (matching `Array#each_with_index`'s existing 2-arg calling precedent):
+  `each_key`/`each_value` (yield one), `group_by` (a fresh Hash mapping each
+  distinct block result to an Array of the `[k, v]` pairs that produced it,
+  growing a group's array via the SAME `_sir_array_push_one` `Array#push`
+  uses), `partition` (`[matching_pairs, non_matching_pairs]`, each a fresh
+  Array). `each`/`map`/`select`/`reject`/`sort_by`/`sum` widen to accept a
+  Hash receiver alongside their existing Array-only forms — `Hash#map`
+  returns an Array (not a re-keyed Hash) and `Hash#sort_by` returns an Array
+  of `[k, v]` pairs, both matching Ruby's `Enumerable` semantics; `select`/
+  `reject` return a fresh Hash (unlike Array's, which return an Array).
+- **Security, applied from the start this time**: every helper here
+  snapshots BOTH `m->len` AND the `entries` pointer into locals once before
+  its loop, exactly the discipline slice 4 had to retrofit (twice) for
+  Array — since slice 6's `delete`/`clear` mutators already existed before
+  these block helpers were added, there was no window where the bug could
+  ship unguarded.
+- **Security fix (found while implementing `Hash#delete`, and it exposed an
+  ALREADY-MERGED bug)**: `delete` and `Array#shift` (slice 4) originally
+  compacted their backing buffer IN PLACE (no reallocation) after removing
+  an entry. That's unsafe against a block-taking helper's pointer snapshot:
+  snapshotting a pointer is only safe against a mutator that REALLOCATES
+  (like `push`) — the snapshot and the new buffer are then different memory,
+  so the OLD one (still valid; this arena never frees) keeps reading exactly
+  what it saw at snapshot time. An in-place compact instead mutates the SAME
+  memory the snapshot points into, silently corrupting an in-flight outer
+  iteration (elements shift under it — some read twice, some skipped).
+  Both `delete` and `Array#shift` now reallocate a fresh, one-smaller buffer
+  instead, closing the gap. Pinned by new tests in both this crate's Hash
+  and (retroactively) Array test suites: `each` deleting/shifting from its
+  own receiver mid-iteration now correctly sees every ORIGINAL element
+  exactly once.
+
+**Anti-RCE preserved:** the method name is a compiler-emitted quoted C literal
+used only as a `strcmp` target — never reflection.
+
 ## 0.27.0 — Collections slice 6: Hash non-block methods
 
 No new `Feature`.

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -178,10 +178,18 @@ after a `pop`/`shift` — the same "iterate a snapshot" convention
 `_sir_seq_iter`'s `ForEach` already uses; **slice 6** (Hash non-block
 methods): `keys`/`values`/`to_a`/`to_h`/`dig`/`merge`/`invert` (all
 non-mutating), plus `delete`/`clear` — the FIRST Hash methods that mutate
-the receiver (`delete` shifts later entries down like `Array#shift`;
-`clear` resets `len` in place like `Array#pop`).  `fetch`/`to_a` widen to
-accept a Hash receiver alongside their Array forms; `dig` is polymorphic
-over Hash/Array from the start.  A
+the receiver (`delete` removes an entry; `clear` resets `len` in place like
+`Array#pop`).  `fetch`/`to_a` widen to accept a Hash receiver alongside
+their Array forms; `dig` is polymorphic over Hash/Array from the start;
+**slice 7** (Hash block methods): `each_key`/`each_value`/`group_by`/
+`partition`, plus `each`/`map`/`select`/`reject`/`sort_by`/`sum` widening to
+accept a Hash receiver (`map`/`sort_by` return an Array, `select`/`reject`
+return a Hash — matching Ruby's `Enumerable`-over-Hash semantics).  Both
+`delete` and `Array#shift` now REALLOCATE a fresh, smaller buffer instead of
+compacting in place — an in-place compact mutates the SAME memory a
+block-taking helper's pointer snapshot points into, silently corrupting an
+in-flight outer iteration; reallocating (like `push` already did) leaves any
+outer snapshot reading unmodified memory, restoring the safe invariant.  A
 wrong-type receiver or argument raises `NoMethodError`; a built-in method not
 lowered yet is still rejected cleanly.
 

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -1769,9 +1769,12 @@ fn variadic_helper(name: &str) -> Option<&'static str> {
 /// receiver alongside their slice-2 String arms); slice 6 = Hash non-block
 /// methods (`keys`/`values`/`to_h`/`dig`/`merge`/`delete`/`clear`/`invert`;
 /// `fetch`/`to_a` widen to accept a Hash receiver alongside their Array
-/// forms). The dispatcher raises `NoMethodError` on an unsupported receiver
-/// type or a malformed call (missing/extra args, a non-closure block
-/// position), matching Ruby.
+/// forms); slice 7 = Hash methods taking a trailing BLOCK argument
+/// (`each_key`/`each_value`/`group_by`/`partition`; `each`/`map`/`select`/
+/// `reject`/`sort_by`/`sum` widen to accept a Hash receiver alongside their
+/// slice-3/5 Array forms). The dispatcher raises `NoMethodError` on an
+/// unsupported receiver type or a malformed call (missing/extra args, a
+/// non-closure block position), matching Ruby.
 fn is_builtin_method(name: &str) -> bool {
     matches!(
         name,
@@ -1789,6 +1792,8 @@ fn is_builtin_method(name: &str) -> bool {
         | "push" | "pop" | "shift" | "fetch" | "values_at" | "rotate" | "zip"
         // slice 6 — Hash non-block methods
         | "keys" | "values" | "to_h" | "dig" | "merge" | "delete" | "clear" | "invert"
+        // slice 7 — Hash block methods
+        | "each_key" | "each_value" | "group_by" | "partition"
     )
 }
 

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -1944,6 +1944,17 @@ static SirValue _sir_hash_delete(SirMap *m, SirValue key) {
     }
     m->entries = ne;
     m->len = new_len;
+    /* SECURITY: `cap` (unlike `SirSeq`, `SirMap` DOES track spare capacity
+     * for `_sir_map_put`'s amortized growth) must stay in sync with the
+     * buffer just allocated — it is now tightly sized to `new_len`, with NO
+     * spare slots. Leaving `m->cap` at its old, larger value would desync
+     * `_sir_map_put`'s `if (m->len == m->cap)` grow check: a later `put`
+     * would see `len < cap`, skip growing, and write directly at
+     * `entries[len]` — one past the end of THIS tightly-sized buffer, a
+     * heap out-of-bounds write. (Caught by security review: reallocating
+     * without updating `cap` is a real, ordinary-Ruby-reachable bug, not a
+     * theoretical one — `h.delete(k); h[new_key] = v` triggers it.) */
+    m->cap = new_len;
     return v;
 }
 /* `clear` — removes every entry IN PLACE (just resets `len`; the backing

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -1749,11 +1749,27 @@ static SirValue _sir_array_pop(SirSeq *s) {
     s->len--;
     return v;
 }
+/* SECURITY FIX (found while implementing Hash#delete, slice 7 — see that
+ * function's own note): `shift` must NOT compact `s->items` IN PLACE. A
+ * block-taking helper (slice 5) that snapshots `s->items` as a POINTER
+ * before its loop is only safe against a LATER `push` because `push`
+ * reallocates a fresh buffer and leaves the old one untouched; the snapshot
+ * and the live array are then *different* memory. An in-place shift instead
+ * mutates the SAME memory the snapshot POINTS INTO, so the outer helper's
+ * "frozen" view silently corrupts too (elements shift under it, some read
+ * twice, some never read) — this was a live bug in the very first version
+ * of this function (merged in slice 4, before any helper called into it
+ * from inside a block's iteration). Reallocating a fresh, smaller buffer —
+ * exactly like `push` growing one — restores the safe invariant: any
+ * pointer snapshotted before this call keeps pointing at unmodified memory. */
 static SirValue _sir_array_shift(SirSeq *s) {
     if (s->len == 0) return _sir_nil();
     SirValue v = s->items[0];
-    for (int64_t i = 1; i < s->len; i++) s->items[i - 1] = s->items[i];
-    s->len--;
+    int64_t new_len = s->len - 1;
+    SirValue *ni = (new_len > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)new_len) : NULL;
+    for (int64_t i = 0; i < new_len; i++) ni[i] = s->items[i + 1];
+    s->items = ni;
+    s->len = new_len;
     return v;
 }
 static SirValue _sir_array_include(SirSeq *s, SirValue needle) {
@@ -1901,18 +1917,33 @@ static SirValue _sir_hash_merge(SirMap *m, SirValue other) {
     return _sir_map_wrap(r);
 }
 /* `delete(k)` — the FIRST Hash method that mutates the receiver: removes the
- * entry (shifting later entries down by one, matching `Array#shift`'s
- * in-place style — no reallocation) and returns its value, or nil if `k`
- * wasn't present. No block-taking Hash helper exists yet (slice 7), so no
- * mid-iteration mutation is reachable here — but slice 7 must apply the
- * same len+entries-pointer snapshot discipline slice 4 established for
- * Array once it lands. */
+ * entry and returns its value, or nil if `k` wasn't present.
+ *
+ * SECURITY: reallocates a fresh, one-smaller `entries` buffer rather than
+ * compacting `m->entries` IN PLACE (`Array#shift`'s ORIGINAL shape, and a
+ * real bug there — see that function's own note, fixed alongside this one).
+ * A block-taking helper (slice 7, below) snapshots `m->entries` as a POINTER
+ * before its loop; that snapshot is only safe against a mutator that
+ * REALLOCATES (the mutator's new buffer and the snapshot's old one are then
+ * different memory — the old one, still valid in this never-freeing arena,
+ * keeps reading exactly what it saw at snapshot time). An in-place compact
+ * instead mutates the SAME memory the snapshot points into, silently
+ * corrupting an in-flight outer iteration (entries shift under it — some
+ * read twice, some skipped). Reallocating avoids that entirely. */
 static SirValue _sir_hash_delete(SirMap *m, SirValue key) {
     int64_t at = _sir_map_find(m, key);
     if (at < 0) return _sir_nil();
     SirValue v = m->entries[at].val;
-    for (int64_t i = at + 1; i < m->len; i++) m->entries[i - 1] = m->entries[i];
-    m->len--;
+    int64_t new_len = m->len - 1;
+    struct SirMapEntry *ne =
+        (new_len > 0) ? (struct SirMapEntry *)_sir_alloc(sizeof(struct SirMapEntry) * (size_t)new_len) : NULL;
+    int64_t j = 0;
+    for (int64_t i = 0; i < m->len; i++) {
+        if (i == at) continue;
+        ne[j++] = m->entries[i];
+    }
+    m->entries = ne;
+    m->len = new_len;
     return v;
 }
 /* `clear` — removes every entry IN PLACE (just resets `len`; the backing
@@ -1929,6 +1960,150 @@ static SirValue _sir_hash_invert(SirMap *m) {
     SirMap *r = _sir_map_new(m->len);
     for (int64_t i = 0; i < m->len; i++) _sir_map_put(r, m->entries[i].val, m->entries[i].key);
     return _sir_map_wrap(r);
+}
+
+/* ---- Collections slice 7: Hash block methods -------------------------------
+ *
+ * SECURITY: exactly the discipline slice 4 established for Array (and had to
+ * retrofit there, twice, after security review) — applied HERE FROM THE
+ * START since slice 6's `delete`/`clear` mutators already exist by the time
+ * these block-taking helpers are added. Every helper snapshots BOTH `m->len`
+ * AND the `entries` pointer into locals ONCE, before its loop, and reads
+ * only through those locals — never `m->len`/`m->entries` directly — so a
+ * block that calls `delete`/`clear` on the SAME map it's iterating can't
+ * read past a buffer `delete`'s in-place shift (or a future growing
+ * mutator) has since invalidated. Each block is called with TWO arguments,
+ * `(key, value)` — matching `Array#each_with_index`'s existing 2-arg
+ * precedent — regardless of how many params the Ruby block declares (extra
+ * args a 1-param block doesn't bind are simply unused, the same block-arity
+ * flexibility Ruby itself has). */
+
+static SirValue _sir_hash_each(SirMap *m, SirValue block) {
+    int64_t n = m->len;
+    struct SirMapEntry *entries = m->entries;
+    for (int64_t i = 0; i < n; i++) _sir_apply(block, 2, entries[i].key, entries[i].val);
+    return _sir_map_wrap(m);  /* Hash#each returns the receiver */
+}
+static SirValue _sir_hash_each_key(SirMap *m, SirValue block) {
+    int64_t n = m->len;
+    struct SirMapEntry *entries = m->entries;
+    for (int64_t i = 0; i < n; i++) _sir_apply(block, 1, entries[i].key);
+    return _sir_map_wrap(m);
+}
+static SirValue _sir_hash_each_value(SirMap *m, SirValue block) {
+    int64_t n = m->len;
+    struct SirMapEntry *entries = m->entries;
+    for (int64_t i = 0; i < n; i++) _sir_apply(block, 1, entries[i].val);
+    return _sir_map_wrap(m);
+}
+/* `map` returns an ARRAY of the block's results (matching Ruby's
+ * `Enumerable#map` over a Hash — NOT a re-keyed Hash). */
+static SirValue _sir_hash_map(SirMap *m, SirValue block) {
+    int64_t n = m->len;
+    struct SirMapEntry *entries = m->entries;
+    SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    r->len = n;
+    r->items = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)n) : NULL;
+    for (int64_t i = 0; i < n; i++) r->items[i] = _sir_apply(block, 2, entries[i].key, entries[i].val);
+    return _sir_seq_wrap(r);
+}
+/* Shared by `select` (keep_if_truthy=1) / `reject` (keep_if_truthy=0) — both
+ * return a FRESH HASH (unlike `Array#select`/`reject`, which return an
+ * Array), matching Ruby's `Hash#select`/`Hash#reject`. */
+static SirValue _sir_hash_filter(SirMap *m, SirValue block, int keep_if_truthy) {
+    int64_t n = m->len;
+    struct SirMapEntry *entries = m->entries;
+    SirMap *r = _sir_map_new(n);
+    for (int64_t i = 0; i < n; i++) {
+        int truthy = _sir_truthy(_sir_apply(block, 2, entries[i].key, entries[i].val));
+        if (truthy == keep_if_truthy) _sir_map_put(r, entries[i].key, entries[i].val);
+    }
+    return _sir_map_wrap(r);
+}
+/* Schwartzian transform over `[k, v]` PAIRS (mirrors `Array#sort_by`).
+ * Returns an ARRAY of `[k, v]` pairs sorted by the block's key — Ruby's
+ * `Hash#sort_by` (via `Enumerable`) always returns an Array, not a re-sorted
+ * Hash (Hash order isn't independently `<=>`-able). */
+static SirValue _sir_hash_sort_by(SirMap *m, SirValue block) {
+    int64_t n = m->len;
+    struct SirMapEntry *entries = m->entries;
+    SirValue *keys = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)n) : NULL;
+    SirValue *pairs = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)n) : NULL;
+    for (int64_t i = 0; i < n; i++) {
+        keys[i] = _sir_apply(block, 2, entries[i].key, entries[i].val);
+        pairs[i] = _sir_seq_lit(2, entries[i].key, entries[i].val);
+    }
+    for (int64_t i = 1; i < n; i++) {
+        SirValue key = keys[i], val = pairs[i];
+        int64_t j = i - 1;
+        while (j >= 0 && _sir_truthy(_sir_lt(key, keys[j]))) {
+            keys[j + 1] = keys[j];
+            pairs[j + 1] = pairs[j];
+            j--;
+        }
+        keys[j + 1] = key;
+        pairs[j + 1] = val;
+    }
+    SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    r->len = n;
+    r->items = pairs;
+    return _sir_seq_wrap(r);
+}
+/* `group_by` — a FRESH Hash mapping each distinct block result to an ARRAY
+ * of the `[k, v]` pairs that produced it, in first-encountered group order
+ * (matching Ruby). A group's value array must GROW across multiple matching
+ * entries (unlike a plain `_sir_map_put`, which overwrites), so an existing
+ * group is appended to via `_sir_array_push_one` (the SAME growth helper
+ * `Array#push` uses); a new group starts as a fresh 1-element array. */
+static SirValue _sir_hash_group_by(SirMap *m, SirValue block) {
+    int64_t n = m->len;
+    struct SirMapEntry *entries = m->entries;
+    SirMap *r = _sir_map_new(0);
+    for (int64_t i = 0; i < n; i++) {
+        SirValue key = _sir_apply(block, 2, entries[i].key, entries[i].val);
+        SirValue pair = _sir_seq_lit(2, entries[i].key, entries[i].val);
+        int64_t at = _sir_map_find(r, key);
+        if (at >= 0) {
+            _sir_array_push_one(r->entries[at].val.as.seq, pair);
+        } else {
+            _sir_map_put(r, key, _sir_seq_lit(1, pair));
+        }
+    }
+    return _sir_map_wrap(r);
+}
+/* `partition` — `[matching_pairs, non_matching_pairs]`, each a fresh Array
+ * of `[k, v]` pairs (mirrors `Enumerable#partition` over a Hash's pairs). */
+static SirValue _sir_hash_partition(SirMap *m, SirValue block) {
+    int64_t n = m->len;
+    struct SirMapEntry *entries = m->entries;
+    SirSeq *yes = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    SirSeq *no = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    yes->items = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)n) : NULL;
+    no->items = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)n) : NULL;
+    int64_t ny = 0, nn = 0;
+    for (int64_t i = 0; i < n; i++) {
+        SirValue pair = _sir_seq_lit(2, entries[i].key, entries[i].val);
+        if (_sir_truthy(_sir_apply(block, 2, entries[i].key, entries[i].val))) yes->items[ny++] = pair;
+        else no->items[nn++] = pair;
+    }
+    yes->len = ny;
+    no->len = nn;
+    return _sir_seq_lit(2, _sir_seq_wrap(yes), _sir_seq_wrap(no));
+}
+/* `sum { |k, v| ... }` — sums the block's return value over every entry,
+ * starting the accumulator at integer `0` (mirrors `Array#sum`'s default,
+ * reusing the SAME `_sir_plus_v` int/float promotion `+` uses). */
+static SirValue _sir_hash_sum(SirMap *m, SirValue block) {
+    int64_t n = m->len;
+    struct SirMapEntry *entries = m->entries;
+    SirValue acc = _sir_int(0);
+    for (int64_t i = 0; i < n; i++) {
+        SirValue pair[2];
+        pair[0] = acc;
+        pair[1] = _sir_apply(block, 2, entries[i].key, entries[i].val);
+        acc = _sir_plus_v(pair, 2);
+    }
+    return acc;
 }
 
 /* ---- Collections slice 1: built-in String methods --------------------------
@@ -2004,6 +2179,8 @@ static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, Si
         if (recv.tag == SIR_SEQ) return _sir_array_max(recv.as.seq);
     } else if (strcmp(m, "sum") == 0) {
         if (recv.tag == SIR_SEQ) return _sir_array_sum(recv.as.seq);
+        if (recv.tag == SIR_MAP && argc == 1 && args[0].tag == SIR_CLOSURE)
+            return _sir_hash_sum(recv.as.map, args[0]);
     } else if (strcmp(m, "uniq") == 0) {
         if (recv.tag == SIR_SEQ) return _sir_array_uniq(recv.as.seq);
     } else if (strcmp(m, "compact") == 0) {
@@ -2022,15 +2199,23 @@ static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, Si
     else if (strcmp(m, "each") == 0) {
         if (recv.tag == SIR_SEQ && argc == 1 && args[0].tag == SIR_CLOSURE)
             return _sir_array_each(recv.as.seq, args[0]);
+        if (recv.tag == SIR_MAP && argc == 1 && args[0].tag == SIR_CLOSURE)
+            return _sir_hash_each(recv.as.map, args[0]);
     } else if (strcmp(m, "map") == 0) {
         if (recv.tag == SIR_SEQ && argc == 1 && args[0].tag == SIR_CLOSURE)
             return _sir_array_map(recv.as.seq, args[0]);
+        if (recv.tag == SIR_MAP && argc == 1 && args[0].tag == SIR_CLOSURE)
+            return _sir_hash_map(recv.as.map, args[0]);
     } else if (strcmp(m, "select") == 0) {
         if (recv.tag == SIR_SEQ && argc == 1 && args[0].tag == SIR_CLOSURE)
             return _sir_array_filter(recv.as.seq, args[0], 1);
+        if (recv.tag == SIR_MAP && argc == 1 && args[0].tag == SIR_CLOSURE)
+            return _sir_hash_filter(recv.as.map, args[0], 1);
     } else if (strcmp(m, "reject") == 0) {
         if (recv.tag == SIR_SEQ && argc == 1 && args[0].tag == SIR_CLOSURE)
             return _sir_array_filter(recv.as.seq, args[0], 0);
+        if (recv.tag == SIR_MAP && argc == 1 && args[0].tag == SIR_CLOSURE)
+            return _sir_hash_filter(recv.as.map, args[0], 0);
     } else if (strcmp(m, "any?") == 0) {
         if (recv.tag == SIR_SEQ && argc == 1 && args[0].tag == SIR_CLOSURE)
             return _sir_array_any(recv.as.seq, args[0]);
@@ -2043,12 +2228,28 @@ static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, Si
     } else if (strcmp(m, "sort_by") == 0) {
         if (recv.tag == SIR_SEQ && argc == 1 && args[0].tag == SIR_CLOSURE)
             return _sir_array_sort_by(recv.as.seq, args[0]);
+        if (recv.tag == SIR_MAP && argc == 1 && args[0].tag == SIR_CLOSURE)
+            return _sir_hash_sort_by(recv.as.map, args[0]);
     } else if (strcmp(m, "each_with_index") == 0) {
         if (recv.tag == SIR_SEQ && argc == 1 && args[0].tag == SIR_CLOSURE)
             return _sir_array_each_with_index(recv.as.seq, args[0]);
     } else if (strcmp(m, "reduce") == 0 || strcmp(m, "inject") == 0) {
         if (recv.tag == SIR_SEQ && argc >= 1 && argc <= 2 && args[argc - 1].tag == SIR_CLOSURE)
             return _sir_array_reduce(recv.as.seq, argc, args);
+    }
+    /* Collections slice 7: Hash block methods. */
+    else if (strcmp(m, "each_key") == 0) {
+        if (recv.tag == SIR_MAP && argc == 1 && args[0].tag == SIR_CLOSURE)
+            return _sir_hash_each_key(recv.as.map, args[0]);
+    } else if (strcmp(m, "each_value") == 0) {
+        if (recv.tag == SIR_MAP && argc == 1 && args[0].tag == SIR_CLOSURE)
+            return _sir_hash_each_value(recv.as.map, args[0]);
+    } else if (strcmp(m, "group_by") == 0) {
+        if (recv.tag == SIR_MAP && argc == 1 && args[0].tag == SIR_CLOSURE)
+            return _sir_hash_group_by(recv.as.map, args[0]);
+    } else if (strcmp(m, "partition") == 0) {
+        if (recv.tag == SIR_MAP && argc == 1 && args[0].tag == SIR_CLOSURE)
+            return _sir_hash_partition(recv.as.map, args[0]);
     }
     /* Collections slice 4: Array mutation + 1-arg query methods. */
     else if (strcmp(m, "push") == 0) {

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_array_mutation_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_array_mutation_methods.rs
@@ -238,7 +238,7 @@ fn count_with_block_pushing_to_the_receiver_terminates() {
 fn array_each_shrinking_then_growing_the_receiver_does_not_overread() {
     // Security regression: snapshotting `len` ALONE is not enough -- `push`
     // reallocates its new buffer sized to the CURRENT (live) `s->len`, so a
-    // block that first shrinks the receiver (`pop`/`shift`, in place, no
+    // block that first shrinks the receiver (`pop`, len-only, no
     // reallocation) and THEN pushes produces a buffer smaller than a `len`
     // already snapshotted by an outer iterating helper. Continuing to read
     // via a live `s->items` pointer up to that stale, larger snapshot would
@@ -248,6 +248,25 @@ fn array_each_shrinking_then_growing_the_receiver_does_not_overread() {
     // buffer (`each`'s own snapshot at entry), never the shrunk/regrown one.
     match run_ruby("a = [1, 2, 3, 4, 5]\na.each { |x| a.pop\na.pop\na.push(99)\nputs x }\n") {
         Some(out) => assert_eq!(out, "1\n2\n3\n4\n5\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn each_shifting_the_receiver_does_not_corrupt_an_in_flight_snapshot() {
+    // Security regression (found while implementing Hash#delete, which has
+    // the identical shape): `shift`'s ORIGINAL implementation compacted
+    // `s->items` IN PLACE (no reallocation) -- but a block-taking helper
+    // snapshots the `items` POINTER, not a copy of the data, before its
+    // loop. Snapshotting a pointer is only safe against a mutator that
+    // REALLOCATES (like `push`): the snapshot and the mutator's new buffer
+    // are then different memory. An in-place compact instead mutates the
+    // SAME memory the snapshot points into, silently corrupting an
+    // in-flight outer iteration -- elements shift under it, some get read
+    // twice, some get skipped. `shift` now reallocates too, so `each` must
+    // still see the ORIGINAL 3 elements here, each exactly once.
+    match run_ruby("a = [1, 2, 3]\na.each { |x| a.shift\nputs x }\n") {
+        Some(out) => assert_eq!(out, "1\n2\n3\n"),
         None => eprintln!("skip: no cc"),
     }
 }

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_hash_block_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_hash_block_methods.rs
@@ -1,0 +1,170 @@
+//! Execution proof for Collections slice 7 (Hash block methods) on the C
+//! backend — lower REAL Ruby source, emit C, compile with a real cc, run,
+//! assert stdout. Skips gracefully when no `cc` is present.
+//!
+//! A bare comparison used as a block's TAIL expression (e.g. `{ |k,v| v > 1
+//! }`) currently fails to lower for every operator except `==` -- a
+//! pre-existing `ruby-to-semantic-ir` frontend bug found and worked around
+//! the same way in the Array block-methods tests (assign-then-return:
+//! `{ |k,v| r = v > 1\nr }`), not something this slice touches.
+
+use std::process::Command;
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    ["cc", "clang", "gcc"]
+        .iter()
+        .find(|c| {
+            Command::new(c)
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        })
+        .map(|s| s.to_string())
+}
+
+fn run_ruby(src: &str) -> Option<String> {
+    let cc = find_cc()?;
+    let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
+    let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
+    let dir = std::env::temp_dir();
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    src.hash(&mut hasher);
+    let stem = format!("sirc_hashblk_{}_{}", std::process::id(), hasher.finish());
+    let cpath = dir.join(format!("{stem}.c"));
+    let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::write(&cpath, &art.source).expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        art.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "program exited non-zero");
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn hash_each_yields_key_and_value_and_returns_the_receiver() {
+    // (String interpolation isn't accepted by the C backend yet -- a
+    // separate, pre-existing gap -- so key/value print on their own lines.)
+    match run_ruby("h = {1 => \"a\", 2 => \"b\"}\nputs h.each { |k, v| puts k\nputs v }.keys\n") {
+        Some(out) => assert_eq!(out, "1\na\n2\nb\n[1, 2]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn hash_each_key_and_each_value() {
+    match run_ruby(
+        "h = {1 => \"a\", 2 => \"b\"}\nh.each_key { |k| puts k }\nh.each_value { |v| puts v }\n",
+    ) {
+        Some(out) => assert_eq!(out, "1\n2\na\nb\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn hash_map_returns_an_array_not_a_hash() {
+    match run_ruby("h = {1 => 10, 2 => 20}\nputs h.map { |k, v| k + v }\n") {
+        Some(out) => assert_eq!(out, "[11, 22]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn hash_select_and_reject_return_hashes() {
+    match run_ruby(
+        "h = {1 => 10, 2 => 20, 3 => 30}\nputs h.select { |k, v| r = v > 15\nr }\nputs h.reject { |k, v| r = v > 15\nr }\n",
+    ) {
+        Some(out) => assert_eq!(out, "{2: 20, 3: 30}\n{1: 10}\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn hash_sort_by_returns_an_array_of_pairs() {
+    match run_ruby("h = {3 => \"c\", 1 => \"a\", 2 => \"b\"}\nputs h.sort_by { |k, v| k }\n") {
+        Some(out) => assert_eq!(out, "[[1, a], [2, b], [3, c]]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn hash_group_by_groups_pairs_by_the_block_result() {
+    // (Bracket-index READ, `g[true]`, only parses as a bare assignment RHS --
+    // a separate, pre-existing frontend gap -- so `.fetch` is used instead.)
+    match run_ruby(
+        "h = {1 => \"a\", 2 => \"b\", 3 => \"c\", 4 => \"d\"}\ng = h.group_by { |k, v| r = k > 2\nr }\nputs g.fetch(true)\nputs g.fetch(false)\n",
+    ) {
+        Some(out) => assert_eq!(out, "[[3, c], [4, d]]\n[[1, a], [2, b]]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn hash_partition_splits_into_matching_and_non_matching() {
+    match run_ruby(
+        "h = {1 => \"a\", 2 => \"b\", 3 => \"c\"}\np = h.partition { |k, v| r = k > 1\nr }\nputs p\n",
+    ) {
+        Some(out) => assert_eq!(out, "[[[2, b], [3, c]], [[1, a]]]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn hash_sum_with_block() {
+    match run_ruby("h = {1 => 10, 2 => 20, 3 => 30}\nputs h.sum { |k, v| k + v }\n") {
+        Some(out) => assert_eq!(out, "66\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn hash_block_methods_chain() {
+    // `map` returns an Array, so an Array built-in dispatches on it.
+    match run_ruby("h = {1 => 10, 2 => 20}\nputs h.map { |k, v| v }.sort.reverse\n") {
+        Some(out) => assert_eq!(out, "[20, 10]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn each_deleting_from_the_receiver_terminates_and_does_not_overread() {
+    // Security regression: `each`'s len/entries snapshot is taken BEFORE the
+    // loop, so a block that deletes from the SAME map being iterated (1)
+    // does not observe the shrink mid-iteration, and (2) does not read past
+    // the entries buffer as `delete` shifts entries down. `each` must still
+    // see the ORIGINAL 3 keys/values.
+    match run_ruby(
+        "h = {1 => \"a\", 2 => \"b\", 3 => \"c\"}\nh.each { |k, v| h.delete(k)\nputs k\nputs v }\nputs h.keys\n",
+    ) {
+        Some(out) => assert_eq!(out, "1\na\n2\nb\n3\nc\n[]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn map_clearing_the_receiver_does_not_overrun_its_output_buffer() {
+    // The Hash analogue of the Array map/push security regression: `map`
+    // pre-allocates its output sized to the receiver's length; if the block
+    // clears the SAME receiver mid-loop, `map`'s snapshot must still see the
+    // ORIGINAL 3 entries (not 0), and the process must not crash.
+    match run_ruby("h = {1 => 10, 2 => 20, 3 => 30}\nb = h.map { |k, v| h.clear\nv }\nputs b\n") {
+        Some(out) => assert_eq!(out, "[10, 20, 30]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_hash_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_hash_methods.rs
@@ -113,6 +113,139 @@ fn hash_delete_mutates_a_shared_binding() {
     }
 }
 
+// The Ruby frontend has no source syntax for a bracket-index assignment
+// TARGET (`h[k] = v`) yet — confirmed while writing this test ("Unexpected
+// token: =") — so the regression below hand-builds a `semantic_ir::Module`
+// directly (`Stmt::MapSet`), the same workaround the pre-existing
+// cyclic-array/cyclic-map tests already use for an unrelated reason.
+mod insert_after_delete {
+    use std::path::PathBuf;
+    use std::process::Command;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use semantic_ir::{
+        Block, EffectSet, Expr, Feature, FeatureManifest, Function, MapEntry, Metadata, Module,
+        Scope, Span, Stmt, CURRENT_SIR_VERSION,
+    };
+
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    fn run(module: &Module) -> Option<String> {
+        let cc = super::find_cc()?;
+        let artifact = semantic_ir_to_c::compile(module).expect("C backend compile (no panic)");
+        let dir = std::env::temp_dir();
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let stem = format!("sirc_hashm_delcap_{}_{}", std::process::id(), n);
+        let cpath: PathBuf = dir.join(format!("{stem}.c"));
+        let exe: PathBuf = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+        std::fs::write(&cpath, &artifact.source).expect("write .c");
+        let out = Command::new(&cc)
+            .args(["-std=c99", "-Wall", "-o"])
+            .arg(&exe)
+            .arg(&cpath)
+            .output()
+            .expect("spawn cc");
+        assert!(
+            out.status.success(),
+            "compile failed:\n{}\n--- source ---\n{}",
+            String::from_utf8_lossy(&out.stderr),
+            artifact.source
+        );
+        let r = Command::new(&exe).output().expect("run");
+        assert!(r.status.success(), "run failed (exit {:?})", r.status.code());
+        Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+    }
+
+    fn s() -> Span {
+        Span::synthetic()
+    }
+    fn ilit(v: i64) -> Expr {
+        Expr::IntLit { value: v, span: s() }
+    }
+    fn slit(v: &str) -> Expr {
+        Expr::StrLit { value: v.into(), span: s() }
+    }
+    fn local(name: &str) -> Expr {
+        Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
+    }
+    fn bc(name: &str, args: Vec<Expr>) -> Expr {
+        Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+    }
+    fn puts(arg: Expr) -> Stmt {
+        Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: s() }
+    }
+    fn let_(name: &str, value: Expr) -> Stmt {
+        Stmt::LetBinding { name: name.into(), sir_type: None, value, span: s() }
+    }
+    fn delete_call(key: i64) -> Stmt {
+        Stmt::ExprStmt {
+            expr: bc("__method__", vec![local("h"), slit("delete"), ilit(key)]),
+            span: s(),
+        }
+    }
+    fn map_set(key: i64, value: &str) -> Stmt {
+        Stmt::MapSet { map: local("h"), key: ilit(key), value: slit(value), span: s() }
+    }
+
+    #[test]
+    fn hash_insert_after_delete_does_not_overflow_the_reallocated_buffer() {
+        // Security regression: `delete` reallocates a fresh, tightly-sized
+        // buffer (see its own runtime.rs comment) but an early draft forgot
+        // to sync `m->cap` to the new (smaller) size, leaving
+        // `_sir_map_put`'s `len == cap` grow-check desynced -- a later
+        // `h[k] = v` would see `len < cap`, skip growing, and write one past
+        // the end of the tightly-sized buffer (a heap out-of-bounds write).
+        // Reachable by entirely ordinary code: delete a key, then assign a
+        // new one. Repeated twice (delete+insert, delete+insert again) to
+        // also exercise the grow-triggering `len == cap` path on the SECOND
+        // insert.
+        let m = Module {
+            name: "hashdelcapprog".into(),
+            manifest: FeatureManifest::from_features(&[Feature::Maps, Feature::Strings]),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![Function {
+                name: "main".into(),
+                params: vec![],
+                return_type: None,
+                captures: vec![],
+                body: Block {
+                    stmts: vec![
+                        let_(
+                            "h",
+                            Expr::MapLit {
+                                entries: vec![
+                                    MapEntry { key: ilit(1), value: slit("a") },
+                                    MapEntry { key: ilit(2), value: slit("b") },
+                                    MapEntry { key: ilit(3), value: slit("c") },
+                                ],
+                                span: s(),
+                            },
+                        ),
+                        delete_call(1),
+                        map_set(4, "d"),
+                        delete_call(2),
+                        map_set(5, "e"),
+                        puts(local("h")),
+                    ],
+                    value: Expr::NilLit { span: s() },
+                    span: s(),
+                },
+                effects: EffectSet::PURE,
+                metadata: Metadata::new(),
+                span: s(),
+            }],
+            globals: vec![],
+            metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+            span: s(),
+        };
+        match run(&m) {
+            Some(out) => assert_eq!(out, "{3: c, 4: d, 5: e}\n"),
+            None => eprintln!("skip: no cc"),
+        }
+    }
+}
+
 #[test]
 fn hash_clear_empties_and_returns_the_receiver() {
     match run_ruby("h = {1 => \"a\", 2 => \"b\"}\nputs h.clear.keys\nputs h.empty?\n") {


### PR DESCRIPTION
## Summary
- New Hash methods taking a trailing block: `each_key`/`each_value`/`group_by`/`partition`, plus `each`/`map`/`select`/`reject`/`sort_by`/`sum` widening to accept a Hash receiver alongside their Array-only forms (`Hash#map`/`sort_by` return an Array, `select`/`reject` return a Hash — matching Ruby's `Enumerable`-over-Hash semantics).
- Every helper snapshots both `len` and the `entries` pointer before its loop **from the start** (slice 6's `delete`/`clear` mutators already existed when these were added, so there was no unguarded window this time).
- **Security fix to already-merged code, found while implementing `delete`**: `delete` and `Array#shift` (slice 4) originally compacted their backing buffer **in place**. That's unsafe against a block helper's pointer snapshot — snapshotting a pointer is only safe against a mutator that *reallocates* (like `push`); an in-place compact mutates the same memory the snapshot aliases, silently corrupting an in-flight outer iteration. Both now reallocate a fresh, smaller buffer instead.
- **Security fix, round 2**: that reallocation fix for `delete` introduced a *new* CRITICAL bug — it resized `m->entries` without syncing `m->cap`, the field `_sir_map_put`'s growth check relies on, causing a real heap out-of-bounds write on the very next insert after any delete (`h.delete(k); h[new] = v`). Fixed by setting `m->cap = new_len` alongside the reallocation.
- Along the way, discovered (not fixed here, tracked on the backlog) that bracket-index syntax (`x[i]` read almost everywhere, and `h[k] = v` write entirely) has no real Ruby source support yet — a separate, pre-existing frontend gap. The new regression test for the `cap` fix hand-builds the IR directly to work around it.

## Test plan
- [x] `cargo test -p semantic-ir-to-c` — full suite green, including retroactive Array `shift` regression tests and the new hand-built-IR `cap`-desync regression
- [x] `cargo clippy -p semantic-ir-to-c --all-targets` — clean
- [x] Security review — 2 rounds, PASSED (round 1 found the CRITICAL `cap` desync; round 2 verified the fix and re-audited every `entries`/`cap`-touching site)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>