### PR TITLE
feat(chief): reconcile registered host lifecycle

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -753,6 +753,7 @@ members = [
     "chief-of-staff-channel-endpoints",
     "chief-of-staff-secure-host-channel",
     "chief-of-staff-service-registry",
+    "chief-of-staff-service-reconciler",
     "chief-of-staff-tool-api",
     "chief-of-staff-host-runtime",
     "chief-of-staff-smart-home-tools",

--- a/code/packages/rust/chief-of-staff-service-reconciler/BUILD
+++ b/code/packages/rust/chief-of-staff-service-reconciler/BUILD
@@ -1,0 +1,1 @@
+cargo test -p chief-of-staff-service-reconciler -- --nocapture

--- a/code/packages/rust/chief-of-staff-service-reconciler/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-service-reconciler/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Add deterministic desired-state reconciliation over the CAS-backed service registry.
+- Add authoritative supervisor observations with package identity and heartbeat validation.
+- Add first-launch, restart-policy, quarantine, and crash-recovery state transitions.
+- Claim one bounded start or stop mutation per host before invoking the supervisor.

--- a/code/packages/rust/chief-of-staff-service-reconciler/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-service-reconciler/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "chief-of-staff-service-reconciler"
+version = "0.1.0"
+edition = "2021"
+description = "Deterministic registry-to-supervisor reconciliation for the D18 Chief orchestrator"
+license = "MIT"
+
+[dependencies]
+chief-of-staff-channel-crypto = { path = "../chief-of-staff-channel-crypto" }
+chief-of-staff-service-registry = { path = "../chief-of-staff-service-registry" }
+
+[dev-dependencies]
+storage-core = { path = "../storage-core" }

--- a/code/packages/rust/chief-of-staff-service-reconciler/README.md
+++ b/code/packages/rust/chief-of-staff-service-reconciler/README.md
@@ -1,0 +1,23 @@
+# chief-of-staff-service-reconciler
+
+`chief-of-staff-service-reconciler` is the deterministic lifecycle bridge
+between D18's durable service registry and an authoritative host-process
+supervisor.
+
+It ignores cached PIDs for liveness, validates current supervisor evidence,
+checks the live package hash, applies restart policy, detects stale heartbeats,
+and CAS-writes the resulting observation. Start and stop operations are exposed
+through an injected trait, so the crate performs no process, filesystem,
+network, clock, or random access itself.
+
+Each host tick performs at most one supervisor mutation. Transitional state is
+claimed with CAS before that mutation, making concurrent operator edits and
+orchestrator crash recovery converge on subsequent ticks.
+
+## Validation
+
+```sh
+cargo test -p chief-of-staff-service-reconciler -- --nocapture
+cargo clippy -p chief-of-staff-service-reconciler --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-service-reconciler --no-deps
+```

--- a/code/packages/rust/chief-of-staff-service-reconciler/required_capabilities.json
+++ b/code/packages/rust/chief-of-staff-service-reconciler/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/chief-of-staff-service-reconciler",
+  "capabilities": [],
+  "justification": "Pure lifecycle reconciliation over injected registry and supervisor contracts. The package directly performs no filesystem, process, network, environment, clock, random, or stream access."
+}

--- a/code/packages/rust/chief-of-staff-service-reconciler/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-service-reconciler/src/lib.rs
@@ -1,0 +1,1639 @@
+//! Deterministic D18 service-registry reconciliation.
+//!
+//! Cached registry observations are durable recovery hints, not process
+//! authority. This crate accepts fresh evidence from an injected supervisor,
+//! converges one bounded tick, and performs no I/O of its own.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use chief_of_staff_channel_crypto::ChannelId;
+use chief_of_staff_service_registry::{
+    DesiredState, HostEntry, HostName, HostObservation, HostRegistration, HostStatus, LoadedHost,
+    RegistryError, RestartPolicy, ServiceRegistry,
+};
+use core::fmt::{self, Display, Formatter};
+
+const RESTART_COUNTER_EXHAUSTED: &str = "restart counter exhausted";
+
+/// Validated lifecycle phase reported by the process authority.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SupervisorPhase {
+    /// The process exists but has not completed its secure bootstrap.
+    Starting,
+    /// The process has a live authenticated control channel and heartbeat.
+    Running,
+    /// The supervisor is draining or terminating the process.
+    Stopping,
+    /// The process exited and no longer has a live PID or channel.
+    Exited {
+        /// Process exit code, or `None` for a signal or unavailable status.
+        exit_code: Option<i32>,
+    },
+}
+
+/// A current, structurally validated observation from process authority.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SupervisorObservation {
+    /// No owned process instance exists for the registered host name.
+    Absent,
+    /// An owned instance exists and is bound to the supplied package hash.
+    Instance(SupervisorInstance),
+}
+
+impl SupervisorObservation {
+    /// Construct an absent observation.
+    pub fn absent() -> Self {
+        Self::Absent
+    }
+
+    /// Construct a starting instance.
+    pub fn starting(
+        package_hash: [u8; 32],
+        process_id: u32,
+        started_at_ns: u64,
+        last_heartbeat_ns: Option<u64>,
+        control_channel_id: Option<ChannelId>,
+    ) -> Result<Self, ObservationError> {
+        SupervisorInstance::new(
+            package_hash,
+            SupervisorPhase::Starting,
+            Some(process_id),
+            Some(started_at_ns),
+            last_heartbeat_ns,
+            control_channel_id,
+        )
+        .map(Self::Instance)
+    }
+
+    /// Construct a running instance.
+    pub fn running(
+        package_hash: [u8; 32],
+        process_id: u32,
+        started_at_ns: u64,
+        last_heartbeat_ns: u64,
+        control_channel_id: ChannelId,
+    ) -> Result<Self, ObservationError> {
+        SupervisorInstance::new(
+            package_hash,
+            SupervisorPhase::Running,
+            Some(process_id),
+            Some(started_at_ns),
+            Some(last_heartbeat_ns),
+            Some(control_channel_id),
+        )
+        .map(Self::Instance)
+    }
+
+    /// Construct a stopping instance.
+    pub fn stopping(
+        package_hash: [u8; 32],
+        process_id: u32,
+        started_at_ns: u64,
+        last_heartbeat_ns: Option<u64>,
+        control_channel_id: Option<ChannelId>,
+    ) -> Result<Self, ObservationError> {
+        SupervisorInstance::new(
+            package_hash,
+            SupervisorPhase::Stopping,
+            Some(process_id),
+            Some(started_at_ns),
+            last_heartbeat_ns,
+            control_channel_id,
+        )
+        .map(Self::Instance)
+    }
+
+    /// Construct an exited instance without retaining live authority fields.
+    pub fn exited(
+        package_hash: [u8; 32],
+        exit_code: Option<i32>,
+        started_at_ns: Option<u64>,
+        last_heartbeat_ns: Option<u64>,
+    ) -> Result<Self, ObservationError> {
+        SupervisorInstance::new(
+            package_hash,
+            SupervisorPhase::Exited { exit_code },
+            None,
+            started_at_ns,
+            last_heartbeat_ns,
+            None,
+        )
+        .map(Self::Instance)
+    }
+}
+
+/// One owned process instance and its package identity.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SupervisorInstance {
+    package_hash: [u8; 32],
+    phase: SupervisorPhase,
+    process_id: Option<u32>,
+    started_at_ns: Option<u64>,
+    last_heartbeat_ns: Option<u64>,
+    control_channel_id: Option<ChannelId>,
+}
+
+impl SupervisorInstance {
+    fn new(
+        package_hash: [u8; 32],
+        phase: SupervisorPhase,
+        process_id: Option<u32>,
+        started_at_ns: Option<u64>,
+        last_heartbeat_ns: Option<u64>,
+        control_channel_id: Option<ChannelId>,
+    ) -> Result<Self, ObservationError> {
+        let status = match phase {
+            SupervisorPhase::Starting => HostStatus::Starting,
+            SupervisorPhase::Running => HostStatus::Running,
+            SupervisorPhase::Stopping => HostStatus::Stopping,
+            SupervisorPhase::Exited { exit_code } => HostStatus::Crashed { exit_code },
+        };
+        HostObservation::new(
+            status,
+            process_id,
+            started_at_ns,
+            last_heartbeat_ns,
+            control_channel_id,
+            0,
+            None,
+        )
+        .map_err(ObservationError::RegistryValidation)?;
+        Ok(Self {
+            package_hash,
+            phase,
+            process_id,
+            started_at_ns,
+            last_heartbeat_ns,
+            control_channel_id,
+        })
+    }
+
+    /// Return the exact package hash used to launch this process.
+    pub fn package_hash(&self) -> &[u8; 32] {
+        &self.package_hash
+    }
+
+    /// Return the current authoritative lifecycle phase.
+    pub fn phase(&self) -> SupervisorPhase {
+        self.phase
+    }
+
+    /// Return the live process ID, when active.
+    pub fn process_id(&self) -> Option<u32> {
+        self.process_id
+    }
+
+    /// Return the supervisor-observed monotonic start time.
+    pub fn started_at_ns(&self) -> Option<u64> {
+        self.started_at_ns
+    }
+
+    /// Return the last authenticated heartbeat time.
+    pub fn last_heartbeat_ns(&self) -> Option<u64> {
+        self.last_heartbeat_ns
+    }
+
+    /// Return the current authenticated control-channel identifier.
+    pub fn control_channel_id(&self) -> Option<ChannelId> {
+        self.control_channel_id
+    }
+}
+
+/// Structural failure while constructing supervisor evidence.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ObservationError {
+    /// The shape violates the durable registry observation contract.
+    RegistryValidation(RegistryError),
+}
+
+impl Display for ObservationError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RegistryValidation(error) => write!(formatter, "invalid observation: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for ObservationError {}
+
+/// Process authority injected by the runnable orchestrator.
+pub trait HostSupervisor {
+    /// Concrete supervisor failure type.
+    type Error;
+
+    /// Inspect current authority for this exact registration.
+    fn inspect(
+        &mut self,
+        registration: &HostRegistration,
+    ) -> Result<SupervisorObservation, Self::Error>;
+
+    /// Idempotently begin one verified host launch.
+    fn start(&mut self, registration: &HostRegistration) -> Result<(), Self::Error>;
+
+    /// Idempotently begin stopping the named host.
+    fn stop(&mut self, host_name: &HostName) -> Result<(), Self::Error>;
+}
+
+/// Validated health configuration for one reconciliation tick.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReconcileConfig {
+    max_heartbeat_age_ns: u64,
+}
+
+impl ReconcileConfig {
+    /// Require a non-zero maximum heartbeat age.
+    pub fn new(max_heartbeat_age_ns: u64) -> Result<Self, ConfigError> {
+        if max_heartbeat_age_ns == 0 {
+            return Err(ConfigError::ZeroHeartbeatAge);
+        }
+        Ok(Self {
+            max_heartbeat_age_ns,
+        })
+    }
+
+    /// Return the maximum accepted heartbeat age.
+    pub fn max_heartbeat_age_ns(self) -> u64 {
+        self.max_heartbeat_age_ns
+    }
+}
+
+/// Invalid reconciliation configuration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConfigError {
+    /// A zero heartbeat age would make every non-future heartbeat ambiguous.
+    ZeroHeartbeatAge,
+}
+
+impl Display for ConfigError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("maximum heartbeat age must be non-zero")
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+/// Stable action performed for one registry entry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReconcileAction {
+    /// Only the durable observation was refreshed or already matched.
+    Observed,
+    /// One start mutation was claimed and issued.
+    Started,
+    /// One stop mutation was claimed and issued.
+    Stopped,
+    /// Restart policy or quarantine intentionally suppressed a mutation.
+    Deferred,
+}
+
+/// Outcome for one host in a full reconciliation tick.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HostReconcileOutcome {
+    host_name: HostName,
+    action: ReconcileAction,
+    status: HostStatus,
+}
+
+impl HostReconcileOutcome {
+    fn new(host_name: HostName, action: ReconcileAction, status: HostStatus) -> Self {
+        Self {
+            host_name,
+            action,
+            status,
+        }
+    }
+
+    /// Return the reconciled host name.
+    pub fn host_name(&self) -> &HostName {
+        &self.host_name
+    }
+
+    /// Return the bounded action performed during this tick.
+    pub fn action(&self) -> ReconcileAction {
+        self.action
+    }
+
+    /// Return the durable status after the tick.
+    pub fn status(&self) -> &HostStatus {
+        &self.status
+    }
+}
+
+/// Stable host-name-ordered outcomes for one full registry pass.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReconcileReport {
+    outcomes: Vec<HostReconcileOutcome>,
+}
+
+impl ReconcileReport {
+    /// Borrow every per-host outcome in registry order.
+    pub fn outcomes(&self) -> &[HostReconcileOutcome] {
+        &self.outcomes
+    }
+}
+
+/// Operation name attached to a supervisor failure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SupervisorOperation {
+    /// Inspect live process authority.
+    Inspect,
+    /// Begin a host launch.
+    Start,
+    /// Begin host termination.
+    Stop,
+}
+
+impl Display for SupervisorOperation {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Inspect => formatter.write_str("inspect"),
+            Self::Start => formatter.write_str("start"),
+            Self::Stop => formatter.write_str("stop"),
+        }
+    }
+}
+
+/// Explicit reconciliation failure.
+#[derive(Debug)]
+pub enum ReconcileError<E> {
+    /// Durable registry read or CAS failure.
+    Registry(RegistryError),
+    /// Current supervisor evidence contains a future timestamp.
+    FutureObservation {
+        /// Host whose observation is later than the caller-provided clock.
+        host_name: HostName,
+    },
+    /// An injected supervisor operation failed.
+    Supervisor {
+        /// Host whose operation failed.
+        host_name: HostName,
+        /// Failed operation.
+        operation: SupervisorOperation,
+        /// Original supervisor error.
+        source: E,
+    },
+}
+
+impl<E: Display> Display for ReconcileError<E> {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Registry(error) => write!(formatter, "registry reconciliation failed: {error}"),
+            Self::FutureObservation { host_name } => {
+                write!(
+                    formatter,
+                    "supervisor observation is in the future: {host_name}"
+                )
+            }
+            Self::Supervisor {
+                host_name,
+                operation,
+                source,
+            } => write!(
+                formatter,
+                "supervisor {operation} failed for {host_name}: {source}"
+            ),
+        }
+    }
+}
+
+impl<E: std::error::Error + 'static> std::error::Error for ReconcileError<E> {}
+
+impl<E> From<RegistryError> for ReconcileError<E> {
+    fn from(error: RegistryError) -> Self {
+        Self::Registry(error)
+    }
+}
+
+/// Stateless registry-to-supervisor reconciliation kernel.
+pub struct ServiceReconciler<'a> {
+    registry: ServiceRegistry<'a>,
+    config: ReconcileConfig,
+}
+
+impl<'a> ServiceReconciler<'a> {
+    /// Bind a registry handle and validated health configuration.
+    pub fn new(registry: ServiceRegistry<'a>, config: ReconcileConfig) -> Self {
+        Self { registry, config }
+    }
+
+    /// Reconcile every registered host in stable host-name order.
+    pub fn reconcile_all<S: HostSupervisor>(
+        &self,
+        supervisor: &mut S,
+        now_ns: u64,
+    ) -> Result<ReconcileReport, ReconcileError<S::Error>> {
+        let loaded = self.registry.list()?;
+        let mut outcomes = Vec::with_capacity(loaded.len());
+        for host in loaded {
+            outcomes.push(self.reconcile_one(supervisor, host, now_ns)?);
+        }
+        Ok(ReconcileReport { outcomes })
+    }
+
+    fn reconcile_one<S: HostSupervisor>(
+        &self,
+        supervisor: &mut S,
+        loaded: LoadedHost,
+        now_ns: u64,
+    ) -> Result<HostReconcileOutcome, ReconcileError<S::Error>> {
+        let registration = loaded.entry().registration();
+        let host_name = registration.host_name().clone();
+        let observed =
+            supervisor
+                .inspect(registration)
+                .map_err(|source| ReconcileError::Supervisor {
+                    host_name: host_name.clone(),
+                    operation: SupervisorOperation::Inspect,
+                    source,
+                })?;
+        validate_time(&host_name, &observed, now_ns)?;
+        match loaded.entry().desired_state() {
+            DesiredState::Stopped => self.reconcile_stopped(supervisor, loaded, observed, now_ns),
+            DesiredState::Running => self.reconcile_running(supervisor, loaded, observed, now_ns),
+        }
+    }
+
+    fn reconcile_stopped<S: HostSupervisor>(
+        &self,
+        supervisor: &mut S,
+        loaded: LoadedHost,
+        observed: SupervisorObservation,
+        _now_ns: u64,
+    ) -> Result<HostReconcileOutcome, ReconcileError<S::Error>> {
+        match observed {
+            SupervisorObservation::Absent => self.persist_status(
+                &loaded,
+                inactive_observation(loaded.entry().observation(), HostStatus::Stopped, None)?,
+                ReconcileAction::Observed,
+            ),
+            SupervisorObservation::Instance(instance)
+                if matches!(instance.phase(), SupervisorPhase::Exited { .. }) =>
+            {
+                self.persist_status(
+                    &loaded,
+                    inactive_observation(
+                        loaded.entry().observation(),
+                        HostStatus::Stopped,
+                        Some(&instance),
+                    )?,
+                    ReconcileAction::Observed,
+                )
+            }
+            SupervisorObservation::Instance(instance) => {
+                self.stop_instance(supervisor, loaded, &instance, HostStatus::Stopping)
+            }
+        }
+    }
+
+    fn reconcile_running<S: HostSupervisor>(
+        &self,
+        supervisor: &mut S,
+        loaded: LoadedHost,
+        observed: SupervisorObservation,
+        now_ns: u64,
+    ) -> Result<HostReconcileOutcome, ReconcileError<S::Error>> {
+        if let HostStatus::Quarantined { until_ns, reason } = loaded.entry().observation().status()
+        {
+            if now_ns < *until_ns {
+                let status = HostStatus::Quarantined {
+                    until_ns: *until_ns,
+                    reason: reason.clone(),
+                };
+                return match observed {
+                    SupervisorObservation::Instance(instance)
+                        if !matches!(instance.phase(), SupervisorPhase::Exited { .. }) =>
+                    {
+                        self.stop_instance(supervisor, loaded, &instance, status)
+                    }
+                    _ => self.persist_status(
+                        &loaded,
+                        inactive_observation(loaded.entry().observation(), status, None)?,
+                        ReconcileAction::Deferred,
+                    ),
+                };
+            }
+        }
+        match observed {
+            SupervisorObservation::Absent => {
+                if should_start_absent(loaded.entry(), now_ns) {
+                    self.start_instance(supervisor, loaded, now_ns, false)
+                } else {
+                    let status = deferred_status(loaded.entry().observation(), now_ns);
+                    self.persist_status(
+                        &loaded,
+                        inactive_observation(loaded.entry().observation(), status, None)?,
+                        ReconcileAction::Deferred,
+                    )
+                }
+            }
+            SupervisorObservation::Instance(instance)
+                if instance.package_hash() != loaded.entry().registration().package_hash() =>
+            {
+                if matches!(instance.phase(), SupervisorPhase::Exited { .. }) {
+                    self.start_instance(supervisor, loaded, now_ns, true)
+                } else {
+                    self.stop_instance(supervisor, loaded, &instance, HostStatus::Restarting)
+                }
+            }
+            SupervisorObservation::Instance(instance) => match instance.phase() {
+                SupervisorPhase::Starting => self.persist_instance(
+                    &loaded,
+                    &instance,
+                    HostStatus::Starting,
+                    ReconcileAction::Observed,
+                ),
+                SupervisorPhase::Stopping => self.persist_instance(
+                    &loaded,
+                    &instance,
+                    HostStatus::Stopping,
+                    ReconcileAction::Deferred,
+                ),
+                SupervisorPhase::Running => {
+                    let heartbeat = instance
+                        .last_heartbeat_ns()
+                        .expect("running observation validation requires a heartbeat");
+                    if now_ns - heartbeat > self.config.max_heartbeat_age_ns {
+                        if restart_after_failure(loaded.entry().registration().restart_policy()) {
+                            self.stop_instance(
+                                supervisor,
+                                loaded,
+                                &instance,
+                                HostStatus::Restarting,
+                            )
+                        } else {
+                            self.stop_instance(supervisor, loaded, &instance, HostStatus::Stopping)
+                        }
+                    } else {
+                        self.persist_instance(
+                            &loaded,
+                            &instance,
+                            HostStatus::Running,
+                            ReconcileAction::Observed,
+                        )
+                    }
+                }
+                SupervisorPhase::Exited { exit_code } => {
+                    if restart_after_exit(loaded.entry().registration().restart_policy(), exit_code)
+                    {
+                        self.start_instance(supervisor, loaded, now_ns, true)
+                    } else {
+                        let status = if exit_code == Some(0) {
+                            HostStatus::Stopped
+                        } else {
+                            HostStatus::Crashed { exit_code }
+                        };
+                        self.persist_status(
+                            &loaded,
+                            inactive_observation(
+                                loaded.entry().observation(),
+                                status,
+                                Some(&instance),
+                            )?,
+                            ReconcileAction::Deferred,
+                        )
+                    }
+                }
+            },
+        }
+    }
+
+    fn start_instance<S: HostSupervisor>(
+        &self,
+        supervisor: &mut S,
+        loaded: LoadedHost,
+        now_ns: u64,
+        observed_previous_attempt: bool,
+    ) -> Result<HostReconcileOutcome, ReconcileError<S::Error>> {
+        let previous = loaded.entry().observation();
+        let retrying_claim = !observed_previous_attempt
+            && (matches!(previous.status(), HostStatus::Starting)
+                || matches!(previous.status(), HostStatus::Restarting)
+                    && previous.process_id().is_none());
+        let restarting = if retrying_claim {
+            matches!(previous.status(), HostStatus::Restarting)
+        } else {
+            observed_previous_attempt || has_previous_attempt(previous)
+        };
+        let (restart_count, last_restart_ns) = if retrying_claim {
+            (previous.restart_count(), previous.last_restart_ns())
+        } else if restarting {
+            match previous.restart_count().checked_add(1) {
+                Some(count) => (count, Some(now_ns)),
+                None => {
+                    let quarantined = HostObservation::new(
+                        HostStatus::Quarantined {
+                            until_ns: u64::MAX,
+                            reason: RESTART_COUNTER_EXHAUSTED.to_string(),
+                        },
+                        None,
+                        previous.started_at_ns(),
+                        previous.last_heartbeat_ns(),
+                        None,
+                        previous.restart_count(),
+                        previous.last_restart_ns(),
+                    )?;
+                    return self.persist_status(&loaded, quarantined, ReconcileAction::Deferred);
+                }
+            }
+        } else {
+            (previous.restart_count(), previous.last_restart_ns())
+        };
+        let transition = HostObservation::new(
+            if restarting {
+                HostStatus::Restarting
+            } else {
+                HostStatus::Starting
+            },
+            None,
+            None,
+            None,
+            None,
+            restart_count,
+            last_restart_ns,
+        )?;
+        let claimed = self.replace_observation(&loaded, transition)?;
+        let registration = claimed.entry().registration();
+        let host_name = registration.host_name().clone();
+        if let Err(source) = supervisor.start(registration) {
+            let failed = HostObservation::new(
+                HostStatus::Crashed { exit_code: None },
+                None,
+                None,
+                None,
+                None,
+                restart_count,
+                last_restart_ns,
+            )
+            .expect("reconciler constructs a valid inactive failure");
+            let _ = self.replace_observation::<S::Error>(&claimed, failed);
+            return Err(ReconcileError::Supervisor {
+                host_name,
+                operation: SupervisorOperation::Start,
+                source,
+            });
+        }
+        Ok(HostReconcileOutcome::new(
+            host_name,
+            ReconcileAction::Started,
+            claimed.entry().observation().status().clone(),
+        ))
+    }
+
+    fn stop_instance<S: HostSupervisor>(
+        &self,
+        supervisor: &mut S,
+        loaded: LoadedHost,
+        instance: &SupervisorInstance,
+        transition_status: HostStatus,
+    ) -> Result<HostReconcileOutcome, ReconcileError<S::Error>> {
+        let preserve_transition_on_failure =
+            matches!(transition_status, HostStatus::Quarantined { .. });
+        let transition = if preserve_transition_on_failure {
+            inactive_observation(loaded.entry().observation(), transition_status, None)?
+        } else {
+            instance_observation(loaded.entry().observation(), instance, transition_status)?
+        };
+        let claimed = self.replace_observation(&loaded, transition)?;
+        let host_name = claimed.entry().registration().host_name().clone();
+        if let Err(source) = supervisor.stop(&host_name) {
+            if !preserve_transition_on_failure {
+                let restored = phase_observation(loaded.entry().observation(), instance)
+                    .expect("validated supervisor evidence maps to a registry observation");
+                let _ = self.replace_observation::<S::Error>(&claimed, restored);
+            }
+            return Err(ReconcileError::Supervisor {
+                host_name,
+                operation: SupervisorOperation::Stop,
+                source,
+            });
+        }
+        Ok(HostReconcileOutcome::new(
+            host_name,
+            ReconcileAction::Stopped,
+            claimed.entry().observation().status().clone(),
+        ))
+    }
+
+    fn persist_instance<E>(
+        &self,
+        loaded: &LoadedHost,
+        instance: &SupervisorInstance,
+        status: HostStatus,
+        action: ReconcileAction,
+    ) -> Result<HostReconcileOutcome, ReconcileError<E>> {
+        self.persist_status(
+            loaded,
+            instance_observation(loaded.entry().observation(), instance, status)?,
+            action,
+        )
+    }
+
+    fn persist_status<E>(
+        &self,
+        loaded: &LoadedHost,
+        observation: HostObservation,
+        action: ReconcileAction,
+    ) -> Result<HostReconcileOutcome, ReconcileError<E>> {
+        let host_name = loaded.entry().registration().host_name().clone();
+        let status = observation.status().clone();
+        if loaded.entry().observation() != &observation {
+            self.replace_observation(loaded, observation)?;
+        }
+        Ok(HostReconcileOutcome::new(host_name, action, status))
+    }
+
+    fn replace_observation<E>(
+        &self,
+        loaded: &LoadedHost,
+        observation: HostObservation,
+    ) -> Result<LoadedHost, ReconcileError<E>> {
+        let replacement = loaded.entry().clone().with_observation(observation);
+        self.registry
+            .update(loaded, &replacement)
+            .map_err(ReconcileError::Registry)
+    }
+}
+
+fn validate_time<E>(
+    host_name: &HostName,
+    observed: &SupervisorObservation,
+    now_ns: u64,
+) -> Result<(), ReconcileError<E>> {
+    let SupervisorObservation::Instance(instance) = observed else {
+        return Ok(());
+    };
+    if instance.started_at_ns().is_some_and(|time| time > now_ns)
+        || instance
+            .last_heartbeat_ns()
+            .is_some_and(|time| time > now_ns)
+    {
+        return Err(ReconcileError::FutureObservation {
+            host_name: host_name.clone(),
+        });
+    }
+    Ok(())
+}
+
+fn should_start_absent(entry: &HostEntry, now_ns: u64) -> bool {
+    let observation = entry.observation();
+    match observation.status() {
+        HostStatus::Starting | HostStatus::Restarting => true,
+        HostStatus::Running | HostStatus::Crashed { .. } => {
+            restart_after_failure(entry.registration().restart_policy())
+        }
+        HostStatus::Stopping => entry.registration().restart_policy() != RestartPolicy::Never,
+        HostStatus::Stopped => {
+            observation.started_at_ns().is_none()
+                || entry.registration().restart_policy() == RestartPolicy::Always
+        }
+        HostStatus::Quarantined { until_ns, .. } => {
+            now_ns >= *until_ns && entry.registration().restart_policy() != RestartPolicy::Never
+        }
+    }
+}
+
+fn deferred_status(observation: &HostObservation, now_ns: u64) -> HostStatus {
+    match observation.status() {
+        HostStatus::Quarantined { until_ns, reason } if now_ns < *until_ns => {
+            HostStatus::Quarantined {
+                until_ns: *until_ns,
+                reason: reason.clone(),
+            }
+        }
+        HostStatus::Crashed { exit_code } => HostStatus::Crashed {
+            exit_code: *exit_code,
+        },
+        HostStatus::Running => HostStatus::Crashed { exit_code: None },
+        _ => HostStatus::Stopped,
+    }
+}
+
+fn restart_after_exit(policy: RestartPolicy, exit_code: Option<i32>) -> bool {
+    match policy {
+        RestartPolicy::Always => true,
+        RestartPolicy::OnFailure => exit_code != Some(0),
+        RestartPolicy::Never => false,
+    }
+}
+
+fn restart_after_failure(policy: RestartPolicy) -> bool {
+    matches!(policy, RestartPolicy::Always | RestartPolicy::OnFailure)
+}
+
+fn has_previous_attempt(observation: &HostObservation) -> bool {
+    observation.started_at_ns().is_some()
+        || matches!(
+            observation.status(),
+            HostStatus::Running
+                | HostStatus::Restarting
+                | HostStatus::Stopping
+                | HostStatus::Crashed { .. }
+                | HostStatus::Quarantined { .. }
+        )
+}
+
+fn phase_observation(
+    previous: &HostObservation,
+    instance: &SupervisorInstance,
+) -> Result<HostObservation, RegistryError> {
+    let status = match instance.phase() {
+        SupervisorPhase::Starting => HostStatus::Starting,
+        SupervisorPhase::Running => HostStatus::Running,
+        SupervisorPhase::Stopping => HostStatus::Stopping,
+        SupervisorPhase::Exited { exit_code } => {
+            if exit_code == Some(0) {
+                HostStatus::Stopped
+            } else {
+                HostStatus::Crashed { exit_code }
+            }
+        }
+    };
+    if matches!(instance.phase(), SupervisorPhase::Exited { .. }) {
+        inactive_observation(previous, status, Some(instance))
+    } else {
+        instance_observation(previous, instance, status)
+    }
+}
+
+fn instance_observation(
+    previous: &HostObservation,
+    instance: &SupervisorInstance,
+    status: HostStatus,
+) -> Result<HostObservation, RegistryError> {
+    HostObservation::new(
+        status,
+        instance.process_id(),
+        instance.started_at_ns(),
+        instance.last_heartbeat_ns(),
+        instance.control_channel_id(),
+        previous.restart_count(),
+        previous.last_restart_ns(),
+    )
+}
+
+fn inactive_observation(
+    previous: &HostObservation,
+    status: HostStatus,
+    instance: Option<&SupervisorInstance>,
+) -> Result<HostObservation, RegistryError> {
+    HostObservation::new(
+        status,
+        None,
+        instance
+            .and_then(SupervisorInstance::started_at_ns)
+            .or(previous.started_at_ns()),
+        instance
+            .and_then(SupervisorInstance::last_heartbeat_ns)
+            .or(previous.last_heartbeat_ns()),
+        None,
+        previous.restart_count(),
+        previous.last_restart_ns(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chief_of_staff_service_registry::{PackagePath, ServiceRegistry};
+    use std::collections::BTreeMap;
+    use storage_core::InMemoryStorageBackend;
+
+    const NOW: u64 = 1_000;
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct FakeError(&'static str);
+
+    impl Display for FakeError {
+        fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+            formatter.write_str(self.0)
+        }
+    }
+
+    impl std::error::Error for FakeError {}
+
+    #[derive(Default)]
+    struct FakeSupervisor {
+        observations: BTreeMap<String, SupervisorObservation>,
+        starts: Vec<String>,
+        stops: Vec<String>,
+        fail_inspect: bool,
+        fail_start: bool,
+        fail_stop: bool,
+    }
+
+    impl FakeSupervisor {
+        fn with(host: &str, observation: SupervisorObservation) -> Self {
+            let mut observations = BTreeMap::new();
+            observations.insert(host.to_string(), observation);
+            Self {
+                observations,
+                ..Self::default()
+            }
+        }
+    }
+
+    impl HostSupervisor for FakeSupervisor {
+        type Error = FakeError;
+
+        fn inspect(
+            &mut self,
+            registration: &HostRegistration,
+        ) -> Result<SupervisorObservation, Self::Error> {
+            if self.fail_inspect {
+                return Err(FakeError("inspect failed"));
+            }
+            Ok(self
+                .observations
+                .get(registration.host_name().as_str())
+                .cloned()
+                .unwrap_or(SupervisorObservation::Absent))
+        }
+
+        fn start(&mut self, registration: &HostRegistration) -> Result<(), Self::Error> {
+            if self.fail_start {
+                return Err(FakeError("start failed"));
+            }
+            self.starts
+                .push(registration.host_name().as_str().to_string());
+            Ok(())
+        }
+
+        fn stop(&mut self, host_name: &HostName) -> Result<(), Self::Error> {
+            if self.fail_stop {
+                return Err(FakeError("stop failed"));
+            }
+            self.stops.push(host_name.as_str().to_string());
+            Ok(())
+        }
+    }
+
+    fn channel(byte: u8) -> ChannelId {
+        let mut value = [byte; 16];
+        value[6] = 0x70;
+        value[8] = 0x80;
+        ChannelId(value)
+    }
+
+    fn name(value: &str) -> HostName {
+        HostName::new(value).unwrap()
+    }
+
+    fn registration(host: &str, policy: RestartPolicy, hash: u8) -> HostRegistration {
+        HostRegistration::new(
+            name(host),
+            PackagePath::new(format!("agents/{host}.agent")).unwrap(),
+            [hash; 32],
+            policy,
+        )
+    }
+
+    fn register(
+        backend: &InMemoryStorageBackend,
+        host: &str,
+        policy: RestartPolicy,
+        desired: DesiredState,
+        observation: HostObservation,
+    ) {
+        ServiceRegistry::new(backend)
+            .register(&HostEntry::new(
+                registration(host, policy, 7),
+                desired,
+                observation,
+            ))
+            .unwrap();
+    }
+
+    fn reconciler(backend: &InMemoryStorageBackend) -> ServiceReconciler<'_> {
+        ServiceReconciler::new(
+            ServiceRegistry::new(backend),
+            ReconcileConfig::new(100).unwrap(),
+        )
+    }
+
+    fn load(backend: &InMemoryStorageBackend, host: &str) -> HostEntry {
+        ServiceRegistry::new(backend)
+            .load(&name(host))
+            .unwrap()
+            .unwrap()
+            .entry()
+            .clone()
+    }
+
+    fn running_observation(restarts: u32) -> HostObservation {
+        HostObservation::new(
+            HostStatus::Running,
+            Some(42),
+            Some(800),
+            Some(950),
+            Some(channel(1)),
+            restarts,
+            (restarts > 0).then_some(700),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn configuration_and_observation_constructors_validate_and_expose_fields() {
+        assert_eq!(ReconcileConfig::new(0), Err(ConfigError::ZeroHeartbeatAge));
+        assert_eq!(
+            ConfigError::ZeroHeartbeatAge.to_string(),
+            "maximum heartbeat age must be non-zero"
+        );
+        let config = ReconcileConfig::new(12).unwrap();
+        assert_eq!(config.max_heartbeat_age_ns(), 12);
+
+        let absent = SupervisorObservation::absent();
+        assert_eq!(absent, SupervisorObservation::Absent);
+        let starting = SupervisorObservation::starting([7; 32], 41, 10, None, None).unwrap();
+        let SupervisorObservation::Instance(instance) = starting else {
+            panic!("expected instance");
+        };
+        assert_eq!(instance.package_hash(), &[7; 32]);
+        assert_eq!(instance.phase(), SupervisorPhase::Starting);
+        assert_eq!(instance.process_id(), Some(41));
+        assert_eq!(instance.started_at_ns(), Some(10));
+        assert_eq!(instance.last_heartbeat_ns(), None);
+        assert_eq!(instance.control_channel_id(), None);
+
+        assert!(SupervisorObservation::starting([7; 32], 0, 10, None, None).is_err());
+        let invalid =
+            SupervisorObservation::running([7; 32], 1, 10, 11, ChannelId([0; 16])).unwrap_err();
+        assert!(invalid.to_string().starts_with("invalid observation:"));
+        assert!(SupervisorObservation::exited([7; 32], Some(0), None, Some(1)).is_err());
+    }
+
+    #[test]
+    fn first_launch_runs_once_for_every_policy_in_stable_order() {
+        let backend = InMemoryStorageBackend::new();
+        for (host, policy) in [
+            ("zeta-host", RestartPolicy::Never),
+            ("alpha-host", RestartPolicy::Always),
+            ("middle-host", RestartPolicy::OnFailure),
+        ] {
+            register(
+                &backend,
+                host,
+                policy,
+                DesiredState::Running,
+                HostObservation::stopped(),
+            );
+        }
+        let mut supervisor = FakeSupervisor::default();
+        let report = reconciler(&backend)
+            .reconcile_all(&mut supervisor, NOW)
+            .unwrap();
+        assert_eq!(
+            supervisor.starts,
+            vec!["alpha-host", "middle-host", "zeta-host"]
+        );
+        assert_eq!(report.outcomes().len(), 3);
+        assert_eq!(report.outcomes()[0].host_name().as_str(), "alpha-host");
+        assert_eq!(report.outcomes()[0].action(), ReconcileAction::Started);
+        assert_eq!(report.outcomes()[0].status(), &HostStatus::Starting);
+    }
+
+    #[test]
+    fn clean_exit_restarts_only_always_and_failed_exit_obeys_policy() {
+        for (policy, exit_code, should_restart) in [
+            (RestartPolicy::Always, Some(0), true),
+            (RestartPolicy::OnFailure, Some(0), false),
+            (RestartPolicy::Never, Some(0), false),
+            (RestartPolicy::Always, Some(9), true),
+            (RestartPolicy::OnFailure, Some(9), true),
+            (RestartPolicy::Never, Some(9), false),
+            (RestartPolicy::OnFailure, None, true),
+        ] {
+            let backend = InMemoryStorageBackend::new();
+            register(
+                &backend,
+                "mail-host",
+                policy,
+                DesiredState::Running,
+                HostObservation::stopped(),
+            );
+            let exited =
+                SupervisorObservation::exited([7; 32], exit_code, Some(800), Some(900)).unwrap();
+            let mut supervisor = FakeSupervisor::with("mail-host", exited);
+            let outcome = reconciler(&backend)
+                .reconcile_all(&mut supervisor, NOW)
+                .unwrap()
+                .outcomes()[0]
+                .clone();
+            assert_eq!(outcome.action() == ReconcileAction::Started, should_restart);
+            assert_eq!(!supervisor.starts.is_empty(), should_restart);
+            let persisted = load(&backend, "mail-host");
+            if should_restart {
+                assert_eq!(persisted.observation().status(), &HostStatus::Restarting);
+                assert_eq!(persisted.observation().restart_count(), 1);
+                assert_eq!(persisted.observation().last_restart_ns(), Some(NOW));
+            } else if exit_code == Some(0) {
+                assert_eq!(persisted.observation().status(), &HostStatus::Stopped);
+            } else {
+                assert_eq!(
+                    persisted.observation().status(),
+                    &HostStatus::Crashed { exit_code }
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn current_running_evidence_replaces_stale_cache_and_honors_age_boundary() {
+        for heartbeat in [900, 901] {
+            let backend = InMemoryStorageBackend::new();
+            register(
+                &backend,
+                "mail-host",
+                RestartPolicy::OnFailure,
+                DesiredState::Running,
+                HostObservation::new(
+                    HostStatus::Running,
+                    Some(999),
+                    Some(1),
+                    Some(2),
+                    Some(channel(2)),
+                    2,
+                    Some(1),
+                )
+                .unwrap(),
+            );
+            let observed =
+                SupervisorObservation::running([7; 32], 42, 800, heartbeat, channel(3)).unwrap();
+            let mut supervisor = FakeSupervisor::with("mail-host", observed);
+            let report = reconciler(&backend)
+                .reconcile_all(&mut supervisor, NOW)
+                .unwrap();
+            assert_eq!(report.outcomes()[0].action(), ReconcileAction::Observed);
+            let persisted = load(&backend, "mail-host");
+            assert_eq!(persisted.observation().process_id(), Some(42));
+            assert_eq!(persisted.observation().last_heartbeat_ns(), Some(heartbeat));
+            assert_eq!(persisted.observation().restart_count(), 2);
+            assert!(supervisor.stops.is_empty());
+        }
+    }
+
+    #[test]
+    fn stale_heartbeat_is_drained_and_policy_controls_relaunch_marker() {
+        for (policy, status) in [
+            (RestartPolicy::Always, HostStatus::Restarting),
+            (RestartPolicy::OnFailure, HostStatus::Restarting),
+            (RestartPolicy::Never, HostStatus::Stopping),
+        ] {
+            let backend = InMemoryStorageBackend::new();
+            register(
+                &backend,
+                "mail-host",
+                policy,
+                DesiredState::Running,
+                HostObservation::stopped(),
+            );
+            let observed =
+                SupervisorObservation::running([7; 32], 42, 700, 899, channel(1)).unwrap();
+            let mut supervisor = FakeSupervisor::with("mail-host", observed);
+            let report = reconciler(&backend)
+                .reconcile_all(&mut supervisor, NOW)
+                .unwrap();
+            assert_eq!(report.outcomes()[0].action(), ReconcileAction::Stopped);
+            assert_eq!(supervisor.stops, vec!["mail-host"]);
+            assert_eq!(load(&backend, "mail-host").observation().status(), &status);
+        }
+    }
+
+    #[test]
+    fn future_observation_and_inspect_failure_are_explicit() {
+        let backend = InMemoryStorageBackend::new();
+        register(
+            &backend,
+            "mail-host",
+            RestartPolicy::Always,
+            DesiredState::Running,
+            HostObservation::stopped(),
+        );
+        let observed =
+            SupervisorObservation::running([7; 32], 42, NOW, NOW + 1, channel(1)).unwrap();
+        let mut supervisor = FakeSupervisor::with("mail-host", observed);
+        let error = reconciler(&backend)
+            .reconcile_all(&mut supervisor, NOW)
+            .unwrap_err();
+        assert!(matches!(error, ReconcileError::FutureObservation { .. }));
+        assert!(error.to_string().contains("mail-host"));
+
+        let mut supervisor = FakeSupervisor {
+            fail_inspect: true,
+            ..FakeSupervisor::default()
+        };
+        let error = reconciler(&backend)
+            .reconcile_all(&mut supervisor, NOW)
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            ReconcileError::Supervisor {
+                operation: SupervisorOperation::Inspect,
+                ..
+            }
+        ));
+        assert!(error.to_string().contains("inspect failed"));
+    }
+
+    #[test]
+    fn mismatched_package_is_stopped_before_registered_package_starts() {
+        let backend = InMemoryStorageBackend::new();
+        register(
+            &backend,
+            "mail-host",
+            RestartPolicy::Never,
+            DesiredState::Running,
+            HostObservation::stopped(),
+        );
+        let observed = SupervisorObservation::running([8; 32], 42, 800, 950, channel(1)).unwrap();
+        let mut supervisor = FakeSupervisor::with("mail-host", observed);
+        let first = reconciler(&backend)
+            .reconcile_all(&mut supervisor, NOW)
+            .unwrap();
+        assert_eq!(first.outcomes()[0].action(), ReconcileAction::Stopped);
+        assert_eq!(supervisor.stops, vec!["mail-host"]);
+        assert!(supervisor.starts.is_empty());
+        assert_eq!(
+            load(&backend, "mail-host").observation().status(),
+            &HostStatus::Restarting
+        );
+
+        supervisor.observations.clear();
+        let second = reconciler(&backend)
+            .reconcile_all(&mut supervisor, NOW + 1)
+            .unwrap();
+        assert_eq!(second.outcomes()[0].action(), ReconcileAction::Started);
+        assert_eq!(supervisor.starts, vec!["mail-host"]);
+        assert_eq!(load(&backend, "mail-host").observation().restart_count(), 1);
+    }
+
+    #[test]
+    fn stopped_intent_drains_active_and_normalizes_inactive_state() {
+        let backend = InMemoryStorageBackend::new();
+        register(
+            &backend,
+            "mail-host",
+            RestartPolicy::Always,
+            DesiredState::Stopped,
+            running_observation(1),
+        );
+        let observed = SupervisorObservation::starting([8; 32], 42, 800, None, None).unwrap();
+        let mut supervisor = FakeSupervisor::with("mail-host", observed);
+        let report = reconciler(&backend)
+            .reconcile_all(&mut supervisor, NOW)
+            .unwrap();
+        assert_eq!(report.outcomes()[0].action(), ReconcileAction::Stopped);
+        assert_eq!(supervisor.stops, vec!["mail-host"]);
+        assert_eq!(
+            load(&backend, "mail-host").observation().status(),
+            &HostStatus::Stopping
+        );
+
+        supervisor.observations.clear();
+        let report = reconciler(&backend)
+            .reconcile_all(&mut supervisor, NOW + 1)
+            .unwrap();
+        assert_eq!(report.outcomes()[0].action(), ReconcileAction::Observed);
+        let persisted = load(&backend, "mail-host");
+        assert_eq!(persisted.observation().status(), &HostStatus::Stopped);
+        assert_eq!(persisted.observation().process_id(), None);
+        assert_eq!(persisted.observation().restart_count(), 1);
+    }
+
+    #[test]
+    fn exited_or_absent_stopped_intent_preserves_lifecycle_history() {
+        for (observation, expected_start) in [
+            (SupervisorObservation::Absent, 800),
+            (
+                SupervisorObservation::exited([7; 32], Some(9), Some(810), Some(820)).unwrap(),
+                810,
+            ),
+        ] {
+            let backend = InMemoryStorageBackend::new();
+            register(
+                &backend,
+                "mail-host",
+                RestartPolicy::OnFailure,
+                DesiredState::Stopped,
+                running_observation(2),
+            );
+            let mut supervisor = FakeSupervisor::with("mail-host", observation);
+            reconciler(&backend)
+                .reconcile_all(&mut supervisor, NOW)
+                .unwrap();
+            let persisted = load(&backend, "mail-host");
+            assert_eq!(persisted.observation().status(), &HostStatus::Stopped);
+            assert_eq!(persisted.observation().restart_count(), 2);
+            assert_eq!(
+                persisted.observation().started_at_ns(),
+                Some(expected_start)
+            );
+        }
+    }
+
+    #[test]
+    fn quarantine_defers_then_expires_and_overflow_fails_closed() {
+        let backend = InMemoryStorageBackend::new();
+        let quarantined = HostObservation::new(
+            HostStatus::Quarantined {
+                until_ns: NOW + 1,
+                reason: "cooldown".to_string(),
+            },
+            None,
+            Some(700),
+            Some(800),
+            None,
+            2,
+            Some(600),
+        )
+        .unwrap();
+        register(
+            &backend,
+            "mail-host",
+            RestartPolicy::OnFailure,
+            DesiredState::Running,
+            quarantined,
+        );
+        let mut supervisor = FakeSupervisor::default();
+        let deferred = reconciler(&backend)
+            .reconcile_all(&mut supervisor, NOW)
+            .unwrap();
+        assert_eq!(deferred.outcomes()[0].action(), ReconcileAction::Deferred);
+        assert!(supervisor.starts.is_empty());
+        supervisor.observations.insert(
+            "mail-host".to_string(),
+            SupervisorObservation::running([7; 32], 42, 700, 950, channel(1)).unwrap(),
+        );
+        supervisor.fail_stop = true;
+        let error = reconciler(&backend)
+            .reconcile_all(&mut supervisor, NOW)
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            ReconcileError::Supervisor {
+                operation: SupervisorOperation::Stop,
+                ..
+            }
+        ));
+        assert!(matches!(
+            load(&backend, "mail-host").observation().status(),
+            HostStatus::Quarantined { .. }
+        ));
+        supervisor.fail_stop = false;
+        let drained = reconciler(&backend)
+            .reconcile_all(&mut supervisor, NOW)
+            .unwrap();
+        assert_eq!(drained.outcomes()[0].action(), ReconcileAction::Stopped);
+        assert_eq!(supervisor.stops, vec!["mail-host"]);
+        assert!(matches!(
+            load(&backend, "mail-host").observation().status(),
+            HostStatus::Quarantined { .. }
+        ));
+        supervisor.observations.clear();
+        let started = reconciler(&backend)
+            .reconcile_all(&mut supervisor, NOW + 1)
+            .unwrap();
+        assert_eq!(started.outcomes()[0].action(), ReconcileAction::Started);
+        assert_eq!(load(&backend, "mail-host").observation().restart_count(), 3);
+
+        let backend = InMemoryStorageBackend::new();
+        let exhausted = HostObservation::new(
+            HostStatus::Crashed { exit_code: None },
+            None,
+            Some(700),
+            Some(800),
+            None,
+            u32::MAX,
+            Some(600),
+        )
+        .unwrap();
+        register(
+            &backend,
+            "mail-host",
+            RestartPolicy::Always,
+            DesiredState::Running,
+            exhausted,
+        );
+        let mut supervisor = FakeSupervisor::default();
+        let report = reconciler(&backend)
+            .reconcile_all(&mut supervisor, NOW)
+            .unwrap();
+        assert_eq!(report.outcomes()[0].action(), ReconcileAction::Deferred);
+        assert!(supervisor.starts.is_empty());
+        assert_eq!(
+            load(&backend, "mail-host").observation().status(),
+            &HostStatus::Quarantined {
+                until_ns: u64::MAX,
+                reason: RESTART_COUNTER_EXHAUSTED.to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn absent_cached_states_apply_recovery_policy() {
+        let cases = [
+            (HostStatus::Starting, RestartPolicy::Never, true, 1),
+            (HostStatus::Restarting, RestartPolicy::Never, true, 1),
+            (HostStatus::Running, RestartPolicy::OnFailure, true, 2),
+            (HostStatus::Running, RestartPolicy::Never, false, 1),
+            (HostStatus::Stopping, RestartPolicy::OnFailure, true, 2),
+            (HostStatus::Stopping, RestartPolicy::Never, false, 1),
+            (HostStatus::Stopped, RestartPolicy::Always, true, 2),
+            (HostStatus::Stopped, RestartPolicy::OnFailure, false, 1),
+        ];
+        for (status, policy, starts, expected_restarts) in cases {
+            let backend = InMemoryStorageBackend::new();
+            let observation = if status == HostStatus::Running {
+                running_observation(1)
+            } else {
+                HostObservation::new(status, None, Some(700), Some(800), None, 1, Some(600))
+                    .unwrap()
+            };
+            register(
+                &backend,
+                "mail-host",
+                policy,
+                DesiredState::Running,
+                observation,
+            );
+            let mut supervisor = FakeSupervisor::default();
+            let report = reconciler(&backend)
+                .reconcile_all(&mut supervisor, NOW)
+                .unwrap();
+            assert_eq!(
+                report.outcomes()[0].action() == ReconcileAction::Started,
+                starts
+            );
+            assert_eq!(
+                load(&backend, "mail-host").observation().restart_count(),
+                expected_restarts
+            );
+        }
+    }
+
+    #[test]
+    fn starting_stopping_and_exited_supervisor_phases_are_persisted() {
+        let observations = [
+            (
+                SupervisorObservation::starting([7; 32], 42, 800, None, None).unwrap(),
+                HostStatus::Starting,
+                ReconcileAction::Observed,
+            ),
+            (
+                SupervisorObservation::stopping([7; 32], 42, 800, Some(900), Some(channel(1)))
+                    .unwrap(),
+                HostStatus::Stopping,
+                ReconcileAction::Deferred,
+            ),
+        ];
+        for (observed, status, action) in observations {
+            let backend = InMemoryStorageBackend::new();
+            register(
+                &backend,
+                "mail-host",
+                RestartPolicy::OnFailure,
+                DesiredState::Running,
+                HostObservation::stopped(),
+            );
+            let mut supervisor = FakeSupervisor::with("mail-host", observed);
+            let report = reconciler(&backend)
+                .reconcile_all(&mut supervisor, NOW)
+                .unwrap();
+            assert_eq!(report.outcomes()[0].action(), action);
+            assert_eq!(load(&backend, "mail-host").observation().status(), &status);
+        }
+    }
+
+    #[test]
+    fn start_and_stop_failures_leave_recoverable_observations() {
+        let backend = InMemoryStorageBackend::new();
+        register(
+            &backend,
+            "mail-host",
+            RestartPolicy::OnFailure,
+            DesiredState::Running,
+            HostObservation::stopped(),
+        );
+        let mut supervisor = FakeSupervisor {
+            fail_start: true,
+            ..FakeSupervisor::default()
+        };
+        let error = reconciler(&backend)
+            .reconcile_all(&mut supervisor, NOW)
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            ReconcileError::Supervisor {
+                operation: SupervisorOperation::Start,
+                ..
+            }
+        ));
+        assert_eq!(
+            load(&backend, "mail-host").observation().status(),
+            &HostStatus::Crashed { exit_code: None }
+        );
+
+        let backend = InMemoryStorageBackend::new();
+        register(
+            &backend,
+            "mail-host",
+            RestartPolicy::Always,
+            DesiredState::Stopped,
+            HostObservation::stopped(),
+        );
+        let observed = SupervisorObservation::running([7; 32], 42, 800, 950, channel(1)).unwrap();
+        let mut supervisor = FakeSupervisor {
+            fail_stop: true,
+            ..FakeSupervisor::with("mail-host", observed)
+        };
+        let error = reconciler(&backend)
+            .reconcile_all(&mut supervisor, NOW)
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            ReconcileError::Supervisor {
+                operation: SupervisorOperation::Stop,
+                ..
+            }
+        ));
+        assert_eq!(
+            load(&backend, "mail-host").observation().status(),
+            &HostStatus::Running
+        );
+    }
+
+    struct ConflictingSupervisor<'a> {
+        backend: &'a InMemoryStorageBackend,
+        starts: usize,
+    }
+
+    impl HostSupervisor for ConflictingSupervisor<'_> {
+        type Error = FakeError;
+
+        fn inspect(
+            &mut self,
+            registration: &HostRegistration,
+        ) -> Result<SupervisorObservation, Self::Error> {
+            let registry = ServiceRegistry::new(self.backend);
+            let loaded = registry.load(registration.host_name()).unwrap().unwrap();
+            let changed = loaded
+                .entry()
+                .clone()
+                .with_desired_state(DesiredState::Stopped);
+            registry.update(&loaded, &changed).unwrap();
+            Ok(SupervisorObservation::Absent)
+        }
+
+        fn start(&mut self, _registration: &HostRegistration) -> Result<(), Self::Error> {
+            self.starts += 1;
+            Ok(())
+        }
+
+        fn stop(&mut self, _host_name: &HostName) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn claim_cas_conflict_prevents_external_mutation() {
+        let backend = InMemoryStorageBackend::new();
+        register(
+            &backend,
+            "mail-host",
+            RestartPolicy::Always,
+            DesiredState::Running,
+            HostObservation::stopped(),
+        );
+        let mut supervisor = ConflictingSupervisor {
+            backend: &backend,
+            starts: 0,
+        };
+        let error = reconciler(&backend)
+            .reconcile_all(&mut supervisor, NOW)
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            ReconcileError::Registry(RegistryError::ConcurrentUpdate(_))
+        ));
+        assert_eq!(supervisor.starts, 0);
+    }
+
+    #[test]
+    fn public_error_and_operation_diagnostics_are_bounded() {
+        assert_eq!(SupervisorOperation::Inspect.to_string(), "inspect");
+        assert_eq!(SupervisorOperation::Start.to_string(), "start");
+        assert_eq!(SupervisorOperation::Stop.to_string(), "stop");
+        let error: ReconcileError<FakeError> =
+            ReconcileError::Registry(RegistryError::TooManyHosts);
+        assert!(error.to_string().contains("4096-host"));
+        let error = ReconcileError::Supervisor {
+            host_name: name("mail-host"),
+            operation: SupervisorOperation::Start,
+            source: FakeError("offline"),
+        };
+        assert_eq!(
+            error.to_string(),
+            "supervisor start failed for mail-host: offline"
+        );
+    }
+}

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -1564,6 +1564,14 @@ Channels are persistent, append-only logs stored on disk. This means crash recov
 is straightforward: find the last successfully processed message and resume from the
 next one.
 
+Host discovery follows the same durable-but-reverified rule. The service registry
+stores desired state and the orchestrator's last bounded observation, but cached PIDs
+and channel IDs are never process authority. On every startup and health tick, the
+orchestrator reconciles registry entries against fresh supervisor evidence, verifies
+the live package hash, applies restart policy, and CAS-updates the observation. The
+detailed state machine is specified in
+[`service-registry-reconciliation.md`](service-registry-reconciliation.md).
+
 **Analogy:** Imagine a stack of numbered memos on a desk. Each staffer has a
 bookmark showing which memo they last read. If the staffer goes home sick and comes
 back the next day, they just pick up from their bookmark. The memos are still there,

--- a/code/specs/service-registry-reconciliation.md
+++ b/code/specs/service-registry-reconciliation.md
@@ -1,0 +1,164 @@
+# D18 Service Registry Reconciliation
+
+## Status
+
+This document specifies the dependency-light reconciliation kernel between the
+D18 durable service registry and an authoritative host-process supervisor.
+
+The implementation package is `chief-of-staff-service-reconciler`.
+
+## Purpose
+
+The service registry persists operator intent and the orchestrator's last
+bounded observation. It is not process authority: cached PIDs, channel IDs, and
+health timestamps must never be trusted after an orchestrator restart.
+
+The reconciler repeatedly compares each registry entry with a fresh supervisor
+observation and converges the host toward `DesiredState`. It does not spawn
+processes itself. A caller supplies a supervisor implementation that can
+inspect, start, and stop a host.
+
+## Boundaries
+
+The reconciler:
+
+- reads and CAS-updates `chief-of-staff-service-registry` entries;
+- treats the supervisor observation as the only live-process evidence;
+- verifies that a live process belongs to the registered package hash;
+- applies durable `Always`, `OnFailure`, and `Never` restart policy;
+- rejects observations from the future and stale running heartbeats;
+- performs at most one supervisor mutation per host per tick; and
+- reports stable, host-name-ordered outcomes.
+
+The reconciler does not:
+
+- open files, sockets, or processes;
+- read agent manifests or capabilities;
+- verify package signatures;
+- mint secure-channel identifiers;
+- poll clocks or sleep; or
+- own daemon scheduling, backoff, rate limiting, or circuit breakers.
+
+Time, storage, and process authority remain injected. The runnable
+orchestrator composes this kernel with package verification, the secure host
+channel, and a concrete OS-process supervisor.
+
+## Authoritative Supervisor Contract
+
+One supervisor observation is either `Absent` or an `Instance` containing:
+
+- the exact package hash used to launch it;
+- lifecycle status: `Starting`, `Running`, `Stopping`, or `Exited`;
+- process ID and start time while active;
+- last heartbeat and UUID-v7 control-channel ID while running; and
+- an optional exit code after exit (`0` means clean; non-zero or missing means
+  failure).
+
+Constructors enforce bounded structural validity. An active instance requires a
+non-zero PID and start time. A running instance additionally requires a
+heartbeat and control channel. An exited instance retains no PID or channel.
+Heartbeats cannot precede process start. Reconciliation also rejects start or
+heartbeat timestamps later than the caller-provided monotonic `now_ns`.
+
+`HostSupervisor::inspect` must derive this evidence from an owned process
+handle, authenticated control channel, or equivalent authoritative source. PID
+existence alone is insufficient because PIDs can be reused.
+
+## Reconciliation Tick
+
+The caller loads registry entries in stable host-name order and invokes one
+bounded tick with `now_ns` and a non-zero maximum heartbeat age.
+
+Each host tick follows this sequence:
+
+1. Inspect the supervisor. Ignore all cached liveness fields for authority.
+2. Validate the observation and compare its package hash to the registration.
+3. Derive one of `Observe`, `Start`, `Stop`, or `Defer`.
+4. For `Start` or `Stop`, CAS a transitional registry observation before the
+   external mutation.
+5. Perform exactly one idempotent supervisor mutation.
+6. Leave final liveness discovery to the next tick. If the mutation fails,
+   best-effort CAS an inactive failure observation so a later tick can recover.
+
+A concurrent registry edit can make either CAS fail. No supervisor mutation is
+performed if the transition claim loses its CAS. If desired state changes after
+a successful claim, a later tick observes the new revision and converges it.
+This is bounded eventual convergence across storage and process systems, not an
+impossible cross-system atomic transaction.
+
+## Decision Matrix
+
+### Desired `Stopped`
+
+- `Absent` or `Exited`: record `Stopped` and preserve lifecycle counters.
+- Active matching or mismatched instance: claim `Stopping`, then stop it.
+
+### Desired `Running`
+
+- Matching, fresh `Running`: record the authoritative live observation.
+- Matching `Starting`: record `Starting`.
+- Matching `Stopping`: defer until it becomes absent or exited.
+- Mismatched active instance: claim `Restarting`, then stop it. A later tick
+  starts only the registered package.
+- Stale matching `Running`: restart only if policy permits; otherwise stop and
+  record the failure.
+- `Exited(0)`: `Always` restarts; `OnFailure` and `Never` record `Stopped`.
+- `Exited(non-zero)` or `Exited(None)`: `Always` and `OnFailure` restart;
+  `Never` records `Crashed`.
+- `Absent` with no prior start evidence: start once for every policy, including
+  `Never`.
+- `Absent` after a clean completion: restart only for `Always`.
+- `Absent` after failure: restart for `Always` and `OnFailure`.
+- Cached `Starting` or `Restarting` with no authoritative instance: retry the
+  interrupted launch.
+- Unexpired `Quarantined`: defer. At expiry, restart only if policy permits.
+
+`restart_count` increments only when relaunching a previously started or failed
+host, not on its first launch. Overflow fails closed into a permanent
+quarantine. The caller-provided time becomes `last_restart_ns`.
+
+## Heartbeat and Identity Safety
+
+Age uses `now_ns - last_heartbeat_ns`; it never uses wall-clock time. A heartbeat
+is stale only when its age is strictly greater than the configured maximum, so
+the boundary itself remains healthy.
+
+A package hash mismatch is never adopted into the registry. The reconciler
+first stops that instance and records `Restarting`; it does not start a second
+same-name instance in the same tick.
+
+The reconciler copies PID and channel ID only from a validated current
+supervisor observation. When an instance becomes inactive, both are cleared.
+
+## Errors and Boundedness
+
+Registry corruption, CAS conflicts, invalid supervisor observations, and
+supervisor failures are explicit errors. Diagnostics contain host names and
+operation names but no package bodies, secrets, channel payloads, or manifest
+contents.
+
+One full tick is bounded to 4096 registry entries by the registry itself and at
+most one start or stop call per entry. No internal retry loop, sleep, or
+unbounded allocation is allowed.
+
+## Required Tests
+
+The package must cover at least:
+
+- first launch for all restart policies;
+- clean and failed exits under every restart policy;
+- stale cached PID ignored after orchestrator restart;
+- fresh and boundary-age heartbeats retained;
+- future and stale heartbeat handling;
+- package-hash mismatch drained before replacement;
+- stopped intent winning over any active state;
+- quarantine deferral and expiry;
+- restart counter preservation, increment, and overflow;
+- claim CAS failure causing no supervisor mutation;
+- supervisor start/stop failure recovery state;
+- stable multi-host ordering and one mutation per host; and
+- malformed supervisor observations and UUID-v7 channel validation.
+
+Line coverage must be at least 95 percent. The crate must forbid unsafe code and
+declare no direct filesystem, network, environment, process, clock, random, or
+stream capability.

--- a/code/specs/service-registry-reconciliation.md
+++ b/code/specs/service-registry-reconciliation.md
@@ -77,8 +77,10 @@ Each host tick follows this sequence:
 4. For `Start` or `Stop`, CAS a transitional registry observation before the
    external mutation.
 5. Perform exactly one idempotent supervisor mutation.
-6. Leave final liveness discovery to the next tick. If the mutation fails,
-   best-effort CAS an inactive failure observation so a later tick can recover.
+6. Leave final liveness discovery to the next tick. If start fails, best-effort
+   CAS an inactive failure observation. If stop fails, restore the authoritative
+   live observation, except that a durable quarantine remains in force. A later
+   tick retries convergence.
 
 A concurrent registry edit can make either CAS fail. No supervisor mutation is
 performed if the transition claim loses its CAS. If desired state changes after
@@ -111,7 +113,9 @@ impossible cross-system atomic transaction.
 - `Absent` after failure: restart for `Always` and `OnFailure`.
 - Cached `Starting` or `Restarting` with no authoritative instance: retry the
   interrupted launch.
-- Unexpired `Quarantined`: defer. At expiry, restart only if policy permits.
+- Unexpired `Quarantined`: defer while absent and drain any unexpectedly active
+  instance without clearing the quarantine. At expiry, restart only if policy
+  permits.
 
 `restart_count` increments only when relaunching a previously started or failed
 host, not on its first launch. Overflow fails closed into a permanent


### PR DESCRIPTION
## Summary

- add the D18 registry-to-supervisor reconciliation specification
- add `chief-of-staff-service-reconciler` with authoritative package identity and health observations
- converge desired running/stopped state with CAS claims and at most one supervisor mutation per host per tick
- enforce restart policies, stale-heartbeat recovery, mismatch draining, quarantine, and counter exhaustion
- keep all process, filesystem, network, clock, and random capabilities injected

## Validation

- `cargo test -p chief-of-staff-service-registry -p chief-of-staff-service-reconciler -- --nocapture`
- `cargo clippy -p chief-of-staff-service-reconciler --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-service-reconciler --no-deps`
- standalone `BUILD`
- tarpaulin: 351/368 lines, 95.38%
- repository build planner: 1 changed package, 24 affected, 24/24 built

Part of #128.
