### PR TITLE
fix(sir-c): Array#sum ignored a block argument

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.28.1 — fix: `Array#sum` ignored a block argument
+
+The 0-arg `sum` dispatch arm (slice 3) never checked `argc`/`args`, so
+`arr.sum { |x| .. }` — Ruby's block form, which sums the block's
+*transformed* values (`[1, 2].sum { |x| x * 2 }` == `6`) — silently summed
+the raw elements instead, ignoring the block entirely. Same latent-shadowing
+shape as the slice-3 `count` gap (fixed in slice 5), found while
+implementing `Hash#sum`'s block form (slice 7), which correctly guarded on
+`argc`/the closure tag from the start. Fixed with a new `_sir_array_sum_by`
+helper (snapshotting `len`/`items` before its loop, like every other
+block-taking helper here), dispatched only when `argc == 1` and the arg is
+a closure; the 0-arg form is now itself gated on `argc == 0`.
+
 ## 0.28.0 — Collections slice 7: Hash block methods
 
 No new `Feature`.

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -1498,6 +1498,25 @@ static SirValue _sir_array_sum(SirSeq *s) {
     }
     return acc;
 }
+/* `sum { |x| ... }` — Ruby's `Array#sum` accepts an optional block that
+ * transforms each element before summing (`[1, 2].sum { |x| x * 2 }` == 6).
+ * The 0-arg form above ignored `argc`/`args` entirely, so a block call
+ * silently fell through to it and summed the RAW elements instead — the
+ * same latent-shadowing shape the slice-3 `count` gap had (fixed in slice
+ * 5) before this one was ever exercised with a block. Snapshots `len`/
+ * `items` before the loop like every other block-taking helper here. */
+static SirValue _sir_array_sum_by(SirSeq *s, SirValue block) {
+    int64_t n = s->len;
+    SirValue *items = s->items;
+    SirValue acc = _sir_int(0);
+    for (int64_t i = 0; i < n; i++) {
+        SirValue pair[2];
+        pair[0] = acc;
+        pair[1] = _sir_apply(block, 1, items[i]);
+        acc = _sir_plus_v(pair, 2);
+    }
+    return acc;
+}
 /* First-occurrence order preserved (matches Ruby); dedup via `_sir_value_eq`
  * (structural, so `[[1], [1]].uniq` collapses to one `[1]`) — O(n^2), same
  * trade-off as `sort` above. Over-allocates to `s->len` (a safe upper bound on
@@ -2189,7 +2208,10 @@ static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, Si
     } else if (strcmp(m, "max") == 0) {
         if (recv.tag == SIR_SEQ) return _sir_array_max(recv.as.seq);
     } else if (strcmp(m, "sum") == 0) {
-        if (recv.tag == SIR_SEQ) return _sir_array_sum(recv.as.seq);
+        if (recv.tag == SIR_SEQ) {
+            if (argc == 0) return _sir_array_sum(recv.as.seq);
+            if (argc == 1 && args[0].tag == SIR_CLOSURE) return _sir_array_sum_by(recv.as.seq, args[0]);
+        }
         if (recv.tag == SIR_MAP && argc == 1 && args[0].tag == SIR_CLOSURE)
             return _sir_hash_sum(recv.as.map, args[0]);
     } else if (strcmp(m, "uniq") == 0) {

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_array_block_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_array_block_methods.rs
@@ -193,3 +193,23 @@ fn reduce_on_empty_with_initial_returns_it_untouched() {
         None => eprintln!("skip: no cc"),
     }
 }
+
+#[test]
+fn sum_with_block_transforms_before_summing() {
+    // Regression: the 0-arg `sum` arm (slice 3) ignored argc/args entirely,
+    // so `arr.sum { |x| .. }` silently summed the RAW elements instead of
+    // the block's transformed values -- the same latent-shadowing shape the
+    // slice-3 `count` gap had before it was fixed in slice 5.
+    match run_ruby("puts [1, 2, 3].sum\nputs [1, 2, 3].sum { |x| x * 2 }\n") {
+        Some(out) => assert_eq!(out, "6\n12\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn sum_with_block_on_empty_is_zero() {
+    match run_ruby("puts [].sum { |x| x * 2 }\n") {
+        Some(out) => assert_eq!(out, "0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}


### PR DESCRIPTION
## Summary
- The 0-arg `sum` dispatch arm (slice 3) never checked `argc`/`args`, so `arr.sum { |x| .. }` silently summed the raw elements instead of the block's transformed values — Ruby's `Array#sum` block form (`[1,2].sum { |x| x*2 }` == `6`) was being ignored, not just unsupported.
- Found while implementing `Hash#sum`'s block form (slice 7, PR #9668), which correctly guarded from the start.
- Fix: new `_sir_array_sum_by` helper (snapshots `len`/`items` before its loop, matching every other block-taking helper in this file) dispatched only when `argc == 1` and the arg is a closure; the 0-arg form now gates on `argc == 0`.

## Test plan
- [x] `cargo test -p semantic-ir-to-c` — full suite green, 2 new tests
- [x] `cargo clippy -p semantic-ir-to-c --all-targets` — clean
- [x] Security review — PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>