### PR TITLE
Implement verified D18 process host supervisor

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -755,6 +755,7 @@ members = [
     "chief-of-staff-host-control-protocol",
     "chief-of-staff-service-registry",
     "chief-of-staff-service-reconciler",
+    "chief-of-staff-process-supervisor",
     "chief-of-staff-tool-api",
     "chief-of-staff-host-runtime",
     "chief-of-staff-smart-home-tools",

--- a/code/packages/rust/chief-of-staff-process-supervisor/BUILD
+++ b/code/packages/rust/chief-of-staff-process-supervisor/BUILD
@@ -1,0 +1,1 @@
+cargo test -p chief-of-staff-process-supervisor -- --nocapture

--- a/code/packages/rust/chief-of-staff-process-supervisor/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-process-supervisor/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0
+
+- Add exact package re-verification before every host spawn.
+- Add bounded pipe framing and fresh secure-channel bootstrap.
+- Add authenticated readiness, heartbeat, and graceful termination handling.
+- Add owned child reaping with hard-kill fallback and drop cleanup.
+- Implement the D18 service reconciler's authoritative supervisor contract.

--- a/code/packages/rust/chief-of-staff-process-supervisor/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-process-supervisor/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "chief-of-staff-process-supervisor"
+version = "0.1.0"
+edition = "2021"
+description = "Verified OS-process supervision for D18 Chief hosts"
+license = "MIT"
+
+[dependencies]
+chief-of-staff-channel-crypto = { path = "../chief-of-staff-channel-crypto" }
+chief-of-staff-host-control-protocol = { path = "../chief-of-staff-host-control-protocol" }
+chief-of-staff-host-runtime = { path = "../chief-of-staff-host-runtime" }
+chief-of-staff-secure-host-channel = { path = "../chief-of-staff-secure-host-channel" }
+chief-of-staff-service-reconciler = { path = "../chief-of-staff-service-reconciler" }
+chief-of-staff-service-registry = { path = "../chief-of-staff-service-registry" }
+chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
+coding_adventures_uuid = { path = "../uuid" }
+coding_adventures_x3dh = { path = "../x3dh" }
+
+[dev-dependencies]
+coding_adventures_ed25519 = { path = "../ed25519" }
+coding_adventures_sha256 = { path = "../sha256" }
+
+[[bin]]
+name = "process-supervisor-test-child"
+path = "src/bin/process_supervisor_test_child.rs"
+test = false

--- a/code/packages/rust/chief-of-staff-process-supervisor/README.md
+++ b/code/packages/rust/chief-of-staff-process-supervisor/README.md
@@ -1,0 +1,19 @@
+# chief-of-staff-process-supervisor
+
+`chief-of-staff-process-supervisor` is the concrete OS-process authority for
+D18 Chief hosts. It re-verifies a registered signed package immediately before
+each spawn, owns and reaps the child, bootstraps a fresh UUID-v7 secure channel,
+and reports readiness and heartbeat only after authenticated control messages.
+
+The crate implements the dependency-light service reconciler's
+`HostSupervisor` interface. It deliberately leaves durable restart policy,
+scheduling, backoff, and registry updates to the reconciler and runnable
+orchestrator.
+
+## Validation
+
+```sh
+cargo test -p chief-of-staff-process-supervisor -- --nocapture
+cargo clippy -p chief-of-staff-process-supervisor --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-process-supervisor --no-deps
+```

--- a/code/packages/rust/chief-of-staff-process-supervisor/required_capabilities.json
+++ b/code/packages/rust/chief-of-staff-process-supervisor/required_capabilities.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/chief-of-staff-process-supervisor",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "*",
+      "justification": "Re-verifies the registered signed package directory immediately before every process launch."
+    },
+    {
+      "category": "proc",
+      "action": "exec",
+      "target": "*",
+      "justification": "Launches the orchestrator-configured host executable without invoking a shell."
+    },
+    {
+      "category": "proc",
+      "action": "signal",
+      "target": "*",
+      "justification": "Hard-kills an owned host child after protocol failure or graceful-shutdown timeout."
+    },
+    {
+      "category": "time",
+      "action": "read",
+      "target": "*",
+      "justification": "Samples monotonic receipt, launch, and graceful-shutdown deadline times."
+    },
+    {
+      "category": "time",
+      "action": "sleep",
+      "target": "*",
+      "justification": "Performs bounded short waits while enforcing a graceful-shutdown deadline."
+    }
+  ],
+  "justification": "Concrete process authority that verifies package files, launches and reaps configured children, transports authenticated control records over pipes, and enforces bounded monotonic deadlines."
+}

--- a/code/packages/rust/chief-of-staff-process-supervisor/src/bin/process_supervisor_test_child.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/src/bin/process_supervisor_test_child.rs
@@ -1,0 +1,67 @@
+use chief_of_staff_host_runtime::{
+    verify_agent_package, PackageKeyType, PackageKeyring, TrustedPackageKey,
+};
+use chief_of_staff_process_supervisor::ChildProcessControl;
+use chief_of_staff_tool_api::PrivilegeTier;
+use std::io::{self, Write};
+use std::path::Path;
+use std::thread;
+use std::time::Duration;
+
+const TEST_PUBLIC_KEY: [u8; 32] = [
+    25, 127, 107, 35, 225, 108, 133, 50, 198, 171, 200, 56, 250, 205, 94, 167, 137, 190, 12, 118,
+    178, 146, 3, 52, 3, 155, 250, 139, 61, 54, 141, 97,
+];
+
+fn has_marker(name: &str) -> bool {
+    Path::new(name).is_file()
+}
+
+fn run() -> Result<(), Box<dyn std::error::Error>> {
+    if has_marker("SILENT_BOOTSTRAP") {
+        thread::sleep(Duration::from_secs(10));
+        return Ok(());
+    }
+    if has_marker("OVERSIZED_BOOTSTRAP") {
+        let mut stdout = io::stdout().lock();
+        stdout.write_all(&((1024_u32 * 1024) + 1).to_be_bytes())?;
+        stdout.flush()?;
+        thread::sleep(Duration::from_secs(10));
+        return Ok(());
+    }
+
+    let mut keyring = PackageKeyring::new();
+    keyring.trust(TrustedPackageKey::new(
+        "prod-test",
+        PackageKeyType::Production,
+        TEST_PUBLIC_KEY,
+        PrivilegeTier::Tier3,
+    )?)?;
+    let package = verify_agent_package(Path::new("."), &keyring)?;
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut control = ChildProcessControl::bootstrap(stdin.lock(), stdout.lock())?;
+
+    if has_marker("EXIT_BEFORE_READY") {
+        return Ok(());
+    }
+    let mut digest = package.digest();
+    if has_marker("WRONG_READY") {
+        digest[0] ^= 0xff;
+    }
+    control.ready(digest)?;
+    if !has_marker("NO_HEARTBEAT") {
+        control.heartbeat()?;
+    }
+    control.receive_terminate()?;
+    if has_marker("IGNORE_TERMINATE") {
+        thread::sleep(Duration::from_secs(10));
+    }
+    Ok(())
+}
+
+fn main() {
+    if run().is_err() {
+        std::process::exit(70);
+    }
+}

--- a/code/packages/rust/chief-of-staff-process-supervisor/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/src/lib.rs
@@ -1,0 +1,948 @@
+//! Verified OS-process supervision for D18 Chief hosts.
+//!
+//! The service registry contains durable intent, not process authority. This
+//! adapter re-verifies packages, owns child handles, carries the secure control
+//! protocol over bounded pipes, and fails closed on transport or protocol error.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use chief_of_staff_channel_crypto::ChannelId;
+use chief_of_staff_host_control_protocol::{
+    ChildControl, ChildEvent, OrchestratorControl, OrchestratorEvent,
+};
+use chief_of_staff_host_runtime::{verify_agent_package, PackageKeyring};
+use chief_of_staff_secure_host_channel::{
+    BootstrapOffer, ChildBootstrap, ClientHello, HostId, OrchestratorBootstrap, SessionId,
+};
+use chief_of_staff_service_reconciler::{HostSupervisor, SupervisorObservation};
+use chief_of_staff_service_registry::{HostName, HostRegistration};
+use coding_adventures_x3dh::IdentityKeyPair;
+use core::fmt::{self, Display, Formatter};
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::io::{self, BufReader, BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, ExitStatus, Stdio};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, TryRecvError};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+const MAX_RECORD_BYTES: usize = 1024 * 1024;
+const MAX_FIXED_ARGUMENTS: usize = 128;
+const MAX_PENDING_RECORDS: usize = 64;
+const STOP_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Stable, input-independent process-supervision failure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProcessSupervisorError {
+    /// Program, argument, or timeout configuration is invalid.
+    InvalidConfiguration,
+    /// Signed-package verification failed.
+    PackageVerification,
+    /// The verified package identity differs from the registered hash.
+    PackageMismatch,
+    /// A fresh valid UUID-v7 session could not be produced.
+    SessionGeneration,
+    /// Secure-channel bootstrap construction or authentication failed.
+    Bootstrap,
+    /// Process creation or required pipe acquisition failed.
+    Spawn,
+    /// A pipe read, write, flush, or process-management operation failed.
+    ProcessIo,
+    /// The child did not complete secure bootstrap before the deadline.
+    BootstrapTimeout,
+    /// A length-prefixed stream record was invalid or incomplete.
+    Framing,
+    /// Authenticated host-control processing failed closed.
+    Control,
+    /// A different package is already active under this host name.
+    ActivePackageMismatch,
+}
+
+impl Display for ProcessSupervisorError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidConfiguration => "process-supervisor: invalid configuration",
+            Self::PackageVerification => "process-supervisor: package verification failed",
+            Self::PackageMismatch => "process-supervisor: package identity mismatch",
+            Self::SessionGeneration => "process-supervisor: session generation failed",
+            Self::Bootstrap => "process-supervisor: secure bootstrap failed",
+            Self::Spawn => "process-supervisor: child spawn failed",
+            Self::ProcessIo => "process-supervisor: process I/O failed",
+            Self::BootstrapTimeout => "process-supervisor: bootstrap timed out",
+            Self::Framing => "process-supervisor: invalid framed record",
+            Self::Control => "process-supervisor: host-control failure",
+            Self::ActivePackageMismatch => "process-supervisor: active package identity mismatch",
+        })
+    }
+}
+
+impl std::error::Error for ProcessSupervisorError {}
+
+/// One shell-free executable plus bounded fixed arguments used for every host.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HostProgram {
+    executable: PathBuf,
+    arguments: Vec<OsString>,
+}
+
+impl HostProgram {
+    /// Validate a host executable and its fixed arguments.
+    pub fn new<I, S>(
+        executable: impl Into<PathBuf>,
+        arguments: I,
+    ) -> Result<Self, ProcessSupervisorError>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<OsString>,
+    {
+        let executable = executable.into();
+        let arguments = arguments.into_iter().map(Into::into).collect::<Vec<_>>();
+        if !executable.is_absolute() || arguments.len() > MAX_FIXED_ARGUMENTS {
+            return Err(ProcessSupervisorError::InvalidConfiguration);
+        }
+        Ok(Self {
+            executable,
+            arguments,
+        })
+    }
+
+    /// Return the configured executable path.
+    pub fn executable(&self) -> &Path {
+        &self.executable
+    }
+
+    /// Return the shell-free fixed argument list.
+    pub fn arguments(&self) -> &[OsString] {
+        &self.arguments
+    }
+}
+
+/// Validated launch and deadline configuration.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProcessSupervisorConfig {
+    program: HostProgram,
+    bootstrap_timeout: Duration,
+    graceful_stop_timeout: Duration,
+}
+
+impl ProcessSupervisorConfig {
+    /// Construct configuration with non-zero bounded waits.
+    pub fn new(
+        program: HostProgram,
+        bootstrap_timeout: Duration,
+        graceful_stop_timeout: Duration,
+    ) -> Result<Self, ProcessSupervisorError> {
+        if bootstrap_timeout.is_zero() || graceful_stop_timeout.is_zero() {
+            return Err(ProcessSupervisorError::InvalidConfiguration);
+        }
+        Ok(Self {
+            program,
+            bootstrap_timeout,
+            graceful_stop_timeout,
+        })
+    }
+
+    /// Return the configured host program.
+    pub fn program(&self) -> &HostProgram {
+        &self.program
+    }
+
+    /// Return the secure-bootstrap deadline.
+    pub fn bootstrap_timeout(&self) -> Duration {
+        self.bootstrap_timeout
+    }
+
+    /// Return the graceful-stop deadline.
+    pub fn graceful_stop_timeout(&self) -> Duration {
+        self.graceful_stop_timeout
+    }
+}
+
+/// Trusted monotonic nanosecond source.
+pub trait MonotonicClock: Send + Sync {
+    /// Sample opaque monotonic nanoseconds.
+    fn now_ns(&self) -> u64;
+}
+
+/// Monotonic clock measured from one process-local `Instant` origin.
+pub struct SystemMonotonicClock {
+    origin: Instant,
+}
+
+impl SystemMonotonicClock {
+    /// Create a fresh process-local origin.
+    pub fn new() -> Self {
+        Self {
+            origin: Instant::now(),
+        }
+    }
+}
+
+impl Default for SystemMonotonicClock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MonotonicClock for SystemMonotonicClock {
+    fn now_ns(&self) -> u64 {
+        self.origin.elapsed().as_nanos().min(u64::MAX as u128) as u64
+    }
+}
+
+/// Source of fresh valid UUID-v7 secure-session identities.
+pub trait SessionIdSource {
+    /// Return the next per-spawn session.
+    fn next_session(&mut self) -> Result<SessionId, ProcessSupervisorError>;
+}
+
+/// Production UUID-v7 session source.
+#[derive(Default)]
+pub struct UuidV7SessionIdSource;
+
+impl SessionIdSource for UuidV7SessionIdSource {
+    fn next_session(&mut self) -> Result<SessionId, ProcessSupervisorError> {
+        let uuid =
+            coding_adventures_uuid::v7().map_err(|_| ProcessSupervisorError::SessionGeneration)?;
+        SessionId::new(uuid.bytes()).map_err(|_| ProcessSupervisorError::SessionGeneration)
+    }
+}
+
+enum ReaderEvent {
+    Record { bytes: Vec<u8>, received_at_ns: u64 },
+    Failure(ProcessSupervisorError),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InstancePhase {
+    Starting,
+    Running,
+    Stopping,
+    Exited { exit_code: Option<i32> },
+}
+
+struct OwnedInstance {
+    package_hash: [u8; 32],
+    child: Option<Child>,
+    stdin: Option<BufWriter<ChildStdin>>,
+    reader: Option<JoinHandle<()>>,
+    records: Receiver<ReaderEvent>,
+    control: Option<OrchestratorControl>,
+    phase: InstancePhase,
+    process_id: u32,
+    started_at_ns: u64,
+    last_heartbeat_ns: Option<u64>,
+    channel_id: ChannelId,
+}
+
+impl OwnedInstance {
+    fn is_active(&self) -> bool {
+        !matches!(self.phase, InstancePhase::Exited { .. })
+    }
+
+    fn finish_exit(&mut self, status: ExitStatus) {
+        self.child.take();
+        self.stdin.take();
+        if let Some(reader) = self.reader.take() {
+            let _ = reader.join();
+        }
+        self.control.take();
+        self.phase = InstancePhase::Exited {
+            exit_code: status.code(),
+        };
+    }
+
+    fn hard_kill_and_reap(&mut self) -> Result<(), ProcessSupervisorError> {
+        self.stdin.take();
+        let status = if let Some(child) = self.child.as_mut() {
+            match child
+                .try_wait()
+                .map_err(|_| ProcessSupervisorError::ProcessIo)?
+            {
+                Some(status) => status,
+                None => {
+                    child
+                        .kill()
+                        .map_err(|_| ProcessSupervisorError::ProcessIo)?;
+                    child
+                        .wait()
+                        .map_err(|_| ProcessSupervisorError::ProcessIo)?
+                }
+            }
+        } else {
+            return Ok(());
+        };
+        self.finish_exit(status);
+        Ok(())
+    }
+
+    fn refresh(&mut self) -> Result<(), ProcessSupervisorError> {
+        if matches!(self.phase, InstancePhase::Exited { .. }) {
+            return Ok(());
+        }
+        loop {
+            match self.records.try_recv() {
+                Ok(ReaderEvent::Record {
+                    bytes,
+                    received_at_ns,
+                }) => {
+                    let event = self
+                        .control
+                        .as_mut()
+                        .ok_or(ProcessSupervisorError::Control)?
+                        .receive_child(&bytes, received_at_ns)
+                        .map_err(|_| ProcessSupervisorError::Control);
+                    match event {
+                        Ok(ChildEvent::Ready { received_at_ns, .. })
+                        | Ok(ChildEvent::Heartbeat { received_at_ns }) => {
+                            self.phase = InstancePhase::Running;
+                            self.last_heartbeat_ns = Some(received_at_ns);
+                        }
+                        Err(error) => {
+                            let _ = self.hard_kill_and_reap();
+                            return Err(error);
+                        }
+                    }
+                }
+                Ok(ReaderEvent::Failure(error)) => {
+                    let _ = self.hard_kill_and_reap();
+                    return Err(error);
+                }
+                Err(TryRecvError::Empty | TryRecvError::Disconnected) => break,
+            }
+        }
+
+        if let Some(child) = self.child.as_mut() {
+            if let Some(status) = child
+                .try_wait()
+                .map_err(|_| ProcessSupervisorError::ProcessIo)?
+            {
+                self.finish_exit(status);
+            }
+        }
+        Ok(())
+    }
+
+    fn observation(&self) -> Result<SupervisorObservation, ProcessSupervisorError> {
+        let result = match self.phase {
+            InstancePhase::Starting => SupervisorObservation::starting(
+                self.package_hash,
+                self.process_id,
+                self.started_at_ns,
+                None,
+                None,
+            ),
+            InstancePhase::Running => SupervisorObservation::running(
+                self.package_hash,
+                self.process_id,
+                self.started_at_ns,
+                self.last_heartbeat_ns
+                    .ok_or(ProcessSupervisorError::Control)?,
+                self.channel_id,
+            ),
+            InstancePhase::Stopping => SupervisorObservation::stopping(
+                self.package_hash,
+                self.process_id,
+                self.started_at_ns,
+                self.last_heartbeat_ns,
+                Some(self.channel_id),
+            ),
+            InstancePhase::Exited { exit_code } => SupervisorObservation::exited(
+                self.package_hash,
+                exit_code,
+                Some(self.started_at_ns),
+                self.last_heartbeat_ns,
+            ),
+        };
+        result.map_err(|_| ProcessSupervisorError::Control)
+    }
+}
+
+/// Concrete verified process authority for the D18 service reconciler.
+pub struct ProcessHostSupervisor<'a> {
+    config: ProcessSupervisorConfig,
+    keyring: &'a PackageKeyring,
+    identity: &'a IdentityKeyPair,
+    clock: Arc<dyn MonotonicClock>,
+    sessions: Box<dyn SessionIdSource>,
+    instances: BTreeMap<String, OwnedInstance>,
+}
+
+impl<'a> ProcessHostSupervisor<'a> {
+    /// Construct a supervisor around injected package trust, identity, time, and sessions.
+    pub fn new(
+        config: ProcessSupervisorConfig,
+        keyring: &'a PackageKeyring,
+        identity: &'a IdentityKeyPair,
+        clock: Arc<dyn MonotonicClock>,
+        sessions: Box<dyn SessionIdSource>,
+    ) -> Self {
+        Self {
+            config,
+            keyring,
+            identity,
+            clock,
+            sessions,
+            instances: BTreeMap::new(),
+        }
+    }
+
+    fn spawn_verified(
+        &mut self,
+        registration: &HostRegistration,
+    ) -> Result<OwnedInstance, ProcessSupervisorError> {
+        let package_path = Path::new(registration.package_path().as_str());
+        let package = verify_agent_package(package_path, self.keyring)
+            .map_err(|_| ProcessSupervisorError::PackageVerification)?;
+        if package.digest() != *registration.package_hash() {
+            return Err(ProcessSupervisorError::PackageMismatch);
+        }
+
+        let session = self.sessions.next_session()?;
+        let host = HostId::new(registration.host_name().as_str().to_owned())
+            .map_err(|_| ProcessSupervisorError::Bootstrap)?;
+        let bootstrap = OrchestratorBootstrap::new(self.identity, host, session)
+            .map_err(|_| ProcessSupervisorError::Bootstrap)?;
+        let offer = bootstrap
+            .offer()
+            .map_err(|_| ProcessSupervisorError::Bootstrap)?;
+
+        let mut command = Command::new(self.config.program.executable());
+        command
+            .args(self.config.program.arguments())
+            .current_dir(package.path())
+            .env_clear()
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+        let mut child = command.spawn().map_err(|_| ProcessSupervisorError::Spawn)?;
+        let process_id = child.id();
+        let started_at_ns = self.clock.now_ns();
+        let child_stdin = match child.stdin.take() {
+            Some(stdin) => stdin,
+            None => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(ProcessSupervisorError::Spawn);
+            }
+        };
+        let child_stdout = match child.stdout.take() {
+            Some(stdout) => stdout,
+            None => {
+                drop(child_stdin);
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(ProcessSupervisorError::Spawn);
+            }
+        };
+        let mut stdin = BufWriter::new(child_stdin);
+        let (sender, records) = mpsc::sync_channel(MAX_PENDING_RECORDS);
+        let clock = Arc::clone(&self.clock);
+        let reader = thread::spawn(move || {
+            let mut stdout = BufReader::new(child_stdout);
+            loop {
+                match read_record(&mut stdout) {
+                    Ok(bytes) => {
+                        let received_at_ns = clock.now_ns();
+                        if sender
+                            .send(ReaderEvent::Record {
+                                bytes,
+                                received_at_ns,
+                            })
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    Err(error) => {
+                        let _ = sender.send(ReaderEvent::Failure(error));
+                        break;
+                    }
+                }
+            }
+        });
+
+        let startup = (|| {
+            write_record(&mut stdin, offer.as_bytes())?;
+            let hello = match records.recv_timeout(self.config.bootstrap_timeout) {
+                Ok(ReaderEvent::Record { bytes, .. }) => ClientHello::from_bytes(&bytes)
+                    .map_err(|_| ProcessSupervisorError::Bootstrap)?,
+                Ok(ReaderEvent::Failure(error)) => return Err(error),
+                Err(RecvTimeoutError::Timeout) => {
+                    return Err(ProcessSupervisorError::BootstrapTimeout)
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    return Err(ProcessSupervisorError::ProcessIo)
+                }
+            };
+            let channel = bootstrap
+                .accept(&hello)
+                .map_err(|_| ProcessSupervisorError::Bootstrap)?;
+            OrchestratorControl::new(channel, *registration.package_hash())
+                .map_err(|_| ProcessSupervisorError::Control)
+        })();
+
+        match startup {
+            Ok(control) => Ok(OwnedInstance {
+                package_hash: *registration.package_hash(),
+                child: Some(child),
+                stdin: Some(stdin),
+                reader: Some(reader),
+                records,
+                channel_id: ChannelId(control.session_id().as_bytes()),
+                control: Some(control),
+                phase: InstancePhase::Starting,
+                process_id,
+                started_at_ns,
+                last_heartbeat_ns: None,
+            }),
+            Err(error) => {
+                drop(stdin);
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = reader.join();
+                Err(error)
+            }
+        }
+    }
+}
+
+impl HostSupervisor for ProcessHostSupervisor<'_> {
+    type Error = ProcessSupervisorError;
+
+    fn inspect(
+        &mut self,
+        registration: &HostRegistration,
+    ) -> Result<SupervisorObservation, Self::Error> {
+        let Some(instance) = self.instances.get_mut(registration.host_name().as_str()) else {
+            return Ok(SupervisorObservation::absent());
+        };
+        instance.refresh()?;
+        instance.observation()
+    }
+
+    fn start(&mut self, registration: &HostRegistration) -> Result<(), Self::Error> {
+        if let Some(instance) = self.instances.get_mut(registration.host_name().as_str()) {
+            instance.refresh()?;
+            if instance.is_active() {
+                return if instance.package_hash == *registration.package_hash() {
+                    Ok(())
+                } else {
+                    Err(ProcessSupervisorError::ActivePackageMismatch)
+                };
+            }
+        }
+        let instance = self.spawn_verified(registration)?;
+        self.instances
+            .insert(registration.host_name().as_str().to_owned(), instance);
+        Ok(())
+    }
+
+    fn stop(&mut self, host_name: &HostName) -> Result<(), Self::Error> {
+        let Some(instance) = self.instances.get_mut(host_name.as_str()) else {
+            return Ok(());
+        };
+        instance.refresh()?;
+        if matches!(
+            instance.phase,
+            InstancePhase::Stopping | InstancePhase::Exited { .. }
+        ) {
+            return Ok(());
+        }
+
+        instance.phase = InstancePhase::Stopping;
+        let terminate = instance
+            .control
+            .as_mut()
+            .ok_or(ProcessSupervisorError::Control)?
+            .terminate()
+            .map_err(|_| ProcessSupervisorError::Control);
+        let write_result = terminate.and_then(|frame| {
+            let stdin = instance
+                .stdin
+                .as_mut()
+                .ok_or(ProcessSupervisorError::ProcessIo)?;
+            write_record(stdin, &frame)
+        });
+        if let Err(error) = write_result {
+            let _ = instance.hard_kill_and_reap();
+            return Err(error);
+        }
+
+        let deadline = Instant::now() + self.config.graceful_stop_timeout;
+        loop {
+            if let Some(status) = instance
+                .child
+                .as_mut()
+                .ok_or(ProcessSupervisorError::ProcessIo)?
+                .try_wait()
+                .map_err(|_| ProcessSupervisorError::ProcessIo)?
+            {
+                instance.finish_exit(status);
+                return Ok(());
+            }
+            let now = Instant::now();
+            if now >= deadline {
+                return instance.hard_kill_and_reap();
+            }
+            thread::sleep(STOP_POLL_INTERVAL.min(deadline - now));
+        }
+    }
+}
+
+impl Drop for ProcessHostSupervisor<'_> {
+    fn drop(&mut self) {
+        for instance in self.instances.values_mut() {
+            if instance.is_active() {
+                let _ = instance.hard_kill_and_reap();
+            }
+        }
+    }
+}
+
+/// Child-side secure bootstrap and lifecycle protocol over caller-owned streams.
+pub struct ChildProcessControl<R: Read, W: Write> {
+    reader: R,
+    writer: W,
+    control: ChildControl,
+}
+
+impl<R: Read, W: Write> ChildProcessControl<R, W> {
+    /// Read one offer, authenticate it, write one hello, and retain the live channel.
+    pub fn bootstrap(mut reader: R, mut writer: W) -> Result<Self, ProcessSupervisorError> {
+        let offer = read_record(&mut reader)?;
+        let offer =
+            BootstrapOffer::from_bytes(&offer).map_err(|_| ProcessSupervisorError::Bootstrap)?;
+        let (channel, hello) =
+            ChildBootstrap::open(&offer).map_err(|_| ProcessSupervisorError::Bootstrap)?;
+        write_record(&mut writer, hello.as_bytes())?;
+        let control = ChildControl::new(channel).map_err(|_| ProcessSupervisorError::Control)?;
+        Ok(Self {
+            reader,
+            writer,
+            control,
+        })
+    }
+
+    /// Send one authenticated readiness record with the independently verified hash.
+    pub fn ready(&mut self, package_hash: [u8; 32]) -> Result<(), ProcessSupervisorError> {
+        let frame = self
+            .control
+            .ready(package_hash)
+            .map_err(|_| ProcessSupervisorError::Control)?;
+        write_record(&mut self.writer, &frame)
+    }
+
+    /// Send one authenticated heartbeat after readiness.
+    pub fn heartbeat(&mut self) -> Result<(), ProcessSupervisorError> {
+        let frame = self
+            .control
+            .heartbeat()
+            .map_err(|_| ProcessSupervisorError::Control)?;
+        write_record(&mut self.writer, &frame)
+    }
+
+    /// Block for and authenticate the orchestrator's graceful termination request.
+    pub fn receive_terminate(&mut self) -> Result<(), ProcessSupervisorError> {
+        let frame = read_record(&mut self.reader)?;
+        match self
+            .control
+            .receive_orchestrator(&frame)
+            .map_err(|_| ProcessSupervisorError::Control)?
+        {
+            OrchestratorEvent::Terminate => Ok(()),
+        }
+    }
+
+    /// Return this launch's UUID-v7 secure-session identity.
+    pub fn session_id(&self) -> SessionId {
+        self.control.session_id()
+    }
+}
+
+fn write_record(writer: &mut impl Write, payload: &[u8]) -> Result<(), ProcessSupervisorError> {
+    if payload.is_empty() || payload.len() > MAX_RECORD_BYTES {
+        return Err(ProcessSupervisorError::Framing);
+    }
+    let length = u32::try_from(payload.len()).map_err(|_| ProcessSupervisorError::Framing)?;
+    writer
+        .write_all(&length.to_be_bytes())
+        .and_then(|()| writer.write_all(payload))
+        .and_then(|()| writer.flush())
+        .map_err(|_| ProcessSupervisorError::ProcessIo)
+}
+
+fn read_record(reader: &mut impl Read) -> Result<Vec<u8>, ProcessSupervisorError> {
+    let mut length = [0u8; 4];
+    reader.read_exact(&mut length).map_err(map_read_error)?;
+    let length = u32::from_be_bytes(length) as usize;
+    if length == 0 || length > MAX_RECORD_BYTES {
+        return Err(ProcessSupervisorError::Framing);
+    }
+    let mut payload = vec![0u8; length];
+    reader.read_exact(&mut payload).map_err(map_read_error)?;
+    Ok(payload)
+}
+
+fn map_read_error(error: io::Error) -> ProcessSupervisorError {
+    match error.kind() {
+        io::ErrorKind::UnexpectedEof => ProcessSupervisorError::Framing,
+        _ => ProcessSupervisorError::ProcessIo,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chief_of_staff_host_control_protocol::ControlState;
+    use coding_adventures_x3dh::generate_identity_keypair;
+    use std::sync::mpsc::{channel, Receiver, Sender};
+
+    struct MemoryReader {
+        receiver: Receiver<Vec<u8>>,
+        pending: Vec<u8>,
+        offset: usize,
+    }
+
+    impl MemoryReader {
+        fn new(receiver: Receiver<Vec<u8>>) -> Self {
+            Self {
+                receiver,
+                pending: Vec::new(),
+                offset: 0,
+            }
+        }
+    }
+
+    impl Read for MemoryReader {
+        fn read(&mut self, output: &mut [u8]) -> io::Result<usize> {
+            if self.offset == self.pending.len() {
+                self.pending = self
+                    .receiver
+                    .recv()
+                    .map_err(|_| io::Error::new(io::ErrorKind::UnexpectedEof, "closed"))?;
+                self.offset = 0;
+            }
+            let count = output.len().min(self.pending.len() - self.offset);
+            output[..count].copy_from_slice(&self.pending[self.offset..self.offset + count]);
+            self.offset += count;
+            Ok(count)
+        }
+    }
+
+    struct MemoryWriter(Sender<Vec<u8>>);
+
+    impl Write for MemoryWriter {
+        fn write(&mut self, input: &[u8]) -> io::Result<usize> {
+            self.0
+                .send(input.to_vec())
+                .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "closed"))?;
+            Ok(input.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct FailingIo;
+
+    impl Read for FailingIo {
+        fn read(&mut self, _output: &mut [u8]) -> io::Result<usize> {
+            Err(io::Error::other("secret read failure"))
+        }
+    }
+
+    impl Write for FailingIo {
+        fn write(&mut self, _input: &[u8]) -> io::Result<usize> {
+            Err(io::Error::other("secret write failure"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::other("secret flush failure"))
+        }
+    }
+
+    #[test]
+    fn framing_accepts_exact_bounded_record() {
+        let mut wire = Vec::new();
+        write_record(&mut wire, b"hello").unwrap();
+        assert_eq!(read_record(&mut wire.as_slice()).unwrap(), b"hello");
+    }
+
+    #[test]
+    fn framing_rejects_zero_oversized_and_truncated_records() {
+        assert_eq!(
+            read_record(&mut [0u8; 4].as_slice()),
+            Err(ProcessSupervisorError::Framing)
+        );
+        assert_eq!(
+            read_record(&mut ((MAX_RECORD_BYTES as u32 + 1).to_be_bytes()).as_slice()),
+            Err(ProcessSupervisorError::Framing)
+        );
+        assert_eq!(
+            read_record(&mut [0, 0, 0, 2, 1].as_slice()),
+            Err(ProcessSupervisorError::Framing)
+        );
+        assert_eq!(
+            write_record(&mut Vec::new(), &[]),
+            Err(ProcessSupervisorError::Framing)
+        );
+        assert_eq!(
+            write_record(&mut Vec::new(), &vec![0; MAX_RECORD_BYTES + 1]),
+            Err(ProcessSupervisorError::Framing)
+        );
+        assert_eq!(
+            write_record(&mut FailingIo, b"record"),
+            Err(ProcessSupervisorError::ProcessIo)
+        );
+        assert_eq!(
+            read_record(&mut FailingIo),
+            Err(ProcessSupervisorError::ProcessIo)
+        );
+    }
+
+    #[test]
+    fn configuration_is_bounded_and_diagnostics_are_redacted() {
+        assert_eq!(
+            HostProgram::new("", std::iter::empty::<&str>()),
+            Err(ProcessSupervisorError::InvalidConfiguration)
+        );
+        assert_eq!(
+            HostProgram::new("relative-host", std::iter::empty::<&str>()),
+            Err(ProcessSupervisorError::InvalidConfiguration)
+        );
+        let too_many = (0..=MAX_FIXED_ARGUMENTS).map(|_| "x");
+        assert_eq!(
+            HostProgram::new("host", too_many),
+            Err(ProcessSupervisorError::InvalidConfiguration)
+        );
+        let executable = std::env::current_exe().unwrap();
+        let program = HostProgram::new(&executable, ["secret-argument"]).unwrap();
+        assert_eq!(
+            ProcessSupervisorConfig::new(program.clone(), Duration::ZERO, Duration::from_secs(1)),
+            Err(ProcessSupervisorError::InvalidConfiguration)
+        );
+        let config = ProcessSupervisorConfig::new(
+            program.clone(),
+            Duration::from_secs(2),
+            Duration::from_secs(3),
+        )
+        .unwrap();
+        assert_eq!(config.program(), &program);
+        assert_eq!(config.bootstrap_timeout(), Duration::from_secs(2));
+        assert_eq!(config.graceful_stop_timeout(), Duration::from_secs(3));
+        assert_eq!(program.executable(), executable);
+        assert_eq!(
+            program.arguments(),
+            &[std::ffi::OsStr::new("secret-argument")]
+        );
+        assert!(!ProcessSupervisorError::Spawn.to_string().contains("secret"));
+    }
+
+    #[test]
+    fn production_sources_create_valid_values() {
+        let clock = SystemMonotonicClock::new();
+        let first = clock.now_ns();
+        let second = clock.now_ns();
+        assert!(second >= first);
+        let session = UuidV7SessionIdSource.next_session().unwrap();
+        assert_eq!(session.as_bytes()[6] >> 4, 7);
+    }
+
+    #[test]
+    fn error_type_is_standard_error() {
+        let cases = [
+            (
+                ProcessSupervisorError::InvalidConfiguration,
+                "invalid configuration",
+            ),
+            (
+                ProcessSupervisorError::PackageVerification,
+                "package verification failed",
+            ),
+            (
+                ProcessSupervisorError::PackageMismatch,
+                "package identity mismatch",
+            ),
+            (
+                ProcessSupervisorError::SessionGeneration,
+                "session generation failed",
+            ),
+            (ProcessSupervisorError::Bootstrap, "secure bootstrap failed"),
+            (ProcessSupervisorError::Spawn, "child spawn failed"),
+            (ProcessSupervisorError::ProcessIo, "process I/O failed"),
+            (
+                ProcessSupervisorError::BootstrapTimeout,
+                "bootstrap timed out",
+            ),
+            (ProcessSupervisorError::Framing, "invalid framed record"),
+            (ProcessSupervisorError::Control, "host-control failure"),
+            (
+                ProcessSupervisorError::ActivePackageMismatch,
+                "active package identity mismatch",
+            ),
+        ];
+        for (error, suffix) in cases {
+            let standard: &dyn std::error::Error = &error;
+            assert_eq!(
+                standard.to_string(),
+                format!("process-supervisor: {suffix}")
+            );
+        }
+    }
+
+    #[test]
+    fn child_stream_helper_completes_authenticated_lifecycle() {
+        let (to_child, child_input) = channel();
+        let (to_parent, parent_input) = channel();
+        let mut parent_writer = MemoryWriter(to_child);
+        let mut parent_reader = MemoryReader::new(parent_input);
+        let child_reader = MemoryReader::new(child_input);
+        let child_writer = MemoryWriter(to_parent);
+        let mut session_bytes = [0u8; 16];
+        session_bytes[6] = 0x70;
+        session_bytes[8] = 0x80;
+        session_bytes[15] = 9;
+        let session = SessionId::new(session_bytes).unwrap();
+        let identity = generate_identity_keypair();
+        let bootstrap =
+            OrchestratorBootstrap::new(&identity, HostId::new("memory-host").unwrap(), session)
+                .unwrap();
+        let offer = bootstrap.offer().unwrap();
+        let package_hash = [23; 32];
+
+        let child = thread::spawn(move || {
+            let mut control = ChildProcessControl::bootstrap(child_reader, child_writer).unwrap();
+            assert_eq!(control.session_id(), session);
+            control.ready(package_hash).unwrap();
+            control.heartbeat().unwrap();
+            control.receive_terminate().unwrap();
+        });
+
+        write_record(&mut parent_writer, offer.as_bytes()).unwrap();
+        let hello = ClientHello::from_bytes(&read_record(&mut parent_reader).unwrap()).unwrap();
+        let channel = bootstrap.accept(&hello).unwrap();
+        let mut control = OrchestratorControl::new(channel, package_hash).unwrap();
+        let ready = read_record(&mut parent_reader).unwrap();
+        assert!(matches!(
+            control.receive_child(&ready, 10).unwrap(),
+            ChildEvent::Ready {
+                received_at_ns: 10,
+                ..
+            }
+        ));
+        let heartbeat = read_record(&mut parent_reader).unwrap();
+        assert_eq!(
+            control.receive_child(&heartbeat, 11).unwrap(),
+            ChildEvent::Heartbeat { received_at_ns: 11 }
+        );
+        let terminate = control.terminate().unwrap();
+        write_record(&mut parent_writer, &terminate).unwrap();
+        child.join().unwrap();
+        assert_eq!(control.state(), ControlState::Terminating);
+    }
+}

--- a/code/packages/rust/chief-of-staff-process-supervisor/tests/process_supervisor.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/tests/process_supervisor.rs
@@ -1,0 +1,406 @@
+use chief_of_staff_host_runtime::{
+    DenoLaunchPlan, PackageKeyType, PackageKeyring, TrustedPackageKey,
+};
+use chief_of_staff_process_supervisor::{
+    HostProgram, MonotonicClock, ProcessHostSupervisor, ProcessSupervisorConfig,
+    ProcessSupervisorError, SessionIdSource,
+};
+use chief_of_staff_secure_host_channel::SessionId;
+use chief_of_staff_service_reconciler::{HostSupervisor, SupervisorObservation, SupervisorPhase};
+use chief_of_staff_service_registry::{HostName, HostRegistration, PackagePath, RestartPolicy};
+use chief_of_staff_tool_api::PrivilegeTier;
+use coding_adventures_ed25519::{generate_keypair, sign};
+use coding_adventures_sha256::Sha256Hasher;
+use coding_adventures_x3dh::generate_identity_keypair;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const TEST_SEED: [u8; 32] = [42; 32];
+const TEST_KEY_ID: &str = "prod-test";
+const HASH_DOMAIN: &[u8] = b"chief-agent-package-v1\0";
+
+struct TestPackage {
+    path: PathBuf,
+    digest: [u8; 32],
+}
+
+impl TestPackage {
+    fn new(label: &str, marker: Option<&str>) -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "chief-process-supervisor-{label}-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(path.join("code")).unwrap();
+        fs::write(path.join("manifest.json"), b"{\"runtime\":\"typescript\"}").unwrap();
+        DenoLaunchPlan::write_launch_script(&path).unwrap();
+        fs::write(
+            path.join("code/agent_runtime.ts"),
+            b"console.log('fixture');\n",
+        )
+        .unwrap();
+        if let Some(marker) = marker {
+            fs::write(path.join(marker), b"1").unwrap();
+        }
+        fs::write(path.join("PUBKEY_ID"), TEST_KEY_ID).unwrap();
+        let digest = package_digest(&path);
+        let (_, secret_key) = generate_keypair(&TEST_SEED);
+        fs::write(path.join("SIGNATURE"), sign(&digest, &secret_key)).unwrap();
+        Self { path, digest }
+    }
+
+    fn registration(&self, host: &str) -> HostRegistration {
+        HostRegistration::new(
+            HostName::new(host).unwrap(),
+            PackagePath::new(self.path.to_str().unwrap()).unwrap(),
+            self.digest,
+            RestartPolicy::Always,
+        )
+    }
+}
+
+impl Drop for TestPackage {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+fn package_digest(path: &Path) -> [u8; 32] {
+    let mut files = vec![
+        (
+            "code/agent_runtime.ts".to_owned(),
+            fs::read(path.join("code/agent_runtime.ts")).unwrap(),
+        ),
+        (
+            "launch.sh".to_owned(),
+            fs::read(path.join("launch.sh")).unwrap(),
+        ),
+        (
+            "manifest.json".to_owned(),
+            fs::read(path.join("manifest.json")).unwrap(),
+        ),
+    ];
+    for marker in [
+        "EXIT_BEFORE_READY",
+        "IGNORE_TERMINATE",
+        "NO_HEARTBEAT",
+        "OVERSIZED_BOOTSTRAP",
+        "SILENT_BOOTSTRAP",
+        "WRONG_READY",
+    ] {
+        let marker_path = path.join(marker);
+        if marker_path.is_file() {
+            files.push((marker.to_owned(), fs::read(marker_path).unwrap()));
+        }
+    }
+    files.sort_by(|left, right| left.0.cmp(&right.0));
+    let mut hasher = Sha256Hasher::new();
+    hasher.update(HASH_DOMAIN);
+    for (name, bytes) in files {
+        hasher.update(&(name.len() as u64).to_be_bytes());
+        hasher.update(name.as_bytes());
+        hasher.update(&(bytes.len() as u64).to_be_bytes());
+        hasher.update(&bytes);
+    }
+    hasher.digest()
+}
+
+fn keyring() -> PackageKeyring {
+    let (public_key, _) = generate_keypair(&TEST_SEED);
+    let mut keyring = PackageKeyring::new();
+    keyring
+        .trust(
+            TrustedPackageKey::new(
+                TEST_KEY_ID,
+                PackageKeyType::Production,
+                public_key,
+                PrivilegeTier::Tier3,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+    keyring
+}
+
+#[derive(Default)]
+struct TestClock(AtomicU64);
+
+impl MonotonicClock for TestClock {
+    fn now_ns(&self) -> u64 {
+        self.0.fetch_add(1, Ordering::SeqCst) + 1
+    }
+}
+
+struct TestSessions(u8);
+
+impl SessionIdSource for TestSessions {
+    fn next_session(&mut self) -> Result<SessionId, ProcessSupervisorError> {
+        self.0 = self.0.wrapping_add(1);
+        let mut bytes = [0u8; 16];
+        bytes[6] = 0x70;
+        bytes[8] = 0x80;
+        bytes[15] = self.0;
+        SessionId::new(bytes).map_err(|_| ProcessSupervisorError::SessionGeneration)
+    }
+}
+
+fn new_supervisor<'a>(
+    keyring: &'a PackageKeyring,
+    identity: &'a coding_adventures_x3dh::IdentityKeyPair,
+    bootstrap_timeout: Duration,
+    graceful_timeout: Duration,
+) -> ProcessHostSupervisor<'a> {
+    let program = HostProgram::new(
+        env!("CARGO_BIN_EXE_process-supervisor-test-child"),
+        std::iter::empty::<&str>(),
+    )
+    .unwrap();
+    let config =
+        ProcessSupervisorConfig::new(program, bootstrap_timeout, graceful_timeout).unwrap();
+    ProcessHostSupervisor::new(
+        config,
+        keyring,
+        identity,
+        Arc::new(TestClock::default()),
+        Box::new(TestSessions(0)),
+    )
+}
+
+fn await_phase(
+    supervisor: &mut ProcessHostSupervisor<'_>,
+    registration: &HostRegistration,
+    expected: SupervisorPhase,
+) -> chief_of_staff_service_reconciler::SupervisorInstance {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        match supervisor.inspect(registration) {
+            Ok(SupervisorObservation::Instance(instance)) if instance.phase() == expected => {
+                return instance
+            }
+            Ok(_) => {}
+            Err(error) => panic!("unexpected supervisor error: {error}"),
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {expected:?}"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[test]
+fn real_child_reaches_running_and_stops_gracefully() {
+    let package = TestPackage::new("graceful", None);
+    let registration = package.registration("fixture-host");
+    let keyring = keyring();
+    let identity = generate_identity_keypair();
+    let mut supervisor = new_supervisor(
+        &keyring,
+        &identity,
+        Duration::from_secs(3),
+        Duration::from_secs(1),
+    );
+
+    supervisor.start(&registration).unwrap();
+    let starting = supervisor.inspect(&registration).unwrap();
+    let first_pid = match starting {
+        SupervisorObservation::Instance(instance) => instance.process_id().unwrap(),
+        SupervisorObservation::Absent => panic!("spawned child was absent"),
+    };
+    supervisor.start(&registration).unwrap();
+    let running = await_phase(&mut supervisor, &registration, SupervisorPhase::Running);
+    assert_eq!(running.process_id(), Some(first_pid));
+    assert_eq!(running.package_hash(), &package.digest);
+    assert!(running.last_heartbeat_ns().is_some());
+    assert!(running.control_channel_id().is_some());
+
+    supervisor.stop(registration.host_name()).unwrap();
+    let exited = await_phase(
+        &mut supervisor,
+        &registration,
+        SupervisorPhase::Exited { exit_code: Some(0) },
+    );
+    assert_eq!(exited.process_id(), None);
+    supervisor.stop(registration.host_name()).unwrap();
+}
+
+#[test]
+fn exact_hash_is_checked_before_spawn_and_active_hash_cannot_change() {
+    let package = TestPackage::new("identity", None);
+    let mut registration = package.registration("identity-host");
+    let keyring = keyring();
+    let identity = generate_identity_keypair();
+    let mut supervisor = new_supervisor(
+        &keyring,
+        &identity,
+        Duration::from_secs(3),
+        Duration::from_millis(200),
+    );
+
+    let mut wrong_hash = package.digest;
+    wrong_hash[0] ^= 0xff;
+    registration = HostRegistration::new(
+        registration.host_name().clone(),
+        registration.package_path().clone(),
+        wrong_hash,
+        RestartPolicy::Always,
+    );
+    assert_eq!(
+        supervisor.start(&registration),
+        Err(ProcessSupervisorError::PackageMismatch)
+    );
+
+    let registration = package.registration("identity-host");
+    supervisor.start(&registration).unwrap();
+    let different = HostRegistration::new(
+        registration.host_name().clone(),
+        registration.package_path().clone(),
+        wrong_hash,
+        RestartPolicy::Always,
+    );
+    assert_eq!(
+        supervisor.start(&different),
+        Err(ProcessSupervisorError::ActivePackageMismatch)
+    );
+    supervisor.stop(registration.host_name()).unwrap();
+}
+
+#[test]
+fn bootstrap_timeout_and_oversized_record_are_cleaned_up() {
+    for (label, marker, timeout, expected) in [
+        (
+            "timeout",
+            "SILENT_BOOTSTRAP",
+            Duration::from_millis(250),
+            ProcessSupervisorError::BootstrapTimeout,
+        ),
+        (
+            "oversized",
+            "OVERSIZED_BOOTSTRAP",
+            Duration::from_secs(3),
+            ProcessSupervisorError::Framing,
+        ),
+    ] {
+        let package = TestPackage::new(label, Some(marker));
+        let registration = package.registration(&format!("{label}-host"));
+        let keyring = keyring();
+        let identity = generate_identity_keypair();
+        let mut supervisor =
+            new_supervisor(&keyring, &identity, timeout, Duration::from_millis(100));
+        assert_eq!(supervisor.start(&registration), Err(expected));
+        assert_eq!(
+            supervisor.inspect(&registration).unwrap(),
+            SupervisorObservation::Absent
+        );
+    }
+}
+
+#[test]
+fn wrong_ready_and_exit_before_ready_fail_closed() {
+    for (label, marker, expected) in [
+        (
+            "wrong-ready",
+            "WRONG_READY",
+            ProcessSupervisorError::Control,
+        ),
+        (
+            "early-exit",
+            "EXIT_BEFORE_READY",
+            ProcessSupervisorError::Framing,
+        ),
+    ] {
+        let package = TestPackage::new(label, Some(marker));
+        let registration = package.registration(&format!("{label}-host"));
+        let keyring = keyring();
+        let identity = generate_identity_keypair();
+        let mut supervisor = new_supervisor(
+            &keyring,
+            &identity,
+            Duration::from_secs(3),
+            Duration::from_millis(100),
+        );
+        supervisor.start(&registration).unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if let Err(error) = supervisor.inspect(&registration) {
+                assert_eq!(error, expected);
+                break;
+            }
+            assert!(Instant::now() < deadline, "failure was not observed");
+            thread::sleep(Duration::from_millis(10));
+        }
+        let exited = supervisor.inspect(&registration).unwrap();
+        assert!(matches!(
+            exited,
+            SupervisorObservation::Instance(ref instance)
+                if matches!(instance.phase(), SupervisorPhase::Exited { .. })
+        ));
+    }
+}
+
+#[test]
+fn graceful_timeout_hard_kills_and_drop_reaps() {
+    let package = TestPackage::new("hard-kill", Some("IGNORE_TERMINATE"));
+    let registration = package.registration("hard-kill-host");
+    let keyring = keyring();
+    let identity = generate_identity_keypair();
+    let mut supervisor = new_supervisor(
+        &keyring,
+        &identity,
+        Duration::from_secs(3),
+        Duration::from_millis(100),
+    );
+    supervisor.start(&registration).unwrap();
+    await_phase(&mut supervisor, &registration, SupervisorPhase::Running);
+    let started = Instant::now();
+    supervisor.stop(registration.host_name()).unwrap();
+    assert!(started.elapsed() >= Duration::from_millis(90));
+    assert!(matches!(
+        supervisor.inspect(&registration).unwrap(),
+        SupervisorObservation::Instance(ref instance)
+            if matches!(instance.phase(), SupervisorPhase::Exited { .. })
+    ));
+
+    let second = TestPackage::new("drop", None);
+    let second_registration = second.registration("drop-host");
+    let mut dropped = new_supervisor(
+        &keyring,
+        &identity,
+        Duration::from_secs(3),
+        Duration::from_millis(100),
+    );
+    dropped.start(&second_registration).unwrap();
+    await_phase(&mut dropped, &second_registration, SupervisorPhase::Running);
+    drop(dropped);
+}
+
+#[test]
+fn invalid_package_fails_before_process_creation() {
+    let path = std::env::temp_dir().join(format!("chief-process-invalid-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&path);
+    let registration = HostRegistration::new(
+        HostName::new("invalid-host").unwrap(),
+        PackagePath::new(path.to_str().unwrap()).unwrap(),
+        [0; 32],
+        RestartPolicy::Never,
+    );
+    let keyring = keyring();
+    let identity = generate_identity_keypair();
+    let mut supervisor = new_supervisor(
+        &keyring,
+        &identity,
+        Duration::from_secs(1),
+        Duration::from_secs(1),
+    );
+    assert_eq!(
+        supervisor.start(&registration),
+        Err(ProcessSupervisorError::PackageVerification)
+    );
+}

--- a/code/specs/host-control-protocol.md
+++ b/code/specs/host-control-protocol.md
@@ -133,7 +133,8 @@ The package has no direct filesystem, network, stream, environment, process, clo
 or random capability. It receives complete encrypted frames and trusted receipt
 times from its caller. Length-prefix framing, pipe ownership, process launch/reap,
 heartbeat scheduling, time sampling, and hard-kill fallback belong to the concrete
-process-supervisor adapter.
+process-supervisor adapter specified in
+[`process-host-supervisor.md`](process-host-supervisor.md).
 
 ## Required Tests
 

--- a/code/specs/orchestrator.md
+++ b/code/specs/orchestrator.md
@@ -195,11 +195,27 @@ human even in an autonomous deployment.
 
 ### Host Supervisor
 
-The orchestrator is a `Supervisor` (from `supervisor` crate) at the
-root of the OS-process tree. Every host is a `ChildKind::HostProcess`
-child. Strategies and restart policies are defined per-host in the
-agent package's `manifest.json` and copied into the corresponding
-`ChildSpec` at registration time:
+The orchestrator composes the durable service registry and deterministic
+reconciler with the concrete process adapter specified in
+[`process-host-supervisor.md`](process-host-supervisor.md). The adapter is the
+root of the owned OS-process tree: it re-verifies the signed package immediately
+before every spawn, creates one fresh UUID-v7 secure session, and reports
+readiness and heartbeat only after authenticated host-control messages.
+
+Restart policy remains durable registry intent interpreted by the reconciler;
+the process adapter does not invent a second policy engine. Host capability
+manifests are validated before registration and again as part of package
+verification before launch. The runnable orchestrator supplies its trusted
+package keyring, process configuration, monotonic clock, and long-lived X3DH
+identity to the adapter.
+
+The adapter owns and reaps every child it reports. It does not adopt cached
+registry PIDs, invoke a shell, or treat PID existence as authority. Graceful
+shutdown uses an authenticated `Terminate` record followed by a bounded
+hard-kill fallback.
+
+An earlier prototype described this integration through the generic
+`supervisor` crate and a `ChildSpec` like this:
 
 ```rust
 let host_spec = ChildSpec {
@@ -214,16 +230,16 @@ let host_spec = ChildSpec {
 };
 ```
 
-The supervisor's capability-inheritance check (defined in
-`supervisor.md`) ensures the host's manifest is a subset of the
-orchestrator's own. The orchestrator's manifest is broad
+The generic supervisor's capability-inheritance check (defined in
+`supervisor.md`) remains useful for in-process task trees. The orchestrator's
+manifest is broad
 (`supervise`, `proc:fork`, `proc:exec:*`, `vault:admin`,
 `fs:read:./agents/*`) because it spawns processes; hosts have
 narrower manifests appropriate to their job.
 
-When a host crashes, the supervisor's restart strategy decides what
-happens. The orchestrator does not invent its own logic — it consumes
-what `supervisor` provides.
+For D18 host processes, crash recovery is instead driven by the durable service
+registry's `RestartPolicy` through the service reconciler, so restart decisions
+survive orchestrator restarts and are not split across two authorities.
 
 ### Service Registry
 

--- a/code/specs/process-host-supervisor.md
+++ b/code/specs/process-host-supervisor.md
@@ -22,8 +22,9 @@ remain responsibilities of the reconciler and runnable orchestrator.
 
 ## Process Contract
 
-One configured host program contains a non-empty executable path and at most
-128 fixed arguments. The adapter never invokes a shell. It launches the program
+One configured host program contains a non-empty absolute executable path and
+at most 128 fixed arguments. The adapter never invokes a shell or performs
+ambient `PATH` resolution. It launches the program
 with piped standard input and output and with the verified package directory as
 its working directory. Standard error is inherited so diagnostics do not share
 the authenticated protocol stream.
@@ -34,7 +35,9 @@ Standard input and output carry binary records:
 u32 big-endian payload length | payload bytes
 ```
 
-Payloads are between 1 byte and 1 MiB inclusive. Writers flush each complete
+Payloads are between 1 byte and 1 MiB inclusive. At most 64 complete records may
+wait between the reader and supervisor, so a flooding child receives pipe
+backpressure rather than consuming unbounded parent memory. Writers flush each complete
 record. Readers reject zero length, oversized length, truncation, or I/O failure
 before handing a payload to the secure-channel or control protocol. An invalid
 stream is terminal for that child.

--- a/code/specs/process-host-supervisor.md
+++ b/code/specs/process-host-supervisor.md
@@ -1,0 +1,148 @@
+# D18 Process Host Supervisor
+
+## Status
+
+This document specifies the concrete OS-process adapter that connects the D18
+service reconciler to verified agent packages, secure host channels, and the
+authenticated host-control protocol.
+
+The implementation package is `chief-of-staff-process-supervisor`.
+
+## Purpose
+
+The durable service registry records intent but is not process authority. The
+process host supervisor owns every child it reports, independently verifies the
+registered package immediately before each launch, bootstraps one fresh secure
+session, and derives readiness and heartbeat evidence only from authenticated
+child messages.
+
+The adapter implements `chief_of_staff_service_reconciler::HostSupervisor`. It
+does not implement scheduling, restart policy, backoff, or durable state; those
+remain responsibilities of the reconciler and runnable orchestrator.
+
+## Process Contract
+
+One configured host program contains a non-empty executable path and at most
+128 fixed arguments. The adapter never invokes a shell. It launches the program
+with piped standard input and output and with the verified package directory as
+its working directory. Standard error is inherited so diagnostics do not share
+the authenticated protocol stream.
+
+Standard input and output carry binary records:
+
+```text
+u32 big-endian payload length | payload bytes
+```
+
+Payloads are between 1 byte and 1 MiB inclusive. Writers flush each complete
+record. Readers reject zero length, oversized length, truncation, or I/O failure
+before handing a payload to the secure-channel or control protocol. An invalid
+stream is terminal for that child.
+
+After spawning, the parent writes one `BootstrapOffer` and waits for one
+`ClientHello`. The wait has a non-zero configured real-time bound. The accepted
+secure channel is wrapped in `OrchestratorControl`. Subsequent framed records
+are encrypted host-control frames. The child-side helper performs the inverse
+bootstrap over any `Read` and `Write`, then exposes only `ready`, `heartbeat`,
+and `receive_terminate` operations.
+
+## Package and Identity Safety
+
+Before every actual spawn, including a restart, the adapter:
+
+1. verifies the package signature and contents with the injected trusted
+   `PackageKeyring`;
+2. compares the verified SHA-256 identity to the exact hash stored in the
+   `HostRegistration`; and
+3. refuses to launch on any verification or identity mismatch.
+
+The child independently verifies its package before sending
+`Ready(package_hash)`. A mismatched authenticated readiness record closes the
+control endpoint and terminates the child.
+
+Every launch receives a fresh non-zero UUID-v7 `SessionId` from an injected
+source. The session ID becomes the registry `ChannelId`; the adapter never mints
+a second channel identity. The orchestrator X3DH identity is borrowed rather
+than copied, preserving its zeroizing key ownership.
+
+## Process Authority
+
+The adapter retains the `std::process::Child` handle, framed pipe endpoints,
+reader thread, authenticated control state, exact launch hash, and lifecycle
+timestamps for each host name. It never adopts a PID from the registry or treats
+PID existence as ownership.
+
+`inspect` first drains all complete reader events and authenticates them with
+the orchestrator control endpoint, then samples child exit state through the
+owned handle. It reports:
+
+- `Starting` after spawn and secure bootstrap, before matching readiness;
+- `Running` only after matching authenticated readiness, with the trusted
+  receipt time of the latest authenticated readiness or heartbeat;
+- `Stopping` after graceful termination or forced-kill initiation; and
+- `Exited` after reaping, retaining the exit code when available.
+
+Reader receipt times come from the injected monotonic clock after a complete
+frame is received. Child-supplied timestamps are never accepted. EOF, framing
+failure, authentication failure, illegal control ordering, package mismatch,
+or premature exit fails closed and triggers process cleanup.
+
+## Start and Stop Idempotency
+
+`start` is idempotent for an active owned child launched from the same package
+hash. It refuses a second active launch with a different registered hash. A new
+launch may replace an absent or reaped instance.
+
+`stop` is idempotent for absent, already-stopping, and exited hosts. For an
+active secure session it writes one authenticated `Terminate`, waits until the
+configured non-zero graceful deadline, and hard-kills then reaps the process if
+it has not exited. A control write failure causes immediate hard-kill cleanup.
+
+Dropping the adapter hard-kills and reaps all remaining owned children and
+joins their reader threads. No process is intentionally orphaned.
+
+## Injected Sources
+
+Production adapters are provided for:
+
+- UUID-v7 session generation; and
+- monotonic nanosecond sampling from one `Instant` origin.
+
+Tests inject deterministic session and clock sources. Time values in supervisor
+observations are opaque monotonic values and must not be compared with wall
+clock time.
+
+## Public API
+
+The package exposes:
+
+- validated `ProcessSupervisorConfig` and `HostProgram` values;
+- `MonotonicClock` and `SessionIdSource` interfaces plus production adapters;
+- `ProcessHostSupervisor`, implementing the reconciler `HostSupervisor` trait;
+- `ChildProcessControl<R, W>` for host-runtime integration; and
+- bounded, input-independent `ProcessSupervisorError` diagnostics.
+
+## Capabilities
+
+The concrete adapter requires direct filesystem/package-read, process
+spawn/kill/reap, pipe I/O, clock, randomness, and thread capabilities. It opens
+no network sockets, reads no ambient environment variables, invokes no shell,
+and persists no state.
+
+## Required Tests
+
+The package must cover:
+
+- zero-length, oversized, truncated, and valid framed records;
+- invalid configuration and stable redacted diagnostics;
+- signature or registered-hash failure before process spawn;
+- real cross-platform child bootstrap, matching readiness, heartbeat, and
+  graceful termination;
+- idempotent same-hash start and refusal of an active different-hash launch;
+- bootstrap timeout, malformed bootstrap, wrong readiness, and exit-before-ready
+  cleanup;
+- graceful-stop timeout with hard-kill fallback;
+- exited observations retaining exit status without PID authority; and
+- drop-time cleanup of every owned child.
+
+The package forbids unsafe code and targets at least 90 percent line coverage.

--- a/code/specs/service-registry-reconciliation.md
+++ b/code/specs/service-registry-reconciliation.md
@@ -43,7 +43,8 @@ Time, storage, and process authority remain injected. The runnable
 orchestrator composes this kernel with package verification, the secure host
 channel, the authenticated lifecycle messages defined in
 [`host-control-protocol.md`](host-control-protocol.md), and a concrete OS-process
-supervisor.
+supervisor specified in
+[`process-host-supervisor.md`](process-host-supervisor.md).
 
 ## Authoritative Supervisor Contract
 


### PR DESCRIPTION
## Summary

- specify the concrete D18 OS-process supervisor boundary and reconcile the orchestrator design with durable registry restart authority
- add `chief-of-staff-process-supervisor` with exact signed-package re-verification, fresh UUID-v7 secure bootstrap, bounded framed pipes, and authenticated Ready/Heartbeat evidence
- own, terminate, hard-kill, and reap every reported child without shell execution, ambient environment inheritance, PID adoption, or an unbounded reader queue
- add a child-side stream helper plus real cross-platform process fixtures for graceful and fail-closed lifecycle paths

## Validation

- `cargo test -p chief-of-staff-process-supervisor -- --nocapture`
- `cargo clippy -p chief-of-staff-process-supervisor --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-process-supervisor --no-deps`
- standalone `BUILD`
- repository build planner: all 30 affected Rust packages built successfully
- instrumented line coverage: 93.43%

Progresses #128. The next prioritized slice after merge is the minimal runnable orchestrator core that composes registry storage, reconciliation, this supervisor, channel endpoints, and the host runtime.