### PR TITLE
fix(spice): lower parser MOS junction capacitance

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS model-card `CJ` values before lowering
+  valid bottom-junction capacitance densities.
 - Reject negative and non-finite MOS instance `PS` values before lowering
   valid source diffusion perimeters.
 - Reject negative and non-finite MOS instance `PD` values before lowering

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1969,6 +1969,10 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(params["RSH"]) or params["RSH"] < 0.0
         ):
             raise NetlistParseError("MOSFET RSH must be finite and non-negative")
+        if "CJ" in params and (
+            not math.isfinite(params["CJ"]) or params["CJ"] < 0.0
+        ):
+            raise NetlistParseError("MOSFET CJ must be finite and non-negative")
         nominal_temperature = params.get("T_NOM", params.get("TNOM"))
         if nominal_temperature is not None and (
             not math.isfinite(nominal_temperature) or nominal_temperature <= 0.0

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1816,6 +1816,33 @@ def test_lowers_valid_mosfet_model_sheet_resistance(
     assert float(sheet_resistance) == mosfet.model.model.params.RSH
 
 
+@pytest.mark.parametrize("junction_capacitance", ["-1p", "1e999"])
+def test_rejects_invalid_mosfet_model_junction_capacitance(
+    junction_capacitance: str,
+) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="MOSFET CJ must be finite and non-negative",
+    ):
+        parse_netlist(
+            f".model nfast NMOS(CJ={junction_capacitance})\nM1 d g s b nfast\n"
+        )
+
+
+@pytest.mark.parametrize(
+    ("junction_capacitance", "expected"), [("0", 0.0), ("2p", 2.0e-12)]
+)
+def test_lowers_valid_mosfet_model_junction_capacitance(
+    junction_capacitance: str, expected: float
+) -> None:
+    parsed = parse_netlist(
+        f".model nfast NMOS(CJ={junction_capacitance})\nM1 d g s b nfast\n"
+    )
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(mosfet.model.model.params.CJ, expected)
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS model-card `CJ` values and lower valid
+  bottom-junction capacitance densities instead of silently dropping them.
 - Reject negative and non-finite MOS instance `PS` values and lower valid
   source diffusion perimeters instead of silently dropping them.
 - Reject negative and non-finite MOS instance `PD` values and lower valid

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1276,6 +1276,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET RSH must be finite and non-negative");
   }
+  const junctionCapacitance = params.get("CJ");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    junctionCapacitance !== undefined &&
+    (!Number.isFinite(junctionCapacitance) || junctionCapacitance < 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET CJ must be finite and non-negative");
+  }
   const nominalTemperature = params.get("T_NOM") ?? params.get("TNOM");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1376,6 +1384,7 @@ function isMosfetParam(name: keyof MosfetLevel1Params): boolean {
     "AS",
     "PD",
     "PS",
+    "CJ",
     "IS",
     "N_SUB",
     "T_NOM",

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1699,6 +1699,28 @@ Xright c d load
     expect(element.params.RSH).toBe(Number(sheetResistance));
   });
 
+  it.each(["-1p", "1e999"])(
+    "rejects invalid MOSFET model CJ=%s",
+    (junctionCapacitance) => {
+      expect(() =>
+        parseNetlist(`.model nfast NMOS(CJ=${junctionCapacitance})\nM1 d g s b nfast\n`),
+      ).toThrow("MOSFET CJ must be finite and non-negative");
+    },
+  );
+
+  it.each([
+    ["0", 0.0],
+    ["2p", 2.0e-12],
+  ])("lowers valid MOSFET model CJ=%s", (junctionCapacitance, expected) => {
+    const parsed = parseNetlist(
+      `.model nfast NMOS(CJ=${junctionCapacitance})\nM1 d g s b nfast\n`,
+    );
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.CJ).toBeCloseTo(expected, 15);
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4249,11 +4249,17 @@ the Rust, Python, and TypeScript surfaces together.
      diagnostic while zero and positive drain diffusion perimeters lower into
      Level-1 parameters.
 
+389. Python and TypeScript Berkeley SPICE MOS source-perimeter parity.
+   - Status: completed in PR 9684.
+   - Negative and non-finite instance `PS` values are rejected with the shared
+     diagnostic while zero and positive source diffusion perimeters lower into
+     Level-1 parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
-   - TypeScript still needs canonical lowering for `PS`, `CJ`, `CJSW`, `JS`,
-     `PB`, `MJ`,
+   - TypeScript still needs canonical lowering for `CJ`, `CJSW`, `JS`, `PB`,
+     `MJ`,
      `MJSW`, `FC`, `KF`, and `AF`; Python already lowers these canonical fields
      but still needs matching facade validation coverage.
    - Align the `CJS` and `CJD` aliases with canonical `CBS` and `CBD` in both


### PR DESCRIPTION
## Summary
- validate MOS model-card `CJ` as finite and non-negative in Python and TypeScript
- lower valid TypeScript bottom-junction capacitance densities into Level-1 parameters
- record the merged source-perimeter slice and advance the prioritized parity backlog

## Verification
- Python: 176 tests passed; 88.43% coverage; Ruff clean
- TypeScript: dependent spice-engine build, parser build, 169 tests passed; 84.88% line coverage
- repeated both parser suites after rebasing onto current origin/main