### PR TITLE
fix(human-languages): clean Sanskrit book warnings

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -77,9 +77,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B07 | Complete (#9675) | Remove Gujarati's missing punctuation glyphs and LaTeX layout/bookmark warnings. | Canonical recap labels, main-font punctuation, bookmark-safe Gujarati, natural page bottoms, and explicit static-font shapes make the forced six-chapter build warning-free. |
 | HL-B08 | Complete (#9680) | Publish Punjabi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
 | HL-B09 | Complete (#9683) | Remove Punjabi's LaTeX layout, duplicate-label, font-shape, and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Gurmukhi, natural page bottoms, explicit static-font shapes, and a shorter running title make the forced six-chapter build warning-free. |
-| HL-B10 | Complete in this PR | Publish Sanskrit Chapter 6 from its three canonical lessons rather than hand-copying another book chapter. | All three schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
-| HL-B11 | Next | Remove Sanskrit's LaTeX layout, duplicate-label, font-shape, and Unicode bookmark warnings. | A forced six-chapter build succeeds with no missing glyphs but reports three overfull boxes, seven underfull boxes, four duplicate practice labels, 28 Hyperref warnings, and three font-shape warnings; the clean-build signal is zero of each. |
-| HL-B12 | Queued | Publish Bengali Chapter 6 from its canonical lesson rather than hand-copying another book chapter. | The duration audit confirms authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
+| HL-B10 | Complete (#9690) | Publish Sanskrit Chapter 6 from its three canonical lessons rather than hand-copying another book chapter. | All three schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
+| HL-B11 | Complete in this PR | Remove Sanskrit's LaTeX layout, duplicate-label, font-shape, and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Devanagari, natural page bottoms, explicit static-font shapes, and shorter running titles make the forced six-chapter build warning-free. |
+| HL-B12 | Next | Publish Bengali Chapter 6 from its canonical lesson rather than hand-copying another book chapter. | The duration audit confirms authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
 | HL-B13 | Queued | Remove Bengali's missing glyphs and LaTeX layout/bookmark warnings. | A forced build succeeds but reports six missing glyphs, one overfull box, four underfull boxes, four duplicate practice labels, and 27 Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B14 | Queued | Publish Italian Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Italian has canonical app content through Chapter 17, but its downloadable PDF contains only Chapter 1; schema-v2 migration plus generation should close that drift safely. |
 | HL-B15 | Queued | Remove Italian's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds but reports one underfull box and three Hyperref warnings; the clean-build signal is zero of each. |
@@ -432,6 +432,22 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   overfull, duplicate-label, bookmark, or font warning. The full build's three
   font-shape warnings and seven underfull warnings are now recorded accurately
   in HL-B11 alongside the older handwritten warning debt.
+
+## Findings from HL-B11
+
+- Sanskrit's five authored recap anchors now use stable chapter-qualified ids
+  (`SA-C01-practice` through `SA-C05-practice`) instead of five copies of
+  `lesson:practice`.
+- Devanagari is retained in the PDF outline while the presentation-only font
+  switch is suppressed there. The vendored static font is selected explicitly
+  for regular, bold, italic, and bold-italic requests, preserving the existing
+  glyph appearance without unavailable-shape substitutions.
+- Short pages now end naturally around kept-together lesson callouts. Concise
+  running titles for the long “you,” “what,” and *karomi* sections remove the
+  three overfull headings without removing lesson content. The forced 35-page
+  XeLaTeX build reports zero package or LaTeX warnings, missing glyphs,
+  overfull boxes, underfull boxes, and duplicate destinations. HL-B12 is next:
+  publish Bengali Chapter 6 through the canonical pipeline.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/sanskrit/CHANGELOG.md
+++ b/code/learning/human-languages/sanskrit/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Book warning cleanup — 2026-08-03
+
+- Replaced five duplicate recap anchors with stable chapter-qualified labels.
+- Preserved Devanagari in PDF bookmarks while suppressing the font-only command
+  there, and mapped the vendored static font to every requested shape.
+- Let short lesson pages end naturally and shortened three running titles so a
+  forced six-chapter build has no layout, bookmark, label, font, or glyph
+  warnings.
+
 ## Canonical Chapter 6 publication — 2026-08-03
 
 - Migrated all three number lessons to schema v2 with the shared

--- a/code/learning/human-languages/sanskrit/README.md
+++ b/code/learning/human-languages/sanskrit/README.md
@@ -52,6 +52,10 @@ Compiles with XeLaTeX using the **vendored** Noto Sans Devanagari font
 Generated Devanagari runs use that font while section bookmarks use the
 lessons' Latin romanization.
 
+The forced six-chapter build is warning-free: chapter-qualified recap anchors,
+bookmark-safe Devanagari, natural page bottoms, explicit static-font shapes,
+and concise running titles keep the downloadable PDF and its outline clean.
+
 ## Files
 
 - [`lessons/`](./lessons/) · [`pronunciation-reference.md`](./pronunciation-reference.md)

--- a/code/learning/human-languages/sanskrit/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch01-greetings.tex
@@ -137,7 +137,7 @@ universal --- these old languages preferred to \emph{say what they meant}.
 \end{culture}
 
 \section{Recap}
-\label{lesson:practice}
+\label{SA-C01-practice}
 
 \begin{center}
 \begin{tabular}{@{}lll@{}}

--- a/code/learning/human-languages/sanskrit/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch02-introductions.tex
@@ -58,7 +58,7 @@ n\=ama \ldots asti}, with an explicit \emph{asti} --- the Indo-European way, kep
 by Latin and English too.
 \end{grammarlens}
 
-\section{\sk{भवान्} / \sk{त्वम्} \emph{(bhav\=an / tvam)} --- ``you,'' respectful and familiar}
+\section[\sk{भवान्} and \sk{त्वम्} --- respectful and familiar]{\sk{भवान्} and \sk{त्वम्} \emph{(bhav\=an, tvam)} --- ``you,'' respectful and familiar}
 \label{lesson:bhavan-tvam}
 
 \begin{cousinweb}
@@ -74,7 +74,7 @@ English archaic \textbf{thou}, Latin \emph{t\=u}, Hindi \emph{t\=u}. \sk{भव�
 someone as though speaking \emph{about} them --- ``is your honour well?''
 \end{grammarlens}
 
-\section{\sk{किम्} \emph{(kim)} --- ``what,'' the source of the question-words}
+\section[\sk{किम्} \emph{(kim)} --- ``what'']{\sk{किम्} \emph{(kim)} --- ``what,'' root of many question-words}
 \label{lesson:kim}
 
 \begin{cousinweb}
@@ -109,7 +109,7 @@ Indian thought uses for the deepest happiness.
 \end{cousinweb}
 
 \section{The whole exchange}
-\label{lesson:practice}
+\label{SA-C02-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/sanskrit/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch03-responding.tex
@@ -73,7 +73,7 @@ Hindi (\emph{cint\=a mat karo}). ``Think nothing of it.''
 \end{cousinweb}
 
 \section{The whole exchange}
-\label{lesson:practice}
+\label{SA-C03-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/sanskrit/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch04-farewells.tex
@@ -66,7 +66,7 @@ for economy, letting tense carry the load.
 \end{grammarlens}
 
 \section{The farewells}
-\label{lesson:practice}
+\label{SA-C04-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/sanskrit/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch05-first-verbs.tex
@@ -76,7 +76,7 @@ separate word for ``in'' --- it is folded into the noun's ending, the ancestor o
 Hindi's and Bengali's postpositions.
 \end{grammarlens}
 
-\section{\sk{करोमि} \emph{(karomi)} --- ``I do,'' from the root behind \emph{karma}}
+\section[\sk{करोमि} --- ``I do'' and \emph{karma}]{\sk{करोमि} \emph{(karomi)} --- ``I do,'' from the root behind \emph{karma}}
 \label{lesson:karomi}
 
 \begin{cousinweb}
@@ -91,7 +91,7 @@ Bengali's \emph{k\=aj kar\=a} are its worn-down grandchildren.
 \end{cousinweb}
 
 \section{Sentences about yourself}
-\label{lesson:practice}
+\label{SA-C05-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/sanskrit/book/preamble.tex
+++ b/code/learning/human-languages/sanskrit/book/preamble.tex
@@ -39,7 +39,13 @@
 
 % Vendored Devanagari font (../../_fonts/ from <lang>/book/); \sk{...} = inline
 % Sanskrit snippet.
-\newfontfamily\sanskritfont[Path=../../_fonts/, Script=Devanagari]{NotoSansDevanagari-Static.ttf}
+\newfontfamily\sanskritfont[
+  Path=../../_fonts/,
+  Script=Devanagari,
+  BoldFont=NotoSansDevanagari-Static.ttf,
+  ItalicFont=NotoSansDevanagari-Static.ttf,
+  BoldItalicFont=NotoSansDevanagari-Static.ttf
+]{NotoSansDevanagari-Static.ttf}
 \newcommand{\sk}[1]{{\sanskritfont #1}}
 
 \hypersetup{
@@ -48,6 +54,14 @@
   pdfsubject={Etymology-driven Sanskrit curriculum},
   pdfkeywords={Sanskrit, Devanagari, Indo-European, language learning}
 }
+\pdfstringdefDisableCommands{%
+  \def\sk#1{#1}% Keep Devanagari text while dropping font-only presentation.
+  \def\sanskritfont{}%
+}
+
+% Lesson callouts are deliberately kept together when they fit. Let short pages
+% end naturally instead of stretching their vertical glue around those boxes.
+\raggedbottom
 
 \newtcolorbox{cousinweb}{
   breakable, skin=enhanced, colback=yellow!8, colframe=yellow!45!black,


### PR DESCRIPTION
## Summary
- make Sanskrit Devanagari bookmarks and static font shapes warning-safe
- replace duplicate recap anchors with chapter-qualified labels
- remove remaining overfull and underfull layout warnings with concise running titles and natural page bottoms
- record HL-B11 complete and prioritize Bengali Chapter 6 next

## Validation
- `npm run check:books`
- forced 35-page XeLaTeX rebuild
- zero overfull/underfull boxes, duplicate labels, Hyperref/font/package/LaTeX warnings, and missing glyphs
- visual inspection of nine formerly affected pages
- PDF outline audit (readable Devanagari plus generated romanized entries)
- `git diff --check`