### PR TITLE
fix(spice): lower parser MOS bulk potential

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite MOS model-card `PB` values before
+  lowering valid bulk-junction potentials.
 - Reject negative and non-finite MOS model-card `JS` values before lowering
   valid junction saturation-current densities.
 - Reject negative and non-finite MOS model-card `CJSW` values before lowering

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1981,6 +1981,10 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(params["JS"]) or params["JS"] < 0.0
         ):
             raise NetlistParseError("MOSFET JS must be finite and non-negative")
+        if "PB" in params and (
+            not math.isfinite(params["PB"]) or params["PB"] <= 0.0
+        ):
+            raise NetlistParseError("MOSFET PB must be finite and positive")
         nominal_temperature = params.get("T_NOM", params.get("TNOM"))
         if nominal_temperature is not None and (
             not math.isfinite(nominal_temperature) or nominal_temperature <= 0.0

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1897,6 +1897,26 @@ def test_lowers_valid_mosfet_model_junction_current(
     assert isclose(mosfet.model.model.params.JS, expected)
 
 
+@pytest.mark.parametrize("bulk_potential", ["0", "-0.1", "1e999"])
+def test_rejects_invalid_mosfet_model_bulk_potential(
+    bulk_potential: str,
+) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="MOSFET PB must be finite and positive",
+    ):
+        parse_netlist(
+            f".model nfast NMOS(PB={bulk_potential})\nM1 d g s b nfast\n"
+        )
+
+
+def test_lowers_positive_mosfet_model_bulk_potential() -> None:
+    parsed = parse_netlist(".model nfast NMOS(PB=0.72)\nM1 d g s b nfast\n")
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(mosfet.model.model.params.PB, 0.72)
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite MOS model-card `PB` values and lower
+  valid bulk-junction potentials instead of silently dropping them.
 - Reject negative and non-finite MOS model-card `JS` values and lower valid
   junction saturation-current densities instead of silently dropping them.
 - Reject negative and non-finite MOS model-card `CJSW` values and lower valid

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1300,6 +1300,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET JS must be finite and non-negative");
   }
+  const bulkPotential = params.get("PB");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    bulkPotential !== undefined &&
+    (!Number.isFinite(bulkPotential) || bulkPotential <= 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET PB must be finite and positive");
+  }
   const nominalTemperature = params.get("T_NOM") ?? params.get("TNOM");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1403,6 +1411,7 @@ function isMosfetParam(name: keyof MosfetLevel1Params): boolean {
     "CJ",
     "CJSW",
     "JS",
+    "PB",
     "IS",
     "N_SUB",
     "T_NOM",

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1762,6 +1762,23 @@ Xright c d load
     expect(element.params.JS).toBeCloseTo(expected, 15);
   });
 
+  it.each(["0", "-0.1", "1e999"])(
+    "rejects invalid MOSFET model PB=%s",
+    (bulkPotential) => {
+      expect(() =>
+        parseNetlist(`.model nfast NMOS(PB=${bulkPotential})\nM1 d g s b nfast\n`),
+      ).toThrow("MOSFET PB must be finite and positive");
+    },
+  );
+
+  it("lowers positive MOSFET model PB", () => {
+    const parsed = parseNetlist(".model nfast NMOS(PB=0.72)\nM1 d g s b nfast\n");
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.PB).toBeCloseTo(0.72, 15);
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4267,11 +4267,17 @@ the Rust, Python, and TypeScript surfaces together.
      shared diagnostic while zero and positive sidewall-junction capacitance
      densities lower into Level-1 parameters.
 
+392. Python and TypeScript Berkeley SPICE MOS junction-current parity.
+   - Status: completed in PR 9699.
+   - Negative and non-finite model-card `JS` values are rejected with the
+     shared diagnostic while zero and positive junction saturation-current
+     densities lower into Level-1 parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
-   - TypeScript still needs canonical lowering for `JS`, `PB`, `MJ`, `MJSW`,
-     `FC`, `KF`, and `AF`; Python already lowers these canonical fields
+   - TypeScript still needs canonical lowering for `PB`, `MJ`, `MJSW`, `FC`,
+     `KF`, and `AF`; Python already lowers these canonical fields
      but still needs matching facade validation coverage.
    - Align the `CJS` and `CJD` aliases with canonical `CBS` and `CBD` in both
      facades after the canonical-field slices.


### PR DESCRIPTION
## Summary
- validate MOS model-card `PB` as finite and positive in Python and TypeScript
- lower valid TypeScript bulk-junction potentials into Level-1 parameters
- record the merged `JS` slice and advance the prioritized parity backlog

## Verification
- Python: 188 tests passed; 88.49% coverage; Ruff clean
- TypeScript: dependent spice-engine build, parser build, 181 tests passed; 85.02% line coverage