### PR TITLE
fix(spice): lower MOS junction capacitance aliases

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower MOS model-card `CJS` and `CJD` aliases as canonical `CBS`
+  and `CBD` junction capacitances.
 - Reject negative and non-finite MOS model-card `AF` values before lowering
   valid flicker-noise exponents.
 - Reject negative and non-finite MOS model-card `KF` values before lowering

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1977,6 +1977,19 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(params["CJSW"]) or params["CJSW"] < 0.0
         ):
             raise NetlistParseError("MOSFET CJSW must be finite and non-negative")
+        for parameter_name, canonical in (
+            ("CBS", "CBS"),
+            ("CJS", "CBS"),
+            ("CBD", "CBD"),
+            ("CJD", "CBD"),
+        ):
+            if parameter_name in params and (
+                not math.isfinite(params[parameter_name])
+                or params[parameter_name] < 0.0
+            ):
+                raise NetlistParseError(
+                    f"MOSFET {canonical} must be finite and non-negative"
+                )
         if "JS" in params and (
             not math.isfinite(params["JS"]) or params["JS"] < 0.0
         ):
@@ -2051,6 +2064,8 @@ _LEVEL1_PARAM_ALIASES = {
     "VTO": "VT0",
     "VTH": "VT0",
     "LAM": "LAMBDA",
+    "CJS": "CBS",
+    "CJD": "CBD",
 }
 
 

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -2030,6 +2030,36 @@ def test_lowers_valid_mosfet_model_flicker_noise_exponent(exponent: str) -> None
     assert isclose(mosfet.model.model.params.AF, float(exponent))
 
 
+@pytest.mark.parametrize(
+    ("alias", "canonical"),
+    [("CJS", "CBS"), ("CJD", "CBD")],
+)
+@pytest.mark.parametrize("capacitance", ["-1p", "1e999"])
+def test_rejects_invalid_mosfet_junction_capacitance_aliases(
+    alias: str, canonical: str, capacitance: str
+) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match=f"MOSFET {canonical} must be finite and non-negative",
+    ):
+        parse_netlist(
+            f".model nfast NMOS({alias}={capacitance})\nM1 d g s b nfast\n"
+        )
+
+
+@pytest.mark.parametrize(
+    ("alias", "canonical"),
+    [("CJS", "CBS"), ("CJD", "CBD")],
+)
+def test_lowers_mosfet_junction_capacitance_aliases(
+    alias: str, canonical: str
+) -> None:
+    parsed = parse_netlist(f".model nfast NMOS({alias}=2p)\nM1 d g s b nfast\n")
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(getattr(mosfet.model.model.params, canonical), 2.0e-12)
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower MOS model-card `CJS` and `CJD` aliases as canonical `CBS`
+  and `CBD` junction capacitances.
 - Reject negative and non-finite MOS model-card `AF` values and lower valid
   flicker-noise exponents instead of silently dropping them.
 - Reject negative and non-finite MOS model-card `KF` values and lower valid

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1292,6 +1292,21 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET CJSW must be finite and non-negative");
   }
+  for (const [name, canonical] of [
+    ["CBS", "CBS"],
+    ["CJS", "CBS"],
+    ["CBD", "CBD"],
+    ["CJD", "CBD"],
+  ] as const) {
+    const capacitance = params.get(name);
+    if (
+      (kind === "NMOS" || kind === "PMOS") &&
+      capacitance !== undefined &&
+      (!Number.isFinite(capacitance) || capacitance < 0.0)
+    ) {
+      throw new NetlistParseError(`MOSFET ${canonical} must be finite and non-negative`);
+    }
+  }
   const junctionCurrent = params.get("JS");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1404,6 +1419,8 @@ const MOSFET_PARAM_ALIASES = new Map<string, keyof MosfetLevel1Params>([
   ["N", "N_SUB"],
   ["TNOM", "T_NOM"],
   ["UO", "U0"],
+  ["CJS", "CBS"],
+  ["CJD", "CBD"],
 ]);
 
 function mosfetParams(

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1865,6 +1865,20 @@ Xright c d load
     expect(element.params.AF).toBe(Number(exponent));
   });
 
+  it.each([
+    ["CJS", "CBS"],
+    ["CJD", "CBD"],
+  ] as const)("validates and lowers MOSFET %s as %s", (alias, canonical) => {
+    expect(() =>
+      parseNetlist(`.model nfast NMOS(${alias}=-1p)\nM1 d g s b nfast\n`),
+    ).toThrow(`MOSFET ${canonical} must be finite and non-negative`);
+    const parsed = parseNetlist(`.model nfast NMOS(${alias}=2p)\nM1 d g s b nfast\n`);
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params[canonical]).toBeCloseTo(2.0e-12, 18);
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4303,13 +4303,17 @@ the Rust, Python, and TypeScript surfaces together.
      shared diagnostic while zero and positive flicker-noise coefficients
      lower into Level-1 parameters.
 
+398. Python and TypeScript Berkeley SPICE MOS flicker-noise exponent parity.
+   - Status: completed in PR 9718.
+   - Negative and non-finite model-card `AF` values are rejected with the
+     shared diagnostic while zero and positive flicker-noise exponents lower
+     into Level-1 parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
-   - TypeScript still needs canonical lowering for `AF`; Python already lowers
-     this canonical field but still needs matching facade validation coverage.
    - Align the `CJS` and `CJD` aliases with canonical `CBS` and `CBD` in both
-     facades after the canonical-field slices.
+     facades.
 
 2. Python and TypeScript Berkeley SPICE MOS electrostatic-default parity.
    - Validate and consume `NSS` / `TPG`, then derive `VT0`, `GAMMA`, and `PHI`


### PR DESCRIPTION
## Summary

- validate MOS `CBS`/`CJS` and `CBD`/`CJD` model-card values with canonical finite, nonnegative diagnostics
- lower `CJS` and `CJD` through both parser facades as canonical `CBS` and `CBD`
- reconcile the SPICE plan with merged AF parity and update parser changelogs

## Verification

- Python `spice-netlist-parser`: `bash BUILD` (215 tests, 88.62% coverage)
- Python `spice-netlist-parser`: `.venv/bin/ruff check .`
- TypeScript `spice-engine`: `bash BUILD` (448 tests)
- TypeScript `spice-netlist-parser`: `bash BUILD` (204 tests)
- TypeScript `spice-netlist-parser`: `npm run test:coverage` (204 tests, 85.32% line coverage)