### PR TITLE
fix(ruby): evaluate canonical Starlark BUILD files

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,14 +11,9 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": {
-    "item_id": "build-tool-ruby-starlark-runtime-closure",
-    "number": 9660,
-    "url": "https://github.com/adhithyan15/coding-adventures/pull/9660",
-    "branch": "codex/build-tool-ruby-starlark-runtime-closure"
-  },
+  "active_pr": null,
   "last_inventory": {
-    "revision": "bce05ed6abe668df1339c4169e63fa1ed3c8d666",
+    "revision": "bfe51311154b51f9aed40becab19d17126f75ac0",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1227,
@@ -393,20 +388,20 @@
     {
       "id": "build-tool-ruby-starlark-runtime-closure",
       "title": "Make the Ruby build tool declare and load its Starlark runtime closure",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-ruby-engine-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-ruby-starlark-runtime-closure",
       "pr_number": 9660,
-      "notes": "Selected after merged PR #9648 and the collision-clean b3a6616a inventory. The build tool lazily required coding_adventures_starlark_interpreter whenever a Starlark BUILD file was present, but its Gemfile declared only progress_bar and test gems; a clean source-tree invocation therefore aborted with LoadError until every Ruby package lib directory was injected through RUBYLIB. The implementation imports the interpreter's authoritative repository-local Gemfile closure, makes the existing evaluator integration test mandatory, and proves a clean Bundler subprocess resolves the exact repository feature with RUBYLIB and RUBYOPT removed and network proxies pointed at a dead loopback endpoint. Exact-base validation on bce05ed6 passed 297 Ruby runs/589 assertions with one existing Windows platform skip and 87.91% line/72.05% branch coverage; 38 interpreter runs/60 assertions; Ruby syntax, changed-file Lint/Security RuboCop, and zero-advisory bundle audit; canonical Go test/vet/trimpath build and a 300-package Ruby plan; 17 schema and 40 runner conformance tests plus the valid 37-case/56-file corpus; and a real 258-Lua-package source-tree plan with zero LoadErrors. The plan also reproduced all 44 separately owned canonical Starlark parse fallbacks without widening this runtime-closure slice. Collision, diff, state, and credential checks are clean. The post-merge dependency/leverage pass ranked this ahead of Haskell and Elixir UTF-8 because Ruby 3.4.9 is already validated locally, the fix is the narrowest unblocked build-tool boundary, and it unlocks the dependent 44-case canonical BUILD compatibility repair. Ready PR #9660 reached 17 terminal green/skipped/neutral checks at c3863989fbdbf747df85f4cc4bced59e86c64021, but GitHub rejected auto-complete because main moved during the request. The branch then rebased conflict-free onto bce05ed6, refreshed the inventory, classified the new Chief service-registry singleton, and reran the complete exact-base suite before the lease-guarded update."
+      "notes": "Selected after merged PR #9648 and the collision-clean b3a6616a inventory. The build tool lazily required coding_adventures_starlark_interpreter whenever a Starlark BUILD file was present, but its Gemfile declared only progress_bar and test gems; a clean source-tree invocation therefore aborted with LoadError until every Ruby package lib directory was injected through RUBYLIB. The implementation imports the interpreter's authoritative repository-local Gemfile closure, makes the existing evaluator integration test mandatory, and proves a clean Bundler subprocess resolves the exact repository feature with RUBYLIB and RUBYOPT removed and network proxies pointed at a dead loopback endpoint. Exact-base validation on bce05ed6 passed 297 Ruby runs/589 assertions with one existing Windows platform skip and 87.91% line/72.05% branch coverage; 38 interpreter runs/60 assertions; Ruby syntax, changed-file Lint/Security RuboCop, and zero-advisory bundle audit; canonical Go test/vet/trimpath build and a 300-package Ruby plan; 17 schema and 40 runner conformance tests plus the valid 37-case/56-file corpus; and a real 258-Lua-package source-tree plan with zero LoadErrors. The plan also reproduced all 44 separately owned canonical Starlark parse fallbacks without widening this runtime-closure slice. Collision, diff, state, and credential checks are clean. The post-merge dependency/leverage pass ranked this ahead of Haskell and Elixir UTF-8 because Ruby 3.4.9 is already validated locally, the fix is the narrowest unblocked build-tool boundary, and it unlocks the dependent 44-case canonical BUILD compatibility repair. Ready PR #9660 reached 17 terminal green/skipped/neutral checks at c3863989fbdbf747df85f4cc4bced59e86c64021, but GitHub rejected auto-complete because main moved during the request. The branch then rebased conflict-free onto bce05ed6, refreshed the inventory, classified the new Chief service-registry singleton, and reran the complete exact-base suite before the lease-guarded update. PR #9660 merged through the guarded auto-complete command on 2026-08-03 as bfe51311154b51f9aed40becab19d17126f75ac0 after all 17 rebased exact-head checks were terminal: both detects, both fixture consumers, both Ubuntu builds, macOS, Windows, both CI gates, CodeQL detection, and Ruby analysis passed; four irrelevant analyzers skipped and the CodeQL aggregate was neutral."
     },
     {
       "id": "build-tool-ruby-starlark-canonical-build-compatibility",
       "title": "Make the Ruby Starlark path parse canonical BUILD files without fallback",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-ruby-starlark-runtime-closure"],
-      "branch": null,
+      "branch": "codex/build-tool-ruby-starlark-canonical-compatibility",
       "pr_number": null,
-      "notes": "Discovered after supplying the repository Ruby libraries to the real Lua plan. The Ruby Starlark interpreter emits 44 repeatable end-of-file parse errors for canonical Elixir, Go, and Rust BUILD templates and the build tool silently falls back to raw commands; the plan still succeeds at 258 Lua packages and 382 edges. Minimize the failing template suffixes into language-neutral fixtures, repair the parser/compiler boundary or evaluator contract, fail closed where structured declarations are required, and prove exact plan equivalence across affected platform templates."
+      "notes": "Discovered after supplying the repository Ruby libraries to the real Lua plan. The Ruby Starlark interpreter emits 44 repeatable end-of-file parse errors for canonical Elixir, Go, and Rust BUILD templates and the build tool silently falls back to raw commands; the plan still succeeds at 258 Lua packages and 382 edges. Minimize the failing template suffixes into language-neutral fixtures, repair the parser/compiler boundary or evaluator contract, fail closed where structured declarations are required, and prove exact plan equivalence across affected platform templates. Selected after PR #9660 merged and the collision-clean bfe51311 inventory. The dependency/leverage pass ranked this ahead of the independent Haskell and Elixir UTF-8 slices because the runtime closure directly unblocked it, it removes 44 silent canonical BUILD fallbacks from a supported build-tool implementation, and the Ruby/interpreter toolchain and exact plan baselines are already warm; the Chief service-registry and channel work remain dependency-blocked."
     },
     {
       "id": "build-tool-perl-runtime-security-floor",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -401,7 +401,16 @@
       "depends_on": ["build-tool-ruby-starlark-runtime-closure"],
       "branch": "codex/build-tool-ruby-starlark-canonical-compatibility",
       "pr_number": null,
-      "notes": "Discovered after supplying the repository Ruby libraries to the real Lua plan. The Ruby Starlark interpreter emits 44 repeatable end-of-file parse errors for canonical Elixir, Go, and Rust BUILD templates and the build tool silently falls back to raw commands; the plan still succeeds at 258 Lua packages and 382 edges. Minimize the failing template suffixes into language-neutral fixtures, repair the parser/compiler boundary or evaluator contract, fail closed where structured declarations are required, and prove exact plan equivalence across affected platform templates. Selected after PR #9660 merged and the collision-clean bfe51311 inventory. The dependency/leverage pass ranked this ahead of the independent Haskell and Elixir UTF-8 slices because the runtime closure directly unblocked it, it removes 44 silent canonical BUILD fallbacks from a supported build-tool implementation, and the Ruby/interpreter toolchain and exact plan baselines are already warm; the Chief service-registry and channel work remain dependency-blocked."
+      "notes": "Discovered after supplying the repository Ruby libraries to the real Lua plan. The Ruby Starlark interpreter emits 44 repeatable end-of-file parse errors for canonical Elixir, Go, and Rust BUILD templates and the build tool silently falls back to raw commands; the plan still succeeds at 258 Lua packages and 382 edges. Minimize the failing template suffixes into language-neutral fixtures, repair the parser/compiler boundary or evaluator contract, fail closed where structured declarations are required, and prove exact plan equivalence across affected platform templates. Selected after PR #9660 merged and the collision-clean bfe51311 inventory. The dependency/leverage pass ranked this ahead of the independent Haskell and Elixir UTF-8 slices because the runtime closure directly unblocked it, it removes 44 silent canonical BUILD fallbacks from a supported build-tool implementation, and the Ruby/interpreter toolchain and exact plan baselines are already warm; the Chief service-registry and channel work remain dependency-blocked. Implemented canonical EOF token order, exact keyword operands and binding, defining-module globals, normalized v1 context propagation, strict structured-command extraction, root-redacted fail-closed diagnostics, and the canonical multiline shared fixture. Exact real-plan comparison matches every field for all 9 Elixir, 6 Go, and 29 Rust Starlark records; the 258-package/382-edge Lua plan has zero Starlark warnings. Local validation passes all seven Ruby suites, including 302 build-tool runs/614 assertions with one existing Windows platform skip and 88.04% line/71.11% branch coverage; the 37-case/56-file corpus; Go test/vet/trimpath build; zero-advisory Ruby audit; current dependencies; a collision-clean rebased 4a66c66d inventory of 1,228 identities and 4,376 slots; state, diff, JSON, and credential checks. The exact ten already-owned Lua BUILD_windows debts remain unchanged."
+    },
+    {
+      "id": "build-tool-ruby-language-identity-registry",
+      "title": "Bring Ruby build-tool discovery to the canonical language and identity registry",
+      "status": "pending",
+      "depends_on": ["build-tool-ruby-starlark-canonical-build-compatibility"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered while proving the 44 canonical Starlark package records against the Go oracle. Ruby and Go agree on package counts and on every affected Starlark record field, but Ruby's dependency-edge identities omit the canonical programs segment: the Go/Ruby set differences are 42/42 for Go and 76/76 for Rust, while Elixir has 21 Go-only and 12 Ruby-only edges plus nine independently missing semantic edges. Lua has the same conduit-hello identity drift and one Go-only edge. Adopt the canonical language and package-identity registry, preserve repository-relative program identities such as go/programs/build-tool, rust/programs/closurec, and elixir/programs/ircd, then consume language-neutral identity and dependency-edge fixtures across canonical and legacy BUILD paths. Keep the separately owned missing semantic dependency edges out of the Starlark evaluator compatibility slice."
     },
     {
       "id": "build-tool-perl-runtime-security-floor",
@@ -932,6 +941,24 @@
       "branch": null,
       "pr_number": null,
       "notes": "Discovered in the collision-clean bce05ed6 inventory after PR #9655 added Rust-only chief-of-staff-service-registry. Define language-neutral fixtures for bounded host names and package paths, versioned host-record codecs, restart/desired-state/status invariants, stable namespaced keys and host-name ordering, immutable package registration, idempotent create-if-absent, revision-CAS update/delete, corrupt-record rejection, and restart recovery over an injected StorageBackend. Depend on the channel-crypto vectors for the shared ChannelId contract. Backend and filesystem durability, process liveness and supervision, trusted clocks, spawning, reconciliation effects, and secure-channel handshakes remain injected or native."
+    },
+    {
+      "id": "secure-channel-primitive-stack-portable-conformance",
+      "title": "Fixture and classify the portable secure-channel primitive stack",
+      "status": "pending",
+      "depends_on": ["rust-singletons-20260730-classification"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Materialized from the dependency audit for the Rust-only chief-of-staff-secure-host-channel package. Define language-neutral vectors and stable errors for X3DH bundle validation and transcript derivation, Double Ratchet header/state transitions and skipped-key bounds, and the Vault secure-channel C1/CN wire wrapper before any dependent protocol port. Separate deterministic codecs and caller-supplied entropy/key operations from OS CSPRNG access, key custody, mutable prekey publication, zeroization guarantees, and constant-time primitive availability; record reviewed lane exceptions wherever a safe cryptographic implementation is unavailable rather than substituting educationally insecure code."
+    },
+    {
+      "id": "chief-secure-host-channel-portable-conformance",
+      "title": "Fixture and expand the portable Chief secure host channel",
+      "status": "pending",
+      "depends_on": ["secure-channel-primitive-stack-portable-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-clean 4a66c66d inventory after PR #9664 added Rust-only chief-of-staff-secure-host-channel. The crate is zero-capability and transport-independent. Define language-neutral fixtures for bounded bootstrap offers and authenticated client hellos, exact D18F frame encoding, host/session/direction/sequence AAD, monotonic send and receive sequencing, malformed-frame rejection before state advance, and terminal close after authentication failure. Expand only after the X3DH/Double-Ratchet/Vault secure-channel primitive contract lands; fresh key generation, key custody, process spawning, pipes, sockets, filesystem access, and supervisor lifecycle remain injected or native."
     },
     {
       "id": "venture-browser-qt-portable-bridge-and-native-host",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,18 +11,23 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": {
+    "item_id": "build-tool-ruby-starlark-canonical-build-compatibility",
+    "number": 9677,
+    "url": "https://github.com/adhithyan15/coding-adventures/pull/9677",
+    "branch": "codex/build-tool-ruby-starlark-canonical-compatibility"
+  },
   "last_inventory": {
-    "revision": "bfe51311154b51f9aed40becab19d17126f75ac0",
+    "revision": "4a66c66dfde5eb1cf1f39283bf71d2ae6396edca",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1227,
-    "implementation_package_slots": 4375,
+    "implementation_identities": 1228,
+    "implementation_package_slots": 4376,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 271,
-    "singleton_packages": 777,
-    "singleton_missing_slots": 10878,
-    "rust_singletons": 582,
+    "singleton_packages": 778,
+    "singleton_missing_slots": 10892,
+    "rust_singletons": 583,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -397,11 +402,11 @@
     {
       "id": "build-tool-ruby-starlark-canonical-build-compatibility",
       "title": "Make the Ruby Starlark path parse canonical BUILD files without fallback",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-ruby-starlark-runtime-closure"],
       "branch": "codex/build-tool-ruby-starlark-canonical-compatibility",
-      "pr_number": null,
-      "notes": "Discovered after supplying the repository Ruby libraries to the real Lua plan. The Ruby Starlark interpreter emits 44 repeatable end-of-file parse errors for canonical Elixir, Go, and Rust BUILD templates and the build tool silently falls back to raw commands; the plan still succeeds at 258 Lua packages and 382 edges. Minimize the failing template suffixes into language-neutral fixtures, repair the parser/compiler boundary or evaluator contract, fail closed where structured declarations are required, and prove exact plan equivalence across affected platform templates. Selected after PR #9660 merged and the collision-clean bfe51311 inventory. The dependency/leverage pass ranked this ahead of the independent Haskell and Elixir UTF-8 slices because the runtime closure directly unblocked it, it removes 44 silent canonical BUILD fallbacks from a supported build-tool implementation, and the Ruby/interpreter toolchain and exact plan baselines are already warm; the Chief service-registry and channel work remain dependency-blocked. Implemented canonical EOF token order, exact keyword operands and binding, defining-module globals, normalized v1 context propagation, strict structured-command extraction, root-redacted fail-closed diagnostics, and the canonical multiline shared fixture. Exact real-plan comparison matches every field for all 9 Elixir, 6 Go, and 29 Rust Starlark records; the 258-package/382-edge Lua plan has zero Starlark warnings. Local validation passes all seven Ruby suites, including 302 build-tool runs/614 assertions with one existing Windows platform skip and 88.04% line/71.11% branch coverage; the 37-case/56-file corpus; Go test/vet/trimpath build; zero-advisory Ruby audit; current dependencies; a collision-clean rebased 4a66c66d inventory of 1,228 identities and 4,376 slots; state, diff, JSON, and credential checks. The exact ten already-owned Lua BUILD_windows debts remain unchanged."
+      "pr_number": 9677,
+      "notes": "Discovered after supplying the repository Ruby libraries to the real Lua plan. The Ruby Starlark interpreter emits 44 repeatable end-of-file parse errors for canonical Elixir, Go, and Rust BUILD templates and the build tool silently falls back to raw commands; the plan still succeeds at 258 Lua packages and 382 edges. Minimize the failing template suffixes into language-neutral fixtures, repair the parser/compiler boundary or evaluator contract, fail closed where structured declarations are required, and prove exact plan equivalence across affected platform templates. Selected after PR #9660 merged and the collision-clean bfe51311 inventory. The dependency/leverage pass ranked this ahead of the independent Haskell and Elixir UTF-8 slices because the runtime closure directly unblocked it, it removes 44 silent canonical BUILD fallbacks from a supported build-tool implementation, and the Ruby/interpreter toolchain and exact plan baselines are already warm; the Chief service-registry and channel work remain dependency-blocked. Implemented canonical EOF token order, exact keyword operands and binding, defining-module globals, normalized v1 context propagation, strict structured-command extraction, root-redacted fail-closed diagnostics, and the canonical multiline shared fixture. Exact real-plan comparison matches every field for all 9 Elixir, 6 Go, and 29 Rust Starlark records; the 258-package/382-edge Lua plan has zero Starlark warnings. Local validation passes all seven Ruby suites, including 302 build-tool runs/614 assertions with one existing Windows platform skip and 88.04% line/71.11% branch coverage; the 37-case/56-file corpus; Go test/vet/trimpath build; zero-advisory Ruby audit; current dependencies; a collision-clean rebased 4a66c66d inventory of 1,228 identities and 4,376 slots; state, diff, JSON, and credential checks. The exact ten already-owned Lua BUILD_windows debts remain unchanged. Ready PR #9677 opened at exact head 7e3d3a08eb5a800ad748450bf613288e84ed80ec; checks are pending and auto-complete remains disabled until every exact-head check is terminal green or skipped."
     },
     {
       "id": "build-tool-ruby-language-identity-registry",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed — Ruby Canonical Starlark BUILD Compatibility
+- Ruby's Starlark stack now closes indented files in the specified token order,
+  preserves `r`/`b`-leading identifiers, binds mixed keyword calls, and keeps
+  defining-module globals across nested loads.
+- The Ruby build tool injects the normalized v1 evaluation context, validates
+  structured commands, and fails closed after Starlark classification instead
+  of silently falling back to raw shell lines; evaluation errors redact the
+  checkout root.
+
 ### Fixed — Venture Windows CI Acceptance
 - The pull-request Windows runner now derives a dedicated Venture acceptance
   flag from the shared build plan, installs MSVC and .NET only when that slice

--- a/code/packages/ruby/lexer/CHANGELOG.md
+++ b/code/packages/ruby/lexer/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased] — F10 declarative lexer mode transitions
 
+### Fixed
+- Indentation-sensitive token streams now emit the final logical `NEWLINE`
+  before any remaining `DEDENT` tokens and the terminal `EOF`, matching the
+  grammar contract for canonical multiline Starlark blocks.
+
 ### Added
 - `GrammarLexer` now interprets the declarative mode-transition table on a
   `TokenGrammar` (F10), the Ruby port of the Rust `grammar_lexer.rs` and

--- a/code/packages/ruby/lexer/README.md
+++ b/code/packages/ruby/lexer/README.md
@@ -11,6 +11,10 @@ Breaks source code into tokens -- the smallest meaningful units of a programming
 
 Both produce identical `Token` objects so downstream tools (parser) don't care which one generated the tokens.
 
+For indentation-sensitive grammars, the stream closes with the final logical
+`NEWLINE`, any remaining `DEDENT` tokens, and then `EOF`. This order lets a
+parser finish the last suite before it reaches end of input.
+
 ## Usage
 
 ```ruby

--- a/code/packages/ruby/lexer/lib/coding_adventures/lexer/grammar_lexer.rb
+++ b/code/packages/ruby/lexer/lib/coding_adventures/lexer/grammar_lexer.rb
@@ -797,19 +797,22 @@ module CodingAdventures
           )
         end
 
-        # EOF: emit remaining DEDENTs.
-        while @indent_stack.length > 1
-          @indent_stack.pop
+        # EOF: terminate the final simple statement before closing blocks.
+        # The parser's simple_stmt production consumes NEWLINE, so emitting a
+        # DEDENT first leaves the last statement inside a function/conditional
+        # unterminated. This matches Python's NEWLINE, DEDENT..., EOF order.
+        if tokens.empty? || tokens.last.type != TokenType::NEWLINE
           tokens << Token.new(
-            type: "DEDENT", value: "",
+            type: TokenType::NEWLINE, value: "\\n",
             line: @line, column: @column
           )
         end
 
-        # Final NEWLINE if the last token isn't one.
-        if tokens.empty? || tokens.last.type != TokenType::NEWLINE
+        # Emit remaining DEDENTs after the statement terminator.
+        while @indent_stack.length > 1
+          @indent_stack.pop
           tokens << Token.new(
-            type: TokenType::NEWLINE, value: "\\n",
+            type: "DEDENT", value: "",
             line: @line, column: @column
           )
         end

--- a/code/packages/ruby/lexer/test/test_grammar_lexer.rb
+++ b/code/packages/ruby/lexer/test/test_grammar_lexer.rb
@@ -280,6 +280,13 @@ class TestGrammarLexer < Minitest::Test
     assert_includes types, "DEDENT"
   end
 
+  def test_indentation_eof_terminates_statement_before_dedent
+    source = "if x:\n    y = 1\n"
+    types = GL.new(source, starlark_grammar).tokenize.map(&:type)
+
+    assert_equal [TT::NEWLINE, "DEDENT", TT::EOF], types.last(3)
+  end
+
   def test_indentation_nested
     source = "if x:\n    if y:\n        z = 1\n"
     tokens = GL.new(source, starlark_grammar).tokenize

--- a/code/packages/ruby/starlark_ast_to_bytecode_compiler/CHANGELOG.md
+++ b/code/packages/ruby/starlark_ast_to_bytecode_compiler/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this package will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- `CALL_FUNCTION_KW` now records positional and keyword argument counts
+  separately, preserving mixed calls for the VM.
+- Bare identifiers beginning with `r`, `R`, `b`, or `B` are no longer treated
+  as prefixed string literals unless the prefix is followed by a quote.
+
 ## [0.1.0] - 2026-03-21
 
 ### Added

--- a/code/packages/ruby/starlark_ast_to_bytecode_compiler/README.md
+++ b/code/packages/ruby/starlark_ast_to_bytecode_compiler/README.md
@@ -67,6 +67,10 @@ The compiler defines 46 opcodes covering all Starlark language features:
 | I/O | PRINT_VALUE |
 | VM Control | HALT |
 
+`CALL_FUNCTION_KW` carries `[positional_count, keyword_count]`; keyword names
+and values remain paired on the stack so mixed calls can be bound without
+guessing how many positional arguments preceded them.
+
 ## Dependencies
 
 - `coding_adventures_bytecode_compiler` -- GenericCompiler framework

--- a/code/packages/ruby/starlark_ast_to_bytecode_compiler/lib/coding_adventures/starlark_ast_to_bytecode_compiler/compiler.rb
+++ b/code/packages/ruby/starlark_ast_to_bytecode_compiler/lib/coding_adventures/starlark_ast_to_bytecode_compiler/compiler.rb
@@ -342,6 +342,15 @@ module CodingAdventures
         # If the lexer already stripped quotes, return as-is.
         return s unless has_prefix || has_quotes
 
+        # A bare lexer value beginning with r/b is ordinary content, not a
+        # prefixed literal. Only treat prefix letters as syntax when the
+        # prefix run is immediately followed by a quote.
+        if has_prefix && !has_quotes
+          after_prefix = s.dup
+          after_prefix = after_prefix[1..] while !after_prefix.empty? && %w[r R b B].include?(after_prefix[0])
+          return s if after_prefix.empty? || !['"', "'"].include?(after_prefix[0])
+        end
+
         # Strip optional prefix (r, b, rb, br, etc.)
         raw = false
         while s.length > 0 && %w[r R b B].include?(s[0])
@@ -1208,7 +1217,9 @@ module CodingAdventures
         end
 
         if kw_count > 0
-          compiler.emit(Op::CALL_FUNCTION_KW, positional_count + kw_count)
+          # Preserve both counts. Keyword arguments occupy two stack slots
+          # (name, value), while positional arguments occupy one.
+          compiler.emit(Op::CALL_FUNCTION_KW, [positional_count, kw_count])
         else
           compiler.emit(Op::CALL_FUNCTION, positional_count)
         end

--- a/code/packages/ruby/starlark_ast_to_bytecode_compiler/test/test_compiler.rb
+++ b/code/packages/ruby/starlark_ast_to_bytecode_compiler/test/test_compiler.rb
@@ -400,8 +400,19 @@ class TestCompiler < Minitest::Test
   def test_function_call_with_kwargs
     code = compile("f(x=1, y=2)\n")
 
-    assert has_opcode?(code, Op::CALL_FUNCTION_KW),
+    instruction = code.instructions.find { |item| item.opcode == Op::CALL_FUNCTION_KW }
+    assert instruction,
       "Expected CALL_FUNCTION_KW opcode\nDisassembly:\n#{Compiler.disassemble(code)}"
+    assert_equal [0, 2], instruction.operand
+  end
+
+  def test_function_call_with_positional_and_keyword_counts
+    code = compile("f(1, y=2, z=3)\n")
+    instruction = code.instructions.find { |item| item.opcode == Op::CALL_FUNCTION_KW }
+
+    assert instruction,
+      "Expected CALL_FUNCTION_KW opcode\nDisassembly:\n#{Compiler.disassemble(code)}"
+    assert_equal [1, 2], instruction.operand
   end
 
   # ================================================================
@@ -678,6 +689,12 @@ class TestCompiler < Minitest::Test
   def test_parse_string_literal_bare
     # Already stripped by lexer
     assert_equal "hello", Compiler.parse_string_literal("hello")
+  end
+
+  def test_parse_string_literal_bare_values_keep_prefix_letters
+    %w[rule rust_library build Binary].each do |value|
+      assert_equal value, Compiler.parse_string_literal(value)
+    end
   end
 
   def test_parse_string_literal_empty

--- a/code/packages/ruby/starlark_interpreter/CHANGELOG.md
+++ b/code/packages/ruby/starlark_interpreter/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `coding_adventures_starlark_interpreter` will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- Imported functions now retain the globals of the module that defined them,
+  including helpers and injected rule functions used by nested Starlark loads.
+- Loaded symbols whose names begin with `r` or `b`, such as `rust_library`,
+  preserve their full identifiers through compilation and execution.
+
 ## [0.1.0] - 2026-03-21
 
 ### Added

--- a/code/packages/ruby/starlark_interpreter/README.md
+++ b/code/packages/ruby/starlark_interpreter/README.md
@@ -12,6 +12,8 @@ Key features:
 - **Caching**: Loaded modules are cached to avoid re-execution
 - **File resolver**: Configurable resolution of module labels to file contents
 - **File interpretation**: Read and execute `.star` files from disk
+- **Defining-module globals**: Loaded functions keep their own helpers and
+  injected globals across nested module boundaries
 
 ## How It Fits in the Stack
 

--- a/code/packages/ruby/starlark_interpreter/test/test_interpreter.rb
+++ b/code/packages/ruby/starlark_interpreter/test/test_interpreter.rb
@@ -229,6 +229,42 @@ class TestStarlarkInterpreter < Minitest::Test
     assert_equal 42, result.variables["result"]
   end
 
+  def test_load_symbol_keeps_leading_raw_prefix_letter
+    files = {
+      "//rules.star" => <<~STARLARK
+        def rust_library(name):
+            return {"rule": "rust_library", "name": name}
+      STARLARK
+    }
+    resolver = ->(label) { files[label] }
+
+    result = interpret(<<~STARLARK, file_resolver: resolver)
+      load("//rules.star", "rust_library")
+      target = rust_library(name = "demo")
+    STARLARK
+
+    assert_equal({"rule" => "rust_library", "name" => "demo"}, result.variables["target"])
+  end
+
+  def test_loaded_function_keeps_its_module_globals
+    files = {
+      "//helper.star" => "def command():\n    return \"test\"\n",
+      "//rules.star" => <<~STARLARK
+        load("//helper.star", "command")
+        def target(name):
+            return [name, command()]
+      STARLARK
+    }
+    resolver = ->(label) { files[label] }
+
+    result = interpret(<<~STARLARK, file_resolver: resolver)
+      load("//rules.star", "target")
+      result = target(name = "demo")
+    STARLARK
+
+    assert_equal ["demo", "test"], result.variables["result"]
+  end
+
   def test_load_multiple_symbols
     resolver = ->(label) {
       files = {

--- a/code/packages/ruby/starlark_lexer/test/test_starlark_lexer.rb
+++ b/code/packages/ruby/starlark_lexer/test/test_starlark_lexer.rb
@@ -194,6 +194,13 @@ class TestStarlarkLexer < Minitest::Test
     assert indent_idx > colon_idx, "INDENT should come after COLON"
   end
 
+  def test_final_statement_newline_precedes_dedent
+    source = "def foo():\n    return {}\n"
+    types = token_types(source)
+
+    assert_equal [TT::NEWLINE, DEDENT_TYPE, TT::EOF], types.last(3)
+  end
+
   # ------------------------------------------------------------------
   # Operators: multi-character operators
   # ------------------------------------------------------------------

--- a/code/packages/ruby/starlark_parser/test/test_starlark_parser.rb
+++ b/code/packages/ruby/starlark_parser/test/test_starlark_parser.rb
@@ -71,6 +71,25 @@ class TestStarlarkParser < Minitest::Test
     refute_nil number_token, "Expected INT token '1' in AST"
   end
 
+  def test_function_can_end_with_multiline_structured_return
+    source = <<~STARLARK
+      def build_target(name):
+          return {
+              "rule": "demo_library",
+              "name": name,
+              "commands": [
+                  {"type": "cmd", "program": "demo", "args": ["test"]},
+              ],
+          }
+    STARLARK
+
+    ast = parse(source)
+
+    assert_equal "file", ast.rule_name
+    assert_equal 1, find_nodes_by_rule(ast, "def_stmt").length
+    assert_equal 1, find_nodes_by_rule(ast, "return_stmt").length
+  end
+
   # ------------------------------------------------------------------
   # Expression: 1 + 2 * 3
   # ------------------------------------------------------------------

--- a/code/packages/ruby/starlark_vm/CHANGELOG.md
+++ b/code/packages/ruby/starlark_vm/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to `coding_adventures_starlark_vm` will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- Function calls bind positional and keyword arguments independently, reject
+  unknown, duplicate, and missing arguments, and apply declared defaults.
+- Functions retain their defining module globals, so a function imported with
+  `load()` can call helpers and builtins from its own module without leaking or
+  overwriting the caller's global scope.
+
 ## [0.1.0] - 2026-03-21
 
 ### Added

--- a/code/packages/ruby/starlark_vm/README.md
+++ b/code/packages/ruby/starlark_vm/README.md
@@ -47,6 +47,10 @@ result = CodingAdventures::StarlarkVM.execute_starlark("print(\"hello world\")\n
 result.output  # => ["hello world"]
 ```
 
+Functions support positional arguments, keyword arguments, and defaults.
+Each function captures its defining module's globals, which keeps nested
+`load()` calls deterministic while restoring the caller's globals afterward.
+
 ### Manual VM Setup
 
 ```ruby

--- a/code/packages/ruby/starlark_vm/lib/coding_adventures/starlark_vm/handlers.rb
+++ b/code/packages/ruby/starlark_vm/lib/coding_adventures/starlark_vm/handlers.rb
@@ -588,7 +588,11 @@ module CodingAdventures
             defaults: defaults,
             name: param_names.empty? ? "<lambda>" : "<function>",
             param_count: param_names.length,
-            param_names: param_names
+            param_names: param_names,
+            # Capture the defining module namespace by reference. Loaded
+            # functions must resolve globals from their own module, including
+            # symbols imported before the function definition.
+            globals: v.variables
           )
           v.push(func)
           v.advance_pc
@@ -632,26 +636,34 @@ module CodingAdventures
 
         # CALL_FUNCTION_KW: Call a function with keyword arguments.
         #
-        # The operand is the total number of arguments (positional + keyword).
+        # The operand is [positional_count, keyword_count].
         # Keyword arguments are interleaved on the stack as name-value pairs:
         #
         #   [callable, pos_arg0, ..., kw_name0, kw_val0, kw_name1, kw_val1, ...]
         #
-        # We detect keyword args by checking if a value is a string that
-        # matches a parameter name. The compiler pushes LOAD_CONST for the
-        # keyword name followed by the expression value.
+        # Keeping both counts is necessary because every keyword occupies two
+        # stack slots while a positional argument occupies one.
         vm.register_opcode(op::CALL_FUNCTION_KW, ->(v, instr, c) {
-          arg_count = instr.operand
-          # Pop all args as a flat list
-          all_args = []
-          arg_count.times { all_args.unshift(v.pop) }
+          positional_count, keyword_count = instr.operand
+
+          keyword_pairs = []
+          keyword_count.times do
+            value = v.pop
+            name = v.pop
+            keyword_pairs.unshift([name, value])
+          end
+
+          positional = []
+          positional_count.times { positional.unshift(v.pop) }
           callable = v.pop
 
           if callable.is_a?(StarlarkFunction)
             # call_starlark_function_kw handles PC advancement internally
-            call_starlark_function_kw(v, callable, all_args, c)
+            call_starlark_function_kw(v, callable, positional, keyword_pairs, c)
           elsif callable.is_a?(CodingAdventures::VirtualMachine::BuiltinFunction)
-            result = callable.implementation.call(all_args)
+            raise "TypeError: builtin keyword arguments are not supported" unless keyword_pairs.empty?
+
+            result = callable.implementation.call(positional)
             v.push(result)
             v.advance_pc
           else
@@ -1051,7 +1063,7 @@ module CodingAdventures
       #   3. Set up local variables with parameter bindings
       #   4. Execute the function body
       #   5. The RETURN_VALUE handler restores the caller's state
-      def self.call_starlark_function(vm, func, args, code)
+      def self.call_starlark_function(vm, func, args, _code)
         param_count = func.param_count
         default_count = func.defaults.length
 
@@ -1073,7 +1085,7 @@ module CodingAdventures
         # everything on the Ruby stack (this method's local variables).
         saved_pc = vm.pc
         saved_halted = vm.halted
-        saved_variables = vm.variables.dup
+        saved_variables = vm.variables
         saved_locals = vm.locals
         saved_stack = vm.stack.dup
 
@@ -1091,6 +1103,7 @@ module CodingAdventures
           new_locals[name] = args[i] if i < args.length
         end
         vm.locals = new_locals
+        vm.variables = func.globals
         vm.stack = []
         vm.pc = 0
         vm.halted = false
@@ -1127,44 +1140,45 @@ module CodingAdventures
 
       # Call a StarlarkFunction with keyword arguments.
       #
-      # Keyword arguments arrive as alternating name-value pairs mixed
-      # with positional arguments. We match them to parameter names.
-      def self.call_starlark_function_kw(vm, func, all_args, code)
-        # The compiler pushes keyword name strings before their values.
-        # We need to separate positional from keyword args.
-        # Keyword args: if an arg is a string that matches a param name
-        # and the next arg exists, treat as keyword.
+      # Keyword arguments arrive as explicit name-value pairs alongside a
+      # separate positional list. We bind them to declared parameter slots.
+      def self.call_starlark_function_kw(vm, func, positional, keyword_pairs, code)
         param_names = func.param_names
-        positional = []
-        kwargs = {}
-
-        i = 0
-        while i < all_args.length
-          val = all_args[i]
-          if val.is_a?(String) && param_names.include?(val) && i + 1 < all_args.length
-            kwargs[val] = all_args[i + 1]
-            i += 2
-          else
-            positional << val
-            i += 1
-          end
+        if positional.length > func.param_count
+          raise "TypeError: #{func.name}() takes #{func.param_count} " \
+                "arguments (#{positional.length} given)"
         end
 
-        # Build final args array matching parameter order
-        final_args = Array.new(func.param_count)
+        missing = Object.new
+        final_args = Array.new(func.param_count, missing)
         positional.each_with_index { |val, idx| final_args[idx] = val }
-        kwargs.each do |name, val|
+
+        keyword_pairs.each do |name, val|
+          unless name.is_a?(String) && param_names.include?(name)
+            raise "TypeError: #{func.name}() got an unexpected keyword argument #{name.inspect}"
+          end
+
           idx = param_names.index(name)
-          final_args[idx] = val if idx
+          unless final_args[idx].equal?(missing)
+            raise "TypeError: #{func.name}() got multiple values for argument #{name.inspect}"
+          end
+          final_args[idx] = val
         end
 
-        # Fill remaining with defaults
-        func.param_names.each_with_index do |name, idx|
-          next unless final_args[idx].nil?
+        func.param_names.each_index do |idx|
+          next unless final_args[idx].equal?(missing)
+
           default_offset = idx - (func.param_count - func.defaults.length)
           if default_offset >= 0 && default_offset < func.defaults.length
             final_args[idx] = func.defaults[default_offset]
           end
+        end
+
+        missing_names = param_names.each_index.filter_map do |idx|
+          param_names[idx] if final_args[idx].equal?(missing)
+        end
+        unless missing_names.empty?
+          raise "TypeError: #{func.name}() missing required arguments: #{missing_names.join(', ')}"
         end
 
         call_starlark_function(vm, func, final_args, code)

--- a/code/packages/ruby/starlark_vm/lib/coding_adventures/starlark_vm/types.rb
+++ b/code/packages/ruby/starlark_vm/lib/coding_adventures/starlark_vm/types.rb
@@ -43,14 +43,15 @@ module CodingAdventures
     #   param_names: ["name", "greeting"]
     #
     class StarlarkFunction
-      attr_reader :code, :defaults, :name, :param_count, :param_names
+      attr_reader :code, :defaults, :name, :param_count, :param_names, :globals
 
-      def initialize(code:, defaults: [], name: "<lambda>", param_count: 0, param_names: [])
+      def initialize(code:, defaults: [], name: "<lambda>", param_count: 0, param_names: [], globals: {})
         @code = code
         @defaults = defaults
         @name = name
         @param_count = param_count
         @param_names = param_names
+        @globals = globals
       end
 
       def to_s

--- a/code/packages/ruby/starlark_vm/test/test_vm.rb
+++ b/code/packages/ruby/starlark_vm/test/test_vm.rb
@@ -339,6 +339,30 @@ class TestStarlarkVM < Minitest::Test
     assert_equal "Hi world", result.variables["result"]
   end
 
+  def test_function_keyword_arguments_use_declared_parameter_names
+    source = <<~STARLARK
+      def target(name, srcs = [], deps = []):
+          return [name, srcs, deps]
+      result = target(name = "demo", srcs = ["src.py"], deps = ["python/base"])
+    STARLARK
+
+    result = exec(source)
+
+    assert_equal ["demo", ["src.py"], ["python/base"]], result.variables["result"]
+  end
+
+  def test_function_mixed_positional_and_keyword_arguments
+    source = <<~STARLARK
+      def target(name, srcs = [], deps = []):
+          return [name, srcs, deps]
+      result = target("demo", deps = ["python/base"])
+    STARLARK
+
+    result = exec(source)
+
+    assert_equal ["demo", [], ["python/base"]], result.variables["result"]
+  end
+
   def test_function_returning_none
     source = <<~STARLARK
       def noop():
@@ -733,6 +757,7 @@ class TestStarlarkVM < Minitest::Test
     assert_equal 2, func.param_count
     assert_equal ["a", "b"], func.param_names
     assert_equal [], func.defaults
+    assert_equal({}, func.globals)
   end
 
   # ================================================================

--- a/code/programs/ruby/build-tool/CHANGELOG.md
+++ b/code/programs/ruby/build-tool/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to the Ruby build tool are documented in this file.
 
 ### Changed
 
+- Canonical multiline Starlark `BUILD` files now parse and evaluate without a
+  raw-command fallback. The evaluator injects the normalized v1 context,
+  supports nested loaded rule functions and keyword arguments, and extracts
+  validated structured commands deterministically.
+- Once a `BUILD` file is classified as Starlark, parse, load, evaluation,
+  target-selection, and structured-command errors fail closed instead of being
+  downgraded to warnings and reinterpreted as shell lines.
+- Starlark evaluation failures redact the checkout root from CLI diagnostics.
 - The build-tool Gemfile now imports the repository-owned Starlark
   interpreter's authoritative dependency closure. Clean `bundle exec` source-
   tree runs load the evaluator without manual `RUBYLIB`, and tests no longer

--- a/code/programs/ruby/build-tool/README.md
+++ b/code/programs/ruby/build-tool/README.md
@@ -43,6 +43,21 @@ The resolver never inserts replacement characters and never includes the host
 checkout root in this error. A literal U+FFFD character encoded correctly as
 UTF-8 remains valid metadata.
 
+## Canonical Starlark BUILD Files
+
+Canonical Starlark files are evaluated with the normalized build-tool v1
+context (`version`, `os`, `arch`, `cpu_count`, `ci`, and `repo_root`). Loaded
+rule functions retain their defining module globals, and returned structured
+commands are validated as `program` plus string `args` before being rendered
+deterministically for the existing executor boundary.
+
+After discovery classifies a file as Starlark, parsing, loading, evaluation,
+target selection, and structured-command extraction are fail-closed. The tool
+does not reinterpret a failed Starlark file as legacy shell commands. Legacy
+fallback remains available only when a valid selected target intentionally
+provides no structured command list. Failure diagnostics redact the checkout
+root while retaining the package identity and stable evaluation detail.
+
 ## Testing
 
 ```bash

--- a/code/programs/ruby/build-tool/build.rb
+++ b/code/programs/ruby/build-tool/build.rb
@@ -277,11 +277,16 @@ module BuildTool
         result = begin
           StarlarkEvaluator.evaluate_build_file(build_file.to_s, pkg.path.to_s, root.to_s)
         rescue StandardError => e
-          $stderr.puts "Warning: Starlark eval failed for #{pkg.name}: #{e.message}"
-          nil
+          $stderr.puts "Error: Starlark evaluation failed for #{pkg.name}: #{e.message}"
+          return 1
         end
 
-        if result && result.targets.any?
+        if result.targets.empty?
+          $stderr.puts "Error: Starlark evaluation failed for #{pkg.name}: no targets declared"
+          return 1
+        end
+
+        if result.targets.any?
           t = result.targets.first
           pkg = pkg.with(
             declared_srcs: t.srcs,

--- a/code/programs/ruby/build-tool/lib/build_tool/starlark_evaluator.rb
+++ b/code/programs/ruby/build-tool/lib/build_tool/starlark_evaluator.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require "etc"
+require "json"
+require "rbconfig"
+
 # ==========================================================================
 # starlark_evaluator.rb -- Starlark BUILD File Evaluation
 # ==========================================================================
@@ -86,8 +90,10 @@ module BuildTool
   #     entry_point: ""
   #   )
   # --------------------------------------------------------------------------
-  Target = Data.define(:rule, :name, :srcs, :deps, :test_runner, :entry_point) do
-    def initialize(rule:, name:, srcs: [], deps: [], test_runner: "", entry_point: "")
+  StructuredCommand = Data.define(:program, :args)
+
+  Target = Data.define(:rule, :name, :srcs, :deps, :test_runner, :entry_point, :commands) do
+    def initialize(rule:, name:, srcs: [], deps: [], test_runner: "", entry_point: "", commands: nil)
       super
     end
   end
@@ -189,9 +195,10 @@ module BuildTool
     # @param build_file_path [String] Path to the BUILD file.
     # @param pkg_dir [String] Package directory (for future glob() support).
     # @param repo_root [String] Repository root (for resolving load() paths).
+    # @param context [Hash, nil] Optional normalized v1 context (fixtures).
     # @return [BuildFileResult] The extracted targets.
     # @raise [RuntimeError] If the file cannot be read or evaluated.
-    def evaluate_build_file(build_file_path, pkg_dir, repo_root)
+    def evaluate_build_file(build_file_path, _pkg_dir, repo_root, context: nil)
       # Step 1: Read the BUILD file.
       content = File.read(build_file_path)
 
@@ -225,7 +232,8 @@ module BuildTool
       # the file_resolver and runs the full pipeline.
       result = CodingAdventures::StarlarkInterpreter.interpret(
         content,
-        file_resolver: file_resolver
+        file_resolver: file_resolver,
+        globals: {"_ctx" => context || evaluation_context(repo_root)}
       )
 
       # Step 4: Extract targets from the result.
@@ -233,9 +241,45 @@ module BuildTool
 
       BuildFileResult.new(targets: targets)
     rescue Errno::ENOENT => e
-      raise "reading BUILD file: #{e.message}"
+      raise "reading BUILD file: #{redact_repo_root(e.message, repo_root)}"
     rescue StandardError => e
-      raise "evaluating BUILD file #{build_file_path}: #{e.message}"
+      raise "evaluating BUILD file: #{redact_repo_root(e.message, repo_root)}"
+    end
+
+    # Build the runner-owned v1 context injected into every loaded module.
+    def evaluation_context(repo_root)
+      {
+        "version" => 1,
+        "os" => normalized_os,
+        "arch" => normalized_arch,
+        "cpu_count" => Etc.nprocessors,
+        "ci" => %w[1 true yes].include?(ENV.fetch("CI", "").downcase),
+        "repo_root" => File.expand_path(repo_root).tr("\\", "/")
+      }
+    end
+
+    def normalized_os
+      host_os = RbConfig::CONFIG.fetch("host_os", "").downcase
+      return "windows" if host_os.match?(/mswin|mingw|cygwin/)
+      return "darwin" if host_os.include?("darwin")
+      return "linux" if host_os.include?("linux")
+      return "freebsd" if host_os.include?("freebsd")
+
+      host_os.split("-").first
+    end
+
+    def normalized_arch
+      host_cpu = RbConfig::CONFIG.fetch("host_cpu", "").downcase
+      return "amd64" if %w[x86_64 x64 amd64].include?(host_cpu)
+      return "arm64" if %w[aarch64 arm64].include?(host_cpu)
+
+      host_cpu
+    end
+
+    def redact_repo_root(message, repo_root)
+      expanded = File.expand_path(repo_root)
+      variants = [expanded, expanded.tr("\\", "/"), expanded.tr("/", "\\")].uniq
+      variants.reduce(message.to_s) { |redacted, path| redacted.gsub(path, "<repo>") }
     end
 
     # generate_commands -- Convert a Target into shell commands.
@@ -260,6 +304,12 @@ module BuildTool
     # @param target [Target] The target to generate commands for.
     # @return [Array<String>] Shell commands to execute.
     def generate_commands(target)
+      unless target.commands.nil?
+        return target.commands.map do |command|
+          ([command.program] + command.args).map { |token| render_command_token(token) }.join(" ")
+        end
+      end
+
       case target.rule
       when "py_library"
         runner = target.test_runner.empty? ? "pytest" : target.test_runner
@@ -353,9 +403,43 @@ module BuildTool
           srcs: get_string_list(raw, "srcs"),
           deps: get_string_list(raw, "deps"),
           test_runner: get_string(raw, "test_runner"),
-          entry_point: get_string(raw, "entry_point")
+          entry_point: get_string(raw, "entry_point"),
+          commands: extract_commands(raw, i)
         )
       end
+    end
+
+    def extract_commands(raw_target, target_index)
+      return nil unless raw_target.key?("commands")
+
+      raw_commands = raw_target["commands"]
+      unless raw_commands.is_a?(Array)
+        raise "_targets[#{target_index}].commands is not a list"
+      end
+
+      raw_commands.each_with_index.filter_map do |raw_command, command_index|
+        next if raw_command.nil?
+
+        prefix = "_targets[#{target_index}].commands[#{command_index}]"
+        raise "#{prefix} is not a dict" unless raw_command.is_a?(Hash)
+        raise "#{prefix}.type must be cmd" unless raw_command["type"] == "cmd"
+
+        program = raw_command["program"]
+        raise "#{prefix}.program must be a non-empty string" unless program.is_a?(String) && !program.empty?
+
+        args = raw_command.fetch("args", [])
+        unless args.is_a?(Array) && args.all? { |arg| arg.is_a?(String) }
+          raise "#{prefix}.args must be a list of strings"
+        end
+
+        StructuredCommand.new(program: program, args: args)
+      end
+    end
+
+    def render_command_token(token)
+      return token if token.match?(/\A[A-Za-z0-9_@%+=:,\.\/-]+\z/)
+
+      JSON.generate(token)
     end
 
     # get_string -- Safely extract a string value from a hash.

--- a/code/programs/ruby/build-tool/test/test_starlark_evaluator.rb
+++ b/code/programs/ruby/build-tool/test/test_starlark_evaluator.rb
@@ -319,6 +319,7 @@ class TestStarlarkEvaluator < Minitest::Test
     assert_equal [], target.deps
     assert_equal "", target.test_runner
     assert_equal "", target.entry_point
+    assert_nil target.commands
   end
 
   def test_target_with_all_fields
@@ -445,6 +446,41 @@ class TestStarlarkEvaluator < Minitest::Test
     assert_equal "bin-b", targets[1].name
   end
 
+  def test_extract_targets_preserves_structured_commands
+    variables = {
+      "_targets" => [{
+        "rule" => "demo_library",
+        "name" => "demo",
+        "commands" => [
+          {"type" => "cmd", "program" => "demo", "args" => ["test", "a b"]},
+          nil
+        ]
+      }]
+    }
+
+    target = BuildTool::StarlarkEvaluator.send(:extract_targets, variables).fetch(0)
+
+    assert_equal 1, target.commands.length
+    assert_equal "demo", target.commands.fetch(0).program
+    assert_equal ["test", "a b"], target.commands.fetch(0).args
+    assert_equal ['demo test "a b"'], BuildTool::StarlarkEvaluator.generate_commands(target)
+  end
+
+  def test_extract_targets_rejects_malformed_structured_commands
+    variables = {
+      "_targets" => [{
+        "rule" => "demo_library",
+        "name" => "demo",
+        "commands" => [{"type" => "cmd", "program" => "demo", "args" => "test"}]
+      }]
+    }
+
+    error = assert_raises(RuntimeError) do
+      BuildTool::StarlarkEvaluator.send(:extract_targets, variables)
+    end
+    assert_includes error.message, "commands[0].args"
+  end
+
   # ==========================================================================
   # get_string / get_string_list helper tests
   # ==========================================================================
@@ -538,6 +574,85 @@ class TestStarlarkEvaluator < Minitest::Test
 
     assert_instance_of BuildTool::BuildFileResult, result
     assert_equal [], result.targets
+  ensure
+    FileUtils.rm_rf(dir) if dir
+  end
+
+  def test_evaluates_language_neutral_nested_load_fixture
+    repo_root = Pathname(__dir__).join("../../../../..").expand_path
+    fixture_path = repo_root / "code/specs/fixtures/build-tool-v1/cases/starlark-structured-context.json"
+    fixture = JSON.parse(fixture_path.read)
+    dir = create_temp_dir
+
+    fixture.fetch("workspace").fetch("files").each do |file|
+      write_file(dir / file.fetch("path"), file.fetch("content_utf8"))
+    end
+
+    entrypoint = fixture.fetch("input").fetch("options").fetch("entrypoint")
+    context = fixture.fetch("input").fetch("options").fetch("context").merge(
+      "repo_root" => dir.to_s.tr("\\", "/")
+    )
+    result = BuildTool::StarlarkEvaluator.evaluate_build_file(
+      (dir / entrypoint).to_s,
+      (dir / "code/packages/python/demo").to_s,
+      dir.to_s,
+      context: context
+    )
+
+    expected = fixture.fetch("expected").fetch("result").fetch("targets").first
+    target = result.targets.fetch(0)
+    assert_equal expected.fetch("rule"), target.rule
+    assert_equal expected.fetch("name"), target.name
+    assert_equal expected.fetch("srcs"), target.srcs
+    assert_equal expected.fetch("deps"), target.deps
+    assert_equal expected.fetch("rendered_commands"), BuildTool::StarlarkEvaluator.generate_commands(target)
+  ensure
+    FileUtils.rm_rf(dir) if dir
+  end
+
+  def test_cli_fails_closed_when_detected_starlark_cannot_be_evaluated
+    dir = create_temp_dir
+    write_file(
+      dir / "code/packages/ruby/demo/BUILD",
+      "load(\"missing.star\", \"demo\")\n_targets = [demo(name = \"demo\")]\n"
+    )
+    tool_dir = Pathname(__dir__).parent
+    env = {"BUNDLE_GEMFILE" => (tool_dir / "Gemfile").to_s}
+
+    _stdout, stderr, status = Open3.capture3(
+      env,
+      "bundle", "exec", RbConfig.ruby, (tool_dir / "build.rb").to_s,
+      "--root", dir.to_s, "--language", "ruby", "--force", "--dry-run",
+      chdir: tool_dir.to_s
+    )
+
+    assert_equal 1, status.exitstatus
+    assert_includes stderr, "Error: Starlark evaluation failed for ruby/demo"
+    refute_includes stderr, "Warning: Starlark eval failed"
+    refute_includes stderr.tr("\\", "/"), dir.to_s.tr("\\", "/")
+  ensure
+    FileUtils.rm_rf(dir) if dir
+  end
+
+  def test_cli_fails_closed_when_detected_starlark_declares_no_targets
+    dir = create_temp_dir
+    write_file(
+      dir / "code/packages/ruby/demo/BUILD",
+      "def helper():\n    return 1\n"
+    )
+    tool_dir = Pathname(__dir__).parent
+    env = {"BUNDLE_GEMFILE" => (tool_dir / "Gemfile").to_s}
+
+    _stdout, stderr, status = Open3.capture3(
+      env,
+      "bundle", "exec", RbConfig.ruby, (tool_dir / "build.rb").to_s,
+      "--root", dir.to_s, "--language", "ruby", "--force", "--dry-run",
+      chdir: tool_dir.to_s
+    )
+
+    assert_equal 1, status.exitstatus
+    assert_includes stderr, "Error: Starlark evaluation failed for ruby/demo: no targets declared"
+    refute_includes stderr.tr("\\", "/"), dir.to_s.tr("\\", "/")
   ensure
     FileUtils.rm_rf(dir) if dir
   end

--- a/code/specs/14-starlark.md
+++ b/code/specs/14-starlark.md
@@ -842,7 +842,11 @@ The lexer (all 5 languages) must be extended to:
 
    e. **Handle blank lines and comment-only lines.** These do NOT affect indentation. Skip them without emitting `NEWLINE`.
 
-   f. **Handle end-of-file.** Emit `DEDENT` for each remaining indentation level, then `NEWLINE` (if not already emitted), then `EOF`.
+   f. **Handle end-of-file.** Emit `NEWLINE` first (if the final logical
+      statement has not already emitted one), then one `DEDENT` for each
+      remaining indentation level, then `EOF`. The terminating `NEWLINE`
+      belongs to the final `simple_stmt`; emitting a `DEDENT` before it makes
+      a correctly terminated final block unparsable.
 
    g. **Reject tabs.** If a tab character appears in leading whitespace, emit an error.
 

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -342,6 +342,13 @@ Final parity requires:
 - a declared fallback for legacy targets that do not yet expose structured
   commands.
 
+Once a selected canonical `BUILD` is identified as Starlark, parse, load,
+evaluation, target-shape, and structured-command errors are fatal. An
+implementation MUST NOT reinterpret that source as legacy shell commands or
+retain raw `BUILD` lines after an evaluation error. The declared legacy
+fallback applies only after successful evaluation of a valid target that does
+not expose structured commands.
+
 Starlark evaluation MUST NOT read undeclared host files, environment variables,
 network resources, clocks, random sources, or process APIs.
 

--- a/code/specs/fixtures/build-tool-v1/CHANGELOG.md
+++ b/code/specs/fixtures/build-tool-v1/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-08-03
+
+- Expanded the structured Starlark command/context case to use the canonical
+  multiline target return shape, including trailing commas, so adapters must
+  parse the same form used by repository rule helpers.
+
 ## 2026-08-02
 
 - Added discovery cases for every canonical language bucket missing from the

--- a/code/specs/fixtures/build-tool-v1/README.md
+++ b/code/specs/fixtures/build-tool-v1/README.md
@@ -35,7 +35,7 @@ emerging OCaml lane. It records front-door and shared-engine state but contains
 no executable commands. Every adapter is currently marked missing, so a valid
 inventory is not reported as conformance success.
 
-The 36-case bootstrap corpus covers every process-free v1 domain:
+The 37-case bootstrap corpus covers every process-free v1 domain:
 
 - canonical membership and language-registry classification, fixture-tree
   exclusion, fail-closed duplicate package identities, plus Windows, macOS,

--- a/code/specs/fixtures/build-tool-v1/cases/starlark-structured-context.json
+++ b/code/specs/fixtures/build-tool-v1/cases/starlark-structured-context.json
@@ -19,7 +19,7 @@
       },
       {
         "path": "code/build/defs.star",
-        "content_utf8": "load(\"code/build/cmd.star\", \"test_command\")\ndef demo_target(name):\n    return {\"rule\": \"python_library\", \"name\": name, \"srcs\": [\"src/demo.py\"], \"deps\": [], \"commands\": [test_command()]}\n"
+        "content_utf8": "load(\"code/build/cmd.star\", \"test_command\")\ndef demo_target(name):\n    return {\n        \"rule\": \"python_library\",\n        \"name\": name,\n        \"srcs\": [\"src/demo.py\"],\n        \"deps\": [],\n        \"commands\": [test_command()],\n    }\n"
       },
       {
         "path": "code/build/cmd.star",

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -122,7 +122,7 @@ The loop must not start by attempting 10,878 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`bce05ed6abe668df1339c4169e63fa1ed3c8d666` is collision-clean at 1,227
+`bfe51311154b51f9aed40becab19d17126f75ac0` is collision-clean at 1,227
 normalized implementation identities, 4,375 implementation slots, 172
 high-consensus packages, 271 high-consensus missing slots, 777 singletons, 582
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
@@ -301,8 +301,11 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   canonical Go test/vet/build and a 300-package Ruby plan, the 17+40
   conformance suites and 37-case/56-file corpus, and a real 258-package Ruby-
   engine plan with zero LoadErrors while preserving all 44 separately owned
-  canonical Starlark parse fallbacks. Ready PR #9660 is the sole active parity
-  PR;
+  canonical Starlark parse fallbacks. PR #9660 merged as `bfe5131115` after all
+  17 rebased exact-head checks passed, skipped, or completed neutrally. The
+  refreshed leverage pass selected the now-unblocked canonical BUILD
+  compatibility child next because it removes all 44 silent fallbacks using
+  the already-validated Ruby and interpreter toolchains;
 - make the TypeScript build-tool git-diff suite portable on Windows. The strict-
   UTF-8 validation run found two hard-coded `/bin/sh` invocations and five
   POSIX-only `/repo` path fixtures. Merged PR #9592 is the completed slice: it

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -122,9 +122,9 @@ The loop must not start by attempting 10,878 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`bfe51311154b51f9aed40becab19d17126f75ac0` is collision-clean at 1,227
-normalized implementation identities, 4,375 implementation slots, 172
-high-consensus packages, 271 high-consensus missing slots, 777 singletons, 582
+`4a66c66dfde5eb1cf1f39283bf71d2ae6396edca` is collision-clean at 1,228
+normalized implementation identities, 4,376 implementation slots, 172
+high-consensus packages, 271 high-consensus missing slots, 778 singletons, 583
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
 The seventeen newest mixed Rust identities are `smart-home-camera-media`,
 `smart-home-onvif-integration`, `smart-home-shelly-integration`,
@@ -210,6 +210,17 @@ candidates. Filesystem durability, process liveness and supervision, trusted
 clocks, spawning, effectful reconciliation, and secure-channel handshakes stay
 injected or native. Its dedicated backlog owner depends on the shared channel-
 crypto identifier vectors and cannot bypass that prerequisite.
+
+The `4a66c66d` refresh added `chief-of-staff-secure-host-channel`, a zero-
+capability, transport-independent protocol kernel. Its bounded bootstrap and
+hello records, exact `D18F` framing, AAD construction, sequencing, malformed-
+frame rejection, and terminal authentication-failure state are portable
+fixture candidates. The implementation depends on the Rust-only X3DH, Double
+Ratchet, and Vault secure-channel stack, so a separate prerequisite owner first
+defines safe vectors, injected entropy and key boundaries, and reviewed lane
+exceptions. Process spawning, pipes, sockets, key custody, and supervisor
+lifecycle remain native; the host-channel item cannot bypass its primitive
+stack dependency.
 
 This loop delivers only deterministic, authority-free package contracts and
 implementations. DNS/UDP/TCP/TLS, endpoint review, credentials and Vault,
@@ -305,7 +316,18 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   17 rebased exact-head checks passed, skipped, or completed neutrally. The
   refreshed leverage pass selected the now-unblocked canonical BUILD
   compatibility child next because it removes all 44 silent fallbacks using
-  the already-validated Ruby and interpreter toolchains;
+  the already-validated Ruby and interpreter toolchains. The current slice now
+  parses the canonical multiline return shape, preserves loaded-module globals
+  and keyword-call structure, injects the normalized v1 context, validates
+  structured commands, and fails closed with a root-redacted diagnostic. The
+  exact real-plan comparison matches every field for all 9 Elixir, 6 Go, and
+  29 Rust Starlark records and the 258-package Lua plan emits zero Starlark
+  warnings. Validation passes 302 Ruby build-tool runs/614 assertions at
+  88.04% line and 71.11% branch coverage, all six downstream Ruby language
+  suites, canonical Go test/vet/build, and the valid 37-case/56-file corpus.
+  The comparison separately found Ruby's package identities omit the canonical
+  `programs` segment in dependency edges; that registry migration is logged as
+  a dependent pending child rather than widening this evaluator repair;
 - make the TypeScript build-tool git-diff suite portable on Windows. The strict-
   UTF-8 validation run found two hard-coded `/bin/sh` invocations and five
   POSIX-only `/repo` path fixtures. Merged PR #9592 is the completed slice: it


### PR DESCRIPTION
## Summary

- make Ruby indentation-sensitive lexing close canonical multiline Starlark blocks as `NEWLINE`, remaining `DEDENT`s, then `EOF`
- preserve `r`/`b`-leading identifiers, bind positional and keyword arguments exactly, and retain defining-module globals across nested `load()` calls
- inject the normalized build-tool v1 context, validate and render structured commands, and fail closed with root-redacted diagnostics after Starlark classification
- expand the language-neutral structured-context fixture and document the contract; record the separately owned Ruby package-identity drift and newly discovered secure-channel dependency work in the parity backlog

## Validation

- full Ruby suites: lexer 137/290, Starlark lexer 33/119, parser 11/54, compiler 139/703, VM 111/127, interpreter 40/62, build tool 302/614; zero failures/errors
- Ruby build-tool coverage: 88.04% line, 71.11% branch; one existing Windows platform skip
- exact real plans: 258 Lua packages with zero Starlark warnings; all 9 Elixir, 6 Go, and 29 Rust Starlark records match the Go oracle field-for-field
- committed diff dry-run: 14 Ruby packages in the dependency closure, zero Starlark warnings
- shared conformance corpus: valid 37 cases / 56 files
- canonical Go reference: `go test ./...`, `go vet ./...`, and `go build -trimpath ./...`
- Ruby dependency audit: no advisories; dependencies current
- RuboCop Security: 13 changed Ruby files, no offenses; no error-level Lint/Security offenses (nine warning-level legacy offenses remain in pre-existing lines of touched files)
- parity inventory: schema v3, 1,228 identities, 4,376 slots, zero collisions, zero unknown buckets
- JSON/state graph, `git diff --check`, credential-pattern scan: clean
- BUILD validation reproduces only the exact ten already-backlogged Lua `BUILD_windows` sibling-install debts