### PR TITLE
fix(ruby): bracket-index read/write (a[i], a[i] = v) had no grammar rule

### DIFF
--- a/code/grammars/ruby/ruby.grammar
+++ b/code/grammars/ruby/ruby.grammar
@@ -25,7 +25,7 @@
 # than PUTS, TRUE, FALSE, NIL as token types.
 
 program      = { statement } ;
-statement    = endless_def_statement | def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | case_statement | begin_statement | return_statement | break_statement | next_statement | redo_statement | retry_statement | yield_statement | alias_statement | undef_statement | multi_assignment | modifier_statement | rightward_assignment | assignment | defined_expression | method_with_block | method_call | method_call_no_paren | expression_stmt ;
+statement    = endless_def_statement | def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | case_statement | begin_statement | return_statement | break_statement | next_statement | redo_statement | retry_statement | yield_statement | alias_statement | undef_statement | multi_assignment | modifier_statement | rightward_assignment | index_assignment | assignment | defined_expression | method_with_block | method_call | method_call_no_paren | expression_stmt ;
 # Phase 6r — multiple assignment `a, b = 1, 2`.
 #
 # Placed BEFORE `modifier_statement` and `assignment` so the multi-LHS
@@ -470,6 +470,19 @@ ensure_clause   = "ensure" { !"end" statement } ;
 # on Op tokens (Plus/Minus/Star/Slash) and the two Name-typed
 # logicals (`||`/`&&`) to avoid colliding with comparison ops which
 # the lexer fuses directly.
+# Bug fix — bracket-index WRITE (`recv[expr] = value`) had NO grammar
+# support at all (not even the narrow "assignment RHS only" support the read
+# side accidentally had): `assignment`'s LHS is a bare `NAME`, so `h[4] = "d"`
+# hit a hard parse error ("Unexpected token: =") the moment the parser saw
+# `[` where an assignment operator was expected. Placed BEFORE `assignment`
+# so the bracket form wins — `assignment` itself fails to match cleanly on
+# `NAME [` anyway (no assignment operator follows a bare `NAME` there), so
+# this ordering doesn't shadow anything. v0 scope: a single bracket on a
+# bare NAME receiver (`a[i] = v`, `h[k] = v`) — a dotted/chained receiver
+# (`obj.data[i] = v`) or nested brackets on the LHS (`a[i][j] = v`) are NOT
+# covered by this rule (falls through to a clean parse-error, not a silent
+# misparse); can be widened later if needed.
+index_assignment = NAME index_suffix EQUALS expression ;
 assignment   = NAME ( EQUALS | "+=" | "-=" | "*=" | "/=" | "%=" | "**=" | "<<=" | ">>=" | "&=" | "|=" | "^=" | "||=" | "&&=" ) expression ;
 # Phase 7e — Ruby 3.0 rightward (single-line) assignment `expr => var`.
 #
@@ -808,7 +821,19 @@ term         = factor { ( STAR | SLASH ) factor } ;
 # a `call_arg`/`LPAREN`), so it parses as bare-`super` then the enclosing
 # `sum` applies `+ 1` to the produced value.
 super_expr   = "super" [ super_args ] ;
-factor       = ( defined_expression | lambda_literal | super_expr | method_call | NUMBER | STRING | NAME | ( !"end" !"rescue" !"ensure" !"else" !"elsif" !"when" !"then" !"in" !"do" KEYWORD ) | symbol_literal | array_literal | hash_literal | LPAREN expression RPAREN | unary_minus ) { dot_call | scope_resolution } ;
+# Bug fix — bracket-index READ (`recv[expr]`) had no general postfix
+# production at all: `factor`'s postfix repetition only admitted `dot_call`/
+# `scope_resolution`, so `[...]` after a receiver was NEVER recognized as an
+# index — `array_literal`'s OWN leading `LBRACKET` would instead grab it as
+# an unrelated, freestanding array literal (a SEPARATE statement wherever a
+# statement boundary was reachable, e.g. `puts g[1]` silently became
+# `puts(g)` plus a discarded `[1]`; a hard parse error everywhere a fresh
+# statement wasn't reachable, e.g. `puts(g[1])` as a call argument). Adding
+# `index_suffix` alongside `dot_call`/`scope_resolution` here closes that
+# gap uniformly for every expression position — chained forms like
+# `a[0][1]` or `h[k].foo` fall out for free from the SAME repetition.
+index_suffix = LBRACKET expression RBRACKET ;
+factor       = ( defined_expression | lambda_literal | super_expr | method_call | NUMBER | STRING | NAME | ( !"end" !"rescue" !"ensure" !"else" !"elsif" !"when" !"then" !"in" !"do" KEYWORD ) | symbol_literal | array_literal | hash_literal | LPAREN expression RPAREN | unary_minus ) { dot_call | scope_resolution | index_suffix } ;
 # Phase 6w — arrow-lambda literal `->(params){body}` / `->{body}`.
 #
 # Ruby 1.9+ shorthand for creating a `Proc`/`Lambda`.  The parameter

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.7.0] - 2026-08-03
+
+### Fixed — bracket-index (`a[i]` / `a[i] = v`) had no grammar rule at all
+
+Reads only "worked" by accident, and only as a bare assignment RHS: `x =
+g[1]` silently split into TWO statements (`x = g`, then a dangling,
+unparsed `[1]`) instead of being one statement that reads element `1` of
+`g`. An earlier probe wrongly concluded this "worked" by checking whether
+the generated C source *contained* the string `_sir_seq_index` — that
+helper is emitted as boilerplate runtime in every generated file regardless
+of whether it's actually called, so the check always passed. Dumping the
+actual AST showed the true (broken) parse shape. Writes failed to parse at
+all: `a[0] = 9` raised "Unexpected token: =", since no rule existed for
+`[...]` on an assignment's left-hand side.
+
+Fixed by adding two new grammar rules:
+
+- `index_suffix = LBRACKET expression RBRACKET` — a new postfix repetition
+  alternative in `factor` (alongside `dot_call`/`scope_resolution`), so
+  `recv[expr]` parses anywhere a postfix chain can appear, including
+  chained reads like `a[i][j]`.
+- `index_assignment = NAME index_suffix EQUALS expression` — a new
+  top-level `statement` alternative (checked before the ordinary
+  `assignment` rule), covering `name[expr] = value`.
+
+v0 scope: `index_assignment`'s left-hand side is a bare `NAME` receiver
+only — no dotted (`obj.arr[i] = v`) or chained (`a[i][j] = v`) receivers.
+Reads have no such limit (`index_suffix` composes through `factor`'s
+existing postfix repetition).
+
+### Added
+
+- `test_bracket_index_read_parses_as_one_statement`,
+  `test_bracket_index_read_in_call_argument_position`,
+  `test_bracket_index_chains`, `test_bracket_index_write_parses`,
+  `test_bracket_index_write_is_not_confused_with_plain_assignment` — parse-
+  shape regression tests for the fix above.
+
 ## [0.6.0] - 2026-08-03
 
 ### Fixed — bare comparison/logical statement mis-parsed as a paren-less call

--- a/code/packages/rust/ruby-parser/Cargo.toml
+++ b/code/packages/rust/ruby-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-ruby-parser"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Ruby parser — parses Ruby source code into an AST using the grammar-driven parser and the ruby.grammar file"
 

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -39,6 +39,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"multi_assignment"#.to_string() },
                 GrammarElement::RuleReference { name: r#"modifier_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"rightward_assignment"#.to_string() },
+                GrammarElement::RuleReference { name: r#"index_assignment"#.to_string() },
                 GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
                 GrammarElement::RuleReference { name: r#"defined_expression"#.to_string() },
                 GrammarElement::RuleReference { name: r#"method_with_block"#.to_string() },
@@ -699,6 +700,16 @@ pub fn parser_grammar() -> ParserGrammar {
             line_number: 453,
         },
         GrammarRule {
+            name: r#"index_assignment"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::RuleReference { name: r#"index_suffix"#.to_string() },
+                GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+            ] },
+            line_number: 485,
+        },
+        GrammarRule {
             name: r#"assignment"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
@@ -720,7 +731,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 473,
+            line_number: 486,
         },
         GrammarRule {
             name: r#"rightward_assignment"#.to_string(),
@@ -729,7 +740,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"=>"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 492,
+            line_number: 505,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -752,7 +763,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 509,
+            line_number: 522,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -775,7 +786,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"block"#.to_string() }) },
             ] },
-            line_number: 510,
+            line_number: 523,
         },
         GrammarRule {
             name: r#"scope_resolution"#.to_string(),
@@ -786,7 +797,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
                     ] }) },
             ] },
-            line_number: 518,
+            line_number: 531,
         },
         GrammarRule {
             name: r#"call_arg"#.to_string(),
@@ -805,7 +816,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 573,
+            line_number: 586,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -830,17 +841,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 617,
+            line_number: 630,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 620,
+            line_number: 633,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 727,
+            line_number: 740,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -853,7 +864,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 728,
+            line_number: 741,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -876,7 +887,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 729,
+            line_number: 742,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -890,7 +901,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 730,
+            line_number: 743,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -904,7 +915,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 731,
+            line_number: 744,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -915,7 +926,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 738,
+            line_number: 751,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -933,7 +944,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 739,
+            line_number: 752,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -947,7 +958,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 740,
+            line_number: 753,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -961,7 +972,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 741,
+            line_number: 754,
         },
         GrammarRule {
             name: r#"super_expr"#.to_string(),
@@ -969,7 +980,16 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"super"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"super_args"#.to_string() }) },
             ] },
-            line_number: 810,
+            line_number: 823,
+        },
+        GrammarRule {
+            name: r#"index_suffix"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LBRACKET"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
+            ] },
+            line_number: 835,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -1007,9 +1027,10 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::Alternation { choices: vec![
                         GrammarElement::RuleReference { name: r#"dot_call"#.to_string() },
                         GrammarElement::RuleReference { name: r#"scope_resolution"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"index_suffix"#.to_string() },
                     ] }) },
             ] },
-            line_number: 811,
+            line_number: 836,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -1022,7 +1043,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 830,
+            line_number: 855,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -1030,7 +1051,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 831,
+            line_number: 856,
         },
         GrammarRule {
             name: r#"defined_expression"#.to_string(),
@@ -1038,7 +1059,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"defined?"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 842,
+            line_number: 867,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -1050,7 +1071,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 849,
+            line_number: 874,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -1065,7 +1086,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 850,
+            line_number: 875,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -1080,7 +1101,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 851,
+            line_number: 876,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -1100,7 +1121,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 852,
+            line_number: 877,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -5109,5 +5109,101 @@ mod tests {
             );
         }
     }
+
+    // -------------------------------------------------------------------
+    // Bug fix: bracket-index read/write (`a[i]`, `a[i] = v`) had no grammar
+    // rule at all. Reads only "worked" as a bare assignment RHS by accident
+    // (`x = g[1]` silently split into TWO statements: `x = g` then a
+    // dangling `[1]`, discovered via an AST-dump probe after an earlier,
+    // WRONG belief -- based on a substring-search probe -- that it worked
+    // correctly). Writes (`a[i] = v`) failed to parse at all ("Unexpected
+    // token: ="). Fixed by adding `index_suffix = LBRACKET expression
+    // RBRACKET` as a new postfix repetition in `factor` (covers reads,
+    // including chained `a[i][j]`), and `index_assignment = NAME
+    // index_suffix EQUALS expression` as a new statement alternative (v0
+    // scope: bare NAME receiver only, no dotted/chained LHS).
+    // -------------------------------------------------------------------
+
+    /// Recursively search for a node with the given `rule_name` anywhere in
+    /// the tree (depth-first, not just direct children) -- unlike
+    /// `count_statements`/`find_def_statement` above, which only look at
+    /// direct children of a known parent shape.
+    fn tree_contains_rule(node: &GrammarASTNode, rule: &str) -> bool {
+        if node.rule_name == rule {
+            return true;
+        }
+        node.children.iter().any(|c| match c {
+            ASTNodeOrToken::Node(n) => tree_contains_rule(n, rule),
+            ASTNodeOrToken::Token(_) => false,
+        })
+    }
+
+    #[test]
+    fn test_bracket_index_read_parses_as_one_statement() {
+        // Before the fix, `x = g[1]` silently split into TWO statements
+        // (`x = g`, then a dangling, unparsed `[1]`). It must now be ONE.
+        let ast = parse_ruby("x = g[1]\n");
+        assert_program_root(&ast);
+        assert_eq!(
+            count_statements(&ast),
+            1,
+            "`x = g[1]` must parse as exactly one statement, not split at `[`"
+        );
+        assert!(
+            tree_contains_rule(&ast, "index_suffix"),
+            "expected an `index_suffix` node somewhere in the tree"
+        );
+    }
+
+    #[test]
+    fn test_bracket_index_read_in_call_argument_position() {
+        // `puts(a[1])` and the no-paren form `puts a[1]` must both parse as
+        // one statement with an `index_suffix` inside the call argument.
+        for src in ["puts(a[1])\n", "puts a[1]\n"] {
+            let ast = parse_ruby(src);
+            assert_program_root(&ast);
+            assert_eq!(count_statements(&ast), 1, "`{src}` should be one statement");
+            assert!(
+                tree_contains_rule(&ast, "index_suffix"),
+                "`{src}` should contain an `index_suffix` node"
+            );
+        }
+    }
+
+    #[test]
+    fn test_bracket_index_chains() {
+        // `a[1][0]` -- `factor`'s postfix repetition applies `index_suffix`
+        // more than once, so a chained read parses as one statement too.
+        let ast = parse_ruby("puts a[1][0]\n");
+        assert_program_root(&ast);
+        assert_eq!(count_statements(&ast), 1);
+        assert!(tree_contains_rule(&ast, "index_suffix"));
+    }
+
+    #[test]
+    fn test_bracket_index_write_parses() {
+        // `a[0] = 9` failed to parse at all before the fix ("Unexpected
+        // token: ="). It must now parse as one `index_assignment` statement.
+        for src in ["a[0] = 9\n", "h[\"b\"] = 2\n", "h[2] = \"b\"\n", "h[:sym] = 1\n"] {
+            let ast = parse_ruby(src);
+            assert_program_root(&ast);
+            assert_eq!(count_statements(&ast), 1, "`{src}` should be one statement");
+            assert!(
+                tree_contains_rule(&ast, "index_assignment"),
+                "`{src}` should contain an `index_assignment` node"
+            );
+        }
+    }
+
+    #[test]
+    fn test_bracket_index_write_is_not_confused_with_plain_assignment() {
+        // A plain assignment (`x = 1`) must NOT be mis-routed through the new
+        // `index_assignment` alternative -- it has no `[` at all, so the
+        // grammar's ordinary `assignment` rule must still handle it.
+        let ast = parse_ruby("x = 1\n");
+        assert_program_root(&ast);
+        assert_eq!(count_statements(&ast), 1);
+        assert!(!tree_contains_rule(&ast, "index_assignment"));
+    }
 }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## 0.8.0 — lower bracket-index read/write through `__method__` dispatch
+
+`ruby-parser` 0.7.0 adds real grammar rules for `recv[k]` (read,
+`index_suffix`) and `recv[k] = v` (write, `index_assignment`) — previously
+neither had a grammar rule at all (see that crate's CHANGELOG). This
+release adds the corresponding lowering:
+
+- `recv[k]` → `BuiltinCall("__method__", [recv, StrLit("[]"), k])`
+- `recv[k] = v` → `ExprStmt(BuiltinCall("__method__", [recv, StrLit("[]="), k, v]))`
+
+Both ride the SAME narrow-waist `__method__` dispatch every other
+Collections built-in uses (`.map`, `.each`, …) — no new IR node, no new
+`Feature`. This routes the Array-vs-Hash decision to the BACKEND, at
+RUNTIME, based on the receiver's actual tag.
+
+An earlier version of this lowering used a compile-time heuristic instead
+(mirroring `python-to-semantic-ir`'s documented convention: a string-
+literal-key index lowers to `Feature::Maps`/`Expr::MapGet`/`Stmt::MapSet`,
+any other index lowers to `Feature::Sequences`/`Expr::SeqIndex`/
+`Stmt::SeqSet`). That heuristic mis-routes a Hash write whose key isn't a
+string literal — `h[2] = "b"` on an int-keyed Hash, or `h[:sym] = 1` on a
+symbol-keyed Hash — to the Array path regardless of `h`'s actual type,
+which crashes at runtime (`_sir_seq_set` exits on a non-sequence receiver).
+Both are common, legitimate Ruby. The `__method__` design was chosen
+specifically because it cannot mis-route: the C backend's
+`_sir_builtin_method_v` checks `recv.tag` itself, so the index's syntactic
+shape is irrelevant to which path runs.
+
+v0 scope carries over from `ruby-parser`: `index_assignment`'s left-hand
+side must be a bare local/param `NAME` — no dotted or chained receivers.
+
+### Added
+
+- `bracket_index_read_lowers_to_method_dispatch`,
+  `bracket_index_write_lowers_to_method_dispatch`,
+  `bracket_index_write_with_non_string_key_is_not_a_seq_set`,
+  `chained_bracket_index_read_nests_method_dispatch`,
+  `bracket_index_read_and_write_pass_sir_validator` — lowering-shape and
+  validator regression tests, including the non-string-key case that
+  motivated the design above.
+
 ## 0.7.1 — regression tests for a `ruby-parser` grammar fix
 
 No behavior change in this crate — the actual fix (a bare comparison/logical

--- a/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruby-to-semantic-ir"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 description = "Ruby AST → narrow-waist Semantic IR. Phase 5 of the Ruby parser project — first frontend for the ruby-parser → SIR pipeline."
 

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -9442,4 +9442,125 @@ b = "y"
             );
         }
     }
+
+    // -----------------------------------------------------------------
+    // Bug fix: bracket-index read/write lowering.
+    //
+    // Both `a[i]` (read) and `a[i] = v` (write) route through the SAME
+    // `__method__` dispatch every other Collections built-in uses --
+    // `__method__(recv, "[]", index)` / `__method__(recv, "[]=", index,
+    // value)` -- rather than a compile-time guess (Array vs Hash) from the
+    // INDEX's syntactic shape. An earlier version of this lowering used
+    // such a heuristic (string-literal key -> Map, else -> Seq, matching
+    // `python-to-semantic-ir`'s convention) but it mis-routes a Hash write
+    // with a non-string key (e.g. `h[2] = "b"` on an int-keyed Hash) to the
+    // Array path, which crashes at runtime. Dispatching on the RECEIVER's
+    // actual runtime tag instead can never mis-route, regardless of the
+    // index's type.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn bracket_index_read_lowers_to_method_dispatch() {
+        // A trailing `puts x` keeps `x = a[1]` from being tail-promoted into
+        // `body.value` (only the LAST top-level statement is ever promoted,
+        // and only when it's a bare `expression_stmt`/method call — see
+        // `lower_program`), so the assignment lands in `body.stmts` as an
+        // ordinary `LetBinding` we can inspect directly.
+        let m = lower("a = [1, 2, 3]\nx = a[1]\nputs x\n");
+        let main = main_body(&m);
+        let value = main.stmts.iter().find_map(|s| match s {
+            Stmt::LetBinding { name, value, .. } | Stmt::LetStarBinding { name, value, .. } if name == "x" => Some(value),
+            _ => None,
+        }).expect("expected `x = ...` LetBinding");
+        match value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "__method__");
+                assert_eq!(args.len(), 3, "__method__(recv, \"[]\", index)");
+                assert!(matches!(&args[0], Expr::VarRef { name, .. } if name == "a"));
+                assert!(matches!(&args[1], Expr::StrLit { value, .. } if value == "[]"));
+                assert!(matches!(&args[2], Expr::IntLit { value: 1, .. }));
+            }
+            other => panic!("expected __method__ BuiltinCall for `a[1]`, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn bracket_index_write_lowers_to_method_dispatch() {
+        let m = lower("a[0] = 9\n");
+        let main = main_body(&m);
+        let stmt = main.stmts.first().expect("expected one statement");
+        match stmt {
+            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. } => {
+                assert_eq!(name, "__method__");
+                assert_eq!(args.len(), 4, "__method__(recv, \"[]=\", index, value)");
+                assert!(matches!(&args[0], Expr::VarRef { name, .. } if name == "a"));
+                assert!(matches!(&args[1], Expr::StrLit { value, .. } if value == "[]="));
+                assert!(matches!(&args[2], Expr::IntLit { value: 0, .. }));
+                assert!(matches!(&args[3], Expr::IntLit { value: 9, .. }));
+            }
+            other => panic!("expected __method__ BuiltinCall statement for `a[0] = 9`, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn bracket_index_write_with_non_string_key_is_not_a_seq_set() {
+        // The heuristic this replaced would have mis-routed this to
+        // `Stmt::SeqSet` (int key -> "must be an Array"), which crashes at
+        // runtime when `h` is actually a Hash. The `__method__` dispatch
+        // carries the index through untouched -- no type decision is made
+        // at lowering time at all.
+        let m = lower("h[2] = \"b\"\n");
+        let main = main_body(&m);
+        let stmt = main.stmts.first().expect("expected one statement");
+        assert!(
+            !matches!(stmt, Stmt::SeqSet { .. }),
+            "must not lower to SeqSet -- the receiver's type is unknown at lowering time"
+        );
+        match stmt {
+            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. } => {
+                assert_eq!(name, "__method__");
+                assert!(matches!(&args[1], Expr::StrLit { value, .. } if value == "[]="));
+                assert!(matches!(&args[2], Expr::IntLit { value: 2, .. }));
+            }
+            other => panic!("expected __method__ BuiltinCall statement, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn chained_bracket_index_read_nests_method_dispatch() {
+        // `a[1][0]` -- the outer `__method__("[]", ...)` receives the
+        // inner `__method__("[]", ...)` as ITS receiver. A trailing `puts x`
+        // keeps `x = a[1][0]` out of the tail-promoted `body.value` slot
+        // (see the comment on `bracket_index_read_lowers_to_method_dispatch`).
+        let m = lower("a = [[1, 2], [3, 4]]\nx = a[1][0]\nputs x\n");
+        let main = main_body(&m);
+        let value = main.stmts.iter().find_map(|s| match s {
+            Stmt::LetBinding { name, value, .. } | Stmt::LetStarBinding { name, value, .. } if name == "x" => Some(value),
+            _ => None,
+        }).expect("expected `x = ...` LetBinding");
+        match value {
+            Expr::BuiltinCall { name, args, .. } if name == "__method__" => {
+                assert!(matches!(&args[1], Expr::StrLit { value, .. } if value == "[]"));
+                match &args[0] {
+                    Expr::BuiltinCall { name: inner_name, args: inner_args, .. } => {
+                        assert_eq!(inner_name, "__method__");
+                        assert!(matches!(&inner_args[1], Expr::StrLit { value, .. } if value == "[]"));
+                    }
+                    other => panic!("expected nested __method__ receiver, got {:?}", other),
+                }
+            }
+            other => panic!("expected __method__ BuiltinCall for `a[1][0]`, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn bracket_index_read_and_write_pass_sir_validator() {
+        // `[]=`'s receiver must already exist (bracket-assignment mutates,
+        // it can't create a binding), so `a`/`h` are declared first.
+        let m = lower(
+            "a = [[1, 2], [3, 4]]\nh = {}\na[0] = 9\nh[\"k\"] = 1\nputs a[0]\nputs h[\"k\"]\nputs a[1][0]\n",
+        );
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected bracket-index program: {:?}", result);
+    }
 }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -1071,6 +1071,7 @@ impl Lowerer {
     fn lower_statement_inner(&mut self, node: &GrammarASTNode) -> Result<Stmt, RubyLowerError> {
         match node.rule_name.as_str() {
             "assignment" => self.lower_assignment(node),
+            "index_assignment" => self.lower_index_assignment(node),
             "rightward_assignment" => self.lower_rightward_assignment(node),
             // Phase 23b (FC) — `defined?(x)` in statement position (the
             // grammar lists `defined_expression` in the statement
@@ -9545,10 +9546,126 @@ impl Lowerer {
                 } else if sub.rule_name == "scope_resolution" {
                     // Phase 15d (FC) — `::Name` step.
                     recv = self.fold_one_scope_resolution(recv, sub)?;
+                } else if sub.rule_name == "index_suffix" {
+                    // Bug fix — `[expr]` postfix, e.g. `arr[i]` / `h[k]`.
+                    recv = self.fold_one_index_suffix(recv, sub)?;
                 }
             }
         }
         Ok(recv)
+    }
+
+    /// Lower a single `index_suffix` step (`[expr]`). Grammar shape:
+    ///     index_suffix = LBRACKET expression RBRACKET ;
+    ///
+    /// `[]` is REAL Ruby method syntax (`recv[k]` is sugar for
+    /// `recv.[](k)`) — so rather than guessing between `Expr::SeqIndex`
+    /// (Array) and `Expr::MapGet` (Hash) from the INDEX's syntactic shape
+    /// (a heuristic `python-to-semantic-ir` uses for the same ambiguity,
+    /// and this frontend's first draft copied — reverted after it mis-typed
+    /// a REAL, common case: a Hash with a non-string key, e.g.
+    /// `h[2] = "b"` on an int-keyed Hash, routes on the KEY's shape alone,
+    /// not the RECEIVER's actual runtime type), this lowers to the SAME
+    /// `__method__` envelope every other built-in/user method call already
+    /// uses. The runtime dispatcher then checks the RECEIVER's ACTUAL tag
+    /// (Array vs Hash) — genuinely polymorphic, not a guess, so it can
+    /// never mis-route regardless of the index's type.
+    fn fold_one_index_suffix(
+        &mut self,
+        base: Expr,
+        node: &GrammarASTNode,
+    ) -> Result<Expr, RubyLowerError> {
+        let expr_node = self
+            .find_node_child(node, "expression")
+            .ok_or_else(|| RubyLowerError {
+                message: "index_suffix missing index expression".to_string(),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            })?;
+        let index = self.lower_expression(expr_node)?;
+        let span = self.span_of(node);
+        self.features_used.insert(Feature::Strings);
+        Ok(Expr::BuiltinCall {
+            name: "__method__".to_string(),
+            args: vec![
+                base,
+                Expr::StrLit {
+                    value: "[]".to_string(),
+                    span: span.clone(),
+                },
+                index,
+            ],
+            effects: EffectSet::PURE,
+            span,
+        })
+    }
+
+    /// Lower an `index_assignment` statement (`recv[expr] = value`).
+    /// Grammar shape:
+    ///     index_assignment = NAME index_suffix EQUALS expression ;
+    ///
+    /// `recv[k] = v` is sugar for `recv.[]=(k, v)` — lowered to the SAME
+    /// `__method__` envelope `fold_one_index_suffix` uses for reads (see
+    /// its own doc comment for why this reuses method dispatch instead of
+    /// a compile-time Array-vs-Hash guess). v0 scope: a bare `NAME`
+    /// receiver only (`a[i] = v`, `h[k] = v`) — a dotted/chained receiver
+    /// (`obj.data[i] = v`) isn't covered (the grammar rule itself doesn't
+    /// admit one, so that shape falls through to a clean parse error
+    /// rather than a silent misparse).
+    fn lower_index_assignment(&mut self, node: &GrammarASTNode) -> Result<Stmt, RubyLowerError> {
+        let (name, name_span) = self.expect_first_name_token(node)?;
+        let index_suffix_node =
+            self.find_node_child(node, "index_suffix")
+                .ok_or_else(|| RubyLowerError {
+                    message: "index_assignment missing index_suffix".to_string(),
+                    line: node.start_line.unwrap_or(0),
+                    column: node.start_column.unwrap_or(0),
+                })?;
+        let index_expr_node = self
+            .find_node_child(index_suffix_node, "expression")
+            .ok_or_else(|| RubyLowerError {
+                message: "index_assignment's index_suffix missing expression".to_string(),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            })?;
+        let index = self.lower_expression(index_expr_node)?;
+        let value_node = self
+            .find_node_child(node, "expression")
+            .ok_or_else(|| RubyLowerError {
+                message: "index_assignment missing RHS expression".to_string(),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            })?;
+        let value = self.lower_expression(value_node)?;
+        let span = self.span_of(node);
+        let scope = if self.current_params.contains(&name) {
+            Scope::Param
+        } else {
+            Scope::Local
+        };
+        let receiver = Expr::VarRef {
+            name,
+            scope,
+            span: name_span,
+        };
+        self.features_used.insert(Feature::Strings);
+        Ok(Stmt::ExprStmt {
+            expr: Expr::BuiltinCall {
+                name: "__method__".to_string(),
+                args: vec![
+                    receiver,
+                    Expr::StrLit {
+                        value: "[]=".to_string(),
+                        span: span.clone(),
+                    },
+                    index,
+                    value,
+                ],
+                effects: EffectSet::PURE,
+                span: span.clone(),
+            },
+            span,
+        })
     }
 
     /// Lower a single `scope_resolution` step (`::Name`).  Grammar shape

--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.29.0 — bracket-index read/write (`recv[k]` / `recv[k] = v`)
+
+New dispatch arms for `"[]"` (read) and `"[]="` (write) in
+`_sir_builtin_method_v`, reached via `ruby-to-semantic-ir` 0.8.0's new
+`__method__("[]"/"[]=" ...)` lowering for Ruby's `recv[k]`/`recv[k] = v`
+syntax (real method syntax: `recv.[](k)`/`recv.[]=(k, v)`). Both branch on
+the RECEIVER's actual `SIR_SEQ`/`SIR_MAP` tag at runtime and delegate to
+the existing `_sir_seq_index`/`_sir_map_get` and `_sir_seq_set`/
+`_sir_map_set` helpers — no new runtime logic, just a new named entry point
+into machinery every other Array/Hash method already goes through.
+
+This replaces an earlier, REJECTED design where the Ruby frontend guessed
+Array-vs-Hash from the INDEX's syntactic shape at compile time (a
+string-literal key → Hash, anything else → Array). That heuristic mis-types
+a Hash with a non-string key — `h[2] = "b"` on an int-keyed Hash routed to
+`_sir_seq_set` regardless of `h`'s real type, which `exit()`s on a
+non-sequence receiver. Dispatching on the receiver's ACTUAL tag here, at
+runtime, can never mis-route: the index's type is irrelevant to which
+helper runs. As with every other bracket-index frontend gap, this was only
+reachable at all once `ruby-parser` grew a grammar rule for it — see that
+crate's 0.7.0 CHANGELOG entry for the parse-side half of this fix.
+
+### Added
+
+- `tests/compile_and_run_index_bracket.rs` — 11 execution-proof tests: Array
+  and Hash read/write, out-of-bounds/missing-key → `nil`, chained reads
+  (`a[1][0]`), updating an existing Hash key in place, a cyclic write
+  (`a[0] = a`), and — the case that motivated the runtime-dispatch design —
+  Hash writes with integer and symbol keys, which the rejected heuristic
+  would have crashed on.
+
 ## 0.28.1 — fix: `Array#sum` ignored a block argument
 
 The 0-arg `sum` dispatch arm (slice 3) never checked `argc`/`args`, so

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.28.1"
+version = "0.29.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -191,7 +191,13 @@ block-taking helper's pointer snapshot points into, silently corrupting an
 in-flight outer iteration; reallocating (like `push` already did) leaves any
 outer snapshot reading unmodified memory, restoring the safe invariant.  A
 wrong-type receiver or argument raises `NoMethodError`; a built-in method not
-lowered yet is still rejected cleanly.
+lowered yet is still rejected cleanly.  **Bracket-index** (`recv[k]` /
+`recv[k] = v`, Ruby's `[]`/`[]=`) rides the same `__method__` dispatch:
+`"[]"`/`"[]="` branch on the RECEIVER's actual `SIR_SEQ`/`SIR_MAP` tag at
+runtime and delegate to the existing index/get and set helpers — never a
+compile-time guess from the index's syntactic shape, so a Hash with a
+non-string key (an int or symbol key) can never be mis-routed to the Array
+path.
 
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
 `Intrinsics`, a `class << self` singleton, and

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -1772,8 +1772,12 @@ fn variadic_helper(name: &str) -> Option<&'static str> {
 /// forms); slice 7 = Hash methods taking a trailing BLOCK argument
 /// (`each_key`/`each_value`/`group_by`/`partition`; `each`/`map`/`select`/
 /// `reject`/`sort_by`/`sum` widen to accept a Hash receiver alongside their
-/// slice-3/5 Array forms). The dispatcher raises `NoMethodError` on an
-/// unsupported receiver type or a malformed call (missing/extra args, a
+/// slice-3/5 Array forms). `[]`/`[]=` (bracket-index read/write, Ruby's
+/// `recv.[](k)`/`recv.[]=(k, v)`) dispatch on the RECEIVER's actual runtime
+/// tag (Array vs Hash) — never a compile-time guess from the index's
+/// syntactic shape, so a Hash with a non-string key (e.g. an int or symbol
+/// key) can never be mis-routed. The dispatcher raises `NoMethodError` on
+/// an unsupported receiver type or a malformed call (missing/extra args, a
 /// non-closure block position), matching Ruby.
 fn is_builtin_method(name: &str) -> bool {
     matches!(
@@ -1794,6 +1798,8 @@ fn is_builtin_method(name: &str) -> bool {
         | "keys" | "values" | "to_h" | "dig" | "merge" | "delete" | "clear" | "invert"
         // slice 7 — Hash block methods
         | "each_key" | "each_value" | "group_by" | "partition"
+        // bracket-index read/write
+        | "[]" | "[]="
     )
 }
 

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -2326,6 +2326,23 @@ static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, Si
     } else if (strcmp(m, "invert") == 0) {
         if (recv.tag == SIR_MAP && argc == 0) return _sir_hash_invert(recv.as.map);
     }
+    /* Bug fix — `recv[k]` / `recv[k] = v` (Ruby's `[]`/`[]=`, real method
+       syntax: `recv.[](k)` / `recv.[]=(k, v)`). The frontend used to guess
+       Array-vs-Hash from the INDEX's syntactic shape at compile time (a
+       heuristic that mis-typed a real, common case: a Hash with a
+       non-string key, e.g. `h[2] = "b"` on an int-keyed Hash, routed to
+       Array's `_sir_seq_set` regardless of the receiver's actual type,
+       which EXITS on a non-sequence). Routing through the SAME `__method__`
+       dispatch every other built-in uses instead checks the RECEIVER's
+       ACTUAL tag here, at runtime — genuinely polymorphic, so it can never
+       mis-route regardless of the index's type. */
+    else if (strcmp(m, "[]") == 0) {
+        if (recv.tag == SIR_SEQ && argc == 1) return _sir_seq_index(recv, args[0]);
+        if (recv.tag == SIR_MAP && argc == 1) return _sir_map_get(recv, args[0]);
+    } else if (strcmp(m, "[]=") == 0) {
+        if (recv.tag == SIR_SEQ && argc == 2) return _sir_seq_set(recv, args[0], args[1]);
+        if (recv.tag == SIR_MAP && argc == 2) return _sir_map_set(recv, args[0], args[1]);
+    }
     /* Collections slice 2: 1-arg String queries (arg is a String); slice 4
        widens `include?`/`index` to accept an Array receiver too. */
     else if (strcmp(m, "include?") == 0) {

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_index_bracket.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_index_bracket.rs
@@ -1,0 +1,164 @@
+//! Execution proof for the bracket-index bug fix on the C backend — lower
+//! REAL Ruby source (`a[i]`, `a[i] = v`), emit C, compile with a real cc,
+//! run, assert stdout. Skips gracefully when no `cc` is present.
+//!
+//! `recv[k]` / `recv[k] = v` lower to `__method__(recv, "[]", k)` /
+//! `__method__(recv, "[]=", k, v)` — the SAME narrow-waist dispatch every
+//! other Collections built-in uses, so this proves the runtime dispatch in
+//! `semantic-ir-to-c`'s `_sir_builtin_method_v` (the `"[]"`/`"[]="` arms)
+//! genuinely branches on the RECEIVER's actual tag (Array vs Hash), not a
+//! compile-time guess from the index's syntactic shape. The critical cases
+//! are the non-string-key Hash writes (`h[2] = ...`, `h[:sym] = ...`) — the
+//! rejected heuristic design (string-literal key -> Map, else -> Seq) would
+//! have mis-routed these to the Array path and crashed.
+
+use std::process::Command;
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    ["cc", "clang", "gcc"]
+        .iter()
+        .find(|c| {
+            Command::new(c)
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        })
+        .map(|s| s.to_string())
+}
+
+fn run_ruby(src: &str) -> Option<String> {
+    let cc = find_cc()?;
+    let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
+    let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
+    let dir = std::env::temp_dir();
+    // Hash the full source, not just its length -- see the temp-file-collision
+    // fix elsewhere in this test suite (equal-length sources run as parallel
+    // threads in the SAME process and would collide on a length-keyed stem).
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    src.hash(&mut hasher);
+    let stem = format!("sirc_idxbr_{}_{}", std::process::id(), hasher.finish());
+    let cpath = dir.join(format!("{stem}.c"));
+    let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::write(&cpath, &art.source).expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        art.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "program exited non-zero");
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn array_read_in_call_argument_and_bare_statement_position() {
+    match run_ruby("a = [10, 20, 30]\nputs(a[1])\nputs a[2]\n") {
+        Some(out) => assert_eq!(out, "20\n30\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_read_into_a_variable() {
+    // The bug this fixes: `x = g[1]` used to silently split into two
+    // statements (`x = g`, dangling `[1]`) instead of reading the element.
+    match run_ruby("g = [5, 6, 7]\nx = g[1]\nputs x\n") {
+        Some(out) => assert_eq!(out, "6\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_write_then_read_back() {
+    match run_ruby("a = [1, 2, 3]\na[0] = 9\nputs a\n") {
+        Some(out) => assert_eq!(out, "[9, 2, 3]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_read_out_of_bounds_is_nil() {
+    match run_ruby("a = [1, 2, 3]\nputs a[10]\n") {
+        Some(out) => assert_eq!(out, "nil\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn hash_read_and_write_with_string_key() {
+    match run_ruby("h = {}\nh[\"b\"] = 2\nputs h[\"b\"]\nputs h\n") {
+        Some(out) => assert_eq!(out, "2\n{b: 2}\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn hash_write_with_integer_key_does_not_crash() {
+    // The critical regression case: the rejected string-literal-key
+    // heuristic mis-routed this to Array's `_sir_seq_set` (the key isn't a
+    // StrLit), which EXITS at runtime with "sir: []= on a non-sequence"
+    // because `h` is actually a SirMap. The `__method__` dispatch instead
+    // checks `h`'s ACTUAL runtime tag, so an int key on a Hash just works.
+    match run_ruby("h = {1 => \"a\"}\nh[2] = \"b\"\nputs h\n") {
+        Some(out) => assert_eq!(out, "{1: a, 2: b}\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn hash_write_with_symbol_key_does_not_crash() {
+    match run_ruby("h = {}\nh[:sym] = 1\nputs h\n") {
+        Some(out) => assert_eq!(out, "{sym: 1}\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn hash_read_missing_key_is_nil() {
+    match run_ruby("h = {\"a\" => 1}\nputs h[\"missing\"]\n") {
+        Some(out) => assert_eq!(out, "nil\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn hash_write_updates_an_existing_key_in_place() {
+    match run_ruby("h = {\"a\" => 1}\nh[\"a\"] = 99\nputs h[\"a\"]\n") {
+        Some(out) => assert_eq!(out, "99\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn chained_array_read() {
+    match run_ruby("a = [[1, 2], [3, 4]]\nputs a[1][0]\n") {
+        Some(out) => assert_eq!(out, "3\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn cyclic_write_does_not_crash() {
+    // `a[0] = a` -- a self-referential array, constructible now that
+    // bracket-index write is real. Proves the new dispatch path shares the
+    // same aliasing-safe mutators as the rest of Collections (no special
+    // casing needed) and that display/exit code stay sane on a cycle.
+    match run_ruby("a = [0]\na[0] = a\nputs \"ok\"\n") {
+        Some(out) => assert_eq!(out, "ok\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}


### PR DESCRIPTION
## Summary

- `recv[k]` (Array/Hash read) had no proper grammar rule — it only "worked" by accident as a bare assignment RHS: `x = g[1]` silently split into TWO statements (`x = g`, then a dangling unparsed `[1]`) instead of reading an element. `recv[k] = v` (write) failed to parse at all ("Unexpected token: =").
- Adds `index_suffix = LBRACKET expression RBRACKET` (new postfix repetition in `factor`, covers chained reads like `a[i][j]`) and `index_assignment = NAME index_suffix EQUALS expression` (new statement alternative; v0 scope: bare `NAME` receiver only, no dotted/chained LHS) to `ruby.grammar`.
- Lowers both through the SAME narrow-waist `__method__("[]"/"[]=", ...)` dispatch every other Collections built-in uses — `recv[k]` → `__method__(recv, "[]", k)`, `recv[k] = v` → `__method__(recv, "[]=", k, v)`.
- **Design note**: an earlier version used a compile-time heuristic (string-literal key → Hash, else → Array, matching `python-to-semantic-ir`'s convention) but this mis-routes a Hash write with a non-string key (`h[2] = "b"` on an int-keyed Hash, or a symbol key) to the Array path, which crashes at runtime. The `__method__` dispatch instead checks the RECEIVER's actual runtime tag in the C backend, so it can never mis-route regardless of the index's type.
- Adds the corresponding `"[]"`/`"[]="` dispatch arms to `semantic-ir-to-c`'s `_sir_builtin_method_v` (delegating to the existing `_sir_seq_index`/`_sir_map_get`/`_sir_seq_set`/`_sir_map_set` helpers) and the `is_builtin_method` allowlist.

Versions: `ruby-parser` 0.6.0 → 0.7.0, `ruby-to-semantic-ir` 0.7.1 → 0.8.0, `semantic-ir-to-c` 0.28.1 → 0.29.0.

## Test plan
- [x] New parser-level parse-shape tests (`ruby-parser`): bare-statement read, call-argument-position read, chained reads, write parsing, write-vs-plain-assignment disambiguation — 5 new tests, 296 total, all green.
- [x] New lowering-shape + validator tests (`ruby-to-semantic-ir`): read/write lower to `__method__`, chained reads nest correctly, non-string-key Hash write does NOT lower to `SeqSet`, full validator pass — 5 new tests, 436 total, all green.
- [x] New execution-proof tests (`semantic-ir-to-c`, real `cc` compile+run): Array/Hash read+write, OOB/missing-key → `nil`, chained reads, in-place key update, cyclic write, and the critical int/symbol-keyed Hash write regression case — 11 new tests, all green.
- [x] Full cross-crate regression suite (`ruby-parser`, `ruby-to-semantic-ir`, `semantic-ir-to-c`, `semantic-ir-to-{typescript,python,ruby,go,rust,javascript}`, `sir-conformance`) — all green, both pre- and post-rebase onto latest `origin/main`.
- [x] `cargo clippy` on all three touched crates — clean.
- [x] Security review (sub-agent) — PASSED, no vulnerabilities found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)