### PR TITLE
feat(sir-c): Collections slice 8 — remaining String methods

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## 0.30.0 — Collections slice 8: remaining String methods
+
+New `_sir_builtin_method_v` dispatch arms (all guarded on `recv.tag ==
+SIR_STR`, matching every prior slice's polymorphism discipline): `capitalize`,
+`swapcase`, `strip`/`lstrip`/`rstrip`, `chomp` (no-arg and 1-arg literal-
+separator forms), `chars`/`bytes`/`each_char` (block), `split` (no-arg
+whitespace-run form and 1-arg literal-separator form), `replace`, `sub`/`gsub`
+(literal, non-regex), `to_i`/`to_f`, `to_sym`, `tr`. Semantics are matched
+against the Python/TS `sir-runtime-oop` reference catalog — this cascade's
+cross-backend golden source — not always byte-for-byte true Ruby; see
+`code/specs/sir-collection-methods.md`'s new "C backend lane" addendum for
+the full slice cascade history and this slice's documented scope cuts
+(char-set methods `count`/`delete`/`squeeze`, padding methods `ljust`/
+`rjust`/`center`, and the `*`/`+` String operators — the last because Ruby
+binary operators have no `__method__` lowering path at all yet, same
+pre-existing gap as `<<` for `Array#push`).
+
+Two safety properties worth calling out:
+
+- **`chars`/`bytes`/`each_char` are genuinely distinct**, not the same byte
+  loop under two names: `chars`/`each_char` are UTF-8-CHARACTER-aware (a
+  multi-byte sequence is one element), `bytes` returns the raw byte values.
+  A malformed/truncated UTF-8 lead byte falls back to a 1-byte step rather
+  than over-reading past the string's NUL terminator.
+- **`sub`/`gsub` treat an empty search pattern as a no-op** (the receiver
+  comes back unchanged) rather than Python's convention of inserting the
+  replacement between every character. A zero-length match would otherwise
+  need explicit forward-progress handling to avoid an infinite scan; this
+  keeps the helper provably terminating on any input without it — a
+  DoS-safety floor consistent with this backend's other "never hang on
+  adversarial input" guards (the flatten depth+budget cap, the
+  `_sir_value_eq`/`_sir_fmt` cycle caps).
+
+### Added
+
+- `tests/compile_and_run_string_methods_slice8.rs` — 17 execution-proof
+  tests (real `cc` compile+run): every new method, the UTF-8-vs-byte
+  `chars`/`bytes` distinction on a multi-byte character, and the
+  empty-pattern `sub`/`gsub` no-op guard.
+- `collection_string_slice8_methods_route_to_the_builtin_dispatcher` — an
+  emit-shape test mirroring slice 1/2's dispatcher-routing tests.
+
+### Changed
+
+- `builtin_method_dispatch_is_rejected` (a pre-existing test asserting an
+  unsupported method name is cleanly rejected) used `strip` as its example —
+  now supported by this slice, so it would have started passing for the
+  wrong reason. Repointed to `ljust`, one of this slice's explicitly
+  deferred methods.
+
 ## 0.29.0 — bracket-index read/write (`recv[k]` / `recv[k] = v`)
 
 New dispatch arms for `"[]"` (read) and `"[]="` (write) in

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -197,7 +197,17 @@ lowered yet is still rejected cleanly.  **Bracket-index** (`recv[k]` /
 runtime and delegate to the existing index/get and set helpers — never a
 compile-time guess from the index's syntactic shape, so a Hash with a
 non-string key (an int or symbol key) can never be mis-routed to the Array
-path.
+path.  **Slice 8** (remaining String methods): `capitalize`, `swapcase`,
+`strip`/`lstrip`/`rstrip`, `chomp`, `chars`/`bytes`/`each_char` (UTF-8-
+CHARACTER-aware — a multi-byte sequence is one `chars`/`each_char` element,
+unlike `bytes`, which is byte-naive by design), `split`, `replace`, `sub`/
+`gsub` (literal, non-regex — an empty pattern is a no-op, not an infinite
+scan), `to_i`/`to_f`, `to_sym`, `tr`.  Semantics are matched against the
+Python/TS `sir-runtime-oop` reference catalog (this cascade's cross-backend
+golden source), not always byte-for-byte true Ruby; char-set methods
+(`count`/`delete`/`squeeze`), padding methods (`ljust`/`rjust`/`center`), and
+the `*`/`+` String operators are explicitly deferred — see
+`code/specs/sir-collection-methods.md`'s "C backend lane" addendum.
 
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
 `Intrinsics`, a `class << self` singleton, and

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -1776,9 +1776,13 @@ fn variadic_helper(name: &str) -> Option<&'static str> {
 /// `recv.[](k)`/`recv.[]=(k, v)`) dispatch on the RECEIVER's actual runtime
 /// tag (Array vs Hash) — never a compile-time guess from the index's
 /// syntactic shape, so a Hash with a non-string key (e.g. an int or symbol
-/// key) can never be mis-routed. The dispatcher raises `NoMethodError` on
-/// an unsupported receiver type or a malformed call (missing/extra args, a
-/// non-closure block position), matching Ruby.
+/// key) can never be mis-routed. Slice 8 = the remaining String methods:
+/// `capitalize`/`swapcase`, `strip`/`lstrip`/`rstrip`, `chomp`, `chars`/
+/// `bytes`/`each_char` (UTF-8-character-aware, not byte-naive), `split`,
+/// `replace`/`sub`/`gsub`, `to_i`/`to_f`/`to_sym`, `tr` — semantics matched
+/// against the Python/TS `sir-runtime-oop` reference catalog. The dispatcher
+/// raises `NoMethodError` on an unsupported receiver type or a malformed
+/// call (missing/extra args, a non-closure block position), matching Ruby.
 fn is_builtin_method(name: &str) -> bool {
     matches!(
         name,
@@ -1800,6 +1804,10 @@ fn is_builtin_method(name: &str) -> bool {
         | "each_key" | "each_value" | "group_by" | "partition"
         // bracket-index read/write
         | "[]" | "[]="
+        // slice 8 — remaining String methods
+        | "capitalize" | "swapcase" | "strip" | "lstrip" | "rstrip" | "chomp"
+        | "chars" | "bytes" | "each_char" | "split" | "replace" | "sub" | "gsub"
+        | "to_i" | "to_f" | "to_sym" | "tr"
     )
 }
 

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -2136,6 +2136,293 @@ static SirValue _sir_hash_sum(SirMap *m, SirValue block) {
     return acc;
 }
 
+/* ---- Collections slice 8: remaining String methods --------------------------
+ *
+ * Semantics matched against the Python/TS `sir-runtime-oop` reference catalog
+ * (the cross-backend golden source this cascade's runtimes agree against),
+ * not always byte-for-byte true Ruby -- e.g. `split(sep)` keeps trailing
+ * empty fields like Python's `str.split`, not Ruby's drop-trailing-empties
+ * rule. No `<ctype.h>` locale dependency (matches slice 1's ASCII-only case
+ * mapping): whitespace/case checks are hand-rolled ASCII tests. */
+
+static int _sir_is_ascii_ws(char c) {
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
+}
+
+static char *_sir_str_capitalize(const char *s) {
+    size_t n = strlen(s), i;
+    char *p = (char *)_sir_alloc(n + 1);
+    for (i = 0; i < n; i++) {
+        char c = s[i];
+        if (i == 0) p[i] = (c >= 'a' && c <= 'z') ? (char)(c - 32) : c;
+        else        p[i] = (c >= 'A' && c <= 'Z') ? (char)(c + 32) : c;
+    }
+    p[n] = '\0';
+    return p;
+}
+
+static char *_sir_str_swapcase(const char *s) {
+    size_t n = strlen(s), i;
+    char *p = (char *)_sir_alloc(n + 1);
+    for (i = 0; i < n; i++) {
+        char c = s[i];
+        if (c >= 'a' && c <= 'z')      p[i] = (char)(c - 32);
+        else if (c >= 'A' && c <= 'Z') p[i] = (char)(c + 32);
+        else                           p[i] = c;
+    }
+    p[n] = '\0';
+    return p;
+}
+
+/* `strip`/`lstrip`/`rstrip` -- trim ASCII whitespace from either/both ends. */
+static char *_sir_str_strip_range(const char *s, int left, int right) {
+    size_t n = strlen(s);
+    size_t start = 0, end = n;
+    if (left)  while (start < end && _sir_is_ascii_ws(s[start])) start++;
+    if (right) while (end > start && _sir_is_ascii_ws(s[end - 1])) end--;
+    {
+        size_t len = end - start;
+        char *p = (char *)_sir_alloc(len + 1);
+        memcpy(p, s + start, len);
+        p[len] = '\0';
+        return p;
+    }
+}
+
+/* `chomp([sep])` -- no-arg form removes ONE trailing "\r\n", else one
+ * trailing "\n" or "\r"; the 1-arg form removes a trailing LITERAL `sep`
+ * only when the string actually ends with it. `sep == NULL` selects the
+ * no-arg form. */
+static char *_sir_str_chomp(const char *s, const char *sep) {
+    size_t n = strlen(s);
+    size_t cut = n;
+    if (sep) {
+        size_t sl = strlen(sep);
+        if (sl > 0 && n >= sl && strcmp(s + n - sl, sep) == 0) cut = n - sl;
+    } else if (n >= 2 && s[n - 2] == '\r' && s[n - 1] == '\n') {
+        cut = n - 2;
+    } else if (n >= 1 && (s[n - 1] == '\n' || s[n - 1] == '\r')) {
+        cut = n - 1;
+    }
+    {
+        char *p = (char *)_sir_alloc(cut + 1);
+        memcpy(p, s, cut);
+        p[cut] = '\0';
+        return p;
+    }
+}
+
+/* UTF-8 lead-byte sequence length (1-4), so `chars`/`each_char` split by
+ * CHARACTER rather than byte -- unlike `bytes` below. Falls back to 1 on a
+ * malformed or truncated sequence so a hostile/invalid byte string still
+ * terminates in O(n), never over-reading past the NUL. */
+static int _sir_utf8_char_len(const char *s) {
+    unsigned char c = (unsigned char)s[0];
+    int n, i;
+    if (c < 0x80)             n = 1;
+    else if ((c & 0xE0) == 0xC0) n = 2;
+    else if ((c & 0xF0) == 0xE0) n = 3;
+    else if ((c & 0xF8) == 0xF0) n = 4;
+    else                       n = 1;
+    for (i = 1; i < n; i++) {
+        if (s[i] == '\0' || ((unsigned char)s[i] & 0xC0) != 0x80) return 1;
+    }
+    return n;
+}
+
+/* `chars` -- allocates `strlen(s)` slots (the worst case: every byte is its
+ * own 1-byte character) and fills the actual (smaller, for multi-byte input)
+ * count. */
+static SirValue _sir_str_chars(const char *s) {
+    size_t n = strlen(s), i = 0;
+    SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    r->items = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * n) : NULL;
+    int64_t k = 0;
+    while (i < n) {
+        int len = _sir_utf8_char_len(s + i);
+        char *buf = (char *)_sir_alloc((size_t)len + 1);
+        memcpy(buf, s + i, (size_t)len);
+        buf[len] = '\0';
+        r->items[k++] = _sir_str(buf);
+        i += (size_t)len;
+    }
+    r->len = k;
+    return _sir_seq_wrap(r);
+}
+
+/* `bytes` -- the RAW byte values (0-255) as an Array of Integers, matching
+ * the Python/TS reference (`list(recv.encode("utf-8"))`). */
+static SirValue _sir_str_bytes(const char *s) {
+    size_t n = strlen(s), i;
+    SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    r->items = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * n) : NULL;
+    for (i = 0; i < n; i++) r->items[i] = _sir_int((int64_t)(unsigned char)s[i]);
+    r->len = (int64_t)n;
+    return _sir_seq_wrap(r);
+}
+
+/* `each_char { |c| .. }` -- UTF-8-aware like `chars`; returns the (immutable,
+ * so unaliased) receiver, matching `Array#each`'s return-the-receiver rule. */
+static SirValue _sir_str_each_char(const char *s, SirValue block) {
+    size_t n = strlen(s), i = 0;
+    while (i < n) {
+        int len = _sir_utf8_char_len(s + i);
+        char *buf = (char *)_sir_alloc((size_t)len + 1);
+        memcpy(buf, s + i, (size_t)len);
+        buf[len] = '\0';
+        _sir_apply(block, 1, _sir_str(buf));
+        i += (size_t)len;
+    }
+    return _sir_str(s);
+}
+
+/* `split` -- no-arg splits on RUNS of ASCII whitespace, dropping leading and
+ * trailing empty fields (awk-style, matching Python's `str.split()`); with a
+ * String separator, splits on LITERAL occurrences of it, KEEPING empty
+ * fields between consecutive separators (matching Python's `str.split(sep)`
+ * -- the chosen cross-backend reference, not Ruby's drop-trailing-empties
+ * rule; see the file-header note above). An empty separator returns a
+ * single-element Array of the whole string -- a documented degenerate case
+ * that sidesteps a zero-length-match infinite loop. */
+static SirValue _sir_str_split_ws(const char *s) {
+    size_t n = strlen(s), i = 0;
+    SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    r->items = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * n) : NULL;
+    int64_t k = 0;
+    while (i < n) {
+        size_t start, len;
+        char *buf;
+        while (i < n && _sir_is_ascii_ws(s[i])) i++;
+        if (i >= n) break;
+        start = i;
+        while (i < n && !_sir_is_ascii_ws(s[i])) i++;
+        len = i - start;
+        buf = (char *)_sir_alloc(len + 1);
+        memcpy(buf, s + start, len);
+        buf[len] = '\0';
+        r->items[k++] = _sir_str(buf);
+    }
+    r->len = k;
+    return _sir_seq_wrap(r);
+}
+static SirValue _sir_str_split_sep(const char *s, const char *sep) {
+    size_t sl = strlen(s), pl = strlen(sep);
+    SirSeq *r;
+    int64_t k = 0;
+    const char *p;
+    if (pl == 0) return _sir_seq_lit(1, _sir_str(_sir_dup(s)));
+    r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    /* Worst case (`sep` is a single char, every char is a separator): sl+1
+       fields -- a safe, tight upper bound since pl >= 1 here. */
+    r->items = (SirValue *)_sir_alloc(sizeof(SirValue) * (sl + 1));
+    p = s;
+    for (;;) {
+        const char *hit = strstr(p, sep);
+        size_t len = hit ? (size_t)(hit - p) : strlen(p);
+        char *buf = (char *)_sir_alloc(len + 1);
+        memcpy(buf, p, len);
+        buf[len] = '\0';
+        r->items[k++] = _sir_str(buf);
+        if (!hit) break;
+        p = hit + pl;
+    }
+    r->len = k;
+    return _sir_seq_wrap(r);
+}
+
+/* `sub`/`gsub` -- literal (non-regex) first-occurrence / all-occurrences
+ * replacement, matching the Python/TS reference (`str.replace`, no
+ * back-reference expansion). `max_repl < 0` means unlimited (bounded
+ * naturally: at most `strlen(s)/strlen(pat)` occurrences exist). An EMPTY
+ * pattern is treated as "no match" -- the original string comes back
+ * unchanged -- rather than Python's convention of inserting `repl` between
+ * every character: that would need special-cased forward-progress handling
+ * to avoid a zero-length-match infinite scan, and this keeps the helper
+ * provably terminating on any input without it. */
+static char *_sir_str_replace_n(const char *s, const char *pat, const char *repl, int64_t max_repl) {
+    size_t pl = strlen(pat), rl = strlen(repl);
+    int64_t count = 0;
+    const char *p;
+    if (pl == 0) return _sir_dup(s);
+    p = s;
+    while (max_repl < 0 || count < max_repl) {
+        const char *hit = strstr(p, pat);
+        if (!hit) break;
+        count++;
+        p = hit + pl;
+    }
+    if (count == 0) return _sir_dup(s);
+    {
+        size_t sl = strlen(s);
+        size_t out_len = sl - (size_t)count * pl + (size_t)count * rl;
+        char *out = (char *)_sir_alloc(out_len + 1);
+        char *w = out;
+        const char *r = s;
+        int64_t done = 0;
+        while (done < count) {
+            const char *hit = strstr(r, pat);
+            size_t pre = (size_t)(hit - r);
+            memcpy(w, r, pre); w += pre;
+            memcpy(w, repl, rl); w += rl;
+            r = hit + pl;
+            done++;
+        }
+        {
+            size_t rest = strlen(r);
+            memcpy(w, r, rest); w += rest;
+        }
+        *w = '\0';
+        return out;
+    }
+}
+
+/* `to_i`/`to_f` -- parse a LEADING numeric prefix (optional whitespace, sign,
+ * digits), matching Ruby's never-raise `String#to_i`/`#to_f`: an
+ * unparseable string yields `0`/`0.0` rather than an exception. `strtoll`/
+ * `strtod` already implement exactly this "longest valid prefix, ignore the
+ * rest" scan; only the "no digits at all" case needs an explicit check. */
+static int64_t _sir_str_to_i(const char *s) {
+    char *end;
+    long long v = strtoll(s, &end, 10);
+    return (end == s) ? 0 : (int64_t)v;
+}
+static double _sir_str_to_f(const char *s) {
+    char *end;
+    double v = strtod(s, &end);
+    return (end == s) ? 0.0 : v;
+}
+
+/* `tr(from, to)` -- Ruby character-translation: each char of `recv` present
+ * in `from` is replaced by the char at the SAME position in `to`; a shorter
+ * `to` repeats its LAST char for extra `from` positions; an EMPTY `to`
+ * deletes matching chars; a `from` char repeated later wins (last mapping).
+ * The char-RANGE (`"a-z"`) and NEGATION (`"^abc"`) forms are a documented
+ * follow-up -- literal-set-only, same scope precedent as `sub`/`gsub`. */
+static char *_sir_str_tr(const char *s, const char *from, const char *to) {
+    size_t n = strlen(s), fl = strlen(from), tl = strlen(to), i;
+    /* has[c]: 0 = passthrough, 1 = translate via table[c], 2 = delete. */
+    unsigned char has[256];
+    char table[256];
+    char *out;
+    size_t w = 0;
+    memset(has, 0, sizeof(has));
+    for (i = 0; i < fl; i++) {
+        unsigned char c = (unsigned char)from[i];
+        if (tl == 0) { has[c] = 2; continue; }
+        table[c] = (i < tl) ? to[i] : to[tl - 1];
+        has[c] = 1;
+    }
+    out = (char *)_sir_alloc(n + 1);
+    for (i = 0; i < n; i++) {
+        unsigned char c = (unsigned char)s[i];
+        if (has[c] == 1)      out[w++] = table[c];
+        else if (has[c] == 2) { /* delete: emit nothing */ }
+        else                   out[w++] = (char)c;
+    }
+    out[w] = '\0';
+    return out;
+}
+
 /* ---- Collections slice 1: built-in String methods --------------------------
  *
  * A `__method__` dispatch whose name is a KNOWN built-in method — and which the
@@ -2365,6 +2652,52 @@ static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, Si
             return p ? _sir_int((int64_t)(p - recv.as.s)) : _sir_nil();
         }
         if (recv.tag == SIR_SEQ && argc >= 1) return _sir_array_index(recv.as.seq, args[0]);
+    }
+    /* Collections slice 8: remaining String methods. */
+    else if (strcmp(m, "capitalize") == 0) {
+        if (recv.tag == SIR_STR) return _sir_str(_sir_str_capitalize(recv.as.s));
+    } else if (strcmp(m, "swapcase") == 0) {
+        if (recv.tag == SIR_STR) return _sir_str(_sir_str_swapcase(recv.as.s));
+    } else if (strcmp(m, "strip") == 0) {
+        if (recv.tag == SIR_STR) return _sir_str(_sir_str_strip_range(recv.as.s, 1, 1));
+    } else if (strcmp(m, "lstrip") == 0) {
+        if (recv.tag == SIR_STR) return _sir_str(_sir_str_strip_range(recv.as.s, 1, 0));
+    } else if (strcmp(m, "rstrip") == 0) {
+        if (recv.tag == SIR_STR) return _sir_str(_sir_str_strip_range(recv.as.s, 0, 1));
+    } else if (strcmp(m, "chomp") == 0) {
+        if (recv.tag == SIR_STR) {
+            const char *sep = (argc >= 1 && args[0].tag == SIR_STR) ? args[0].as.s : NULL;
+            return _sir_str(_sir_str_chomp(recv.as.s, sep));
+        }
+    } else if (strcmp(m, "chars") == 0) {
+        if (recv.tag == SIR_STR) return _sir_str_chars(recv.as.s);
+    } else if (strcmp(m, "bytes") == 0) {
+        if (recv.tag == SIR_STR) return _sir_str_bytes(recv.as.s);
+    } else if (strcmp(m, "each_char") == 0) {
+        if (recv.tag == SIR_STR && argc == 1 && args[0].tag == SIR_CLOSURE)
+            return _sir_str_each_char(recv.as.s, args[0]);
+    } else if (strcmp(m, "split") == 0) {
+        if (recv.tag == SIR_STR) {
+            if (argc == 0) return _sir_str_split_ws(recv.as.s);
+            if (argc >= 1 && args[0].tag == SIR_STR) return _sir_str_split_sep(recv.as.s, args[0].as.s);
+        }
+    } else if (strcmp(m, "replace") == 0) {
+        if (recv.tag == SIR_STR && argc == 1 && args[0].tag == SIR_STR) return args[0];
+    } else if (strcmp(m, "sub") == 0) {
+        if (recv.tag == SIR_STR && argc == 2 && args[0].tag == SIR_STR && args[1].tag == SIR_STR)
+            return _sir_str(_sir_str_replace_n(recv.as.s, args[0].as.s, args[1].as.s, 1));
+    } else if (strcmp(m, "gsub") == 0) {
+        if (recv.tag == SIR_STR && argc == 2 && args[0].tag == SIR_STR && args[1].tag == SIR_STR)
+            return _sir_str(_sir_str_replace_n(recv.as.s, args[0].as.s, args[1].as.s, -1));
+    } else if (strcmp(m, "to_i") == 0) {
+        if (recv.tag == SIR_STR) return _sir_int(_sir_str_to_i(recv.as.s));
+    } else if (strcmp(m, "to_f") == 0) {
+        if (recv.tag == SIR_STR) return _sir_float(_sir_str_to_f(recv.as.s));
+    } else if (strcmp(m, "to_sym") == 0) {
+        if (recv.tag == SIR_STR) return _sir_sym(recv.as.s);
+    } else if (strcmp(m, "tr") == 0) {
+        if (recv.tag == SIR_STR && argc == 2 && args[0].tag == SIR_STR && args[1].tag == SIR_STR)
+            return _sir_str(_sir_str_tr(recv.as.s, args[0].as.s, args[1].as.s));
     }
     return _sir_raise(
         _sir_error("NoMethodError", _sir_str(_sir_cat("undefined method ", m))));

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_string_methods_slice8.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_string_methods_slice8.rs
@@ -1,0 +1,207 @@
+//! Execution proof for Collections slice 8 (remaining String methods) on the
+//! C backend — lower REAL Ruby source, emit C, compile with a real cc, run,
+//! assert stdout. Skips gracefully when no `cc` is present.
+//!
+//! Semantics are matched against the Python/TS `sir-runtime-oop` reference
+//! catalog (the cross-backend golden source this cascade's runtimes agree
+//! against) rather than always byte-for-byte true Ruby — e.g. `split(sep)`
+//! keeps trailing empty fields like Python's `str.split`, not Ruby's
+//! drop-trailing-empties rule; see the runtime.rs file-header comment on the
+//! slice-8 helpers for the full rationale.
+
+use std::process::Command;
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    ["cc", "clang", "gcc"]
+        .iter()
+        .find(|c| {
+            Command::new(c)
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        })
+        .map(|s| s.to_string())
+}
+
+fn run_ruby(src: &str) -> Option<String> {
+    let cc = find_cc()?;
+    let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
+    let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
+    let dir = std::env::temp_dir();
+    // Hash the full source, not just its length -- two tests with equal-length
+    // sources run as parallel threads in the SAME process and would collide on
+    // a length-keyed stem (see the temp-file-collision fix elsewhere in this
+    // test suite).
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    src.hash(&mut hasher);
+    let stem = format!("sirc_str8_{}_{}", std::process::id(), hasher.finish());
+    let cpath = dir.join(format!("{stem}.c"));
+    let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::write(&cpath, &art.source).expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        art.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "program exited non-zero");
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn capitalize_and_swapcase() {
+    match run_ruby("puts \"heLLo WORLD\".capitalize\nputs \"heLLo\".swapcase\n") {
+        Some(out) => assert_eq!(out, "Hello world\nHEllO\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn strip_family() {
+    match run_ruby("puts \"  hi  \".strip\nputs \"  hi  \".lstrip\nputs \"  hi  \".rstrip\n") {
+        Some(out) => assert_eq!(out, "hi\nhi  \n  hi\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn chomp_default_and_with_separator() {
+    match run_ruby("puts \"hi\\n\".chomp\nputs \"hi\\r\\n\".chomp\nputs \"hi!!\".chomp(\"!!\")\n") {
+        Some(out) => assert_eq!(out, "hi\nhi\nhi\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn chars_and_bytes() {
+    match run_ruby("puts \"ab\".chars\nputs \"ab\".bytes\n") {
+        Some(out) => assert_eq!(out, "[a, b]\n[97, 98]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn each_char_yields_every_character_in_order() {
+    match run_ruby("\"abc\".each_char { |c| puts c }\n") {
+        Some(out) => assert_eq!(out, "a\nb\nc\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn split_no_arg_splits_on_whitespace_runs() {
+    match run_ruby("puts \"  a  b c  \".split\n") {
+        Some(out) => assert_eq!(out, "[a, b, c]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn split_with_separator() {
+    match run_ruby("puts \"a,b,c\".split(\",\")\n") {
+        Some(out) => assert_eq!(out, "[a, b, c]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn replace_overwrites_the_whole_string() {
+    match run_ruby("puts \"old\".replace(\"new\")\n") {
+        Some(out) => assert_eq!(out, "new\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn sub_replaces_only_the_first_occurrence() {
+    match run_ruby("puts \"aaa\".sub(\"a\", \"b\")\n") {
+        Some(out) => assert_eq!(out, "baa\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn gsub_replaces_every_occurrence() {
+    match run_ruby("puts \"aaa\".gsub(\"a\", \"b\")\n") {
+        Some(out) => assert_eq!(out, "bbb\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn to_i_and_to_f_parse_leading_numeric_prefix() {
+    match run_ruby(
+        "puts \"42abc\".to_i\nputs \"abc\".to_i\nputs \"3.5xyz\".to_f\nputs \"nope\".to_f\n",
+    ) {
+        Some(out) => assert_eq!(out, "42\n0\n3.5\n0.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn to_sym_interns_the_string() {
+    match run_ruby("x = \"hello\".to_sym\nputs x\n") {
+        Some(out) => assert_eq!(out, "hello\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn tr_translates_matching_characters() {
+    match run_ruby("puts \"hello\".tr(\"el\", \"ip\")\n") {
+        Some(out) => assert_eq!(out, "hippo\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn tr_with_empty_to_deletes_matching_characters() {
+    match run_ruby("puts \"hello\".tr(\"l\", \"\")\n") {
+        Some(out) => assert_eq!(out, "heo\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn tr_shorter_to_repeats_its_last_character() {
+    match run_ruby("puts \"hello\".tr(\"lo\", \"p\")\n") {
+        Some(out) => assert_eq!(out, "heppp\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn multibyte_utf8_chars_is_codepoint_aware_not_byte_naive() {
+    // "café" -- the 'é' is a 2-byte UTF-8 sequence. `.chars` must yield 4
+    // elements (one per character), not 5 (one per byte); `.bytes` must
+    // yield 5 (the raw byte count), proving the two are genuinely distinct.
+    match run_ruby("puts \"café\".chars.length\nputs \"café\".bytes.length\n") {
+        Some(out) => assert_eq!(out, "4\n5\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn empty_pattern_sub_gsub_are_no_ops_not_infinite_loops() {
+    // The documented degenerate-case guard: an empty search pattern returns
+    // the receiver unchanged (never hangs). Also exercises the process exit
+    // code (a hang would timeout `run`, not return non-zero).
+    match run_ruby("puts \"abc\".sub(\"\", \"X\")\nputs \"abc\".gsub(\"\", \"X\")\n") {
+        Some(out) => assert_eq!(out, "abc\nabc\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}

--- a/code/packages/rust/semantic-ir-to-c/tests/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/emit.rs
@@ -143,17 +143,20 @@ fn string_literals_are_trigraph_safe() {
 
 #[test]
 fn builtin_method_dispatch_is_rejected() {
-    // A built-in method NOT in the Collections slice yet (`strip`) lowers to a
-    // `__method__` dispatch the module never registers via `__def_method__`, so
-    // the allowlist rejects it cleanly (rather than emitting a call that
-    // `NoMethodError`s at runtime).  (`length`/`upcase`/… ARE lowered now — see
+    // A built-in method NOT in the Collections slice yet (`ljust` — one of
+    // slice 8's explicitly-deferred padding methods, see that slice's
+    // CHANGELOG/spec-addendum entry) lowers to a `__method__` dispatch the
+    // module never registers via `__def_method__`, so the allowlist rejects
+    // it cleanly (rather than emitting a call that `NoMethodError`s at
+    // runtime).  (`length`/`upcase`/`strip`/… ARE lowered now — see
     // `collection_string_methods_route_to_the_builtin_dispatcher` and the
-    // `compile_and_run_string_methods` execution proof.)
-    let m = lower_ruby("puts \"hi\".strip");
+    // `compile_and_run_string_methods`/`compile_and_run_string_methods_slice8`
+    // execution proofs.)
+    let m = lower_ruby("puts \"hi\".ljust(5)");
     let err = compile(&m).expect_err("rejects a not-yet-lowered built-in method dispatch");
     assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
     assert!(
-        err.message.contains("strip"),
+        err.message.contains("ljust"),
         "names the built-in method: {}",
         err.message
     );
@@ -327,6 +330,27 @@ fn collection_string_query_passes_its_argument() {
     assert!(
         src.contains(", 1, _sir_str(\"ell\"))"),
         "the dispatcher is passed argc=1 and the quoted substring argument\n{src}"
+    );
+}
+
+#[test]
+fn collection_string_slice8_methods_route_to_the_builtin_dispatcher() {
+    // Collections slice 8: a 1-arg String method (`sub`, taking a pattern and
+    // a replacement) routes to the runtime dispatcher and carries both
+    // arguments through, same shape as slice 1/2's String methods.
+    let m = lower_ruby("puts \"aaa\".sub(\"a\", \"b\")");
+    let src = compile(&m).unwrap().source;
+    assert!(
+        src.contains("_sir_builtin_method("),
+        "a slice-8 String method dispatches through the runtime dispatcher\n{src}"
+    );
+    assert!(
+        src.contains("\"sub\""),
+        "the method name is a quoted C string literal\n{src}"
+    );
+    assert!(
+        src.contains(", 2, _sir_str(\"a\"), _sir_str(\"b\"))"),
+        "the dispatcher is passed argc=2 and both quoted string arguments\n{src}"
     );
 }
 

--- a/code/specs/sir-collection-methods.md
+++ b/code/specs/sir-collection-methods.md
@@ -154,6 +154,65 @@ security-review gate, `cargo build --workspace` before pushing anything core-tou
 - **Runtime parity:** the Go/Rust runtime catalogs match the Python/TS method names + semantics
   (same v0 set); a shared golden-program suite runs through all five backends.
 
+## Addendum — the C backend lane (2026-08-02/03, retroactive spec sync)
+
+**Why this section exists:** the C lane below was built without a preceding spec
+update — a process gap against this repo's "specs first" standard. This addendum
+brings the spec in sync with what actually shipped, per the standing rule that a
+diverged implementation must update the spec and call out what changed and why.
+
+### What diverged from the original design
+
+- **No `Feature::MethodDispatch` flag was added.** C1 above proposed a dedicated
+  feature so a backend could accept collection methods without accepting classes.
+  In practice, every `__method__` call's method-name argument is an `Expr::StrLit`,
+  so the existing `Feature::Strings` gate already covers it for free — a backend
+  that accepts `Strings` can already receive a module containing `__method__`
+  calls, no new variant needed. The C backend instead gates structurally: an
+  `is_builtin_method` allowlist (`semantic-ir-to-c/src/emit.rs`) rejects any
+  `__method__` call whose method name it doesn't recognize, at emit time, before
+  ever reaching the runtime — the same "reject cleanly, don't emit code that fails
+  at runtime" posture C1 wanted, achieved without the extra `Feature` variant.
+- **A C backend lane was never in the C1–C6 milestone table.** The table above
+  only planned Python/JS frontends (C2/C3), the JS backend (C4), and new Go/Rust
+  runtime *packages* (C5/C6). The C backend took a different shape entirely: no
+  separate runtime package — the v0 catalog is dispatched directly inside
+  `semantic-ir-to-c`'s existing runtime-C-source template (`_sir_builtin_method_v`
+  in `runtime.rs`), delivered as a **slice cascade** (below) rather than one PR.
+
+### C-backend slice cascade (actual delivery)
+
+Each slice is Ruby-frontend → `__method__` dispatch (already existed, see "Current
+state" above) → a batch of C runtime dispatch arms + `is_builtin_method` entries,
+shipped as its own spec-adjacent PR (tests + changelog + README each time, per this
+repo's standard workflow):
+
+| Slice | Content | Status | PR |
+|-------|---------|--------|-----|
+| 1 | 0-arity String: `length`/`size`, `upcase`, `downcase`, `reverse`, `empty?`, `to_s` | ✅ merged | #9273 |
+| 2 | 1-arg String queries: `include?`, `start_with?`, `end_with?`, `index` | ✅ merged | #9277 |
+| 3 | 0-arg Array query/transform: `count`, `first`, `last`, `sort`, `min`, `max`, `sum`, `uniq`, `compact`, `flatten`, `to_a` | ✅ merged | #9617 |
+| 4 | Array mutation + 1-arg query: `push`, `pop`, `shift`, `fetch`, `values_at`, `rotate`, `zip` | ✅ merged | #9650 |
+| 5 | Array block methods: `each`, `map`, `select`, `reject`, `any?`, `all?`, `none?`, `sort_by`, `each_with_index`, `reduce`/`inject` | ✅ merged | #9628 |
+| 6 | Hash non-block: `keys`, `values`, `to_h`, `dig`, `merge`, `delete`, `clear`, `invert` | ✅ merged | #9657 |
+| 7 | Hash block: `each_key`, `each_value`, `group_by`, `partition` (+ `each`/`map`/`select`/`reject`/`sort_by`/`sum` widen to Hash) | ✅ merged | #9668 |
+| — | Bug fix: `Array#sum` ignored a block argument | ✅ merged | #9673 |
+| — | Bug fix: bracket-index (`a[i]`/`a[i] = v`) had no grammar rule at all — new `__method__("[]"/"[]=", …)` dispatch | ✅ merged | #9686 |
+| 8 | Remaining String methods: `capitalize`, `strip`/`lstrip`/`rstrip`, `chomp`, `chars`, `bytes`, `split`, `replace`, `sub`, `gsub`, `to_i`, `to_f`, `to_sym`, `swapcase`, `tr`, `each_char` (block) — semantics matched against the Python/TS `sir-runtime-oop` reference catalog | 🚧 this PR | — |
+| 9 | Numeric methods: `abs`, `to_i`, `to_f`, `even?`, `odd?`, `zero?`, `positive?`, `negative?`, `pred`, `floor`, `ceil`, `round`, `divmod`, `fdiv`, `clamp`, `between?`, `gcd`, `digits` + block methods `times`/`upto`/`downto`/`step` | planned | — |
+| 10 | Symbol + Object/Bool generic methods | planned | — |
+| — | Cross-backend conformance corpus for the full collection-method catalog | planned | — |
+
+**Explicitly out of scope for slice 8** (deferred, not silently dropped): Ruby's
+char-set String methods (`count`/`delete`/`squeeze` taking a character-set string),
+padding methods (`ljust`/`rjust`/`center`), and the `*`/`+` String operators.
+`*`/`+` in particular are Ruby *binary operators*, not dot-calls — the Ruby
+frontend has no lowering path for them at all yet (same pre-existing gap as `<<`
+for `Array#push`; see the "Ruby frontend: add `<<` as a binary operator" backlog
+item), so there is nothing for a C dispatch arm to receive regardless. The
+char-set and padding methods are deferred to keep this slice reviewable at a
+similar size to its predecessors; they are tracked as follow-up work.
+
 ## Out of scope (documented)
 
 - Comprehensions (`[x*2 for x in xs]`, Ruby `map`-via-block is in scope but Python/Ruby


### PR DESCRIPTION
## Summary

- New `_sir_builtin_method_v` dispatch arms in `semantic-ir-to-c`: `capitalize`, `swapcase`, `strip`/`lstrip`/`rstrip`, `chomp`, `chars`/`bytes`/`each_char` (block), `split`, `replace`, `sub`/`gsub` (literal, non-regex), `to_i`/`to_f`, `to_sym`, `tr`.
- Semantics matched against the Python/TS `sir-runtime-oop` reference catalog (this cascade's cross-backend golden source), not always byte-for-byte true Ruby — documented divergences (e.g. `split(sep)` keeps trailing empty fields like Python's `str.split`) are called out in the code comments.
- `chars`/`each_char` are UTF-8-CHARACTER-aware (a multi-byte sequence is one element); `bytes` stays byte-naive — proven distinct by a dedicated test on a multi-byte character.
- `sub`/`gsub` treat an empty search pattern as a no-op rather than risking a zero-length-match infinite scan.
- **Explicitly deferred** (to keep this slice reviewable at a similar size to its predecessors): char-set methods (`count`/`delete`/`squeeze`), padding methods (`ljust`/`rjust`/`center`), and the `*`/`+` String operators (no `__method__` lowering path exists for Ruby binary operators at all yet — same pre-existing gap as `<<` for `Array#push`).
- **Spec sync**: `code/specs/sir-collection-methods.md` gets a new "C backend lane" addendum. The original spec's C1–C6 milestone table never planned a C backend at all (only a `Feature::MethodDispatch` flag + Python/JS frontends + Go/Rust runtime packages) — this addendum documents the actual slice-cascade delivery (slices 1–7 already merged, this PR's slice 8, planned 9/10 + conformance corpus) and why no `MethodDispatch` feature was needed (`Feature::Strings` already covers `__method__` dispatch, since the method name is always a `StrLit`).

`semantic-ir-to-c` 0.29.0 → 0.30.0.

## Test plan
- [x] New execution-proof tests (`compile_and_run_string_methods_slice8.rs`, real `cc` compile+run): 17 tests covering every new method, the UTF-8-vs-byte `chars`/`bytes` distinction, and the empty-pattern `sub`/`gsub` no-op guard — all green.
- [x] New emit-shape test (`collection_string_slice8_methods_route_to_the_builtin_dispatcher`) mirroring slice 1/2's dispatcher-routing tests.
- [x] Repointed a now-stale pre-existing test (`builtin_method_dispatch_is_rejected`, which used `strip` as its "not yet supported" example) to `ljust`, one of this slice's genuinely-still-deferred methods.
- [x] Full `semantic-ir-to-c` + `ruby-parser` + `ruby-to-semantic-ir` regression suite — all green, both pre- and post-rebase onto latest `origin/main`.
- [x] `cargo clippy` — clean.
- [x] Security review (sub-agent, focused on C memory safety in the new runtime helpers — buffer sizing, UTF-8 decoder bounds, `tr`'s lookup-table indexing, `sub`/`gsub` termination) — PASSED, no vulnerabilities found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)