### PR TITLE
Report paragraph recovery from MathML foreign content

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- A paragraph end tag that breaks out of MathML foreign content now reports
+  the Standard's parse error, covering 2 previously silent malformed corpus
+  cases without changing DOM recovery.
 - A `li` start tag now reports the Standard's parse error when implied-end-tag
   recovery closes a non-current list item, covering 2 previously silent
   malformed corpus cases without changing DOM recovery.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the specialized in-body list-item start-tag diagnostic slice, 2,007 of
-those cases emit at least one lexer or parser diagnostic and 176 remain
+After the specialized paragraph foreign-content diagnostic slice, 2,009 of
+those cases emit at least one lexer or parser diagnostic and 174 remain
 uncovered.
 Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
 These are reviewed rather than automatically removed: 89 are full-document
@@ -55,10 +55,11 @@ original mode; synthetic text fragment contexts remain diagnostic-free.
 The in-body "any other end tag" parse error is now reported when implied end
 tags leave the matching open element non-current, including special-element
 scope stops and nested formatting recovery. Remaining in-body work covers
-specialized paragraph and adoption-agency branches. Heading end tags now report
+adoption-agency and formatting-reconstruction branches. Heading end tags report
 the specialized parse error when no heading is in scope or the current heading
-does not match the token. A `li` start tag now also reports the specialized
-parse error when its implied-end-tag recovery closes a non-current list item.
+does not match the token. A `li` start tag reports when its implied-end-tag
+recovery closes a non-current list item, and a paragraph end tag reports when it
+breaks out of MathML foreign content.
 
 Prioritized work items:
 

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -6709,6 +6709,12 @@ impl HtmlParser {
                 || self.current_namespace() == Some("svg")
                 || (self.current_namespace() == Some("math") && name == "p"))
         {
+            if self.current_namespace() == Some("math") && name == "p" {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-p-end-tag-in-foreign-content",
+                    "end tag `</p>` in MathML foreign content forced HTML recovery",
+                ));
+            }
             self.pop_foreign_elements();
         } else if self.current_namespace().is_some()
             && !self.current_element_is(name)
@@ -33269,6 +33275,18 @@ mod tests {
             .parser_diagnostics
             .iter()
             .any(|diagnostic| diagnostic.code == "unexpected-li-start-tag"));
+    }
+
+    #[test]
+    fn reports_paragraph_end_tag_recovery_from_mathml_foreign_content() {
+        let output = parse_html_with_diagnostics("<!doctype html><p><math></p>a").unwrap();
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-p-end-tag-in-foreign-content",
+                "end tag `</p>` in MathML foreign content forced HTML recovery"
+            )]
+        );
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 176);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2007);
+    assert_eq!(missing_diagnostic_cases, 174);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2009);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report the current HTML Standard parse error when a paragraph end tag breaks out of MathML foreign content
- cover the two previously silent retained-corpus rows without changing any of the 2,637 checked DOM outputs
- ratchet diagnostic coverage from 2,007 to 2,009 covered cases and 176 to 174 missing cases; undeclared diagnostics remain 139

## Evidence
- WPT tree construction: 1,934/1,934 signatures, zero missing at `a73cf1e91a6a95e4c5c39494d8fbfdab0b38cae1`
- html5lib tokenizer: 6,806/6,806 signatures, zero missing and zero normalized skips at `224991ec10db04f056a89eed8b0bd8695fd2950e`

## Validation
- `cargo test -p coding-adventures-html-parser --test tree_construction_test`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- parser audit manifest, Rust-test, and coverage checks
- generated HTML fixture and README inventory checks
- `git diff --check`

This is a bounded diagnostic-conformance slice; it does not claim full browser conformance.