### PR TITLE
fix(spice): lower parser MOS junction current

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS model-card `JS` values before lowering
+  valid junction saturation-current densities.
 - Reject negative and non-finite MOS model-card `CJSW` values before lowering
   valid sidewall-junction capacitance densities.
 - Reject negative and non-finite MOS model-card `CJ` values before lowering

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1977,6 +1977,10 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(params["CJSW"]) or params["CJSW"] < 0.0
         ):
             raise NetlistParseError("MOSFET CJSW must be finite and non-negative")
+        if "JS" in params and (
+            not math.isfinite(params["JS"]) or params["JS"] < 0.0
+        ):
+            raise NetlistParseError("MOSFET JS must be finite and non-negative")
         nominal_temperature = params.get("T_NOM", params.get("TNOM"))
         if nominal_temperature is not None and (
             not math.isfinite(nominal_temperature) or nominal_temperature <= 0.0

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1870,6 +1870,33 @@ def test_lowers_valid_mosfet_model_sidewall_capacitance(
     assert isclose(mosfet.model.model.params.CJSW, expected)
 
 
+@pytest.mark.parametrize("junction_current", ["-1p", "1e999"])
+def test_rejects_invalid_mosfet_model_junction_current(
+    junction_current: str,
+) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="MOSFET JS must be finite and non-negative",
+    ):
+        parse_netlist(
+            f".model nfast NMOS(JS={junction_current})\nM1 d g s b nfast\n"
+        )
+
+
+@pytest.mark.parametrize(
+    ("junction_current", "expected"), [("0", 0.0), ("4p", 4.0e-12)]
+)
+def test_lowers_valid_mosfet_model_junction_current(
+    junction_current: str, expected: float
+) -> None:
+    parsed = parse_netlist(
+        f".model nfast NMOS(JS={junction_current})\nM1 d g s b nfast\n"
+    )
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(mosfet.model.model.params.JS, expected)
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS model-card `JS` values and lower valid
+  junction saturation-current densities instead of silently dropping them.
 - Reject negative and non-finite MOS model-card `CJSW` values and lower valid
   sidewall-junction capacitance densities instead of silently dropping them.
 - Reject negative and non-finite MOS model-card `CJ` values and lower valid

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1292,6 +1292,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET CJSW must be finite and non-negative");
   }
+  const junctionCurrent = params.get("JS");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    junctionCurrent !== undefined &&
+    (!Number.isFinite(junctionCurrent) || junctionCurrent < 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET JS must be finite and non-negative");
+  }
   const nominalTemperature = params.get("T_NOM") ?? params.get("TNOM");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1394,6 +1402,7 @@ function isMosfetParam(name: keyof MosfetLevel1Params): boolean {
     "PS",
     "CJ",
     "CJSW",
+    "JS",
     "IS",
     "N_SUB",
     "T_NOM",

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1743,6 +1743,25 @@ Xright c d load
     expect(element.params.CJSW).toBeCloseTo(expected, 15);
   });
 
+  it.each(["-1p", "1e999"])("rejects invalid MOSFET model JS=%s", (junctionCurrent) => {
+    expect(() =>
+      parseNetlist(`.model nfast NMOS(JS=${junctionCurrent})\nM1 d g s b nfast\n`),
+    ).toThrow("MOSFET JS must be finite and non-negative");
+  });
+
+  it.each([
+    ["0", 0.0],
+    ["4p", 4.0e-12],
+  ])("lowers valid MOSFET model JS=%s", (junctionCurrent, expected) => {
+    const parsed = parseNetlist(
+      `.model nfast NMOS(JS=${junctionCurrent})\nM1 d g s b nfast\n`,
+    );
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.JS).toBeCloseTo(expected, 15);
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4261,11 +4261,17 @@ the Rust, Python, and TypeScript surfaces together.
      shared diagnostic while zero and positive bottom-junction capacitance
      densities lower into Level-1 parameters.
 
+391. Python and TypeScript Berkeley SPICE MOS sidewall-capacitance parity.
+   - Status: completed in PR 9693.
+   - Negative and non-finite model-card `CJSW` values are rejected with the
+     shared diagnostic while zero and positive sidewall-junction capacitance
+     densities lower into Level-1 parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
-   - TypeScript still needs canonical lowering for `CJSW`, `JS`, `PB`, `MJ`,
-     `MJSW`, `FC`, `KF`, and `AF`; Python already lowers these canonical fields
+   - TypeScript still needs canonical lowering for `JS`, `PB`, `MJ`, `MJSW`,
+     `FC`, `KF`, and `AF`; Python already lowers these canonical fields
      but still needs matching facade validation coverage.
    - Align the `CJS` and `CJD` aliases with canonical `CBS` and `CBD` in both
      facades after the canonical-field slices.


### PR DESCRIPTION
## Summary
- validate MOS model-card `JS` as finite and non-negative in Python and TypeScript
- lower valid TypeScript junction saturation-current densities into Level-1 parameters
- record the merged `CJSW` slice and advance the prioritized parity backlog

## Verification
- Python: 184 tests passed; 88.47% coverage; Ruff clean
- TypeScript: dependent spice-engine build, parser build, 177 tests passed; 84.97% line coverage
- repeated both parser suites after rebasing onto current origin/main