### PR TITLE
feat(human-languages): publish Sanskrit chapter 6

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -76,9 +76,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B06 | Complete (#9669) | Publish Gujarati Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
 | HL-B07 | Complete (#9675) | Remove Gujarati's missing punctuation glyphs and LaTeX layout/bookmark warnings. | Canonical recap labels, main-font punctuation, bookmark-safe Gujarati, natural page bottoms, and explicit static-font shapes make the forced six-chapter build warning-free. |
 | HL-B08 | Complete (#9680) | Publish Punjabi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
-| HL-B09 | Complete in this PR | Remove Punjabi's LaTeX layout, duplicate-label, font-shape, and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Gurmukhi, natural page bottoms, explicit static-font shapes, and a shorter running title make the forced six-chapter build warning-free. |
-| HL-B10 | Next | Publish Sanskrit Chapter 6 from its three canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
-| HL-B11 | Queued | Remove Sanskrit's LaTeX layout, duplicate-label, and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs but reports three overfull boxes, six underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
+| HL-B09 | Complete (#9683) | Remove Punjabi's LaTeX layout, duplicate-label, font-shape, and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Gurmukhi, natural page bottoms, explicit static-font shapes, and a shorter running title make the forced six-chapter build warning-free. |
+| HL-B10 | Complete in this PR | Publish Sanskrit Chapter 6 from its three canonical lessons rather than hand-copying another book chapter. | All three schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
+| HL-B11 | Next | Remove Sanskrit's LaTeX layout, duplicate-label, font-shape, and Unicode bookmark warnings. | A forced six-chapter build succeeds with no missing glyphs but reports three overfull boxes, seven underfull boxes, four duplicate practice labels, 28 Hyperref warnings, and three font-shape warnings; the clean-build signal is zero of each. |
 | HL-B12 | Queued | Publish Bengali Chapter 6 from its canonical lesson rather than hand-copying another book chapter. | The duration audit confirms authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
 | HL-B13 | Queued | Remove Bengali's missing glyphs and LaTeX layout/bookmark warnings. | A forced build succeeds but reports six missing glyphs, one overfull box, four underfull boxes, four duplicate practice labels, and 27 Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B14 | Queued | Publish Italian Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Italian has canonical app content through Chapter 17, but its downloadable PDF contains only Chapter 1; schema-v2 migration plus generation should close that drift safely. |
@@ -406,6 +406,32 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   The forced 30-page XeLaTeX build now reports zero package or LaTeX warnings,
   missing glyphs, overfull boxes, underfull boxes, and duplicate destinations.
   HL-B10 is next: publish Sanskrit Chapter 6 through the canonical pipeline.
+
+## Findings from HL-B10
+
+- Sanskrit Chapter 6 now comes from its three canonical schema-v2 lessons. The
+  generator manifest and Language Ladder independently combine the same ordered
+  lesson hashes, so the app and downloadable book cannot drift silently.
+- All three lessons realize `SPINE-COUNT-ONE-TO-FIVE`, then extend it with
+  Sanskrit's dual and gendered numeral forms, the daughter languages' neuter
+  inheritance, PIE sound-law outcomes, and qualified lexical histories.
+- The canonical prose now says Sanskrit preserves the Old Indo-Aryan forms
+  behind the daughter languages and labels *four*'s `f-` as the usual analogy
+  explanation rather than presenting either relationship too absolutely.
+- The strict knowledge gate confirms every prompt against its block and
+  prerequisite frontier. The corpus report remains at 1,065 lessons and 20
+  books, with zero duration violations, zero unknown prerequisites, and 253
+  lesson chapters without book chapters. Sanskrit becomes the fifth
+  mixed-schema track.
+- The forced letter-size XeLaTeX build is 35 pages. Visual inspection of all
+  five generated pages found shaped Devanagari, width-aware grammar and
+  sound-law tables, intact callouts and recall prompts, and no clipping. The PDF
+  outline retains all three romanized section bookmarks.
+- A text mapping renders the PIE superscript `ʷ` without a missing glyph. The
+  generated chapter adds one visually benign underfull-page warning but no new
+  overfull, duplicate-label, bookmark, or font warning. The full build's three
+  font-shape warnings and seven underfull warnings are now recorded accurately
+  in HL-B11 alongside the older handwritten warning debt.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -74,7 +74,7 @@ edition is authored.
 | [Telugu](./telugu/README.md) | Dravidian / Telugu (vendored font) | Chapters 1-2 authored (lessons + book) |
 | [Malayalam](./malayalam/README.md) | Dravidian / Malayalam (vendored font) | Chapters 1-2 authored (lessons + book) |
 | [Latin](./latin/README.md) | Italic / Latin (**taproot**) | Chapter 1 (Greetings) authored (lessons + book) |
-| [Sanskrit](./sanskrit/README.md) | Indo-Aryan / Devanagari (**taproot**) | Chapter 1 (Greetings) authored (lessons + book) |
+| [Sanskrit](./sanskrit/README.md) | Indo-Aryan / Devanagari (**taproot**) | Chapters 1–6 authored (lessons + book; Chapter 6 canonical/generated) |
 | [Russian](./russian/README.md) | Slavic / Cyrillic | Chapters 1-2 authored (lessons + book) |
 | [Persian](./persian/README.md) | Iranian / Perso-Arabic | Shared-spine pilot plus a two-chapter starter book |
 | [Urdu](./urdu/README.md) | Indo-Aryan / Urdu Nastaliq | Shared-spine pilot plus a two-chapter starter book |

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -69,6 +69,15 @@
       "output": "punjabi/book/chapters/ch06-numbers-1-5.tex",
       "unicodeScript": "Gurmukhi",
       "scriptCommand": "pa"
+    },
+    {
+      "language": "sanskrit",
+      "chapter": 6,
+      "title": "Numbers One to Five",
+      "label": "ch:numbers-one-to-five",
+      "output": "sanskrit/book/chapters/ch06-numbers-1-5.tex",
+      "unicodeScript": "Devanagari",
+      "scriptCommand": "sk"
     }
   ]
 }

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -33,6 +33,17 @@
       "tex": "punjabi/book/chapters/ch06-numbers-1-5.tex"
     },
     {
+      "language": "sanskrit",
+      "chapter": 6,
+      "sourceHash": "fnv1a64:578064b0aec01cee",
+      "lessonIds": [
+        "SA-C06-numbers-1-5",
+        "SA-C06-number-cognates",
+        "SA-C06-pancha-travels"
+      ],
+      "tex": "sanskrit/book/chapters/ch06-numbers-1-5.tex"
+    },
+    {
       "language": "spanish",
       "chapter": 1,
       "sourceHash": "fnv1a64:ad881fd61b3c4d60",

--- a/code/learning/human-languages/sanskrit/CHANGELOG.md
+++ b/code/learning/human-languages/sanskrit/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Canonical Chapter 6 publication — 2026-08-03
+
+- Migrated all three number lessons to schema v2 with the shared
+  `SPINE-COUNT-ONE-TO-FIVE` can-do node, explicit sub-five-minute budgets, and
+  block-level knowledge closure.
+- Generated the downloadable Chapter 6 from the same ordered lesson AST and
+  source hash that Language Ladder loads, rather than maintaining another copy.
+- Preserved Devanagari forms, gender/dual tables, sound-law comparisons, and
+  romanized section bookmarks in the generated chapter.
+
 ## Sub-five-minute remediation — 2026-08-02
 
 - Corrected nine declared five-minute estimates whose computed durations were

--- a/code/learning/human-languages/sanskrit/README.md
+++ b/code/learning/human-languages/sanskrit/README.md
@@ -41,14 +41,16 @@ book.
   *pentagon*, and the qualified history of *punch*—three prerequisite-ordered
   micro-lessons.
 
-Chapters 1–5 are in the book. Chapter 6 is canonical app-ready lesson content;
-its one-source book publication remains explicitly tracked in the shared
-backlog.
+Chapters 1–6 are in the book. Chapter 6 is generated from the same canonical
+schema-v2 lesson AST and source hashes that Language Ladder loads, while the
+first five chapters retain their authored long-form narrative during migration.
 
 ## Book / fonts
 
 Compiles with XeLaTeX using the **vendored** Noto Sans Devanagari font
 (`../../_fonts/NotoSansDevanagari-Static.ttf`). `latexmk -xelatex book.tex`.
+Generated Devanagari runs use that font while section bookmarks use the
+lessons' Latin romanization.
 
 ## Files
 

--- a/code/learning/human-languages/sanskrit/book/book.tex
+++ b/code/learning/human-languages/sanskrit/book/book.tex
@@ -79,4 +79,6 @@ under CC~BY-SA~4.0.
 
 \input{chapters/ch05-first-verbs}
 
+\input{chapters/ch06-numbers-1-5}
+
 \end{document}

--- a/code/learning/human-languages/sanskrit/book/chapters/ch06-numbers-1-5.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch06-numbers-1-5.tex
@@ -1,0 +1,161 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:578064b0aec01cee
+% canonical-lessons: SA-C06-numbers-1-5, SA-C06-number-cognates, SA-C06-pancha-travels
+
+\chapter{Numbers One to Five}
+\label{ch:numbers-one-to-five}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[eka dva tri catur pañca]{\sk{एक}, \sk{द्व}, \sk{त्रि}, \sk{चतुर्}, \sk{पञ्च} — one to five}
+
+\label{lesson:SA-C06-numbers-1-5}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} This chapter does something the other Indic chapters can't do alone. Sanskrit preserves the \textbf{Old Indo-Aryan forms behind} the Hindi, Marathi, Bengali, Gujarati and Punjabi ones — and, at the same time, these forms are \textbf{cousins} of the English ones. Learn five and you get a foothold in both directions.
+\end{quote}
+
+\subsection*{You'll want to know: the five}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{stem} & \textbf{masculine} & \textbf{\textbf{neuter}} \\
+\midrule
+1 & \emph{éka-} & \textbf{\sk{एकः}} \emph{ékaḥ} & \sk{एकम्} \emph{ékam} \\
+2 & \emph{dvá-} & \textbf{\sk{द्वौ}} \emph{dváu} & \sk{द्वे} \emph{dvé} \\
+3 & \emph{tri-} & \textbf{\sk{त्रयः}} \emph{tráyaḥ} & \textbf{\sk{त्रीणि}} \emph{trī́ṇi} \\
+4 & \emph{catúr-} & \textbf{\sk{चत्वारः}} \emph{catvā́raḥ} & \textbf{\sk{चत्वारि}} \emph{catvā́ri} \\
+5 & \sk{पञ्च} \emph{páñca} & — & — \\
+\bottomrule
+\end{tabularx}
+
+Three notes, and the third one matters more than it looks.
+
+\textbf{Sanskrit has a dual} — a separate number for exactly two things — which is why "two" is \emph{dváu} rather than a plural.
+
+\emph{\textbf{Pañca\emph{ barely inflects\textbf{ in the nominative and accusative. It is also the one you already half-know.}}}}
+
+\textbf{And Sanskrit numbers have gender.} Look at the last column. When you meet these words again in Hindi, Marathi, Bengali, Gujarati or Punjabi, they will mostly descend from the \textbf{neuter} forms — \emph{trī́ṇi} and \emph{catvā́ri}, not \emph{tráyaḥ} and \emph{catvā́raḥ}. Keep that column in view; the daughter lessons depend on it.
+
+\begin{grammarlens}[title={What you've built: two directions}]
+These five forms point in two directions. The next lesson lines them up with Latin and English and explains the sound laws. A final short lesson follows \emph{pañca} into \emph{Punjab}, \emph{pentagon}, and the qualified history of \emph{punch}.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "eka, dva, tri, catur, pañca"{]}
+  \item {[}YOU SAY: the exactly-two category — dual{]}
+  \item {[}YOU SAY: the daughter-language column — neuter{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Give one to five in Sanskrit. (\emph{Eka, dva, tri, catur, pañca}.) Why does "two" look unusual? (Sanskrit has a \textbf{dual} — a form for exactly two.) Which column will the modern languages mostly descend from? (\textbf{The neuter} — \emph{trī́ṇi}, \emph{catvā́ri}.) Which number barely changes across gender in this table? (\emph{Pañca}.) Next: connect the Sanskrit forms west to Latin and English.
+\end{tcolorbox}
+\section[eka · dva · tri · catur · pañca]{The Sanskrit numbers are English cousins}
+
+\label{lesson:SA-C06-number-cognates}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Give the five stems: \emph{eka, dva, tri, catur, pañca}.
+\end{quote}
+
+\begin{grammarlens}[title={What you've built: one family, not borrowing}]
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Sanskrit} & \textbf{Latin} & \textbf{English} \\
+\midrule
+\emph{éka-} & \emph{ūnus} & \textbf{one} \\
+\emph{dvá-} & \emph{duo} & \textbf{two} \\
+\emph{tri-} & \emph{trēs} & \textbf{three} \\
+\emph{catúr-} & \emph{quattuor} & \textbf{four} \\
+\emph{páñca} & \emph{quīnque} & \textbf{five} \\
+\bottomrule
+\end{tabularx}
+
+Sanskrit, Latin, and English inherited these from one family. Numbers resist replacement, so their relationship remains audible after millennia.
+
+The first row needs one caveat: \emph{éka-} and \emph{ūnus/one} use the same root with different suffixes, PIE \textbackslash{}\textbf{oy-ko-\emph{ versus \textbackslash{}\textbf{óynos\emph{. They are relatives rather than the same complete word. The other four rows continue the same word.}}}}
+\end{grammarlens}
+
+\begin{cousinweb}
+PIE \textbackslash{}\textbf{kʷ\emph{ was a }k\emph{ with rounded lips. In \textbackslash{}\textbf{kʷetwóres\emph{ “four,” three branches treated it differently:}}}}
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{branch} & \textbf{outcome} & \textbf{example} \\
+\midrule
+Latin & kept \emph{qu-} & \emph{\textbf{qu}attuor} \\
+Indo-Iranian & merged it with \emph{k}, then palatalised before front vowels & \emph{\textbf{c}atvāri} \\
+Germanic & shifted it to \emph{hw-} & \emph{\textbf{wh}at}, \emph{\textbf{wh}o} \\
+\bottomrule
+\end{tabularx}
+
+Sanskrit \emph{c-} is therefore a regular result, not a random replacement. The same sequence helps explain \emph{pañca}'s \emph{ñc}.
+\end{cousinweb}
+
+\begin{cousinweb}
+The \textbf{f-} of \emph{five} does not come from \textbackslash{}\textbf{kʷ\emph{. It comes from initial \textbackslash{}\textbf{p\emph{, changed to }f\emph{ by \textbf{Grimm's law}, as in }pater $\to$ father\emph{ and }pēs $\to$ foot\emph{.}}}}
+
+English \emph{four} is irregular. By the sound rule it should begin \emph{hw-} like \emph{what}. Its \emph{f-} is usually explained as analogy with neighbouring \emph{five}. Counting words can reshape one another.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: \emph{tri, trēs, three}{]}
+  \item {[}YOU SAY: rounded \emph{k} — \emph{quattuor, catvāri, what}{]}
+  \item {[}YOU SAY: initial \emph{p $\to$ f} — \emph{pañca/five}{]}
+  \item {[}YOU SAY: regular inheritance or borrowing — inheritance{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Are the Latin and Sanskrit forms borrowed from one another? (No: they are inherited cousins.) What are the three outcomes of \textbackslash{}\textbf{kʷ\emph{? (Latin }qu-\emph{, Indo-Iranian }c-\emph{ after merger and palatalisation, Germanic }hw-\emph{.) Where does }five\emph{'s initial }f\emph{ come from? (PIE }p\emph{ by Grimm's law.) What is the usual explanation for }four\emph{ also beginning with }f\emph{? (Analogy with neighbouring }five\emph{.)}}
+\end{tcolorbox}
+\section[pañca]{\emph{Pañca} hiding in familiar words}
+
+\label{lesson:SA-C06-pancha-travels}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Say Sanskrit “five.” (\emph{Pañca}.) Give its English cousin. (\emph{Five}.)
+\end{quote}
+
+\begin{cousinweb}
+\textbf{Punjab} comes from Persian \emph{panj-āb}, “five waters,” for the land of five rivers spanning India and Pakistan. Persian \emph{panj} is the Iranian cousin of Indic \emph{pañca}: both descend from the same Indo-Iranian and PIE number root.
+
+The place-name is Persian, not Sanskrit, but the family resemblance is real.
+\end{cousinweb}
+
+\begin{cousinweb}
+Greek \emph{\textbf{pente}} is another descendant of the same root. It appears in \textbf{pentagon}, a five-sided figure, and \textbf{pentathlon}, a five-event contest.
+\end{cousinweb}
+
+\begin{cousinweb}
+The usual account derives \textbf{punch}, the drink, from Hindi \emph{pāṁch} $\leftarrow$ Sanskrit \emph{pañca}, because the drink was said to contain five ingredients.
+
+That origin is not unanimous. A rival derives the word from \textbf{puncheon}, a type of cask. Keep the useful connection with a label: “the common five-ingredients account,” not an unquestioned fact.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: \emph{panj + āb} — five waters{]}
+  \item {[}YOU SAY: Greek \emph{pente} — pentagon, pentathlon{]}
+  \item {[}YOU SAY: \emph{punch} — common account, not certain{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \emph{Punjab} mean? (“Five waters.”) Is Persian \emph{panj} borrowed from Sanskrit? (No: it is an Iranian cousin.) Which Greek form hides in \emph{pentagon}? (\emph{Pente}.) What caution belongs with the drink \emph{punch}? (The five-ingredients derivation is common, but \emph{puncheon} is a rival account.)
+\end{tcolorbox}

--- a/code/learning/human-languages/sanskrit/book/preamble.tex
+++ b/code/learning/human-languages/sanskrit/book/preamble.tex
@@ -22,12 +22,14 @@
 \newunicodechar{ṣ}{\d{s}}
 \newunicodechar{ṉ}{\b{n}}
 \newunicodechar{ḷ}{\d{l}}
+\newunicodechar{ʷ}{\textsuperscript{w}}
 
 \usepackage[table]{xcolor}
 \usepackage{tcolorbox}
 \tcbuselibrary{skins,breakable}
 \usepackage{booktabs}
 \usepackage{longtable}
+\usepackage{tabularx}
 \usepackage{array}
 \usepackage[hidelinks]{hyperref}
 \usepackage{titlesec}
@@ -57,10 +59,10 @@
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
   fonttitle=\bfseries, title={Why it's said this way}
 }
-\newtcolorbox{grammarlens}{
+\newtcolorbox{grammarlens}[1][]{
   breakable, skin=enhanced, colback=blue!5, colframe=blue!35!black,
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
-  fonttitle=\bfseries, title={Grammar Lens}
+  fonttitle=\bfseries, title={Grammar Lens}, #1
 }
 \newtcolorbox{sounds}{
   breakable, skin=enhanced, colback=green!6, colframe=green!30!black,

--- a/code/learning/human-languages/sanskrit/lessons/SA-C06-number-cognates.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C06-number-cognates.md
@@ -1,24 +1,42 @@
 ---
+schema_version: 2
 id: SA-C06-number-cognates
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 350
 chapter: 6
 type: etymology
 headword: एक · द्व · त्रि · चतुर् · पञ्च
+romanization: eka · dva · tri · catur · pañca
 gloss: the Sanskrit, Latin, and English number family and the sound laws between them
 prerequisites: [SA-C06-numbers-1-5]
 sounds: [inherent-a]
 roots: [pie-oyko, pie-dwoh, pie-treyes, pie-kwetwores, pie-penkwe]
 etymology_hook: "Sanskrit catur, Latin quattuor, and English four continue one root; PIE rounded k went to Latin qu, Indo-Iranian c, and Germanic hw"
-est_minutes: 4
+duration:
+  max_seconds: 270
+requires:
+  knowledge: [SA-LEX-NUMBERS-ONE-TO-FIVE, SA-HISTORY-SANSKRIT-NUMERAL-ANCHOR]
+introduces:
+  knowledge: [SA-COMPARISON-NUMERAL-FAMILY, SA-ETYMON-EKA-SUFFIX-CAVEAT, SA-HISTORY-NUMERAL-INHERITANCE, SA-SOUND-PIE-KW-OUTCOMES, SA-SOUND-GRIMMS-LAW-P-TO-F, SA-HISTORY-FOUR-FIVE-ANALOGY]
+practises:
+  knowledge: [SA-LEX-NUMBERS-ONE-TO-FIVE, SA-HISTORY-SANSKRIT-NUMERAL-ANCHOR, SA-COMPARISON-NUMERAL-FAMILY, SA-ETYMON-EKA-SUFFIX-CAVEAT, SA-HISTORY-NUMERAL-INHERITANCE, SA-SOUND-PIE-KW-OUTCOMES, SA-SOUND-GRIMMS-LAW-P-TO-F, SA-HISTORY-FOUR-FIVE-ANALOGY]
+skills: [listening, speaking, reading]
+modes: [interpretive, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: classical
 reviews_of: [SA-C06-numbers-1-5]
 ---
 
 # The Sanskrit numbers are English cousins
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[SA-LEX-NUMBERS-ONE-TO-FIVE] -->
 
 [PAUSE 2s] Give the five stems: *eka, dva, tri, catur, pañca*.
 
-## One family, not borrowing
+## What you've built: one family, not borrowing
+<!-- hl-knowledge: introduces=[SA-COMPARISON-NUMERAL-FAMILY, SA-ETYMON-EKA-SUFFIX-CAVEAT, SA-HISTORY-NUMERAL-INHERITANCE]; assesses=[] -->
 
 | Sanskrit | Latin | English |
 |---|---|---|
@@ -35,7 +53,8 @@ The first row needs one caveat: *éka-* and *ūnus/one* use the same root with
 different suffixes, PIE \**oy-ko-* versus \**óynos*. They are relatives rather
 than the same complete word. The other four rows continue the same word.
 
-## Rounded *k* goes three ways
+## The word, taken apart — rounded *k* goes three ways
+<!-- hl-knowledge: introduces=[SA-SOUND-PIE-KW-OUTCOMES]; assesses=[] -->
 
 PIE \**kʷ* was a *k* with rounded lips. In \**kʷetwóres* “four,” three branches
 treated it differently:
@@ -49,16 +68,18 @@ treated it differently:
 Sanskrit *c-* is therefore a regular result, not a random replacement. The same
 sequence helps explain *pañca*'s *ñc*.
 
-## Two different English *f* stories
+## The word, taken apart — two different English *f* stories
+<!-- hl-knowledge: introduces=[SA-SOUND-GRIMMS-LAW-P-TO-F, SA-HISTORY-FOUR-FIVE-ANALOGY]; assesses=[] -->
 
 The **f-** of *five* does not come from \**kʷ*. It comes from initial \**p*,
 changed to *f* by **Grimm's law**, as in *pater → father* and *pēs → foot*.
 
 English *four* is irregular. By the sound rule it should begin *hw-* like
-*what*. Its *f-* was copied from neighbouring *five*. Counting words can reshape
-one another.
+*what*. Its *f-* is usually explained as analogy with neighbouring *five*.
+Counting words can reshape one another.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[SA-LEX-NUMBERS-ONE-TO-FIVE, SA-HISTORY-SANSKRIT-NUMERAL-ANCHOR, SA-COMPARISON-NUMERAL-FAMILY, SA-ETYMON-EKA-SUFFIX-CAVEAT, SA-HISTORY-NUMERAL-INHERITANCE, SA-SOUND-PIE-KW-OUTCOMES, SA-SOUND-GRIMMS-LAW-P-TO-F, SA-HISTORY-FOUR-FIVE-ANALOGY] -->
 
 [PAUSE 1s]
 - [YOU SAY: *tri, trēs, three*]
@@ -67,9 +88,11 @@ one another.
 - [YOU SAY: regular inheritance or borrowing — inheritance]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[SA-COMPARISON-NUMERAL-FAMILY, SA-HISTORY-NUMERAL-INHERITANCE, SA-SOUND-PIE-KW-OUTCOMES, SA-SOUND-GRIMMS-LAW-P-TO-F, SA-HISTORY-FOUR-FIVE-ANALOGY] -->
 
 [PAUSE 3s] Are the Latin and Sanskrit forms borrowed from one another? (No:
 they are inherited cousins.) What are the three outcomes of \**kʷ*? (Latin
 *qu-*, Indo-Iranian *c-* after merger and palatalisation, Germanic *hw-*.) Where
-does *five*'s initial *f* come from? (PIE *p* by Grimm's law.) Why does *four*
-also begin with *f*? (Analogy with neighbouring *five*.)
+does *five*'s initial *f* come from? (PIE *p* by Grimm's law.) What is the usual
+explanation for *four* also beginning with *f*? (Analogy with neighbouring
+*five*.)

--- a/code/learning/human-languages/sanskrit/lessons/SA-C06-numbers-1-5.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C06-numbers-1-5.md
@@ -1,28 +1,47 @@
 ---
+schema_version: 2
 id: SA-C06-numbers-1-5
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 340
 chapter: 6
 type: word
 headword: एक द्व त्रि चतुर् पञ्च
-gloss: one to five — the ancestors of every Indo-Aryan number, and cousins of the English ones
+romanization: eka dva tri catur pañca
+gloss: one to five — Old Indo-Aryan ancestors preserved in Sanskrit, and cousins of the English ones
 concept_tag: SA-NUMBERS-1-5
 prerequisites: [SA-C01-namaskara]
 sounds: [inherent-a, visarga, long-aa]
 roots: [pie-oyko, pie-dwoh, pie-treyes, pie-kwetwores, pie-penkwe]
 etymology_hook: "Learn the five Sanskrit stems and their gendered forms first; the next two short lessons trace their Indo-European cousins and pancha's travels"
-est_minutes: 3
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [SA-LEX-NUMBERS-ONE-TO-FIVE, SA-GRAMMAR-NUMERAL-DUAL, SA-GRAMMAR-NUMERAL-GENDER, SA-HISTORY-INDO-ARYAN-NEUTER-FORMS, SA-HISTORY-SANSKRIT-NUMERAL-ANCHOR]
+practises:
+  knowledge: [SA-LEX-NUMBERS-ONE-TO-FIVE, SA-GRAMMAR-NUMERAL-DUAL, SA-GRAMMAR-NUMERAL-GENDER, SA-HISTORY-INDO-ARYAN-NEUTER-FORMS, SA-HISTORY-SANSKRIT-NUMERAL-ANCHOR]
+skills: [listening, speaking, reading]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: classical
 reviews_of: [SA-C01-namaskara]
 ---
 
 # एक, द्व, त्रि, चतुर्, पञ्च — one to five
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[SA-HISTORY-SANSKRIT-NUMERAL-ANCHOR]; assesses=[] -->
 
 [PAUSE 2s] This chapter does something the other Indic chapters can't do alone.
-Sanskrit's numbers are the **source** of the Hindi, Marathi, Bengali, Gujarati
-and Punjabi ones — and, at the same time, the **cousins** of the English ones.
-Learn these five and you get a foothold in both directions.
+Sanskrit preserves the **Old Indo-Aryan forms behind** the Hindi, Marathi,
+Bengali, Gujarati and Punjabi ones — and, at the same time, these forms are
+**cousins** of the English ones. Learn five and you get a foothold in both
+directions.
 
-## The five
+## You'll want to know: the five
+<!-- hl-knowledge: introduces=[SA-LEX-NUMBERS-ONE-TO-FIVE, SA-GRAMMAR-NUMERAL-DUAL, SA-GRAMMAR-NUMERAL-GENDER, SA-HISTORY-INDO-ARYAN-NEUTER-FORMS]; assesses=[] -->
 
 | | stem | masculine | **neuter** |
 |---|---|---|---|
@@ -45,13 +64,15 @@ these words again in Hindi, Marathi, Bengali, Gujarati or Punjabi, they will
 mostly descend from the **neuter** forms — *trī́ṇi* and *catvā́ri*, not *tráyaḥ*
 and *catvā́raḥ*. Keep that column in view; the daughter lessons depend on it.
 
-## What comes next
+## What you've built: two directions
+<!-- hl-knowledge: introduces=[]; assesses=[SA-LEX-NUMBERS-ONE-TO-FIVE, SA-HISTORY-SANSKRIT-NUMERAL-ANCHOR] -->
 
 These five forms point in two directions. The next lesson lines them up with
 Latin and English and explains the sound laws. A final short lesson follows
 *pañca* into *Punjab*, *pentagon*, and the qualified history of *punch*.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[SA-LEX-NUMBERS-ONE-TO-FIVE, SA-GRAMMAR-NUMERAL-DUAL, SA-GRAMMAR-NUMERAL-GENDER, SA-HISTORY-INDO-ARYAN-NEUTER-FORMS, SA-HISTORY-SANSKRIT-NUMERAL-ANCHOR] -->
 
 [PAUSE 1s]
 - [YOU SAY: "eka, dva, tri, catur, pañca"]
@@ -59,6 +80,7 @@ Latin and English and explains the sound laws. A final short lesson follows
 - [YOU SAY: the daughter-language column — neuter]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[SA-LEX-NUMBERS-ONE-TO-FIVE, SA-GRAMMAR-NUMERAL-DUAL, SA-GRAMMAR-NUMERAL-GENDER, SA-HISTORY-INDO-ARYAN-NEUTER-FORMS, SA-HISTORY-SANSKRIT-NUMERAL-ANCHOR] -->
 
 [PAUSE 3s] Give one to five in Sanskrit. (*Eka, dva, tri, catur, pañca*.) Why
 does "two" look unusual? (Sanskrit has a **dual** — a form for exactly two.)

--- a/code/learning/human-languages/sanskrit/lessons/SA-C06-pancha-travels.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C06-pancha-travels.md
@@ -1,24 +1,42 @@
 ---
+schema_version: 2
 id: SA-C06-pancha-travels
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 360
 chapter: 6
 type: etymology
 headword: पञ्च
+romanization: pañca
 gloss: five inside Punjab, pentagon, and the debated history of punch
 prerequisites: [SA-C06-number-cognates]
 sounds: [inherent-a]
 roots: [pie-penkwe]
 etymology_hook: "Sanskrit pancha, Persian panj, and Greek pente share a root; Punjab means five waters, while punch from five ingredients is the usual but disputed account"
-est_minutes: 3
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [SA-LEX-NUMBERS-ONE-TO-FIVE, SA-COMPARISON-NUMERAL-FAMILY, SA-HISTORY-NUMERAL-INHERITANCE]
+introduces:
+  knowledge: [SA-HISTORY-PUNJAB-FIVE-WATERS, SA-ETYMON-PANJ-PANCA-COGNATE, SA-ETYMON-PENTE-DESCENDANTS, SA-ETYMON-PUNCH-DISPUTED]
+practises:
+  knowledge: [SA-LEX-NUMBERS-ONE-TO-FIVE, SA-COMPARISON-NUMERAL-FAMILY, SA-HISTORY-NUMERAL-INHERITANCE, SA-HISTORY-PUNJAB-FIVE-WATERS, SA-ETYMON-PANJ-PANCA-COGNATE, SA-ETYMON-PENTE-DESCENDANTS, SA-ETYMON-PUNCH-DISPUTED]
+skills: [listening, speaking, reading]
+modes: [interpretive, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: classical
 reviews_of: [SA-C06-numbers-1-5, SA-C06-number-cognates]
 ---
 
 # *Pañca* hiding in familiar words
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[SA-LEX-NUMBERS-ONE-TO-FIVE, SA-COMPARISON-NUMERAL-FAMILY, SA-HISTORY-NUMERAL-INHERITANCE] -->
 
 [PAUSE 2s] Say Sanskrit “five.” (*Pañca*.) Give its English cousin. (*Five*.)
 
-## Five waters
+## The word, taken apart — five waters
+<!-- hl-knowledge: introduces=[SA-HISTORY-PUNJAB-FIVE-WATERS, SA-ETYMON-PANJ-PANCA-COGNATE]; assesses=[] -->
 
 **Punjab** comes from Persian *panj-āb*, “five waters,” for the land of five
 rivers spanning India and Pakistan. Persian *panj* is the Iranian cousin of
@@ -26,12 +44,14 @@ Indic *pañca*: both descend from the same Indo-Iranian and PIE number root.
 
 The place-name is Persian, not Sanskrit, but the family resemblance is real.
 
-## Greek buildings and contests
+## The word, taken apart — Greek buildings and contests
+<!-- hl-knowledge: introduces=[SA-ETYMON-PENTE-DESCENDANTS]; assesses=[] -->
 
 Greek ***pente*** is another descendant of the same root. It appears in
 **pentagon**, a five-sided figure, and **pentathlon**, a five-event contest.
 
-## The qualified *punch* story
+## The word, taken apart — the qualified *punch* story
+<!-- hl-knowledge: introduces=[SA-ETYMON-PUNCH-DISPUTED]; assesses=[] -->
 
 The usual account derives **punch**, the drink, from Hindi *pāṁch* ← Sanskrit
 *pañca*, because the drink was said to contain five ingredients.
@@ -41,6 +61,7 @@ of cask. Keep the useful connection with a label: “the common five-ingredients
 account,” not an unquestioned fact.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[SA-HISTORY-PUNJAB-FIVE-WATERS, SA-ETYMON-PANJ-PANCA-COGNATE, SA-ETYMON-PENTE-DESCENDANTS, SA-ETYMON-PUNCH-DISPUTED] -->
 
 [PAUSE 1s]
 - [YOU SAY: *panj + āb* — five waters]
@@ -48,6 +69,7 @@ account,” not an unquestioned fact.
 - [YOU SAY: *punch* — common account, not certain]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[SA-HISTORY-PUNJAB-FIVE-WATERS, SA-ETYMON-PANJ-PANCA-COGNATE, SA-ETYMON-PENTE-DESCENDANTS, SA-ETYMON-PUNCH-DISPUTED] -->
 
 [PAUSE 3s] What does *Punjab* mean? (“Five waters.”) Is Persian *panj* borrowed
 from Sanskrit? (No: it is an Iranian cousin.) Which Greek form hides in

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -17,6 +17,9 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
   Gujarati-script runs and bookmark-safe romanization from the shared AST.
 - Generate Punjabi Chapter 6 from its two strict canonical lessons, preserving
   Gurmukhi runs and bookmark-safe romanization from the shared AST.
+- Generate Sanskrit Chapter 6 from its three strict canonical lessons,
+  preserving Devanagari forms, comparison tables, and romanized bookmarks from
+  the shared AST.
 
 ### Added — block-boundary knowledge closure
 

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -10,9 +10,9 @@
   while retaining `est_minutes` for unmigrated tracks.
 - Independently combine loaded lesson fingerprints and show `book synced` for a
   generated chapter only when the app AST matches the committed book manifest;
-  Spanish Chapters 1–6 now verify all 51 migrated lessons this way, and Marathi
-  Gujarati, Marathi, and Punjabi Chapter 6 verify both of their canonical
-  lessons independently of the book generator.
+  Spanish Chapters 1–6 now verify all 51 migrated lessons this way; Gujarati,
+  Marathi, and Punjabi Chapter 6 verify both canonical lessons, while Sanskrit
+  Chapter 6 verifies all three, independently of the book generator.
 
 ## 0.25.0 — the same syllable in its sister scripts (syllabary, PR 9)
 

--- a/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
@@ -18,12 +18,17 @@ describe("generated book source hashes", () => {
     expect(bookHashStatus(lessons, "spanish", chapter)).toBe("synced");
   });
 
-  it.each(["gujarati", "marathi", "punjabi"])(
-    "matches the browser-loaded %s Chapter 6 AST across both lessons",
-    (language) => {
+  it.each([
+    ["gujarati", 2],
+    ["marathi", 2],
+    ["punjabi", 2],
+    ["sanskrit", 3],
+  ])(
+    "matches the browser-loaded %s Chapter 6 AST across %i lessons",
+    (language, count) => {
       const lessons = loadLessons();
       const expected = expectedBookHash(language, 6);
-      expect(expected?.lessonIds).toHaveLength(2);
+      expect(expected?.lessonIds).toHaveLength(count);
       expect(actualChapterHash(lessons, language, 6)).toBe(expected?.sourceHash);
       expect(bookHashStatus(lessons, language, 6)).toBe("synced");
     },


### PR DESCRIPTION
## Summary
- migrate Sanskrit Chapter 6's forms, cognates, and *pañca* travel lessons to schema v2 on the shared `SPINE-COUNT-ONE-TO-FIVE` node
- generate the downloadable Devanagari chapter from those three canonical lessons and verify the same ordered hashes in Language Ladder
- preserve Sanskrit-specific dual/gender grammar, PIE sound laws, and qualified lexical histories while tightening two etymological claims

## Validation
- `npm test` — human-language-data (80 tests)
- `npm run check:books`
- curriculum report — 1,065 lessons, 0 duration violations, 0 unknown prerequisites, 253 lesson chapters without book chapters
- `npm test` — Language Ladder (286 tests)
- `npm run build` — Language Ladder
- forced XeLaTeX build — 35 pages, 0 missing glyphs
- visual inspection of all five generated pages plus PDF outline audit
- `git diff --check`

The remaining handwritten-book warnings, including the one generated short-page warning, are measured explicitly in follow-up HL-B11.
