### PR TITLE
fix(spice): lower parser MOS flicker-noise coefficient

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS model-card `KF` values before lowering
+  valid flicker-noise coefficients.
 - Reject MOS model-card `FC` values outside `[0, 1)` or non-finite values
   before lowering valid forward-bias depletion coefficients.
 - Reject negative and non-finite MOS model-card `MJSW` values before lowering

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1997,6 +1997,10 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(params["FC"]) or not 0.0 <= params["FC"] < 1.0
         ):
             raise NetlistParseError("MOSFET FC must be finite and in [0, 1)")
+        if "KF" in params and (
+            not math.isfinite(params["KF"]) or params["KF"] < 0.0
+        ):
+            raise NetlistParseError("MOSFET KF must be finite and non-negative")
         nominal_temperature = params.get("T_NOM", params.get("TNOM"))
         if nominal_temperature is not None and (
             not math.isfinite(nominal_temperature) or nominal_temperature <= 0.0

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1990,6 +1990,29 @@ def test_lowers_valid_mosfet_model_forward_bias_coefficient(
     assert isclose(mosfet.model.model.params.FC, float(coefficient))
 
 
+@pytest.mark.parametrize("coefficient", ["-1e-18", "1e999"])
+def test_rejects_invalid_mosfet_model_flicker_noise_coefficient(
+    coefficient: str,
+) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="MOSFET KF must be finite and non-negative",
+    ):
+        parse_netlist(f".model nfast NMOS(KF={coefficient})\nM1 d g s b nfast\n")
+
+
+@pytest.mark.parametrize("coefficient", ["0", "2e-18"])
+def test_lowers_valid_mosfet_model_flicker_noise_coefficient(
+    coefficient: str,
+) -> None:
+    parsed = parse_netlist(
+        f".model nfast NMOS(KF={coefficient})\nM1 d g s b nfast\n"
+    )
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(mosfet.model.model.params.KF, float(coefficient))
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS model-card `KF` values and lower valid
+  flicker-noise coefficients instead of silently dropping them.
 - Reject MOS model-card `FC` values outside `[0, 1)` or non-finite values and
   lower valid forward-bias depletion coefficients instead of silently dropping them.
 - Reject negative and non-finite MOS model-card `MJSW` values and lower valid

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1334,6 +1334,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET FC must be finite and in [0, 1)");
   }
+  const flickerNoiseCoefficient = params.get("KF");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    flickerNoiseCoefficient !== undefined &&
+    (!Number.isFinite(flickerNoiseCoefficient) || flickerNoiseCoefficient < 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET KF must be finite and non-negative");
+  }
   const nominalTemperature = params.get("T_NOM") ?? params.get("TNOM");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1441,6 +1449,7 @@ function isMosfetParam(name: keyof MosfetLevel1Params): boolean {
     "MJ",
     "MJSW",
     "FC",
+    "KF",
     "IS",
     "N_SUB",
     "T_NOM",

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1834,6 +1834,23 @@ Xright c d load
     expect(element.params.FC).toBe(Number(coefficient));
   });
 
+  it.each(["-1e-18", "1e999"])(
+    "rejects invalid MOSFET model KF=%s",
+    (coefficient) => {
+      expect(() =>
+        parseNetlist(`.model nfast NMOS(KF=${coefficient})\nM1 d g s b nfast\n`),
+      ).toThrow("MOSFET KF must be finite and non-negative");
+    },
+  );
+
+  it.each(["0", "2e-18"])("lowers valid MOSFET model KF=%s", (coefficient) => {
+    const parsed = parseNetlist(`.model nfast NMOS(KF=${coefficient})\nM1 d g s b nfast\n`);
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.KF).toBe(Number(coefficient));
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4291,11 +4291,17 @@ the Rust, Python, and TypeScript surfaces together.
      shared diagnostic while zero and positive sidewall-junction grading
      coefficients lower into Level-1 parameters.
 
+396. Python and TypeScript Berkeley SPICE MOS forward-bias parity.
+   - Status: completed in PR 9714.
+   - Non-finite model-card `FC` values and values outside `[0, 1)` are rejected
+     with the shared diagnostic while valid forward-bias depletion
+     coefficients lower into Level-1 parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
-   - TypeScript still needs canonical lowering for `FC`, `KF`, and `AF`;
-     Python already lowers these canonical fields
+   - TypeScript still needs canonical lowering for `KF` and `AF`; Python
+     already lowers these canonical fields
      but still needs matching facade validation coverage.
    - Align the `CJS` and `CJD` aliases with canonical `CBS` and `CBD` in both
      facades after the canonical-field slices.


### PR DESCRIPTION
## Summary

- validate MOS model-card `KF` as finite and nonnegative in Python and TypeScript
- lower valid `KF` values through the TypeScript parser instead of silently dropping them
- reconcile the SPICE plan with merged FC parity and update both parser changelogs

## Verification

- Python `spice-netlist-parser`: `bash BUILD` (205 tests, 88.57% coverage)
- Python `spice-netlist-parser`: `.venv/bin/ruff check .`
- TypeScript `spice-engine`: `bash BUILD` (448 tests)
- TypeScript `spice-netlist-parser`: `bash BUILD` (198 tests)
- TypeScript `spice-netlist-parser`: `npm run test:coverage` (198 tests, 85.21% line coverage)