### PR TITLE
feat(wasm-execution): W04 -- real garbage collection for the WasmGC struct heap

### DIFF
--- a/code/packages/rust/wasm-execution/CHANGELOG.md
+++ b/code/packages/rust/wasm-execution/CHANGELOG.md
@@ -55,6 +55,22 @@ crate. A long-running WASM-compiled program could allocate without bound.
   objects while keeping exactly one alive, proving both that the kept
   object survives with its field intact and that the live count is
   reclaimed mid-run rather than left to accumulate.
+- **Security-review fixes, before this landed**:
+  - `sweep` now also drops `gc_heap`'s trailing run of tombstoned slots
+    (removing their indices from `free_list` too). Without this, the
+    arena's length — and therefore `mark`/`sweep`'s O(len) cost — was a
+    monotonically non-decreasing high-water mark for the life of a call: a
+    program that transiently spiked the live count high, then settled into
+    low-retention churn, would keep paying that peak cost on every
+    subsequent collection. Not compaction (no live object moves or is
+    renumbered) — only provably-all-garbage trailing capacity is dropped.
+  - `gc::alloc`'s new-handle assignment now uses a checked `u32` conversion
+    (clean trap on failure) instead of an unchecked `as u32` cast, so an
+    eventual overflow (practically unreachable — it implies 100+GB of
+    live, uncollected heap) can't silently alias a fresh object's handle
+    onto an already-occupied lower index.
+  - Tests: `sweep_shrinks_arena_when_everything_is_reclaimed`,
+    `sweep_does_not_truncate_past_a_live_object_in_the_middle`.
 - See `code/specs/W04-wasm-gc.md` for the full design rationale.
 
 ## [0.5.0] — 2026-07-07

--- a/code/packages/rust/wasm-execution/CHANGELOG.md
+++ b/code/packages/rust/wasm-execution/CHANGELOG.md
@@ -2,6 +2,61 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.6.0] — 2026-08-03 (W04 — real garbage collection for `gc_heap`)
+
+The WasmGC struct heap (`gc_heap`) was, until now, an append-only arena with
+no reclamation — its own doc comment justified this as "bounded by the VM's
+instruction budget," a budget that does not actually exist anywhere in this
+crate. A long-running WASM-compiled program could allocate without bound.
+
+- **New `gc` module**: a real mark-and-sweep collector over a **tombstone +
+  free-list slot arena** — `gc_heap: Vec<GcStruct>` becomes
+  `Vec<Option<GcStruct>>` (`Some` = live, `None` = a reclaimed slot ready
+  for reuse). Compaction is out of scope: a `WasmValue::Ref(Some(handle))`
+  is a `Vec` index (a WASM-spec-mandated representation), so shrinking the
+  arena would silently invalidate every other live handle past the removed
+  index. No generation tag is needed to guard a reused slot against
+  aliasing a stale reference — mark-sweep's ordinary soundness argument
+  (nothing left unmarked is reachable, given an exhaustive root walk)
+  already rules that out, since every handle a program can hold either sat
+  in a scanned root or was freshly minted.
+- **Root set**: every `WasmValue::Ref(Some(_))` in `ctx.globals`,
+  `ctx.typed_locals`, **every** `ctx.saved_frames[*].locals` (a paused
+  caller's locals — missing this would free something a suspended caller
+  still references), and the interpreter's operand stack
+  (`GenericVM::typed_stack`, via the existing `REF_TAG` convention),
+  traced transitively through each object's own fields — cycle-safe by
+  construction (a worklist walk with a `marked` visited set, not naive
+  recursion). Precise, with no `HeapKind`-style schema needed: a
+  `GcStruct` field is a tagged `WasmValue`, self-describing as a reference
+  or not.
+- **Checked at two chokepoints**: `execute_branch` (every taken
+  `br`/`br_if`/`br_table` — a loop's back-edge is a branch to its own loop
+  label) and the internal `call_function` helper (every `call`/
+  `call_indirect`, nested or not) — both of this crate's independent
+  dispatch loops (`GenericVM::execute_with_context` and the hand-inlined
+  loop inside `call_function`) route through these two shared functions, so
+  instrumenting them covers both loops without adding anything WASM-specific
+  to the generic `virtual-machine` crate's own dispatch code. Mirrors the
+  existing "safepoints at back-edges and calls" convention rather than a
+  per-instruction counter.
+- **Adaptive object-count threshold**, mirroring `gc-core::FlatHeap::should_collect`/
+  `adapt_threshold` verbatim (just in units of live objects rather than
+  bytes, since this heap has no byte-size concept). New `gc-core` path
+  dependency, reusing its representation-agnostic `GcProfile`/`GcCycleStats`
+  for diagnostic consistency with the native-AOT and `vm-core` GC paths —
+  exposed via new `WasmExecutionEngine::gc_live_object_count()` /
+  `gc_profile()` accessors (`gc_heap` itself still resets every call, as it
+  always has; only the counters are written back).
+- Tests: `gc`'s own unit tests (`mark`/`sweep`/`alloc`/threshold-adaptation
+  in isolation, including cycle-safety and a saved-caller-frame root) plus
+  `end_to_end_loop_reclaims_garbage_and_preserves_kept_object` — a real WASM
+  loop, driven through actual bytecode dispatch, that allocates 2000
+  objects while keeping exactly one alive, proving both that the kept
+  object survives with its field intact and that the live count is
+  reclaimed mid-run rather than left to accumulate.
+- See `code/specs/W04-wasm-gc.md` for the full design rationale.
+
 ## [0.5.0] — 2026-07-07
 
 ### Added — `memory.copy` bulk-memory op (E4-dyn runtime string concat)

--- a/code/packages/rust/wasm-execution/Cargo.toml
+++ b/code/packages/rust/wasm-execution/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "wasm-execution"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "WebAssembly 1.0 wasm-execution"
 
 [dependencies]
-wasm-leb128 = { path = "../wasm-leb128" }
-wasm-types = { path = "../wasm-types" }
-wasm-opcodes = { path = "../wasm-opcodes" }
-wasm-module-parser = { path = "../wasm-module-parser" }
-virtual-machine = { path = "../virtual-machine" }
+gc-core             = { path = "../gc-core" }
+wasm-leb128         = { path = "../wasm-leb128" }
+wasm-types          = { path = "../wasm-types" }
+wasm-opcodes        = { path = "../wasm-opcodes" }
+wasm-module-parser  = { path = "../wasm-module-parser" }
+virtual-machine     = { path = "../virtual-machine" }

--- a/code/packages/rust/wasm-execution/README.md
+++ b/code/packages/rust/wasm-execution/README.md
@@ -11,20 +11,35 @@ emitted:
 - **`struct.new` / `struct.get` / `struct.set`** and **`ref.null` / `ref.is_null`**
   (0.3.0) — a GC object heap backs the lisp **cons cell** (`$LispyPair`).
   References are a new `WasmValue::Ref(Option<handle>)` (`None` = null = lisp
-  `nil`); the heap is an append-only arena bounded by the VM instruction budget.
-  `(CAR (CONS 7 9))` executes to `7`.  Register struct field counts via
+  `nil`). `(CAR (CONS 7 9))` executes to `7`.  Register struct field counts via
   `WasmExecutionEngine::set_struct_field_counts` (the parser will supply these
   automatically in L3b-3a-3c).
 - **`ref.test` / `ref.test null`** (0.4.0) — the WasmGC type-test op that
   McCarthy `pair?` lowers to: pop a reference, push `i32 1` if it is a (non-null)
   `$LispyPair` struct reference, else `0`. `pair?(cons)` → 1; `pair?(atom)` and
   `pair?(nil)` → 0.
+- **Real garbage collection** (0.6.0, W04) — the object heap is a real
+  mark-and-sweep collector, not an append-only arena: unreachable objects
+  are reclaimed and their slots reused, so a long-running loop or recursive
+  program no longer grows the heap without bound. Precise, cycle-safe root
+  scanning (globals, locals, every suspended caller frame, the operand
+  stack) with no per-type schema needed — a `GcStruct` field is a tagged
+  `WasmValue`, self-describing as a reference or not. Checked at loop
+  back-edges and calls (mirroring the same "safepoints" convention the
+  native-AOT collector uses), with an adaptive object-count threshold
+  mirroring `gc-core::FlatHeap`'s heuristic. Compaction is explicitly out of
+  scope — a `Ref` handle is a `Vec` index, so relocating objects would need
+  rewriting every handle-holding location instead of just this collector's
+  own bookkeeping. See `code/specs/W04-wasm-gc.md` and
+  `WasmExecutionEngine::gc_live_object_count()` / `gc_profile()`.
 
 All GC failure modes (null dereference, out-of-range field, missing arity,
-unknown opcode) are clean traps, never panics.
+unknown opcode, or a handle to an already-collected object) are clean
+traps, never panics.
 
 ## Dependencies
 
+- gc-core (W04 — `GcProfile`/`GcCycleStats` diagnostics for the object-heap collector)
 - wasm-leb128
 - wasm-types
 - wasm-opcodes

--- a/code/packages/rust/wasm-execution/src/gc.rs
+++ b/code/packages/rust/wasm-execution/src/gc.rs
@@ -33,7 +33,7 @@
 use crate::{GcStruct, WasmExecutionContext, WasmValue, REF_NULL_SENTINEL, REF_TAG};
 use gc_core::profile::GcCycleStats;
 use gc_core::GcProfile;
-use virtual_machine::{GenericVM, Value};
+use virtual_machine::{GenericVM, VMError, Value};
 
 /// Object-count threshold a fresh [`GcState`] starts at (analogous to
 /// `gc-core`'s `INITIAL_THRESHOLD`, but counting live objects rather than
@@ -158,6 +158,23 @@ fn mark(vm: &GenericVM, ctx: &WasmExecutionContext) -> Vec<bool> {
 /// the field-vector memory it held), tombstone it to `None`, and push its
 /// index onto the free list for `struct.new` to reuse. Returns the number
 /// of objects freed.
+///
+/// Also shrinks `gc_heap`'s trailing run of tombstoned slots, if any (a
+/// security-review finding, not just tidiness): `mark`'s `marked` vector and
+/// this function's own sweep loop both cost O(`gc_heap.len()`), and without
+/// this, that length is a monotonically non-decreasing high-water mark for
+/// the whole call — a program that transiently spikes the live count (and,
+/// via `adapt_threshold`, the collection threshold) high, then settles into
+/// a low-retention allocate/discard steady state, would otherwise pay that
+/// peak cost on *every* subsequent collection for the rest of the call, an
+/// unbounded amplification relative to its actual live-object count. This is
+/// **not** compaction — no live object moves or is renumbered, so it doesn't
+/// need the handle-rewriting machinery compaction would (see `W04-wasm-gc.md`
+/// §2); it only drops Vec capacity that's provably all-garbage at the tail.
+/// A live/dead-interleaved tail (the highest-indexed object still live) sees
+/// no benefit from this pass alone, but a low-retention churn pattern —
+/// exactly the one the finding describes — keeps shrinking back down as the
+/// previously-highest survivor is eventually collected on a later cycle too.
 fn sweep(ctx: &mut WasmExecutionContext, marked: &[bool]) -> usize {
     // Disjoint field borrows off one `&mut WasmExecutionContext` — sound
     // because `gc_heap` and `gc_state` are different fields, not aliases.
@@ -171,6 +188,16 @@ fn sweep(ctx: &mut WasmExecutionContext, marked: &[bool]) -> usize {
         }
     }
     gc_state.live_count -= freed;
+
+    while matches!(gc_heap.last(), Some(None)) {
+        gc_heap.pop();
+    }
+    // Every truncated index no longer exists in gc_heap at all, so it must
+    // not be left in free_list — a later alloc() reusing it would index past
+    // the (now shorter) Vec's end.
+    let new_len = gc_heap.len() as u32;
+    gc_state.free_list.retain(|&idx| idx < new_len);
+
     freed
 }
 
@@ -203,16 +230,26 @@ pub(crate) fn maybe_collect(vm: &GenericVM, ctx: &mut WasmExecutionContext) {
 /// Allocate a `GcStruct`, reusing a tombstoned slot from `gc_state.free_list`
 /// before growing `gc_heap` — the free-list half of the slot-arena design.
 /// Returns the new object's handle.
-pub(crate) fn alloc(ctx: &mut WasmExecutionContext, obj: GcStruct) -> u32 {
+///
+/// A handle is a `u32` (the WASM-spec-mandated representation), so growing
+/// `gc_heap` past `u32::MAX` entries would silently wrap the new handle onto
+/// an already-occupied low index — a wrong-object aliasing bug, not a
+/// memory-safety one (still a checked Rust index), but a real logic error a
+/// security review flagged. Guarded here with a checked conversion so that
+/// (practically unreachable — it implies 100+GB of simultaneously live,
+/// uncollected heap) case is a clean trap instead of silent corruption.
+pub(crate) fn alloc(ctx: &mut WasmExecutionContext, obj: GcStruct) -> Result<u32, VMError> {
     let WasmExecutionContext { gc_heap, gc_state, .. } = ctx;
     gc_state.live_count += 1;
     if let Some(idx) = gc_state.free_list.pop() {
         gc_heap[idx as usize] = Some(obj);
-        idx
+        Ok(idx)
     } else {
-        let handle = gc_heap.len() as u32;
+        let handle = u32::try_from(gc_heap.len()).map_err(|_| {
+            VMError::GenericError("gc_heap exceeded u32::MAX live objects".to_string())
+        })?;
         gc_heap.push(Some(obj));
-        handle
+        Ok(handle)
     }
 }
 
@@ -290,17 +327,24 @@ mod tests {
         assert_eq!(high.threshold, MAX_THRESHOLD, "never exceeds the ceiling");
     }
 
+    /// `alloc` returning `Result` only guards a practically-unreachable
+    /// `u32` overflow (needs 100+GB of live heap); tests below don't
+    /// exercise that path, so unwrap it away for readability.
+    fn alloc_ok(ctx: &mut WasmExecutionContext, obj: GcStruct) -> u32 {
+        alloc(ctx, obj).unwrap()
+    }
+
     #[test]
     fn alloc_reuses_free_list_before_growing() {
         let mut ctx = empty_ctx();
 
-        let a = alloc(&mut ctx, obj(vec![WasmValue::I32(1)]));
-        let b = alloc(&mut ctx, obj(vec![WasmValue::I32(2)]));
+        let a = alloc_ok(&mut ctx, obj(vec![WasmValue::I32(1)]));
+        let b = alloc_ok(&mut ctx, obj(vec![WasmValue::I32(2)]));
         assert_eq!(ctx.gc_heap.len(), 2);
 
         ctx.gc_state.free_list.push(a);
         ctx.gc_state.live_count -= 1; // simulate a's collection
-        let c = alloc(&mut ctx, obj(vec![WasmValue::I32(3)]));
+        let c = alloc_ok(&mut ctx, obj(vec![WasmValue::I32(3)]));
         assert_eq!(c, a, "reused the freed slot instead of growing");
         assert_eq!(ctx.gc_heap.len(), 2, "arena did not grow");
         assert_eq!(
@@ -316,9 +360,9 @@ mod tests {
         let vm = GenericVM::new();
 
         // c <- b <- a, only `a` is a root (a global).
-        let c = alloc(&mut ctx, obj(vec![WasmValue::I32(42)]));
-        let b = alloc(&mut ctx, obj(vec![WasmValue::Ref(Some(c))]));
-        let a = alloc(&mut ctx, obj(vec![WasmValue::Ref(Some(b))]));
+        let c = alloc_ok(&mut ctx, obj(vec![WasmValue::I32(42)]));
+        let b = alloc_ok(&mut ctx, obj(vec![WasmValue::Ref(Some(c))]));
+        let a = alloc_ok(&mut ctx, obj(vec![WasmValue::Ref(Some(b))]));
         ctx.globals.push(WasmValue::Ref(Some(a)));
 
         let marked = mark(&vm, &ctx);
@@ -331,12 +375,12 @@ mod tests {
         ctx.gc_state.threshold = 1; // force collection eligibility
         let vm = GenericVM::new();
 
-        let c = alloc(&mut ctx, obj(vec![WasmValue::I32(42)]));
-        let b = alloc(&mut ctx, obj(vec![WasmValue::Ref(Some(c))]));
-        let a = alloc(&mut ctx, obj(vec![WasmValue::Ref(Some(b))]));
+        let c = alloc_ok(&mut ctx, obj(vec![WasmValue::I32(42)]));
+        let b = alloc_ok(&mut ctx, obj(vec![WasmValue::Ref(Some(c))]));
+        let a = alloc_ok(&mut ctx, obj(vec![WasmValue::Ref(Some(b))]));
         ctx.globals.push(WasmValue::Ref(Some(a)));
         // Pure garbage: unreachable from anything.
-        let garbage = alloc(&mut ctx, obj(vec![WasmValue::I32(999)]));
+        let garbage = alloc_ok(&mut ctx, obj(vec![WasmValue::I32(999)]));
 
         maybe_collect(&vm, &mut ctx);
 
@@ -344,8 +388,12 @@ mod tests {
         assert!(ctx.gc_heap[a as usize].is_some());
         assert!(ctx.gc_heap[b as usize].is_some());
         assert!(ctx.gc_heap[c as usize].is_some());
-        assert!(ctx.gc_heap[garbage as usize].is_none(), "unreachable object tombstoned");
-        assert_eq!(ctx.gc_state.free_list, vec![garbage], "its slot is ready for reuse");
+        // `garbage` was the last-allocated (highest-index, trailing) object,
+        // so the sweep's trailing-truncation shrinks it away entirely rather
+        // than leaving a `None` at its old index — its slot doesn't exist at
+        // all anymore, not "exists but empty".
+        assert_eq!(ctx.gc_heap.len(), garbage as usize, "the trailing garbage slot was truncated away");
+        assert!(ctx.gc_state.free_list.is_empty(), "no stale index left for a slot that no longer exists");
         assert_eq!(ctx.gc_state.profile.total_collections, 1);
         assert_eq!(ctx.gc_state.profile.total_freed, 1);
     }
@@ -362,16 +410,17 @@ mod tests {
 
         // Allocate both first (fields default to I32(0)), then wire the cycle
         // via struct.set-equivalent direct field mutation.
-        let x = alloc(&mut ctx, obj(vec![WasmValue::I32(0)]));
-        let y = alloc(&mut ctx, obj(vec![WasmValue::Ref(Some(x))]));
+        let x = alloc_ok(&mut ctx, obj(vec![WasmValue::I32(0)]));
+        let y = alloc_ok(&mut ctx, obj(vec![WasmValue::Ref(Some(x))]));
         ctx.gc_heap[x as usize].as_mut().unwrap().fields[0] = WasmValue::Ref(Some(y));
         // No root anywhere points at x or y.
 
         maybe_collect(&vm, &mut ctx);
 
         assert_eq!(ctx.gc_state.live_count, 0, "the cycle is unreachable, so both members are freed");
-        assert!(ctx.gc_heap[x as usize].is_none());
-        assert!(ctx.gc_heap[y as usize].is_none());
+        // Both were garbage, both trailing -> the whole arena truncates away.
+        assert_eq!(ctx.gc_heap.len(), 0);
+        let _ = (x, y);
     }
 
     /// A live root sitting only in a *suspended caller's* frame (not the
@@ -382,7 +431,7 @@ mod tests {
         let mut ctx = empty_ctx();
         let vm = GenericVM::new();
 
-        let kept = alloc(&mut ctx, obj(vec![WasmValue::I32(7)]));
+        let kept = alloc_ok(&mut ctx, obj(vec![WasmValue::I32(7)]));
         // The active frame's locals don't reference it...
         ctx.typed_locals = vec![WasmValue::I32(0)];
         // ...but a paused caller, one level up the call stack, does.
@@ -399,5 +448,60 @@ mod tests {
 
         let marked = mark(&vm, &ctx);
         assert!(marked[kept as usize], "a saved caller frame's local is a live root");
+    }
+
+    /// Security-review fix: `gc_heap`'s trailing tombstoned slots are
+    /// dropped after a sweep that reclaims everything, so the arena's
+    /// length — and therefore future `mark`/`sweep` cost — actually shrinks
+    /// back down instead of being pinned at its lifetime peak. Also proves
+    /// `free_list` never retains an index for a slot that no longer exists
+    /// (which would otherwise panic the next `alloc` that tries to reuse it).
+    #[test]
+    fn sweep_shrinks_arena_when_everything_is_reclaimed() {
+        let mut ctx = empty_ctx();
+        ctx.gc_state.threshold = 1;
+        let vm = GenericVM::new();
+
+        for i in 0..50 {
+            alloc_ok(&mut ctx, obj(vec![WasmValue::I32(i)]));
+        }
+        assert_eq!(ctx.gc_heap.len(), 50);
+        // No roots anywhere -- everything is garbage.
+
+        maybe_collect(&vm, &mut ctx);
+
+        assert_eq!(ctx.gc_state.live_count, 0);
+        assert_eq!(ctx.gc_heap.len(), 0, "the fully-garbage arena shrinks back to empty");
+        assert!(ctx.gc_state.free_list.is_empty(), "no stale indices left to reuse");
+
+        // A later alloc still works correctly against the shrunk arena.
+        let fresh = alloc_ok(&mut ctx, obj(vec![WasmValue::I32(7)]));
+        assert_eq!(fresh, 0, "reuses index 0 in the now-empty arena");
+        assert_eq!(ctx.gc_heap.len(), 1);
+    }
+
+    /// A live object sitting in the *middle* of the arena (not at the tail)
+    /// blocks the trailing-truncation optimization from reaching past it —
+    /// proving the fix is honestly partial (as documented), not a silent
+    /// full compaction in disguise.
+    #[test]
+    fn sweep_does_not_truncate_past_a_live_object_in_the_middle() {
+        let mut ctx = empty_ctx();
+        ctx.gc_state.threshold = 1;
+        let vm = GenericVM::new();
+
+        let garbage_before = alloc_ok(&mut ctx, obj(vec![WasmValue::I32(1)]));
+        let kept = alloc_ok(&mut ctx, obj(vec![WasmValue::I32(2)]));
+        let garbage_after = alloc_ok(&mut ctx, obj(vec![WasmValue::I32(3)]));
+        ctx.globals.push(WasmValue::Ref(Some(kept)));
+
+        maybe_collect(&vm, &mut ctx);
+
+        assert_eq!(ctx.gc_state.live_count, 1);
+        // The trailing garbage slot is truncated away...
+        assert_eq!(ctx.gc_heap.len(), (kept + 1) as usize, "truncated only past the last live object");
+        assert!(ctx.gc_heap[kept as usize].is_some(), "the live object itself is untouched");
+        assert!(ctx.gc_heap[garbage_before as usize].is_none(), "garbage before it is tombstoned, not removed");
+        let _ = garbage_after; // consumed by the truncation, not separately observable
     }
 }

--- a/code/packages/rust/wasm-execution/src/gc.rs
+++ b/code/packages/rust/wasm-execution/src/gc.rs
@@ -1,0 +1,403 @@
+//! Real garbage collection for [`crate::WasmExecutionContext::gc_heap`] — see
+//! `code/specs/W04-wasm-gc.md` for the full design rationale.
+//!
+//! # Why not `gc-core`'s `FlatHeap`?
+//!
+//! `FlatHeap` is a raw-pointer collector (`alloc(n, kind) -> *mut u8`).
+//! `gc_heap` is `Vec<Option<GcStruct>>`, indexed by literal position — a
+//! `WasmValue::Ref(Some(handle))` **is** a `Vec` index, a WASM-spec-mandated
+//! representation this collector cannot redesign. Removing entries by
+//! shifting the `Vec` would silently invalidate every other live handle
+//! pointing past the removed index (that's compaction — explicitly out of
+//! scope, see the module doc in `lib.rs` and the spec). So this is a
+//! **tombstone + free-list slot arena**: a dead slot becomes `None` (its
+//! `GcStruct` — and the memory its `fields: Vec<WasmValue>` held — is
+//! dropped, genuine reclamation) and its index joins [`GcState::free_list`]
+//! for `struct.new` to reuse, rather than being physically removed.
+//!
+//! No generation tag is needed to guard against a reused slot aliasing a
+//! stale handle (the usual reason a "generational arena" carries one):
+//! mark-sweep's ordinary soundness argument — nothing left unmarked is
+//! reachable, provided the root walk is exhaustive — already rules that out.
+//! Every handle a WASM program can hold either sat in a location the mark
+//! phase scans, or was freshly minted by `struct.new`; there is no way to
+//! manufacture or retain a handle from outside that root set.
+//!
+//! # Precise scanning is free here
+//!
+//! Unlike `FlatHeap`, which traces raw untyped words and needs a registered
+//! `HeapKind` field-offset map to know which words are pointers, a
+//! `GcStruct` field is a tagged `WasmValue` — exactly `Ref(Some(_))`,
+//! `Ref(None)`, or a numeric variant, self-describing with no schema needed.
+
+use crate::{GcStruct, WasmExecutionContext, WasmValue, REF_NULL_SENTINEL, REF_TAG};
+use gc_core::profile::GcCycleStats;
+use gc_core::GcProfile;
+use virtual_machine::{GenericVM, Value};
+
+/// Object-count threshold a fresh [`GcState`] starts at (analogous to
+/// `gc-core`'s `INITIAL_THRESHOLD`, but counting live objects rather than
+/// bytes — this heap has no byte-size concept).
+pub const INITIAL_THRESHOLD: usize = 1024;
+
+/// Ceiling `adapt_threshold` will never grow past — load-bearing for safety,
+/// not just tuning: without it a retention-heavy program could double the
+/// threshold toward `usize::MAX`, making collection never fire again.
+pub const MAX_THRESHOLD: usize = 1 << 24;
+
+/// Per-call GC bookkeeping threaded alongside `gc_heap` on
+/// [`WasmExecutionContext`] — reset fresh every call, exactly like the heap
+/// itself (see the "Lifetime" section of `W04-wasm-gc.md`: `gc_heap` has no
+/// cross-call continuity today, so neither does this).
+#[derive(Debug, Clone)]
+pub struct GcState {
+    /// Reclaimed `gc_heap` indices, checked by `struct.new` before growing
+    /// the arena.
+    pub free_list: Vec<u32>,
+    /// Live object count, tracked incrementally (incremented on
+    /// `struct.new`, decremented per object during sweep) rather than
+    /// recomputed by scanning `gc_heap` — the same "avoid an O(n) count on a
+    /// hot path" reasoning behind `vm-core`'s `gc_object_count` field.
+    pub live_count: usize,
+    /// Collect when `live_count` reaches this; adapted after every cycle
+    /// (see [`adapt_threshold`]).
+    pub threshold: usize,
+    /// Diagnostic history, reused as-is from `gc-core` (a pure numeric
+    /// accumulator with no `FlatHeap`/pointer coupling) for consistency with
+    /// the native-AOT and `vm-core` paths.
+    pub profile: GcProfile,
+}
+
+impl Default for GcState {
+    fn default() -> Self {
+        GcState {
+            free_list: Vec::new(),
+            live_count: 0,
+            threshold: INITIAL_THRESHOLD,
+            profile: GcProfile::default(),
+        }
+    }
+}
+
+/// Whether the live count has reached the threshold — pure policy, mirrors
+/// `gc-core::FlatHeap::should_collect`: it names no roots and runs no
+/// collection itself.
+fn should_collect(state: &GcState) -> bool {
+    state.live_count >= state.threshold
+}
+
+/// Re-tune the threshold after a cycle, given the live count *before* it —
+/// the identical heuristic `gc-core::FlatHeap::adapt_threshold` uses (ported
+/// verbatim, just in units of objects instead of bytes): more than half the
+/// pre-cycle live set survived → double (capped at [`MAX_THRESHOLD`]);
+/// otherwise → halve (floored at [`INITIAL_THRESHOLD`]).
+fn adapt_threshold(state: &mut GcState, prev_live: usize) {
+    if state.live_count > prev_live / 2 {
+        state.threshold = (state.threshold * 2).min(MAX_THRESHOLD);
+    } else {
+        state.threshold = (state.threshold / 2).max(INITIAL_THRESHOLD);
+    }
+}
+
+/// Push every `Ref(Some(_))` found in `values` onto the mark worklist.
+fn push_roots_from_values(values: &[WasmValue], work: &mut Vec<u32>) {
+    for v in values {
+        if let WasmValue::Ref(Some(h)) = v {
+            work.push(*h);
+        }
+    }
+}
+
+/// Push every live reference held on the interpreter's operand stack, using
+/// the same `REF_TAG`/`REF_NULL_SENTINEL` convention `to_typed`/`from_typed`
+/// already establish for round-tripping a [`WasmValue::Ref`] through the
+/// generic typed stack.
+fn push_roots_from_stack(vm: &GenericVM, work: &mut Vec<u32>) {
+    for tv in &vm.typed_stack {
+        if tv.value_type == REF_TAG {
+            if let Value::Int(h) = tv.value {
+                if h != REF_NULL_SENTINEL {
+                    work.push(h as u32);
+                }
+            }
+        }
+    }
+}
+
+/// Collect the current, root-reachable set of `gc_heap` indices —
+/// transitive and cycle-safe: a worklist walk with a `marked` visited set,
+/// so a cycle (`struct.set` can point one live object's field at another
+/// that points back) just re-adds an already-`true` index and no-ops.
+fn mark(vm: &GenericVM, ctx: &WasmExecutionContext) -> Vec<bool> {
+    let heap_len = ctx.gc_heap.len();
+    let mut marked = vec![false; heap_len];
+    let mut work: Vec<u32> = Vec::new();
+
+    push_roots_from_values(&ctx.globals, &mut work);
+    push_roots_from_values(&ctx.typed_locals, &mut work);
+    for frame in &ctx.saved_frames {
+        push_roots_from_values(&frame.locals, &mut work);
+    }
+    push_roots_from_stack(vm, &mut work);
+
+    while let Some(h) = work.pop() {
+        let idx = h as usize;
+        if idx >= heap_len || marked[idx] {
+            continue;
+        }
+        marked[idx] = true;
+        if let Some(obj) = &ctx.gc_heap[idx] {
+            push_roots_from_values(&obj.fields, &mut work);
+        }
+    }
+
+    marked
+}
+
+/// Reclaim every unmarked, currently-live slot: drop its `GcStruct` (freeing
+/// the field-vector memory it held), tombstone it to `None`, and push its
+/// index onto the free list for `struct.new` to reuse. Returns the number
+/// of objects freed.
+fn sweep(ctx: &mut WasmExecutionContext, marked: &[bool]) -> usize {
+    // Disjoint field borrows off one `&mut WasmExecutionContext` — sound
+    // because `gc_heap` and `gc_state` are different fields, not aliases.
+    let WasmExecutionContext { gc_heap, gc_state, .. } = ctx;
+    let mut freed = 0usize;
+    for i in 0..gc_heap.len() {
+        if !marked[i] && gc_heap[i].is_some() {
+            gc_heap[i] = None;
+            gc_state.free_list.push(i as u32);
+            freed += 1;
+        }
+    }
+    gc_state.live_count -= freed;
+    freed
+}
+
+/// Collect if `ctx.gc_state`'s threshold says a collection is due — the
+/// entry point `execute_branch` (every taken `br`/`br_if`/`br_table`, i.e.
+/// every loop back-edge) and the internal `call_function` helper (every
+/// `call`/`call_indirect`, nested or not) both call on every dispatch,
+/// mirroring the existing "safepoints at back-edges and calls" convention
+/// (see `W04-wasm-gc.md` §4) rather than a per-instruction counter — which
+/// would need threading a budget through the generic, WASM-agnostic
+/// `virtual-machine` crate's dispatch loop, coupling it to this crate's GC.
+pub(crate) fn maybe_collect(vm: &GenericVM, ctx: &mut WasmExecutionContext) {
+    if !should_collect(&ctx.gc_state) {
+        return;
+    }
+    let live_before = ctx.gc_state.live_count;
+    let marked = mark(vm, ctx);
+    let freed = sweep(ctx, &marked);
+
+    ctx.gc_state.profile.record_cycle(&GcCycleStats {
+        freed,
+        survived: ctx.gc_state.live_count,
+        pause_ns: 0,
+        heap_size_before: live_before,
+        heap_size_after: ctx.gc_state.live_count,
+    });
+    adapt_threshold(&mut ctx.gc_state, live_before);
+}
+
+/// Allocate a `GcStruct`, reusing a tombstoned slot from `gc_state.free_list`
+/// before growing `gc_heap` — the free-list half of the slot-arena design.
+/// Returns the new object's handle.
+pub(crate) fn alloc(ctx: &mut WasmExecutionContext, obj: GcStruct) -> u32 {
+    let WasmExecutionContext { gc_heap, gc_state, .. } = ctx;
+    gc_state.live_count += 1;
+    if let Some(idx) = gc_state.free_list.pop() {
+        gc_heap[idx as usize] = Some(obj);
+        idx
+    } else {
+        let handle = gc_heap.len() as u32;
+        gc_heap.push(Some(obj));
+        handle
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{SavedFrame, WasmExecutionContext};
+    use std::collections::HashMap;
+
+    fn obj(fields: Vec<WasmValue>) -> GcStruct {
+        GcStruct { type_idx: 0, fields }
+    }
+
+    /// A bare `WasmExecutionContext` with every non-heap field trivially
+    /// empty — enough to unit-test `alloc`/`mark`/`sweep` directly without
+    /// the full raw-bytecode harness `lib.rs`'s own tests use.
+    fn empty_ctx() -> WasmExecutionContext {
+        WasmExecutionContext {
+            memory: None,
+            tables: Vec::new(),
+            globals: Vec::new(),
+            global_types: Vec::new(),
+            func_types: Vec::new(),
+            func_bodies: Vec::new(),
+            host_functions: Vec::new(),
+            typed_locals: Vec::new(),
+            label_stack: Vec::new(),
+            control_flow_map: HashMap::new(),
+            saved_frames: Vec::new(),
+            returned: false,
+            br_table_targets: Vec::new(),
+            gc_ops: Vec::new(),
+            gc_heap: Vec::new(),
+            struct_field_counts: Vec::new(),
+            gc_state: GcState::default(),
+        }
+    }
+
+    #[test]
+    fn should_collect_fires_at_threshold() {
+        let mut state = GcState { threshold: 10, ..GcState::default() };
+        state.live_count = 9;
+        assert!(!should_collect(&state));
+        state.live_count = 10;
+        assert!(should_collect(&state));
+    }
+
+    #[test]
+    fn adapt_threshold_doubles_when_retention_high() {
+        let mut state = GcState { threshold: 1000, ..GcState::default() };
+        state.live_count = 600; // > half of 1000 survived
+        adapt_threshold(&mut state, 1000);
+        assert_eq!(state.threshold, 2000);
+    }
+
+    #[test]
+    fn adapt_threshold_halves_when_garbage_heavy() {
+        // 4096, well above INITIAL_THRESHOLD's floor, so halving is actually
+        // observable rather than immediately clamped back up to the floor.
+        let mut state = GcState { threshold: 4096, ..GcState::default() };
+        state.live_count = 400; // <= half of 4096 survived
+        adapt_threshold(&mut state, 4096);
+        assert_eq!(state.threshold, 2048);
+    }
+
+    #[test]
+    fn adapt_threshold_respects_floor_and_ceiling() {
+        let mut low = GcState { threshold: INITIAL_THRESHOLD, ..GcState::default() };
+        adapt_threshold(&mut low, 100); // low.live_count (0) <= 50 -> halve
+        assert_eq!(low.threshold, INITIAL_THRESHOLD, "never drops below the floor");
+
+        let mut high = GcState { threshold: MAX_THRESHOLD, ..GcState::default() };
+        high.live_count = MAX_THRESHOLD; // > half survived -> double
+        adapt_threshold(&mut high, MAX_THRESHOLD);
+        assert_eq!(high.threshold, MAX_THRESHOLD, "never exceeds the ceiling");
+    }
+
+    #[test]
+    fn alloc_reuses_free_list_before_growing() {
+        let mut ctx = empty_ctx();
+
+        let a = alloc(&mut ctx, obj(vec![WasmValue::I32(1)]));
+        let b = alloc(&mut ctx, obj(vec![WasmValue::I32(2)]));
+        assert_eq!(ctx.gc_heap.len(), 2);
+
+        ctx.gc_state.free_list.push(a);
+        ctx.gc_state.live_count -= 1; // simulate a's collection
+        let c = alloc(&mut ctx, obj(vec![WasmValue::I32(3)]));
+        assert_eq!(c, a, "reused the freed slot instead of growing");
+        assert_eq!(ctx.gc_heap.len(), 2, "arena did not grow");
+        assert_eq!(
+            ctx.gc_heap[b as usize].as_ref().unwrap().fields[0],
+            WasmValue::I32(2),
+            "b's slot untouched by a's reuse"
+        );
+    }
+
+    #[test]
+    fn mark_finds_transitively_reachable_objects_through_a_field_chain() {
+        let mut ctx = empty_ctx();
+        let vm = GenericVM::new();
+
+        // c <- b <- a, only `a` is a root (a global).
+        let c = alloc(&mut ctx, obj(vec![WasmValue::I32(42)]));
+        let b = alloc(&mut ctx, obj(vec![WasmValue::Ref(Some(c))]));
+        let a = alloc(&mut ctx, obj(vec![WasmValue::Ref(Some(b))]));
+        ctx.globals.push(WasmValue::Ref(Some(a)));
+
+        let marked = mark(&vm, &ctx);
+        assert!(marked[a as usize] && marked[b as usize] && marked[c as usize]);
+    }
+
+    #[test]
+    fn maybe_collect_reclaims_unreachable_and_preserves_reachable_chain() {
+        let mut ctx = empty_ctx();
+        ctx.gc_state.threshold = 1; // force collection eligibility
+        let vm = GenericVM::new();
+
+        let c = alloc(&mut ctx, obj(vec![WasmValue::I32(42)]));
+        let b = alloc(&mut ctx, obj(vec![WasmValue::Ref(Some(c))]));
+        let a = alloc(&mut ctx, obj(vec![WasmValue::Ref(Some(b))]));
+        ctx.globals.push(WasmValue::Ref(Some(a)));
+        // Pure garbage: unreachable from anything.
+        let garbage = alloc(&mut ctx, obj(vec![WasmValue::I32(999)]));
+
+        maybe_collect(&vm, &mut ctx);
+
+        assert_eq!(ctx.gc_state.live_count, 3, "a, b, c survive; garbage is reclaimed");
+        assert!(ctx.gc_heap[a as usize].is_some());
+        assert!(ctx.gc_heap[b as usize].is_some());
+        assert!(ctx.gc_heap[c as usize].is_some());
+        assert!(ctx.gc_heap[garbage as usize].is_none(), "unreachable object tombstoned");
+        assert_eq!(ctx.gc_state.free_list, vec![garbage], "its slot is ready for reuse");
+        assert_eq!(ctx.gc_state.profile.total_collections, 1);
+        assert_eq!(ctx.gc_state.profile.total_freed, 1);
+    }
+
+    /// Two objects whose fields point at each other, reachable from nothing —
+    /// proves the worklist mark is genuinely cycle-safe (a naive unguarded
+    /// recursive mark would loop forever) and that an unreachable cycle is
+    /// still collected, not kept alive just because it references itself.
+    #[test]
+    fn cyclic_but_unreachable_objects_are_both_collected() {
+        let mut ctx = empty_ctx();
+        ctx.gc_state.threshold = 1;
+        let vm = GenericVM::new();
+
+        // Allocate both first (fields default to I32(0)), then wire the cycle
+        // via struct.set-equivalent direct field mutation.
+        let x = alloc(&mut ctx, obj(vec![WasmValue::I32(0)]));
+        let y = alloc(&mut ctx, obj(vec![WasmValue::Ref(Some(x))]));
+        ctx.gc_heap[x as usize].as_mut().unwrap().fields[0] = WasmValue::Ref(Some(y));
+        // No root anywhere points at x or y.
+
+        maybe_collect(&vm, &mut ctx);
+
+        assert_eq!(ctx.gc_state.live_count, 0, "the cycle is unreachable, so both members are freed");
+        assert!(ctx.gc_heap[x as usize].is_none());
+        assert!(ctx.gc_heap[y as usize].is_none());
+    }
+
+    /// A live root sitting only in a *suspended caller's* frame (not the
+    /// active frame) must still be found — the one root source with no
+    /// equivalent test anywhere else in this codebase's GC work.
+    #[test]
+    fn mark_finds_roots_in_saved_caller_frames() {
+        let mut ctx = empty_ctx();
+        let vm = GenericVM::new();
+
+        let kept = alloc(&mut ctx, obj(vec![WasmValue::I32(7)]));
+        // The active frame's locals don't reference it...
+        ctx.typed_locals = vec![WasmValue::I32(0)];
+        // ...but a paused caller, one level up the call stack, does.
+        ctx.saved_frames.push(SavedFrame {
+            locals: vec![WasmValue::Ref(Some(kept))],
+            label_stack: Vec::new(),
+            stack_height: 0,
+            control_flow_map: HashMap::new(),
+            return_pc: 0,
+            return_arity: 0,
+            br_table_targets: Vec::new(),
+            gc_ops: Vec::new(),
+        });
+
+        let marked = mark(&vm, &ctx);
+        assert!(marked[kept as usize], "a saved caller frame's local is a live root");
+    }
+}

--- a/code/packages/rust/wasm-execution/src/lib.rs
+++ b/code/packages/rust/wasm-execution/src/lib.rs
@@ -1654,7 +1654,7 @@ fn register_numeric_i64(vm: &mut GenericVM) {
                     *slot = pop_wasm(vm)?;
                 }
                 let obj = GcStruct { type_idx: op.type_idx, fields };
-                let handle = gc::alloc(ctx, obj);
+                let handle = gc::alloc(ctx, obj)?;
                 push_wasm(vm, WasmValue::Ref(Some(handle)));
             }
 

--- a/code/packages/rust/wasm-execution/src/lib.rs
+++ b/code/packages/rust/wasm-execution/src/lib.rs
@@ -48,6 +48,8 @@
 //! This crate is part of the coding-adventures monorepo, a ground-up
 //! implementation of the computing stack from transistors to operating systems.
 
+mod gc;
+
 use std::any::Any;
 use std::collections::HashMap;
 
@@ -1191,11 +1193,14 @@ pub struct SavedFrame {
 /// (`fields[0]` = car, `fields[1]` = cdr).  Each field is itself an `anyref`
 /// (an `I32` i31 payload, or a nested `Ref` to another cons / null).
 ///
-/// The heap is an **append-only arena**: `struct.new` pushes a new object and
-/// returns its index as the handle; there is no reclamation.  That is correct
-/// and sufficient for terminating lisp evaluation — the total number of
-/// allocations is bounded by the VM's instruction budget, so a program cannot
-/// allocate unboundedly without first exhausting its step budget.
+/// The heap (`WasmExecutionContext::gc_heap`) is a real, collected mark-sweep
+/// arena (W04) — see the [`gc`](crate::gc) module for the collector itself.
+/// It is a **tombstone + free-list slot arena**, not a plain growable `Vec`:
+/// a `WasmValue::Ref(Some(handle))` is a `Vec` index (a WASM-spec-mandated
+/// representation), so a dead object's slot is tombstoned to `None` and its
+/// index reused by a later `struct.new`, rather than the `Vec` being
+/// shrunk — shrinking it would silently invalidate every other live handle
+/// pointing past the removed index.
 #[derive(Debug, Clone, PartialEq)]
 pub struct GcStruct {
     /// The struct type index this object was allocated with (`struct.new N`).
@@ -1228,18 +1233,24 @@ pub struct WasmExecutionContext {
     /// holds the decoded `(sub, type_idx, field_idx)`.  Like `br_table_targets`
     /// this is per-function and saved/restored across calls.
     pub gc_ops: Vec<GcOp>,
-    /// The WasmGC object heap (LANG77 L3b-3a-3b) — an append-only arena of
-    /// `struct.new` allocations.  A `WasmValue::Ref(Some(h))` indexes into this
-    /// Vec.  **Module-global**: it persists across calls within one run (a cons
-    /// built in a callee and returned stays live), so it is *not* saved/restored
-    /// per call.
-    pub gc_heap: Vec<GcStruct>,
+    /// The WasmGC object heap (LANG77 L3b-3a-3b) — a real, collected
+    /// mark-sweep arena (W04): `Some` is a live object, `None` is a
+    /// tombstoned/reclaimed slot available for reuse (see the
+    /// [`gc`](crate::gc) module). A `WasmValue::Ref(Some(h))` indexes into
+    /// this Vec.  **Module-global**: it persists across calls within one run
+    /// (a cons built in a callee and returned stays live), so it is *not*
+    /// saved/restored per call.
+    pub gc_heap: Vec<Option<GcStruct>>,
     /// Field counts per struct type index (LANG77 L3b-3a-3b).  `struct.new N`
     /// pops `struct_field_counts[N]` field values.  Supplied by the embedder via
     /// [`WasmExecutionEngine::set_struct_field_counts`] (the parser does not yet
     /// surface struct type definitions to the engine); empty by default, in
     /// which case any `struct.*` op is a clean trap.  Module-global / constant.
     pub struct_field_counts: Vec<u32>,
+    /// GC bookkeeping (free list, live count, adaptive threshold, profile)
+    /// alongside `gc_heap` — see [`gc::GcState`](crate::gc::GcState).
+    /// Module-global for the same reason `gc_heap` is.
+    pub gc_state: gc::GcState,
 }
 
 /// One decoded WasmGC instruction's immediates — see [`DecodedOperand::Gc`].
@@ -1413,6 +1424,12 @@ fn execute_branch(
 
     // Jump.
     vm.jump_to(label.target_pc);
+
+    // GC checkpoint (W04): every taken branch is a candidate loop back-edge
+    // (a loop iterates by branching to its own loop label), so this is the
+    // natural "safepoint at back-edges" chokepoint — see gc::maybe_collect.
+    gc::maybe_collect(vm, ctx);
+
     Ok(())
 }
 
@@ -1636,17 +1653,23 @@ fn register_numeric_i64(vm: &mut GenericVM) {
                 for slot in fields.iter_mut().rev() {
                     *slot = pop_wasm(vm)?;
                 }
-                let handle = ctx.gc_heap.len() as u32;
-                ctx.gc_heap.push(GcStruct { type_idx: op.type_idx, fields });
+                let obj = GcStruct { type_idx: op.type_idx, fields };
+                let handle = gc::alloc(ctx, obj);
                 push_wasm(vm, WasmValue::Ref(Some(handle)));
             }
 
-            // struct.get <type_idx> <field_idx>: read a field.
+            // struct.get <type_idx> <field_idx>: read a field. A `None` slot
+            // (out-of-range *or* tombstoned by a collection) is the same
+            // clean-trap case — both mean "not a live object".
             0x02 => {
                 let handle = pop_struct_ref(vm, "struct.get")?;
-                let obj = ctx.gc_heap.get(handle as usize).ok_or_else(|| {
-                    VMError::GenericError(format!("struct.get: dangling handle {handle}"))
-                })?;
+                let obj = ctx
+                    .gc_heap
+                    .get(handle as usize)
+                    .and_then(|slot| slot.as_ref())
+                    .ok_or_else(|| {
+                        VMError::GenericError(format!("struct.get: dangling handle {handle}"))
+                    })?;
                 let val = *obj.fields.get(op.field_idx as usize).ok_or_else(|| {
                     VMError::GenericError(format!(
                         "struct.get: field {} out of range for struct with {} field(s)",
@@ -1657,14 +1680,19 @@ fn register_numeric_i64(vm: &mut GenericVM) {
                 push_wasm(vm, val);
             }
 
-            // struct.set <type_idx> <field_idx>: write a field.
+            // struct.set <type_idx> <field_idx>: write a field. Same
+            // None-slot clean-trap reasoning as struct.get above.
             0x04 => {
                 // Stack order: ... ref, value (value on top).
                 let val = pop_wasm(vm)?;
                 let handle = pop_struct_ref(vm, "struct.set")?;
-                let obj = ctx.gc_heap.get_mut(handle as usize).ok_or_else(|| {
-                    VMError::GenericError(format!("struct.set: dangling handle {handle}"))
-                })?;
+                let obj = ctx
+                    .gc_heap
+                    .get_mut(handle as usize)
+                    .and_then(|slot| slot.as_mut())
+                    .ok_or_else(|| {
+                        VMError::GenericError(format!("struct.set: dangling handle {handle}"))
+                    })?;
                 let slot = obj.fields.get_mut(op.field_idx as usize).ok_or_else(|| {
                     VMError::GenericError(format!(
                         "struct.set: field {} out of range",
@@ -2867,6 +2895,12 @@ fn call_function(
     ctx: &mut WasmExecutionContext,
     func_index: usize,
 ) -> VMResult<()> {
+    // GC checkpoint (W04): every call/call_indirect (nested or recursive)
+    // routes through this one shared helper, so this single call site is the
+    // "safepoint at calls" chokepoint for both of this crate's independent
+    // dispatch loops — see gc::maybe_collect.
+    gc::maybe_collect(vm, ctx);
+
     let func_type = ctx
         .func_types
         .get(func_index)
@@ -3055,6 +3089,14 @@ pub struct WasmExecutionEngine {
     /// set with [`WasmExecutionEngine::set_struct_field_counts`].  Flows into the
     /// execution context so `struct.new N` knows how many fields to pop.
     struct_field_counts: Vec<u32>,
+    /// GC bookkeeping from the most recently completed [`Self::call_function`]
+    /// (W04). `gc_heap` itself isn't persisted here — it's rebuilt fresh every
+    /// call, same as `struct_field_counts` isn't — but the *counters* (live
+    /// object count, collection/freed/survived history) are written back
+    /// after execution so a caller (or a test) can inspect them via
+    /// [`Self::gc_live_object_count`] / [`Self::gc_profile`] without needing
+    /// access to the ephemeral `WasmExecutionContext` itself.
+    last_gc_state: gc::GcState,
 }
 
 impl WasmExecutionEngine {
@@ -3074,6 +3116,7 @@ impl WasmExecutionEngine {
             func_bodies: config.func_bodies,
             host_functions: config.host_functions,
             struct_field_counts: Vec::new(),
+            last_gc_state: gc::GcState::default(),
         }
     }
 
@@ -3086,6 +3129,22 @@ impl WasmExecutionEngine {
     pub fn set_struct_field_counts(&mut self, counts: Vec<u32>) -> &mut Self {
         self.struct_field_counts = counts;
         self
+    }
+
+    /// Live `gc_heap` object count as of the most recently completed
+    /// [`Self::call_function`] (W04). `gc_heap` itself resets every call, so
+    /// this reflects only that one call's allocation/collection activity,
+    /// not a running total across calls.
+    pub fn gc_live_object_count(&self) -> usize {
+        self.last_gc_state.live_count
+    }
+
+    /// Diagnostic history (collections run, objects freed/survived,
+    /// fragmentation/survival-ratio estimates) from the most recently
+    /// completed [`Self::call_function`] — the same `gc_core::GcProfile`
+    /// type the native-AOT and `vm-core` GC paths use, for consistency.
+    pub fn gc_profile(&self) -> &gc_core::GcProfile {
+        &self.last_gc_state.profile
     }
 
     /// Consume the engine and return the mutated runtime state.
@@ -3185,8 +3244,12 @@ impl WasmExecutionEngine {
             gc_ops,
             // The GC heap starts empty and grows as `struct.new` allocates; it
             // lives for the whole call so a cons built in a callee survives.
+            // Real mark-sweep collection now runs against it (W04) at loop
+            // back-edges and calls, so a long call no longer grows it
+            // without bound.
             gc_heap: Vec::new(),
             struct_field_counts: self.struct_field_counts.clone(),
+            gc_state: gc::GcState::default(),
         };
 
         let code = CodeObject {
@@ -3206,6 +3269,10 @@ impl WasmExecutionEngine {
         // Update globals back.
         self.globals = ctx.globals;
         self.host_functions = ctx.host_functions;
+        // gc_heap itself is not persisted (see its own doc comment above);
+        // the counters are, so a caller can inspect this call's GC activity
+        // via gc_live_object_count()/gc_profile() (W04).
+        self.last_gc_state = ctx.gc_state;
 
         // Collect return values.
         let mut results = Vec::new();
@@ -3691,6 +3758,100 @@ mod tests {
         ];
         let mut engine = gc_engine(code, vec![ValueType::I32], vec![2]);
         assert!(engine.call_function(0, &[]).is_err());
+    }
+
+    // ── W04: real GC — end-to-end reclamation through real dispatch ────────
+    //
+    // These drive an actual loop through the real `execute_branch`/`br_if`
+    // dispatch path (not gc.rs's own direct-call unit tests), proving the
+    // *wiring* — that a real, long-running WASM loop crossing the adaptive
+    // threshold is actually collected, not just that the mark/sweep
+    // algorithm is correct in isolation.
+
+    /// A loop allocates 2000 "garbage" objects (each iteration's `struct.new`
+    /// overwrites the previous one's only reference) while a single `kept`
+    /// object, allocated once before the loop, survives throughout. Proves
+    /// both halves at once: `kept`'s field reads back correctly (nothing
+    /// live was wrongly collected) and `gc_live_object_count()` stays far
+    /// below 2001 (the garbage was actually reclaimed mid-run, not just
+    /// leaked into an ever-growing arena — the exact gap W04 closes).
+    #[test]
+    fn end_to_end_loop_reclaims_garbage_and_preserves_kept_object() {
+        const LIMIT: i64 = 2000; // well past gc::INITIAL_THRESHOLD (1024)
+
+        let mut code: Vec<u8> = Vec::new();
+        // kept (local 1) = struct.new(box(999))
+        code.push(0x41);
+        code.extend(wasm_leb128::encode_signed(999));
+        code.extend([0xFB, 0x00, 0x00]); // struct.new 0
+        code.extend([0x21, 0x01]); // local.set 1
+
+        // i (local 0) = 0
+        code.extend([0x41, 0x00, 0x21, 0x00]);
+
+        // loop (empty block type)
+        code.extend([0x03, 0x40]);
+        {
+            // garbage (local 2) = struct.new(box(i)) -- overwritten every
+            // iteration, so the previous garbage object loses its only root.
+            code.extend([0x20, 0x00]); // local.get 0
+            code.extend([0xFB, 0x00, 0x00]); // struct.new 0
+            code.extend([0x21, 0x02]); // local.set 2
+
+            // i = i + 1
+            code.extend([0x20, 0x00, 0x41, 0x01, 0x6A, 0x21, 0x00]);
+
+            // if i < LIMIT: br_if 0 (back to the loop label)
+            code.push(0x20);
+            code.push(0x00); // local.get 0
+            code.push(0x41);
+            code.extend(wasm_leb128::encode_signed(LIMIT));
+            code.push(0x48); // i32.lt_s
+            code.extend([0x0D, 0x00]); // br_if 0
+        }
+        code.push(0x0B); // end (loop)
+
+        // return kept.field0
+        code.extend([0x20, 0x01]); // local.get 1
+        code.extend([0xFB, 0x02, 0x00, 0x00]); // struct.get 0 0
+        code.push(0x0B); // end (function)
+
+        let func_type = FuncType { params: vec![], results: vec![ValueType::I32] };
+        let body = FunctionBody {
+            locals: vec![ValueType::I32, ValueType::I32, ValueType::I32],
+            code,
+        };
+        let mut engine = WasmExecutionEngine::new(WasmEngineConfig {
+            memory: None,
+            tables: vec![],
+            globals: vec![],
+            global_types: vec![],
+            func_types: vec![func_type],
+            func_bodies: vec![Some(body)],
+            host_functions: vec![None],
+        });
+        engine.set_struct_field_counts(vec![1]); // one struct type, one field
+
+        let result = engine.call_function(0, &[]).unwrap();
+        assert_eq!(result, vec![WasmValue::I32(999)], "kept object's field survives intact");
+        // The adaptive threshold floors at gc::INITIAL_THRESHOLD (1024, mirroring
+        // FlatHeap's own heuristic verbatim), so with LIMIT=2000 only one full
+        // collection cycle completes before the loop ends — the live count
+        // settles well under half of everything ever allocated, not anywhere
+        // near LIMIT + 1, which is the actual, meaningful proof of reclamation
+        // (an uncollected arena would report exactly 2001 here).
+        assert!(
+            engine.gc_live_object_count() < (LIMIT as usize) / 2,
+            "garbage was reclaimed mid-loop, not left to accumulate to ~{}: got {}",
+            LIMIT + 1,
+            engine.gc_live_object_count()
+        );
+        assert!(engine.gc_profile().total_collections >= 1, "at least one real collection ran");
+        assert!(
+            engine.gc_profile().total_freed as i64 >= LIMIT / 2,
+            "a substantial number of garbage objects were actually freed, not just some: got {}",
+            engine.gc_profile().total_freed
+        );
     }
 
     #[test]

--- a/code/specs/W04-wasm-gc.md
+++ b/code/specs/W04-wasm-gc.md
@@ -63,6 +63,25 @@ trap cleanly — the same fail-closed convention `struct_get_on_null_traps_clean
 already established, just extended to cover a reclaimed handle the same way
 it covers a dangling one.
 
+**The arena's length shrinks when it can (a security-review finding, not
+just tidiness).** Because the free-list reuses tombstoned indices rather
+than shrinking `gc_heap`, its length is otherwise a monotonically
+non-decreasing high-water mark for the life of a call — and `mark`/`sweep`
+both cost O(`gc_heap.len()`), not O(live objects). A program that
+transiently spikes the live count (and, via `adapt_threshold`, the
+collection threshold) high, then settles into a low-retention
+allocate/discard steady state, would otherwise pay that peak cost on every
+subsequent collection for the rest of the call. `sweep` closes this by
+dropping `gc_heap`'s trailing run of tombstoned slots after reclaiming them
+(and removing those indices from the free list, since they no longer exist
+in the — now shorter — `Vec` at all). This is **not** compaction: no live
+object moves or is renumbered, so it needs none of §2's handle-rewriting
+machinery — it only drops Vec capacity that's provably all garbage at the
+tail. A live object sitting in the middle of the arena blocks truncation
+from reaching past it, so this is a partial, honest mitigation for the
+realistic churn pattern the finding describes, not a full compaction in
+disguise.
+
 ## 3. Root set — transitive and cycle-safe (the heap is graph-shaped)
 
 `struct.set` can store a `Ref` into a field after construction, so cycles

--- a/code/specs/W04-wasm-gc.md
+++ b/code/specs/W04-wasm-gc.md
@@ -1,0 +1,151 @@
+# W04 — real garbage collection for the in-repo WASM engine
+
+> Status: complete. Closes a gap found by direct investigation (reading
+> `wasm-execution`'s actual source, not its own doc comments): the WasmGC
+> struct heap (`gc_heap: Vec<GcStruct>`, LANG77 L3b-3a-3b) was an
+> **append-only arena with no reclamation**, justified by a claim — "bounded
+> by the VM's instruction budget" — that does not hold: no such budget
+> exists anywhere in `wasm-execution` (confirmed by grep: no
+> `max_instructions`/`fuel`/instruction-counter of any kind). A long-running
+> WASM-compiled Twig program could allocate without bound.
+
+## 1. Why this isn't just "port `gc-core`'s `FlatHeap`"
+
+`FlatHeap` is a raw-pointer collector: `alloc(n, kind) -> *mut u8`, and a
+`HeapRef` is a real machine address. `wasm-execution`'s heap is
+fundamentally different: `gc_heap: Vec<GcStruct>`, and a
+`WasmValue::Ref(Some(handle))` **is a `Vec` index** — a WASM-spec-mandated
+representation (`ref.null`/non-null `anyref` handles), not something this
+collector is free to redesign. That one fact drives the whole design below:
+
+- **Compaction is out of scope.** Removing a dead entry by shifting the
+  `Vec` would silently invalidate every other live handle pointing past the
+  removed index. Making that safe would need a full transitive trace *and*
+  a rewrite pass over every handle-holding location (nested struct fields,
+  locals, saved call frames, the operand stack) — the classic moving-GC
+  cost, and there is no per-field type schema today to drive precise
+  pointer rewriting even if it were in scope. `gc-core`'s own
+  `AdaptivePolicy` already treats `GcAlgorithm::Compacting` as advisory-only
+  until an algorithm actually implements it (`policy.rs`); this collector
+  keeps that framing rather than enacting it.
+- **Precise root/field scanning is free, for the opposite reason
+  `gc-core`'s native collector needs a registered `kind`.** `FlatHeap`
+  traces raw, untyped 8-byte words, so it needs a `HeapKind` field-offset map
+  to know which words are pointers. `WasmValue` is a tagged Rust enum — a
+  field is *exactly* `Ref(Some(_))`, `Ref(None)`, or a numeric variant, with
+  no ambiguity and no schema needed. An `i31ref` payload is carried as a
+  plain `I32`, never as the same representation as a real handle, so there
+  is no possible confusion between a boxed small int and a heap reference.
+
+## 2. Design: a tombstone + free-list slot arena
+
+The standard non-moving pattern for a `Vec`-backed heap (a "generational
+arena" without the generation tag): `gc_heap: Vec<GcStruct>` becomes
+`gc_heap: Vec<Option<GcStruct>>` (`Some` = live, `None` = free), plus a new
+`gc_free_list: Vec<u32>` of reclaimed indices that `struct.new` checks
+before growing the `Vec`.
+
+**Why no generation tag is needed (the "ABA problem" this pattern usually
+guards against doesn't apply here):** mark-sweep's ordinary soundness
+argument — nothing left unmarked is reachable, provided the root walk is
+exhaustive — is sufficient. Every handle a WASM program can ever hold either
+sat in a location the mark phase scans (a global, a local, a saved frame's
+locals, the operand stack, or transitively through a marked struct's own
+fields) or was freshly minted by `struct.new`. There is no way for code to
+manufacture or retain a handle from *outside* that root set, so a
+reclaimed-and-reused slot can never be aliased by a stale reference — the
+same invariant `gc-core`'s `FlatHeap` and `vm-core`'s `FlatHeap`-backed
+`gc_alloc` already depend on, just without needing `FlatHeap`'s pointer
+machinery to enforce it.
+
+`struct.get`/`struct.set` on a `None` slot (out-of-range *or* tombstoned)
+trap cleanly — the same fail-closed convention `struct_get_on_null_traps_cleanly`
+already established, just extended to cover a reclaimed handle the same way
+it covers a dangling one.
+
+## 3. Root set — transitive and cycle-safe (the heap is graph-shaped)
+
+`struct.set` can store a `Ref` into a field after construction, so cycles
+are constructible (`obj A`'s field → `obj B`, `obj B`'s field mutated to →
+`obj A`). The mark phase is a worklist walk with a `marked: Vec<bool>`
+visited set (cycle-safe by construction — a cycle just means the worklist
+re-adds an index that's already `true` and the check no-ops), seeded from
+every `WasmValue::Ref(Some(_))` found in:
+
+- `ctx.globals`
+- `ctx.typed_locals` — the active call frame
+- **every** `ctx.saved_frames[*].locals` — every suspended caller frame; a
+  paused caller can hold a live reference a callee doesn't know about, so
+  missing this would free something still in use
+- the interpreter's operand stack (`GenericVM::typed_stack`, decoded via the
+  existing `REF_TAG`/`REF_NULL_SENTINEL` convention `wasm-execution` already
+  uses to round-trip a `WasmValue::Ref` through the generic typed stack)
+
+then transitively through each marked object's own `fields: Vec<WasmValue>`.
+
+## 4. When to check: the existing "safepoints at back-edges and calls" convention
+
+Rather than a per-instruction counter (which `wasm-execution` doesn't have,
+and which would need threading through the generic, WASM-agnostic
+`virtual-machine` crate's dispatch loop — a crate this collector must not
+couple to `wasm-execution`'s GC), collection is checked at the same two
+places every WASM-level "more work is about to happen" event already
+funnels through, regardless of which of `wasm-execution`'s two independent
+dispatch loops is running:
+
+- **`execute_branch`** — the single shared helper every taken `br`/`br_if`/
+  `br_table` routes through. A loop's back-edge is a branch to a loop label;
+  checking here catches every loop iteration.
+- **the internal `call_function` helper** — the single shared helper every
+  `call`/`call_indirect` routes through, including nested/recursive calls
+  (it runs its own inlined instruction loop against the same
+  `context_handlers` table `execute_with_context` uses, so a check placed
+  here does not need to also be placed in that inlined loop separately).
+
+Both of `wasm-execution`'s dispatch loops (`GenericVM::execute_with_context`,
+and the hand-inlined loop inside the internal `call_function`) dispatch
+through the *same* `vm.context_handlers` map and, transitively, the same
+`execute_branch`/`call_function` helpers — so instrumenting those two
+functions covers both loops without touching either loop's own code, and
+without adding anything WASM-specific to the generic `virtual-machine`
+crate.
+
+Threshold policy mirrors `FlatHeap::should_collect`/`adapt_threshold`
+(`gc-core/src/flat_heap.rs`) conceptually, adapted to an **object-count**
+threshold (there's no byte-size concept for a `Vec<Option<GcStruct>>` heap):
+collect when the live count crosses the threshold; double it if more than
+half the pre-cycle live set survived, halve it otherwise. The live count
+itself is tracked incrementally (`gc_live_count`, incremented on
+`struct.new`, decremented per object during sweep) rather than recomputed
+by scanning — the same "avoid an O(n) count on a hot path" reasoning behind
+`vm-core`'s `gc_object_count` field (`vm-core` 0.21.1's security fix).
+
+## 5. Reusing `gc-core`'s policy/profile types
+
+`gc_core::profile::{GcProfile, GcCycleStats}` and
+`gc_core::policy::{AdaptivePolicy, GcPolicy, PolicyDecision, GcAlgorithm}`
+are pure numeric accumulators with no `FlatHeap`/pointer coupling — reused
+as-is here via a new `gc-core` path dependency, recording a `GcCycleStats`
+after every cycle for diagnostic consistency with the native-AOT and
+`vm-core` paths. Nothing here acts on an `AdaptivePolicy::SuggestSwitch`
+recommendation (compaction stays advisory-only, per §2).
+
+## 6. Lifetime: per-call, matching the existing architecture
+
+`gc_heap` (and, now, the free list/threshold/profile alongside it) is
+rebuilt fresh on every `WasmExecutionEngine::call_function` — there is no
+cross-call heap continuity in this engine today, and this design does not
+change that. What changes is that a **single long-running call** — one that
+loops or recurses enough to allocate heavily — no longer grows its heap
+without bound.
+
+## 7. Explicitly out of scope
+
+- Compaction (§2) and generational collection — `GcProfile`/`AdaptivePolicy`
+  can *suggest* either; nothing implements them here.
+- `vm-core`/`jit-core`'s separate, still-uncollected bump arena for what
+  Twig's `alloc`/`field_load`/`field_store` ops actually emit — a different
+  crate, a different fix, tracked separately.
+- Real external WASM engines (wasmtime/V8) — this collector is for our own
+  in-repo interpreter only; a real engine already has its own GC for the
+  same emitted WasmGC bytecode regardless of what this collector does.


### PR DESCRIPTION
## Summary

Following PR #9638 (vm-core's real GC), the user asked whether Twig's garbage collector is fully working across all 7 backends. A grounded investigation (reading source, not docs) found our own in-repo WASM interpreter (`wasm-execution`) was the one gap: its `gc_heap` was an **append-only arena with no reclamation**, whose own doc comment justified this as "bounded by the VM's instruction budget" — a budget that does not actually exist anywhere in the crate (confirmed by grep). A long-running WASM-compiled Twig program could allocate without bound.

This PR gives `wasm-execution` a real, tested mark-and-sweep collector.

- **Tombstone + free-list slot arena** — `gc_heap: Vec<GcStruct>` → `Vec<Option<GcStruct>>`. Compaction is explicitly out of scope: a `WasmValue::Ref(Some(handle))` is a `Vec` index (a WASM-spec-mandated representation), so shrinking the arena by removing entries would silently invalidate every other live handle past the removed index.
- **Precise, transitive, cycle-safe root scanning** — globals, the active frame's locals, *every* suspended caller frame's locals, and the operand stack, traced through each object's own fields via an iterative (not recursive) worklist. No `HeapKind`-style schema needed — a `GcStruct` field is a tagged `WasmValue`, self-describing as a reference or not.
- **Checked at two chokepoints** (`execute_branch`, the internal `call_function` helper) that together cover both of this crate's independent dispatch loops without adding anything WASM-specific to the generic `virtual-machine` crate — mirroring the existing "safepoints at back-edges and calls" convention.
- **Adaptive object-count threshold**, mirroring `gc-core::FlatHeap`'s heuristic verbatim. New `gc-core` dependency, reusing its `GcProfile`/`GcCycleStats` for diagnostic consistency with the native-AOT and `vm-core` GC paths.
- **Security-review fixes**: (1) MEDIUM — the arena's length was a monotonic high-water mark, so `mark`/`sweep`'s O(len) cost stayed pinned at a program's peak live-object count even after the live set crashed back down; fixed by shrinking `gc_heap`'s trailing tombstoned run after each sweep (not compaction — no live object moves). (2) LOW — an unchecked `u32` cast on a growing handle now traps cleanly instead of silently aliasing (practically unreachable, but hardened).

New spec: `code/specs/W04-wasm-gc.md`.

## Test plan

- [x] `cargo test -p wasm-execution`: 159 passed (unit tests for the collector in isolation — mark/sweep/alloc/threshold-adaptation/cycle-safety/saved-frame-roots/arena-shrinking — plus `end_to_end_loop_reclaims_garbage_and_preserves_kept_object`, a real WASM loop driven through actual bytecode dispatch)
- [x] `cargo test -p wasm-runtime` and `-p lang-aot --test wasm_emit --test e6d7a_wasm_closures`: unaffected (30 + 17 + 5 + 22 passing)
- [x] `cargo test -p lang-aot --test lang_matrix`: same 5 pre-existing, environment-specific failures (JVM/LLVM toolchain quirks on this host) already confirmed against a pristine `origin/main` in an earlier, unrelated investigation
- [x] `cargo check --workspace` (excluding pre-existing, unrelated platform-gated crates): clean
- [x] `cargo clippy -D warnings` on wasm-execution, wasm-runtime, and the relevant lang-aot test targets: clean
- [x] Security review (2 rounds): round 1 found one MEDIUM + one LOW finding, both fixed and verified closed in round 2 — "SECURITY REVIEW PASSED"

🤖 Generated with [Claude Code](https://claude.com/claude-code)