### PR TITLE
feat(adj): harden process containment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,22 @@ jobs:
           python3 -m unittest discover -s code/scripts/tests -p 'test_phy00_phy01_fixtures.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_adj_stdlib_report.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_adj_stdlib_manifest.py'
+          ADJ_CGROUP_ORIGINAL=$(awk -F: '$1 == "0" {print $3}' /proc/self/cgroup)
+          ADJ_CGROUP_ROOT="/sys/fs/cgroup/adj-provenance-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ADJ_CGROUP_SHELL_PID=$$
+          cleanup_adj_cgroup() {
+            printf '%s\n' "$ADJ_CGROUP_SHELL_PID" | sudo tee "/sys/fs/cgroup${ADJ_CGROUP_ORIGINAL}/cgroup.procs" >/dev/null
+            sudo rmdir "$ADJ_CGROUP_ROOT"
+          }
+          sudo mkdir "$ADJ_CGROUP_ROOT"
+          sudo chown "$(id -u):$(id -g)" \
+            "$ADJ_CGROUP_ROOT" \
+            "$ADJ_CGROUP_ROOT/cgroup.procs" \
+            "$ADJ_CGROUP_ROOT/cgroup.threads" \
+            "$ADJ_CGROUP_ROOT/cgroup.subtree_control"
+          printf '%s\n' "$ADJ_CGROUP_SHELL_PID" | sudo tee "$ADJ_CGROUP_ROOT/cgroup.procs" >/dev/null
+          export ADJ_PROVENANCE_CGROUP_ROOT="$ADJ_CGROUP_ROOT"
+          trap cleanup_adj_cgroup EXIT
           python3 -m unittest discover -s code/scripts/tests -p 'test_adj_stdlib_provenance.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_onvif_origin_fixtures.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_schema.py'
@@ -122,6 +138,9 @@ jobs:
             --formula-inventory-binary code/packages/rust/target/debug/adj-formula-inventory \
             --formula-audit-binary code/packages/rust/target/debug/adj-formula-audit \
             > /tmp/adj-stdlib-provenance.json
+          cleanup_adj_cgroup
+          trap - EXIT
+          unset ADJ_PROVENANCE_CGROUP_ROOT
           (cd code/programs/go/capability-cage-generator && go test ./...)
           (cd code/packages/go/ca-capability-analyzer && go test ./...)
           (cd code/packages/go/capability-cage && go test ./...)
@@ -360,11 +379,11 @@ jobs:
       - name: Test ADJ Windows Job containment
         if: runner.os == 'Windows'
         shell: pwsh
-        run: python -m unittest discover -s code/scripts/tests -p test_adj_stdlib_provenance.py -k windows_job -k process_tree -k windows_containment -k job_close_root
+        run: python -m unittest discover -s code/scripts/tests -p test_adj_stdlib_provenance.py -k windows_job -k process_tree -k windows_containment -k job_close_root -k raw_pipe_close -k stuck_stdout -k stuck_drain
 
-      - name: Test ADJ POSIX process-group containment
+      - name: Test ADJ macOS strict-containment boundary
         if: runner.os == 'macOS'
-        run: python3 -m unittest discover -s code/scripts/tests -p test_adj_stdlib_provenance.py -k posix_process -k process_tree
+        run: python3 -m unittest discover -s code/scripts/tests -p test_adj_stdlib_provenance.py -k posix_process -k process_tree -k guardian -k drain -k raw_pipe_close
 
       - name: Install uv
         if: needs.detect.outputs.needs_python == 'true'

--- a/code/scripts/adj_process_guardian.py
+++ b/code/scripts/adj_process_guardian.py
@@ -1,0 +1,589 @@
+#!/usr/bin/env python3
+"""Linux cgroup-v2 guardian for ADJ trusted helper commands.
+
+The verifier owns the write end of a private control pipe.  EOF requests the
+same bounded cleanup path used after normal command exit, so verifier death
+does not strand descendants that leave the command's original process group.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import errno
+import json
+import os
+import selectors
+import signal
+import sys
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+CGROUP2_SUPER_MAGIC = 0x63677270
+GUARDIAN_CONTRACT = "adj-stdlib/process-guardian/v1"
+MAX_CONTROL_BYTES = 4096
+PR_SET_CHILD_SUBREAPER = 36
+POSIX_SIGKILL = getattr(signal, "SIGKILL", 9)
+
+
+class GuardianError(RuntimeError):
+    """A fail-closed containment setup or cleanup error."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        cleanup_causes: tuple[GuardianError, ...] = (),
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.cleanup_causes = cleanup_causes
+
+    def with_cleanup(self, *causes: GuardianError) -> GuardianError:
+        return GuardianError(
+            self.code,
+            str(self),
+            cleanup_causes=(*self.cleanup_causes, *causes),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "cleanup_causes": [cause.to_dict() for cause in self.cleanup_causes],
+            "error": str(self),
+            "error_code": self.code,
+        }
+
+
+def _append_failure(
+    primary: GuardianError | None, failure: GuardianError
+) -> GuardianError:
+    return failure if primary is None else primary.with_cleanup(failure)
+
+
+def _guardian_failure(
+    error: BaseException, *, code: str, message: str
+) -> GuardianError:
+    if isinstance(error, GuardianError):
+        return error
+    failure = GuardianError(code, message)
+    failure.__cause__ = error
+    return failure
+
+
+@dataclass(frozen=True)
+class CgroupHandle:
+    root_fd: int
+    child_fd: int
+    name: str
+
+
+class _LinuxStatFs(ctypes.Structure):
+    _fields_ = [
+        ("f_type", ctypes.c_long),
+        ("f_bsize", ctypes.c_long),
+        ("f_blocks", ctypes.c_ulong),
+        ("f_bfree", ctypes.c_ulong),
+        ("f_bavail", ctypes.c_ulong),
+        ("f_files", ctypes.c_ulong),
+        ("f_ffree", ctypes.c_ulong),
+        ("f_fsid", ctypes.c_int * 2),
+        ("f_namelen", ctypes.c_long),
+        ("f_frsize", ctypes.c_long),
+        ("f_flags", ctypes.c_long),
+        ("f_spare", ctypes.c_long * 4),
+    ]
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def _open_at(root_fd: int, name: str, flags: int) -> int:
+    return os.open(
+        name,
+        flags | os.O_CLOEXEC | getattr(os, "O_NOFOLLOW", 0),
+        dir_fd=root_fd,
+    )
+
+
+def _read_small_at(root_fd: int, name: str) -> bytes:
+    try:
+        descriptor = _open_at(root_fd, name, os.O_RDONLY)
+        try:
+            value = os.read(descriptor, MAX_CONTROL_BYTES + 1)
+        finally:
+            os.close(descriptor)
+    except OSError as error:
+        raise GuardianError(
+            "CGROUP_CONTROL_READ_FAILED",
+            f"could not read delegated cgroup control {name}",
+        ) from error
+    if len(value) > MAX_CONTROL_BYTES:
+        raise GuardianError(
+            "CGROUP_CONTROL_OVERSIZE",
+            f"delegated cgroup control {name} exceeds its byte ceiling",
+        )
+    return value
+
+
+def _write_small_at(root_fd: int, name: str, value: bytes) -> None:
+    try:
+        descriptor = _open_at(root_fd, name, os.O_WRONLY)
+        try:
+            written = os.write(descriptor, value)
+        finally:
+            os.close(descriptor)
+    except OSError as error:
+        raise GuardianError(
+            "CGROUP_CONTROL_WRITE_FAILED",
+            f"could not write delegated cgroup control {name}",
+        ) from error
+    if written != len(value):
+        raise GuardianError(
+            "CGROUP_CONTROL_SHORT_WRITE",
+            f"delegated cgroup control {name} accepted a short write",
+        )
+
+
+def cgroup_is_empty(raw: bytes) -> bool:
+    try:
+        lines = raw.decode("ascii", errors="strict").splitlines()
+    except UnicodeDecodeError as error:
+        raise GuardianError(
+            "CGROUP_EVENTS_INVALID", "cgroup.events is not strict ASCII"
+        ) from error
+    populated: list[str] = []
+    for line in lines:
+        fields = line.split()
+        if len(fields) != 2:
+            raise GuardianError(
+                "CGROUP_EVENTS_INVALID", "cgroup.events contains an invalid field"
+            )
+        if fields[0] == "populated":
+            populated.append(fields[1])
+    if len(populated) != 1 or populated[0] not in {"0", "1"}:
+        raise GuardianError(
+            "CGROUP_EVENTS_INVALID",
+            "cgroup.events must contain one exact populated field",
+        )
+    return populated[0] == "0"
+
+
+def validate_cgroup2_descriptor(descriptor: int) -> None:
+    result = _LinuxStatFs()
+    library = ctypes.CDLL(None, use_errno=True)
+    if library.fstatfs(ctypes.c_int(descriptor), ctypes.byref(result)) != 0:
+        selected_errno = ctypes.get_errno()
+        raise GuardianError(
+            "CGROUP_DELEGATION_INVALID",
+            "delegated cgroup root filesystem could not be identified",
+        ) from OSError(selected_errno, os.strerror(selected_errno))
+    if result.f_type != CGROUP2_SUPER_MAGIC:
+        raise GuardianError(
+            "CGROUP_DELEGATION_INVALID",
+            "delegated command root is not a cgroup v2 filesystem",
+        )
+
+
+def _enable_subreaper() -> None:
+    library = ctypes.CDLL(None, use_errno=True)
+    result = library.prctl(
+        ctypes.c_int(PR_SET_CHILD_SUBREAPER),
+        ctypes.c_ulong(1),
+        ctypes.c_ulong(0),
+        ctypes.c_ulong(0),
+        ctypes.c_ulong(0),
+    )
+    if result != 0:
+        selected_errno = ctypes.get_errno()
+        raise GuardianError(
+            "SUBREAPER_UNAVAILABLE", "guardian could not become a child subreaper"
+        ) from OSError(selected_errno, os.strerror(selected_errno))
+
+
+def create_command_cgroup(root_fd: int) -> CgroupHandle:
+    validate_cgroup2_descriptor(root_fd)
+    name = f"adj-provenance-{os.getpid()}-{time.monotonic_ns():x}"
+    created = False
+    try:
+        os.mkdir(name, mode=0o700, dir_fd=root_fd)
+        created = True
+        child_fd = _open_at(
+            root_fd,
+            name,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+        )
+    except OSError as error:
+        primary = GuardianError(
+            "CGROUP_CREATE_FAILED", "fresh command cgroup could not be created"
+        )
+        primary.__cause__ = error
+        if created:
+            try:
+                os.rmdir(name, dir_fd=root_fd)
+            except OSError as rollback_error:
+                primary = primary.with_cleanup(
+                    _guardian_failure(
+                        rollback_error,
+                        code="CGROUP_ROLLBACK_REMOVE_FAILED",
+                        message="partial command cgroup could not be removed",
+                    )
+                )
+        raise primary from error
+    try:
+        for control, flags in (
+            ("cgroup.kill", os.O_WRONLY),
+            ("cgroup.procs", os.O_WRONLY),
+            ("cgroup.events", os.O_RDONLY),
+        ):
+            descriptor = _open_at(child_fd, control, flags)
+            os.close(descriptor)
+        if not cgroup_is_empty(_read_small_at(child_fd, "cgroup.events")):
+            raise GuardianError(
+                "CGROUP_CREATE_FAILED", "fresh command cgroup is already populated"
+            )
+        return CgroupHandle(root_fd=root_fd, child_fd=child_fd, name=name)
+    except (GuardianError, OSError) as error:
+        primary = _guardian_failure(
+            error,
+            code="CGROUP_CONTROL_VALIDATION_FAILED",
+            message="fresh command cgroup controls could not be validated",
+        )
+        try:
+            os.close(child_fd)
+        except OSError as rollback_error:
+            primary = primary.with_cleanup(
+                _guardian_failure(
+                    rollback_error,
+                    code="CGROUP_ROLLBACK_CLOSE_FAILED",
+                    message="partial command cgroup descriptor could not be closed",
+                )
+            )
+        try:
+            os.rmdir(name, dir_fd=root_fd)
+        except OSError as rollback_error:
+            primary = primary.with_cleanup(
+                _guardian_failure(
+                    rollback_error,
+                    code="CGROUP_ROLLBACK_REMOVE_FAILED",
+                    message="partial command cgroup could not be removed",
+                )
+            )
+        raise primary from error
+
+
+def _reap_children(deadline: float) -> bool:
+    while True:
+        if time.monotonic() >= deadline:
+            return False
+        try:
+            child, _status = os.waitpid(-1, os.WNOHANG)
+        except ChildProcessError:
+            return True
+        if child <= 0:
+            return True
+
+
+def cleanup_command_cgroup(
+    cgroup: CgroupHandle,
+    deadline: float,
+    *,
+    process_group: int | None = None,
+) -> None:
+    cleanup_error: GuardianError | None = None
+    try:
+        _write_small_at(cgroup.child_fd, "cgroup.kill", b"1\n")
+    except GuardianError as error:
+        cleanup_error = error
+    if process_group is not None:
+        try:
+            os.killpg(process_group, POSIX_SIGKILL)
+        except OSError as error:
+            if error.errno != errno.ESRCH:
+                failure = GuardianError(
+                    "PROCESS_GROUP_KILL_FAILED", "supplemental process-group termination failed"
+                )
+                failure.__cause__ = error
+                cleanup_error = _append_failure(cleanup_error, failure)
+    empty = False
+    while time.monotonic() < deadline:
+        try:
+            empty = cgroup_is_empty(_read_small_at(cgroup.child_fd, "cgroup.events"))
+        except GuardianError as error:
+            cleanup_error = _append_failure(cleanup_error, error)
+            break
+        if empty:
+            break
+        time.sleep(0.01)
+    try:
+        os.close(cgroup.child_fd)
+    except OSError as error:
+        failure = GuardianError(
+            "CGROUP_DESCRIPTOR_CLOSE_FAILED",
+            "command cgroup descriptor could not be closed",
+        )
+        failure.__cause__ = error
+        cleanup_error = _append_failure(cleanup_error, failure)
+    if empty:
+        try:
+            os.rmdir(cgroup.name, dir_fd=cgroup.root_fd)
+        except OSError as error:
+            failure = GuardianError(
+                "CGROUP_REMOVE_FAILED",
+                "empty command cgroup could not be removed",
+            )
+            failure.__cause__ = error
+            cleanup_error = _append_failure(cleanup_error, failure)
+    if not empty:
+        cleanup_error = _append_failure(
+            cleanup_error,
+            GuardianError(
+                "CGROUP_CLEANUP_TIMEOUT",
+                "command cgroup did not become empty before the cleanup deadline",
+            ),
+        )
+    if cleanup_error is not None:
+        raise cleanup_error
+
+
+def _child_exec(command: Sequence[str], gate_fd: int) -> None:
+    try:
+        os.setsid()
+        if os.read(gate_fd, 1) != b"1":
+            os._exit(125)
+        os.close(gate_fd)
+        null_fd = os.open("/dev/null", os.O_RDONLY | os.O_CLOEXEC)
+        os.dup2(null_fd, 0)
+        if null_fd > 2:
+            os.close(null_fd)
+        os.execvpe(command[0], list(command), os.environ.copy())
+    except BaseException:  # noqa: BLE001 - a pre-exec child cannot unwind safely
+        os._exit(127)
+
+
+def _wait_status_returncode(status: int) -> int:
+    return os.waitstatus_to_exitcode(status)
+
+
+def _monitor(control_fd: int, child_pid: int) -> tuple[int | None, bool]:
+    selected = selectors.DefaultSelector()
+    os.set_blocking(control_fd, False)
+    selected.register(control_fd, selectors.EVENT_READ)
+    try:
+        while True:
+            waited, status = os.waitpid(child_pid, os.WNOHANG)
+            if waited == child_pid:
+                return _wait_status_returncode(status), False
+            for _key, _mask in selected.select(0.05):
+                try:
+                    control = os.read(control_fd, 1)
+                except BlockingIOError:
+                    continue
+                if control != b"":
+                    raise GuardianError(
+                        "CONTROL_PROTOCOL_INVALID",
+                        "guardian control pipe accepts EOF only",
+                    )
+                return None, True
+    finally:
+        selected.close()
+
+
+def supervise(
+    command: Sequence[str],
+    *,
+    control_fd: int,
+    status_fd: int | None = None,
+    cgroup_root: str,
+    cleanup_timeout_seconds: float,
+) -> dict[str, Any]:
+    if not sys.platform.startswith("linux") or not hasattr(os, "fork"):
+        raise GuardianError(
+            "PLATFORM_UNSUPPORTED", "strict process guarding requires Linux"
+        )
+    if not command:
+        raise GuardianError("COMMAND_INVALID", "guarded command must not be empty")
+    if cleanup_timeout_seconds <= 0:
+        raise GuardianError(
+            "CLEANUP_BOUND_INVALID", "guardian cleanup bound must be positive"
+        )
+    root_flags = (
+        os.O_RDONLY
+        | os.O_CLOEXEC
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    try:
+        root_fd = os.open(cgroup_root, root_flags)
+    except OSError as error:
+        raise GuardianError(
+            "CGROUP_DELEGATION_INVALID", "delegated cgroup root could not be opened"
+        ) from error
+    cgroup: CgroupHandle | None = None
+    gate_read = -1
+    gate_write = -1
+    child_pid: int | None = None
+    returncode: int | None = None
+    verifier_gone = False
+    primary_error: GuardianError | None = None
+    try:
+        _enable_subreaper()
+        cgroup = create_command_cgroup(root_fd)
+        gate_read, gate_write = os.pipe2(os.O_CLOEXEC)
+        child_pid = os.fork()
+        if child_pid == 0:
+            os.close(gate_write)
+            os.close(control_fd)
+            if status_fd is not None:
+                os.close(status_fd)
+            os.close(root_fd)
+            _child_exec(command, gate_read)
+            os._exit(127)
+        os.close(gate_read)
+        gate_read = -1
+        _write_small_at(
+            cgroup.child_fd, "cgroup.procs", f"{child_pid}\n".encode("ascii")
+        )
+        if os.write(gate_write, b"1") != 1:
+            raise GuardianError(
+                "CHILD_RELEASE_FAILED", "contained command could not be released"
+            )
+        os.close(gate_write)
+        gate_write = -1
+        returncode, verifier_gone = _monitor(control_fd, child_pid)
+    except GuardianError as error:
+        primary_error = error
+    except OSError as error:
+        primary_error = GuardianError(
+            "GUARDIAN_RUNTIME_FAILED", "guardian process operation failed"
+        )
+        primary_error.__cause__ = error
+    finally:
+        cleanup_deadline = time.monotonic() + cleanup_timeout_seconds
+        for descriptor in (gate_read, gate_write):
+            if descriptor >= 0:
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
+        if cgroup is not None:
+            try:
+                cleanup_command_cgroup(
+                    cgroup,
+                    cleanup_deadline,
+                    process_group=child_pid if returncode is None else None,
+                )
+            except GuardianError as cleanup_error:
+                primary_error = cleanup_error.with_cleanup(
+                    *((primary_error,) if primary_error is not None else ())
+                )
+        if child_pid is not None:
+            while True:
+                try:
+                    waited, status = os.waitpid(child_pid, os.WNOHANG)
+                except ChildProcessError:
+                    break
+                if waited == child_pid:
+                    if returncode is None:
+                        returncode = _wait_status_returncode(status)
+                    break
+                if time.monotonic() >= cleanup_deadline:
+                    break
+                time.sleep(0.01)
+            if returncode is None:
+                primary_error = _append_failure(
+                    primary_error,
+                    GuardianError(
+                        "ROOT_REAP_FAILED",
+                        "guarded root was not reaped before the deadline",
+                    ),
+                )
+        if not _reap_children(cleanup_deadline):
+            primary_error = _append_failure(
+                primary_error,
+                GuardianError(
+                    "ADOPTED_REAP_TIMEOUT",
+                    "adopted descendants were not reaped before the cleanup deadline",
+                ),
+            )
+        try:
+            os.close(root_fd)
+        except OSError as error:
+            failure = GuardianError(
+                "CGROUP_ROOT_CLOSE_FAILED",
+                "delegated cgroup root descriptor could not be closed",
+            )
+            failure.__cause__ = error
+            primary_error = _append_failure(primary_error, failure)
+    if primary_error is not None:
+        raise primary_error
+    assert returncode is not None
+    return {
+        "cleanup_confirmed": True,
+        "contract": GUARDIAN_CONTRACT,
+        "returncode": returncode,
+        "verifier_gone": verifier_gone,
+    }
+
+
+def _write_status(status_fd: int, value: dict[str, Any]) -> None:
+    raw = canonical_json_bytes(value)
+    if len(raw) > MAX_CONTROL_BYTES:
+        raise GuardianError(
+            "STATUS_OVERSIZE", "guardian status exceeds its byte ceiling"
+        )
+    if os.write(status_fd, raw) != len(raw):
+        raise GuardianError(
+            "STATUS_SHORT_WRITE", "guardian status write was incomplete"
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--control-fd", type=int, required=True)
+    parser.add_argument("--status-fd", type=int, required=True)
+    parser.add_argument("--cgroup-root", required=True)
+    parser.add_argument("--cleanup-timeout-seconds", type=float, required=True)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    command = list(args.command)
+    if command[:1] == ["--"]:
+        command = command[1:]
+    try:
+        status = supervise(
+            command,
+            control_fd=args.control_fd,
+            status_fd=args.status_fd,
+            cgroup_root=args.cgroup_root,
+            cleanup_timeout_seconds=args.cleanup_timeout_seconds,
+        )
+        exit_code = 0
+    except GuardianError as error:
+        status = {
+            "cleanup_confirmed": False,
+            "contract": GUARDIAN_CONTRACT,
+            **error.to_dict(),
+        }
+        exit_code = 125
+    try:
+        _write_status(args.status_fd, status)
+    except (GuardianError, OSError):
+        exit_code = 126
+    finally:
+        for descriptor in (args.control_fd, args.status_fd):
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/adj_stdlib_provenance.py
+++ b/code/scripts/adj_stdlib_provenance.py
@@ -16,9 +16,11 @@ import html
 import json
 import os
 import re
+import selectors
 import signal
 import stat
 import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -55,7 +57,7 @@ RECEIPT_HEADERS = {
     "etag",
     "last-modified",
 }
-LIFECYCLE_FAILURE_CONTRACT = "adj-stdlib/process-lifecycle-failure/v1"
+LIFECYCLE_FAILURE_CONTRACT = "adj-stdlib/process-lifecycle-failure/v2"
 POSIX_SIGKILL = getattr(signal, "SIGKILL", 9)
 LIFECYCLE_STAGES = frozenset(
     {
@@ -66,6 +68,8 @@ LIFECYCLE_STAGES = frozenset(
         "command.parse",
         "command.shape",
         "command.timeout",
+        "containment.configure",
+        "containment.confirm",
         "job.assign",
         "job.close",
         "job.configure",
@@ -97,6 +101,7 @@ class LifecycleFailure:
     message: str
     api: str | None = None
     error_code: int | None = None
+    status_code: str | None = None
     cleanup_causes: tuple[LifecycleFailure, ...] = ()
 
     def __post_init__(self) -> None:
@@ -113,6 +118,12 @@ class LifecycleFailure:
             or isinstance(self.error_code, bool)
         ):
             raise ValueError("lifecycle failure error code must be an integer or null")
+        if self.status_code is not None and (
+            not isinstance(self.status_code, str) or not self.status_code
+        ):
+            raise ValueError(
+                "lifecycle failure status code must be null or a non-empty string"
+            )
         if not isinstance(self.cleanup_causes, tuple) or not all(
             isinstance(cause, LifecycleFailure) for cause in self.cleanup_causes
         ):
@@ -133,6 +144,7 @@ class LifecycleFailure:
             "error_code": self.error_code,
             "message": self.message,
             "stage": self.stage,
+            "status_code": self.status_code,
         }
         if include_contract:
             result["contract"] = LIFECYCLE_FAILURE_CONTRACT
@@ -193,6 +205,7 @@ def _lifecycle_error(
     *,
     api: str | None = None,
     error_code: int | None = None,
+    status_code: str | None = None,
     cleanup_causes: Sequence[LifecycleFailure] = (),
     legacy_args: tuple[Any, ...] | None = None,
 ) -> _LifecycleError:
@@ -201,6 +214,7 @@ def _lifecycle_error(
             stage=stage,
             api=api,
             error_code=error_code,
+            status_code=status_code,
             message=message,
             cleanup_causes=tuple(cleanup_causes),
         ),
@@ -1274,6 +1288,221 @@ class _WindowsKillJob:
             self._handle = None
 
 
+class _PosixGuardian:
+    """Verifier-side handles for one external Linux cgroup guardian."""
+
+    CONTRACT = "adj-stdlib/process-guardian/v1"
+    MAX_STATUS_BYTES = 4096
+    CGROUP_ENV = "ADJ_PROVENANCE_CGROUP_ROOT"
+
+    def __init__(self, command: Sequence[str], cleanup_timeout_seconds: float) -> None:
+        if not sys.platform.startswith("linux"):
+            raise _lifecycle_error(
+                "containment.configure",
+                "strict process containment is unavailable on this POSIX platform",
+                api="cgroup.kill",
+            )
+        cgroup_root = os.environ.get(self.CGROUP_ENV)
+        if not cgroup_root or not os.path.isabs(cgroup_root):
+            raise _lifecycle_error(
+                "containment.configure",
+                f"{self.CGROUP_ENV} must name an absolute delegated cgroup v2 root",
+                api="cgroup.kill",
+            )
+        self._control_read = -1
+        self._control_write = -1
+        self._status_read = -1
+        self._status_write = -1
+        self._cleanup_requested = False
+        try:
+            self._control_read, self._control_write = os.pipe()
+            self._status_read, self._status_write = os.pipe()
+            for descriptor in (
+                self._control_read,
+                self._control_write,
+                self._status_read,
+                self._status_write,
+            ):
+                os.set_inheritable(descriptor, False)
+        except OSError:
+            self.close()
+            raise
+        guardian_path = Path(__file__).with_name("adj_process_guardian.py").resolve()
+        self.command = [
+            sys.executable,
+            os.fspath(guardian_path),
+            "--control-fd",
+            str(self._control_read),
+            "--status-fd",
+            str(self._status_write),
+            "--cgroup-root",
+            cgroup_root,
+            "--cleanup-timeout-seconds",
+            f"{cleanup_timeout_seconds:g}",
+            "--",
+            *command,
+        ]
+        self.popen_options = {
+            "pass_fds": (self._control_read, self._status_write),
+            "start_new_session": True,
+        }
+
+    def _close_owned(self, name: str) -> None:
+        descriptor = getattr(self, name)
+        if descriptor < 0:
+            return
+        setattr(self, name, -1)
+        os.close(descriptor)
+
+    def parent_started(self) -> None:
+        failures: list[OSError] = []
+        for name in ("_control_read", "_status_write"):
+            try:
+                self._close_owned(name)
+            except OSError as error:
+                failures.append(error)
+        if failures:
+            raise failures[0]
+
+    def launch_failed(self) -> None:
+        self.close()
+
+    def request_cleanup(self) -> bool:
+        if self._cleanup_requested:
+            return False
+        self._cleanup_requested = True
+        self._close_owned("_control_write")
+        return True
+
+    def read_status(self, timeout_seconds: float) -> dict[str, Any]:
+        self.request_cleanup()
+        raw = bytearray()
+        deadline = time.monotonic() + timeout_seconds
+        selected = selectors.DefaultSelector()
+        os.set_blocking(self._status_read, False)
+        selected.register(self._status_read, selectors.EVENT_READ)
+        try:
+            while len(raw) <= self.MAX_STATUS_BYTES:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0 or not selected.select(remaining):
+                    raise _lifecycle_error(
+                        "containment.confirm",
+                        (
+                            "process guardian status did not close within "
+                            f"{timeout_seconds:g} seconds"
+                        ),
+                        api="guardian.status",
+                    )
+                try:
+                    chunk = os.read(
+                        self._status_read,
+                        self.MAX_STATUS_BYTES + 1 - len(raw),
+                    )
+                except BlockingIOError:
+                    continue
+                if not chunk:
+                    break
+                raw.extend(chunk)
+        finally:
+            selected.close()
+        self._close_owned("_status_read")
+        if not raw or len(raw) > self.MAX_STATUS_BYTES:
+            raise _lifecycle_error(
+                "containment.confirm",
+                "process guardian status is missing or exceeds its byte ceiling",
+                api="guardian.status",
+            )
+        try:
+            status = json.loads(bytes(raw).decode("utf-8", errors="strict"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise _lifecycle_error(
+                "containment.confirm",
+                "process guardian status is not UTF-8 JSON",
+                api="guardian.status",
+                error_code=_os_error_code(error) if isinstance(error, OSError) else None,
+            ) from error
+        if bytes(raw) != canonical_json_bytes(status):
+            raise _lifecycle_error(
+                "containment.confirm",
+                "process guardian status is not canonical JSON",
+                api="guardian.status",
+            )
+        return status
+
+    def close(self) -> None:
+        for name in (
+            "_control_read",
+            "_control_write",
+            "_status_read",
+            "_status_write",
+        ):
+            descriptor = getattr(self, name)
+            if descriptor >= 0:
+                try:
+                    self._close_owned(name)
+                except OSError:
+                    pass
+
+
+@dataclass
+class _DrainEndpoint:
+    name: str
+    stream: Any
+    output: bytearray
+    limit: int
+    index: int
+    thread: threading.Thread | None = None
+
+
+class _RawPipeCloseAttempt:
+    """Observe a potentially blocking raw-stream close without blocking teardown."""
+
+    def __init__(self, endpoint: _DrainEndpoint) -> None:
+        self.endpoint = endpoint
+        self._done = threading.Event()
+        self._error: BaseException | None = None
+        raw_stream = getattr(endpoint.stream, "raw", endpoint.stream)
+
+        def close_raw() -> None:
+            try:
+                raw_stream.close()
+            except BaseException as error:  # noqa: BLE001 - report worker failures
+                self._error = error
+            finally:
+                self._done.set()
+
+        self._thread = threading.Thread(
+            target=close_raw,
+            name=f"adj-close-{endpoint.name}",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def observe(self, timeout_seconds: float) -> LifecycleFailure | None:
+        if not self._done.wait(timeout_seconds):
+            return LifecycleFailure(
+                stage="pipe.close",
+                api=f"Popen.{self.endpoint.name}.raw.close",
+                error_code=None,
+                message=(
+                    f"{self.endpoint.name} raw pipe close timed out after "
+                    f"{timeout_seconds:g} seconds"
+                ),
+            )
+        if self._error is None:
+            return None
+        return LifecycleFailure(
+            stage="pipe.close",
+            api=f"Popen.{self.endpoint.name}.raw.close",
+            error_code=(
+                _os_error_code(self._error)
+                if isinstance(self._error, OSError)
+                else None
+            ),
+            message=f"{self.endpoint.name} raw pipe close failed: {self._error}",
+        )
+
+
 def _terminate_process_tree(
     process: subprocess.Popen[bytes],
     windows_job: _WindowsKillJob | None,
@@ -1381,17 +1610,27 @@ def _run_json_command(
     label: str,
     timeout_seconds: float = 60,
     drain_timeout_seconds: float = 5,
+    raw_close_timeout_seconds: float = 1,
     windows_job_factory: Callable[[], _WindowsKillJob] = _WindowsKillJob,
+    posix_guardian_factory: Callable[..., _PosixGuardian] = _PosixGuardian,
+    raw_close_attempt_factory: Callable[[_DrainEndpoint], _RawPipeCloseAttempt] = (
+        _RawPipeCloseAttempt
+    ),
     process_tree_terminator: (
         Callable[[subprocess.Popen[bytes], _WindowsKillJob | None], None] | None
     ) = None,
 ) -> dict[str, Any]:
     if not command:
         raise ProvenanceError(f"{label} command must not be empty")
-    if timeout_seconds <= 0 or drain_timeout_seconds <= 0:
+    if (
+        timeout_seconds <= 0
+        or drain_timeout_seconds <= 0
+        or raw_close_timeout_seconds <= 0
+    ):
         raise ProvenanceError(f"{label} timeout bounds must be positive")
     terminate_process_tree = process_tree_terminator or _terminate_process_tree
     windows_job: _WindowsKillJob | None = None
+    posix_guardian: _PosixGuardian | None = None
     if os.name == "nt":
         try:
             windows_job = windows_job_factory()
@@ -1402,6 +1641,7 @@ def _run_json_command(
                 detail,
                 lifecycle=replace(failure, message=detail),
             ) from error
+    full_command = [*command, *arguments]
     popen_options: dict[str, Any] = {}
     if os.name == "nt":
         popen_options["creationflags"] = (
@@ -1410,15 +1650,38 @@ def _run_json_command(
             | 0x00000004
         )
     else:
-        popen_options["start_new_session"] = True
+        try:
+            posix_guardian = posix_guardian_factory(
+                full_command,
+                cleanup_timeout_seconds=drain_timeout_seconds,
+            )
+        except OSError as error:
+            detail = f"{label} failed to configure strict process containment: {error}"
+            failure = (
+                error.failure
+                if isinstance(error, _LifecycleError)
+                else _failure_from_error(
+                    error,
+                    stage="containment.configure",
+                    api="guardian.setup",
+                )
+            )
+            raise ProvenanceError(
+                detail,
+                lifecycle=replace(failure, message=detail),
+            ) from error
+        full_command = posix_guardian.command
+        popen_options.update(posix_guardian.popen_options)
     try:
         process = subprocess.Popen(
-            [*command, *arguments],
+            full_command,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             **popen_options,
         )
     except OSError as error:
+        if posix_guardian is not None:
+            posix_guardian.launch_failed()
         cleanup_failures: list[LifecycleFailure] = []
         close_failure_text: list[str] = []
         if windows_job is not None:
@@ -1453,6 +1716,198 @@ def _run_json_command(
         raise ProvenanceError(
             detail, lifecycle=replace(failure, message=detail)
         ) from error
+    recovery_wait_seconds = (
+        drain_timeout_seconds * 2
+        if posix_guardian is not None
+        else drain_timeout_seconds
+    )
+    def guardian_failure_record(
+        record: Any,
+        *,
+        process_returncode: int | None,
+        depth: int = 0,
+    ) -> LifecycleFailure:
+        if depth > 16 or not isinstance(record, dict) or set(record) != {
+            "cleanup_causes",
+            "error",
+            "error_code",
+        }:
+            raise _lifecycle_error(
+                "containment.confirm",
+                "failed process guardian status is malformed",
+                api="guardian.status",
+            )
+        error_text = record.get("error")
+        status_code = record.get("error_code")
+        causes = record.get("cleanup_causes")
+        if not (
+            isinstance(error_text, str)
+            and error_text
+            and isinstance(status_code, str)
+            and status_code
+            and isinstance(causes, list)
+        ):
+            raise _lifecycle_error(
+                "containment.confirm",
+                "failed process guardian status is malformed",
+                api="guardian.status",
+            )
+        cleanup_causes = tuple(
+            guardian_failure_record(
+                cause,
+                process_returncode=None,
+                depth=depth + 1,
+            )
+            for cause in causes
+        )
+        return LifecycleFailure(
+            stage="containment.confirm",
+            api="guardian.status",
+            error_code=process_returncode,
+            status_code=status_code,
+            message=(
+                "process guardian did not confirm cleanup: "
+                f"{status_code}: {error_text}"
+            ),
+            cleanup_causes=cleanup_causes,
+        )
+
+    def guardian_status_returncode(
+        status: Any, *, guardian_returncode: int
+    ) -> int:
+        if (
+            not isinstance(status, dict)
+            or status.get("contract") != posix_guardian.CONTRACT
+        ):
+            raise _lifecycle_error(
+                "containment.confirm",
+                "process guardian status contract disagrees",
+                api="guardian.status",
+            )
+        if status.get("cleanup_confirmed") is True:
+            if set(status) != {
+                "cleanup_confirmed",
+                "contract",
+                "returncode",
+                "verifier_gone",
+            } or not (
+                isinstance(status["returncode"], int)
+                and not isinstance(status["returncode"], bool)
+                and isinstance(status["verifier_gone"], bool)
+                and guardian_returncode == 0
+            ):
+                raise _lifecycle_error(
+                    "containment.confirm",
+                    "successful process guardian status is malformed",
+                    api="guardian.status",
+                )
+            return status["returncode"]
+        if set(status) != {
+            "cleanup_confirmed",
+            "contract",
+            "cleanup_causes",
+            "error",
+            "error_code",
+        } or status.get("cleanup_confirmed") is not False:
+            raise _lifecycle_error(
+                "containment.confirm",
+                "failed process guardian status is malformed",
+                api="guardian.status",
+            )
+        raise _LifecycleError(
+            guardian_failure_record(
+                {
+                    "cleanup_causes": status["cleanup_causes"],
+                    "error": status["error"],
+                    "error_code": status["error_code"],
+                },
+                process_returncode=guardian_returncode,
+            )
+        )
+
+    if posix_guardian is not None:
+        try:
+            posix_guardian.parent_started()
+        except OSError as error:
+            cleanup_failures: list[LifecycleFailure] = []
+            try:
+                posix_guardian.request_cleanup()
+            except OSError as cleanup_error:
+                cleanup_failures.append(
+                    _failure_from_error(
+                        cleanup_error,
+                        stage="process_tree.terminate",
+                        api="guardian.control",
+                    )
+                )
+            try:
+                guardian_returncode = process.wait(timeout=recovery_wait_seconds)
+                status = posix_guardian.read_status(drain_timeout_seconds)
+                guardian_status_returncode(
+                    status, guardian_returncode=guardian_returncode
+                )
+            except subprocess.TimeoutExpired:
+                cleanup_failures.append(
+                    LifecycleFailure(
+                        stage="process.wait",
+                        api="Popen.wait",
+                        error_code=None,
+                        message=(
+                            "process guardian did not exit after parent handoff "
+                            f"within {recovery_wait_seconds:g} seconds"
+                        ),
+                    )
+                )
+            except OSError as wait_error:
+                cleanup_failures.append(
+                    wait_error.failure
+                    if isinstance(wait_error, _LifecycleError)
+                    else _failure_from_error(
+                        wait_error,
+                        stage="process.wait",
+                        api="Popen.wait",
+                    )
+                )
+            close_deadline = time.monotonic() + raw_close_timeout_seconds
+            for pipe_index, (pipe_name, stream) in enumerate(
+                (("stdout", process.stdout), ("stderr", process.stderr))
+            ):
+                endpoint = _DrainEndpoint(
+                    pipe_name,
+                    stream,
+                    bytearray(),
+                    0,
+                    pipe_index,
+                )
+                try:
+                    attempt = raw_close_attempt_factory(endpoint)
+                    close_failure = attempt.observe(
+                        max(0, close_deadline - time.monotonic())
+                    )
+                except BaseException as close_error:  # noqa: BLE001 - fail closed
+                    close_failure = LifecycleFailure(
+                        stage="pipe.close",
+                        api=f"Popen.{pipe_name}.raw.close",
+                        error_code=(
+                            _os_error_code(close_error)
+                            if isinstance(close_error, OSError)
+                            else None
+                        ),
+                        message=f"{pipe_name} raw pipe close failed: {close_error}",
+                    )
+                if close_failure is not None:
+                    cleanup_failures.append(close_failure)
+            posix_guardian.close()
+            detail = f"{label} failed to complete process guardian handoff: {error}"
+            failure = _failure_from_error(
+                error,
+                stage="containment.configure",
+                api="guardian.parent_handoff",
+            ).with_cleanup(*cleanup_failures)
+            raise ProvenanceError(
+                detail,
+                lifecycle=replace(failure, message=detail),
+            ) from error
     if windows_job is not None:
         def fail_containment(error: OSError, default_stage: str) -> None:
             containment_errors = [str(error)]
@@ -1559,6 +2014,7 @@ def _run_json_command(
     failure_event_lock = threading.Lock()
     failure_events: list[LifecycleFailure] = []
     termination_failures: list[LifecycleFailure] = []
+    containment_failures: list[LifecycleFailure] = []
     pipe_read_failures: list[LifecycleFailure | None] = [None, None]
     pipe_read_event_indices: list[int | None] = [None, None]
     pipe_read_terminated_process = [False, False]
@@ -1572,8 +2028,20 @@ def _run_json_command(
         with failure_event_lock:
             failure_events[index] = failure
 
-    def terminate() -> None:
+    def terminate(*, force: bool = False) -> None:
         with termination_lock:
+            if posix_guardian is not None:
+                try:
+                    posix_guardian.request_cleanup()
+                except OSError as error:
+                    failure = _failure_from_error(
+                        error,
+                        stage="process_tree.terminate",
+                        api="guardian.control",
+                    )
+                    termination_failures.append(failure)
+                    record_failure_event(failure)
+                return
             try:
                 terminate_process_tree(process, windows_job)
             except OSError as error:
@@ -1643,33 +2111,40 @@ def _run_json_command(
                 terminate()
                 return
 
-    threads = (
-        threading.Thread(
-            target=drain,
-            args=(process.stdout, stdout, MAX_OBJECT_BYTES, 0, "stdout"),
-            daemon=True,
-        ),
-        threading.Thread(
-            target=drain,
-            args=(process.stderr, stderr, 4096, 1, "stderr"),
-            daemon=True,
-        ),
+    endpoints = (
+        _DrainEndpoint("stdout", process.stdout, stdout, MAX_OBJECT_BYTES, 0),
+        _DrainEndpoint("stderr", process.stderr, stderr, 4096, 1),
     )
-    for thread in threads:
-        thread.start()
+    for endpoint in endpoints:
+        endpoint.thread = threading.Thread(
+            target=drain,
+            args=(
+                endpoint.stream,
+                endpoint.output,
+                endpoint.limit,
+                endpoint.index,
+                endpoint.name,
+            ),
+            name=f"adj-drain-{endpoint.name}",
+            daemon=True,
+        )
+        endpoint.thread.start()
+    threads = tuple(endpoint.thread for endpoint in endpoints)
     timeout_error: subprocess.TimeoutExpired | None = None
     wait_failure: LifecycleFailure | None = None
     recovery_wait_failures: list[LifecycleFailure] = []
     returncode: int | None = None
     close_failures: list[LifecycleFailure] = []
     pipe_close_failures: list[LifecycleFailure] = []
+    drain_failure_record: LifecycleFailure | None = None
+    raw_close_endpoints: set[str] = set()
     try:
         returncode = process.wait(timeout=timeout_seconds)
     except subprocess.TimeoutExpired as error:
         timeout_error = error
         terminate()
         try:
-            returncode = process.wait(timeout=drain_timeout_seconds)
+            returncode = process.wait(timeout=recovery_wait_seconds)
         except subprocess.TimeoutExpired:
             recovery_failure = LifecycleFailure(
                 stage="process.wait",
@@ -1677,14 +2152,14 @@ def _run_json_command(
                 error_code=None,
                 message=(
                     "process wait after command timeout timed out after "
-                    f"{drain_timeout_seconds:g} seconds"
+                    f"{recovery_wait_seconds:g} seconds"
                 ),
             )
             recovery_wait_failures.append(recovery_failure)
             record_failure_event(recovery_failure)
-            terminate()
+            terminate(force=True)
             try:
-                returncode = process.wait(timeout=drain_timeout_seconds)
+                returncode = process.wait(timeout=recovery_wait_seconds)
             except subprocess.TimeoutExpired:
                 final_failure = LifecycleFailure(
                     stage="process.wait",
@@ -1692,7 +2167,7 @@ def _run_json_command(
                     error_code=None,
                     message=(
                         "final process wait timed out after "
-                        f"{drain_timeout_seconds:g} seconds"
+                        f"{recovery_wait_seconds:g} seconds"
                     ),
                 )
                 recovery_wait_failures.append(final_failure)
@@ -1720,9 +2195,9 @@ def _run_json_command(
             )
             recovery_wait_failures.append(recovery_failure)
             record_failure_event(recovery_failure)
-            terminate()
+            terminate(force=True)
             try:
-                returncode = process.wait(timeout=drain_timeout_seconds)
+                returncode = process.wait(timeout=recovery_wait_seconds)
             except (OSError, subprocess.TimeoutExpired) as final_error:
                 if isinstance(final_error, subprocess.TimeoutExpired):
                     final_failure = LifecycleFailure(
@@ -1731,7 +2206,7 @@ def _run_json_command(
                         error_code=None,
                         message=(
                             "final process wait timed out after "
-                            f"{drain_timeout_seconds:g} seconds"
+                            f"{recovery_wait_seconds:g} seconds"
                         ),
                     )
                 else:
@@ -1757,7 +2232,7 @@ def _run_json_command(
         )
         terminate()
         try:
-            returncode = process.wait(timeout=drain_timeout_seconds)
+            returncode = process.wait(timeout=recovery_wait_seconds)
         except subprocess.TimeoutExpired:
             retry_failure = LifecycleFailure(
                 stage="process.wait",
@@ -1765,14 +2240,14 @@ def _run_json_command(
                 error_code=None,
                 message=(
                     "process wait retry timed out after "
-                    f"{drain_timeout_seconds:g} seconds"
+                    f"{recovery_wait_seconds:g} seconds"
                 ),
             )
             recovery_wait_failures.append(retry_failure)
             record_failure_event(retry_failure)
-            terminate()
+            terminate(force=True)
             try:
-                returncode = process.wait(timeout=drain_timeout_seconds)
+                returncode = process.wait(timeout=recovery_wait_seconds)
             except (OSError, subprocess.TimeoutExpired) as final_error:
                 if isinstance(final_error, subprocess.TimeoutExpired):
                     final_failure = LifecycleFailure(
@@ -1781,7 +2256,7 @@ def _run_json_command(
                         error_code=None,
                         message=(
                             "final process wait timed out after "
-                            f"{drain_timeout_seconds:g} seconds"
+                            f"{recovery_wait_seconds:g} seconds"
                         ),
                     )
                 else:
@@ -1806,9 +2281,9 @@ def _run_json_command(
             )
             recovery_wait_failures.append(retry_failure)
             record_failure_event(retry_failure)
-            terminate()
+            terminate(force=True)
             try:
-                returncode = process.wait(timeout=drain_timeout_seconds)
+                returncode = process.wait(timeout=recovery_wait_seconds)
             except (OSError, subprocess.TimeoutExpired) as final_error:
                 if isinstance(final_error, subprocess.TimeoutExpired):
                     final_failure = LifecycleFailure(
@@ -1817,7 +2292,7 @@ def _run_json_command(
                         error_code=None,
                         message=(
                             "final process wait timed out after "
-                            f"{drain_timeout_seconds:g} seconds"
+                        f"{recovery_wait_seconds:g} seconds"
                         ),
                     )
                 else:
@@ -1870,14 +2345,80 @@ def _run_json_command(
         final_drain_deadline = time.monotonic() + 1
         for thread in stuck_drains:
             thread.join(timeout=max(0, final_drain_deadline - time.monotonic()))
-    drain_failure = any(thread.is_alive() for thread in threads)
-    drain_failure_record: LifecycleFailure | None = None
-    if drain_failure:
-        drain_failure_record = LifecycleFailure(
-            stage="pipe.drain",
-            message="output pipes did not close within bounds",
-        )
-        record_failure_event(drain_failure_record)
+        stuck_endpoints = [
+            endpoint
+            for endpoint in endpoints
+            if endpoint.thread is not None and endpoint.thread.is_alive()
+        ]
+        if stuck_endpoints:
+            drain_failure_record = LifecycleFailure(
+                stage="pipe.drain",
+                message="output pipes did not close within bounds",
+            )
+            record_failure_event(drain_failure_record)
+            attempts: list[tuple[_DrainEndpoint, _RawPipeCloseAttempt]] = []
+            for endpoint in stuck_endpoints:
+                raw_close_endpoints.add(endpoint.name)
+                try:
+                    attempts.append(
+                        (endpoint, raw_close_attempt_factory(endpoint))
+                    )
+                except BaseException as error:  # noqa: BLE001 - fail closed
+                    failure = LifecycleFailure(
+                        stage="pipe.close",
+                        api=f"Popen.{endpoint.name}.raw.close",
+                        error_code=(
+                            _os_error_code(error)
+                            if isinstance(error, OSError)
+                            else None
+                        ),
+                        message=(
+                            f"{endpoint.name} raw pipe close could not start: {error}"
+                        ),
+                    )
+                    pipe_close_failures.append(failure)
+                    record_failure_event(failure)
+            raw_close_deadline = time.monotonic() + raw_close_timeout_seconds
+            for _endpoint, attempt in attempts:
+                failure = attempt.observe(
+                    max(0, raw_close_deadline - time.monotonic())
+                )
+                if failure is not None:
+                    pipe_close_failures.append(failure)
+                    record_failure_event(failure)
+            for endpoint in stuck_endpoints:
+                assert endpoint.thread is not None
+                endpoint.thread.join(
+                    timeout=max(0, raw_close_deadline - time.monotonic())
+                )
+    if posix_guardian is not None:
+        guardian_returncode = returncode
+        try:
+            if guardian_returncode is None:
+                raise _lifecycle_error(
+                    "containment.confirm",
+                    "process guardian did not exit before the cleanup deadline",
+                    api="guardian.status",
+                )
+            status = posix_guardian.read_status(drain_timeout_seconds)
+            returncode = guardian_status_returncode(
+                status, guardian_returncode=guardian_returncode
+            )
+        except OSError as error:
+            failure = (
+                error.failure
+                if isinstance(error, _LifecycleError)
+                else _failure_from_error(
+                    error,
+                    stage="containment.confirm",
+                    api="guardian.status",
+                )
+            )
+            containment_failures.append(failure)
+            record_failure_event(failure)
+        finally:
+            posix_guardian.close()
+    drain_failure = drain_failure_record is not None
     causal_pipe_read_exit: LifecycleFailure | None = None
     if (
         returncode is not None
@@ -1891,25 +2432,27 @@ def _run_json_command(
             message=f"process exited {returncode} after pipe-read termination",
         )
         record_failure_event(causal_pipe_read_exit)
-    if not drain_failure:
-        for pipe_name, stream in (
-            ("stdout", process.stdout),
-            ("stderr", process.stderr),
+    for endpoint in endpoints:
+        if endpoint.name in raw_close_endpoints or (
+            endpoint.thread is not None and endpoint.thread.is_alive()
         ):
-            try:
-                stream.close()
-            except OSError as error:
-                message = f"{pipe_name} pipe close failed: {error}"
-                close_failure = replace(
-                    _failure_from_error(
-                        error,
-                        stage="pipe.close",
-                        api=f"Popen.{pipe_name}.close",
-                    ),
-                    message=message,
-                )
-                pipe_close_failures.append(close_failure)
-                record_failure_event(close_failure)
+            continue
+        pipe_name = endpoint.name
+        stream = endpoint.stream
+        try:
+            stream.close()
+        except OSError as error:
+            message = f"{pipe_name} pipe close failed: {error}"
+            close_failure = replace(
+                _failure_from_error(
+                    error,
+                    stage="pipe.close",
+                    api=f"Popen.{pipe_name}.close",
+                ),
+                message=message,
+            )
+            pipe_close_failures.append(close_failure)
+            record_failure_event(close_failure)
     pipe_read_failure_events = [
         (
             pipe_read_event_indices[index],
@@ -1925,6 +2468,7 @@ def _run_json_command(
     ]
     cleanup_failures = [
         *termination_failures,
+        *containment_failures,
         *close_failures,
         *pipe_close_failures,
     ]
@@ -1934,6 +2478,9 @@ def _run_json_command(
             "failed to terminate process tree: "
             + termination_failures[0].message
         )
+    cleanup_failure_text.extend(
+        failure.message for failure in containment_failures
+    )
     if close_failures:
         close_failure = close_failures[0]
         close_text = close_failure.message
@@ -1998,6 +2545,9 @@ def _run_json_command(
         primary_failure = wait_failure
         for failure in pipe_read_failure_records:
             add_cleanup_failure(failure)
+    elif containment_failures:
+        primary_failure = containment_failures[0]
+        primary_error = primary_failure.message
     elif returncode is not None and returncode != 0 and not any(
         terminated
         for _event_index, _failure, terminated in pipe_read_failure_events
@@ -2080,6 +2630,15 @@ def _run_json_command(
             *(event for event in failure_events if event is not primary)
         )
         detail = f"{label} failed to terminate process tree: {failure.message}"
+        raise ProvenanceError(
+            detail, lifecycle=replace(failure, message=detail)
+        )
+    if containment_failures:
+        primary = containment_failures[0]
+        failure = primary.with_cleanup(
+            *(event for event in failure_events if event is not primary)
+        )
+        detail = f"{label} failed to confirm process containment: {failure.message}"
         raise ProvenanceError(
             detail, lifecycle=replace(failure, message=detail)
         )

--- a/code/scripts/tests/test_adj_stdlib_provenance.py
+++ b/code/scripts/tests/test_adj_stdlib_provenance.py
@@ -2454,6 +2454,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         )
         self.assertEqual(process.wait.call_count, 3)
 
+    @mock.patch.object(provenance.os, "name", "nt")
     def test_posix_process_unreaped_timeout_does_not_claim_exit(self) -> None:
         process = mock.Mock(pid=404)
         process.wait.side_effect = [

--- a/code/scripts/tests/test_adj_stdlib_provenance.py
+++ b/code/scripts/tests/test_adj_stdlib_provenance.py
@@ -2399,6 +2399,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
 
         process.kill.assert_called_once_with()
 
+    @mock.patch.object(provenance.os, "name", "nt")
     def test_posix_process_repeated_termination_failures_are_ordered(self) -> None:
         process = mock.Mock(pid=404)
         process.wait.side_effect = [
@@ -2486,6 +2487,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         self.assertFalse(any("exited None" in cause.message for cause in failure.cleanup_causes))
         self.assertEqual(process.wait.call_count, 3)
 
+    @mock.patch.object(provenance.os, "name", "nt")
     def test_posix_process_failure_preserves_both_pipe_close_causes(self) -> None:
         process = mock.Mock(pid=404)
         process.wait.side_effect = [
@@ -2786,6 +2788,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             ["job.terminate", "job.close"],
         )
 
+    @mock.patch.object(provenance.os, "name", "nt")
     def test_json_command_timeout_preserves_stuck_drain_failure(self) -> None:
         process = mock.Mock()
         process.stdout = mock.Mock()
@@ -2831,6 +2834,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         process.stdout.close.assert_not_called()
         process.stderr.close.assert_not_called()
 
+    @mock.patch.object(provenance.os, "name", "nt")
     def test_json_command_primary_stuck_drain_is_not_self_causal(self) -> None:
         process = mock.Mock(pid=404)
         process.stdout = mock.Mock()
@@ -2867,6 +2871,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         self.assertEqual(failure.cleanup_causes, ())
         self.assertEqual(failure.message, str(raised.exception))
 
+    @mock.patch.object(provenance.os, "name", "nt")
     def test_stuck_stdout_raw_close_does_not_skip_healthy_stderr(self) -> None:
         process = mock.Mock(pid=404)
         process.wait.return_value = 0
@@ -2943,6 +2948,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         self.assertTrue(attempt._done.wait(1))
         self.assertIn("timed out", failure.message)
 
+    @mock.patch.object(provenance.os, "name", "nt")
     def test_raw_pipe_close_start_failure_is_ordered_after_drain(self) -> None:
         process = mock.Mock(pid=404)
         process.wait.return_value = 0
@@ -2976,6 +2982,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             ["pipe.close", "pipe.close"],
         )
 
+    @mock.patch.object(provenance.os, "name", "nt")
     def test_json_command_pipe_read_failure_fails_closed(self) -> None:
         process = mock.Mock(pid=404)
         process.wait.return_value = -9
@@ -3014,6 +3021,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         )
         self.assertEqual(failure.message, str(raised.exception))
 
+    @mock.patch.object(provenance.os, "name", "nt")
     def test_json_command_child_exit_precedes_later_pipe_read_failure(self) -> None:
         process = mock.Mock()
         process.wait.return_value = 7
@@ -3052,6 +3060,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         )
         self.assertEqual(failure.message, str(raised.exception))
 
+    @mock.patch.object(provenance.os, "name", "nt")
     def test_json_command_reader_primary_follows_event_order(self) -> None:
         process = mock.Mock(pid=404)
         process.wait.return_value = -9
@@ -3099,6 +3108,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             ],
         )
 
+    @mock.patch.object(provenance.os, "name", "nt")
     def test_json_command_pipe_read_preserves_poll_failure(self) -> None:
         process = mock.Mock(pid=404)
         process.wait.return_value = -9
@@ -3135,6 +3145,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         )
         self.assertEqual(failure.message, str(raised.exception))
 
+    @mock.patch.object(provenance.os, "name", "nt")
     def test_json_command_wait_failure_and_retry_are_structured(self) -> None:
         process = mock.Mock(pid=404)
         process.wait.side_effect = [
@@ -3173,6 +3184,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         )
         self.assertEqual(failure.message, str(raised.exception))
 
+    @mock.patch.object(provenance.os, "name", "nt")
     def test_json_command_wait_failure_preserves_retry_timeout(self) -> None:
         process = mock.Mock(pid=404)
         process.wait.side_effect = [
@@ -3219,6 +3231,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         )
         self.assertEqual(failure.message, str(raised.exception))
 
+    @mock.patch.object(provenance.os, "name", "nt")
     def test_json_command_timeout_preserves_recovery_wait_timeout(self) -> None:
         process = mock.Mock(pid=404)
         process.wait.side_effect = [
@@ -3263,6 +3276,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         )
         self.assertEqual(failure.message, str(raised.exception))
 
+    @mock.patch.object(provenance.os, "name", "nt")
     def test_json_command_pipe_close_failure_is_structured(self) -> None:
         process = mock.Mock()
         process.wait.return_value = 0

--- a/code/scripts/tests/test_adj_stdlib_provenance.py
+++ b/code/scripts/tests/test_adj_stdlib_provenance.py
@@ -7,6 +7,7 @@ import json
 import multiprocessing
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -23,6 +24,7 @@ SCRIPTS_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 provenance = importlib.import_module("adj_stdlib_provenance")
+guardian = importlib.import_module("adj_process_guardian")
 arithmetic_builder = importlib.import_module("build_adj_arithmetic_provenance")
 ratio_builder = importlib.import_module("build_adj_ratio_provenance")
 percent_of_builder = importlib.import_module("build_adj_percent_of_provenance")
@@ -47,6 +49,50 @@ def acquire_cas_lock_with_alternate_temp(
 
 
 class AdjStdlibProvenanceTests(unittest.TestCase):
+    class FakePosixGuardian:
+        CONTRACT = "adj-stdlib/process-guardian/v1"
+
+        def __init__(
+            self,
+            command: object,
+            cleanup_timeout_seconds: float,
+            *,
+            status: dict[str, object] | None = None,
+        ) -> None:
+            self.command = ["guardian", *command]
+            self.cleanup_timeout_seconds = cleanup_timeout_seconds
+            self.popen_options = {"start_new_session": True}
+            self.status = status or {
+                "cleanup_confirmed": True,
+                "contract": self.CONTRACT,
+                "returncode": 0,
+                "verifier_gone": False,
+            }
+            self.cleanup_requests = 0
+            self.parent_started_calls = 0
+            self.launch_failed_calls = 0
+            self.close_calls = 0
+
+        def parent_started(self) -> None:
+            self.parent_started_calls += 1
+
+        def launch_failed(self) -> None:
+            self.launch_failed_calls += 1
+
+        def request_cleanup(self) -> bool:
+            if self.cleanup_requests:
+                return False
+            self.cleanup_requests = 1
+            return True
+
+        def read_status(self, timeout_seconds: float) -> dict[str, object]:
+            self.assert_positive_timeout = timeout_seconds > 0
+            self.request_cleanup()
+            return self.status
+
+        def close(self) -> None:
+            self.close_calls += 1
+
     def test_lifecycle_failure_is_immutable_and_canonical(self) -> None:
         cleanup = provenance.LifecycleFailure(
             stage="job.close",
@@ -70,12 +116,14 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                     "error_code": 6,
                     "message": "close failed",
                     "stage": "job.close",
+                    "status_code": None,
                 }
             ],
-            "contract": "adj-stdlib/process-lifecycle-failure/v1",
+            "contract": "adj-stdlib/process-lifecycle-failure/v2",
             "error_code": 87,
             "message": "configuration failed",
             "stage": "job.configure",
+            "status_code": None,
         }
 
         self.assertEqual(failure.to_dict(), expected)
@@ -105,6 +153,11 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             ("message", "", "message must be a non-empty string"),
             ("api", "", "API must be null or a non-empty string"),
             ("error_code", True, "error code must be an integer or null"),
+            (
+                "status_code",
+                "",
+                "status code must be null or a non-empty string",
+            ),
             (
                 "cleanup_causes",
                 [cleanup],
@@ -352,6 +405,27 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                 return
             time.sleep(0.05)
         self.fail(f"process {pid} remained alive")
+
+    def linux_process_starttime(self, pid: int) -> str | None:
+        try:
+            raw = Path(f"/proc/{pid}/stat").read_text(encoding="ascii")
+        except (OSError, UnicodeDecodeError):
+            return None
+        tail = raw.rsplit(")", 1)
+        if len(tail) != 2:
+            return None
+        fields = tail[1].split()
+        return fields[19] if len(fields) > 19 else None
+
+    def assert_linux_process_identity_exits(
+        self, pid: int, starttime: str, *, timeout: float = 5
+    ) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self.linux_process_starttime(pid) != starttime:
+                return
+            time.sleep(0.05)
+        self.fail(f"Linux process identity {pid}:{starttime} remained alive")
 
     def rust_binary_command(self, name: str) -> list[str]:
         suffix = ".exe" if os.name == "nt" else ""
@@ -1626,6 +1700,621 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         killpg.assert_called_once_with(process.pid, provenance.POSIX_SIGKILL)
         process.kill.assert_called_once_with()
 
+    def test_posix_process_guardian_configuration_fails_before_launch(self) -> None:
+        failure = provenance._lifecycle_error(
+            "containment.configure",
+            "delegated cgroup unavailable",
+            api="cgroup.kill",
+        )
+        factory = mock.Mock(side_effect=failure)
+
+        with (
+            mock.patch.object(provenance.os, "name", "posix"),
+            mock.patch.object(provenance.subprocess, "Popen") as popen,
+            self.assertRaisesRegex(
+                provenance.ProvenanceError,
+                "failed to configure strict process containment",
+            ) as raised,
+        ):
+            provenance._run_json_command(
+                ["fixture"],
+                [],
+                label="guardian setup fixture",
+                posix_guardian_factory=factory,
+            )
+
+        self.assertEqual(raised.exception.lifecycle.stage, "containment.configure")
+        popen.assert_not_called()
+
+    def test_posix_process_strict_containment_rejects_unsupported_platform(
+        self,
+    ) -> None:
+        with (
+            mock.patch.object(provenance.os, "name", "posix"),
+            mock.patch.object(provenance.sys, "platform", "darwin"),
+            mock.patch.object(provenance.subprocess, "Popen") as popen,
+            self.assertRaisesRegex(
+                provenance.ProvenanceError,
+                "strict process containment is unavailable",
+            ) as raised,
+        ):
+            provenance._run_json_command(
+                ["fixture"], [], label="unsupported containment fixture"
+            )
+
+        self.assertEqual(raised.exception.lifecycle.stage, "containment.configure")
+        popen.assert_not_called()
+
+    def test_posix_guardian_partial_pipe_setup_closes_owned_descriptors(self) -> None:
+        with (
+            mock.patch.object(provenance.sys, "platform", "linux"),
+            mock.patch.dict(
+                provenance.os.environ,
+                {provenance._PosixGuardian.CGROUP_ENV: "/delegated"},
+            ),
+            mock.patch.object(
+                provenance.os,
+                "pipe",
+                side_effect=[(10, 11), OSError(24, "too many open files")],
+            ),
+            mock.patch.object(provenance.os, "close") as close,
+            self.assertRaisesRegex(OSError, "too many open files"),
+        ):
+            provenance._PosixGuardian(["fixture"], 1)
+
+        self.assertEqual(
+            close.call_args_list,
+            [mock.call(10), mock.call(11)],
+        )
+
+    def test_posix_guardian_inheritability_failure_closes_all_pipes(self) -> None:
+        with (
+            mock.patch.object(provenance.sys, "platform", "linux"),
+            mock.patch.dict(
+                provenance.os.environ,
+                {provenance._PosixGuardian.CGROUP_ENV: "/delegated"},
+            ),
+            mock.patch.object(
+                provenance.os,
+                "pipe",
+                side_effect=[(10, 11), (12, 13)],
+            ),
+            mock.patch.object(
+                provenance.os,
+                "set_inheritable",
+                side_effect=[None, None, OSError(5, "injected inherit failure")],
+            ),
+            mock.patch.object(provenance.os, "close") as close,
+            self.assertRaisesRegex(OSError, "injected inherit failure"),
+        ):
+            provenance._PosixGuardian(["fixture"], 1)
+
+        self.assertEqual(
+            close.call_args_list,
+            [mock.call(10), mock.call(11), mock.call(12), mock.call(13)],
+        )
+
+    def test_posix_guardian_handoff_failure_requests_cleanup(self) -> None:
+        process = mock.Mock(pid=404)
+        process.wait.return_value = 125
+        fake = self.FakePosixGuardian(
+            [],
+            0.1,
+            status={
+                "cleanup_confirmed": False,
+                "contract": self.FakePosixGuardian.CONTRACT,
+                "cleanup_causes": [
+                    {
+                        "cleanup_causes": [],
+                        "error": "child release failed",
+                        "error_code": "CHILD_RELEASE_FAILED",
+                    }
+                ],
+                "error": "cgroup remained populated",
+                "error_code": "CGROUP_CLEANUP_TIMEOUT",
+            },
+        )
+        fake.parent_started = mock.Mock(
+            side_effect=OSError(5, "injected parent handoff failure")
+        )
+        close_attempt = mock.Mock()
+        close_attempt.observe.return_value = None
+
+        with (
+            mock.patch.object(provenance.os, "name", "posix"),
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError,
+                "failed to complete process guardian handoff",
+            ) as raised,
+        ):
+            provenance._run_json_command(
+                ["fixture"],
+                [],
+                label="guardian handoff fixture",
+                drain_timeout_seconds=0.1,
+                posix_guardian_factory=lambda *_args, **_kwargs: fake,
+                raw_close_attempt_factory=mock.Mock(return_value=close_attempt),
+            )
+
+        self.assertEqual(raised.exception.lifecycle.stage, "containment.configure")
+        self.assertEqual(raised.exception.lifecycle.api, "guardian.parent_handoff")
+        self.assertEqual(fake.cleanup_requests, 1)
+        self.assertEqual(fake.close_calls, 1)
+        process.wait.assert_called_once_with(timeout=0.2)
+        containment = raised.exception.lifecycle.cleanup_causes[0]
+        self.assertEqual(containment.status_code, "CGROUP_CLEANUP_TIMEOUT")
+        self.assertEqual(
+            containment.cleanup_causes[0].status_code, "CHILD_RELEASE_FAILED"
+        )
+
+    def test_posix_process_guardian_attests_child_returncode(self) -> None:
+        process = mock.Mock(pid=404)
+        process.wait.return_value = 0
+        process.stdout.read.side_effect = [b"{}\n", b""]
+        process.stderr.read.return_value = b""
+        created: list[AdjStdlibProvenanceTests.FakePosixGuardian] = []
+
+        def factory(command: object, cleanup_timeout_seconds: float) -> object:
+            result = self.FakePosixGuardian(command, cleanup_timeout_seconds)
+            created.append(result)
+            return result
+
+        with (
+            mock.patch.object(provenance.os, "name", "posix"),
+            mock.patch.object(
+                provenance.subprocess, "Popen", return_value=process
+            ) as popen,
+        ):
+            result = provenance._run_json_command(
+                ["fixture"],
+                ["argument"],
+                label="guardian success fixture",
+                posix_guardian_factory=factory,
+            )
+
+        self.assertEqual(result, {})
+        self.assertEqual(created[0].parent_started_calls, 1)
+        self.assertEqual(created[0].cleanup_requests, 1)
+        self.assertEqual(created[0].close_calls, 1)
+        self.assertTrue(created[0].assert_positive_timeout)
+        self.assertEqual(popen.call_args.args[0], ["guardian", "fixture", "argument"])
+
+    def test_posix_process_guardian_failure_rejects_valid_json(self) -> None:
+        process = mock.Mock(pid=404)
+        process.wait.return_value = 125
+        process.stdout.read.side_effect = [b"{}\n", b""]
+        process.stderr.read.return_value = b""
+        status = {
+            "cleanup_confirmed": False,
+            "contract": self.FakePosixGuardian.CONTRACT,
+            "cleanup_causes": [
+                {
+                    "cleanup_causes": [],
+                    "error": "child release failed",
+                    "error_code": "CHILD_RELEASE_FAILED",
+                }
+            ],
+            "error": "cgroup remained populated",
+            "error_code": "CGROUP_CLEANUP_TIMEOUT",
+        }
+        fake = self.FakePosixGuardian([], 1, status=status)
+
+        with (
+            mock.patch.object(provenance.os, "name", "posix"),
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError,
+                "CGROUP_CLEANUP_TIMEOUT",
+            ) as raised,
+        ):
+            provenance._run_json_command(
+                ["fixture"],
+                [],
+                label="guardian failure fixture",
+                posix_guardian_factory=lambda *_args, **_kwargs: fake,
+            )
+
+        self.assertEqual(raised.exception.lifecycle.stage, "containment.confirm")
+        self.assertEqual(raised.exception.lifecycle.api, "guardian.status")
+        self.assertEqual(
+            raised.exception.lifecycle.status_code,
+            "CGROUP_CLEANUP_TIMEOUT",
+        )
+        self.assertEqual(
+            raised.exception.lifecycle.cleanup_causes[0].status_code,
+            "CHILD_RELEASE_FAILED",
+        )
+
+    def test_posix_process_timeout_escalates_after_guardian_request(self) -> None:
+        process = mock.Mock(pid=404)
+        process.wait.side_effect = [
+            subprocess.TimeoutExpired(["fixture"], 0.2),
+            subprocess.TimeoutExpired(["fixture"], 0.1),
+            0,
+        ]
+        process.stdout.read.return_value = b""
+        process.stderr.read.return_value = b""
+        fake = self.FakePosixGuardian(
+            [],
+            0.1,
+            status={
+                "cleanup_confirmed": True,
+                "contract": self.FakePosixGuardian.CONTRACT,
+                "returncode": -9,
+                "verifier_gone": True,
+            },
+        )
+        terminator = mock.Mock()
+
+        with (
+            mock.patch.object(provenance.os, "name", "posix"),
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            self.assertRaisesRegex(provenance.ProvenanceError, "timed out"),
+        ):
+            provenance._run_json_command(
+                ["fixture"],
+                [],
+                label="guardian timeout fixture",
+                timeout_seconds=0.2,
+                drain_timeout_seconds=0.1,
+                posix_guardian_factory=lambda *_args, **_kwargs: fake,
+                process_tree_terminator=terminator,
+            )
+
+        self.assertGreaterEqual(fake.cleanup_requests, 1)
+        terminator.assert_not_called()
+
+    def test_guardian_cgroup_events_require_one_exact_populated_field(self) -> None:
+        self.assertTrue(guardian.cgroup_is_empty(b"populated 0\nfrozen 0\n"))
+        self.assertFalse(guardian.cgroup_is_empty(b"populated 1\n"))
+        for raw in (
+            b"",
+            b"populated 0\npopulated 1\n",
+            b"populated maybe\n",
+            b"populated 0 extra\n",
+            b"populated \xff\n",
+        ):
+            with self.subTest(raw=raw), self.assertRaises(guardian.GuardianError):
+                guardian.cgroup_is_empty(raw)
+
+    def test_guardian_error_status_preserves_cleanup_causality(self) -> None:
+        primary = guardian.GuardianError(
+            "CHILD_RELEASE_FAILED", "child release failed"
+        )
+        cleanup = guardian.GuardianError(
+            "CGROUP_CLEANUP_TIMEOUT", "cgroup remained populated"
+        ).with_cleanup(primary)
+
+        self.assertEqual(
+            cleanup.to_dict(),
+            {
+                "cleanup_causes": [
+                    {
+                        "cleanup_causes": [],
+                        "error": "child release failed",
+                        "error_code": "CHILD_RELEASE_FAILED",
+                    }
+                ],
+                "error": "cgroup remained populated",
+                "error_code": "CGROUP_CLEANUP_TIMEOUT",
+            },
+        )
+
+    def test_guardian_main_serializes_compound_cleanup_failure(self) -> None:
+        control_read, control_write = os.pipe()
+        status_read, status_write = os.pipe()
+        primary = guardian.GuardianError(
+            "CHILD_RELEASE_FAILED", "child release failed"
+        )
+        cleanup = guardian.GuardianError(
+            "CGROUP_CLEANUP_TIMEOUT", "cgroup remained populated"
+        ).with_cleanup(primary)
+        try:
+            with mock.patch.object(guardian, "supervise", side_effect=cleanup):
+                returncode = guardian.main(
+                    [
+                        "--control-fd",
+                        str(control_read),
+                        "--status-fd",
+                        str(status_write),
+                        "--cgroup-root",
+                        "/delegated",
+                        "--cleanup-timeout-seconds",
+                        "1",
+                        "--",
+                        "fixture",
+                    ]
+                )
+            control_read = -1
+            status_write = -1
+            raw = os.read(status_read, guardian.MAX_CONTROL_BYTES + 1)
+            status = json.loads(raw.decode("utf-8"))
+            self.assertEqual(returncode, 125)
+            self.assertEqual(status["error_code"], "CGROUP_CLEANUP_TIMEOUT")
+            self.assertEqual(
+                status["cleanup_causes"][0]["error_code"],
+                "CHILD_RELEASE_FAILED",
+            )
+        finally:
+            for descriptor in (
+                control_read,
+                control_write,
+                status_read,
+                status_write,
+            ):
+                if descriptor >= 0:
+                    os.close(descriptor)
+
+    def test_guardian_reaping_respects_cleanup_deadline(self) -> None:
+        with (
+            mock.patch.object(guardian.time, "monotonic", return_value=1.0),
+            mock.patch.object(guardian.os, "waitpid") as waitpid,
+        ):
+            self.assertFalse(guardian._reap_children(1.0))
+
+        waitpid.assert_not_called()
+
+    def test_guardian_status_bytes_round_trip_through_verifier_contract(self) -> None:
+        status = {
+            "cleanup_confirmed": True,
+            "contract": provenance._PosixGuardian.CONTRACT,
+            "returncode": -9,
+            "verifier_gone": True,
+        }
+        control_read, control_write = os.pipe()
+        status_read, status_write = os.pipe()
+        verifier = provenance._PosixGuardian.__new__(provenance._PosixGuardian)
+        verifier._control_read = -1
+        verifier._control_write = control_write
+        verifier._status_read = status_read
+        verifier._status_write = -1
+        verifier._cleanup_requested = False
+
+        selector = mock.Mock()
+        selector.select.return_value = [(mock.Mock(), provenance.selectors.EVENT_READ)]
+        try:
+            raw = guardian.canonical_json_bytes(status)
+            self.assertEqual(raw, provenance.canonical_json_bytes(status))
+            os.write(status_write, raw)
+            os.close(status_write)
+            status_write = -1
+            with (
+                mock.patch.object(provenance.os, "set_blocking", create=True),
+                mock.patch.object(
+                    provenance.selectors, "DefaultSelector", return_value=selector
+                ),
+            ):
+                self.assertEqual(verifier.read_status(1), status)
+            self.assertEqual(os.read(control_read, 1), b"")
+        finally:
+            verifier.close()
+            for descriptor in (control_read, status_write):
+                if descriptor >= 0:
+                    os.close(descriptor)
+
+    def test_guardian_cleanup_requires_empty_cgroup_before_removal(self) -> None:
+        cgroup = guardian.CgroupHandle(root_fd=10, child_fd=11, name="known")
+        with (
+            mock.patch.object(guardian, "_write_small_at") as write,
+            mock.patch.object(
+                guardian, "_read_small_at", return_value=b"populated 0\n"
+            ) as read,
+            mock.patch.object(guardian.os, "killpg", create=True) as kill_group,
+            mock.patch.object(guardian.os, "close") as close,
+            mock.patch.object(guardian.os, "rmdir") as remove,
+        ):
+            guardian.cleanup_command_cgroup(
+                cgroup, time.monotonic() + 1, process_group=123
+            )
+
+        write.assert_called_once_with(11, "cgroup.kill", b"1\n")
+        kill_group.assert_called_once_with(123, guardian.POSIX_SIGKILL)
+        read.assert_called_once_with(11, "cgroup.events")
+        close.assert_called_once_with(11)
+        remove.assert_called_once_with("known", dir_fd=10)
+
+    def test_guardian_cgroup_open_failure_preserves_rollback_failure(self) -> None:
+        with (
+            mock.patch.object(guardian, "validate_cgroup2_descriptor"),
+            mock.patch.object(guardian.os, "mkdir"),
+            mock.patch.object(
+                guardian, "_open_at", side_effect=OSError(5, "open failed")
+            ),
+            mock.patch.object(
+                guardian.os, "rmdir", side_effect=OSError(16, "remove failed")
+            ),
+            self.assertRaisesRegex(
+                guardian.GuardianError, "fresh command cgroup could not be created"
+            ) as raised,
+        ):
+            guardian.create_command_cgroup(10)
+
+        self.assertEqual(raised.exception.code, "CGROUP_CREATE_FAILED")
+        self.assertEqual(
+            [cause.code for cause in raised.exception.cleanup_causes],
+            ["CGROUP_ROLLBACK_REMOVE_FAILED"],
+        )
+
+    def test_guardian_cgroup_validation_preserves_all_rollback_failures(self) -> None:
+        validation_error = guardian.GuardianError(
+            "CONTROL_OPEN_FAILED", "control open failed"
+        )
+        with (
+            mock.patch.object(guardian, "validate_cgroup2_descriptor"),
+            mock.patch.object(guardian.os, "mkdir"),
+            mock.patch.object(guardian, "_open_at", side_effect=[11, validation_error]),
+            mock.patch.object(
+                guardian.os, "close", side_effect=OSError(5, "close failed")
+            ),
+            mock.patch.object(
+                guardian.os, "rmdir", side_effect=OSError(16, "remove failed")
+            ),
+            self.assertRaisesRegex(
+                guardian.GuardianError, "control open failed"
+            ) as raised,
+        ):
+            guardian.create_command_cgroup(10)
+
+        self.assertEqual(raised.exception.code, "CONTROL_OPEN_FAILED")
+        self.assertEqual(
+            [cause.code for cause in raised.exception.cleanup_causes],
+            ["CGROUP_ROLLBACK_CLOSE_FAILED", "CGROUP_ROLLBACK_REMOVE_FAILED"],
+        )
+
+    def test_guardian_cleanup_failure_never_removes_unproven_cgroup(self) -> None:
+        cgroup = guardian.CgroupHandle(root_fd=10, child_fd=11, name="known")
+        with (
+            mock.patch.object(
+                guardian,
+                "_write_small_at",
+                side_effect=guardian.GuardianError("KILL_FAILED", "kill failed"),
+            ),
+            mock.patch.object(
+                guardian, "_read_small_at", return_value=b"populated 1\n"
+            ),
+            mock.patch.object(
+                guardian.time,
+                "monotonic",
+                side_effect=[0.0, 0.0, 1.0],
+            ),
+            mock.patch.object(guardian.time, "sleep"),
+            mock.patch.object(guardian.os, "close"),
+            mock.patch.object(guardian.os, "rmdir") as remove,
+            self.assertRaisesRegex(
+                guardian.GuardianError, "kill failed"
+            ) as raised,
+        ):
+            guardian.cleanup_command_cgroup(cgroup, 0.5)
+
+        remove.assert_not_called()
+        self.assertEqual(raised.exception.code, "KILL_FAILED")
+        self.assertEqual(
+            [cause.code for cause in raised.exception.cleanup_causes],
+            ["CGROUP_CLEANUP_TIMEOUT"],
+        )
+
+    def test_guardian_reap_timeout_appends_to_cleanup_failure(self) -> None:
+        cgroup = guardian.CgroupHandle(root_fd=10, child_fd=11, name="known")
+        cleanup_error = guardian.GuardianError(
+            "CGROUP_CLEANUP_TIMEOUT", "cgroup remained populated"
+        )
+        with (
+            mock.patch.object(guardian.sys, "platform", "linux"),
+            mock.patch.object(guardian.os, "O_CLOEXEC", 0, create=True),
+            mock.patch.object(guardian.os, "WNOHANG", 1, create=True),
+            mock.patch.object(guardian.os, "open", return_value=10),
+            mock.patch.object(guardian, "_enable_subreaper"),
+            mock.patch.object(
+                guardian, "create_command_cgroup", return_value=cgroup
+            ),
+            mock.patch.object(
+                guardian.os, "pipe2", return_value=(20, 21), create=True
+            ),
+            mock.patch.object(guardian.os, "fork", return_value=321, create=True),
+            mock.patch.object(guardian.os, "close"),
+            mock.patch.object(guardian, "_write_small_at"),
+            mock.patch.object(guardian.os, "write", return_value=1),
+            mock.patch.object(guardian, "_monitor", return_value=(0, False)),
+            mock.patch.object(
+                guardian, "cleanup_command_cgroup", side_effect=cleanup_error
+            ),
+            mock.patch.object(
+                guardian.os, "waitpid", side_effect=ChildProcessError
+            ),
+            mock.patch.object(guardian, "_reap_children", return_value=False),
+            self.assertRaisesRegex(
+                guardian.GuardianError, "cgroup remained populated"
+            ) as raised,
+        ):
+            guardian.supervise(
+                ["fixture"],
+                control_fd=5,
+                cgroup_root="/delegated",
+                cleanup_timeout_seconds=1,
+            )
+
+        self.assertEqual(raised.exception.code, "CGROUP_CLEANUP_TIMEOUT")
+        self.assertEqual(
+            [cause.code for cause in raised.exception.cleanup_causes],
+            ["ADOPTED_REAP_TIMEOUT"],
+        )
+
+    def test_guardian_assigns_cgroup_before_releasing_child(self) -> None:
+        cgroup = guardian.CgroupHandle(root_fd=10, child_fd=11, name="known")
+        events: list[str] = []
+
+        def write_control(root_fd: int, name: str, value: bytes) -> None:
+            self.assertEqual((root_fd, name, value), (11, "cgroup.procs", b"321\n"))
+            events.append("assign")
+
+        def release(descriptor: int, value: bytes) -> int:
+            self.assertEqual((descriptor, value), (21, b"1"))
+            events.append("release")
+            return 1
+
+        with (
+            mock.patch.object(guardian.sys, "platform", "linux"),
+            mock.patch.object(guardian.os, "O_CLOEXEC", 0, create=True),
+            mock.patch.object(guardian.os, "WNOHANG", 1, create=True),
+            mock.patch.object(guardian.os, "open", return_value=10),
+            mock.patch.object(guardian, "_enable_subreaper"),
+            mock.patch.object(
+                guardian, "create_command_cgroup", return_value=cgroup
+            ),
+            mock.patch.object(
+                guardian.os, "pipe2", return_value=(20, 21), create=True
+            ),
+            mock.patch.object(guardian.os, "fork", return_value=321, create=True),
+            mock.patch.object(guardian.os, "close"),
+            mock.patch.object(guardian, "_write_small_at", side_effect=write_control),
+            mock.patch.object(guardian.os, "write", side_effect=release),
+            mock.patch.object(guardian, "_monitor", return_value=(0, False)),
+            mock.patch.object(guardian, "cleanup_command_cgroup") as cleanup,
+            mock.patch.object(
+                guardian.os, "waitpid", side_effect=ChildProcessError
+            ),
+            mock.patch.object(guardian, "_reap_children") as reap,
+        ):
+            status = guardian.supervise(
+                ["fixture"],
+                control_fd=5,
+                cgroup_root="/delegated",
+                cleanup_timeout_seconds=1,
+            )
+
+        self.assertEqual(events, ["assign", "release"])
+        self.assertEqual(status["returncode"], 0)
+        self.assertTrue(status["cleanup_confirmed"])
+        cleanup.assert_called_once()
+        reap.assert_called_once()
+
+    def test_guardian_cgroup_setup_failure_precedes_fork(self) -> None:
+        setup_error = guardian.GuardianError(
+            "CGROUP_DELEGATION_INVALID", "delegation invalid"
+        )
+        with (
+            mock.patch.object(guardian.sys, "platform", "linux"),
+            mock.patch.object(guardian.os, "O_CLOEXEC", 0, create=True),
+            mock.patch.object(guardian.os, "open", return_value=10),
+            mock.patch.object(guardian, "_enable_subreaper"),
+            mock.patch.object(
+                guardian, "create_command_cgroup", side_effect=setup_error
+            ),
+            mock.patch.object(guardian.os, "fork", create=True) as fork,
+            mock.patch.object(guardian.os, "close"),
+            mock.patch.object(guardian, "_reap_children"),
+            self.assertRaisesRegex(guardian.GuardianError, "delegation invalid"),
+        ):
+            guardian.supervise(
+                ["fixture"],
+                control_fd=5,
+                cgroup_root="/delegated",
+                cleanup_timeout_seconds=1,
+            )
+
+        fork.assert_not_called()
+
     def test_posix_process_group_permission_failure_is_structured(self) -> None:
         process = self.windows_process()
         process.poll.return_value = None
@@ -2108,6 +2797,8 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         threads = [mock.Mock(), mock.Mock()]
         for thread in threads:
             thread.is_alive.return_value = True
+        raw_attempt = mock.Mock()
+        raw_attempt.observe.return_value = None
 
         with (
             mock.patch.object(provenance.subprocess, "Popen", return_value=process),
@@ -2127,6 +2818,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                 timeout_seconds=0.1,
                 drain_timeout_seconds=0.1,
                 windows_job_factory=mock.Mock,
+                raw_close_attempt_factory=mock.Mock(return_value=raw_attempt),
             )
 
         failure = raised.exception.lifecycle
@@ -2147,6 +2839,8 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         threads = [mock.Mock(), mock.Mock()]
         for thread in threads:
             thread.is_alive.return_value = True
+        raw_attempt = mock.Mock()
+        raw_attempt.observe.return_value = None
 
         with (
             mock.patch.object(provenance.subprocess, "Popen", return_value=process),
@@ -2165,12 +2859,122 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                 drain_timeout_seconds=0.1,
                 windows_job_factory=mock.Mock,
                 process_tree_terminator=mock.Mock(),
+                raw_close_attempt_factory=mock.Mock(return_value=raw_attempt),
             )
 
         failure = raised.exception.lifecycle
         self.assertEqual(failure.stage, "pipe.drain")
         self.assertEqual(failure.cleanup_causes, ())
         self.assertEqual(failure.message, str(raised.exception))
+
+    def test_stuck_stdout_raw_close_does_not_skip_healthy_stderr(self) -> None:
+        process = mock.Mock(pid=404)
+        process.wait.return_value = 0
+        stdout_thread = mock.Mock()
+        stdout_thread.is_alive.return_value = True
+        stderr_thread = mock.Mock()
+        stderr_thread.is_alive.return_value = False
+        raw_failure = provenance.LifecycleFailure(
+            stage="pipe.close",
+            api="Popen.stdout.raw.close",
+            error_code=None,
+            message="stdout raw pipe close timed out after 0.1 seconds",
+        )
+        raw_attempt = mock.Mock()
+        raw_attempt.observe.return_value = raw_failure
+        raw_factory = mock.Mock(return_value=raw_attempt)
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            mock.patch.object(
+                provenance.threading,
+                "Thread",
+                side_effect=[stdout_thread, stderr_thread],
+            ),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError,
+                "output pipes did not close within bounds.*raw pipe close timed out",
+            ) as raised,
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="one stuck drain fixture",
+                drain_timeout_seconds=0.1,
+                raw_close_timeout_seconds=0.1,
+                windows_job_factory=mock.Mock,
+                process_tree_terminator=mock.Mock(),
+                raw_close_attempt_factory=raw_factory,
+            )
+
+        failure = raised.exception.lifecycle
+        self.assertEqual(failure.stage, "pipe.drain")
+        self.assertEqual(
+            [(cause.stage, cause.api) for cause in failure.cleanup_causes],
+            [("pipe.close", "Popen.stdout.raw.close")],
+        )
+        self.assertEqual(raw_factory.call_args.args[0].name, "stdout")
+        process.stdout.close.assert_not_called()
+        process.stderr.close.assert_called_once_with()
+
+    def test_raw_pipe_close_attempt_has_independent_observation_bound(self) -> None:
+        release = threading.Event()
+        raw = mock.Mock()
+
+        def blocked_close() -> None:
+            release.wait(5)
+            raise OSError(5, "late close failure")
+
+        raw.close.side_effect = blocked_close
+        stream = mock.Mock(raw=raw)
+        endpoint = provenance._DrainEndpoint(
+            "stdout", stream, bytearray(), 1, 0
+        )
+        attempt = provenance._RawPipeCloseAttempt(endpoint)
+        started = time.monotonic()
+        failure = attempt.observe(0.05)
+
+        self.assertLess(time.monotonic() - started, 0.5)
+        self.assertIsNotNone(failure)
+        assert failure is not None
+        self.assertEqual(failure.stage, "pipe.close")
+        self.assertIn("timed out", failure.message)
+        release.set()
+        self.assertTrue(attempt._done.wait(1))
+        self.assertIn("timed out", failure.message)
+
+    def test_raw_pipe_close_start_failure_is_ordered_after_drain(self) -> None:
+        process = mock.Mock(pid=404)
+        process.wait.return_value = 0
+        threads = [mock.Mock(), mock.Mock()]
+        for thread in threads:
+            thread.is_alive.return_value = True
+
+        with (
+            mock.patch.object(provenance.subprocess, "Popen", return_value=process),
+            mock.patch.object(provenance.threading, "Thread", side_effect=threads),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError,
+                "output pipes did not close within bounds.*could not start",
+            ) as raised,
+        ):
+            provenance._run_json_command(
+                [sys.executable],
+                [],
+                label="raw close start fixture",
+                drain_timeout_seconds=0.1,
+                windows_job_factory=mock.Mock,
+                process_tree_terminator=mock.Mock(),
+                raw_close_attempt_factory=mock.Mock(
+                    side_effect=OSError(5, "injected raw close start failure")
+                ),
+            )
+
+        self.assertEqual(raised.exception.lifecycle.stage, "pipe.drain")
+        self.assertEqual(
+            [cause.stage for cause in raised.exception.lifecycle.cleanup_causes],
+            ["pipe.close", "pipe.close"],
+        )
 
     def test_json_command_pipe_read_failure_fails_closed(self) -> None:
         process = mock.Mock(pid=404)
@@ -2644,6 +3448,10 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                 )
                 self.assertEqual(close_calls, 2)
 
+    @unittest.skipUnless(
+        os.name == "nt" or sys.platform.startswith("linux"),
+        "strict process containment backend",
+    )
     def test_process_tree_timeout_kills_descendant_pipe_holders(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             pid_path = Path(directory) / "child.pid"
@@ -2677,6 +3485,10 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             self.assertLess(time.monotonic() - started, 8)
             self.assert_process_exits(int(pid_path.read_text()))
 
+    @unittest.skipUnless(
+        os.name == "nt" or sys.platform.startswith("linux"),
+        "strict process containment backend",
+    )
     def test_process_tree_parent_exit_kills_descendant_pipe_holders(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             pid_path = Path(directory) / "child.pid"
@@ -2708,6 +3520,196 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             self.assertTrue(pid_path.exists(), "descendant never reached readiness")
             self.assertLess(time.monotonic() - started, 4)
             self.assert_process_exits(int(pid_path.read_text()))
+
+    @unittest.skipUnless(
+        sys.platform.startswith("linux")
+        and bool(os.environ.get("ADJ_PROVENANCE_CGROUP_ROOT")),
+        "delegated Linux cgroup v2 fixture",
+    )
+    def test_posix_guardian_contains_new_session_descendant(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            identity_path = Path(directory) / "child.identity"
+            child = (
+                "import os, pathlib, time; "
+                "raw=pathlib.Path(f'/proc/{os.getpid()}/stat').read_text(); "
+                "start=raw.rsplit(')',1)[1].split()[19]; "
+                f"pathlib.Path({str(identity_path)!r}).write_text(f'{{os.getpid()}} {{start}}'); "
+                "time.sleep(30)"
+            )
+            parent = (
+                "import pathlib, subprocess, sys, time; "
+                f"subprocess.Popen([sys.executable, '-c', {child!r}], start_new_session=True); "
+                f"p=pathlib.Path({str(identity_path)!r}); "
+                "deadline=time.monotonic()+5; "
+                "exec(\"while not p.exists() and time.monotonic() < deadline:\\n time.sleep(0.01)\"); "
+                "sys.stdout.buffer.write(b'{}\\n'); sys.stdout.buffer.flush()"
+            )
+
+            result = provenance._run_json_command(
+                [sys.executable, "-c", parent],
+                [],
+                label="new-session descendant fixture",
+                timeout_seconds=5,
+                drain_timeout_seconds=2,
+            )
+
+            self.assertEqual(result, {})
+            pid_text, starttime = identity_path.read_text().split()
+            self.assert_linux_process_identity_exits(int(pid_text), starttime)
+
+    @unittest.skipUnless(
+        sys.platform.startswith("linux")
+        and bool(os.environ.get("ADJ_PROVENANCE_CGROUP_ROOT")),
+        "delegated Linux cgroup v2 fixture",
+    )
+    def test_posix_guardian_timeout_contains_new_session_descendant(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            identity_path = Path(directory) / "child.identity"
+            child = (
+                "import os, pathlib, time; "
+                "raw=pathlib.Path(f'/proc/{os.getpid()}/stat').read_text(); "
+                "start=raw.rsplit(')',1)[1].split()[19]; "
+                f"pathlib.Path({str(identity_path)!r}).write_text(f'{{os.getpid()}} {{start}}'); "
+                "time.sleep(30)"
+            )
+            parent = (
+                "import pathlib, subprocess, sys, time; "
+                f"subprocess.Popen([sys.executable, '-c', {child!r}], start_new_session=True); "
+                f"p=pathlib.Path({str(identity_path)!r}); "
+                "deadline=time.monotonic()+5; "
+                "exec(\"while not p.exists() and time.monotonic() < deadline:\\n time.sleep(0.01)\"); "
+                "time.sleep(30)"
+            )
+
+            cgroup_root = Path(os.environ["ADJ_PROVENANCE_CGROUP_ROOT"])
+            baseline = {path.name for path in cgroup_root.glob("adj-provenance-*")}
+            with self.assertRaisesRegex(
+                provenance.ProvenanceError, "timed out"
+            ) as raised:
+                provenance._run_json_command(
+                    [sys.executable, "-c", parent],
+                    [],
+                    label="new-session timeout fixture",
+                    timeout_seconds=1,
+                    drain_timeout_seconds=2,
+                )
+
+            pid_text, starttime = identity_path.read_text().split()
+            self.assert_linux_process_identity_exits(int(pid_text), starttime)
+            self.assertEqual(raised.exception.lifecycle.stage, "command.timeout")
+
+            def lifecycle_stages(failure: object) -> list[str]:
+                if failure is None:
+                    return []
+                result = [failure.stage]
+                for cause in failure.cleanup_causes:
+                    result.extend(lifecycle_stages(cause))
+                return result
+
+            self.assertNotIn(
+                "containment.confirm", lifecycle_stages(raised.exception.lifecycle)
+            )
+            current = {path.name for path in cgroup_root.glob("adj-provenance-*")}
+            deadline = time.monotonic() + 5
+            while current != baseline and time.monotonic() < deadline:
+                time.sleep(0.05)
+                current = {
+                    path.name for path in cgroup_root.glob("adj-provenance-*")
+                }
+            self.assertEqual(current, baseline)
+
+    @unittest.skipUnless(
+        sys.platform.startswith("linux")
+        and bool(os.environ.get("ADJ_PROVENANCE_CGROUP_ROOT")),
+        "delegated Linux cgroup v2 fixture",
+    )
+    def test_posix_guardian_closes_protocol_descriptors_before_exec(self) -> None:
+        command = (
+            "import json, os; "
+            "scan=os.scandir('/proc/self/fd'); "
+            "candidates=[int(entry.name) for entry in scan if int(entry.name)>2]; "
+            "scan.close(); fds=[]; "
+            "exec(\"for fd in candidates:\\n"
+            " try:\\n  os.fstat(fd); fds.append(fd)\\n"
+            " except OSError:\\n  pass\"); "
+            "print(json.dumps({'fds':fds}, indent=2, sort_keys=True))"
+        )
+
+        result = provenance._run_json_command(
+            [sys.executable, "-c", command],
+            [],
+            label="guardian descriptor fixture",
+            timeout_seconds=5,
+            drain_timeout_seconds=2,
+        )
+
+        self.assertEqual(result, {"fds": []})
+
+    @unittest.skipUnless(
+        sys.platform.startswith("linux")
+        and bool(os.environ.get("ADJ_PROVENANCE_CGROUP_ROOT")),
+        "delegated Linux cgroup v2 fixture",
+    )
+    def test_posix_guardian_cleans_after_verifier_sigkill(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            identity_path = root / "child.identity"
+            child = (
+                "import os, pathlib, time; "
+                "raw=pathlib.Path(f'/proc/{os.getpid()}/stat').read_text(); "
+                "start=raw.rsplit(')',1)[1].split()[19]; "
+                f"pathlib.Path({str(identity_path)!r}).write_text(f'{{os.getpid()}} {{start}}'); "
+                "time.sleep(30)"
+            )
+            guarded = (
+                "import pathlib, subprocess, sys, time; "
+                f"subprocess.Popen([sys.executable, '-c', {child!r}], start_new_session=True); "
+                f"p=pathlib.Path({str(identity_path)!r}); "
+                "deadline=time.monotonic()+5; "
+                "exec(\"while not p.exists() and time.monotonic() < deadline:\\n time.sleep(0.01)\"); "
+                "time.sleep(30)"
+            )
+            harness = (
+                "import sys; "
+                f"sys.path.insert(0, {str(SCRIPTS_DIR)!r}); "
+                "import adj_stdlib_provenance as p; "
+                f"p._run_json_command([sys.executable, '-c', {guarded!r}], [], "
+                "label='crash fixture', timeout_seconds=30, drain_timeout_seconds=2)"
+            )
+            cgroup_root = Path(os.environ["ADJ_PROVENANCE_CGROUP_ROOT"])
+            baseline = {path.name for path in cgroup_root.glob("adj-provenance-*")}
+            verifier = subprocess.Popen(
+                [sys.executable, "-c", harness],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            current = baseline
+            try:
+                deadline = time.monotonic() + 8
+                while not identity_path.exists() and time.monotonic() < deadline:
+                    time.sleep(0.05)
+                self.assertTrue(identity_path.exists(), "guarded child never started")
+                pid_text, starttime = identity_path.read_text().split()
+                os.kill(verifier.pid, signal.SIGKILL)
+                verifier.wait(timeout=5)
+                self.assert_linux_process_identity_exits(int(pid_text), starttime)
+                deadline = time.monotonic() + 5
+                while time.monotonic() < deadline:
+                    current = {
+                        path.name for path in cgroup_root.glob("adj-provenance-*")
+                    }
+                    if current == baseline:
+                        break
+                    time.sleep(0.05)
+                self.assertEqual(current, baseline)
+            finally:
+                if verifier.poll() is None:
+                    verifier.kill()
+                    verifier.wait(timeout=5)
+                assert verifier.stdout is not None
+                assert verifier.stderr is not None
+                verifier.stdout.close()
+                verifier.stderr.close()
 
     @unittest.skipUnless(os.name == "nt", "Windows Job Object behavior")
     def test_windows_job_assigns_before_process_execution(self) -> None:

--- a/code/specs/ADJ-STDLIB-COVERAGE.md
+++ b/code/specs/ADJ-STDLIB-COVERAGE.md
@@ -327,9 +327,13 @@ option mapping, or judge/evaluation failure.
      between all inventoried formula roots and witnessed query dependencies. These
      are six replay examples, not a universal proof over every input; boundary,
      exceptional, and property-based execution coverage remains backlog work.
-13d. **Complete:** every trusted parser/audit subprocess bound applies to its
-     complete process tree and to pipe-drain joins, so a timed-out descendant cannot
-     keep provenance verification alive indefinitely.
+13d. **Complete for the original process group:** every trusted parser/audit
+     subprocess starts in a fresh session. Verifier-observed timeout, output
+     overflow, I/O failure, or command-parent exit applies bounded termination to
+     that process group, kills and reaps the root as a fallback, and bounds pipe
+     drain. This tranche did not contain a descendant that called `setsid()`, and
+     its in-process cleanup did not survive abrupt verifier death; 13i closes those
+     gaps where the host exposes a hard containment primitive.
 13e. **Complete:** verified execution inputs resolve uniquely across the complete
      bundle closure. Each normalized input pins its owning bundle role and ID, exact
      ADJ source and IR, and exact cited snapshot and IR; dependency-owned inputs also
@@ -346,10 +350,11 @@ option mapping, or judge/evaluation failure.
      termination before the root-process fallback. The Windows PR matrix runs the
      focused fake and real-process containment slice.
 13g. **Complete:** process lifecycle failures are immutable recursive records with a
-     stable `stage`, native `api`, numeric `error_code`, human `message`, and ordered
-     `cleanup_causes`. `ProvenanceError.lifecycle` exposes the record while preserving
+     stable `stage`, native `api`, numeric `error_code`, symbolic `status_code`, human
+     `message`, and ordered `cleanup_causes`. `ProvenanceError.lifecycle` exposes the
+     record while preserving
      legacy exception text and arguments. `to_dict()` provides the versioned
-     `adj-stdlib/process-lifecycle-failure/v1` projection, and CLI failures include it
+     `adj-stdlib/process-lifecycle-failure/v2` projection, and CLI failures include it
      as `lifecycle_failure` without removing the legacy `error` or `valid` fields.
      Native setup and enumeration errors, process launch and containment, command
      timeout/output/exit/decoding, taskkill and root fallback, pipe drain, termination,
@@ -362,14 +367,34 @@ option mapping, or judge/evaluation failure.
      stdout/stderr close failures remain in the lifecycle tree. An attempt-ordered event
      ledger preserves concurrent reader causality and every repeated termination, and a
      final bounded wait reaps the root after recovery termination. Hosted Linux runs the
-     full provenance suite in `detect`; hosted macOS runs the focused POSIX/process-tree
-     selector with pinned Python, and the Windows selector includes all Job and generic
-     process-tree cases.
-13i. **Backlog:** contain descendants that deliberately create a new session and add
-     kill-on-verifier-crash semantics for POSIX, where `start_new_session=True` alone
-     cannot guarantee cleanup after abrupt verifier termination. Add independently
-     bounded raw-handle closure for readers that remain stuck after tree termination;
-     ordinary buffered `close()` can itself block behind a concurrent read.
+     full provenance suite in `detect`; hosted macOS runs the focused unsupported-
+     boundary, guardian-protocol, process-tree, drain, and raw-close selector with
+     pinned Python, and the Windows selector includes all Job, generic process-tree,
+     drain, and raw-close cases.
+13i. **Complete with an explicit platform boundary:** Linux strict execution now uses
+     one short-lived external guardian per command. The guardian validates an operator-
+     delegated cgroup-v2 root, becomes a subreaper, creates a fresh command cgroup,
+     forks behind a gate, writes the root to `cgroup.procs`, and releases it only after
+     containment exists. Normal root exit, explicit cancellation, and EOF on the
+     verifier's private control pipe share one monotonic cleanup deadline. Cleanup
+     writes `cgroup.kill`, supplements it with a still-identity-safe process-group
+     signal when the root has not been reaped, requires one exact `populated 0` field,
+     reaps the root and adopted descendants, and removes the cgroup. A separate bounded
+     canonical status pipe must attest cleanup before helper JSON can be accepted;
+     symbolic guardian codes and compound cleanup causes project directly into v2
+     lifecycle fields without message parsing.
+     Hosted Linux creates and enters a temporary delegated cgroup and exercises both a
+     `setsid()` descendant and verifier `SIGKILL`. Windows retains pre-exec suspended
+     Job assignment and kernel `KILL_ON_JOB_CLOSE`. macOS and generic POSIX have no
+     equivalent unprivileged hard container, so strict helper execution rejects before
+     launch rather than silently weakening the claim. Reader channels retain explicit
+     identity; a stuck channel starts an independently observed raw-owner close worker,
+     healthy channels still close normally, and timeout, start failure, or close failure
+     remains ordered lifecycle evidence. A permanently wedged close may retain its raw
+     owner in a daemon worker until host exit, but cannot block verification or permit
+     output acceptance. The guarantee assumes the guardian and kernel remain alive and
+     the trusted helper does not attack the same-UID guardian or delegated cgroup;
+     defending against that stronger adversary requires a privilege boundary.
 
 ### Wave 2: complete K-8 foundations
 

--- a/code/specs/data/adj-stdlib-provenance/README.md
+++ b/code/specs/data/adj-stdlib-provenance/README.md
@@ -117,18 +117,25 @@ can prune the old unreachable graph.
 
 This separation prevents an untrusted source locator from turning the verifier
 into a network or SSRF primitive. Reads are bounded and reject links and Windows
-reparse points; object writes are exclusive; index writes are atomic. Trusted
-parser and audit commands run in isolated process groups; output overflow or timeout
-terminates the complete process tree, and pipe-drain joins have their own bound.
+reparse points; object writes are exclusive; index writes are atomic. Trusted parser
+and audit commands use a hard platform containment boundary. Windows assigns a
+suspended root to a kill-on-close Job before execution. Linux requires the absolute
+`ADJ_PROVENANCE_CGROUP_ROOT` path to an operator-delegated cgroup-v2 subtree; an
+external guardian assigns the command to a fresh child before release, survives
+verifier death through a private control-pipe EOF, and accepts cleanup only after
+`cgroup.kill`, exact `populated 0`, reaping, and child removal. macOS and generic POSIX
+strict execution reject before launch because process groups cannot contain a
+descendant that creates another session.
 Windows Job lifecycle calls are fault-injected in platform-neutral tests and exercised
 against real suspended processes in the Windows PR matrix. Native enumeration errors,
 truncated thread records, incomplete resumes, termination failures, and handle-close
 failures all prevent a verifier result from being accepted.
 Lifecycle failures remain human-readable but also expose an immutable recursive record
-through `ProvenanceError.lifecycle`: stage, native API, numeric error code, message, and
-ordered cleanup causes. Its `to_dict()` projection is canonical JSON-ready, so callers
+through `ProvenanceError.lifecycle`: stage, native API, numeric error code, symbolic
+status code, message, and ordered cleanup causes. Its `to_dict()` projection is
+canonical JSON-ready, so callers
 do not need to parse localized operating-system messages to diagnose containment. The
-projection is versioned as `adj-stdlib/process-lifecycle-failure/v1`; CLI failures add
+projection is versioned as `adj-stdlib/process-lifecycle-failure/v2`; CLI failures add
 it as `lifecycle_failure` while retaining the existing `error` and `valid` fields.
 Process-wait, pipe-read, and pipe-close faults are records too; partial output is never
 accepted merely because its prefix happens to be valid canonical JSON.
@@ -136,7 +143,16 @@ POSIX group termination is fault-injected independently of the host OS: lookup m
 permission errors, poll failures, root-process fallback, and simultaneous pipe-close
 failures retain API-attempt ordering. Repeated termination attempts are never collapsed,
 concurrent reader failures use event order, and recovery ends with a bounded root wait.
-Linux runs the complete suite and macOS runs the focused POSIX/process-tree gate before
-merge.
+Linux runs the complete suite; macOS runs the focused unsupported-boundary, guardian-
+protocol, process-tree, drain, and raw-close gate before merge.
+The Linux gate enters its delegated root before running the provenance suite, then uses
+real fixtures to prove cleanup of a `setsid()` descendant and cleanup after verifier
+`SIGKILL`. Guardian status travels on a separate bounded canonical pipe, so helper
+bytes cannot forge containment success. Stuck pipe readers use independently bounded
+raw-owner close attempts; healthy channels close independently, and every unconfirmed
+close fails closed. The guardian threat model covers accidental session escape and
+abrupt verifier death while the guardian and kernel remain alive. A same-UID helper
+that deliberately attacks the guardian or delegated cgroup requires a stronger
+privilege boundary.
 Existing hashes are reused, while missing or changed bytes, claims, transforms, graph
 edges, receipts, partitions, and projections fail closed.


### PR DESCRIPTION
## Summary
- add a Linux cgroup-v2 guardian that contains session-escaping descendants and cleans up when the verifier dies
- require bounded canonical cleanup attestation and preserve symbolic, recursive lifecycle failures end to end
- add independently bounded raw pipe-owner closure and explicit fail-closed macOS behavior
- exercise delegated cgroups, verifier SIGKILL, leaked descriptor checks, compound fault injection, and Windows/macOS selectors in CI

## Validation
- `python code/scripts/tests/test_adj_stdlib_provenance.py` (174 passed, 5 platform skips)
- focused guardian tests (23 passed, 4 delegated-Linux skips)
- Windows containment selector (48 passed)
- Ruff and `py_compile`
- ADJ structural report gate
- ADJ manifest: 6 roots, 10 objectives, valid
- ADJ provenance: 6 bundles, 84 objects, 9 snapshots, valid
- workflow YAML parse and `git diff --check`
- two independent read-only reviewer passes, no remaining P0-P2 findings

## Platform boundary
Hosted Linux is authoritative for the real delegated cgroup-v2 tests. Windows retains suspended Job assignment with kill-on-close. macOS rejects strict helper execution before launch because process groups cannot contain a descendant that creates a new session.