### PR TITLE
feat(human-languages): publish Punjabi chapter 6

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -74,9 +74,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B04 | Complete (#9661) | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
 | HL-B05 | Complete (#9663) | Remove Marathi's duplicate practice labels and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Devanagari, natural page bottoms, and explicit static-font shapes make the forced six-chapter build warning-free. |
 | HL-B06 | Complete (#9669) | Publish Gujarati Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
-| HL-B07 | Complete in this PR | Remove Gujarati's missing punctuation glyphs and LaTeX layout/bookmark warnings. | Canonical recap labels, main-font punctuation, bookmark-safe Gujarati, natural page bottoms, and explicit static-font shapes make the forced six-chapter build warning-free. |
-| HL-B08 | Next | Publish Punjabi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
-| HL-B09 | Queued | Remove Punjabi's LaTeX layout, duplicate-label, and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs but reports one overfull box, four underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
+| HL-B07 | Complete (#9675) | Remove Gujarati's missing punctuation glyphs and LaTeX layout/bookmark warnings. | Canonical recap labels, main-font punctuation, bookmark-safe Gujarati, natural page bottoms, and explicit static-font shapes make the forced six-chapter build warning-free. |
+| HL-B08 | Complete in this PR | Publish Punjabi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
+| HL-B09 | Next | Remove Punjabi's LaTeX layout, duplicate-label, font-shape, and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs but reports one overfull box, four underfull boxes, four duplicate practice labels, 28 Hyperref warnings, and three font-shape warnings; the clean-build signal is zero of each. |
 | HL-B10 | Queued | Publish Sanskrit Chapter 6 from its three canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
 | HL-B11 | Queued | Remove Sanskrit's LaTeX layout, duplicate-label, and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs but reports three overfull boxes, six underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B12 | Queued | Publish Bengali Chapter 6 from its canonical lesson rather than hand-copying another book chapter. | The duration audit confirms authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
@@ -363,6 +363,29 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   zero package or LaTeX warnings, missing glyphs, overfull boxes, underfull
   boxes, and duplicate destinations. HL-B08 is next: publish Punjabi Chapter 6
   through the same canonical pipeline.
+
+## Findings from HL-B08
+
+- Punjabi Chapter 6 now comes from its two canonical schema-v2 lessons. The
+  generator manifest and Language Ladder independently combine the same ordered
+  lesson hashes, so the app and downloadable book cannot drift silently.
+- Both lessons realize `SPINE-COUNT-ONE-TO-FIVE` while retaining Punjabi's
+  Gurmukhi top-line clue, addak/tippi distinction, Chapter 5 five-rivers
+  callback, and the independent Punjabi/Persian paths to *panj*.
+- The strict knowledge gate confirms every prompt against its block and
+  prerequisite frontier. The corpus report now has 1,065 lessons, 20 books,
+  zero duration violations, zero unknown prerequisites, and 254 lesson chapters
+  without book chapters. Punjabi joins Spanish, Marathi, and Gujarati as the
+  fourth mixed-schema track.
+- The forced letter-size XeLaTeX build is 30 pages. Visual inspection of all
+  four generated pages found shaped Gurmukhi, width-aware comparison tables,
+  intact callouts, a complete spaced-recall close, and no clipping. The PDF
+  outline retains the romanized `ikk do tinn chār panj` and `panj · panj`
+  section bookmarks.
+- The generated chapter adds no new missing-glyph, overfull, underfull,
+  duplicate-label, bookmark, or font warning. The audit did expose three
+  pre-existing font-shape warnings omitted from the earlier inventory; HL-B09
+  now includes those alongside the handwritten chapters' other warning debt.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -66,7 +66,7 @@ edition is authored.
 | [Arabic](./arabic/README.md) | Semitic / Arabic (vendored font) | Chapters 1-2 authored (script inline) |
 | [Hindi](./hindi/README.md) | Indo-Aryan / Devanagari | Chapters 1-2 authored (lessons + book) |
 | [Marathi](./marathi/README.md) | Indo-Aryan / Devanagari | Chapters 1-6 authored (lessons + book) |
-| [Punjabi](./punjabi/README.md) | Indo-Aryan / Gurmukhi (vendored font) | Chapter 1 (Greetings) authored (lessons + book) |
+| [Punjabi](./punjabi/README.md) | Indo-Aryan / Gurmukhi (vendored font) | Chapters 1-6 authored (lessons + book, script inline) |
 | [Bengali](./bengali/README.md) | Indo-Aryan / Bengali (vendored font) | Chapter 1 (Greetings) authored (lessons + book) |
 | [Gujarati](./gujarati/README.md) | Indo-Aryan / Gujarati (vendored font) | Chapters 1-6 authored (lessons + book, script inline) |
 | [Tamil](./tamil/README.md) | Dravidian / Tamil (vendored font) | Chapters 1-2 authored (lessons + book) |

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -60,6 +60,15 @@
       "output": "marathi/book/chapters/ch06-numbers-1-5.tex",
       "unicodeScript": "Devanagari",
       "scriptCommand": "mr"
+    },
+    {
+      "language": "punjabi",
+      "chapter": 6,
+      "title": "Numbers One to Five",
+      "label": "ch:numbers-one-to-five",
+      "output": "punjabi/book/chapters/ch06-numbers-1-5.tex",
+      "unicodeScript": "Gurmukhi",
+      "scriptCommand": "pa"
     }
   ]
 }

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -23,6 +23,16 @@
       "tex": "marathi/book/chapters/ch06-numbers-1-5.tex"
     },
     {
+      "language": "punjabi",
+      "chapter": 6,
+      "sourceHash": "fnv1a64:f165e75f6db9bbe5",
+      "lessonIds": [
+        "PA-C06-numbers-1-5",
+        "PA-C06-panj-convergence"
+      ],
+      "tex": "punjabi/book/chapters/ch06-numbers-1-5.tex"
+    },
+    {
       "language": "spanish",
       "chapter": 1,
       "sourceHash": "fnv1a64:ad881fd61b3c4d60",

--- a/code/learning/human-languages/punjabi/CHANGELOG.md
+++ b/code/learning/human-languages/punjabi/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Canonical Chapter 6 publication — 2026-08-03
+
+- Migrated both number lessons to schema v2 with the shared
+  `SPINE-COUNT-ONE-TO-FIVE` can-do node, explicit sub-five-minute budgets, and
+  block-level knowledge closure.
+- Generated the downloadable Chapter 6 from the same ordered lesson AST and
+  source hash that Language Ladder loads, rather than maintaining another copy.
+- Preserved Gurmukhi inline with the book's vendored font and used romanized
+  section short titles for stable PDF bookmarks.
+
 ## Sub-five-minute remediation — 2026-08-02
 
 - Corrected nine declared five-minute estimates whose computed durations were

--- a/code/learning/human-languages/punjabi/README.md
+++ b/code/learning/human-languages/punjabi/README.md
@@ -41,14 +41,16 @@ book.
   counting-and-Gurmukhi lesson followed by a prerequisite-ordered explanation
   of why native Punjabi *panj* and Persian *panj* are convergence, not borrowing.
 
-Chapters 1–5 are in the book. Chapter 6 is canonical app-ready lesson content;
-its one-source book publication remains explicitly tracked in the shared
-backlog.
+Chapters 1–6 are in the book. Chapter 6 is generated from the same canonical
+schema-v2 lesson AST and source hashes that Language Ladder loads, while the
+first five chapters retain their authored long-form narrative during migration.
 
 ## Book / fonts
 
 Compiles with XeLaTeX using the **vendored** Noto Sans Gurmukhi font
 (`../../_fonts/NotoSansGurmukhi-Static.ttf`). `latexmk -xelatex book.tex`.
+Generated Gurmukhi runs use that font while section bookmarks use the lessons'
+Latin romanization.
 
 ## Files
 

--- a/code/learning/human-languages/punjabi/book/book.tex
+++ b/code/learning/human-languages/punjabi/book/book.tex
@@ -72,4 +72,6 @@ Released under CC~BY-SA~4.0.
 
 \input{chapters/ch05-first-verbs}
 
+\input{chapters/ch06-numbers-1-5}
+
 \end{document}

--- a/code/learning/human-languages/punjabi/book/chapters/ch06-numbers-1-5.tex
+++ b/code/learning/human-languages/punjabi/book/chapters/ch06-numbers-1-5.tex
@@ -1,0 +1,127 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:f165e75f6db9bbe5
+% canonical-lessons: PA-C06-numbers-1-5, PA-C06-panj-convergence
+
+\chapter{Numbers One to Five}
+\label{ch:numbers-one-to-five}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[ikk do tinn chār panj]{\pa{ਇੱਕ}, \pa{ਦੋ}, \pa{ਤਿੰਨ}, \pa{ਚਾਰ}, \pa{ਪੰਜ} — one to five}
+
+\label{lesson:PA-C06-numbers-1-5}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Four of these are new. The fifth you have known since \textbf{Chapter 5} — you just didn't know it was a number.
+\end{quote}
+
+\subsection*{You'll want to know: the five}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{Punjabi} & \textbf{said} \\
+\midrule
+1 & \textbf{\pa{ਇੱਕ}} & \emph{ikk} \\
+2 & \textbf{\pa{ਦੋ}} & \emph{do} \\
+3 & \textbf{\pa{ਤਿੰਨ}} & \emph{tinn} \\
+4 & \textbf{\pa{ਚਾਰ}} & \emph{chār} \\
+5 & \textbf{\pa{ਪੰਜ}} & \emph{panj} \\
+\bottomrule
+\end{tabularx}
+
+This is \textbf{Gurmukhi}, not Devanagari — a related but distinct script. It does have a top line like Devanagari's, so words hang from a bar in the same way.
+
+Two marks worth telling apart, because they look similar and do different jobs:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\pa{ੱ}} — the \textbf{addak}, on \emph{ikk}. It \textbf{doubles the following consonant}.
+  \item \textbf{\pa{ੰ}} — the \textbf{tippi}, on \emph{tinn} and \emph{panj}. It marks a \textbf{nasal}.
+\end{itemize}
+
+(So \emph{tinn}'s double \emph{n} is not the addak's doing — that word is spelled with a nasal mark, and the doubling is in the pronunciation.)
+
+\begin{grammarlens}[title={What you've built: \pa{ਪੰਜ} as a number}]
+Chapter 5 took the name \textbf{\pa{ਪੰਜਾਬੀ}} (\emph{panjābī}) apart for you: Persian \textbf{\pa{ਪੰਜ}} \emph{panj}, "five," plus \textbf{\pa{ਆਬ}} \emph{āb}, "water" — the language \textbf{of the five rivers}.
+
+You learned \emph{panj} there as a piece of a place-name. Here it arrives as what it actually is: \textbf{the number five}, an ordinary word you will count with.
+
+The next prerequisite-ordered lesson explains an important twist: Punjabi's numeral and the Persian word reached the same \emph{panj} shape independently.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "ikk, do, tinn, chār, panj"{]}
+  \item {[}YOU SAY: the two marks — "\textbf{addak} doubles, \textbf{tippi} nasalises"{]}
+  \item {[}YOU SAY: the Ch. 5 callback — "\textbf{panj} + \textbf{āb} = five rivers"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Count to five in Punjabi. (\emph{Ikk, do, tinn, chār, panj}.) What script is this? (\textbf{Gurmukhi} — related to Devanagari, and it has a top line too.) What does \textbf{\pa{ੱ}} and \textbf{\pa{ੰ}} each do? (\textbf{Addak} doubles the following consonant; \textbf{tippi} marks a nasal.) Chapter 5 told you \emph{panjābī} means "of the five rivers." What has changed now? (\emph{\textbf{Panj\emph{ is a number you can count with\textbf{, not just a piece of a name.) Next: learn why Punjabi and Persian both say \emph{panj}.}}}}
+\end{tcolorbox}
+\section[panj · panj]{Why two branches both arrived at \emph{panj}}
+
+\label{lesson:PA-C06-panj-convergence}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Say “five” in Punjabi. (\emph{Panj}.) Where did Chapter 5 first show that shape? (Inside Persian \emph{panj + āb}, “five waters.”)
+\end{quote}
+
+\begin{grammarlens}[title={What you've built: the surprising family comparison}]
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{“five”} \\
+\midrule
+Sanskrit & \emph{pañca} \\
+Hindi & \emph{pāṁch} \\
+Bengali & \emph{pā̃ch} \\
+Gujarati & \emph{pā̃ch} \\
+\textbf{Punjabi} & \emph{\textbf{panj}} \\
+\textbf{Persian} & \emph{\textbf{panj}} \\
+\bottomrule
+\end{tabularx}
+
+The neighbours keep a \textbf{-ch} shape. Punjabi matches Persian \textbf{-j}, but the obvious borrowing story is wrong.
+\end{grammarlens}
+
+\begin{cousinweb}
+Punjabi \emph{panj} is inherited from Sanskrit \emph{pañca}. North-western Indo-Aryan regularly \textbf{voiced a stop after a nasal}, turning \emph{-ñc-} into \emph{-nj-}.
+
+Punjabi \textbf{panjāh} “fifty” (from Sanskrit \emph{pañcāśat}) makes the rule visible; Hindi \textbf{pacās} shows the same source changing differently.
+\end{cousinweb}
+
+\begin{cousinweb}
+Persian independently voiced ancestral \emph{č} to \emph{j}: Iranian \emph{panč} became \emph{panj}. Two Indo-Iranian branches therefore reached the same shape separately:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{branch} & \textbf{path} \\
+\midrule
+Punjabi & Sanskrit \emph{pañca} $\to$ nasal-triggered \emph{-nj-} \\
+Persian & Iranian \emph{panč} $\to$ voiced \emph{panj} \\
+\bottomrule
+\end{tabularx}
+
+This is \textbf{convergence, not borrowing}. The \textbf{place-name} \emph{Punjab} is Persian; Punjabi's look-alike \textbf{numeral} is inherited from Sanskrit.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: Punjabi's path and proof — Sanskrit \emph{pañca} $\to$ post-nasal \emph{-nj-}; \emph{panjāh / pacās}{]}
+  \item {[}YOU SAY: Persian's path and the conclusion — \emph{panč} $\to$ \emph{panj} independently; convergence, not borrowing{]}
+  \item {[}YOU SAY: Persian place-name, inherited Punjabi number{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Borrowed from Persian? (No: Punjabi \emph{panj} inherits Sanskrit \emph{pañca}.) What made \emph{-nj-}? (A post-nasal stop voiced.) Evidence? (\emph{Panjāh / pacās}.) Persian's path? (Its ancestral \emph{č} voiced separately.) In \emph{Punjab}, what is Persian? (The place-name; Punjabi's number is homegrown.)
+\end{tcolorbox}

--- a/code/learning/human-languages/punjabi/book/preamble.tex
+++ b/code/learning/human-languages/punjabi/book/preamble.tex
@@ -19,6 +19,7 @@
 \tcbuselibrary{skins,breakable}
 \usepackage{booktabs}
 \usepackage{longtable}
+\usepackage{tabularx}
 \usepackage{array}
 \usepackage[hidelinks]{hyperref}
 \usepackage{titlesec}
@@ -48,10 +49,10 @@
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
   fonttitle=\bfseries, title={Why it's said this way}
 }
-\newtcolorbox{grammarlens}{
+\newtcolorbox{grammarlens}[1][]{
   breakable, skin=enhanced, colback=blue!5, colframe=blue!35!black,
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
-  fonttitle=\bfseries, title={Grammar Lens}
+  fonttitle=\bfseries, title={Grammar Lens}, #1
 }
 \newtcolorbox{sounds}{
   breakable, skin=enhanced, colback=green!6, colframe=green!30!black,

--- a/code/learning/human-languages/punjabi/lessons/PA-C06-numbers-1-5.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C06-numbers-1-5.md
@@ -1,26 +1,44 @@
 ---
+schema_version: 2
 id: PA-C06-numbers-1-5
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 340
 chapter: 6
 type: word
 headword: ਇੱਕ ਦੋ ਤਿੰਨ ਚਾਰ ਪੰਜ
+romanization: ikk do tinn chār panj
 gloss: one to five — meeting the panj of Punjabi as an actual number
 concept_tag: PA-NUMBERS-1-5
 prerequisites: [PA-C01-sat-sri-akal, PA-C05-main-punjabi-bolda-han]
 sounds: [sihari-i, tippi-nasal, kanna-aa]
 roots: [sanskrit-panca, persian-panj]
 etymology_hook: "Chapter 5 introduced panj inside panjabi; learn it as the ordinary number five here, then trace Punjabi and Persian panj as convergence in the next short lesson"
-est_minutes: 3
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [PA-LEX-NUMBERS-ONE-TO-FIVE, PA-SCRIPT-GURMUKHI-TOP-LINE, PA-SCRIPT-ADDAK-DOUBLING, PA-SCRIPT-TIPPI-NASAL, PA-HISTORY-PANJABI-FIVE-RIVERS]
+practises:
+  knowledge: [PA-LEX-NUMBERS-ONE-TO-FIVE, PA-SCRIPT-GURMUKHI-TOP-LINE, PA-SCRIPT-ADDAK-DOUBLING, PA-SCRIPT-TIPPI-NASAL, PA-HISTORY-PANJABI-FIVE-RIVERS]
+skills: [listening, speaking, reading]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [PA-C01-sat-sri-akal, PA-C05-main-punjabi-bolda-han]
 ---
 
 # ਇੱਕ, ਦੋ, ਤਿੰਨ, ਚਾਰ, ਪੰਜ — one to five
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Four of these are new. The fifth you have known since **Chapter 5** —
 you just didn't know it was a number.
 
-## The five
+## You'll want to know: the five
+<!-- hl-knowledge: introduces=[PA-LEX-NUMBERS-ONE-TO-FIVE, PA-SCRIPT-GURMUKHI-TOP-LINE, PA-SCRIPT-ADDAK-DOUBLING, PA-SCRIPT-TIPPI-NASAL]; assesses=[] -->
 
 | | Punjabi | said |
 |---|---|---|
@@ -41,7 +59,8 @@ Two marks worth telling apart, because they look similar and do different jobs:
 (So *tinn*'s double *n* is not the addak's doing — that word is spelled with a
 nasal mark, and the doubling is in the pronunciation.)
 
-## ਪੰਜ — a word you already know
+## What you've built: ਪੰਜ as a number
+<!-- hl-knowledge: introduces=[PA-HISTORY-PANJABI-FIVE-RIVERS]; assesses=[] -->
 
 Chapter 5 took the name **ਪੰਜਾਬੀ** (*panjābī*) apart for you: Persian **ਪੰਜ**
 *panj*, "five," plus **ਆਬ** *āb*, "water" — the language **of the five rivers**.
@@ -53,6 +72,7 @@ The next prerequisite-ordered lesson explains an important twist: Punjabi's
 numeral and the Persian word reached the same *panj* shape independently.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PA-LEX-NUMBERS-ONE-TO-FIVE, PA-SCRIPT-GURMUKHI-TOP-LINE, PA-SCRIPT-ADDAK-DOUBLING, PA-SCRIPT-TIPPI-NASAL, PA-HISTORY-PANJABI-FIVE-RIVERS] -->
 
 [PAUSE 1s]
 - [YOU SAY: "ikk, do, tinn, chār, panj"]
@@ -60,6 +80,7 @@ numeral and the Persian word reached the same *panj* shape independently.
 - [YOU SAY: the Ch. 5 callback — "**panj** + **āb** = five rivers"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PA-LEX-NUMBERS-ONE-TO-FIVE, PA-SCRIPT-GURMUKHI-TOP-LINE, PA-SCRIPT-ADDAK-DOUBLING, PA-SCRIPT-TIPPI-NASAL, PA-HISTORY-PANJABI-FIVE-RIVERS] -->
 
 [PAUSE 3s] Count to five in Punjabi. (*Ikk, do, tinn, chār, panj*.) What script is
 this? (**Gurmukhi** — related to Devanagari, and it has a top line too.) What does

--- a/code/learning/human-languages/punjabi/lessons/PA-C06-panj-convergence.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C06-panj-convergence.md
@@ -1,25 +1,43 @@
 ---
+schema_version: 2
 id: PA-C06-panj-convergence
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 350
 chapter: 6
 type: etymology
 headword: ਪੰਜ · panj
+romanization: panj · panj
 gloss: why Punjabi and Persian independently reached the same word-shape for five
 prerequisites: [PA-C06-numbers-1-5]
 sounds: [tippi-nasal]
 roots: [sanskrit-panca, persian-panj]
 etymology_hook: "Punjabi panj is inherited from Sanskrit pancha, not borrowed from Persian; both branches voiced different ancestral ch sounds to j and converged"
-est_minutes: 4
+duration:
+  max_seconds: 270
+requires:
+  knowledge: [PA-LEX-NUMBERS-ONE-TO-FIVE, PA-HISTORY-PANJABI-FIVE-RIVERS]
+introduces:
+  knowledge: [PA-COMPARISON-PANJ-MATCH, PA-ETYMON-PANJ-PANCA-INHERITANCE, PA-SOUND-NASAL-STOP-VOICING, PA-EVIDENCE-PANJAH-PACAS, PA-ETYMON-PERSIAN-PANJ-INDEPENDENT, PA-HISTORY-PANJ-CONVERGENCE]
+practises:
+  knowledge: [PA-LEX-NUMBERS-ONE-TO-FIVE, PA-HISTORY-PANJABI-FIVE-RIVERS, PA-COMPARISON-PANJ-MATCH, PA-ETYMON-PANJ-PANCA-INHERITANCE, PA-SOUND-NASAL-STOP-VOICING, PA-EVIDENCE-PANJAH-PACAS, PA-ETYMON-PERSIAN-PANJ-INDEPENDENT, PA-HISTORY-PANJ-CONVERGENCE]
+skills: [listening, speaking, reading]
+modes: [interpretive, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [PA-C06-numbers-1-5, PA-C05-main-punjabi-bolda-han]
 ---
 
 # Why two branches both arrived at *panj*
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[PA-LEX-NUMBERS-ONE-TO-FIVE, PA-HISTORY-PANJABI-FIVE-RIVERS] -->
 
 [PAUSE 2s] Say “five” in Punjabi. (*Panj*.) Where did Chapter 5 first show that
 shape? (Inside Persian *panj + āb*, “five waters.”)
 
-## The surprising family comparison
+## What you've built: the surprising family comparison
+<!-- hl-knowledge: introduces=[PA-COMPARISON-PANJ-MATCH]; assesses=[] -->
 
 | language | “five” |
 |---|---|
@@ -33,47 +51,43 @@ shape? (Inside Persian *panj + āb*, “five waters.”)
 The neighbours keep a **-ch** shape. Punjabi matches Persian **-j**, but the
 obvious borrowing story is wrong.
 
-## Punjabi's numeral is homegrown
+## The word, taken apart — Punjabi's numeral is homegrown
+<!-- hl-knowledge: introduces=[PA-ETYMON-PANJ-PANCA-INHERITANCE, PA-SOUND-NASAL-STOP-VOICING, PA-EVIDENCE-PANJAH-PACAS]; assesses=[] -->
 
-Punjabi *panj* is its own inherited descendant of Sanskrit *pañca*.
-North-western Indo-Aryan regularly **voiced a stop after a nasal**, turning
-*-ñc-* into *-nj-*.
+Punjabi *panj* is inherited from Sanskrit *pañca*. North-western Indo-Aryan
+regularly **voiced a stop after a nasal**, turning *-ñc-* into *-nj-*.
 
-Punjabi **panjāh** “fifty” makes the rule visible: it descends from Sanskrit
-*pañcāśat*, while Hindi has **pacās**, with no *j*. The same Sanskrit source
-changes differently in the two languages.
+Punjabi **panjāh** “fifty” (from Sanskrit *pañcāśat*) makes the rule visible;
+Hindi **pacās** shows the same source changing differently.
 
-## Persian reached the shape separately
+## The word, taken apart — Persian reached the shape separately
+<!-- hl-knowledge: introduces=[PA-ETYMON-PERSIAN-PANJ-INDEPENDENT, PA-HISTORY-PANJ-CONVERGENCE]; assesses=[] -->
 
-Persian independently voiced its own ancestral *č* to *j* on the way from Old
-to Middle Persian. The two branches of Indo-Iranian therefore reached *panj*
-through separate histories:
+Persian independently voiced ancestral *č* to *j*: Iranian *panč* became
+*panj*. Two Indo-Iranian branches therefore reached the same shape separately:
 
 | branch | path |
 |---|---|
 | Punjabi | Sanskrit *pañca* → nasal-triggered *-nj-* |
 | Persian | Iranian *panč* → voiced *panj* |
 
-This is **convergence, not borrowing**. It explains why the Persian place-name
-*Punjab* feels native in Punjabi: the borrowed name and the homegrown numeral
-had already grown into the same shape.
-
-The **place-name** is Persian, reflecting centuries of Persian administration.
-The Punjabi **numeral** is inherited.
+This is **convergence, not borrowing**. The **place-name** *Punjab* is Persian;
+Punjabi's look-alike **numeral** is inherited from Sanskrit.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PA-LEX-NUMBERS-ONE-TO-FIVE, PA-HISTORY-PANJABI-FIVE-RIVERS, PA-COMPARISON-PANJ-MATCH, PA-ETYMON-PANJ-PANCA-INHERITANCE, PA-SOUND-NASAL-STOP-VOICING, PA-EVIDENCE-PANJAH-PACAS, PA-ETYMON-PERSIAN-PANJ-INDEPENDENT, PA-HISTORY-PANJ-CONVERGENCE] -->
 
 [PAUSE 1s]
-- [YOU SAY: Punjabi's source — Sanskrit *pañca*]
-- [YOU SAY: the same-source proof — Punjabi *panjāh*, Hindi *pacās*]
-- [YOU SAY: two independent paths, one result — *panj*]
-- [YOU SAY: borrowing or convergence — convergence]
+- [YOU SAY: Punjabi's path and proof — Sanskrit *pañca* → post-nasal *-nj-*;
+  *panjāh / pacās*]
+- [YOU SAY: Persian's path and the conclusion — *panč* → *panj* independently;
+  convergence, not borrowing]
+- [YOU SAY: Persian place-name, inherited Punjabi number]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PA-LEX-NUMBERS-ONE-TO-FIVE, PA-HISTORY-PANJABI-FIVE-RIVERS, PA-COMPARISON-PANJ-MATCH, PA-ETYMON-PANJ-PANCA-INHERITANCE, PA-SOUND-NASAL-STOP-VOICING, PA-EVIDENCE-PANJAH-PACAS, PA-ETYMON-PERSIAN-PANJ-INDEPENDENT, PA-HISTORY-PANJ-CONVERGENCE] -->
 
-[PAUSE 3s] Is Punjabi *panj* borrowed from Persian? (No: it is inherited from
-*pañca*.) What sound environment produced Punjabi *-nj-*? (A stop after a nasal
-became voiced.) Which “fifty” pair demonstrates it? (*Panjāh / pacās*.) Why does
-Persian also have *panj*? (It voiced its own ancestral *č* separately.) What is
-Persian and what is native in *Punjab*? (The place-name is Persian; Punjabi's
-number is homegrown.)
+[PAUSE 3s] Borrowed from Persian? (No: Punjabi *panj* inherits Sanskrit
+*pañca*.) What made *-nj-*? (A post-nasal stop voiced.) Evidence? (*Panjāh /
+pacās*.) Persian's path? (Its ancestral *č* voiced separately.) In *Punjab*,
+what is Persian? (The place-name; Punjabi's number is homegrown.)

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
   same ordered source hash to Language Ladder.
 - Generate Gujarati Chapter 6 from its two strict canonical lessons, preserving
   Gujarati-script runs and bookmark-safe romanization from the shared AST.
+- Generate Punjabi Chapter 6 from its two strict canonical lessons, preserving
+  Gurmukhi runs and bookmark-safe romanization from the shared AST.
 
 ### Added — block-boundary knowledge closure
 

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -11,8 +11,8 @@
 - Independently combine loaded lesson fingerprints and show `book synced` for a
   generated chapter only when the app AST matches the committed book manifest;
   Spanish Chapters 1–6 now verify all 51 migrated lessons this way, and Marathi
-  and Gujarati Chapter 6 verify both of their canonical lessons independently
-  of the book generator.
+  Gujarati, Marathi, and Punjabi Chapter 6 verify both of their canonical
+  lessons independently of the book generator.
 
 ## 0.25.0 — the same syllable in its sister scripts (syllabary, PR 9)
 

--- a/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
@@ -18,7 +18,7 @@ describe("generated book source hashes", () => {
     expect(bookHashStatus(lessons, "spanish", chapter)).toBe("synced");
   });
 
-  it.each(["gujarati", "marathi"])(
+  it.each(["gujarati", "marathi", "punjabi"])(
     "matches the browser-loaded %s Chapter 6 AST across both lessons",
     (language) => {
       const lessons = loadLessons();


### PR DESCRIPTION
## Summary
- migrate Punjabi Chapter 6's counting and *panj* convergence lessons to schema v2 on the shared `SPINE-COUNT-ONE-TO-FIVE` node
- generate the downloadable Gurmukhi chapter from those canonical lessons and verify the same ordered hashes in Language Ladder
- record the reduced book-coverage gap and expand HL-B09 with the pre-existing font-shape warnings found by the PDF audit

## Validation
- `npm test` — human-language-data (80 tests)
- `npm run check:books`
- curriculum report — 1,065 lessons, 0 duration violations, 0 unknown prerequisites, 254 lesson chapters without book chapters
- `npm test` — Language Ladder (285 tests)
- `npm run build` — Language Ladder
- `latexmk -gg -xelatex -interaction=nonstopmode -halt-on-error book.tex` — 30-page Punjabi PDF
- visual inspection of every generated page plus PDF outline inspection
- `git diff --check`
