### PR TITLE
Fix required CI gate event isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -883,12 +883,15 @@ jobs:
   # individual label cannot be required by branch protection: a PR that does
   # not produce that label would have the check "expected" forever and never
   # merge. Requiring THIS job instead gives branch protection one stable
-  # context (`CI gate`) that passes only when every required job succeeded —
-  # or was legitimately skipped (e.g. an empty build matrix when nothing
-  # relevant changed). `if: always()` makes the gate itself run even when a
+  # pull-request context (`CI gate`) that passes only when every required job
+  # succeeded — or was legitimately skipped (e.g. an empty build matrix when
+  # nothing relevant changed). Push workflows deliberately publish `CI push
+  # gate` instead: using the protected context for both events lets a faster
+  # branch push satisfy protection while the pull-request macOS/Windows matrix
+  # is still running. `if: always()` makes the gate itself run even when a
   # dependency failed, so it can report the failure rather than being skipped.
   ci-gate:
-    name: CI gate
+    name: ${{ github.event_name == 'pull_request' && 'CI gate' || 'CI push gate' }}
     needs: [detect, phy00-phy01-fixture-consumers, build]
     if: always()
     runs-on: ubuntu-latest

--- a/code/programs/mosaic/venture-browser/ACCEPTANCE-BACKLOG.md
+++ b/code/programs/mosaic/venture-browser/ACCEPTANCE-BACKLOG.md
@@ -5,6 +5,10 @@ cross-platform proving application. Items are ordered by risk and dependency.
 
 ## Prioritized discoveries
 
+- [x] **P0 CI regression — required gate event isolation.** Keep the protected
+  `CI gate` context exclusive to pull-request workflows. Branch and main push
+  workflows publish `CI push gate` so a fast push build cannot auto-complete a
+  PR while required macOS or Windows acceptance is still running.
 - [x] **P0 architecture — shared native host controller.** Move Mosaic event
   reduction, status/chrome synchronization, scrolling, scrollbar projection,
   link activation, and hover state into one host-neutral Rust controller used

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- Isolate the branch-protection `CI gate` to pull-request workflows so push CI
+  cannot auto-complete Venture changes before required macOS and Windows
+  acceptance builds finish.
 - Keep the authoritative POSIX `BUILD` wrapper compatible with the repository
   build tool's `/bin/sh` executor instead of requiring Bash `pipefail` syntax.
 

--- a/code/scripts/tests/test_venture_windows_ci_acceptance.py
+++ b/code/scripts/tests/test_venture_windows_ci_acceptance.py
@@ -147,6 +147,15 @@ class VentureWindowsCIAcceptanceTests(unittest.TestCase):
         )
         self.assertIn("cargo test -p venture-browser-macos", workflow)
 
+    def test_required_gate_is_exclusive_to_pull_request_runs(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(
+            "name: ${{ github.event_name == 'pull_request' && 'CI gate' "
+            "|| 'CI push gate' }}",
+            workflow,
+        )
+        self.assertNotIn("\n    name: CI gate\n", workflow)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- reserve the branch-protection `CI gate` context for pull-request workflows
- publish `CI push gate` from branch and main push workflows so push success cannot satisfy PR protection early
- ratchet the Venture Windows CI contract and record the discovered P0 acceptance regression

## Why
PR #9697 auto-completed after the push `CI gate` succeeded while its pull-request Windows build and pull-request aggregate gate were still pending. Both workflow events emitted the same protected context, allowing the faster push run to satisfy branch protection.

## Validation
- `python3 code/scripts/tests/test_venture_windows_ci_acceptance.py` (12 passed)
- Python bytecode compilation for the updated test
- Ruby YAML parse plus dynamic gate contract assertion
- `git diff --check`

This PR is intentionally ready for review. Auto-complete will remain disabled until both workflow events prove the new names and every required pull-request build is terminal green.