### PR TITLE
fix(adj): fault-inject Windows Job lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,11 +351,16 @@ jobs:
           go-version: '1.23'
 
       - name: Set up Python
-        if: needs.detect.outputs.needs_python == 'true'
+        if: needs.detect.outputs.needs_python == 'true' || runner.os == 'Windows'
         uses: actions/setup-python@v5
         with:
           python-version: '3.13'
           allow-prereleases: true
+
+      - name: Test ADJ Windows Job containment
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: python -m unittest discover -s code/scripts/tests -p test_adj_stdlib_provenance.py -k windows_job
 
       - name: Install uv
         if: needs.detect.outputs.needs_python == 'true'

--- a/code/scripts/adj_stdlib_provenance.py
+++ b/code/scripts/adj_stdlib_provenance.py
@@ -23,7 +23,7 @@ import tempfile
 import threading
 import time
 import xml.etree.ElementTree as ET
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from datetime import datetime
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -895,7 +895,14 @@ def _validate_formula_inventory(
 class _WindowsKillJob:
     """Own a Windows process tree until verification has drained its output."""
 
-    def __init__(self) -> None:
+    ERROR_NO_MORE_FILES = 18
+
+    def __init__(
+        self,
+        kernel32: Any | None = None,
+        last_error: Callable[[], int] | None = None,
+        set_last_error: Callable[[int], None] | None = None,
+    ) -> None:
         class LargeInteger(ctypes.Structure):
             _fields_ = [("quad_part", ctypes.c_longlong)]
 
@@ -932,7 +939,22 @@ class _WindowsKillJob:
                 ("peak_job_memory_used", ctypes.c_size_t),
             ]
 
-        self._kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        class ThreadEntry(ctypes.Structure):
+            _fields_ = [
+                ("size", ctypes.c_ulong),
+                ("usage", ctypes.c_ulong),
+                ("thread_id", ctypes.c_ulong),
+                ("owner_process_id", ctypes.c_ulong),
+                ("base_priority", ctypes.c_long),
+                ("priority_delta", ctypes.c_long),
+                ("flags", ctypes.c_ulong),
+            ]
+
+        if kernel32 is None:
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        self._kernel32 = kernel32
+        self._last_error = last_error or ctypes.get_last_error
+        self._set_last_error = set_last_error or ctypes.set_last_error
         self._kernel32.CreateJobObjectW.argtypes = [ctypes.c_void_p, ctypes.c_wchar_p]
         self._kernel32.CreateJobObjectW.restype = ctypes.c_void_p
         self._kernel32.SetInformationJobObject.argtypes = [
@@ -951,37 +973,6 @@ class _WindowsKillJob:
         self._kernel32.TerminateJobObject.restype = ctypes.c_int
         self._kernel32.CloseHandle.argtypes = [ctypes.c_void_p]
         self._kernel32.CloseHandle.restype = ctypes.c_int
-
-        handle = self._kernel32.CreateJobObjectW(None, None)
-        if not handle:
-            raise ctypes.WinError(ctypes.get_last_error())
-        self._handle: int | None = handle
-        limits = ExtendedLimitInformation()
-        limits.basic_limit_information.limit_flags = 0x00002000
-        if not self._kernel32.SetInformationJobObject(
-            handle, 9, ctypes.byref(limits), ctypes.sizeof(limits)
-        ):
-            error = ctypes.WinError(ctypes.get_last_error())
-            self.close()
-            raise error
-
-    def assign(self, process: subprocess.Popen[bytes]) -> None:
-        if self._handle is None or not self._kernel32.AssignProcessToJobObject(
-            self._handle, int(process._handle)  # type: ignore[attr-defined]
-        ):
-            raise ctypes.WinError(ctypes.get_last_error())
-
-    def resume(self, process: subprocess.Popen[bytes]) -> None:
-        class ThreadEntry(ctypes.Structure):
-            _fields_ = [
-                ("size", ctypes.c_ulong),
-                ("usage", ctypes.c_ulong),
-                ("thread_id", ctypes.c_ulong),
-                ("owner_process_id", ctypes.c_ulong),
-                ("base_priority", ctypes.c_long),
-                ("priority_delta", ctypes.c_long),
-                ("flags", ctypes.c_ulong),
-            ]
 
         self._kernel32.CreateToolhelp32Snapshot.argtypes = [
             ctypes.c_ulong,
@@ -1007,48 +998,159 @@ class _WindowsKillJob:
         self._kernel32.ResumeThread.argtypes = [ctypes.c_void_p]
         self._kernel32.ResumeThread.restype = ctypes.c_ulong
 
+        self._thread_entry_type = ThreadEntry
+        self._thread_entry_owner_end = (
+            ThreadEntry.owner_process_id.offset + ctypes.sizeof(ctypes.c_ulong)
+        )
+
+        handle = self._kernel32.CreateJobObjectW(None, None)
+        if not handle:
+            raise self._error("CreateJobObjectW")
+        self._handle: int | None = handle
+        limits = ExtendedLimitInformation()
+        limits.basic_limit_information.limit_flags = 0x00002000
+        if not self._kernel32.SetInformationJobObject(
+            handle, 9, ctypes.byref(limits), ctypes.sizeof(limits)
+        ):
+            error = self._error("SetInformationJobObject")
+            try:
+                self.close()
+            except OSError as close_error:
+                try:
+                    self.close()
+                except OSError as retry_error:
+                    cleanup_error = OSError(
+                        f"{close_error}; close retry also failed: {retry_error}"
+                    )
+                    raise self._with_cleanup_error(
+                        error, cleanup_error
+                    ) from error
+            raise error
+
+    def _error(self, operation: str, code: int | None = None) -> OSError:
+        if code is None:
+            code = self._last_error()
+        if hasattr(ctypes, "WinError"):
+            detail = str(ctypes.WinError(code))
+        else:
+            detail = f"Windows error {code}"
+        return OSError(code, f"{operation} failed: {detail}")
+
+    @staticmethod
+    def _with_cleanup_error(primary: OSError, cleanup: OSError) -> OSError:
+        return OSError(f"{primary}; cleanup also failed: {cleanup}")
+
+    def _close_handle(self, handle: int, label: str) -> None:
+        if not self._kernel32.CloseHandle(handle):
+            raise self._error(f"CloseHandle({label})")
+
+    def _validate_thread_entry(self, entry: ctypes.Structure) -> None:
+        if entry.size < self._thread_entry_owner_end:
+            raise OSError(
+                "thread enumeration returned a truncated THREADENTRY32 "
+                f"record ({entry.size} bytes; need {self._thread_entry_owner_end})"
+            )
+
+    def assign(self, process: subprocess.Popen[bytes]) -> None:
+        if self._handle is None:
+            raise OSError("cannot assign a process to a closed Windows Job")
+        if not self._kernel32.AssignProcessToJobObject(
+            self._handle,
+            int(process._handle),  # type: ignore[attr-defined]
+        ):
+            raise self._error("AssignProcessToJobObject")
+
+    def resume(self, process: subprocess.Popen[bytes]) -> None:
         snapshot = self._kernel32.CreateToolhelp32Snapshot(0x00000004, 0)
         if snapshot == ctypes.c_void_p(-1).value:
-            raise ctypes.WinError(ctypes.get_last_error())
+            raise self._error("CreateToolhelp32Snapshot")
+        resume_error: OSError | None = None
+        resumed = False
         try:
-            entry = ThreadEntry()
+            entry = self._thread_entry_type()
             entry.size = ctypes.sizeof(entry)
+            self._set_last_error(0)
             found = self._kernel32.Thread32First(snapshot, ctypes.byref(entry))
+            first_error = self._last_error() if not found else 0
+            if not found and first_error != self.ERROR_NO_MORE_FILES:
+                raise self._error("Thread32First", first_error)
             while found:
+                self._validate_thread_entry(entry)
                 if entry.owner_process_id == process.pid:
                     thread = self._kernel32.OpenThread(0x0002, False, entry.thread_id)
                     if not thread:
-                        raise ctypes.WinError(ctypes.get_last_error())
+                        raise self._error("OpenThread")
+                    thread_error: OSError | None = None
                     try:
-                        if self._kernel32.ResumeThread(thread) == 0xFFFFFFFF:
-                            raise ctypes.WinError(ctypes.get_last_error())
+                        previous_suspend_count = self._kernel32.ResumeThread(thread)
+                        if previous_suspend_count == 0xFFFFFFFF:
+                            thread_error = self._error("ResumeThread")
+                        elif previous_suspend_count != 1:
+                            thread_error = OSError(
+                                "ResumeThread did not release the CREATE_SUSPENDED "
+                                f"process (previous suspend count {previous_suspend_count})"
+                            )
                     finally:
-                        self._kernel32.CloseHandle(thread)
-                    return
+                        try:
+                            self._close_handle(thread, "thread")
+                        except OSError as close_error:
+                            if thread_error is not None:
+                                raise self._with_cleanup_error(
+                                    thread_error, close_error
+                                ) from thread_error
+                            raise
+                    if thread_error is not None:
+                        raise thread_error
+                    resumed = True
+                    break
+                entry.size = ctypes.sizeof(entry)
+                self._set_last_error(0)
                 found = self._kernel32.Thread32Next(snapshot, ctypes.byref(entry))
+                next_error = self._last_error() if not found else 0
+                if not found and next_error != self.ERROR_NO_MORE_FILES:
+                    raise self._error("Thread32Next", next_error)
+        except OSError as error:
+            resume_error = error
         finally:
-            self._kernel32.CloseHandle(snapshot)
+            try:
+                self._close_handle(snapshot, "thread snapshot")
+            except OSError as close_error:
+                if resume_error is not None:
+                    raise self._with_cleanup_error(
+                        resume_error, close_error
+                    ) from resume_error
+                raise
+        if resume_error is not None:
+            raise resume_error
+        if resumed:
+            return
         raise OSError(f"suspended process {process.pid} has no primary thread")
 
     def terminate(self) -> None:
-        if self._handle is not None:
-            self._kernel32.TerminateJobObject(self._handle, 1)
+        if self._handle is not None and not self._kernel32.TerminateJobObject(
+            self._handle, 1
+        ):
+            raise self._error("TerminateJobObject")
 
     def close(self) -> None:
         if self._handle is not None:
-            self._kernel32.CloseHandle(self._handle)
+            self._close_handle(self._handle, "job")
             self._handle = None
 
 
 def _terminate_process_tree(
     process: subprocess.Popen[bytes], windows_job: _WindowsKillJob | None
 ) -> None:
+    errors: list[OSError] = []
     if os.name == "nt":
         if windows_job is not None:
-            windows_job.terminate()
-        else:
             try:
-                subprocess.run(
+                windows_job.terminate()
+            except OSError as error:
+                errors.append(error)
+        if windows_job is None or errors:
+            try:
+                result = subprocess.run(
                     ["taskkill", "/PID", str(process.pid), "/T", "/F"],
                     check=False,
                     creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
@@ -1056,15 +1158,24 @@ def _terminate_process_tree(
                     stdout=subprocess.DEVNULL,
                     timeout=5,
                 )
-            except (OSError, subprocess.TimeoutExpired):
-                pass
+                if result.returncode != 0:
+                    errors.append(
+                        OSError(f"taskkill /T exited {result.returncode}")
+                    )
+            except (OSError, subprocess.TimeoutExpired) as error:
+                errors.append(OSError(f"taskkill /T failed: {error}"))
     else:
         try:
             os.killpg(process.pid, signal.SIGKILL)
         except ProcessLookupError:
             pass
     if process.poll() is None:
-        process.kill()
+        try:
+            process.kill()
+        except OSError as error:
+            errors.append(OSError(f"root process kill failed: {error}"))
+    if errors:
+        raise OSError("; ".join(str(error) for error in errors))
 
 
 def _run_json_command(
@@ -1074,6 +1185,7 @@ def _run_json_command(
     label: str,
     timeout_seconds: float = 60,
     drain_timeout_seconds: float = 5,
+    windows_job_factory: Callable[[], _WindowsKillJob] = _WindowsKillJob,
 ) -> dict[str, Any]:
     if not command:
         raise ProvenanceError(f"{label} command must not be empty")
@@ -1082,14 +1194,18 @@ def _run_json_command(
     windows_job: _WindowsKillJob | None = None
     if os.name == "nt":
         try:
-            windows_job = _WindowsKillJob()
+            windows_job = windows_job_factory()
         except OSError as error:
-            raise ProvenanceError(f"{label} failed to create process job: {error}") from error
+            raise ProvenanceError(
+                f"{label} failed to create process job: {error}"
+            ) from error
     popen_options: dict[str, Any] = {}
     if os.name == "nt":
-        popen_options["creationflags"] = getattr(
-            subprocess, "CREATE_NEW_PROCESS_GROUP", 0
-        ) | getattr(subprocess, "CREATE_NO_WINDOW", 0) | 0x00000004
+        popen_options["creationflags"] = (
+            getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+            | getattr(subprocess, "CREATE_NO_WINDOW", 0)
+            | 0x00000004
+        )
     else:
         popen_options["start_new_session"] = True
     try:
@@ -1100,35 +1216,73 @@ def _run_json_command(
             **popen_options,
         )
     except OSError as error:
+        close_error: OSError | None = None
         if windows_job is not None:
-            windows_job.close()
-        raise ProvenanceError(f"{label} failed to run: {error}") from error
+            try:
+                windows_job.close()
+            except OSError as cleanup_error:
+                try:
+                    windows_job.close()
+                except OSError as retry_error:
+                    close_error = OSError(
+                        f"{cleanup_error}; close retry also failed: {retry_error}"
+                    )
+                else:
+                    close_error = cleanup_error
+        detail = f"{label} failed to run: {error}"
+        if close_error is not None:
+            detail += f"; failed to close process job: {close_error}"
+        raise ProvenanceError(detail) from error
     if windows_job is not None:
         try:
             windows_job.assign(process)
             windows_job.resume(process)
         except OSError as error:
+            containment_errors = [str(error)]
             try:
-                _terminate_process_tree(process, windows_job)
+                try:
+                    _terminate_process_tree(process, windows_job)
+                except OSError as termination_error:
+                    containment_errors.append(str(termination_error))
                 try:
                     process.wait(timeout=drain_timeout_seconds)
                 except subprocess.TimeoutExpired:
-                    process.kill()
+                    try:
+                        process.kill()
+                    except OSError as kill_error:
+                        containment_errors.append(
+                            f"root process kill failed: {kill_error}"
+                        )
             finally:
-                windows_job.close()
+                try:
+                    windows_job.close()
+                except OSError as close_error:
+                    containment_errors.append(str(close_error))
+                    try:
+                        windows_job.close()
+                    except OSError as retry_error:
+                        containment_errors.append(
+                            f"close retry also failed: {retry_error}"
+                        )
                 process.stdout.close()
                 process.stderr.close()
             raise ProvenanceError(
-                f"{label} failed to contain process tree: {error}"
+                f"{label} failed to contain process tree: "
+                + "; ".join(containment_errors)
             ) from error
     stdout = bytearray()
     stderr = bytearray()
     overflow = threading.Event()
     termination_lock = threading.Lock()
+    termination_errors: list[OSError] = []
 
     def terminate() -> None:
         with termination_lock:
-            _terminate_process_tree(process, windows_job)
+            try:
+                _terminate_process_tree(process, windows_job)
+            except OSError as error:
+                if not termination_errors:
+                    termination_errors.append(error)
 
     def drain(stream: Any, output: bytearray, limit: int) -> None:
         while True:
@@ -1156,6 +1310,7 @@ def _run_json_command(
         thread.start()
     timeout_error: subprocess.TimeoutExpired | None = None
     returncode: int | None = None
+    close_error: OSError | None = None
     try:
         returncode = process.wait(timeout=timeout_seconds)
     except subprocess.TimeoutExpired as error:
@@ -1168,7 +1323,21 @@ def _run_json_command(
     finally:
         with termination_lock:
             if windows_job is not None:
-                windows_job.close()
+                try:
+                    windows_job.close()
+                except OSError as error:
+                    close_error = error
+                    try:
+                        _terminate_process_tree(process, windows_job)
+                    except OSError as termination_error:
+                        if not termination_errors:
+                            termination_errors.append(termination_error)
+                    try:
+                        windows_job.close()
+                    except OSError as retry_error:
+                        close_error = OSError(
+                            f"{error}; close retry also failed: {retry_error}"
+                        )
         drain_deadline = time.monotonic() + drain_timeout_seconds
         for thread in threads:
             thread.join(timeout=max(0, drain_deadline - time.monotonic()))
@@ -1178,27 +1347,60 @@ def _run_json_command(
         final_drain_deadline = time.monotonic() + 1
         for thread in stuck_drains:
             thread.join(timeout=max(0, final_drain_deadline - time.monotonic()))
-    if any(thread.is_alive() for thread in threads):
-        raise ProvenanceError(f"{label} output pipes did not close within bounds")
-    process.stdout.close()
-    process.stderr.close()
+    cleanup_failures: list[str] = []
+    if termination_errors:
+        cleanup_failures.append(
+            f"failed to terminate process tree: {termination_errors[0]}"
+        )
+    if close_error is not None:
+        cleanup_failures.append(f"failed to close process job: {close_error}")
+
+    def with_cleanup_failures(primary: str) -> str:
+        if not cleanup_failures:
+            return primary
+        return primary + "; " + "; ".join(cleanup_failures)
+
+    drain_failure = any(thread.is_alive() for thread in threads)
+    if not drain_failure:
+        process.stdout.close()
+        process.stderr.close()
+    primary_error: str | None = None
+    primary_cause: BaseException | None = None
+    value: Any = None
+    drain_error = f"{label} output pipes did not close within bounds"
     if timeout_error is not None:
-        raise ProvenanceError(
-            f"{label} timed out after {timeout_seconds:g} seconds"
-        ) from timeout_error
-    if overflow.is_set():
-        raise ProvenanceError(f"{label} output exceeds byte limit")
-    if returncode != 0:
+        primary_error = f"{label} timed out after {timeout_seconds:g} seconds"
+        primary_cause = timeout_error
+    elif overflow.is_set():
+        primary_error = f"{label} output exceeds byte limit"
+    elif returncode != 0:
         detail = bytes(stderr).decode("utf-8", errors="replace").strip()
-        raise ProvenanceError(f"{label} exited {returncode}: {detail}")
-    try:
-        value = json.loads(bytes(stdout).decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as error:
-        raise ProvenanceError(f"{label} did not emit UTF-8 JSON") from error
-    if not isinstance(value, dict):
-        raise ProvenanceError(f"{label} output must be an object")
-    if bytes(stdout) != canonical_json_bytes(value):
-        raise ProvenanceError(f"{label} output is not canonical JSON")
+        primary_error = f"{label} exited {returncode}: {detail}"
+    elif drain_failure:
+        primary_error = drain_error
+    else:
+        try:
+            value = json.loads(bytes(stdout).decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            primary_error = f"{label} did not emit UTF-8 JSON"
+            primary_cause = error
+        else:
+            if not isinstance(value, dict):
+                primary_error = f"{label} output must be an object"
+            elif bytes(stdout) != canonical_json_bytes(value):
+                primary_error = f"{label} output is not canonical JSON"
+    if drain_failure and primary_error != drain_error:
+        cleanup_failures.append("output pipes did not close within bounds")
+    if primary_error is not None:
+        raise ProvenanceError(with_cleanup_failures(primary_error)) from primary_cause
+    if termination_errors:
+        raise ProvenanceError(
+            f"{label} failed to terminate process tree: {termination_errors[0]}"
+        ) from termination_errors[0]
+    if close_error is not None:
+        raise ProvenanceError(
+            f"{label} failed to close process job: {close_error}"
+        ) from close_error
     return value
 
 

--- a/code/scripts/tests/test_adj_stdlib_provenance.py
+++ b/code/scripts/tests/test_adj_stdlib_provenance.py
@@ -43,6 +43,33 @@ def acquire_cas_lock_with_alternate_temp(
 
 
 class AdjStdlibProvenanceTests(unittest.TestCase):
+    def fake_windows_kernel32(self) -> mock.Mock:
+        kernel32 = mock.Mock()
+        kernel32.CreateJobObjectW.return_value = 101
+        kernel32.SetInformationJobObject.return_value = 1
+        kernel32.AssignProcessToJobObject.return_value = 1
+        kernel32.TerminateJobObject.return_value = 1
+        kernel32.CloseHandle.return_value = 1
+        kernel32.CreateToolhelp32Snapshot.return_value = 202
+        kernel32.Thread32First.return_value = 0
+        kernel32.Thread32Next.return_value = 0
+        kernel32.OpenThread.return_value = 303
+        kernel32.ResumeThread.return_value = 1
+        return kernel32
+
+    def windows_job(
+        self, kernel32: mock.Mock, error_code: list[int] | None = None
+    ) -> object:
+        errors = error_code or [5]
+        return provenance._WindowsKillJob(
+            kernel32, lambda: errors[0], mock.Mock()
+        )
+
+    def windows_process(self, *, pid: int = 404) -> mock.Mock:
+        process = mock.Mock(pid=pid)
+        process._handle = 505
+        return process
+
     def process_is_alive(self, pid: int) -> bool:
         if os.name == "nt":
             kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
@@ -671,7 +698,786 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             ):
                 provenance._run_formula_inventory(command, source)
 
-    def test_json_command_timeout_kills_descendant_pipe_holders(self) -> None:
+    def test_windows_job_creation_failure_is_named_and_fail_closed(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        kernel32.CreateJobObjectW.return_value = 0
+
+        with self.assertRaisesRegex(OSError, "CreateJobObjectW failed"):
+            self.windows_job(kernel32)
+
+        kernel32.CloseHandle.assert_not_called()
+
+    def test_windows_job_setup_failure_closes_created_handle(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        kernel32.SetInformationJobObject.return_value = 0
+
+        with self.assertRaisesRegex(OSError, "SetInformationJobObject failed"):
+            self.windows_job(kernel32)
+
+        kernel32.CloseHandle.assert_called_once_with(101)
+
+    def test_windows_job_setup_installs_kill_on_close(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        job = self.windows_job(kernel32)
+
+        handle, information_class, pointer, size = (
+            kernel32.SetInformationJobObject.call_args.args
+        )
+        self.assertEqual(handle, 101)
+        self.assertEqual(information_class, 9)
+        self.assertEqual(
+            pointer._obj.basic_limit_information.limit_flags,  # type: ignore[attr-defined]
+            0x00002000,
+        )
+        self.assertEqual(size, ctypes.sizeof(pointer._obj))  # type: ignore[attr-defined]
+        job.close()
+
+    def test_windows_job_setup_preserves_close_failure(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        kernel32.SetInformationJobObject.return_value = 0
+        kernel32.CloseHandle.return_value = 0
+
+        with self.assertRaisesRegex(
+            OSError,
+            "SetInformationJobObject failed.*cleanup also failed.*CloseHandle\\(job\\)",
+        ):
+            self.windows_job(kernel32)
+
+        self.assertEqual(kernel32.CloseHandle.call_count, 2)
+
+    def test_windows_job_setup_retries_transient_close_failure(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        kernel32.SetInformationJobObject.return_value = 0
+        kernel32.CloseHandle.side_effect = [0, 1]
+
+        with self.assertRaisesRegex(OSError, "SetInformationJobObject failed"):
+            self.windows_job(kernel32)
+
+        self.assertEqual(kernel32.CloseHandle.call_count, 2)
+
+    def test_windows_job_preserves_distinct_native_error_codes(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        error_register = [0]
+
+        def fail_setup(*_arguments: object) -> int:
+            error_register[0] = 87
+            return 0
+
+        def fail_close(_handle: int) -> int:
+            error_register[0] = 6
+            return 0
+
+        kernel32.SetInformationJobObject.side_effect = fail_setup
+        kernel32.CloseHandle.side_effect = fail_close
+
+        with self.assertRaisesRegex(
+            OSError,
+            "SetInformationJobObject failed.*87.*CloseHandle\\(job\\) failed.*6",
+        ):
+            provenance._WindowsKillJob(
+                kernel32,
+                lambda: error_register[0],
+                lambda value: error_register.__setitem__(0, value),
+            )
+
+    def test_windows_job_assignment_failure_is_named(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        job = self.windows_job(kernel32)
+        kernel32.AssignProcessToJobObject.return_value = 0
+
+        with self.assertRaisesRegex(OSError, "AssignProcessToJobObject failed"):
+            job.assign(self.windows_process())
+
+        job.close()
+
+    def test_windows_job_closed_assignment_uses_local_state_error(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        job = self.windows_job(kernel32)
+        job.close()
+
+        with self.assertRaisesRegex(OSError, "closed Windows Job"):
+            job.assign(self.windows_process())
+
+        kernel32.AssignProcessToJobObject.assert_not_called()
+
+    def test_windows_job_snapshot_failure_is_named(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        job = self.windows_job(kernel32)
+        kernel32.CreateToolhelp32Snapshot.return_value = ctypes.c_void_p(-1).value
+
+        with self.assertRaisesRegex(OSError, "CreateToolhelp32Snapshot failed"):
+            job.resume(self.windows_process())
+
+        job.close()
+
+    def test_windows_job_thread_first_failure_is_not_treated_as_end(self) -> None:
+        for error_code in (0, 5):
+            with self.subTest(error_code=error_code):
+                kernel32 = self.fake_windows_kernel32()
+                job = self.windows_job(kernel32, [error_code])
+
+                with self.assertRaisesRegex(OSError, "Thread32First failed"):
+                    job.resume(self.windows_process())
+
+                job._set_last_error.assert_called_once_with(0)
+                kernel32.CloseHandle.assert_called_once_with(202)
+                job.close()
+
+    def test_windows_job_thread_error_is_captured_before_cleanup(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        error_register = [99]
+
+        def fail_first(_snapshot: int, _pointer: object) -> int:
+            error_register[0] = 5
+            return 0
+
+        def close_with_different_error(_handle: int) -> int:
+            error_register[0] = 6
+            return 1
+
+        kernel32.Thread32First.side_effect = fail_first
+        kernel32.CloseHandle.side_effect = close_with_different_error
+        job = provenance._WindowsKillJob(
+            kernel32,
+            lambda: error_register[0],
+            lambda value: error_register.__setitem__(0, value),
+        )
+
+        with self.assertRaisesRegex(OSError, "Thread32First failed.*5"):
+            job.resume(self.windows_process())
+
+        self.assertEqual(error_register, [6])
+        job.close()
+
+    def test_windows_job_thread_first_no_more_files_means_no_thread(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        job = self.windows_job(kernel32, [provenance._WindowsKillJob.ERROR_NO_MORE_FILES])
+
+        with self.assertRaisesRegex(OSError, "has no primary thread"):
+            job.resume(self.windows_process(pid=404))
+
+        kernel32.CloseHandle.assert_called_once_with(202)
+        job.close()
+
+    def test_windows_job_thread_next_failure_is_not_treated_as_end(self) -> None:
+        for error_code in (0, 5):
+            with self.subTest(error_code=error_code):
+                kernel32 = self.fake_windows_kernel32()
+                job = self.windows_job(kernel32, [error_code])
+
+                def unrelated_thread(_snapshot: int, pointer: object) -> int:
+                    pointer._obj.owner_process_id = 999  # type: ignore[attr-defined]
+                    pointer._obj.thread_id = 606  # type: ignore[attr-defined]
+                    return 1
+
+                kernel32.Thread32First.side_effect = unrelated_thread
+
+                with self.assertRaisesRegex(OSError, "Thread32Next failed"):
+                    job.resume(self.windows_process(pid=404))
+
+                self.assertEqual(
+                    job._set_last_error.call_args_list,
+                    [mock.call(0), mock.call(0)],
+                )
+                job.close()
+
+    def test_windows_job_rejects_truncated_thread_record(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        job = self.windows_job(kernel32)
+
+        def truncated_thread(_snapshot: int, pointer: object) -> int:
+            pointer._obj.size = job._thread_entry_owner_end - 1  # type: ignore[attr-defined]
+            return 1
+
+        kernel32.Thread32First.side_effect = truncated_thread
+
+        with self.assertRaisesRegex(OSError, "truncated THREADENTRY32"):
+            job.resume(self.windows_process())
+
+        job.close()
+
+    def test_windows_job_resets_thread_record_size_before_next(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        job = self.windows_job(
+            kernel32, [provenance._WindowsKillJob.ERROR_NO_MORE_FILES]
+        )
+        observed_sizes: list[int] = []
+
+        def unrelated_thread(_snapshot: int, pointer: object) -> int:
+            pointer._obj.owner_process_id = 999  # type: ignore[attr-defined]
+            pointer._obj.size = job._thread_entry_owner_end  # type: ignore[attr-defined]
+            return 1
+
+        def no_next_thread(_snapshot: int, pointer: object) -> int:
+            observed_sizes.append(pointer._obj.size)  # type: ignore[attr-defined]
+            return 0
+
+        kernel32.Thread32First.side_effect = unrelated_thread
+        kernel32.Thread32Next.side_effect = no_next_thread
+
+        with self.assertRaisesRegex(OSError, "has no primary thread"):
+            job.resume(self.windows_process())
+
+        self.assertEqual(observed_sizes, [ctypes.sizeof(job._thread_entry_type)])
+        job.close()
+
+    def test_windows_job_traverses_to_primary_thread(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        job = self.windows_job(kernel32)
+
+        def unrelated_thread(_snapshot: int, pointer: object) -> int:
+            pointer._obj.owner_process_id = 999  # type: ignore[attr-defined]
+            pointer._obj.thread_id = 606  # type: ignore[attr-defined]
+            return 1
+
+        def primary_thread(_snapshot: int, pointer: object) -> int:
+            pointer._obj.owner_process_id = 404  # type: ignore[attr-defined]
+            pointer._obj.thread_id = 707  # type: ignore[attr-defined]
+            return 1
+
+        kernel32.Thread32First.side_effect = unrelated_thread
+        kernel32.Thread32Next.side_effect = primary_thread
+
+        job.resume(self.windows_process(pid=404))
+
+        kernel32.OpenThread.assert_called_once_with(0x0002, False, 707)
+        job.close()
+
+    def test_windows_job_open_thread_failure_is_named(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        job = self.windows_job(kernel32)
+
+        def primary_thread(_snapshot: int, pointer: object) -> int:
+            pointer._obj.owner_process_id = 404  # type: ignore[attr-defined]
+            pointer._obj.thread_id = 606  # type: ignore[attr-defined]
+            return 1
+
+        kernel32.Thread32First.side_effect = primary_thread
+        kernel32.OpenThread.return_value = 0
+
+        with self.assertRaisesRegex(OSError, "OpenThread failed"):
+            job.resume(self.windows_process(pid=404))
+
+        job.close()
+
+    def test_windows_job_resume_failure_closes_thread_and_snapshot(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        job = self.windows_job(kernel32)
+
+        def primary_thread(_snapshot: int, pointer: object) -> int:
+            pointer._obj.owner_process_id = 404  # type: ignore[attr-defined]
+            pointer._obj.thread_id = 606  # type: ignore[attr-defined]
+            return 1
+
+        kernel32.Thread32First.side_effect = primary_thread
+        kernel32.ResumeThread.return_value = 0xFFFFFFFF
+
+        with self.assertRaisesRegex(OSError, "ResumeThread failed"):
+            job.resume(self.windows_process(pid=404))
+
+        self.assertEqual(
+            kernel32.CloseHandle.call_args_list,
+            [mock.call(303), mock.call(202)],
+        )
+        job.close()
+
+    def test_windows_job_requires_exact_suspended_resume_count(self) -> None:
+        for previous_suspend_count in (0, 2):
+            with self.subTest(previous_suspend_count=previous_suspend_count):
+                kernel32 = self.fake_windows_kernel32()
+                job = self.windows_job(kernel32)
+
+                def primary_thread(_snapshot: int, pointer: object) -> int:
+                    pointer._obj.owner_process_id = 404  # type: ignore[attr-defined]
+                    pointer._obj.thread_id = 606  # type: ignore[attr-defined]
+                    return 1
+
+                kernel32.Thread32First.side_effect = primary_thread
+                kernel32.ResumeThread.return_value = previous_suspend_count
+
+                with self.assertRaisesRegex(
+                    OSError, f"previous suspend count {previous_suspend_count}"
+                ):
+                    job.resume(self.windows_process(pid=404))
+
+                job.close()
+
+    def test_windows_job_exact_resume_success_closes_both_handles(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        job = self.windows_job(kernel32)
+
+        def primary_thread(_snapshot: int, pointer: object) -> int:
+            pointer._obj.owner_process_id = 404  # type: ignore[attr-defined]
+            pointer._obj.thread_id = 606  # type: ignore[attr-defined]
+            return 1
+
+        kernel32.Thread32First.side_effect = primary_thread
+
+        job.resume(self.windows_process(pid=404))
+
+        self.assertEqual(
+            kernel32.CloseHandle.call_args_list,
+            [mock.call(303), mock.call(202)],
+        )
+        job.close()
+
+    def test_windows_job_thread_close_failure_still_closes_snapshot(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        job = self.windows_job(kernel32)
+
+        def primary_thread(_snapshot: int, pointer: object) -> int:
+            pointer._obj.owner_process_id = 404  # type: ignore[attr-defined]
+            pointer._obj.thread_id = 606  # type: ignore[attr-defined]
+            return 1
+
+        kernel32.Thread32First.side_effect = primary_thread
+        kernel32.CloseHandle.side_effect = lambda handle: int(handle != 303)
+
+        with self.assertRaisesRegex(OSError, "CloseHandle\\(thread\\) failed"):
+            job.resume(self.windows_process(pid=404))
+
+        self.assertEqual(
+            kernel32.CloseHandle.call_args_list,
+            [mock.call(303), mock.call(202)],
+        )
+        job.close()
+
+    def test_windows_job_resume_preserves_thread_close_failure(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        job = self.windows_job(kernel32)
+
+        def primary_thread(_snapshot: int, pointer: object) -> int:
+            pointer._obj.owner_process_id = 404  # type: ignore[attr-defined]
+            pointer._obj.thread_id = 606  # type: ignore[attr-defined]
+            return 1
+
+        kernel32.Thread32First.side_effect = primary_thread
+        kernel32.ResumeThread.return_value = 0xFFFFFFFF
+        kernel32.CloseHandle.side_effect = lambda handle: int(handle != 303)
+
+        with self.assertRaisesRegex(
+            OSError, "ResumeThread failed.*cleanup also failed.*CloseHandle\\(thread\\)"
+        ):
+            job.resume(self.windows_process(pid=404))
+
+        job.close()
+
+    def test_windows_job_resume_preserves_snapshot_close_failure(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        job = self.windows_job(kernel32)
+
+        def primary_thread(_snapshot: int, pointer: object) -> int:
+            pointer._obj.owner_process_id = 404  # type: ignore[attr-defined]
+            pointer._obj.thread_id = 606  # type: ignore[attr-defined]
+            return 1
+
+        kernel32.Thread32First.side_effect = primary_thread
+        kernel32.ResumeThread.return_value = 0xFFFFFFFF
+        kernel32.CloseHandle.side_effect = lambda handle: int(handle != 202)
+
+        with self.assertRaisesRegex(
+            OSError,
+            "ResumeThread failed.*cleanup also failed.*CloseHandle\\(thread snapshot\\)",
+        ):
+            job.resume(self.windows_process(pid=404))
+
+        job.close()
+
+    def test_windows_job_snapshot_close_failure_is_named(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        job = self.windows_job(
+            kernel32, [provenance._WindowsKillJob.ERROR_NO_MORE_FILES]
+        )
+        kernel32.CloseHandle.side_effect = lambda handle: int(handle != 202)
+
+        with self.assertRaisesRegex(OSError, "CloseHandle\\(thread snapshot\\) failed"):
+            job.resume(self.windows_process())
+
+        job.close()
+
+    def test_windows_job_termination_failure_is_named(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        job = self.windows_job(kernel32)
+        kernel32.TerminateJobObject.return_value = 0
+
+        with self.assertRaisesRegex(OSError, "TerminateJobObject failed"):
+            job.terminate()
+
+        job.close()
+
+    def test_windows_job_close_failure_keeps_handle_for_retry(self) -> None:
+        kernel32 = self.fake_windows_kernel32()
+        job = self.windows_job(kernel32)
+        kernel32.CloseHandle.return_value = 0
+
+        with self.assertRaisesRegex(OSError, "CloseHandle\\(job\\) failed"):
+            job.close()
+
+        kernel32.CloseHandle.return_value = 1
+        job.close()
+        job.close()
+        self.assertEqual(kernel32.CloseHandle.call_count, 2)
+
+    def test_windows_job_termination_failure_still_kills_parent(self) -> None:
+        process = self.windows_process()
+        process.poll.return_value = None
+        job = mock.Mock()
+        job.terminate.side_effect = OSError("TerminateJobObject failed")
+        taskkill = mock.Mock(
+            return_value=subprocess.CompletedProcess(["taskkill"], 0)
+        )
+
+        with (
+            mock.patch.object(provenance.os, "name", "nt"),
+            mock.patch.object(provenance.subprocess, "run", taskkill),
+            self.assertRaisesRegex(OSError, "TerminateJobObject failed"),
+        ):
+            provenance._terminate_process_tree(process, job)
+
+        self.assertEqual(taskkill.call_args.args[0][:3], ["taskkill", "/PID", "404"])
+        self.assertIn("/T", taskkill.call_args.args[0])
+        self.assertIn("/F", taskkill.call_args.args[0])
+        self.assertEqual(taskkill.call_args.kwargs["timeout"], 5)
+        process.kill.assert_called_once_with()
+
+    def test_windows_job_taskkill_failures_remain_observable(self) -> None:
+        for taskkill_failure, expected in (
+            (
+                subprocess.CompletedProcess(["taskkill"], 7),
+                "taskkill /T exited 7",
+            ),
+            (
+                subprocess.TimeoutExpired(["taskkill"], 5),
+                "taskkill /T failed",
+            ),
+        ):
+            with self.subTest(expected=expected):
+                process = self.windows_process()
+                process.poll.return_value = None
+                job = mock.Mock()
+                job.terminate.side_effect = OSError("TerminateJobObject failed")
+                if isinstance(taskkill_failure, BaseException):
+                    taskkill = mock.Mock(side_effect=taskkill_failure)
+                else:
+                    taskkill = mock.Mock(return_value=taskkill_failure)
+
+                with (
+                    mock.patch.object(provenance.os, "name", "nt"),
+                    mock.patch.object(provenance.subprocess, "run", taskkill),
+                    self.assertRaisesRegex(OSError, expected),
+                ):
+                    provenance._terminate_process_tree(process, job)
+
+                self.assertIn("/T", taskkill.call_args.args[0])
+                self.assertIn("/F", taskkill.call_args.args[0])
+                self.assertEqual(taskkill.call_args.kwargs["timeout"], 5)
+                process.kill.assert_called_once_with()
+
+    @unittest.skipUnless(os.name == "nt", "Windows Job Object behavior")
+    def test_windows_job_factory_failure_precedes_process_launch(self) -> None:
+        factory = mock.Mock(side_effect=OSError("injected CreateJobObjectW failure"))
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen") as popen,
+            self.assertRaisesRegex(
+                provenance.ProvenanceError, "failed to create process job"
+            ),
+        ):
+            provenance._run_json_command(
+                [sys.executable, "-c", "print('{}')"],
+                [],
+                label="job factory fixture",
+                windows_job_factory=factory,
+            )
+
+        popen.assert_not_called()
+
+    @unittest.skipUnless(os.name == "nt", "Windows Job Object behavior")
+    def test_windows_job_popen_failure_preserves_close_failure(self) -> None:
+        job = mock.Mock()
+        job.close.side_effect = OSError("injected CloseHandle(job) failure")
+
+        with (
+            mock.patch.object(
+                provenance.subprocess,
+                "Popen",
+                side_effect=OSError("injected process launch failure"),
+            ),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError,
+                "failed to run.*process launch failure.*failed to close process job",
+            ),
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="launch cleanup fixture",
+                windows_job_factory=lambda: job,
+            )
+
+        self.assertEqual(job.close.call_count, 2)
+
+    @unittest.skipUnless(os.name == "nt", "Windows Job Object behavior")
+    def test_windows_job_containment_failure_cleans_process_and_pipes(self) -> None:
+        original_popen = subprocess.Popen
+        for failing_stage in ("assign", "resume"):
+            with self.subTest(failing_stage=failing_stage):
+                processes: list[subprocess.Popen[bytes]] = []
+                job = mock.Mock()
+                getattr(job, failing_stage).side_effect = OSError(
+                    f"injected {failing_stage} failure"
+                )
+                job.close.side_effect = [
+                    OSError("injected transient CloseHandle(job) failure"),
+                    None,
+                ]
+
+                def capture_process(
+                    *args: object,
+                    _processes: list[subprocess.Popen[bytes]] = processes,
+                    **kwargs: object,
+                ) -> object:
+                    process = original_popen(*args, **kwargs)
+                    _processes.append(process)
+                    return process
+
+                with (
+                    mock.patch.object(
+                        provenance.subprocess, "Popen", capture_process
+                    ),
+                    self.assertRaisesRegex(
+                        provenance.ProvenanceError,
+                        f"failed to contain process tree.*{failing_stage} failure",
+                    ),
+                ):
+                    provenance._run_json_command(
+                        [sys.executable, "-c", "print('{}')"],
+                        [],
+                        label="containment cleanup fixture",
+                        drain_timeout_seconds=0.2,
+                        windows_job_factory=lambda job=job: job,
+                    )
+
+                self.assertEqual(len(processes), 1)
+                self.assertIsNotNone(processes[0].poll())
+                self.assertTrue(processes[0].stdout.closed)
+                self.assertTrue(processes[0].stderr.closed)
+                job.terminate.assert_called_once_with()
+                self.assertEqual(job.close.call_count, 2)
+                if failing_stage == "assign":
+                    job.resume.assert_not_called()
+                else:
+                    job.assign.assert_called_once_with(processes[0])
+
+    @unittest.skipUnless(os.name == "nt", "Windows Job Object behavior")
+    def test_windows_job_containment_preserves_final_kill_failure(self) -> None:
+        process = mock.Mock()
+        process.stdout = mock.Mock()
+        process.stderr = mock.Mock()
+        process.wait.side_effect = subprocess.TimeoutExpired(["fixture"], 0.1)
+        process.kill.side_effect = OSError("injected TerminateProcess failure")
+        job = mock.Mock()
+        job.assign.side_effect = OSError("injected assignment failure")
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            mock.patch.object(
+                provenance,
+                "_terminate_process_tree",
+                side_effect=OSError("injected tree termination failure"),
+            ),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError,
+                "assignment failure.*tree termination failure.*root process kill failed.*TerminateProcess failure",
+            ),
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="final kill fixture",
+                drain_timeout_seconds=0.1,
+                windows_job_factory=lambda: job,
+            )
+
+        job.close.assert_called_once_with()
+        process.stdout.close.assert_called_once_with()
+        process.stderr.close.assert_called_once_with()
+
+    @unittest.skipUnless(os.name == "nt", "Windows Job Object behavior")
+    def test_windows_job_timeout_preserves_termination_and_close_failures(self) -> None:
+        job = mock.Mock()
+        job.terminate.side_effect = OSError("injected TerminateJobObject failure")
+        job.close.side_effect = OSError("injected CloseHandle(job) failure")
+
+        with self.assertRaisesRegex(
+            provenance.ProvenanceError,
+            "timed out.*failed to terminate process tree.*failed to close process job",
+        ):
+            provenance._run_json_command(
+                [sys.executable, "-c", "print('{}')"],
+                [],
+                label="timeout cleanup fixture",
+                timeout_seconds=0.1,
+                drain_timeout_seconds=0.2,
+                windows_job_factory=lambda: job,
+            )
+
+        self.assertGreaterEqual(job.terminate.call_count, 1)
+        self.assertEqual(job.close.call_count, 2)
+
+    @unittest.skipUnless(os.name == "nt", "Windows Job Object behavior")
+    def test_windows_job_overflow_preserves_termination_and_close_failures(self) -> None:
+        class FaultingJob:
+            def __init__(self) -> None:
+                self.inner = provenance._WindowsKillJob()
+
+            def assign(self, process: subprocess.Popen[bytes]) -> None:
+                self.inner.assign(process)
+
+            def resume(self, process: subprocess.Popen[bytes]) -> None:
+                self.inner.resume(process)
+
+            def terminate(self) -> None:
+                self.inner.terminate()
+                raise OSError("injected TerminateJobObject failure")
+
+            def close(self) -> None:
+                self.inner.close()
+                raise OSError("injected CloseHandle(job) failure")
+
+        with (
+            mock.patch.object(provenance, "MAX_OBJECT_BYTES", 1024),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError,
+                "output exceeds byte limit.*failed to terminate process tree.*failed to close process job",
+            ),
+        ):
+            provenance._run_json_command(
+                [
+                    sys.executable,
+                    "-c",
+                    "import sys; sys.stdout.buffer.write(b'x' * 2048)",
+                ],
+                [],
+                label="overflow cleanup fixture",
+                timeout_seconds=5,
+                drain_timeout_seconds=0.2,
+                windows_job_factory=FaultingJob,
+            )
+
+    def test_json_command_timeout_preserves_stuck_drain_failure(self) -> None:
+        process = mock.Mock()
+        process.stdout = mock.Mock()
+        process.stderr = mock.Mock()
+        process.wait.side_effect = [
+            subprocess.TimeoutExpired(["fixture"], 0.1),
+            -9,
+        ]
+        threads = [mock.Mock(), mock.Mock()]
+        for thread in threads:
+            thread.is_alive.return_value = True
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            mock.patch.object(
+                provenance.threading, "Thread", side_effect=threads
+            ),
+            mock.patch.object(provenance, "_terminate_process_tree"),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError,
+                "timed out after 0.1 seconds.*output pipes did not close within bounds",
+            ),
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="stuck drain fixture",
+                timeout_seconds=0.1,
+                drain_timeout_seconds=0.1,
+                windows_job_factory=mock.Mock,
+            )
+
+        process.stdout.close.assert_not_called()
+        process.stderr.close.assert_not_called()
+
+    @unittest.skipUnless(os.name == "nt", "Windows Job Object behavior")
+    def test_windows_job_close_failure_terminates_and_retries(self) -> None:
+        original_close = provenance._WindowsKillJob.close
+        original_terminate = provenance._WindowsKillJob.terminate
+        close_calls = 0
+        terminate_calls = 0
+
+        def fail_first_close(job: object) -> None:
+            nonlocal close_calls
+            close_calls += 1
+            if close_calls == 1:
+                raise OSError("injected CloseHandle(job) failure")
+            original_close(job)
+
+        def tracked_terminate(job: object) -> None:
+            nonlocal terminate_calls
+            terminate_calls += 1
+            original_terminate(job)
+
+        with (
+            mock.patch.object(
+                provenance._WindowsKillJob, "close", fail_first_close
+            ),
+            mock.patch.object(
+                provenance._WindowsKillJob, "terminate", tracked_terminate
+            ),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError,
+                "failed to close process job.*injected CloseHandle",
+            ),
+        ):
+            provenance._run_json_command(
+                [sys.executable, "-c", "print('{}')"],
+                [],
+                label="close retry fixture",
+            )
+
+        self.assertEqual(close_calls, 2)
+        self.assertEqual(terminate_calls, 1)
+
+    @unittest.skipUnless(os.name == "nt", "Windows Job Object behavior")
+    def test_windows_job_cleanup_failure_preserves_command_error(self) -> None:
+        for command, expected in (
+            ("import sys; sys.exit(7)", "exited 7"),
+            ("print('not-json')", "did not emit UTF-8 JSON"),
+        ):
+            with self.subTest(expected=expected):
+                original_close = provenance._WindowsKillJob.close
+                close_calls = 0
+
+                def fail_first_close(
+                    job: object,
+                    _original_close=original_close,
+                ) -> None:
+                    nonlocal close_calls
+                    close_calls += 1
+                    if close_calls == 1:
+                        raise OSError("injected CloseHandle(job) failure")
+                    _original_close(job)
+
+                with (
+                    mock.patch.object(
+                        provenance._WindowsKillJob, "close", fail_first_close
+                    ),
+                    self.assertRaisesRegex(
+                        provenance.ProvenanceError,
+                        expected + ".*failed to close process job",
+                    ),
+                ):
+                    provenance._run_json_command(
+                        [sys.executable, "-c", command],
+                        [],
+                        label="causal cleanup fixture",
+                    )
+
+                self.assertEqual(close_calls, 2)
+
+    def test_windows_job_timeout_kills_descendant_pipe_holders(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             pid_path = Path(directory) / "child.pid"
             child = (
@@ -704,7 +1510,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             self.assertLess(time.monotonic() - started, 8)
             self.assert_process_exits(int(pid_path.read_text()))
 
-    def test_json_command_parent_exit_kills_descendant_pipe_holders(self) -> None:
+    def test_windows_job_parent_exit_kills_descendant_pipe_holders(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             pid_path = Path(directory) / "child.pid"
             child = (
@@ -737,7 +1543,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             self.assert_process_exits(int(pid_path.read_text()))
 
     @unittest.skipUnless(os.name == "nt", "Windows Job Object behavior")
-    def test_json_command_assigns_job_before_process_execution(self) -> None:
+    def test_windows_job_assigns_before_process_execution(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             marker = Path(directory) / "process-started"
             command = (

--- a/code/specs/ADJ-STDLIB-COVERAGE.md
+++ b/code/specs/ADJ-STDLIB-COVERAGE.md
@@ -335,9 +335,19 @@ option mapping, or judge/evaluation failure.
      ADJ source and IR, and exact cited snapshot and IR; dependency-owned inputs also
      pin the owning bundle hash. Root-query ownership is parent-bound because its own
      bundle hash would form a content-addressing cycle through the witness.
-13f. **Backlog:** add native-API fault injection for Windows Job creation, assignment,
-     thread discovery, resume, termination, and handle-close failures so each inspected
-     fail-closed branch also has an executable regression fixture.
+13f. **Complete:** injectable native-API fixtures exercise Windows Job creation,
+     kill-on-close setup, assignment, snapshot and thread discovery, exact suspended
+     resume, termination, and every handle-close boundary. Enumeration clears and
+     captures last-error state, accepts only `ERROR_NO_MORE_FILES` as exhaustion,
+     rejects truncated thread records, and restores their advertised size before
+     advancing. Cleanup failures retain the causal error; constructor rollback retries
+     a failed close, while runtime close failures retain the handle for checked Job
+     termination and a close retry. Failed Job termination invokes bounded `/T` tree
+     termination before the root-process fallback. The Windows PR matrix runs the
+     focused fake and real-process containment slice.
+13g. **Backlog:** replace concatenated Windows lifecycle error text with structured
+     stage, API, error-code, and cleanup-cause records so callers can inspect failures
+     without parsing localized operating-system messages.
 
 ### Wave 2: complete K-8 foundations
 

--- a/code/specs/data/adj-stdlib-provenance/README.md
+++ b/code/specs/data/adj-stdlib-provenance/README.md
@@ -120,5 +120,9 @@ into a network or SSRF primitive. Reads are bounded and reject links and Windows
 reparse points; object writes are exclusive; index writes are atomic. Trusted
 parser and audit commands run in isolated process groups; output overflow or timeout
 terminates the complete process tree, and pipe-drain joins have their own bound.
+Windows Job lifecycle calls are fault-injected in platform-neutral tests and exercised
+against real suspended processes in the Windows PR matrix. Native enumeration errors,
+truncated thread records, incomplete resumes, termination failures, and handle-close
+failures all prevent a verifier result from being accepted.
 Existing hashes are reused, while missing or changed bytes, claims, transforms, graph
 edges, receipts, partitions, and projections fail closed.


### PR DESCRIPTION
## Summary
- make every Windows Job native boundary injectable and fail closed, including exact last-error capture, bounded thread-record validation, and exact suspended resume semantics
- preserve primary command failures while appending termination, drain, and handle-cleanup failures; retry close boundaries and use bounded taskkill /T /F before root fallback
- add verifier-level fault injection for creation, launch, assignment, resume, timeout, overflow, termination, close, and final-kill failures
- run the focused fake and real-process Windows containment slice in the PR build matrix

## Defensibility
- clears last-error before Thread32First/Next and accepts only ERROR_NO_MORE_FILES as exhaustion
- rejects truncated THREADENTRY32 records and restores structure size before traversal
- requires ResumeThread to report exactly one suspended level
- keeps causal and cleanup failures observable, including taskkill nonzero/timeout and stuck-pipe outcomes
- independent Windows systems and test/workflow reviews report no P0-P2 findings
- logs structured lifecycle errors as follow-up backlog item 13g rather than claiming string records are structured

## Validation
- focused Windows selector: 39 tests passed
- full provenance suite: 118 tests passed, 1 expected skip
- strict provenance verification: 6 bundles, 84 objects, 9 snapshots
- strict curriculum manifest: 6 roots, 10 objectives, no errors
- Rust formula audit: 5 tests passed
- Ruff, py_compile, workflow YAML parse, and git diff checks passed