### PR TITLE
feat(sir-c): Collections slice 10 — Symbol + universal Object/Bool methods

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 0.32.0 — Collections slice 10: Symbol + universal Object/Bool methods
+
+New `_sir_builtin_method_v` dispatch arms:
+
+- **Symbol** widens `to_s`/`length`/`size`/`empty?`/`upcase`/`downcase`/
+  `to_sym` to accept a `SIR_SYM` receiver, REUSING the same String helpers
+  slice 1/8 already built (a Symbol's name is stored the identical way a
+  String's is). `upcase`/`downcase` are the one exception: they re-intern
+  the result as a fresh SYMBOL, not a String (`:foo.upcase == :FOO`).
+  `inspect` (`:name`) is Symbol-specific — no String equivalent.
+- **Universal `Object` methods**: `nil?`, `equal?` (Ruby's object-IDENTITY
+  comparison — pointer identity for every heap-boxed type, distinct from
+  `==`'s structural/value equality, which this slice doesn't touch),
+  `itself`, `frozen?` (a fixed, receiver-TYPE-only answer — this v0 runtime
+  has no per-object mutability tracking, so it reports the Ruby-always-
+  frozen primitives (`nil`/bool/Integer/Float/Symbol) as frozen and
+  everything else as not).
+- **`TrueClass`/`FalseClass`**: eager (non-short-circuit) `&`/`|`/`^`.
+  Distinct from `&&`/`||`, which the frontend lowers to `If` and never
+  reaches a method dispatch at all — these are only reached via an
+  EXPLICIT dot-call (`true.&(x)`), and coerce their argument by Ruby
+  truthiness (`0`/`""` are truthy, unlike Python), not by C's `int` rules.
+
+`code/specs/sir-collection-methods.md`'s "C backend lane" table is updated;
+slice 9 marked merged (#9713), this PR is slice 10. Deferred (documented,
+tracked as follow-up, same discipline as slices 8/9): `respond_to?`
+(needs a full reflective query across the user-method table AND the
+entire `is_builtin_method` catalog), `dup`/`clone` (needs a generic copy
+helper), generic `to_s`/`inspect`/`==`/`!=` on an arbitrary receiver
+(needs `_sir_fmt`'s `FILE*`-writing display machinery refactored to build
+a `SirValue` String instead), `freeze`/`tap`/`then`/`yield_self`
+(low-value with no mutability-tracking or block-less Enumerator return in
+this v0).
+
+### Added
+
+- `tests/compile_and_run_symbol_object_methods.rs` — 11 execution-proof
+  tests (real `cc` compile+run): every new Symbol/Object/Bool method, the
+  Symbol-vs-String return-type distinction for `upcase`/`downcase`, and
+  `equal?`'s pointer-identity-vs-structural-equality distinction (two
+  separately-built arrays with equal content are NOT `equal?`; the same
+  array through an alias IS).
+- `collection_symbol_slice10_methods_route_to_the_builtin_dispatcher` — an
+  emit-shape test mirroring the prior slices' dispatcher-routing tests.
+
 ## 0.31.0 — Collections slice 9: Numeric methods
 
 ### Fixed (CI — Linux link failure)

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -224,6 +224,16 @@ DoS cap needed, since this runtime's integer is a fixed `int64_t`), and the
 BLOCK-taking `times`/`upto`/`downto`/`step` (a zero `step` stride is a
 documented no-op, never a hang); `to_i`/`to_f` widen to accept a numeric
 receiver alongside their slice-8 String forms.
+**Slice 10** (Symbol + universal Object/Bool methods): Symbol widens
+`to_s`/`length`/`size`/`empty?`/`upcase`/`downcase`/`to_sym` from the
+slice-1/8 String helpers (`upcase`/`downcase` re-intern as a fresh Symbol,
+not a String) and adds Symbol-only `inspect` (`:name`); universal `Object`
+methods `nil?`/`equal?`/`itself`/`frozen?` (`equal?` is pointer identity,
+distinct from `==`'s structural equality; `frozen?` is a fixed,
+receiver-TYPE-only answer — no per-object mutability tracking in this v0);
+`TrueClass`/`FalseClass`'s eager (non-short-circuit) `&`/`|`/`^`, reachable
+only via an explicit dot-call (`true.&(x)`) since `&&`/`||` lower to `If`
+and never reach a method dispatch.
 
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
 `Intrinsics`, a `class << self` singleton, and

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -1785,9 +1785,15 @@ fn variadic_helper(name: &str) -> Option<&'static str> {
 /// Ruby), `zero?`/`positive?`/`negative?`, `floor`/`ceil`/`round` (0-arg
 /// form), `divmod`/`fdiv`, `clamp`/`between?`, `gcd`, `digits`, and the
 /// BLOCK-taking `times`/`upto`/`downto`/`step`; `to_i`/`to_f` widen to accept
-/// a numeric receiver alongside their slice-8 String forms. The dispatcher
-/// raises `NoMethodError` on an unsupported receiver type or a malformed
-/// call (missing/extra args, a non-closure block position), matching Ruby.
+/// a numeric receiver alongside their slice-8 String forms. Slice 10 =
+/// Symbol + universal Object/Bool methods: `to_s`/`length`/`size`/`upcase`/
+/// `downcase`/`empty?`/`to_sym` widen to a Symbol receiver (reusing the
+/// slice-1/8 String helpers; `upcase`/`downcase` re-intern as a fresh
+/// Symbol), `inspect` (Symbol-only, `:name`), universal `nil?`/`equal?`/
+/// `itself`/`frozen?`, and `TrueClass`/`FalseClass`'s eager (non-short-
+/// circuit) `&`/`|`/`^`. The dispatcher raises `NoMethodError` on an
+/// unsupported receiver type or a malformed call (missing/extra args, a
+/// non-closure block position), matching Ruby.
 fn is_builtin_method(name: &str) -> bool {
     matches!(
         name,
@@ -1817,6 +1823,8 @@ fn is_builtin_method(name: &str) -> bool {
         | "abs" | "even?" | "odd?" | "zero?" | "positive?" | "negative?" | "pred"
         | "floor" | "ceil" | "round" | "divmod" | "fdiv" | "clamp" | "between?"
         | "gcd" | "digits" | "times" | "upto" | "downto" | "step"
+        // slice 10 — Symbol + universal Object/Bool methods
+        | "inspect" | "nil?" | "equal?" | "itself" | "frozen?" | "&" | "|" | "^"
     )
 }
 

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -2675,6 +2675,63 @@ static SirValue _sir_num_step(SirValue recv, SirValue limit, SirValue stride, Si
     return recv;
 }
 
+/* ---- Collections slice 10: Symbol + Object/Bool generic methods -------------
+ *
+ * Symbol's `to_s`/`length`/`size`/`upcase`/`downcase`/`empty?` reuse the
+ * SAME helpers slice 1/8 built for String (a `SIR_SYM`'s name is stored the
+ * identical way a `SIR_STR`'s is, `.as.s`) — only the WRAPPING differs:
+ * `upcase`/`downcase` re-intern the result as a fresh Symbol (Ruby:
+ * `:foo.upcase == :FOO`, a Symbol, not a String), everything else returns
+ * the same type String's arm does. `inspect` is Symbol-specific (prefixes
+ * `:`, no String equivalent). `to_sym` is the identity (already a Symbol). */
+
+static SirValue _sir_sym_inspect(const char *name) {
+    return _sir_str(_sir_cat(":", name));
+}
+
+/* `equal?` -- Ruby's OBJECT-IDENTITY comparison (`a.equal?(b)`), distinct
+ * from `==`'s structural/value equality (`_sir_value_eq`, unaffected by this
+ * slice). For a heap-boxed type (String/Symbol/Array/Hash/Pair/Closure/
+ * Instance) identity IS pointer identity -- two SEPARATELY built values with
+ * equal content are NOT `equal?`, only two handles to the SAME allocation
+ * are (`x = [1]; y = [1]; x.equal?(y)` is false; `y = x; x.equal?(y)` is
+ * true). For a scalar (nil/bool/int/float) Ruby has no separate identity
+ * from value, so this compares by value -- which for a `SIR_SYM` also
+ * reduces to pointer identity, since symbols are interned (`_sir_intern`
+ * hands back the SAME pointer for the same name). */
+static SirValue _sir_object_equal_p(SirValue a, SirValue b) {
+    if (a.tag != b.tag) return _sir_bool(0);
+    switch (a.tag) {
+        case SIR_NIL:      return _sir_bool(1);
+        case SIR_BOOL:     return _sir_bool(a.as.b == b.as.b);
+        case SIR_INT:      return _sir_bool(a.as.i == b.as.i);
+        case SIR_FLOAT:    return _sir_bool(a.as.f == b.as.f);
+        case SIR_STR:      /* fallthrough */
+        case SIR_SYM:      return _sir_bool(a.as.s == b.as.s);
+        case SIR_PAIR:     return _sir_bool(a.as.pair == b.as.pair);
+        case SIR_CLOSURE:  return _sir_bool(a.as.clo == b.as.clo);
+        case SIR_SEQ:      return _sir_bool(a.as.seq == b.as.seq);
+        case SIR_MAP:      return _sir_bool(a.as.map == b.as.map);
+        case SIR_ERROR:    return _sir_bool(a.as.err == b.as.err);
+        case SIR_INSTANCE: return _sir_bool(a.as.inst == b.as.inst);
+        default:           return _sir_bool(0);  /* SIR_MISSING: never user-observed */
+    }
+}
+
+/* `frozen?` -- v0 has no mutability tracking, so this reports the
+ * ALWAYS-immutable primitives as frozen (matching Ruby: small Integers,
+ * Symbols, `true`/`false`/`nil`, and Floats are unconditionally frozen) and
+ * everything else (String/Array/Hash/Instance, all mutable in this runtime)
+ * as not — a fixed, receiver-type-only answer, not a real per-object flag. */
+static SirValue _sir_object_frozen_p(SirValue v) {
+    switch (v.tag) {
+        case SIR_NIL: case SIR_BOOL: case SIR_INT: case SIR_FLOAT: case SIR_SYM:
+            return _sir_bool(1);
+        default:
+            return _sir_bool(0);
+    }
+}
+
 /* ---- Collections slice 1: built-in String methods --------------------------
  *
  * A `__method__` dispatch whose name is a KNOWN built-in method — and which the
@@ -2691,22 +2748,30 @@ static SirValue _sir_num_step(SirValue recv, SirValue limit, SirValue stride, Si
  * wraps this to collect/free the varargs, exactly like `_sir_plus`. */
 static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, SirValue *args) {
     if (strcmp(m, "length") == 0 || strcmp(m, "size") == 0) {
-        if (recv.tag == SIR_STR) return _sir_int((int64_t)strlen(recv.as.s));
+        if (recv.tag == SIR_STR || recv.tag == SIR_SYM) return _sir_int((int64_t)strlen(recv.as.s));
         if (recv.tag == SIR_SEQ) return _sir_int(recv.as.seq->len);
         if (recv.tag == SIR_MAP) return _sir_int(recv.as.map->len);
     } else if (strcmp(m, "upcase") == 0) {
         if (recv.tag == SIR_STR) return _sir_str(_sir_str_upcase(recv.as.s));
+        /* Symbol#upcase re-interns the result as a fresh SYMBOL, not a
+           String (Ruby: `:foo.upcase == :FOO`) -- the one arm here that
+           can't just widen the String helper's return type. */
+        if (recv.tag == SIR_SYM) return _sir_sym(_sir_str_upcase(recv.as.s));
     } else if (strcmp(m, "downcase") == 0) {
         if (recv.tag == SIR_STR) return _sir_str(_sir_str_downcase(recv.as.s));
+        if (recv.tag == SIR_SYM) return _sir_sym(_sir_str_downcase(recv.as.s));
     } else if (strcmp(m, "reverse") == 0) {
         if (recv.tag == SIR_STR) return _sir_str(_sir_str_reverse(recv.as.s));
         if (recv.tag == SIR_SEQ) return _sir_array_reverse(recv.as.seq);
     } else if (strcmp(m, "empty?") == 0) {
-        if (recv.tag == SIR_STR) return _sir_bool(recv.as.s[0] == '\0');
+        if (recv.tag == SIR_STR || recv.tag == SIR_SYM) return _sir_bool(recv.as.s[0] == '\0');
         if (recv.tag == SIR_SEQ) return _sir_bool(recv.as.seq->len == 0);
         if (recv.tag == SIR_MAP) return _sir_bool(recv.as.map->len == 0);
     } else if (strcmp(m, "to_s") == 0) {
         if (recv.tag == SIR_STR) return recv;  /* String#to_s is the string itself */
+        if (recv.tag == SIR_SYM) return _sir_str(recv.as.s);  /* Symbol#to_s -- the bare name, no `:` */
+    } else if (strcmp(m, "inspect") == 0) {
+        if (recv.tag == SIR_SYM) return _sir_sym_inspect(recv.as.s);
     }
     /* Collections slice 3: 0-arg Array query/transform methods. */
     else if (strcmp(m, "count") == 0) {
@@ -2956,6 +3021,7 @@ static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, Si
         if (_sir_is_num(recv)) return _sir_to_f(recv);
     } else if (strcmp(m, "to_sym") == 0) {
         if (recv.tag == SIR_STR) return _sir_sym(recv.as.s);
+        if (recv.tag == SIR_SYM) return recv;  /* Symbol#to_sym is the identity */
     } else if (strcmp(m, "tr") == 0) {
         if (recv.tag == SIR_STR && argc == 2 && args[0].tag == SIR_STR && args[1].tag == SIR_STR)
             return _sir_str(_sir_str_tr(recv.as.s, args[0].as.s, args[1].as.s));
@@ -3030,6 +3096,29 @@ static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, Si
         if (_sir_is_num(recv) && argc == 3 && _sir_is_num(args[0]) && _sir_is_num(args[1])
             && args[2].tag == SIR_CLOSURE)
             return _sir_num_step(recv, args[0], args[1], args[2]);
+    }
+    /* Collections slice 10: universal Object methods + Bool operators. */
+    else if (strcmp(m, "nil?") == 0) {
+        return _sir_bool(recv.tag == SIR_NIL);
+    } else if (strcmp(m, "equal?") == 0) {
+        if (argc == 1) return _sir_object_equal_p(recv, args[0]);
+    } else if (strcmp(m, "itself") == 0) {
+        if (argc == 0) return recv;
+    } else if (strcmp(m, "frozen?") == 0) {
+        if (argc == 0) return _sir_object_frozen_p(recv);
+    } else if (strcmp(m, "&") == 0) {
+        /* TrueClass/FalseClass#& -- EAGER (both operands are already-computed
+           SirValues by the time a __method__ dispatch reaches here), Ruby-
+           truthiness-coercing logical AND. Distinct from the SHORT-CIRCUITING
+           `&&`, which the frontend lowers to `If`, never to a method call. */
+        if (recv.tag == SIR_BOOL && argc == 1)
+            return _sir_bool(_sir_truthy(recv) && _sir_truthy(args[0]));
+    } else if (strcmp(m, "|") == 0) {
+        if (recv.tag == SIR_BOOL && argc == 1)
+            return _sir_bool(_sir_truthy(recv) || _sir_truthy(args[0]));
+    } else if (strcmp(m, "^") == 0) {
+        if (recv.tag == SIR_BOOL && argc == 1)
+            return _sir_bool(_sir_truthy(recv) != _sir_truthy(args[0]));
     }
     return _sir_raise(
         _sir_error("NoMethodError", _sir_str(_sir_cat("undefined method ", m))));

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_symbol_object_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_symbol_object_methods.rs
@@ -1,0 +1,160 @@
+//! Execution proof for Collections slice 10 (Symbol + universal Object/Bool
+//! methods) on the C backend — lower REAL Ruby source, emit C, compile with
+//! a real cc, run, assert stdout. Skips gracefully when no `cc` is present.
+
+use std::process::Command;
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    ["cc", "clang", "gcc"]
+        .iter()
+        .find(|c| {
+            Command::new(c)
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        })
+        .map(|s| s.to_string())
+}
+
+fn run_ruby(src: &str) -> Option<String> {
+    let cc = find_cc()?;
+    let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
+    let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
+    let dir = std::env::temp_dir();
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    src.hash(&mut hasher);
+    let stem = format!("sirc_sym10_{}_{}", std::process::id(), hasher.finish());
+    let cpath = dir.join(format!("{stem}.c"));
+    let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::write(&cpath, &art.source).expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .arg("-lm") // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        art.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "program exited non-zero");
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn symbol_to_s_length_size_empty() {
+    match run_ruby("puts :hello.to_s\nputs :hello.length\nputs :hello.size\nputs :\"\".empty?\n") {
+        Some(out) => assert_eq!(out, "hello\n5\n5\n#t\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn symbol_upcase_downcase_return_a_fresh_symbol_not_a_string() {
+    // `:foo.upcase == :FOO` -- a Symbol, not a String; proven by round-
+    // tripping through `to_sym` (identity on a Symbol) and `to_s`.
+    match run_ruby("x = :foo.upcase\nputs x\nputs x.to_sym.to_s\n") {
+        Some(out) => assert_eq!(out, "FOO\nFOO\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn symbol_inspect_prefixes_a_colon() {
+    match run_ruby("puts :hello.inspect\n") {
+        Some(out) => assert_eq!(out, ":hello\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn symbol_to_sym_is_the_identity() {
+    match run_ruby("x = :hello\nputs x.to_sym.equal?(x)\n") {
+        Some(out) => assert_eq!(out, "#t\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn nil_p_across_receiver_types() {
+    match run_ruby("puts nil.nil?\nputs 0.nil?\nputs \"\".nil?\nputs false.nil?\n") {
+        Some(out) => assert_eq!(out, "#t\n#f\n#f\n#f\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn itself_returns_the_receiver() {
+    match run_ruby("puts 5.itself\nputs \"hi\".itself\n") {
+        Some(out) => assert_eq!(out, "5\nhi\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn frozen_p_is_true_for_immutable_primitives_false_for_mutable_ones() {
+    match run_ruby(
+        "puts nil.frozen?\nputs true.frozen?\nputs 5.frozen?\nputs 3.5.frozen?\nputs :sym.frozen?\n\
+         puts \"str\".frozen?\nputs [1].frozen?\n",
+    ) {
+        Some(out) => assert_eq!(out, "#t\n#t\n#t\n#t\n#t\n#f\n#f\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn equal_p_is_pointer_identity_not_structural_equality() {
+    // Two SEPARATELY built arrays with equal content are NOT `equal?`
+    // (structural equality is `==`, unaffected by this slice); the SAME
+    // array through an alias IS.
+    match run_ruby(
+        "a = [1, 2]\nb = [1, 2]\nputs a.equal?(b)\nc = a\nputs a.equal?(c)\n",
+    ) {
+        Some(out) => assert_eq!(out, "#f\n#t\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn equal_p_on_scalars_and_symbols_is_value_identity() {
+    // Scalars/Symbols have no separate identity from value in Ruby (and
+    // Symbols are interned, so this reduces to the same pointer-identity
+    // check as the heap-boxed case above).
+    match run_ruby("puts 5.equal?(5)\nputs :sym.equal?(:sym)\nputs nil.equal?(nil)\n") {
+        Some(out) => assert_eq!(out, "#t\n#t\n#t\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn equal_p_returns_false_across_different_types() {
+    match run_ruby("puts 5.equal?(\"5\")\nputs nil.equal?(false)\n") {
+        Some(out) => assert_eq!(out, "#f\n#f\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn bool_and_or_xor_are_eager_and_ruby_truthiness_coercing() {
+    // `true & nil == false`, `false | 0 == true` -- eager (not `&&`/`||`
+    // short-circuit, which the frontend lowers to `If`, never a method
+    // call), and every non-nil/non-false operand coerces to truthy
+    // (`0`/`""` included -- Ruby's rule, unlike Python's).
+    match run_ruby(
+        "puts(true.&(nil))\nputs(false.|(0))\nputs(true.^(true))\nputs(true.^(false))\n",
+    ) {
+        Some(out) => assert_eq!(out, "#f\n#t\n#f\n#t\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}

--- a/code/packages/rust/semantic-ir-to-c/tests/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/emit.rs
@@ -334,6 +334,27 @@ fn collection_string_query_passes_its_argument() {
 }
 
 #[test]
+fn collection_symbol_slice10_methods_route_to_the_builtin_dispatcher() {
+    // Collections slice 10: a Symbol receiver's 0-arg method (`inspect`)
+    // routes to the runtime dispatcher, same shape as the String/Array/Hash/
+    // Numeric slices; the receiver is a quoted `_sir_sym(...)` literal.
+    let m = lower_ruby("puts :hello.inspect");
+    let src = compile(&m).unwrap().source;
+    assert!(
+        src.contains("_sir_builtin_method("),
+        "a slice-10 Symbol method dispatches through the runtime dispatcher\n{src}"
+    );
+    assert!(
+        src.contains("\"inspect\""),
+        "the method name is a quoted C string literal\n{src}"
+    );
+    assert!(
+        src.contains("_sir_sym(\"hello\")"),
+        "the Symbol receiver is a quoted C string literal\n{src}"
+    );
+}
+
+#[test]
 fn collection_numeric_slice9_methods_route_to_the_builtin_dispatcher() {
     // Collections slice 9: a 2-arg Numeric method (`clamp`) routes to the
     // runtime dispatcher and carries both arguments through, same shape as

--- a/code/specs/sir-collection-methods.md
+++ b/code/specs/sir-collection-methods.md
@@ -199,8 +199,8 @@ repo's standard workflow):
 | — | Bug fix: `Array#sum` ignored a block argument | ✅ merged | #9673 |
 | — | Bug fix: bracket-index (`a[i]`/`a[i] = v`) had no grammar rule at all — new `__method__("[]"/"[]=", …)` dispatch | ✅ merged | #9686 |
 | 8 | Remaining String methods: `capitalize`, `strip`/`lstrip`/`rstrip`, `chomp`, `chars`, `bytes`, `split`, `replace`, `sub`, `gsub`, `to_i`, `to_f`, `to_sym`, `swapcase`, `tr`, `each_char` (block) — semantics matched against the Python/TS `sir-runtime-oop` reference catalog | ✅ merged | #9694 |
-| 9 | Numeric methods: `abs`, `to_i`, `to_f`, `even?`, `odd?`, `zero?`, `positive?`, `negative?`, `pred`, `floor`, `ceil`, `round`, `divmod`, `fdiv`, `clamp`, `between?`, `gcd`, `digits` + block methods `times`/`upto`/`downto`/`step` | 🚧 this PR | — |
-| 10 | Symbol + Object/Bool generic methods | planned | — |
+| 9 | Numeric methods: `abs`, `to_i`, `to_f`, `even?`, `odd?`, `zero?`, `positive?`, `negative?`, `pred`, `floor`, `ceil`, `round`, `divmod`, `fdiv`, `clamp`, `between?`, `gcd`, `digits` + block methods `times`/`upto`/`downto`/`step` | ✅ merged | #9713 |
+| 10 | Symbol + Object/Bool generic methods: `to_s`/`length`/`size`/`upcase`/`downcase`/`inspect`/`empty?`/`to_sym` widen to a Symbol receiver (reusing the slice-1/8 String helpers — `upcase`/`downcase` return a fresh interned Symbol, not a String); universal `Object` methods `nil?`/`equal?`/`itself`/`frozen?`; `TrueClass`/`FalseClass` eager (non-short-circuit) `&`/`\|`/`^` | 🚧 this PR | — |
 | — | Cross-backend conformance corpus for the full collection-method catalog | planned | — |
 
 **Explicitly out of scope for slice 8** (deferred, not silently dropped): Ruby's
@@ -217,6 +217,20 @@ similar size to its predecessors; they are tracked as follow-up work.
 form (only the 0-arg `round` is implemented) — deferred for the same
 "keep the slice reviewable" reason, tracked as follow-up work alongside
 slice 8's deferrals.
+
+**Explicitly out of scope for slice 10**: `respond_to?` (needs a full
+reflective query across BOTH the user-defined method table and the entire
+`is_builtin_method` catalog — a materially larger undertaking than this
+slice's other methods); `dup`/`clone` (shallow-copy semantics for
+Array/Hash, identity for scalars — needs a generic copy helper this v0
+runtime doesn't have yet); generic `to_s`/`inspect`/`==`/`!=` on an
+ARBITRARY receiver (the display-conversion machinery this needs,
+`_sir_fmt`, writes directly to a `FILE*` rather than building a string —
+capturing it into a `SirValue` String needs its own follow-up refactor);
+`freeze`/`tap`/`then`/`yield_self` (identity/pipeline methods with no
+observable effect in a v0 with no mutability-tracking or block-less
+Enumerator return — low value until either lands). All tracked as
+follow-up work, same deferral discipline as slices 8/9.
 
 ## Out of scope (documented)
 


### PR DESCRIPTION
## Summary

- Symbol widens `to_s`/`length`/`size`/`empty?`/`upcase`/`downcase`/`to_sym` from the slice-1/8 String helpers (`upcase`/`downcase` re-intern the result as a fresh **Symbol**, not a String — `:foo.upcase == :FOO`), plus Symbol-only `inspect` (`:name`).
- Universal `Object` methods: `nil?`, `equal?` (Ruby's object-**identity** comparison — pointer identity for every heap-boxed type, distinct from `==`'s structural/value equality, which this slice doesn't touch), `itself`, `frozen?` (a fixed, receiver-**type**-only answer: this v0 runtime has no per-object mutability tracking, so it reports the Ruby-always-frozen primitives — `nil`/bool/Integer/Float/Symbol — as frozen and everything else as not).
- `TrueClass`/`FalseClass`'s eager (non-short-circuit) `&`/`|`/`\|`/`^` — reachable only via an explicit dot-call (`true.&(x)`), since `&&`/`||` lower to `If` and never reach a method dispatch at all.
- **Spec sync**: `code/specs/sir-collection-methods.md`'s C-backend-lane table marks slice 9 merged (#9713) and this PR as slice 10.
- **Explicitly deferred** (documented, same discipline as slices 8/9): `respond_to?`, `dup`/`clone`, generic `to_s`/`inspect`/`==`/`!=` on an arbitrary receiver (needs `_sir_fmt`'s `FILE*`-writing display machinery refactored to build a String instead), `freeze`/`tap`/`then`/`yield_self`.

`semantic-ir-to-c` 0.31.0 → 0.32.0.

## Test plan
- [x] 11 execution-proof tests (`compile_and_run_symbol_object_methods.rs`, real `cc` compile+run): every new method, the Symbol-vs-String return-type distinction for `upcase`/`downcase`, and `equal?`'s pointer-identity-vs-structural-equality distinction — all green.
- [x] Emit-shape test (`collection_symbol_slice10_methods_route_to_the_builtin_dispatcher`).
- [x] Full `semantic-ir-to-c` + `ruby-parser` + `ruby-to-semantic-ir` regression suite — all green, pre- and post-rebase onto latest `origin/main`.
- [x] `cargo clippy` — clean.
- [x] Security review (sub-agent — focused on `SirTag` switch exhaustiveness in the new `equal?`/`frozen?` helpers, union field-name correctness, and confirming `&`/`|`/`^`'s new dot-call dispatch path can't collide with the pre-existing, separate top-level bitwise-operator `BuiltinCall` path) — **PASSED on the first round** (this slice's identity/type-tag logic carried much lower arithmetic risk than the preceding Numeric slice, which needed 4 review rounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)