### PR TITLE
feat(human-languages): publish Bengali chapter 6

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -78,9 +78,10 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B08 | Complete (#9680) | Publish Punjabi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
 | HL-B09 | Complete (#9683) | Remove Punjabi's LaTeX layout, duplicate-label, font-shape, and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Gurmukhi, natural page bottoms, explicit static-font shapes, and a shorter running title make the forced six-chapter build warning-free. |
 | HL-B10 | Complete (#9690) | Publish Sanskrit Chapter 6 from its three canonical lessons rather than hand-copying another book chapter. | All three schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
-| HL-B11 | Complete in this PR | Remove Sanskrit's LaTeX layout, duplicate-label, font-shape, and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Devanagari, natural page bottoms, explicit static-font shapes, and shorter running titles make the forced six-chapter build warning-free. |
-| HL-B12 | Next | Publish Bengali Chapter 6 from its canonical lesson rather than hand-copying another book chapter. | The duration audit confirms authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
-| HL-B13 | Queued | Remove Bengali's missing glyphs and LaTeX layout/bookmark warnings. | A forced build succeeds but reports six missing glyphs, one overfull box, four underfull boxes, four duplicate practice labels, and 27 Hyperref warnings; the clean-build signal is zero of each. |
+| HL-B11 | Complete (#9698) | Remove Sanskrit's LaTeX layout, duplicate-label, font-shape, and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Devanagari, natural page bottoms, explicit static-font shapes, and shorter running titles make the forced six-chapter build warning-free. |
+| HL-B12 | Complete in this PR | Publish Bengali Chapter 6 from its canonical lesson rather than hand-copying another book chapter. | The schema-v2 lesson now generates the PDF chapter from the same source hash independently verified by Language Ladder. |
+| HL-B13 | Next | Remove Bengali's missing glyphs and LaTeX layout/bookmark warnings. | A forced six-chapter build succeeds but reports six missing glyphs, one overfull box, five underfull boxes, four duplicate practice labels, 27 Hyperref warnings, and three font-shape warnings; the clean-build signal is zero of each. |
+| HL-I01 | Queued | Reduce unified all-books workflow setup time without splitting the single publication bundle. | The exact-merge Sanskrit cleanup run spent seven minutes installing TeX Live, while a redundant PR run remained there beyond eighteen minutes; cache or pre-bake the toolchain and keep all 20 books plus bundle verification in one job. |
 | HL-B14 | Queued | Publish Italian Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Italian has canonical app content through Chapter 17, but its downloadable PDF contains only Chapter 1; schema-v2 migration plus generation should close that drift safely. |
 | HL-B15 | Queued | Remove Italian's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds but reports one underfull box and three Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B16 | Queued | Publish Portuguese Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Portuguese has canonical app content through Chapter 17, but its downloadable PDF contains only Chapter 1; schema-v2 migration plus generation should close that drift safely. |
@@ -448,6 +449,33 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   XeLaTeX build reports zero package or LaTeX warnings, missing glyphs,
   overfull boxes, underfull boxes, and duplicate destinations. HL-B12 is next:
   publish Bengali Chapter 6 through the canonical pipeline.
+
+## Findings from HL-B12
+
+- Bengali Chapter 6 now comes from its canonical schema-v2 lesson. The
+  generator manifest and Language Ladder independently combine the same source
+  hash, so the app and downloadable book cannot drift silently.
+- The lesson realizes `SPINE-COUNT-ONE-TO-FIVE` in a 290-second boundary and
+  extends it with Bengali script, chandrabindu nasalization, the conservative
+  vowel in *dui*, the everyday numeral's simplified *dv-* cluster, and the
+  qualified Assamese/Odia/Nepali comparison.
+- HL-I01 records publication latency observed after HL-B11: content drift and
+  Bengali's warning debt remain learner-visible priorities ahead of optimizing
+  a successful but slow single-job TeX setup.
+- The strict data suite passes all 80 tests; Language Ladder passes all 287
+  tests and its production build. The report remains at 1,065 lessons and 20
+  books with zero duration violations and zero unknown prerequisites, while
+  book drift falls to 252 lesson chapters and Bengali becomes the sixth
+  mixed-schema track.
+- The forced letter-size XeLaTeX build is 29 pages. Visual inspection of all
+  three generated pages found shaped Bengali, width-aware numeral and etymology
+  tables, an intact chandrabindu and recall box, and no clipping. The outline
+  retains the authored `ek dui tin chār pā̃ch` bookmark.
+- The generated chapter adds one visually benign underfull-page warning but no
+  new missing glyph, overfull, duplicate-label, bookmark, or font warning. The
+  full build's six missing glyphs, one overfull box, five underfull boxes, four
+  duplicate recap labels, 27 Hyperref warnings, and three font-shape warnings
+  are recorded accurately in HL-B13.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -67,7 +67,7 @@ edition is authored.
 | [Hindi](./hindi/README.md) | Indo-Aryan / Devanagari | Chapters 1-2 authored (lessons + book) |
 | [Marathi](./marathi/README.md) | Indo-Aryan / Devanagari | Chapters 1-6 authored (lessons + book) |
 | [Punjabi](./punjabi/README.md) | Indo-Aryan / Gurmukhi (vendored font) | Chapters 1-6 authored (lessons + book, script inline) |
-| [Bengali](./bengali/README.md) | Indo-Aryan / Bengali (vendored font) | Chapter 1 (Greetings) authored (lessons + book) |
+| [Bengali](./bengali/README.md) | Indo-Aryan / Bengali (vendored font) | Chapters 1–6 authored (lessons + book; Chapter 6 canonical/generated) |
 | [Gujarati](./gujarati/README.md) | Indo-Aryan / Gujarati (vendored font) | Chapters 1-6 authored (lessons + book, script inline) |
 | [Tamil](./tamil/README.md) | Dravidian / Tamil (vendored font) | Chapters 1-2 authored (lessons + book) |
 | [Kannada](./kannada/README.md) | Dravidian / Kannada (vendored font) | Chapters 1-2 authored (lessons + book) |

--- a/code/learning/human-languages/bengali/CHANGELOG.md
+++ b/code/learning/human-languages/bengali/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Canonical Chapter 6 publication — 2026-08-03
+
+- Migrated the numbers lesson to schema v2 with the shared
+  `SPINE-COUNT-ONE-TO-FIVE` can-do node, a 290-second ceiling, and block-level
+  knowledge closure.
+- Generated the downloadable Chapter 6 from the same lesson AST and source hash
+  that Language Ladder loads instead of maintaining a second content copy.
+- Preserved Bengali numeral forms, the chandrabindu note, the qualified history
+  of *dui*, and bookmark-safe romanization in the generated chapter; the book
+  preamble now supplies the shared width-aware table renderer it uses.
+
 ## Sub-five-minute remediation — 2026-08-02
 
 - Corrected eleven declared five-minute estimates whose computed durations were

--- a/code/learning/human-languages/bengali/README.md
+++ b/code/learning/human-languages/bengali/README.md
@@ -39,11 +39,17 @@ book.
 - **Chapter 5 — First Verbs** ([`lessons/BN-C05-*`](./lessons/)): bôlā, **āmi
   bānglā bôli**, thākā (← *sthā* → *stand/stay*), kāj kôrā, practice. The verb
   never changes for gender. In the book.
+- **Chapter 6 — Numbers 1–5** ([`lessons/BN-C06-*`](./lessons/)): *ek, dui, tin,
+  chār, pā̃ch*, the chandrabindu, and the conservative vowel in *dui*. In the
+  book from the same canonical schema-v2 lesson AST and source hash that
+  Language Ladder loads.
 
 ## Book / fonts
 
 Compiles with XeLaTeX using the **vendored** Noto Sans Bengali font
 (`../../_fonts/NotoSansBengali-Static.ttf`). `latexmk -xelatex book.tex`.
+Chapter 6 is generated from the canonical lesson; its Bengali-script runs use
+that font while its section bookmarks use authored romanization.
 
 ## Files
 

--- a/code/learning/human-languages/bengali/book/book.tex
+++ b/code/learning/human-languages/bengali/book/book.tex
@@ -74,4 +74,6 @@ Released under CC~BY-SA~4.0.
 
 \input{chapters/ch05-first-verbs}
 
+\input{chapters/ch06-numbers-1-5}
+
 \end{document}

--- a/code/learning/human-languages/bengali/book/chapters/ch06-numbers-1-5.tex
+++ b/code/learning/human-languages/bengali/book/chapters/ch06-numbers-1-5.tex
@@ -1,0 +1,76 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:28baeae54e13a2dc
+% canonical-lessons: BN-C06-numbers-1-5
+
+\chapter{Numbers One to Five}
+\label{ch:numbers-one-to-five}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[ek dui tin chār pā̃ch]{\bn{এক}, \bn{দুই}, \bn{তিন}, \bn{চার}, \bn{পাঁচ} — one to five}
+
+\label{lesson:BN-C06-numbers-1-5}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Bengali writes in its own script, but the words underneath are the same family you'd hear in Delhi or Mumbai — with one number that preserves something both of them lost.
+\end{quote}
+
+\subsection*{You'll want to know: the five}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{Bengali} & \textbf{said} \\
+\midrule
+1 & \textbf{\bn{এক}} & \emph{ek} \\
+2 & \textbf{\bn{দুই}} & \emph{dui} \\
+3 & \textbf{\bn{তিন}} & \emph{tin} \\
+4 & \textbf{\bn{চার}} & \emph{chār} \\
+5 & \textbf{\bn{পাঁচ}} & \emph{pā̃ch} \\
+\bottomrule
+\end{tabularx}
+
+The \textbf{\bn{ঁ}} on \emph{pā̃ch} is the \textbf{chandrabindu}, the same moon-dot Hindi uses, nasalising the vowel.
+
+\begin{cousinweb}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{2} \\
+\midrule
+Sanskrit & stem \emph{dvá-} (masc. \emph{dváu}, fem./neut. \emph{dvé}) \\
+Prakrit & \emph{do} / \emph{duve} \\
+Hindi & \emph{do} \\
+Marathi & \emph{don} \\
+\textbf{Bengali} & \emph{\textbf{dui}} \\
+\bottomrule
+\end{tabularx}
+
+Hindi and Marathi flattened the old form into a single \emph{o}. Bengali kept a trace of the following \textbf{-i}, which is why it has two syllables where its neighbours have one.
+
+The \emph{dv-} cluster itself is gone from the \textbf{numeral} in all of them. (Not from the languages — \emph{dv-} is alive in words borrowed straight back out of Sanskrit, like Bengali \textbf{\bn{দ্বার}} \emph{dvār} "door." It's the everyday inherited word that simplified.)
+
+And Bengali isn't unique in keeping that vowel: \textbf{Assamese, Odia and Nepali} have \emph{dui} too. Among the four languages in this chapter it stands alone; across the eastern Indo-Aryan languages it has plenty of company.
+\end{cousinweb}
+
+\begin{sounds}
+Bengali's inherent vowel leans toward \textbf{o}, not \emph{a} — which is why the greeting from Chapter 1 is \emph{nomoshkar} where Hindi says \emph{namaskār}.
+
+You won't hear that in these five numbers, as it happens: \textbf{\bn{এক}} opens with the independent vowel \bn{এ}, and none of the others has a bare inherent-vowel syllable either. Mentioned so you don't go looking for it here — but keep it in mind the moment a word does have one.
+
+Don't let a neighbouring language's spelling tell you how Bengali sounds.
+\end{sounds}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "ek, dui, tin, chār, pā̃ch"{]}
+  \item {[}YOU SAY: the twos — "dvá- … do … don … \textbf{dui}"{]}
+  \item {[}YOU SAY: the Ch. 1 echo — "\textbf{no}moshkar, not \textbf{na}maskār"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Count to five in Bengali. (\emph{Ek, dui, tin, chār, pā̃ch}.) What does \textbf{\bn{দুই}} keep that Hindi and Marathi flattened away? (\textbf{The following \emph{-i}}, which is why it has two syllables.) Is Bengali alone in that? (\textbf{No} — Assamese, Odia and Nepali have \emph{dui} too; it's alone only among the four here.) Did the \emph{dv-} cluster survive anywhere in the everyday numeral? (\textbf{No} — though \emph{dv-} is alive in words re-borrowed from Sanskrit, like \emph{dvār} "door".) What is the \textbf{\bn{ঁ}}? (The \textbf{chandrabindu}, nasalising the vowel.) Next: six to ten.
+\end{tcolorbox}

--- a/code/learning/human-languages/bengali/book/preamble.tex
+++ b/code/learning/human-languages/bengali/book/preamble.tex
@@ -19,6 +19,7 @@
 \tcbuselibrary{skins,breakable}
 \usepackage{booktabs}
 \usepackage{longtable}
+\usepackage{tabularx}
 \usepackage{array}
 \usepackage[hidelinks]{hyperref}
 \usepackage{titlesec}

--- a/code/learning/human-languages/bengali/lessons/BN-C06-numbers-1-5.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C06-numbers-1-5.md
@@ -1,27 +1,45 @@
 ---
+schema_version: 2
 id: BN-C06-numbers-1-5
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 340
 chapter: 6
 type: word
 headword: এক দুই তিন চার পাঁচ
+romanization: ek dui tin chār pā̃ch
 gloss: one to five — and the "two" that kept its Sanskrit vowel
 concept_tag: BN-NUMBERS-1-5
 prerequisites: [BN-C01-nomoshkar]
 sounds: [long-aa, chandrabindu-nasal, i-sign]
 roots: [sanskrit-dvi, sanskrit-panca]
 etymology_hook: "Bengali দুই dui keeps a trace of the vowel following the old dv- that Hindi and Marathi flattened into do/don — which is why it has two syllables where they have one; it shares this with Assamese, Odia and Nepali, and is unusual only among the four languages compared here"
-est_minutes: 4
+duration:
+  max_seconds: 290
+requires:
+  knowledge: []
+introduces:
+  knowledge: [BN-LEX-NUMBERS-ONE-TO-FIVE, BN-SCRIPT-CHANDRABINDU-NASAL, BN-ETYMON-DUI-COMPARISON, BN-HISTORY-DV-NUMERAL-SIMPLIFICATION, BN-HISTORY-DUI-AREAL-COMPANY, BN-SOUND-INHERENT-O-NOT-IN-NUMBERS]
+practises:
+  knowledge: [BN-LEX-NUMBERS-ONE-TO-FIVE, BN-SCRIPT-CHANDRABINDU-NASAL, BN-ETYMON-DUI-COMPARISON, BN-HISTORY-DV-NUMERAL-SIMPLIFICATION, BN-HISTORY-DUI-AREAL-COMPANY, BN-SOUND-INHERENT-O-NOT-IN-NUMBERS]
+skills: [listening, speaking, reading]
+modes: [interpretive, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [BN-C01-nomoshkar]
 ---
 
 # এক, দুই, তিন, চার, পাঁচ — one to five
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Bengali writes in its own script, but the words underneath are the
 same family you'd hear in Delhi or Mumbai — with one number that preserves
 something both of them lost.
 
-## The five
+## You'll want to know: the five
+<!-- hl-knowledge: introduces=[BN-LEX-NUMBERS-ONE-TO-FIVE, BN-SCRIPT-CHANDRABINDU-NASAL]; assesses=[] -->
 
 | | Bengali | said |
 |---|---|---|
@@ -34,7 +52,8 @@ something both of them lost.
 The **ঁ** on *pā̃ch* is the **chandrabindu**, the same moon-dot Hindi uses,
 nasalising the vowel.
 
-## দুই — the conservative two
+## The word, taken apart — দুই and the conservative two
+<!-- hl-knowledge: introduces=[BN-ETYMON-DUI-COMPARISON, BN-HISTORY-DV-NUMERAL-SIMPLIFICATION, BN-HISTORY-DUI-AREAL-COMPANY]; assesses=[] -->
 
 | language | 2 |
 |---|---|
@@ -57,7 +76,8 @@ And Bengali isn't unique in keeping that vowel: **Assamese, Odia and Nepali**
 have *dui* too. Among the four languages in this chapter it stands alone; across
 the eastern Indo-Aryan languages it has plenty of company.
 
-## A note on how Bengali sounds
+## Sounds you'll need: where Bengali's inherent *ô* does not appear
+<!-- hl-knowledge: introduces=[BN-SOUND-INHERENT-O-NOT-IN-NUMBERS]; assesses=[] -->
 
 Bengali's inherent vowel leans toward **o**, not *a* — which is why the greeting
 from Chapter 1 is *nomoshkar* where Hindi says *namaskār*.
@@ -70,6 +90,7 @@ moment a word does have one.
 Don't let a neighbouring language's spelling tell you how Bengali sounds.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[BN-LEX-NUMBERS-ONE-TO-FIVE, BN-ETYMON-DUI-COMPARISON, BN-SOUND-INHERENT-O-NOT-IN-NUMBERS] -->
 
 [PAUSE 1s]
 - [YOU SAY: "ek, dui, tin, chār, pā̃ch"]
@@ -77,6 +98,7 @@ Don't let a neighbouring language's spelling tell you how Bengali sounds.
 - [YOU SAY: the Ch. 1 echo — "**no**moshkar, not **na**maskār"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[BN-LEX-NUMBERS-ONE-TO-FIVE, BN-SCRIPT-CHANDRABINDU-NASAL, BN-ETYMON-DUI-COMPARISON, BN-HISTORY-DV-NUMERAL-SIMPLIFICATION, BN-HISTORY-DUI-AREAL-COMPANY, BN-SOUND-INHERENT-O-NOT-IN-NUMBERS] -->
 
 [PAUSE 3s] Count to five in Bengali. (*Ek, dui, tin, chār, pā̃ch*.) What does
 **দুই** keep that Hindi and Marathi flattened away? (**The following *-i***,

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -44,6 +44,15 @@
       "output": "spanish/book/chapters/ch06-first-verbs.tex"
     },
     {
+      "language": "bengali",
+      "chapter": 6,
+      "title": "Numbers One to Five",
+      "label": "ch:numbers-one-to-five",
+      "output": "bengali/book/chapters/ch06-numbers-1-5.tex",
+      "unicodeScript": "Bengali",
+      "scriptCommand": "bn"
+    },
+    {
       "language": "gujarati",
       "chapter": 6,
       "title": "Numbers One to Five",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -3,6 +3,15 @@
   "algorithm": "fnv1a64",
   "chapters": [
     {
+      "language": "bengali",
+      "chapter": 6,
+      "sourceHash": "fnv1a64:28baeae54e13a2dc",
+      "lessonIds": [
+        "BN-C06-numbers-1-5"
+      ],
+      "tex": "bengali/book/chapters/ch06-numbers-1-5.tex"
+    },
+    {
       "language": "gujarati",
       "chapter": 6,
       "sourceHash": "fnv1a64:388a6950ab136cc1",

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -20,6 +20,9 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 - Generate Sanskrit Chapter 6 from its three strict canonical lessons,
   preserving Devanagari forms, comparison tables, and romanized bookmarks from
   the shared AST.
+- Generate Bengali Chapter 6 from its strict canonical lesson, preserving the
+  Bengali numeral forms, *dui* history, and bookmark-safe romanization from the
+  shared AST.
 
 ### Added — block-boundary knowledge closure
 

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -12,7 +12,8 @@
   generated chapter only when the app AST matches the committed book manifest;
   Spanish Chapters 1–6 now verify all 51 migrated lessons this way; Gujarati,
   Marathi, and Punjabi Chapter 6 verify both canonical lessons, while Sanskrit
-  Chapter 6 verifies all three, independently of the book generator.
+  Chapter 6 verifies all three and Bengali Chapter 6 verifies its canonical
+  lesson, independently of the book generator.
 
 ## 0.25.0 — the same syllable in its sister scripts (syllabary, PR 9)
 

--- a/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
@@ -19,6 +19,7 @@ describe("generated book source hashes", () => {
   });
 
   it.each([
+    ["bengali", 1],
     ["gujarati", 2],
     ["marathi", 2],
     ["punjabi", 2],


### PR DESCRIPTION
## Summary
- migrate Bengali Chapter 6 to schema v2 on the shared count-one-to-five spine
- generate the Bengali PDF chapter from the same canonical lesson hash Language Ladder verifies
- preserve Bengali script, *dui* etymology, tables, chandrabindu guidance, and romanized bookmarks
- log unified TeX setup latency as HL-I01 while prioritizing Bengali warning cleanup next

## Validation
- human-language-data: 80 tests passed
- Language Ladder: 287 tests passed and production build succeeded
- `npm run check:books`
- curriculum report: 1,065 lessons, zero duration violations, zero unknown prerequisites, 252 remaining lesson/book gaps
- forced 29-page XeLaTeX build
- visual inspection of all three generated pages and PDF outline audit
- `git diff --check`

## Existing book debt
The generated chapter adds one visually benign underfull page but no new missing glyph, overfull, duplicate-label, bookmark, or font warning. The measured six-chapter warning inventory is recorded in HL-B13 for the next PR.