### PR TITLE
feat(sir-c): Collections slice 9 — Numeric methods

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -31,12 +31,88 @@ Three points worth calling out:
   zero iterations up front — the same DoS-safety floor slice 8's empty-
   pattern `sub`/`gsub` guard holds for string scanning.
 
+### Security (found and fixed by the pre-push review, before ever merging)
+
+- **`gcd`/`digits` negated a possibly-`INT64_MIN` value with a bare unary
+  `-`.** `-INT64_MIN` is signed-overflow UB (no positive `int64_t` can hold
+  its magnitude, 2^63) — verified to actually misbehave: the same code gave
+  `gcd(INT64_MIN, 6) == -2` at `-O0` but `== 2` at `-O1`/`-O2`/`-Os`, and
+  under one configuration the UB got compiled into a hardware trap
+  (`SIGTRAP`) instead of returning at all. Fixed with a new
+  `_sir_i64_abs_u` helper that computes the magnitude in `uint64_t` (whose
+  well-defined wraparound covers `INT64_MIN` correctly), mirroring the
+  `_sir_itdiv`/`_sir_itmod` `INT64_MIN`/`-1` guard this file already uses
+  for the analogous hazard on `/`/`%`.
+- **`floor`/`ceil`/`round` cast a `double` to `int64_t` with no range/NaN
+  guard.** A `(int64_t)` cast on a non-finite or out-of-int64-range double
+  is UB — verified platform-dependent (this machine's arm64 saturates;
+  x86's `cvttsd2si` yields a different "integer indefinite" value for the
+  same input). Fixed with `_sir_f64_to_i64_saturating`, which clamps to
+  `INT64_MAX`/`INT64_MIN`/`0` before the cast, matching this runtime's
+  other numeric conversions' never-raise floor (e.g. `_sir_mask_to`).
+
+A second review round on the fixes above surfaced three MORE overflow bugs
+in the same neighborhood (all fixed before merge, none ever reached `main`):
+
+- **`gcd`'s own fix had a narrowing-overflow gap**: `0.gcd(x) == x.abs` in
+  Ruby, and `|INT64_MIN|` is exactly `2^63` — one past `INT64_MAX`
+  (`2^63-1`). Casting that magnitude back to `int64_t` silently wrapped to
+  `INT64_MIN`. Since this runtime has no bignum to hold the true value, it
+  now saturates to `INT64_MAX` instead — the same "true value doesn't fit,
+  clamp rather than wrap" convention `_sir_f64_to_i64_saturating` uses.
+- **`divmod` had TWO distinct overflow paths**, not the one round 1 fixed
+  for `floor`/`ceil`/`round`: (1) `INT64_MIN / -1` is itself signed-overflow
+  UB in C (the pre-existing `_sir_ifloordiv` this called into has no guard
+  for it, unlike its siblings `_sir_itdiv`/`_sir_itmod`) — special-cased,
+  since dividing by `-1` always divides evenly; (2) computing the floored
+  remainder via `a - q * b` re-invites overflow through the back door even
+  when the division itself is fine — `INT64_MIN.divmod(3)` floors to
+  `q = -3074457345618258603`, and `q * b` ALONE overflows `int64_t` by 1,
+  even though the true remainder (`1`) fits trivially. Fixed by adjusting
+  the TRUNCATING remainder (`a % b`, then `+ b` if the sign needs fixing)
+  directly instead of ever multiplying `q * b`.
+- **`upto`/`downto`/`step` could increment their loop counter past int64
+  range** on the LAST iteration, before the loop's own continuation check
+  had a chance to stop it — e.g. `i++` in `for (; i <= n; i++)` is UB the
+  instant `i == INT64_MAX` (`upto`) or `i == INT64_MIN` (`downto`), and
+  `INT64_MAX.upto(INT64_MAX) { ... }` is exactly the one-iteration case that
+  hits it. Fixed by applying the block FIRST, then checking "was that the
+  boundary value" and breaking BEFORE ever advancing past it (`upto`/
+  `downto`), and by checking `v + stride` for overflow before performing it
+  in `step` (stopping the iteration there instead — there is no next
+  in-range value to visit anyway).
+
+A THIRD review round, prompted by round 2's finding that the SAME "bare
+negation"/"bare float cast" patterns kept recurring, swept for every
+remaining instance and found two more call sites that had gone unfixed
+purely because earlier rounds fixed the pattern where they happened to be
+looking, not everywhere the pattern appeared:
+
+- **`abs`/`pred` had the identical `-INT64_MIN`/`INT64_MIN - 1` overflow**
+  `gcd`/`digits`/`divmod` were already fixed for. `abs(INT64_MIN)` used to
+  return a NEGATIVE number (the wrapped result of the UB negation); `pred`
+  used to wrap to `INT64_MAX`, the opposite end of the range. Both now
+  saturate (via the existing `_sir_i64_abs_u` for `abs`, an explicit
+  boundary check for `pred`) instead of wrapping.
+- **Widening `to_i` to accept a numeric receiver routed a Float through
+  the pre-existing generic `_sir_to_i`**, whose cast is the identical UB
+  `floor`/`ceil`/`round` were fixed for in round 1 — just not swept to this
+  new call site. Now routes a Float receiver through
+  `_sir_f64_to_i64_saturating` directly instead.
+
 ### Added
 
-- `tests/compile_and_run_numeric_methods.rs` — 18 execution-proof tests
+- `tests/compile_and_run_numeric_methods.rs` — 27 execution-proof tests
   (real `cc` compile+run): every new method, `divmod`'s catchable
-  `ZeroDivisionError`, `fdiv`'s never-raises floor, and the zero-stride
-  `step` termination guard.
+  `ZeroDivisionError`, `fdiv`'s never-raises floor, the zero-stride `step`
+  termination guard, and regressions for all seven overflow fixes above
+  (`gcd`/`digits` on a runtime-constructed `INT64_MIN`, `floor`/`ceil`/
+  `round` on `Infinity`/`-Infinity`/`NaN`/a huge finite float, `divmod` by
+  `-1` and by `3` on `INT64_MIN`, `gcd` with a zero operand, `upto`/`downto`
+  at the exact int64 boundary, `step` where the stride would cross
+  `INT64_MAX`, `abs`/`pred` on `INT64_MIN`, `to_i` on `Infinity`/
+  `-Infinity`/`NaN`). All seven were caught and fixed pre-merge across
+  three security review rounds — none ever reached `main`.
 - `collection_numeric_slice9_methods_route_to_the_builtin_dispatcher` — an
   emit-shape test mirroring the String/Array/Hash slices' dispatcher-routing
   tests.

--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## 0.31.0 — Collections slice 9: Numeric methods
+
+New `_sir_builtin_method_v` dispatch arms for `Integer`/`Float`: `abs`,
+`even?`/`odd?`/`pred` (Integer-only — true Ruby, unlike the looser dynamic
+typing the Python/TS `sir-runtime-oop` reference uses), `zero?`/`positive?`/
+`negative?`, `floor`/`ceil`/`round` (0-arg form only — the multi-digit
+`round(ndigits)` form is a documented follow-up, deferred the same way
+slice 8 deferred `ljust`/`rjust`/`center`), `divmod`, `fdiv`, `clamp`,
+`between?`, `gcd`, `digits`, and the BLOCK-taking `times`/`upto`/`downto`/
+`step`. `to_i`/`to_f` (previously String-only, slice 8) widen to accept a
+numeric receiver via the existing `_sir_to_i`/`_sir_to_f` conversions.
+
+Three points worth calling out:
+
+- **`digits` needs no bignum-DoS cap**, unlike the Python reference: this
+  runtime's `SirValue` integer is a fixed `int64_t`, never arbitrary
+  precision, so the output is naturally bounded at 19 decimal digits — the
+  reference's bit-length-cap guard has nothing to guard against here.
+- **`divmod` raises a catchable `ZeroDivisionError`** on a zero divisor
+  (the class was already registered in the exception hierarchy for
+  `rescue`, just never raised from a division site) rather than the raw
+  `exit(1)` the primitive `/`/`%` operators still fall back to — a
+  deliberately nicer, more Ruby-faithful failure mode for this new call
+  site, not a regression to those pre-existing operators. `fdiv` by
+  contrast NEVER raises (Ruby's Float division doesn't), returning
+  `Infinity`/`-Infinity`/`NaN` instead, matching the reference.
+- **`step` with a zero stride is a documented no-op**, not a hang: a zero
+  stride never crosses `limit` in a naive loop, so it is special-cased to
+  zero iterations up front — the same DoS-safety floor slice 8's empty-
+  pattern `sub`/`gsub` guard holds for string scanning.
+
+### Added
+
+- `tests/compile_and_run_numeric_methods.rs` — 18 execution-proof tests
+  (real `cc` compile+run): every new method, `divmod`'s catchable
+  `ZeroDivisionError`, `fdiv`'s never-raises floor, and the zero-stride
+  `step` termination guard.
+- `collection_numeric_slice9_methods_route_to_the_builtin_dispatcher` — an
+  emit-shape test mirroring the String/Array/Hash slices' dispatcher-routing
+  tests.
+
+### Notes
+
+- Discovered (not fixed here, tracked separately): `puts (-5).abs` — a
+  paren-less command call whose argument is a space-separated parenthesized
+  expression immediately followed by a dot-chain — mis-parses as `puts(-5)`
+  plus a dangling `.abs` that raises `NoMethodError`, instead of one
+  statement. `puts((-5).abs)` (explicit call parens) sidesteps it and is
+  used throughout the new tests. Same family as the already-fixed
+  bare-comparison-statement and bracket-index frontend bugs.
+
 ## 0.30.0 — Collections slice 8: remaining String methods
 
 New `_sir_builtin_method_v` dispatch arms (all guarded on `recv.tag ==

--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## 0.31.0 — Collections slice 9: Numeric methods
 
+### Fixed (CI — Linux link failure)
+
+- **Every emitted C program failed to LINK on Linux** with `undefined
+  reference to 'floor'`/`'ceil'` (confirmed on `ubuntu-latest` CI; macOS and
+  Windows were unaffected). This slice's `floor`/`ceil`/`round`/`abs` are
+  the FIRST `<math.h>` function calls the embedded runtime template makes —
+  and the template is pasted into every generated `.c` file regardless of
+  whether the source program actually calls a Numeric method, so this broke
+  every single test in the crate on Linux, not just this slice's own.
+  glibc ships `libm` as a separate archive from `libc` (unlike macOS's
+  libSystem, which folds it in), so linking requires an explicit `-lm`.
+  Fixed by adding `-lm` to every test file's `cc` invocation (30 call sites
+  across 26 files) and documenting the requirement in the README for real
+  downstream consumers of the generated C.
+
 New `_sir_builtin_method_v` dispatch arms for `Integer`/`Float`: `abs`,
 `even?`/`odd?`/`pred` (Integer-only — true Ruby, unlike the looser dynamic
 typing the Python/TS `sir-runtime-oop` reference uses), `zero?`/`positive?`/

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -31,6 +31,13 @@ The included `tests/compile_and_run.rs` compiles and runs every corpus program
 through a real compiler (see below); the design itself is verified against all
 three.
 
+**Linking**: the embedded runtime uses `<math.h>` functions (`floor`/`ceil`/
+`fabs`, backing Numeric methods like `floor`/`ceil`/`round`/`abs`). MSVC and
+Clang/GCC on macOS link these in automatically; **GCC/Clang on Linux need an
+explicit `-lm`** on the compile/link command (glibc ships libm as a separate
+archive) — e.g. `cc -std=c99 -o prog prog.c -lm`. Omitting it produces an
+`undefined reference to 'floor'`-style link error, not a compile error.
+
 ## Usage
 
 ```rust

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -208,6 +208,15 @@ golden source), not always byte-for-byte true Ruby; char-set methods
 (`count`/`delete`/`squeeze`), padding methods (`ljust`/`rjust`/`center`), and
 the `*`/`+` String operators are explicitly deferred — see
 `code/specs/sir-collection-methods.md`'s "C backend lane" addendum.
+**Slice 9** (Numeric methods): `abs`, `even?`/`odd?`/`pred` (Integer-only,
+matching true Ruby), `zero?`/`positive?`/`negative?`, `floor`/`ceil`/`round`
+(0-arg form), `divmod` (raises a catchable `ZeroDivisionError` on a zero
+divisor), `fdiv` (never raises — returns `Infinity`/`-Infinity`/`NaN`
+instead), `clamp`/`between?`, `gcd`, `digits` (naturally bounded — no bignum
+DoS cap needed, since this runtime's integer is a fixed `int64_t`), and the
+BLOCK-taking `times`/`upto`/`downto`/`step` (a zero `step` stride is a
+documented no-op, never a hang); `to_i`/`to_f` widen to accept a numeric
+receiver alongside their slice-8 String forms.
 
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
 `Intrinsics`, a `class << self` singleton, and

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -1780,7 +1780,12 @@ fn variadic_helper(name: &str) -> Option<&'static str> {
 /// `capitalize`/`swapcase`, `strip`/`lstrip`/`rstrip`, `chomp`, `chars`/
 /// `bytes`/`each_char` (UTF-8-character-aware, not byte-naive), `split`,
 /// `replace`/`sub`/`gsub`, `to_i`/`to_f`/`to_sym`, `tr` — semantics matched
-/// against the Python/TS `sir-runtime-oop` reference catalog. The dispatcher
+/// against the Python/TS `sir-runtime-oop` reference catalog. Slice 9 =
+/// Numeric methods: `abs`, `even?`/`odd?`/`pred` (Integer-only, matching true
+/// Ruby), `zero?`/`positive?`/`negative?`, `floor`/`ceil`/`round` (0-arg
+/// form), `divmod`/`fdiv`, `clamp`/`between?`, `gcd`, `digits`, and the
+/// BLOCK-taking `times`/`upto`/`downto`/`step`; `to_i`/`to_f` widen to accept
+/// a numeric receiver alongside their slice-8 String forms. The dispatcher
 /// raises `NoMethodError` on an unsupported receiver type or a malformed
 /// call (missing/extra args, a non-closure block position), matching Ruby.
 fn is_builtin_method(name: &str) -> bool {
@@ -1808,6 +1813,10 @@ fn is_builtin_method(name: &str) -> bool {
         | "capitalize" | "swapcase" | "strip" | "lstrip" | "rstrip" | "chomp"
         | "chars" | "bytes" | "each_char" | "split" | "replace" | "sub" | "gsub"
         | "to_i" | "to_f" | "to_sym" | "tr"
+        // slice 9 — Numeric methods
+        | "abs" | "even?" | "odd?" | "zero?" | "positive?" | "negative?" | "pred"
+        | "floor" | "ceil" | "round" | "divmod" | "fdiv" | "clamp" | "between?"
+        | "gcd" | "digits" | "times" | "upto" | "downto" | "step"
     )
 }
 

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -2439,14 +2439,29 @@ static char *_sir_str_tr(const char *s, const char *from, const char *to) {
  * follow-up, deferred for the same "keep the slice reviewable" reason slice
  * 8 deferred `ljust`/`rjust`/`center`. */
 
+/* A `double`-to-`int64_t` cast is UB (platform-dependent -- e.g. saturates
+ * on arm64, gives INT64_MIN "integer indefinite" on x86) once the value is
+ * non-finite or outside int64 range. `floor`/`ceil`/`round` on a hostile
+ * huge/inf/nan Float must not depend on which CPU the C got compiled for,
+ * so every cast below goes through this guard first: out-of-range/non-finite
+ * saturates to INT64_MAX/INT64_MIN (never-raise floor, matching this
+ * runtime's other numeric conversions, e.g. `_sir_mask_to`/`_sir_convert`
+ * never trap either). */
+static int64_t _sir_f64_to_i64_saturating(double f) {
+    if (!(f == f)) return 0;                 /* NaN -> 0 */
+    if (f >= 9223372036854775807.0) return INT64_MAX;
+    if (f < -9223372036854775808.0) return INT64_MIN;
+    return (int64_t)f;
+}
+
 static SirValue _sir_num_floor(SirValue v) {
     if (v.tag == SIR_INT) return v;
-    if (v.tag == SIR_FLOAT) return _sir_int((int64_t)floor(v.as.f));
+    if (v.tag == SIR_FLOAT) return _sir_int(_sir_f64_to_i64_saturating(floor(v.as.f)));
     return v;
 }
 static SirValue _sir_num_ceil(SirValue v) {
     if (v.tag == SIR_INT) return v;
-    if (v.tag == SIR_FLOAT) return _sir_int((int64_t)ceil(v.as.f));
+    if (v.tag == SIR_FLOAT) return _sir_int(_sir_f64_to_i64_saturating(ceil(v.as.f)));
     return v;
 }
 /* Round-half-AWAY-from-zero (Ruby's rule; unlike Python's banker's rounding,
@@ -2456,7 +2471,7 @@ static SirValue _sir_num_round(SirValue v) {
     if (v.tag == SIR_FLOAT) {
         double f = v.as.f;
         double r = (f >= 0.0) ? floor(f + 0.5) : ceil(f - 0.5);
-        return _sir_int((int64_t)r);
+        return _sir_int(_sir_f64_to_i64_saturating(r));
     }
     return v;
 }
@@ -2476,8 +2491,35 @@ static SirValue _sir_num_divmod(SirValue recv, SirValue divisor) {
         if (b == 0) {
             return _sir_raise(_sir_error("ZeroDivisionError", _sir_str("divided by 0")));
         }
-        q = _sir_ifloordiv(a, b);
-        r = a - q * b;
+        /* Two DISTINCT overflow hazards, both avoided below rather than
+           computed and patched up:
+           (1) `a / b` / `a % b` (C's own operators, which `_sir_ifloordiv`
+               used verbatim) are signed-overflow UB for `a == INT64_MIN,
+               b == -1` -- so that ONE combination is special-cased first:
+               it divides evenly (remainder always 0), so the quotient is
+               just `-a`, saturated to `INT64_MIN` for the single input
+               (`a == INT64_MIN`) where `-a` itself would overflow --
+               mirroring the wraparound convention `_sir_itdiv` already uses
+               for this exact pair.
+           (2) For every OTHER `b`, computing the floored remainder via
+               `a - q * b` (an earlier version of this function) re-invites
+               overflow through the BACK door: e.g. `a = INT64_MIN, b = 3`
+               floors to `q = -3074457345618258603`, and `q * b` alone
+               overflows `int64_t` by 1 computing an intermediate product
+               that the FINAL remainder (1) never needed. Adjusting the
+               truncating remainder directly (`tr + b`, bounded in
+               magnitude by `b` and hence always in range) instead of
+               multiplying sidesteps this -- the standard truncating-to-
+               floored conversion, done without a multiply. */
+        if (b == -1) {
+            q = (a == INT64_MIN) ? INT64_MIN : -a;
+            return _sir_seq_lit(2, _sir_int(q), _sir_int(0));
+        }
+        {
+            int64_t tq = a / b, tr = a % b;
+            if (tr != 0 && ((tr < 0) != (b < 0))) { q = tq - 1; r = tr + b; }
+            else { q = tq; r = tr; }
+        }
         return _sir_seq_lit(2, _sir_int(q), _sir_int(r));
     }
     {
@@ -2505,12 +2547,33 @@ static SirValue _sir_num_fdiv(SirValue recv, SirValue divisor) {
     return _sir_float(a / b);
 }
 
+/* `-INT64_MIN` is signed-overflow UB (its magnitude, 2^63, has no positive
+ * `int64_t` representation) -- confirmed to actually misbehave under
+ * optimization (wrong answers, and in one configuration a hardware trap) on
+ * this project's own toolchain, not just a theoretical hazard. Every caller
+ * that needs "the magnitude of a possibly-INT64_MIN value" goes through this
+ * helper instead of a bare unary `-`, computing it in `uint64_t` (well-
+ * defined two's-complement wraparound covers the full range including
+ * `INT64_MIN`'s magnitude, which does not fit back in an `int64_t`). */
+static uint64_t _sir_i64_abs_u(int64_t n) {
+    return (n < 0) ? (uint64_t)0 - (uint64_t)n : (uint64_t)n;
+}
+
 static SirValue _sir_num_gcd(SirValue recv, SirValue other) {
-    int64_t a = _sir_as_int(recv), b = _sir_as_int(other);
-    if (a < 0) a = -a;
-    if (b < 0) b = -b;
-    while (b != 0) { int64_t t = b; b = a % b; a = t; }
-    return _sir_int(a);
+    uint64_t a = _sir_i64_abs_u(_sir_as_int(recv));
+    uint64_t b = _sir_i64_abs_u(_sir_as_int(other));
+    while (b != 0) { uint64_t t = b; b = a % b; a = t; }
+    /* `a` is the gcd's magnitude, bounded by `min(|recv|,|other|)` when
+       NEITHER is 0, but by `max(|recv|,|other|)` when one IS 0 (Ruby:
+       `0.gcd(x) == x.abs`) -- and `|INT64_MIN|` is exactly `2^63`, one past
+       `INT64_MAX` (`2^63-1`). A bare `(int64_t)a` narrowing there is an
+       out-of-range conversion (confirmed to silently wrap to `INT64_MIN` in
+       practice) -- e.g. `0.gcd(INT64_MIN)`. Since this runtime has no
+       bignum to hold the true value, this saturates to `INT64_MAX` instead,
+       the same never-raise-by-saturating convention `_sir_f64_to_i64_
+       saturating` uses just above for the analogous "true value doesn't
+       fit" case. */
+    return _sir_int(a > (uint64_t)INT64_MAX ? INT64_MAX : (int64_t)a);
 }
 
 /* `digits` -- base-10 digits, LEAST-significant first (`123.digits ==
@@ -2518,13 +2581,12 @@ static SirValue _sir_num_gcd(SirValue recv, SirValue other) {
  * 19 decimal digits, so no separate DoS cap is needed (unlike the Python
  * reference's arbitrary-precision receiver). `0.digits == [0]`. */
 static SirValue _sir_num_digits(SirValue recv) {
-    int64_t n = _sir_as_int(recv);
+    uint64_t n = _sir_i64_abs_u(_sir_as_int(recv));
     SirValue buf[20];
     int64_t k = 0;
     SirSeq *r;
-    if (n < 0) n = -n;
     if (n == 0) buf[k++] = _sir_int(0);
-    while (n > 0) { buf[k++] = _sir_int(n % 10); n /= 10; }
+    while (n > 0) { buf[k++] = _sir_int((int64_t)(n % 10)); n /= 10; }
     r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
     r->items = (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)k);
     memcpy(r->items, buf, sizeof(SirValue) * (size_t)k);
@@ -2543,22 +2605,49 @@ static SirValue _sir_num_times(SirValue recv, SirValue block) {
     for (int64_t i = 0; i < n; i++) _sir_apply(block, 1, _sir_int(i));
     return recv;
 }
+/* `i++`/`i--` in a `for (; i <= n; i++)`-shaped loop is signed-overflow UB
+ * the moment `i == INT64_MAX` (`upto`) or `i == INT64_MIN` (`downto`) --
+ * reachable from plain Ruby source (`INT64_MAX.upto(INT64_MAX) { |i| .. }`
+ * is one iteration whose loop-continuation test would still increment past
+ * the top). Both loops below instead apply the block FIRST, then check for
+ * "was that the last (boundary) value" and `break` BEFORE ever advancing
+ * past it -- so the increment/decrement is only ever reached when doing so
+ * is safe. */
 static SirValue _sir_num_upto(SirValue recv, SirValue limit, SirValue block) {
     int64_t i = _sir_as_int(recv), n = _sir_as_int(limit);
-    for (; i <= n; i++) _sir_apply(block, 1, _sir_int(i));
+    if (i > n) return recv;
+    for (;;) {
+        _sir_apply(block, 1, _sir_int(i));
+        if (i == n) break;
+        i++;
+    }
     return recv;
 }
 static SirValue _sir_num_downto(SirValue recv, SirValue limit, SirValue block) {
     int64_t i = _sir_as_int(recv), n = _sir_as_int(limit);
-    for (; i >= n; i--) _sir_apply(block, 1, _sir_int(i));
+    if (i < n) return recv;
+    for (;;) {
+        _sir_apply(block, 1, _sir_int(i));
+        if (i == n) break;
+        i--;
+    }
     return recv;
+}
+/* `v + st` would be signed-overflow UB if it crossed int64 range -- checked
+ * BEFORE performing the addition (computing it first and inspecting the
+ * result would already be the UB), so this is safe to call unconditionally. */
+static int _sir_i64_add_overflows(int64_t a, int64_t b) {
+    return (b >= 0) ? (a > INT64_MAX - b) : (a < INT64_MIN - b);
 }
 /* `step(limit, stride = 1) { |i| .. }` -- a stride of 0 would loop forever
  * (never crosses `limit`), so it is a documented no-op (zero iterations)
  * rather than a hang, the same DoS-safety floor `sub`/`gsub`'s empty-pattern
- * guard holds for string scanning. Promotes to float stepping if EITHER the
- * receiver or the stride is a Float (matches Ruby: `1.step(2, 0.5)` yields
- * floats), otherwise stays in exact int64 arithmetic. */
+ * guard holds for string scanning. A stride that would carry `v` past
+ * int64 range (e.g. a huge stride near `INT64_MAX`) stops the iteration
+ * there instead of overflowing -- there is no next in-range value to visit
+ * anyway. Promotes to float stepping if EITHER the receiver or the stride
+ * is a Float (matches Ruby: `1.step(2, 0.5)` yields floats), otherwise
+ * stays in exact int64 arithmetic. */
 static SirValue _sir_num_step(SirValue recv, SirValue limit, SirValue stride, SirValue block) {
     int use_float = (recv.tag == SIR_FLOAT || stride.tag == SIR_FLOAT || limit.tag == SIR_FLOAT);
     if (use_float) {
@@ -2569,8 +2658,19 @@ static SirValue _sir_num_step(SirValue recv, SirValue limit, SirValue stride, Si
     } else {
         int64_t v = _sir_as_int(recv), lim = _sir_as_int(limit), st = _sir_as_int(stride);
         if (st == 0) return recv;
-        if (st > 0) { for (; v <= lim; v += st) _sir_apply(block, 1, _sir_int(v)); }
-        else        { for (; v >= lim; v += st) _sir_apply(block, 1, _sir_int(v)); }
+        if (st > 0) {
+            for (; v <= lim; ) {
+                _sir_apply(block, 1, _sir_int(v));
+                if (_sir_i64_add_overflows(v, st)) break;
+                v += st;
+            }
+        } else {
+            for (; v >= lim; ) {
+                _sir_apply(block, 1, _sir_int(v));
+                if (_sir_i64_add_overflows(v, st)) break;
+                v += st;
+            }
+        }
     }
     return recv;
 }
@@ -2843,7 +2943,14 @@ static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, Si
             return _sir_str(_sir_str_replace_n(recv.as.s, args[0].as.s, args[1].as.s, -1));
     } else if (strcmp(m, "to_i") == 0) {
         if (recv.tag == SIR_STR) return _sir_int(_sir_str_to_i(recv.as.s));
-        if (_sir_is_num(recv)) return _sir_to_i(recv);
+        /* A Float receiver must NOT reach the generic `_sir_to_i` here: it
+           bottoms out in a bare `(int64_t)v.as.f` cast (`_sir_as_int`,
+           pre-existing, used by many unrelated call sites this PR does not
+           touch), UB for a non-finite or out-of-int64-range Float -- the
+           SAME hazard `floor`/`ceil`/`round` already guard against just
+           below. Routed through the same saturating helper instead. */
+        if (recv.tag == SIR_FLOAT) return _sir_int(_sir_f64_to_i64_saturating(recv.as.f));
+        if (recv.tag == SIR_INT) return _sir_to_i(recv);
     } else if (strcmp(m, "to_f") == 0) {
         if (recv.tag == SIR_STR) return _sir_float(_sir_str_to_f(recv.as.s));
         if (_sir_is_num(recv)) return _sir_to_f(recv);
@@ -2855,7 +2962,15 @@ static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, Si
     }
     /* Collections slice 9: Numeric methods. */
     else if (strcmp(m, "abs") == 0) {
-        if (recv.tag == SIR_INT) return _sir_int(recv.as.i < 0 ? -recv.as.i : recv.as.i);
+        /* Same `-INT64_MIN` hazard `_sir_i64_abs_u`'s doc comment describes
+           (confirmed to misbehave under optimization) -- reused here rather
+           than a bare unary `-`, saturating to INT64_MAX for the one input
+           whose true magnitude (2^63) doesn't fit (this runtime has no
+           bignum), matching `gcd`'s convention for the same situation. */
+        if (recv.tag == SIR_INT) {
+            uint64_t u = _sir_i64_abs_u(recv.as.i);
+            return _sir_int(u > (uint64_t)INT64_MAX ? INT64_MAX : (int64_t)u);
+        }
         if (recv.tag == SIR_FLOAT) return _sir_float(fabs(recv.as.f));
     } else if (strcmp(m, "even?") == 0) {
         if (recv.tag == SIR_INT) return _sir_bool(recv.as.i % 2 == 0);
@@ -2868,7 +2983,12 @@ static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, Si
     } else if (strcmp(m, "negative?") == 0) {
         if (_sir_is_num(recv)) return _sir_bool(_sir_as_num(recv) < 0.0);
     } else if (strcmp(m, "pred") == 0) {
-        if (recv.tag == SIR_INT) return _sir_int(recv.as.i - 1);
+        /* `INT64_MIN - 1` is signed-overflow UB (confirmed to wrap to
+           INT64_MAX in practice, the opposite end of the range) -- there is
+           no smaller representable Integer, so this saturates at the floor
+           rather than wrapping, the same never-raise convention every other
+           fix in this slice uses. */
+        if (recv.tag == SIR_INT) return _sir_int(recv.as.i == INT64_MIN ? INT64_MIN : recv.as.i - 1);
     } else if (strcmp(m, "floor") == 0) {
         if (_sir_is_num(recv)) return _sir_num_floor(recv);
     } else if (strcmp(m, "ceil") == 0) {

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -2423,6 +2423,158 @@ static char *_sir_str_tr(const char *s, const char *from, const char *to) {
     return out;
 }
 
+/* ---- Collections slice 9: Numeric methods ------------------------------------
+ *
+ * `Integer`/`Float` methods. Semantics matched against the Python/TS
+ * `sir-runtime-oop` reference catalog, with one deliberate divergence: this
+ * runtime's `SirValue` int is a fixed `int64_t` (never arbitrary precision),
+ * so `digits` needs none of the reference's bignum-DoS bit-length cap — an
+ * int64 magnitude produces at most 19 decimal digits, an already-bounded
+ * output. `even?`/`odd?`/`pred` are gated to `SIR_INT` only (true Ruby: these
+ * are `Integer`-only methods, unlike the reference's looser dynamic-typing
+ * convention) — a `Float` receiver falls through to `NoMethodError`, matching
+ * this backend's existing typed-dispatch discipline (e.g. `upcase` is
+ * `SIR_STR`-only). `floor`/`ceil`/`round` take no `ndigits` argument in this
+ * slice (the 0-arg form only); the multi-digit rounding form is a documented
+ * follow-up, deferred for the same "keep the slice reviewable" reason slice
+ * 8 deferred `ljust`/`rjust`/`center`. */
+
+static SirValue _sir_num_floor(SirValue v) {
+    if (v.tag == SIR_INT) return v;
+    if (v.tag == SIR_FLOAT) return _sir_int((int64_t)floor(v.as.f));
+    return v;
+}
+static SirValue _sir_num_ceil(SirValue v) {
+    if (v.tag == SIR_INT) return v;
+    if (v.tag == SIR_FLOAT) return _sir_int((int64_t)ceil(v.as.f));
+    return v;
+}
+/* Round-half-AWAY-from-zero (Ruby's rule; unlike Python's banker's rounding,
+ * already the convention this runtime's `sir-runtime-oop` reference uses). */
+static SirValue _sir_num_round(SirValue v) {
+    if (v.tag == SIR_INT) return v;
+    if (v.tag == SIR_FLOAT) {
+        double f = v.as.f;
+        double r = (f >= 0.0) ? floor(f + 0.5) : ceil(f - 0.5);
+        return _sir_int((int64_t)r);
+    }
+    return v;
+}
+
+/* `divmod(divisor)` -- `[quotient, remainder]`, quotient FLOORED (via the
+ * existing `_sir_ifloordiv`, the SAME floor-division `/` uses), remainder
+ * takes the DIVISOR's sign. A zero divisor raises a catchable
+ * `ZeroDivisionError` (the class is already registered in the exception
+ * hierarchy for `rescue`) rather than the raw `exit(1)` the primitive `/`
+ * operator falls back to -- this is a NICER, more Ruby-faithful failure
+ * mode, not a regression: nothing upstream of this new dispatch arm relied
+ * on the exit-on-zero behavior. */
+static SirValue _sir_num_divmod(SirValue recv, SirValue divisor) {
+    if (recv.tag == SIR_INT && divisor.tag == SIR_INT) {
+        int64_t a = recv.as.i, b = divisor.as.i;
+        int64_t q, r;
+        if (b == 0) {
+            return _sir_raise(_sir_error("ZeroDivisionError", _sir_str("divided by 0")));
+        }
+        q = _sir_ifloordiv(a, b);
+        r = a - q * b;
+        return _sir_seq_lit(2, _sir_int(q), _sir_int(r));
+    }
+    {
+        double a = _sir_as_num(recv), b = _sir_as_num(divisor);
+        double q, r;
+        if (b == 0.0) {
+            return _sir_raise(_sir_error("ZeroDivisionError", _sir_str("divided by 0")));
+        }
+        q = floor(a / b);
+        r = a - q * b;
+        return _sir_seq_lit(2, _sir_float(q), _sir_float(r));
+    }
+}
+
+/* `fdiv(other)` -- floating-point division; UNLIKE `/`/`divmod` this never
+ * raises: a zero divisor yields Infinity/-Infinity/NaN (Ruby's Float
+ * division never raises), matching the reference's never-raise-on-Float
+ * floor. */
+static SirValue _sir_num_fdiv(SirValue recv, SirValue divisor) {
+    double a = _sir_as_num(recv), b = _sir_as_num(divisor);
+    if (b == 0.0) {
+        if (a == 0.0) return _sir_float(0.0 / 0.0); /* NaN */
+        return _sir_float(a > 0.0 ? (1.0 / 0.0) : (-1.0 / 0.0)); /* +-Infinity */
+    }
+    return _sir_float(a / b);
+}
+
+static SirValue _sir_num_gcd(SirValue recv, SirValue other) {
+    int64_t a = _sir_as_int(recv), b = _sir_as_int(other);
+    if (a < 0) a = -a;
+    if (b < 0) b = -b;
+    while (b != 0) { int64_t t = b; b = a % b; a = t; }
+    return _sir_int(a);
+}
+
+/* `digits` -- base-10 digits, LEAST-significant first (`123.digits ==
+ * [3, 2, 1]`). Bounded by construction: an `int64_t` magnitude has at most
+ * 19 decimal digits, so no separate DoS cap is needed (unlike the Python
+ * reference's arbitrary-precision receiver). `0.digits == [0]`. */
+static SirValue _sir_num_digits(SirValue recv) {
+    int64_t n = _sir_as_int(recv);
+    SirValue buf[20];
+    int64_t k = 0;
+    SirSeq *r;
+    if (n < 0) n = -n;
+    if (n == 0) buf[k++] = _sir_int(0);
+    while (n > 0) { buf[k++] = _sir_int(n % 10); n /= 10; }
+    r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    r->items = (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)k);
+    memcpy(r->items, buf, sizeof(SirValue) * (size_t)k);
+    r->len = k;
+    return _sir_seq_wrap(r);
+}
+
+/* `times { |i| .. }` / `upto(n) { |i| .. }` / `downto(n) { |i| .. }` --
+ * Integer-only block iteration; each returns the (unchanged) receiver,
+ * matching `Array#each`'s return-the-receiver convention. Bounded by the
+ * receiver/argument's own int64 magnitude -- no separate iteration cap
+ * needed (a hostile huge count just runs a long time, the same cost profile
+ * `ForRange`/`Array#each` already have for a huge input). */
+static SirValue _sir_num_times(SirValue recv, SirValue block) {
+    int64_t n = _sir_as_int(recv);
+    for (int64_t i = 0; i < n; i++) _sir_apply(block, 1, _sir_int(i));
+    return recv;
+}
+static SirValue _sir_num_upto(SirValue recv, SirValue limit, SirValue block) {
+    int64_t i = _sir_as_int(recv), n = _sir_as_int(limit);
+    for (; i <= n; i++) _sir_apply(block, 1, _sir_int(i));
+    return recv;
+}
+static SirValue _sir_num_downto(SirValue recv, SirValue limit, SirValue block) {
+    int64_t i = _sir_as_int(recv), n = _sir_as_int(limit);
+    for (; i >= n; i--) _sir_apply(block, 1, _sir_int(i));
+    return recv;
+}
+/* `step(limit, stride = 1) { |i| .. }` -- a stride of 0 would loop forever
+ * (never crosses `limit`), so it is a documented no-op (zero iterations)
+ * rather than a hang, the same DoS-safety floor `sub`/`gsub`'s empty-pattern
+ * guard holds for string scanning. Promotes to float stepping if EITHER the
+ * receiver or the stride is a Float (matches Ruby: `1.step(2, 0.5)` yields
+ * floats), otherwise stays in exact int64 arithmetic. */
+static SirValue _sir_num_step(SirValue recv, SirValue limit, SirValue stride, SirValue block) {
+    int use_float = (recv.tag == SIR_FLOAT || stride.tag == SIR_FLOAT || limit.tag == SIR_FLOAT);
+    if (use_float) {
+        double v = _sir_as_num(recv), lim = _sir_as_num(limit), st = _sir_as_num(stride);
+        if (st == 0.0) return recv;
+        if (st > 0.0) { for (; v <= lim; v += st) _sir_apply(block, 1, _sir_float(v)); }
+        else          { for (; v >= lim; v += st) _sir_apply(block, 1, _sir_float(v)); }
+    } else {
+        int64_t v = _sir_as_int(recv), lim = _sir_as_int(limit), st = _sir_as_int(stride);
+        if (st == 0) return recv;
+        if (st > 0) { for (; v <= lim; v += st) _sir_apply(block, 1, _sir_int(v)); }
+        else        { for (; v >= lim; v += st) _sir_apply(block, 1, _sir_int(v)); }
+    }
+    return recv;
+}
+
 /* ---- Collections slice 1: built-in String methods --------------------------
  *
  * A `__method__` dispatch whose name is a KNOWN built-in method — and which the
@@ -2691,13 +2843,73 @@ static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, Si
             return _sir_str(_sir_str_replace_n(recv.as.s, args[0].as.s, args[1].as.s, -1));
     } else if (strcmp(m, "to_i") == 0) {
         if (recv.tag == SIR_STR) return _sir_int(_sir_str_to_i(recv.as.s));
+        if (_sir_is_num(recv)) return _sir_to_i(recv);
     } else if (strcmp(m, "to_f") == 0) {
         if (recv.tag == SIR_STR) return _sir_float(_sir_str_to_f(recv.as.s));
+        if (_sir_is_num(recv)) return _sir_to_f(recv);
     } else if (strcmp(m, "to_sym") == 0) {
         if (recv.tag == SIR_STR) return _sir_sym(recv.as.s);
     } else if (strcmp(m, "tr") == 0) {
         if (recv.tag == SIR_STR && argc == 2 && args[0].tag == SIR_STR && args[1].tag == SIR_STR)
             return _sir_str(_sir_str_tr(recv.as.s, args[0].as.s, args[1].as.s));
+    }
+    /* Collections slice 9: Numeric methods. */
+    else if (strcmp(m, "abs") == 0) {
+        if (recv.tag == SIR_INT) return _sir_int(recv.as.i < 0 ? -recv.as.i : recv.as.i);
+        if (recv.tag == SIR_FLOAT) return _sir_float(fabs(recv.as.f));
+    } else if (strcmp(m, "even?") == 0) {
+        if (recv.tag == SIR_INT) return _sir_bool(recv.as.i % 2 == 0);
+    } else if (strcmp(m, "odd?") == 0) {
+        if (recv.tag == SIR_INT) return _sir_bool(recv.as.i % 2 != 0);
+    } else if (strcmp(m, "zero?") == 0) {
+        if (_sir_is_num(recv)) return _sir_bool(_sir_as_num(recv) == 0.0);
+    } else if (strcmp(m, "positive?") == 0) {
+        if (_sir_is_num(recv)) return _sir_bool(_sir_as_num(recv) > 0.0);
+    } else if (strcmp(m, "negative?") == 0) {
+        if (_sir_is_num(recv)) return _sir_bool(_sir_as_num(recv) < 0.0);
+    } else if (strcmp(m, "pred") == 0) {
+        if (recv.tag == SIR_INT) return _sir_int(recv.as.i - 1);
+    } else if (strcmp(m, "floor") == 0) {
+        if (_sir_is_num(recv)) return _sir_num_floor(recv);
+    } else if (strcmp(m, "ceil") == 0) {
+        if (_sir_is_num(recv)) return _sir_num_ceil(recv);
+    } else if (strcmp(m, "round") == 0) {
+        if (_sir_is_num(recv) && argc == 0) return _sir_num_round(recv);
+    } else if (strcmp(m, "divmod") == 0) {
+        if (_sir_is_num(recv) && argc == 1 && _sir_is_num(args[0]))
+            return _sir_num_divmod(recv, args[0]);
+    } else if (strcmp(m, "fdiv") == 0) {
+        if (_sir_is_num(recv) && argc == 1 && _sir_is_num(args[0]))
+            return _sir_num_fdiv(recv, args[0]);
+    } else if (strcmp(m, "clamp") == 0) {
+        if (_sir_is_num(recv) && argc == 2 && _sir_is_num(args[0]) && _sir_is_num(args[1])) {
+            if (_sir_truthy(_sir_lt(recv, args[0]))) return args[0];
+            if (_sir_truthy(_sir_gt(recv, args[1]))) return args[1];
+            return recv;
+        }
+    } else if (strcmp(m, "between?") == 0) {
+        if (_sir_is_num(recv) && argc == 2 && _sir_is_num(args[0]) && _sir_is_num(args[1]))
+            return _sir_bool(_sir_truthy(_sir_ge(recv, args[0])) && _sir_truthy(_sir_le(recv, args[1])));
+    } else if (strcmp(m, "gcd") == 0) {
+        if (recv.tag == SIR_INT && argc == 1 && args[0].tag == SIR_INT)
+            return _sir_num_gcd(recv, args[0]);
+    } else if (strcmp(m, "digits") == 0) {
+        if (recv.tag == SIR_INT) return _sir_num_digits(recv);
+    } else if (strcmp(m, "times") == 0) {
+        if (recv.tag == SIR_INT && argc == 1 && args[0].tag == SIR_CLOSURE)
+            return _sir_num_times(recv, args[0]);
+    } else if (strcmp(m, "upto") == 0) {
+        if (recv.tag == SIR_INT && argc == 2 && args[0].tag == SIR_INT && args[1].tag == SIR_CLOSURE)
+            return _sir_num_upto(recv, args[0], args[1]);
+    } else if (strcmp(m, "downto") == 0) {
+        if (recv.tag == SIR_INT && argc == 2 && args[0].tag == SIR_INT && args[1].tag == SIR_CLOSURE)
+            return _sir_num_downto(recv, args[0], args[1]);
+    } else if (strcmp(m, "step") == 0) {
+        if (_sir_is_num(recv) && argc == 2 && _sir_is_num(args[0]) && args[1].tag == SIR_CLOSURE)
+            return _sir_num_step(recv, args[0], _sir_int(1), args[1]);
+        if (_sir_is_num(recv) && argc == 3 && _sir_is_num(args[0]) && _sir_is_num(args[1])
+            && args[2].tag == SIR_CLOSURE)
+            return _sir_num_step(recv, args[0], args[1], args[2]);
     }
     return _sir_raise(
         _sir_error("NoMethodError", _sir_str(_sir_cat("undefined method ", m))));

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run.rs
@@ -60,6 +60,7 @@ fn compile_and_run(cc: &str, module: &semantic_ir::Module, name: &str) -> String
         .arg("-o")
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn C compiler");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_array_block_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_array_block_methods.rs
@@ -47,6 +47,7 @@ fn run_ruby(src: &str) -> Option<String> {
         .args(["-std=c99", "-Wall", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_array_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_array_methods.rs
@@ -47,6 +47,7 @@ fn run_ruby(src: &str) -> Option<String> {
         .args(["-std=c99", "-Wall", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(
@@ -204,6 +205,7 @@ mod cyclic {
             .args(["-std=c99", "-Wall", "-o"])
             .arg(&exe)
             .arg(&cpath)
+            .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
             .output()
             .expect("spawn cc");
         assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_array_mutation_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_array_mutation_methods.rs
@@ -48,6 +48,7 @@ fn run_ruby(src: &str) -> Option<String> {
         .args(["-std=c99", "-Wall", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_class_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_class_methods.rs
@@ -48,6 +48,7 @@ fn run_ruby(src: &str) -> Option<String> {
         .args(["-std=c99", "-Wall", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_class_vars.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_class_vars.rs
@@ -48,6 +48,7 @@ fn run_ruby(src: &str) -> Option<String> {
         .args(["-std=c99", "-Wall", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_classes.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_classes.rs
@@ -52,6 +52,7 @@ fn run(module: &Module) -> Option<String> {
         .args(["-std=c99", "-Wall", "-Werror=unused-variable", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_conversions.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_conversions.rs
@@ -51,6 +51,7 @@ fn compile_and_run(cc: &str, module: &Module) -> String {
         .arg("-o")
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn C compiler");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_defaultparams.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_defaultparams.rs
@@ -54,6 +54,7 @@ fn run(module: &Module) -> Option<String> {
         .args(["-std=c99", "-Wall", "-Werror=unused-variable", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_exceptions.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_exceptions.rs
@@ -58,6 +58,7 @@ fn run_raw(module: &Module) -> Option<(String, bool)> {
         .args(["-std=c99", "-Wall", "-Werror=unused-variable", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_floats.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_floats.rs
@@ -57,6 +57,7 @@ fn run(module: &Module) -> Option<String> {
         .args(["-std=c99", "-Wall", "-Werror=unused-variable", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_forrange.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_forrange.rs
@@ -52,6 +52,7 @@ fn compile_and_run(cc: &str, module: &Module) -> String {
         .args(["-std=c99", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn C compiler");
     assert!(
@@ -219,6 +220,7 @@ fn for_range_with_unused_counter_compiles_under_werror() {
         .args(["-std=c99", "-Wall", "-Werror=unused-variable", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_hash_block_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_hash_block_methods.rs
@@ -44,6 +44,7 @@ fn run_ruby(src: &str) -> Option<String> {
         .args(["-std=c99", "-Wall", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_hash_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_hash_methods.rs
@@ -38,6 +38,7 @@ fn run_ruby(src: &str) -> Option<String> {
         .args(["-std=c99", "-Wall", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(
@@ -143,6 +144,7 @@ mod insert_after_delete {
             .args(["-std=c99", "-Wall", "-o"])
             .arg(&exe)
             .arg(&cpath)
+            .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
             .output()
             .expect("spawn cc");
         assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_index_bracket.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_index_bracket.rs
@@ -51,6 +51,7 @@ fn run_ruby(src: &str) -> Option<String> {
         .args(["-std=c99", "-Wall", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_inheritance.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_inheritance.rs
@@ -50,6 +50,7 @@ fn run_ruby(src: &str) -> Option<String> {
         .args(["-std=c99", "-Wall", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_ivars.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_ivars.rs
@@ -48,6 +48,7 @@ fn run_ruby(src: &str) -> Option<String> {
         .args(["-std=c99", "-Wall", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_keywordparams.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_keywordparams.rs
@@ -54,6 +54,7 @@ fn run(module: &Module) -> Option<String> {
         .args(["-std=c99", "-Wall", "-Werror=unused-variable", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_maps.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_maps.rs
@@ -55,6 +55,7 @@ fn run(module: &Module) -> Option<String> {
         .args(["-std=c99", "-Wall", "-Werror=unused-variable", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_methods.rs
@@ -47,6 +47,7 @@ fn run_ruby(src: &str) -> Option<String> {
         .args(["-std=c99", "-Wall", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_modules.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_modules.rs
@@ -49,6 +49,7 @@ fn run_ruby(src: &str) -> Option<String> {
         .args(["-std=c99", "-Wall", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_numeric_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_numeric_methods.rs
@@ -42,6 +42,7 @@ fn run_ruby(src: &str) -> Option<String> {
         .args(["-std=c99", "-Wall", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_numeric_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_numeric_methods.rs
@@ -158,6 +158,46 @@ fn gcd_computes_the_greatest_common_divisor() {
 }
 
 #[test]
+fn gcd_and_digits_on_int64_min_do_not_hit_negation_ub() {
+    // Regression: `gcd`/`digits` used to negate a NEGATIVE `int64_t` with a
+    // bare unary `-` to get its magnitude. `-INT64_MIN` is signed-overflow
+    // UB (no positive `int64_t` can hold 2^63) -- verified to actually give
+    // build-dependent WRONG answers (and, under some optimization levels, a
+    // hardware trap) before the fix, not just a theoretical concern.
+    // `-9223372036854775807 - 1` constructs INT64_MIN without a literal that
+    // itself overflows i64::MAX during lexing (`-9223372036854775808` as a
+    // single token doesn't parse: the positive digit run overflows first).
+    match run_ruby(
+        "x = -9223372036854775807 - 1\nputs x.gcd(6)\nputs x.digits.length\n",
+    ) {
+        Some(out) => assert_eq!(out, "2\n19\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn floor_ceil_round_saturate_on_non_finite_or_out_of_range_floats() {
+    // Regression: a bare `(int64_t)double_value` cast is UB once the value
+    // is non-finite or exceeds int64 range -- verified platform-dependent
+    // (arm64 saturates, x86 gives a different "integer indefinite" value for
+    // the SAME input). Guarded to saturate deterministically to
+    // INT64_MAX/INT64_MIN/0 regardless of target, matching this runtime's
+    // other numeric conversions' never-raise floor.
+    match run_ruby(
+        "puts((1.0 / 0.0).floor)\n\
+         puts((-1.0 / 0.0).ceil)\n\
+         puts((1.0 / 0.0 * 0.0).round)\n\
+         puts(1.0e300.floor)\n",
+    ) {
+        Some(out) => assert_eq!(
+            out,
+            "9223372036854775807\n-9223372036854775808\n0\n9223372036854775807\n"
+        ),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
 fn digits_returns_least_significant_digit_first() {
     match run_ruby("puts 123.digits\nputs 0.digits\n") {
         Some(out) => assert_eq!(out, "[3, 2, 1]\n[0]\n"),
@@ -205,6 +245,106 @@ fn step_with_zero_stride_is_a_safe_no_op_not_a_hang() {
 fn to_i_and_to_f_widen_to_numeric_receivers() {
     match run_ruby("puts 3.5.to_i\nputs 3.to_f\n") {
         Some(out) => assert_eq!(out, "3\n3.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn divmod_by_negative_one_does_not_overflow_on_int64_min() {
+    // Regression: `INT64_MIN / -1` is signed-overflow UB in C -- and unlike
+    // the OTHER divmod overflow below, this one is UB in the DIVISION
+    // ITSELF, not just an intermediate product. Special-cased since it
+    // divides evenly.
+    match run_ruby("x = -9223372036854775807 - 1\nputs(x.divmod(-1))\n") {
+        Some(out) => assert_eq!(out, "[-9223372036854775808, 0]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn divmod_near_int64_min_does_not_overflow_computing_the_remainder() {
+    // Regression: an EARLIER version computed the floored remainder as
+    // `a - q * b`. For `a = INT64_MIN, b = 3`, the floored quotient is
+    // `-3074457345618258603`, and `q * b` ALONE overflows `int64_t` by 1 --
+    // even though the final remainder (1) fits trivially. Fixed by adjusting
+    // the TRUNCATING remainder (`a % b`) directly instead of multiplying.
+    match run_ruby("x = -9223372036854775807 - 1\nputs(x.divmod(3))\n") {
+        Some(out) => assert_eq!(out, "[-3074457345618258603, 1]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn gcd_with_a_zero_operand_saturates_instead_of_overflowing() {
+    // Regression: `0.gcd(x) == x.abs` in Ruby, and `|INT64_MIN|` is exactly
+    // 2^63 -- one past `INT64_MAX` (2^63-1). This runtime has no bignum to
+    // hold the true value, so it saturates to `INT64_MAX` rather than
+    // narrowing-overflowing into `(int64_t)` (which silently wrapped to
+    // INT64_MIN before the fix).
+    match run_ruby("x = -9223372036854775807 - 1\nputs(0.gcd(x))\n") {
+        Some(out) => assert_eq!(out, "9223372036854775807\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn upto_downto_at_the_int64_boundary_do_not_overflow_the_counter() {
+    // Regression: `for (; i <= n; i++)` increments `i` past `n` even on the
+    // LAST iteration before the loop test re-runs and stops it -- UB the
+    // moment `i == INT64_MAX` (`upto`) or `i == INT64_MIN` (`downto`).
+    // `INT64_MAX.upto(INT64_MAX)` / `INT64_MIN.downto(INT64_MIN)` are each
+    // exactly one iteration and must not crash or hang.
+    match run_ruby(
+        "x = 9223372036854775807\nx.upto(x) { |i| puts i }\n\
+         y = -9223372036854775807 - 1\ny.downto(y) { |i| puts i }\n",
+    ) {
+        Some(out) => assert_eq!(out, "9223372036854775807\n-9223372036854775808\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn step_stops_rather_than_overflowing_when_the_stride_would_cross_int64_max() {
+    // Regression: `v += st` overflows once `v` is close enough to
+    // `INT64_MAX` that adding `st` would cross it. There is no next
+    // in-range value to visit, so the fix stops the iteration there instead
+    // of computing the (UB) overflowing sum.
+    match run_ruby(
+        "x = 9223372036854775806\nx.step(9223372036854775807, 5) { |i| puts i }\nputs \"done\"\n",
+    ) {
+        Some(out) => assert_eq!(out, "9223372036854775806\ndone\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn abs_and_pred_on_int64_min_saturate_instead_of_overflowing() {
+    // Round-3 regression: `abs`/`pred` had the SAME `-INT64_MIN`/`INT64_MIN
+    // - 1` overflow hazard already fixed for `gcd`/`digits` and `divmod`,
+    // just not swept to these two call sites in the earlier rounds.
+    // `abs(INT64_MIN)` used to return a NEGATIVE number (`-INT64_MIN`
+    // wrapped); `pred(INT64_MIN)` used to wrap to `INT64_MAX`, the opposite
+    // end of the range. Both now saturate at the representable floor/ceiling.
+    match run_ruby("x = -9223372036854775807 - 1\nputs(x.abs)\nputs(x.pred)\n") {
+        Some(out) => assert_eq!(out, "9223372036854775807\n-9223372036854775808\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn to_i_on_a_non_finite_float_saturates_instead_of_overflowing() {
+    // Round-3 regression: widening `to_i` to accept a numeric receiver
+    // (this slice) routed a Float through the pre-existing generic
+    // `_sir_to_i`, whose `(int64_t)` cast is UB for a non-finite or
+    // out-of-range Float -- the SAME hazard `floor`/`ceil`/`round` already
+    // guard against. Now routes through the same saturating helper.
+    match run_ruby(
+        "puts((1.0 / 0.0).to_i)\nputs((-1.0 / 0.0).to_i)\nputs((1.0 / 0.0 * 0.0).to_i)\n",
+    ) {
+        Some(out) => assert_eq!(
+            out,
+            "9223372036854775807\n-9223372036854775808\n0\n"
+        ),
         None => eprintln!("skip: no cc"),
     }
 }

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_numeric_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_numeric_methods.rs
@@ -1,0 +1,210 @@
+//! Execution proof for Collections slice 9 (Numeric methods) on the C
+//! backend — lower REAL Ruby source, emit C, compile with a real cc, run,
+//! assert stdout. Skips gracefully when no `cc` is present.
+//!
+//! Semantics are matched against the Python/TS `sir-runtime-oop` reference
+//! catalog. `even?`/`odd?`/`pred` are Integer-only here (true Ruby), unlike
+//! that reference's looser dynamic typing.
+
+use std::process::Command;
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    ["cc", "clang", "gcc"]
+        .iter()
+        .find(|c| {
+            Command::new(c)
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        })
+        .map(|s| s.to_string())
+}
+
+fn run_ruby(src: &str) -> Option<String> {
+    let cc = find_cc()?;
+    let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
+    let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
+    let dir = std::env::temp_dir();
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    src.hash(&mut hasher);
+    let stem = format!("sirc_num9_{}_{}", std::process::id(), hasher.finish());
+    let cpath = dir.join(format!("{stem}.c"));
+    let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::write(&cpath, &art.source).expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        art.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "program exited non-zero");
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn abs_works_on_int_and_float() {
+    // `puts (-5).abs` (space before the paren) hits a pre-existing frontend
+    // parsing quirk unrelated to this slice (Ruby's command-call-with-a-
+    // parenthesized-argument grouping) -- `puts(...)` with the call's own
+    // parens sidesteps it, same workaround used throughout this file.
+    match run_ruby("puts((-5).abs)\nputs((-2.5).abs)\n") {
+        Some(out) => assert_eq!(out, "5\n2.5\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn even_and_odd_predicates() {
+    match run_ruby("puts 4.even?\nputs 4.odd?\nputs 5.even?\nputs 5.odd?\n") {
+        Some(out) => assert_eq!(out, "#t\n#f\n#f\n#t\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn zero_positive_negative_predicates() {
+    match run_ruby("puts 0.zero?\nputs 5.positive?\nputs((-5).negative?)\n") {
+        Some(out) => assert_eq!(out, "#t\n#t\n#t\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn pred_decrements_an_integer() {
+    match run_ruby("puts 5.pred\n") {
+        Some(out) => assert_eq!(out, "4\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn floor_ceil_round_on_a_float() {
+    match run_ruby("puts 3.7.floor\nputs 3.2.ceil\nputs 3.5.round\nputs((-3.5).round)\n") {
+        Some(out) => assert_eq!(out, "3\n4\n4\n-4\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn floor_ceil_round_on_an_integer_are_identity() {
+    match run_ruby("puts 3.floor\nputs 3.ceil\nputs 3.round\n") {
+        Some(out) => assert_eq!(out, "3\n3\n3\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn divmod_floors_the_quotient_and_signs_the_remainder_like_the_divisor() {
+    match run_ruby("puts 7.divmod(3)\nputs((-7).divmod(3))\n") {
+        Some(out) => assert_eq!(out, "[2, 1]\n[-3, 2]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn divmod_by_zero_raises_zero_division_error() {
+    match run_ruby(
+        "begin\n  puts 1.divmod(0)\nrescue ZeroDivisionError => e\n  puts \"caught\"\nend\n",
+    ) {
+        Some(out) => assert_eq!(out, "caught\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn fdiv_never_raises_on_a_zero_divisor() {
+    match run_ruby("puts 1.fdiv(0)\nputs((-1).fdiv(0))\nputs 0.fdiv(0)\n") {
+        Some(out) => assert_eq!(out, "Infinity\n-Infinity\nNaN\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn clamp_bounds_a_value_into_a_range() {
+    match run_ruby("puts 10.clamp(1, 5)\nputs((-10).clamp(1, 5))\nputs 3.clamp(1, 5)\n") {
+        Some(out) => assert_eq!(out, "5\n1\n3\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn between_checks_an_inclusive_range() {
+    match run_ruby("puts 3.between?(1, 5)\nputs 10.between?(1, 5)\n") {
+        Some(out) => assert_eq!(out, "#t\n#f\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn gcd_computes_the_greatest_common_divisor() {
+    match run_ruby("puts 12.gcd(18)\nputs((-12).gcd(18))\n") {
+        Some(out) => assert_eq!(out, "6\n6\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn digits_returns_least_significant_digit_first() {
+    match run_ruby("puts 123.digits\nputs 0.digits\n") {
+        Some(out) => assert_eq!(out, "[3, 2, 1]\n[0]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn times_yields_zero_through_n_minus_one() {
+    match run_ruby("3.times { |i| puts i }\n") {
+        Some(out) => assert_eq!(out, "0\n1\n2\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn upto_and_downto_are_inclusive() {
+    match run_ruby("1.upto(3) { |i| puts i }\n3.downto(1) { |i| puts i }\n") {
+        Some(out) => assert_eq!(out, "1\n2\n3\n3\n2\n1\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn step_with_default_and_explicit_stride() {
+    match run_ruby("1.step(5) { |i| puts i }\n1.step(10, 3) { |i| puts i }\n") {
+        Some(out) => assert_eq!(out, "1\n2\n3\n4\n5\n1\n4\n7\n10\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn step_with_zero_stride_is_a_safe_no_op_not_a_hang() {
+    // The DoS-safety guard: a zero stride would never cross `limit` in a naive
+    // implementation. `run` asserts the process exits 0 -- a hang would
+    // timeout the test rather than return non-zero, so this proves it
+    // terminates, not just that it "looks right."
+    match run_ruby("1.step(5, 0) { |i| puts i }\nputs \"done\"\n") {
+        Some(out) => assert_eq!(out, "done\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn to_i_and_to_f_widen_to_numeric_receivers() {
+    match run_ruby("puts 3.5.to_i\nputs 3.to_f\n") {
+        Some(out) => assert_eq!(out, "3\n3.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_sequences.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_sequences.rs
@@ -53,6 +53,7 @@ fn run(module: &Module) -> Option<String> {
         .args(["-std=c99", "-Wall", "-Werror=unused-variable", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_shortcircuit.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_shortcircuit.rs
@@ -56,6 +56,7 @@ fn run(module: &Module) -> Option<String> {
         .args(["-std=c99", "-Wall", "-Werror=unused-variable", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_string_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_string_methods.rs
@@ -48,6 +48,7 @@ fn run_ruby(src: &str) -> Option<String> {
         .args(["-std=c99", "-Wall", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_string_methods_slice8.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_string_methods_slice8.rs
@@ -49,6 +49,7 @@ fn run_ruby(src: &str) -> Option<String> {
         .args(["-std=c99", "-Wall", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_string_queries.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_string_queries.rs
@@ -47,6 +47,7 @@ fn run_ruby(src: &str) -> Option<String> {
         .args(["-std=c99", "-Wall", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("spawn cc");
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/emit.rs
@@ -334,6 +334,27 @@ fn collection_string_query_passes_its_argument() {
 }
 
 #[test]
+fn collection_numeric_slice9_methods_route_to_the_builtin_dispatcher() {
+    // Collections slice 9: a 2-arg Numeric method (`clamp`) routes to the
+    // runtime dispatcher and carries both arguments through, same shape as
+    // the String/Array/Hash slices.
+    let m = lower_ruby("puts 10.clamp(1, 5)");
+    let src = compile(&m).unwrap().source;
+    assert!(
+        src.contains("_sir_builtin_method("),
+        "a slice-9 Numeric method dispatches through the runtime dispatcher\n{src}"
+    );
+    assert!(
+        src.contains("\"clamp\""),
+        "the method name is a quoted C string literal\n{src}"
+    );
+    assert!(
+        src.contains(", 2, _sir_int(1LL), _sir_int(5LL))"),
+        "the dispatcher is passed argc=2 and both integer arguments\n{src}"
+    );
+}
+
+#[test]
 fn collection_string_slice8_methods_route_to_the_builtin_dispatcher() {
     // Collections slice 8: a 1-arg String method (`sub`, taking a pattern and
     // a replacement) routes to the runtime dispatcher and carries both

--- a/code/specs/sir-collection-methods.md
+++ b/code/specs/sir-collection-methods.md
@@ -198,8 +198,8 @@ repo's standard workflow):
 | 7 | Hash block: `each_key`, `each_value`, `group_by`, `partition` (+ `each`/`map`/`select`/`reject`/`sort_by`/`sum` widen to Hash) | ✅ merged | #9668 |
 | — | Bug fix: `Array#sum` ignored a block argument | ✅ merged | #9673 |
 | — | Bug fix: bracket-index (`a[i]`/`a[i] = v`) had no grammar rule at all — new `__method__("[]"/"[]=", …)` dispatch | ✅ merged | #9686 |
-| 8 | Remaining String methods: `capitalize`, `strip`/`lstrip`/`rstrip`, `chomp`, `chars`, `bytes`, `split`, `replace`, `sub`, `gsub`, `to_i`, `to_f`, `to_sym`, `swapcase`, `tr`, `each_char` (block) — semantics matched against the Python/TS `sir-runtime-oop` reference catalog | 🚧 this PR | — |
-| 9 | Numeric methods: `abs`, `to_i`, `to_f`, `even?`, `odd?`, `zero?`, `positive?`, `negative?`, `pred`, `floor`, `ceil`, `round`, `divmod`, `fdiv`, `clamp`, `between?`, `gcd`, `digits` + block methods `times`/`upto`/`downto`/`step` | planned | — |
+| 8 | Remaining String methods: `capitalize`, `strip`/`lstrip`/`rstrip`, `chomp`, `chars`, `bytes`, `split`, `replace`, `sub`, `gsub`, `to_i`, `to_f`, `to_sym`, `swapcase`, `tr`, `each_char` (block) — semantics matched against the Python/TS `sir-runtime-oop` reference catalog | ✅ merged | #9694 |
+| 9 | Numeric methods: `abs`, `to_i`, `to_f`, `even?`, `odd?`, `zero?`, `positive?`, `negative?`, `pred`, `floor`, `ceil`, `round`, `divmod`, `fdiv`, `clamp`, `between?`, `gcd`, `digits` + block methods `times`/`upto`/`downto`/`step` | 🚧 this PR | — |
 | 10 | Symbol + Object/Bool generic methods | planned | — |
 | — | Cross-backend conformance corpus for the full collection-method catalog | planned | — |
 
@@ -212,6 +212,11 @@ for `Array#push`; see the "Ruby frontend: add `<<` as a binary operator" backlog
 item), so there is nothing for a C dispatch arm to receive regardless. The
 char-set and padding methods are deferred to keep this slice reviewable at a
 similar size to its predecessors; they are tracked as follow-up work.
+
+**Explicitly out of scope for slice 9**: the multi-digit `round(ndigits)`
+form (only the 0-arg `round` is implemented) — deferred for the same
+"keep the slice reviewable" reason, tracked as follow-up work alongside
+slice 8's deferrals.
 
 ## Out of scope (documented)
 


### PR DESCRIPTION
## Summary

- New `_sir_builtin_method_v` dispatch arms for `Integer`/`Float`: `abs`, `even?`/`odd?`/`pred` (Integer-only, true Ruby), `zero?`/`positive?`/`negative?`, `floor`/`ceil`/`round` (0-arg form), `divmod` (raises a catchable `ZeroDivisionError`), `fdiv` (never raises), `clamp`, `between?`, `gcd`, `digits`, and the BLOCK-taking `times`/`upto`/`downto`/`step`. `to_i`/`to_f` (String-only since slice 8) widen to accept a numeric receiver.
- **Explicitly deferred**: the multi-digit `round(ndigits)` form (0-arg only in this slice).
- **Spec sync**: `code/specs/sir-collection-methods.md`'s "C backend lane" addendum table is updated to mark slice 8 merged and slice 9 as this PR.

## Security — three rounds of pre-push review, all fixed before ever reaching `main`

This slice is almost entirely fixed-width `int64_t`/`double` arithmetic near representable-range boundaries, which turned out to be a rich source of real UB. Three review rounds, each sweeping the same recurring pattern family (bare negation near `INT64_MIN`, bare float→int64 casts near non-finite/out-of-range values) until a round came back clean:

- **Round 1**: `gcd`/`digits` negated a possibly-`INT64_MIN` value with a bare unary `-` (confirmed to give *different wrong answers* at different optimization levels, and a hardware trap under one config); `floor`/`ceil`/`round` cast a `double` to `int64_t` with no range/NaN guard (confirmed platform-dependent between arm64 and x86).
- **Round 2**: `gcd`'s own fix could still narrowing-overflow (`0.gcd(INT64_MIN)`); `divmod` had two distinct overflow paths (`INT64_MIN / -1` itself, and a separate `q * b` multiplication overflow computing the remainder); `upto`/`downto`/`step` could increment their loop counter past int64 range on the boundary iteration.
- **Round 3**: `abs`/`pred` had the identical negation/decrement overflow already fixed elsewhere, just not swept to those two call sites; widening `to_i` routed a Float through a pre-existing helper with the same cast UB `floor`/`ceil`/`round` were already fixed for.
- **Round 4**: clean — `SECURITY REVIEW PASSED`.

All fixes saturate at the representable boundary (`INT64_MAX`/`INT64_MIN`/`0`) rather than wrapping, matching this runtime's existing never-raise numeric-conversion convention. Every fix has a dedicated regression test, verified UB-free under UBSan at `-O2`.

`semantic-ir-to-c` 0.30.0 → 0.31.0.

## Test plan
- [x] 27 execution-proof tests (`compile_and_run_numeric_methods.rs`, real `cc` compile+run): every method, `divmod`'s catchable exception, `fdiv`'s never-raises floor, `step`'s zero-stride guard, and a dedicated regression for each of the 7 overflow fixes above — all green.
- [x] Emit-shape test (`collection_numeric_slice9_methods_route_to_the_builtin_dispatcher`).
- [x] Full `semantic-ir-to-c` + `ruby-parser` + `ruby-to-semantic-ir` regression suite — all green, pre- and post-rebase onto latest `origin/main`.
- [x] `cargo clippy` — clean.
- [x] Four rounds of security review (sub-agent, C memory/arithmetic safety focus) — converged clean.

## Notes
- Discovered but not fixed here (tracked separately): `puts (-5).abs` (space before a parenthesized argument, then a dot-chain) mis-parses as two statements — a pre-existing frontend gap, same family as the already-fixed bare-comparison and bracket-index bugs. Worked around with `puts((-5).abs)` throughout the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)