### PR TITLE
fix(spice): lower parser MOS source perimeter

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS instance `PS` values before lowering
+  valid source diffusion perimeters.
 - Reject negative and non-finite MOS instance `PD` values before lowering
   valid drain diffusion perimeters.
 - Reject negative and non-finite MOS instance `AS` values before lowering

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1345,6 +1345,10 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             not math.isfinite(instance_params["PD"]) or instance_params["PD"] < 0.0
         ):
             raise NetlistParseError("MOSFET PD must be finite and non-negative")
+        if "PS" in instance_params and (
+            not math.isfinite(instance_params["PS"]) or instance_params["PS"] < 0.0
+        ):
+            raise NetlistParseError("MOSFET PS must be finite and non-negative")
         return Mosfet(
             name,
             fields[1],

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1065,6 +1065,32 @@ def test_lowers_valid_mosfet_instance_drain_perimeter(
     assert isclose(mosfet.model.model.params.PD, expected)
 
 
+@pytest.mark.parametrize("source_perimeter", ["-1u", "1e999"])
+def test_rejects_invalid_mosfet_instance_source_perimeter(
+    source_perimeter: str,
+) -> None:
+    with pytest.raises(
+        NetlistParseError, match="MOSFET PS must be finite and non-negative"
+    ):
+        parse_netlist(
+            f".model nfast NMOS\nM1 d g s b nfast PS={source_perimeter}\n"
+        )
+
+
+@pytest.mark.parametrize(
+    ("source_perimeter", "expected"), [("0", 0.0), ("7u", 7.0e-6)]
+)
+def test_lowers_valid_mosfet_instance_source_perimeter(
+    source_perimeter: str, expected: float
+) -> None:
+    parsed = parse_netlist(
+        f".model nfast NMOS\nM1 d g s b nfast PS={source_perimeter}\n"
+    )
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(mosfet.model.model.params.PS, expected)
+
+
 def test_parse_pwl_and_sin_source_waveforms() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS instance `PS` values and lower valid
+  source diffusion perimeters instead of silently dropping them.
 - Reject negative and non-finite MOS instance `PD` values and lower valid
   drain diffusion perimeters instead of silently dropping them.
 - Reject negative and non-finite MOS instance `AS` values and lower valid

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1375,6 +1375,7 @@ function isMosfetParam(name: keyof MosfetLevel1Params): boolean {
     "AD",
     "AS",
     "PD",
+    "PS",
     "IS",
     "N_SUB",
     "T_NOM",
@@ -1625,6 +1626,13 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       (!Number.isFinite(drainPerimeter) || drainPerimeter < 0.0)
     ) {
       throw new NetlistParseError("MOSFET PD must be finite and non-negative");
+    }
+    const sourcePerimeter = instanceParams.get("PS");
+    if (
+      sourcePerimeter !== undefined &&
+      (!Number.isFinite(sourcePerimeter) || sourcePerimeter < 0.0)
+    ) {
+      throw new NetlistParseError("MOSFET PS must be finite and non-negative");
     }
     return mosfet(
       name,

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1045,6 +1045,26 @@ Mp out gate vdd vdd pfast W=3u L=250n
     expect(element.params.PD).toBeCloseTo(expected, 15);
   });
 
+  it.each(["-1u", "1e999"])(
+    "rejects invalid MOSFET instance PS=%s",
+    (sourcePerimeter) => {
+      expect(() =>
+        parseNetlist(`.model nfast NMOS\nM1 d g s b nfast PS=${sourcePerimeter}\n`),
+      ).toThrow("MOSFET PS must be finite and non-negative");
+    },
+  );
+
+  it.each([
+    ["0", 0.0],
+    ["7u", 7.0e-6],
+  ])("lowers valid MOSFET instance PS=%s", (sourcePerimeter, expected) => {
+    const parsed = parseNetlist(`.model nfast NMOS\nM1 d g s b nfast PS=${sourcePerimeter}\n`);
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.PS).toBeCloseTo(expected, 15);
+  });
+
   it("parses PWL and SIN source waveforms", () => {
     const parsed = parseNetlist(`
 V1 in 0 PWL(0 0, 1n 1.8, 2n 0)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4243,11 +4243,17 @@ the Rust, Python, and TypeScript surfaces together.
      diagnostic while zero and positive source diffusion areas lower into
      Level-1 parameters.
 
+388. Python and TypeScript Berkeley SPICE MOS drain-perimeter parity.
+   - Status: completed in PR 9682.
+   - Negative and non-finite instance `PD` values are rejected with the shared
+     diagnostic while zero and positive drain diffusion perimeters lower into
+     Level-1 parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
-   - TypeScript still needs canonical lowering for `PD`, `PS`, `CJ`, `CJSW`,
-     `JS`, `PB`, `MJ`,
+   - TypeScript still needs canonical lowering for `PS`, `CJ`, `CJSW`, `JS`,
+     `PB`, `MJ`,
      `MJSW`, `FC`, `KF`, and `AF`; Python already lowers these canonical fields
      but still needs matching facade validation coverage.
    - Align the `CJS` and `CJD` aliases with canonical `CBS` and `CBD` in both


### PR DESCRIPTION
## Summary
- validate MOS instance `PS` as finite and non-negative in Python and TypeScript
- lower valid TypeScript source diffusion perimeters into Level-1 parameters
- record the merged drain-perimeter slice and advance the prioritized parity backlog

## Verification
- Python: 172 tests passed; 88.41% coverage; Ruff clean
- TypeScript: dependent spice-engine build, parser build, 165 tests passed; 84.83% line coverage