### PR TITLE
feat(smart-home): add Axis VAPIX inspection

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -12,21 +12,21 @@
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
   "active_pr": {
-    "number": 9691,
-    "url": "https://github.com/adhithyan15/coding-adventures/pull/9691",
-    "branch": "codex/build-tool-ruby-language-identity-registry"
+    "number": 9703,
+    "url": "https://github.com/adhithyan15/coding-adventures/pull/9703",
+    "branch": "codex/build-tool-go-language-identity-registry"
   },
   "last_inventory": {
-    "revision": "29d78677fe65719e0b84e2441e9a568a67e7f4f4",
+    "revision": "b42d1683d85daa9fd26cb96da3d928612034aa24",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1230,
-    "implementation_package_slots": 4378,
+    "implementation_identities": 1233,
+    "implementation_package_slots": 4381,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 271,
-    "singleton_packages": 780,
-    "singleton_missing_slots": 10920,
-    "rust_singletons": 585,
+    "singleton_packages": 783,
+    "singleton_missing_slots": 10962,
+    "rust_singletons": 588,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -410,11 +410,11 @@
     {
       "id": "build-tool-ruby-language-identity-registry",
       "title": "Bring Ruby build-tool discovery to the canonical language and identity registry",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-ruby-starlark-canonical-build-compatibility"],
       "branch": "codex/build-tool-ruby-language-identity-registry",
       "pr_number": 9691,
-      "notes": "Discovered while proving the 44 canonical Starlark package records against the Go oracle. Ruby and Go agree on package counts and on every affected Starlark record field, but Ruby's dependency-edge identities omit the canonical programs segment: the Go/Ruby set differences are 42/42 for Go and 76/76 for Rust, while Elixir has 21 Go-only and 12 Ruby-only edges plus nine independently missing semantic edges. Lua has the same conduit-hello identity drift and one Go-only edge. Adopt the canonical language and package-identity registry, preserve repository-relative program identities such as go/programs/build-tool, rust/programs/closurec, and elixir/programs/ircd, then consume language-neutral identity and dependency-edge fixtures across canonical and legacy BUILD paths. Keep the separately owned missing semantic dependency edges out of the Starlark evaluator compatibility slice. Selected after PR #9677 merged and the collision-clean fbd52e79 inventory. The dependency/leverage pass ranks this directly unblocked cross-language graph repair ahead of the independent Haskell and Elixir UTF-8 children because it corrects canonical identity and edge semantics across Lua, Elixir, Go, and Rust plans while the Ruby toolchain, exact Go comparisons, and affected fixtures are already warm; all newly classified Chief items remain dependency-blocked. Implemented the complete canonical discovery registry, exact package/program identities, specification-tree exclusion, root-redacted duplicate-identity failure with CLI exit 2, and qualified legacy BUILD dependency comments. On rebased 29d78677, validation passes 307 Ruby runs/632 assertions with one existing Windows platform skip and 89.43% line/72.55% branch coverage; 17 schema and 40 runner tests; the valid 38-case/61-file corpus; 37 TypeScript, 12 Rust, and five Swift shared discovery consumers; Go test/vet/trimpath build; zero-advisory current Ruby dependencies; Security lint; collision-clean 1,230-identity/4,378-slot inventory; JSON, diff, and credential checks. The exact real plans contain 4,776 unique Ruby identities with no backslash paths; Go, Rust, and Lua package and edge sets match Go exactly at 301/936, 928/2,250, and 258/383. The separately logged Elixir semantic delta is 13 set differences, and the build-file gate reproduces only the exact ten already-owned Lua BUILD_windows debts. Ready PR #9691 opened at exact head 122c1894d00893b182f58f1c98b27efc72df9cc6; initial checks are queued and guarded auto-complete remains disabled until every exact-head check is terminal green, skipped, or neutral."
+      "notes": "Discovered while proving the 44 canonical Starlark package records against the Go oracle. Ruby and Go agree on package counts and on every affected Starlark record field, but Ruby's dependency-edge identities omit the canonical programs segment: the Go/Ruby set differences are 42/42 for Go and 76/76 for Rust, while Elixir has 21 Go-only and 12 Ruby-only edges plus nine independently missing semantic edges. Lua has the same conduit-hello identity drift and one Go-only edge. Adopt the canonical language and package-identity registry, preserve repository-relative program identities such as go/programs/build-tool, rust/programs/closurec, and elixir/programs/ircd, then consume language-neutral identity and dependency-edge fixtures across canonical and legacy BUILD paths. Keep the separately owned missing semantic dependency edges out of the Starlark evaluator compatibility slice. Selected after PR #9677 merged and the collision-clean fbd52e79 inventory. The dependency/leverage pass ranks this directly unblocked cross-language graph repair ahead of the independent Haskell and Elixir UTF-8 children because it corrects canonical identity and edge semantics across Lua, Elixir, Go, and Rust plans while the Ruby toolchain, exact Go comparisons, and affected fixtures are already warm; all newly classified Chief items remain dependency-blocked. Implemented the complete canonical discovery registry, exact package/program identities, specification-tree exclusion, root-redacted duplicate-identity failure with CLI exit 2, and qualified legacy BUILD dependency comments. On rebased 29d78677, validation passes 307 Ruby runs/632 assertions with one existing Windows platform skip and 89.43% line/72.55% branch coverage; 17 schema and 40 runner tests; the valid 38-case/61-file corpus; 37 TypeScript, 12 Rust, and five Swift shared discovery consumers; Go test/vet/trimpath build; zero-advisory current Ruby dependencies; Security lint; collision-clean 1,230-identity/4,378-slot inventory; JSON, diff, and credential checks. The exact real plans contain 4,776 unique Ruby identities with no backslash paths; Go, Rust, and Lua package and edge sets match Go exactly at 301/936, 928/2,250, and 258/383. The separately logged Elixir semantic delta is 13 set differences, and the build-file gate reproduces only the exact ten already-owned Lua BUILD_windows debts. Ready PR #9691 opened at exact head 122c1894d00893b182f58f1c98b27efc72df9cc6. Guarded squash auto-completion merged exact head 5a499cdfe11a741bc11c5f0f1cfaf937f0e6c069 as 9ad8105f384d692196e93221fe6b5c619754dd84 after all 17 checks were terminal: twelve succeeded, four skipped, and one completed neutrally."
     },
     {
       "id": "build-tool-elixir-resolution-semantic-parity",
@@ -428,11 +428,11 @@
     {
       "id": "build-tool-go-language-identity-registry",
       "title": "Bring Go build-tool discovery to the complete canonical language registry",
-      "status": "pending",
+      "status": "pr-open",
       "depends_on": ["build-tool-fixtures"],
-      "branch": null,
-      "pr_number": null,
-      "notes": "Discovered by the real full-plan comparison for the Ruby identity slice. Ruby and Go both discover 4,776 packages, but Go classifies all fourteen Mosaic packages and programs as unknown while Ruby follows the shared canonical registry and preserves mosaic/programs identities. Make Go consume the existing language-registry and duplicate-identity fixtures, include every canonical and retained host bucket, exclude specification fixture trees, and prove a collision-free full plan without widening into the separately owned resolver-semantic edges."
+      "branch": "codex/build-tool-go-language-identity-registry",
+      "pr_number": 9703,
+      "notes": "Discovered by the real full-plan comparison for the Ruby identity slice. Ruby and Go both discovered 4,776 packages, but Go classified all fourteen Mosaic packages and programs as unknown while Ruby followed the shared canonical registry and preserved mosaic/programs identities. Selected after PR #9691 merged and the collision-clean 9ad8105f inventory because this unblocked, shared-fixture-backed repository primitive precedes the independent Elixir semantic, Haskell/Elixir UTF-8, and leaf-package items. The implementation now recognizes every canonical, emerging, target, domain, build, and retained host bucket only at an exact packages/programs boundary; preserves program identities; excludes specification and build-artifact trees; and rejects collisions with the typed, root-redacted DUPLICATE_PACKAGE_IDENTITY contract and CLI exit 2. On rebased base b42d1683, exact-head validation passes gofmt, all Go tests at 73.6% aggregate coverage and 93.9% discovery coverage, go vet, the race detector, trimpath build, module verification, govulncheck with zero reachable vulnerabilities, 17 schema tests, 40 runner tests, and the valid 38-case/61-file fixture corpus. Independent Go and Ruby real plans match all 4,779 (name, language, rel_path) tuples with zero duplicates or backslashes, all 14 Mosaic identities canonical, and only the intentional unknown/blog bucket. The committed Go-lane dry-run selects 13 of 301 packages and skips 288. The full standalone validator reproduces the separately owned 73-gap debt gate: 12 Python, 3 Swift, and 58 TypeScript. Ready PR #9703 opened at initial head d58b29bb after the exact-base validation; the state-only PR transition will establish the monitored exact head."
     },
     {
       "id": "build-tool-perl-runtime-security-floor",
@@ -1007,7 +1007,7 @@
       "depends_on": ["rust-singletons-20260730-classification"],
       "branch": null,
       "pr_number": null,
-      "notes": "Discovered in the collision-clean ec53a3f9 inventory after PR #9615 added Rust-only venture-browser-qt. Reconcile its deterministic BrowserHostController projection, Mosaic event decoding, input normalization, and C-ABI state/error contract with venture-browser-core and the Windows/macOS bridge owners, using shared language-neutral fixtures where portable. Classify Cairo rasterization, Qt Quick/QML registration, dynamic-library loading, C++ adapter code, native pointer and buffer lifetimes, CMake/Qt discovery, and live application launch as native-source or wrapper behavior with direct platform tests rather than all-language gaps."
+      "notes": "Discovered in the collision-clean ec53a3f9 inventory after PR #9615 added Rust-only venture-browser-qt. Reconcile its deterministic BrowserHostController projection, Mosaic event decoding, input normalization, and C-ABI state/error contract with venture-browser-core and the Windows/macOS bridge owners, using shared language-neutral fixtures where portable. Classify Cairo rasterization, Qt Quick/QML registration, dynamic-library loading, C++ adapter code, native pointer and buffer lifetimes, CMake/Qt discovery, and live application launch as native-source or wrapper behavior with direct platform tests rather than all-language gaps. The collision-clean 481a30c3 inventory adds venture-browser-cairo under this same owner: it centralizes the backend-neutral native session and Cairo RGBA renderer behind unsafe Qt, Flutter, and Compose C ABIs, while reusable controller, event, navigation, scrolling, hover, link, and projection behavior remains owned by venture-browser-core fixtures."
     },
     {
       "id": "smart-home-camera-media-security-boundary-hardening",
@@ -1599,6 +1599,24 @@
       "branch": null,
       "pr_number": null,
       "notes": "Keep both emerging until package/scaffold/build-tool maturity and applicability are explicit."
+    },
+    {
+      "id": "chief-process-supervisor-native-authority-review",
+      "title": "Review the Chief process supervisor native-authority exception",
+      "status": "pending",
+      "depends_on": ["chief-service-reconciler-portable-conformance", "chief-host-control-protocol-portable-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-clean 9ad8105f inventory after PR #9687 added Rust-only chief-of-staff-process-supervisor. The crate is explicitly the concrete OS-process authority: it re-verifies package files, executes and signals child processes, owns pipes and reaping, reads and sleeps against monotonic time, and performs secure bootstrap over portable dependency contracts. Review and record native-lane exceptions after the service-reconciler and host-control protocol cores are fixture-complete; do not create unsafe all-language process-control ports."
+    },
+    {
+      "id": "chief-orchestrator-core-portable-conformance",
+      "title": "Fixture and expand the portable Chief orchestrator core",
+      "status": "pending",
+      "depends_on": ["chief-channel-endpoints-portable-conformance", "chief-service-reconciler-portable-conformance", "chief-process-supervisor-native-authority-review"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-clean 481a30c3 inventory after PR #9696 added Rust-only chief-of-staff-orchestrator-core. The zero-capability, transport-independent core composes injected storage, supervisor, channel authorization, and monotonic time. Define language-neutral fixtures for stable host registration/listing, desired-state transitions, bounded one-tick reconciliation, clock regression, health inspection, safe deregistration, authorize-before-mutate channel creation/destruction, idempotency, stable errors, and payload-blind/keyless behavior. Expand only after the channel endpoint and service reconciler contracts land and the concrete process supervisor has a reviewed native-authority exception."
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -883,12 +883,15 @@ jobs:
   # individual label cannot be required by branch protection: a PR that does
   # not produce that label would have the check "expected" forever and never
   # merge. Requiring THIS job instead gives branch protection one stable
-  # context (`CI gate`) that passes only when every required job succeeded —
-  # or was legitimately skipped (e.g. an empty build matrix when nothing
-  # relevant changed). `if: always()` makes the gate itself run even when a
+  # pull-request context (`CI gate`) that passes only when every required job
+  # succeeded — or was legitimately skipped (e.g. an empty build matrix when
+  # nothing relevant changed). Push workflows deliberately publish `CI push
+  # gate` instead: using the protected context for both events lets a faster
+  # branch push satisfy protection while the pull-request macOS/Windows matrix
+  # is still running. `if: always()` makes the gate itself run even when a
   # dependency failed, so it can report the failure rather than being skipped.
   ci-gate:
-    name: CI gate
+    name: ${{ github.event_name == 'pull_request' && 'CI gate' || 'CI push gate' }}
     needs: [detect, phy00-phy01-fixture-consumers, build]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,7 +351,7 @@ jobs:
           go-version: '1.23'
 
       - name: Set up Python
-        if: needs.detect.outputs.needs_python == 'true' || runner.os == 'Windows'
+        if: needs.detect.outputs.needs_python == 'true' || runner.os == 'Windows' || runner.os == 'macOS'
         uses: actions/setup-python@v5
         with:
           python-version: '3.13'
@@ -360,7 +360,11 @@ jobs:
       - name: Test ADJ Windows Job containment
         if: runner.os == 'Windows'
         shell: pwsh
-        run: python -m unittest discover -s code/scripts/tests -p test_adj_stdlib_provenance.py -k windows_job
+        run: python -m unittest discover -s code/scripts/tests -p test_adj_stdlib_provenance.py -k windows_job -k process_tree -k windows_containment -k job_close_root
+
+      - name: Test ADJ POSIX process-group containment
+        if: runner.os == 'macOS'
+        run: python3 -m unittest discover -s code/scripts/tests -p test_adj_stdlib_provenance.py -k posix_process -k process_tree
 
       - name: Install uv
         if: needs.detect.outputs.needs_python == 'true'

--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -78,9 +78,10 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B08 | Complete (#9680) | Publish Punjabi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
 | HL-B09 | Complete (#9683) | Remove Punjabi's LaTeX layout, duplicate-label, font-shape, and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Gurmukhi, natural page bottoms, explicit static-font shapes, and a shorter running title make the forced six-chapter build warning-free. |
 | HL-B10 | Complete (#9690) | Publish Sanskrit Chapter 6 from its three canonical lessons rather than hand-copying another book chapter. | All three schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
-| HL-B11 | Complete in this PR | Remove Sanskrit's LaTeX layout, duplicate-label, font-shape, and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Devanagari, natural page bottoms, explicit static-font shapes, and shorter running titles make the forced six-chapter build warning-free. |
-| HL-B12 | Next | Publish Bengali Chapter 6 from its canonical lesson rather than hand-copying another book chapter. | The duration audit confirms authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
-| HL-B13 | Queued | Remove Bengali's missing glyphs and LaTeX layout/bookmark warnings. | A forced build succeeds but reports six missing glyphs, one overfull box, four underfull boxes, four duplicate practice labels, and 27 Hyperref warnings; the clean-build signal is zero of each. |
+| HL-B11 | Complete (#9698) | Remove Sanskrit's LaTeX layout, duplicate-label, font-shape, and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Devanagari, natural page bottoms, explicit static-font shapes, and shorter running titles make the forced six-chapter build warning-free. |
+| HL-B12 | Complete in this PR | Publish Bengali Chapter 6 from its canonical lesson rather than hand-copying another book chapter. | The schema-v2 lesson now generates the PDF chapter from the same source hash independently verified by Language Ladder. |
+| HL-B13 | Next | Remove Bengali's missing glyphs and LaTeX layout/bookmark warnings. | A forced six-chapter build succeeds but reports six missing glyphs, one overfull box, five underfull boxes, four duplicate practice labels, 27 Hyperref warnings, and three font-shape warnings; the clean-build signal is zero of each. |
+| HL-I01 | Queued | Reduce unified all-books workflow setup time without splitting the single publication bundle. | The exact-merge Sanskrit cleanup run spent seven minutes installing TeX Live, while a redundant PR run remained there beyond eighteen minutes; cache or pre-bake the toolchain and keep all 20 books plus bundle verification in one job. |
 | HL-B14 | Queued | Publish Italian Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Italian has canonical app content through Chapter 17, but its downloadable PDF contains only Chapter 1; schema-v2 migration plus generation should close that drift safely. |
 | HL-B15 | Queued | Remove Italian's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds but reports one underfull box and three Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B16 | Queued | Publish Portuguese Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Portuguese has canonical app content through Chapter 17, but its downloadable PDF contains only Chapter 1; schema-v2 migration plus generation should close that drift safely. |
@@ -448,6 +449,33 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   XeLaTeX build reports zero package or LaTeX warnings, missing glyphs,
   overfull boxes, underfull boxes, and duplicate destinations. HL-B12 is next:
   publish Bengali Chapter 6 through the canonical pipeline.
+
+## Findings from HL-B12
+
+- Bengali Chapter 6 now comes from its canonical schema-v2 lesson. The
+  generator manifest and Language Ladder independently combine the same source
+  hash, so the app and downloadable book cannot drift silently.
+- The lesson realizes `SPINE-COUNT-ONE-TO-FIVE` in a 290-second boundary and
+  extends it with Bengali script, chandrabindu nasalization, the conservative
+  vowel in *dui*, the everyday numeral's simplified *dv-* cluster, and the
+  qualified Assamese/Odia/Nepali comparison.
+- HL-I01 records publication latency observed after HL-B11: content drift and
+  Bengali's warning debt remain learner-visible priorities ahead of optimizing
+  a successful but slow single-job TeX setup.
+- The strict data suite passes all 80 tests; Language Ladder passes all 287
+  tests and its production build. The report remains at 1,065 lessons and 20
+  books with zero duration violations and zero unknown prerequisites, while
+  book drift falls to 252 lesson chapters and Bengali becomes the sixth
+  mixed-schema track.
+- The forced letter-size XeLaTeX build is 29 pages. Visual inspection of all
+  three generated pages found shaped Bengali, width-aware numeral and etymology
+  tables, an intact chandrabindu and recall box, and no clipping. The outline
+  retains the authored `ek dui tin chār pā̃ch` bookmark.
+- The generated chapter adds one visually benign underfull-page warning but no
+  new missing glyph, overfull, duplicate-label, bookmark, or font warning. The
+  full build's six missing glyphs, one overfull box, five underfull boxes, four
+  duplicate recap labels, 27 Hyperref warnings, and three font-shape warnings
+  are recorded accurately in HL-B13.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -67,7 +67,7 @@ edition is authored.
 | [Hindi](./hindi/README.md) | Indo-Aryan / Devanagari | Chapters 1-2 authored (lessons + book) |
 | [Marathi](./marathi/README.md) | Indo-Aryan / Devanagari | Chapters 1-6 authored (lessons + book) |
 | [Punjabi](./punjabi/README.md) | Indo-Aryan / Gurmukhi (vendored font) | Chapters 1-6 authored (lessons + book, script inline) |
-| [Bengali](./bengali/README.md) | Indo-Aryan / Bengali (vendored font) | Chapter 1 (Greetings) authored (lessons + book) |
+| [Bengali](./bengali/README.md) | Indo-Aryan / Bengali (vendored font) | Chapters 1–6 authored (lessons + book; Chapter 6 canonical/generated) |
 | [Gujarati](./gujarati/README.md) | Indo-Aryan / Gujarati (vendored font) | Chapters 1-6 authored (lessons + book, script inline) |
 | [Tamil](./tamil/README.md) | Dravidian / Tamil (vendored font) | Chapters 1-2 authored (lessons + book) |
 | [Kannada](./kannada/README.md) | Dravidian / Kannada (vendored font) | Chapters 1-2 authored (lessons + book) |

--- a/code/learning/human-languages/bengali/CHANGELOG.md
+++ b/code/learning/human-languages/bengali/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Canonical Chapter 6 publication — 2026-08-03
+
+- Migrated the numbers lesson to schema v2 with the shared
+  `SPINE-COUNT-ONE-TO-FIVE` can-do node, a 290-second ceiling, and block-level
+  knowledge closure.
+- Generated the downloadable Chapter 6 from the same lesson AST and source hash
+  that Language Ladder loads instead of maintaining a second content copy.
+- Preserved Bengali numeral forms, the chandrabindu note, the qualified history
+  of *dui*, and bookmark-safe romanization in the generated chapter; the book
+  preamble now supplies the shared width-aware table renderer it uses.
+
 ## Sub-five-minute remediation — 2026-08-02
 
 - Corrected eleven declared five-minute estimates whose computed durations were

--- a/code/learning/human-languages/bengali/README.md
+++ b/code/learning/human-languages/bengali/README.md
@@ -39,11 +39,17 @@ book.
 - **Chapter 5 — First Verbs** ([`lessons/BN-C05-*`](./lessons/)): bôlā, **āmi
   bānglā bôli**, thākā (← *sthā* → *stand/stay*), kāj kôrā, practice. The verb
   never changes for gender. In the book.
+- **Chapter 6 — Numbers 1–5** ([`lessons/BN-C06-*`](./lessons/)): *ek, dui, tin,
+  chār, pā̃ch*, the chandrabindu, and the conservative vowel in *dui*. In the
+  book from the same canonical schema-v2 lesson AST and source hash that
+  Language Ladder loads.
 
 ## Book / fonts
 
 Compiles with XeLaTeX using the **vendored** Noto Sans Bengali font
 (`../../_fonts/NotoSansBengali-Static.ttf`). `latexmk -xelatex book.tex`.
+Chapter 6 is generated from the canonical lesson; its Bengali-script runs use
+that font while its section bookmarks use authored romanization.
 
 ## Files
 

--- a/code/learning/human-languages/bengali/book/book.tex
+++ b/code/learning/human-languages/bengali/book/book.tex
@@ -74,4 +74,6 @@ Released under CC~BY-SA~4.0.
 
 \input{chapters/ch05-first-verbs}
 
+\input{chapters/ch06-numbers-1-5}
+
 \end{document}

--- a/code/learning/human-languages/bengali/book/chapters/ch06-numbers-1-5.tex
+++ b/code/learning/human-languages/bengali/book/chapters/ch06-numbers-1-5.tex
@@ -1,0 +1,76 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:28baeae54e13a2dc
+% canonical-lessons: BN-C06-numbers-1-5
+
+\chapter{Numbers One to Five}
+\label{ch:numbers-one-to-five}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[ek dui tin chār pā̃ch]{\bn{এক}, \bn{দুই}, \bn{তিন}, \bn{চার}, \bn{পাঁচ} — one to five}
+
+\label{lesson:BN-C06-numbers-1-5}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Bengali writes in its own script, but the words underneath are the same family you'd hear in Delhi or Mumbai — with one number that preserves something both of them lost.
+\end{quote}
+
+\subsection*{You'll want to know: the five}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{Bengali} & \textbf{said} \\
+\midrule
+1 & \textbf{\bn{এক}} & \emph{ek} \\
+2 & \textbf{\bn{দুই}} & \emph{dui} \\
+3 & \textbf{\bn{তিন}} & \emph{tin} \\
+4 & \textbf{\bn{চার}} & \emph{chār} \\
+5 & \textbf{\bn{পাঁচ}} & \emph{pā̃ch} \\
+\bottomrule
+\end{tabularx}
+
+The \textbf{\bn{ঁ}} on \emph{pā̃ch} is the \textbf{chandrabindu}, the same moon-dot Hindi uses, nasalising the vowel.
+
+\begin{cousinweb}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{2} \\
+\midrule
+Sanskrit & stem \emph{dvá-} (masc. \emph{dváu}, fem./neut. \emph{dvé}) \\
+Prakrit & \emph{do} / \emph{duve} \\
+Hindi & \emph{do} \\
+Marathi & \emph{don} \\
+\textbf{Bengali} & \emph{\textbf{dui}} \\
+\bottomrule
+\end{tabularx}
+
+Hindi and Marathi flattened the old form into a single \emph{o}. Bengali kept a trace of the following \textbf{-i}, which is why it has two syllables where its neighbours have one.
+
+The \emph{dv-} cluster itself is gone from the \textbf{numeral} in all of them. (Not from the languages — \emph{dv-} is alive in words borrowed straight back out of Sanskrit, like Bengali \textbf{\bn{দ্বার}} \emph{dvār} "door." It's the everyday inherited word that simplified.)
+
+And Bengali isn't unique in keeping that vowel: \textbf{Assamese, Odia and Nepali} have \emph{dui} too. Among the four languages in this chapter it stands alone; across the eastern Indo-Aryan languages it has plenty of company.
+\end{cousinweb}
+
+\begin{sounds}
+Bengali's inherent vowel leans toward \textbf{o}, not \emph{a} — which is why the greeting from Chapter 1 is \emph{nomoshkar} where Hindi says \emph{namaskār}.
+
+You won't hear that in these five numbers, as it happens: \textbf{\bn{এক}} opens with the independent vowel \bn{এ}, and none of the others has a bare inherent-vowel syllable either. Mentioned so you don't go looking for it here — but keep it in mind the moment a word does have one.
+
+Don't let a neighbouring language's spelling tell you how Bengali sounds.
+\end{sounds}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "ek, dui, tin, chār, pā̃ch"{]}
+  \item {[}YOU SAY: the twos — "dvá- … do … don … \textbf{dui}"{]}
+  \item {[}YOU SAY: the Ch. 1 echo — "\textbf{no}moshkar, not \textbf{na}maskār"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Count to five in Bengali. (\emph{Ek, dui, tin, chār, pā̃ch}.) What does \textbf{\bn{দুই}} keep that Hindi and Marathi flattened away? (\textbf{The following \emph{-i}}, which is why it has two syllables.) Is Bengali alone in that? (\textbf{No} — Assamese, Odia and Nepali have \emph{dui} too; it's alone only among the four here.) Did the \emph{dv-} cluster survive anywhere in the everyday numeral? (\textbf{No} — though \emph{dv-} is alive in words re-borrowed from Sanskrit, like \emph{dvār} "door".) What is the \textbf{\bn{ঁ}}? (The \textbf{chandrabindu}, nasalising the vowel.) Next: six to ten.
+\end{tcolorbox}

--- a/code/learning/human-languages/bengali/book/preamble.tex
+++ b/code/learning/human-languages/bengali/book/preamble.tex
@@ -19,6 +19,7 @@
 \tcbuselibrary{skins,breakable}
 \usepackage{booktabs}
 \usepackage{longtable}
+\usepackage{tabularx}
 \usepackage{array}
 \usepackage[hidelinks]{hyperref}
 \usepackage{titlesec}

--- a/code/learning/human-languages/bengali/lessons/BN-C06-numbers-1-5.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C06-numbers-1-5.md
@@ -1,27 +1,45 @@
 ---
+schema_version: 2
 id: BN-C06-numbers-1-5
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 340
 chapter: 6
 type: word
 headword: এক দুই তিন চার পাঁচ
+romanization: ek dui tin chār pā̃ch
 gloss: one to five — and the "two" that kept its Sanskrit vowel
 concept_tag: BN-NUMBERS-1-5
 prerequisites: [BN-C01-nomoshkar]
 sounds: [long-aa, chandrabindu-nasal, i-sign]
 roots: [sanskrit-dvi, sanskrit-panca]
 etymology_hook: "Bengali দুই dui keeps a trace of the vowel following the old dv- that Hindi and Marathi flattened into do/don — which is why it has two syllables where they have one; it shares this with Assamese, Odia and Nepali, and is unusual only among the four languages compared here"
-est_minutes: 4
+duration:
+  max_seconds: 290
+requires:
+  knowledge: []
+introduces:
+  knowledge: [BN-LEX-NUMBERS-ONE-TO-FIVE, BN-SCRIPT-CHANDRABINDU-NASAL, BN-ETYMON-DUI-COMPARISON, BN-HISTORY-DV-NUMERAL-SIMPLIFICATION, BN-HISTORY-DUI-AREAL-COMPANY, BN-SOUND-INHERENT-O-NOT-IN-NUMBERS]
+practises:
+  knowledge: [BN-LEX-NUMBERS-ONE-TO-FIVE, BN-SCRIPT-CHANDRABINDU-NASAL, BN-ETYMON-DUI-COMPARISON, BN-HISTORY-DV-NUMERAL-SIMPLIFICATION, BN-HISTORY-DUI-AREAL-COMPANY, BN-SOUND-INHERENT-O-NOT-IN-NUMBERS]
+skills: [listening, speaking, reading]
+modes: [interpretive, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [BN-C01-nomoshkar]
 ---
 
 # এক, দুই, তিন, চার, পাঁচ — one to five
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Bengali writes in its own script, but the words underneath are the
 same family you'd hear in Delhi or Mumbai — with one number that preserves
 something both of them lost.
 
-## The five
+## You'll want to know: the five
+<!-- hl-knowledge: introduces=[BN-LEX-NUMBERS-ONE-TO-FIVE, BN-SCRIPT-CHANDRABINDU-NASAL]; assesses=[] -->
 
 | | Bengali | said |
 |---|---|---|
@@ -34,7 +52,8 @@ something both of them lost.
 The **ঁ** on *pā̃ch* is the **chandrabindu**, the same moon-dot Hindi uses,
 nasalising the vowel.
 
-## দুই — the conservative two
+## The word, taken apart — দুই and the conservative two
+<!-- hl-knowledge: introduces=[BN-ETYMON-DUI-COMPARISON, BN-HISTORY-DV-NUMERAL-SIMPLIFICATION, BN-HISTORY-DUI-AREAL-COMPANY]; assesses=[] -->
 
 | language | 2 |
 |---|---|
@@ -57,7 +76,8 @@ And Bengali isn't unique in keeping that vowel: **Assamese, Odia and Nepali**
 have *dui* too. Among the four languages in this chapter it stands alone; across
 the eastern Indo-Aryan languages it has plenty of company.
 
-## A note on how Bengali sounds
+## Sounds you'll need: where Bengali's inherent *ô* does not appear
+<!-- hl-knowledge: introduces=[BN-SOUND-INHERENT-O-NOT-IN-NUMBERS]; assesses=[] -->
 
 Bengali's inherent vowel leans toward **o**, not *a* — which is why the greeting
 from Chapter 1 is *nomoshkar* where Hindi says *namaskār*.
@@ -70,6 +90,7 @@ moment a word does have one.
 Don't let a neighbouring language's spelling tell you how Bengali sounds.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[BN-LEX-NUMBERS-ONE-TO-FIVE, BN-ETYMON-DUI-COMPARISON, BN-SOUND-INHERENT-O-NOT-IN-NUMBERS] -->
 
 [PAUSE 1s]
 - [YOU SAY: "ek, dui, tin, chār, pā̃ch"]
@@ -77,6 +98,7 @@ Don't let a neighbouring language's spelling tell you how Bengali sounds.
 - [YOU SAY: the Ch. 1 echo — "**no**moshkar, not **na**maskār"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[BN-LEX-NUMBERS-ONE-TO-FIVE, BN-SCRIPT-CHANDRABINDU-NASAL, BN-ETYMON-DUI-COMPARISON, BN-HISTORY-DV-NUMERAL-SIMPLIFICATION, BN-HISTORY-DUI-AREAL-COMPANY, BN-SOUND-INHERENT-O-NOT-IN-NUMBERS] -->
 
 [PAUSE 3s] Count to five in Bengali. (*Ek, dui, tin, chār, pā̃ch*.) What does
 **দুই** keep that Hindi and Marathi flattened away? (**The following *-i***,

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -44,6 +44,15 @@
       "output": "spanish/book/chapters/ch06-first-verbs.tex"
     },
     {
+      "language": "bengali",
+      "chapter": 6,
+      "title": "Numbers One to Five",
+      "label": "ch:numbers-one-to-five",
+      "output": "bengali/book/chapters/ch06-numbers-1-5.tex",
+      "unicodeScript": "Bengali",
+      "scriptCommand": "bn"
+    },
+    {
       "language": "gujarati",
       "chapter": 6,
       "title": "Numbers One to Five",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -3,6 +3,15 @@
   "algorithm": "fnv1a64",
   "chapters": [
     {
+      "language": "bengali",
+      "chapter": 6,
+      "sourceHash": "fnv1a64:28baeae54e13a2dc",
+      "lessonIds": [
+        "BN-C06-numbers-1-5"
+      ],
+      "tex": "bengali/book/chapters/ch06-numbers-1-5.tex"
+    },
+    {
       "language": "gujarati",
       "chapter": 6,
       "sourceHash": "fnv1a64:388a6950ab136cc1",

--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite MOS model-card `PB` values before
+  lowering valid bulk-junction potentials.
 - Reject negative and non-finite MOS model-card `JS` values before lowering
   valid junction saturation-current densities.
 - Reject negative and non-finite MOS model-card `CJSW` values before lowering

--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS model-card `MJ` values before lowering
+  valid bottom-junction grading coefficients.
 - Reject zero, negative, and non-finite MOS model-card `PB` values before
   lowering valid bulk-junction potentials.
 - Reject negative and non-finite MOS model-card `JS` values before lowering

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1985,6 +1985,10 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(params["PB"]) or params["PB"] <= 0.0
         ):
             raise NetlistParseError("MOSFET PB must be finite and positive")
+        if "MJ" in params and (
+            not math.isfinite(params["MJ"]) or params["MJ"] < 0.0
+        ):
+            raise NetlistParseError("MOSFET MJ must be finite and non-negative")
         nominal_temperature = params.get("T_NOM", params.get("TNOM"))
         if nominal_temperature is not None and (
             not math.isfinite(nominal_temperature) or nominal_temperature <= 0.0

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1981,6 +1981,10 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(params["JS"]) or params["JS"] < 0.0
         ):
             raise NetlistParseError("MOSFET JS must be finite and non-negative")
+        if "PB" in params and (
+            not math.isfinite(params["PB"]) or params["PB"] <= 0.0
+        ):
+            raise NetlistParseError("MOSFET PB must be finite and positive")
         nominal_temperature = params.get("T_NOM", params.get("TNOM"))
         if nominal_temperature is not None and (
             not math.isfinite(nominal_temperature) or nominal_temperature <= 0.0

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1897,6 +1897,26 @@ def test_lowers_valid_mosfet_model_junction_current(
     assert isclose(mosfet.model.model.params.JS, expected)
 
 
+@pytest.mark.parametrize("bulk_potential", ["0", "-0.1", "1e999"])
+def test_rejects_invalid_mosfet_model_bulk_potential(
+    bulk_potential: str,
+) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="MOSFET PB must be finite and positive",
+    ):
+        parse_netlist(
+            f".model nfast NMOS(PB={bulk_potential})\nM1 d g s b nfast\n"
+        )
+
+
+def test_lowers_positive_mosfet_model_bulk_potential() -> None:
+    parsed = parse_netlist(".model nfast NMOS(PB=0.72)\nM1 d g s b nfast\n")
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(mosfet.model.model.params.PB, 0.72)
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1917,6 +1917,31 @@ def test_lowers_positive_mosfet_model_bulk_potential() -> None:
     assert isclose(mosfet.model.model.params.PB, 0.72)
 
 
+@pytest.mark.parametrize("grading_coefficient", ["-0.1", "1e999"])
+def test_rejects_invalid_mosfet_model_junction_grading(
+    grading_coefficient: str,
+) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="MOSFET MJ must be finite and non-negative",
+    ):
+        parse_netlist(
+            f".model nfast NMOS(MJ={grading_coefficient})\nM1 d g s b nfast\n"
+        )
+
+
+@pytest.mark.parametrize("grading_coefficient", ["0", "0.45"])
+def test_lowers_valid_mosfet_model_junction_grading(
+    grading_coefficient: str,
+) -> None:
+    parsed = parse_netlist(
+        f".model nfast NMOS(MJ={grading_coefficient})\nM1 d g s b nfast\n"
+    )
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(mosfet.model.model.params.MJ, float(grading_coefficient))
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -926,6 +926,7 @@ members = [
     "smart-home-lifx-lan-integration",
     "smart-home-kasa-lan-integration",
     "smart-home-reolink-integration",
+    "smart-home-axis-vapix-integration",
     "smart-home-roku-ecp-integration",
     "smart-home-sonos-upnp-integration",
     "smart-home-heos-cli-integration",

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -927,6 +927,7 @@ members = [
     "smart-home-lifx-lan-integration",
     "smart-home-kasa-lan-integration",
     "smart-home-reolink-integration",
+    "smart-home-axis-vapix-integration",
     "smart-home-roku-ecp-integration",
     "smart-home-sonos-upnp-integration",
     "smart-home-heos-cli-integration",

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -725,6 +725,7 @@ members = [
     "ieee802154-core",
     "ieee802154-security",
     "http1",
+    "websocket-core",
     "http1-client",
     "storage-core",
     "storage-local-folder",

--- a/code/packages/rust/smart-home-axis-vapix-integration/BUILD
+++ b/code/packages/rust/smart-home-axis-vapix-integration/BUILD
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cargo test -p smart-home-axis-vapix-integration

--- a/code/packages/rust/smart-home-axis-vapix-integration/BUILD
+++ b/code/packages/rust/smart-home-axis-vapix-integration/BUILD
@@ -1,4 +1,1 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
 cargo test -p smart-home-axis-vapix-integration

--- a/code/packages/rust/smart-home-axis-vapix-integration/CHANGELOG.md
+++ b/code/packages/rust/smart-home-axis-vapix-integration/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Add Axis video/NVR mDNS discovery records.
+- Add HTTPS Basic-auth VAPIX device and API inspection with Vault-backed plans.
+- Add authorized D23 runtime installation and real loopback HTTP transport proof.

--- a/code/packages/rust/smart-home-axis-vapix-integration/Cargo.toml
+++ b/code/packages/rust/smart-home-axis-vapix-integration/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "smart-home-axis-vapix-integration"
+version = "0.1.0"
+edition = "2021"
+description = "Authenticated Axis VAPIX discovery and inspection for the smart-home runtime"
+license = "MIT"
+
+[dependencies]
+base64 = "0.22"
+coding_adventures_zeroize = { path = "../zeroize" }
+http-core = { path = "../http-core" }
+http1 = { path = "../http1" }
+serde_json = "1"
+smart-home-core = { path = "../smart-home-core" }
+smart-home-discovery = { path = "../smart-home-discovery" }
+smart-home-local-http = { path = "../smart-home-local-http" }
+smart-home-runtime = { path = "../smart-home-runtime" }
+tls-platform = { path = "../tls-platform" }
+url-parser = { path = "../url-parser" }

--- a/code/packages/rust/smart-home-axis-vapix-integration/README.md
+++ b/code/packages/rust/smart-home-axis-vapix-integration/README.md
@@ -1,0 +1,27 @@
+# smart-home-axis-vapix-integration
+
+Production-facing Axis VAPIX discovery and read-only inspection for D23.
+
+The package:
+
+- discovers documented `_axis-video._tcp.local` and `_axis-nvr._tcp.local`
+  advertisements through the shared mDNS runtime;
+- requires credential-free HTTPS origins for production, with plain HTTP
+  permitted only for loopback transport tests;
+- represents credentials as a `VaultRef` in request plans and materializes the
+  Basic authorization value only inside the bounded transport;
+- calls the authenticated Basic Device Information and API Discovery JSON CGIs;
+- normalizes Axis identity, firmware, product type, and the supported VAPIX API
+  list into one confirmed camera entity; and
+- authorizes D23 reads before credentials or transport are touched.
+
+PTZ control, event streaming, snapshots, and media transfer remain separate
+slices because they require capability/permission probes, event lifecycle, or a
+camera-media executor beyond identity inspection.
+
+Protocol references:
+
+- [Axis VAPIX authentication](https://developer.axis.com/vapix/authentication/)
+- [Axis basic device information](https://developer.axis.com/vapix/network-video/basic-device-information/)
+- [Axis API Discovery](https://developer.axis.com/vapix/network-video/api-discovery-service/)
+- [Axis mDNS-SD](https://developer.axis.com/vapix/network-video/mdns-sd-api/)

--- a/code/packages/rust/smart-home-axis-vapix-integration/src/lib.rs
+++ b/code/packages/rust/smart-home-axis-vapix-integration/src/lib.rs
@@ -1,0 +1,1207 @@
+//! Authenticated Axis VAPIX discovery and inspection for D23.
+
+#![forbid(unsafe_code)]
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use coding_adventures_zeroize::Zeroizing;
+use http1::{parse_response_head, Http1ParseError};
+use http_core::BodyKind;
+use serde_json::{json, Map as JsonMap, Value as JsonValue};
+use smart_home_core::{
+    AgentId, Bridge, BridgeId, BridgeTransport, Capability, CapabilityId, CapabilityMode, Device,
+    DeviceId, Entity, EntityId, EntityKind, Health, IntegrationId, Metadata, ProtocolFamily,
+    ProtocolIdentifier, SmartHomeTool, StateConfidence, StateSnapshot, StateSource, Value,
+    ValueKind, VaultRef,
+};
+use smart_home_discovery::{
+    run_mdns_ipv4_scan, DiscoveryConfidence, DiscoveryRecord, DiscoverySource, MdnsAdvertisement,
+    MdnsScanOptions, MdnsScanResult, PairingRequirement,
+};
+use smart_home_local_http::{
+    LocalHttpAuth, LocalHttpEndpoint, LocalHttpError, LocalHttpMethod, LocalHttpRequestPlan,
+    LocalHttpRequestTemplate, LocalHttpScheme,
+};
+use smart_home_runtime::{RuntimeError, SmartHomeRuntime};
+use std::collections::BTreeSet;
+use std::fmt;
+use std::io::{self, Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::time::Duration;
+use tls_platform::{default_connector, TlsConfig, TlsConnector};
+use url_parser::{Url, UrlError};
+
+pub const VERSION: &str = "0.1.0";
+pub const INTEGRATION_ID: &str = "axis_vapix";
+pub const PROTOCOL_ID: &str = "axis_vapix";
+pub const VIDEO_MDNS_SERVICE_TYPE: &str = "_axis-video._tcp.local";
+pub const NVR_MDNS_SERVICE_TYPE: &str = "_axis-nvr._tcp.local";
+pub const BASIC_DEVICE_INFO_PATH: &str = "/axis-cgi/basicdeviceinfo.cgi";
+pub const API_DISCOVERY_PATH: &str = "/axis-cgi/apidiscovery.cgi";
+pub const DEFAULT_MAX_DISCOVERY_RESPONSES: usize = 128;
+pub const DEFAULT_MAX_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
+
+#[derive(Debug)]
+pub enum AxisError {
+    Validation(String),
+    Discovery(String),
+    LocalHttp(LocalHttpError),
+    Url(UrlError),
+    Io(String),
+    Tls(String),
+    Http(String),
+    HttpStatus(u16),
+    ResponseTooLarge { limit: usize },
+    TruncatedBody { expected: usize, actual: usize },
+    Json(serde_json::Error),
+    Api { code: i64, message: String },
+    MissingField(&'static str),
+    Runtime(RuntimeError),
+}
+
+impl fmt::Display for AxisError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Validation(message) => write!(formatter, "invalid Axis VAPIX input: {message}"),
+            Self::Discovery(message) => write!(formatter, "Axis mDNS discovery failed: {message}"),
+            Self::LocalHttp(error) => error.fmt(formatter),
+            Self::Url(error) => write!(formatter, "invalid Axis VAPIX URL: {error}"),
+            Self::Io(message) => write!(formatter, "Axis LAN I/O failed: {message}"),
+            Self::Tls(message) => write!(formatter, "Axis TLS failed: {message}"),
+            Self::Http(message) => write!(formatter, "invalid Axis HTTP response: {message}"),
+            Self::HttpStatus(status) => write!(formatter, "Axis endpoint returned HTTP {status}"),
+            Self::ResponseTooLarge { limit } => {
+                write!(formatter, "Axis response exceeds {limit} bytes")
+            }
+            Self::TruncatedBody { expected, actual } => write!(
+                formatter,
+                "Axis response is truncated: expected {expected} bytes, got {actual}"
+            ),
+            Self::Json(error) => write!(formatter, "invalid Axis JSON: {error}"),
+            Self::Api { code, message } => {
+                write!(formatter, "Axis VAPIX error {code}: {message}")
+            }
+            Self::MissingField(field) => write!(formatter, "Axis response is missing {field}"),
+            Self::Runtime(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for AxisError {}
+
+impl From<LocalHttpError> for AxisError {
+    fn from(error: LocalHttpError) -> Self {
+        Self::LocalHttp(error)
+    }
+}
+
+impl From<UrlError> for AxisError {
+    fn from(error: UrlError) -> Self {
+        Self::Url(error)
+    }
+}
+
+impl From<serde_json::Error> for AxisError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}
+
+impl From<RuntimeError> for AxisError {
+    fn from(error: RuntimeError) -> Self {
+        Self::Runtime(error)
+    }
+}
+
+pub struct AxisCredentials {
+    username: Zeroizing<String>,
+    password: Zeroizing<String>,
+}
+
+impl AxisCredentials {
+    pub fn new(
+        username: impl Into<String>,
+        password: impl Into<String>,
+    ) -> Result<Self, AxisError> {
+        let username = username.into();
+        let password = password.into();
+        if username.trim().is_empty() || password.is_empty() {
+            return Err(AxisError::Validation(
+                "username and password must not be empty".to_string(),
+            ));
+        }
+        if has_unsafe_http_text(&username) || has_unsafe_http_text(&password) {
+            return Err(AxisError::Validation(
+                "credentials contain unsafe HTTP text".to_string(),
+            ));
+        }
+        Ok(Self {
+            username: Zeroizing::new(username),
+            password: Zeroizing::new(password),
+        })
+    }
+}
+
+impl fmt::Debug for AxisCredentials {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("AxisCredentials([REDACTED])")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AxisConfig {
+    pub bridge_id: BridgeId,
+    pub base_url: String,
+    pub credential_ref: VaultRef,
+    pub timeout: Duration,
+}
+
+impl AxisConfig {
+    pub fn new(
+        bridge_id: BridgeId,
+        base_url: impl Into<String>,
+        credential_ref: VaultRef,
+    ) -> Result<Self, AxisError> {
+        let base_url = base_url.into().trim_end_matches('/').to_string();
+        let parsed = Url::parse(&base_url)?;
+        let host = parsed
+            .host
+            .as_deref()
+            .ok_or(AxisError::MissingField("base URL host"))?;
+        let secure = parsed.scheme == "https";
+        let test_loopback = parsed.scheme == "http" && is_loopback_host(host);
+        if (!secure && !test_loopback)
+            || parsed.userinfo.is_some()
+            || parsed.query.is_some()
+            || parsed.fragment.is_some()
+            || !matches!(parsed.path.as_str(), "" | "/")
+        {
+            return Err(AxisError::Validation(
+                "base URL must be a credential-free HTTPS origin; HTTP is test-only on loopback"
+                    .to_string(),
+            ));
+        }
+        Ok(Self {
+            bridge_id,
+            base_url,
+            credential_ref,
+            timeout: Duration::from_secs(5),
+        })
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout.max(Duration::from_millis(1));
+        self
+    }
+
+    fn endpoint(&self) -> Result<LocalHttpEndpoint, AxisError> {
+        let parsed = Url::parse(&self.base_url)?;
+        let host = parsed
+            .host
+            .as_deref()
+            .ok_or(AxisError::MissingField("base URL host"))?;
+        let scheme = match parsed.scheme.as_str() {
+            "https" => LocalHttpScheme::Https,
+            "http" if is_loopback_host(host) => LocalHttpScheme::Http,
+            _ => {
+                return Err(AxisError::Validation(
+                    "Axis endpoint is not an approved HTTPS or loopback origin".to_string(),
+                ))
+            }
+        };
+        Ok(LocalHttpEndpoint::new(
+            IntegrationId::trusted(INTEGRATION_ID),
+            self.bridge_id.clone(),
+            scheme,
+            host.to_string(),
+        )?
+        .with_port(parsed.port.unwrap_or_else(|| scheme.default_port()))
+        .with_metadata(Metadata::new("http.profile", "axis.vapix")))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AxisDeviceInformation {
+    pub brand: String,
+    pub product_full_name: String,
+    pub product_number: String,
+    pub product_type: String,
+    pub serial_number: String,
+    pub firmware_version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AxisApi {
+    pub id: String,
+    pub version: String,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AxisSnapshot {
+    pub device: AxisDeviceInformation,
+    pub apis: Vec<AxisApi>,
+}
+
+pub fn scan_video_mdns_ipv4(
+    discovered_at_ms: u64,
+    timeout: Duration,
+) -> Result<MdnsScanResult, AxisError> {
+    scan_mdns_ipv4(VIDEO_MDNS_SERVICE_TYPE, discovered_at_ms, timeout)
+}
+
+pub fn scan_nvr_mdns_ipv4(
+    discovered_at_ms: u64,
+    timeout: Duration,
+) -> Result<MdnsScanResult, AxisError> {
+    scan_mdns_ipv4(NVR_MDNS_SERVICE_TYPE, discovered_at_ms, timeout)
+}
+
+fn scan_mdns_ipv4(
+    service_type: &str,
+    discovered_at_ms: u64,
+    timeout: Duration,
+) -> Result<MdnsScanResult, AxisError> {
+    let options = MdnsScanOptions::new(service_type, discovered_at_ms, timeout)
+        .map_err(|error| AxisError::Discovery(error.to_string()))?
+        .with_max_responses(DEFAULT_MAX_DISCOVERY_RESPONSES);
+    run_mdns_ipv4_scan(options).map_err(|error| AxisError::Discovery(error.to_string()))
+}
+
+pub fn discovery_record(advertisement: &MdnsAdvertisement) -> Result<DiscoveryRecord, AxisError> {
+    let service_type = advertisement.service_type.trim_end_matches('.');
+    if ![VIDEO_MDNS_SERVICE_TYPE, NVR_MDNS_SERVICE_TYPE]
+        .iter()
+        .map(|value| value.trim_end_matches('.'))
+        .any(|value| value == service_type)
+    {
+        return Err(AxisError::Validation(format!(
+            "unexpected Axis mDNS service type `{}`",
+            advertisement.service_type
+        )));
+    }
+    let instance_identity = advertisement
+        .instance_name
+        .rsplit_once(" - ")
+        .map(|(_, identity)| identity)
+        .unwrap_or(&advertisement.instance_name);
+    let advertised_identity = advertisement
+        .txt_value("macaddress")
+        .or_else(|| advertisement.txt_value("mac_address"))
+        .unwrap_or(instance_identity);
+    let native_id = stable_component(advertised_identity);
+    if native_id.is_empty() {
+        return Err(AxisError::Validation(
+            "Axis advertisement has no stable identity".to_string(),
+        ));
+    }
+    let scheme = if advertisement.port == 443 {
+        "https"
+    } else {
+        "http"
+    };
+    Ok(DiscoveryRecord::new(
+        IntegrationId::trusted(INTEGRATION_ID),
+        ProtocolFamily::Vendor(PROTOCOL_ID.to_string()),
+        native_id,
+        DiscoverySource::Mdns,
+        BridgeTransport::LanHttp,
+        advertisement.discovered_at_ms,
+    )
+    .map_err(|error| AxisError::Discovery(error.to_string()))?
+    .with_display_name(advertisement.instance_name.clone())
+    .with_address(advertisement.endpoint_with_scheme(scheme))
+    .with_confidence(DiscoveryConfidence::Candidate)
+    .with_pairing_requirement(PairingRequirement::Credentials)
+    .with_metadata(
+        "smart_home.discovery.service_type",
+        &advertisement.service_type,
+    )
+    .with_metadata("axis.discovery.requires_verified_https", "true"))
+}
+
+pub trait AxisTransport {
+    fn execute(
+        &mut self,
+        plan: &LocalHttpRequestPlan,
+        credentials: &AxisCredentials,
+    ) -> Result<Vec<u8>, AxisError>;
+}
+
+pub struct AxisLanTransport {
+    connector: Box<dyn TlsConnector>,
+    tls_config: TlsConfig,
+    maximum_response_bytes: usize,
+}
+
+impl Default for AxisLanTransport {
+    fn default() -> Self {
+        Self::new(default_connector(), TlsConfig::https_default())
+    }
+}
+
+impl AxisLanTransport {
+    pub fn new(connector: Box<dyn TlsConnector>, tls_config: TlsConfig) -> Self {
+        Self {
+            connector,
+            tls_config,
+            maximum_response_bytes: DEFAULT_MAX_RESPONSE_BYTES,
+        }
+    }
+
+    pub fn with_maximum_response_bytes(mut self, maximum: usize) -> Self {
+        self.maximum_response_bytes = maximum.max(1);
+        self
+    }
+}
+
+impl AxisTransport for AxisLanTransport {
+    fn execute(
+        &mut self,
+        plan: &LocalHttpRequestPlan,
+        credentials: &AxisCredentials,
+    ) -> Result<Vec<u8>, AxisError> {
+        let url = Url::parse(&plan.url)?;
+        let host = url
+            .host
+            .as_deref()
+            .ok_or(AxisError::MissingField("request URL host"))?;
+        let port = url
+            .effective_port()
+            .ok_or(AxisError::MissingField("request URL port"))?;
+        if url.scheme == "http" && !is_loopback_host(host) {
+            return Err(AxisError::Validation(
+                "Basic credentials may use HTTP only on loopback tests".to_string(),
+            ));
+        }
+        let timeout = Duration::from_millis(plan.timeout_ms.max(1));
+        let request = Zeroizing::new(encode_http_request(&url, plan, credentials)?);
+        let response = match url.scheme.as_str() {
+            "http" => {
+                let mut stream = connect_tcp(host, port, timeout)?;
+                write_request(&mut stream, &request)?;
+                read_bounded(&mut stream, self.maximum_response_bytes)?
+            }
+            "https" => {
+                let mut config = self.tls_config.clone();
+                config.connect_timeout = timeout;
+                config.read_timeout = Some(timeout);
+                config.write_timeout = Some(timeout);
+                let mut stream = self
+                    .connector
+                    .connect(host, port, &config)
+                    .map_err(|error| AxisError::Tls(error.to_string()))?;
+                write_request(&mut stream, &request)?;
+                let bytes = read_bounded(&mut stream, self.maximum_response_bytes)?;
+                stream
+                    .close_notify()
+                    .map_err(|error| AxisError::Tls(error.to_string()))?;
+                bytes
+            }
+            scheme => {
+                return Err(AxisError::Validation(format!(
+                    "unsupported Axis URL scheme `{scheme}`"
+                )))
+            }
+        };
+        decode_http_response(&response, self.maximum_response_bytes)
+    }
+}
+
+pub struct AxisClient<T> {
+    config: AxisConfig,
+    credentials: AxisCredentials,
+    endpoint: LocalHttpEndpoint,
+    transport: T,
+}
+
+impl<T: AxisTransport> AxisClient<T> {
+    pub fn new(
+        config: AxisConfig,
+        credentials: AxisCredentials,
+        transport: T,
+    ) -> Result<Self, AxisError> {
+        let endpoint = config.endpoint()?;
+        Ok(Self {
+            config,
+            credentials,
+            endpoint,
+            transport,
+        })
+    }
+
+    pub fn config(&self) -> &AxisConfig {
+        &self.config
+    }
+
+    pub fn transport(&self) -> &T {
+        &self.transport
+    }
+
+    pub fn inspect(&mut self) -> Result<AxisSnapshot, AxisError> {
+        let properties = self.post_json(
+            BASIC_DEVICE_INFO_PATH,
+            &json!({"apiVersion":"1.0","context":"smart-home","method":"getAllProperties"}),
+        )?;
+        let apis = self.post_json(
+            API_DISCOVERY_PATH,
+            &json!({"apiVersion":"1.0","context":"smart-home","method":"getApiList"}),
+        )?;
+        parse_snapshot(&properties, &apis)
+    }
+
+    fn post_json(&mut self, path: &str, body: &JsonValue) -> Result<JsonValue, AxisError> {
+        let template = LocalHttpRequestTemplate::new(LocalHttpMethod::Post, path)?
+            .with_accept("application/json")
+            .with_content_type("application/json")
+            .with_timeout_ms(duration_ms(self.config.timeout))
+            .with_idempotent(true)
+            .with_auth(LocalHttpAuth::Basic {
+                vault_ref: self.config.credential_ref.clone(),
+            });
+        let plan = template.plan(&self.endpoint, serde_json::to_vec(body)?)?;
+        let bytes = self.transport.execute(&plan, &self.credentials)?;
+        let value: JsonValue = serde_json::from_slice(&bytes)?;
+        if let Some(error) = value.get("error") {
+            return Err(AxisError::Api {
+                code: error.get("code").and_then(JsonValue::as_i64).unwrap_or(-1),
+                message: error
+                    .get("message")
+                    .and_then(JsonValue::as_str)
+                    .unwrap_or("device rejected request")
+                    .to_string(),
+            });
+        }
+        Ok(value)
+    }
+}
+
+impl<T> fmt::Debug for AxisClient<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AxisClient")
+            .field("config", &self.config)
+            .field("credentials", &"[REDACTED]")
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstalledAxisDevice {
+    pub bridge_id: BridgeId,
+    pub device_id: DeviceId,
+    pub camera_entity_id: EntityId,
+}
+
+pub struct AxisRuntimeIntegration<T> {
+    client: AxisClient<T>,
+}
+
+impl<T: AxisTransport> AxisRuntimeIntegration<T> {
+    pub fn new(client: AxisClient<T>) -> Self {
+        Self { client }
+    }
+
+    pub fn inspect_and_install_authorized(
+        &mut self,
+        runtime: &mut SmartHomeRuntime,
+        principal_id: AgentId,
+        observed_at_ms: u64,
+    ) -> Result<InstalledAxisDevice, AxisError> {
+        authorize_read(runtime, principal_id, observed_at_ms)?;
+        let snapshot = self.client.inspect()?;
+        install_snapshot(runtime, &self.client.config, &snapshot, observed_at_ms)
+    }
+}
+
+pub fn paired_discovery_record(
+    config: &AxisConfig,
+    snapshot: &AxisSnapshot,
+    discovered_at_ms: u64,
+) -> Result<DiscoveryRecord, AxisError> {
+    Ok(DiscoveryRecord::new(
+        IntegrationId::trusted(INTEGRATION_ID),
+        ProtocolFamily::Vendor(PROTOCOL_ID.to_string()),
+        stable_component(&snapshot.device.serial_number),
+        DiscoverySource::Manual,
+        BridgeTransport::LanHttp,
+        discovered_at_ms,
+    )
+    .map_err(|error| AxisError::Discovery(error.to_string()))?
+    .with_display_name(snapshot.device.product_full_name.clone())
+    .with_address(config.base_url.clone())
+    .with_hardware_model(snapshot.device.product_number.clone())
+    .with_firmware_version(snapshot.device.firmware_version.clone())
+    .with_confidence(DiscoveryConfidence::Paired)
+    .with_pairing_requirement(PairingRequirement::Credentials)
+    .with_metadata("axis.protocol", PROTOCOL_ID)
+    .with_metadata("axis.api_count", snapshot.apis.len().to_string()))
+}
+
+pub fn install_snapshot(
+    runtime: &mut SmartHomeRuntime,
+    config: &AxisConfig,
+    snapshot: &AxisSnapshot,
+    observed_at_ms: u64,
+) -> Result<InstalledAxisDevice, AxisError> {
+    let native_id = stable_component(&snapshot.device.serial_number);
+    if native_id.is_empty() {
+        return Err(AxisError::Validation(
+            "device serial does not contain a stable identifier".to_string(),
+        ));
+    }
+    let device_id = DeviceId::trusted(format!("axis:{native_id}"));
+    let camera_entity_id = EntityId::trusted(format!("axis:{native_id}:camera"));
+
+    let mut bridge = Bridge::new(
+        config.bridge_id.clone(),
+        IntegrationId::trusted(INTEGRATION_ID),
+        BridgeTransport::LanHttp,
+    );
+    bridge.address = Some(config.base_url.clone());
+    bridge.hardware_model = Some(snapshot.device.product_number.clone());
+    bridge.firmware_version = Some(snapshot.device.firmware_version.clone());
+    bridge.auth_ref = Some(config.credential_ref.clone());
+    bridge.health = Health::Online;
+    bridge.last_seen_at_ms = Some(observed_at_ms);
+    bridge.identifiers = vec![protocol_identifier("https_endpoint", &config.base_url)?];
+    bridge.metadata = vec![
+        Metadata::new("axis.transport", "authenticated_https_basic"),
+        Metadata::new("axis.api_count", snapshot.apis.len().to_string()),
+    ];
+    runtime.upsert_bridge(bridge)?;
+
+    runtime.upsert_device(Device {
+        device_id: device_id.clone(),
+        bridge_id: config.bridge_id.clone(),
+        manufacturer: snapshot.device.brand.clone(),
+        model: snapshot.device.product_number.clone(),
+        name: snapshot.device.product_full_name.clone(),
+        serial: Some(snapshot.device.serial_number.clone()),
+        firmware_version: Some(snapshot.device.firmware_version.clone()),
+        room_id: None,
+        entity_ids: vec![camera_entity_id.clone()],
+        identifiers: vec![protocol_identifier(
+            "serial",
+            &snapshot.device.serial_number,
+        )?],
+        health: Health::Online,
+        metadata: vec![Metadata::new(
+            "axis.product_type",
+            snapshot.device.product_type.clone(),
+        )],
+    })?;
+
+    runtime.upsert_entity(Entity {
+        entity_id: camera_entity_id.clone(),
+        device_id: device_id.clone(),
+        kind: EntityKind::Camera,
+        name: snapshot.device.product_full_name.clone(),
+        capabilities: vec![Capability::new(
+            CapabilityId::trusted("camera.device_info"),
+            CapabilityMode::Observe,
+            ValueKind::Object,
+        )],
+        state: Some(StateSnapshot {
+            entity_id: camera_entity_id.clone(),
+            value: snapshot_value(snapshot),
+            source: StateSource::Poll,
+            observed_at_ms,
+            received_at_ms: observed_at_ms,
+            expires_at_ms: None,
+            confidence: StateConfidence::Confirmed,
+        }),
+        metadata: vec![Metadata::new("axis.protocol", PROTOCOL_ID)],
+    })?;
+
+    Ok(InstalledAxisDevice {
+        bridge_id: config.bridge_id.clone(),
+        device_id,
+        camera_entity_id,
+    })
+}
+
+fn authorize_read(
+    runtime: &mut SmartHomeRuntime,
+    principal_id: AgentId,
+    now_ms: u64,
+) -> Result<(), AxisError> {
+    let tool = SmartHomeTool::GetState;
+    let decision = runtime.authorize_tool_for_principal(principal_id.clone(), tool, now_ms);
+    if decision.missing_capabilities.is_empty() {
+        Ok(())
+    } else {
+        Err(AxisError::Runtime(RuntimeError::UnauthorizedTool {
+            principal_id,
+            tool,
+            missing_capabilities: decision.missing_capabilities,
+        }))
+    }
+}
+
+fn parse_snapshot(properties: &JsonValue, apis: &JsonValue) -> Result<AxisSnapshot, AxisError> {
+    let properties = properties
+        .pointer("/data/propertyList")
+        .and_then(JsonValue::as_object)
+        .ok_or(AxisError::MissingField("data.propertyList"))?;
+    let device = AxisDeviceInformation {
+        brand: required_string(properties, "Brand")?,
+        product_full_name: required_string(properties, "ProdFullName")?,
+        product_number: required_string(properties, "ProdNbr")?,
+        product_type: required_string(properties, "ProdType")?,
+        serial_number: required_string(properties, "SerialNumber")?,
+        firmware_version: required_string(properties, "Version")?,
+    };
+    let api_list = apis
+        .pointer("/data/apiList")
+        .and_then(JsonValue::as_array)
+        .ok_or(AxisError::MissingField("data.apiList"))?;
+    let mut parsed_apis = Vec::with_capacity(api_list.len());
+    for api in api_list {
+        let api = api
+            .as_object()
+            .ok_or(AxisError::MissingField("data.apiList[]"))?;
+        parsed_apis.push(AxisApi {
+            id: required_string(api, "id")?,
+            version: required_string(api, "version")?,
+            status: required_string(api, "status")?,
+        });
+    }
+    parsed_apis.sort_by(|left, right| {
+        left.id
+            .cmp(&right.id)
+            .then_with(|| left.version.cmp(&right.version))
+    });
+    Ok(AxisSnapshot {
+        device,
+        apis: parsed_apis,
+    })
+}
+
+fn required_string(
+    object: &JsonMap<String, JsonValue>,
+    field: &'static str,
+) -> Result<String, AxisError> {
+    object
+        .get(field)
+        .and_then(JsonValue::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+        .ok_or(AxisError::MissingField(field))
+}
+
+fn snapshot_value(snapshot: &AxisSnapshot) -> Value {
+    Value::Object(vec![
+        (
+            "product_type".to_string(),
+            Value::Text(snapshot.device.product_type.clone()),
+        ),
+        (
+            "product_number".to_string(),
+            Value::Text(snapshot.device.product_number.clone()),
+        ),
+        (
+            "serial_number".to_string(),
+            Value::Text(snapshot.device.serial_number.clone()),
+        ),
+        (
+            "firmware_version".to_string(),
+            Value::Text(snapshot.device.firmware_version.clone()),
+        ),
+        (
+            "apis".to_string(),
+            Value::Array(
+                snapshot
+                    .apis
+                    .iter()
+                    .map(|api| {
+                        Value::Object(vec![
+                            ("id".to_string(), Value::Text(api.id.clone())),
+                            ("version".to_string(), Value::Text(api.version.clone())),
+                            ("status".to_string(), Value::Text(api.status.clone())),
+                        ])
+                    })
+                    .collect(),
+            ),
+        ),
+    ])
+}
+
+fn protocol_identifier(kind: &str, value: &str) -> Result<ProtocolIdentifier, AxisError> {
+    ProtocolIdentifier::new(ProtocolFamily::Vendor(PROTOCOL_ID.to_string()), kind, value)
+        .map_err(|error| AxisError::Validation(error.to_string()))
+}
+
+fn stable_component(value: &str) -> String {
+    let mut output = String::new();
+    let mut separator = false;
+    for character in value.chars().flat_map(char::to_lowercase) {
+        if character.is_ascii_alphanumeric() {
+            output.push(character);
+            separator = false;
+        } else if !output.is_empty() && !separator {
+            output.push('-');
+            separator = true;
+        }
+    }
+    output.trim_matches('-').to_string()
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    matches!(host, "localhost" | "127.0.0.1" | "::1")
+}
+
+fn has_unsafe_http_text(value: &str) -> bool {
+    value.contains(['\r', '\n', '\0'])
+}
+
+fn encode_http_request(
+    url: &Url,
+    plan: &LocalHttpRequestPlan,
+    credentials: &AxisCredentials,
+) -> Result<Vec<u8>, AxisError> {
+    let host = url
+        .host
+        .as_deref()
+        .ok_or(AxisError::MissingField("request URL host"))?;
+    let port = url
+        .effective_port()
+        .ok_or(AxisError::MissingField("request URL port"))?;
+    let target = if url.path.is_empty() {
+        "/".to_string()
+    } else if let Some(query) = &url.query {
+        format!("{}?{query}", url.path)
+    } else {
+        url.path.clone()
+    };
+    if has_unsafe_http_text(&target) || has_unsafe_http_text(host) {
+        return Err(AxisError::Validation(
+            "request target contains unsafe HTTP text".to_string(),
+        ));
+    }
+    let default_port = if url.scheme == "https" { 443 } else { 80 };
+    let host_header = if port == default_port {
+        host.to_string()
+    } else {
+        format!("{host}:{port}")
+    };
+    let mut request = format!(
+        "{} {target} HTTP/1.1\r\nHost: {host_header}\r\nConnection: close\r\n",
+        plan.method.as_str()
+    )
+    .into_bytes();
+    let mut seen = BTreeSet::new();
+    for header in &plan.headers {
+        if has_unsafe_http_text(&header.name) || has_unsafe_http_text(&header.value) {
+            return Err(AxisError::Validation(
+                "request header contains unsafe HTTP text".to_string(),
+            ));
+        }
+        seen.insert(header.name.to_ascii_lowercase());
+        if header.name.eq_ignore_ascii_case("Authorization") {
+            let raw = Zeroizing::new(format!(
+                "{}:{}",
+                credentials.username.as_str(),
+                credentials.password.as_str()
+            ));
+            let encoded = Zeroizing::new(BASE64.encode(raw.as_bytes()));
+            request.extend_from_slice(
+                format!("Authorization: Basic {}\r\n", encoded.as_str()).as_bytes(),
+            );
+        } else {
+            request.extend_from_slice(format!("{}: {}\r\n", header.name, header.value).as_bytes());
+        }
+    }
+    if !seen.contains("authorization") {
+        return Err(AxisError::Validation(
+            "Axis request plan is missing Vault-backed Basic authorization".to_string(),
+        ));
+    }
+    if !seen.contains("content-length") {
+        request.extend_from_slice(format!("Content-Length: {}\r\n", plan.body.len()).as_bytes());
+    }
+    request.extend_from_slice(b"\r\n");
+    request.extend_from_slice(&plan.body);
+    Ok(request)
+}
+
+fn connect_tcp(host: &str, port: u16, timeout: Duration) -> Result<TcpStream, AxisError> {
+    let addresses = (host, port)
+        .to_socket_addrs()
+        .map_err(|error| AxisError::Io(error.to_string()))?
+        .collect::<Vec<_>>();
+    let mut last_error = None;
+    for address in addresses {
+        match TcpStream::connect_timeout(&address, timeout) {
+            Ok(stream) => {
+                stream
+                    .set_read_timeout(Some(timeout))
+                    .map_err(|error| AxisError::Io(error.to_string()))?;
+                stream
+                    .set_write_timeout(Some(timeout))
+                    .map_err(|error| AxisError::Io(error.to_string()))?;
+                return Ok(stream);
+            }
+            Err(error) => last_error = Some(error),
+        }
+    }
+    Err(AxisError::Io(
+        last_error
+            .unwrap_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::AddrNotAvailable,
+                    "host resolved to no addresses",
+                )
+            })
+            .to_string(),
+    ))
+}
+
+fn write_request(writer: &mut dyn Write, request: &[u8]) -> Result<(), AxisError> {
+    writer
+        .write_all(request)
+        .map_err(|error| AxisError::Io(error.to_string()))
+}
+
+fn read_bounded(reader: &mut dyn Read, maximum: usize) -> Result<Vec<u8>, AxisError> {
+    let mut bytes = Vec::new();
+    let mut buffer = [0u8; 8192];
+    loop {
+        let read = reader
+            .read(&mut buffer)
+            .map_err(|error| AxisError::Io(error.to_string()))?;
+        if read == 0 {
+            break;
+        }
+        if read > maximum.saturating_sub(bytes.len()) {
+            return Err(AxisError::ResponseTooLarge { limit: maximum });
+        }
+        bytes.extend_from_slice(&buffer[..read]);
+    }
+    Ok(bytes)
+}
+
+fn decode_http_response(bytes: &[u8], maximum: usize) -> Result<Vec<u8>, AxisError> {
+    let parsed = parse_response_head(bytes)
+        .map_err(|error: Http1ParseError| AxisError::Http(error.to_string()))?;
+    if !(200..300).contains(&parsed.head.status) {
+        return Err(AxisError::HttpStatus(parsed.head.status));
+    }
+    let input = &bytes[parsed.body_offset..];
+    let body = match parsed.body_kind {
+        BodyKind::None => Vec::new(),
+        BodyKind::ContentLength(expected) => {
+            if input.len() < expected {
+                return Err(AxisError::TruncatedBody {
+                    expected,
+                    actual: input.len(),
+                });
+            }
+            input[..expected].to_vec()
+        }
+        BodyKind::UntilEof => input.to_vec(),
+        BodyKind::Chunked => decode_chunked(input, maximum)?,
+    };
+    if body.len() > maximum {
+        return Err(AxisError::ResponseTooLarge { limit: maximum });
+    }
+    Ok(body)
+}
+
+fn decode_chunked(input: &[u8], maximum: usize) -> Result<Vec<u8>, AxisError> {
+    let mut cursor = 0usize;
+    let mut output = Vec::new();
+    loop {
+        let offset = input[cursor..]
+            .windows(2)
+            .position(|window| window == b"\r\n")
+            .ok_or_else(|| AxisError::Http("missing chunk-size terminator".to_string()))?;
+        let end = cursor + offset;
+        let size_text = std::str::from_utf8(&input[cursor..end])
+            .map_err(|_| AxisError::Http("chunk size is not ASCII".to_string()))?
+            .split(';')
+            .next()
+            .unwrap_or_default();
+        let size = usize::from_str_radix(size_text.trim(), 16)
+            .map_err(|_| AxisError::Http("invalid chunk size".to_string()))?;
+        cursor = end + 2;
+        if size == 0 {
+            return Ok(output);
+        }
+        if size > maximum.saturating_sub(output.len()) {
+            return Err(AxisError::ResponseTooLarge { limit: maximum });
+        }
+        let chunk_end = cursor
+            .checked_add(size)
+            .ok_or_else(|| AxisError::Http("chunk size overflow".to_string()))?;
+        if input.len() < chunk_end + 2 || &input[chunk_end..chunk_end + 2] != b"\r\n" {
+            return Err(AxisError::Http("truncated chunk".to_string()));
+        }
+        output.extend_from_slice(&input[cursor..chunk_end]);
+        cursor = chunk_end + 2;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use smart_home_core::{CapabilityGrant, CapabilityGrantId, PrivilegeTier};
+    use std::net::TcpListener;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+
+    const DEVICE_INFO: &str = r#"{"apiVersion":"1.0","context":"smart-home","data":{"propertyList":{"Brand":"AXIS","ProdFullName":"AXIS Q1785-LE Network Camera","ProdNbr":"Q1785-LE","ProdType":"Network Camera","SerialNumber":"ACCC8EAF8C30","Version":"12.1.0"}}}"#;
+    const API_LIST: &str = r#"{"apiVersion":"1.0","context":"smart-home","data":{"apiList":[{"id":"ptz-control","version":"1.0","status":"released"},{"id":"basic-device-info","version":"1.2","status":"released"}]}}"#;
+
+    fn response(body: &str) -> Vec<u8> {
+        format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len()).into_bytes()
+    }
+
+    fn start_server(
+        payloads: Vec<Vec<u8>>,
+    ) -> (u16, Arc<Mutex<Vec<String>>>, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let captured = Arc::clone(&requests);
+        let handle = thread::spawn(move || {
+            for payload in payloads {
+                let (mut stream, _) = listener.accept().unwrap();
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(2)))
+                    .unwrap();
+                let mut bytes = Vec::new();
+                let mut buffer = [0u8; 4096];
+                loop {
+                    let read = stream.read(&mut buffer).unwrap();
+                    if read == 0 {
+                        break;
+                    }
+                    bytes.extend_from_slice(&buffer[..read]);
+                    let header_end = bytes.windows(4).position(|window| window == b"\r\n\r\n");
+                    if let Some(header_end) = header_end {
+                        let head = String::from_utf8_lossy(&bytes[..header_end]);
+                        let length = head
+                            .lines()
+                            .find_map(|line| line.strip_prefix("Content-Length: "))
+                            .and_then(|value| value.parse::<usize>().ok())
+                            .unwrap_or(0);
+                        if bytes.len() >= header_end + 4 + length {
+                            break;
+                        }
+                    }
+                }
+                captured
+                    .lock()
+                    .unwrap()
+                    .push(String::from_utf8(bytes).unwrap());
+                stream.write_all(&payload).unwrap();
+            }
+        });
+        (port, requests, handle)
+    }
+
+    fn config(port: u16) -> AxisConfig {
+        AxisConfig::new(
+            BridgeId::trusted("axis.test"),
+            format!("http://127.0.0.1:{port}"),
+            VaultRef::trusted("vault://axis/test"),
+        )
+        .unwrap()
+    }
+
+    fn credentials() -> AxisCredentials {
+        AxisCredentials::new("root", "secret").unwrap()
+    }
+
+    fn grant(runtime: &mut SmartHomeRuntime, principal: &AgentId) {
+        let _ = runtime.registry_mut().upsert_capability_grant(
+            CapabilityGrant::for_all_smart_home(
+                CapabilityGrantId::trusted("grant:axis-test"),
+                principal.clone(),
+                PrivilegeTier::LowRisk,
+                "test",
+                1_000,
+            )
+            .with_expiry(20_000),
+        );
+    }
+
+    #[test]
+    fn documented_axis_mdns_services_become_credential_candidates() {
+        for service_type in [VIDEO_MDNS_SERVICE_TYPE, NVR_MDNS_SERVICE_TYPE] {
+            let advertisement = MdnsAdvertisement::new(
+                service_type,
+                "AXIS Q1785-LE - ACCC8EAF8C30",
+                "axis-accc8eaf8c30.local",
+                443,
+                1_000,
+            )
+            .unwrap()
+            .with_address("192.0.2.25")
+            .unwrap()
+            .with_txt("macaddress", "ACCC8EAF8C30")
+            .unwrap();
+            let record = discovery_record(&advertisement).unwrap();
+            assert_eq!(record.native_bridge_id, "accc8eaf8c30");
+            assert_eq!(record.address.as_deref(), Some("https://192.0.2.25:443"));
+            assert_eq!(record.confidence, DiscoveryConfidence::Candidate);
+            assert_eq!(record.pairing_requirement, PairingRequirement::Credentials);
+        }
+
+        let advertisement = MdnsAdvertisement::new(
+            VIDEO_MDNS_SERVICE_TYPE,
+            "AXIS Q1785-LE - ACCC8EAF8C30",
+            "axis-accc8eaf8c30.local",
+            443,
+            1_000,
+        )
+        .unwrap();
+        assert_eq!(
+            discovery_record(&advertisement).unwrap().native_bridge_id,
+            "accc8eaf8c30"
+        );
+    }
+
+    #[test]
+    fn config_requires_https_outside_loopback_and_rejects_url_credentials() {
+        assert!(AxisConfig::new(
+            BridgeId::trusted("axis.insecure"),
+            "http://192.0.2.25",
+            VaultRef::trusted("vault://axis/test")
+        )
+        .is_err());
+        assert!(AxisConfig::new(
+            BridgeId::trusted("axis.userinfo"),
+            "https://root:secret@axis.local",
+            VaultRef::trusted("vault://axis/test")
+        )
+        .is_err());
+        assert!(AxisConfig::new(
+            BridgeId::trusted("axis.secure"),
+            "https://axis.local",
+            VaultRef::trusted("vault://axis/test")
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn real_http_inspection_installs_confirmed_axis_camera() {
+        let (port, requests, handle) =
+            start_server(vec![response(DEVICE_INFO), response(API_LIST)]);
+        let client =
+            AxisClient::new(config(port), credentials(), AxisLanTransport::default()).unwrap();
+        let mut integration = AxisRuntimeIntegration::new(client);
+        let principal = AgentId::trusted("agent:axis-read");
+        let mut runtime = SmartHomeRuntime::new();
+        grant(&mut runtime, &principal);
+        let installed = integration
+            .inspect_and_install_authorized(&mut runtime, principal, 5_000)
+            .unwrap();
+        handle.join().unwrap();
+
+        let device = runtime.registry().device(&installed.device_id).unwrap();
+        assert_eq!(device.manufacturer, "AXIS");
+        assert_eq!(device.model, "Q1785-LE");
+        assert_eq!(device.serial.as_deref(), Some("ACCC8EAF8C30"));
+        let camera = runtime
+            .registry()
+            .entity(&installed.camera_entity_id)
+            .unwrap();
+        assert_eq!(camera.kind, EntityKind::Camera);
+        assert_eq!(
+            camera.state.as_ref().unwrap().confidence,
+            StateConfidence::Confirmed
+        );
+        let bridge = runtime.registry().bridge(&installed.bridge_id).unwrap();
+        assert_eq!(
+            bridge.auth_ref.as_ref().unwrap().as_str(),
+            "vault://axis/test"
+        );
+
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(requests[0].contains(&format!("POST {BASIC_DEVICE_INFO_PATH} HTTP/1.1")));
+        assert!(requests[1].contains(&format!("POST {API_DISCOVERY_PATH} HTTP/1.1")));
+        assert!(requests
+            .iter()
+            .all(|request| request.contains("Authorization: Basic cm9vdDpzZWNyZXQ=")));
+        assert!(requests.iter().all(|request| !request.contains("vault://")));
+    }
+
+    #[derive(Debug)]
+    struct CountingTransport(Arc<AtomicUsize>);
+
+    impl AxisTransport for CountingTransport {
+        fn execute(
+            &mut self,
+            _plan: &LocalHttpRequestPlan,
+            _credentials: &AxisCredentials,
+        ) -> Result<Vec<u8>, AxisError> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Ok(Vec::new())
+        }
+    }
+
+    #[test]
+    fn denied_read_reaches_no_transport_or_credentials() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let client = AxisClient::new(
+            AxisConfig::new(
+                BridgeId::trusted("axis.denied"),
+                "http://127.0.0.1",
+                VaultRef::trusted("vault://axis/denied"),
+            )
+            .unwrap(),
+            credentials(),
+            CountingTransport(Arc::clone(&calls)),
+        )
+        .unwrap();
+        let mut integration = AxisRuntimeIntegration::new(client);
+        assert!(matches!(
+            integration.inspect_and_install_authorized(
+                &mut SmartHomeRuntime::new(),
+                AgentId::trusted("agent:denied"),
+                5_000,
+            ),
+            Err(AxisError::Runtime(_))
+        ));
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn parser_sorts_api_inventory() {
+        let properties: JsonValue = serde_json::from_str(DEVICE_INFO).unwrap();
+        let apis: JsonValue = serde_json::from_str(API_LIST).unwrap();
+        let snapshot = parse_snapshot(&properties, &apis).unwrap();
+        assert_eq!(snapshot.device.product_number, "Q1785-LE");
+        assert_eq!(snapshot.apis[0].id, "basic-device-info");
+        assert_eq!(snapshot.apis[1].id, "ptz-control");
+    }
+
+    #[test]
+    fn client_rejects_vapix_errors() {
+        let (port, _requests, handle) = start_server(vec![response(
+            r#"{"apiVersion":"1.0","error":{"code":1000,"message":"bad input"}}"#,
+        )]);
+        let mut client =
+            AxisClient::new(config(port), credentials(), AxisLanTransport::default()).unwrap();
+        assert!(matches!(
+            client.inspect(),
+            Err(AxisError::Api { code: 1000, message }) if message == "bad input"
+        ));
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn response_bounds_are_enforced() {
+        assert!(matches!(
+            decode_http_response(&response("{}"), 1),
+            Err(AxisError::ResponseTooLarge { limit: 1 })
+        ));
+    }
+}

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- Add the first-party Axis VAPIX mDNS and authenticated inspection runtime.
 - Record capability-probed Reolink preset recall and bounded PTZ movement over
   the authenticated local CGI runtime.
 

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -45202,6 +45202,34 @@ pub fn first_party_catalog() -> Vec<IntegrationCatalogEntry> {
             PrimitiveFamily::Supervision,
         ]),
         base_entry(
+            "axis_vapix",
+            "Axis VAPIX",
+            "Authenticated local Axis camera and NVR discovery plus device and API inspection.",
+            IntegrationCategory::CameraMedia,
+            ConnectivityClass::LocalPolling,
+            ImplementationStatus::FirstPartyRuntime,
+            3,
+            "axis_vapix",
+        )
+        .with_capabilities(&["smart_home.read"])
+        .with_entities(&[EntityKind::Camera])
+        .with_discovery(&[DiscoveryMechanism::Mdns, DiscoveryMechanism::Manual])
+        .with_auth(&[AuthMode::UsernamePassword])
+        .with_protocols(vec![ProtocolFamily::Vendor("axis_vapix".to_string())])
+        .with_primitives(&[
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::Mdns,
+            PrimitiveFamily::LocalHttp,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::VaultLease,
+            PrimitiveFamily::Supervision,
+        ])
+        .with_notes(&[
+            "Production inspection requires HTTPS Basic authentication; plain HTTP is accepted only for loopback transport tests.",
+            "PTZ control, event streaming, snapshots, and media transfer remain separate capability-specific work.",
+        ]),
+        base_entry(
             "reolink",
             "Reolink",
             "Authenticated local Reolink camera and NVR inspection plus verified recording and bounded PTZ control.",
@@ -80956,6 +80984,36 @@ mod tests {
             .required_primitives
             .contains(&PrimitiveFamily::VaultLease));
         assert!(!reolink
+            .required_primitives
+            .contains(&PrimitiveFamily::CameraMedia));
+    }
+
+    #[test]
+    fn axis_entry_exposes_authenticated_vapix_runtime_primitives() {
+        let catalog = first_party_catalog();
+        let axis = find_entry(&catalog, &IntegrationId::trusted("axis_vapix")).unwrap();
+
+        assert_eq!(
+            axis.implementation_status,
+            ImplementationStatus::FirstPartyRuntime
+        );
+        assert_eq!(axis.connectivity, ConnectivityClass::LocalPolling);
+        assert_eq!(
+            axis.supported_protocols,
+            vec![ProtocolFamily::Vendor("axis_vapix".to_string())]
+        );
+        assert_eq!(axis.auth_modes, vec![AuthMode::UsernamePassword]);
+        assert_eq!(axis.target_entity_kinds, vec![EntityKind::Camera]);
+        assert!(axis
+            .discovery_mechanisms
+            .contains(&DiscoveryMechanism::Mdns));
+        assert!(axis
+            .required_primitives
+            .contains(&PrimitiveFamily::LocalHttp));
+        assert!(axis
+            .required_primitives
+            .contains(&PrimitiveFamily::VaultLease));
+        assert!(!axis
             .required_primitives
             .contains(&PrimitiveFamily::CameraMedia));
     }

--- a/code/packages/rust/websocket-core/BUILD
+++ b/code/packages/rust/websocket-core/BUILD
@@ -1,0 +1,1 @@
+cargo test -p websocket-core -- --nocapture

--- a/code/packages/rust/websocket-core/CHANGELOG.md
+++ b/code/packages/rust/websocket-core/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0
+
+- Add strict bounded RFC 6455 server and client upgrade handshakes.
+- Add incremental frame decoding with masking, canonical-length, opcode,
+  control-frame, and size validation.
+- Add bounded fragmented text/binary message assembly with interleaved control
+  events.
+- Add validated close payloads and automatic pong/close reply construction.

--- a/code/packages/rust/websocket-core/Cargo.toml
+++ b/code/packages/rust/websocket-core/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "websocket-core"
+version = "0.1.0"
+edition = "2021"
+description = "Transport-independent RFC 6455 handshake, frame, and message core"
+license = "MIT"
+
+[dependencies]
+coding_adventures_sha1 = { path = "../sha1" }
+http-core = { path = "../http-core" }
+http1 = { path = "../http1" }

--- a/code/packages/rust/websocket-core/README.md
+++ b/code/packages/rust/websocket-core/README.md
@@ -1,0 +1,18 @@
+# websocket-core
+
+`websocket-core` is a transport-independent RFC 6455 protocol state machine.
+It validates and serializes HTTP upgrades, incrementally decodes frames,
+enforces masking and canonical lengths, reassembles fragmented messages, and
+validates ping, pong, and close controls.
+
+The package opens no sockets and generates no randomness. A runtime adapter
+supplies stream I/O, deadlines, and a fresh unpredictable mask key for every
+client frame.
+
+## Validation
+
+```sh
+cargo test -p websocket-core
+cargo clippy -p websocket-core --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p websocket-core --no-deps
+```

--- a/code/packages/rust/websocket-core/required_capabilities.json
+++ b/code/packages/rust/websocket-core/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/websocket-core",
+  "capabilities": [],
+  "justification": "Pure bounded byte parsing, serialization, hashing, masking, and protocol state transitions over caller-owned memory. The package opens no sockets and delegates random mask generation to runtime adapters."
+}

--- a/code/packages/rust/websocket-core/src/lib.rs
+++ b/code/packages/rust/websocket-core/src/lib.rs
@@ -1,0 +1,1542 @@
+//! Transport-independent RFC 6455 WebSocket protocol core.
+//!
+//! This crate owns bounded handshake, frame, fragmentation, and control-frame
+//! semantics. It performs no network I/O and delegates random client mask-key
+//! generation to its runtime caller.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use coding_adventures_sha1::sum1;
+use core::fmt::{self, Display, Formatter};
+use http1::{parse_request_head, parse_response_head};
+use http_core::{BodyKind, Header, HttpVersion};
+
+const WEBSOCKET_GUID: &[u8] = b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+/// Maximum accepted HTTP upgrade head, including its terminating CRLF line.
+pub const MAX_HANDSHAKE_BYTES: usize = 16 * 1024;
+
+/// Typed, payload-free WebSocket protocol failure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WebSocketError {
+    /// A complete HTTP upgrade head has not arrived yet.
+    IncompleteHandshake,
+    /// The HTTP upgrade head exceeded the fixed protocol bound.
+    HandshakeTooLarge,
+    /// The HTTP upgrade syntax or required field set is invalid.
+    InvalidHandshake,
+    /// A caller-supplied host or request target could inject HTTP syntax.
+    HeaderInjection,
+    /// A Base64 value is not canonical padded RFC 4648 encoding.
+    InvalidBase64,
+    /// One or more reserved frame bits were set without an extension.
+    ReservedBits,
+    /// The frame opcode is reserved or unknown.
+    InvalidOpcode,
+    /// The peer or local encoder violated its required masking direction.
+    MaskDirection,
+    /// An extended frame length did not use its shortest wire encoding.
+    NonCanonicalLength,
+    /// A declared frame payload exceeds the configured frame bound.
+    FrameTooLarge,
+    /// A control frame is fragmented, oversized, or structurally invalid.
+    InvalidControlFrame,
+    /// A close status code or UTF-8 reason is invalid.
+    InvalidCloseFrame,
+    /// A complete text message is not valid UTF-8.
+    InvalidUtf8,
+    /// Data-frame fragmentation state is invalid.
+    InvalidFragmentation,
+    /// An assembled message exceeds the configured message bound.
+    MessageTooLarge,
+    /// Data arrived after the inbound close event.
+    ClosedSession,
+}
+
+impl Display for WebSocketError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            Self::IncompleteHandshake => "websocket: incomplete handshake",
+            Self::HandshakeTooLarge => "websocket: handshake exceeds limit",
+            Self::InvalidHandshake => "websocket: invalid handshake",
+            Self::HeaderInjection => "websocket: unsafe handshake field",
+            Self::InvalidBase64 => "websocket: invalid base64",
+            Self::ReservedBits => "websocket: reserved frame bits set",
+            Self::InvalidOpcode => "websocket: invalid frame opcode",
+            Self::MaskDirection => "websocket: invalid frame mask direction",
+            Self::NonCanonicalLength => "websocket: non-canonical frame length",
+            Self::FrameTooLarge => "websocket: frame exceeds limit",
+            Self::InvalidControlFrame => "websocket: invalid control frame",
+            Self::InvalidCloseFrame => "websocket: invalid close frame",
+            Self::InvalidUtf8 => "websocket: invalid text encoding",
+            Self::InvalidFragmentation => "websocket: invalid fragmentation state",
+            Self::MessageTooLarge => "websocket: message exceeds limit",
+            Self::ClosedSession => "websocket: data after close",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for WebSocketError {}
+
+/// Serialized client upgrade request and the accept value its response needs.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ClientHandshake {
+    bytes: Vec<u8>,
+    expected_accept: String,
+}
+
+impl ClientHandshake {
+    /// Borrow the complete HTTP/1.1 client upgrade request.
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Borrow the exact `Sec-WebSocket-Accept` value expected from the server.
+    pub fn expected_accept(&self) -> &str {
+        &self.expected_accept
+    }
+}
+
+/// Validated server upgrade response and consumed request-head length.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ServerHandshake {
+    response: Vec<u8>,
+    consumed: usize,
+}
+
+impl ServerHandshake {
+    /// Borrow the complete HTTP 101 response.
+    pub fn response(&self) -> &[u8] {
+        &self.response
+    }
+
+    /// Return the request bytes consumed before any coalesced frame bytes.
+    pub fn consumed(&self) -> usize {
+        self.consumed
+    }
+}
+
+/// Build a bounded client upgrade request from a caller-generated nonce.
+pub fn build_client_request(
+    host: &str,
+    target: &str,
+    nonce: [u8; 16],
+) -> Result<ClientHandshake, WebSocketError> {
+    validate_host(host)?;
+    validate_target(target)?;
+    let key = encode_base64(&nonce);
+    let expected_accept = derive_accept(&key);
+    let request = format!(
+        "GET {target} HTTP/1.1\r\nHost: {host}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: {key}\r\nSec-WebSocket-Version: 13\r\n\r\n"
+    )
+    .into_bytes();
+    if request.len() > MAX_HANDSHAKE_BYTES {
+        return Err(WebSocketError::HandshakeTooLarge);
+    }
+    Ok(ClientHandshake {
+        bytes: request,
+        expected_accept,
+    })
+}
+
+/// Validate one server HTTP 101 response and return its consumed head length.
+pub fn validate_client_response(
+    input: &[u8],
+    expected_accept: &str,
+) -> Result<usize, WebSocketError> {
+    let end = complete_head(input)?;
+    let parsed =
+        parse_response_head(&input[..end]).map_err(|_| WebSocketError::InvalidHandshake)?;
+    validate_header_bytes(&parsed.head.headers)?;
+    if parsed.head.version != http_1_1()
+        || parsed.head.status != 101
+        || parsed.body_kind != BodyKind::None
+        || !contains_header_token(&parsed.head.headers, "Upgrade", "websocket")
+        || !contains_header_token(&parsed.head.headers, "Connection", "Upgrade")
+        || one_header(&parsed.head.headers, "Sec-WebSocket-Accept")? != expected_accept
+        || has_header(&parsed.head.headers, "Content-Length")
+        || has_header(&parsed.head.headers, "Transfer-Encoding")
+        || has_header(&parsed.head.headers, "Sec-WebSocket-Extensions")
+        || has_header(&parsed.head.headers, "Sec-WebSocket-Protocol")
+    {
+        return Err(WebSocketError::InvalidHandshake);
+    }
+    Ok(parsed.body_offset)
+}
+
+/// Validate a server-side upgrade request and construct its HTTP 101 response.
+pub fn accept_server_request(input: &[u8]) -> Result<ServerHandshake, WebSocketError> {
+    let end = complete_head(input)?;
+    let parsed = parse_request_head(&input[..end]).map_err(|_| WebSocketError::InvalidHandshake)?;
+    validate_header_bytes(&parsed.head.headers)?;
+    if parsed.head.method != "GET"
+        || parsed.head.version != http_1_1()
+        || parsed.body_kind != BodyKind::None
+        || one_header(&parsed.head.headers, "Host")?.is_empty()
+        || !contains_header_token(&parsed.head.headers, "Upgrade", "websocket")
+        || !contains_header_token(&parsed.head.headers, "Connection", "Upgrade")
+        || one_header(&parsed.head.headers, "Sec-WebSocket-Version")? != "13"
+        || has_header(&parsed.head.headers, "Content-Length")
+        || has_header(&parsed.head.headers, "Transfer-Encoding")
+        || has_header(&parsed.head.headers, "Sec-WebSocket-Extensions")
+        || has_header(&parsed.head.headers, "Sec-WebSocket-Protocol")
+    {
+        return Err(WebSocketError::InvalidHandshake);
+    }
+    let key = one_header(&parsed.head.headers, "Sec-WebSocket-Key")?;
+    validate_websocket_key(key)?;
+    let accept = derive_accept(key);
+    let response = format!(
+        "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: {accept}\r\n\r\n"
+    )
+    .into_bytes();
+    Ok(ServerHandshake {
+        response,
+        consumed: parsed.body_offset,
+    })
+}
+
+/// Derive RFC 6455's padded Base64 accept value from key header text.
+pub fn derive_accept(key: &str) -> String {
+    let mut source = Vec::with_capacity(key.len() + WEBSOCKET_GUID.len());
+    source.extend_from_slice(key.as_bytes());
+    source.extend_from_slice(WEBSOCKET_GUID);
+    encode_base64(&sum1(&source))
+}
+
+fn http_1_1() -> HttpVersion {
+    HttpVersion { major: 1, minor: 1 }
+}
+
+fn complete_head(input: &[u8]) -> Result<usize, WebSocketError> {
+    if let Some(index) = input.windows(4).position(|window| window == b"\r\n\r\n") {
+        let end = index + 4;
+        if end > MAX_HANDSHAKE_BYTES {
+            Err(WebSocketError::HandshakeTooLarge)
+        } else {
+            validate_available_crlf(&input[..end])?;
+            Ok(end)
+        }
+    } else {
+        validate_available_crlf(input)?;
+        if input.len() >= MAX_HANDSHAKE_BYTES {
+            Err(WebSocketError::HandshakeTooLarge)
+        } else {
+            Err(WebSocketError::IncompleteHandshake)
+        }
+    }
+}
+
+fn validate_available_crlf(input: &[u8]) -> Result<(), WebSocketError> {
+    for (index, byte) in input.iter().copied().enumerate() {
+        if byte == b'\n' && (index == 0 || input[index - 1] != b'\r') {
+            return Err(WebSocketError::InvalidHandshake);
+        }
+        if byte == b'\r' && index + 1 < input.len() && input[index + 1] != b'\n' {
+            return Err(WebSocketError::InvalidHandshake);
+        }
+    }
+    Ok(())
+}
+
+fn validate_host(host: &str) -> Result<(), WebSocketError> {
+    if host.is_empty() || !host.bytes().all(|byte| (0x21..=0x7e).contains(&byte)) {
+        return Err(WebSocketError::HeaderInjection);
+    }
+    Ok(())
+}
+
+fn validate_target(target: &str) -> Result<(), WebSocketError> {
+    if !target.starts_with('/')
+        || target.contains('#')
+        || !target.bytes().all(|byte| (0x21..=0x7e).contains(&byte))
+    {
+        return Err(WebSocketError::HeaderInjection);
+    }
+    Ok(())
+}
+
+fn validate_header_bytes(headers: &[Header]) -> Result<(), WebSocketError> {
+    if headers.iter().any(|header| {
+        header.name.bytes().any(|byte| byte <= 0x20 || byte >= 0x7f)
+            || header
+                .value
+                .bytes()
+                .any(|byte| byte < 0x20 && byte != b'\t' || byte == 0x7f)
+    }) {
+        return Err(WebSocketError::InvalidHandshake);
+    }
+    Ok(())
+}
+
+fn header_values<'a>(headers: &'a [Header], name: &str) -> Vec<&'a str> {
+    headers
+        .iter()
+        .filter(|header| header.name.eq_ignore_ascii_case(name))
+        .map(|header| header.value.as_str())
+        .collect()
+}
+
+fn has_header(headers: &[Header], name: &str) -> bool {
+    !header_values(headers, name).is_empty()
+}
+
+fn one_header<'a>(headers: &'a [Header], name: &str) -> Result<&'a str, WebSocketError> {
+    let mut values = header_values(headers, name).into_iter();
+    let value = values.next().ok_or(WebSocketError::InvalidHandshake)?;
+    if values.next().is_some() {
+        return Err(WebSocketError::InvalidHandshake);
+    }
+    Ok(value)
+}
+
+fn contains_header_token(headers: &[Header], name: &str, token: &str) -> bool {
+    header_values(headers, name).into_iter().any(|value| {
+        value
+            .split(',')
+            .map(str::trim)
+            .any(|candidate| candidate.eq_ignore_ascii_case(token))
+    })
+}
+
+fn validate_websocket_key(key: &str) -> Result<(), WebSocketError> {
+    let decoded = decode_base64(key)?;
+    if decoded.len() != 16 || encode_base64(&decoded) != key {
+        return Err(WebSocketError::InvalidBase64);
+    }
+    Ok(())
+}
+
+fn encode_base64(input: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut output = String::with_capacity(input.len().div_ceil(3) * 4);
+    for chunk in input.chunks(3) {
+        let first = chunk[0];
+        let second = chunk.get(1).copied().unwrap_or(0);
+        let third = chunk.get(2).copied().unwrap_or(0);
+        output.push(ALPHABET[(first >> 2) as usize] as char);
+        output.push(ALPHABET[(((first & 0x03) << 4) | (second >> 4)) as usize] as char);
+        if chunk.len() >= 2 {
+            output.push(ALPHABET[(((second & 0x0f) << 2) | (third >> 6)) as usize] as char);
+        } else {
+            output.push('=');
+        }
+        if chunk.len() == 3 {
+            output.push(ALPHABET[(third & 0x3f) as usize] as char);
+        } else {
+            output.push('=');
+        }
+    }
+    output
+}
+
+fn decode_base64(input: &str) -> Result<Vec<u8>, WebSocketError> {
+    if input.is_empty() || !input.len().is_multiple_of(4) {
+        return Err(WebSocketError::InvalidBase64);
+    }
+    let bytes = input.as_bytes();
+    let mut output = Vec::with_capacity(input.len() / 4 * 3);
+    for (index, chunk) in bytes.chunks_exact(4).enumerate() {
+        let last = index + 1 == input.len() / 4;
+        let pad_two = chunk[2] == b'=';
+        let pad_three = chunk[3] == b'=';
+        if !last && (pad_two || pad_three) || pad_two && !pad_three {
+            return Err(WebSocketError::InvalidBase64);
+        }
+        let first = base64_value(chunk[0])?;
+        let second = base64_value(chunk[1])?;
+        let third = if pad_two { 0 } else { base64_value(chunk[2])? };
+        let fourth = if pad_three {
+            0
+        } else {
+            base64_value(chunk[3])?
+        };
+        output.push((first << 2) | (second >> 4));
+        if !pad_two {
+            output.push((second << 4) | (third >> 2));
+        }
+        if !pad_three {
+            output.push((third << 6) | fourth);
+        }
+    }
+    Ok(output)
+}
+
+fn base64_value(byte: u8) -> Result<u8, WebSocketError> {
+    match byte {
+        b'A'..=b'Z' => Ok(byte - b'A'),
+        b'a'..=b'z' => Ok(byte - b'a' + 26),
+        b'0'..=b'9' => Ok(byte - b'0' + 52),
+        b'+' => Ok(62),
+        b'/' => Ok(63),
+        _ => Err(WebSocketError::InvalidBase64),
+    }
+}
+
+/// Whether the local protocol endpoint is a WebSocket client or server.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EndpointRole {
+    /// Sends masked frames and receives unmasked frames.
+    Client,
+    /// Sends unmasked frames and receives masked frames.
+    Server,
+}
+
+/// RFC 6455 frame opcode supported without extensions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Opcode {
+    /// Continuation of an open fragmented data message.
+    Continuation,
+    /// UTF-8 text data.
+    Text,
+    /// Arbitrary binary data.
+    Binary,
+    /// Close control.
+    Close,
+    /// Ping control.
+    Ping,
+    /// Pong control.
+    Pong,
+}
+
+impl Opcode {
+    fn from_nibble(value: u8) -> Result<Self, WebSocketError> {
+        match value {
+            0x0 => Ok(Self::Continuation),
+            0x1 => Ok(Self::Text),
+            0x2 => Ok(Self::Binary),
+            0x8 => Ok(Self::Close),
+            0x9 => Ok(Self::Ping),
+            0xa => Ok(Self::Pong),
+            _ => Err(WebSocketError::InvalidOpcode),
+        }
+    }
+
+    fn nibble(self) -> u8 {
+        match self {
+            Self::Continuation => 0x0,
+            Self::Text => 0x1,
+            Self::Binary => 0x2,
+            Self::Close => 0x8,
+            Self::Ping => 0x9,
+            Self::Pong => 0xa,
+        }
+    }
+
+    fn is_control(self) -> bool {
+        matches!(self, Self::Close | Self::Ping | Self::Pong)
+    }
+
+    fn is_data(self) -> bool {
+        matches!(self, Self::Text | Self::Binary | Self::Continuation)
+    }
+}
+
+/// One validated, unmasked WebSocket frame.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Frame {
+    fin: bool,
+    opcode: Opcode,
+    payload: Vec<u8>,
+}
+
+impl Frame {
+    /// Construct one frame and validate control-frame structure.
+    pub fn new(
+        fin: bool,
+        opcode: Opcode,
+        payload: impl Into<Vec<u8>>,
+    ) -> Result<Self, WebSocketError> {
+        let frame = Self {
+            fin,
+            opcode,
+            payload: payload.into(),
+        };
+        validate_frame(&frame)?;
+        Ok(frame)
+    }
+
+    /// Construct a final text frame.
+    pub fn text(text: impl Into<String>) -> Self {
+        Self {
+            fin: true,
+            opcode: Opcode::Text,
+            payload: text.into().into_bytes(),
+        }
+    }
+
+    /// Construct a final binary frame.
+    pub fn binary(payload: impl Into<Vec<u8>>) -> Self {
+        Self {
+            fin: true,
+            opcode: Opcode::Binary,
+            payload: payload.into(),
+        }
+    }
+
+    /// Construct a final ping frame.
+    pub fn ping(payload: impl Into<Vec<u8>>) -> Result<Self, WebSocketError> {
+        Self::new(true, Opcode::Ping, payload)
+    }
+
+    /// Construct a final pong frame.
+    pub fn pong(payload: impl Into<Vec<u8>>) -> Result<Self, WebSocketError> {
+        Self::new(true, Opcode::Pong, payload)
+    }
+
+    /// Construct a close frame with an optional status code and reason.
+    pub fn close(code: Option<u16>, reason: &str) -> Result<Self, WebSocketError> {
+        Self::new(true, Opcode::Close, encode_close_payload(code, reason)?)
+    }
+
+    /// Whether this frame finishes its data message.
+    pub fn is_final(&self) -> bool {
+        self.fin
+    }
+
+    /// Return this frame's opcode.
+    pub fn opcode(&self) -> Opcode {
+        self.opcode
+    }
+
+    /// Borrow the unmasked application payload.
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+}
+
+/// Serialize one outbound frame while enforcing the local role's mask rule.
+pub fn encode_frame(
+    role: EndpointRole,
+    frame: &Frame,
+    mask_key: Option<[u8; 4]>,
+) -> Result<Vec<u8>, WebSocketError> {
+    validate_frame(frame)?;
+    let masked = match role {
+        EndpointRole::Client => {
+            if mask_key.is_none() {
+                return Err(WebSocketError::MaskDirection);
+            }
+            true
+        }
+        EndpointRole::Server => {
+            if mask_key.is_some() {
+                return Err(WebSocketError::MaskDirection);
+            }
+            false
+        }
+    };
+    let payload_len = frame.payload.len();
+    let extension_len = if payload_len <= 125 {
+        0
+    } else if payload_len <= u16::MAX as usize {
+        2
+    } else {
+        8
+    };
+    let mut output = Vec::with_capacity(2 + extension_len + usize::from(masked) * 4 + payload_len);
+    output.push(if frame.fin { 0x80 } else { 0 } | frame.opcode.nibble());
+    let mask_bit = if masked { 0x80 } else { 0 };
+    match payload_len {
+        0..=125 => output.push(mask_bit | payload_len as u8),
+        126..=65535 => {
+            output.push(mask_bit | 126);
+            output.extend_from_slice(&(payload_len as u16).to_be_bytes());
+        }
+        _ => {
+            output.push(mask_bit | 127);
+            output.extend_from_slice(&(payload_len as u64).to_be_bytes());
+        }
+    }
+    if let Some(key) = mask_key {
+        output.extend_from_slice(&key);
+        output.extend(
+            frame
+                .payload
+                .iter()
+                .enumerate()
+                .map(|(index, byte)| byte ^ key[index % 4]),
+        );
+    } else {
+        output.extend_from_slice(&frame.payload);
+    }
+    Ok(output)
+}
+
+/// Split one complete text or binary message into bounded data frames.
+pub fn fragment_message(
+    opcode: Opcode,
+    payload: &[u8],
+    max_frame_payload: usize,
+) -> Result<Vec<Frame>, WebSocketError> {
+    if !matches!(opcode, Opcode::Text | Opcode::Binary) || max_frame_payload == 0 {
+        return Err(WebSocketError::InvalidFragmentation);
+    }
+    if opcode == Opcode::Text && core::str::from_utf8(payload).is_err() {
+        return Err(WebSocketError::InvalidUtf8);
+    }
+    if payload.is_empty() {
+        return Ok(vec![Frame::new(true, opcode, Vec::new())?]);
+    }
+    let chunks = payload.chunks(max_frame_payload).collect::<Vec<_>>();
+    let last_index = chunks.len() - 1;
+    chunks
+        .into_iter()
+        .enumerate()
+        .map(|(index, chunk)| {
+            Frame::new(
+                index == last_index,
+                if index == 0 {
+                    opcode
+                } else {
+                    Opcode::Continuation
+                },
+                chunk.to_vec(),
+            )
+        })
+        .collect()
+}
+
+fn validate_frame(frame: &Frame) -> Result<(), WebSocketError> {
+    if frame.opcode.is_control() && (!frame.fin || frame.payload.len() > 125) {
+        return Err(WebSocketError::InvalidControlFrame);
+    }
+    if frame.opcode == Opcode::Close {
+        decode_close_payload(&frame.payload)?;
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+struct ParsedFrameHeader {
+    fin: bool,
+    opcode: Opcode,
+    header_len: usize,
+    payload_len: usize,
+    mask_key: Option<[u8; 4]>,
+}
+
+/// Incremental inbound frame decoder with a fixed per-frame payload bound.
+pub struct FrameDecoder {
+    role: EndpointRole,
+    max_frame_payload: usize,
+    buffer: Vec<u8>,
+}
+
+impl FrameDecoder {
+    /// Construct an empty decoder for frames received by this local role.
+    pub fn new(role: EndpointRole, max_frame_payload: usize) -> Self {
+        Self {
+            role,
+            max_frame_payload,
+            buffer: Vec::new(),
+        }
+    }
+
+    /// Return bytes retained for one incomplete frame.
+    pub fn buffered_len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    /// Add arbitrary stream bytes and return every newly completed frame.
+    pub fn push(&mut self, input: &[u8]) -> Result<Vec<Frame>, WebSocketError> {
+        let mut cursor = 0;
+        let mut frames = Vec::new();
+        loop {
+            if self.buffer.len() < 2 {
+                if cursor == input.len() {
+                    break;
+                }
+                fill_to(&mut self.buffer, input, &mut cursor, 2);
+                continue;
+            }
+            let header_len = declared_header_len(&self.buffer);
+            if self.buffer.len() < header_len {
+                if cursor == input.len() {
+                    break;
+                }
+                fill_to(&mut self.buffer, input, &mut cursor, header_len);
+                continue;
+            }
+            let header = parse_frame_header(&self.buffer[..header_len], self.role)?;
+            if header.payload_len > self.max_frame_payload {
+                return Err(WebSocketError::FrameTooLarge);
+            }
+            let total = header
+                .header_len
+                .checked_add(header.payload_len)
+                .ok_or(WebSocketError::FrameTooLarge)?;
+            if self.buffer.len() < total {
+                if cursor == input.len() {
+                    break;
+                }
+                fill_to(&mut self.buffer, input, &mut cursor, total);
+                continue;
+            }
+            let mut payload = self.buffer[header.header_len..total].to_vec();
+            if let Some(key) = header.mask_key {
+                for (index, byte) in payload.iter_mut().enumerate() {
+                    *byte ^= key[index % 4];
+                }
+            }
+            let frame = Frame {
+                fin: header.fin,
+                opcode: header.opcode,
+                payload,
+            };
+            validate_frame(&frame)?;
+            frames.push(frame);
+            self.buffer.clear();
+        }
+        Ok(frames)
+    }
+}
+
+fn fill_to(buffer: &mut Vec<u8>, input: &[u8], cursor: &mut usize, target: usize) {
+    let count = (target - buffer.len()).min(input.len() - *cursor);
+    buffer.extend_from_slice(&input[*cursor..*cursor + count]);
+    *cursor += count;
+}
+
+fn declared_header_len(prefix: &[u8]) -> usize {
+    let extended = match prefix[1] & 0x7f {
+        126 => 2,
+        127 => 8,
+        _ => 0,
+    };
+    2 + extended + if prefix[1] & 0x80 != 0 { 4 } else { 0 }
+}
+
+fn parse_frame_header(
+    header: &[u8],
+    role: EndpointRole,
+) -> Result<ParsedFrameHeader, WebSocketError> {
+    if header[0] & 0x70 != 0 {
+        return Err(WebSocketError::ReservedBits);
+    }
+    let fin = header[0] & 0x80 != 0;
+    let opcode = Opcode::from_nibble(header[0] & 0x0f)?;
+    let masked = header[1] & 0x80 != 0;
+    let expected_mask = role == EndpointRole::Server;
+    if masked != expected_mask {
+        return Err(WebSocketError::MaskDirection);
+    }
+    let short = header[1] & 0x7f;
+    let mut offset = 2;
+    let payload_u64 = match short {
+        126 => {
+            let length = u16::from_be_bytes([header[offset], header[offset + 1]]) as u64;
+            offset += 2;
+            if length < 126 {
+                return Err(WebSocketError::NonCanonicalLength);
+            }
+            length
+        }
+        127 => {
+            let length = u64::from_be_bytes(
+                header[offset..offset + 8]
+                    .try_into()
+                    .expect("validated frame header length"),
+            );
+            offset += 8;
+            if length < 65_536 || length & (1 << 63) != 0 {
+                return Err(WebSocketError::NonCanonicalLength);
+            }
+            length
+        }
+        length => u64::from(length),
+    };
+    let payload_len = usize::try_from(payload_u64).map_err(|_| WebSocketError::FrameTooLarge)?;
+    if opcode.is_control() && (!fin || payload_len > 125) {
+        return Err(WebSocketError::InvalidControlFrame);
+    }
+    let mask_key = if masked {
+        let key = header[offset..offset + 4]
+            .try_into()
+            .expect("validated frame mask length");
+        Some(key)
+    } else {
+        None
+    };
+    Ok(ParsedFrameHeader {
+        fin,
+        opcode,
+        header_len: header.len(),
+        payload_len,
+        mask_key,
+    })
+}
+
+/// Validated close status and reason.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CloseMessage {
+    code: Option<u16>,
+    reason: String,
+}
+
+impl CloseMessage {
+    /// Return the peer-supplied close status, when present.
+    pub fn code(&self) -> Option<u16> {
+        self.code
+    }
+
+    /// Borrow the validated UTF-8 close reason.
+    pub fn reason(&self) -> &str {
+        &self.reason
+    }
+}
+
+/// One complete inbound data or control event.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MessageEvent {
+    /// Complete validated UTF-8 text.
+    Text(String),
+    /// Complete arbitrary binary data.
+    Binary(Vec<u8>),
+    /// Ping control application bytes.
+    Ping(Vec<u8>),
+    /// Pong control application bytes.
+    Pong(Vec<u8>),
+    /// Close control status and reason.
+    Close(CloseMessage),
+}
+
+/// Bounded data-message fragmentation and control-event assembler.
+pub struct MessageAssembler {
+    max_message_payload: usize,
+    fragment: Option<(Opcode, Vec<u8>)>,
+    closed: bool,
+}
+
+impl MessageAssembler {
+    /// Construct an empty assembler with a fixed complete-message bound.
+    pub fn new(max_message_payload: usize) -> Self {
+        Self {
+            max_message_payload,
+            fragment: None,
+            closed: false,
+        }
+    }
+
+    /// Whether a non-final text or binary message is currently open.
+    pub fn is_fragmented(&self) -> bool {
+        self.fragment.is_some()
+    }
+
+    /// Whether an inbound close event has been accepted.
+    pub fn is_closed(&self) -> bool {
+        self.closed
+    }
+
+    /// Consume one validated frame and possibly emit one complete event.
+    pub fn push(&mut self, frame: Frame) -> Result<Option<MessageEvent>, WebSocketError> {
+        validate_frame(&frame)?;
+        if self.closed && frame.opcode.is_data() {
+            return Err(WebSocketError::ClosedSession);
+        }
+        match frame.opcode {
+            Opcode::Ping => Ok(Some(MessageEvent::Ping(frame.payload))),
+            Opcode::Pong => Ok(Some(MessageEvent::Pong(frame.payload))),
+            Opcode::Close => {
+                let close = decode_close_payload(&frame.payload)?;
+                self.fragment = None;
+                self.closed = true;
+                Ok(Some(MessageEvent::Close(close)))
+            }
+            Opcode::Text | Opcode::Binary if self.fragment.is_some() => {
+                Err(WebSocketError::InvalidFragmentation)
+            }
+            Opcode::Text | Opcode::Binary if frame.fin => {
+                self.ensure_message_bound(frame.payload.len())?;
+                complete_data_event(frame.opcode, frame.payload).map(Some)
+            }
+            Opcode::Text | Opcode::Binary => {
+                self.ensure_message_bound(frame.payload.len())?;
+                self.fragment = Some((frame.opcode, frame.payload));
+                Ok(None)
+            }
+            Opcode::Continuation => {
+                let (opcode, mut payload) = self
+                    .fragment
+                    .take()
+                    .ok_or(WebSocketError::InvalidFragmentation)?;
+                let total = payload
+                    .len()
+                    .checked_add(frame.payload.len())
+                    .ok_or(WebSocketError::MessageTooLarge)?;
+                self.ensure_message_bound(total)?;
+                payload.extend_from_slice(&frame.payload);
+                if frame.fin {
+                    complete_data_event(opcode, payload).map(Some)
+                } else {
+                    self.fragment = Some((opcode, payload));
+                    Ok(None)
+                }
+            }
+        }
+    }
+
+    fn ensure_message_bound(&self, length: usize) -> Result<(), WebSocketError> {
+        if length > self.max_message_payload {
+            Err(WebSocketError::MessageTooLarge)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Construct the RFC-required automatic reply for ping or close events.
+pub fn control_reply(event: &MessageEvent) -> Option<Frame> {
+    match event {
+        MessageEvent::Ping(payload) => Some(Frame {
+            fin: true,
+            opcode: Opcode::Pong,
+            payload: payload.clone(),
+        }),
+        MessageEvent::Close(close) => Some(Frame {
+            fin: true,
+            opcode: Opcode::Close,
+            payload: encode_close_payload(close.code, &close.reason)
+                .expect("validated close event remains valid"),
+        }),
+        MessageEvent::Text(_) | MessageEvent::Binary(_) | MessageEvent::Pong(_) => None,
+    }
+}
+
+fn complete_data_event(opcode: Opcode, payload: Vec<u8>) -> Result<MessageEvent, WebSocketError> {
+    match opcode {
+        Opcode::Text => String::from_utf8(payload)
+            .map(MessageEvent::Text)
+            .map_err(|_| WebSocketError::InvalidUtf8),
+        Opcode::Binary => Ok(MessageEvent::Binary(payload)),
+        _ => Err(WebSocketError::InvalidFragmentation),
+    }
+}
+
+fn decode_close_payload(payload: &[u8]) -> Result<CloseMessage, WebSocketError> {
+    if payload.is_empty() {
+        return Ok(CloseMessage {
+            code: None,
+            reason: String::new(),
+        });
+    }
+    if payload.len() == 1 {
+        return Err(WebSocketError::InvalidCloseFrame);
+    }
+    let code = u16::from_be_bytes([payload[0], payload[1]]);
+    if !valid_close_code(code) {
+        return Err(WebSocketError::InvalidCloseFrame);
+    }
+    let reason = core::str::from_utf8(&payload[2..])
+        .map_err(|_| WebSocketError::InvalidCloseFrame)?
+        .to_string();
+    Ok(CloseMessage {
+        code: Some(code),
+        reason,
+    })
+}
+
+fn encode_close_payload(code: Option<u16>, reason: &str) -> Result<Vec<u8>, WebSocketError> {
+    match code {
+        None if reason.is_empty() => Ok(Vec::new()),
+        None => Err(WebSocketError::InvalidCloseFrame),
+        Some(code) if !valid_close_code(code) || reason.len() > 123 => {
+            Err(WebSocketError::InvalidCloseFrame)
+        }
+        Some(code) => {
+            let mut payload = Vec::with_capacity(2 + reason.len());
+            payload.extend_from_slice(&code.to_be_bytes());
+            payload.extend_from_slice(reason.as_bytes());
+            Ok(payload)
+        }
+    }
+}
+
+fn valid_close_code(code: u16) -> bool {
+    matches!(
+        code,
+        1000 | 1001 | 1002 | 1003 | 1007 | 1008 | 1009 | 1010 | 1011 | 1012 | 1013 | 1014
+    ) || (3000..=4999).contains(&code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RFC_KEY: &str = "dGhlIHNhbXBsZSBub25jZQ==";
+    const RFC_ACCEPT: &str = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=";
+
+    fn request_with(lines: &[&str]) -> Vec<u8> {
+        let mut request = String::from("GET /chat HTTP/1.1\r\n");
+        for line in lines {
+            request.push_str(line);
+            request.push_str("\r\n");
+        }
+        request.push_str("\r\n");
+        request.into_bytes()
+    }
+
+    fn valid_request() -> Vec<u8> {
+        request_with(&[
+            "Host: server.example.com",
+            "Upgrade: websocket",
+            "Connection: keep-alive, Upgrade",
+            "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+            "Sec-WebSocket-Version: 13",
+        ])
+    }
+
+    fn valid_response(accept: &str) -> Vec<u8> {
+        format!(
+            "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: {accept}\r\n\r\n"
+        )
+        .into_bytes()
+    }
+
+    #[test]
+    fn rfc_accept_example_and_server_handshake_preserve_coalesced_bytes() {
+        assert_eq!(derive_accept(RFC_KEY), RFC_ACCEPT);
+        let mut input = valid_request();
+        let consumed = input.len();
+        input.extend_from_slice(&[0x81, 0x01, b'\n']);
+        let handshake = accept_server_request(&input).expect("valid server handshake");
+        assert_eq!(handshake.consumed(), consumed);
+        assert_eq!(&input[handshake.consumed()..], [0x81, 0x01, b'\n']);
+        assert_eq!(handshake.response(), valid_response(RFC_ACCEPT));
+    }
+
+    #[test]
+    fn client_request_and_response_round_trip() {
+        let nonce = *b"the sample nonce";
+        let client = build_client_request("server.example.com", "/chat?room=1", nonce)
+            .expect("valid client request");
+        let request = core::str::from_utf8(client.bytes()).expect("ASCII request");
+        assert!(request.starts_with("GET /chat?room=1 HTTP/1.1\r\n"));
+        assert!(request.contains(&format!("Sec-WebSocket-Key: {RFC_KEY}\r\n")));
+        assert_eq!(client.expected_accept(), RFC_ACCEPT);
+
+        let mut response = valid_response(client.expected_accept());
+        let consumed = response.len();
+        response.extend_from_slice(&[0x81, 0x00]);
+        assert_eq!(
+            validate_client_response(&response, client.expected_accept()).expect("valid response"),
+            consumed
+        );
+    }
+
+    #[test]
+    fn handshake_is_incremental_strict_crlf_and_bounded() {
+        assert_eq!(
+            accept_server_request(b"GET / HTTP/1.1\r\n"),
+            Err(WebSocketError::IncompleteHandshake)
+        );
+        assert_eq!(
+            accept_server_request(b"GET / HTTP/1.1\n\n"),
+            Err(WebSocketError::InvalidHandshake)
+        );
+        assert_eq!(
+            accept_server_request(b"GET / HTTP/1.1\rX"),
+            Err(WebSocketError::InvalidHandshake)
+        );
+        assert_eq!(
+            accept_server_request(&vec![b'a'; MAX_HANDSHAKE_BYTES]),
+            Err(WebSocketError::HandshakeTooLarge)
+        );
+        let mut oversized = vec![b'a'; MAX_HANDSHAKE_BYTES + 1];
+        oversized.extend_from_slice(b"\r\n\r\n");
+        assert_eq!(
+            accept_server_request(&oversized),
+            Err(WebSocketError::HandshakeTooLarge)
+        );
+    }
+
+    #[test]
+    fn client_builder_rejects_field_injection_and_oversize() {
+        for (host, target) in [
+            ("", "/"),
+            ("example.com\r\nX: y", "/"),
+            ("example.com", "relative"),
+            ("example.com", "/bad path"),
+            ("example.com", "/path#fragment"),
+            ("éxample.com", "/"),
+        ] {
+            assert_eq!(
+                build_client_request(host, target, [0; 16]),
+                Err(WebSocketError::HeaderInjection)
+            );
+        }
+        let huge_target = format!("/{}", "a".repeat(MAX_HANDSHAKE_BYTES));
+        assert_eq!(
+            build_client_request("example.com", &huge_target, [0; 16]),
+            Err(WebSocketError::HandshakeTooLarge)
+        );
+    }
+
+    #[test]
+    fn server_rejects_missing_conflicting_and_unsupported_upgrade_fields() {
+        let cases = vec![
+            b"POST /chat HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n".to_vec(),
+            b"GET /chat HTTP/1.0\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n".to_vec(),
+            request_with(&["Upgrade: websocket", "Connection: Upgrade", "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==", "Sec-WebSocket-Version: 13"]),
+            request_with(&["Host: x", "Host: y", "Upgrade: websocket", "Connection: Upgrade", "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==", "Sec-WebSocket-Version: 13"]),
+            request_with(&["Host: x", "Connection: Upgrade", "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==", "Sec-WebSocket-Version: 13"]),
+            request_with(&["Host: x", "Upgrade: h2c", "Connection: keep-alive", "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==", "Sec-WebSocket-Version: 13"]),
+            request_with(&["Host: x", "Upgrade: websocket", "Connection: Upgrade", "Sec-WebSocket-Version: 13"]),
+            request_with(&["Host: x", "Upgrade: websocket", "Connection: Upgrade", "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==", "Sec-WebSocket-Version: 12"]),
+            request_with(&["Host: x", "Upgrade: websocket", "Connection: Upgrade", "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==", "Sec-WebSocket-Version: 13", "Sec-WebSocket-Version: 13"]),
+            request_with(&["Host: x", "Upgrade: websocket", "Connection: Upgrade", "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==", "Sec-WebSocket-Version: 13", "Sec-WebSocket-Extensions: permessage-deflate"]),
+            request_with(&["Host: x", "Upgrade: websocket", "Connection: Upgrade", "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==", "Sec-WebSocket-Version: 13", "Sec-WebSocket-Protocol: chat"]),
+            request_with(&["Host: x", "Upgrade: websocket", "Connection: Upgrade", "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==", "Sec-WebSocket-Version: 13", "Content-Length: 0"]),
+            request_with(&["Host: x", "Upgrade: websocket", "Connection: Upgrade", "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==", "Sec-WebSocket-Version: 13", "Transfer-Encoding: chunked"]),
+            request_with(&["Host: x\u{7f}", "Upgrade: websocket", "Connection: Upgrade", "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==", "Sec-WebSocket-Version: 13"]),
+        ];
+        for request in cases {
+            assert!(
+                accept_server_request(&request).is_err(),
+                "request must fail"
+            );
+        }
+    }
+
+    #[test]
+    fn server_requires_one_canonical_sixteen_byte_key() {
+        for key in [
+            "not-base64",
+            "YQ==",
+            "dGhlIHNhbXBsZSBub25jZQ=",
+            "dGhlIHNhbXBsZSBub25jZR==",
+            "dGhlIHNhbXBsZSBub25jZQ!!",
+        ] {
+            let request = request_with(&[
+                "Host: x",
+                "Upgrade: websocket",
+                "Connection: Upgrade",
+                &format!("Sec-WebSocket-Key: {key}"),
+                "Sec-WebSocket-Version: 13",
+            ]);
+            assert!(matches!(
+                accept_server_request(&request),
+                Err(WebSocketError::InvalidBase64)
+            ));
+        }
+        let duplicate = request_with(&[
+            "Host: x",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+            "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+            "Sec-WebSocket-Version: 13",
+        ]);
+        assert_eq!(
+            accept_server_request(&duplicate),
+            Err(WebSocketError::InvalidHandshake)
+        );
+        assert_eq!(decode_base64("+///").unwrap(), [0xfb, 0xff, 0xff]);
+        assert_eq!(
+            decode_base64("YQ==YQ=="),
+            Err(WebSocketError::InvalidBase64)
+        );
+    }
+
+    #[test]
+    fn client_rejects_invalid_upgrade_responses() {
+        let cases = [
+            "HTTP/1.0 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n",
+            "HTTP/1.1 200 OK\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n",
+            "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n",
+            "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: close\r\nSec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n",
+            "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: wrong\r\n\r\n",
+            "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\nSec-WebSocket-Extensions: x\r\n\r\n",
+            "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\nSec-WebSocket-Protocol: chat\r\n\r\n",
+            "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\nContent-Length: 0\r\n\r\n",
+            "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\nTransfer-Encoding: chunked\r\n\r\n",
+        ];
+        for response in cases {
+            assert_eq!(
+                validate_client_response(response.as_bytes(), RFC_ACCEPT),
+                Err(WebSocketError::InvalidHandshake)
+            );
+        }
+        assert_eq!(
+            validate_client_response(b"HTTP/1.1 101 Switching Protocols\r\n", RFC_ACCEPT),
+            Err(WebSocketError::IncompleteHandshake)
+        );
+    }
+
+    fn round_trip(role: EndpointRole, frame: &Frame, key: Option<[u8; 4]>) -> Frame {
+        let wire = encode_frame(role, frame, key).expect("encode frame");
+        let peer = match role {
+            EndpointRole::Client => EndpointRole::Server,
+            EndpointRole::Server => EndpointRole::Client,
+        };
+        let mut decoder = FrameDecoder::new(peer, frame.payload.len().max(1));
+        decoder.push(&wire).expect("decode frame").remove(0)
+    }
+
+    #[test]
+    fn frame_round_trips_small_extended_and_large_lengths() {
+        for length in [0, 1, 125, 126, 65_535, 65_536] {
+            let frame = Frame::binary(vec![0x5a; length]);
+            assert_eq!(round_trip(EndpointRole::Server, &frame, None), frame);
+            assert_eq!(
+                round_trip(EndpointRole::Client, &frame, Some([1, 2, 3, 4])),
+                frame
+            );
+        }
+    }
+
+    #[test]
+    fn rfc_masked_hello_example_decodes_exactly() {
+        let wire = [
+            0x81, 0x85, 0x37, 0xfa, 0x21, 0x3d, 0x7f, 0x9f, 0x4d, 0x51, 0x58,
+        ];
+        let frames = FrameDecoder::new(EndpointRole::Server, 5)
+            .push(&wire)
+            .expect("decode RFC masked frame");
+        assert_eq!(frames, [Frame::text("Hello")]);
+        assert_eq!(
+            encode_frame(EndpointRole::Server, &Frame::text("Hello"), None).unwrap(),
+            b"\x81\x05Hello"
+        );
+    }
+
+    #[test]
+    fn decoder_accepts_bytewise_input_and_multiple_frames() {
+        let first = Frame::text("hello");
+        let second = Frame::binary([1, 2, 3]);
+        let mut wire = encode_frame(EndpointRole::Server, &first, None).unwrap();
+        wire.extend_from_slice(&encode_frame(EndpointRole::Server, &second, None).unwrap());
+        let mut decoder = FrameDecoder::new(EndpointRole::Client, 100);
+        let mut decoded = Vec::new();
+        for byte in &wire {
+            decoded.extend(decoder.push(core::slice::from_ref(byte)).unwrap());
+        }
+        assert_eq!(decoded, [first, second]);
+        assert_eq!(decoder.buffered_len(), 0);
+
+        let partial = encode_frame(EndpointRole::Server, &Frame::text("partial"), None).unwrap();
+        assert!(decoder.push(&partial[..3]).unwrap().is_empty());
+        assert_eq!(decoder.buffered_len(), 3);
+        assert_eq!(decoder.push(&partial[3..]).unwrap().len(), 1);
+
+        let mut masked_extended = FrameDecoder::new(EndpointRole::Server, 126);
+        assert!(masked_extended.push(&[0x82, 0xfe, 0]).unwrap().is_empty());
+        assert_eq!(masked_extended.buffered_len(), 3);
+    }
+
+    #[test]
+    fn every_control_and_fragment_opcode_round_trips_on_wire() {
+        let frames = [
+            Frame::new(false, Opcode::Continuation, [1]).unwrap(),
+            Frame::ping([2]).unwrap(),
+            Frame::pong([3]).unwrap(),
+            Frame::close(Some(1000), "done").unwrap(),
+        ];
+        for frame in frames {
+            assert_eq!(round_trip(EndpointRole::Server, &frame, None), frame);
+            assert_eq!(
+                round_trip(EndpointRole::Client, &frame, Some([4, 3, 2, 1])),
+                frame
+            );
+        }
+    }
+
+    #[test]
+    fn encoder_and_decoder_enforce_mask_direction() {
+        let frame = Frame::text("hello");
+        assert_eq!(
+            encode_frame(EndpointRole::Client, &frame, None),
+            Err(WebSocketError::MaskDirection)
+        );
+        assert_eq!(
+            encode_frame(EndpointRole::Server, &frame, Some([0; 4])),
+            Err(WebSocketError::MaskDirection)
+        );
+        let server_wire = encode_frame(EndpointRole::Server, &frame, None).unwrap();
+        assert_eq!(
+            FrameDecoder::new(EndpointRole::Server, 10).push(&server_wire),
+            Err(WebSocketError::MaskDirection)
+        );
+        let client_wire = encode_frame(EndpointRole::Client, &frame, Some([9; 4])).unwrap();
+        assert_eq!(
+            FrameDecoder::new(EndpointRole::Client, 10).push(&client_wire),
+            Err(WebSocketError::MaskDirection)
+        );
+    }
+
+    #[test]
+    fn decoder_rejects_reserved_opcode_and_noncanonical_lengths() {
+        let cases = [
+            (vec![0xc1, 0], WebSocketError::ReservedBits),
+            (vec![0x83, 0], WebSocketError::InvalidOpcode),
+            (vec![0x82, 126, 0, 125], WebSocketError::NonCanonicalLength),
+            (
+                vec![0x82, 127, 0, 0, 0, 0, 0, 0, 0xff, 0xff],
+                WebSocketError::NonCanonicalLength,
+            ),
+            (
+                vec![0x82, 127, 0x80, 0, 0, 0, 0, 1, 0, 0],
+                WebSocketError::NonCanonicalLength,
+            ),
+            (vec![0x09, 0], WebSocketError::InvalidControlFrame),
+            (vec![0x89, 126, 0, 126], WebSocketError::InvalidControlFrame),
+        ];
+        for (wire, expected) in cases {
+            assert_eq!(
+                FrameDecoder::new(EndpointRole::Client, usize::MAX).push(&wire),
+                Err(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn decoder_rejects_declared_oversize_before_payload_arrives() {
+        let mut decoder = FrameDecoder::new(EndpointRole::Client, 4);
+        assert_eq!(decoder.push(&[0x82, 5]), Err(WebSocketError::FrameTooLarge));
+        let mut decoder = FrameDecoder::new(EndpointRole::Client, 125);
+        assert_eq!(
+            decoder.push(&[0x82, 126, 0, 126]),
+            Err(WebSocketError::FrameTooLarge)
+        );
+    }
+
+    #[test]
+    fn frame_constructors_validate_controls_and_close_payloads() {
+        assert_eq!(
+            Frame::new(false, Opcode::Ping, []),
+            Err(WebSocketError::InvalidControlFrame)
+        );
+        assert_eq!(
+            Frame::ping(vec![0; 126]),
+            Err(WebSocketError::InvalidControlFrame)
+        );
+        assert_eq!(
+            Frame::new(true, Opcode::Close, [1]),
+            Err(WebSocketError::InvalidCloseFrame)
+        );
+        assert_eq!(
+            Frame::close(Some(1005), "reserved"),
+            Err(WebSocketError::InvalidCloseFrame)
+        );
+        assert_eq!(
+            Frame::new(true, Opcode::Close, 1005_u16.to_be_bytes()),
+            Err(WebSocketError::InvalidCloseFrame)
+        );
+        assert_eq!(
+            Frame::close(None, "reason without code"),
+            Err(WebSocketError::InvalidCloseFrame)
+        );
+        assert_eq!(
+            Frame::close(Some(1000), &"x".repeat(124)),
+            Err(WebSocketError::InvalidCloseFrame)
+        );
+        assert_eq!(
+            Frame::new(true, Opcode::Close, [0x03, 0xe8, 0xff]),
+            Err(WebSocketError::InvalidCloseFrame)
+        );
+        assert!(Frame::pong([1, 2]).is_ok());
+        assert_eq!(Frame::close(None, "").unwrap().payload(), []);
+        assert_eq!(
+            complete_data_event(Opcode::Ping, Vec::new()),
+            Err(WebSocketError::InvalidFragmentation)
+        );
+    }
+
+    #[test]
+    fn fragmentation_reassembles_split_utf8_with_interleaved_ping() {
+        let source = "héllo".as_bytes();
+        let fragments = fragment_message(Opcode::Text, source, 2).expect("fragment text");
+        assert_eq!(fragments.len(), 3);
+        assert_eq!(fragments[0].opcode(), Opcode::Text);
+        assert!(!fragments[0].is_final());
+        assert_eq!(fragments[2].opcode(), Opcode::Continuation);
+        assert!(fragments[2].is_final());
+
+        let mut assembler = MessageAssembler::new(100);
+        assert_eq!(assembler.push(fragments[0].clone()).unwrap(), None);
+        assert!(assembler.is_fragmented());
+        let ping = assembler
+            .push(Frame::ping(b"still here".to_vec()).unwrap())
+            .unwrap()
+            .expect("ping event");
+        assert_eq!(ping, MessageEvent::Ping(b"still here".to_vec()));
+        let pong = control_reply(&ping).expect("automatic pong");
+        assert_eq!(pong.opcode(), Opcode::Pong);
+        assert_eq!(pong.payload(), b"still here");
+        assert!(assembler.push(fragments[1].clone()).unwrap().is_none());
+        assert_eq!(
+            assembler.push(fragments[2].clone()).unwrap(),
+            Some(MessageEvent::Text("héllo".to_string()))
+        );
+        assert!(!assembler.is_fragmented());
+    }
+
+    #[test]
+    fn one_mebibyte_binary_message_fragments_and_reassembles() {
+        let payload = (0..1024 * 1024)
+            .map(|index| (index % 251) as u8)
+            .collect::<Vec<_>>();
+        let fragments = fragment_message(Opcode::Binary, &payload, 64 * 1024).unwrap();
+        assert_eq!(fragments.len(), 16);
+        let mut assembler = MessageAssembler::new(payload.len());
+        let mut event = None;
+        for fragment in fragments {
+            event = assembler.push(fragment).unwrap().or(event);
+        }
+        assert_eq!(event, Some(MessageEvent::Binary(payload)));
+    }
+
+    #[test]
+    fn assembler_emits_binary_and_pong_events() {
+        let mut assembler = MessageAssembler::new(10);
+        assert_eq!(
+            assembler.push(Frame::binary([1, 2, 3])).unwrap(),
+            Some(MessageEvent::Binary(vec![1, 2, 3]))
+        );
+        assert_eq!(
+            assembler.push(Frame::pong([4, 5]).unwrap()).unwrap(),
+            Some(MessageEvent::Pong(vec![4, 5]))
+        );
+        assert!(control_reply(&MessageEvent::Binary(vec![])).is_none());
+        assert!(control_reply(&MessageEvent::Pong(vec![])).is_none());
+        assert!(control_reply(&MessageEvent::Text(String::new())).is_none());
+    }
+
+    #[test]
+    fn assembler_rejects_fragmentation_utf8_and_size_failures() {
+        let mut assembler = MessageAssembler::new(3);
+        assert_eq!(
+            assembler.push(Frame::new(true, Opcode::Continuation, []).unwrap()),
+            Err(WebSocketError::InvalidFragmentation)
+        );
+        assert_eq!(
+            assembler.push(Frame::new(false, Opcode::Text, b"ab".to_vec()).unwrap()),
+            Ok(None)
+        );
+        assert_eq!(
+            assembler.push(Frame::binary([1])),
+            Err(WebSocketError::InvalidFragmentation)
+        );
+
+        let mut oversized = MessageAssembler::new(3);
+        oversized
+            .push(Frame::new(false, Opcode::Binary, [1, 2]).unwrap())
+            .unwrap();
+        assert_eq!(
+            oversized.push(Frame::new(true, Opcode::Continuation, [3, 4]).unwrap()),
+            Err(WebSocketError::MessageTooLarge)
+        );
+        let mut complete_oversized = MessageAssembler::new(1);
+        assert_eq!(
+            complete_oversized.push(Frame::binary([1, 2])),
+            Err(WebSocketError::MessageTooLarge)
+        );
+        let mut invalid_text = MessageAssembler::new(10);
+        assert_eq!(
+            invalid_text.push(Frame::new(true, Opcode::Text, [0xff]).unwrap()),
+            Err(WebSocketError::InvalidUtf8)
+        );
+    }
+
+    #[test]
+    fn fragment_helper_validates_inputs_and_empty_messages() {
+        assert_eq!(
+            fragment_message(Opcode::Ping, b"x", 1),
+            Err(WebSocketError::InvalidFragmentation)
+        );
+        assert_eq!(
+            fragment_message(Opcode::Binary, b"x", 0),
+            Err(WebSocketError::InvalidFragmentation)
+        );
+        assert_eq!(
+            fragment_message(Opcode::Text, &[0xff], 1),
+            Err(WebSocketError::InvalidUtf8)
+        );
+        let empty = fragment_message(Opcode::Binary, b"", 8).unwrap();
+        assert_eq!(empty, [Frame::binary([])]);
+    }
+
+    #[test]
+    fn close_event_exposes_validated_status_and_builds_echo() {
+        let mut assembler = MessageAssembler::new(10);
+        assembler
+            .push(Frame::new(false, Opcode::Binary, [1, 2]).unwrap())
+            .unwrap();
+        assert!(assembler.is_fragmented());
+        let event = assembler
+            .push(Frame::close(Some(1000), "done").unwrap())
+            .unwrap()
+            .expect("close event");
+        let MessageEvent::Close(close) = &event else {
+            panic!("expected close event");
+        };
+        assert_eq!(close.code(), Some(1000));
+        assert_eq!(close.reason(), "done");
+        assert!(assembler.is_closed());
+        assert!(!assembler.is_fragmented());
+        assert_eq!(
+            assembler.push(Frame::text("late")),
+            Err(WebSocketError::ClosedSession)
+        );
+        assert_eq!(
+            assembler.push(Frame::pong([]).unwrap()).unwrap(),
+            Some(MessageEvent::Pong(Vec::new()))
+        );
+        let echo = control_reply(&event).expect("close echo");
+        assert_eq!(echo, Frame::close(Some(1000), "done").unwrap());
+
+        let empty_event = MessageEvent::Close(decode_close_payload(&[]).unwrap());
+        let MessageEvent::Close(empty_close) = &empty_event else {
+            unreachable!()
+        };
+        assert_eq!(empty_close.code(), None);
+        assert_eq!(empty_close.reason(), "");
+        assert_eq!(
+            control_reply(&empty_event).unwrap(),
+            Frame::close(None, "").unwrap()
+        );
+    }
+
+    #[test]
+    fn valid_close_code_ranges_are_enforced() {
+        for code in [1000, 1014, 3000, 4999] {
+            assert!(Frame::close(Some(code), "").is_ok());
+        }
+        for code in [0, 999, 1004, 1005, 1006, 1015, 2000, 2999, 5000] {
+            assert_eq!(
+                Frame::close(Some(code), ""),
+                Err(WebSocketError::InvalidCloseFrame)
+            );
+        }
+    }
+
+    #[test]
+    fn diagnostics_are_stable_and_payload_free() {
+        let errors = [
+            WebSocketError::IncompleteHandshake,
+            WebSocketError::HandshakeTooLarge,
+            WebSocketError::InvalidHandshake,
+            WebSocketError::HeaderInjection,
+            WebSocketError::InvalidBase64,
+            WebSocketError::ReservedBits,
+            WebSocketError::InvalidOpcode,
+            WebSocketError::MaskDirection,
+            WebSocketError::NonCanonicalLength,
+            WebSocketError::FrameTooLarge,
+            WebSocketError::InvalidControlFrame,
+            WebSocketError::InvalidCloseFrame,
+            WebSocketError::InvalidUtf8,
+            WebSocketError::InvalidFragmentation,
+            WebSocketError::MessageTooLarge,
+            WebSocketError::ClosedSession,
+        ];
+        for error in errors {
+            let rendered = error.to_string();
+            assert!(rendered.starts_with("websocket:"));
+            assert!(!rendered.contains(RFC_KEY));
+            assert!(!rendered.contains("payload"));
+        }
+    }
+}

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -20,6 +20,9 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 - Generate Sanskrit Chapter 6 from its three strict canonical lessons,
   preserving Devanagari forms, comparison tables, and romanized bookmarks from
   the shared AST.
+- Generate Bengali Chapter 6 from its strict canonical lesson, preserving the
+  Bengali numeral forms, *dui* history, and bookmark-safe romanization from the
+  shared AST.
 
 ### Added — block-boundary knowledge closure
 

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS model-card `MJ` values and lower valid
+  bottom-junction grading coefficients instead of silently dropping them.
 - Reject zero, negative, and non-finite MOS model-card `PB` values and lower
   valid bulk-junction potentials instead of silently dropping them.
 - Reject negative and non-finite MOS model-card `JS` values and lower valid

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite MOS model-card `PB` values and lower
+  valid bulk-junction potentials instead of silently dropping them.
 - Reject negative and non-finite MOS model-card `JS` values and lower valid
   junction saturation-current densities instead of silently dropping them.
 - Reject negative and non-finite MOS model-card `CJSW` values and lower valid

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1308,6 +1308,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET PB must be finite and positive");
   }
+  const gradingCoefficient = params.get("MJ");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    gradingCoefficient !== undefined &&
+    (!Number.isFinite(gradingCoefficient) || gradingCoefficient < 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET MJ must be finite and non-negative");
+  }
   const nominalTemperature = params.get("T_NOM") ?? params.get("TNOM");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1412,6 +1420,7 @@ function isMosfetParam(name: keyof MosfetLevel1Params): boolean {
     "CJSW",
     "JS",
     "PB",
+    "MJ",
     "IS",
     "N_SUB",
     "T_NOM",

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1300,6 +1300,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET JS must be finite and non-negative");
   }
+  const bulkPotential = params.get("PB");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    bulkPotential !== undefined &&
+    (!Number.isFinite(bulkPotential) || bulkPotential <= 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET PB must be finite and positive");
+  }
   const nominalTemperature = params.get("T_NOM") ?? params.get("TNOM");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1403,6 +1411,7 @@ function isMosfetParam(name: keyof MosfetLevel1Params): boolean {
     "CJ",
     "CJSW",
     "JS",
+    "PB",
     "IS",
     "N_SUB",
     "T_NOM",

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1779,6 +1779,25 @@ Xright c d load
     expect(element.params.PB).toBeCloseTo(0.72, 15);
   });
 
+  it.each(["-0.1", "1e999"])(
+    "rejects invalid MOSFET model MJ=%s",
+    (gradingCoefficient) => {
+      expect(() =>
+        parseNetlist(`.model nfast NMOS(MJ=${gradingCoefficient})\nM1 d g s b nfast\n`),
+      ).toThrow("MOSFET MJ must be finite and non-negative");
+    },
+  );
+
+  it.each(["0", "0.45"])("lowers valid MOSFET model MJ=%s", (gradingCoefficient) => {
+    const parsed = parseNetlist(
+      `.model nfast NMOS(MJ=${gradingCoefficient})\nM1 d g s b nfast\n`,
+    );
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.MJ).toBe(Number(gradingCoefficient));
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1762,6 +1762,23 @@ Xright c d load
     expect(element.params.JS).toBeCloseTo(expected, 15);
   });
 
+  it.each(["0", "-0.1", "1e999"])(
+    "rejects invalid MOSFET model PB=%s",
+    (bulkPotential) => {
+      expect(() =>
+        parseNetlist(`.model nfast NMOS(PB=${bulkPotential})\nM1 d g s b nfast\n`),
+      ).toThrow("MOSFET PB must be finite and positive");
+    },
+  );
+
+  it("lowers positive MOSFET model PB", () => {
+    const parsed = parseNetlist(".model nfast NMOS(PB=0.72)\nM1 d g s b nfast\n");
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.PB).toBeCloseTo(0.72, 15);
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/programs/go/build-tool/CHANGELOG.md
+++ b/code/programs/go/build-tool/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to the Go build tool will be documented in this file.
 
 ### Added
 
+- **Canonical discovery identity registry.** Go discovery now consumes the
+  shared language-registry and duplicate-identity fixtures, recognizes every
+  canonical package/program bucket including Mosaic, Twig, OCaml, and retained
+  `.NET` hosts, preserves the `programs` identity segment, and excludes
+  specification fixture trees.
+- **Fail-closed duplicate identities.** Two directories that normalize to one
+  graph name now return typed `DUPLICATE_PACKAGE_IDENTITY` details with sorted
+  repository-relative paths; the CLI prints the stable root-redacted
+  diagnostic and exits `2`.
 - **C and C++ as first-class languages.** `inferLanguage` now recognizes `c`
   and `cpp` path components (exact-match, so `c` never fires inside `csharp` or
   `cpp`). Existing C++ packages (`cpp/conduit`, `cpp/conduit-hello`,

--- a/code/programs/go/build-tool/README.md
+++ b/code/programs/go/build-tool/README.md
@@ -66,7 +66,7 @@ On Windows, use the compiled `.exe`:
 | `-force` | false | Rebuild everything regardless of cache |
 | `-dry-run` | false | Show what would build without executing |
 | `-jobs` | NumCPU | Maximum parallel build jobs |
-| `-language` | all | Filter to: python, ruby, go, rust, typescript, elixir, lua, perl, swift, dart, java, kotlin, haskell, dotnet, or all |
+| `-language` | all | Filter to any canonical discovery bucket, or `all` |
 | `-diff-base` | origin/main | Git ref to diff against for change detection |
 | `-cache-file` | .build-cache.json | Path to the build cache file |
 
@@ -77,6 +77,25 @@ contract. In particular, Lua `.rockspec` files must be strict UTF-8. Invalid
 bytes stop resolution with `METADATA_INVALID_UTF8`, identify the package and
 repository-relative manifest, and return CLI exit code 2 without exposing the
 checkout path or silently replacing input.
+
+## Canonical discovery identities
+
+Discovery uses only the exact bucket immediately below a `packages` or
+`programs` path component. It recognizes every established implementation
+lane, the emerging C, C++, and OCaml lanes, the WASM target, the Mosaic and
+Twig domain languages, the Starlark build language, and the retained shared
+`.NET` host bucket. Programs keep a `programs` segment, such as
+`go/programs/build-tool`, so they cannot collide with a library of the same
+name. Specification fixture trees are not buildable packages.
+
+Discovery fails closed when two directories normalize to the same identity:
+
+```text
+DUPLICATE_PACKAGE_IDENTITY: package=unknown/demo paths=code/packages/alpha/demo,code/packages/beta/demo
+```
+
+The diagnostic contains sorted repository-relative paths, never the checkout
+root, and the CLI returns exit code `2`.
 
 ## Architecture
 

--- a/code/programs/go/build-tool/discovery_error_test.go
+++ b/code/programs/go/build-tool/discovery_error_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/adhithyan15/coding-adventures/code/programs/go/build-tool/internal/discovery"
+)
+
+type duplicateIdentityFixture struct {
+	Workspace struct {
+		Files []struct {
+			Path        string `json:"path"`
+			ContentUTF8 string `json:"content_utf8"`
+		} `json:"files"`
+	} `json:"workspace"`
+	Expected struct {
+		Diagnostics []struct {
+			Code    string `json:"code"`
+			Package string `json:"package"`
+			Details struct {
+				Paths []string `json:"paths"`
+			} `json:"details"`
+		} `json:"diagnostics"`
+	} `json:"expected"`
+}
+
+func materializeDuplicateIdentityFixture(t *testing.T) (string, duplicateIdentityFixture) {
+	t.Helper()
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not locate main-package test source")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(sourceFile), "..", "..", "..", ".."))
+	data, err := os.ReadFile(filepath.Join(repoRoot, "code", "specs", "fixtures", "build-tool-v1", "cases", "discovery-duplicate-identity.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixture duplicateIdentityFixture
+	if err := json.Unmarshal(data, &fixture); err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	for _, file := range fixture.Workspace.Files {
+		path := filepath.Join(root, filepath.FromSlash(file.Path))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(file.ContentUTF8), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root, fixture
+}
+
+func TestFormatDiscoveryErrorUsesStableDuplicateDiagnostic(t *testing.T) {
+	err := &discovery.DuplicatePackageIdentityError{
+		Code:    "DUPLICATE_PACKAGE_IDENTITY",
+		Package: "unknown/demo",
+		Paths:   []string{"code/packages/alpha/demo", "code/packages/beta/demo"},
+	}
+	message, exitCode := formatDiscoveryError(err)
+	if exitCode != 2 || message != err.Error() {
+		t.Fatalf("duplicate diagnostic = (%q, %d), want (%q, 2)", message, exitCode, err.Error())
+	}
+}
+
+func TestFormatDiscoveryErrorKeepsOperationalFailuresDistinct(t *testing.T) {
+	message, exitCode := formatDiscoveryError(errors.New("discovery failed"))
+	if exitCode != 1 || message != "Error: discovery failed" {
+		t.Fatalf("operational failure = (%q, %d), want (%q, 1)", message, exitCode, "Error: discovery failed")
+	}
+}
+
+func TestRunFailsClosedOnDuplicatePackageIdentity(t *testing.T) {
+	root, fixture := materializeDuplicateIdentityFixture(t)
+	diagnostic := fixture.Expected.Diagnostics[0]
+
+	originalArgs := os.Args
+	originalFlags := flag.CommandLine
+	originalStderr := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		os.Args = originalArgs
+		flag.CommandLine = originalFlags
+		os.Stderr = originalStderr
+		reader.Close()
+		writer.Close()
+	})
+	flag.CommandLine = flag.NewFlagSet("build-tool-test", flag.ContinueOnError)
+	os.Args = []string{"build-tool", "-root", root, "-force", "-dry-run", "-validate-build-files=false"}
+	os.Stderr = writer
+
+	exitCode := run()
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = originalStderr
+	stderr, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if exitCode != 2 {
+		t.Fatalf("run exit code = %d, want 2; stderr=%s", exitCode, stderr)
+	}
+	wantPaths := diagnostic.Details.Paths
+	want := diagnostic.Code + ": package=" + diagnostic.Package + " paths=" + strings.Join(wantPaths, ",") + "\n"
+	if string(stderr) != want {
+		t.Fatalf("stderr = %q, want %q", stderr, want)
+	}
+	if strings.Contains(string(stderr), root) {
+		t.Fatalf("front door leaked workspace root: %s", stderr)
+	}
+	if !slices.IsSorted(wantPaths) {
+		t.Fatalf("fixture paths must be sorted: %v", wantPaths)
+	}
+}

--- a/code/programs/go/build-tool/internal/discovery/discovery.go
+++ b/code/programs/go/build-tool/internal/discovery/discovery.go
@@ -34,13 +34,13 @@
 //
 // # Language inference
 //
-// We infer a package's language from its directory path. If the path contains
-// a known language name as a component under "packages" or "programs", that is
-// the language. The package name is "{language}/{dirname}", e.g.,
-// "python/logic-gates" or "go/directed-graph".
+// We infer a package's language only from the exact bucket immediately below a
+// "packages" or "programs" boundary. Programs retain a "programs" identity
+// segment, for example "go/programs/build-tool".
 package discovery
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -60,11 +60,36 @@ type Package struct {
 	Name          string   // Qualified name, e.g. "python/logic-gates"
 	Path          string   // Absolute path to the package directory
 	BuildCommands []string // Lines from the BUILD file (commands to execute)
-	Language      string   // Inferred language: "python", "ruby", "go", "rust", "typescript", "elixir", "lua", "perl", "swift", "dart", "wasm", "c", "cpp", "csharp", "fsharp", "dotnet", "starlark", or "unknown"
+	Language      string   // Canonical package/program bucket, or "unknown"
 	BuildContent  string   // Raw BUILD file content (used for Starlark detection)
 	IsStarlark    bool     // Whether this BUILD file is Starlark (vs shell)
 	DeclaredSrcs  []string // Explicit source files from Starlark srcs field
 	DeclaredDeps  []string // Explicit deps from Starlark deps field
+}
+
+// DuplicatePackageIdentityError reports two or more package directories that
+// normalize to one graph identity. Paths are stable repository-relative
+// identities so diagnostics never disclose the checkout root.
+type DuplicatePackageIdentityError struct {
+	Code    string
+	Package string
+	Paths   []string
+}
+
+func (e *DuplicatePackageIdentityError) Error() string {
+	return fmt.Sprintf("%s: package=%s paths=%s", e.Code, e.Package, strings.Join(e.Paths, ","))
+}
+
+// knownLanguages is the canonical discovery registry. The package-parity
+// denominator is defined separately; dotnet remains a shared host bucket.
+var knownLanguages = map[string]bool{
+	"csharp": true, "dart": true, "elixir": true, "fsharp": true,
+	"go": true, "haskell": true, "java": true, "kotlin": true,
+	"lua": true, "perl": true, "python": true, "ruby": true,
+	"rust": true, "swift": true, "typescript": true,
+	"c": true, "cpp": true, "ocaml": true,
+	"wasm": true, "mosaic": true, "twig": true, "starlark": true,
+	"dotnet": true,
 }
 
 // skipDirs is the set of directory names that should never be traversed
@@ -117,25 +142,27 @@ func readLines(filepath string) []string {
 	return lines
 }
 
-// inferLanguage inspects the directory path to determine the programming
-// language. We look for known language names ("python", "ruby", "go", "rust",
-// "typescript", "elixir", "lua", "perl", "swift", "dart", "wasm", "haskell",
-// "starlark", "c", "cpp", "csharp", "fsharp", "dotnet") as path components.
-// For example, "/repo/code/packages/python/logic-gates" yields "python" and
-// "/repo/code/programs/dotnet/hello-world-csharp" yields "dotnet".
-//
-// The match is by *exact* path component, so "c" matches only a literal `c/`
-// directory (e.g. code/packages/c/ringbuf) — it never matches inside "csharp"
-// or "cpp". Likewise "cpp" matches only a `cpp/` directory.
-func inferLanguage(path string) string {
-	// Split the path into its components and search for a known language.
+// packageBoundary returns the final packages/programs boundary in path. The
+// final boundary is authoritative so nested temporary fixture roots retain
+// their own identity rather than borrowing a bucket from a host checkout.
+func packageBoundary(path string) (kind, bucket string, ok bool) {
 	parts := strings.Split(filepath.ToSlash(path), "/")
-	for _, lang := range []string{"python", "ruby", "go", "rust", "typescript", "elixir", "lua", "perl", "swift", "dart", "wasm", "haskell", "starlark", "java", "kotlin", "cpp", "c", "csharp", "fsharp", "dotnet"} {
-		for _, part := range parts {
-			if part == lang {
-				return lang
-			}
+	for index := 0; index+1 < len(parts); index++ {
+		if parts[index] == "packages" || parts[index] == "programs" {
+			kind = parts[index]
+			bucket = parts[index+1]
+			ok = true
 		}
+	}
+	return kind, bucket, ok
+}
+
+// inferLanguage accepts only canonical exact boundary buckets. A canonical
+// word elsewhere in the path cannot change an unknown bucket.
+func inferLanguage(path string) string {
+	_, bucket, ok := packageBoundary(path)
+	if ok && knownLanguages[bucket] {
+		return bucket
 	}
 	return "unknown"
 }
@@ -154,11 +181,30 @@ func inferLanguage(path string) string {
 //
 //	"go/programs/grammar-tools"
 func inferPackageName(path, language string) string {
-	normalized := filepath.ToSlash(path)
-	if strings.Contains(normalized, "/programs/") {
+	kind, _, _ := packageBoundary(path)
+	if kind == "programs" {
 		return language + "/programs/" + filepath.Base(path)
 	}
 	return language + "/" + filepath.Base(path)
+}
+
+func repositoryPackagePath(root, packagePath string) string {
+	parts := strings.Split(filepath.ToSlash(packagePath), "/")
+	canonicalStart := -1
+	for index := 0; index+1 < len(parts); index++ {
+		if parts[index] == "code" && (parts[index+1] == "packages" || parts[index+1] == "programs") {
+			canonicalStart = index
+		}
+	}
+	if canonicalStart >= 0 {
+		return strings.Join(parts[canonicalStart:], "/")
+	}
+
+	relative, err := filepath.Rel(root, packagePath)
+	if err == nil && relative != "." && relative != "" && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return filepath.ToSlash(relative)
+	}
+	return filepath.Base(packagePath)
 }
 
 // getBuildFile returns the path to the appropriate BUILD file for the current
@@ -292,13 +338,37 @@ func walkDirs(directory string, packages *[]Package) {
 //
 // This is the main entry point for the discovery module. The root
 // parameter should typically be the "code/" directory inside the repo.
-func DiscoverPackages(root string) []Package {
+func DiscoverPackages(root string) ([]Package, error) {
 	var packages []Package
 	walkDirs(root, &packages)
 	sort.Slice(packages, func(i, j int) bool {
+		if packages[i].Name == packages[j].Name {
+			return packages[i].Path < packages[j].Path
+		}
 		return packages[i].Name < packages[j].Name
 	})
-	return packages
+
+	for index := 0; index < len(packages); {
+		end := index + 1
+		for end < len(packages) && packages[end].Name == packages[index].Name {
+			end++
+		}
+		if end-index > 1 {
+			paths := make([]string, 0, end-index)
+			for _, pkg := range packages[index:end] {
+				paths = append(paths, repositoryPackagePath(root, pkg.Path))
+			}
+			sort.Strings(paths)
+			return nil, &DuplicatePackageIdentityError{
+				Code:    "DUPLICATE_PACKAGE_IDENTITY",
+				Package: packages[index].Name,
+				Paths:   paths,
+			}
+		}
+		index = end
+	}
+
+	return packages, nil
 }
 
 // ReadLines is exported for use by the resolver (to read go.mod, etc.).

--- a/code/programs/go/build-tool/internal/discovery/discovery_test.go
+++ b/code/programs/go/build-tool/internal/discovery/discovery_test.go
@@ -28,6 +28,15 @@ func makeFixture(t *testing.T, tree map[string]string) string {
 	return root
 }
 
+func mustDiscoverPackages(t *testing.T, root string) []Package {
+	t.Helper()
+	packages, err := DiscoverPackages(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return packages
+}
+
 // ---------------------------------------------------------------------------
 // Tests for readLines
 // ---------------------------------------------------------------------------
@@ -338,7 +347,7 @@ func TestDiscoverSimplePackage(t *testing.T) {
 		"packages/python/pkg-a/src/main.py":    "print('hello')\n",
 	})
 
-	packages := DiscoverPackages(root)
+	packages := mustDiscoverPackages(t, root)
 	if len(packages) != 1 {
 		t.Fatalf("expected 1 package, got %d", len(packages))
 	}
@@ -361,7 +370,7 @@ func TestDiscoverMultiplePackages(t *testing.T) {
 		"packages/python/pkg-b/BUILD": "echo b",
 	})
 
-	packages := DiscoverPackages(root)
+	packages := mustDiscoverPackages(t, root)
 	if len(packages) != 2 {
 		t.Fatalf("expected 2 packages, got %d", len(packages))
 	}
@@ -376,7 +385,7 @@ func TestDiscoverMultiplePackages(t *testing.T) {
 
 func TestDiscoverEmptyDirectory(t *testing.T) {
 	root := t.TempDir()
-	packages := DiscoverPackages(root)
+	packages := mustDiscoverPackages(t, root)
 	if len(packages) != 0 {
 		t.Fatalf("expected 0 packages, got %d", len(packages))
 	}
@@ -386,7 +395,7 @@ func TestDiscoverNoBUILD(t *testing.T) {
 	root := makeFixture(t, map[string]string{
 		"subdir/nothing": "just a file",
 	})
-	packages := DiscoverPackages(root)
+	packages := mustDiscoverPackages(t, root)
 	if len(packages) != 0 {
 		t.Fatalf("expected 0 packages, got %d", len(packages))
 	}
@@ -395,17 +404,17 @@ func TestDiscoverNoBUILD(t *testing.T) {
 func TestDiscoverDiamondStructure(t *testing.T) {
 	// Four packages at the same level — the diamond dependency shape.
 	root := makeFixture(t, map[string]string{
-		"pkgs/python/pkg-a/BUILD":       "echo a",
-		"pkgs/python/pkg-a/src/main.py": "pass",
-		"pkgs/python/pkg-b/BUILD":       "echo b",
-		"pkgs/python/pkg-b/src/main.py": "pass",
-		"pkgs/python/pkg-c/BUILD":       "echo c",
-		"pkgs/python/pkg-c/src/main.py": "pass",
-		"pkgs/python/pkg-d/BUILD":       "echo d",
-		"pkgs/python/pkg-d/src/main.py": "pass",
+		"packages/python/pkg-a/BUILD":       "echo a",
+		"packages/python/pkg-a/src/main.py": "pass",
+		"packages/python/pkg-b/BUILD":       "echo b",
+		"packages/python/pkg-b/src/main.py": "pass",
+		"packages/python/pkg-c/BUILD":       "echo c",
+		"packages/python/pkg-c/src/main.py": "pass",
+		"packages/python/pkg-d/BUILD":       "echo d",
+		"packages/python/pkg-d/src/main.py": "pass",
 	})
 
-	packages := DiscoverPackages(root)
+	packages := mustDiscoverPackages(t, root)
 	if len(packages) != 4 {
 		t.Fatalf("expected 4 packages, got %d", len(packages))
 	}
@@ -428,7 +437,7 @@ func TestDiscoverMultiLanguage(t *testing.T) {
 		"programs/python/app/BUILD":    "echo app",
 	})
 
-	packages := DiscoverPackages(root)
+	packages := mustDiscoverPackages(t, root)
 	if len(packages) != 6 {
 		t.Fatalf("expected 6 packages, got %d", len(packages))
 	}
@@ -449,7 +458,7 @@ func TestDiscoverBUILDStopsRecursion(t *testing.T) {
 		"pkg-a/sub/BUILD": "echo sub",
 	})
 
-	packages := DiscoverPackages(root)
+	packages := mustDiscoverPackages(t, root)
 	if len(packages) != 1 {
 		t.Fatalf("expected 1 package (BUILD stops recursion), got %d", len(packages))
 	}
@@ -470,7 +479,7 @@ func TestDiscoverSkipsSkipListDirs(t *testing.T) {
 		"packages/python/pkg-b/__pycache__/BUILD":  "echo pycache",
 	})
 
-	packages := DiscoverPackages(root)
+	packages := mustDiscoverPackages(t, root)
 	// Should only find pkg-a and pkg-b (BUILD stops recursion at pkg level,
 	// so .venv and node_modules inside pkg-a are irrelevant). .git at root
 	// is skipped.
@@ -486,7 +495,7 @@ func TestDiscoverSkipsTargetDir(t *testing.T) {
 		"packages/rust/lib-rs/target/debug/BUILD": "echo target",
 	})
 
-	packages := DiscoverPackages(root)
+	packages := mustDiscoverPackages(t, root)
 	// BUILD at lib-rs stops recursion, so target is not reached anyway.
 	// But verify the package is found.
 	if len(packages) != 1 {
@@ -505,7 +514,7 @@ func TestDiscoverSkipsRootLevelSkipDirs(t *testing.T) {
 		"vendor/some-dep/BUILD":        "echo vendor",
 	})
 
-	packages := DiscoverPackages(root)
+	packages := mustDiscoverPackages(t, root)
 	if len(packages) != 1 {
 		t.Fatalf("expected 1 package, got %d: %v", len(packages), packages)
 	}
@@ -521,7 +530,7 @@ func TestDiscoverSkipsSpecificationFixtureTrees(t *testing.T) {
 		"specs/fixtures/scaffold-generator/program/BUILD": "opam exec -- dune build",
 	})
 
-	packages := DiscoverPackages(root)
+	packages := mustDiscoverPackages(t, root)
 	if len(packages) != 1 {
 		t.Fatalf("expected only the real package, got %d: %v", len(packages), packages)
 	}

--- a/code/programs/go/build-tool/internal/discovery/identity_registry_test.go
+++ b/code/programs/go/build-tool/internal/discovery/identity_registry_test.go
@@ -1,0 +1,128 @@
+package discovery
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+)
+
+type sharedDiscoveryFixture struct {
+	Workspace struct {
+		Files []struct {
+			Path        string `json:"path"`
+			ContentUTF8 string `json:"content_utf8"`
+		} `json:"files"`
+	} `json:"workspace"`
+	Expected struct {
+		Result struct {
+			Packages []struct {
+				Name     string `json:"name"`
+				Language string `json:"language"`
+				RelPath  string `json:"rel_path"`
+			} `json:"packages"`
+		} `json:"result"`
+		Diagnostics []struct {
+			Code    string `json:"code"`
+			Path    string `json:"path"`
+			Package string `json:"package"`
+			Details struct {
+				Paths []string `json:"paths"`
+			} `json:"details"`
+		} `json:"diagnostics"`
+	} `json:"expected"`
+}
+
+func loadSharedDiscoveryFixture(t *testing.T, filename string) sharedDiscoveryFixture {
+	t.Helper()
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not locate discovery test source")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(sourceFile), "..", "..", "..", "..", "..", ".."))
+	fixturePath := filepath.Join(repoRoot, "code", "specs", "fixtures", "build-tool-v1", "cases", filename)
+	data, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixture sharedDiscoveryFixture
+	if err := json.Unmarshal(data, &fixture); err != nil {
+		t.Fatal(err)
+	}
+	return fixture
+}
+
+func materializeSharedDiscoveryFixture(t *testing.T, fixture sharedDiscoveryFixture) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, file := range fixture.Workspace.Files {
+		path := filepath.Join(root, filepath.FromSlash(file.Path))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(file.ContentUTF8), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func TestDiscoverPackagesConsumesSharedLanguageRegistry(t *testing.T) {
+	fixture := loadSharedDiscoveryFixture(t, "discovery-language-registry.json")
+	root := materializeSharedDiscoveryFixture(t, fixture)
+
+	packages, err := DiscoverPackages(filepath.Join(root, "code"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual := make([]string, 0, len(packages))
+	for _, pkg := range packages {
+		relPath, err := filepath.Rel(root, pkg.Path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		actual = append(actual, strings.Join([]string{pkg.Name, pkg.Language, filepath.ToSlash(relPath)}, "|"))
+	}
+	want := make([]string, 0, len(fixture.Expected.Result.Packages))
+	for _, pkg := range fixture.Expected.Result.Packages {
+		want = append(want, strings.Join([]string{pkg.Name, pkg.Language, pkg.RelPath}, "|"))
+	}
+	if !slices.Equal(actual, want) {
+		t.Fatalf("discovery registry mismatch\n got: %v\nwant: %v", actual, want)
+	}
+}
+
+func TestDiscoverPackagesFailsClosedOnSharedDuplicateIdentity(t *testing.T) {
+	fixture := loadSharedDiscoveryFixture(t, "discovery-duplicate-identity.json")
+	root := materializeSharedDiscoveryFixture(t, fixture)
+
+	_, err := DiscoverPackages(filepath.Join(root, "code"))
+	var duplicate *DuplicatePackageIdentityError
+	if !errors.As(err, &duplicate) {
+		t.Fatalf("error = %T %v, want *DuplicatePackageIdentityError", err, err)
+	}
+	diagnostic := fixture.Expected.Diagnostics[0]
+	if duplicate.Code != diagnostic.Code {
+		t.Fatalf("code = %q, want %q", duplicate.Code, diagnostic.Code)
+	}
+	if duplicate.Package != diagnostic.Package {
+		t.Fatalf("package = %q, want %q", duplicate.Package, diagnostic.Package)
+	}
+	if !slices.Equal(duplicate.Paths, diagnostic.Details.Paths) {
+		t.Fatalf("paths = %v, want %v", duplicate.Paths, diagnostic.Details.Paths)
+	}
+	if duplicate.Paths[0] != diagnostic.Path {
+		t.Fatalf("primary path = %q, want %q", duplicate.Paths[0], diagnostic.Path)
+	}
+	wantMessage := diagnostic.Code + ": package=" + diagnostic.Package + " paths=" + strings.Join(diagnostic.Details.Paths, ",")
+	if duplicate.Error() != wantMessage {
+		t.Fatalf("message = %q, want %q", duplicate.Error(), wantMessage)
+	}
+	if strings.Contains(duplicate.Error(), root) {
+		t.Fatalf("duplicate diagnostic leaked workspace root: %s", duplicate)
+	}
+}

--- a/code/programs/go/build-tool/main.go
+++ b/code/programs/go/build-tool/main.go
@@ -97,6 +97,14 @@ func formatResolverError(err error) (string, int) {
 	return fmt.Sprintf("Error: %v", err), 1
 }
 
+func formatDiscoveryError(err error) (string, int) {
+	var duplicateError *discovery.DuplicatePackageIdentityError
+	if errors.As(err, &duplicateError) {
+		return duplicateError.Error(), 2
+	}
+	return fmt.Sprintf("Error: %v", err), 1
+}
+
 // expandAffectedSetWithPrereqs ensures all transitive prerequisites of the
 // currently affected packages are also scheduled. This matters on fresh CI
 // runners: some package BUILD steps materialize local dependency state
@@ -150,7 +158,7 @@ func run() int {
 	force := flag.Bool("force", false, "Rebuild everything regardless of cache")
 	dryRun := flag.Bool("dry-run", false, "Show what would build without executing")
 	jobs := flag.Int("jobs", runtime.NumCPU(), "Max parallel jobs")
-	language := flag.String("language", "all", "Filter to package language: python, ruby, go, rust, typescript, elixir, lua, perl, swift, dart, wasm, c, cpp, csharp, fsharp, dotnet, all")
+	language := flag.String("language", "all", "Filter to a canonical package language or all")
 	diffBase := flag.String("diff-base", "origin/main", "Git ref to diff against for change detection (default: origin/main)")
 	cacheFile := flag.String("cache-file", ".build-cache.json", "Path to cache file (fallback when git diff unavailable)")
 	detectLanguages := flag.Bool("detect-languages", false, "Output which language toolchains are needed based on git diff, then exit")
@@ -329,7 +337,12 @@ func run() int {
 
 	if !usedPlan {
 		// Step 2: Discover packages.
-		packages = discovery.DiscoverPackages(codeRoot)
+		packages, err = discovery.DiscoverPackages(codeRoot)
+		if err != nil {
+			message, exitCode := formatDiscoveryError(err)
+			fmt.Fprintln(os.Stderr, message)
+			return exitCode
+		}
 		if len(packages) == 0 {
 			fmt.Fprintln(os.Stderr, "No packages found.")
 			return 0

--- a/code/programs/mosaic/venture-browser/ACCEPTANCE-BACKLOG.md
+++ b/code/programs/mosaic/venture-browser/ACCEPTANCE-BACKLOG.md
@@ -5,6 +5,10 @@ cross-platform proving application. Items are ordered by risk and dependency.
 
 ## Prioritized discoveries
 
+- [x] **P0 CI regression — required gate event isolation.** Keep the protected
+  `CI gate` context exclusive to pull-request workflows. Branch and main push
+  workflows publish `CI push gate` so a fast push build cannot auto-complete a
+  PR while required macOS or Windows acceptance is still running.
 - [x] **P0 architecture — shared native host controller.** Move Mosaic event
   reduction, status/chrome synchronization, scrolling, scrollbar projection,
   link activation, and hover state into one host-neutral Rust controller used

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- Isolate the branch-protection `CI gate` to pull-request workflows so push CI
+  cannot auto-complete Venture changes before required macOS and Windows
+  acceptance builds finish.
 - Keep the authoritative POSIX `BUILD` wrapper compatible with the repository
   build tool's `/bin/sh` executor instead of requiring Bash `pipefail` syntax.
 

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -12,7 +12,8 @@
   generated chapter only when the app AST matches the committed book manifest;
   Spanish Chapters 1–6 now verify all 51 migrated lessons this way; Gujarati,
   Marathi, and Punjabi Chapter 6 verify both canonical lessons, while Sanskrit
-  Chapter 6 verifies all three, independently of the book generator.
+  Chapter 6 verifies all three and Bengali Chapter 6 verifies its canonical
+  lesson, independently of the book generator.
 
 ## 0.25.0 — the same syllable in its sister scripts (syllabary, PR 9)
 

--- a/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
@@ -19,6 +19,7 @@ describe("generated book source hashes", () => {
   });
 
   it.each([
+    ["bengali", 1],
     ["gujarati", 2],
     ["marathi", 2],
     ["punjabi", 2],

--- a/code/scripts/adj_stdlib_provenance.py
+++ b/code/scripts/adj_stdlib_provenance.py
@@ -56,6 +56,7 @@ RECEIPT_HEADERS = {
     "last-modified",
 }
 LIFECYCLE_FAILURE_CONTRACT = "adj-stdlib/process-lifecycle-failure/v1"
+POSIX_SIGKILL = getattr(signal, "SIGKILL", 9)
 LIFECYCLE_STAGES = frozenset(
     {
         "command.canonical",
@@ -1274,10 +1275,15 @@ class _WindowsKillJob:
 
 
 def _terminate_process_tree(
-    process: subprocess.Popen[bytes], windows_job: _WindowsKillJob | None
+    process: subprocess.Popen[bytes],
+    windows_job: _WindowsKillJob | None,
+    *,
+    platform_name: str | None = None,
+    kill_process_group: Callable[[int, int], None] | None = None,
 ) -> None:
     failures: list[LifecycleFailure] = []
-    if os.name == "nt":
+    platform_name = os.name if platform_name is None else platform_name
+    if platform_name == "nt":
         if windows_job is not None:
             try:
                 windows_job.terminate()
@@ -1318,10 +1324,20 @@ def _terminate_process_tree(
                     )
                 )
     else:
+        if kill_process_group is None:
+            kill_process_group = os.killpg
         try:
-            os.killpg(process.pid, signal.SIGKILL)
+            kill_process_group(process.pid, POSIX_SIGKILL)
         except ProcessLookupError:
             pass
+        except OSError as error:
+            failures.append(
+                _failure_from_error(
+                    error,
+                    stage="process_tree.terminate",
+                    api="os.killpg",
+                )
+            )
     try:
         process_running = process.poll() is None
     except OSError as error:
@@ -1336,6 +1352,8 @@ def _terminate_process_tree(
     if process_running:
         try:
             process.kill()
+        except ProcessLookupError:
+            pass
         except OSError as error:
             failures.append(
                 LifecycleFailure(
@@ -1364,11 +1382,15 @@ def _run_json_command(
     timeout_seconds: float = 60,
     drain_timeout_seconds: float = 5,
     windows_job_factory: Callable[[], _WindowsKillJob] = _WindowsKillJob,
+    process_tree_terminator: (
+        Callable[[subprocess.Popen[bytes], _WindowsKillJob | None], None] | None
+    ) = None,
 ) -> dict[str, Any]:
     if not command:
         raise ProvenanceError(f"{label} command must not be empty")
     if timeout_seconds <= 0 or drain_timeout_seconds <= 0:
         raise ProvenanceError(f"{label} timeout bounds must be positive")
+    terminate_process_tree = process_tree_terminator or _terminate_process_tree
     windows_job: _WindowsKillJob | None = None
     if os.name == "nt":
         try:
@@ -1437,7 +1459,7 @@ def _run_json_command(
             cleanup_failures: list[LifecycleFailure] = []
             try:
                 try:
-                    _terminate_process_tree(process, windows_job)
+                    terminate_process_tree(process, windows_job)
                 except OSError as termination_error:
                     containment_errors.append(str(termination_error))
                     cleanup_failures.append(
@@ -1534,21 +1556,32 @@ def _run_json_command(
     stderr = bytearray()
     overflow = threading.Event()
     termination_lock = threading.Lock()
+    failure_event_lock = threading.Lock()
+    failure_events: list[LifecycleFailure] = []
     termination_failures: list[LifecycleFailure] = []
     pipe_read_failures: list[LifecycleFailure | None] = [None, None]
+    pipe_read_event_indices: list[int | None] = [None, None]
     pipe_read_terminated_process = [False, False]
+
+    def record_failure_event(failure: LifecycleFailure) -> int:
+        with failure_event_lock:
+            failure_events.append(failure)
+            return len(failure_events) - 1
+
+    def replace_failure_event(index: int, failure: LifecycleFailure) -> None:
+        with failure_event_lock:
+            failure_events[index] = failure
 
     def terminate() -> None:
         with termination_lock:
             try:
-                _terminate_process_tree(process, windows_job)
+                terminate_process_tree(process, windows_job)
             except OSError as error:
-                if not termination_failures:
-                    termination_failures.append(
-                        _failure_from_error(
-                            error, stage="process_tree.terminate"
-                        )
-                    )
+                failure = _failure_from_error(
+                    error, stage="process_tree.terminate"
+                )
+                termination_failures.append(failure)
+                record_failure_event(failure)
 
     def drain(
         stream: Any,
@@ -1570,6 +1603,11 @@ def _run_json_command(
                     ),
                     message=message,
                 )
+                read_failure = pipe_read_failures[pipe_index]
+                assert read_failure is not None
+                pipe_read_event_indices[pipe_index] = record_failure_event(
+                    read_failure
+                )
                 try:
                     process_running = process.poll() is None
                 except OSError as poll_error:
@@ -1585,6 +1623,11 @@ def _run_json_command(
                             ),
                             message=poll_message,
                         )
+                    )
+                    event_index = pipe_read_event_indices[pipe_index]
+                    assert event_index is not None
+                    replace_failure_event(
+                        event_index, pipe_read_failures[pipe_index]
                     )
                     process_running = True
                 if process_running:
@@ -1616,6 +1659,7 @@ def _run_json_command(
         thread.start()
     timeout_error: subprocess.TimeoutExpired | None = None
     wait_failure: LifecycleFailure | None = None
+    recovery_wait_failures: list[LifecycleFailure] = []
     returncode: int | None = None
     close_failures: list[LifecycleFailure] = []
     pipe_close_failures: list[LifecycleFailure] = []
@@ -1627,7 +1671,7 @@ def _run_json_command(
         try:
             returncode = process.wait(timeout=drain_timeout_seconds)
         except subprocess.TimeoutExpired:
-            wait_failure = LifecycleFailure(
+            recovery_failure = LifecycleFailure(
                 stage="process.wait",
                 api="Popen.wait",
                 error_code=None,
@@ -1636,10 +1680,37 @@ def _run_json_command(
                     f"{drain_timeout_seconds:g} seconds"
                 ),
             )
+            recovery_wait_failures.append(recovery_failure)
+            record_failure_event(recovery_failure)
             terminate()
+            try:
+                returncode = process.wait(timeout=drain_timeout_seconds)
+            except subprocess.TimeoutExpired:
+                final_failure = LifecycleFailure(
+                    stage="process.wait",
+                    api="Popen.wait",
+                    error_code=None,
+                    message=(
+                        "final process wait timed out after "
+                        f"{drain_timeout_seconds:g} seconds"
+                    ),
+                )
+                recovery_wait_failures.append(final_failure)
+                record_failure_event(final_failure)
+            except OSError as final_error:
+                final_failure = replace(
+                    _failure_from_error(
+                        final_error,
+                        stage="process.wait",
+                        api="Popen.wait",
+                    ),
+                    message=f"final process wait failed: {final_error}",
+                )
+                recovery_wait_failures.append(final_failure)
+                record_failure_event(final_failure)
         except OSError as wait_error:
             message = f"process wait after timeout failed: {wait_error}"
-            wait_failure = replace(
+            recovery_failure = replace(
                 _failure_from_error(
                     wait_error,
                     stage="process.wait",
@@ -1647,6 +1718,33 @@ def _run_json_command(
                 ),
                 message=message,
             )
+            recovery_wait_failures.append(recovery_failure)
+            record_failure_event(recovery_failure)
+            terminate()
+            try:
+                returncode = process.wait(timeout=drain_timeout_seconds)
+            except (OSError, subprocess.TimeoutExpired) as final_error:
+                if isinstance(final_error, subprocess.TimeoutExpired):
+                    final_failure = LifecycleFailure(
+                        stage="process.wait",
+                        api="Popen.wait",
+                        error_code=None,
+                        message=(
+                            "final process wait timed out after "
+                            f"{drain_timeout_seconds:g} seconds"
+                        ),
+                    )
+                else:
+                    final_failure = replace(
+                        _failure_from_error(
+                            final_error,
+                            stage="process.wait",
+                            api="Popen.wait",
+                        ),
+                        message=f"final process wait failed: {final_error}",
+                    )
+                recovery_wait_failures.append(final_failure)
+                record_failure_event(final_failure)
     except OSError as error:
         message = f"{label} process wait failed: {error}"
         wait_failure = replace(
@@ -1661,31 +1759,78 @@ def _run_json_command(
         try:
             returncode = process.wait(timeout=drain_timeout_seconds)
         except subprocess.TimeoutExpired:
-            retry_message = (
-                "process wait retry timed out after "
-                f"{drain_timeout_seconds:g} seconds"
+            retry_failure = LifecycleFailure(
+                stage="process.wait",
+                api="Popen.wait",
+                error_code=None,
+                message=(
+                    "process wait retry timed out after "
+                    f"{drain_timeout_seconds:g} seconds"
+                ),
             )
-            wait_failure = wait_failure.with_cleanup(
-                LifecycleFailure(
-                    stage="process.wait",
-                    api="Popen.wait",
-                    error_code=None,
-                    message=retry_message,
-                )
-            )
+            recovery_wait_failures.append(retry_failure)
+            record_failure_event(retry_failure)
             terminate()
-        except OSError as retry_error:
-            retry_message = f"process wait retry failed: {retry_error}"
-            wait_failure = wait_failure.with_cleanup(
-                replace(
-                    _failure_from_error(
-                        retry_error,
+            try:
+                returncode = process.wait(timeout=drain_timeout_seconds)
+            except (OSError, subprocess.TimeoutExpired) as final_error:
+                if isinstance(final_error, subprocess.TimeoutExpired):
+                    final_failure = LifecycleFailure(
                         stage="process.wait",
                         api="Popen.wait",
-                    ),
-                    message=retry_message,
-                )
+                        error_code=None,
+                        message=(
+                            "final process wait timed out after "
+                            f"{drain_timeout_seconds:g} seconds"
+                        ),
+                    )
+                else:
+                    final_failure = replace(
+                        _failure_from_error(
+                            final_error,
+                            stage="process.wait",
+                            api="Popen.wait",
+                        ),
+                        message=f"final process wait failed: {final_error}",
+                    )
+                recovery_wait_failures.append(final_failure)
+                record_failure_event(final_failure)
+        except OSError as retry_error:
+            retry_failure = replace(
+                _failure_from_error(
+                    retry_error,
+                    stage="process.wait",
+                    api="Popen.wait",
+                ),
+                message=f"process wait retry failed: {retry_error}",
             )
+            recovery_wait_failures.append(retry_failure)
+            record_failure_event(retry_failure)
+            terminate()
+            try:
+                returncode = process.wait(timeout=drain_timeout_seconds)
+            except (OSError, subprocess.TimeoutExpired) as final_error:
+                if isinstance(final_error, subprocess.TimeoutExpired):
+                    final_failure = LifecycleFailure(
+                        stage="process.wait",
+                        api="Popen.wait",
+                        error_code=None,
+                        message=(
+                            "final process wait timed out after "
+                            f"{drain_timeout_seconds:g} seconds"
+                        ),
+                    )
+                else:
+                    final_failure = replace(
+                        _failure_from_error(
+                            final_error,
+                            stage="process.wait",
+                            api="Popen.wait",
+                        ),
+                        message=f"final process wait failed: {final_error}",
+                    )
+                recovery_wait_failures.append(final_failure)
+                record_failure_event(final_failure)
     finally:
         with termination_lock:
             if windows_job is not None:
@@ -1695,8 +1840,9 @@ def _run_json_command(
                     close_failure = _failure_from_error(
                         error, stage="job.close"
                     )
+                    close_event_index = record_failure_event(close_failure)
                     try:
-                        _terminate_process_tree(process, windows_job)
+                        terminate_process_tree(process, windows_job)
                     except OSError as termination_error:
                         close_failure = close_failure.with_cleanup(
                             _failure_from_error(
@@ -1713,6 +1859,7 @@ def _run_json_command(
                                 stage="job.close",
                             )
                         )
+                    replace_failure_event(close_event_index, close_failure)
                     close_failures.append(close_failure)
         drain_deadline = time.monotonic() + drain_timeout_seconds
         for thread in threads:
@@ -1724,6 +1871,26 @@ def _run_json_command(
         for thread in stuck_drains:
             thread.join(timeout=max(0, final_drain_deadline - time.monotonic()))
     drain_failure = any(thread.is_alive() for thread in threads)
+    drain_failure_record: LifecycleFailure | None = None
+    if drain_failure:
+        drain_failure_record = LifecycleFailure(
+            stage="pipe.drain",
+            message="output pipes did not close within bounds",
+        )
+        record_failure_event(drain_failure_record)
+    causal_pipe_read_exit: LifecycleFailure | None = None
+    if (
+        returncode is not None
+        and returncode != 0
+        and any(pipe_read_terminated_process)
+    ):
+        causal_pipe_read_exit = LifecycleFailure(
+            stage="command.exit",
+            api="Popen.wait",
+            error_code=returncode,
+            message=f"process exited {returncode} after pipe-read termination",
+        )
+        record_failure_event(causal_pipe_read_exit)
     if not drain_failure:
         for pipe_name, stream in (
             ("stdout", process.stdout),
@@ -1733,23 +1900,28 @@ def _run_json_command(
                 stream.close()
             except OSError as error:
                 message = f"{pipe_name} pipe close failed: {error}"
-                pipe_close_failures.append(
-                    replace(
-                        _failure_from_error(
-                            error,
-                            stage="pipe.close",
-                            api=f"Popen.{pipe_name}.close",
-                        ),
-                        message=message,
-                    )
+                close_failure = replace(
+                    _failure_from_error(
+                        error,
+                        stage="pipe.close",
+                        api=f"Popen.{pipe_name}.close",
+                    ),
+                    message=message,
                 )
+                pipe_close_failures.append(close_failure)
+                record_failure_event(close_failure)
     pipe_read_failure_events = [
-        (failure, pipe_read_terminated_process[index])
+        (
+            pipe_read_event_indices[index],
+            failure,
+            pipe_read_terminated_process[index],
+        )
         for index, failure in enumerate(pipe_read_failures)
         if failure is not None
     ]
+    pipe_read_failure_events.sort(key=lambda item: item[0])
     pipe_read_failure_records = [
-        failure for failure, _terminated in pipe_read_failure_events
+        failure for _event_index, failure, _terminated in pipe_read_failure_events
     ]
     cleanup_failures = [
         *termination_failures,
@@ -1780,6 +1952,9 @@ def _run_json_command(
         )
     cleanup_failure_text.extend(
         failure.message for failure in pipe_close_failures
+    )
+    cleanup_failure_text.extend(
+        failure.message for failure in recovery_wait_failures
     )
 
     def add_cleanup_failure(failure: LifecycleFailure) -> None:
@@ -1823,8 +1998,9 @@ def _run_json_command(
         primary_failure = wait_failure
         for failure in pipe_read_failure_records:
             add_cleanup_failure(failure)
-    elif returncode != 0 and not any(
-        terminated for _failure, terminated in pipe_read_failure_events
+    elif returncode is not None and returncode != 0 and not any(
+        terminated
+        for _event_index, _failure, terminated in pipe_read_failure_events
     ):
         detail = bytes(stderr).decode("utf-8", errors="replace").strip()
         primary_error = f"{label} exited {returncode}: {detail}"
@@ -1839,7 +2015,7 @@ def _run_json_command(
     elif pipe_read_failure_records:
         causal_failures = [
             failure
-            for failure, terminated in pipe_read_failure_events
+            for _event_index, failure, terminated in pipe_read_failure_events
             if terminated
         ]
         primary_failure = (
@@ -1849,20 +2025,12 @@ def _run_json_command(
         for failure in pipe_read_failure_records:
             if failure is not primary_failure:
                 add_cleanup_failure(failure)
-        if returncode != 0:
-            add_cleanup_failure(
-                LifecycleFailure(
-                    stage="command.exit",
-                    api="Popen.wait",
-                    error_code=returncode,
-                    message=f"process exited {returncode} after pipe-read termination",
-                )
-            )
+        if causal_pipe_read_exit is not None:
+            cleanup_failure_text.append(causal_pipe_read_exit.message)
     elif drain_failure:
         primary_error = drain_error
-        primary_failure = LifecycleFailure(
-            stage="pipe.drain", message=primary_error
-        )
+        assert drain_failure_record is not None
+        primary_failure = drain_failure_record
     else:
         try:
             decoded = bytes(stdout).decode("utf-8")
@@ -1893,31 +2061,32 @@ def _run_json_command(
                         stage="command.canonical", message=primary_error
                     )
     if drain_failure and primary_error != drain_error:
-        drain_failure_record = LifecycleFailure(
-            stage="pipe.drain",
-            message="output pipes did not close within bounds",
-        )
-        cleanup_failures.append(drain_failure_record)
+        assert drain_failure_record is not None
         cleanup_failure_text.append(drain_failure_record.message)
     if primary_error is not None:
         assert primary_failure is not None
         final_message = with_cleanup_failures(primary_error)
-        failure = primary_failure.with_cleanup(*cleanup_failures)
+        ordered_cleanup = [
+            event for event in failure_events if event is not primary_failure
+        ]
+        failure = primary_failure.with_cleanup(*ordered_cleanup)
         raise ProvenanceError(
             final_message,
             lifecycle=replace(failure, message=final_message),
         ) from primary_cause
     if termination_failures:
-        failure = termination_failures[0].with_cleanup(
-            *termination_failures[1:], *close_failures, *pipe_close_failures
+        primary = termination_failures[0]
+        failure = primary.with_cleanup(
+            *(event for event in failure_events if event is not primary)
         )
         detail = f"{label} failed to terminate process tree: {failure.message}"
         raise ProvenanceError(
             detail, lifecycle=replace(failure, message=detail)
         )
     if close_failures:
-        failure = close_failures[0].with_cleanup(
-            *close_failures[1:], *pipe_close_failures
+        primary = close_failures[0]
+        failure = primary.with_cleanup(
+            *(event for event in failure_events if event is not primary)
         )
         close_text = failure.message
         for recovery_failure in failure.cleanup_causes:
@@ -1941,7 +2110,10 @@ def _run_json_command(
             detail, lifecycle=replace(failure, message=detail)
         )
     if pipe_close_failures:
-        failure = pipe_close_failures[0].with_cleanup(*pipe_close_failures[1:])
+        primary = pipe_close_failures[0]
+        failure = primary.with_cleanup(
+            *(event for event in failure_events if event is not primary)
+        )
         detail = f"{label} failed to close output pipe: {failure.message}"
         raise ProvenanceError(
             detail, lifecycle=replace(failure, message=detail)

--- a/code/scripts/tests/test_adj_stdlib_provenance.py
+++ b/code/scripts/tests/test_adj_stdlib_provenance.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import unittest
 from contextlib import redirect_stdout
@@ -1610,6 +1611,247 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         )
         process.kill.assert_called_once_with()
 
+    def test_posix_process_group_lookup_miss_uses_root_fallback(self) -> None:
+        process = self.windows_process()
+        process.poll.return_value = None
+        killpg = mock.Mock(side_effect=ProcessLookupError(3, "group absent"))
+
+        provenance._terminate_process_tree(
+            process,
+            None,
+            platform_name="posix",
+            kill_process_group=killpg,
+        )
+
+        killpg.assert_called_once_with(process.pid, provenance.POSIX_SIGKILL)
+        process.kill.assert_called_once_with()
+
+    def test_posix_process_group_permission_failure_is_structured(self) -> None:
+        process = self.windows_process()
+        process.poll.return_value = None
+        killpg = mock.Mock(side_effect=PermissionError(13, "permission denied"))
+
+        with self.assertRaisesRegex(OSError, "permission denied") as raised:
+            provenance._terminate_process_tree(
+                process,
+                None,
+                platform_name="posix",
+                kill_process_group=killpg,
+            )
+
+        failure = raised.exception.failure
+        self.assertEqual(
+            (failure.stage, failure.api, failure.error_code),
+            ("process_tree.terminate", "os.killpg", 13),
+        )
+        process.kill.assert_called_once_with()
+
+    def test_posix_process_group_fallback_failures_are_ordered(self) -> None:
+        process = self.windows_process()
+        process.poll.side_effect = OSError(6, "poll failed")
+        process.kill.side_effect = OSError(1, "root kill failed")
+        killpg = mock.Mock(side_effect=PermissionError(13, "killpg failed"))
+
+        with self.assertRaisesRegex(OSError, "root kill failed") as raised:
+            provenance._terminate_process_tree(
+                process,
+                None,
+                platform_name="posix",
+                kill_process_group=killpg,
+            )
+
+        failure = raised.exception.failure
+        self.assertEqual(
+            (failure.stage, failure.api, failure.error_code),
+            ("process_tree.terminate", "os.killpg", 13),
+        )
+        self.assertEqual(
+            [
+                (cause.stage, cause.api, cause.error_code)
+                for cause in failure.cleanup_causes
+            ],
+            [
+                ("process.poll", "Popen.poll", 6),
+                ("process.terminate", "Popen.kill", 1),
+            ],
+        )
+
+    def test_posix_process_root_fallback_failure_is_structured(self) -> None:
+        process = self.windows_process()
+        process.poll.return_value = None
+        process.kill.side_effect = OSError(1, "root kill failed")
+        killpg = mock.Mock()
+
+        with self.assertRaisesRegex(OSError, "root kill failed") as raised:
+            provenance._terminate_process_tree(
+                process,
+                None,
+                platform_name="posix",
+                kill_process_group=killpg,
+            )
+
+        failure = raised.exception.failure
+        self.assertEqual(
+            (failure.stage, failure.api, failure.error_code),
+            ("process.terminate", "Popen.kill", 1),
+        )
+
+    def test_posix_process_root_lookup_miss_is_benign(self) -> None:
+        process = self.windows_process()
+        process.poll.return_value = None
+        process.kill.side_effect = ProcessLookupError(3, "root absent")
+
+        provenance._terminate_process_tree(
+            process,
+            None,
+            platform_name="posix",
+            kill_process_group=mock.Mock(),
+        )
+
+        process.kill.assert_called_once_with()
+
+    def test_posix_process_repeated_termination_failures_are_ordered(self) -> None:
+        process = mock.Mock(pid=404)
+        process.wait.side_effect = [
+            subprocess.TimeoutExpired(["fixture"], 0.2),
+            subprocess.TimeoutExpired(["fixture"], 0.1),
+            -9,
+        ]
+        process.stdout.read.return_value = b""
+        process.stderr.read.return_value = b""
+        terminator = mock.Mock(
+            side_effect=[
+                provenance._lifecycle_error(
+                    "process_tree.terminate",
+                    "killpg failed",
+                    api="os.killpg",
+                    error_code=13,
+                ),
+                provenance._lifecycle_error(
+                    "process.terminate",
+                    "root kill failed",
+                    api="Popen.kill",
+                    error_code=1,
+                ),
+            ]
+        )
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            self.assertRaisesRegex(provenance.ProvenanceError, "timed out") as raised,
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="repeated termination fixture",
+                timeout_seconds=0.2,
+                drain_timeout_seconds=0.1,
+                windows_job_factory=mock.Mock,
+                process_tree_terminator=terminator,
+            )
+
+        failure = raised.exception.lifecycle
+        self.assertEqual(
+            [
+                (cause.stage, cause.api, cause.error_code)
+                for cause in failure.cleanup_causes
+            ],
+            [
+                ("process_tree.terminate", "os.killpg", 13),
+                ("process.wait", "Popen.wait", None),
+                ("process.terminate", "Popen.kill", 1),
+            ],
+        )
+        self.assertEqual(process.wait.call_count, 3)
+
+    def test_posix_process_unreaped_timeout_does_not_claim_exit(self) -> None:
+        process = mock.Mock(pid=404)
+        process.wait.side_effect = [
+            subprocess.TimeoutExpired(["fixture"], 0.2),
+            subprocess.TimeoutExpired(["fixture"], 0.1),
+            subprocess.TimeoutExpired(["fixture"], 0.1),
+        ]
+        process.poll.return_value = None
+        process.stdout.read.side_effect = OSError(5, "stdout read failed")
+        process.stderr.read.return_value = b""
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            self.assertRaisesRegex(provenance.ProvenanceError, "timed out") as raised,
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="unreaped timeout fixture",
+                timeout_seconds=0.2,
+                drain_timeout_seconds=0.1,
+                windows_job_factory=mock.Mock,
+                process_tree_terminator=mock.Mock(),
+            )
+
+        failure = raised.exception.lifecycle
+        self.assertNotIn(
+            "command.exit",
+            [cause.stage for cause in failure.cleanup_causes],
+        )
+        self.assertFalse(any("exited None" in cause.message for cause in failure.cleanup_causes))
+        self.assertEqual(process.wait.call_count, 3)
+
+    def test_posix_process_failure_preserves_both_pipe_close_causes(self) -> None:
+        process = mock.Mock(pid=404)
+        process.wait.side_effect = [
+            subprocess.TimeoutExpired(["fixture"], 0.1),
+            OSError(6, "recovery wait failed"),
+            -9,
+        ]
+        process.stdout.read.return_value = b""
+        process.stderr.read.return_value = b""
+        process.stdout.close.side_effect = OSError(5, "stdout close failed")
+        process.stderr.close.side_effect = OSError(6, "stderr close failed")
+        terminator = mock.Mock(
+            side_effect=[
+                provenance._lifecycle_error(
+                    "process_tree.terminate",
+                    "killpg failed",
+                    api="os.killpg",
+                    error_code=13,
+                ),
+                None,
+            ]
+        )
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError,
+                "timed out.*killpg failed.*stdout close failed.*stderr close failed",
+            ) as raised,
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="POSIX compound cleanup fixture",
+                timeout_seconds=0.1,
+                windows_job_factory=mock.Mock,
+                process_tree_terminator=terminator,
+            )
+
+        failure = raised.exception.lifecycle
+        self.assertEqual(failure.stage, "command.timeout")
+        self.assertEqual(
+            [
+                (cause.stage, cause.api, cause.error_code)
+                for cause in failure.cleanup_causes
+            ],
+            [
+                ("process_tree.terminate", "os.killpg", 13),
+                ("process.wait", "Popen.wait", 6),
+                ("pipe.close", "Popen.stdout.close", 5),
+                ("pipe.close", "Popen.stderr.close", 6),
+            ],
+        )
+        self.assertEqual(failure.message, str(raised.exception))
+
     @unittest.skipUnless(os.name == "nt", "Windows Job Object behavior")
     def test_windows_job_factory_failure_precedes_process_launch(self) -> None:
         factory = mock.Mock(side_effect=OSError("injected CreateJobObjectW failure"))
@@ -1897,6 +2139,39 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         process.stdout.close.assert_not_called()
         process.stderr.close.assert_not_called()
 
+    def test_json_command_primary_stuck_drain_is_not_self_causal(self) -> None:
+        process = mock.Mock(pid=404)
+        process.stdout = mock.Mock()
+        process.stderr = mock.Mock()
+        process.wait.return_value = 0
+        threads = [mock.Mock(), mock.Mock()]
+        for thread in threads:
+            thread.is_alive.return_value = True
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            mock.patch.object(
+                provenance.threading, "Thread", side_effect=threads
+            ),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError,
+                "output pipes did not close within bounds",
+            ) as raised,
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="primary stuck drain fixture",
+                drain_timeout_seconds=0.1,
+                windows_job_factory=mock.Mock,
+                process_tree_terminator=mock.Mock(),
+            )
+
+        failure = raised.exception.lifecycle
+        self.assertEqual(failure.stage, "pipe.drain")
+        self.assertEqual(failure.cleanup_causes, ())
+        self.assertEqual(failure.message, str(raised.exception))
+
     def test_json_command_pipe_read_failure_fails_closed(self) -> None:
         process = mock.Mock(pid=404)
         process.wait.return_value = -9
@@ -1941,6 +2216,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         process.poll.return_value = 7
         process.stdout.read.side_effect = OSError(5, "injected stdout read failure")
         process.stderr.read.return_value = b""
+        process.stdout.close.side_effect = OSError(6, "injected stdout close failure")
 
         with (
             mock.patch.object(provenance.subprocess, "Popen", return_value=process),
@@ -1965,9 +2241,59 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                 (cause.stage, cause.api, cause.error_code)
                 for cause in failure.cleanup_causes
             ],
-            [("pipe.read", "Popen.stdout.read", 5)],
+            [
+                ("pipe.read", "Popen.stdout.read", 5),
+                ("pipe.close", "Popen.stdout.close", 6),
+            ],
         )
         self.assertEqual(failure.message, str(raised.exception))
+
+    def test_json_command_reader_primary_follows_event_order(self) -> None:
+        process = mock.Mock(pid=404)
+        process.wait.return_value = -9
+        process.poll.side_effect = [None, -9]
+        stderr_failed = threading.Event()
+
+        def stdout_read(_size: int) -> bytes:
+            stderr_failed.wait(1)
+            raise OSError(5, "stdout read failed")
+
+        def stderr_read(_size: int) -> bytes:
+            stderr_failed.set()
+            raise OSError(6, "stderr read failed")
+
+        process.stdout.read.side_effect = stdout_read
+        process.stderr.read.side_effect = stderr_read
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError, "stderr pipe read failed"
+            ) as raised,
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="reader order fixture",
+                windows_job_factory=mock.Mock,
+                process_tree_terminator=mock.Mock(),
+            )
+
+        failure = raised.exception.lifecycle
+        self.assertEqual(
+            (failure.stage, failure.api, failure.error_code),
+            ("pipe.read", "Popen.stderr.read", 6),
+        )
+        self.assertEqual(
+            [
+                (cause.stage, cause.api, cause.error_code)
+                for cause in failure.cleanup_causes
+            ],
+            [
+                ("pipe.read", "Popen.stdout.read", 5),
+                ("command.exit", "Popen.wait", -9),
+            ],
+        )
 
     def test_json_command_pipe_read_preserves_poll_failure(self) -> None:
         process = mock.Mock(pid=404)
@@ -2010,6 +2336,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         process.wait.side_effect = [
             OSError(5, "injected wait failure"),
             OSError(6, "injected wait retry failure"),
+            -9,
         ]
         process.stdout.read.return_value = b""
         process.stderr.read.return_value = b""
@@ -2047,6 +2374,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         process.wait.side_effect = [
             OSError(5, "injected wait failure"),
             subprocess.TimeoutExpired(["fixture"], 0.1),
+            -9,
         ]
         process.stdout.read.return_value = b""
         process.stderr.read.return_value = b""
@@ -2092,6 +2420,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         process.wait.side_effect = [
             subprocess.TimeoutExpired(["fixture"], 0.2),
             subprocess.TimeoutExpired(["fixture"], 0.1),
+            -9,
         ]
         process.stdout.read.return_value = b""
         process.stderr.read.return_value = b""
@@ -2315,7 +2644,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                 )
                 self.assertEqual(close_calls, 2)
 
-    def test_windows_job_timeout_kills_descendant_pipe_holders(self) -> None:
+    def test_process_tree_timeout_kills_descendant_pipe_holders(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             pid_path = Path(directory) / "child.pid"
             child = (
@@ -2348,7 +2677,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             self.assertLess(time.monotonic() - started, 8)
             self.assert_process_exits(int(pid_path.read_text()))
 
-    def test_windows_job_parent_exit_kills_descendant_pipe_holders(self) -> None:
+    def test_process_tree_parent_exit_kills_descendant_pipe_holders(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             pid_path = Path(directory) / "child.pid"
             child = (

--- a/code/scripts/tests/test_venture_windows_ci_acceptance.py
+++ b/code/scripts/tests/test_venture_windows_ci_acceptance.py
@@ -147,6 +147,15 @@ class VentureWindowsCIAcceptanceTests(unittest.TestCase):
         )
         self.assertIn("cargo test -p venture-browser-macos", workflow)
 
+    def test_required_gate_is_exclusive_to_pull_request_runs(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(
+            "name: ${{ github.event_name == 'pull_request' && 'CI gate' "
+            "|| 'CI push gate' }}",
+            workflow,
+        )
+        self.assertNotIn("\n    name: CI gate\n", workflow)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/code/specs/ADJ-STDLIB-COVERAGE.md
+++ b/code/specs/ADJ-STDLIB-COVERAGE.md
@@ -356,9 +356,20 @@ option mapping, or judge/evaluation failure.
      process waits, pipe reads and closes, and close retries all retain
      machine-inspectable causal structure. Worker-thread I/O faults fail closed even
      when the bytes received before the fault happen to form valid canonical JSON.
-13h. **Backlog:** add platform-neutral fault injection for POSIX process-group
-     termination, including `killpg` permission/lookup failures, root-kill fallback,
-     simultaneous pipe cleanup failures, and hosted Linux/macOS execution gates.
+13h. **Complete:** POSIX process-group termination now has platform-neutral injection
+     for lookup misses, permission failures, process polling, root-kill fallback, and
+     ordered compound failures. Runner-level terminator injection proves simultaneous
+     stdout/stderr close failures remain in the lifecycle tree. An attempt-ordered event
+     ledger preserves concurrent reader causality and every repeated termination, and a
+     final bounded wait reaps the root after recovery termination. Hosted Linux runs the
+     full provenance suite in `detect`; hosted macOS runs the focused POSIX/process-tree
+     selector with pinned Python, and the Windows selector includes all Job and generic
+     process-tree cases.
+13i. **Backlog:** contain descendants that deliberately create a new session and add
+     kill-on-verifier-crash semantics for POSIX, where `start_new_session=True` alone
+     cannot guarantee cleanup after abrupt verifier termination. Add independently
+     bounded raw-handle closure for readers that remain stuck after tree termination;
+     ordinary buffered `close()` can itself block behind a concurrent read.
 
 ### Wave 2: complete K-8 foundations
 

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -905,6 +905,26 @@ state that the portable CGI contract cannot read back:
 - A real loopback HTTP test proves probing, preset filtering, denial, recall,
   bounded start/stop movement, logout, and exact native request shapes.
 
+## Current Axis VAPIX Inspection Slice
+
+This slice adds a second vendor-specific camera/NVR runtime using Axis's
+documented local discovery and authenticated JSON APIs:
+
+- The shared production mDNS scanner targets `_axis-video._tcp.local` and
+  `_axis-nvr._tcp.local`, preserving advertisements as credential-required
+  candidates until authenticated identity verifies them.
+- Production configuration requires a credential-free HTTPS origin and a
+  `VaultRef`; Basic credentials are materialized only inside the bounded TLS
+  transport. Plain HTTP is restricted to loopback transport tests.
+- The host calls `basicdeviceinfo.cgi` and `apidiscovery.cgi`, rejects VAPIX
+  errors, bounds response sizes, and normalizes product identity, firmware, and
+  the device's sorted public API inventory.
+- D23 authorizes the read before credentials or network transport are touched,
+  then installs one confirmed camera entity and a paired Axis bridge without
+  exposing secrets in request plans, runtime metadata, or debug output.
+- A real loopback HTTP test proves both JSON requests, Basic-auth materialization,
+  response parsing, runtime installation, and denial before transport.
+
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
@@ -916,29 +936,38 @@ and then by prerequisite readiness:
    credential-bearing values use Vault leasing and destination validation.
 3. Add authenticated HEOS source browsing and queue insertion only after the
    account/session and Vault-leasing prerequisites are concrete.
-4. Add another vendor-specific camera or NVR integration where authenticated
+4. Extend Axis VAPIX with capability-probed position/preset inspection and
+   bounded PTZ control, including operator permission and PTZ control-queue
+   semantics, over the existing authenticated HTTPS host.
+5. Add another vendor-specific camera or NVR integration where authenticated
    protocol and transport primitives are concrete.
-5. Add Reolink snapshot, recording search/download, and playback operations only
+6. Add Axis event streaming only after a concrete WebSocket event host and
+   digest or short-lived session-token authentication lifecycle exist.
+7. Add Axis snapshots and media transfer only through the camera-media lease and
+   a concrete media executor.
+8. Add reusable HTTP Digest authentication before supporting Axis devices that
+   cannot expose the preferred HTTPS Basic-auth path.
+9. Add Reolink snapshot, recording search/download, and playback operations only
    through the existing camera-media lease and a concrete media executor.
-6. Add Reolink current-position, zoom, guard-point, or patrol controls only when
+10. Add Reolink current-position, zoom, guard-point, or patrol controls only when
    each operation has a capability-specific probe and the firmware exposes the
    native state needed to avoid invented orientation claims.
-7. Add Reolink push events only after a concrete webhook or event-stream host
+11. Add Reolink push events only after a concrete webhook or event-stream host
    and subscription lifecycle exist.
-8. Add authenticated KLAP/Tapo devices and other broader-device families only
+12. Add authenticated KLAP/Tapo devices and other broader-device families only
    after their authentication and session prerequisites are concrete.
-9. Add ONVIF PullPoint events once a concrete event host and subscription
+13. Add ONVIF PullPoint events once a concrete event host and subscription
    lifecycle exist.
-10. Add RTSP media transfer and recording once concrete media transfer and
+14. Add RTSP media transfer and recording once concrete media transfer and
    recorder host primitives exist.
-11. Add a production Matter commissioning, secure-session, and network host only
+15. Add a production Matter commissioning, secure-session, and network host only
    after certificate, fabric, Interaction Model encoding, subscription, and
    transport prerequisites exist.
-12. Add a Thread border-router host only after an actual host transport exists.
-13. Add a production Zigbee coordinator, join, and security host only after
-    concrete coordinator transport and security primitives exist.
-14. Add production Z-Wave inclusion and S2 only after concrete host transport
-    and security primitives exist.
+16. Add a Thread border-router host only after an actual host transport exists.
+17. Add a production Zigbee coordinator, join, and security host only after
+   concrete coordinator transport and security primitives exist.
+18. Add production Z-Wave inclusion and S2 only after concrete host transport
+   and security primitives exist.
 
 ## End-To-End Definition
 

--- a/code/specs/data/adj-stdlib-provenance/README.md
+++ b/code/specs/data/adj-stdlib-provenance/README.md
@@ -132,5 +132,11 @@ projection is versioned as `adj-stdlib/process-lifecycle-failure/v1`; CLI failur
 it as `lifecycle_failure` while retaining the existing `error` and `valid` fields.
 Process-wait, pipe-read, and pipe-close faults are records too; partial output is never
 accepted merely because its prefix happens to be valid canonical JSON.
+POSIX group termination is fault-injected independently of the host OS: lookup misses,
+permission errors, poll failures, root-process fallback, and simultaneous pipe-close
+failures retain API-attempt ordering. Repeated termination attempts are never collapsed,
+concurrent reader failures use event order, and recovery ends with a bounded root wait.
+Linux runs the complete suite and macOS runs the focused POSIX/process-tree gate before
+merge.
 Existing hashes are reused, while missing or changed bytes, claims, transforms, graph
 edges, receipts, partitions, and projections fail closed.

--- a/code/specs/event-loop-native-backends.md
+++ b/code/specs/event-loop-native-backends.md
@@ -705,6 +705,10 @@ For `websocket-runtime`:
 - dependence on the generic event substrate and stream layer rather than on a
   bespoke WebSocket-specific loop
 
+The byte-level handshake, frame, fragmentation, and control semantics are
+owned by [`websocket-core.md`](websocket-core.md). The runtime composes that
+pure state machine with stream I/O, deadlines, and random client mask keys.
+
 For `ui-event-core`:
 
 - keyboard, mouse, touch, focus, resize, and close event vocabulary

--- a/code/specs/orchestrator.md
+++ b/code/specs/orchestrator.md
@@ -248,7 +248,9 @@ The transport-independent daemon composition is specified in
 registry to deterministic reconciliation, authoritative process supervision,
 and authorized channel-topology mutation while remaining keyless and
 payload-blind. WebSocket serving, CLI parsing, daemon installation, and loop
-scheduling remain outer adapters.
+scheduling remain outer adapters. The transport-independent RFC 6455 contract
+for that outer server is specified in
+[`websocket-core.md`](websocket-core.md).
 
 A durable registry of host intent plus the orchestrator's last observation:
 

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -116,15 +116,15 @@ package slots and found zero canonical collisions or unknown language buckets:
 | Present in 10-15 languages | 172 | 271 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 780 | 10,920 |
+| Present in one language | 783 | 10,962 |
 
-The loop must not start by attempting 10,920 singleton ports. It should finish
+The loop must not start by attempting 10,962 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`29d78677fe65719e0b84e2441e9a568a67e7f4f4` is collision-clean at 1,230
-normalized implementation identities, 4,378 implementation slots, 172
-high-consensus packages, 271 high-consensus missing slots, 780 singletons, 585
+`b42d1683d85daa9fd26cb96da3d928612034aa24` is collision-clean at 1,233
+normalized implementation identities, 4,381 implementation slots, 172
+high-consensus packages, 271 high-consensus missing slots, 783 singletons, 588
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
 The seventeen newest mixed Rust identities are `smart-home-camera-media`,
 `smart-home-onvif-integration`, `smart-home-shelly-integration`,
@@ -242,6 +242,27 @@ filesystems, networks, package verification, and supervisor effects remain
 injected or native. Its dedicated backlog owner depends on the secure-host-
 channel contract and therefore remains dependency-blocked.
 
+The `9ad8105f` refresh added `chief-of-staff-process-supervisor`. This crate is
+the concrete native authority behind the portable reconciler and host-control
+contracts: it reads and re-verifies signed package files, spawns, signals, owns,
+and reaps child processes, transports bootstrap records over pipes, and samples
+and sleeps against monotonic time. Its deterministic protocol seams already
+belong to the service-reconciler, host-control, and secure-channel backlog
+owners. A dedicated dependency-blocked review now owns the native-lane
+exceptions; the parity loop must not manufacture unsafe process-control ports.
+
+The `481a30c3` refresh adds `chief-of-staff-orchestrator-core` and
+`venture-browser-cairo`. The Chief core is a zero-capability, transport-
+independent coordinator over injected storage, supervision, authorization,
+and monotonic time. Stable host lifecycle, bounded reconciliation, health,
+clock regression, safe deregistration, authorize-before-mutate channel wiring,
+idempotency, and payload-blind errors now have a dependency-shaped portable
+owner. The Cairo crate centralizes a native RGBA renderer and unsafe Qt,
+Flutter, and Compose C ABIs around `venture-browser-core`; its reusable event,
+navigation, scrolling, hover, link, and projection behavior joins the existing
+Venture bridge owner, while Cairo rendering, pointers, buffers, dynamic
+libraries, and toolkit launch remain native exceptions.
+
 This loop delivers only deterministic, authority-free package contracts and
 implementations. DNS/UDP/TCP/TLS, endpoint review, credentials and Vault,
 capability approval, runtime mutation, native executors, and host hardening are
@@ -357,18 +378,31 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   rebased `29d78677` passes 307 Ruby tests at 89.43% line and 72.55% branch
   coverage, all shared fixture consumers, the valid 38-case/61-file corpus,
   Go test/vet/build, dependency and security checks, and the collision-clean
-  1,230-identity inventory without widening the completed evaluator repair;
+  1,230-identity inventory without widening the completed evaluator repair.
+  Guarded squash auto-completion merged PR #9691 as `9ad8105f38` after all 17
+  exact-head checks were terminal: twelve succeeded, four skipped, and one
+  completed neutrally;
 - adjudicate the residual Ruby/Go Elixir resolver semantics after canonical
   identities remove the structural drift. The real 282-package plans differ
   on eleven Go-only and two Ruby-only edges; the Ruby-only pair corresponds to
   declared `grammar_tools` program dependencies, so the follow-up must derive
   language-neutral fixtures from actual Mix metadata instead of assuming that
   either engine is the oracle. This child depends on the identity migration;
-- bring Go discovery to the complete shared language registry. The full-plan
-  comparison finds the same 4,776 package directories in Ruby and Go, but Go
-  classifies all fourteen Mosaic packages and programs as `unknown`. The
-  dedicated child consumes the existing registry and duplicate-identity
-  fixtures and keeps resolver-semantic work separate;
+- bring Go discovery to the complete shared language registry. The selected
+  implementation recognizes every canonical and retained bucket only at an
+  exact `packages` or `programs` boundary, preserves program identities,
+  excludes specification and build-artifact trees, and fails closed on a
+  duplicate with the shared typed, root-redacted diagnostic and CLI exit 2.
+  On rebased `b42d1683`, independent Go and Ruby real plans match all 4,779
+  `(name, language, rel_path)` tuples with zero duplicate or backslash paths,
+  all fourteen Mosaic identities canonical, and only the intentional
+  `unknown/blog` bucket. Exact-head validation passes gofmt, the full Go suite
+  at 73.6% aggregate and 93.9% discovery coverage, vet, race, trimpath build,
+  module verification, zero-reachable-vulnerability govulncheck, the 17+40
+  conformance suites, and the valid 38-case/61-file corpus. The committed Go-
+  lane dry-run selects 13 of 301 packages and skips 288. The full validator
+  separately reproduces the owned 73-gap BUILD debt gate: 12 Python, 3 Swift,
+  and 58 TypeScript. Resolver-semantic work remains a separate child;
 - make the TypeScript build-tool git-diff suite portable on Windows. The strict-
   UTF-8 validation run found two hard-coded `/bin/sh` invocations and five
   POSIX-only `/repo` path fixtures. Merged PR #9592 is the completed slice: it

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4273,11 +4273,17 @@ the Rust, Python, and TypeScript surfaces together.
      shared diagnostic while zero and positive junction saturation-current
      densities lower into Level-1 parameters.
 
+393. Python and TypeScript Berkeley SPICE MOS bulk-potential parity.
+   - Status: completed in PR 9700.
+   - Zero, negative, and non-finite model-card `PB` values are rejected with
+     the shared diagnostic while positive bulk-junction potentials lower into
+     Level-1 parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
-   - TypeScript still needs canonical lowering for `PB`, `MJ`, `MJSW`, `FC`,
-     `KF`, and `AF`; Python already lowers these canonical fields
+   - TypeScript still needs canonical lowering for `MJ`, `MJSW`, `FC`, `KF`,
+     and `AF`; Python already lowers these canonical fields
      but still needs matching facade validation coverage.
    - Align the `CJS` and `CJD` aliases with canonical `CBS` and `CBD` in both
      facades after the canonical-field slices.

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4267,11 +4267,17 @@ the Rust, Python, and TypeScript surfaces together.
      shared diagnostic while zero and positive sidewall-junction capacitance
      densities lower into Level-1 parameters.
 
+392. Python and TypeScript Berkeley SPICE MOS junction-current parity.
+   - Status: completed in PR 9699.
+   - Negative and non-finite model-card `JS` values are rejected with the
+     shared diagnostic while zero and positive junction saturation-current
+     densities lower into Level-1 parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
-   - TypeScript still needs canonical lowering for `JS`, `PB`, `MJ`, `MJSW`,
-     `FC`, `KF`, and `AF`; Python already lowers these canonical fields
+   - TypeScript still needs canonical lowering for `PB`, `MJ`, `MJSW`, `FC`,
+     `KF`, and `AF`; Python already lowers these canonical fields
      but still needs matching facade validation coverage.
    - Align the `CJS` and `CJD` aliases with canonical `CBS` and `CBD` in both
      facades after the canonical-field slices.

--- a/code/specs/websocket-core.md
+++ b/code/specs/websocket-core.md
@@ -1,0 +1,186 @@
+# WebSocket Protocol Core
+
+## Status
+
+This document specifies the portable, transport-independent RFC 6455 core that
+unblocks the D18 Chief daemon and operator CLI.
+
+The first implementation package is Rust `websocket-core`. The byte-level
+contract is intentionally suitable for later Python, Go, Ruby, TypeScript, and
+Elixir ports required by D18 issue #137.
+
+## Purpose and Layering
+
+The protocol core owns only:
+
+- strict HTTP/1.1 upgrade validation and serialization;
+- `Sec-WebSocket-Accept` derivation;
+- incremental frame decoding and frame serialization;
+- masking and canonical payload lengths;
+- fragmentation and UTF-8 message assembly; and
+- ping, pong, and close-frame validation.
+
+It does not open sockets, resolve DNS, select TLS, generate randomness, run an
+event loop, schedule keepalives, retry connections, or dispatch application
+commands. A later `websocket-runtime` package composes this core with TCP and
+the repository stream/event abstractions.
+
+```text
+tcp / stream reactor
+        |
+websocket-runtime          connection I/O, deadlines, random mask keys
+        |
+websocket-core             handshake, frames, messages, control semantics
+        |
+Chief daemon / CLI         authenticated application protocol
+```
+
+## Bounded Handshake
+
+The core accepts at most 16 KiB for one HTTP upgrade head. Callers may retain
+bytes after the returned consumed offset as the beginning of the WebSocket
+frame stream.
+
+A server request is accepted only when all of these hold:
+
+- the head uses CRLF line endings and ends in one empty CRLF line;
+- the request is `GET`, HTTP/1.1, and has no HTTP body framing;
+- exactly one non-empty `Host` header is present;
+- `Upgrade` contains the case-insensitive token `websocket`;
+- `Connection` contains the case-insensitive token `Upgrade`;
+- exactly one `Sec-WebSocket-Version` is present and equals `13`;
+- exactly one `Sec-WebSocket-Key` is present;
+- the key is canonical padded Base64 decoding to exactly 16 bytes; and
+- extensions and subprotocol negotiation are absent in version 0.1.
+
+The successful response is exactly HTTP/1.1 status 101 with `Upgrade`,
+`Connection`, and `Sec-WebSocket-Accept` headers. The accept value is padded
+Base64 of SHA-1 over the key text followed by RFC 6455's fixed GUID.
+
+The client request builder receives a caller-generated 16-byte nonce. This
+keeps random-number authority in the runtime adapter. It validates the host and
+request target against CR/LF injection before serializing a bounded request.
+The client response validator requires status 101, the two upgrade tokens, the
+exact expected accept value, no body framing, and no unsupported negotiated
+extension or subprotocol.
+
+Handshake diagnostics identify fields and failure classes but never reproduce
+header values, request targets, or buffered bytes.
+
+## Frames
+
+`EndpointRole` is either `Client` or `Server` and describes the local endpoint.
+An inbound decoder enforces the peer's masking rule:
+
+- a server must receive masked frames; and
+- a client must receive unmasked frames.
+
+An outbound encoder enforces the inverse. Client callers supply a fresh
+unpredictable four-byte mask key for every frame; server callers must not
+supply one. The protocol core never invents a constant or counter-based mask.
+
+The frame decoder is incremental. It buffers incomplete headers or payloads,
+returns every complete frame in wire order, and retains any incomplete suffix.
+It rejects before payload allocation when the declared length exceeds the
+configured frame bound.
+
+Every decoded frame must satisfy:
+
+- RSV1, RSV2, and RSV3 are zero because extensions are unsupported;
+- the opcode is continuation, text, binary, close, ping, or pong;
+- 16-bit and 64-bit extended lengths use their shortest canonical encoding;
+- the high bit of a 64-bit length is zero;
+- control frames are final and contain at most 125 bytes;
+- close payloads are either empty or contain a two-byte code plus UTF-8 reason;
+- close payload length one is invalid; and
+- close codes are RFC-defined protocol/application codes, not reserved
+  pseudo-codes.
+
+Unknown opcodes, non-canonical lengths, mask-direction violations, oversized
+declared lengths, and malformed controls are protocol errors.
+
+## Message Assembly
+
+The message assembler receives validated frames and emits:
+
+- complete text messages;
+- complete binary messages;
+- ping and pong events;
+- a validated close event; or
+- no event while a fragmented data message remains incomplete.
+
+Only text and binary frames may begin fragmentation. Continuations require an
+open fragmented message, and a second data start while fragmented data is open
+is rejected. Control frames may appear between fragments without disturbing
+the open message.
+
+The assembler checks its configured message bound before extending buffered
+data. Text is validated as UTF-8 only when the complete message is available,
+so a multi-byte scalar may cross fragment boundaries. A received close frame
+ends inbound data delivery; any later data or continuation frame is rejected.
+
+The core exposes a control-reply helper:
+
+- ping maps to a pong with the identical application payload;
+- close maps to an echo close frame; and
+- other events have no automatic reply.
+
+The runtime decides when to write the reply, when to stop accepting outbound
+application data, and when to close the underlying stream.
+
+## Public API Shape
+
+The portable conceptual surface is:
+
+```text
+build_client_request(host, target, nonce) -> { bytes, expected_accept }
+validate_client_response(bytes, expected_accept) -> consumed | error
+accept_server_request(bytes) -> { response_bytes, consumed } | error
+
+FrameDecoder(role, max_frame_bytes).push(bytes) -> Frame[] | error
+encode_frame(role, frame, optional_mask_key) -> bytes | error
+
+MessageAssembler(max_message_bytes).push(frame) -> Event? | error
+control_reply(event) -> Frame?
+```
+
+Concrete language names may follow local conventions while preserving the same
+validation and state transitions.
+
+## Errors and Recovery
+
+Errors are typed into incomplete input, handshake validation, frame protocol,
+UTF-8, size-limit, fragmentation-state, and closed-session failures.
+Incomplete handshake or frame input is not a protocol error and may be retried
+with more bytes. After any other decoder or assembler error, a runtime must
+send close code 1002 when possible and discard that protocol state.
+
+No error display includes payload bytes, mask keys, handshake nonces, header
+values, or close reasons.
+
+## Capability Contract
+
+The core declares no direct filesystem, network, process, environment, clock,
+random, or stream capability. SHA-1 and HTTP parsing are pure dependencies.
+The runtime package will declare network, clock, random, and stream
+capabilities when it composes concrete adapters.
+
+## Required Tests
+
+The Rust package must cover at least 95 percent of lines and include:
+
+- the RFC accept-key example;
+- strict valid server and client handshakes with coalesced frame bytes;
+- every required handshake field failure and CR/LF injection rejection;
+- small, 16-bit, and 64-bit frame lengths;
+- canonical-length, RSV, opcode, direction-mask, and size-limit failures;
+- masked and unmasked text/binary frames;
+- incremental byte-by-byte decoding and multiple frames in one input;
+- fragmented text with a UTF-8 scalar split across frames;
+- interleaved ping during fragmentation and automatic pong construction;
+- invalid fragmentation transitions and oversized assembled messages;
+- close-code/reason validation and close echo construction; and
+- payload-free stable error diagnostics.
+
+Real TCP and browser interoperability tests belong to `websocket-runtime`,
+where connection scheduling and operating-system I/O exist.


### PR DESCRIPTION
## Summary

- discover documented Axis camera and NVR mDNS services and preserve them as credential-required candidates
- inspect Basic Device Information and API Discovery over bounded HTTPS Basic auth, with Vault-backed request plans and credentials materialized only inside the transport
- authorize reads before credentials or I/O, install confirmed Axis camera state, and reprioritize the remaining Smart Home backlog with concrete Axis follow-ups

## Validation

- `cargo test -p smart-home-axis-vapix-integration` (7 passed)
- `cargo test -p smart-home-integration-catalog` (328 passed)
- `cargo clippy -p smart-home-axis-vapix-integration -p smart-home-integration-catalog --all-targets -- -D warnings`
- `bash smart-home-axis-vapix-integration/BUILD`
- `bash smart-home-integration-catalog/BUILD`

## Protocol references

- https://developer.axis.com/vapix/authentication/
- https://developer.axis.com/vapix/network-video/basic-device-information/
- https://developer.axis.com/vapix/network-video/api-discovery-service/
- https://developer.axis.com/vapix/network-video/mdns-sd-api/