### PR TITLE
feat(adj): structure lifecycle failures

### DIFF
--- a/code/scripts/adj_stdlib_provenance.py
+++ b/code/scripts/adj_stdlib_provenance.py
@@ -24,6 +24,7 @@ import threading
 import time
 import xml.etree.ElementTree as ET
 from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass, replace
 from datetime import datetime
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -54,10 +55,156 @@ RECEIPT_HEADERS = {
     "etag",
     "last-modified",
 }
+LIFECYCLE_FAILURE_CONTRACT = "adj-stdlib/process-lifecycle-failure/v1"
+LIFECYCLE_STAGES = frozenset(
+    {
+        "command.canonical",
+        "command.decode",
+        "command.exit",
+        "command.output_limit",
+        "command.parse",
+        "command.shape",
+        "command.timeout",
+        "job.assign",
+        "job.close",
+        "job.configure",
+        "job.create",
+        "job.terminate",
+        "pipe.close",
+        "pipe.drain",
+        "pipe.read",
+        "process.launch",
+        "process.poll",
+        "process.terminate",
+        "process.wait",
+        "process_tree.terminate",
+        "thread.close",
+        "thread.enumerate",
+        "thread.open",
+        "thread.resume",
+        "thread.snapshot",
+        "thread_snapshot.close",
+    }
+)
+
+
+@dataclass(frozen=True)
+class LifecycleFailure:
+    """Machine-inspectable process lifecycle failure with recursive cleanup causes."""
+
+    stage: str
+    message: str
+    api: str | None = None
+    error_code: int | None = None
+    cleanup_causes: tuple[LifecycleFailure, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.stage, str) or self.stage not in LIFECYCLE_STAGES:
+            raise ValueError(f"unknown lifecycle failure stage: {self.stage}")
+        if not isinstance(self.message, str) or not self.message:
+            raise ValueError("lifecycle failure message must be a non-empty string")
+        if self.api is not None and (
+            not isinstance(self.api, str) or not self.api
+        ):
+            raise ValueError("lifecycle failure API must be null or a non-empty string")
+        if self.error_code is not None and (
+            not isinstance(self.error_code, int)
+            or isinstance(self.error_code, bool)
+        ):
+            raise ValueError("lifecycle failure error code must be an integer or null")
+        if not isinstance(self.cleanup_causes, tuple) or not all(
+            isinstance(cause, LifecycleFailure) for cause in self.cleanup_causes
+        ):
+            raise ValueError(
+                "lifecycle failure cleanup causes must be a tuple of lifecycle failures"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return self._to_dict(include_contract=True)
+
+    def _to_dict(self, *, include_contract: bool) -> dict[str, Any]:
+        result = {
+            "api": self.api,
+            "cleanup_causes": [
+                cause._to_dict(include_contract=False)
+                for cause in self.cleanup_causes
+            ],
+            "error_code": self.error_code,
+            "message": self.message,
+            "stage": self.stage,
+        }
+        if include_contract:
+            result["contract"] = LIFECYCLE_FAILURE_CONTRACT
+        return result
+
+    def with_cleanup(self, *causes: LifecycleFailure) -> LifecycleFailure:
+        return replace(self, cleanup_causes=(*self.cleanup_causes, *causes))
 
 
 class ProvenanceError(ValueError):
     """A stable, user-actionable provenance validation failure."""
+
+    def __init__(
+        self, message: str, *, lifecycle: LifecycleFailure | None = None
+    ) -> None:
+        super().__init__(message)
+        self.lifecycle = lifecycle
+
+
+class _LifecycleError(OSError):
+    def __init__(
+        self,
+        failure: LifecycleFailure,
+        *,
+        legacy_args: tuple[Any, ...] | None = None,
+    ) -> None:
+        super().__init__(*(legacy_args or (failure.message,)))
+        self.failure = failure
+
+
+def _os_error_code(error: OSError) -> int | None:
+    code = getattr(error, "winerror", None)
+    return code if code is not None else error.errno
+
+
+def _failure_from_error(
+    error: BaseException,
+    *,
+    stage: str,
+    api: str | None = None,
+    error_code: int | None = None,
+) -> LifecycleFailure:
+    if isinstance(error, _LifecycleError):
+        return error.failure
+    if error_code is None and isinstance(error, OSError):
+        error_code = _os_error_code(error)
+    return LifecycleFailure(
+        stage=stage,
+        api=api,
+        error_code=error_code,
+        message=str(error),
+    )
+
+
+def _lifecycle_error(
+    stage: str,
+    message: str,
+    *,
+    api: str | None = None,
+    error_code: int | None = None,
+    cleanup_causes: Sequence[LifecycleFailure] = (),
+    legacy_args: tuple[Any, ...] | None = None,
+) -> _LifecycleError:
+    return _LifecycleError(
+        LifecycleFailure(
+            stage=stage,
+            api=api,
+            error_code=error_code,
+            message=message,
+            cleanup_causes=tuple(cleanup_causes),
+        ),
+        legacy_args=legacy_args,
+    )
 
 
 def canonical_json_bytes(value: Any) -> bytes:
@@ -663,75 +810,11 @@ def _json_object(cas: Cas, digest: str, expected_kind: str) -> dict[str, Any]:
 def _run_formula_inventory(
     parser_command: Sequence[str], source_path: Path
 ) -> dict[str, Any]:
-    if not parser_command:
-        raise ProvenanceError("formula inventory parser command must not be empty")
-    try:
-        process = subprocess.Popen(
-            [*parser_command, os.fspath(source_path)],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-    except OSError as error:
-        raise ProvenanceError(
-            f"formula inventory parser failed to run: {error}"
-        ) from error
-    stdout = bytearray()
-    stderr = bytearray()
-    overflow = threading.Event()
-
-    def drain(stream: Any, output: bytearray, limit: int) -> None:
-        while True:
-            chunk = stream.read(65536)
-            if not chunk:
-                return
-            remaining = limit - len(output)
-            output.extend(chunk[:remaining])
-            if len(chunk) > remaining:
-                overflow.set()
-                process.kill()
-                return
-
-    stdout_thread = threading.Thread(
-        target=drain,
-        args=(process.stdout, stdout, MAX_OBJECT_BYTES),
-        daemon=True,
+    return _run_json_command(
+        parser_command,
+        [os.fspath(source_path)],
+        label="formula inventory parser",
     )
-    stderr_thread = threading.Thread(
-        target=drain,
-        args=(process.stderr, stderr, 4096),
-        daemon=True,
-    )
-    stdout_thread.start()
-    stderr_thread.start()
-    try:
-        returncode = process.wait(timeout=60)
-    except subprocess.TimeoutExpired as error:
-        process.kill()
-        process.wait()
-        raise ProvenanceError(
-            "formula inventory parser timed out after 60 seconds"
-        ) from error
-    finally:
-        stdout_thread.join()
-        stderr_thread.join()
-        process.stdout.close()
-        process.stderr.close()
-    if overflow.is_set():
-        raise ProvenanceError("formula inventory parser output exceeds byte limit")
-    if returncode != 0:
-        detail = bytes(stderr).decode("utf-8", errors="replace").strip()
-        raise ProvenanceError(f"formula inventory parser exited {returncode}: {detail}")
-    try:
-        value = json.loads(bytes(stdout).decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as error:
-        raise ProvenanceError(
-            "formula inventory parser did not emit UTF-8 JSON"
-        ) from error
-    if not isinstance(value, dict):
-        raise ProvenanceError("formula inventory parser output must be an object")
-    if bytes(stdout) != canonical_json_bytes(value):
-        raise ProvenanceError("formula inventory parser output is not canonical JSON")
-    return value
 
 
 def _validate_formula_inventory_value(
@@ -1005,65 +1088,108 @@ class _WindowsKillJob:
 
         handle = self._kernel32.CreateJobObjectW(None, None)
         if not handle:
-            raise self._error("CreateJobObjectW")
+            raise self._error("job.create", "CreateJobObjectW")
         self._handle: int | None = handle
         limits = ExtendedLimitInformation()
         limits.basic_limit_information.limit_flags = 0x00002000
         if not self._kernel32.SetInformationJobObject(
             handle, 9, ctypes.byref(limits), ctypes.sizeof(limits)
         ):
-            error = self._error("SetInformationJobObject")
+            error = self._error("job.configure", "SetInformationJobObject")
             try:
                 self.close()
             except OSError as close_error:
                 try:
                     self.close()
                 except OSError as retry_error:
-                    cleanup_error = OSError(
-                        f"{close_error}; close retry also failed: {retry_error}"
+                    cleanup_error = self._with_cleanup_error(
+                        close_error, retry_error
                     )
                     raise self._with_cleanup_error(
                         error, cleanup_error
                     ) from error
             raise error
 
-    def _error(self, operation: str, code: int | None = None) -> OSError:
+    def _error(
+        self,
+        stage: str,
+        operation: str,
+        code: int | None = None,
+        *,
+        display_operation: str | None = None,
+    ) -> _LifecycleError:
         if code is None:
             code = self._last_error()
         if hasattr(ctypes, "WinError"):
             detail = str(ctypes.WinError(code))
         else:
             detail = f"Windows error {code}"
-        return OSError(code, f"{operation} failed: {detail}")
+        display_operation = display_operation or operation
+        legacy_error = OSError(code, f"{display_operation} failed: {detail}")
+        return _lifecycle_error(
+            stage,
+            str(legacy_error),
+            api=operation,
+            error_code=code,
+            legacy_args=legacy_error.args,
+        )
 
     @staticmethod
-    def _with_cleanup_error(primary: OSError, cleanup: OSError) -> OSError:
-        return OSError(f"{primary}; cleanup also failed: {cleanup}")
+    def _with_cleanup_error(
+        primary: OSError, cleanup: OSError
+    ) -> _LifecycleError:
+        failure = _failure_from_error(
+            primary, stage="process_tree.terminate"
+        )
+        cleanup_failure = _failure_from_error(
+            cleanup, stage="job.close"
+        )
+        message = f"{primary}; cleanup also failed: {cleanup}"
+        return _LifecycleError(
+            replace(
+                failure,
+                message=message,
+                cleanup_causes=(*failure.cleanup_causes, cleanup_failure),
+            ),
+            legacy_args=(message,),
+        )
 
     def _close_handle(self, handle: int, label: str) -> None:
         if not self._kernel32.CloseHandle(handle):
-            raise self._error(f"CloseHandle({label})")
+            stage = {
+                "job": "job.close",
+                "thread": "thread.close",
+                "thread snapshot": "thread_snapshot.close",
+            }[label]
+            raise self._error(
+                stage,
+                "CloseHandle",
+                display_operation=f"CloseHandle({label})",
+            )
 
     def _validate_thread_entry(self, entry: ctypes.Structure) -> None:
         if entry.size < self._thread_entry_owner_end:
-            raise OSError(
+            raise _lifecycle_error(
+                "thread.enumerate",
                 "thread enumeration returned a truncated THREADENTRY32 "
-                f"record ({entry.size} bytes; need {self._thread_entry_owner_end})"
+                f"record ({entry.size} bytes; need {self._thread_entry_owner_end})",
             )
 
     def assign(self, process: subprocess.Popen[bytes]) -> None:
         if self._handle is None:
-            raise OSError("cannot assign a process to a closed Windows Job")
+            raise _lifecycle_error(
+                "job.assign", "cannot assign a process to a closed Windows Job"
+            )
         if not self._kernel32.AssignProcessToJobObject(
             self._handle,
             int(process._handle),  # type: ignore[attr-defined]
         ):
-            raise self._error("AssignProcessToJobObject")
+            raise self._error("job.assign", "AssignProcessToJobObject")
 
     def resume(self, process: subprocess.Popen[bytes]) -> None:
         snapshot = self._kernel32.CreateToolhelp32Snapshot(0x00000004, 0)
         if snapshot == ctypes.c_void_p(-1).value:
-            raise self._error("CreateToolhelp32Snapshot")
+            raise self._error("thread.snapshot", "CreateToolhelp32Snapshot")
         resume_error: OSError | None = None
         resumed = False
         try:
@@ -1073,22 +1199,26 @@ class _WindowsKillJob:
             found = self._kernel32.Thread32First(snapshot, ctypes.byref(entry))
             first_error = self._last_error() if not found else 0
             if not found and first_error != self.ERROR_NO_MORE_FILES:
-                raise self._error("Thread32First", first_error)
+                raise self._error("thread.enumerate", "Thread32First", first_error)
             while found:
                 self._validate_thread_entry(entry)
                 if entry.owner_process_id == process.pid:
                     thread = self._kernel32.OpenThread(0x0002, False, entry.thread_id)
                     if not thread:
-                        raise self._error("OpenThread")
+                        raise self._error("thread.open", "OpenThread")
                     thread_error: OSError | None = None
                     try:
                         previous_suspend_count = self._kernel32.ResumeThread(thread)
                         if previous_suspend_count == 0xFFFFFFFF:
-                            thread_error = self._error("ResumeThread")
+                            thread_error = self._error(
+                                "thread.resume", "ResumeThread"
+                            )
                         elif previous_suspend_count != 1:
-                            thread_error = OSError(
+                            thread_error = _lifecycle_error(
+                                "thread.resume",
                                 "ResumeThread did not release the CREATE_SUSPENDED "
-                                f"process (previous suspend count {previous_suspend_count})"
+                                f"process (previous suspend count {previous_suspend_count})",
+                                api="ResumeThread",
                             )
                     finally:
                         try:
@@ -1108,7 +1238,9 @@ class _WindowsKillJob:
                 found = self._kernel32.Thread32Next(snapshot, ctypes.byref(entry))
                 next_error = self._last_error() if not found else 0
                 if not found and next_error != self.ERROR_NO_MORE_FILES:
-                    raise self._error("Thread32Next", next_error)
+                    raise self._error(
+                        "thread.enumerate", "Thread32Next", next_error
+                    )
         except OSError as error:
             resume_error = error
         finally:
@@ -1124,13 +1256,16 @@ class _WindowsKillJob:
             raise resume_error
         if resumed:
             return
-        raise OSError(f"suspended process {process.pid} has no primary thread")
+        raise _lifecycle_error(
+            "thread.enumerate",
+            f"suspended process {process.pid} has no primary thread",
+        )
 
     def terminate(self) -> None:
         if self._handle is not None and not self._kernel32.TerminateJobObject(
             self._handle, 1
         ):
-            raise self._error("TerminateJobObject")
+            raise self._error("job.terminate", "TerminateJobObject")
 
     def close(self) -> None:
         if self._handle is not None:
@@ -1141,14 +1276,16 @@ class _WindowsKillJob:
 def _terminate_process_tree(
     process: subprocess.Popen[bytes], windows_job: _WindowsKillJob | None
 ) -> None:
-    errors: list[OSError] = []
+    failures: list[LifecycleFailure] = []
     if os.name == "nt":
         if windows_job is not None:
             try:
                 windows_job.terminate()
             except OSError as error:
-                errors.append(error)
-        if windows_job is None or errors:
+                failures.append(
+                    _failure_from_error(error, stage="job.terminate")
+                )
+        if windows_job is None or failures:
             try:
                 result = subprocess.run(
                     ["taskkill", "/PID", str(process.pid), "/T", "/F"],
@@ -1159,23 +1296,64 @@ def _terminate_process_tree(
                     timeout=5,
                 )
                 if result.returncode != 0:
-                    errors.append(
-                        OSError(f"taskkill /T exited {result.returncode}")
+                    failures.append(
+                        LifecycleFailure(
+                            stage="process_tree.terminate",
+                            api="taskkill",
+                            error_code=result.returncode,
+                            message=f"taskkill /T exited {result.returncode}",
+                        )
                     )
             except (OSError, subprocess.TimeoutExpired) as error:
-                errors.append(OSError(f"taskkill /T failed: {error}"))
+                failures.append(
+                    LifecycleFailure(
+                        stage="process_tree.terminate",
+                        api="taskkill",
+                        error_code=(
+                            _os_error_code(error)
+                            if isinstance(error, OSError)
+                            else None
+                        ),
+                        message=f"taskkill /T failed: {error}",
+                    )
+                )
     else:
         try:
             os.killpg(process.pid, signal.SIGKILL)
         except ProcessLookupError:
             pass
-    if process.poll() is None:
+    try:
+        process_running = process.poll() is None
+    except OSError as error:
+        failures.append(
+            _failure_from_error(
+                error,
+                stage="process.poll",
+                api="Popen.poll",
+            )
+        )
+        process_running = True
+    if process_running:
         try:
             process.kill()
         except OSError as error:
-            errors.append(OSError(f"root process kill failed: {error}"))
-    if errors:
-        raise OSError("; ".join(str(error) for error in errors))
+            failures.append(
+                LifecycleFailure(
+                    stage="process.terminate",
+                    api="Popen.kill",
+                    error_code=_os_error_code(error),
+                    message=f"root process kill failed: {error}",
+                )
+            )
+    if failures:
+        primary, *cleanup = failures
+        raise _LifecycleError(
+            replace(
+                primary,
+                message="; ".join(failure.message for failure in failures),
+                cleanup_causes=(*primary.cleanup_causes, *cleanup),
+            )
+        )
 
 
 def _run_json_command(
@@ -1196,8 +1374,11 @@ def _run_json_command(
         try:
             windows_job = windows_job_factory()
         except OSError as error:
+            detail = f"{label} failed to create process job: {error}"
+            failure = _failure_from_error(error, stage="job.create")
             raise ProvenanceError(
-                f"{label} failed to create process job: {error}"
+                detail,
+                lifecycle=replace(failure, message=detail),
             ) from error
     popen_options: dict[str, Any] = {}
     if os.name == "nt":
@@ -1216,34 +1397,54 @@ def _run_json_command(
             **popen_options,
         )
     except OSError as error:
-        close_error: OSError | None = None
+        cleanup_failures: list[LifecycleFailure] = []
+        close_failure_text: list[str] = []
         if windows_job is not None:
             try:
                 windows_job.close()
             except OSError as cleanup_error:
+                close_failure = _failure_from_error(
+                    cleanup_error, stage="job.close"
+                )
+                close_failure_text.append(close_failure.message)
                 try:
                     windows_job.close()
                 except OSError as retry_error:
-                    close_error = OSError(
-                        f"{cleanup_error}; close retry also failed: {retry_error}"
+                    retry_failure = _failure_from_error(
+                        retry_error, stage="job.close"
                     )
-                else:
-                    close_error = cleanup_error
+                    close_failure = close_failure.with_cleanup(retry_failure)
+                    close_failure_text.append(
+                        f"close retry also failed: {retry_failure.message}"
+                    )
+                cleanup_failures.append(close_failure)
         detail = f"{label} failed to run: {error}"
-        if close_error is not None:
-            detail += f"; failed to close process job: {close_error}"
-        raise ProvenanceError(detail) from error
+        if close_failure_text:
+            detail += "; failed to close process job: " + "; ".join(
+                close_failure_text
+            )
+        failure = _failure_from_error(
+            error,
+            stage="process.launch",
+            api="Popen",
+        ).with_cleanup(*cleanup_failures)
+        raise ProvenanceError(
+            detail, lifecycle=replace(failure, message=detail)
+        ) from error
     if windows_job is not None:
-        try:
-            windows_job.assign(process)
-            windows_job.resume(process)
-        except OSError as error:
+        def fail_containment(error: OSError, default_stage: str) -> None:
             containment_errors = [str(error)]
+            cleanup_failures: list[LifecycleFailure] = []
             try:
                 try:
                     _terminate_process_tree(process, windows_job)
                 except OSError as termination_error:
                     containment_errors.append(str(termination_error))
+                    cleanup_failures.append(
+                        _failure_from_error(
+                            termination_error, stage="process_tree.terminate"
+                        )
+                    )
                 try:
                     process.wait(timeout=drain_timeout_seconds)
                 except subprocess.TimeoutExpired:
@@ -1253,40 +1454,143 @@ def _run_json_command(
                         containment_errors.append(
                             f"root process kill failed: {kill_error}"
                         )
+                        cleanup_failures.append(
+                            _failure_from_error(
+                                kill_error,
+                                stage="process.terminate",
+                                api="Popen.kill",
+                            )
+                        )
+                except OSError as wait_error:
+                    containment_errors.append(f"process wait failed: {wait_error}")
+                    cleanup_failures.append(
+                        _failure_from_error(
+                            wait_error,
+                            stage="process.wait",
+                            api="Popen.wait",
+                        )
+                    )
             finally:
                 try:
                     windows_job.close()
                 except OSError as close_error:
                     containment_errors.append(str(close_error))
+                    close_failure = _failure_from_error(
+                        close_error, stage="job.close"
+                    )
                     try:
                         windows_job.close()
                     except OSError as retry_error:
                         containment_errors.append(
                             f"close retry also failed: {retry_error}"
                         )
-                process.stdout.close()
-                process.stderr.close()
-            raise ProvenanceError(
+                        close_failure = close_failure.with_cleanup(
+                            _failure_from_error(
+                                retry_error,
+                                stage="job.close",
+                            )
+                        )
+                    cleanup_failures.append(close_failure)
+                for pipe_name, stream in (
+                    ("stdout", process.stdout),
+                    ("stderr", process.stderr),
+                ):
+                    try:
+                        stream.close()
+                    except OSError as pipe_error:
+                        message = f"{pipe_name} pipe close failed: {pipe_error}"
+                        containment_errors.append(message)
+                        cleanup_failures.append(
+                            replace(
+                                _failure_from_error(
+                                    pipe_error,
+                                    stage="pipe.close",
+                                    api=f"Popen.{pipe_name}.close",
+                                ),
+                                message=message,
+                            )
+                        )
+            detail = (
                 f"{label} failed to contain process tree: "
                 + "; ".join(containment_errors)
+            )
+            failure = _failure_from_error(
+                error, stage=default_stage
+            ).with_cleanup(*cleanup_failures)
+            raise ProvenanceError(
+                detail,
+                lifecycle=replace(failure, message=detail),
             ) from error
+
+        try:
+            windows_job.assign(process)
+        except OSError as error:
+            fail_containment(error, "job.assign")
+        try:
+            windows_job.resume(process)
+        except OSError as error:
+            fail_containment(error, "thread.resume")
     stdout = bytearray()
     stderr = bytearray()
     overflow = threading.Event()
     termination_lock = threading.Lock()
-    termination_errors: list[OSError] = []
+    termination_failures: list[LifecycleFailure] = []
+    pipe_read_failures: list[LifecycleFailure | None] = [None, None]
+    pipe_read_terminated_process = [False, False]
 
     def terminate() -> None:
         with termination_lock:
             try:
                 _terminate_process_tree(process, windows_job)
             except OSError as error:
-                if not termination_errors:
-                    termination_errors.append(error)
+                if not termination_failures:
+                    termination_failures.append(
+                        _failure_from_error(
+                            error, stage="process_tree.terminate"
+                        )
+                    )
 
-    def drain(stream: Any, output: bytearray, limit: int) -> None:
+    def drain(
+        stream: Any,
+        output: bytearray,
+        limit: int,
+        pipe_index: int,
+        pipe_name: str,
+    ) -> None:
         while True:
-            chunk = stream.read(65536)
+            try:
+                chunk = stream.read(65536)
+            except OSError as error:
+                message = f"{pipe_name} pipe read failed: {error}"
+                pipe_read_failures[pipe_index] = replace(
+                    _failure_from_error(
+                        error,
+                        stage="pipe.read",
+                        api=f"Popen.{pipe_name}.read",
+                    ),
+                    message=message,
+                )
+                try:
+                    process_running = process.poll() is None
+                except OSError as poll_error:
+                    poll_message = f"process status poll failed: {poll_error}"
+                    read_failure = pipe_read_failures[pipe_index]
+                    assert read_failure is not None
+                    pipe_read_failures[pipe_index] = read_failure.with_cleanup(
+                        replace(
+                            _failure_from_error(
+                                poll_error,
+                                stage="process.poll",
+                                api="Popen.poll",
+                            ),
+                            message=poll_message,
+                        )
+                    )
+                    process_running = True
+                if process_running:
+                    pipe_read_terminated_process[pipe_index] = True
+                    terminate()
+                return
             if not chunk:
                 return
             remaining = limit - len(output)
@@ -1299,18 +1603,22 @@ def _run_json_command(
     threads = (
         threading.Thread(
             target=drain,
-            args=(process.stdout, stdout, MAX_OBJECT_BYTES),
+            args=(process.stdout, stdout, MAX_OBJECT_BYTES, 0, "stdout"),
             daemon=True,
         ),
         threading.Thread(
-            target=drain, args=(process.stderr, stderr, 4096), daemon=True
+            target=drain,
+            args=(process.stderr, stderr, 4096, 1, "stderr"),
+            daemon=True,
         ),
     )
     for thread in threads:
         thread.start()
     timeout_error: subprocess.TimeoutExpired | None = None
+    wait_failure: LifecycleFailure | None = None
     returncode: int | None = None
-    close_error: OSError | None = None
+    close_failures: list[LifecycleFailure] = []
+    pipe_close_failures: list[LifecycleFailure] = []
     try:
         returncode = process.wait(timeout=timeout_seconds)
     except subprocess.TimeoutExpired as error:
@@ -1319,25 +1627,93 @@ def _run_json_command(
         try:
             returncode = process.wait(timeout=drain_timeout_seconds)
         except subprocess.TimeoutExpired:
+            wait_failure = LifecycleFailure(
+                stage="process.wait",
+                api="Popen.wait",
+                error_code=None,
+                message=(
+                    "process wait after command timeout timed out after "
+                    f"{drain_timeout_seconds:g} seconds"
+                ),
+            )
             terminate()
+        except OSError as wait_error:
+            message = f"process wait after timeout failed: {wait_error}"
+            wait_failure = replace(
+                _failure_from_error(
+                    wait_error,
+                    stage="process.wait",
+                    api="Popen.wait",
+                ),
+                message=message,
+            )
+    except OSError as error:
+        message = f"{label} process wait failed: {error}"
+        wait_failure = replace(
+            _failure_from_error(
+                error,
+                stage="process.wait",
+                api="Popen.wait",
+            ),
+            message=message,
+        )
+        terminate()
+        try:
+            returncode = process.wait(timeout=drain_timeout_seconds)
+        except subprocess.TimeoutExpired:
+            retry_message = (
+                "process wait retry timed out after "
+                f"{drain_timeout_seconds:g} seconds"
+            )
+            wait_failure = wait_failure.with_cleanup(
+                LifecycleFailure(
+                    stage="process.wait",
+                    api="Popen.wait",
+                    error_code=None,
+                    message=retry_message,
+                )
+            )
+            terminate()
+        except OSError as retry_error:
+            retry_message = f"process wait retry failed: {retry_error}"
+            wait_failure = wait_failure.with_cleanup(
+                replace(
+                    _failure_from_error(
+                        retry_error,
+                        stage="process.wait",
+                        api="Popen.wait",
+                    ),
+                    message=retry_message,
+                )
+            )
     finally:
         with termination_lock:
             if windows_job is not None:
                 try:
                     windows_job.close()
                 except OSError as error:
-                    close_error = error
+                    close_failure = _failure_from_error(
+                        error, stage="job.close"
+                    )
                     try:
                         _terminate_process_tree(process, windows_job)
                     except OSError as termination_error:
-                        if not termination_errors:
-                            termination_errors.append(termination_error)
+                        close_failure = close_failure.with_cleanup(
+                            _failure_from_error(
+                                termination_error,
+                                stage="process_tree.terminate",
+                            )
+                        )
                     try:
                         windows_job.close()
                     except OSError as retry_error:
-                        close_error = OSError(
-                            f"{error}; close retry also failed: {retry_error}"
+                        close_failure = close_failure.with_cleanup(
+                            _failure_from_error(
+                                retry_error,
+                                stage="job.close",
+                            )
                         )
+                    close_failures.append(close_failure)
         drain_deadline = time.monotonic() + drain_timeout_seconds
         for thread in threads:
             thread.join(timeout=max(0, drain_deadline - time.monotonic()))
@@ -1347,60 +1723,229 @@ def _run_json_command(
         final_drain_deadline = time.monotonic() + 1
         for thread in stuck_drains:
             thread.join(timeout=max(0, final_drain_deadline - time.monotonic()))
-    cleanup_failures: list[str] = []
-    if termination_errors:
-        cleanup_failures.append(
-            f"failed to terminate process tree: {termination_errors[0]}"
-        )
-    if close_error is not None:
-        cleanup_failures.append(f"failed to close process job: {close_error}")
-
-    def with_cleanup_failures(primary: str) -> str:
-        if not cleanup_failures:
-            return primary
-        return primary + "; " + "; ".join(cleanup_failures)
-
     drain_failure = any(thread.is_alive() for thread in threads)
     if not drain_failure:
-        process.stdout.close()
-        process.stderr.close()
+        for pipe_name, stream in (
+            ("stdout", process.stdout),
+            ("stderr", process.stderr),
+        ):
+            try:
+                stream.close()
+            except OSError as error:
+                message = f"{pipe_name} pipe close failed: {error}"
+                pipe_close_failures.append(
+                    replace(
+                        _failure_from_error(
+                            error,
+                            stage="pipe.close",
+                            api=f"Popen.{pipe_name}.close",
+                        ),
+                        message=message,
+                    )
+                )
+    pipe_read_failure_events = [
+        (failure, pipe_read_terminated_process[index])
+        for index, failure in enumerate(pipe_read_failures)
+        if failure is not None
+    ]
+    pipe_read_failure_records = [
+        failure for failure, _terminated in pipe_read_failure_events
+    ]
+    cleanup_failures = [
+        *termination_failures,
+        *close_failures,
+        *pipe_close_failures,
+    ]
+    cleanup_failure_text: list[str] = []
+    if termination_failures:
+        cleanup_failure_text.append(
+            "failed to terminate process tree: "
+            + termination_failures[0].message
+        )
+    if close_failures:
+        close_failure = close_failures[0]
+        close_text = close_failure.message
+        for recovery_failure in close_failure.cleanup_causes:
+            if recovery_failure.stage == "job.close":
+                close_text += (
+                    "; close retry also failed: " + recovery_failure.message
+                )
+            else:
+                close_text += (
+                    "; recovery termination failed: "
+                    + recovery_failure.message
+                )
+        cleanup_failure_text.append(
+            "failed to close process job: " + close_text
+        )
+    cleanup_failure_text.extend(
+        failure.message for failure in pipe_close_failures
+    )
+
+    def add_cleanup_failure(failure: LifecycleFailure) -> None:
+        cleanup_failures.append(failure)
+        cleanup_failure_text.append(failure.message)
+
+    def with_cleanup_failures(primary: str) -> str:
+        if not cleanup_failure_text:
+            return primary
+        return primary + "; " + "; ".join(cleanup_failure_text)
+
     primary_error: str | None = None
     primary_cause: BaseException | None = None
+    primary_failure: LifecycleFailure | None = None
     value: Any = None
     drain_error = f"{label} output pipes did not close within bounds"
     if timeout_error is not None:
         primary_error = f"{label} timed out after {timeout_seconds:g} seconds"
         primary_cause = timeout_error
+        primary_failure = LifecycleFailure(
+            stage="command.timeout",
+            api="Popen.wait",
+            error_code=None,
+            message=primary_error,
+        )
+        if wait_failure is not None:
+            add_cleanup_failure(wait_failure)
+        for failure in pipe_read_failure_records:
+            add_cleanup_failure(failure)
     elif overflow.is_set():
         primary_error = f"{label} output exceeds byte limit"
-    elif returncode != 0:
+        primary_failure = LifecycleFailure(
+            stage="command.output_limit", message=primary_error
+        )
+        if wait_failure is not None:
+            add_cleanup_failure(wait_failure)
+        for failure in pipe_read_failure_records:
+            add_cleanup_failure(failure)
+    elif wait_failure is not None:
+        primary_error = wait_failure.message
+        primary_failure = wait_failure
+        for failure in pipe_read_failure_records:
+            add_cleanup_failure(failure)
+    elif returncode != 0 and not any(
+        terminated for _failure, terminated in pipe_read_failure_events
+    ):
         detail = bytes(stderr).decode("utf-8", errors="replace").strip()
         primary_error = f"{label} exited {returncode}: {detail}"
+        primary_failure = LifecycleFailure(
+            stage="command.exit",
+            api="Popen.wait",
+            error_code=returncode,
+            message=primary_error,
+        )
+        for failure in pipe_read_failure_records:
+            add_cleanup_failure(failure)
+    elif pipe_read_failure_records:
+        causal_failures = [
+            failure
+            for failure, terminated in pipe_read_failure_events
+            if terminated
+        ]
+        primary_failure = (
+            causal_failures[0] if causal_failures else pipe_read_failure_records[0]
+        )
+        primary_error = primary_failure.message
+        for failure in pipe_read_failure_records:
+            if failure is not primary_failure:
+                add_cleanup_failure(failure)
+        if returncode != 0:
+            add_cleanup_failure(
+                LifecycleFailure(
+                    stage="command.exit",
+                    api="Popen.wait",
+                    error_code=returncode,
+                    message=f"process exited {returncode} after pipe-read termination",
+                )
+            )
     elif drain_failure:
         primary_error = drain_error
+        primary_failure = LifecycleFailure(
+            stage="pipe.drain", message=primary_error
+        )
     else:
         try:
-            value = json.loads(bytes(stdout).decode("utf-8"))
-        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            decoded = bytes(stdout).decode("utf-8")
+        except UnicodeDecodeError as error:
             primary_error = f"{label} did not emit UTF-8 JSON"
             primary_cause = error
+            primary_failure = LifecycleFailure(
+                stage="command.decode", message=primary_error
+            )
         else:
-            if not isinstance(value, dict):
-                primary_error = f"{label} output must be an object"
-            elif bytes(stdout) != canonical_json_bytes(value):
-                primary_error = f"{label} output is not canonical JSON"
+            try:
+                value = json.loads(decoded)
+            except json.JSONDecodeError as error:
+                primary_error = f"{label} did not emit UTF-8 JSON"
+                primary_cause = error
+                primary_failure = LifecycleFailure(
+                    stage="command.parse", message=primary_error
+                )
+            else:
+                if not isinstance(value, dict):
+                    primary_error = f"{label} output must be an object"
+                    primary_failure = LifecycleFailure(
+                        stage="command.shape", message=primary_error
+                    )
+                elif bytes(stdout) != canonical_json_bytes(value):
+                    primary_error = f"{label} output is not canonical JSON"
+                    primary_failure = LifecycleFailure(
+                        stage="command.canonical", message=primary_error
+                    )
     if drain_failure and primary_error != drain_error:
-        cleanup_failures.append("output pipes did not close within bounds")
+        drain_failure_record = LifecycleFailure(
+            stage="pipe.drain",
+            message="output pipes did not close within bounds",
+        )
+        cleanup_failures.append(drain_failure_record)
+        cleanup_failure_text.append(drain_failure_record.message)
     if primary_error is not None:
-        raise ProvenanceError(with_cleanup_failures(primary_error)) from primary_cause
-    if termination_errors:
+        assert primary_failure is not None
+        final_message = with_cleanup_failures(primary_error)
+        failure = primary_failure.with_cleanup(*cleanup_failures)
         raise ProvenanceError(
-            f"{label} failed to terminate process tree: {termination_errors[0]}"
-        ) from termination_errors[0]
-    if close_error is not None:
+            final_message,
+            lifecycle=replace(failure, message=final_message),
+        ) from primary_cause
+    if termination_failures:
+        failure = termination_failures[0].with_cleanup(
+            *termination_failures[1:], *close_failures, *pipe_close_failures
+        )
+        detail = f"{label} failed to terminate process tree: {failure.message}"
         raise ProvenanceError(
-            f"{label} failed to close process job: {close_error}"
-        ) from close_error
+            detail, lifecycle=replace(failure, message=detail)
+        )
+    if close_failures:
+        failure = close_failures[0].with_cleanup(
+            *close_failures[1:], *pipe_close_failures
+        )
+        close_text = failure.message
+        for recovery_failure in failure.cleanup_causes:
+            if recovery_failure.stage == "job.close":
+                close_text += (
+                    "; close retry also failed: " + recovery_failure.message
+                )
+            elif recovery_failure.stage in {
+                "job.terminate",
+                "process.terminate",
+                "process_tree.terminate",
+            }:
+                close_text += (
+                    "; recovery termination failed: "
+                    + recovery_failure.message
+                )
+            else:
+                close_text += "; cleanup also failed: " + recovery_failure.message
+        detail = f"{label} failed to close process job: {close_text}"
+        raise ProvenanceError(
+            detail, lifecycle=replace(failure, message=detail)
+        )
+    if pipe_close_failures:
+        failure = pipe_close_failures[0].with_cleanup(*pipe_close_failures[1:])
+        detail = f"{label} failed to close output pipe: {failure.message}"
+        raise ProvenanceError(
+            detail, lifecycle=replace(failure, message=detail)
+        )
     return value
 
 
@@ -3693,9 +4238,18 @@ def main() -> int:
         json.JSONDecodeError,
         ProvenanceError,
     ) as error:
-        print(
-            json.dumps({"error": str(error), "valid": False}, indent=2, sort_keys=True)
-        )
+        failure = {
+            "error": str(error),
+            "valid": False,
+        }
+        lifecycle = None
+        if isinstance(error, ProvenanceError):
+            lifecycle = error.lifecycle
+        elif isinstance(error, _LifecycleError):
+            lifecycle = error.failure
+        if lifecycle is not None:
+            failure["lifecycle_failure"] = lifecycle.to_dict()
+        print(json.dumps(failure, indent=2, sort_keys=True))
         return 1
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0

--- a/code/scripts/tests/test_adj_stdlib_provenance.py
+++ b/code/scripts/tests/test_adj_stdlib_provenance.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ctypes
 import importlib
+import io
 import json
 import multiprocessing
 import os
@@ -11,7 +12,9 @@ import sys
 import tempfile
 import time
 import unittest
+from contextlib import redirect_stdout
 from copy import deepcopy
+from dataclasses import FrozenInstanceError
 from pathlib import Path
 from unittest import mock
 
@@ -43,6 +46,252 @@ def acquire_cas_lock_with_alternate_temp(
 
 
 class AdjStdlibProvenanceTests(unittest.TestCase):
+    def test_lifecycle_failure_is_immutable_and_canonical(self) -> None:
+        cleanup = provenance.LifecycleFailure(
+            stage="job.close",
+            api="CloseHandle",
+            error_code=6,
+            message="close failed",
+        )
+        failure = provenance.LifecycleFailure(
+            stage="job.configure",
+            api="SetInformationJobObject",
+            error_code=87,
+            message="configuration failed",
+            cleanup_causes=(cleanup,),
+        )
+        expected = {
+            "api": "SetInformationJobObject",
+            "cleanup_causes": [
+                {
+                    "api": "CloseHandle",
+                    "cleanup_causes": [],
+                    "error_code": 6,
+                    "message": "close failed",
+                    "stage": "job.close",
+                }
+            ],
+            "contract": "adj-stdlib/process-lifecycle-failure/v1",
+            "error_code": 87,
+            "message": "configuration failed",
+            "stage": "job.configure",
+        }
+
+        self.assertEqual(failure.to_dict(), expected)
+        self.assertEqual(
+            provenance.canonical_json_bytes(failure.to_dict()),
+            provenance.canonical_json_bytes(expected),
+        )
+        extended = failure.with_cleanup(
+            provenance.LifecycleFailure(
+                stage="process.terminate", message="fallback failed"
+            )
+        )
+        self.assertEqual(len(failure.cleanup_causes), 1)
+        self.assertEqual(len(extended.cleanup_causes), 2)
+        projected = failure.to_dict()
+        projected["stage"] = "changed"
+        projected["cleanup_causes"][0]["error_code"] = 999
+        self.assertEqual(failure.stage, "job.configure")
+        self.assertEqual(failure.cleanup_causes[0].error_code, 6)
+        with self.assertRaises(FrozenInstanceError):
+            failure.stage = "changed"  # type: ignore[misc]
+        with self.assertRaisesRegex(ValueError, "unknown lifecycle failure stage"):
+            provenance.LifecycleFailure(
+                stage="free-form.stage", message="not allowed"
+            )
+        for field, value, expected_message in (
+            ("message", "", "message must be a non-empty string"),
+            ("api", "", "API must be null or a non-empty string"),
+            ("error_code", True, "error code must be an integer or null"),
+            (
+                "cleanup_causes",
+                [cleanup],
+                "cleanup causes must be a tuple",
+            ),
+            (
+                "cleanup_causes",
+                ("not-a-failure",),
+                "cleanup causes must be a tuple",
+            ),
+        ):
+            with self.subTest(field=field, value=value):
+                arguments = {
+                    "stage": "job.configure",
+                    "message": "valid message",
+                    field: value,
+                }
+                with self.assertRaisesRegex(ValueError, expected_message):
+                    provenance.LifecycleFailure(**arguments)
+
+    def test_provenance_error_keeps_legacy_text_without_lifecycle(self) -> None:
+        error = provenance.ProvenanceError("legacy validation failure")
+
+        self.assertEqual(str(error), "legacy validation failure")
+        self.assertEqual(error.args, ("legacy validation failure",))
+        self.assertIsNone(error.lifecycle)
+
+        lifecycle = provenance.LifecycleFailure(
+            stage="job.create", message="native display text"
+        )
+        structured = provenance._LifecycleError(lifecycle)
+        wrapped = provenance.ProvenanceError(
+            "legacy wrapper text", lifecycle=lifecycle
+        )
+        self.assertEqual(str(structured), "native display text")
+        self.assertEqual(structured.args, ("native display text",))
+        self.assertEqual(str(wrapped), "legacy wrapper text")
+        self.assertEqual(wrapped.args, ("legacy wrapper text",))
+        self.assertIs(wrapped.lifecycle, lifecycle)
+
+    def test_lifecycle_identity_does_not_depend_on_display_message(self) -> None:
+        failures = [
+            provenance._failure_from_error(
+                OSError(message),
+                stage="job.assign",
+                api="AssignProcessToJobObject",
+                error_code=5,
+            )
+            for message in ("WrongApi code 999", "locale-B unrelated")
+        ]
+
+        self.assertEqual(
+            [
+                (failure.stage, failure.api, failure.error_code)
+                for failure in failures
+            ],
+            [
+                ("job.assign", "AssignProcessToJobObject", 5),
+                ("job.assign", "AssignProcessToJobObject", 5),
+            ],
+        )
+        self.assertNotEqual(failures[0].message, failures[1].message)
+
+    def test_cli_projects_lifecycle_failure_without_replacing_legacy_fields(self) -> None:
+        lifecycle = provenance.LifecycleFailure(
+            stage="command.timeout",
+            api="Popen.wait",
+            message="formula audit timed out",
+        )
+        error = provenance.ProvenanceError(
+            "legacy CLI error", lifecycle=lifecycle
+        )
+        output = io.StringIO()
+
+        with (
+            mock.patch.object(sys, "argv", ["adj_stdlib_provenance.py", "verify"]),
+            mock.patch.object(
+                provenance, "validate_repository", side_effect=error
+            ),
+            redirect_stdout(output),
+        ):
+            returncode = provenance.main()
+
+        self.assertEqual(returncode, 1)
+        self.assertEqual(
+            json.loads(output.getvalue()),
+            {
+                "error": "legacy CLI error",
+                "lifecycle_failure": lifecycle.to_dict(),
+                "valid": False,
+            },
+        )
+
+    def test_cli_plain_provenance_error_keeps_original_key_set(self) -> None:
+        output = io.StringIO()
+
+        with (
+            mock.patch.object(sys, "argv", ["adj_stdlib_provenance.py", "verify"]),
+            mock.patch.object(
+                provenance,
+                "validate_repository",
+                side_effect=provenance.ProvenanceError("plain failure"),
+            ),
+            redirect_stdout(output),
+        ):
+            returncode = provenance.main()
+
+        self.assertEqual(returncode, 1)
+        self.assertEqual(
+            json.loads(output.getvalue()),
+            {"error": "plain failure", "valid": False},
+        )
+
+    def test_cli_projects_unwrapped_native_lifecycle_error(self) -> None:
+        lifecycle = provenance.LifecycleFailure(
+            stage="job.create",
+            api="CreateJobObjectW",
+            error_code=5,
+            message="native failure",
+        )
+        output = io.StringIO()
+
+        with (
+            mock.patch.object(sys, "argv", ["adj_stdlib_provenance.py", "verify"]),
+            mock.patch.object(
+                provenance,
+                "validate_repository",
+                side_effect=provenance._LifecycleError(lifecycle),
+            ),
+            redirect_stdout(output),
+        ):
+            returncode = provenance.main()
+
+        self.assertEqual(returncode, 1)
+        self.assertEqual(
+            json.loads(output.getvalue())["lifecycle_failure"],
+            lifecycle.to_dict(),
+        )
+
+    def test_formula_replay_failure_reaches_cli_with_lifecycle(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, _ = self.build_repository(
+                root, with_formula_inventory=True
+            )
+            schema_path = (
+                Path(__file__).resolve().parents[3] / provenance.DEFAULT_SCHEMA
+            )
+            output = io.StringIO()
+            launch_error = OSError(13, "translated access denied")
+            launch_error.winerror = 5  # type: ignore[attr-defined]
+
+            with (
+                mock.patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "adj_stdlib_provenance.py",
+                        "--repo-root",
+                        str(root),
+                        "verify",
+                        "--cas",
+                        str(cas_root),
+                        "--manifest",
+                        str(manifest_path),
+                        "--schema",
+                        str(schema_path),
+                        "--formula-inventory-binary",
+                        "missing-parser",
+                    ],
+                ),
+                mock.patch.object(
+                    provenance.subprocess, "Popen", side_effect=launch_error
+                ),
+                redirect_stdout(output),
+            ):
+                returncode = provenance.main()
+
+        self.assertEqual(returncode, 1)
+        payload = json.loads(output.getvalue())
+        lifecycle = payload["lifecycle_failure"]
+        self.assertEqual(
+            (lifecycle["stage"], lifecycle["api"], lifecycle["error_code"]),
+            ("process.launch", "Popen", 5),
+        )
+        self.assertEqual(payload["error"], lifecycle["message"])
+        self.assertFalse(payload["valid"])
+
     def fake_windows_kernel32(self) -> mock.Mock:
         kernel32 = mock.Mock()
         kernel32.CreateJobObjectW.return_value = 101
@@ -694,9 +943,57 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                 mock.patch.object(provenance, "MAX_OBJECT_BYTES", 1024),
                 self.assertRaisesRegex(
                     provenance.ProvenanceError, "output exceeds byte limit"
-                ),
+                ) as raised,
             ):
                 provenance._run_formula_inventory(command, source)
+
+            self.assertEqual(
+                raised.exception.lifecycle.stage, "command.output_limit"
+            )
+
+    def test_formula_inventory_execution_exposes_lifecycle_failures(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "source.adj"
+            source.write_bytes(b"")
+            launch_error = OSError(13, "translated access denied")
+            launch_error.winerror = 5  # type: ignore[attr-defined]
+
+            with (
+                mock.patch.object(
+                    provenance.subprocess, "Popen", side_effect=launch_error
+                ),
+                self.assertRaisesRegex(
+                    provenance.ProvenanceError, "failed to run"
+                ) as raised,
+            ):
+                provenance._run_formula_inventory(["parser"], source)
+
+            self.assertEqual(
+                (
+                    raised.exception.lifecycle.stage,
+                    raised.exception.lifecycle.api,
+                    raised.exception.lifecycle.error_code,
+                ),
+                ("process.launch", "Popen", 5),
+            )
+
+            for payload, expected_stage in (
+                ("import sys; sys.stdout.buffer.write(b'\\xff')", "command.decode"),
+                ("print('not-json')", "command.parse"),
+            ):
+                with (
+                    self.subTest(expected_stage=expected_stage),
+                    self.assertRaisesRegex(
+                        provenance.ProvenanceError, "did not emit UTF-8 JSON"
+                    ) as raised,
+                ):
+                    provenance._run_formula_inventory(
+                        [sys.executable, "-c", payload], source
+                    )
+
+                self.assertEqual(
+                    raised.exception.lifecycle.stage, expected_stage
+                )
 
     def test_windows_job_creation_failure_is_named_and_fail_closed(self) -> None:
         kernel32 = self.fake_windows_kernel32()
@@ -750,21 +1047,33 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         kernel32.SetInformationJobObject.return_value = 0
         kernel32.CloseHandle.side_effect = [0, 1]
 
-        with self.assertRaisesRegex(OSError, "SetInformationJobObject failed"):
+        with self.assertRaisesRegex(
+            OSError, "SetInformationJobObject failed"
+        ) as raised:
             self.windows_job(kernel32)
 
+        detail = (
+            str(ctypes.WinError(5))
+            if hasattr(ctypes, "WinError")
+            else "Windows error 5"
+        )
+        legacy = OSError(5, f"SetInformationJobObject failed: {detail}")
+        self.assertEqual(raised.exception.args, legacy.args)
+        self.assertEqual(str(raised.exception), str(legacy))
+        self.assertEqual(raised.exception.failure.cleanup_causes, ())
         self.assertEqual(kernel32.CloseHandle.call_count, 2)
 
     def test_windows_job_preserves_distinct_native_error_codes(self) -> None:
         kernel32 = self.fake_windows_kernel32()
         error_register = [0]
+        close_codes = iter((6, 32))
 
         def fail_setup(*_arguments: object) -> int:
             error_register[0] = 87
             return 0
 
         def fail_close(_handle: int) -> int:
-            error_register[0] = 6
+            error_register[0] = next(close_codes)
             return 0
 
         kernel32.SetInformationJobObject.side_effect = fail_setup
@@ -772,22 +1081,45 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
 
         with self.assertRaisesRegex(
             OSError,
-            "SetInformationJobObject failed.*87.*CloseHandle\\(job\\) failed.*6",
-        ):
+            "SetInformationJobObject failed.*87.*CloseHandle\\(job\\) failed.*6.*CloseHandle\\(job\\) failed.*32",
+        ) as raised:
             provenance._WindowsKillJob(
                 kernel32,
                 lambda: error_register[0],
                 lambda value: error_register.__setitem__(0, value),
             )
 
+        failure = raised.exception.failure
+        self.assertEqual(
+            (failure.stage, failure.api, failure.error_code),
+            ("job.configure", "SetInformationJobObject", 87),
+        )
+        self.assertEqual(len(failure.cleanup_causes), 1)
+        close = failure.cleanup_causes[0]
+        self.assertEqual(
+            (close.stage, close.api, close.error_code),
+            ("job.close", "CloseHandle", 6),
+        )
+        self.assertEqual(len(close.cleanup_causes), 1)
+        self.assertEqual(close.cleanup_causes[0].error_code, 32)
+
     def test_windows_job_assignment_failure_is_named(self) -> None:
         kernel32 = self.fake_windows_kernel32()
         job = self.windows_job(kernel32)
         kernel32.AssignProcessToJobObject.return_value = 0
 
-        with self.assertRaisesRegex(OSError, "AssignProcessToJobObject failed"):
+        with self.assertRaisesRegex(
+            OSError, "AssignProcessToJobObject failed"
+        ) as raised:
             job.assign(self.windows_process())
 
+        if hasattr(ctypes, "WinError"):
+            detail = str(ctypes.WinError(5))
+        else:
+            detail = "Windows error 5"
+        legacy = OSError(5, f"AssignProcessToJobObject failed: {detail}")
+        self.assertEqual(raised.exception.args, legacy.args)
+        self.assertEqual(str(raised.exception), str(legacy))
         job.close()
 
     def test_windows_job_closed_assignment_uses_local_state_error(self) -> None:
@@ -843,9 +1175,17 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             lambda value: error_register.__setitem__(0, value),
         )
 
-        with self.assertRaisesRegex(OSError, "Thread32First failed.*5"):
+        with self.assertRaisesRegex(OSError, "Thread32First failed.*5") as raised:
             job.resume(self.windows_process())
 
+        self.assertEqual(
+            (
+                raised.exception.failure.stage,
+                raised.exception.failure.api,
+                raised.exception.failure.error_code,
+            ),
+            ("thread.enumerate", "Thread32First", 5),
+        )
         self.assertEqual(error_register, [6])
         job.close()
 
@@ -1057,9 +1397,21 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
 
         with self.assertRaisesRegex(
             OSError, "ResumeThread failed.*cleanup also failed.*CloseHandle\\(thread\\)"
-        ):
+        ) as raised:
             job.resume(self.windows_process(pid=404))
 
+        failure = raised.exception.failure
+        self.assertEqual(
+            (failure.stage, failure.api, failure.error_code),
+            ("thread.resume", "ResumeThread", 5),
+        )
+        self.assertEqual(
+            [
+                (cause.stage, cause.api, cause.error_code)
+                for cause in failure.cleanup_causes
+            ],
+            [("thread.close", "CloseHandle", 5)],
+        )
         job.close()
 
     def test_windows_job_resume_preserves_snapshot_close_failure(self) -> None:
@@ -1078,9 +1430,17 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         with self.assertRaisesRegex(
             OSError,
             "ResumeThread failed.*cleanup also failed.*CloseHandle\\(thread snapshot\\)",
-        ):
+        ) as raised:
             job.resume(self.windows_process(pid=404))
 
+        failure = raised.exception.failure
+        self.assertEqual(
+            [
+                (cause.stage, cause.api, cause.error_code)
+                for cause in failure.cleanup_causes
+            ],
+            [("thread_snapshot.close", "CloseHandle", 5)],
+        )
         job.close()
 
     def test_windows_job_snapshot_close_failure_is_named(self) -> None:
@@ -1141,21 +1501,32 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         process.kill.assert_called_once_with()
 
     def test_windows_job_taskkill_failures_remain_observable(self) -> None:
-        for taskkill_failure, expected in (
+        translated_error = OSError(13, "translated access denied")
+        translated_error.winerror = 5  # type: ignore[attr-defined]
+        for taskkill_failure, expected, taskkill_code in (
             (
                 subprocess.CompletedProcess(["taskkill"], 7),
                 "taskkill /T exited 7",
+                7,
             ),
             (
                 subprocess.TimeoutExpired(["taskkill"], 5),
                 "taskkill /T failed",
+                None,
             ),
+            (OSError(2, "taskkill missing"), "taskkill /T failed", 2),
+            (translated_error, "taskkill /T failed", 5),
         ):
             with self.subTest(expected=expected):
                 process = self.windows_process()
                 process.poll.return_value = None
                 job = mock.Mock()
-                job.terminate.side_effect = OSError("TerminateJobObject failed")
+                job.terminate.side_effect = provenance._lifecycle_error(
+                    "job.terminate",
+                    "TerminateJobObject failed",
+                    api="TerminateJobObject",
+                    error_code=5,
+                )
                 if isinstance(taskkill_failure, BaseException):
                     taskkill = mock.Mock(side_effect=taskkill_failure)
                 else:
@@ -1164,14 +1535,77 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                 with (
                     mock.patch.object(provenance.os, "name", "nt"),
                     mock.patch.object(provenance.subprocess, "run", taskkill),
-                    self.assertRaisesRegex(OSError, expected),
+                    self.assertRaisesRegex(OSError, expected) as raised,
                 ):
                     provenance._terminate_process_tree(process, job)
 
+                failure = raised.exception.failure
+                self.assertEqual(
+                    (failure.stage, failure.api, failure.error_code),
+                    ("job.terminate", "TerminateJobObject", 5),
+                )
+                self.assertEqual(len(failure.cleanup_causes), 1)
+                self.assertEqual(
+                    (
+                        failure.cleanup_causes[0].stage,
+                        failure.cleanup_causes[0].api,
+                        failure.cleanup_causes[0].error_code,
+                    ),
+                    ("process_tree.terminate", "taskkill", taskkill_code),
+                )
                 self.assertIn("/T", taskkill.call_args.args[0])
                 self.assertIn("/F", taskkill.call_args.args[0])
                 self.assertEqual(taskkill.call_args.kwargs["timeout"], 5)
                 process.kill.assert_called_once_with()
+
+    def test_windows_job_root_kill_failure_is_ordered_after_taskkill(self) -> None:
+        process = self.windows_process()
+        process.poll.return_value = None
+        process.kill.side_effect = OSError(6, "TerminateProcess failed")
+        job = mock.Mock()
+        job.terminate.side_effect = provenance._lifecycle_error(
+            "job.terminate",
+            "TerminateJobObject failed",
+            api="TerminateJobObject",
+            error_code=5,
+        )
+        taskkill = mock.Mock(
+            return_value=subprocess.CompletedProcess(["taskkill"], 7)
+        )
+
+        with (
+            mock.patch.object(provenance.os, "name", "nt"),
+            mock.patch.object(provenance.subprocess, "run", taskkill),
+            self.assertRaisesRegex(OSError, "TerminateProcess failed") as raised,
+        ):
+            provenance._terminate_process_tree(process, job)
+
+        failure = raised.exception.failure
+        self.assertEqual(
+            [
+                (cause.stage, cause.api, cause.error_code)
+                for cause in failure.cleanup_causes
+            ],
+            [
+                ("process_tree.terminate", "taskkill", 7),
+                ("process.terminate", "Popen.kill", 6),
+            ],
+        )
+
+    def test_process_tree_poll_failure_is_structured_before_root_kill(self) -> None:
+        process = self.windows_process()
+        process.poll.side_effect = OSError(6, "injected poll failure")
+        job = mock.Mock()
+
+        with self.assertRaisesRegex(OSError, "injected poll failure") as raised:
+            provenance._terminate_process_tree(process, job)
+
+        failure = raised.exception.failure
+        self.assertEqual(
+            (failure.stage, failure.api, failure.error_code),
+            ("process.poll", "Popen.poll", 6),
+        )
+        process.kill.assert_called_once_with()
 
     @unittest.skipUnless(os.name == "nt", "Windows Job Object behavior")
     def test_windows_job_factory_failure_precedes_process_launch(self) -> None:
@@ -1181,7 +1615,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             mock.patch.object(provenance.subprocess, "Popen") as popen,
             self.assertRaisesRegex(
                 provenance.ProvenanceError, "failed to create process job"
-            ),
+            ) as raised,
         ):
             provenance._run_json_command(
                 [sys.executable, "-c", "print('{}')"],
@@ -1190,6 +1624,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                 windows_job_factory=factory,
             )
 
+        self.assertEqual(raised.exception.lifecycle.stage, "job.create")
         popen.assert_not_called()
 
     @unittest.skipUnless(os.name == "nt", "Windows Job Object behavior")
@@ -1206,7 +1641,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             self.assertRaisesRegex(
                 provenance.ProvenanceError,
                 "failed to run.*process launch failure.*failed to close process job",
-            ),
+            ) as raised,
         ):
             provenance._run_json_command(
                 [sys.executable],
@@ -1215,6 +1650,15 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                 windows_job_factory=lambda: job,
             )
 
+        failure = raised.exception.lifecycle
+        self.assertEqual(
+            (failure.stage, failure.api),
+            ("process.launch", "Popen"),
+        )
+        self.assertEqual(failure.message, str(raised.exception))
+        self.assertEqual(len(failure.cleanup_causes), 1)
+        self.assertEqual(failure.cleanup_causes[0].stage, "job.close")
+        self.assertEqual(len(failure.cleanup_causes[0].cleanup_causes), 1)
         self.assertEqual(job.close.call_count, 2)
 
     @unittest.skipUnless(os.name == "nt", "Windows Job Object behavior")
@@ -1248,7 +1692,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                     self.assertRaisesRegex(
                         provenance.ProvenanceError,
                         f"failed to contain process tree.*{failing_stage} failure",
-                    ),
+                    ) as raised,
                 ):
                     provenance._run_json_command(
                         [sys.executable, "-c", "print('{}')"],
@@ -1258,6 +1702,16 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                         windows_job_factory=lambda job=job: job,
                     )
 
+                failure = raised.exception.lifecycle
+                self.assertEqual(
+                    failure.stage,
+                    "job.assign" if failing_stage == "assign" else "thread.resume",
+                )
+                self.assertEqual(failure.message, str(raised.exception))
+                self.assertEqual(
+                    [cause.stage for cause in failure.cleanup_causes],
+                    ["job.close"],
+                )
                 self.assertEqual(len(processes), 1)
                 self.assertIsNotNone(processes[0].poll())
                 self.assertTrue(processes[0].stdout.closed)
@@ -1289,7 +1743,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             self.assertRaisesRegex(
                 provenance.ProvenanceError,
                 "assignment failure.*tree termination failure.*root process kill failed.*TerminateProcess failure",
-            ),
+            ) as raised,
         ):
             provenance._run_json_command(
                 [sys.executable],
@@ -1299,6 +1753,14 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                 windows_job_factory=lambda: job,
             )
 
+        failure = raised.exception.lifecycle
+        self.assertIsNotNone(failure)
+        self.assertEqual(failure.stage, "job.assign")
+        self.assertEqual(failure.message, str(raised.exception))
+        self.assertEqual(
+            [cause.stage for cause in failure.cleanup_causes],
+            ["process_tree.terminate", "process.terminate"],
+        )
         job.close.assert_called_once_with()
         process.stdout.close.assert_called_once_with()
         process.stderr.close.assert_called_once_with()
@@ -1312,7 +1774,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         with self.assertRaisesRegex(
             provenance.ProvenanceError,
             "timed out.*failed to terminate process tree.*failed to close process job",
-        ):
+        ) as raised:
             provenance._run_json_command(
                 [sys.executable, "-c", "print('{}')"],
                 [],
@@ -1322,6 +1784,19 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                 windows_job_factory=lambda: job,
             )
 
+        failure = raised.exception.lifecycle
+        self.assertIsNotNone(failure)
+        self.assertEqual(failure.stage, "command.timeout")
+        self.assertEqual(failure.api, "Popen.wait")
+        self.assertEqual(failure.message, str(raised.exception))
+        self.assertEqual(
+            [cause.stage for cause in failure.cleanup_causes],
+            ["job.terminate", "job.close"],
+        )
+        self.assertEqual(
+            [cause.stage for cause in failure.cleanup_causes[1].cleanup_causes],
+            ["job.terminate", "job.close"],
+        )
         self.assertGreaterEqual(job.terminate.call_count, 1)
         self.assertEqual(job.close.call_count, 2)
 
@@ -1350,7 +1825,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             self.assertRaisesRegex(
                 provenance.ProvenanceError,
                 "output exceeds byte limit.*failed to terminate process tree.*failed to close process job",
-            ),
+            ) as raised,
         ):
             provenance._run_json_command(
                 [
@@ -1364,6 +1839,18 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                 drain_timeout_seconds=0.2,
                 windows_job_factory=FaultingJob,
             )
+
+        failure = raised.exception.lifecycle
+        self.assertEqual(failure.stage, "command.output_limit")
+        self.assertEqual(failure.message, str(raised.exception))
+        self.assertEqual(
+            [cause.stage for cause in failure.cleanup_causes],
+            ["job.terminate", "job.close"],
+        )
+        self.assertEqual(
+            [cause.stage for cause in failure.cleanup_causes[1].cleanup_causes],
+            ["job.terminate", "job.close"],
+        )
 
     def test_json_command_timeout_preserves_stuck_drain_failure(self) -> None:
         process = mock.Mock()
@@ -1386,7 +1873,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             self.assertRaisesRegex(
                 provenance.ProvenanceError,
                 "timed out after 0.1 seconds.*output pipes did not close within bounds",
-            ),
+            ) as raised,
         ):
             provenance._run_json_command(
                 [sys.executable],
@@ -1397,8 +1884,333 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                 windows_job_factory=mock.Mock,
             )
 
+        failure = raised.exception.lifecycle
+        self.assertEqual(failure.stage, "command.timeout")
+        self.assertEqual(failure.message, str(raised.exception))
+        self.assertEqual(
+            [cause.stage for cause in failure.cleanup_causes],
+            ["pipe.drain"],
+        )
         process.stdout.close.assert_not_called()
         process.stderr.close.assert_not_called()
+
+    def test_json_command_pipe_read_failure_fails_closed(self) -> None:
+        process = mock.Mock()
+        process.wait.return_value = -9
+        process.poll.return_value = None
+        process.stdout.read.side_effect = [
+            b"{}\n",
+            OSError(5, "injected stdout read failure"),
+        ]
+        process.stderr.read.return_value = b""
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError, "stdout pipe read failed"
+            ) as raised,
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="pipe read fixture",
+                windows_job_factory=mock.Mock,
+            )
+
+        failure = raised.exception.lifecycle
+        self.assertEqual(
+            (failure.stage, failure.api, failure.error_code),
+            ("pipe.read", "Popen.stdout.read", 5),
+        )
+        self.assertEqual(
+            [
+                (cause.stage, cause.api, cause.error_code)
+                for cause in failure.cleanup_causes
+            ],
+            [("command.exit", "Popen.wait", -9)],
+        )
+        self.assertEqual(failure.message, str(raised.exception))
+
+    def test_json_command_child_exit_precedes_later_pipe_read_failure(self) -> None:
+        process = mock.Mock()
+        process.wait.return_value = 7
+        process.poll.return_value = 7
+        process.stdout.read.side_effect = OSError(5, "injected stdout read failure")
+        process.stderr.read.return_value = b""
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError, "exited 7.*stdout pipe read failed"
+            ) as raised,
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="prior exit fixture",
+                windows_job_factory=mock.Mock,
+            )
+
+        failure = raised.exception.lifecycle
+        self.assertEqual(
+            (failure.stage, failure.api, failure.error_code),
+            ("command.exit", "Popen.wait", 7),
+        )
+        self.assertEqual(
+            [
+                (cause.stage, cause.api, cause.error_code)
+                for cause in failure.cleanup_causes
+            ],
+            [("pipe.read", "Popen.stdout.read", 5)],
+        )
+        self.assertEqual(failure.message, str(raised.exception))
+
+    def test_json_command_pipe_read_preserves_poll_failure(self) -> None:
+        process = mock.Mock()
+        process.wait.return_value = -9
+        process.poll.side_effect = [OSError(6, "injected poll failure"), None]
+        process.stdout.read.side_effect = OSError(5, "injected stdout read failure")
+        process.stderr.read.return_value = b""
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError,
+                "stdout pipe read failed.*process exited -9",
+            ) as raised,
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="poll failure fixture",
+                windows_job_factory=mock.Mock,
+            )
+
+        failure = raised.exception.lifecycle
+        self.assertEqual(failure.stage, "pipe.read")
+        self.assertEqual(
+            [
+                (cause.stage, cause.api, cause.error_code)
+                for cause in failure.cleanup_causes
+            ],
+            [
+                ("process.poll", "Popen.poll", 6),
+                ("command.exit", "Popen.wait", -9),
+            ],
+        )
+        self.assertEqual(failure.message, str(raised.exception))
+
+    def test_json_command_wait_failure_and_retry_are_structured(self) -> None:
+        process = mock.Mock()
+        process.wait.side_effect = [
+            OSError(5, "injected wait failure"),
+            OSError(6, "injected wait retry failure"),
+        ]
+        process.stdout.read.return_value = b""
+        process.stderr.read.return_value = b""
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError, "process wait failed"
+            ) as raised,
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="wait fixture",
+                windows_job_factory=mock.Mock,
+            )
+
+        failure = raised.exception.lifecycle
+        self.assertEqual(
+            (failure.stage, failure.api, failure.error_code),
+            ("process.wait", "Popen.wait", 5),
+        )
+        self.assertEqual(
+            [
+                (cause.stage, cause.api, cause.error_code)
+                for cause in failure.cleanup_causes
+            ],
+            [("process.wait", "Popen.wait", 6)],
+        )
+        self.assertEqual(failure.message, str(raised.exception))
+
+    def test_json_command_wait_failure_preserves_retry_timeout(self) -> None:
+        process = mock.Mock()
+        process.wait.side_effect = [
+            OSError(5, "injected wait failure"),
+            subprocess.TimeoutExpired(["fixture"], 0.1),
+        ]
+        process.stdout.read.return_value = b""
+        process.stderr.read.return_value = b""
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError, "process wait failed"
+            ) as raised,
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="wait timeout fixture",
+                drain_timeout_seconds=0.1,
+                windows_job_factory=mock.Mock,
+            )
+
+        failure = raised.exception.lifecycle
+        self.assertEqual(
+            (failure.stage, failure.api, failure.error_code),
+            ("process.wait", "Popen.wait", 5),
+        )
+        self.assertEqual(
+            [
+                (cause.stage, cause.api, cause.error_code, cause.message)
+                for cause in failure.cleanup_causes
+            ],
+            [
+                (
+                    "process.wait",
+                    "Popen.wait",
+                    None,
+                    "process wait retry timed out after 0.1 seconds",
+                )
+            ],
+        )
+        self.assertEqual(failure.message, str(raised.exception))
+
+    def test_json_command_timeout_preserves_recovery_wait_timeout(self) -> None:
+        process = mock.Mock()
+        process.wait.side_effect = [
+            subprocess.TimeoutExpired(["fixture"], 0.2),
+            subprocess.TimeoutExpired(["fixture"], 0.1),
+        ]
+        process.stdout.read.return_value = b""
+        process.stderr.read.return_value = b""
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError, "timed out after 0.2 seconds"
+            ) as raised,
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="double timeout fixture",
+                timeout_seconds=0.2,
+                drain_timeout_seconds=0.1,
+                windows_job_factory=mock.Mock,
+            )
+
+        failure = raised.exception.lifecycle
+        self.assertEqual(failure.stage, "command.timeout")
+        self.assertEqual(
+            [
+                (cause.stage, cause.api, cause.error_code, cause.message)
+                for cause in failure.cleanup_causes
+            ],
+            [
+                (
+                    "process.wait",
+                    "Popen.wait",
+                    None,
+                    "process wait after command timeout timed out after 0.1 seconds",
+                )
+            ],
+        )
+        self.assertEqual(failure.message, str(raised.exception))
+
+    def test_json_command_pipe_close_failure_is_structured(self) -> None:
+        process = mock.Mock()
+        process.wait.return_value = 0
+        process.stdout.read.side_effect = [b"{}\n", b""]
+        process.stderr.read.return_value = b""
+        process.stdout.close.side_effect = OSError(5, "injected stdout close failure")
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError, "failed to close output pipe"
+            ) as raised,
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="pipe close fixture",
+                windows_job_factory=mock.Mock,
+            )
+
+        failure = raised.exception.lifecycle
+        self.assertEqual(
+            (failure.stage, failure.api, failure.error_code),
+            ("pipe.close", "Popen.stdout.close", 5),
+        )
+        self.assertEqual(failure.message, str(raised.exception))
+
+    @unittest.skipUnless(os.name == "nt", "Windows Job Object behavior")
+    def test_job_close_root_renders_pipe_close_as_cleanup(self) -> None:
+        process = mock.Mock()
+        process.wait.return_value = 0
+        process.stdout.read.side_effect = [b"{}\n", b""]
+        process.stderr.read.return_value = b""
+        process.stdout.close.side_effect = OSError(5, "injected stdout close failure")
+        job = mock.Mock()
+        job.close.side_effect = [OSError(6, "injected job close failure"), None]
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError,
+                "failed to close process job.*cleanup also failed: stdout pipe close failed",
+            ) as raised,
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="combined close fixture",
+                windows_job_factory=lambda: job,
+            )
+
+        failure = raised.exception.lifecycle
+        self.assertEqual(failure.stage, "job.close")
+        self.assertEqual(
+            [cause.stage for cause in failure.cleanup_causes],
+            ["pipe.close"],
+        )
+        self.assertNotIn("recovery termination failed", str(raised.exception))
+        self.assertEqual(failure.message, str(raised.exception))
+
+    @unittest.skipUnless(os.name == "nt", "Windows Job Object behavior")
+    def test_windows_containment_preserves_pipe_close_failure(self) -> None:
+        process = mock.Mock()
+        process.wait.return_value = 0
+        process.stdout.close.side_effect = OSError(5, "injected stdout close failure")
+        job = mock.Mock()
+        job.assign.side_effect = OSError(87, "injected assignment failure")
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError,
+                "assignment failure.*stdout pipe close failed",
+            ) as raised,
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="containment pipe close fixture",
+                windows_job_factory=lambda: job,
+            )
+
+        failure = raised.exception.lifecycle
+        self.assertEqual(failure.stage, "job.assign")
+        self.assertEqual(
+            [cause.stage for cause in failure.cleanup_causes],
+            ["pipe.close"],
+        )
+        self.assertEqual(failure.message, str(raised.exception))
 
     @unittest.skipUnless(os.name == "nt", "Windows Job Object behavior")
     def test_windows_job_close_failure_terminates_and_retries(self) -> None:
@@ -1429,22 +2241,30 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             self.assertRaisesRegex(
                 provenance.ProvenanceError,
                 "failed to close process job.*injected CloseHandle",
-            ),
+            ) as raised,
         ):
             provenance._run_json_command(
-                [sys.executable, "-c", "print('{}')"],
+                [
+                    sys.executable,
+                    "-c",
+                    "import sys; sys.stdout.buffer.write(b'{}\\n')",
+                ],
                 [],
                 label="close retry fixture",
             )
 
+        failure = raised.exception.lifecycle
+        self.assertEqual(failure.stage, "job.close")
+        self.assertEqual(failure.message, str(raised.exception))
+        self.assertEqual(failure.cleanup_causes, ())
         self.assertEqual(close_calls, 2)
         self.assertEqual(terminate_calls, 1)
 
     @unittest.skipUnless(os.name == "nt", "Windows Job Object behavior")
     def test_windows_job_cleanup_failure_preserves_command_error(self) -> None:
-        for command, expected in (
-            ("import sys; sys.exit(7)", "exited 7"),
-            ("print('not-json')", "did not emit UTF-8 JSON"),
+        for command, expected, stage, error_code in (
+            ("import sys; sys.exit(7)", "exited 7", "command.exit", 7),
+            ("print('not-json')", "did not emit UTF-8 JSON", "command.parse", None),
         ):
             with self.subTest(expected=expected):
                 original_close = provenance._WindowsKillJob.close
@@ -1467,7 +2287,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                     self.assertRaisesRegex(
                         provenance.ProvenanceError,
                         expected + ".*failed to close process job",
-                    ),
+                    ) as raised,
                 ):
                     provenance._run_json_command(
                         [sys.executable, "-c", command],
@@ -1475,6 +2295,16 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                         label="causal cleanup fixture",
                     )
 
+                failure = raised.exception.lifecycle
+                self.assertIsNotNone(failure)
+                self.assertEqual(
+                    (failure.stage, failure.error_code),
+                    (stage, error_code),
+                )
+                self.assertEqual(
+                    [cause.stage for cause in failure.cleanup_causes],
+                    ["job.close"],
+                )
                 self.assertEqual(close_calls, 2)
 
     def test_windows_job_timeout_kills_descendant_pipe_holders(self) -> None:

--- a/code/scripts/tests/test_adj_stdlib_provenance.py
+++ b/code/scripts/tests/test_adj_stdlib_provenance.py
@@ -1597,7 +1597,10 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         process.poll.side_effect = OSError(6, "injected poll failure")
         job = mock.Mock()
 
-        with self.assertRaisesRegex(OSError, "injected poll failure") as raised:
+        with (
+            mock.patch.object(provenance.os, "killpg", create=True),
+            self.assertRaisesRegex(OSError, "injected poll failure") as raised,
+        ):
             provenance._terminate_process_tree(process, job)
 
         failure = raised.exception.failure
@@ -1895,7 +1898,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         process.stderr.close.assert_not_called()
 
     def test_json_command_pipe_read_failure_fails_closed(self) -> None:
-        process = mock.Mock()
+        process = mock.Mock(pid=404)
         process.wait.return_value = -9
         process.poll.return_value = None
         process.stdout.read.side_effect = [
@@ -1906,6 +1909,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
 
         with (
             mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            mock.patch.object(provenance.os, "killpg", create=True),
             self.assertRaisesRegex(
                 provenance.ProvenanceError, "stdout pipe read failed"
             ) as raised,
@@ -1966,7 +1970,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         self.assertEqual(failure.message, str(raised.exception))
 
     def test_json_command_pipe_read_preserves_poll_failure(self) -> None:
-        process = mock.Mock()
+        process = mock.Mock(pid=404)
         process.wait.return_value = -9
         process.poll.side_effect = [OSError(6, "injected poll failure"), None]
         process.stdout.read.side_effect = OSError(5, "injected stdout read failure")
@@ -1974,6 +1978,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
 
         with (
             mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            mock.patch.object(provenance.os, "killpg", create=True),
             self.assertRaisesRegex(
                 provenance.ProvenanceError,
                 "stdout pipe read failed.*process exited -9",
@@ -2001,7 +2006,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         self.assertEqual(failure.message, str(raised.exception))
 
     def test_json_command_wait_failure_and_retry_are_structured(self) -> None:
-        process = mock.Mock()
+        process = mock.Mock(pid=404)
         process.wait.side_effect = [
             OSError(5, "injected wait failure"),
             OSError(6, "injected wait retry failure"),
@@ -2011,6 +2016,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
 
         with (
             mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            mock.patch.object(provenance.os, "killpg", create=True),
             self.assertRaisesRegex(
                 provenance.ProvenanceError, "process wait failed"
             ) as raised,
@@ -2037,7 +2043,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         self.assertEqual(failure.message, str(raised.exception))
 
     def test_json_command_wait_failure_preserves_retry_timeout(self) -> None:
-        process = mock.Mock()
+        process = mock.Mock(pid=404)
         process.wait.side_effect = [
             OSError(5, "injected wait failure"),
             subprocess.TimeoutExpired(["fixture"], 0.1),
@@ -2047,6 +2053,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
 
         with (
             mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            mock.patch.object(provenance.os, "killpg", create=True),
             self.assertRaisesRegex(
                 provenance.ProvenanceError, "process wait failed"
             ) as raised,
@@ -2081,7 +2088,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         self.assertEqual(failure.message, str(raised.exception))
 
     def test_json_command_timeout_preserves_recovery_wait_timeout(self) -> None:
-        process = mock.Mock()
+        process = mock.Mock(pid=404)
         process.wait.side_effect = [
             subprocess.TimeoutExpired(["fixture"], 0.2),
             subprocess.TimeoutExpired(["fixture"], 0.1),
@@ -2091,6 +2098,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
 
         with (
             mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            mock.patch.object(provenance.os, "killpg", create=True),
             self.assertRaisesRegex(
                 provenance.ProvenanceError, "timed out after 0.2 seconds"
             ) as raised,

--- a/code/specs/ADJ-STDLIB-COVERAGE.md
+++ b/code/specs/ADJ-STDLIB-COVERAGE.md
@@ -345,9 +345,20 @@ option mapping, or judge/evaluation failure.
      termination and a close retry. Failed Job termination invokes bounded `/T` tree
      termination before the root-process fallback. The Windows PR matrix runs the
      focused fake and real-process containment slice.
-13g. **Backlog:** replace concatenated Windows lifecycle error text with structured
-     stage, API, error-code, and cleanup-cause records so callers can inspect failures
-     without parsing localized operating-system messages.
+13g. **Complete:** process lifecycle failures are immutable recursive records with a
+     stable `stage`, native `api`, numeric `error_code`, human `message`, and ordered
+     `cleanup_causes`. `ProvenanceError.lifecycle` exposes the record while preserving
+     legacy exception text and arguments. `to_dict()` provides the versioned
+     `adj-stdlib/process-lifecycle-failure/v1` projection, and CLI failures include it
+     as `lifecycle_failure` without removing the legacy `error` or `valid` fields.
+     Native setup and enumeration errors, process launch and containment, command
+     timeout/output/exit/decoding, taskkill and root fallback, pipe drain, termination,
+     process waits, pipe reads and closes, and close retries all retain
+     machine-inspectable causal structure. Worker-thread I/O faults fail closed even
+     when the bytes received before the fault happen to form valid canonical JSON.
+13h. **Backlog:** add platform-neutral fault injection for POSIX process-group
+     termination, including `killpg` permission/lookup failures, root-kill fallback,
+     simultaneous pipe cleanup failures, and hosted Linux/macOS execution gates.
 
 ### Wave 2: complete K-8 foundations
 

--- a/code/specs/data/adj-stdlib-provenance/README.md
+++ b/code/specs/data/adj-stdlib-provenance/README.md
@@ -124,5 +124,13 @@ Windows Job lifecycle calls are fault-injected in platform-neutral tests and exe
 against real suspended processes in the Windows PR matrix. Native enumeration errors,
 truncated thread records, incomplete resumes, termination failures, and handle-close
 failures all prevent a verifier result from being accepted.
+Lifecycle failures remain human-readable but also expose an immutable recursive record
+through `ProvenanceError.lifecycle`: stage, native API, numeric error code, message, and
+ordered cleanup causes. Its `to_dict()` projection is canonical JSON-ready, so callers
+do not need to parse localized operating-system messages to diagnose containment. The
+projection is versioned as `adj-stdlib/process-lifecycle-failure/v1`; CLI failures add
+it as `lifecycle_failure` while retaining the existing `error` and `valid` fields.
+Process-wait, pipe-read, and pipe-close faults are records too; partial output is never
+accepted merely because its prefix happens to be valid canonical JSON.
 Existing hashes are reused, while missing or changed bytes, claims, transforms, graph
 edges, receipts, partitions, and projections fail closed.


### PR DESCRIPTION
## Summary
- add immutable, versioned lifecycle failure records with constrained stages, exact APIs, native error codes, and ordered recursive cleanup causes
- route formula inventory replay through the shared bounded process runner and expose lifecycle failures additively in CLI JSON
- fail closed across launch, containment, waits, polls, pipe I/O, termination, and close recovery while preserving legacy exception text and arguments
- document completed backlog item 13g and record POSIX fault injection as backlog item 13h

## Validation
- `python code/scripts/tests/test_adj_stdlib_provenance.py` (137 passed, 1 expected skip)
- strict CAS verification (6 bundles, 84 objects, 9 snapshots, valid)
- curriculum manifest validation (6 roots, 10 objectives, no errors)
- Ruff, py_compile, and git diff check
- independent final review by two subagents: no P0-P2 findings