### PR TITLE
feat(adj): fault-inject POSIX lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,7 +351,7 @@ jobs:
           go-version: '1.23'
 
       - name: Set up Python
-        if: needs.detect.outputs.needs_python == 'true' || runner.os == 'Windows'
+        if: needs.detect.outputs.needs_python == 'true' || runner.os == 'Windows' || runner.os == 'macOS'
         uses: actions/setup-python@v5
         with:
           python-version: '3.13'
@@ -360,7 +360,11 @@ jobs:
       - name: Test ADJ Windows Job containment
         if: runner.os == 'Windows'
         shell: pwsh
-        run: python -m unittest discover -s code/scripts/tests -p test_adj_stdlib_provenance.py -k windows_job
+        run: python -m unittest discover -s code/scripts/tests -p test_adj_stdlib_provenance.py -k windows_job -k process_tree -k windows_containment -k job_close_root
+
+      - name: Test ADJ POSIX process-group containment
+        if: runner.os == 'macOS'
+        run: python3 -m unittest discover -s code/scripts/tests -p test_adj_stdlib_provenance.py -k posix_process -k process_tree
 
       - name: Install uv
         if: needs.detect.outputs.needs_python == 'true'

--- a/code/scripts/adj_stdlib_provenance.py
+++ b/code/scripts/adj_stdlib_provenance.py
@@ -56,6 +56,7 @@ RECEIPT_HEADERS = {
     "last-modified",
 }
 LIFECYCLE_FAILURE_CONTRACT = "adj-stdlib/process-lifecycle-failure/v1"
+POSIX_SIGKILL = getattr(signal, "SIGKILL", 9)
 LIFECYCLE_STAGES = frozenset(
     {
         "command.canonical",
@@ -1274,10 +1275,15 @@ class _WindowsKillJob:
 
 
 def _terminate_process_tree(
-    process: subprocess.Popen[bytes], windows_job: _WindowsKillJob | None
+    process: subprocess.Popen[bytes],
+    windows_job: _WindowsKillJob | None,
+    *,
+    platform_name: str | None = None,
+    kill_process_group: Callable[[int, int], None] | None = None,
 ) -> None:
     failures: list[LifecycleFailure] = []
-    if os.name == "nt":
+    platform_name = os.name if platform_name is None else platform_name
+    if platform_name == "nt":
         if windows_job is not None:
             try:
                 windows_job.terminate()
@@ -1318,10 +1324,20 @@ def _terminate_process_tree(
                     )
                 )
     else:
+        if kill_process_group is None:
+            kill_process_group = os.killpg
         try:
-            os.killpg(process.pid, signal.SIGKILL)
+            kill_process_group(process.pid, POSIX_SIGKILL)
         except ProcessLookupError:
             pass
+        except OSError as error:
+            failures.append(
+                _failure_from_error(
+                    error,
+                    stage="process_tree.terminate",
+                    api="os.killpg",
+                )
+            )
     try:
         process_running = process.poll() is None
     except OSError as error:
@@ -1336,6 +1352,8 @@ def _terminate_process_tree(
     if process_running:
         try:
             process.kill()
+        except ProcessLookupError:
+            pass
         except OSError as error:
             failures.append(
                 LifecycleFailure(
@@ -1364,11 +1382,15 @@ def _run_json_command(
     timeout_seconds: float = 60,
     drain_timeout_seconds: float = 5,
     windows_job_factory: Callable[[], _WindowsKillJob] = _WindowsKillJob,
+    process_tree_terminator: (
+        Callable[[subprocess.Popen[bytes], _WindowsKillJob | None], None] | None
+    ) = None,
 ) -> dict[str, Any]:
     if not command:
         raise ProvenanceError(f"{label} command must not be empty")
     if timeout_seconds <= 0 or drain_timeout_seconds <= 0:
         raise ProvenanceError(f"{label} timeout bounds must be positive")
+    terminate_process_tree = process_tree_terminator or _terminate_process_tree
     windows_job: _WindowsKillJob | None = None
     if os.name == "nt":
         try:
@@ -1437,7 +1459,7 @@ def _run_json_command(
             cleanup_failures: list[LifecycleFailure] = []
             try:
                 try:
-                    _terminate_process_tree(process, windows_job)
+                    terminate_process_tree(process, windows_job)
                 except OSError as termination_error:
                     containment_errors.append(str(termination_error))
                     cleanup_failures.append(
@@ -1534,21 +1556,32 @@ def _run_json_command(
     stderr = bytearray()
     overflow = threading.Event()
     termination_lock = threading.Lock()
+    failure_event_lock = threading.Lock()
+    failure_events: list[LifecycleFailure] = []
     termination_failures: list[LifecycleFailure] = []
     pipe_read_failures: list[LifecycleFailure | None] = [None, None]
+    pipe_read_event_indices: list[int | None] = [None, None]
     pipe_read_terminated_process = [False, False]
+
+    def record_failure_event(failure: LifecycleFailure) -> int:
+        with failure_event_lock:
+            failure_events.append(failure)
+            return len(failure_events) - 1
+
+    def replace_failure_event(index: int, failure: LifecycleFailure) -> None:
+        with failure_event_lock:
+            failure_events[index] = failure
 
     def terminate() -> None:
         with termination_lock:
             try:
-                _terminate_process_tree(process, windows_job)
+                terminate_process_tree(process, windows_job)
             except OSError as error:
-                if not termination_failures:
-                    termination_failures.append(
-                        _failure_from_error(
-                            error, stage="process_tree.terminate"
-                        )
-                    )
+                failure = _failure_from_error(
+                    error, stage="process_tree.terminate"
+                )
+                termination_failures.append(failure)
+                record_failure_event(failure)
 
     def drain(
         stream: Any,
@@ -1570,6 +1603,11 @@ def _run_json_command(
                     ),
                     message=message,
                 )
+                read_failure = pipe_read_failures[pipe_index]
+                assert read_failure is not None
+                pipe_read_event_indices[pipe_index] = record_failure_event(
+                    read_failure
+                )
                 try:
                     process_running = process.poll() is None
                 except OSError as poll_error:
@@ -1585,6 +1623,11 @@ def _run_json_command(
                             ),
                             message=poll_message,
                         )
+                    )
+                    event_index = pipe_read_event_indices[pipe_index]
+                    assert event_index is not None
+                    replace_failure_event(
+                        event_index, pipe_read_failures[pipe_index]
                     )
                     process_running = True
                 if process_running:
@@ -1616,6 +1659,7 @@ def _run_json_command(
         thread.start()
     timeout_error: subprocess.TimeoutExpired | None = None
     wait_failure: LifecycleFailure | None = None
+    recovery_wait_failures: list[LifecycleFailure] = []
     returncode: int | None = None
     close_failures: list[LifecycleFailure] = []
     pipe_close_failures: list[LifecycleFailure] = []
@@ -1627,7 +1671,7 @@ def _run_json_command(
         try:
             returncode = process.wait(timeout=drain_timeout_seconds)
         except subprocess.TimeoutExpired:
-            wait_failure = LifecycleFailure(
+            recovery_failure = LifecycleFailure(
                 stage="process.wait",
                 api="Popen.wait",
                 error_code=None,
@@ -1636,10 +1680,37 @@ def _run_json_command(
                     f"{drain_timeout_seconds:g} seconds"
                 ),
             )
+            recovery_wait_failures.append(recovery_failure)
+            record_failure_event(recovery_failure)
             terminate()
+            try:
+                returncode = process.wait(timeout=drain_timeout_seconds)
+            except subprocess.TimeoutExpired:
+                final_failure = LifecycleFailure(
+                    stage="process.wait",
+                    api="Popen.wait",
+                    error_code=None,
+                    message=(
+                        "final process wait timed out after "
+                        f"{drain_timeout_seconds:g} seconds"
+                    ),
+                )
+                recovery_wait_failures.append(final_failure)
+                record_failure_event(final_failure)
+            except OSError as final_error:
+                final_failure = replace(
+                    _failure_from_error(
+                        final_error,
+                        stage="process.wait",
+                        api="Popen.wait",
+                    ),
+                    message=f"final process wait failed: {final_error}",
+                )
+                recovery_wait_failures.append(final_failure)
+                record_failure_event(final_failure)
         except OSError as wait_error:
             message = f"process wait after timeout failed: {wait_error}"
-            wait_failure = replace(
+            recovery_failure = replace(
                 _failure_from_error(
                     wait_error,
                     stage="process.wait",
@@ -1647,6 +1718,33 @@ def _run_json_command(
                 ),
                 message=message,
             )
+            recovery_wait_failures.append(recovery_failure)
+            record_failure_event(recovery_failure)
+            terminate()
+            try:
+                returncode = process.wait(timeout=drain_timeout_seconds)
+            except (OSError, subprocess.TimeoutExpired) as final_error:
+                if isinstance(final_error, subprocess.TimeoutExpired):
+                    final_failure = LifecycleFailure(
+                        stage="process.wait",
+                        api="Popen.wait",
+                        error_code=None,
+                        message=(
+                            "final process wait timed out after "
+                            f"{drain_timeout_seconds:g} seconds"
+                        ),
+                    )
+                else:
+                    final_failure = replace(
+                        _failure_from_error(
+                            final_error,
+                            stage="process.wait",
+                            api="Popen.wait",
+                        ),
+                        message=f"final process wait failed: {final_error}",
+                    )
+                recovery_wait_failures.append(final_failure)
+                record_failure_event(final_failure)
     except OSError as error:
         message = f"{label} process wait failed: {error}"
         wait_failure = replace(
@@ -1661,31 +1759,78 @@ def _run_json_command(
         try:
             returncode = process.wait(timeout=drain_timeout_seconds)
         except subprocess.TimeoutExpired:
-            retry_message = (
-                "process wait retry timed out after "
-                f"{drain_timeout_seconds:g} seconds"
+            retry_failure = LifecycleFailure(
+                stage="process.wait",
+                api="Popen.wait",
+                error_code=None,
+                message=(
+                    "process wait retry timed out after "
+                    f"{drain_timeout_seconds:g} seconds"
+                ),
             )
-            wait_failure = wait_failure.with_cleanup(
-                LifecycleFailure(
-                    stage="process.wait",
-                    api="Popen.wait",
-                    error_code=None,
-                    message=retry_message,
-                )
-            )
+            recovery_wait_failures.append(retry_failure)
+            record_failure_event(retry_failure)
             terminate()
-        except OSError as retry_error:
-            retry_message = f"process wait retry failed: {retry_error}"
-            wait_failure = wait_failure.with_cleanup(
-                replace(
-                    _failure_from_error(
-                        retry_error,
+            try:
+                returncode = process.wait(timeout=drain_timeout_seconds)
+            except (OSError, subprocess.TimeoutExpired) as final_error:
+                if isinstance(final_error, subprocess.TimeoutExpired):
+                    final_failure = LifecycleFailure(
                         stage="process.wait",
                         api="Popen.wait",
-                    ),
-                    message=retry_message,
-                )
+                        error_code=None,
+                        message=(
+                            "final process wait timed out after "
+                            f"{drain_timeout_seconds:g} seconds"
+                        ),
+                    )
+                else:
+                    final_failure = replace(
+                        _failure_from_error(
+                            final_error,
+                            stage="process.wait",
+                            api="Popen.wait",
+                        ),
+                        message=f"final process wait failed: {final_error}",
+                    )
+                recovery_wait_failures.append(final_failure)
+                record_failure_event(final_failure)
+        except OSError as retry_error:
+            retry_failure = replace(
+                _failure_from_error(
+                    retry_error,
+                    stage="process.wait",
+                    api="Popen.wait",
+                ),
+                message=f"process wait retry failed: {retry_error}",
             )
+            recovery_wait_failures.append(retry_failure)
+            record_failure_event(retry_failure)
+            terminate()
+            try:
+                returncode = process.wait(timeout=drain_timeout_seconds)
+            except (OSError, subprocess.TimeoutExpired) as final_error:
+                if isinstance(final_error, subprocess.TimeoutExpired):
+                    final_failure = LifecycleFailure(
+                        stage="process.wait",
+                        api="Popen.wait",
+                        error_code=None,
+                        message=(
+                            "final process wait timed out after "
+                            f"{drain_timeout_seconds:g} seconds"
+                        ),
+                    )
+                else:
+                    final_failure = replace(
+                        _failure_from_error(
+                            final_error,
+                            stage="process.wait",
+                            api="Popen.wait",
+                        ),
+                        message=f"final process wait failed: {final_error}",
+                    )
+                recovery_wait_failures.append(final_failure)
+                record_failure_event(final_failure)
     finally:
         with termination_lock:
             if windows_job is not None:
@@ -1695,8 +1840,9 @@ def _run_json_command(
                     close_failure = _failure_from_error(
                         error, stage="job.close"
                     )
+                    close_event_index = record_failure_event(close_failure)
                     try:
-                        _terminate_process_tree(process, windows_job)
+                        terminate_process_tree(process, windows_job)
                     except OSError as termination_error:
                         close_failure = close_failure.with_cleanup(
                             _failure_from_error(
@@ -1713,6 +1859,7 @@ def _run_json_command(
                                 stage="job.close",
                             )
                         )
+                    replace_failure_event(close_event_index, close_failure)
                     close_failures.append(close_failure)
         drain_deadline = time.monotonic() + drain_timeout_seconds
         for thread in threads:
@@ -1724,6 +1871,26 @@ def _run_json_command(
         for thread in stuck_drains:
             thread.join(timeout=max(0, final_drain_deadline - time.monotonic()))
     drain_failure = any(thread.is_alive() for thread in threads)
+    drain_failure_record: LifecycleFailure | None = None
+    if drain_failure:
+        drain_failure_record = LifecycleFailure(
+            stage="pipe.drain",
+            message="output pipes did not close within bounds",
+        )
+        record_failure_event(drain_failure_record)
+    causal_pipe_read_exit: LifecycleFailure | None = None
+    if (
+        returncode is not None
+        and returncode != 0
+        and any(pipe_read_terminated_process)
+    ):
+        causal_pipe_read_exit = LifecycleFailure(
+            stage="command.exit",
+            api="Popen.wait",
+            error_code=returncode,
+            message=f"process exited {returncode} after pipe-read termination",
+        )
+        record_failure_event(causal_pipe_read_exit)
     if not drain_failure:
         for pipe_name, stream in (
             ("stdout", process.stdout),
@@ -1733,23 +1900,28 @@ def _run_json_command(
                 stream.close()
             except OSError as error:
                 message = f"{pipe_name} pipe close failed: {error}"
-                pipe_close_failures.append(
-                    replace(
-                        _failure_from_error(
-                            error,
-                            stage="pipe.close",
-                            api=f"Popen.{pipe_name}.close",
-                        ),
-                        message=message,
-                    )
+                close_failure = replace(
+                    _failure_from_error(
+                        error,
+                        stage="pipe.close",
+                        api=f"Popen.{pipe_name}.close",
+                    ),
+                    message=message,
                 )
+                pipe_close_failures.append(close_failure)
+                record_failure_event(close_failure)
     pipe_read_failure_events = [
-        (failure, pipe_read_terminated_process[index])
+        (
+            pipe_read_event_indices[index],
+            failure,
+            pipe_read_terminated_process[index],
+        )
         for index, failure in enumerate(pipe_read_failures)
         if failure is not None
     ]
+    pipe_read_failure_events.sort(key=lambda item: item[0])
     pipe_read_failure_records = [
-        failure for failure, _terminated in pipe_read_failure_events
+        failure for _event_index, failure, _terminated in pipe_read_failure_events
     ]
     cleanup_failures = [
         *termination_failures,
@@ -1780,6 +1952,9 @@ def _run_json_command(
         )
     cleanup_failure_text.extend(
         failure.message for failure in pipe_close_failures
+    )
+    cleanup_failure_text.extend(
+        failure.message for failure in recovery_wait_failures
     )
 
     def add_cleanup_failure(failure: LifecycleFailure) -> None:
@@ -1823,8 +1998,9 @@ def _run_json_command(
         primary_failure = wait_failure
         for failure in pipe_read_failure_records:
             add_cleanup_failure(failure)
-    elif returncode != 0 and not any(
-        terminated for _failure, terminated in pipe_read_failure_events
+    elif returncode is not None and returncode != 0 and not any(
+        terminated
+        for _event_index, _failure, terminated in pipe_read_failure_events
     ):
         detail = bytes(stderr).decode("utf-8", errors="replace").strip()
         primary_error = f"{label} exited {returncode}: {detail}"
@@ -1839,7 +2015,7 @@ def _run_json_command(
     elif pipe_read_failure_records:
         causal_failures = [
             failure
-            for failure, terminated in pipe_read_failure_events
+            for _event_index, failure, terminated in pipe_read_failure_events
             if terminated
         ]
         primary_failure = (
@@ -1849,20 +2025,12 @@ def _run_json_command(
         for failure in pipe_read_failure_records:
             if failure is not primary_failure:
                 add_cleanup_failure(failure)
-        if returncode != 0:
-            add_cleanup_failure(
-                LifecycleFailure(
-                    stage="command.exit",
-                    api="Popen.wait",
-                    error_code=returncode,
-                    message=f"process exited {returncode} after pipe-read termination",
-                )
-            )
+        if causal_pipe_read_exit is not None:
+            cleanup_failure_text.append(causal_pipe_read_exit.message)
     elif drain_failure:
         primary_error = drain_error
-        primary_failure = LifecycleFailure(
-            stage="pipe.drain", message=primary_error
-        )
+        assert drain_failure_record is not None
+        primary_failure = drain_failure_record
     else:
         try:
             decoded = bytes(stdout).decode("utf-8")
@@ -1893,31 +2061,32 @@ def _run_json_command(
                         stage="command.canonical", message=primary_error
                     )
     if drain_failure and primary_error != drain_error:
-        drain_failure_record = LifecycleFailure(
-            stage="pipe.drain",
-            message="output pipes did not close within bounds",
-        )
-        cleanup_failures.append(drain_failure_record)
+        assert drain_failure_record is not None
         cleanup_failure_text.append(drain_failure_record.message)
     if primary_error is not None:
         assert primary_failure is not None
         final_message = with_cleanup_failures(primary_error)
-        failure = primary_failure.with_cleanup(*cleanup_failures)
+        ordered_cleanup = [
+            event for event in failure_events if event is not primary_failure
+        ]
+        failure = primary_failure.with_cleanup(*ordered_cleanup)
         raise ProvenanceError(
             final_message,
             lifecycle=replace(failure, message=final_message),
         ) from primary_cause
     if termination_failures:
-        failure = termination_failures[0].with_cleanup(
-            *termination_failures[1:], *close_failures, *pipe_close_failures
+        primary = termination_failures[0]
+        failure = primary.with_cleanup(
+            *(event for event in failure_events if event is not primary)
         )
         detail = f"{label} failed to terminate process tree: {failure.message}"
         raise ProvenanceError(
             detail, lifecycle=replace(failure, message=detail)
         )
     if close_failures:
-        failure = close_failures[0].with_cleanup(
-            *close_failures[1:], *pipe_close_failures
+        primary = close_failures[0]
+        failure = primary.with_cleanup(
+            *(event for event in failure_events if event is not primary)
         )
         close_text = failure.message
         for recovery_failure in failure.cleanup_causes:
@@ -1941,7 +2110,10 @@ def _run_json_command(
             detail, lifecycle=replace(failure, message=detail)
         )
     if pipe_close_failures:
-        failure = pipe_close_failures[0].with_cleanup(*pipe_close_failures[1:])
+        primary = pipe_close_failures[0]
+        failure = primary.with_cleanup(
+            *(event for event in failure_events if event is not primary)
+        )
         detail = f"{label} failed to close output pipe: {failure.message}"
         raise ProvenanceError(
             detail, lifecycle=replace(failure, message=detail)

--- a/code/scripts/tests/test_adj_stdlib_provenance.py
+++ b/code/scripts/tests/test_adj_stdlib_provenance.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import unittest
 from contextlib import redirect_stdout
@@ -1610,6 +1611,247 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         )
         process.kill.assert_called_once_with()
 
+    def test_posix_process_group_lookup_miss_uses_root_fallback(self) -> None:
+        process = self.windows_process()
+        process.poll.return_value = None
+        killpg = mock.Mock(side_effect=ProcessLookupError(3, "group absent"))
+
+        provenance._terminate_process_tree(
+            process,
+            None,
+            platform_name="posix",
+            kill_process_group=killpg,
+        )
+
+        killpg.assert_called_once_with(process.pid, provenance.POSIX_SIGKILL)
+        process.kill.assert_called_once_with()
+
+    def test_posix_process_group_permission_failure_is_structured(self) -> None:
+        process = self.windows_process()
+        process.poll.return_value = None
+        killpg = mock.Mock(side_effect=PermissionError(13, "permission denied"))
+
+        with self.assertRaisesRegex(OSError, "permission denied") as raised:
+            provenance._terminate_process_tree(
+                process,
+                None,
+                platform_name="posix",
+                kill_process_group=killpg,
+            )
+
+        failure = raised.exception.failure
+        self.assertEqual(
+            (failure.stage, failure.api, failure.error_code),
+            ("process_tree.terminate", "os.killpg", 13),
+        )
+        process.kill.assert_called_once_with()
+
+    def test_posix_process_group_fallback_failures_are_ordered(self) -> None:
+        process = self.windows_process()
+        process.poll.side_effect = OSError(6, "poll failed")
+        process.kill.side_effect = OSError(1, "root kill failed")
+        killpg = mock.Mock(side_effect=PermissionError(13, "killpg failed"))
+
+        with self.assertRaisesRegex(OSError, "root kill failed") as raised:
+            provenance._terminate_process_tree(
+                process,
+                None,
+                platform_name="posix",
+                kill_process_group=killpg,
+            )
+
+        failure = raised.exception.failure
+        self.assertEqual(
+            (failure.stage, failure.api, failure.error_code),
+            ("process_tree.terminate", "os.killpg", 13),
+        )
+        self.assertEqual(
+            [
+                (cause.stage, cause.api, cause.error_code)
+                for cause in failure.cleanup_causes
+            ],
+            [
+                ("process.poll", "Popen.poll", 6),
+                ("process.terminate", "Popen.kill", 1),
+            ],
+        )
+
+    def test_posix_process_root_fallback_failure_is_structured(self) -> None:
+        process = self.windows_process()
+        process.poll.return_value = None
+        process.kill.side_effect = OSError(1, "root kill failed")
+        killpg = mock.Mock()
+
+        with self.assertRaisesRegex(OSError, "root kill failed") as raised:
+            provenance._terminate_process_tree(
+                process,
+                None,
+                platform_name="posix",
+                kill_process_group=killpg,
+            )
+
+        failure = raised.exception.failure
+        self.assertEqual(
+            (failure.stage, failure.api, failure.error_code),
+            ("process.terminate", "Popen.kill", 1),
+        )
+
+    def test_posix_process_root_lookup_miss_is_benign(self) -> None:
+        process = self.windows_process()
+        process.poll.return_value = None
+        process.kill.side_effect = ProcessLookupError(3, "root absent")
+
+        provenance._terminate_process_tree(
+            process,
+            None,
+            platform_name="posix",
+            kill_process_group=mock.Mock(),
+        )
+
+        process.kill.assert_called_once_with()
+
+    def test_posix_process_repeated_termination_failures_are_ordered(self) -> None:
+        process = mock.Mock(pid=404)
+        process.wait.side_effect = [
+            subprocess.TimeoutExpired(["fixture"], 0.2),
+            subprocess.TimeoutExpired(["fixture"], 0.1),
+            -9,
+        ]
+        process.stdout.read.return_value = b""
+        process.stderr.read.return_value = b""
+        terminator = mock.Mock(
+            side_effect=[
+                provenance._lifecycle_error(
+                    "process_tree.terminate",
+                    "killpg failed",
+                    api="os.killpg",
+                    error_code=13,
+                ),
+                provenance._lifecycle_error(
+                    "process.terminate",
+                    "root kill failed",
+                    api="Popen.kill",
+                    error_code=1,
+                ),
+            ]
+        )
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            self.assertRaisesRegex(provenance.ProvenanceError, "timed out") as raised,
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="repeated termination fixture",
+                timeout_seconds=0.2,
+                drain_timeout_seconds=0.1,
+                windows_job_factory=mock.Mock,
+                process_tree_terminator=terminator,
+            )
+
+        failure = raised.exception.lifecycle
+        self.assertEqual(
+            [
+                (cause.stage, cause.api, cause.error_code)
+                for cause in failure.cleanup_causes
+            ],
+            [
+                ("process_tree.terminate", "os.killpg", 13),
+                ("process.wait", "Popen.wait", None),
+                ("process.terminate", "Popen.kill", 1),
+            ],
+        )
+        self.assertEqual(process.wait.call_count, 3)
+
+    def test_posix_process_unreaped_timeout_does_not_claim_exit(self) -> None:
+        process = mock.Mock(pid=404)
+        process.wait.side_effect = [
+            subprocess.TimeoutExpired(["fixture"], 0.2),
+            subprocess.TimeoutExpired(["fixture"], 0.1),
+            subprocess.TimeoutExpired(["fixture"], 0.1),
+        ]
+        process.poll.return_value = None
+        process.stdout.read.side_effect = OSError(5, "stdout read failed")
+        process.stderr.read.return_value = b""
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            self.assertRaisesRegex(provenance.ProvenanceError, "timed out") as raised,
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="unreaped timeout fixture",
+                timeout_seconds=0.2,
+                drain_timeout_seconds=0.1,
+                windows_job_factory=mock.Mock,
+                process_tree_terminator=mock.Mock(),
+            )
+
+        failure = raised.exception.lifecycle
+        self.assertNotIn(
+            "command.exit",
+            [cause.stage for cause in failure.cleanup_causes],
+        )
+        self.assertFalse(any("exited None" in cause.message for cause in failure.cleanup_causes))
+        self.assertEqual(process.wait.call_count, 3)
+
+    def test_posix_process_failure_preserves_both_pipe_close_causes(self) -> None:
+        process = mock.Mock(pid=404)
+        process.wait.side_effect = [
+            subprocess.TimeoutExpired(["fixture"], 0.1),
+            OSError(6, "recovery wait failed"),
+            -9,
+        ]
+        process.stdout.read.return_value = b""
+        process.stderr.read.return_value = b""
+        process.stdout.close.side_effect = OSError(5, "stdout close failed")
+        process.stderr.close.side_effect = OSError(6, "stderr close failed")
+        terminator = mock.Mock(
+            side_effect=[
+                provenance._lifecycle_error(
+                    "process_tree.terminate",
+                    "killpg failed",
+                    api="os.killpg",
+                    error_code=13,
+                ),
+                None,
+            ]
+        )
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError,
+                "timed out.*killpg failed.*stdout close failed.*stderr close failed",
+            ) as raised,
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="POSIX compound cleanup fixture",
+                timeout_seconds=0.1,
+                windows_job_factory=mock.Mock,
+                process_tree_terminator=terminator,
+            )
+
+        failure = raised.exception.lifecycle
+        self.assertEqual(failure.stage, "command.timeout")
+        self.assertEqual(
+            [
+                (cause.stage, cause.api, cause.error_code)
+                for cause in failure.cleanup_causes
+            ],
+            [
+                ("process_tree.terminate", "os.killpg", 13),
+                ("process.wait", "Popen.wait", 6),
+                ("pipe.close", "Popen.stdout.close", 5),
+                ("pipe.close", "Popen.stderr.close", 6),
+            ],
+        )
+        self.assertEqual(failure.message, str(raised.exception))
+
     @unittest.skipUnless(os.name == "nt", "Windows Job Object behavior")
     def test_windows_job_factory_failure_precedes_process_launch(self) -> None:
         factory = mock.Mock(side_effect=OSError("injected CreateJobObjectW failure"))
@@ -1897,6 +2139,39 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         process.stdout.close.assert_not_called()
         process.stderr.close.assert_not_called()
 
+    def test_json_command_primary_stuck_drain_is_not_self_causal(self) -> None:
+        process = mock.Mock(pid=404)
+        process.stdout = mock.Mock()
+        process.stderr = mock.Mock()
+        process.wait.return_value = 0
+        threads = [mock.Mock(), mock.Mock()]
+        for thread in threads:
+            thread.is_alive.return_value = True
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            mock.patch.object(
+                provenance.threading, "Thread", side_effect=threads
+            ),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError,
+                "output pipes did not close within bounds",
+            ) as raised,
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="primary stuck drain fixture",
+                drain_timeout_seconds=0.1,
+                windows_job_factory=mock.Mock,
+                process_tree_terminator=mock.Mock(),
+            )
+
+        failure = raised.exception.lifecycle
+        self.assertEqual(failure.stage, "pipe.drain")
+        self.assertEqual(failure.cleanup_causes, ())
+        self.assertEqual(failure.message, str(raised.exception))
+
     def test_json_command_pipe_read_failure_fails_closed(self) -> None:
         process = mock.Mock(pid=404)
         process.wait.return_value = -9
@@ -1941,6 +2216,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         process.poll.return_value = 7
         process.stdout.read.side_effect = OSError(5, "injected stdout read failure")
         process.stderr.read.return_value = b""
+        process.stdout.close.side_effect = OSError(6, "injected stdout close failure")
 
         with (
             mock.patch.object(provenance.subprocess, "Popen", return_value=process),
@@ -1965,9 +2241,59 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                 (cause.stage, cause.api, cause.error_code)
                 for cause in failure.cleanup_causes
             ],
-            [("pipe.read", "Popen.stdout.read", 5)],
+            [
+                ("pipe.read", "Popen.stdout.read", 5),
+                ("pipe.close", "Popen.stdout.close", 6),
+            ],
         )
         self.assertEqual(failure.message, str(raised.exception))
+
+    def test_json_command_reader_primary_follows_event_order(self) -> None:
+        process = mock.Mock(pid=404)
+        process.wait.return_value = -9
+        process.poll.side_effect = [None, -9]
+        stderr_failed = threading.Event()
+
+        def stdout_read(_size: int) -> bytes:
+            stderr_failed.wait(1)
+            raise OSError(5, "stdout read failed")
+
+        def stderr_read(_size: int) -> bytes:
+            stderr_failed.set()
+            raise OSError(6, "stderr read failed")
+
+        process.stdout.read.side_effect = stdout_read
+        process.stderr.read.side_effect = stderr_read
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError, "stderr pipe read failed"
+            ) as raised,
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="reader order fixture",
+                windows_job_factory=mock.Mock,
+                process_tree_terminator=mock.Mock(),
+            )
+
+        failure = raised.exception.lifecycle
+        self.assertEqual(
+            (failure.stage, failure.api, failure.error_code),
+            ("pipe.read", "Popen.stderr.read", 6),
+        )
+        self.assertEqual(
+            [
+                (cause.stage, cause.api, cause.error_code)
+                for cause in failure.cleanup_causes
+            ],
+            [
+                ("pipe.read", "Popen.stdout.read", 5),
+                ("command.exit", "Popen.wait", -9),
+            ],
+        )
 
     def test_json_command_pipe_read_preserves_poll_failure(self) -> None:
         process = mock.Mock(pid=404)
@@ -2010,6 +2336,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         process.wait.side_effect = [
             OSError(5, "injected wait failure"),
             OSError(6, "injected wait retry failure"),
+            -9,
         ]
         process.stdout.read.return_value = b""
         process.stderr.read.return_value = b""
@@ -2047,6 +2374,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         process.wait.side_effect = [
             OSError(5, "injected wait failure"),
             subprocess.TimeoutExpired(["fixture"], 0.1),
+            -9,
         ]
         process.stdout.read.return_value = b""
         process.stderr.read.return_value = b""
@@ -2092,6 +2420,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         process.wait.side_effect = [
             subprocess.TimeoutExpired(["fixture"], 0.2),
             subprocess.TimeoutExpired(["fixture"], 0.1),
+            -9,
         ]
         process.stdout.read.return_value = b""
         process.stderr.read.return_value = b""
@@ -2315,7 +2644,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                 )
                 self.assertEqual(close_calls, 2)
 
-    def test_windows_job_timeout_kills_descendant_pipe_holders(self) -> None:
+    def test_process_tree_timeout_kills_descendant_pipe_holders(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             pid_path = Path(directory) / "child.pid"
             child = (
@@ -2348,7 +2677,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             self.assertLess(time.monotonic() - started, 8)
             self.assert_process_exits(int(pid_path.read_text()))
 
-    def test_windows_job_parent_exit_kills_descendant_pipe_holders(self) -> None:
+    def test_process_tree_parent_exit_kills_descendant_pipe_holders(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             pid_path = Path(directory) / "child.pid"
             child = (

--- a/code/specs/ADJ-STDLIB-COVERAGE.md
+++ b/code/specs/ADJ-STDLIB-COVERAGE.md
@@ -356,9 +356,20 @@ option mapping, or judge/evaluation failure.
      process waits, pipe reads and closes, and close retries all retain
      machine-inspectable causal structure. Worker-thread I/O faults fail closed even
      when the bytes received before the fault happen to form valid canonical JSON.
-13h. **Backlog:** add platform-neutral fault injection for POSIX process-group
-     termination, including `killpg` permission/lookup failures, root-kill fallback,
-     simultaneous pipe cleanup failures, and hosted Linux/macOS execution gates.
+13h. **Complete:** POSIX process-group termination now has platform-neutral injection
+     for lookup misses, permission failures, process polling, root-kill fallback, and
+     ordered compound failures. Runner-level terminator injection proves simultaneous
+     stdout/stderr close failures remain in the lifecycle tree. An attempt-ordered event
+     ledger preserves concurrent reader causality and every repeated termination, and a
+     final bounded wait reaps the root after recovery termination. Hosted Linux runs the
+     full provenance suite in `detect`; hosted macOS runs the focused POSIX/process-tree
+     selector with pinned Python, and the Windows selector includes all Job and generic
+     process-tree cases.
+13i. **Backlog:** contain descendants that deliberately create a new session and add
+     kill-on-verifier-crash semantics for POSIX, where `start_new_session=True` alone
+     cannot guarantee cleanup after abrupt verifier termination. Add independently
+     bounded raw-handle closure for readers that remain stuck after tree termination;
+     ordinary buffered `close()` can itself block behind a concurrent read.
 
 ### Wave 2: complete K-8 foundations
 

--- a/code/specs/data/adj-stdlib-provenance/README.md
+++ b/code/specs/data/adj-stdlib-provenance/README.md
@@ -132,5 +132,11 @@ projection is versioned as `adj-stdlib/process-lifecycle-failure/v1`; CLI failur
 it as `lifecycle_failure` while retaining the existing `error` and `valid` fields.
 Process-wait, pipe-read, and pipe-close faults are records too; partial output is never
 accepted merely because its prefix happens to be valid canonical JSON.
+POSIX group termination is fault-injected independently of the host OS: lookup misses,
+permission errors, poll failures, root-process fallback, and simultaneous pipe-close
+failures retain API-attempt ordering. Repeated termination attempts are never collapsed,
+concurrent reader failures use event order, and recovery ends with a bounded root wait.
+Linux runs the complete suite and macOS runs the focused POSIX/process-tree gate before
+merge.
 Existing hashes are reused, while missing or changed bytes, claims, transforms, graph
 edges, receipts, partitions, and projections fail closed.


### PR DESCRIPTION
## Summary
- make POSIX process-tree termination injectable and preserve benign lookup-miss semantics
- record lifecycle cleanup failures in actual attempt order, including repeated termination and final bounded reap failures
- add platform-neutral fault injection plus focused Linux, macOS, and Windows CI selectors, with remaining containment debt tracked as 13i

## Validation
- `python -m unittest discover -s code/scripts/tests -p test_adj_stdlib_provenance.py` (147 passed, 1 expected skip)
- Windows/process-tree selector (43 passed)
- POSIX/process-tree selector (11 passed)
- provenance CAS verification (6 bundles, 84 objects, 9 snapshots, valid)
- coverage manifest validation (6 roots, 10 objectives, no errors)
- workflow YAML parse and `git diff --check`
- two independent reviewer agents reported no P0-P2 findings in the completed 13h scope