### PR TITLE
feat(smart-home): add Axis VAPIX PTZ controls

### DIFF
--- a/code/packages/rust/smart-home-axis-vapix-integration/CHANGELOG.md
+++ b/code/packages/rust/smart-home-axis-vapix-integration/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.0
+
+- Add capability-probed Axis position and preset inspection.
+- Add authorized preset recall and five-second-bounded directional movement.
+- Honor native PTZ control queues with transport-only cookies and explicit
+  queue release and movement stop.
+
 ## 0.1.0
 
 - Add Axis video/NVR mDNS discovery records.

--- a/code/packages/rust/smart-home-axis-vapix-integration/Cargo.toml
+++ b/code/packages/rust/smart-home-axis-vapix-integration/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "smart-home-axis-vapix-integration"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "Authenticated Axis VAPIX discovery and inspection for the smart-home runtime"
+description = "Authenticated Axis VAPIX discovery, inspection, and bounded PTZ control"
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/smart-home-axis-vapix-integration/README.md
+++ b/code/packages/rust/smart-home-axis-vapix-integration/README.md
@@ -1,6 +1,7 @@
 # smart-home-axis-vapix-integration
 
-Production-facing Axis VAPIX discovery and read-only inspection for D23.
+Production-facing Axis VAPIX discovery, inspection, and bounded PTZ control for
+D23.
 
 The package:
 
@@ -11,13 +12,24 @@ The package:
 - represents credentials as a `VaultRef` in request plans and materializes the
   Basic authorization value only inside the bounded transport;
 - calls the authenticated Basic Device Information and API Discovery JSON CGIs;
+- probes the documented PTZ command inventory, current position, server presets,
+  native speed control, and `CtlQueueing` mode before advertising `camera.ptz`;
+- recalls only probed presets and bounds continuous directional movement to five
+  seconds, followed by an explicit `0,0` stop;
+- obtains exclusive PTZ control through `ptzqueue.cgi` when queueing is enabled,
+  keeps the returned cookie out of request plans and debug output, and drops the
+  queue lease after each command;
 - normalizes Axis identity, firmware, product type, and the supported VAPIX API
   list into one confirmed camera entity; and
-- authorizes D23 reads before credentials or transport are touched.
+- authorizes D23 reads and human-approved PTZ commands before credentials or
+  transport are touched; and
+- preserves confirmed position from inspection instead of inventing optimistic
+  orientation after movement.
 
-PTZ control, event streaming, snapshots, and media transfer remain separate
-slices because they require capability/permission probes, event lifecycle, or a
-camera-media executor beyond identity inspection.
+The first production slice intentionally targets VAPIX camera 1. Event
+streaming, snapshots, media transfer, multi-channel enumeration, and advanced
+zoom/guard-tour control remain separate slices with additional host or
+capability prerequisites.
 
 Protocol references:
 
@@ -25,3 +37,4 @@ Protocol references:
 - [Axis basic device information](https://developer.axis.com/vapix/network-video/basic-device-information/)
 - [Axis API Discovery](https://developer.axis.com/vapix/network-video/api-discovery-service/)
 - [Axis mDNS-SD](https://developer.axis.com/vapix/network-video/mdns-sd-api/)
+- [Axis PTZ API](https://developer.axis.com/vapix/network-video/pantiltzoom-api/)

--- a/code/packages/rust/smart-home-axis-vapix-integration/src/lib.rs
+++ b/code/packages/rust/smart-home-axis-vapix-integration/src/lib.rs
@@ -5,13 +5,13 @@
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use coding_adventures_zeroize::Zeroizing;
 use http1::{parse_response_head, Http1ParseError};
-use http_core::BodyKind;
+use http_core::{find_header, BodyKind};
 use serde_json::{json, Map as JsonMap, Value as JsonValue};
 use smart_home_core::{
-    AgentId, Bridge, BridgeId, BridgeTransport, Capability, CapabilityId, CapabilityMode, Device,
-    DeviceId, Entity, EntityId, EntityKind, Health, IntegrationId, Metadata, ProtocolFamily,
-    ProtocolIdentifier, SmartHomeTool, StateConfidence, StateSnapshot, StateSource, Value,
-    ValueKind, VaultRef,
+    AgentId, Bridge, BridgeId, BridgeTransport, Capability, CapabilityId, CapabilityMode,
+    CommandResult, CommandType, Device, DeviceControlCommandType, DeviceId, Entity, EntityId,
+    EntityKind, Health, IntegrationId, Metadata, ProtocolFamily, ProtocolIdentifier, SmartHomeTool,
+    StateConfidence, StateSnapshot, StateSource, Value, ValueKind, VaultRef,
 };
 use smart_home_discovery::{
     run_mdns_ipv4_scan, DiscoveryConfidence, DiscoveryRecord, DiscoverySource, MdnsAdvertisement,
@@ -21,24 +21,32 @@ use smart_home_local_http::{
     LocalHttpAuth, LocalHttpEndpoint, LocalHttpError, LocalHttpMethod, LocalHttpRequestPlan,
     LocalHttpRequestTemplate, LocalHttpScheme,
 };
-use smart_home_runtime::{RuntimeError, SmartHomeRuntime};
-use std::collections::BTreeSet;
+use smart_home_runtime::{RuntimeCommandToolRequest, RuntimeError, SmartHomeRuntime};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::io::{self, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
+use std::thread;
 use std::time::Duration;
 use tls_platform::{default_connector, TlsConfig, TlsConnector};
 use url_parser::{Url, UrlError};
 
-pub const VERSION: &str = "0.1.0";
+pub const VERSION: &str = "0.2.0";
 pub const INTEGRATION_ID: &str = "axis_vapix";
 pub const PROTOCOL_ID: &str = "axis_vapix";
 pub const VIDEO_MDNS_SERVICE_TYPE: &str = "_axis-video._tcp.local";
 pub const NVR_MDNS_SERVICE_TYPE: &str = "_axis-nvr._tcp.local";
 pub const BASIC_DEVICE_INFO_PATH: &str = "/axis-cgi/basicdeviceinfo.cgi";
 pub const API_DISCOVERY_PATH: &str = "/axis-cgi/apidiscovery.cgi";
+pub const PTZ_CONTROL_PATH: &str = "/axis-cgi/com/ptz.cgi";
+pub const PTZ_QUEUE_PATH: &str = "/axis-cgi/com/ptzqueue.cgi";
+pub const PARAM_PATH: &str = "/axis-cgi/param.cgi";
 pub const DEFAULT_MAX_DISCOVERY_RESPONSES: usize = 128;
 pub const DEFAULT_MAX_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
+pub const MIN_PTZ_SPEED: u32 = 1;
+pub const MAX_PTZ_SPEED: u32 = 100;
+pub const MAX_PTZ_DURATION_MS: u64 = 5_000;
+const PTZ_CAMERA: u32 = 1;
 
 #[derive(Debug)]
 pub enum AxisError {
@@ -50,11 +58,26 @@ pub enum AxisError {
     Tls(String),
     Http(String),
     HttpStatus(u16),
-    ResponseTooLarge { limit: usize },
-    TruncatedBody { expected: usize, actual: usize },
+    ResponseTooLarge {
+        limit: usize,
+    },
+    TruncatedBody {
+        expected: usize,
+        actual: usize,
+    },
     Json(serde_json::Error),
-    Api { code: i64, message: String },
+    Api {
+        code: i64,
+        message: String,
+    },
     MissingField(&'static str),
+    UnknownEntity(EntityId),
+    UnsupportedCommand(CommandType),
+    InvalidCommandArguments {
+        command_type: CommandType,
+        expected: &'static str,
+    },
+    PtzQueueUnavailable,
     Runtime(RuntimeError),
 }
 
@@ -81,6 +104,22 @@ impl fmt::Display for AxisError {
                 write!(formatter, "Axis VAPIX error {code}: {message}")
             }
             Self::MissingField(field) => write!(formatter, "Axis response is missing {field}"),
+            Self::UnknownEntity(entity_id) => {
+                write!(formatter, "unknown Axis entity {}", entity_id.as_str())
+            }
+            Self::UnsupportedCommand(command_type) => {
+                write!(formatter, "unsupported Axis command {command_type:?}")
+            }
+            Self::InvalidCommandArguments {
+                command_type,
+                expected,
+            } => write!(
+                formatter,
+                "invalid arguments for Axis command {command_type:?}; expected {expected}"
+            ),
+            Self::PtzQueueUnavailable => {
+                formatter.write_str("Axis PTZ control queue did not grant exclusive control")
+            }
             Self::Runtime(error) => error.fmt(formatter),
         }
     }
@@ -236,10 +275,49 @@ pub struct AxisApi {
     pub status: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct AxisSnapshot {
     pub device: AxisDeviceInformation,
     pub apis: Vec<AxisApi>,
+    pub ptz: Option<AxisPtzSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AxisPtzPosition {
+    pub pan: Option<f64>,
+    pub tilt: Option<f64>,
+    pub zoom: Option<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AxisPtzPreset {
+    pub id: u32,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AxisPtzQueueMode {
+    Disabled,
+    Required,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AxisPtzSnapshot {
+    pub camera: u32,
+    pub position: AxisPtzPosition,
+    pub presets: Vec<AxisPtzPreset>,
+    pub supports_continuous_pan_tilt: bool,
+    pub supports_server_presets: bool,
+    pub supports_speed: bool,
+    pub queue_mode: AxisPtzQueueMode,
+}
+
+impl AxisPtzSnapshot {
+    fn commandable(&self) -> bool {
+        self.supports_speed
+            && (self.supports_continuous_pan_tilt
+                || (self.supports_server_presets && !self.presets.is_empty()))
+    }
 }
 
 pub fn scan_video_mdns_ipv4(
@@ -324,7 +402,51 @@ pub trait AxisTransport {
         &mut self,
         plan: &LocalHttpRequestPlan,
         credentials: &AxisCredentials,
-    ) -> Result<Vec<u8>, AxisError>;
+        session_cookie: Option<&str>,
+    ) -> Result<AxisHttpResponse, AxisError>;
+}
+
+pub struct AxisHttpResponse {
+    pub body: Vec<u8>,
+    session_cookie: Option<Zeroizing<String>>,
+}
+
+impl AxisHttpResponse {
+    pub fn new(body: Vec<u8>) -> Self {
+        Self {
+            body,
+            session_cookie: None,
+        }
+    }
+
+    pub fn with_session_cookie(
+        body: Vec<u8>,
+        session_cookie: impl Into<String>,
+    ) -> Result<Self, AxisError> {
+        let session_cookie = session_cookie.into();
+        if session_cookie.trim().is_empty() || has_unsafe_http_text(&session_cookie) {
+            return Err(AxisError::Validation(
+                "session cookie is empty or contains unsafe HTTP text".to_string(),
+            ));
+        }
+        Ok(Self {
+            body,
+            session_cookie: Some(Zeroizing::new(session_cookie)),
+        })
+    }
+}
+
+impl fmt::Debug for AxisHttpResponse {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AxisHttpResponse")
+            .field("body_bytes", &self.body.len())
+            .field(
+                "session_cookie",
+                &self.session_cookie.as_ref().map(|_| "[REDACTED]"),
+            )
+            .finish()
+    }
 }
 
 pub struct AxisLanTransport {
@@ -359,7 +481,8 @@ impl AxisTransport for AxisLanTransport {
         &mut self,
         plan: &LocalHttpRequestPlan,
         credentials: &AxisCredentials,
-    ) -> Result<Vec<u8>, AxisError> {
+        session_cookie: Option<&str>,
+    ) -> Result<AxisHttpResponse, AxisError> {
         let url = Url::parse(&plan.url)?;
         let host = url
             .host
@@ -374,7 +497,12 @@ impl AxisTransport for AxisLanTransport {
             ));
         }
         let timeout = Duration::from_millis(plan.timeout_ms.max(1));
-        let request = Zeroizing::new(encode_http_request(&url, plan, credentials)?);
+        let request = Zeroizing::new(encode_http_request(
+            &url,
+            plan,
+            credentials,
+            session_cookie,
+        )?);
         let response = match url.scheme.as_str() {
             "http" => {
                 let mut stream = connect_tcp(host, port, timeout)?;
@@ -446,7 +574,11 @@ impl<T: AxisTransport> AxisClient<T> {
             API_DISCOVERY_PATH,
             &json!({"apiVersion":"1.0","context":"smart-home","method":"getApiList"}),
         )?;
-        parse_snapshot(&properties, &apis)
+        let mut snapshot = parse_snapshot(&properties, &apis)?;
+        if snapshot.apis.iter().any(|api| api.id == "ptz-control") {
+            snapshot.ptz = Some(self.inspect_ptz(PTZ_CAMERA)?);
+        }
+        Ok(snapshot)
     }
 
     fn post_json(&mut self, path: &str, body: &JsonValue) -> Result<JsonValue, AxisError> {
@@ -459,8 +591,8 @@ impl<T: AxisTransport> AxisClient<T> {
                 vault_ref: self.config.credential_ref.clone(),
             });
         let plan = template.plan(&self.endpoint, serde_json::to_vec(body)?)?;
-        let bytes = self.transport.execute(&plan, &self.credentials)?;
-        let value: JsonValue = serde_json::from_slice(&bytes)?;
+        let response = self.transport.execute(&plan, &self.credentials, None)?;
+        let value: JsonValue = serde_json::from_slice(&response.body)?;
         if let Some(error) = value.get("error") {
             return Err(AxisError::Api {
                 code: error.get("code").and_then(JsonValue::as_i64).unwrap_or(-1),
@@ -472,6 +604,145 @@ impl<T: AxisTransport> AxisClient<T> {
             });
         }
         Ok(value)
+    }
+
+    fn get_text(
+        &mut self,
+        target: &str,
+        session_cookie: Option<&str>,
+    ) -> Result<AxisHttpResponse, AxisError> {
+        let template = LocalHttpRequestTemplate::new(LocalHttpMethod::Get, target)?
+            .with_accept("text/plain")
+            .with_timeout_ms(duration_ms(self.config.timeout))
+            .with_idempotent(false)
+            .with_auth(LocalHttpAuth::Basic {
+                vault_ref: self.config.credential_ref.clone(),
+            });
+        let plan = template.plan(&self.endpoint, Vec::new())?;
+        let response = self
+            .transport
+            .execute(&plan, &self.credentials, session_cookie)?;
+        reject_ptz_error(&response.body)?;
+        Ok(response)
+    }
+
+    fn inspect_ptz(&mut self, camera: u32) -> Result<AxisPtzSnapshot, AxisError> {
+        let info = self.get_text(&format!("{PTZ_CONTROL_PATH}?info=1&camera={camera}"), None)?;
+        let info = response_text(&info.body)?;
+        let supports_continuous_pan_tilt = info
+            .lines()
+            .any(|line| line.trim_start().starts_with("continuouspantiltmove="));
+        let supports_server_presets = info
+            .lines()
+            .any(|line| line.trim_start().starts_with("gotoserverpresetno="));
+        let supports_speed = info
+            .lines()
+            .any(|line| line.trim_start().starts_with("speed="));
+        let position = self.get_text(
+            &format!("{PTZ_CONTROL_PATH}?query=position&camera={camera}"),
+            None,
+        )?;
+        let presets = if supports_server_presets {
+            let response = self.get_text(
+                &format!("{PTZ_CONTROL_PATH}?query=presetposall&camera={camera}"),
+                None,
+            )?;
+            parse_ptz_presets(response_text(&response.body)?)?
+        } else {
+            Vec::new()
+        };
+        let queue = self.get_text(
+            &format!("{PARAM_PATH}?action=list&group=PTZ.Various.V{camera}.CtlQueueing"),
+            None,
+        )?;
+        Ok(AxisPtzSnapshot {
+            camera,
+            position: parse_ptz_position(response_text(&position.body)?)?,
+            presets,
+            supports_continuous_pan_tilt,
+            supports_server_presets,
+            supports_speed,
+            queue_mode: parse_queue_mode(response_text(&queue.body)?)?,
+        })
+    }
+
+    pub fn recall_ptz_preset(
+        &mut self,
+        camera: u32,
+        preset_id: u32,
+        speed: u32,
+        queue_mode: AxisPtzQueueMode,
+    ) -> Result<(), AxisError> {
+        self.with_ptz_control(camera, queue_mode, |client, cookie| {
+            client.get_text(
+                &format!(
+                    "{PTZ_CONTROL_PATH}?gotoserverpresetno={preset_id}&speed={speed}&camera={camera}"
+                ),
+                cookie,
+            )?;
+            Ok(())
+        })
+    }
+
+    pub fn move_ptz_bounded(
+        &mut self,
+        camera: u32,
+        direction: AxisPtzDirection,
+        speed: u32,
+        duration_ms: u64,
+        queue_mode: AxisPtzQueueMode,
+    ) -> Result<(), AxisError> {
+        self.with_ptz_control(camera, queue_mode, |client, cookie| {
+            let (pan, tilt) = direction.velocity(speed);
+            client.get_text(
+                &format!("{PTZ_CONTROL_PATH}?continuouspantiltmove={pan},{tilt}&camera={camera}"),
+                cookie,
+            )?;
+            thread::sleep(Duration::from_millis(duration_ms));
+            client.get_text(
+                &format!("{PTZ_CONTROL_PATH}?continuouspantiltmove=0,0&camera={camera}"),
+                cookie,
+            )?;
+            Ok(())
+        })
+    }
+
+    fn with_ptz_control<R>(
+        &mut self,
+        camera: u32,
+        queue_mode: AxisPtzQueueMode,
+        operation: impl FnOnce(&mut Self, Option<&str>) -> Result<R, AxisError>,
+    ) -> Result<R, AxisError> {
+        if queue_mode == AxisPtzQueueMode::Disabled {
+            return operation(self, None);
+        }
+        let response = self.get_text(
+            &format!("{PTZ_QUEUE_PATH}?control=request&camera={camera}"),
+            None,
+        )?;
+        let queue_position = parse_queue_position(response_text(&response.body)?);
+        if queue_position != Some(1) {
+            if let Some(cookie) = response.session_cookie.as_ref() {
+                let _ = self.get_text(
+                    &format!("{PTZ_QUEUE_PATH}?control=drop&camera={camera}"),
+                    Some(cookie.as_str()),
+                );
+            }
+            return Err(AxisError::PtzQueueUnavailable);
+        }
+        let cookie = response
+            .session_cookie
+            .ok_or(AxisError::PtzQueueUnavailable)?;
+        let result = operation(self, Some(cookie.as_str()));
+        let drop_result = self.get_text(
+            &format!("{PTZ_QUEUE_PATH}?control=drop&camera={camera}"),
+            Some(cookie.as_str()),
+        );
+        match (result, drop_result) {
+            (Err(error), _) => Err(error),
+            (Ok(_), Err(error)) => Err(error),
+            (Ok(value), Ok(_)) => Ok(value),
+        }
     }
 }
 
@@ -492,13 +763,65 @@ pub struct InstalledAxisDevice {
     pub camera_entity_id: EntityId,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AxisPtzDirection {
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
+impl AxisPtzDirection {
+    fn from_label(label: &str) -> Option<Self> {
+        match label {
+            "left" => Some(Self::Left),
+            "right" => Some(Self::Right),
+            "up" => Some(Self::Up),
+            "down" => Some(Self::Down),
+            _ => None,
+        }
+    }
+
+    fn velocity(self, speed: u32) -> (i32, i32) {
+        let speed = i32::try_from(speed).unwrap_or(i32::MAX);
+        match self {
+            Self::Left => (-speed, 0),
+            Self::Right => (speed, 0),
+            Self::Up => (0, speed),
+            Self::Down => (0, -speed),
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Left => "left",
+            Self::Right => "right",
+            Self::Up => "up",
+            Self::Down => "down",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AxisPtzSupport {
+    camera: u32,
+    preset_ids: BTreeSet<u32>,
+    supports_continuous_pan_tilt: bool,
+    supports_server_presets: bool,
+    queue_mode: AxisPtzQueueMode,
+}
+
 pub struct AxisRuntimeIntegration<T> {
     client: AxisClient<T>,
+    ptz_entities: BTreeMap<EntityId, AxisPtzSupport>,
 }
 
 impl<T: AxisTransport> AxisRuntimeIntegration<T> {
     pub fn new(client: AxisClient<T>) -> Self {
-        Self { client }
+        Self {
+            client,
+            ptz_entities: BTreeMap::new(),
+        }
     }
 
     pub fn inspect_and_install_authorized(
@@ -509,7 +832,81 @@ impl<T: AxisTransport> AxisRuntimeIntegration<T> {
     ) -> Result<InstalledAxisDevice, AxisError> {
         authorize_read(runtime, principal_id, observed_at_ms)?;
         let snapshot = self.client.inspect()?;
-        install_snapshot(runtime, &self.client.config, &snapshot, observed_at_ms)
+        let installed = install_snapshot(runtime, &self.client.config, &snapshot, observed_at_ms)?;
+        self.ptz_entities.clear();
+        if let Some(ptz) = snapshot.ptz.as_ref().filter(|ptz| ptz.commandable()) {
+            self.ptz_entities.insert(
+                installed.camera_entity_id.clone(),
+                AxisPtzSupport {
+                    camera: ptz.camera,
+                    preset_ids: ptz.presets.iter().map(|preset| preset.id).collect(),
+                    supports_continuous_pan_tilt: ptz.supports_continuous_pan_tilt,
+                    supports_server_presets: ptz.supports_server_presets,
+                    queue_mode: ptz.queue_mode,
+                },
+            );
+        }
+        Ok(installed)
+    }
+
+    pub fn dispatch_command_authorized(
+        &mut self,
+        runtime: &mut SmartHomeRuntime,
+        principal_id: AgentId,
+        request: RuntimeCommandToolRequest,
+        now_ms: u64,
+    ) -> Result<CommandResult, AxisError> {
+        let support = self
+            .ptz_entities
+            .get(&request.entity_id)
+            .cloned()
+            .ok_or_else(|| AxisError::UnknownEntity(request.entity_id.clone()))?;
+        match request.command_type {
+            CommandType::DeviceControl(DeviceControlCommandType::RecallCameraPtzPreset) => {
+                let (preset_id, speed) = ptz_preset_arguments(&request)?;
+                if !support.supports_server_presets || !support.preset_ids.contains(&preset_id) {
+                    return invalid_command_arguments(
+                        request.command_type,
+                        "an object with a probed preset_id and speed from 1 through 100",
+                    );
+                }
+                let command = runtime.authorize_command_tool(principal_id, request, now_ms)?;
+                let mut result = runtime.submit_command(command, now_ms)?;
+                self.client.recall_ptz_preset(
+                    support.camera,
+                    preset_id,
+                    speed,
+                    support.queue_mode,
+                )?;
+                result.message = Some(format!(
+                    "Axis camera {} accepted PTZ preset {preset_id}",
+                    support.camera
+                ));
+                Ok(result)
+            }
+            CommandType::DeviceControl(DeviceControlCommandType::MoveCameraPtz) => {
+                if !support.supports_continuous_pan_tilt {
+                    return Err(AxisError::UnsupportedCommand(request.command_type));
+                }
+                let (direction, speed, duration_ms) = ptz_move_arguments(&request)?;
+                let command = runtime.authorize_command_tool(principal_id, request, now_ms)?;
+                let mut result = runtime.submit_command(command, now_ms)?;
+                self.client.move_ptz_bounded(
+                    support.camera,
+                    direction,
+                    speed,
+                    duration_ms,
+                    support.queue_mode,
+                )?;
+                result.message = Some(format!(
+                    "Axis camera {} completed bounded PTZ {} movement",
+                    support.camera,
+                    direction.label()
+                ));
+                Ok(result)
+            }
+            command_type => Err(AxisError::UnsupportedCommand(command_type)),
+        }
     }
 }
 
@@ -591,16 +988,24 @@ pub fn install_snapshot(
         )],
     })?;
 
+    let mut capabilities = vec![Capability::new(
+        CapabilityId::trusted("camera.device_info"),
+        CapabilityMode::Observe,
+        ValueKind::Object,
+    )];
+    if snapshot
+        .ptz
+        .as_ref()
+        .is_some_and(AxisPtzSnapshot::commandable)
+    {
+        capabilities.push(Capability::camera_ptz());
+    }
     runtime.upsert_entity(Entity {
         entity_id: camera_entity_id.clone(),
         device_id: device_id.clone(),
         kind: EntityKind::Camera,
         name: snapshot.device.product_full_name.clone(),
-        capabilities: vec![Capability::new(
-            CapabilityId::trusted("camera.device_info"),
-            CapabilityMode::Observe,
-            ValueKind::Object,
-        )],
+        capabilities,
         state: Some(StateSnapshot {
             entity_id: camera_entity_id.clone(),
             value: snapshot_value(snapshot),
@@ -674,6 +1079,7 @@ fn parse_snapshot(properties: &JsonValue, apis: &JsonValue) -> Result<AxisSnapsh
     Ok(AxisSnapshot {
         device,
         apis: parsed_apis,
+        ptz: None,
     })
 }
 
@@ -690,7 +1096,7 @@ fn required_string(
 }
 
 fn snapshot_value(snapshot: &AxisSnapshot) -> Value {
-    Value::Object(vec![
+    let mut fields = vec![
         (
             "product_type".to_string(),
             Value::Text(snapshot.device.product_type.clone()),
@@ -723,7 +1129,232 @@ fn snapshot_value(snapshot: &AxisSnapshot) -> Value {
                     .collect(),
             ),
         ),
+    ];
+    if let Some(ptz) = &snapshot.ptz {
+        fields.push(("ptz".to_string(), ptz_value(ptz)));
+    }
+    Value::Object(fields)
+}
+
+fn ptz_value(ptz: &AxisPtzSnapshot) -> Value {
+    let mut position = Vec::new();
+    if let Some(pan) = ptz.position.pan {
+        position.push(("pan".to_string(), Value::Number(pan)));
+    }
+    if let Some(tilt) = ptz.position.tilt {
+        position.push(("tilt".to_string(), Value::Number(tilt)));
+    }
+    if let Some(zoom) = ptz.position.zoom {
+        position.push(("zoom".to_string(), Value::Number(zoom)));
+    }
+    Value::Object(vec![
+        ("camera".to_string(), Value::Integer(i64::from(ptz.camera))),
+        ("position".to_string(), Value::Object(position)),
+        (
+            "presets".to_string(),
+            Value::Array(
+                ptz.presets
+                    .iter()
+                    .map(|preset| {
+                        Value::Object(vec![
+                            ("id".to_string(), Value::Integer(i64::from(preset.id))),
+                            ("name".to_string(), Value::Text(preset.name.clone())),
+                        ])
+                    })
+                    .collect(),
+            ),
+        ),
+        (
+            "control_queue".to_string(),
+            Value::Text(
+                match ptz.queue_mode {
+                    AxisPtzQueueMode::Disabled => "disabled",
+                    AxisPtzQueueMode::Required => "required",
+                }
+                .to_string(),
+            ),
+        ),
     ])
+}
+
+fn response_text(bytes: &[u8]) -> Result<&str, AxisError> {
+    std::str::from_utf8(bytes)
+        .map_err(|_| AxisError::Http("Axis PTZ response is not UTF-8".to_string()))
+}
+
+fn reject_ptz_error(bytes: &[u8]) -> Result<(), AxisError> {
+    let text = response_text(bytes)?;
+    if text
+        .lines()
+        .any(|line| line.trim_start().starts_with("Error:"))
+    {
+        return Err(AxisError::Api {
+            code: -1,
+            message: text.trim().to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn parse_ptz_position(text: &str) -> Result<AxisPtzPosition, AxisError> {
+    let values = parse_key_values(text);
+    let parse = |field: &'static str| -> Result<Option<f64>, AxisError> {
+        values
+            .get(field)
+            .map(|value| {
+                value.parse::<f64>().map_err(|_| {
+                    AxisError::Validation(format!("PTZ {field} is not a finite number"))
+                })
+            })
+            .transpose()
+            .and_then(|value| {
+                if value.is_some_and(f64::is_finite) {
+                    Ok(value)
+                } else if value.is_some() {
+                    Err(AxisError::Validation(format!(
+                        "PTZ {field} is not a finite number"
+                    )))
+                } else {
+                    Ok(None)
+                }
+            })
+    };
+    let position = AxisPtzPosition {
+        pan: parse("pan")?,
+        tilt: parse("tilt")?,
+        zoom: parse("zoom")?,
+    };
+    if position.pan.is_none() && position.tilt.is_none() && position.zoom.is_none() {
+        return Err(AxisError::MissingField("PTZ position"));
+    }
+    Ok(position)
+}
+
+fn parse_ptz_presets(text: &str) -> Result<Vec<AxisPtzPreset>, AxisError> {
+    let mut presets = Vec::new();
+    for line in text.lines() {
+        let Some((key, value)) = line.trim().split_once('=') else {
+            continue;
+        };
+        let Some(id) = key.strip_prefix("presetposno") else {
+            continue;
+        };
+        let id = id
+            .parse::<u32>()
+            .map_err(|_| AxisError::Validation("invalid Axis preset identifier".to_string()))?;
+        if !value.trim().is_empty() {
+            presets.push(AxisPtzPreset {
+                id,
+                name: value.trim().to_string(),
+            });
+        }
+    }
+    presets.sort_by_key(|preset| preset.id);
+    Ok(presets)
+}
+
+fn parse_queue_mode(text: &str) -> Result<AxisPtzQueueMode, AxisError> {
+    let value = text
+        .lines()
+        .filter_map(|line| line.split_once('=').map(|(_, value)| value.trim()))
+        .next()
+        .ok_or(AxisError::MissingField("PTZ control queue setting"))?;
+    match value.to_ascii_lowercase().as_str() {
+        "yes" | "true" | "1" => Ok(AxisPtzQueueMode::Required),
+        "no" | "false" | "0" => Ok(AxisPtzQueueMode::Disabled),
+        _ => Err(AxisError::Validation(
+            "unrecognized PTZ control queue setting".to_string(),
+        )),
+    }
+}
+
+fn parse_queue_position(text: &str) -> Option<u32> {
+    let marker = "<a name=\"";
+    let start = text.find(marker)? + marker.len();
+    let end = text[start..].find('"')? + start;
+    text[start..end].parse().ok()
+}
+
+fn parse_key_values(text: &str) -> BTreeMap<&str, &str> {
+    text.lines()
+        .filter_map(|line| line.trim().split_once('='))
+        .collect()
+}
+
+fn ptz_preset_arguments(request: &RuntimeCommandToolRequest) -> Result<(u32, u32), AxisError> {
+    match (
+        object_u32(&request.arguments, "preset_id"),
+        object_u32(&request.arguments, "speed"),
+    ) {
+        (Some(preset_id), Some(speed)) if (MIN_PTZ_SPEED..=MAX_PTZ_SPEED).contains(&speed) => {
+            Ok((preset_id, speed))
+        }
+        _ => invalid_command_arguments(
+            request.command_type,
+            "an object with a probed preset_id and speed from 1 through 100",
+        ),
+    }
+}
+
+fn ptz_move_arguments(
+    request: &RuntimeCommandToolRequest,
+) -> Result<(AxisPtzDirection, u32, u64), AxisError> {
+    let direction =
+        object_text(&request.arguments, "direction").and_then(AxisPtzDirection::from_label);
+    let speed = object_u32(&request.arguments, "speed");
+    let duration_ms = object_u64(&request.arguments, "duration_ms");
+    match (direction, speed, duration_ms) {
+        (Some(direction), Some(speed), Some(duration_ms))
+            if (MIN_PTZ_SPEED..=MAX_PTZ_SPEED).contains(&speed)
+                && (1..=MAX_PTZ_DURATION_MS).contains(&duration_ms) =>
+        {
+            Ok((direction, speed, duration_ms))
+        }
+        _ => invalid_command_arguments(
+            request.command_type,
+            "an object with direction left/right/up/down, speed 1 through 100, and duration_ms 1 through 5000",
+        ),
+    }
+}
+
+fn object_field<'a>(value: &'a Value, field: &str) -> Option<&'a Value> {
+    let Value::Object(fields) = value else {
+        return None;
+    };
+    fields
+        .iter()
+        .find_map(|(name, value)| (name == field).then_some(value))
+}
+
+fn object_u32(value: &Value, field: &str) -> Option<u32> {
+    let Value::Integer(value) = object_field(value, field)? else {
+        return None;
+    };
+    u32::try_from(*value).ok()
+}
+
+fn object_u64(value: &Value, field: &str) -> Option<u64> {
+    let Value::Integer(value) = object_field(value, field)? else {
+        return None;
+    };
+    u64::try_from(*value).ok()
+}
+
+fn object_text<'a>(value: &'a Value, field: &str) -> Option<&'a str> {
+    let Value::Text(value) = object_field(value, field)? else {
+        return None;
+    };
+    Some(value)
+}
+
+fn invalid_command_arguments<T>(
+    command_type: CommandType,
+    expected: &'static str,
+) -> Result<T, AxisError> {
+    Err(AxisError::InvalidCommandArguments {
+        command_type,
+        expected,
+    })
 }
 
 fn protocol_identifier(kind: &str, value: &str) -> Result<ProtocolIdentifier, AxisError> {
@@ -762,6 +1393,7 @@ fn encode_http_request(
     url: &Url,
     plan: &LocalHttpRequestPlan,
     credentials: &AxisCredentials,
+    session_cookie: Option<&str>,
 ) -> Result<Vec<u8>, AxisError> {
     let host = url
         .host
@@ -780,6 +1412,11 @@ fn encode_http_request(
     if has_unsafe_http_text(&target) || has_unsafe_http_text(host) {
         return Err(AxisError::Validation(
             "request target contains unsafe HTTP text".to_string(),
+        ));
+    }
+    if session_cookie.is_some_and(has_unsafe_http_text) {
+        return Err(AxisError::Validation(
+            "session cookie contains unsafe HTTP text".to_string(),
         ));
     }
     let default_port = if url.scheme == "https" { 443 } else { 80 };
@@ -811,6 +1448,10 @@ fn encode_http_request(
             request.extend_from_slice(
                 format!("Authorization: Basic {}\r\n", encoded.as_str()).as_bytes(),
             );
+        } else if header.name.eq_ignore_ascii_case("Cookie") {
+            return Err(AxisError::Validation(
+                "session cookies must not be stored in Axis request plans".to_string(),
+            ));
         } else {
             request.extend_from_slice(format!("{}: {}\r\n", header.name, header.value).as_bytes());
         }
@@ -819,6 +1460,9 @@ fn encode_http_request(
         return Err(AxisError::Validation(
             "Axis request plan is missing Vault-backed Basic authorization".to_string(),
         ));
+    }
+    if let Some(cookie) = session_cookie {
+        request.extend_from_slice(format!("Cookie: {cookie}\r\n").as_bytes());
     }
     if !seen.contains("content-length") {
         request.extend_from_slice(format!("Content-Length: {}\r\n", plan.body.len()).as_bytes());
@@ -884,7 +1528,7 @@ fn read_bounded(reader: &mut dyn Read, maximum: usize) -> Result<Vec<u8>, AxisEr
     Ok(bytes)
 }
 
-fn decode_http_response(bytes: &[u8], maximum: usize) -> Result<Vec<u8>, AxisError> {
+fn decode_http_response(bytes: &[u8], maximum: usize) -> Result<AxisHttpResponse, AxisError> {
     let parsed = parse_response_head(bytes)
         .map_err(|error: Http1ParseError| AxisError::Http(error.to_string()))?;
     if !(200..300).contains(&parsed.head.status) {
@@ -908,7 +1552,24 @@ fn decode_http_response(bytes: &[u8], maximum: usize) -> Result<Vec<u8>, AxisErr
     if body.len() > maximum {
         return Err(AxisError::ResponseTooLarge { limit: maximum });
     }
-    Ok(body)
+    let session_cookie = find_header(&parsed.head.headers, "Set-Cookie")
+        .and_then(|value| value.split(';').next())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| {
+            if has_unsafe_http_text(value) {
+                Err(AxisError::Http(
+                    "Set-Cookie contains unsafe HTTP text".to_string(),
+                ))
+            } else {
+                Ok(Zeroizing::new(value.to_string()))
+            }
+        })
+        .transpose()?;
+    Ok(AxisHttpResponse {
+        body,
+        session_cookie,
+    })
 }
 
 fn decode_chunked(input: &[u8], maximum: usize) -> Result<Vec<u8>, AxisError> {
@@ -955,10 +1616,19 @@ mod tests {
     use std::thread;
 
     const DEVICE_INFO: &str = r#"{"apiVersion":"1.0","context":"smart-home","data":{"propertyList":{"Brand":"AXIS","ProdFullName":"AXIS Q1785-LE Network Camera","ProdNbr":"Q1785-LE","ProdType":"Network Camera","SerialNumber":"ACCC8EAF8C30","Version":"12.1.0"}}}"#;
-    const API_LIST: &str = r#"{"apiVersion":"1.0","context":"smart-home","data":{"apiList":[{"id":"ptz-control","version":"1.0","status":"released"},{"id":"basic-device-info","version":"1.2","status":"released"}]}}"#;
+    const API_LIST: &str = r#"{"apiVersion":"1.0","context":"smart-home","data":{"apiList":[{"id":"systemready","version":"1.0","status":"released"},{"id":"basic-device-info","version":"1.2","status":"released"}]}}"#;
+    const PTZ_API_LIST: &str = r#"{"apiVersion":"1.0","context":"smart-home","data":{"apiList":[{"id":"ptz-control","version":"1.0","status":"released"},{"id":"basic-device-info","version":"1.2","status":"released"}]}}"#;
 
     fn response(body: &str) -> Vec<u8> {
         format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len()).into_bytes()
+    }
+
+    fn text_response(body: &str) -> Vec<u8> {
+        format!("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len()).into_bytes()
+    }
+
+    fn queue_response(body: &str) -> Vec<u8> {
+        format!("HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nSet-Cookie: ptz=lease-token; Path=/\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len()).into_bytes()
     }
 
     fn start_server(
@@ -1031,6 +1701,19 @@ mod tests {
         );
     }
 
+    fn command_grant(runtime: &mut SmartHomeRuntime, principal: &AgentId) {
+        let _ = runtime.registry_mut().upsert_capability_grant(
+            CapabilityGrant::for_all_smart_home(
+                CapabilityGrantId::trusted("grant:axis-command-test"),
+                principal.clone(),
+                PrivilegeTier::HumanApproval,
+                "test",
+                1_000,
+            )
+            .with_expiry(20_000),
+        );
+    }
+
     #[test]
     fn documented_axis_mdns_services_become_credential_candidates() {
         for service_type in [VIDEO_MDNS_SERVICE_TYPE, NVR_MDNS_SERVICE_TYPE] {
@@ -1090,6 +1773,32 @@ mod tests {
     }
 
     #[test]
+    fn response_debug_redacts_transport_only_queue_cookie() {
+        let response = AxisHttpResponse::with_session_cookie(Vec::new(), "ptz=secret").unwrap();
+        let debug = format!("{response:?}");
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("secret"));
+    }
+
+    #[test]
+    fn waiting_queue_request_is_dropped_before_control_is_rejected() {
+        let waiting = r#"<a name="2"></a><a name="8"></a><a name="30"></a>"#;
+        let (port, requests, handle) =
+            start_server(vec![queue_response(waiting), text_response("")]);
+        let mut client =
+            AxisClient::new(config(port), credentials(), AxisLanTransport::default()).unwrap();
+        assert!(matches!(
+            client.recall_ptz_preset(1, 3, 50, AxisPtzQueueMode::Required),
+            Err(AxisError::PtzQueueUnavailable)
+        ));
+        handle.join().unwrap();
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(requests[1].contains("control=drop&camera=1"));
+        assert!(requests[1].contains("Cookie: ptz=lease-token"));
+    }
+
+    #[test]
     fn real_http_inspection_installs_confirmed_axis_camera() {
         let (port, requests, handle) =
             start_server(vec![response(DEVICE_INFO), response(API_LIST)]);
@@ -1133,6 +1842,136 @@ mod tests {
         assert!(requests.iter().all(|request| !request.contains("vault://")));
     }
 
+    #[test]
+    fn real_http_ptz_probe_queue_recall_and_bounded_move_are_exact() {
+        let queue_granted = r#"<a name="1"></a><a name="0"></a><a name="30"></a>"#;
+        let (port, requests, handle) = start_server(vec![
+            response(DEVICE_INFO),
+            response(PTZ_API_LIST),
+            text_response("continuouspantiltmove=-100..100,-100..100\ngotoserverpresetno=integer\nspeed=integer\nquery=position\n"),
+            text_response("pan=12.5\ntilt=-3.0\nzoom=2200\n"),
+            text_response("Preset Positions for camera 1\npresetposno1=Home\npresetposno3=Driveway\n"),
+            text_response("root.PTZ.Various.V1.CtlQueueing=yes\n"),
+            queue_response(queue_granted),
+            text_response(""),
+            text_response(""),
+            queue_response(queue_granted),
+            text_response(""),
+            text_response(""),
+            text_response(""),
+        ]);
+        let client =
+            AxisClient::new(config(port), credentials(), AxisLanTransport::default()).unwrap();
+        let mut integration = AxisRuntimeIntegration::new(client);
+        let principal = AgentId::trusted("agent:axis-ptz");
+        let mut runtime = SmartHomeRuntime::new();
+        grant(&mut runtime, &principal);
+        command_grant(&mut runtime, &principal);
+        let installed = integration
+            .inspect_and_install_authorized(&mut runtime, principal.clone(), 5_000)
+            .unwrap();
+        let camera = runtime
+            .registry()
+            .entity(&installed.camera_entity_id)
+            .unwrap();
+        assert!(camera
+            .capabilities
+            .iter()
+            .any(|capability| capability.capability_id == CapabilityId::trusted("camera.ptz")));
+
+        let denied = RuntimeCommandToolRequest::new(
+            installed.camera_entity_id.clone(),
+            CommandType::DeviceControl(DeviceControlCommandType::MoveCameraPtz),
+            Value::Object(vec![
+                ("direction".to_string(), Value::Text("right".to_string())),
+                ("speed".to_string(), Value::Integer(25)),
+                ("duration_ms".to_string(), Value::Integer(1)),
+            ]),
+        );
+        assert!(matches!(
+            integration.dispatch_command_authorized(
+                &mut runtime,
+                AgentId::trusted("agent:axis-denied"),
+                denied,
+                5_500,
+            ),
+            Err(AxisError::Runtime(_))
+        ));
+        let invalid = RuntimeCommandToolRequest::new(
+            installed.camera_entity_id.clone(),
+            CommandType::DeviceControl(DeviceControlCommandType::RecallCameraPtzPreset),
+            Value::Object(vec![
+                ("preset_id".to_string(), Value::Integer(99)),
+                ("speed".to_string(), Value::Integer(50)),
+            ]),
+        );
+        assert!(matches!(
+            integration.dispatch_command_authorized(
+                &mut runtime,
+                principal.clone(),
+                invalid,
+                5_600,
+            ),
+            Err(AxisError::InvalidCommandArguments { .. })
+        ));
+        let preset = integration
+            .dispatch_command_authorized(
+                &mut runtime,
+                principal.clone(),
+                RuntimeCommandToolRequest::new(
+                    installed.camera_entity_id.clone(),
+                    CommandType::DeviceControl(DeviceControlCommandType::RecallCameraPtzPreset),
+                    Value::Object(vec![
+                        ("preset_id".to_string(), Value::Integer(3)),
+                        ("speed".to_string(), Value::Integer(50)),
+                    ]),
+                ),
+                6_000,
+            )
+            .unwrap();
+        let movement = integration
+            .dispatch_command_authorized(
+                &mut runtime,
+                principal,
+                RuntimeCommandToolRequest::new(
+                    installed.camera_entity_id.clone(),
+                    CommandType::DeviceControl(DeviceControlCommandType::MoveCameraPtz),
+                    Value::Object(vec![
+                        ("direction".to_string(), Value::Text("left".to_string())),
+                        ("speed".to_string(), Value::Integer(25)),
+                        ("duration_ms".to_string(), Value::Integer(1)),
+                    ]),
+                ),
+                7_000,
+            )
+            .unwrap();
+        handle.join().unwrap();
+
+        assert!(preset
+            .message
+            .as_deref()
+            .is_some_and(|message| message.contains("preset 3")));
+        assert!(movement
+            .message
+            .as_deref()
+            .is_some_and(|message| message.contains("bounded PTZ left")));
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 13);
+        assert!(requests[2].starts_with(&format!("GET {PTZ_CONTROL_PATH}?info=1&camera=1 ")));
+        assert!(requests[5].contains("group=PTZ.Various.V1.CtlQueueing"));
+        assert!(requests[6].contains("control=request&camera=1"));
+        assert!(requests[7].contains("gotoserverpresetno=3&speed=50&camera=1"));
+        assert!(requests[7].contains("Cookie: ptz=lease-token"));
+        assert!(requests[8].contains("control=drop&camera=1"));
+        assert!(requests[10].contains("continuouspantiltmove=-25,0&camera=1"));
+        assert!(requests[11].contains("continuouspantiltmove=0,0&camera=1"));
+        assert!(requests[12].contains("control=drop&camera=1"));
+        assert!(requests
+            .iter()
+            .all(|request| request.contains("Authorization: Basic cm9vdDpzZWNyZXQ=")));
+        assert!(requests.iter().all(|request| !request.contains("vault://")));
+    }
+
     #[derive(Debug)]
     struct CountingTransport(Arc<AtomicUsize>);
 
@@ -1141,9 +1980,10 @@ mod tests {
             &mut self,
             _plan: &LocalHttpRequestPlan,
             _credentials: &AxisCredentials,
-        ) -> Result<Vec<u8>, AxisError> {
+            _session_cookie: Option<&str>,
+        ) -> Result<AxisHttpResponse, AxisError> {
             self.0.fetch_add(1, Ordering::SeqCst);
-            Ok(Vec::new())
+            Ok(AxisHttpResponse::new(Vec::new()))
         }
     }
 
@@ -1180,7 +2020,7 @@ mod tests {
         let snapshot = parse_snapshot(&properties, &apis).unwrap();
         assert_eq!(snapshot.device.product_number, "Q1785-LE");
         assert_eq!(snapshot.apis[0].id, "basic-device-info");
-        assert_eq!(snapshot.apis[1].id, "ptz-control");
+        assert_eq!(snapshot.apis[1].id, "systemready");
     }
 
     #[test]

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Record capability-probed, queue-aware Axis preset recall and bounded PTZ
+  movement over the authenticated VAPIX host.
 - Add the first-party Axis VAPIX mDNS and authenticated inspection runtime.
 - Record capability-probed Reolink preset recall and bounded PTZ movement over
   the authenticated local CGI runtime.

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -45204,14 +45204,14 @@ pub fn first_party_catalog() -> Vec<IntegrationCatalogEntry> {
         base_entry(
             "axis_vapix",
             "Axis VAPIX",
-            "Authenticated local Axis camera and NVR discovery plus device and API inspection.",
+            "Authenticated local Axis camera and NVR discovery, inspection, and bounded PTZ control.",
             IntegrationCategory::CameraMedia,
             ConnectivityClass::LocalPolling,
             ImplementationStatus::FirstPartyRuntime,
             3,
             "axis_vapix",
         )
-        .with_capabilities(&["smart_home.read"])
+        .with_capabilities(&["smart_home.read", "smart_home.command"])
         .with_entities(&[EntityKind::Camera])
         .with_discovery(&[DiscoveryMechanism::Mdns, DiscoveryMechanism::Manual])
         .with_auth(&[AuthMode::UsernamePassword])
@@ -45227,7 +45227,8 @@ pub fn first_party_catalog() -> Vec<IntegrationCatalogEntry> {
         ])
         .with_notes(&[
             "Production inspection requires HTTPS Basic authentication; plain HTTP is accepted only for loopback transport tests.",
-            "PTZ control, event streaming, snapshots, and media transfer remain separate capability-specific work.",
+            "Camera 1 PTZ is capability-probed, human-approved, queue-aware, and bounded with an explicit native stop.",
+            "Event streaming, snapshots, media transfer, multi-channel PTZ, and advanced PTZ functions remain separate capability-specific work.",
         ]),
         base_entry(
             "reolink",
@@ -81004,6 +81005,9 @@ mod tests {
         );
         assert_eq!(axis.auth_modes, vec![AuthMode::UsernamePassword]);
         assert_eq!(axis.target_entity_kinds, vec![EntityKind::Camera]);
+        assert!(axis
+            .required_capabilities
+            .contains(&CapabilityId::trusted("smart_home.command")));
         assert!(axis
             .discovery_mechanisms
             .contains(&DiscoveryMechanism::Mdns));

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -925,6 +925,28 @@ documented local discovery and authenticated JSON APIs:
 - A real loopback HTTP test proves both JSON requests, Basic-auth materialization,
   response parsing, runtime installation, and denial before transport.
 
+## Current Axis VAPIX PTZ Control Slice
+
+This slice extends the authenticated Axis host with capability-probed physical
+camera control while preserving the device's native arbitration boundary:
+
+- Devices advertising `ptz-control` are inspected through documented `info=1`,
+  `query=position`, `query=presetposall`, and `CtlQueueing` requests for VAPIX
+  camera 1. Confirmed pan, tilt, zoom, and enabled server presets become runtime
+  state without implying broader channel coverage.
+- `camera.ptz` is installed only when native speed control plus continuous
+  pan/tilt or at least one server preset are proven. Unknown queue settings fail
+  closed instead of silently bypassing device arbitration.
+- Preset recall accepts only probed IDs and a 1-100 native speed. Directional
+  movement accepts left/right/up/down, a 1-100 speed, and at most five seconds,
+  then emits an explicit `continuouspantiltmove=0,0` stop.
+- D23 applies the existing human-approval command tier before credentials or
+  transport I/O. Commands acquire and release `ptzqueue.cgi` control when
+  required, while the queue cookie exists only inside the bounded transport.
+- Commands do not invent optimistic orientation after movement. A real loopback
+  test proves probing, denial and argument rejection before I/O, queue-cookie
+  isolation, preset recall, bounded start/stop movement, and queue release.
+
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
@@ -936,37 +958,39 @@ and then by prerequisite readiness:
    credential-bearing values use Vault leasing and destination validation.
 3. Add authenticated HEOS source browsing and queue insertion only after the
    account/session and Vault-leasing prerequisites are concrete.
-4. Extend Axis VAPIX with capability-probed position/preset inspection and
-   bounded PTZ control, including operator permission and PTZ control-queue
-   semantics, over the existing authenticated HTTPS host.
-5. Add another vendor-specific camera or NVR integration where authenticated
+4. Add another vendor-specific camera or NVR integration where authenticated
    protocol and transport primitives are concrete.
-6. Add Axis event streaming only after a concrete WebSocket event host and
-   digest or short-lived session-token authentication lifecycle exist.
-7. Add Axis snapshots and media transfer only through the camera-media lease and
+5. Add Axis event streaming only after the existing WebSocket protocol core has
+   a concrete authenticated host, digest or short-lived session-token lifecycle,
+   and subscription supervision.
+6. Add Axis snapshots and media transfer only through the camera-media lease and
    a concrete media executor.
-8. Add reusable HTTP Digest authentication before supporting Axis devices that
+7. Add reusable HTTP Digest authentication before supporting Axis devices that
    cannot expose the preferred HTTPS Basic-auth path.
-9. Add Reolink snapshot, recording search/download, and playback operations only
+8. Enumerate Axis video sources/channels before extending PTZ beyond the current
+   capability-probed VAPIX camera 1 boundary.
+9. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
+   only when each operation has a specific capability probe and readable state.
+10. Add Reolink snapshot, recording search/download, and playback operations only
    through the existing camera-media lease and a concrete media executor.
-10. Add Reolink current-position, zoom, guard-point, or patrol controls only when
+11. Add Reolink current-position, zoom, guard-point, or patrol controls only when
    each operation has a capability-specific probe and the firmware exposes the
    native state needed to avoid invented orientation claims.
-11. Add Reolink push events only after a concrete webhook or event-stream host
+12. Add Reolink push events only after a concrete webhook or event-stream host
    and subscription lifecycle exist.
-12. Add authenticated KLAP/Tapo devices and other broader-device families only
+13. Add authenticated KLAP/Tapo devices and other broader-device families only
    after their authentication and session prerequisites are concrete.
-13. Add ONVIF PullPoint events once a concrete event host and subscription
+14. Add ONVIF PullPoint events once a concrete event host and subscription
    lifecycle exist.
-14. Add RTSP media transfer and recording once concrete media transfer and
+15. Add RTSP media transfer and recording once concrete media transfer and
    recorder host primitives exist.
-15. Add a production Matter commissioning, secure-session, and network host only
+16. Add a production Matter commissioning, secure-session, and network host only
    after certificate, fabric, Interaction Model encoding, subscription, and
    transport prerequisites exist.
-16. Add a Thread border-router host only after an actual host transport exists.
-17. Add a production Zigbee coordinator, join, and security host only after
+17. Add a Thread border-router host only after an actual host transport exists.
+18. Add a production Zigbee coordinator, join, and security host only after
    concrete coordinator transport and security primitives exist.
-18. Add production Z-Wave inclusion and S2 only after concrete host transport
+19. Add production Z-Wave inclusion and S2 only after concrete host transport
    and security primitives exist.
 
 ## End-To-End Definition


### PR DESCRIPTION
## Summary
- probe Axis VAPIX camera 1 PTZ commands, confirmed position, server presets, native speed support, and control-queue mode
- add D23-authorized preset recall and five-second-bounded directional movement with an explicit native stop
- acquire and release Axis PTZ queue control when required while keeping the session cookie out of request plans, metadata, and debug output
- update the integration catalog and fully reprioritized Smart Home completion inventory

## Validation
- `cargo clippy -p smart-home-axis-vapix-integration --all-targets -- -D warnings`
- `sh smart-home-axis-vapix-integration/BUILD` (10 tests)
- `sh smart-home-integration-catalog/BUILD` (328 tests)
- post-rebase targeted catalog test
- generated `code/packages/rust/Cargo.lock` removed

## Protocol reference
- https://developer.axis.com/vapix/network-video/pantiltzoom-api/
