### PR TITLE
Report malformed heading end tags

### DIFF
--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -22,18 +22,18 @@ exact upstream commits used for the latest completed audit.
 ## Prioritized Queue
 
 The 2026-08-03 upstream audit at WPT
-`d6c801946a63a6c5fec07c3d476b8b021e5eca34` and html5lib-tests
+`8a26b31d60d0f1831bb1711b7587ac125b8d2bf0` and html5lib-tests
 `224991ec10db04f056a89eed8b0bd8695fd2950e` covered all 1,934 WPT
 tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the in-body non-current end-tag diagnostic slice, 2,001 of those cases
-emit at least one lexer or parser diagnostic and 182 remain uncovered. Another 139
-cases emit diagnostics despite having no legacy `#errors` rows. These are
-reviewed rather than automatically removed: 89 are full-document inputs for
-which the legacy fixtures omit the Standard-required missing-doctype error,
-including the current processing-instruction cases.
+After the specialized in-body heading end-tag diagnostic slice, 2,005 of those
+cases emit at least one lexer or parser diagnostic and 178 remain uncovered.
+Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
+These are reviewed rather than automatically removed: 89 are full-document
+inputs for which the legacy fixtures omit the Standard-required missing-doctype
+error, including the current processing-instruction cases.
 
 The concrete document-shell insertion-mode inventory is complete: missing and
 nonconforming doctypes, duplicate shell tags, body/html boundary errors,
@@ -54,13 +54,14 @@ original mode; synthetic text fragment contexts remain diagnostic-free.
 The in-body "any other end tag" parse error is now reported when implied end
 tags leave the matching open element non-current, including special-element
 scope stops and nested formatting recovery. Remaining in-body work covers
-specialized heading, list-item, paragraph, and adoption-agency branches.
+specialized list-item, paragraph, and adoption-agency branches. Heading end
+tags now report the specialized parse error when no heading is in scope or the
+current heading does not match the token.
 
 Prioritized work items:
 
-1. **In-body insertion mode.** Cover specialized heading, list-item,
-   paragraph, adoption-agency, formatting-reconstruction, and stray-tag
-   diagnostics.
+1. **In-body insertion mode.** Cover specialized list-item, paragraph,
+   adoption-agency, formatting-reconstruction, and stray-tag diagnostics.
 2. **Table, select, and template insertion modes.** Cover foster parenting,
    table scopes, select recovery, and template mode-stack errors. The remaining
    fragment EOF inventory includes fostered-anchor `eof-in-table` rows and

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -6933,7 +6933,12 @@ impl HtmlParser {
                 self.remove_pending_formatting_reconstruction(name);
             }
             name if is_heading_element(name) => {
-                self.close_open_heading_if_in_scope(None);
+                if !self.close_open_heading_if_in_scope(Some(name)) {
+                    self.diagnostics.push(ParserDiagnostic::new(
+                        "unexpected-heading-end-tag",
+                        format!("end tag `</{name}>` did not match the current heading element"),
+                    ));
+                }
             }
             _ => self.close_element(name),
         }
@@ -7367,9 +7372,7 @@ impl HtmlParser {
 
     fn close_open_heading_if_in_scope(&mut self, expected_name: Option<&str>) -> bool {
         let Some(index) = self.open_elements.iter().rposition(|path| {
-            element_at_path(&self.document, path).is_some_and(|name| {
-                is_heading_element(name) && expected_name.is_none_or(|expected| name == expected)
-            })
+            element_at_path(&self.document, path).is_some_and(is_heading_element)
         }) else {
             return false;
         };
@@ -7383,8 +7386,13 @@ impl HtmlParser {
             self.pop_current_if(is_heading_element);
             return false;
         }
+        if expected_name.is_some() {
+            self.generate_implied_end_tags_above(index);
+        }
+        let matched_current =
+            expected_name.is_none_or(|expected| self.current_element_is(expected));
         self.open_elements.truncate(index);
-        true
+        matched_current
     }
 
     fn close_open_formatting_element_silently(&mut self, name: &str) -> bool {
@@ -33203,6 +33211,28 @@ mod tests {
                 "source {source:?}"
             );
         }
+    }
+
+    #[test]
+    fn reports_heading_end_tags_without_a_matching_current_heading() {
+        for (source, end_tag) in [
+            ("<!doctype html><p></h3>foo", "h3"),
+            ("<!doctype html><h3><li>abc</h2>foo", "h2"),
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "unexpected-heading-end-tag",
+                    format!("end tag `</{end_tag}>` did not match the current heading element")
+                )],
+                "source {source:?}"
+            );
+        }
+
+        let matching =
+            parse_html_with_diagnostics("<!doctype html><h3><li>abc</h3>foo").unwrap();
+        assert!(matching.parser_diagnostics.is_empty());
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
@@ -14,7 +14,7 @@
     "missing": 0,
     "missing_sources": [],
     "upstream_cases": 1934,
-    "upstream_revision": "d6c801946a63a6c5fec07c3d476b8b021e5eca34",
+    "upstream_revision": "8a26b31d60d0f1831bb1711b7587ac125b8d2bf0",
     "upstream_source": "wpt/html/syntax/parsing/resources"
   }
 }

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 182);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2001);
+    assert_eq!(missing_diagnostic_cases, 178);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2005);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report the current HTML Standard parse error when an in-body heading end tag has no heading in scope or does not match the current heading
- generate implied end tags before checking the current heading while preserving WPT DOM recovery
- close 4 silent malformed corpus rows, from 182 to 178, and refresh the live WPT audit revision

## Evidence
- WPT tree construction: 1,934/1,934 signatures, zero missing at `8a26b31d60d0f1831bb1711b7587ac125b8d2bf0`
- html5lib tokenizer: 6,806/6,806 signatures, zero missing and zero normalized skips at `224991ec10db04f056a89eed8b0bd8695fd2950e`
- checked DOM outputs: 2,637/2,637 unchanged
- declared-error cases with diagnostics: 2,001 -> 2,005
- silent declared-error cases: 182 -> 178
- undeclared-diagnostic cases: 139 unchanged

## Validation
- `cargo test -p coding-adventures-html-parser --test tree_construction_test`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- parser audit manifest, Rust-test, and coverage checks
- generated HTML fixture and README inventory checks
- `git diff --check`