### PR TITLE
fix(html-parser): diagnose text mode EOF

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,10 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- EOF in the tree builder's text insertion mode now reports the Standard's
+  parse error, pops the authored text element, and reprocesses EOF in the
+  original mode, closing 92 previously silent malformed corpus cases without
+  changing DOM recovery or diagnostics for seeded fragment contexts.
 - Fragment parsing now reports the in-body EOF parse error for authored
   disallowed open elements while excluding synthetic context-shell nodes,
   closing 54 previously silent malformed corpus cases without changing DOM

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the fragment in-body EOF diagnostic slice, 1,891 of those cases emit at
-least one lexer or parser diagnostic and 292 remain uncovered. Another 139
+After the text insertion-mode EOF diagnostic slice, 1,983 of those cases emit
+at least one lexer or parser diagnostic and 200 remain uncovered. Another 139
 cases emit diagnostics despite having no legacy `#errors` rows. These are
 reviewed rather than automatically removed: 89 are full-document inputs for
 which the legacy fixtures omit the Standard-required missing-doctype error,
@@ -46,12 +46,15 @@ context and table-wrapper nodes are excluded. Remaining fragment EOF-labeled
 rows depend on table foster-parenting/scope recovery or foreign-content table
 boundaries and stay assigned to those algorithm audits.
 
+Text insertion-mode EOF diagnostics are complete for authored `script`,
+RCDATA, RAWTEXT, and scripting-enabled `noscript` elements. EOF now reports the
+mode's parse error, pops the current text element, and reprocesses EOF in the
+original mode; synthetic text fragment contexts remain diagnostic-free.
+
 Prioritized work items:
 
-1. **In-body and text insertion modes.** Cover scope failures, implied-end-tag
-   recovery, formatting reconstruction, stray start/end tags, and the large
-   executable cluster of unclosed script/style/title/noframes text-mode EOF
-   diagnostics.
+1. **In-body insertion mode.** Cover scope failures, implied-end-tag recovery,
+   formatting reconstruction, and stray start/end tags.
 2. **Table, select, and template insertion modes.** Cover foster parenting,
    table scopes, select recovery, and template mode-stack errors. The remaining
    fragment EOF inventory includes fostered-anchor `eof-in-table` rows and

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4656,6 +4656,13 @@ impl HtmlParser {
                         }));
                     }
                     Token::Eof => {
+                        if self.current_element_is_authored_text_mode_element() {
+                            self.diagnostics.push(ParserDiagnostic::new(
+                                "eof-in-text-mode",
+                                "end of file was reached while parsing a text element",
+                            ));
+                            self.open_elements.pop();
+                        }
                         if (self.is_fragment || self.has_open_element("body"))
                             && self.has_disallowed_authored_open_element_for_eof()
                         {
@@ -8177,6 +8184,28 @@ impl HtmlParser {
                     && is_disallowed_open_element_for_body_end(element)
             })
         })
+    }
+
+    fn current_element_is_authored_text_mode_element(&self) -> bool {
+        self.open_elements
+            .last()
+            .and_then(|path| element_ref_at_path(&self.document, path))
+            .is_some_and(|element| {
+                element.namespace.is_none()
+                    && !has_fragment_context_marker(element)
+                    && (matches!(
+                        element.name.as_str(),
+                        "iframe"
+                            | "noembed"
+                            | "noframes"
+                            | "script"
+                            | "style"
+                            | "textarea"
+                            | "title"
+                            | "xmp"
+                    ) || (element.name == "noscript"
+                        && self.options.scripting == HtmlScriptingMode::Enabled))
+            })
     }
 
     fn has_document_type(&self) -> bool {
@@ -33155,6 +33184,46 @@ mod tests {
                     "end of file was reached with disallowed open elements"
                 )],
                 "context {context:?}, source {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn reports_eof_in_text_insertion_mode() {
+        for source in [
+            "<!doctype html><script>",
+            "<!doctype html><style> EOF",
+            "<!doctype html><title>title",
+            "<!doctype html><frameset></frameset><noframes>fallback",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "eof-in-text-mode",
+                    "end of file was reached while parsing a text element"
+                )],
+                "source {source:?}"
+            );
+        }
+
+        let output = parse_html_fragment_with_diagnostics("<script>").unwrap();
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "eof-in-text-mode",
+                "end of file was reached while parsing a text element"
+            )]
+        );
+    }
+
+    #[test]
+    fn text_fragment_context_eof_does_not_diagnose_the_seeded_element() {
+        for context in ["script", "style", "textarea", "title"] {
+            let output = parse_html_fragment_for_context_with_diagnostics("", context).unwrap();
+            assert!(
+                output.parser_diagnostics.is_empty(),
+                "context {context:?}"
             );
         }
     }

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 292);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1891);
+    assert_eq!(missing_diagnostic_cases, 200);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1983);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report the current Standard's parse error when EOF arrives in the tree builder's text insertion mode
- pop the authored text element before reprocessing EOF in the original insertion mode
- exclude synthetic text fragment context nodes from the diagnostic

## Evidence
- closes 92 silent malformed corpus cases: 292 -> 200
- raises declared-error cases with diagnostics: 1,891 -> 1,983
- preserves all 2,637 checked DOM outputs
- keeps undeclared-diagnostic cases at 139
- live audit: WPT `d6c801946a63a6c5fec07c3d476b8b021e5eca34`, html5lib-tests `224991ec10db04f056a89eed8b0bd8695fd2950e`; 1,934/1,934 tree signatures, 6,806/6,806 tokenizer signatures, zero normalized skips

## Validation
- `cargo test -p coding-adventures-html-parser --test tree_construction_test`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- parser audit manifest, Rust-test, and coverage checks
- generated HTML fixture and README inventory checks
- `git diff --check`
