### PR TITLE
Report non-current in-body end tags

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,10 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- In-body end tags now report the Standard's parse error when implied-end-tag
+  recovery leaves their matching open element non-current, closing 18
+  previously silent malformed corpus cases without changing DOM recovery or
+  undeclared-diagnostic coverage.
 - EOF in the tree builder's text insertion mode now reports the Standard's
   parse error, pops the authored text element, and reprocesses EOF in the
   original mode, closing 92 previously silent malformed corpus cases without

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the text insertion-mode EOF diagnostic slice, 1,983 of those cases emit
-at least one lexer or parser diagnostic and 200 remain uncovered. Another 139
+After the in-body non-current end-tag diagnostic slice, 2,001 of those cases
+emit at least one lexer or parser diagnostic and 182 remain uncovered. Another 139
 cases emit diagnostics despite having no legacy `#errors` rows. These are
 reviewed rather than automatically removed: 89 are full-document inputs for
 which the legacy fixtures omit the Standard-required missing-doctype error,
@@ -51,10 +51,16 @@ RCDATA, RAWTEXT, and scripting-enabled `noscript` elements. EOF now reports the
 mode's parse error, pops the current text element, and reprocesses EOF in the
 original mode; synthetic text fragment contexts remain diagnostic-free.
 
+The in-body "any other end tag" parse error is now reported when implied end
+tags leave the matching open element non-current, including special-element
+scope stops and nested formatting recovery. Remaining in-body work covers
+specialized heading, list-item, paragraph, and adoption-agency branches.
+
 Prioritized work items:
 
-1. **In-body insertion mode.** Cover scope failures, implied-end-tag recovery,
-   formatting reconstruction, and stray start/end tags.
+1. **In-body insertion mode.** Cover specialized heading, list-item,
+   paragraph, adoption-agency, formatting-reconstruction, and stray-tag
+   diagnostics.
 2. **Table, select, and template insertion modes.** Cover foster parenting,
    table scopes, select recovery, and template mode-stack errors. The remaining
    fragment EOF inventory includes fostered-anchor `eof-in-table` rows and

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7002,6 +7002,16 @@ impl HtmlParser {
             {
                 return;
             }
+            let reports_scope_error = !matches!(name, "body" | "html")
+                && special_scope_blocks_end_tag(name)
+                && self
+                    .has_element_above(index, |candidate| !is_implied_end_tag_element(candidate));
+            if reports_scope_error {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-non-current-end-tag",
+                    format!("end tag `</{name}>` was seen before its open element was current"),
+                ));
+            }
             if special_scope_blocks_end_tag(name)
                 && self.has_special_element_above(index)
                 && !(is_paragraph_boundary_element(name)
@@ -33166,6 +33176,32 @@ mod tests {
         for source in ["<!doctype html><p>", "<!doctype html><head>"] {
             let allowed = parse_html_with_diagnostics(source).unwrap();
             assert!(allowed.parser_diagnostics.is_empty(), "source {source:?}");
+        }
+    }
+
+    #[test]
+    fn reports_in_body_end_tags_seen_before_their_open_element_is_current() {
+        for (source, end_tag) in [
+            (
+                "<!doctype html><figcaption><article></figcaption>a",
+                "figcaption",
+            ),
+            ("<!doctype html><address><button></address>a", "address"),
+            ("<!doctype html><font><p><b>test</font>", "font"),
+            ("<!doctype html><select><menuitem></select>", "select"),
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            let expected = ParserDiagnostic::new(
+                "unexpected-non-current-end-tag",
+                format!("end tag `</{end_tag}>` was seen before its open element was current"),
+            );
+            assert!(
+                output
+                    .parser_diagnostics
+                    .iter()
+                    .any(|diagnostic| diagnostic == &expected),
+                "source {source:?}"
+            );
         }
     }
 

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
@@ -14,7 +14,7 @@
     "missing": 0,
     "missing_sources": [],
     "upstream_cases": 1934,
-    "upstream_revision": "8ff51b7de9b569733c5be7d0636c92c258ffdd27",
+    "upstream_revision": "d6c801946a63a6c5fec07c3d476b8b021e5eca34",
     "upstream_source": "wpt/html/syntax/parsing/resources"
   }
 }

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 200);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1983);
+    assert_eq!(missing_diagnostic_cases, 182);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2001);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report the current HTML Standard parse error when in-body implied-end-tag recovery leaves a matching open element non-current
- close 18 silent malformed tree-construction rows (200 to 182) while preserving all 2,637 DOM outputs and 139 undeclared-diagnostic cases
- refresh the checked WPT revision to the live audited d6c801946a63a6c5fec07c3d476b8b021e5eca34 head

## Evidence
- WPT tree construction: 1,934/1,934 signatures, zero missing
- html5lib tokenizer: 6,806/6,806 signatures, zero missing, zero normalized skips
- covered declared-error cases: 1,983 to 2,001

## Validation
- cargo test -p coding-adventures-html-parser --test tree_construction_test
- cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings
- cargo test -p coding-adventures-html-parser
- CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- live WPT/html5lib coverage audit and checked report
- parser audit manifest, Rust-test, and coverage checks
- generated HTML fixture and README inventory checks
- git diff --check