### PR TITLE
feat(human-languages): publish Gujarati chapter 6

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -72,9 +72,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-V02 | Complete (#9653) | Validate learner-facing target-language prompts against block-level knowledge declarations and prerequisite closure. | Schema-v2 production and recall blocks cannot ask for an undeclared form or a form absent from the lesson's transitive knowledge frontier. |
 | HL-V03 | Queued | Compile individual prompt, answer, accepted-variant, feedback, and response-time contracts from typed activity blocks. | Every compiled activity names a non-empty subset of its block's assessed atoms and resolves all answer variants without scraping prose. |
 | HL-B04 | Complete (#9661) | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
-| HL-B05 | Complete in this PR | Remove Marathi's duplicate practice labels and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Devanagari, natural page bottoms, and explicit static-font shapes make the forced six-chapter build warning-free. |
-| HL-B06 | Next | Publish Gujarati Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
-| HL-B07 | Queued | Remove Gujarati's missing punctuation glyphs and LaTeX layout/bookmark warnings. | A forced build succeeds but reports four missing punctuation glyphs, one overfull box, four underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
+| HL-B05 | Complete (#9663) | Remove Marathi's duplicate practice labels and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Devanagari, natural page bottoms, and explicit static-font shapes make the forced six-chapter build warning-free. |
+| HL-B06 | Complete in this PR | Publish Gujarati Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
+| HL-B07 | Next | Remove Gujarati's missing punctuation glyphs and LaTeX layout/bookmark warnings. | A forced build succeeds but reports four missing punctuation glyphs, one overfull box, four underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B08 | Queued | Publish Punjabi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
 | HL-B09 | Queued | Remove Punjabi's LaTeX layout, duplicate-label, and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs but reports one overfull box, four underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B10 | Queued | Publish Sanskrit Chapter 6 from its three canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
@@ -318,6 +318,28 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - The forced 31-page XeLaTeX build now reports zero package or LaTeX warnings,
   missing glyphs, overfull boxes, underfull boxes, and duplicate destinations.
   HL-B06 is next: publish Gujarati Chapter 6 through the same canonical pipeline.
+
+## Findings from HL-B06
+
+- Gujarati Chapter 6 now comes from its two canonical schema-v2 lessons. The
+  generator manifest and Language Ladder independently combine the same ordered
+  lesson hashes, so the app and downloadable book cannot drift silently.
+- Both lessons realize `SPINE-COUNT-ONE-TO-FIVE` while retaining Gujarati's
+  local headless-script clue, the *dvé → be* assimilation path, and the learned
+  restoration of *r* in *traṇ*. Their effective 174- and 253-second boundaries
+  remain below the strict five-minute ceiling.
+- The shared Unicode generator wraps Gujarati runs with the book's existing
+  `\gu` command, while authored romanization supplies readable section
+  bookmarks. The final outline contains `ek be traṇ chār pā̃ch` and `be · traṇ`.
+- The deterministic report now measures 1,065 lessons, 20 books, zero duration
+  violations, zero unknown prerequisites, and 255 lesson chapters without book
+  chapters. Gujarati joins Spanish and Marathi as the third mixed-schema track.
+- The forced letter-size XeLaTeX build is 27 pages. Visual inspection of every
+  generated page found shaped Gujarati, width-aware tables, intact callouts, and
+  no clipping; tightening the final four-question recall kept it on one page.
+- The generated chapter adds no new missing-glyph, overfull, underfull,
+  duplicate-label, bookmark, or font warnings. HL-B07 remains the bounded cleanup
+  for warnings already present in the five handwritten chapters.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -68,7 +68,7 @@ edition is authored.
 | [Marathi](./marathi/README.md) | Indo-Aryan / Devanagari | Chapters 1-6 authored (lessons + book) |
 | [Punjabi](./punjabi/README.md) | Indo-Aryan / Gurmukhi (vendored font) | Chapter 1 (Greetings) authored (lessons + book) |
 | [Bengali](./bengali/README.md) | Indo-Aryan / Bengali (vendored font) | Chapter 1 (Greetings) authored (lessons + book) |
-| [Gujarati](./gujarati/README.md) | Indo-Aryan / Gujarati (vendored font) | Chapters 1-5 authored (new track, script inline) |
+| [Gujarati](./gujarati/README.md) | Indo-Aryan / Gujarati (vendored font) | Chapters 1-6 authored (lessons + book, script inline) |
 | [Tamil](./tamil/README.md) | Dravidian / Tamil (vendored font) | Chapters 1-2 authored (lessons + book) |
 | [Kannada](./kannada/README.md) | Dravidian / Kannada (vendored font) | Chapters 1-2 authored (lessons + book) |
 | [Telugu](./telugu/README.md) | Dravidian / Telugu (vendored font) | Chapters 1-2 authored (lessons + book) |

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -44,6 +44,15 @@
       "output": "spanish/book/chapters/ch06-first-verbs.tex"
     },
     {
+      "language": "gujarati",
+      "chapter": 6,
+      "title": "Numbers One to Five",
+      "label": "ch:numbers-one-to-five",
+      "output": "gujarati/book/chapters/ch06-numbers-1-5.tex",
+      "unicodeScript": "Gujarati",
+      "scriptCommand": "gu"
+    },
+    {
       "language": "marathi",
       "chapter": 6,
       "title": "Numbers One to Five",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -3,6 +3,16 @@
   "algorithm": "fnv1a64",
   "chapters": [
     {
+      "language": "gujarati",
+      "chapter": 6,
+      "sourceHash": "fnv1a64:388a6950ab136cc1",
+      "lessonIds": [
+        "GU-C06-numbers-1-5",
+        "GU-C06-number-histories"
+      ],
+      "tex": "gujarati/book/chapters/ch06-numbers-1-5.tex"
+    },
+    {
       "language": "marathi",
       "chapter": 6,
       "sourceHash": "fnv1a64:d0addd66aaedf900",

--- a/code/learning/human-languages/gujarati/CHANGELOG.md
+++ b/code/learning/human-languages/gujarati/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Canonical Chapter 6 publication — 2026-08-03
+
+- Migrated both number lessons to schema v2 with the shared
+  `SPINE-COUNT-ONE-TO-FIVE` can-do node, explicit sub-five-minute budgets, and
+  block-level knowledge closure.
+- Generated the downloadable Chapter 6 from the same ordered lesson AST and
+  source hash that Language Ladder loads, rather than maintaining another copy.
+- Preserved Gujarati script inline with the book's vendored font and used
+  romanized section short titles for stable PDF bookmarks.
+
 ## Sub-five-minute remediation — 2026-08-02
 
 - Corrected eight declared five-minute estimates whose computed durations were

--- a/code/learning/human-languages/gujarati/README.md
+++ b/code/learning/human-languages/gujarati/README.md
@@ -40,14 +40,16 @@ root, script taught inline, a publishable LaTeX book.
   counting lesson followed by a prerequisite-ordered history of why *be*
   continues Sanskrit *dvé* and why *traṇ* regained an *r* after Prakrit lost it.
 
-Chapters 1–5 are in the book. Chapter 6 is canonical app-ready lesson content;
-its one-source book publication remains explicitly tracked in the shared
-backlog.
+Chapters 1–6 are in the book. Chapter 6 is generated from the same canonical
+schema-v2 lesson AST and source hashes that Language Ladder loads, while the
+first five chapters retain their authored long-form narrative during migration.
 
 ## Book / fonts
 
 Compiles with XeLaTeX using the **vendored** Noto Sans Gujarati font
 (`../../_fonts/NotoSansGujarati-Static.ttf`). `latexmk -xelatex book.tex`.
+Generated Gujarati runs use that font while section bookmarks use the lessons'
+Latin romanization.
 
 ## Files
 

--- a/code/learning/human-languages/gujarati/book/book.tex
+++ b/code/learning/human-languages/gujarati/book/book.tex
@@ -75,4 +75,6 @@ Released under CC~BY-SA~4.0.
 
 \input{chapters/ch05-first-verbs}
 
+\input{chapters/ch06-numbers-1-5}
+
 \end{document}

--- a/code/learning/human-languages/gujarati/book/chapters/ch06-numbers-1-5.tex
+++ b/code/learning/human-languages/gujarati/book/chapters/ch06-numbers-1-5.tex
@@ -1,0 +1,115 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:388a6950ab136cc1
+% canonical-lessons: GU-C06-numbers-1-5, GU-C06-number-histories
+
+\chapter{Numbers One to Five}
+\label{ch:numbers-one-to-five}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[ek be traṇ chār pā̃ch]{\gu{એક}, \gu{બે}, \gu{ત્રણ}, \gu{ચાર}, \gu{પાંચ} — one to five}
+
+\label{lesson:GU-C06-numbers-1-5}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Three of these will look familiar from any other Indian language. Two won't — and both have a reason.
+\end{quote}
+
+\subsection*{You'll want to know: the five}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{Gujarati} & \textbf{said} \\
+\midrule
+1 & \textbf{\gu{એક}} & \emph{ek} \\
+2 & \textbf{\gu{બે}} & \emph{be} \\
+3 & \textbf{\gu{ત્રણ}} & \emph{traṇ} \\
+4 & \textbf{\gu{ચાર}} & \emph{chār} \\
+5 & \textbf{\gu{પાંચ}} & \emph{pā̃ch} \\
+\bottomrule
+\end{tabularx}
+
+Notice the script: Gujarati is Devanagari \textbf{without the top line}. Same letters, same system — the shirorekhā simply isn't drawn. If you've done the Hindi writing track you can feel the relationship immediately.
+
+\begin{grammarlens}[title={What you've built: two surprises and a headless script}]
+Most neighbouring languages have a \emph{d} in “two,” but Gujarati says \textbf{\gu{બે}} \emph{be}. Hindi says \emph{tīn} for “three,” but Gujarati says \textbf{\gu{ત્રણ}} \emph{traṇ}, with an \emph{r}.
+
+Do not carry both histories while the count is still new. Make the five forms automatic first; the next prerequisite-ordered lesson explains why \emph{be} and \emph{traṇ} took those shapes.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "ek, be, traṇ, chār, pā̃ch"{]}
+  \item {[}YOU SAY: the odd two — Gujarati \textbf{be} and \textbf{traṇ}{]}
+  \item {[}YOU SAY: the script clue — Devanagari shapes without a top line{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Count to five in Gujarati. (\emph{Ek, be, traṇ, chār, pā̃ch}.) Why does \textbf{\gu{બે}} look unlike its neighbours? (It begins with \emph{b}, not \emph{d}.) What does \textbf{\gu{ત્રણ}} contain that Hindi \emph{tīn} does not? (\emph{r}.) What is visibly missing from the Gujarati script? (The top line: the \emph{shirorekhā} is not drawn.) Next: trace the two surprising number histories.
+\end{tcolorbox}
+\section[be · traṇ]{Two number histories: \emph{be} and \emph{traṇ}}
+
+\label{lesson:GU-C06-number-histories}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Count once: \emph{ek, be, traṇ, chār, pā̃ch}. Which two forms look least like Hindi or Marathi? (\emph{Be} and \emph{traṇ}.)
+\end{quote}
+
+\begin{cousinweb}
+Sanskrit had gendered forms of “two,” and its daughters selected different parts of that paradigm:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{“two”} & \textbf{route} \\
+\midrule
+Sanskrit & \emph{dváu} (masc.) · \emph{dvé} (fem. and neut.) & — \\
+Hindi & \emph{do} & masculine side \\
+Marathi & \emph{don} & masculine side, plus an analogical \emph{-n} \\
+Bengali & \emph{dui} & disyllabic Prakrit \emph{duve} \\
+\textbf{Gujarati} & \emph{\textbf{be}} & feminine/neuter \emph{dvé} side \\
+\bottomrule
+\end{tabularx}
+
+Gujarati \textbf{\gu{બે}} is not a corruption of \emph{do}. It is a \textbf{different inheritance} from the same Sanskrit paradigm.
+
+The initial cluster changed too. In \emph{dv-}, the dental \emph{d} adopted the \textbf{labial place} of the following \emph{v}: \emph{dv} $\to$ \emph{bb} $\to$ \emph{b}. The first consonant was remade in the shape of its neighbour, then the double simplified.
+\end{cousinweb}
+
+\begin{cousinweb}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{stage} & \textbf{“three”} \\
+\midrule
+Sanskrit neuter & \emph{trī́ṇi} \\
+Prakrit & \emph{tiṇṇi}: \emph{r} already gone \\
+Hindi & \emph{tīn} \\
+\textbf{Gujarati} & \emph{\textbf{traṇ}}: \emph{r} present again \\
+\bottomrule
+\end{tabularx}
+
+The shared \textbf{ṇ} shows that Hindi and Gujarati both descend from neuter \emph{trī́ṇi} through Prakrit \emph{tiṇṇi}. By that stage, the \emph{r} was gone and its weight had moved into doubled \emph{ṇṇ}. Hindi later simplified the double and lengthened the vowel.
+
+Gujarati's \emph{tr-} is generally treated as \textbf{restored from Sanskrit}, not carried through unbroken. Sanskrit remained a literary language and continued to reshape its descendants. \emph{Traṇ} looks older than \emph{tīn}, but it is closer because speakers put the \emph{r} back.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: Gujarati's selected form — feminine/neuter \emph{dvé}{]}
+  \item {[}YOU SAY: the sound path — \emph{dv $\to$ bb $\to$ b}{]}
+  \item {[}YOU SAY: the \emph{r} path — \emph{trī́ṇi $\to$ tiṇṇi $\to$ traṇ}{]}
+  \item {[}YOU SAY: inherited continuously or restored — restored{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Why \emph{be}, not Hindi \emph{do}? (Different Sanskrit forms.) What changed in \emph{dv $\to$ b}? (\emph{D} became labial beside \emph{v}; the double simplified.) Did \emph{traṇ} keep \emph{r}? (No: Sanskrit restored Prakrit's lost \emph{r}.) How can a newer form look older? (Learned restoration.)
+\end{tcolorbox}

--- a/code/learning/human-languages/gujarati/book/preamble.tex
+++ b/code/learning/human-languages/gujarati/book/preamble.tex
@@ -23,6 +23,7 @@
 \tcbuselibrary{skins,breakable}
 \usepackage{booktabs}
 \usepackage{longtable}
+\usepackage{tabularx}
 \usepackage{array}
 \usepackage[hidelinks]{hyperref}
 \usepackage{titlesec}
@@ -52,10 +53,10 @@
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
   fonttitle=\bfseries, title={Why it's said this way}
 }
-\newtcolorbox{grammarlens}{
+\newtcolorbox{grammarlens}[1][]{
   breakable, skin=enhanced, colback=blue!5, colframe=blue!35!black,
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
-  fonttitle=\bfseries, title={Grammar Lens}
+  fonttitle=\bfseries, title={Grammar Lens}, #1
 }
 \newtcolorbox{sounds}{
   breakable, skin=enhanced, colback=green!6, colframe=green!30!black,

--- a/code/learning/human-languages/gujarati/lessons/GU-C06-number-histories.md
+++ b/code/learning/human-languages/gujarati/lessons/GU-C06-number-histories.md
@@ -1,25 +1,43 @@
 ---
+schema_version: 2
 id: GU-C06-number-histories
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 350
 chapter: 6
 type: etymology
 headword: બે · ત્રણ
+romanization: be · traṇ
 gloss: why Gujarati two begins with b and why three regained an r
 prerequisites: [GU-C06-numbers-1-5]
 sounds: [e-sign, inherent-a]
 roots: [sanskrit-dvi, sanskrit-tri]
 etymology_hook: "Gujarati be continues Sanskrit feminine/neuter dve through dv to bb to b; tran's r was restored after Prakrit tiṇṇi had already lost it"
-est_minutes: 4
+duration:
+  max_seconds: 270
+requires:
+  knowledge: [GU-LEX-NUMBERS-ONE-TO-FIVE, GU-FORM-BE-INITIAL-B, GU-FORM-TRAN-R]
+introduces:
+  knowledge: [GU-ETYMON-BE-DVE-SELECTION, GU-SOUND-DV-BB-B, GU-ETYMON-TRAN-R-RESTORATION, GU-HISTORY-LEARNED-RESTORATION]
+practises:
+  knowledge: [GU-LEX-NUMBERS-ONE-TO-FIVE, GU-FORM-BE-INITIAL-B, GU-FORM-TRAN-R, GU-ETYMON-BE-DVE-SELECTION, GU-SOUND-DV-BB-B, GU-ETYMON-TRAN-R-RESTORATION, GU-HISTORY-LEARNED-RESTORATION]
+skills: [listening, speaking, reading]
+modes: [interpretive, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [GU-C06-numbers-1-5]
 ---
 
 # Two number histories: *be* and *traṇ*
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[GU-LEX-NUMBERS-ONE-TO-FIVE, GU-FORM-BE-INITIAL-B, GU-FORM-TRAN-R] -->
 
 [PAUSE 2s] Count once: *ek, be, traṇ, chār, pā̃ch*. Which two forms look least
 like Hindi or Marathi? (*Be* and *traṇ*.)
 
-## બે — a different ancestor
+## The word, taken apart — બે from a different ancestor
+<!-- hl-knowledge: introduces=[GU-ETYMON-BE-DVE-SELECTION, GU-SOUND-DV-BB-B]; assesses=[] -->
 
 Sanskrit had gendered forms of “two,” and its daughters selected different
 parts of that paradigm:
@@ -39,7 +57,8 @@ The initial cluster changed too. In *dv-*, the dental *d* adopted the **labial
 place** of the following *v*: *dv* → *bb* → *b*. The first consonant was remade
 in the shape of its neighbour, then the double simplified.
 
-## ત્રણ — the *r* that came back
+## The word, taken apart — ત્રણ and the *r* that came back
+<!-- hl-knowledge: introduces=[GU-ETYMON-TRAN-R-RESTORATION, GU-HISTORY-LEARNED-RESTORATION]; assesses=[] -->
 
 | stage | “three” |
 |---|---|
@@ -59,6 +78,7 @@ its descendants. *Traṇ* looks older than *tīn*, but it is closer because spea
 put the *r* back.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[GU-LEX-NUMBERS-ONE-TO-FIVE, GU-FORM-BE-INITIAL-B, GU-FORM-TRAN-R, GU-ETYMON-BE-DVE-SELECTION, GU-SOUND-DV-BB-B, GU-ETYMON-TRAN-R-RESTORATION, GU-HISTORY-LEARNED-RESTORATION] -->
 
 [PAUSE 1s]
 - [YOU SAY: Gujarati's selected form — feminine/neuter *dvé*]
@@ -67,9 +87,9 @@ put the *r* back.
 - [YOU SAY: inherited continuously or restored — restored]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[GU-LEX-NUMBERS-ONE-TO-FIVE, GU-FORM-BE-INITIAL-B, GU-FORM-TRAN-R, GU-ETYMON-BE-DVE-SELECTION, GU-SOUND-DV-BB-B, GU-ETYMON-TRAN-R-RESTORATION, GU-HISTORY-LEARNED-RESTORATION] -->
 
-[PAUSE 3s] Why does Gujarati say *be* while Hindi says *do*? (They continue
-different forms of Sanskrit “two.”) What happened in *dv → b*? (*D* assimilated
-to labial *v*, then the double simplified.) Did Gujarati *traṇ* preserve *r*
-continuously? (No: Prakrit had lost it; Sanskrit influence restored it.) Why can
-a newer form look older? (Learned influence can put an ancestral sound back.)
+[PAUSE 3s] Why *be*, not Hindi *do*? (Different Sanskrit forms.) What changed in
+*dv → b*? (*D* became labial beside *v*; the double simplified.) Did *traṇ* keep
+*r*? (No: Sanskrit restored Prakrit's lost *r*.) How can a newer form look older?
+(Learned restoration.)

--- a/code/learning/human-languages/gujarati/lessons/GU-C06-numbers-1-5.md
+++ b/code/learning/human-languages/gujarati/lessons/GU-C06-numbers-1-5.md
@@ -1,26 +1,44 @@
 ---
+schema_version: 2
 id: GU-C06-numbers-1-5
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 340
 chapter: 6
 type: word
 headword: એક બે ત્રણ ચાર પાંચ
+romanization: ek be traṇ chār pā̃ch
 gloss: one to five — the two numbers that don't look like their neighbours'
 concept_tag: GU-NUMBERS-1-5
 prerequisites: [GU-C01-namaste]
 sounds: [long-aa, nasal-aa, e-sign, inherent-a]
 roots: [sanskrit-dvi, sanskrit-tri, sanskrit-panca]
 etymology_hook: "Gujarati be and tran differ from their neighbours; learn the five forms first, then trace be to dve and tran's restored r in the next short lesson"
-est_minutes: 3
+duration:
+  max_seconds: 180
+requires:
+  knowledge: []
+introduces:
+  knowledge: [GU-LEX-NUMBERS-ONE-TO-FIVE, GU-SCRIPT-HEADLESS-CLUE, GU-FORM-BE-INITIAL-B, GU-FORM-TRAN-R]
+practises:
+  knowledge: [GU-LEX-NUMBERS-ONE-TO-FIVE, GU-SCRIPT-HEADLESS-CLUE, GU-FORM-BE-INITIAL-B, GU-FORM-TRAN-R]
+skills: [listening, speaking, reading]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [GU-C01-namaste]
 ---
 
 # એક, બે, ત્રણ, ચાર, પાંચ — one to five
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Three of these will look familiar from any other Indian language.
 Two won't — and both have a reason.
 
-## The five
+## You'll want to know: the five
+<!-- hl-knowledge: introduces=[GU-LEX-NUMBERS-ONE-TO-FIVE]; assesses=[] -->
 
 | | Gujarati | said |
 |---|---|---|
@@ -34,7 +52,8 @@ Notice the script: Gujarati is Devanagari **without the top line**. Same letters
 same system — the shirorekhā simply isn't drawn. If you've done the Hindi writing
 track you can feel the relationship immediately.
 
-## Notice the two surprises
+## What you've built: two surprises and a headless script
+<!-- hl-knowledge: introduces=[GU-SCRIPT-HEADLESS-CLUE, GU-FORM-BE-INITIAL-B, GU-FORM-TRAN-R]; assesses=[] -->
 
 Most neighbouring languages have a *d* in “two,” but Gujarati says **બે** *be*.
 Hindi says *tīn* for “three,” but Gujarati says **ત્રણ** *traṇ*, with an *r*.
@@ -44,6 +63,7 @@ automatic first; the next prerequisite-ordered lesson explains why *be* and
 *traṇ* took those shapes.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[GU-LEX-NUMBERS-ONE-TO-FIVE, GU-SCRIPT-HEADLESS-CLUE, GU-FORM-BE-INITIAL-B, GU-FORM-TRAN-R] -->
 
 [PAUSE 1s]
 - [YOU SAY: "ek, be, traṇ, chār, pā̃ch"]
@@ -51,8 +71,9 @@ automatic first; the next prerequisite-ordered lesson explains why *be* and
 - [YOU SAY: the script clue — Devanagari shapes without a top line]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[GU-LEX-NUMBERS-ONE-TO-FIVE, GU-SCRIPT-HEADLESS-CLUE, GU-FORM-BE-INITIAL-B, GU-FORM-TRAN-R] -->
 
-[PAUSE 3s] Count to five in Gujarati. (*Ek, be, traṇ, chār, pā̃ch*.) Why doesn't
+[PAUSE 3s] Count to five in Gujarati. (*Ek, be, traṇ, chār, pā̃ch*.) Why does
 **બે** look unlike its neighbours? (It begins with *b*, not *d*.) What does
 **ત્રણ** contain that Hindi *tīn* does not? (*r*.) What is visibly missing from
 the Gujarati script? (The top line: the *shirorekhā* is not drawn.) Next: trace

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
   only half of the script-rendering configuration is present.
 - Generate Marathi Chapter 6 from its two strict canonical lessons and expose the
   same ordered source hash to Language Ladder.
+- Generate Gujarati Chapter 6 from its two strict canonical lessons, preserving
+  Gujarati-script runs and bookmark-safe romanization from the shared AST.
 
 ### Added — block-boundary knowledge closure
 

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -11,8 +11,8 @@
 - Independently combine loaded lesson fingerprints and show `book synced` for a
   generated chapter only when the app AST matches the committed book manifest;
   Spanish Chapters 1–6 now verify all 51 migrated lessons this way, and Marathi
-  Chapter 6 verifies both of its canonical lessons independently of the book
-  generator.
+  and Gujarati Chapter 6 verify both of their canonical lessons independently
+  of the book generator.
 
 ## 0.25.0 — the same syllable in its sister scripts (syllabary, PR 9)
 

--- a/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
@@ -18,13 +18,16 @@ describe("generated book source hashes", () => {
     expect(bookHashStatus(lessons, "spanish", chapter)).toBe("synced");
   });
 
-  it("matches the browser-loaded Marathi Chapter 6 AST across both lessons", () => {
-    const lessons = loadLessons();
-    const expected = expectedBookHash("marathi", 6);
-    expect(expected?.lessonIds).toHaveLength(2);
-    expect(actualChapterHash(lessons, "marathi", 6)).toBe(expected?.sourceHash);
-    expect(bookHashStatus(lessons, "marathi", 6)).toBe("synced");
-  });
+  it.each(["gujarati", "marathi"])(
+    "matches the browser-loaded %s Chapter 6 AST across both lessons",
+    (language) => {
+      const lessons = loadLessons();
+      const expected = expectedBookHash(language, 6);
+      expect(expected?.lessonIds).toHaveLength(2);
+      expect(actualChapterHash(lessons, language, 6)).toBe(expected?.sourceHash);
+      expect(bookHashStatus(lessons, language, 6)).toBe("synced");
+    },
+  );
 
   it("reports a generated chapter stale when one canonical lesson changes", () => {
     const lessons = loadLessons();


### PR DESCRIPTION
## Summary

- migrate both Gujarati Chapter 6 micro-lessons to schema v2 on `SPINE-COUNT-ONE-TO-FIVE`, with explicit sub-five-minute budgets and block-level knowledge closure
- generate the downloadable Gujarati chapter from the canonical lesson AST, preserving Gujarati-script font runs and romanized PDF bookmarks
- independently verify the same ordered lesson source hash in Language Ladder and update the curriculum backlog/docs

## Validation

- `@coding-adventures/human-language-data`: 80 tests passed
- `npm run check:books`
- Language Ladder: 284 tests passed; production build passed
- curriculum report: 20 tracks, 1,065 lessons, 0 duration violations, 0 unknown prerequisites
- forced XeLaTeX build: 27 letter-size pages
- visually inspected every generated page and the final recall; no clipping or new generated-chapter glyph/layout warnings
- `git diff --check`

## Known follow-up

The five handwritten Gujarati chapters retain their previously measured punctuation, layout, duplicate-label, bookmark, and font warnings. HL-B07 remains the next bounded cleanup item; this generated chapter adds none of those warnings.