### PR TITLE
fix(iir-to-wasm): grow linear memory instead of trapping past 64 KiB

### DIFF
--- a/code/packages/rust/iir-to-wasm/CHANGELOG.md
+++ b/code/packages/rust/iir-to-wasm/CHANGELOG.md
@@ -17,9 +17,15 @@ out-of-page write.
   `str_concat`'s runtime path, `str_slice`'s runtime path, and
   `call_builtin "input_str"` — before each one writes past the current
   `__array_bump` offset.
-- Raised the module's declared memory `max` from `1` to `65536` (the WASM
-  spec's absolute page ceiling), matching the ceiling `wasm-execution`'s
-  `LinearMemory::grow` already enforced.
+- Raised the module's declared memory `max` from the hardcoded `1` to a new
+  `IIRWasmConfig::max_memory_pages` field (default `1024` pages = 64 MiB),
+  clamped to `65536` (the WASM spec's absolute page ceiling) regardless of
+  configuration. **Security review caught that jumping straight to the 4
+  GiB ceiling unconditionally would itself be a regression**: this backend's
+  allocator never frees, so an unbounded cap would let a long-running or
+  malformed module monotonically consume real host memory with no
+  backstop — a real, caller-configured bound (not the raw spec maximum) is
+  the fix.
 - New `encode_memory_size()`/`encode_memory_grow()` opcode encoders in
   `codegen.rs` (0x3F/0x40, both followed by the reserved memory-index byte).
 - See `AOT00-T1x-wasm-linear-memory-growth.md` for the full writeup,

--- a/code/packages/rust/iir-to-wasm/CHANGELOG.md
+++ b/code/packages/rust/iir-to-wasm/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog — iir-to-wasm
 
+## [0.45.0] — 2026-08-03 (linear memory growth — Twig GC completion, Part 3 stage 1)
+
+Fix a confirmed bug found by direct source reading (not assumed): every
+memory-using module hardcoded `Limits { min: 1, max: Some(1) }` — a single
+64 KiB page with no growth path — and `iir-to-wasm` never emitted a
+`memory.grow` instruction anywhere. Any program whose bump-allocated
+strings/E5 arrays outgrew the first page would trap on the very first
+out-of-page write.
+
+- Added a shared, in-module `$__ensure_capacity(needed_end: i64)` helper
+  (emitted once per module, gated by `uses_memory`, appended after
+  `$__str_eq`/`$__str_cmp` if present) that calls the new `memory.grow`
+  encoder when the requested byte offset exceeds the current page count.
+- Wired a call to it into all four bump-allocation sites — `alloc_array`,
+  `str_concat`'s runtime path, `str_slice`'s runtime path, and
+  `call_builtin "input_str"` — before each one writes past the current
+  `__array_bump` offset.
+- Raised the module's declared memory `max` from `1` to `65536` (the WASM
+  spec's absolute page ceiling), matching the ceiling `wasm-execution`'s
+  `LinearMemory::grow` already enforced.
+- New `encode_memory_size()`/`encode_memory_grow()` opcode encoders in
+  `codegen.rs` (0x3F/0x40, both followed by the reserved memory-index byte).
+- See `AOT00-T1x-wasm-linear-memory-growth.md` for the full writeup,
+  including the explicit stage-2 scope (free-list allocator + conservative
+  collector) this round does **not** yet cover.
+
 ## [0.44.0] — 2026-07-31 (boolean array elements)
 
 `array<bool>` now uses full-width i32 cells in linear memory. The four-byte

--- a/code/packages/rust/iir-to-wasm/Cargo.toml
+++ b/code/packages/rust/iir-to-wasm/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-wasm"
-version = "0.44.0"
+version = "0.45.0"
 edition = "2021"
-description = "IIR → WASM backend — lowers IIRModule to WasmModule. v0.43.0: runtime str_concat now reserves linear memory and __array_bump even without arrays; v0.42.0: runtime str_slice i64 index truncation guard; v0.39.0: runtime str_cmp; v0.36.0: array<str>; v0.30.0: runtime string call results and parameters."
+description = "IIR → WASM backend — lowers IIRModule to WasmModule. v0.45.0: linear memory actually grows past 64 KiB (memory.grow + $__ensure_capacity) instead of trapping; v0.43.0: runtime str_concat now reserves linear memory and __array_bump even without arrays; v0.42.0: runtime str_slice i64 index truncation guard; v0.39.0: runtime str_cmp; v0.36.0: array<str>; v0.30.0: runtime string call results and parameters."
 
 [lib]
 name = "iir_to_wasm"

--- a/code/packages/rust/iir-to-wasm/README.md
+++ b/code/packages/rust/iir-to-wasm/README.md
@@ -118,12 +118,16 @@ through a deprecated intermediate.
   `str_slice`, `call_builtin "input_str"`) calls a shared, in-module
   `$__ensure_capacity(needed_end: i64)` helper before writing, which emits a
   real `memory.grow` when the requested offset would exceed the module's
-  current page count. The declared memory's `max` is `65536` pages (the WASM
-  spec ceiling), not the old hardcoded single page — so a program whose
-  string/array data crosses 64 KiB now grows memory and keeps running instead
-  of trapping on the first out-of-page write. Reclamation (a free-list
-  allocator + a conservative collector over this same linear memory) is a
-  separate, larger follow-up — see `AOT00-T1x-wasm-linear-memory-growth.md`.
+  current page count. The declared memory's `max` comes from
+  `IIRWasmConfig::max_memory_pages` (default `1024` pages = 64 MiB, clamped
+  to the WASM spec's `65536`-page ceiling), not the old hardcoded single
+  page — so a program whose string/array data crosses 64 KiB now grows
+  memory and keeps running instead of trapping on the first out-of-page
+  write. The cap stays configurable rather than jumping straight to the
+  full 4 GiB ceiling because this allocator never frees (reclamation — a
+  free-list allocator + a conservative collector over this same linear
+  memory — is a separate, larger follow-up); see
+  `AOT00-T1x-wasm-linear-memory-growth.md`.
 - **All functions exported**: every function in the IIR module is exported by
   name so host runtimes can invoke them.
 

--- a/code/packages/rust/iir-to-wasm/README.md
+++ b/code/packages/rust/iir-to-wasm/README.md
@@ -113,6 +113,17 @@ through a deprecated intermediate.
   + 4 + idx)` (skipping the header; the literal path loads `offset + idx` with no
   header) — read-only, so no bump-alloc. This **closes the E4d-3b runtime string
   surface**: every `str_*` op now has a runtime path over promoted operands.
+- **Growable linear memory (v0.45.0 — Twig GC completion, Part 3 stage 1)**:
+  every bump-allocation site (`alloc_array`, runtime `str_concat`, runtime
+  `str_slice`, `call_builtin "input_str"`) calls a shared, in-module
+  `$__ensure_capacity(needed_end: i64)` helper before writing, which emits a
+  real `memory.grow` when the requested offset would exceed the module's
+  current page count. The declared memory's `max` is `65536` pages (the WASM
+  spec ceiling), not the old hardcoded single page — so a program whose
+  string/array data crosses 64 KiB now grows memory and keeps running instead
+  of trapping on the first out-of-page write. Reclamation (a free-list
+  allocator + a conservative collector over this same linear memory) is a
+  separate, larger follow-up — see `AOT00-T1x-wasm-linear-memory-growth.md`.
 - **All functions exported**: every function in the IIR module is exported by
   name so host runtimes can invoke them.
 

--- a/code/packages/rust/iir-to-wasm/src/codegen.rs
+++ b/code/packages/rust/iir-to-wasm/src/codegen.rs
@@ -277,6 +277,22 @@ pub fn encode_f64_store(offset: u32) -> Vec<u8> {
     b
 }
 
+/// `memory.size` (0x3F) — push the current size of linear memory, in 64 KiB
+/// pages, as an i32. The trailing `0x00` is the memory index (always 0 — this
+/// backend only ever declares one memory).
+pub fn encode_memory_size() -> Vec<u8> {
+    vec![0x3Fu8, 0x00u8]
+}
+
+/// `memory.grow` (0x40) — pop a page-count delta (i32), grow linear memory by
+/// that many pages, and push the *previous* size in pages (i32), or `-1`
+/// (`0xFFFFFFFF`) if the growth would exceed the memory's declared maximum or
+/// the WASM spec's absolute ceiling (65536 pages / 4 GiB). The trailing
+/// `0x00` is the memory index.
+pub fn encode_memory_grow() -> Vec<u8> {
+    vec![0x40u8, 0x00u8]
+}
+
 /// `i64.add` (0x7C) — i64 addition.
 pub const I64_ADD: u8 = 0x7C;
 
@@ -909,6 +925,12 @@ mod tests {
         assert_eq!(enc[4], 0x02);
         // default = 3
         assert_eq!(enc[5], 0x03);
+    }
+
+    #[test]
+    fn memory_size_and_grow_encode_opcode_plus_memidx() {
+        assert_eq!(encode_memory_size(), vec![0x3F, 0x00]);
+        assert_eq!(encode_memory_grow(), vec![0x40, 0x00]);
     }
 
     #[test]

--- a/code/packages/rust/iir-to-wasm/src/lower.rs
+++ b/code/packages/rust/iir-to-wasm/src/lower.rs
@@ -582,29 +582,54 @@ impl std::error::Error for IIRWasmError {}
 // ---------------------------------------------------------------------------
 
 /// Configuration for the IIR → WASM lowering pass.
-///
-/// Currently only carries the module name (written into a WASM custom section
-/// or used for debugging).  Additional options (e.g. optimisation level,
-/// memory model) can be added here in future versions.
 #[derive(Debug, Clone)]
 pub struct IIRWasmConfig {
     /// The name embedded in the WASM module (used for identification).
     pub module_name: String,
+    /// The declared `max` (in 64 KiB pages) for a memory-using module's linear
+    /// memory — the ceiling `$__ensure_capacity`'s `memory.grow` calls can
+    /// reach before returning `-1` (OOM) and trapping. Clamped to the WASM
+    /// spec's absolute ceiling (`MAX_WASM_MEMORY_PAGES` = 65536 = 4 GiB)
+    /// regardless of what's configured here.
+    ///
+    /// Defaults far below the spec ceiling (see `DEFAULT_MAX_MEMORY_PAGES`):
+    /// this backend's bump allocator never frees (reclamation is a tracked
+    /// follow-up, not yet built — see `AOT00-T1x-wasm-linear-memory-growth.md`),
+    /// so an unbounded cap on a long-running or malicious/malformed IIR module
+    /// would let it monotonically grow linear memory toward 4 GiB of real
+    /// host-committed memory before ever trapping. A caller running trusted,
+    /// bounded programs (typical `lang-aot` test/build usage) can raise this;
+    /// a caller running untrusted input should keep it low.
+    pub max_memory_pages: u32,
 }
+
+/// The WASM spec's absolute linear-memory ceiling: 65536 pages × 64 KiB = 4 GiB.
+/// `wasm-execution`'s `LinearMemory::grow` already enforces this regardless of
+/// what a module declares; `max_memory_pages` is clamped to it too so a
+/// misconfigured caller can't declare something the spec itself would reject.
+const MAX_WASM_MEMORY_PAGES: u32 = 65536;
+
+/// Default `max_memory_pages`: 1024 pages = 64 MiB. Generous for any real
+/// test/build program (the largest program in this crate's own test suite
+/// reserves well under 1 MiB total) while still bounding a runaway
+/// allocation loop to a small fraction of the 4 GiB spec ceiling.
+const DEFAULT_MAX_MEMORY_PAGES: u32 = 1024;
 
 impl Default for IIRWasmConfig {
     fn default() -> Self {
         Self {
             module_name: "iir_module".to_string(),
+            max_memory_pages: DEFAULT_MAX_MEMORY_PAGES,
         }
     }
 }
 
 impl IIRWasmConfig {
-    /// Create a new config with the given module name.
+    /// Create a new config with the given module name (default memory cap).
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             module_name: name.into(),
+            ..Self::default()
         }
     }
 }
@@ -4942,7 +4967,7 @@ fn collect_module_features(module: &IIRModule) -> ModuleFeatures {
 /// `wasm_module_encoder::encode_module` to produce raw `.wasm` bytes.
 pub fn lower_iir_to_wasm(
     module: &IIRModule,
-    _config: &IIRWasmConfig,
+    config: &IIRWasmConfig,
 ) -> Result<WasmModule, IIRWasmError> {
     // ── Step 1: Validate ─────────────────────────────────────────────────────
     let errors = validate_for_wasm(module);
@@ -5490,17 +5515,20 @@ pub fn lower_iir_to_wasm(
     // (`alloc_array`/`str_concat`/`str_slice`/`input_str`) that outgrew the
     // single page had nowhere to grow into. `$__ensure_capacity` now emits
     // real `memory.grow` calls at every one of those sites, so the declared
-    // `max` must allow growth up to the WASM spec's absolute ceiling (65536
-    // pages / 4 GiB) — `memory.grow`'s own return-`-1`-on-failure contract,
-    // already implemented and enforced generically by `wasm-execution`'s
-    // `LinearMemory::grow`, is what actually stops a runaway allocation.
-    const WASM_MAX_PAGES: u32 = 65536;
+    // `max` must allow real growth — `config.max_memory_pages`, clamped to
+    // the WASM spec's absolute ceiling. This backend's allocator is
+    // bump-only and never frees (reclamation is a tracked follow-up, not yet
+    // built), so the cap stays a config-provided bound rather than
+    // unconditionally jumping to the full 4 GiB spec ceiling — a caller
+    // running untrusted or unbounded-loop input keeps a real backstop
+    // instead of relying solely on `wasm-execution`'s own OOM handling.
+    let max_memory_pages = config.max_memory_pages.min(MAX_WASM_MEMORY_PAGES);
     let memories: Vec<wasm_types::MemoryType> = if uses_memory
         || uses_print_str
         || !string_data.is_empty()
     {
         vec![wasm_types::MemoryType {
-            limits: wasm_types::Limits { min: 1, max: Some(WASM_MAX_PAGES) },
+            limits: wasm_types::Limits { min: 1, max: Some(max_memory_pages) },
         }]
     } else {
         vec![]

--- a/code/packages/rust/iir-to-wasm/src/lower.rs
+++ b/code/packages/rust/iir-to-wasm/src/lower.rs
@@ -5522,7 +5522,12 @@ pub fn lower_iir_to_wasm(
     // unconditionally jumping to the full 4 GiB spec ceiling — a caller
     // running untrusted or unbounded-loop input keeps a real backstop
     // instead of relying solely on `wasm-execution`'s own OOM handling.
-    let max_memory_pages = config.max_memory_pages.min(MAX_WASM_MEMORY_PAGES);
+    // `clamp` (not just `.min`): a misconfigured `max_memory_pages: 0` would
+    // otherwise declare `Limits { min: 1, max: Some(0) }` — spec-invalid
+    // (min > max) even though this crate's own encoder and `wasm-execution`
+    // both degrade safely (memory simply never grows). Flooring at 1 keeps
+    // every declared module spec-valid regardless of caller misconfiguration.
+    let max_memory_pages = config.max_memory_pages.clamp(1, MAX_WASM_MEMORY_PAGES);
     let memories: Vec<wasm_types::MemoryType> = if uses_memory
         || uses_print_str
         || !string_data.is_empty()

--- a/code/packages/rust/iir-to-wasm/src/lower.rs
+++ b/code/packages/rust/iir-to-wasm/src/lower.rs
@@ -146,7 +146,7 @@ use wasm_types::{
 use crate::codegen::{
     encode_br, encode_br_table, encode_call, encode_f32_const, encode_f64_const,
     encode_f64_load, encode_f64_store, encode_i32_load, encode_i32_store, encode_i64_load,
-    encode_i64_store,
+    encode_i64_store, encode_memory_grow, encode_memory_size,
     encode_i32_const, encode_i64_const, encode_local_get, encode_local_set, BLOCK, BLOCK_EMPTY,
     DROP, END, F32_ADD, F32_DIV, F32_EQ, F32_GE, F32_GT, F32_LE, F32_LT, F32_MUL, F32_NEG,
     F32_NE, F32_SUB, F64_ADD, F64_CONVERT_I64_S, F64_DIV, F64_EQ, F64_FLOOR, F64_GE, F64_GT,
@@ -1077,6 +1077,13 @@ fn emit_instr(
     // Function index of the in-module `$__str_cmp` helper (present iff the module
     // has a `str_cmp` that can't be folded — see `uses_str_cmp_runtime`).
     str_cmp_fn_idx: Option<u32>,
+    // Function index of the in-module `$__ensure_capacity` helper (present iff
+    // the module uses linear memory — see `uses_memory`). Every bump-allocation
+    // site (`alloc_array`/`str_concat`/`str_slice`/`input_str`) calls it with
+    // the byte offset one past the last byte it's about to write, so linear
+    // memory grows via `memory.grow` instead of silently running off the end
+    // of the module's single declared page.
+    ensure_capacity_fn_idx: Option<u32>,
 ) -> Result<(), IIRWasmError> {
     // Helper closures to resolve variable names.
     let get_reg = |var: &str| -> Result<u32, IIRWasmError> {
@@ -1232,6 +1239,28 @@ fn emit_instr(
                         op: "str_concat (missing __array_bump global)".to_string(),
                     }
                 })?;
+
+                // Ensure linear memory can hold the new block (header + both byte
+                // runs) BEFORE any write touches it: needed_end = bump + 4 + la + lb.
+                let ensure_capacity = ensure_capacity_fn_idx.ok_or_else(|| {
+                    IIRWasmError::UnsupportedOp {
+                        function: fn_name.to_string(),
+                        op: "str_concat runtime path without $__ensure_capacity helper \
+                             (internal error)"
+                            .to_string(),
+                    }
+                })?;
+                code.extend(encode_global_get(bump));
+                code.extend(encode_i32_const(4));
+                code.extend(encode_local_get(ra));
+                code.extend(encode_i32_load(0));
+                code.push(I32_ADD);
+                code.extend(encode_local_get(rb));
+                code.extend(encode_i32_load(0));
+                code.push(I32_ADD);
+                code.extend(encode_i64_extend_i32_u());
+                code.push(I64_ADD);
+                code.extend(encode_call(ensure_capacity));
 
                 // rd = new = i32.wrap(bump)  — the fresh block's base handle.
                 code.extend(encode_global_get(bump));
@@ -1425,6 +1454,26 @@ fn emit_instr(
                 code.push(BLOCK_EMPTY);
                 code.push(UNREACHABLE);
                 code.push(END);
+
+                // Ensure linear memory can hold the new block (header + the run)
+                // BEFORE any write touches it: needed_end = bump + 4 + (end - start).
+                let ensure_capacity = ensure_capacity_fn_idx.ok_or_else(|| {
+                    IIRWasmError::UnsupportedOp {
+                        function: fn_name.to_string(),
+                        op: "str_slice runtime path without $__ensure_capacity helper \
+                             (internal error)"
+                            .to_string(),
+                    }
+                })?;
+                code.extend(encode_global_get(bump));
+                code.extend(encode_i32_const(4));
+                code.extend_from_slice(&push_end);
+                code.extend_from_slice(&push_start);
+                code.push(I32_SUB);
+                code.push(I32_ADD);
+                code.extend(encode_i64_extend_i32_u());
+                code.push(I64_ADD);
+                code.extend(encode_call(ensure_capacity));
 
                 // rd = new = i32.wrap(bump)  — the fresh block's base handle.
                 code.extend(encode_global_get(bump));
@@ -3215,6 +3264,27 @@ fn emit_instr(
             code.push(I64_ADD);
             code.push(I64_ADD);
             code.extend(encode_global_set(bump));
+            // Ensure linear memory can hold the whole block (header + all
+            // elements) BEFORE the header write below — later `array_set`
+            // stores land inside this same reserved region, so one check
+            // here covers them too. needed_end = handle + 8 + count*elemsize
+            // (rd already holds the pre-bump handle, so reuse it rather than
+            // re-reading the now-updated global).
+            let ensure_capacity = ensure_capacity_fn_idx.ok_or_else(|| {
+                IIRWasmError::UnsupportedOp {
+                    function: fn_name.to_string(),
+                    op: "alloc_array without $__ensure_capacity helper (internal error)"
+                        .to_string(),
+                }
+            })?;
+            code.extend(encode_local_get(rd));
+            code.extend(encode_local_get(count_slot));
+            code.extend(encode_i64_const(elem_size as i64));
+            code.push(I64_MUL);
+            code.extend(encode_i64_const(8));
+            code.push(I64_ADD);
+            code.push(I64_ADD);
+            code.extend(encode_call(ensure_capacity));
             // mem[wrap(handle) + 0] = count   (i64 length header).
             code.extend(encode_local_get(rd));
             code.extend(encode_i32_wrap_i64());
@@ -3416,11 +3486,11 @@ fn emit_instr(
                 // the memory writes, so no `i32.store` here.
                 //   Shape: srcs[0]=Var("input_str"), dest=Some(varname)
                 "input_str" => {
-                    // Cap the line at 256 bytes: the module's linear memory is a
-                    // single fixed 64 KiB page (`min=max=1`), and each block is never
-                    // freed (bump-only), so a large MAX would exhaust the page after a
-                    // few reads. 256 covers a BASIC input line; a longer line is
-                    // truncated (V1 permissive contract).
+                    // Cap the line at 256 bytes — comfortably covers a BASIC input
+                    // line; a longer line is truncated (V1 permissive contract).
+                    // Each block is bump-only (never freed), but linear memory now
+                    // grows via `$__ensure_capacity` below, so repeated reads no
+                    // longer exhaust a fixed single page.
                     const INPUT_STR_MAX: i32 = 256;
                     let dest = instr.dest.as_deref().ok_or_else(|| IIRWasmError::InvalidOperand {
                         function: fn_name.to_string(),
@@ -3435,6 +3505,21 @@ fn emit_instr(
                         function: fn_name.to_string(),
                         op: "call_builtin \"input_str\" (missing __array_bump global)".to_string(),
                     })?;
+                    // Ensure linear memory can hold the whole block (header + MAX
+                    // bytes) BEFORE the host writes into it below:
+                    // needed_end = bump + 4 + MAX.
+                    let ensure_capacity = ensure_capacity_fn_idx.ok_or_else(|| {
+                        IIRWasmError::UnsupportedOp {
+                            function: fn_name.to_string(),
+                            op: "call_builtin \"input_str\" without $__ensure_capacity \
+                                 helper (internal error)"
+                                .to_string(),
+                        }
+                    })?;
+                    code.extend(encode_global_get(bump));
+                    code.extend(encode_i64_const((4 + INPUT_STR_MAX) as i64));
+                    code.push(I64_ADD);
+                    code.extend(encode_call(ensure_capacity));
                     // handle (dest, i32) = wrap(current bump).
                     code.extend(encode_global_get(bump));
                     code.extend(encode_i32_wrap_i64());
@@ -3648,6 +3733,7 @@ fn lower_function(
     pow_fn_idx: Option<u32>,
     str_eq_fn_idx: Option<u32>,
     str_cmp_fn_idx: Option<u32>,
+    ensure_capacity_fn_idx: Option<u32>,
 ) -> Result<FunctionBody, IIRWasmError> {
     let param_count = fn_.params.len() as u32;
     let reg_map = build_register_map(fn_);
@@ -3768,6 +3854,7 @@ fn lower_function(
                     pow_fn_idx,
                     str_eq_fn_idx,
                     str_cmp_fn_idx,
+                    ensure_capacity_fn_idx,
                 )?;
             }
 
@@ -3840,6 +3927,7 @@ fn lower_function(
                 pow_fn_idx,
                 str_eq_fn_idx,
                 str_cmp_fn_idx,
+                ensure_capacity_fn_idx,
             )?;
         }
     }
@@ -4020,6 +4108,93 @@ fn lay_runtime_str_block(
         .entry(fn_name.to_string())
         .or_default()
         .insert(dest.to_string());
+}
+
+/// Build the self-contained in-module `$__ensure_capacity(needed_end: i64)`
+/// helper — grows linear memory with `memory.grow` whenever a bump-allocation
+/// site (`alloc_array`/`str_concat`/`str_slice`/`input_str`) is about to write
+/// past the currently-committed memory, instead of trapping or silently
+/// corrupting adjacent data. `needed_end` is the byte offset one past the
+/// last byte the caller is about to write.
+///
+/// ```text
+///   current_bytes = i64(memory.size()) * 65536
+///   if needed_end > current_bytes {
+///     delta_bytes = needed_end - current_bytes
+///     delta_pages = (delta_bytes + 65535) / 65536      ;; round up
+///     if i32(memory.grow(i32(delta_pages))) == -1 { unreachable }  ;; OOM
+///   }
+/// ```
+///
+/// Twig GC completion round (Part 3): this closes the confirmed bug where
+/// every bump-allocation site was capped at the module's single declared
+/// 64 KiB page (`Limits { min: 1, max: Some(1) }`) with no growth path at
+/// all — any program allocating more than ~64 KiB of array/string data
+/// would corrupt memory (writes silently landing past the linear memory
+/// `Vec`'s bounds check, per `wasm-execution`'s own bounds-checked
+/// `LinearMemory` — actually a clean trap there, but *only* because the
+/// interpreter bounds-checks; nothing in the emitted bytecode itself ever
+/// asked for more memory). `wasm-execution`'s `LinearMemory::grow`
+/// (already implemented, tested, and generic — this crate is simply the
+/// first to *emit* a `memory.grow` call site) resizes the backing `Vec`
+/// and enforces the same WASM-spec absolute ceiling (65536 pages / 4 GiB)
+/// `memory.grow`'s own return-`-1`-on-failure contract already covers, so
+/// the `unreachable` here is reached only on genuine, spec-legitimate
+/// exhaustion — not a bug in this helper.
+///
+/// Emitted once per module (gated by `uses_memory` — the same condition that
+/// injects the `__array_bump` global and the memory section itself, since
+/// every consumer of linear memory is exactly the set of ops that can need
+/// more of it) and appended after every IIR-defined function (and after
+/// `$__str_eq`/`$__str_cmp`, if present), so its index is
+/// `fn_idx_base + module.functions.len() + uses_str_eq_runtime as u32 +
+/// uses_str_cmp_runtime as u32`. One scratch local (`current_bytes` = local 1)
+/// is declared here; `needed_end` lives in the `FuncType` as local 0.
+fn build_ensure_capacity_helper() -> FunctionBody {
+    const NEEDED_END: u32 = 0;
+    const CURRENT_BYTES: u32 = 1;
+    let mut c: Vec<u8> = Vec::new();
+
+    // current_bytes = i64(memory.size()) * 65536
+    c.extend(encode_memory_size());
+    c.extend(encode_i64_extend_i32_u());
+    c.extend(encode_i64_const(65536));
+    c.push(I64_MUL);
+    c.extend(encode_local_set(CURRENT_BYTES));
+
+    // if needed_end > current_bytes { ... }
+    c.extend(encode_local_get(NEEDED_END));
+    c.extend(encode_local_get(CURRENT_BYTES));
+    c.push(I64_GT_U);
+    c.push(IF);
+    c.push(BLOCK_EMPTY);
+
+    // delta_pages = i32((needed_end - current_bytes + 65535) / 65536)
+    c.extend(encode_local_get(NEEDED_END));
+    c.extend(encode_local_get(CURRENT_BYTES));
+    c.push(I64_SUB);
+    c.extend(encode_i64_const(65535));
+    c.push(I64_ADD);
+    c.extend(encode_i64_const(65536));
+    c.push(I64_DIV_U);
+    c.extend(encode_i32_wrap_i64());
+
+    // memory.grow returns the *previous* page count, or -1 on failure.
+    c.extend(encode_memory_grow());
+    c.extend(encode_i32_const(-1));
+    c.push(I32_EQ);
+    c.push(IF);
+    c.push(BLOCK_EMPTY);
+    c.push(UNREACHABLE);
+    c.push(END); // end of the OOM-check `if`
+    c.push(END); // end of the `needed_end > current_bytes` `if`
+
+    c.push(END); // function end
+
+    FunctionBody {
+        locals: vec![ValueType::I64], // current_bytes
+        code: c,
+    }
 }
 
 /// Build the self-contained in-module `$__str_eq(a: i32, b: i32) -> i32` helper.
@@ -4916,6 +5091,24 @@ pub fn lower_iir_to_wasm(
         None
     };
 
+    // The `$__ensure_capacity` helper (Twig GC completion round, Part 3) is
+    // appended right after `$__str_eq`/`$__str_cmp` (in that order, whichever
+    // are present) — gated on the same `uses_memory` condition that already
+    // triggers linear memory + the `__array_bump` global, since every
+    // bump-allocation site (`alloc_array`/`str_concat`/`str_slice`/
+    // `input_str`) needs to call it before writing past the current bump
+    // position.
+    let ensure_capacity_fn_idx: Option<u32> = if uses_memory {
+        Some(
+            fn_idx_base
+                + module.functions.len() as u32
+                + u32::from(uses_str_eq_runtime)
+                + u32::from(uses_str_cmp_runtime),
+        )
+    } else {
+        None
+    };
+
     // ── Step 4: Lower each function ──────────────────────────────────────────
 
     let mut types: Vec<FuncType> = Vec::new();
@@ -5228,7 +5421,7 @@ pub fn lower_iir_to_wasm(
             input_i64_fn_idx, input_str_fn_idx,
             sin_fn_idx, cos_fn_idx, ln_fn_idx, exp_fn_idx,
             atan_fn_idx, tan_fn_idx,
-            pow_fn_idx, str_eq_fn_idx, str_cmp_fn_idx,
+            pow_fn_idx, str_eq_fn_idx, str_cmp_fn_idx, ensure_capacity_fn_idx,
         )?;
         code.push(body);
     }
@@ -5261,6 +5454,20 @@ pub fn lower_iir_to_wasm(
         code.push(build_str_cmp_helper());
     }
 
+    // Append the `$__ensure_capacity` helper directly after `$__str_eq`/
+    // `$__str_cmp` (matching `ensure_capacity_fn_idx`, computed above with the
+    // same ordering). One `i64` param (`needed_end`), no results — see
+    // `build_ensure_capacity_helper`'s doc comment for what it does.
+    if ensure_capacity_fn_idx.is_some() {
+        let type_idx = types.len() as u32 + struct_type_offset;
+        types.push(FuncType {
+            params: vec![ValueType::I64],
+            results: vec![],
+        });
+        functions.push(type_idx);
+        code.push(build_ensure_capacity_helper());
+    }
+
     // ── Step 5: Assemble WasmModule ──────────────────────────────────────────
 
     // If the module uses $LispyPair, register the struct type.
@@ -5270,19 +5477,30 @@ pub fn lower_iir_to_wasm(
         vec![]
     };
 
-    // Brainfuck tape: a single 1-page linear memory.  Each WASM memory page is
-    // 64 KiB = 65,536 bytes, comfortably larger than Brainfuck's default 30,000
-    // -cell tape.  The memory is module-defined (not imported); a future
+    // Linear memory starts at a single 64 KiB page — enough for the
+    // Brainfuck tape's default 30,000 cells, small literal-string data
+    // segments, etc. — and is module-defined (not imported); a future
     // extension can add an `import` variant if the host wants to provide
-    // the buffer.  Modules that don't use `load_mem`/`store_mem` get no
-    // memory section, preserving binary compatibility with the existing
-    // non-BF callers (Twig, BASIC, Oct, Nib, Lispy).
+    // the buffer. Modules that don't use `load_mem`/`store_mem`/dynamic
+    // string-and-array allocation get no memory section, preserving binary
+    // compatibility with the existing non-memory callers.
+    //
+    // `max` was previously hardcoded to `Some(1)` — the exact bug this round
+    // (Twig GC completion, Part 3) fixes: any bump-allocation
+    // (`alloc_array`/`str_concat`/`str_slice`/`input_str`) that outgrew the
+    // single page had nowhere to grow into. `$__ensure_capacity` now emits
+    // real `memory.grow` calls at every one of those sites, so the declared
+    // `max` must allow growth up to the WASM spec's absolute ceiling (65536
+    // pages / 4 GiB) — `memory.grow`'s own return-`-1`-on-failure contract,
+    // already implemented and enforced generically by `wasm-execution`'s
+    // `LinearMemory::grow`, is what actually stops a runaway allocation.
+    const WASM_MAX_PAGES: u32 = 65536;
     let memories: Vec<wasm_types::MemoryType> = if uses_memory
         || uses_print_str
         || !string_data.is_empty()
     {
         vec![wasm_types::MemoryType {
-            limits: wasm_types::Limits { min: 1, max: Some(1) },
+            limits: wasm_types::Limits { min: 1, max: Some(WASM_MAX_PAGES) },
         }]
     } else {
         vec![]

--- a/code/packages/rust/iir-to-wasm/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-wasm/tests/test_backend.rs
@@ -2228,3 +2228,54 @@ fn input_str_lowers_and_declares_env_import() {
         "encoded module must declare the env.__input_str import"
     );
 }
+
+/// Twig GC completion round (Part 3): a module that bump-allocates (here, a
+/// single `alloc_array`) must declare linear memory with room to actually
+/// grow — the confirmed bug this round fixes was `Limits { min: 1, max:
+/// Some(1) }` hardcoded on every memory-using module, with no `memory.grow`
+/// call anywhere in the emitted bytecode, so any program allocating past the
+/// first 64 KiB page had no path forward. `$__ensure_capacity` (called from
+/// every bump-allocation site) now emits real `memory.grow`; this asserts the
+/// *other* half of the fix — the module's own declared `max` must actually
+/// permit that growth up to the WASM spec's absolute ceiling.
+#[test]
+fn alloc_array_module_declares_growable_memory_not_capped_at_one_page() {
+    let m = module_one("main", vec![], "void", vec![
+        IIRInstr::new("const", Some("count".into()), vec![Operand::Int(3)], "i64"),
+        IIRInstr::new("alloc_array", Some("h".into()), vec![Operand::Var("count".into())], "array<i64>"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let wm = lower_iir_to_wasm(&m, &IIRWasmConfig::default()).expect("lowering failed");
+    let mem = wm.memories.first().expect("alloc_array module must declare linear memory");
+    assert_eq!(mem.limits.min, 1, "still starts at a single 64 KiB page");
+    assert_eq!(
+        mem.limits.max,
+        Some(65536),
+        "max must allow growth to the WASM spec ceiling, not stay capped at 1 page"
+    );
+    encode_module(&wm).expect("encoding failed");
+}
+
+/// The companion codegen-shape check: an `alloc_array` module must actually
+/// emit `memory.grow` (0x40) and `memory.size` (0x3F) somewhere in its code —
+/// not just declare a growable memory section. Both opcodes are followed by
+/// the reserved memory-index byte `0x00` (this backend only ever declares one
+/// memory), so the two-byte pairs are unambiguous needles.
+#[test]
+fn alloc_array_emits_memory_grow_and_memory_size_opcodes() {
+    let m = module_one("main", vec![], "void", vec![
+        IIRInstr::new("const", Some("count".into()), vec![Operand::Int(3)], "i64"),
+        IIRInstr::new("alloc_array", Some("h".into()), vec![Operand::Var("count".into())], "array<i64>"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let wm = lower_iir_to_wasm(&m, &IIRWasmConfig::default()).expect("lowering failed");
+    let ensure_capacity_code = wm.code.last().expect("$__ensure_capacity body appended").code.as_slice();
+    assert!(
+        ensure_capacity_code.windows(2).any(|w| w == [0x3F, 0x00]),
+        "$__ensure_capacity must call memory.size"
+    );
+    assert!(
+        ensure_capacity_code.windows(2).any(|w| w == [0x40, 0x00]),
+        "$__ensure_capacity must call memory.grow"
+    );
+}

--- a/code/packages/rust/iir-to-wasm/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-wasm/tests/test_backend.rs
@@ -2296,6 +2296,27 @@ fn max_memory_pages_smaller_than_default_is_honored() {
     assert_eq!(mem.limits.max, Some(2), "a smaller configured cap must be honored, not widened");
 }
 
+/// Round-2 security-review finding: a degenerate `max_memory_pages: 0` must
+/// never produce a spec-invalid `Limits { min: 1, max: Some(0) }` (min > max).
+/// The declared max is floored at 1, matching the always-present `min: 1`.
+#[test]
+fn max_memory_pages_zero_is_floored_to_stay_spec_valid() {
+    let m = module_one("main", vec![], "void", vec![
+        IIRInstr::new("const", Some("count".into()), vec![Operand::Int(3)], "i64"),
+        IIRInstr::new("alloc_array", Some("h".into()), vec![Operand::Var("count".into())], "array<i64>"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let config = IIRWasmConfig { max_memory_pages: 0, ..IIRWasmConfig::default() };
+    let wm = lower_iir_to_wasm(&m, &config).expect("lowering failed");
+    let mem = wm.memories.first().expect("alloc_array module must declare linear memory");
+    assert_eq!(mem.limits.min, 1);
+    assert_eq!(
+        mem.limits.max,
+        Some(1),
+        "max_memory_pages: 0 must floor to 1 (== min), never produce min > max"
+    );
+}
+
 /// The companion codegen-shape check: an `alloc_array` module must actually
 /// emit `memory.grow` (0x40) and `memory.size` (0x3F) somewhere in its code —
 /// not just declare a growable memory section. Both opcodes are followed by

--- a/code/packages/rust/iir-to-wasm/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-wasm/tests/test_backend.rs
@@ -2237,7 +2237,11 @@ fn input_str_lowers_and_declares_env_import() {
 /// first 64 KiB page had no path forward. `$__ensure_capacity` (called from
 /// every bump-allocation site) now emits real `memory.grow`; this asserts the
 /// *other* half of the fix — the module's own declared `max` must actually
-/// permit that growth up to the WASM spec's absolute ceiling.
+/// permit growth (not stay capped at 1 page), while still being a
+/// caller-configured, non-4-GiB-by-default bound (this backend's allocator
+/// never frees, so an unconditional jump to the full spec ceiling would let
+/// an unbounded allocation loop consume real host memory with no backstop —
+/// see the security-review finding this addressed).
 #[test]
 fn alloc_array_module_declares_growable_memory_not_capped_at_one_page() {
     let m = module_one("main", vec![], "void", vec![
@@ -2250,10 +2254,46 @@ fn alloc_array_module_declares_growable_memory_not_capped_at_one_page() {
     assert_eq!(mem.limits.min, 1, "still starts at a single 64 KiB page");
     assert_eq!(
         mem.limits.max,
-        Some(65536),
-        "max must allow growth to the WASM spec ceiling, not stay capped at 1 page"
+        Some(1024),
+        "default max must allow real growth (1024 pages = 64 MiB), not stay capped at 1 page"
     );
     encode_module(&wm).expect("encoding failed");
+}
+
+/// `max_memory_pages` is a real caller-facing knob: a config asking for more
+/// pages than the WASM spec allows is clamped down, never passed through
+/// verbatim (a misconfigured caller can't accidentally exceed the spec).
+#[test]
+fn max_memory_pages_is_clamped_to_the_wasm_spec_ceiling() {
+    let m = module_one("main", vec![], "void", vec![
+        IIRInstr::new("const", Some("count".into()), vec![Operand::Int(3)], "i64"),
+        IIRInstr::new("alloc_array", Some("h".into()), vec![Operand::Var("count".into())], "array<i64>"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let config = IIRWasmConfig { max_memory_pages: u32::MAX, ..IIRWasmConfig::default() };
+    let wm = lower_iir_to_wasm(&m, &config).expect("lowering failed");
+    let mem = wm.memories.first().expect("alloc_array module must declare linear memory");
+    assert_eq!(
+        mem.limits.max,
+        Some(65536),
+        "an oversized configured cap must clamp to the WASM spec's 65536-page ceiling"
+    );
+}
+
+/// And a smaller-than-default configured cap is honored verbatim (not
+/// silently widened) — the config is a real, respected bound in both
+/// directions.
+#[test]
+fn max_memory_pages_smaller_than_default_is_honored() {
+    let m = module_one("main", vec![], "void", vec![
+        IIRInstr::new("const", Some("count".into()), vec![Operand::Int(3)], "i64"),
+        IIRInstr::new("alloc_array", Some("h".into()), vec![Operand::Var("count".into())], "array<i64>"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    let config = IIRWasmConfig { max_memory_pages: 2, ..IIRWasmConfig::default() };
+    let wm = lower_iir_to_wasm(&m, &config).expect("lowering failed");
+    let mem = wm.memories.first().expect("alloc_array module must declare linear memory");
+    assert_eq!(mem.limits.max, Some(2), "a smaller configured cap must be honored, not widened");
 }
 
 /// The companion codegen-shape check: an `alloc_array` module must actually

--- a/code/packages/rust/lang-aot/tests/e6d2b_dynamic_arith.rs
+++ b/code/packages/rust/lang-aot/tests/e6d2b_dynamic_arith.rs
@@ -3,11 +3,11 @@
 //! `(+ (car (cons 41 0)) 1)` forces `+` over a **boxed** operand: `car`'s result
 //! is a `ref<any>` tagged word, not a machine int. `lower_dynamic_arith` expands
 //! it to `unbox → add → box`; on the **tagged-i64** world (native aarch64/x86_64
-//! and LLVM) `lower_box_unbox_to_runtime_calls` rewrites those generic ops to
-//! `dyn_box_int` / `dyn_unbox_int` runtime calls, which the backends dispatch to
-//! `__dyn_box_int` / `__dyn_unbox_int` in `dynval_runtime.c`. The final tagged
-//! result is exit-unboxed (`dyn_repr` recognises the `ref<any>` result even for
-//! a **Twig** program, whose bare-`any` params stay gated). Exit 42.
+//! + LLVM) `lower_box_unbox_to_runtime_calls` rewrites those generic ops to
+//!   `dyn_box_int` / `dyn_unbox_int` runtime calls, which the backends dispatch to
+//!   `__dyn_box_int` / `__dyn_unbox_int` in `dynval_runtime.c`. The final tagged
+//!   result is exit-unboxed (`dyn_repr` recognises the `ref<any>` result even for
+//!   a **Twig** program, whose bare-`any` params stay gated). Exit 42.
 //!
 //! **Verified by RUNNING**: emit host IR / native object, link the C runtime,
 //! execute — the exit code is the arithmetic result.

--- a/code/packages/rust/lang-aot/tests/wasm_memory_growth.rs
+++ b/code/packages/rust/lang-aot/tests/wasm_memory_growth.rs
@@ -1,0 +1,155 @@
+//! Twig GC completion round (Part 3): end-to-end proof that WASM linear
+//! memory actually grows past its starting single 64 KiB page.
+//!
+//! Before this round, `iir-to-wasm` hardcoded every memory-using module's
+//! `Limits` to `{ min: 1, max: Some(1) }` and never emitted a `memory.grow`
+//! call anywhere — confirmed by direct source reading, not assumed. Any
+//! program whose bump-allocated strings/arrays outgrew the first page had no
+//! path forward: `wasm-execution`'s bounds-checked `LinearMemory` would trap
+//! on the very first out-of-page write. `wasm-execution`'s `LinearMemory::grow`
+//! itself was already implemented, tested, and generic — this was purely a
+//! codegen gap on the `iir-to-wasm` side.
+//!
+//! This test compiles a REAL ALGOL 60 program (not hand-built IIR) through
+//! the full pipeline and RUNS it on the in-repo `wasm-runtime`, per this
+//! session's standing "verify by running, not just by reading" rule.
+
+use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
+use iir_to_wasm::{lower_iir_to_wasm, IIRWasmConfig};
+use lang_aot::{compile_source_to_wasm, Language};
+use wasm_runtime::WasmRuntime;
+
+/// `alloc_one` bump-allocates a fresh `integer array[1:2000]` every call:
+/// 2000 elements * 8 bytes + an 8-byte length header = 16,008 bytes. Calling
+/// it 40 times over reserves ~640 KB total — ten times the module's starting
+/// single 64 KiB page — so this only succeeds if `$__ensure_capacity`'s
+/// `memory.grow` calls actually fire and linear memory genuinely grows past
+/// the old hardcoded cap. Before this fix, the fourth or fifth call's
+/// element write would land past the single declared page and trap.
+///
+/// Each call's array is otherwise unreachable once the call returns (this
+/// backend's bump allocator never frees, matching the Part 1/2 precedent:
+/// reclamation for WASM linear-memory strings/arrays is a separate, later
+/// piece of this round, not yet built) — the point here is purely that
+/// growing past one page works and execution continues correctly, not that
+/// the memory is reclaimed.
+#[test]
+fn algol_repeated_array_allocation_grows_past_one_page_and_keeps_running() {
+    let source = "begin integer i, result; \
+                  procedure allocone; \
+                  begin integer array a[1:2000]; a[1] := 1 end; \
+                  for i := 1 step 1 until 40 do allocone(); \
+                  result := 42 end";
+    let bytes = compile_source_to_wasm(Language::Algol60, source, "algol_growth")
+        .expect("ALGOL repeated array allocation should emit wasm");
+
+    let rt = WasmRuntime::new();
+    let result = rt
+        .load_and_run(&bytes, "main", &[])
+        .expect("wasm must grow linear memory via memory.grow instead of trapping");
+    assert_eq!(
+        result,
+        vec![42],
+        "execution must continue correctly across multiple memory.grow calls"
+    );
+}
+
+/// Same shape, but through the `str_concat` bump-allocation path instead of
+/// `alloc_array` — proves the fix isn't array-specific.
+///
+/// No frontend source string forces this reliably: ALGOL 60 has no
+/// source-level concatenation operator, and every source-level string
+/// assignment this backend can fold (a literal, or a value provably constant
+/// across a loop) takes the compile-time-literal fast path with zero runtime
+/// allocation — confirmed empirically while writing this test (an ALGOL
+/// "branch-selected between two literals" loop still folded to pre-laid-down
+/// static blocks, never re-allocating per iteration). So this builds IIR by
+/// hand, mirroring `str_literal_call_arg.rs`'s
+/// `runtime_str_concat_allocates_without_array_ops`: a callee whose
+/// `str_concat` operates on its own PARAMETERS (never foldable, since a
+/// function body can't know its caller's literal) allocates a genuine fresh
+/// `[i32 len][bytes]` block on every call, called here in a loop instead of
+/// once. Each call concatenates "HE"+"LLO" = 5 bytes + 4-byte header = 9
+/// bytes; 8000 calls reserve 72,000 bytes — past the single starting 64 KiB
+/// page.
+fn many_str_concat_calls_module(iterations: i64) -> IIRModule {
+    let join = IIRFunction::new(
+        "join",
+        vec![("a".into(), "str".into()), ("b".into(), "str".into())],
+        "str",
+        vec![
+            IIRInstr::new(
+                "str_concat",
+                Some("joined".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())],
+                "str",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("joined".into())], "str"),
+        ],
+    );
+    let main = IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            IIRInstr::new("const", Some("i".into()), vec![Operand::Int(0)], "i64"),
+            IIRInstr::new("const", Some("bound".into()), vec![Operand::Int(iterations)], "i64"),
+            IIRInstr::new("const", Some("one".into()), vec![Operand::Int(1)], "i64"),
+            IIRInstr::new("label", None, vec![Operand::Var("top".into())], "void"),
+            IIRInstr::new(
+                "cmp_ge",
+                Some("done_cond".into()),
+                vec![Operand::Var("i".into()), Operand::Var("bound".into())],
+                "i64",
+            ),
+            IIRInstr::new(
+                "jmp_if_true",
+                None,
+                vec![Operand::Var("done_cond".into()), Operand::Var("done".into())],
+                "void",
+            ),
+            IIRInstr::new("str_const", Some("he".into()), vec![Operand::Str("HE".into())], "str"),
+            IIRInstr::new("str_const", Some("llo".into()), vec![Operand::Str("LLO".into())], "str"),
+            IIRInstr::new(
+                "call",
+                Some("word".into()),
+                vec![Operand::Var("join".into()), Operand::Var("he".into()), Operand::Var("llo".into())],
+                "str",
+            ),
+            IIRInstr::new(
+                "add",
+                Some("i".into()),
+                vec![Operand::Var("i".into()), Operand::Var("one".into())],
+                "i64",
+            ),
+            IIRInstr::new("jmp", None, vec![Operand::Var("top".into())], "void"),
+            IIRInstr::new("label", None, vec![Operand::Var("done".into())], "void"),
+            IIRInstr::new("const", Some("z".into()), vec![Operand::Int(42)], "i64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("z".into())], "i64"),
+        ],
+    );
+    IIRModule {
+        name: "many_str_concat_calls".into(),
+        functions: vec![join, main],
+        entry_point: Some("main".into()),
+        language: "test".into(),
+        exports: vec![],
+        imports: vec![],
+    }
+}
+
+#[test]
+fn repeated_runtime_str_concat_grows_past_one_page_and_keeps_running() {
+    let module = many_str_concat_calls_module(8000);
+    let wasm = lower_iir_to_wasm(&module, &IIRWasmConfig::default()).expect("lowering failed");
+    let bytes = iir_to_wasm::encode_module(&wasm).expect("encoding failed");
+
+    let result = WasmRuntime::new()
+        .load_and_run(&bytes, "main", &[])
+        .expect("repeated runtime str_concat must grow linear memory instead of trapping");
+    assert_eq!(
+        result,
+        vec![42],
+        "execution must continue correctly across multiple memory.grow calls"
+    );
+}

--- a/code/specs/AOT00-T1x-wasm-linear-memory-growth.md
+++ b/code/specs/AOT00-T1x-wasm-linear-memory-growth.md
@@ -1,0 +1,127 @@
+# AOT00-T1x — WASM linear-memory growth for strings/arrays
+
+> Status: stage 1 of 2 complete (growth). Stage 2 (reclamation) is a
+> separate, larger follow-up — see §4.
+
+Twig GC completion round, Part 3 of 3 (Part 1: `vm-core`'s shared `FlatHeap`
+reroute, AOT00-T1v; Part 2: `iir-to-llvm`'s `gc_live_bytes` + `alloc_bytes`/
+`alloc_array` fix). This part closes a gap distinct from both: `W04`'s
+struct-heap collector already gave WASM's *cons/record/closure* values (a
+`WasmValue::Ref` — a `Vec` index) real reclamation. Twig's *other* WASM heap
+— `iir-to-wasm`'s bump-allocated linear-memory strings and E5 arrays — is a
+different representation entirely (a plain `i32` byte offset, no runtime
+type tag), and had no growth path at all.
+
+## 1. The confirmed bug
+
+Direct source reading (not doc comments, not assumption) found, before this
+change:
+
+- Every memory-using module declared `Limits { min: 1, max: Some(1) }`
+  (`iir-to-wasm/src/lower.rs`, module assembly) — a single, hardcoded 64 KiB
+  page, with no way to ask for more.
+- `iir-to-wasm` never emitted a `memory.grow` (0x40) or `memory.size` (0x3F)
+  instruction anywhere. The opcodes existed in the `wasm-opcodes` metadata
+  table but had no encoder in `iir-to-wasm/src/codegen.rs`.
+- The four bump-allocation call sites — `alloc_array`, `str_concat`'s
+  runtime path, `str_slice`'s runtime path, and `call_builtin "input_str"` —
+  all wrote directly at the current `__array_bump` offset with no capacity
+  check.
+
+The result: any Twig (or BASIC/ALGOL/etc.) program whose cumulative
+string/array data crossed 64 KiB would hit `wasm-execution`'s bounds-checked
+`LinearMemory` and trap on the very first out-of-page write. `wasm-execution`
+side was already correct — `LinearMemory::grow` is implemented, tested, and
+spec-compliant (resizes the backing `Vec`, enforces the 65536-page / 4 GiB
+ceiling, returns `-1` on failure) — this was purely a codegen gap: nothing
+ever asked it to grow.
+
+## 2. Fix: a shared `$__ensure_capacity` helper, emitted in-module
+
+Mirrors the shape this backend already uses for `$__str_eq`/`$__str_cmp`: a
+self-contained WASM function, emitted once per module (gated by the same
+`uses_memory` flag that already triggers the `__array_bump` global and the
+memory section itself), appended after all IIR-defined functions.
+
+```text
+$__ensure_capacity(needed_end: i64) -> ()
+  current_bytes = i64(memory.size()) * 65536
+  if needed_end > current_bytes {
+    delta_bytes = needed_end - current_bytes
+    delta_pages = (delta_bytes + 65535) / 65536      ;; round up
+    if i32(memory.grow(i32(delta_pages))) == -1 { unreachable }  ;; OOM
+  }
+```
+
+`needed_end` is "one byte past the last byte this write is about to touch"
+— computed at each of the four call sites from values already on hand
+(the current bump offset plus the block's size), then passed to
+`$__ensure_capacity` **before** any store/`memory.copy` touches that region:
+
+- `alloc_array`: `handle + 8 (i64 length header) + count * elem_size`.
+- `str_concat` (runtime path): `bump + 4 (i32 length header) + len(a) + len(b)`.
+- `str_slice` (runtime path): `bump + 4 + (end - start)`.
+- `call_builtin "input_str"`: `bump + 4 + INPUT_STR_MAX` (256).
+
+The module's own declared `Limits.max` was raised from the hardcoded `1` to
+`65536` (the WASM spec's absolute page ceiling) — the same ceiling
+`LinearMemory::grow` already enforces, so the `unreachable` in
+`$__ensure_capacity` is reached only on genuine, spec-legitimate exhaustion,
+not a self-inflicted cap.
+
+Two opcode encoders were added to `iir-to-wasm/src/codegen.rs`:
+`encode_memory_size()` (0x3F 0x00) and `encode_memory_grow()` (0x40 0x00) —
+the trailing `0x00` in both is the reserved memory-index byte (this backend
+only ever declares one memory).
+
+## 3. Verification
+
+- `iir-to-wasm/tests/test_backend.rs`:
+  `alloc_array_module_declares_growable_memory_not_capped_at_one_page`
+  (asserts `Limits { min: 1, max: Some(65536) }`) and
+  `alloc_array_emits_memory_grow_and_memory_size_opcodes` (asserts the
+  appended `$__ensure_capacity` body actually contains both opcodes).
+- `lang-aot/tests/wasm_memory_growth.rs` — genuine executed end-to-end
+  proof, per this session's "verify by running, not just by reading" rule:
+  - `algol_repeated_array_allocation_grows_past_one_page_and_keeps_running`
+    — a real ALGOL 60 program (`allocone()` called 40 times in a loop,
+    each call bump-allocating a fresh 2000-element `integer array`) reserves
+    ~640 KB total (ten pages) and must still return the right value.
+  - `repeated_runtime_str_concat_grows_past_one_page_and_keeps_running` —
+    hand-built IIR (no ALGOL source could force this: every source-level
+    string operation this backend can fold, ALGOL folds — confirmed
+    empirically while writing this test, see the test's own doc comment),
+    calling a function whose `str_concat` operates on its own parameters
+    (never foldable) 8000 times, reserving ~72 KB.
+  - **Both tests were confirmed to actually catch the regression**: with
+    the `Limits.max` reverted to `1`, both fail with `TrapError: unreachable
+    instruction executed` — the exact failure this fix closes.
+- Full existing `iir-to-wasm`/`wasm-execution`/`lang-aot` suites, including
+  `lang_matrix.rs`'s complete WASM column, stay green (the only failures
+  present are the 5 pre-existing CLR/JVM/LLVM toolchain gaps this session's
+  `babysit-pr` runs already treat as known/ignored, unrelated to WASM).
+- `cargo clippy -p iir-to-wasm -p lang-aot --all-targets -- -D warnings`
+  clean (also fixed one pre-existing, unrelated `doc_lazy_continuation`
+  failure in `lang-aot/tests/e6d2b_dynamic_arith.rs`, hit only because it's
+  in the same clippy invocation — not touched otherwise).
+
+## 4. Explicitly out of scope here (stage 2, tracked as a follow-up)
+
+The user's explicit direction for WASM's linear-memory strings/arrays was
+**"build full reclamation now,"** not just raise the cap. This stage closes
+the growth half of that (nothing could grow at all before this change —
+fixing that first is a genuine, real, independently-shippable improvement:
+programs that would previously always trap past 64 KiB now run correctly).
+It deliberately does **not** yet include:
+
+- A free-list allocator (reused blocks after logical "end of life") — today
+  every allocation is still pure bump; nothing is ever freed. Memory only
+  grows, never shrinks or reuses.
+- A conservative mark-sweep collector over linear memory (treating in-scope
+  `i32` locals/globals as candidate pointers into the arena, per the design
+  sketched in the original plan for this round).
+
+This is a real, load-bearing scope narrowing versus the original ask, and is
+called out explicitly rather than silently dropped: stage 2 (free-list +
+collector) is the necessary next piece of this same round, not a permanently
+deferred item.

--- a/code/specs/AOT00-T1x-wasm-linear-memory-growth.md
+++ b/code/specs/AOT00-T1x-wasm-linear-memory-growth.md
@@ -64,10 +64,19 @@ $__ensure_capacity(needed_end: i64) -> ()
 - `call_builtin "input_str"`: `bump + 4 + INPUT_STR_MAX` (256).
 
 The module's own declared `Limits.max` was raised from the hardcoded `1` to
-`65536` (the WASM spec's absolute page ceiling) — the same ceiling
-`LinearMemory::grow` already enforces, so the `unreachable` in
-`$__ensure_capacity` is reached only on genuine, spec-legitimate exhaustion,
-not a self-inflicted cap.
+a new `IIRWasmConfig::max_memory_pages` field (default `1024` pages = 64
+MiB), clamped to `65536` (the WASM spec's absolute page ceiling) regardless
+of what's configured. **Security review caught that unconditionally jumping
+straight to the 4 GiB spec ceiling would be a real regression**: this
+backend's allocator is bump-only and never frees (stage 2 below), so an
+unbounded cap combined with, say, a simple `input_str`-in-a-loop program
+would let any long-running or malformed module monotonically grow real
+host-committed memory toward 4 GiB with no backstop — where before this fix
+it hit a hard (if accidental) 64 KiB trap almost immediately. Making the cap
+a real, clamped, caller-configured knob keeps `$__ensure_capacity`'s
+`unreachable` reachable on a much smaller, sane bound by default, while
+still letting a caller that genuinely needs more (or needs untrusted-input
+hardening down to an even smaller bound) ask for it explicitly.
 
 Two opcode encoders were added to `iir-to-wasm/src/codegen.rs`:
 `encode_memory_size()` (0x3F 0x00) and `encode_memory_grow()` (0x40 0x00) —
@@ -104,6 +113,16 @@ only ever declares one memory).
   clean (also fixed one pre-existing, unrelated `doc_lazy_continuation`
   failure in `lang-aot/tests/e6d2b_dynamic_arith.rs`, hit only because it's
   in the same clippy invocation — not touched otherwise).
+- `/security-review` (Rust-specialist sub-agent): found one MEDIUM
+  (unconditional 4 GiB memory ceiling with no configurable bound and no
+  reclamation — fixed via `IIRWasmConfig::max_memory_pages`, see above) and
+  one LOW/INFO (non-overflow-checked `needed_end` arithmetic — confirmed
+  pre-existing, not a regression introduced by this diff, and already
+  covered by the same documented trust-boundary trade-off the rest of this
+  backend's bump-allocation arithmetic accepts). Two new tests
+  (`max_memory_pages_is_clamped_to_the_wasm_spec_ceiling`,
+  `max_memory_pages_smaller_than_default_is_honored`) prove the clamp is
+  real in both directions.
 
 ## 4. Explicitly out of scope here (stage 2, tracked as a follow-up)
 


### PR DESCRIPTION
## Summary

Twig GC completion round, Part 3 stage 1 (of the three-part plan: vm-core reroute → LLVM alloc fix → this WASM fix).

- Every memory-using WASM module hardcoded `Limits { min: 1, max: Some(1) }` and `iir-to-wasm` never emitted a `memory.grow` instruction anywhere, so any program whose bump-allocated strings/arrays (`alloc_array`, runtime `str_concat`/`str_slice`, `input_str`) crossed 64 KiB would trap on the first out-of-page write. `wasm-execution`'s `LinearMemory::grow` was already correct/tested — this was purely a codegen gap.
- Adds a shared `$__ensure_capacity(needed_end: i64)` in-module helper (mirrors the existing `$__str_eq`/`$__str_cmp` pattern) that emits real `memory.grow` calls, wired into all four bump-allocation sites before they write.
- Adds `IIRWasmConfig::max_memory_pages` (default 1024 pages = 64 MiB, clamped to the WASM spec's 65536-page ceiling) as the module's declared memory max — **not** an unconditional jump to the 4 GiB ceiling, per a security-review finding: this backend's allocator never frees, so an unbounded cap would let a long-running/malformed module consume real host memory with no backstop.
- Two rounds of `/security-review` (Rust specialist): round 1 caught the unconditional-4GiB-ceiling DoS risk (fixed via the configurable cap); round 2 caught a `max_memory_pages: 0` edge case that could produce a spec-invalid `Limits{min:1,max:Some(0)}` (fixed via `.clamp(1, ..)`).
- Full spec writeup: `code/specs/AOT00-T1x-wasm-linear-memory-growth.md`, including the explicit stage-2 scope (free-list allocator + conservative collector) **not** covered here — this is the growth half of the user's "build full reclamation now" ask; stage 2 is a tracked, real follow-up, not silently dropped.

## Test plan

- [x] `cargo test -p iir-to-wasm -p wasm-execution -p lang-aot` — full existing suites green
- [x] New codegen-shape tests (`iir-to-wasm/tests/test_backend.rs`): growable `Limits`, clamp-up (oversized config), clamp-down (undersized config), zero-floor (degenerate config), `memory.grow`/`memory.size` opcode presence
- [x] New genuinely-executed end-to-end tests (`lang-aot/tests/wasm_memory_growth.rs`): a real ALGOL 60 program crossing 10 pages via repeated array allocation, and hand-built IIR crossing 2 pages via repeated runtime `str_concat` calls — **both confirmed to actually trap when the fix is reverted**, proving the tests are meaningful
- [x] Full `lang-aot --test lang_matrix` — only the 5 pre-existing, known CLR/JVM/LLVM toolchain failures remain (confirmed present on pristine `origin/main`, unrelated to WASM)
- [x] `cargo clippy -p iir-to-wasm -p lang-aot --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)