### PR TITLE
ci(human-languages): focus the unified TeX toolchain

### DIFF
--- a/.github/workflows/human-languages-books.yml
+++ b/.github/workflows/human-languages-books.yml
@@ -53,23 +53,43 @@ jobs:
             > "$GITHUB_WORKSPACE/dist/human-languages/books/curriculum-gaps.txt"
           cat "$GITHUB_WORKSPACE/dist/human-languages/books/curriculum-gaps.txt"
 
-      # Install the COMPLETE TeX Live distribution rather than a hand-picked
-      # list of texlive-* sub-packages. The earlier granular approach broke
-      # CI (`Unable to locate package texlive-lang-indic`) and risked silently
-      # missing font/language packages a book needs. `texlive-full` is a single
-      # guaranteed-to-exist meta-package that bundles every engine (XeLaTeX),
-      # every language collection (Arabic, Indic, etc.), and every font that
-      # ships with TeX Live — including Latin Modern and the Noto families.
-      # This is the "machine that has all the fonts": ubuntu-latest already has
-      # git/node for checkout, and texlive-full supplies the full typesetting
-      # stack, so no Windows/macOS runner is needed for font coverage.
-      # fonts-noto-* additionally register the Noto families with fontconfig
-      # by family name, which the non-Latin-script tracks will want later.
-      - name: Install TeX Live (full)
+      # Keep one shared XeLaTeX toolchain for the one all-books job, but avoid
+      # installing TeX Live's unrelated documentation, music, science, CJK,
+      # and publishing collections. texlive-xetex pulls the LaTeX base,
+      # recommended, and extra layers used by every preamble. The Arabic
+      # collection supplies bidi.sty for Arabic, Persian, and Urdu; every
+      # non-Latin book font is vendored under human-languages/_fonts.
+      - name: Install focused TeX toolchain
         run: |
+          setup_started_at=$(date +%s)
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            texlive-full latexmk fonts-noto-core fonts-noto-extra
+            fontconfig latexmk lmodern texlive-lang-arabic texlive-xetex
+
+          setup_seconds=$(($(date +%s) - setup_started_at))
+          echo "TeX toolchain setup completed in ${setup_seconds}s"
+          echo "TeX toolchain setup: ${setup_seconds}s" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify focused TeX toolchain
+        run: |
+          set -euo pipefail
+
+          for executable in xelatex latexmk kpsewhich fc-match; do
+            command -v "$executable"
+          done
+
+          for tex_asset in \
+            book.cls fontspec.sty newunicodechar.sty xcolor.sty \
+            tcolorbox.sty booktabs.sty longtable.sty tabularx.sty array.sty \
+            hyperref.sty titlesec.sty polyglossia.sty bidi.sty; do
+            asset_path=$(kpsewhich "$tex_asset")
+            test -n "$asset_path"
+            echo "$tex_asset -> $asset_path"
+          done
+
+          latin_modern_path=$(fc-match -f '%{file}\n' 'Latin Modern Roman' | head -n 1)
+          test -f "$latin_modern_path"
+          echo "Latin Modern Roman -> $latin_modern_path"
 
       - name: Build every book
         run: |

--- a/.github/workflows/human-languages-books.yml
+++ b/.github/workflows/human-languages-books.yml
@@ -58,13 +58,15 @@ jobs:
       # and publishing collections. texlive-xetex pulls the LaTeX base,
       # recommended, and extra layers used by every preamble. The Arabic
       # collection supplies bidi.sty for Arabic, Persian, and Urdu; every
-      # non-Latin book font is vendored under human-languages/_fonts.
+      # non-Latin book font is vendored under human-languages/_fonts. The
+      # recommended font collection supplies Hyperref's Zapf Dingbats metric.
       - name: Install focused TeX toolchain
         run: |
           setup_started_at=$(date +%s)
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            fontconfig latexmk lmodern texlive-lang-arabic texlive-xetex
+            fontconfig latexmk lmodern texlive-fonts-recommended \
+            texlive-lang-arabic texlive-xetex
 
           setup_seconds=$(($(date +%s) - setup_started_at))
           echo "TeX toolchain setup completed in ${setup_seconds}s"
@@ -81,7 +83,7 @@ jobs:
           for tex_asset in \
             book.cls fontspec.sty newunicodechar.sty xcolor.sty \
             tcolorbox.sty booktabs.sty longtable.sty tabularx.sty array.sty \
-            hyperref.sty titlesec.sty polyglossia.sty bidi.sty; do
+            hyperref.sty titlesec.sty polyglossia.sty bidi.sty pzdr.tfm; do
             asset_path=$(kpsewhich "$tex_asset")
             test -n "$asset_path"
             echo "$tex_asset -> $asset_path"

--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -508,7 +508,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   packages. Ubuntu's `texlive-xetex` dependency closure provides the LaTeX base,
   recommended, and extra collections containing those packages; the focused
   install adds `texlive-lang-arabic` for `bidi.sty`, `lmodern` for the named
-  Latin Modern faces, and `latexmk` as the build driver.
+  Latin Modern faces, `texlive-fonts-recommended` for Hyperref's `pzdr.tfm`,
+  and `latexmk` as the build driver.
 - All non-Latin faces are repository-vendored static fonts, so the system-wide
   Noto font collections are unrelated to the current builds. A fail-closed
   preflight now resolves the engine, driver, all eleven packages, the class,

--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -80,9 +80,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B10 | Complete (#9690) | Publish Sanskrit Chapter 6 from its three canonical lessons rather than hand-copying another book chapter. | All three schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
 | HL-B11 | Complete (#9698) | Remove Sanskrit's LaTeX layout, duplicate-label, font-shape, and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Devanagari, natural page bottoms, explicit static-font shapes, and shorter running titles make the forced six-chapter build warning-free. |
 | HL-B12 | Complete (#9705) | Publish Bengali Chapter 6 from its canonical lesson rather than hand-copying another book chapter. | The schema-v2 lesson now generates the PDF chapter from the same source hash independently verified by Language Ladder. |
-| HL-B13 | Complete in this PR | Remove Bengali's missing glyphs and LaTeX layout/bookmark warnings. | Main-font punctuation, stable recap labels, bookmark-safe Bengali, natural page bottoms, explicit static-font shapes, and a breakable long title make the forced six-chapter build warning-free. |
-| HL-I01 | Next | Reduce unified all-books workflow setup time without splitting the single publication bundle. | The exact-merge Sanskrit cleanup run spent seven minutes installing TeX Live, while a redundant PR run remained there beyond eighteen minutes; cache or pre-bake the toolchain and keep all 20 books plus bundle verification in one job. |
-| HL-B14 | Queued | Publish Italian Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Italian has canonical app content through Chapter 17, but its downloadable PDF contains only Chapter 1; schema-v2 migration plus generation should close that drift safely. |
+| HL-B13 | Complete (#9711) | Remove Bengali's missing glyphs and LaTeX layout/bookmark warnings. | Main-font punctuation, stable recap labels, bookmark-safe Bengali, natural page bottoms, explicit static-font shapes, and a breakable long title make the forced six-chapter build warning-free. |
+| HL-I01 | Complete in this PR | Reduce unified all-books workflow setup time without splitting the single publication bundle. | A focused, preflighted XeLaTeX dependency closure replaces `texlive-full`; the unchanged job still builds all 20 books, verifies one bundle, and publishes that bundle from `main`. |
+| HL-B14 | Next | Publish Italian Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Italian has canonical app content through Chapter 17, but its downloadable PDF contains only Chapter 1; schema-v2 migration plus generation should close that drift safely. |
 | HL-B15 | Queued | Remove Italian's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds but reports one underfull box and three Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B16 | Queued | Publish Portuguese Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Portuguese has canonical app content through Chapter 17, but its downloadable PDF contains only Chapter 1; schema-v2 migration plus generation should close that drift safely. |
 | HL-B17 | Queued | Remove Portuguese's LaTeX layout warnings. | A forced build succeeds with no missing glyphs, overfull boxes, duplicate labels, or Hyperref warnings, but reports three underfull boxes; the clean-build signal is zero. |
@@ -498,6 +498,25 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   breaks cleanly, split callouts are unclipped, and short pages have deliberate
   natural bottoms. All 39 PDF outline entries remain readable, ending with the
   generated romanized Chapter 6 title.
+
+## Findings from HL-I01
+
+- Three successful unified-publication baselines spent 7:00, 8:09, and 8:02
+  installing `texlive-full`; the most recent then built all 20 books in 1:41.
+  Setup, not the single-job book loop, was the dominant and variable cost.
+- The complete TeX source inventory uses the standard `book` class and eleven
+  packages. Ubuntu's `texlive-xetex` dependency closure provides the LaTeX base,
+  recommended, and extra collections containing those packages; the focused
+  install adds `texlive-lang-arabic` for `bidi.sty`, `lmodern` for the named
+  Latin Modern faces, and `latexmk` as the build driver.
+- All non-Latin faces are repository-vendored static fonts, so the system-wide
+  Noto font collections are unrelated to the current builds. A fail-closed
+  preflight now resolves the engine, driver, all eleven packages, the class,
+  RTL support, and Latin Modern before compiling any book.
+- The workflow remains one job with one setup, one dynamically discovered
+  20-book loop, one verified artifact, and one `main`-only Pages publication.
+  HL-B14 is next: close the learner-visible Italian app/book drift through the
+  same canonical generation path.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -48,8 +48,10 @@ toward generating book and app views from one lesson AST.
 
 The [public book catalog](https://adhithyan15.github.io/coding-adventures/human-languages/books/)
 offers every currently authored LaTeX book as a free PDF download. Pull requests
-install TeX once, compile every book in one job, and retain the complete publication
-bundle as a workflow artifact for review. After a change reaches `main`, the same
+install one focused XeLaTeX toolchain, compile every book in one job, and retain the
+complete publication bundle as a workflow artifact for review. A dependency
+preflight verifies the engine, every package used by the books, RTL support, and
+Latin Modern before compilation begins. After a change reaches `main`, the same
 validated PDFs and a machine-readable `catalog.json` are published to GitHub Pages
 automatically. Tracks without a `book/` directory are omitted until their long-form
 edition is authored.


### PR DESCRIPTION
## Summary

- replace the multi-gigabyte `texlive-full`/system Noto installation with the focused Ubuntu dependency closure used by the books
- retain one job, one setup, the dynamically discovered 20-book build, one verified artifact bundle, and main-only Pages publication
- add a fail-closed preflight for XeLaTeX, latexmk, the `book` class, all 11 imported packages, `bidi.sty`, and Latin Modern
- record the measured 7:00–8:09 full-install baseline and reprioritize the human-languages backlog to Italian canonical book generation

## Why these packages

`texlive-xetex` pulls Ubuntu's LaTeX base, recommended, and extra layers. `texlive-lang-arabic` supplies `bidi.sty` for Arabic, Persian, and Urdu. `lmodern` supplies the explicitly named Latin Modern faces, while every non-Latin face used by the books is already vendored in the repository. `latexmk` remains the build driver and `fontconfig` makes the font preflight explicit.

## Validation

- `npm run check:books`
- Ruby/Psych parses `.github/workflows/human-languages-books.yml`
- static audit confirms all 11 unique `\\usepackage` imports plus `book.cls` are present in the workflow preflight
- `git diff --check`

The branch's `Human Languages Books` run is the acceptance gate for the actual Ubuntu package closure and complete 20-book artifact. Auto-merge will be enabled only after that run is green.