### PR TITLE
Implement runnable D18 orchestrator core

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -756,6 +756,7 @@ members = [
     "chief-of-staff-service-registry",
     "chief-of-staff-service-reconciler",
     "chief-of-staff-process-supervisor",
+    "chief-of-staff-orchestrator-core",
     "chief-of-staff-tool-api",
     "chief-of-staff-host-runtime",
     "chief-of-staff-smart-home-tools",

--- a/code/packages/rust/chief-of-staff-orchestrator-core/BUILD
+++ b/code/packages/rust/chief-of-staff-orchestrator-core/BUILD
@@ -1,0 +1,1 @@
+cargo test -p chief-of-staff-orchestrator-core -- --nocapture

--- a/code/packages/rust/chief-of-staff-orchestrator-core/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-orchestrator-core/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0
+
+- Add bounded register, desired-state, health, reconcile, and safe-deregister APIs.
+- Compose the concrete verified process supervisor through a production constructor.
+- Add authorized durable channel-definition create, load, and destroy operations.
+- Preserve separate durable intent and authoritative process health evidence.
+- Reject monotonic clock regression without advancing failed reconciliation state.

--- a/code/packages/rust/chief-of-staff-orchestrator-core/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-orchestrator-core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "chief-of-staff-orchestrator-core"
+version = "0.1.0"
+edition = "2021"
+description = "Transport-independent runnable orchestration core for D18 Chief"
+license = "MIT"
+
+[dependencies]
+chief-of-staff-channel-crypto = { path = "../chief-of-staff-channel-crypto" }
+chief-of-staff-channel-endpoints = { path = "../chief-of-staff-channel-endpoints" }
+chief-of-staff-host-runtime = { path = "../chief-of-staff-host-runtime" }
+chief-of-staff-process-supervisor = { path = "../chief-of-staff-process-supervisor" }
+chief-of-staff-service-reconciler = { path = "../chief-of-staff-service-reconciler" }
+chief-of-staff-service-registry = { path = "../chief-of-staff-service-registry" }
+coding_adventures_x3dh = { path = "../x3dh" }
+storage-core = { path = "../storage-core" }

--- a/code/packages/rust/chief-of-staff-orchestrator-core/README.md
+++ b/code/packages/rust/chief-of-staff-orchestrator-core/README.md
@@ -1,0 +1,18 @@
+# chief-of-staff-orchestrator-core
+
+`chief-of-staff-orchestrator-core` is the transport-independent application
+layer for the D18 Chief daemon. It composes durable host intent, deterministic
+reconciliation, authoritative process supervision, and authorized channel
+topology behind bounded calls suitable for a later WebSocket server and CLI.
+
+The core is keyless and payload-blind. Verified child processes own host-runtime
+execution and channel endpoint keys; the parent stores topology and coordinates
+lifecycle without reading agent messages or vault secrets.
+
+## Validation
+
+```sh
+cargo test -p chief-of-staff-orchestrator-core -- --nocapture
+cargo clippy -p chief-of-staff-orchestrator-core --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-orchestrator-core --no-deps
+```

--- a/code/packages/rust/chief-of-staff-orchestrator-core/required_capabilities.json
+++ b/code/packages/rust/chief-of-staff-orchestrator-core/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/chief-of-staff-orchestrator-core",
+  "capabilities": [],
+  "justification": "Pure bounded coordination over injected storage, supervisor, authorization, and monotonic-clock interfaces. Concrete adapters retain their own filesystem, process, clock, random, and stream capability declarations."
+}

--- a/code/packages/rust/chief-of-staff-orchestrator-core/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-orchestrator-core/src/lib.rs
@@ -1,0 +1,1067 @@
+//! Transport-independent runnable orchestration for D18 Chief.
+//!
+//! This application layer preserves the distinction between durable intent and
+//! live process authority while remaining keyless, payload-blind, and bounded.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use chief_of_staff_channel_crypto::ChannelId;
+use chief_of_staff_channel_endpoints::{
+    ChannelDefinition, ChannelDefinitionStore, ChannelEndpointError,
+};
+use chief_of_staff_host_runtime::PackageKeyring;
+use chief_of_staff_process_supervisor::{
+    MonotonicClock, ProcessHostSupervisor, ProcessSupervisorConfig, SessionIdSource,
+};
+use chief_of_staff_service_reconciler::{
+    HostSupervisor, ReconcileConfig, ReconcileError, ReconcileReport, ServiceReconciler,
+    SupervisorObservation, SupervisorPhase,
+};
+use chief_of_staff_service_registry::{
+    DesiredState, HostEntry, HostName, HostRegistration, LoadedHost, RegistryError, ServiceRegistry,
+};
+use coding_adventures_x3dh::IdentityKeyPair;
+use core::fmt::{self, Display, Formatter};
+use std::sync::Arc;
+use storage_core::StorageBackend;
+
+/// Exact channel-topology mutation presented to a trust-checking adapter.
+#[derive(Clone, Copy, Debug)]
+pub enum ChannelWiringRequest<'a> {
+    /// Authorize creation of this complete immutable active definition.
+    Create(&'a ChannelDefinition),
+    /// Authorize irreversible destruction of this current definition.
+    Destroy(&'a ChannelDefinition),
+}
+
+impl<'a> ChannelWiringRequest<'a> {
+    /// Return the channel whose topology would change.
+    pub fn channel_id(self) -> ChannelId {
+        match self {
+            Self::Create(definition) | Self::Destroy(definition) => definition.channel_id(),
+        }
+    }
+
+    /// Return the complete durable definition presented for authorization.
+    pub fn definition(self) -> &'a ChannelDefinition {
+        match self {
+            Self::Create(definition) | Self::Destroy(definition) => definition,
+        }
+    }
+}
+
+/// Injected privilege and human-approval boundary for channel topology changes.
+pub trait ChannelWiringAuthorizer {
+    /// Concrete authorization failure retained for programmatic handling.
+    type Error;
+
+    /// Approve this exact mutation or fail before any storage change.
+    fn authorize(&mut self, request: ChannelWiringRequest<'_>) -> Result<(), Self::Error>;
+}
+
+/// Durable intent together with a fresh authoritative supervisor observation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HostHealth {
+    durable: LoadedHost,
+    authoritative: SupervisorObservation,
+}
+
+impl HostHealth {
+    /// Return the durable registry entry and its CAS revision.
+    pub fn durable(&self) -> &LoadedHost {
+        &self.durable
+    }
+
+    /// Return fresh evidence from the owned process supervisor.
+    pub fn authoritative(&self) -> &SupervisorObservation {
+        &self.authoritative
+    }
+}
+
+/// Typed failure from one bounded orchestrator-core operation.
+#[derive(Debug)]
+pub enum OrchestratorCoreError<SupervisorError, AuthorizationError> {
+    /// Durable registry storage, validation, or CAS failure.
+    Registry(RegistryError),
+    /// One deterministic reconciliation tick failed.
+    Reconciliation(ReconcileError<SupervisorError>),
+    /// A direct authoritative health inspection failed.
+    Supervisor {
+        /// Host whose authority could not be inspected.
+        host_name: HostName,
+        /// Original injected supervisor failure.
+        source: SupervisorError,
+    },
+    /// Durable channel topology validation, storage, or CAS failure.
+    Channel(ChannelEndpointError),
+    /// The injected trust boundary denied or failed a topology mutation.
+    Authorization(AuthorizationError),
+    /// Deregistration was requested before durable intent became stopped.
+    HostDesiredRunning(HostName),
+    /// Deregistration was requested while supervisor authority remained active.
+    HostStillActive(HostName),
+    /// The injected monotonic clock moved earlier than a successful prior tick.
+    ClockRegressed,
+}
+
+impl<S, A> Display for OrchestratorCoreError<S, A> {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Registry(_) => formatter.write_str("orchestrator-core: registry failure"),
+            Self::Reconciliation(_) => {
+                formatter.write_str("orchestrator-core: reconciliation failure")
+            }
+            Self::Supervisor { host_name, .. } => {
+                write!(
+                    formatter,
+                    "orchestrator-core: supervisor failure for {host_name}"
+                )
+            }
+            Self::Channel(_) => formatter.write_str("orchestrator-core: channel failure"),
+            Self::Authorization(_) => {
+                formatter.write_str("orchestrator-core: channel authorization failed")
+            }
+            Self::HostDesiredRunning(host_name) => write!(
+                formatter,
+                "orchestrator-core: host still desires running: {host_name}"
+            ),
+            Self::HostStillActive(host_name) => {
+                write!(
+                    formatter,
+                    "orchestrator-core: host is still active: {host_name}"
+                )
+            }
+            Self::ClockRegressed => formatter.write_str("orchestrator-core: clock regressed"),
+        }
+    }
+}
+
+impl<S, A> std::error::Error for OrchestratorCoreError<S, A>
+where
+    S: std::error::Error + 'static,
+    A: std::error::Error + 'static,
+{
+}
+
+/// Bounded application core parameterized by process and authorization adapters.
+pub struct OrchestratorCore<'a, S, A> {
+    backend: &'a dyn StorageBackend,
+    reconciler: ServiceReconciler<'a>,
+    supervisor: S,
+    authorizer: A,
+    clock: Arc<dyn MonotonicClock>,
+    last_reconcile_ns: Option<u64>,
+}
+
+impl<'a, S, A> OrchestratorCore<'a, S, A> {
+    /// Bind storage, reconciliation, process authority, authorization, and time.
+    pub fn new(
+        backend: &'a dyn StorageBackend,
+        supervisor: S,
+        authorizer: A,
+        clock: Arc<dyn MonotonicClock>,
+        reconcile_config: ReconcileConfig,
+    ) -> Self {
+        Self {
+            backend,
+            reconciler: ServiceReconciler::new(ServiceRegistry::new(backend), reconcile_config),
+            supervisor,
+            authorizer,
+            clock,
+            last_reconcile_ns: None,
+        }
+    }
+
+    /// Return the time of the last successful reconciliation tick.
+    pub fn last_reconcile_ns(&self) -> Option<u64> {
+        self.last_reconcile_ns
+    }
+
+    /// Consume the core and return its supervisor for orderly outer shutdown.
+    pub fn into_supervisor(self) -> S {
+        self.supervisor
+    }
+}
+
+impl<S, A> OrchestratorCore<'_, S, A>
+where
+    S: HostSupervisor,
+    A: ChannelWiringAuthorizer,
+{
+    /// Idempotently register immutable package identity and initial desired state.
+    pub fn register_host(
+        &self,
+        registration: HostRegistration,
+        desired_state: DesiredState,
+    ) -> Result<LoadedHost, OrchestratorCoreError<S::Error, A::Error>> {
+        ServiceRegistry::new(self.backend)
+            .register(&HostEntry::registered(registration, desired_state))
+            .map_err(OrchestratorCoreError::Registry)
+    }
+
+    /// Load one durable host without treating its observation as live authority.
+    pub fn load_host(
+        &self,
+        host_name: &HostName,
+    ) -> Result<Option<LoadedHost>, OrchestratorCoreError<S::Error, A::Error>> {
+        ServiceRegistry::new(self.backend)
+            .load(host_name)
+            .map_err(OrchestratorCoreError::Registry)
+    }
+
+    /// List durable hosts in stable host-name order.
+    pub fn list_hosts(&self) -> Result<Vec<LoadedHost>, OrchestratorCoreError<S::Error, A::Error>> {
+        ServiceRegistry::new(self.backend)
+            .list()
+            .map_err(OrchestratorCoreError::Registry)
+    }
+
+    /// CAS-update only the desired lifecycle state of an existing registration.
+    pub fn set_desired_state(
+        &self,
+        host_name: &HostName,
+        desired_state: DesiredState,
+    ) -> Result<LoadedHost, OrchestratorCoreError<S::Error, A::Error>> {
+        let registry = ServiceRegistry::new(self.backend);
+        let loaded = registry
+            .load(host_name)
+            .map_err(OrchestratorCoreError::Registry)?
+            .ok_or_else(|| {
+                OrchestratorCoreError::Registry(RegistryError::HostNotFound(host_name.clone()))
+            })?;
+        if loaded.entry().desired_state() == desired_state {
+            return Ok(loaded);
+        }
+        let replacement = loaded.entry().clone().with_desired_state(desired_state);
+        registry
+            .update(&loaded, &replacement)
+            .map_err(OrchestratorCoreError::Registry)
+    }
+
+    /// Sample time once and perform one stable-order bounded reconciliation tick.
+    pub fn reconcile_once(
+        &mut self,
+    ) -> Result<ReconcileReport, OrchestratorCoreError<S::Error, A::Error>> {
+        let now_ns = self.clock.now_ns();
+        if self
+            .last_reconcile_ns
+            .is_some_and(|previous| now_ns < previous)
+        {
+            return Err(OrchestratorCoreError::ClockRegressed);
+        }
+        let report = self
+            .reconciler
+            .reconcile_all(&mut self.supervisor, now_ns)
+            .map_err(OrchestratorCoreError::Reconciliation)?;
+        self.last_reconcile_ns = Some(now_ns);
+        Ok(report)
+    }
+
+    /// Return durable intent and a separate fresh supervisor observation.
+    pub fn health_check(
+        &mut self,
+        host_name: &HostName,
+    ) -> Result<HostHealth, OrchestratorCoreError<S::Error, A::Error>> {
+        let durable = ServiceRegistry::new(self.backend)
+            .load(host_name)
+            .map_err(OrchestratorCoreError::Registry)?
+            .ok_or_else(|| {
+                OrchestratorCoreError::Registry(RegistryError::HostNotFound(host_name.clone()))
+            })?;
+        let authoritative = self
+            .supervisor
+            .inspect(durable.entry().registration())
+            .map_err(|source| OrchestratorCoreError::Supervisor {
+                host_name: host_name.clone(),
+                source,
+            })?;
+        Ok(HostHealth {
+            durable,
+            authoritative,
+        })
+    }
+
+    /// Delete stopped intent only after process authority is absent or reaped.
+    pub fn deregister_host(
+        &mut self,
+        host_name: &HostName,
+    ) -> Result<(), OrchestratorCoreError<S::Error, A::Error>> {
+        let registry = ServiceRegistry::new(self.backend);
+        let loaded = registry
+            .load(host_name)
+            .map_err(OrchestratorCoreError::Registry)?
+            .ok_or_else(|| {
+                OrchestratorCoreError::Registry(RegistryError::HostNotFound(host_name.clone()))
+            })?;
+        if loaded.entry().desired_state() != DesiredState::Stopped {
+            return Err(OrchestratorCoreError::HostDesiredRunning(host_name.clone()));
+        }
+        let authority = self
+            .supervisor
+            .inspect(loaded.entry().registration())
+            .map_err(|source| OrchestratorCoreError::Supervisor {
+                host_name: host_name.clone(),
+                source,
+            })?;
+        if matches!(
+            authority,
+            SupervisorObservation::Instance(ref instance)
+                if !matches!(instance.phase(), SupervisorPhase::Exited { .. })
+        ) {
+            return Err(OrchestratorCoreError::HostStillActive(host_name.clone()));
+        }
+        registry
+            .deregister(&loaded)
+            .map_err(OrchestratorCoreError::Registry)
+    }
+
+    /// Authorize then idempotently create one durable active channel definition.
+    pub fn create_channel(
+        &mut self,
+        definition: &ChannelDefinition,
+    ) -> Result<ChannelDefinition, OrchestratorCoreError<S::Error, A::Error>> {
+        self.authorizer
+            .authorize(ChannelWiringRequest::Create(definition))
+            .map_err(OrchestratorCoreError::Authorization)?;
+        ChannelDefinitionStore::new(self.backend)
+            .create(definition)
+            .map_err(OrchestratorCoreError::Channel)
+    }
+
+    /// Load durable topology without opening a key-bearing endpoint.
+    pub fn load_channel(
+        &self,
+        channel_id: ChannelId,
+    ) -> Result<Option<ChannelDefinition>, OrchestratorCoreError<S::Error, A::Error>> {
+        ChannelDefinitionStore::new(self.backend)
+            .load(channel_id)
+            .map_err(OrchestratorCoreError::Channel)
+    }
+
+    /// Authorize then irreversibly destroy the current durable definition.
+    pub fn destroy_channel(
+        &mut self,
+        channel_id: ChannelId,
+    ) -> Result<ChannelDefinition, OrchestratorCoreError<S::Error, A::Error>> {
+        let store = ChannelDefinitionStore::new(self.backend);
+        let definition = store
+            .load(channel_id)
+            .map_err(OrchestratorCoreError::Channel)?
+            .ok_or(OrchestratorCoreError::Channel(
+                ChannelEndpointError::DefinitionNotFound,
+            ))?;
+        self.authorizer
+            .authorize(ChannelWiringRequest::Destroy(&definition))
+            .map_err(OrchestratorCoreError::Authorization)?;
+        store
+            .destroy(channel_id)
+            .map_err(OrchestratorCoreError::Channel)
+    }
+}
+
+/// Production process-supervised specialization of the transport-independent core.
+pub type ProcessOrchestratorCore<'a, A> = OrchestratorCore<'a, ProcessHostSupervisor<'a>, A>;
+
+impl<'a, A> OrchestratorCore<'a, ProcessHostSupervisor<'a>, A> {
+    /// Compose package trust, X3DH identity, process authority, storage, and time.
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_process_supervisor(
+        backend: &'a dyn StorageBackend,
+        process_config: ProcessSupervisorConfig,
+        keyring: &'a PackageKeyring,
+        identity: &'a IdentityKeyPair,
+        clock: Arc<dyn MonotonicClock>,
+        sessions: Box<dyn SessionIdSource>,
+        reconcile_config: ReconcileConfig,
+        authorizer: A,
+    ) -> Self {
+        let supervisor = ProcessHostSupervisor::new(
+            process_config,
+            keyring,
+            identity,
+            Arc::clone(&clock),
+            sessions,
+        );
+        Self::new(backend, supervisor, authorizer, clock, reconcile_config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chief_of_staff_channel_crypto::KeyEpoch;
+    use chief_of_staff_channel_endpoints::{
+        AgentId, ChannelLifecycle, OriginatorIdentity, ReceiverIdentity,
+    };
+    use chief_of_staff_process_supervisor::{HostProgram, UuidV7SessionIdSource};
+    use chief_of_staff_service_reconciler::{ReconcileAction, SupervisorOperation};
+    use chief_of_staff_service_registry::{PackagePath, RestartPolicy};
+    use coding_adventures_x3dh::generate_identity_keypair;
+    use std::collections::{BTreeMap, VecDeque};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
+    use std::time::Duration;
+    use storage_core::InMemoryStorageBackend;
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct FakeError(&'static str);
+
+    impl Display for FakeError {
+        fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+            formatter.write_str(self.0)
+        }
+    }
+
+    impl std::error::Error for FakeError {}
+
+    #[derive(Default)]
+    struct SupervisorState {
+        observations: BTreeMap<String, SupervisorObservation>,
+        starts: Vec<String>,
+        stops: Vec<String>,
+        fail_inspect: bool,
+        fail_start: bool,
+    }
+
+    #[derive(Clone, Default)]
+    struct FakeSupervisor(Arc<Mutex<SupervisorState>>);
+
+    impl HostSupervisor for FakeSupervisor {
+        type Error = FakeError;
+
+        fn inspect(
+            &mut self,
+            registration: &HostRegistration,
+        ) -> Result<SupervisorObservation, Self::Error> {
+            let state = self.0.lock().expect("supervisor mutex poisoned");
+            if state.fail_inspect {
+                return Err(FakeError("inspect failed"));
+            }
+            Ok(state
+                .observations
+                .get(registration.host_name().as_str())
+                .cloned()
+                .unwrap_or_else(SupervisorObservation::absent))
+        }
+
+        fn start(&mut self, registration: &HostRegistration) -> Result<(), Self::Error> {
+            let mut state = self.0.lock().expect("supervisor mutex poisoned");
+            if state.fail_start {
+                return Err(FakeError("start failed"));
+            }
+            state
+                .starts
+                .push(registration.host_name().as_str().to_string());
+            Ok(())
+        }
+
+        fn stop(&mut self, host_name: &HostName) -> Result<(), Self::Error> {
+            self.0
+                .lock()
+                .expect("supervisor mutex poisoned")
+                .stops
+                .push(host_name.as_str().to_string());
+            Ok(())
+        }
+    }
+
+    struct TestClock {
+        values: Mutex<VecDeque<u64>>,
+        calls: AtomicUsize,
+    }
+
+    impl TestClock {
+        fn new(values: impl IntoIterator<Item = u64>) -> Self {
+            Self {
+                values: Mutex::new(values.into_iter().collect()),
+                calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl MonotonicClock for TestClock {
+        fn now_ns(&self) -> u64 {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.values
+                .lock()
+                .expect("clock mutex poisoned")
+                .pop_front()
+                .expect("test clock exhausted")
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    enum WiringEvent {
+        Create(ChannelId),
+        Destroy(ChannelId),
+    }
+
+    struct FakeAuthorizer {
+        events: Arc<Mutex<Vec<WiringEvent>>>,
+        allow: bool,
+    }
+
+    impl FakeAuthorizer {
+        fn allowing(events: Arc<Mutex<Vec<WiringEvent>>>) -> Self {
+            Self {
+                events,
+                allow: true,
+            }
+        }
+
+        fn denying(events: Arc<Mutex<Vec<WiringEvent>>>) -> Self {
+            Self {
+                events,
+                allow: false,
+            }
+        }
+    }
+
+    impl ChannelWiringAuthorizer for FakeAuthorizer {
+        type Error = FakeError;
+
+        fn authorize(&mut self, request: ChannelWiringRequest<'_>) -> Result<(), Self::Error> {
+            assert_eq!(request.definition().channel_id(), request.channel_id());
+            let event = match request {
+                ChannelWiringRequest::Create(_) => WiringEvent::Create(request.channel_id()),
+                ChannelWiringRequest::Destroy(_) => WiringEvent::Destroy(request.channel_id()),
+            };
+            self.events
+                .lock()
+                .expect("authorization mutex poisoned")
+                .push(event);
+            if self.allow {
+                Ok(())
+            } else {
+                Err(FakeError("denied"))
+            }
+        }
+    }
+
+    fn name(value: &str) -> HostName {
+        HostName::new(value).expect("valid host name")
+    }
+
+    fn registration(host_name: &str, hash_byte: u8) -> HostRegistration {
+        HostRegistration::new(
+            name(host_name),
+            PackagePath::new(format!("/packages/{host_name}"))
+                .expect("valid portable package path"),
+            [hash_byte; 32],
+            RestartPolicy::Always,
+        )
+    }
+
+    fn channel_id(byte: u8) -> ChannelId {
+        let mut bytes = [byte; 16];
+        bytes[6] = 0x70;
+        bytes[8] = 0x80;
+        ChannelId(bytes)
+    }
+
+    fn definition(byte: u8) -> ChannelDefinition {
+        ChannelDefinition::new(
+            channel_id(byte),
+            OriginatorIdentity {
+                agent_id: AgentId::new(b"originator".to_vec()).expect("valid agent"),
+                public_key: [1; 32],
+            },
+            vec![ReceiverIdentity {
+                agent_id: AgentId::new(b"receiver".to_vec()).expect("valid agent"),
+                public_key: [2; 32],
+            }],
+            100,
+            KeyEpoch(1),
+        )
+        .expect("valid channel definition")
+    }
+
+    fn core<'a>(
+        backend: &'a InMemoryStorageBackend,
+        supervisor: FakeSupervisor,
+        authorizer: FakeAuthorizer,
+        clock: Arc<TestClock>,
+    ) -> OrchestratorCore<'a, FakeSupervisor, FakeAuthorizer> {
+        OrchestratorCore::new(
+            backend,
+            supervisor,
+            authorizer,
+            clock,
+            ReconcileConfig::new(100).expect("valid reconcile config"),
+        )
+    }
+
+    #[test]
+    fn host_registration_listing_and_desired_state_are_idempotent() {
+        let backend = InMemoryStorageBackend::new();
+        let supervisor = FakeSupervisor::default();
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let core = core(
+            &backend,
+            supervisor,
+            FakeAuthorizer::allowing(events),
+            Arc::new(TestClock::new([])),
+        );
+        let bravo = registration("bravo-host", 2);
+        let alpha = registration("alpha-host", 1);
+
+        let first = core
+            .register_host(bravo.clone(), DesiredState::Running)
+            .expect("register bravo");
+        let repeated = core
+            .register_host(bravo, DesiredState::Running)
+            .expect("repeat identical registration");
+        assert_eq!(first, repeated);
+        core.register_host(alpha, DesiredState::Stopped)
+            .expect("register alpha");
+        assert_eq!(
+            core.list_hosts()
+                .expect("list hosts")
+                .iter()
+                .map(|loaded| loaded.entry().registration().host_name().as_str())
+                .collect::<Vec<_>>(),
+            ["alpha-host", "bravo-host"]
+        );
+
+        let unchanged = core
+            .set_desired_state(&name("alpha-host"), DesiredState::Stopped)
+            .expect("idempotent desired state");
+        let changed = core
+            .set_desired_state(&name("alpha-host"), DesiredState::Running)
+            .expect("update desired state");
+        assert_eq!(changed.entry().desired_state(), DesiredState::Running);
+        assert_ne!(unchanged.revision(), changed.revision());
+        assert_eq!(
+            core.load_host(&name("missing-host")).expect("load missing"),
+            None
+        );
+    }
+
+    #[test]
+    fn conflicting_registration_and_unknown_host_updates_are_typed() {
+        let backend = InMemoryStorageBackend::new();
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let core = core(
+            &backend,
+            FakeSupervisor::default(),
+            FakeAuthorizer::allowing(events),
+            Arc::new(TestClock::new([])),
+        );
+        core.register_host(registration("agent-host", 1), DesiredState::Running)
+            .expect("register host");
+        let conflict = core
+            .register_host(registration("agent-host", 2), DesiredState::Running)
+            .expect_err("different package must conflict");
+        assert!(matches!(
+            conflict,
+            OrchestratorCoreError::Registry(RegistryError::ConflictingRegistration(_))
+        ));
+        let missing = core
+            .set_desired_state(&name("missing-host"), DesiredState::Stopped)
+            .expect_err("unknown host must fail");
+        assert!(matches!(
+            missing,
+            OrchestratorCoreError::Registry(RegistryError::HostNotFound(_))
+        ));
+    }
+
+    #[test]
+    fn reconciliation_samples_time_once_and_tracks_only_success() {
+        let backend = InMemoryStorageBackend::new();
+        let supervisor = FakeSupervisor::default();
+        let supervisor_state = Arc::clone(&supervisor.0);
+        let clock = Arc::new(TestClock::new([1_000, 1_001, 1_002]));
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let mut core = core(
+            &backend,
+            supervisor,
+            FakeAuthorizer::allowing(events),
+            Arc::clone(&clock),
+        );
+        core.register_host(registration("agent-host", 1), DesiredState::Running)
+            .expect("register host");
+
+        let report = core.reconcile_once().expect("start tick");
+        assert_eq!(report.outcomes()[0].action(), ReconcileAction::Started);
+        assert_eq!(core.last_reconcile_ns(), Some(1_000));
+        assert_eq!(clock.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            supervisor_state
+                .lock()
+                .expect("supervisor mutex poisoned")
+                .starts,
+            ["agent-host"]
+        );
+
+        supervisor_state
+            .lock()
+            .expect("supervisor mutex poisoned")
+            .fail_inspect = true;
+        let error = core.reconcile_once().expect_err("inspection must fail");
+        assert!(matches!(
+            error,
+            OrchestratorCoreError::Reconciliation(ReconcileError::Supervisor {
+                operation: SupervisorOperation::Inspect,
+                ..
+            })
+        ));
+        assert_eq!(core.last_reconcile_ns(), Some(1_000));
+
+        supervisor_state
+            .lock()
+            .expect("supervisor mutex poisoned")
+            .fail_inspect = false;
+        core.reconcile_once().expect("later successful tick");
+        assert_eq!(core.last_reconcile_ns(), Some(1_002));
+        assert_eq!(clock.calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn reconciliation_drives_start_observe_stop_and_restart() {
+        let backend = InMemoryStorageBackend::new();
+        let supervisor = FakeSupervisor::default();
+        let state = Arc::clone(&supervisor.0);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let mut core = core(
+            &backend,
+            supervisor,
+            FakeAuthorizer::allowing(events),
+            Arc::new(TestClock::new([100, 110, 120, 130])),
+        );
+        let registration = registration("agent-host", 8);
+        core.register_host(registration.clone(), DesiredState::Running)
+            .expect("register host");
+
+        assert_eq!(
+            core.reconcile_once().expect("start tick").outcomes()[0].action(),
+            ReconcileAction::Started
+        );
+        state
+            .lock()
+            .expect("supervisor mutex poisoned")
+            .observations
+            .insert(
+                "agent-host".to_string(),
+                SupervisorObservation::running([8; 32], 17, 101, 109, channel_id(8))
+                    .expect("valid running observation"),
+            );
+        assert_eq!(
+            core.reconcile_once().expect("observation tick").outcomes()[0].action(),
+            ReconcileAction::Observed
+        );
+
+        core.set_desired_state(registration.host_name(), DesiredState::Stopped)
+            .expect("request stop");
+        assert_eq!(
+            core.reconcile_once().expect("stop tick").outcomes()[0].action(),
+            ReconcileAction::Stopped
+        );
+        assert_eq!(
+            state.lock().expect("supervisor mutex poisoned").stops,
+            ["agent-host"]
+        );
+
+        state
+            .lock()
+            .expect("supervisor mutex poisoned")
+            .observations
+            .insert(
+                "agent-host".to_string(),
+                SupervisorObservation::exited([8; 32], Some(0), Some(101), Some(109))
+                    .expect("valid exited observation"),
+            );
+        core.set_desired_state(registration.host_name(), DesiredState::Running)
+            .expect("request restart");
+        assert_eq!(
+            core.reconcile_once().expect("restart tick").outcomes()[0].action(),
+            ReconcileAction::Started
+        );
+        assert_eq!(
+            state.lock().expect("supervisor mutex poisoned").starts,
+            ["agent-host", "agent-host"]
+        );
+    }
+
+    #[test]
+    fn reconciliation_rejects_clock_regression_before_supervisor_io() {
+        let backend = InMemoryStorageBackend::new();
+        let supervisor = FakeSupervisor::default();
+        let state = Arc::clone(&supervisor.0);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let mut core = core(
+            &backend,
+            supervisor,
+            FakeAuthorizer::allowing(events),
+            Arc::new(TestClock::new([20, 19])),
+        );
+        core.reconcile_once().expect("empty first tick");
+        assert!(matches!(
+            core.reconcile_once(),
+            Err(OrchestratorCoreError::ClockRegressed)
+        ));
+        assert!(state
+            .lock()
+            .expect("supervisor mutex poisoned")
+            .starts
+            .is_empty());
+        assert_eq!(core.last_reconcile_ns(), Some(20));
+    }
+
+    #[test]
+    fn health_keeps_cached_state_separate_from_fresh_authority() {
+        let backend = InMemoryStorageBackend::new();
+        let supervisor = FakeSupervisor::default();
+        let state = Arc::clone(&supervisor.0);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let mut core = core(
+            &backend,
+            supervisor,
+            FakeAuthorizer::allowing(events),
+            Arc::new(TestClock::new([])),
+        );
+        let registration = registration("agent-host", 7);
+        core.register_host(registration.clone(), DesiredState::Running)
+            .expect("register host");
+        let running = SupervisorObservation::running([7; 32], 41, 10, 11, channel_id(9))
+            .expect("valid running observation");
+        state
+            .lock()
+            .expect("supervisor mutex poisoned")
+            .observations
+            .insert("agent-host".to_string(), running.clone());
+
+        let health = core.health_check(registration.host_name()).expect("health");
+        assert_eq!(health.authoritative(), &running);
+        assert_eq!(
+            health.durable().entry().observation().status(),
+            &chief_of_staff_service_registry::HostStatus::Stopped
+        );
+
+        state
+            .lock()
+            .expect("supervisor mutex poisoned")
+            .fail_inspect = true;
+        assert!(matches!(
+            core.health_check(registration.host_name()),
+            Err(OrchestratorCoreError::Supervisor { .. })
+        ));
+        assert!(matches!(
+            core.health_check(&name("missing-host")),
+            Err(OrchestratorCoreError::Registry(
+                RegistryError::HostNotFound(_)
+            ))
+        ));
+    }
+
+    #[test]
+    fn deregistration_requires_stopped_intent_and_absent_or_exited_authority() {
+        let backend = InMemoryStorageBackend::new();
+        let supervisor = FakeSupervisor::default();
+        let state = Arc::clone(&supervisor.0);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let mut core = core(
+            &backend,
+            supervisor,
+            FakeAuthorizer::allowing(events),
+            Arc::new(TestClock::new([])),
+        );
+        let registration = registration("agent-host", 3);
+        core.register_host(registration.clone(), DesiredState::Running)
+            .expect("register host");
+        assert!(matches!(
+            core.deregister_host(registration.host_name()),
+            Err(OrchestratorCoreError::HostDesiredRunning(_))
+        ));
+
+        core.set_desired_state(registration.host_name(), DesiredState::Stopped)
+            .expect("stop desired state");
+        state
+            .lock()
+            .expect("supervisor mutex poisoned")
+            .observations
+            .insert(
+                "agent-host".to_string(),
+                SupervisorObservation::starting([3; 32], 7, 1, None, None)
+                    .expect("valid starting observation"),
+            );
+        assert!(matches!(
+            core.deregister_host(registration.host_name()),
+            Err(OrchestratorCoreError::HostStillActive(_))
+        ));
+
+        state
+            .lock()
+            .expect("supervisor mutex poisoned")
+            .observations
+            .insert(
+                "agent-host".to_string(),
+                SupervisorObservation::exited([3; 32], Some(0), Some(1), Some(2))
+                    .expect("valid exited observation"),
+            );
+        core.deregister_host(registration.host_name())
+            .expect("exited host may be removed");
+        assert_eq!(
+            core.load_host(registration.host_name()).expect("load"),
+            None
+        );
+        assert!(matches!(
+            core.deregister_host(registration.host_name()),
+            Err(OrchestratorCoreError::Registry(
+                RegistryError::HostNotFound(_)
+            ))
+        ));
+    }
+
+    #[test]
+    fn channel_mutations_are_authorized_before_storage_changes() {
+        let backend = InMemoryStorageBackend::new();
+        let supervisor = FakeSupervisor::default();
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let mut core = core(
+            &backend,
+            supervisor,
+            FakeAuthorizer::allowing(Arc::clone(&events)),
+            Arc::new(TestClock::new([])),
+        );
+        let definition = definition(4);
+
+        assert_eq!(
+            core.create_channel(&definition).expect("create channel"),
+            definition
+        );
+        assert_eq!(
+            core.create_channel(&definition)
+                .expect("idempotent channel creation"),
+            definition
+        );
+        assert_eq!(
+            core.load_channel(definition.channel_id())
+                .expect("load channel"),
+            Some(definition.clone())
+        );
+        let destroyed = core
+            .destroy_channel(definition.channel_id())
+            .expect("destroy channel");
+        assert_eq!(destroyed.lifecycle(), ChannelLifecycle::Destroyed);
+        assert_eq!(
+            events
+                .lock()
+                .expect("authorization mutex poisoned")
+                .as_slice(),
+            [
+                WiringEvent::Create(definition.channel_id()),
+                WiringEvent::Create(definition.channel_id()),
+                WiringEvent::Destroy(definition.channel_id())
+            ]
+        );
+        assert_eq!(
+            core.destroy_channel(definition.channel_id())
+                .expect("destroying an already destroyed channel is idempotent"),
+            destroyed
+        );
+        assert_eq!(
+            events.lock().expect("authorization mutex poisoned").last(),
+            Some(&WiringEvent::Destroy(definition.channel_id()))
+        );
+    }
+
+    #[test]
+    fn denied_channel_mutations_leave_storage_unchanged() {
+        let backend = InMemoryStorageBackend::new();
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let mut core = core(
+            &backend,
+            FakeSupervisor::default(),
+            FakeAuthorizer::denying(Arc::clone(&events)),
+            Arc::new(TestClock::new([])),
+        );
+        let definition = definition(5);
+        assert!(matches!(
+            core.create_channel(&definition),
+            Err(OrchestratorCoreError::Authorization(FakeError("denied")))
+        ));
+        assert_eq!(
+            core.load_channel(definition.channel_id())
+                .expect("load denied channel"),
+            None
+        );
+
+        ChannelDefinitionStore::new(&backend)
+            .create(&definition)
+            .expect("seed definition");
+        assert!(matches!(
+            core.destroy_channel(definition.channel_id()),
+            Err(OrchestratorCoreError::Authorization(FakeError("denied")))
+        ));
+        assert_eq!(
+            core.load_channel(definition.channel_id())
+                .expect("load preserved channel"),
+            Some(definition.clone())
+        );
+        assert_eq!(
+            events
+                .lock()
+                .expect("authorization mutex poisoned")
+                .as_slice(),
+            [
+                WiringEvent::Create(definition.channel_id()),
+                WiringEvent::Destroy(definition.channel_id())
+            ]
+        );
+    }
+
+    #[test]
+    fn stable_errors_do_not_render_nested_payloads() {
+        let host = name("agent-host");
+        let errors: Vec<OrchestratorCoreError<FakeError, FakeError>> = vec![
+            OrchestratorCoreError::Registry(RegistryError::HostNotFound(host.clone())),
+            OrchestratorCoreError::Supervisor {
+                host_name: host.clone(),
+                source: FakeError("secret supervisor payload"),
+            },
+            OrchestratorCoreError::Channel(ChannelEndpointError::DefinitionNotFound),
+            OrchestratorCoreError::Authorization(FakeError("secret authorization payload")),
+            OrchestratorCoreError::HostDesiredRunning(host.clone()),
+            OrchestratorCoreError::HostStillActive(host),
+            OrchestratorCoreError::ClockRegressed,
+        ];
+        let rendered = errors.iter().map(ToString::to_string).collect::<Vec<_>>();
+        assert!(rendered.iter().all(|message| !message.contains("secret")));
+        assert!(rendered
+            .iter()
+            .all(|message| message.starts_with("orchestrator-core:")));
+    }
+
+    #[test]
+    fn production_constructor_composes_an_empty_process_supervised_core() {
+        let backend = InMemoryStorageBackend::new();
+        let keyring = PackageKeyring::new();
+        let identity = generate_identity_keypair();
+        let executable = std::env::current_exe().expect("current executable");
+        let config = ProcessSupervisorConfig::new(
+            HostProgram::new(executable, std::iter::empty::<&str>()).expect("host program"),
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+        )
+        .expect("process configuration");
+        let clock = Arc::new(TestClock::new([1]));
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let mut core = ProcessOrchestratorCore::with_process_supervisor(
+            &backend,
+            config,
+            &keyring,
+            &identity,
+            clock,
+            Box::<UuidV7SessionIdSource>::default(),
+            ReconcileConfig::new(100).expect("reconcile config"),
+            FakeAuthorizer::allowing(events),
+        );
+        assert!(core
+            .reconcile_once()
+            .expect("empty production tick")
+            .outcomes()
+            .is_empty());
+        drop(core.into_supervisor());
+    }
+}

--- a/code/specs/orchestrator.md
+++ b/code/specs/orchestrator.md
@@ -243,6 +243,13 @@ survive orchestrator restarts and are not split across two authorities.
 
 ### Service Registry
 
+The transport-independent daemon composition is specified in
+[`runnable-orchestrator-core.md`](runnable-orchestrator-core.md). It binds this
+registry to deterministic reconciliation, authoritative process supervision,
+and authorized channel-topology mutation while remaining keyless and
+payload-blind. WebSocket serving, CLI parsing, daemon installation, and loop
+scheduling remain outer adapters.
+
 A durable registry of host intent plus the orchestrator's last observation:
 
 ```rust

--- a/code/specs/process-host-supervisor.md
+++ b/code/specs/process-host-supervisor.md
@@ -18,7 +18,8 @@ child messages.
 
 The adapter implements `chief_of_staff_service_reconciler::HostSupervisor`. It
 does not implement scheduling, restart policy, backoff, or durable state; those
-remain responsibilities of the reconciler and runnable orchestrator.
+remain responsibilities of the reconciler and
+[`runnable-orchestrator-core.md`](runnable-orchestrator-core.md).
 
 ## Process Contract
 

--- a/code/specs/runnable-orchestrator-core.md
+++ b/code/specs/runnable-orchestrator-core.md
@@ -1,0 +1,148 @@
+# D18 Runnable Orchestrator Core
+
+## Status
+
+This document specifies the smallest runnable, transport-independent D18
+orchestrator composition.
+
+The implementation package is `chief-of-staff-orchestrator-core`.
+
+## Purpose
+
+The core binds durable host intent, deterministic reconciliation, authoritative
+process supervision, and durable channel topology behind one bounded API. It is
+the stateful application layer used later by the WebSocket daemon and operator
+CLI; it is not itself a socket server, scheduler, daemon installer, or command
+parser.
+
+The core is deliberately underpowered. It owns no channel master keys, receiver
+private keys, vault secrets, message payloads, or in-process agent handlers.
+Verified child processes integrate `chief-of-staff-host-runtime`; the parent
+coordinates their lifecycle through `chief-of-staff-process-supervisor` and the
+authenticated control channel.
+
+## Composition
+
+The generic core receives:
+
+- one repository `StorageBackend` used by both `ServiceRegistry` and
+  `ChannelDefinitionStore`;
+- one `HostSupervisor` implementation;
+- one injected monotonic clock;
+- validated reconciliation configuration; and
+- one channel-wiring authorizer.
+
+A production constructor composes the core with `ProcessHostSupervisor`, its
+trusted package keyring, long-lived X3DH identity, fixed absolute child program,
+fresh UUID-v7 session source, and the same monotonic clock used for authenticated
+receipt evidence.
+
+The backend and cryptographic trust objects are borrowed from the runnable
+daemon owner. The core does not create a self-referential filesystem backend or
+copy zeroizing identity material.
+
+## Host Intent API
+
+The core exposes bounded operations to:
+
+- register one immutable `HostRegistration` with initial desired state;
+- load or list registered hosts in stable host-name order;
+- CAS-update only `DesiredState` for an existing registration;
+- inspect one host using the owned supervisor as live authority; and
+- deregister one exact loaded revision only when desired state is `Stopped` and
+  supervisor authority reports `Absent` or `Exited`.
+
+Registration preserves the service registry's idempotency rules. A conflicting
+package identity under the same host name is rejected. Desired-state updates do
+not mutate package path, package hash, or restart policy. Deregistration never
+deletes active intent first and then hopes the process stops; callers request
+`Stopped`, reconcile, inspect, and only then delete.
+
+## Bounded Reconciliation
+
+`reconcile_once` samples the injected monotonic clock exactly once and invokes
+one stable-order `ServiceReconciler::reconcile_all` tick. It does not sleep,
+retry forever, or run a background thread. Each host still receives at most one
+supervisor mutation per tick as defined by
+[`service-registry-reconciliation.md`](service-registry-reconciliation.md).
+
+The core rejects a clock sample earlier than its previous successful tick. It
+updates the remembered sample only after reconciliation succeeds, so a failed
+tick can be retried against the same time without creating artificial progress.
+The runnable daemon chooses scheduling cadence and shutdown policy.
+
+On startup, the daemon invokes the same `reconcile_once` operation. Cached PIDs,
+statuses, heartbeats, and control-channel IDs never become live authority merely
+because they were persisted before a restart.
+
+## Health Evidence
+
+`health_check` returns the durable loaded host and a fresh
+`SupervisorObservation`. The two are intentionally distinct:
+
+- durable state answers what was requested and last recorded; and
+- supervisor state answers what this process currently owns and authenticated.
+
+The core does not collapse disagreement into a misleading single status. The
+next reconciliation tick performs convergence and durable CAS updates.
+
+## Channel Topology and Authorization
+
+The core may create, load, and irreversibly destroy durable channel definitions.
+It never opens an originator or receiver endpoint, distributes a key, or reads a
+message. Those operations remain in authorized hosts and the channel endpoint
+packages.
+
+Every create or destroy request is first presented to an injected
+`ChannelWiringAuthorizer`. The authorizer can consult manifest privilege tiers,
+the trust checker, and an approval side channel. An authorization denial or
+authorizer failure performs no storage mutation. The core provides no implicit
+allow-all production path.
+
+Create remains idempotent only for the byte-identical active definition.
+Destroy remains one-way and idempotent through the definition store's revision
+CAS contract.
+
+## Public API
+
+The package exposes:
+
+- `OrchestratorCore<S, A>` for injected supervisors and authorizers;
+- `ProcessOrchestratorCore<A>` plus a production process-composition
+  constructor;
+- `ChannelWiringAuthorizer` and exact create/destroy request values;
+- `HostHealth`, preserving durable and authoritative views;
+- `OrchestratorCoreError`, preserving typed registry, reconciliation,
+  supervisor, channel, and authorization failures; and
+- registration, desired-state, health, reconciliation, channel-topology, and
+  safe-deregistration operations.
+
+Diagnostics must not contain package contents, message payloads, key bytes,
+backend roots, executable arguments, or environment values.
+
+## Capabilities
+
+The generic core performs pure coordination over injected interfaces and
+declares no direct filesystem, network, process, environment, clock, random, or
+stream capability. Concrete storage and process dependencies retain their own
+capability manifests. The future daemon binary will declare the union required
+by the concrete adapters it constructs.
+
+## Required Tests
+
+The package must cover:
+
+- idempotent registration and conflicting immutable identity;
+- stable listing and CAS desired-state updates;
+- one-sample bounded reconciliation with start, observe, stop, and restart
+  behavior through an injected supervisor;
+- clock-regression rejection and retry after a failed tick;
+- health preserving separate durable and authoritative views;
+- safe deregistration refusing desired-running and active hosts;
+- channel create/load/destroy after authorization;
+- authorization denial proving no channel mutation;
+- stable payload-free error diagnostics; and
+- production process-composition construction without spawning until a tick
+  actually requests start.
+
+The package forbids unsafe code and targets at least 95 percent line coverage.

--- a/code/specs/service-registry-reconciliation.md
+++ b/code/specs/service-registry-reconciliation.md
@@ -45,6 +45,8 @@ channel, the authenticated lifecycle messages defined in
 [`host-control-protocol.md`](host-control-protocol.md), and a concrete OS-process
 supervisor specified in
 [`process-host-supervisor.md`](process-host-supervisor.md).
+The minimal transport-independent composition is specified in
+[`runnable-orchestrator-core.md`](runnable-orchestrator-core.md).
 
 ## Authoritative Supervisor Contract
 


### PR DESCRIPTION
## Summary

- specify the smallest transport-independent runnable D18 orchestration composition
- add bounded host registration, desired-state, health, reconciliation, and safe deregistration operations
- require an injected authorization boundary before durable channel topology mutations
- compose the verified process supervisor through a concrete production constructor

This advances #128 and is a focused slice of #138.

## Validation

- cargo test -p chief-of-staff-orchestrator-core (11 passed)
- cargo clippy -p chief-of-staff-orchestrator-core --all-targets -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc -p chief-of-staff-orchestrator-core --no-deps
- package BUILD command
- affected-package planner: 34 built, 12 unrelated skipped
- llvm-cov line coverage: 96.27%
- manual security review: authorization precedes storage mutation; errors do not render nested adapter payloads
