### PR TITLE
fix(spice): lower parser MOS junction grading

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS model-card `MJ` values before lowering
+  valid bottom-junction grading coefficients.
 - Reject zero, negative, and non-finite MOS model-card `PB` values before
   lowering valid bulk-junction potentials.
 - Reject negative and non-finite MOS model-card `JS` values before lowering

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1985,6 +1985,10 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(params["PB"]) or params["PB"] <= 0.0
         ):
             raise NetlistParseError("MOSFET PB must be finite and positive")
+        if "MJ" in params and (
+            not math.isfinite(params["MJ"]) or params["MJ"] < 0.0
+        ):
+            raise NetlistParseError("MOSFET MJ must be finite and non-negative")
         nominal_temperature = params.get("T_NOM", params.get("TNOM"))
         if nominal_temperature is not None and (
             not math.isfinite(nominal_temperature) or nominal_temperature <= 0.0

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1917,6 +1917,31 @@ def test_lowers_positive_mosfet_model_bulk_potential() -> None:
     assert isclose(mosfet.model.model.params.PB, 0.72)
 
 
+@pytest.mark.parametrize("grading_coefficient", ["-0.1", "1e999"])
+def test_rejects_invalid_mosfet_model_junction_grading(
+    grading_coefficient: str,
+) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="MOSFET MJ must be finite and non-negative",
+    ):
+        parse_netlist(
+            f".model nfast NMOS(MJ={grading_coefficient})\nM1 d g s b nfast\n"
+        )
+
+
+@pytest.mark.parametrize("grading_coefficient", ["0", "0.45"])
+def test_lowers_valid_mosfet_model_junction_grading(
+    grading_coefficient: str,
+) -> None:
+    parsed = parse_netlist(
+        f".model nfast NMOS(MJ={grading_coefficient})\nM1 d g s b nfast\n"
+    )
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(mosfet.model.model.params.MJ, float(grading_coefficient))
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS model-card `MJ` values and lower valid
+  bottom-junction grading coefficients instead of silently dropping them.
 - Reject zero, negative, and non-finite MOS model-card `PB` values and lower
   valid bulk-junction potentials instead of silently dropping them.
 - Reject negative and non-finite MOS model-card `JS` values and lower valid

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1308,6 +1308,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET PB must be finite and positive");
   }
+  const gradingCoefficient = params.get("MJ");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    gradingCoefficient !== undefined &&
+    (!Number.isFinite(gradingCoefficient) || gradingCoefficient < 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET MJ must be finite and non-negative");
+  }
   const nominalTemperature = params.get("T_NOM") ?? params.get("TNOM");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1412,6 +1420,7 @@ function isMosfetParam(name: keyof MosfetLevel1Params): boolean {
     "CJSW",
     "JS",
     "PB",
+    "MJ",
     "IS",
     "N_SUB",
     "T_NOM",

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1779,6 +1779,25 @@ Xright c d load
     expect(element.params.PB).toBeCloseTo(0.72, 15);
   });
 
+  it.each(["-0.1", "1e999"])(
+    "rejects invalid MOSFET model MJ=%s",
+    (gradingCoefficient) => {
+      expect(() =>
+        parseNetlist(`.model nfast NMOS(MJ=${gradingCoefficient})\nM1 d g s b nfast\n`),
+      ).toThrow("MOSFET MJ must be finite and non-negative");
+    },
+  );
+
+  it.each(["0", "0.45"])("lowers valid MOSFET model MJ=%s", (gradingCoefficient) => {
+    const parsed = parseNetlist(
+      `.model nfast NMOS(MJ=${gradingCoefficient})\nM1 d g s b nfast\n`,
+    );
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.MJ).toBe(Number(gradingCoefficient));
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4273,11 +4273,17 @@ the Rust, Python, and TypeScript surfaces together.
      shared diagnostic while zero and positive junction saturation-current
      densities lower into Level-1 parameters.
 
+393. Python and TypeScript Berkeley SPICE MOS bulk-potential parity.
+   - Status: completed in PR 9700.
+   - Zero, negative, and non-finite model-card `PB` values are rejected with
+     the shared diagnostic while positive bulk-junction potentials lower into
+     Level-1 parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
-   - TypeScript still needs canonical lowering for `PB`, `MJ`, `MJSW`, `FC`,
-     `KF`, and `AF`; Python already lowers these canonical fields
+   - TypeScript still needs canonical lowering for `MJ`, `MJSW`, `FC`, `KF`,
+     and `AF`; Python already lowers these canonical fields
      but still needs matching facade validation coverage.
    - Align the `CJS` and `CJD` aliases with canonical `CBS` and `CBD` in both
      facades after the canonical-field slices.


### PR DESCRIPTION
## Summary
- validate MOS model-card `MJ` as finite and non-negative in Python and TypeScript
- lower valid TypeScript bottom-junction grading coefficients into Level-1 parameters
- record the merged `PB` slice and advance the prioritized parity backlog

## Verification
- Python: 192 tests passed; 88.51% coverage; Ruff clean
- TypeScript: dependent spice-engine build, parser build, 185 tests passed; 85.07% line coverage