### PR TITLE
fix(human-languages): clean Bengali book warnings

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -79,9 +79,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B09 | Complete (#9683) | Remove Punjabi's LaTeX layout, duplicate-label, font-shape, and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Gurmukhi, natural page bottoms, explicit static-font shapes, and a shorter running title make the forced six-chapter build warning-free. |
 | HL-B10 | Complete (#9690) | Publish Sanskrit Chapter 6 from its three canonical lessons rather than hand-copying another book chapter. | All three schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
 | HL-B11 | Complete (#9698) | Remove Sanskrit's LaTeX layout, duplicate-label, font-shape, and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Devanagari, natural page bottoms, explicit static-font shapes, and shorter running titles make the forced six-chapter build warning-free. |
-| HL-B12 | Complete in this PR | Publish Bengali Chapter 6 from its canonical lesson rather than hand-copying another book chapter. | The schema-v2 lesson now generates the PDF chapter from the same source hash independently verified by Language Ladder. |
-| HL-B13 | Next | Remove Bengali's missing glyphs and LaTeX layout/bookmark warnings. | A forced six-chapter build succeeds but reports six missing glyphs, one overfull box, five underfull boxes, four duplicate practice labels, 27 Hyperref warnings, and three font-shape warnings; the clean-build signal is zero of each. |
-| HL-I01 | Queued | Reduce unified all-books workflow setup time without splitting the single publication bundle. | The exact-merge Sanskrit cleanup run spent seven minutes installing TeX Live, while a redundant PR run remained there beyond eighteen minutes; cache or pre-bake the toolchain and keep all 20 books plus bundle verification in one job. |
+| HL-B12 | Complete (#9705) | Publish Bengali Chapter 6 from its canonical lesson rather than hand-copying another book chapter. | The schema-v2 lesson now generates the PDF chapter from the same source hash independently verified by Language Ladder. |
+| HL-B13 | Complete in this PR | Remove Bengali's missing glyphs and LaTeX layout/bookmark warnings. | Main-font punctuation, stable recap labels, bookmark-safe Bengali, natural page bottoms, explicit static-font shapes, and a breakable long title make the forced six-chapter build warning-free. |
+| HL-I01 | Next | Reduce unified all-books workflow setup time without splitting the single publication bundle. | The exact-merge Sanskrit cleanup run spent seven minutes installing TeX Live, while a redundant PR run remained there beyond eighteen minutes; cache or pre-bake the toolchain and keep all 20 books plus bundle verification in one job. |
 | HL-B14 | Queued | Publish Italian Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Italian has canonical app content through Chapter 17, but its downloadable PDF contains only Chapter 1; schema-v2 migration plus generation should close that drift safely. |
 | HL-B15 | Queued | Remove Italian's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds but reports one underfull box and three Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B16 | Queued | Publish Portuguese Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Portuguese has canonical app content through Chapter 17, but its downloadable PDF contains only Chapter 1; schema-v2 migration plus generation should close that drift safely. |
@@ -476,6 +476,28 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   full build's six missing glyphs, one overfull box, five underfull boxes, four
   duplicate recap labels, 27 Hyperref warnings, and three font-shape warnings
   are recorded accurately in HL-B13.
+
+## Findings from HL-B13
+
+- Bengali's five authored recap anchors now use stable chapter-qualified ids
+  (`BN-C01-practice` through `BN-C05-practice`) instead of five copies of
+  `lesson:practice`.
+- Ellipsis, comma, and morpheme-boundary hyphen punctuation now stays in the
+  Latin main font instead of being asked of the Bengali-only static font.
+  Bengali remains visible in the PDF outline while the presentation-only font
+  command is suppressed there, and all requested font shapes resolve to the
+  vendored static file.
+- Short pages end naturally around kept-together callouts, and the long
+  “we'll meet again” title has a safe line-break point. The forced 29-page
+  XeLaTeX build reports zero package or LaTeX warnings, missing glyphs,
+  overfull boxes, underfull boxes, and duplicate destinations. HL-I01 is next:
+  reduce successful unified-publication setup latency without splitting the
+  single all-books job.
+- Visual regression inspection covered nine formerly affected pages: Bengali
+  shaping and main-font punctuation remain intact, the bilingual farewell title
+  breaks cleanly, split callouts are unclipped, and short pages have deliberate
+  natural bottoms. All 39 PDF outline entries remain readable, ending with the
+  generated romanized Chapter 6 title.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/bengali/CHANGELOG.md
+++ b/code/learning/human-languages/bengali/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Book warning cleanup — 2026-08-03
+
+- Kept punctuation outside the Bengali-only font and replaced five duplicate
+  recap anchors with stable chapter-qualified labels.
+- Preserved Bengali in PDF bookmarks while suppressing the font-only command
+  there, and mapped the vendored static font to every requested shape.
+- Let short lesson pages end naturally and made the long farewell title
+  breakable so the forced six-chapter build has no layout, bookmark, label,
+  font, punctuation-glyph, or package warnings.
+
 ## Canonical Chapter 6 publication — 2026-08-03
 
 - Migrated the numbers lesson to schema v2 with the shared

--- a/code/learning/human-languages/bengali/README.md
+++ b/code/learning/human-languages/bengali/README.md
@@ -51,6 +51,11 @@ Compiles with XeLaTeX using the **vendored** Noto Sans Bengali font
 Chapter 6 is generated from the canonical lesson; its Bengali-script runs use
 that font while its section bookmarks use authored romanization.
 
+The forced six-chapter build is warning-free: main-font punctuation,
+chapter-qualified recap anchors, bookmark-safe Bengali, natural page bottoms,
+explicit static-font shapes, and a breakable long title keep the downloadable
+PDF and its outline clean.
+
 ## Files
 
 - [`lessons/`](./lessons/) · [`pronunciation-reference.md`](./pronunciation-reference.md)

--- a/code/learning/human-languages/bengali/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/bengali/book/chapters/ch01-greetings.tex
@@ -118,7 +118,7 @@ simpler than its neighbours'.
 \end{grammarlens}
 
 \section{Recap}
-\label{lesson:practice}
+\label{BN-C01-practice}
 
 \begin{center}
 \begin{tabular}{@{}lll@{}}

--- a/code/learning/human-languages/bengali/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/bengali/book/chapters/ch02-introductions.tex
@@ -45,7 +45,7 @@ gender away entirely --- one of its great simplifications, which you will meet
 again and again.
 \end{grammarlens}
 
-\section{\bn{আমার নাম \ldots} \emph{(\=am\=ar n\=am \ldots)} --- ``my name is\ldots,'' with no ``is''}
+\section{\bn{আমার নাম}\ldots{} \emph{(\=am\=ar n\=am \ldots)} --- ``my name is\ldots,'' with no ``is''}
 \label{lesson:amar-naam}
 
 \bn{আমার} (my) $+$ \bn{নাম} (name) $+$ name $=$ ``my name \ldots'' $\to$ ``my name
@@ -100,7 +100,7 @@ a r\=aga, where a musician ``converses'' with the notes.
 \end{cousinweb}
 
 \section{The whole exchange}
-\label{lesson:practice}
+\label{BN-C02-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/bengali/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/bengali/book/chapters/ch03-responding.tex
@@ -6,7 +6,7 @@ time, Bengali brings back a verb ``to be'':
 
 \begin{center}
 \bn{তুমি কেমন আছো?} \quad(\emph{tumi k\=emon \=achho} --- ``How are you?'')\\
-\bn{আমি ভালো আছি, ধন্যবাদ।} \quad(\emph{\=ami bh\=alo \=achhi, dh\^{o}nnobad} --- ``I'm well, thank you.'')
+\bn{আমি ভালো আছি}, \bn{ধন্যবাদ।} \quad(\emph{\=ami bh\=alo \=achhi, dh\^{o}nnobad} --- ``I'm well, thank you.'')
 \end{center}
 
 \emph{Practice lessons: \texttt{lessons/BN-C03-*.md}.}
@@ -72,7 +72,7 @@ bh\=alo \=achhi}), ``I am well.''
 \end{cousinweb}
 
 \section{The whole exchange}
-\label{lesson:practice}
+\label{BN-C03-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}
@@ -80,7 +80,7 @@ bh\=alo \=achhi}), ``I am well.''
 Bengali & English \\
 \midrule
 \bn{তুমি কেমন আছো?} & How are you? \\
-\bn{আমি ভালো আছি, ধন্যবাদ।} & I'm well, thank you. \\
+\bn{আমি ভালো আছি}, \bn{ধন্যবাদ।} & I'm well, thank you. \\
 \bn{কোনো ব্যাপার না।} & No matter / you're welcome. \\
 \bottomrule
 \end{tabular}

--- a/code/learning/human-languages/bengali/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/bengali/book/chapters/ch04-farewells.tex
@@ -37,7 +37,7 @@ seeing will happen''), \emph{k\^{o}th\=a h\^{o}be} (``a talk will happen''). The
 event itself is the subject --- no ``we.''
 \end{grammarlens}
 
-\section{\bn{আবার দেখা হবে} \emph{(\=ab\=ar d\ae{}kh\=a h\^{o}be)} --- ``we'll meet again''}
+\section[\bn{আবার দেখা হবে} --- ``we'll meet again'']{\bn{আবার দেখা হবে} \emph{(\=ab\=ar d\ae{}kh\=a h\^{o}be)}\\ --- ``we'll meet again''}
 \label{lesson:abar-dekha-hobe}
 
 \bn{আবার} (again) $+$ \bn{দেখা হবে} (a seeing will happen) $=$ ``\textbf{we'll meet
@@ -57,7 +57,7 @@ verb's tense tells which: \emph{k\=al d\ae{}kh\=a h\^{o}be} (future $\to$
 \end{cousinweb}
 
 \section{The farewells}
-\label{lesson:practice}
+\label{BN-C04-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/bengali/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/bengali/book/chapters/ch05-first-verbs.tex
@@ -16,7 +16,7 @@ Bengali conjugates them:
 \begin{cousinweb}
 \bn{বলা} (\emph{b\^{o}l\=a}, ``to speak, say'') is a native Indo-Aryan verb (the
 same \emph{bol-} as Hindi \emph{boln\=a}, Punjabi \emph{bol\d{n}\=a}). The ending
-\bn{-আ} (\emph{-\=a}) is the infinitive; add \bn{-ই} (\emph{-i}) to the stem for
+-\bn{আ} (\emph{-\=a}) is the infinitive; add -\bn{ই} (\emph{-i}) to the stem for
 ``I speak'': \emph{b\^{o}l-} $+$ \emph{-i} $\to$ \bn{বলি} (\emph{b\^{o}li}).
 \end{cousinweb}
 
@@ -76,7 +76,7 @@ Kolk\=at\=ay th\=aki}) --- stem $+$ the \emph{-i} ``I,'' no gender.
 \end{cousinweb}
 
 \section{Sentences about yourself}
-\label{lesson:practice}
+\label{BN-C05-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/bengali/book/preamble.tex
+++ b/code/learning/human-languages/bengali/book/preamble.tex
@@ -29,7 +29,13 @@
 
 % Vendored Bengali font (../../_fonts/ from <lang>/book/); \bn{...} = inline
 % Bengali snippet.
-\newfontfamily\bengalifont[Path=../../_fonts/, Script=Bengali]{NotoSansBengali-Static.ttf}
+\newfontfamily\bengalifont[
+  Path=../../_fonts/,
+  Script=Bengali,
+  BoldFont=NotoSansBengali-Static.ttf,
+  ItalicFont=NotoSansBengali-Static.ttf,
+  BoldItalicFont=NotoSansBengali-Static.ttf
+]{NotoSansBengali-Static.ttf}
 \newcommand{\bn}[1]{{\bengalifont #1}}
 
 \hypersetup{
@@ -38,6 +44,14 @@
   pdfsubject={Etymology-driven Bengali curriculum},
   pdfkeywords={Bengali, Bangla, Sanskrit, language learning}
 }
+\pdfstringdefDisableCommands{%
+  \def\bn#1{#1}% Keep Bengali text while dropping font-only presentation.
+  \def\bengalifont{}%
+}
+
+% Lesson callouts are deliberately kept together when they fit. Let short pages
+% end naturally instead of stretching their vertical glue around those boxes.
+\raggedbottom
 
 \newtcolorbox{cousinweb}{
   breakable, skin=enhanced, colback=yellow!8, colframe=yellow!45!black,


### PR DESCRIPTION
## Summary
- keep ellipsis, comma, and morpheme-boundary hyphens in the main font so Bengali glyph rendering stays complete
- replace duplicate recap anchors and preserve Bengali text in warning-free PDF bookmarks
- resolve static-font shapes, natural page bottoms, and the long farewell title layout
- mark HL-B13 complete and prioritize unified TeX setup latency (HL-I01) next

## Validation
- `npm run check:books`
- forced 29-page XeLaTeX rebuild
- zero overfull/underfull boxes, duplicate labels, Hyperref/font/package/LaTeX warnings, and missing glyphs
- visual inspection of nine formerly affected pages
- PDF outline audit: 39 readable entries
- `git diff --check`