### PR TITLE
Implement Rust WebSocket TCP runtime adapters

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -726,6 +726,7 @@ members = [
     "ieee802154-security",
     "http1",
     "websocket-core",
+    "websocket-runtime",
     "http1-client",
     "storage-core",
     "storage-local-folder",

--- a/code/packages/rust/websocket-runtime/BUILD
+++ b/code/packages/rust/websocket-runtime/BUILD
@@ -1,0 +1,1 @@
+cargo test -p websocket-runtime -- --nocapture

--- a/code/packages/rust/websocket-runtime/CHANGELOG.md
+++ b/code/packages/rust/websocket-runtime/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Add bounded TCP WebSocket server sessions above `tcp-runtime`.
+- Add a blocking TCP WebSocket client with OS-random nonces and mask keys.
+- Add automatic ping/pong and close progression plus real-socket interop tests.

--- a/code/packages/rust/websocket-runtime/Cargo.toml
+++ b/code/packages/rust/websocket-runtime/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "websocket-runtime"
+version = "0.1.0"
+edition = "2021"
+description = "TCP client and reactor-server adapters for websocket-core"
+license = "MIT"
+
+[dependencies]
+coding_adventures_csprng = { path = "../csprng" }
+tcp-client = { path = "../tcp-client" }
+tcp-runtime = { path = "../tcp-runtime" }
+transport-platform = { path = "../transport-platform" }
+websocket-core = { path = "../websocket-core" }

--- a/code/packages/rust/websocket-runtime/README.md
+++ b/code/packages/rust/websocket-runtime/README.md
@@ -1,0 +1,24 @@
+# websocket-runtime (Rust)
+
+Concrete TCP adapters for the transport-independent `websocket-core` RFC 6455
+state machine.
+
+The package provides:
+
+- a many-connection server above `tcp-runtime`;
+- a blocking client above `tcp-client`;
+- OS CSPRNG nonces and fresh client mask keys;
+- automatic pong and close replies;
+- bounded handshakes, frames, and assembled messages; and
+- real loopback TCP interoperability tests.
+
+TLS (`wss`), extensions, subprotocols, proxies, redirects, reconnects, and
+keepalive deadlines are intentionally outside version 0.1.
+
+## Validation
+
+```sh
+cargo test -p websocket-runtime
+cargo clippy -p websocket-runtime --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p websocket-runtime --no-deps
+```

--- a/code/packages/rust/websocket-runtime/required_capabilities.json
+++ b/code/packages/rust/websocket-runtime/required_capabilities.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/websocket-runtime",
+  "capabilities": [
+    {
+      "category": "net",
+      "action": "dns",
+      "target": "*",
+      "justification": "The blocking WebSocket client resolves caller-supplied hostnames through tcp-client."
+    },
+    {
+      "category": "net",
+      "action": "connect",
+      "target": "*:*",
+      "justification": "The blocking WebSocket client connects to caller-supplied TCP endpoints through tcp-client."
+    },
+    {
+      "category": "net",
+      "action": "listen",
+      "target": "*:*",
+      "justification": "The WebSocket server binds caller-supplied TCP listener addresses through tcp-runtime."
+    }
+  ],
+  "justification": "Concrete WebSocket transport adapter over repository TCP and OS entropy packages; it performs no filesystem, process, environment, standard-stream, or FFI access."
+}

--- a/code/packages/rust/websocket-runtime/src/lib.rs
+++ b/code/packages/rust/websocket-runtime/src/lib.rs
@@ -1,0 +1,1057 @@
+//! TCP adapters for the transport-independent `websocket-core` state machine.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use coding_adventures_csprng::fill_random;
+use core::fmt::{self, Display, Formatter};
+use std::collections::VecDeque;
+use std::net::{SocketAddr, ToSocketAddrs};
+
+use tcp_client::{ConnectOptions, TcpConnection, TcpError};
+use tcp_runtime::{
+    BindAddress, PlatformError, TcpHandlerResult, TcpMailbox, TcpRuntime, TcpRuntimeOptions,
+};
+use transport_platform::TransportPlatform;
+use websocket_core::{
+    accept_server_request, build_client_request, control_reply, encode_frame,
+    validate_client_response, EndpointRole, Frame, FrameDecoder, MessageAssembler, MessageEvent,
+    WebSocketError, MAX_HANDSHAKE_BYTES,
+};
+
+pub use tcp_runtime::{ConnectionId, StopHandle, TcpConnectionInfo as WebSocketConnectionInfo};
+
+const BAD_REQUEST: &[u8] =
+    b"HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n";
+
+/// A transport, entropy, option, or RFC 6455 session failure.
+#[derive(Debug)]
+pub enum WebSocketRuntimeError {
+    /// A runtime size or buffer option was zero.
+    InvalidOptions,
+    /// A listener address could not be resolved.
+    InvalidAddress,
+    /// The repository TCP client failed.
+    Tcp(TcpError),
+    /// The repository TCP server platform failed.
+    Platform(PlatformError),
+    /// The portable WebSocket protocol core rejected input.
+    Protocol(WebSocketError),
+    /// The operating-system CSPRNG was unavailable.
+    EntropyUnavailable,
+    /// TCP ended without a completed WebSocket closing handshake.
+    AbnormalEof,
+    /// The caller tried to use a session after its closing handshake began.
+    ClosedSession,
+}
+
+impl Display for WebSocketRuntimeError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            Self::InvalidOptions => "websocket runtime: invalid options",
+            Self::InvalidAddress => "websocket runtime: invalid listener address",
+            Self::Tcp(_) => "websocket runtime: tcp client failure",
+            Self::Platform(_) => "websocket runtime: tcp server failure",
+            Self::Protocol(_) => "websocket runtime: protocol failure",
+            Self::EntropyUnavailable => "websocket runtime: OS entropy unavailable",
+            Self::AbnormalEof => "websocket runtime: abnormal EOF",
+            Self::ClosedSession => "websocket runtime: session is closing",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for WebSocketRuntimeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Tcp(error) => Some(error),
+            Self::Platform(error) => Some(error),
+            Self::Protocol(error) => Some(error),
+            Self::InvalidOptions
+            | Self::InvalidAddress
+            | Self::EntropyUnavailable
+            | Self::AbnormalEof
+            | Self::ClosedSession => None,
+        }
+    }
+}
+
+impl From<TcpError> for WebSocketRuntimeError {
+    fn from(error: TcpError) -> Self {
+        Self::Tcp(error)
+    }
+}
+
+impl From<PlatformError> for WebSocketRuntimeError {
+    fn from(error: PlatformError) -> Self {
+        Self::Platform(error)
+    }
+}
+
+impl From<WebSocketError> for WebSocketRuntimeError {
+    fn from(error: WebSocketError) -> Self {
+        Self::Protocol(error)
+    }
+}
+
+/// Entropy authority used for client handshake nonces and frame mask keys.
+pub trait EntropySource {
+    /// Completely overwrite `output` with unpredictable bytes.
+    fn fill(&mut self, output: &mut [u8]) -> Result<(), WebSocketRuntimeError>;
+}
+
+/// Production entropy backed by the repository OS CSPRNG package.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct OsEntropy;
+
+impl EntropySource for OsEntropy {
+    fn fill(&mut self, output: &mut [u8]) -> Result<(), WebSocketRuntimeError> {
+        fill_random(output).map_err(|_| WebSocketRuntimeError::EntropyUnavailable)
+    }
+}
+
+/// Bounds and TCP policy for a many-connection WebSocket server.
+#[derive(Clone, Debug)]
+pub struct WebSocketServerOptions {
+    /// Underlying listener, accepted-stream, and reactor policy.
+    pub tcp: TcpRuntimeOptions,
+    /// Maximum bytes accepted in one WebSocket frame payload.
+    pub max_frame_payload: usize,
+    /// Maximum bytes accepted in one assembled data message.
+    pub max_message_payload: usize,
+}
+
+impl Default for WebSocketServerOptions {
+    fn default() -> Self {
+        Self {
+            tcp: TcpRuntimeOptions::default(),
+            max_frame_payload: 1024 * 1024,
+            max_message_payload: 8 * 1024 * 1024,
+        }
+    }
+}
+
+/// Application output for one complete inbound WebSocket event.
+#[derive(Clone, Debug, Default)]
+pub struct WebSocketHandlerResult {
+    /// Validated outbound frames, serialized in order by the runtime.
+    pub frames: Vec<Frame>,
+    /// Whether TCP should close after all returned frames flush.
+    pub close: bool,
+}
+
+impl WebSocketHandlerResult {
+    /// Return one outbound frame while keeping the session open.
+    pub fn send(frame: Frame) -> Self {
+        Self {
+            frames: vec![frame],
+            close: false,
+        }
+    }
+
+    /// Return several outbound frames while keeping the session open.
+    pub fn send_many(frames: impl Into<Vec<Frame>>) -> Self {
+        Self {
+            frames: frames.into(),
+            close: false,
+        }
+    }
+
+    /// Construct and send a close frame, then close TCP after it flushes.
+    pub fn close(code: Option<u16>, reason: &str) -> Result<Self, WebSocketRuntimeError> {
+        Ok(Self {
+            frames: vec![Frame::close(code, reason)?],
+            close: true,
+        })
+    }
+}
+
+struct WebSocketSession {
+    decoder: FrameDecoder,
+    assembler: MessageAssembler,
+}
+
+impl WebSocketSession {
+    fn new(role: EndpointRole, max_frame_payload: usize, max_message_payload: usize) -> Self {
+        Self {
+            decoder: FrameDecoder::new(role, max_frame_payload),
+            assembler: MessageAssembler::new(max_message_payload),
+        }
+    }
+
+    fn push(&mut self, input: &[u8]) -> Result<Vec<MessageEvent>, WebSocketError> {
+        let mut events = Vec::new();
+        for frame in self.decoder.push(input)? {
+            if let Some(event) = self.assembler.push(frame)? {
+                events.push(event);
+            }
+        }
+        Ok(events)
+    }
+}
+
+enum ServerPhase {
+    Handshake(Vec<u8>),
+    Open(WebSocketSession),
+    Closing,
+}
+
+struct ServerConnectionState<S> {
+    application: S,
+    phase: ServerPhase,
+}
+
+/// Many-connection WebSocket server composed over `tcp-runtime`.
+pub struct WebSocketRuntime<P, S = ()> {
+    inner: TcpRuntime<P, ServerConnectionState<S>>,
+}
+
+impl<P: TransportPlatform> WebSocketRuntime<P, ()> {
+    /// Bind a stateless WebSocket server to a caller-provided transport platform.
+    pub fn bind<F>(
+        platform: P,
+        address: BindAddress,
+        options: WebSocketServerOptions,
+        handler: F,
+    ) -> Result<Self, WebSocketRuntimeError>
+    where
+        F: Fn(WebSocketConnectionInfo, MessageEvent) -> WebSocketHandlerResult
+            + Send
+            + Sync
+            + 'static,
+    {
+        Self::bind_with_state(
+            platform,
+            address,
+            options,
+            |_| (),
+            move |info, _, event| handler(info, event),
+            |_, _| {},
+        )
+    }
+}
+
+impl<P: TransportPlatform, S: Send + 'static> WebSocketRuntime<P, S> {
+    /// Bind a stateful WebSocket server to a caller-provided transport platform.
+    pub fn bind_with_state<I, F, C>(
+        platform: P,
+        address: BindAddress,
+        options: WebSocketServerOptions,
+        init: I,
+        handler: F,
+        on_close: C,
+    ) -> Result<Self, WebSocketRuntimeError>
+    where
+        I: Fn(WebSocketConnectionInfo) -> S + Send + Sync + 'static,
+        F: Fn(WebSocketConnectionInfo, &mut S, MessageEvent) -> WebSocketHandlerResult
+            + Send
+            + Sync
+            + 'static,
+        C: Fn(WebSocketConnectionInfo, S) + Send + Sync + 'static,
+    {
+        validate_server_options(&options)?;
+        let max_frame_payload = options.max_frame_payload;
+        let max_message_payload = options.max_message_payload;
+        let inner = TcpRuntime::bind_with_state(
+            platform,
+            address,
+            options.tcp,
+            move |info| ServerConnectionState {
+                application: init(info),
+                phase: ServerPhase::Handshake(Vec::new()),
+            },
+            move |info, state, bytes| {
+                server_input(
+                    info,
+                    state,
+                    bytes,
+                    max_frame_payload,
+                    max_message_payload,
+                    &handler,
+                )
+            },
+            move |info, state| on_close(info, state.application),
+        )?;
+        Ok(Self { inner })
+    }
+
+    /// Return the concrete local address selected by the TCP listener.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.inner.local_addr()
+    }
+
+    /// Return a cloneable cooperative stop handle.
+    pub fn stop_handle(&self) -> StopHandle {
+        self.inner.stop_handle()
+    }
+
+    /// Return the underlying TCP mailbox for advanced byte-level integrations.
+    ///
+    /// Bytes submitted here must already be complete server-role WebSocket
+    /// frames. Normal application replies should use `WebSocketHandlerResult`.
+    pub fn tcp_mailbox(&self) -> TcpMailbox {
+        self.inner.mailbox()
+    }
+
+    /// Serve accepted connections until stopped or the listener fails.
+    pub fn serve(&mut self) -> Result<(), WebSocketRuntimeError> {
+        self.inner.serve().map_err(Into::into)
+    }
+}
+
+fn validate_server_options(options: &WebSocketServerOptions) -> Result<(), WebSocketRuntimeError> {
+    if options.max_frame_payload == 0 || options.max_message_payload == 0 {
+        Err(WebSocketRuntimeError::InvalidOptions)
+    } else {
+        Ok(())
+    }
+}
+
+enum HandshakeProgress {
+    Pending,
+    Accepted {
+        response: Vec<u8>,
+        leftover: Vec<u8>,
+    },
+    Rejected,
+}
+
+fn advance_server_handshake(buffer: &mut Vec<u8>, input: &[u8]) -> HandshakeProgress {
+    if buffer.len().saturating_add(input.len()) > MAX_HANDSHAKE_BYTES {
+        return HandshakeProgress::Rejected;
+    }
+    buffer.extend_from_slice(input);
+    match accept_server_request(buffer) {
+        Ok(handshake) => HandshakeProgress::Accepted {
+            response: handshake.response().to_vec(),
+            leftover: buffer[handshake.consumed()..].to_vec(),
+        },
+        Err(WebSocketError::IncompleteHandshake) => HandshakeProgress::Pending,
+        Err(_) => HandshakeProgress::Rejected,
+    }
+}
+
+fn server_input<S, F>(
+    info: WebSocketConnectionInfo,
+    state: &mut ServerConnectionState<S>,
+    input: &[u8],
+    max_frame_payload: usize,
+    max_message_payload: usize,
+    handler: &F,
+) -> TcpHandlerResult
+where
+    F: Fn(WebSocketConnectionInfo, &mut S, MessageEvent) -> WebSocketHandlerResult,
+{
+    let progress = match &mut state.phase {
+        ServerPhase::Handshake(buffer) => Some(advance_server_handshake(buffer, input)),
+        ServerPhase::Open(session) => {
+            let result = process_open_server(info, &mut state.application, session, input, handler);
+            if result.close {
+                state.phase = ServerPhase::Closing;
+            }
+            return result;
+        }
+        ServerPhase::Closing => return TcpHandlerResult::close(),
+    };
+
+    match progress.expect("handshake phase produces progress") {
+        HandshakeProgress::Pending => TcpHandlerResult::default(),
+        HandshakeProgress::Rejected => {
+            state.phase = ServerPhase::Closing;
+            TcpHandlerResult::write_and_close(BAD_REQUEST)
+        }
+        HandshakeProgress::Accepted {
+            mut response,
+            leftover,
+        } => {
+            state.phase = ServerPhase::Open(WebSocketSession::new(
+                EndpointRole::Server,
+                max_frame_payload,
+                max_message_payload,
+            ));
+            if leftover.is_empty() {
+                return TcpHandlerResult::write(response);
+            }
+            let result = match &mut state.phase {
+                ServerPhase::Open(session) => {
+                    process_open_server(info, &mut state.application, session, &leftover, handler)
+                }
+                _ => unreachable!("accepted handshake creates an open session"),
+            };
+            if result.close {
+                state.phase = ServerPhase::Closing;
+            }
+            response.extend_from_slice(&result.write);
+            TcpHandlerResult {
+                write: response,
+                close: result.close,
+                defer_read: false,
+            }
+        }
+    }
+}
+
+fn process_open_server<S, F>(
+    info: WebSocketConnectionInfo,
+    application: &mut S,
+    session: &mut WebSocketSession,
+    input: &[u8],
+    handler: &F,
+) -> TcpHandlerResult
+where
+    F: Fn(WebSocketConnectionInfo, &mut S, MessageEvent) -> WebSocketHandlerResult,
+{
+    let events = match session.push(input) {
+        Ok(events) => events,
+        Err(error) => return protocol_close(error),
+    };
+    let mut wire = Vec::new();
+    let mut close = false;
+    for event in events {
+        let peer_close = matches!(event, MessageEvent::Close(_));
+        if let Some(reply) = control_reply(&event) {
+            append_server_frame(&mut wire, &reply);
+        }
+        let output = handler(info, application, event);
+        if peer_close {
+            close = true;
+            continue;
+        }
+        for frame in output.frames {
+            append_server_frame(&mut wire, &frame);
+        }
+        close |= output.close;
+    }
+    if close {
+        TcpHandlerResult::write_and_close(wire)
+    } else {
+        TcpHandlerResult::write(wire)
+    }
+}
+
+fn append_server_frame(output: &mut Vec<u8>, frame: &Frame) {
+    let encoded = encode_frame(EndpointRole::Server, frame, None)
+        .expect("validated server frame must encode without a mask");
+    output.extend_from_slice(&encoded);
+}
+
+fn protocol_close(error: WebSocketError) -> TcpHandlerResult {
+    let code = protocol_close_code(error);
+    let frame = Frame::close(Some(code), "").expect("standard close code is valid");
+    let wire =
+        encode_frame(EndpointRole::Server, &frame, None).expect("server close frame must encode");
+    TcpHandlerResult::write_and_close(wire)
+}
+
+/// Bounds and TCP timeouts for the blocking WebSocket client.
+#[derive(Clone, Debug)]
+pub struct WebSocketClientOptions {
+    /// Underlying TCP connect, read, write, and buffering policy.
+    pub tcp: ConnectOptions,
+    /// Maximum bytes accepted in one inbound frame payload.
+    pub max_frame_payload: usize,
+    /// Maximum bytes accepted in one assembled inbound message.
+    pub max_message_payload: usize,
+    /// Maximum bytes requested from one TCP read.
+    pub read_chunk_size: usize,
+}
+
+impl Default for WebSocketClientOptions {
+    fn default() -> Self {
+        Self {
+            tcp: ConnectOptions::default(),
+            max_frame_payload: 1024 * 1024,
+            max_message_payload: 8 * 1024 * 1024,
+            read_chunk_size: 16 * 1024,
+        }
+    }
+}
+
+/// Blocking `ws` client over the repository TCP client adapter.
+pub struct WebSocketClient<E = OsEntropy> {
+    connection: TcpConnection,
+    entropy: E,
+    session: WebSocketSession,
+    pending: VecDeque<MessageEvent>,
+    read_chunk_size: usize,
+    close_sent: bool,
+    close_received: bool,
+}
+
+impl WebSocketClient<OsEntropy> {
+    /// Connect, perform the HTTP upgrade, and return an open blocking client.
+    pub fn connect(
+        host: &str,
+        port: u16,
+        target: &str,
+        options: WebSocketClientOptions,
+    ) -> Result<Self, WebSocketRuntimeError> {
+        Self::connect_with_entropy(host, port, target, options, OsEntropy)
+    }
+}
+
+impl<E: EntropySource> WebSocketClient<E> {
+    /// Connect using an explicit entropy authority.
+    ///
+    /// This constructor exists so deterministic tests and constrained hosts can
+    /// inject an auditable entropy provider. Production callers should use
+    /// `WebSocketClient::connect`.
+    pub fn connect_with_entropy(
+        host: &str,
+        port: u16,
+        target: &str,
+        options: WebSocketClientOptions,
+        mut entropy: E,
+    ) -> Result<Self, WebSocketRuntimeError> {
+        validate_client_options(&options)?;
+        let mut nonce = [0_u8; 16];
+        entropy.fill(&mut nonce)?;
+        let handshake = build_client_request(host, target, nonce)?;
+        let mut connection = tcp_client::connect(host, port, options.tcp)?;
+        connection.write_all(handshake.bytes())?;
+        connection.flush()?;
+        read_client_upgrade(&mut connection, handshake.expected_accept())?;
+        Ok(Self {
+            connection,
+            entropy,
+            session: WebSocketSession::new(
+                EndpointRole::Client,
+                options.max_frame_payload,
+                options.max_message_payload,
+            ),
+            pending: VecDeque::new(),
+            read_chunk_size: options.read_chunk_size,
+            close_sent: false,
+            close_received: false,
+        })
+    }
+
+    /// Send one validated client-role frame with a fresh random mask key.
+    pub fn send_frame(&mut self, frame: &Frame) -> Result<(), WebSocketRuntimeError> {
+        if self.close_sent {
+            return Err(WebSocketRuntimeError::ClosedSession);
+        }
+        self.write_frame(frame)
+    }
+
+    /// Send one complete UTF-8 text message.
+    pub fn send_text(&mut self, text: impl Into<String>) -> Result<(), WebSocketRuntimeError> {
+        self.send_frame(&Frame::text(text))
+    }
+
+    /// Send one complete binary message.
+    pub fn send_binary(
+        &mut self,
+        payload: impl Into<Vec<u8>>,
+    ) -> Result<(), WebSocketRuntimeError> {
+        self.send_frame(&Frame::binary(payload))
+    }
+
+    /// Send one ping control frame.
+    pub fn send_ping(&mut self, payload: impl Into<Vec<u8>>) -> Result<(), WebSocketRuntimeError> {
+        let frame = Frame::ping(payload)?;
+        self.send_frame(&frame)
+    }
+
+    /// Receive the next complete event, preserving coalesced later events.
+    pub fn receive(&mut self) -> Result<MessageEvent, WebSocketRuntimeError> {
+        if let Some(event) = self.pending.pop_front() {
+            return Ok(event);
+        }
+        if self.close_received {
+            return Err(WebSocketRuntimeError::ClosedSession);
+        }
+        loop {
+            let bytes = self.connection.read_chunk(self.read_chunk_size)?;
+            if bytes.is_empty() {
+                return Err(WebSocketRuntimeError::AbnormalEof);
+            }
+            let events = match self.session.push(&bytes) {
+                Ok(events) => events,
+                Err(error) => {
+                    self.send_protocol_close(error)?;
+                    return Err(error.into());
+                }
+            };
+            self.accept_client_events(events)?;
+            if let Some(event) = self.pending.pop_front() {
+                return Ok(event);
+            }
+        }
+    }
+
+    /// Begin a normal closing handshake with a validated status and reason.
+    pub fn close(&mut self, code: Option<u16>, reason: &str) -> Result<(), WebSocketRuntimeError> {
+        if self.close_sent {
+            return Ok(());
+        }
+        let frame = Frame::close(code, reason)?;
+        self.write_frame(&frame)?;
+        self.close_sent = true;
+        Ok(())
+    }
+
+    /// Whether a close frame has been sent or received.
+    pub fn is_closing(&self) -> bool {
+        self.close_sent || self.close_received
+    }
+
+    /// Return the connected peer TCP address.
+    pub fn peer_addr(&self) -> Result<SocketAddr, WebSocketRuntimeError> {
+        self.connection.peer_addr().map_err(Into::into)
+    }
+
+    /// Return the connected local TCP address.
+    pub fn local_addr(&self) -> Result<SocketAddr, WebSocketRuntimeError> {
+        self.connection.local_addr().map_err(Into::into)
+    }
+
+    fn write_frame(&mut self, frame: &Frame) -> Result<(), WebSocketRuntimeError> {
+        let mut mask = [0_u8; 4];
+        self.entropy.fill(&mut mask)?;
+        let wire = encode_frame(EndpointRole::Client, frame, Some(mask))?;
+        self.connection.write_all(&wire)?;
+        self.connection.flush()?;
+        Ok(())
+    }
+
+    fn accept_client_events(
+        &mut self,
+        events: Vec<MessageEvent>,
+    ) -> Result<(), WebSocketRuntimeError> {
+        for event in events {
+            if let Some(reply) = control_reply(&event) {
+                if !self.close_sent {
+                    self.write_frame(&reply)?;
+                }
+            }
+            if matches!(event, MessageEvent::Close(_)) {
+                self.close_received = true;
+                self.close_sent = true;
+            }
+            self.pending.push_back(event);
+        }
+        Ok(())
+    }
+
+    fn send_protocol_close(&mut self, error: WebSocketError) -> Result<(), WebSocketRuntimeError> {
+        if !self.close_sent {
+            let frame = Frame::close(Some(protocol_close_code(error)), "")?;
+            self.write_frame(&frame)?;
+            self.close_sent = true;
+        }
+        Ok(())
+    }
+}
+
+fn validate_client_options(options: &WebSocketClientOptions) -> Result<(), WebSocketRuntimeError> {
+    if options.max_frame_payload == 0
+        || options.max_message_payload == 0
+        || options.read_chunk_size == 0
+    {
+        Err(WebSocketRuntimeError::InvalidOptions)
+    } else {
+        Ok(())
+    }
+}
+
+fn read_client_upgrade(
+    connection: &mut TcpConnection,
+    expected_accept: &str,
+) -> Result<(), WebSocketRuntimeError> {
+    let mut head = Vec::new();
+    loop {
+        let remaining = MAX_HANDSHAKE_BYTES.saturating_sub(head.len());
+        if remaining == 0 {
+            return Err(WebSocketError::HandshakeTooLarge.into());
+        }
+        let line = connection.read_until_limit(b'\n', remaining)?;
+        if line.is_empty() {
+            return Err(WebSocketRuntimeError::AbnormalEof);
+        }
+        head.extend_from_slice(&line);
+        match validate_client_response(&head, expected_accept) {
+            Ok(_) => return Ok(()),
+            Err(WebSocketError::IncompleteHandshake) => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+}
+
+fn protocol_close_code(error: WebSocketError) -> u16 {
+    match error {
+        WebSocketError::InvalidUtf8 => 1007,
+        WebSocketError::FrameTooLarge | WebSocketError::MessageTooLarge => 1009,
+        _ => 1002,
+    }
+}
+
+fn resolve_first<A: ToSocketAddrs>(address: A) -> Result<SocketAddr, WebSocketRuntimeError> {
+    address
+        .to_socket_addrs()
+        .map_err(|_| WebSocketRuntimeError::InvalidAddress)?
+        .next()
+        .ok_or(WebSocketRuntimeError::InvalidAddress)
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+impl WebSocketRuntime<transport_platform::bsd::KqueueTransportPlatform, ()> {
+    /// Bind a stateless server through the host kqueue transport.
+    pub fn bind_kqueue<A, F>(
+        address: A,
+        options: WebSocketServerOptions,
+        handler: F,
+    ) -> Result<Self, WebSocketRuntimeError>
+    where
+        A: ToSocketAddrs,
+        F: Fn(WebSocketConnectionInfo, MessageEvent) -> WebSocketHandlerResult
+            + Send
+            + Sync
+            + 'static,
+    {
+        Self::bind_kqueue_with_state(
+            address,
+            options,
+            |_| (),
+            move |info, _, event| handler(info, event),
+            |_, _| {},
+        )
+    }
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+impl<S: Send + 'static> WebSocketRuntime<transport_platform::bsd::KqueueTransportPlatform, S> {
+    /// Bind a stateful server through the host kqueue transport.
+    pub fn bind_kqueue_with_state<A, I, F, C>(
+        address: A,
+        options: WebSocketServerOptions,
+        init: I,
+        handler: F,
+        on_close: C,
+    ) -> Result<Self, WebSocketRuntimeError>
+    where
+        A: ToSocketAddrs,
+        I: Fn(WebSocketConnectionInfo) -> S + Send + Sync + 'static,
+        F: Fn(WebSocketConnectionInfo, &mut S, MessageEvent) -> WebSocketHandlerResult
+            + Send
+            + Sync
+            + 'static,
+        C: Fn(WebSocketConnectionInfo, S) + Send + Sync + 'static,
+    {
+        let platform = transport_platform::bsd::KqueueTransportPlatform::new()?;
+        Self::bind_with_state(
+            platform,
+            BindAddress::Ip(resolve_first(address)?),
+            options,
+            init,
+            handler,
+            on_close,
+        )
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl WebSocketRuntime<transport_platform::linux::EpollTransportPlatform, ()> {
+    /// Bind a stateless server through the host epoll transport.
+    pub fn bind_epoll<A, F>(
+        address: A,
+        options: WebSocketServerOptions,
+        handler: F,
+    ) -> Result<Self, WebSocketRuntimeError>
+    where
+        A: ToSocketAddrs,
+        F: Fn(WebSocketConnectionInfo, MessageEvent) -> WebSocketHandlerResult
+            + Send
+            + Sync
+            + 'static,
+    {
+        Self::bind_epoll_with_state(
+            address,
+            options,
+            |_| (),
+            move |info, _, event| handler(info, event),
+            |_, _| {},
+        )
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl<S: Send + 'static> WebSocketRuntime<transport_platform::linux::EpollTransportPlatform, S> {
+    /// Bind a stateful server through the host epoll transport.
+    pub fn bind_epoll_with_state<A, I, F, C>(
+        address: A,
+        options: WebSocketServerOptions,
+        init: I,
+        handler: F,
+        on_close: C,
+    ) -> Result<Self, WebSocketRuntimeError>
+    where
+        A: ToSocketAddrs,
+        I: Fn(WebSocketConnectionInfo) -> S + Send + Sync + 'static,
+        F: Fn(WebSocketConnectionInfo, &mut S, MessageEvent) -> WebSocketHandlerResult
+            + Send
+            + Sync
+            + 'static,
+        C: Fn(WebSocketConnectionInfo, S) + Send + Sync + 'static,
+    {
+        let platform = transport_platform::linux::EpollTransportPlatform::new()?;
+        Self::bind_with_state(
+            platform,
+            BindAddress::Ip(resolve_first(address)?),
+            options,
+            init,
+            handler,
+            on_close,
+        )
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl WebSocketRuntime<transport_platform::windows::WindowsTransportPlatform, ()> {
+    /// Bind a stateless server through the host Windows IOCP transport.
+    pub fn bind_windows<A, F>(
+        address: A,
+        options: WebSocketServerOptions,
+        handler: F,
+    ) -> Result<Self, WebSocketRuntimeError>
+    where
+        A: ToSocketAddrs,
+        F: Fn(WebSocketConnectionInfo, MessageEvent) -> WebSocketHandlerResult
+            + Send
+            + Sync
+            + 'static,
+    {
+        Self::bind_windows_with_state(
+            address,
+            options,
+            |_| (),
+            move |info, _, event| handler(info, event),
+            |_, _| {},
+        )
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl<S: Send + 'static> WebSocketRuntime<transport_platform::windows::WindowsTransportPlatform, S> {
+    /// Bind a stateful server through the host Windows IOCP transport.
+    pub fn bind_windows_with_state<A, I, F, C>(
+        address: A,
+        options: WebSocketServerOptions,
+        init: I,
+        handler: F,
+        on_close: C,
+    ) -> Result<Self, WebSocketRuntimeError>
+    where
+        A: ToSocketAddrs,
+        I: Fn(WebSocketConnectionInfo) -> S + Send + Sync + 'static,
+        F: Fn(WebSocketConnectionInfo, &mut S, MessageEvent) -> WebSocketHandlerResult
+            + Send
+            + Sync
+            + 'static,
+        C: Fn(WebSocketConnectionInfo, S) + Send + Sync + 'static,
+    {
+        let platform = transport_platform::windows::WindowsTransportPlatform::new()?;
+        Self::bind_with_state(
+            platform,
+            BindAddress::Ip(resolve_first(address)?),
+            options,
+            init,
+            handler,
+            on_close,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn info() -> WebSocketConnectionInfo {
+        WebSocketConnectionInfo {
+            id: ConnectionId(1),
+            peer_addr: "127.0.0.1:1234".parse().unwrap(),
+            local_addr: "127.0.0.1:4321".parse().unwrap(),
+        }
+    }
+
+    fn state() -> ServerConnectionState<Vec<MessageEvent>> {
+        ServerConnectionState {
+            application: Vec::new(),
+            phase: ServerPhase::Handshake(Vec::new()),
+        }
+    }
+
+    fn request() -> Vec<u8> {
+        build_client_request("localhost", "/chief", [7; 16])
+            .unwrap()
+            .bytes()
+            .to_vec()
+    }
+
+    #[test]
+    fn fragmented_upgrade_then_coalesced_frame_is_processed() {
+        let mut state = state();
+        let request = request();
+        let split = request.len() - 3;
+        let first = server_input(
+            info(),
+            &mut state,
+            &request[..split],
+            1024,
+            1024,
+            &|_, _, _| WebSocketHandlerResult::default(),
+        );
+        assert!(first.write.is_empty());
+
+        let frame = encode_frame(
+            EndpointRole::Client,
+            &Frame::text("hello"),
+            Some([1, 2, 3, 4]),
+        )
+        .unwrap();
+        let mut suffix = request[split..].to_vec();
+        suffix.extend_from_slice(&frame);
+        let second = server_input(
+            info(),
+            &mut state,
+            &suffix,
+            1024,
+            1024,
+            &|_, events, event| {
+                events.push(event);
+                WebSocketHandlerResult::send(Frame::text("echo"))
+            },
+        );
+        assert!(second.write.starts_with(b"HTTP/1.1 101"));
+        assert_eq!(state.application, vec![MessageEvent::Text("hello".into())]);
+        assert!(second.write.ends_with(&[0x81, 4, b'e', b'c', b'h', b'o']));
+    }
+
+    #[test]
+    fn invalid_and_oversized_upgrades_are_bounded_and_closed() {
+        for input in [
+            b"GET / HTTP/1.0\r\n\r\n".as_slice(),
+            &vec![b'x'; MAX_HANDSHAKE_BYTES + 1],
+        ] {
+            let mut state = state();
+            let result = server_input(info(), &mut state, input, 1024, 1024, &|_, _, _| {
+                WebSocketHandlerResult::default()
+            });
+            assert!(result.close);
+            assert_eq!(result.write, BAD_REQUEST);
+        }
+    }
+
+    #[test]
+    fn ping_and_close_receive_automatic_replies() {
+        let mut state = state();
+        let request = request();
+        let accepted = server_input(info(), &mut state, &request, 1024, 1024, &|_, _, _| {
+            WebSocketHandlerResult::default()
+        });
+        assert!(accepted.write.starts_with(b"HTTP/1.1 101"));
+
+        let ping = encode_frame(
+            EndpointRole::Client,
+            &Frame::ping(b"ok".to_vec()).unwrap(),
+            Some([1; 4]),
+        )
+        .unwrap();
+        let pong = server_input(
+            info(),
+            &mut state,
+            &ping,
+            1024,
+            1024,
+            &|_, events, event| {
+                events.push(event);
+                WebSocketHandlerResult::default()
+            },
+        );
+        assert_eq!(pong.write, vec![0x8a, 2, b'o', b'k']);
+
+        let close = encode_frame(
+            EndpointRole::Client,
+            &Frame::close(Some(1000), "bye").unwrap(),
+            Some([2; 4]),
+        )
+        .unwrap();
+        let reply = server_input(
+            info(),
+            &mut state,
+            &close,
+            1024,
+            1024,
+            &|_, events, event| {
+                events.push(event);
+                WebSocketHandlerResult::send(Frame::text("must-not-follow-close"))
+            },
+        );
+        assert!(reply.close);
+        assert_eq!(reply.write[0], 0x88);
+        assert_eq!(reply.write.len(), 7);
+        let after_close = server_input(info(), &mut state, b"ignored", 1024, 1024, &|_, _, _| {
+            WebSocketHandlerResult::default()
+        });
+        assert!(after_close.close);
+        assert!(after_close.write.is_empty());
+    }
+
+    #[test]
+    fn protocol_error_codes_are_specific() {
+        for (error, code) in [
+            (WebSocketError::InvalidUtf8, 1007_u16),
+            (WebSocketError::FrameTooLarge, 1009),
+            (WebSocketError::InvalidOpcode, 1002),
+        ] {
+            let result = protocol_close(error);
+            assert!(result.close);
+            assert_eq!(&result.write[2..4], &code.to_be_bytes());
+        }
+    }
+
+    #[test]
+    fn options_and_error_displays_are_payload_free() {
+        let invalid_server = WebSocketServerOptions {
+            max_frame_payload: 0,
+            ..WebSocketServerOptions::default()
+        };
+        assert!(matches!(
+            validate_server_options(&invalid_server),
+            Err(WebSocketRuntimeError::InvalidOptions)
+        ));
+        let invalid_client = WebSocketClientOptions {
+            read_chunk_size: 0,
+            ..WebSocketClientOptions::default()
+        };
+        assert!(matches!(
+            validate_client_options(&invalid_client),
+            Err(WebSocketRuntimeError::InvalidOptions)
+        ));
+        assert_eq!(
+            WebSocketHandlerResult::send_many(vec![Frame::text("a"), Frame::binary(vec![1])])
+                .frames
+                .len(),
+            2
+        );
+        assert!(
+            WebSocketHandlerResult::close(Some(1000), "done")
+                .unwrap()
+                .close
+        );
+        let error = WebSocketRuntimeError::Protocol(WebSocketError::InvalidHandshake);
+        assert_eq!(error.to_string(), "websocket runtime: protocol failure");
+    }
+}

--- a/code/packages/rust/websocket-runtime/tests/integration.rs
+++ b/code/packages/rust/websocket-runtime/tests/integration.rs
@@ -1,0 +1,276 @@
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use websocket_core::{accept_server_request, Frame, MessageEvent, WebSocketError};
+use websocket_runtime::{
+    EntropySource, WebSocketClient, WebSocketClientOptions, WebSocketConnectionInfo,
+    WebSocketHandlerResult, WebSocketRuntime, WebSocketRuntimeError, WebSocketServerOptions,
+};
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+type HostPlatform = transport_platform::bsd::KqueueTransportPlatform;
+#[cfg(target_os = "linux")]
+type HostPlatform = transport_platform::linux::EpollTransportPlatform;
+#[cfg(target_os = "windows")]
+type HostPlatform = transport_platform::windows::WindowsTransportPlatform;
+
+fn bind_echo_server() -> WebSocketRuntime<HostPlatform, ()> {
+    let options = WebSocketServerOptions::default();
+    let handler = |_: WebSocketConnectionInfo, event: MessageEvent| match event {
+        MessageEvent::Text(text) => WebSocketHandlerResult::send(Frame::text(text)),
+        MessageEvent::Binary(bytes) => WebSocketHandlerResult::send(Frame::binary(bytes)),
+        MessageEvent::Ping(_) | MessageEvent::Pong(_) | MessageEvent::Close(_) => {
+            WebSocketHandlerResult::default()
+        }
+    };
+
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly"
+    ))]
+    return WebSocketRuntime::bind_kqueue("127.0.0.1:0", options, handler).unwrap();
+
+    #[cfg(target_os = "linux")]
+    return WebSocketRuntime::bind_epoll("127.0.0.1:0", options, handler).unwrap();
+
+    #[cfg(target_os = "windows")]
+    return WebSocketRuntime::bind_windows("127.0.0.1:0", options, handler).unwrap();
+}
+
+fn start_echo_server() -> (
+    std::net::SocketAddr,
+    websocket_runtime::StopHandle,
+    thread::JoinHandle<()>,
+) {
+    let mut runtime = bind_echo_server();
+    let address = runtime.local_addr();
+    let stop = runtime.stop_handle();
+    let _mailbox = runtime.tcp_mailbox();
+    let thread = thread::spawn(move || runtime.serve().unwrap());
+    (address, stop, thread)
+}
+
+#[test]
+fn client_and_reactor_server_exchange_all_v1_event_classes() {
+    let (address, stop, server) = start_echo_server();
+    let mut client = WebSocketClient::connect(
+        "127.0.0.1",
+        address.port(),
+        "/chief",
+        WebSocketClientOptions::default(),
+    )
+    .unwrap();
+    assert_eq!(client.peer_addr().unwrap(), address);
+    assert_eq!(client.local_addr().unwrap().ip().to_string(), "127.0.0.1");
+
+    client.send_text("hello").unwrap();
+    assert_eq!(
+        client.receive().unwrap(),
+        MessageEvent::Text("hello".into())
+    );
+
+    client.send_binary(vec![0, 1, 2, 255]).unwrap();
+    assert_eq!(
+        client.receive().unwrap(),
+        MessageEvent::Binary(vec![0, 1, 2, 255])
+    );
+
+    client.send_ping(b"health".to_vec()).unwrap();
+    assert_eq!(
+        client.receive().unwrap(),
+        MessageEvent::Pong(b"health".to_vec())
+    );
+
+    client.close(Some(1000), "done").unwrap();
+    assert!(matches!(client.receive().unwrap(), MessageEvent::Close(_)));
+    assert!(client.is_closing());
+    client.close(Some(1000), "already closing").unwrap();
+    assert!(matches!(
+        client.send_text("too late"),
+        Err(WebSocketRuntimeError::ClosedSession)
+    ));
+    assert!(matches!(
+        client.receive(),
+        Err(WebSocketRuntimeError::ClosedSession)
+    ));
+
+    stop.stop();
+    server.join().unwrap();
+}
+
+#[test]
+fn raw_browser_wire_client_upgrades_and_receives_unmasked_echo() {
+    let (address, stop, server) = start_echo_server();
+    let mut stream = TcpStream::connect(address).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    stream
+        .write_all(
+            b"GET /chief HTTP/1.1\r\nHost: localhost\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n",
+        )
+        .unwrap();
+    stream
+        .write_all(&[
+            0x81, 0x85, 0x37, 0xfa, 0x21, 0x3d, 0x7f, 0x9f, 0x4d, 0x51, 0x58,
+        ])
+        .unwrap();
+
+    let mut reader = BufReader::new(stream);
+    let response = read_http_head(&mut reader);
+    assert!(response.starts_with(b"HTTP/1.1 101 Switching Protocols\r\n"));
+    assert!(response
+        .windows(28)
+        .any(|window| window == b"s3pPLMBiTxaQ9kYGzzhZRbK+xOo="));
+    let mut echo = [0_u8; 7];
+    reader.read_exact(&mut echo).unwrap();
+    assert_eq!(&echo, b"\x81\x05Hello");
+
+    stop.stop();
+    server.join().unwrap();
+}
+
+fn read_http_head(reader: &mut BufReader<TcpStream>) -> Vec<u8> {
+    let mut head = Vec::new();
+    while !head.ends_with(b"\r\n\r\n") {
+        let mut line = Vec::new();
+        reader.read_until(b'\n', &mut line).unwrap();
+        assert!(!line.is_empty());
+        head.extend_from_slice(&line);
+    }
+    head
+}
+
+#[derive(Clone)]
+struct RecordingEntropy {
+    calls: Arc<Mutex<Vec<usize>>>,
+}
+
+impl EntropySource for RecordingEntropy {
+    fn fill(&mut self, output: &mut [u8]) -> Result<(), WebSocketRuntimeError> {
+        let mut calls = self.calls.lock().unwrap();
+        calls.push(output.len());
+        output.fill(calls.len() as u8);
+        Ok(())
+    }
+}
+
+#[test]
+fn client_requests_fresh_nonce_and_mask_entropy_for_every_frame() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let captured_masks = Arc::new(Mutex::new(Vec::new()));
+    let server_masks = Arc::clone(&captured_masks);
+    let server = thread::spawn(move || capture_two_client_frames(listener, server_masks));
+
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let entropy = RecordingEntropy {
+        calls: Arc::clone(&calls),
+    };
+    let mut client = WebSocketClient::connect_with_entropy(
+        "127.0.0.1",
+        port,
+        "/",
+        WebSocketClientOptions::default(),
+        entropy,
+    )
+    .unwrap();
+    client.send_text("a").unwrap();
+    client.send_text("b").unwrap();
+    drop(client);
+    server.join().unwrap();
+
+    assert_eq!(*calls.lock().unwrap(), vec![16, 4, 4]);
+    assert_eq!(*captured_masks.lock().unwrap(), vec![[2; 4], [3; 4]]);
+}
+
+fn capture_two_client_frames(listener: TcpListener, masks: Arc<Mutex<Vec<[u8; 4]>>>) {
+    let (stream, _) = listener.accept().unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    let mut reader = BufReader::new(stream);
+    let request = read_http_head(&mut reader);
+    let handshake = accept_server_request(&request).unwrap();
+    reader.get_mut().write_all(handshake.response()).unwrap();
+    reader.get_mut().flush().unwrap();
+
+    let mut wire = [0_u8; 14];
+    reader.read_exact(&mut wire).unwrap();
+    assert_eq!(&wire[0..2], &[0x81, 0x81]);
+    assert_eq!(&wire[7..9], &[0x81, 0x81]);
+    let first: [u8; 4] = wire[2..6].try_into().unwrap();
+    let second: [u8; 4] = wire[9..13].try_into().unwrap();
+    masks.lock().unwrap().extend([first, second]);
+}
+
+#[test]
+fn client_preserves_coalesced_frames_after_the_upgrade_head() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        let mut reader = BufReader::new(stream);
+        let request = read_http_head(&mut reader);
+        let handshake = accept_server_request(&request).unwrap();
+        let mut response = handshake.response().to_vec();
+        response.extend_from_slice(b"\x81\x03one\x82\x02\x04\x05");
+        reader.get_mut().write_all(&response).unwrap();
+        reader.get_mut().flush().unwrap();
+    });
+
+    let mut client =
+        WebSocketClient::connect("127.0.0.1", port, "/", WebSocketClientOptions::default())
+            .unwrap();
+    assert_eq!(client.receive().unwrap(), MessageEvent::Text("one".into()));
+    assert_eq!(client.receive().unwrap(), MessageEvent::Binary(vec![4, 5]));
+    server.join().unwrap();
+}
+
+#[test]
+fn client_answers_invalid_peer_frames_with_a_masked_protocol_close() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let mut reader = BufReader::new(stream);
+        let request = read_http_head(&mut reader);
+        let handshake = accept_server_request(&request).unwrap();
+        reader.get_mut().write_all(handshake.response()).unwrap();
+        reader.get_mut().write_all(&[0x83, 0]).unwrap();
+        reader.get_mut().flush().unwrap();
+
+        let mut close = [0_u8; 8];
+        reader.read_exact(&mut close).unwrap();
+        assert_eq!(&close[..2], &[0x88, 0x82]);
+        let code = [close[6] ^ close[2], close[7] ^ close[3]];
+        assert_eq!(u16::from_be_bytes(code), 1002);
+    });
+
+    let mut client =
+        WebSocketClient::connect("127.0.0.1", port, "/", WebSocketClientOptions::default())
+            .unwrap();
+    assert!(matches!(
+        client.receive(),
+        Err(WebSocketRuntimeError::Protocol(
+            WebSocketError::InvalidOpcode
+        ))
+    ));
+    assert!(client.is_closing());
+    server.join().unwrap();
+}

--- a/code/specs/websocket-core.md
+++ b/code/specs/websocket-core.md
@@ -22,8 +22,8 @@ The protocol core owns only:
 
 It does not open sockets, resolve DNS, select TLS, generate randomness, run an
 event loop, schedule keepalives, retry connections, or dispatch application
-commands. A later `websocket-runtime` package composes this core with TCP and
-the repository stream/event abstractions.
+commands. [`websocket-runtime.md`](websocket-runtime.md) composes this core
+with TCP and the repository stream/event abstractions.
 
 ```text
 tcp / stream reactor
@@ -182,5 +182,6 @@ The Rust package must cover at least 95 percent of lines and include:
 - close-code/reason validation and close echo construction; and
 - payload-free stable error diagnostics.
 
-Real TCP and browser interoperability tests belong to `websocket-runtime`,
-where connection scheduling and operating-system I/O exist.
+Real TCP and browser-wire interoperability tests belong to
+[`websocket-runtime`](websocket-runtime.md), where connection scheduling and
+operating-system I/O exist.

--- a/code/specs/websocket-runtime.md
+++ b/code/specs/websocket-runtime.md
@@ -1,0 +1,143 @@
+# WebSocket Runtime
+
+## Status
+
+This document specifies the first concrete TCP runtime for the portable
+[`websocket-core`](websocket-core.md) contract. The first implementation is the
+Rust `websocket-runtime` package required by D18 issues #137, #138, and #140.
+
+## Layering
+
+```text
+Chief daemon / operator CLI
+            |
+websocket-runtime        TCP progression, entropy, connection lifecycle
+            |
+websocket-core           bounded RFC 6455 state machine
+            |
+tcp-runtime / tcp-client repository TCP adapters
+```
+
+The runtime must reuse `tcp-runtime` for servers and `tcp-client` for blocking
+clients. It must not create a third socket abstraction or duplicate RFC 6455
+parsing.
+
+## Server Adapter
+
+The server owns one `websocket-core` session per accepted TCP connection. Its
+connection phase is either:
+
+- a bounded HTTP upgrade buffer; or
+- an open frame decoder and message assembler.
+
+Arbitrary TCP read boundaries are valid. A read may contain part of an upgrade,
+the complete upgrade, or the upgrade followed by one or more frames. The server
+retains no more than the core's 16 KiB handshake bound and forwards coalesced
+frame bytes immediately after writing the HTTP 101 response.
+
+Applications receive complete `MessageEvent` values with mutable
+connection-local application state. Their handler may return zero or more
+validated outbound frames plus close-after-flush intent. The adapter encodes
+all server frames unmasked.
+
+The adapter automatically:
+
+- replies to ping with pong carrying the identical payload;
+- echoes a valid close and closes TCP after the reply flushes;
+- maps invalid UTF-8 to close code 1007;
+- maps frame or message size overflow to close code 1009; and
+- maps other post-upgrade protocol failures to close code 1002.
+
+An invalid HTTP upgrade receives a bounded HTTP 400 response and closes after
+flush. Error responses and public errors never include peer-controlled bytes.
+
+## Client Adapter
+
+The blocking client:
+
+1. resolves and connects through `tcp-client` with caller-supplied timeouts;
+2. obtains a fresh 16-byte nonce from the repository OS CSPRNG;
+3. writes the bounded client upgrade request;
+4. reads complete HTTP lines without consuming coalesced frame bytes;
+5. validates the HTTP 101 response through `websocket-core`; and
+6. owns a client-role decoder and message assembler for the open session.
+
+Every client frame obtains a fresh unpredictable four-byte mask key from the
+OS CSPRNG. The adapter never reuses the handshake nonce, a counter, or a fixed
+test key as a production mask.
+
+`receive` preserves all events decoded from a coalesced TCP read. It replies to
+ping and close controls before returning the event to the caller. Clean TCP EOF
+before a WebSocket close exchange is an abnormal-close error.
+
+Version 0.1 supports `ws` over TCP. TLS-backed `wss`, proxy negotiation,
+extensions, subprotocols, redirects, reconnects, keepalive deadlines, and
+asynchronous clients are later work.
+
+## Public API Shape
+
+The initial Rust surface provides:
+
+```text
+WebSocketRuntime::bind(platform, address, options, init, handler, on_close)
+WebSocketRuntime::serve / local_addr / stop_handle / mailbox
+host-OS bind_kqueue / bind_epoll / bind_windows constructors
+
+WebSocketClient::connect(host, port, target, options)
+WebSocketClient::send_frame / send_text / send_binary / send_ping
+WebSocketClient::receive / close
+```
+
+The server handler result contains outbound `Frame` values and
+close-after-flush intent. The mailbox is TCP-flavored in version 0.1; a later
+protocol mailbox may add off-reactor frame encoding with explicit entropy and
+session-state coordination.
+
+## Bounds and Backpressure
+
+Runtime options must expose positive bounds for:
+
+- maximum frame payload;
+- maximum assembled message payload;
+- client read chunk size; and
+- all inherited TCP runtime buffers, connection caps, and queued-write caps.
+
+Invalid zero bounds fail before binding or connecting. The server delegates
+queued-write overflow and connection admission to `tcp-runtime`.
+
+## Errors
+
+`WebSocketRuntimeError` distinguishes:
+
+- invalid options;
+- TCP client failures;
+- TCP server/platform failures;
+- OS entropy failures;
+- protocol failures; and
+- abnormal EOF or use after the closing handshake.
+
+Display strings name only the failure class. They do not include frame
+payloads, mask keys, handshake nonces, header values, request targets, or close
+reasons.
+
+## Capability Contract
+
+The runtime is authorized to resolve arbitrary caller-supplied hosts, connect
+to arbitrary TCP endpoints, and listen on arbitrary caller-supplied local
+addresses. It inherits OS entropy access from `coding_adventures_csprng` and
+socket behavior from `tcp-client` and `tcp-runtime`. It performs no filesystem,
+process, environment, stdin, stdout, or FFI access of its own.
+
+## Required Tests
+
+The Rust package must include:
+
+- fragmented server upgrades and upgrade-plus-frame coalescing;
+- invalid/oversized upgrade rejection;
+- text, binary, ping/pong, and close progression;
+- protocol-error close-code mapping;
+- multiple events preserved from one TCP read;
+- deterministic injected entropy tests proving a fresh nonce and mask per use;
+- real loopback TCP client/server text, binary, ping, and close exchange;
+- a raw RFC 6455 browser-wire client against the server; and
+- Linux, macOS, and Windows build coverage through repository CI.


### PR DESCRIPTION
## Summary

- specify the TCP composition layer above the portable RFC 6455 core
- add a stateful many-connection WebSocket server over `tcp-runtime`
- add a blocking `ws` client over `tcp-client` with OS-random upgrade nonces and a fresh mask key for every frame
- automate ping/pong and close progression, bounded upgrade buffering, protocol close-code mapping, and terminal session states
- declare the concrete DNS/connect/listen capability surface

This is the next Rust slice of #137 and advances #128. It intentionally does not close #137 because that issue also requires the remaining language implementations.

## Validation

- `cargo test -p websocket-runtime -- --nocapture` (10 tests)
- `cargo clippy -p websocket-runtime --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p websocket-runtime --no-deps`
- library coverage: 82.39% lines (repository floor: 80%)
- repository build planner: 951 packages discovered, 13 affected/prerequisite Rust packages built, 938 skipped
- real loopback client/server text, binary, ping/pong, and close exchange
- raw RFC browser-wire masked client frame against the reactor server
- deterministic entropy test proving one fresh nonce and a distinct mask request for every client frame
- malformed peer-frame test proving a masked protocol-close reply

## Security review

- upgrade, frame, message, TCP read, connection, and queued-write bounds remain explicit
- peer-controlled values are absent from runtime error displays and HTTP rejection bodies
- the server suppresses application data after peer close and enters a terminal state before TCP teardown
- the client never reuses a handshake nonce or mask key and stops emitting control replies after sending close
- no unsafe code, filesystem, process, environment, stdio, or FFI access