### PR TITLE
fix(spice): lower parser MOS sidewall capacitance

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS model-card `CJSW` values before lowering
+  valid sidewall-junction capacitance densities.
 - Reject negative and non-finite MOS model-card `CJ` values before lowering
   valid bottom-junction capacitance densities.
 - Reject negative and non-finite MOS instance `PS` values before lowering

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1973,6 +1973,10 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(params["CJ"]) or params["CJ"] < 0.0
         ):
             raise NetlistParseError("MOSFET CJ must be finite and non-negative")
+        if "CJSW" in params and (
+            not math.isfinite(params["CJSW"]) or params["CJSW"] < 0.0
+        ):
+            raise NetlistParseError("MOSFET CJSW must be finite and non-negative")
         nominal_temperature = params.get("T_NOM", params.get("TNOM"))
         if nominal_temperature is not None and (
             not math.isfinite(nominal_temperature) or nominal_temperature <= 0.0

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1843,6 +1843,33 @@ def test_lowers_valid_mosfet_model_junction_capacitance(
     assert isclose(mosfet.model.model.params.CJ, expected)
 
 
+@pytest.mark.parametrize("sidewall_capacitance", ["-1p", "1e999"])
+def test_rejects_invalid_mosfet_model_sidewall_capacitance(
+    sidewall_capacitance: str,
+) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="MOSFET CJSW must be finite and non-negative",
+    ):
+        parse_netlist(
+            f".model nfast NMOS(CJSW={sidewall_capacitance})\nM1 d g s b nfast\n"
+        )
+
+
+@pytest.mark.parametrize(
+    ("sidewall_capacitance", "expected"), [("0", 0.0), ("3p", 3.0e-12)]
+)
+def test_lowers_valid_mosfet_model_sidewall_capacitance(
+    sidewall_capacitance: str, expected: float
+) -> None:
+    parsed = parse_netlist(
+        f".model nfast NMOS(CJSW={sidewall_capacitance})\nM1 d g s b nfast\n"
+    )
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(mosfet.model.model.params.CJSW, expected)
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS model-card `CJSW` values and lower valid
+  sidewall-junction capacitance densities instead of silently dropping them.
 - Reject negative and non-finite MOS model-card `CJ` values and lower valid
   bottom-junction capacitance densities instead of silently dropping them.
 - Reject negative and non-finite MOS instance `PS` values and lower valid

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1284,6 +1284,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET CJ must be finite and non-negative");
   }
+  const sidewallCapacitance = params.get("CJSW");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    sidewallCapacitance !== undefined &&
+    (!Number.isFinite(sidewallCapacitance) || sidewallCapacitance < 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET CJSW must be finite and non-negative");
+  }
   const nominalTemperature = params.get("T_NOM") ?? params.get("TNOM");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1385,6 +1393,7 @@ function isMosfetParam(name: keyof MosfetLevel1Params): boolean {
     "PD",
     "PS",
     "CJ",
+    "CJSW",
     "IS",
     "N_SUB",
     "T_NOM",

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1721,6 +1721,28 @@ Xright c d load
     expect(element.params.CJ).toBeCloseTo(expected, 15);
   });
 
+  it.each(["-1p", "1e999"])(
+    "rejects invalid MOSFET model CJSW=%s",
+    (sidewallCapacitance) => {
+      expect(() =>
+        parseNetlist(`.model nfast NMOS(CJSW=${sidewallCapacitance})\nM1 d g s b nfast\n`),
+      ).toThrow("MOSFET CJSW must be finite and non-negative");
+    },
+  );
+
+  it.each([
+    ["0", 0.0],
+    ["3p", 3.0e-12],
+  ])("lowers valid MOSFET model CJSW=%s", (sidewallCapacitance, expected) => {
+    const parsed = parseNetlist(
+      `.model nfast NMOS(CJSW=${sidewallCapacitance})\nM1 d g s b nfast\n`,
+    );
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.CJSW).toBeCloseTo(expected, 15);
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4255,11 +4255,16 @@ the Rust, Python, and TypeScript surfaces together.
      diagnostic while zero and positive source diffusion perimeters lower into
      Level-1 parameters.
 
+390. Python and TypeScript Berkeley SPICE MOS junction-capacitance parity.
+   - Status: completed in PR 9689.
+   - Negative and non-finite model-card `CJ` values are rejected with the
+     shared diagnostic while zero and positive bottom-junction capacitance
+     densities lower into Level-1 parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
-   - TypeScript still needs canonical lowering for `CJ`, `CJSW`, `JS`, `PB`,
-     `MJ`,
+   - TypeScript still needs canonical lowering for `CJSW`, `JS`, `PB`, `MJ`,
      `MJSW`, `FC`, `KF`, and `AF`; Python already lowers these canonical fields
      but still needs matching facade validation coverage.
    - Align the `CJS` and `CJD` aliases with canonical `CBS` and `CBD` in both


### PR DESCRIPTION
## Summary
- validate MOS model-card `CJSW` as finite and non-negative in Python and TypeScript
- lower valid TypeScript sidewall-junction capacitance densities into Level-1 parameters
- record the merged `CJ` slice and advance the prioritized parity backlog

## Verification
- Python: 180 tests passed; 88.45% coverage; Ruff clean
- TypeScript: dependent spice-engine build, parser build, 173 tests passed; 84.93% line coverage