### PR TITLE
Report non-current list item recovery

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- A `li` start tag now reports the Standard's parse error when implied-end-tag
+  recovery closes a non-current list item, covering 2 previously silent
+  malformed corpus cases without changing DOM recovery.
 - In-body end tags now report the Standard's parse error when implied-end-tag
   recovery leaves their matching open element non-current, closing 18
   previously silent malformed corpus cases without changing DOM recovery or

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -22,7 +22,7 @@ exact upstream commits used for the latest completed audit.
 ## Prioritized Queue
 
 The 2026-08-03 upstream audit at WPT
-`8a26b31d60d0f1831bb1711b7587ac125b8d2bf0` and html5lib-tests
+`a73cf1e91a6a95e4c5c39494d8fbfdab0b38cae1` and html5lib-tests
 `224991ec10db04f056a89eed8b0bd8695fd2950e` covered all 1,934 WPT
 tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,9 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the specialized in-body heading end-tag diagnostic slice, 2,005 of those
-cases emit at least one lexer or parser diagnostic and 178 remain uncovered.
+After the specialized in-body list-item start-tag diagnostic slice, 2,007 of
+those cases emit at least one lexer or parser diagnostic and 176 remain
+uncovered.
 Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
 These are reviewed rather than automatically removed: 89 are full-document
 inputs for which the legacy fixtures omit the Standard-required missing-doctype
@@ -54,9 +55,10 @@ original mode; synthetic text fragment contexts remain diagnostic-free.
 The in-body "any other end tag" parse error is now reported when implied end
 tags leave the matching open element non-current, including special-element
 scope stops and nested formatting recovery. Remaining in-body work covers
-specialized list-item, paragraph, and adoption-agency branches. Heading end
-tags now report the specialized parse error when no heading is in scope or the
-current heading does not match the token.
+specialized paragraph and adoption-agency branches. Heading end tags now report
+the specialized parse error when no heading is in scope or the current heading
+does not match the token. A `li` start tag now also reports the specialized
+parse error when its implied-end-tag recovery closes a non-current list item.
 
 Prioritized work items:
 

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7195,6 +7195,13 @@ impl HtmlParser {
             if !self.current_parent_has_element_ancestor("button") {
                 self.close_open_anchor_for_reconstruction_boundary();
                 self.close_open_element_if(|name| name == "p");
+                if !self.current_element_is("li") && self.open_list_item_in_scope_index().is_some()
+                {
+                    self.diagnostics.push(ParserDiagnostic::new(
+                        "unexpected-li-start-tag",
+                        "start tag `<li>` implied the end of a non-current list item",
+                    ));
+                }
                 self.close_open_list_item_if_in_scope();
             }
         } else if incoming_name == "dt" || incoming_name == "dd" {
@@ -7336,17 +7343,22 @@ impl HtmlParser {
         self.open_elements.truncate(index);
     }
 
-    fn close_open_list_item_if_in_scope(&mut self) -> bool {
-        let Some(index) = self.open_elements.iter().rposition(|path| {
+    fn open_list_item_in_scope_index(&self) -> Option<usize> {
+        let index = self.open_elements.iter().rposition(|path| {
             element_at_path(&self.document, path).is_some_and(|name| name == "li")
-        }) else {
-            return false;
-        };
+        })?;
         if self.open_elements.iter().skip(index + 1).any(|path| {
             element_at_path(&self.document, path).is_some_and(is_list_item_scope_boundary)
         }) {
-            return false;
+            return None;
         }
+        Some(index)
+    }
+
+    fn close_open_list_item_if_in_scope(&mut self) -> bool {
+        let Some(index) = self.open_list_item_in_scope_index() else {
+            return false;
+        };
         self.open_elements.truncate(index);
         true
     }
@@ -33233,6 +33245,30 @@ mod tests {
         let matching =
             parse_html_with_diagnostics("<!doctype html><h3><li>abc</h3>foo").unwrap();
         assert!(matching.parser_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_li_start_tags_that_close_non_current_list_items() {
+        for source in [
+            "<!DOCTYPE html><li><menuitem><li>",
+            "<!DOCTYPE html><html><head></head><body><ul><li><div><p><li></ul></body></html>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "unexpected-li-start-tag",
+                    "start tag `<li>` implied the end of a non-current list item"
+                )],
+                "source {source:?}"
+            );
+        }
+
+        let adjacent = parse_html_with_diagnostics("<!doctype html><ul><li>one<li>two").unwrap();
+        assert!(!adjacent
+            .parser_diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "unexpected-li-start-tag"));
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
@@ -14,7 +14,7 @@
     "missing": 0,
     "missing_sources": [],
     "upstream_cases": 1934,
-    "upstream_revision": "8a26b31d60d0f1831bb1711b7587ac125b8d2bf0",
+    "upstream_revision": "a73cf1e91a6a95e4c5c39494d8fbfdab0b38cae1",
     "upstream_source": "wpt/html/syntax/parsing/resources"
   }
 }

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 178);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2005);
+    assert_eq!(missing_diagnostic_cases, 176);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2007);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary

- report the in-body parse error when a new `li` start tag closes a non-current list item
- cover the two previously silent retained-corpus cases without changing DOM recovery
- ratchet diagnostic coverage from 2,005 to 2,007 covered cases and 178 to 176 missing cases
- refresh the pinned WPT audit revision; the current 1,934-case upstream corpus remains fully represented

## Validation

- `cargo test -p coding-adventures-html-parser`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- WHATWG audit manifest, Rust-test, coverage, and generated smoke-fixture checks
- exact coverage report: tree 1,934/2,637/missing 0; tokenizer 6,806/7,015/7,242/skipped 0/missing 0