### PR TITLE
fix(human-languages): clean Punjabi book warnings

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -75,9 +75,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B05 | Complete (#9663) | Remove Marathi's duplicate practice labels and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Devanagari, natural page bottoms, and explicit static-font shapes make the forced six-chapter build warning-free. |
 | HL-B06 | Complete (#9669) | Publish Gujarati Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
 | HL-B07 | Complete (#9675) | Remove Gujarati's missing punctuation glyphs and LaTeX layout/bookmark warnings. | Canonical recap labels, main-font punctuation, bookmark-safe Gujarati, natural page bottoms, and explicit static-font shapes make the forced six-chapter build warning-free. |
-| HL-B08 | Complete in this PR | Publish Punjabi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
-| HL-B09 | Next | Remove Punjabi's LaTeX layout, duplicate-label, font-shape, and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs but reports one overfull box, four underfull boxes, four duplicate practice labels, 28 Hyperref warnings, and three font-shape warnings; the clean-build signal is zero of each. |
-| HL-B10 | Queued | Publish Sanskrit Chapter 6 from its three canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
+| HL-B08 | Complete (#9680) | Publish Punjabi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
+| HL-B09 | Complete in this PR | Remove Punjabi's LaTeX layout, duplicate-label, font-shape, and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Gurmukhi, natural page bottoms, explicit static-font shapes, and a shorter running title make the forced six-chapter build warning-free. |
+| HL-B10 | Next | Publish Sanskrit Chapter 6 from its three canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
 | HL-B11 | Queued | Remove Sanskrit's LaTeX layout, duplicate-label, and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs but reports three overfull boxes, six underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B12 | Queued | Publish Bengali Chapter 6 from its canonical lesson rather than hand-copying another book chapter. | The duration audit confirms authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
 | HL-B13 | Queued | Remove Bengali's missing glyphs and LaTeX layout/bookmark warnings. | A forced build succeeds but reports six missing glyphs, one overfull box, four underfull boxes, four duplicate practice labels, and 27 Hyperref warnings; the clean-build signal is zero of each. |
@@ -386,6 +386,26 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   duplicate-label, bookmark, or font warning. The audit did expose three
   pre-existing font-shape warnings omitted from the earlier inventory; HL-B09
   now includes those alongside the handwritten chapters' other warning debt.
+
+## Findings from HL-B09
+
+- Each handwritten recap now uses its canonical lesson id (`PA-C01-practice`
+  through `PA-C05-practice`) instead of five copies of `lesson:practice`.
+- Hyperref's PDF-string fallback strips only the `\pa` / `\punjabifont`
+  presentation wrapper. The inspected outline retains readable Gurmukhi and
+  romanization across every handwritten section, while generated Chapter 6
+  keeps its intentional romanized short titles.
+- `\raggedbottom` lets pages around unbreakable lesson callouts end naturally.
+  Visual inspection of all four formerly underfull pages found shaped text,
+  intact boxes, and no clipping, collision, or awkward vertical stretching.
+- The vendored static Gurmukhi file is now explicitly selected for regular,
+  bold, italic, and bold-italic requests. This preserves the existing glyph
+  appearance without reporting unavailable font shapes.
+- The `ਤੂੰ` / `ਤੁਸੀਂ` section now has a natural-language separator and a shorter
+  running title, removing the lone overfull header without changing the lesson.
+  The forced 30-page XeLaTeX build now reports zero package or LaTeX warnings,
+  missing glyphs, overfull boxes, underfull boxes, and duplicate destinations.
+  HL-B10 is next: publish Sanskrit Chapter 6 through the canonical pipeline.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/punjabi/CHANGELOG.md
+++ b/code/learning/human-languages/punjabi/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Warning-clean six-chapter book — 2026-08-03
+
+- Gave each handwritten recap its stable canonical lesson label.
+- Kept Gurmukhi text in PDF bookmarks while removing font-only wrappers from
+  Hyperref's string conversion.
+- Selected the vendored static Gurmukhi font for every requested text shape,
+  let short callout pages end naturally, and shortened the two-forms-of-you
+  running title.
+- The forced 30-page build now has no missing glyphs, duplicate labels,
+  overfull or underfull boxes, font warnings, Hyperref warnings, or other LaTeX
+  package warnings.
+
 ## Canonical Chapter 6 publication — 2026-08-03
 
 - Migrated both number lessons to schema v2 with the shared

--- a/code/learning/human-languages/punjabi/README.md
+++ b/code/learning/human-languages/punjabi/README.md
@@ -50,7 +50,8 @@ first five chapters retain their authored long-form narrative during migration.
 Compiles with XeLaTeX using the **vendored** Noto Sans Gurmukhi font
 (`../../_fonts/NotoSansGurmukhi-Static.ttf`). `latexmk -xelatex book.tex`.
 Generated Gurmukhi runs use that font while section bookmarks use the lessons'
-Latin romanization.
+Latin romanization. A forced six-chapter build is warning-free, and the
+handwritten section bookmarks retain readable Gurmukhi plus romanization.
 
 ## Files
 

--- a/code/learning/human-languages/punjabi/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/punjabi/book/chapters/ch01-greetings.tex
@@ -106,7 +106,7 @@ The ``no'' sits on the ancient negative \emph{na-} --- the same Proto-Indo-Europ
 \end{cousinweb}
 
 \section{Recap}
-\label{lesson:practice}
+\label{PA-C01-practice}
 
 \begin{center}
 \begin{tabular}{@{}lll@{}}

--- a/code/learning/human-languages/punjabi/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/punjabi/book/chapters/ch02-introductions.tex
@@ -69,7 +69,7 @@ middle.
 \pa{ਮੇਰਾ} (my) $+$ \pa{ਨਾਂ} (name) $+$ name $+$ \pa{ਹੈ} (is) $=$ ``my name
 is\ldots'' \emph{Mer\=a n\=a\d{m} Arun hai.} The verb-frame comes last, as always.
 
-\section{\pa{ਤੂੰ} / \pa{ਤੁਸੀਂ} \emph{(t\=u\d{m} / tus\=\i\d{m})} --- ``you,'' familiar and respectful}
+\section[\pa{ਤੂੰ} and \pa{ਤੁਸੀਂ} --- two forms of ``you'']{\pa{ਤੂੰ} and \pa{ਤੁਸੀਂ} \emph{(t\=u\d{m}, tus\=\i\d{m})} --- ``you,'' familiar and respectful}
 \label{lesson:tu-tusi}
 
 \begin{cousinweb}
@@ -117,7 +117,7 @@ vocabularies}: Sanskrit (\emph{n\=a\d{m}}, \emph{hai}) and Perso-Arabic
 \end{cousinweb}
 
 \section{The whole exchange}
-\label{lesson:practice}
+\label{PA-C02-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/punjabi/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/punjabi/book/chapters/ch03-responding.tex
@@ -78,7 +78,7 @@ last.
 \end{cousinweb}
 
 \section{The whole exchange}
-\label{lesson:practice}
+\label{PA-C03-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/punjabi/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/punjabi/book/chapters/ch04-farewells.tex
@@ -56,7 +56,7 @@ keeping: the two vocabularies in one blessing.
 \end{cousinweb}
 
 \section{The farewells}
-\label{lesson:practice}
+\label{PA-C04-practice}
 
 \begin{center}
 \begin{tabular}{@{}lll@{}}

--- a/code/learning/human-languages/punjabi/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/punjabi/book/chapters/ch05-first-verbs.tex
@@ -71,7 +71,7 @@ work.''
 \end{cousinweb}
 
 \section{Sentences about yourself}
-\label{lesson:practice}
+\label{PA-C05-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/punjabi/book/preamble.tex
+++ b/code/learning/human-languages/punjabi/book/preamble.tex
@@ -29,7 +29,13 @@
 
 % Vendored Gurmukhi font (../../_fonts/ from <lang>/book/); \pa{...} = inline
 % Punjabi snippet.
-\newfontfamily\punjabifont[Path=../../_fonts/, Script=Gurmukhi]{NotoSansGurmukhi-Static.ttf}
+\newfontfamily\punjabifont[
+  Path=../../_fonts/,
+  Script=Gurmukhi,
+  BoldFont=NotoSansGurmukhi-Static.ttf,
+  ItalicFont=NotoSansGurmukhi-Static.ttf,
+  BoldItalicFont=NotoSansGurmukhi-Static.ttf
+]{NotoSansGurmukhi-Static.ttf}
 \newcommand{\pa}[1]{{\punjabifont #1}}
 
 \hypersetup{
@@ -38,6 +44,14 @@
   pdfsubject={Etymology-driven Punjabi curriculum},
   pdfkeywords={Punjabi, Gurmukhi, Sanskrit, language learning}
 }
+\pdfstringdefDisableCommands{%
+  \def\pa#1{#1}% Keep Gurmukhi text while dropping font-only presentation.
+  \def\punjabifont{}%
+}
+
+% Lesson callouts are deliberately kept together when they fit. Let short pages
+% end naturally instead of stretching their vertical glue around those boxes.
+\raggedbottom
 
 \newtcolorbox{cousinweb}{
   breakable, skin=enhanced, colback=yellow!8, colframe=yellow!45!black,


### PR DESCRIPTION
## Summary
- replace duplicate handwritten recap labels with stable Punjabi lesson ids
- preserve Gurmukhi in PDF bookmarks while stripping font-only wrappers and selecting the vendored static font for all text shapes
- let callout-heavy pages end naturally and shorten the two-forms-of-you running title

## Validation
- forced 30-page XeLaTeX build: 0 missing glyphs, 0 overfull/underfull boxes, 0 duplicate labels, 0 font/Hyperref/package/LaTeX warnings
- visual inspection of the four formerly underfull pages and the repaired running-header page
- PDF outline audit: 41 readable entries with Gurmukhi and romanization retained
- `npm run check:books`
- `git diff --check`
