### PR TITLE
fix(spice): lower parser MOS flicker-noise exponent

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS model-card `AF` values before lowering
+  valid flicker-noise exponents.
 - Reject negative and non-finite MOS model-card `KF` values before lowering
   valid flicker-noise coefficients.
 - Reject MOS model-card `FC` values outside `[0, 1)` or non-finite values

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -2001,6 +2001,10 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(params["KF"]) or params["KF"] < 0.0
         ):
             raise NetlistParseError("MOSFET KF must be finite and non-negative")
+        if "AF" in params and (
+            not math.isfinite(params["AF"]) or params["AF"] < 0.0
+        ):
+            raise NetlistParseError("MOSFET AF must be finite and non-negative")
         nominal_temperature = params.get("T_NOM", params.get("TNOM"))
         if nominal_temperature is not None and (
             not math.isfinite(nominal_temperature) or nominal_temperature <= 0.0

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -2013,6 +2013,23 @@ def test_lowers_valid_mosfet_model_flicker_noise_coefficient(
     assert isclose(mosfet.model.model.params.KF, float(coefficient))
 
 
+@pytest.mark.parametrize("exponent", ["-0.1", "1e999"])
+def test_rejects_invalid_mosfet_model_flicker_noise_exponent(exponent: str) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="MOSFET AF must be finite and non-negative",
+    ):
+        parse_netlist(f".model nfast NMOS(AF={exponent})\nM1 d g s b nfast\n")
+
+
+@pytest.mark.parametrize("exponent", ["0", "1.5"])
+def test_lowers_valid_mosfet_model_flicker_noise_exponent(exponent: str) -> None:
+    parsed = parse_netlist(f".model nfast NMOS(AF={exponent})\nM1 d g s b nfast\n")
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(mosfet.model.model.params.AF, float(exponent))
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS model-card `AF` values and lower valid
+  flicker-noise exponents instead of silently dropping them.
 - Reject negative and non-finite MOS model-card `KF` values and lower valid
   flicker-noise coefficients instead of silently dropping them.
 - Reject MOS model-card `FC` values outside `[0, 1)` or non-finite values and

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1342,6 +1342,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET KF must be finite and non-negative");
   }
+  const flickerNoiseExponent = params.get("AF");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    flickerNoiseExponent !== undefined &&
+    (!Number.isFinite(flickerNoiseExponent) || flickerNoiseExponent < 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET AF must be finite and non-negative");
+  }
   const nominalTemperature = params.get("T_NOM") ?? params.get("TNOM");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1450,6 +1458,7 @@ function isMosfetParam(name: keyof MosfetLevel1Params): boolean {
     "MJSW",
     "FC",
     "KF",
+    "AF",
     "IS",
     "N_SUB",
     "T_NOM",

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1851,6 +1851,20 @@ Xright c d load
     expect(element.params.KF).toBe(Number(coefficient));
   });
 
+  it.each(["-0.1", "1e999"])("rejects invalid MOSFET model AF=%s", (exponent) => {
+    expect(() =>
+      parseNetlist(`.model nfast NMOS(AF=${exponent})\nM1 d g s b nfast\n`),
+    ).toThrow("MOSFET AF must be finite and non-negative");
+  });
+
+  it.each(["0", "1.5"])("lowers valid MOSFET model AF=%s", (exponent) => {
+    const parsed = parseNetlist(`.model nfast NMOS(AF=${exponent})\nM1 d g s b nfast\n`);
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.AF).toBe(Number(exponent));
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4297,12 +4297,17 @@ the Rust, Python, and TypeScript surfaces together.
      with the shared diagnostic while valid forward-bias depletion
      coefficients lower into Level-1 parameters.
 
+397. Python and TypeScript Berkeley SPICE MOS flicker-noise coefficient parity.
+   - Status: completed in PR 9716.
+   - Negative and non-finite model-card `KF` values are rejected with the
+     shared diagnostic while zero and positive flicker-noise coefficients
+     lower into Level-1 parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
-   - TypeScript still needs canonical lowering for `KF` and `AF`; Python
-     already lowers these canonical fields
-     but still needs matching facade validation coverage.
+   - TypeScript still needs canonical lowering for `AF`; Python already lowers
+     this canonical field but still needs matching facade validation coverage.
    - Align the `CJS` and `CJD` aliases with canonical `CBS` and `CBD` in both
      facades after the canonical-field slices.
 


### PR DESCRIPTION
## Summary

- validate MOS model-card `AF` as finite and nonnegative in Python and TypeScript
- lower valid `AF` values through the TypeScript parser instead of silently dropping them
- reconcile the SPICE plan with merged KF parity and update both parser changelogs

## Verification

- Python `spice-netlist-parser`: `bash BUILD` (209 tests, 88.59% coverage)
- Python `spice-netlist-parser`: `.venv/bin/ruff check .`
- TypeScript `spice-engine`: `bash BUILD` (448 tests)
- TypeScript `spice-netlist-parser`: `bash BUILD` (202 tests)
- TypeScript `spice-netlist-parser`: `npm run test:coverage` (202 tests, 85.26% line coverage)