### PR TITLE
fix(spice): lower parser MOS forward-bias coefficient

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject MOS model-card `FC` values outside `[0, 1)` or non-finite values
+  before lowering valid forward-bias depletion coefficients.
 - Reject negative and non-finite MOS model-card `MJSW` values before lowering
   valid sidewall-junction grading coefficients.
 - Reject negative and non-finite MOS model-card `MJ` values before lowering

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1993,6 +1993,10 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(params["MJSW"]) or params["MJSW"] < 0.0
         ):
             raise NetlistParseError("MOSFET MJSW must be finite and non-negative")
+        if "FC" in params and (
+            not math.isfinite(params["FC"]) or not 0.0 <= params["FC"] < 1.0
+        ):
+            raise NetlistParseError("MOSFET FC must be finite and in [0, 1)")
         nominal_temperature = params.get("T_NOM", params.get("TNOM"))
         if nominal_temperature is not None and (
             not math.isfinite(nominal_temperature) or nominal_temperature <= 0.0

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1967,6 +1967,29 @@ def test_lowers_valid_mosfet_model_sidewall_grading(
     assert isclose(mosfet.model.model.params.MJSW, float(grading_coefficient))
 
 
+@pytest.mark.parametrize("coefficient", ["-0.1", "1", "1e999"])
+def test_rejects_invalid_mosfet_model_forward_bias_coefficient(
+    coefficient: str,
+) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match=r"MOSFET FC must be finite and in \[0, 1\)",
+    ):
+        parse_netlist(f".model nfast NMOS(FC={coefficient})\nM1 d g s b nfast\n")
+
+
+@pytest.mark.parametrize("coefficient", ["0", "0.5"])
+def test_lowers_valid_mosfet_model_forward_bias_coefficient(
+    coefficient: str,
+) -> None:
+    parsed = parse_netlist(
+        f".model nfast NMOS(FC={coefficient})\nM1 d g s b nfast\n"
+    )
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(mosfet.model.model.params.FC, float(coefficient))
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject MOS model-card `FC` values outside `[0, 1)` or non-finite values and
+  lower valid forward-bias depletion coefficients instead of silently dropping them.
 - Reject negative and non-finite MOS model-card `MJSW` values and lower valid
   sidewall-junction grading coefficients instead of silently dropping them.
 - Reject negative and non-finite MOS model-card `MJ` values and lower valid

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1324,6 +1324,16 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET MJSW must be finite and non-negative");
   }
+  const forwardBiasCoefficient = params.get("FC");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    forwardBiasCoefficient !== undefined &&
+    (!Number.isFinite(forwardBiasCoefficient) ||
+      forwardBiasCoefficient < 0.0 ||
+      forwardBiasCoefficient >= 1.0)
+  ) {
+    throw new NetlistParseError("MOSFET FC must be finite and in [0, 1)");
+  }
   const nominalTemperature = params.get("T_NOM") ?? params.get("TNOM");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1430,6 +1440,7 @@ function isMosfetParam(name: keyof MosfetLevel1Params): boolean {
     "PB",
     "MJ",
     "MJSW",
+    "FC",
     "IS",
     "N_SUB",
     "T_NOM",

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1817,6 +1817,23 @@ Xright c d load
     expect(element.params.MJSW).toBe(Number(gradingCoefficient));
   });
 
+  it.each(["-0.1", "1", "1e999"])(
+    "rejects invalid MOSFET model FC=%s",
+    (coefficient) => {
+      expect(() =>
+        parseNetlist(`.model nfast NMOS(FC=${coefficient})\nM1 d g s b nfast\n`),
+      ).toThrow("MOSFET FC must be finite and in [0, 1)");
+    },
+  );
+
+  it.each(["0", "0.5"])("lowers valid MOSFET model FC=%s", (coefficient) => {
+    const parsed = parseNetlist(`.model nfast NMOS(FC=${coefficient})\nM1 d g s b nfast\n`);
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.FC).toBe(Number(coefficient));
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4285,11 +4285,17 @@ the Rust, Python, and TypeScript surfaces together.
      shared diagnostic while zero and positive bottom-junction grading
      coefficients lower into Level-1 parameters.
 
+395. Python and TypeScript Berkeley SPICE MOS sidewall-grading parity.
+   - Status: completed in PR 9709.
+   - Negative and non-finite model-card `MJSW` values are rejected with the
+     shared diagnostic while zero and positive sidewall-junction grading
+     coefficients lower into Level-1 parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
-   - TypeScript still needs canonical lowering for `MJSW`, `FC`, `KF`, and
-     `AF`; Python already lowers these canonical fields
+   - TypeScript still needs canonical lowering for `FC`, `KF`, and `AF`;
+     Python already lowers these canonical fields
      but still needs matching facade validation coverage.
    - Align the `CJS` and `CJD` aliases with canonical `CBS` and `CBD` in both
      facades after the canonical-field slices.


### PR DESCRIPTION
## Summary

- validate MOS model-card `FC` as finite and within `[0, 1)` in Python and TypeScript
- lower valid `FC` values through the TypeScript parser instead of silently dropping them
- reconcile the SPICE plan with merged MJSW parity and update both parser changelogs

## Verification

- Python `spice-netlist-parser`: `bash BUILD` (201 tests, 88.55% coverage)
- Python `spice-netlist-parser`: `.venv/bin/ruff check .`
- TypeScript `spice-engine`: `bash BUILD` (448 tests)
- TypeScript `spice-netlist-parser`: `bash BUILD` (194 tests)
- TypeScript `spice-netlist-parser`: `npm run test:coverage` (194 tests, 85.16% line coverage)