### PR TITLE
fix(spice): lower parser MOS drain area

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS instance `AD` values before lowering
+  valid drain diffusion areas.
 - Reject negative and non-finite MOS instance `NRS` values before lowering
   valid source diffusion square counts.
 - Reject negative and non-finite MOS instance `NRD` values before lowering

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1333,6 +1333,10 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             not math.isfinite(instance_params["NRS"]) or instance_params["NRS"] < 0.0
         ):
             raise NetlistParseError("MOSFET NRS must be finite and non-negative")
+        if "AD" in instance_params and (
+            not math.isfinite(instance_params["AD"]) or instance_params["AD"] < 0.0
+        ):
+            raise NetlistParseError("MOSFET AD must be finite and non-negative")
         return Mosfet(
             name,
             fields[1],

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1003,6 +1003,24 @@ def test_lowers_valid_mosfet_instance_source_squares(
     assert expected == mosfet.model.model.params.NRS
 
 
+@pytest.mark.parametrize("drain_area", ["-1n", "1e999"])
+def test_rejects_invalid_mosfet_instance_drain_area(drain_area: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="MOSFET AD must be finite and non-negative"
+    ):
+        parse_netlist(f".model nfast NMOS\nM1 d g s b nfast AD={drain_area}\n")
+
+
+@pytest.mark.parametrize(("drain_area", "expected"), [("0", 0.0), ("3n", 3.0e-9)])
+def test_lowers_valid_mosfet_instance_drain_area(
+    drain_area: str, expected: float
+) -> None:
+    parsed = parse_netlist(f".model nfast NMOS\nM1 d g s b nfast AD={drain_area}\n")
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(mosfet.model.model.params.AD, expected)
+
+
 def test_parse_pwl_and_sin_source_waveforms() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS instance `AD` values and lower valid
+  drain diffusion areas instead of silently dropping them.
 - Reject negative and non-finite MOS instance `NRS` values and lower valid
   source diffusion square counts instead of silently dropping them.
 - Reject negative and non-finite MOS instance `NRD` values and lower valid

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1372,6 +1372,7 @@ function isMosfetParam(name: keyof MosfetLevel1Params): boolean {
     "RSH",
     "NRD",
     "NRS",
+    "AD",
     "IS",
     "N_SUB",
     "T_NOM",
@@ -1607,6 +1608,10 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       (!Number.isFinite(sourceSquares) || sourceSquares < 0.0)
     ) {
       throw new NetlistParseError("MOSFET NRS must be finite and non-negative");
+    }
+    const drainArea = instanceParams.get("AD");
+    if (drainArea !== undefined && (!Number.isFinite(drainArea) || drainArea < 0.0)) {
+      throw new NetlistParseError("MOSFET AD must be finite and non-negative");
     }
     return mosfet(
       name,

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -991,6 +991,23 @@ Mp out gate vdd vdd pfast W=3u L=250n
     expect(element.params.NRS).toBe(expected);
   });
 
+  it.each(["-1n", "1e999"])("rejects invalid MOSFET instance AD=%s", (drainArea) => {
+    expect(() =>
+      parseNetlist(`.model nfast NMOS\nM1 d g s b nfast AD=${drainArea}\n`),
+    ).toThrow("MOSFET AD must be finite and non-negative");
+  });
+
+  it.each([
+    ["0", 0.0],
+    ["3n", 3.0e-9],
+  ])("lowers valid MOSFET instance AD=%s", (drainArea, expected) => {
+    const parsed = parseNetlist(`.model nfast NMOS\nM1 d g s b nfast AD=${drainArea}\n`);
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.AD).toBeCloseTo(expected, 15);
+  });
+
   it("parses PWL and SIN source waveforms", () => {
     const parsed = parseNetlist(`
 V1 in 0 PWL(0 0, 1n 1.8, 2n 0)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4225,11 +4225,17 @@ the Rust, Python, and TypeScript surfaces together.
      diagnostic while zero and positive drain-square counts lower into Level-1
      parameters.
 
+385. Python and TypeScript Berkeley SPICE MOS source-squares parity.
+   - Status: completed in PR 9667.
+   - Negative and non-finite instance `NRS` values are rejected with the shared
+     diagnostic while zero and positive source-square counts lower into
+     Level-1 parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
-   - TypeScript still needs canonical lowering for `NRS`, `AD`, `AS`, `PD`,
-     `PS`, `CJ`, `CJSW`, `JS`, `PB`, `MJ`,
+   - TypeScript still needs canonical lowering for `AD`, `AS`, `PD`, `PS`,
+     `CJ`, `CJSW`, `JS`, `PB`, `MJ`,
      `MJSW`, `FC`, `KF`, and `AF`; Python already lowers these canonical fields
      but still needs matching facade validation coverage.
    - Align the `CJS` and `CJD` aliases with canonical `CBS` and `CBD` in both


### PR DESCRIPTION
## Summary
- validate MOS instance `AD` as finite and non-negative in Python and TypeScript
- lower valid TypeScript drain diffusion areas into Level-1 parameters
- record the merged source-squares slice and advance the prioritized SPICE backlog

## Verification
- Python spice-netlist-parser: 160 tests passed, 88.35% coverage
- Python Ruff: clean
- TypeScript spice-engine: build passed
- TypeScript spice-netlist-parser: build passed, 153 tests passed
- TypeScript spice-netlist-parser coverage: 84.68% lines