### PR TITLE
fix(human-languages): clean Gujarati book warnings

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -73,9 +73,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-V03 | Queued | Compile individual prompt, answer, accepted-variant, feedback, and response-time contracts from typed activity blocks. | Every compiled activity names a non-empty subset of its block's assessed atoms and resolves all answer variants without scraping prose. |
 | HL-B04 | Complete (#9661) | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
 | HL-B05 | Complete (#9663) | Remove Marathi's duplicate practice labels and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Devanagari, natural page bottoms, and explicit static-font shapes make the forced six-chapter build warning-free. |
-| HL-B06 | Complete in this PR | Publish Gujarati Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
-| HL-B07 | Next | Remove Gujarati's missing punctuation glyphs and LaTeX layout/bookmark warnings. | A forced build succeeds but reports four missing punctuation glyphs, one overfull box, four underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
-| HL-B08 | Queued | Publish Punjabi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
+| HL-B06 | Complete (#9669) | Publish Gujarati Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
+| HL-B07 | Complete in this PR | Remove Gujarati's missing punctuation glyphs and LaTeX layout/bookmark warnings. | Canonical recap labels, main-font punctuation, bookmark-safe Gujarati, natural page bottoms, and explicit static-font shapes make the forced six-chapter build warning-free. |
+| HL-B08 | Next | Publish Punjabi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
 | HL-B09 | Queued | Remove Punjabi's LaTeX layout, duplicate-label, and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs but reports one overfull box, four underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B10 | Queued | Publish Sanskrit Chapter 6 from its three canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
 | HL-B11 | Queued | Remove Sanskrit's LaTeX layout, duplicate-label, and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs but reports three overfull boxes, six underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
@@ -340,6 +340,29 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - The generated chapter adds no new missing-glyph, overfull, underfull,
   duplicate-label, bookmark, or font warnings. HL-B07 remains the bounded cleanup
   for warnings already present in the five handwritten chapters.
+
+## Findings from HL-B07
+
+- Each handwritten recap now uses its canonical lesson id (`GU-C01-practice`
+  through `GU-C05-practice`) instead of five copies of `lesson:practice`.
+- Latin commas and the ellipsis now sit outside `\gu`, so the Gujarati-only
+  static font is asked to shape only Gujarati characters while the visible
+  punctuation remains unchanged.
+- Hyperref's PDF-string fallback strips only the `\gu` / `\gujaratifont`
+  presentation wrapper. The inspected outline keeps readable Gujarati and
+  romanization across all handwritten sections, including `મારું નામ…છે`, while
+  generated Chapter 6 keeps its intentionally Latin short titles.
+- `\raggedbottom` lets pages around unbreakable lesson callouts end naturally.
+  Visual inspection of all four formerly underfull pages plus the repaired
+  Chapter 5 recap found no clipping, collision, or awkward box spacing.
+- The vendored static Gujarati file is now explicitly selected for regular,
+  bold, italic, and bold-italic requests. This preserves the prior glyph
+  appearance without reporting unavailable font shapes.
+- Rephrasing the three copula forms gives TeX natural breakpoints without
+  changing the recap's meaning. The forced 27-page XeLaTeX build now reports
+  zero package or LaTeX warnings, missing glyphs, overfull boxes, underfull
+  boxes, and duplicate destinations. HL-B08 is next: publish Punjabi Chapter 6
+  through the same canonical pipeline.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/gujarati/CHANGELOG.md
+++ b/code/learning/human-languages/gujarati/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Warning-clean six-chapter book — 2026-08-03
+
+- Replaced the five duplicate recap labels with canonical lesson ids and moved
+  Latin punctuation outside the Gujarati-only font command.
+- Preserved readable Gujarati in PDF bookmarks while removing font-only
+  presentation commands from Hyperref's strings.
+- Added natural page bottoms, explicit static-font style mappings, and a
+  breakable copula recap; the forced 27-page build is now warning-free.
+
 ## Canonical Chapter 6 publication — 2026-08-03
 
 - Migrated both number lessons to schema v2 with the shared

--- a/code/learning/human-languages/gujarati/README.md
+++ b/code/learning/human-languages/gujarati/README.md
@@ -50,6 +50,9 @@ Compiles with XeLaTeX using the **vendored** Noto Sans Gujarati font
 (`../../_fonts/NotoSansGujarati-Static.ttf`). `latexmk -xelatex book.tex`.
 Generated Gujarati runs use that font while section bookmarks use the lessons'
 Latin romanization.
+The six-chapter build is warning-clean, and its PDF outline preserves readable
+Gujarati in the handwritten chapters alongside generated bookmark-safe
+romanization.
 
 ## Files
 

--- a/code/learning/human-languages/gujarati/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/gujarati/book/chapters/ch01-greetings.tex
@@ -76,7 +76,7 @@ the verb \emph{to come}. (Familiarly: \gu{આવજે} \emph{\=avje}.)
 \end{cousinweb}
 
 \section{Recap}
-\label{lesson:practice}
+\label{lesson:GU-C01-practice}
 
 \begin{center}
 \begin{tabular}{@{}lll@{}}

--- a/code/learning/human-languages/gujarati/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/gujarati/book/chapters/ch02-introductions.tex
@@ -52,7 +52,7 @@ chhe} (is), \emph{tame chho} (you are, resp.).
 \emph{is}.'' \emph{Chhe} sits at the end.
 \end{grammarlens}
 
-\section{\gu{મારું નામ \ldots છે} --- ``my name is\ldots''}
+\section{\gu{મારું નામ}\ldots\gu{છે} --- ``my name is\ldots''}
 \label{lesson:maarun-naam-chhe}
 
 \gu{મારું} (my) $+$ \gu{નામ} (name) $+$ name $+$ \gu{છે} (is) $=$ ``my name
@@ -102,7 +102,7 @@ name.
 \end{cousinweb}
 
 \section{The whole exchange}
-\label{lesson:practice}
+\label{lesson:GU-C02-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/gujarati/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/gujarati/book/chapters/ch03-responding.tex
@@ -5,7 +5,7 @@ For most Gujaratis this is the real everyday hello:
 
 \begin{center}
 \gu{તમે કેમ છો}? \quad(\emph{tame kem chho} --- ``How are you?'')\\
-\gu{હું મજામાં છું, આભાર}. \quad(\emph{hũ maj\=am\=a\d{m} chhũ, \=abh\=ar} --- ``I'm well, thank you.'')
+\gu{હું મજામાં છું}, \gu{આભાર}. \quad(\emph{hũ maj\=am\=a\d{m} chhũ, \=abh\=ar} --- ``I'm well, thank you.'')
 \end{center}
 
 \emph{Practice lessons: \texttt{lessons/GU-C03-*.md}.}
@@ -62,7 +62,7 @@ fuller form of Chapter 1's \emph{n\=a}. Both from the ancient \emph{na-}, PIE
 \end{cousinweb}
 
 \section{The whole exchange}
-\label{lesson:practice}
+\label{lesson:GU-C03-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}
@@ -70,7 +70,7 @@ fuller form of Chapter 1's \emph{n\=a}. Both from the ancient \emph{na-}, PIE
 Gujarati & English \\
 \midrule
 \gu{તમે કેમ છો}? & How are you? \\
-\gu{હું મજામાં છું, આભાર}. & I'm well, thank you. \\
+\gu{હું મજામાં છું}, \gu{આભાર}. & I'm well, thank you. \\
 \gu{વાંધો નહીં}. & No problem / you're welcome. \\
 \bottomrule
 \end{tabular}

--- a/code/learning/human-languages/gujarati/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/gujarati/book/chapters/ch04-farewells.tex
@@ -53,7 +53,7 @@ tells which: \emph{k\=ale ma\d{l}\=\i shũ} (future $\to$ ``tomorrow we'll meet'
 \end{cousinweb}
 
 \section{The farewells}
-\label{lesson:practice}
+\label{lesson:GU-C04-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/gujarati/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/gujarati/book/chapters/ch05-first-verbs.tex
@@ -65,7 +65,7 @@ karvũ}, ``work-do'' $=$ ``to work''). So \emph{hũ k\=am karũ chhũ} $=$ ``I w
 \end{cousinweb}
 
 \section{Sentences about yourself}
-\label{lesson:practice}
+\label{lesson:GU-C05-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}
@@ -79,7 +79,8 @@ Gujarati & English \\
 \end{tabular}
 \end{center}
 
-Three verbs, one engine: a stem, a person-ending, the copula \emph{chhũ/chhe/chho}
+Three verbs, one engine: a stem, a person-ending, the copula forms
+\emph{chhũ}, \emph{chhe}, and \emph{chho}
 --- the verb always last, ``in'' after its noun. Roots banked: \emph{bolvũ}
 (native), \emph{rahevũ} (\emph{rah-} ``remain''), \emph{karvũ} (\emph{k\d{r}} ---
 root of \emph{namask\=ar}, \emph{karma}; \emph{k\=am} ``work'' $\leftarrow$

--- a/code/learning/human-languages/gujarati/book/preamble.tex
+++ b/code/learning/human-languages/gujarati/book/preamble.tex
@@ -33,7 +33,13 @@
 
 % Vendored Gujarati font (../../_fonts/ from <lang>/book/); \gu{...} = inline
 % Gujarati snippet.
-\newfontfamily\gujaratifont[Path=../../_fonts/, Script=Gujarati]{NotoSansGujarati-Static.ttf}
+\newfontfamily\gujaratifont[
+  Path=../../_fonts/,
+  Script=Gujarati,
+  BoldFont=NotoSansGujarati-Static.ttf,
+  ItalicFont=NotoSansGujarati-Static.ttf,
+  BoldItalicFont=NotoSansGujarati-Static.ttf
+]{NotoSansGujarati-Static.ttf}
 \newcommand{\gu}[1]{{\gujaratifont #1}}
 
 \hypersetup{
@@ -42,6 +48,14 @@
   pdfsubject={Etymology-driven Gujarati curriculum},
   pdfkeywords={Gujarati, Gandhi, Indo-Aryan, language learning}
 }
+\pdfstringdefDisableCommands{%
+  \def\gu#1{#1}% Keep Gujarati text while dropping font-only presentation.
+  \def\gujaratifont{}%
+}
+
+% Lesson callouts are deliberately kept together when they fit. Let short pages
+% end naturally instead of stretching their vertical glue around those boxes.
+\raggedbottom
 
 \newtcolorbox{cousinweb}{
   breakable, skin=enhanced, colback=yellow!8, colframe=yellow!45!black,


### PR DESCRIPTION
## Summary

- replace five duplicate Gujarati recap labels with canonical lesson ids
- keep Latin punctuation outside the Gujarati-only font and map the vendored static font explicitly for all requested styles
- preserve Gujarati text in PDF bookmarks, allow natural page bottoms, and give the Chapter 5 copula recap clean line breaks
- mark HL-B07 complete and prioritize Punjabi Chapter 6 next

## Validation

- forced `latexmk -gg -xelatex -interaction=nonstopmode -halt-on-error book.tex`
- 27 letter-size pages; warning scan reports zero missing glyphs, overfull/underfull boxes, duplicate labels, Hyperref warnings, font warnings, or other LaTeX/package warnings
- visually inspected all four formerly underfull pages plus the repaired Chapter 5 recap
- inspected the PDF outline; handwritten Gujarati titles, punctuation, and romanization remain readable
- `@coding-adventures/human-language-data`: 80 tests passed
- `npm run check:books`
- `git diff --check`