### PR TITLE
fix(html-parser): diagnose fragment EOF open elements

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,10 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Fragment parsing now reports the in-body EOF parse error for authored
+  disallowed open elements while excluding synthetic context-shell nodes,
+  closing 54 previously silent malformed corpus cases without changing DOM
+  recovery or diagnostics for empty contexts.
 - Rejected `frameset` start tags after an explicit body or body-incompatible
   content now report the Standard's in-body parse error without changing DOM
   recovery, closing 39 previously silent malformed corpus cases.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the rejected-frameset diagnostic slice, 1,837 of those cases emit at
-least one lexer or parser diagnostic and 346 remain uncovered. Another 139
+After the fragment in-body EOF diagnostic slice, 1,891 of those cases emit at
+least one lexer or parser diagnostic and 292 remain uncovered. Another 139
 cases emit diagnostics despite having no legacy `#errors` rows. These are
 reviewed rather than automatically removed: 89 are full-document inputs for
 which the legacy fixtures omit the Standard-required missing-doctype error,
@@ -40,28 +40,32 @@ nonconforming doctypes, duplicate shell tags, body/html boundary errors,
 after-body and frameset modes, implied-shell paragraph end tags, and rejected
 frameset starts all report their current-Standard parse errors.
 
+Fragment in-body EOF diagnostics are also complete. Authored disallowed open
+elements now report the same error as full-document parsing, while synthetic
+context and table-wrapper nodes are excluded. Remaining fragment EOF-labeled
+rows depend on table foster-parenting/scope recovery or foreign-content table
+boundaries and stay assigned to those algorithm audits.
+
 Prioritized work items:
 
-1. **Fragment EOF diagnostics.** Audit the current in-body EOF rule against
-   fragment parsing. Legacy fragment fixtures omit many EOF error rows, so add
-   explicit current-WHATWG evidence before extending the full-document
-   diagnostic into fragments.
-2. **In-body and text insertion modes.** Cover scope failures, implied-end-tag
+1. **In-body and text insertion modes.** Cover scope failures, implied-end-tag
    recovery, formatting reconstruction, stray start/end tags, and the large
    executable cluster of unclosed script/style/title/noframes text-mode EOF
    diagnostics.
-3. **Table, select, and template insertion modes.** Cover foster parenting,
-   table scopes, select recovery, and template mode-stack errors.
-4. **Adoption agency and active formatting.** Cover malformed formatting cases
+2. **Table, select, and template insertion modes.** Cover foster parenting,
+   table scopes, select recovery, and template mode-stack errors. The remaining
+   fragment EOF inventory includes fostered-anchor `eof-in-table` rows and
+   MathML/SVG table-boundary scope recovery.
+3. **Adoption agency and active formatting.** Cover malformed formatting cases
    without changing their now-conforming DOM output.
-5. **Foreign content and fragment parsing.** Cover SVG/MathML integration
+4. **Foreign content and fragment parsing.** Cover SVG/MathML integration
    boundaries and context-sensitive fragment errors.
-6. **Diagnostic positions and error taxonomy.** Carry source positions into
+5. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.
-7. **Input boundary review.** Document the Unicode-code-point parser boundary
+6. **Input boundary review.** Document the Unicode-code-point parser boundary
    and either add or explicitly separate byte decoding and encoding sniffing.
-8. **Algorithm and differential audit.** Map implemented states/modes to the
+7. **Algorithm and differential audit.** Map implemented states/modes to the
    current HTML Standard and add deterministic differential/fuzz coverage for
    branches not exercised by the upstream corpora.
 

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4656,9 +4656,8 @@ impl HtmlParser {
                         }));
                     }
                     Token::Eof => {
-                        if !self.is_fragment
-                            && self.has_open_element("body")
-                            && self.has_disallowed_open_element_for_body_end_tag()
+                        if (self.is_fragment || self.has_open_element("body"))
+                            && self.has_disallowed_authored_open_element_for_eof()
                         {
                             self.diagnostics.push(ParserDiagnostic::new(
                                 "eof-with-unclosed-elements",
@@ -8166,28 +8165,16 @@ impl HtmlParser {
 
     fn has_disallowed_open_element_for_body_end_tag(&self) -> bool {
         self.open_elements.iter().any(|path| {
+            element_ref_at_path(&self.document, path)
+                .is_some_and(is_disallowed_open_element_for_body_end)
+        })
+    }
+
+    fn has_disallowed_authored_open_element_for_eof(&self) -> bool {
+        self.open_elements.iter().any(|path| {
             element_ref_at_path(&self.document, path).is_some_and(|element| {
-                element.namespace.is_some()
-                    || !matches!(
-                        element.name.as_str(),
-                        "dd" | "dt"
-                            | "li"
-                            | "optgroup"
-                            | "option"
-                            | "p"
-                            | "rb"
-                            | "rp"
-                            | "rt"
-                            | "rtc"
-                            | "tbody"
-                            | "td"
-                            | "tfoot"
-                            | "th"
-                            | "thead"
-                            | "tr"
-                            | "body"
-                            | "html"
-                    )
+                !has_fragment_context_marker(element)
+                    && is_disallowed_open_element_for_body_end(element)
             })
         })
     }
@@ -9658,6 +9645,30 @@ fn append_missing_attributes(target: &mut Vec<Attribute>, attributes: Vec<Attrib
             target.push(attribute);
         }
     }
+}
+
+fn is_disallowed_open_element_for_body_end(element: &Element) -> bool {
+    element.namespace.is_some()
+        || !matches!(
+            element.name.as_str(),
+            "dd" | "dt"
+                | "li"
+                | "optgroup"
+                | "option"
+                | "p"
+                | "rb"
+                | "rp"
+                | "rt"
+                | "rtc"
+                | "tbody"
+                | "td"
+                | "tfoot"
+                | "th"
+                | "thead"
+                | "tr"
+                | "body"
+                | "html"
+        )
 }
 
 fn body_fragment_nodes(mut document: Document) -> Vec<Node> {
@@ -33126,6 +33137,36 @@ mod tests {
         for source in ["<!doctype html><p>", "<!doctype html><head>"] {
             let allowed = parse_html_with_diagnostics(source).unwrap();
             assert!(allowed.parser_diagnostics.is_empty(), "source {source:?}");
+        }
+    }
+
+    #[test]
+    fn reports_fragment_eof_with_authored_disallowed_open_elements() {
+        for (context, source) in [
+            ("body", "<div>"),
+            ("html", "<span>"),
+            ("svg path", "<nobr>X"),
+        ] {
+            let output = parse_html_fragment_for_context_with_diagnostics(source, context).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "eof-with-unclosed-elements",
+                    "end of file was reached with disallowed open elements"
+                )],
+                "context {context:?}, source {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn fragment_eof_ignores_seeded_contexts_and_allowed_open_elements() {
+        for (context, source) in [("div", ""), ("svg path", ""), ("body", "<p>")] {
+            let output = parse_html_fragment_for_context_with_diagnostics(source, context).unwrap();
+            assert!(
+                output.parser_diagnostics.is_empty(),
+                "context {context:?}, source {source:?}"
+            );
         }
     }
 

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 346);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1837);
+    assert_eq!(missing_diagnostic_cases, 292);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1891);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report the current in-body EOF parse error for authored disallowed open elements during fragment parsing
- exclude synthetic fragment context and wrapper nodes from the authored-open-element check
- record the remaining table foster-parenting and foreign-boundary EOF cases under their owning algorithm audits

## Evidence
- closes 54 silent malformed corpus cases: 346 -> 292
- raises declared-error cases with diagnostics: 1,837 -> 1,891
- preserves all 2,637 checked DOM outputs
- keeps undeclared-diagnostic cases at 139
- live audit: WPT `d6c801946a63a6c5fec07c3d476b8b021e5eca34`, html5lib-tests `224991ec10db04f056a89eed8b0bd8695fd2950e`; 1,934/1,934 tree signatures, 6,806/6,806 tokenizer signatures, zero normalized skips

## Validation
- `cargo test -p coding-adventures-html-parser --test tree_construction_test`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- parser audit manifest, Rust-test, and coverage checks
- generated HTML fixture and README inventory checks
- `git diff --check`
