### PR TITLE
Generate Italian book Chapters 2–17 from canonical lessons

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -81,9 +81,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B11 | Complete (#9698) | Remove Sanskrit's LaTeX layout, duplicate-label, font-shape, and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Devanagari, natural page bottoms, explicit static-font shapes, and shorter running titles make the forced six-chapter build warning-free. |
 | HL-B12 | Complete (#9705) | Publish Bengali Chapter 6 from its canonical lesson rather than hand-copying another book chapter. | The schema-v2 lesson now generates the PDF chapter from the same source hash independently verified by Language Ladder. |
 | HL-B13 | Complete (#9711) | Remove Bengali's missing glyphs and LaTeX layout/bookmark warnings. | Main-font punctuation, stable recap labels, bookmark-safe Bengali, natural page bottoms, explicit static-font shapes, and a breakable long title make the forced six-chapter build warning-free. |
-| HL-I01 | Complete in this PR | Reduce unified all-books workflow setup time without splitting the single publication bundle. | A focused, preflighted XeLaTeX dependency closure replaces `texlive-full`; the unchanged job still builds all 20 books, verifies one bundle, and publishes that bundle from `main`. |
-| HL-B14 | Next | Publish Italian Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Italian has canonical app content through Chapter 17, but its downloadable PDF contains only Chapter 1; schema-v2 migration plus generation should close that drift safely. |
-| HL-B15 | Queued | Remove Italian's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds but reports one underfull box and three Hyperref warnings; the clean-build signal is zero of each. |
+| HL-I01 | Complete (#9715) | Reduce unified all-books workflow setup time without splitting the single publication bundle. | A focused, preflighted XeLaTeX dependency closure replaces `texlive-full`; the unchanged job still builds all 20 books, verifies one bundle, and publishes that bundle from `main`. |
+| HL-B14 | Complete in this PR | Publish Italian Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Forty-nine schema-v2 lessons now generate sixteen chapters whose source hashes are independently verified against the Language Ladder corpus. |
+| HL-B15 | Next | Remove Italian's LaTeX layout and Unicode bookmark warnings. | The expanded 104-page build has zero missing glyphs or duplicate destinations but reports four overfull boxes, ten underfull boxes, and three Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B16 | Queued | Publish Portuguese Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Portuguese has canonical app content through Chapter 17, but its downloadable PDF contains only Chapter 1; schema-v2 migration plus generation should close that drift safely. |
 | HL-B17 | Queued | Remove Portuguese's LaTeX layout warnings. | A forced build succeeds with no missing glyphs, overfull boxes, duplicate labels, or Hyperref warnings, but reports three underfull boxes; the clean-build signal is zero. |
 | HL-B18 | Queued | Publish French Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | The French PDF reaches Chapter 16 while canonical app content continues through Chapter 23; schema-v2 migration plus generation should close that drift safely. |
@@ -516,8 +516,36 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   RTL support, and Latin Modern before compiling any book.
 - The workflow remains one job with one setup, one dynamically discovered
   20-book loop, one verified artifact, and one `main`-only Pages publication.
+  The exact merged-main run installed the focused toolchain in 87 seconds,
+  built all books in 93 seconds, verified the bundle, and published Pages.
   HL-B14 is next: close the learner-visible Italian app/book drift through the
   same canonical generation path.
+
+## Findings from HL-B14
+
+- Italian Chapters 2–17 now comprise 49 strict schema-v2 micro-lessons with
+  explicit shared-spine anchors, prerequisite-closed knowledge atoms, typed
+  teaching blocks, and authored skill, mode, strand, register, variety, and
+  duration contracts. Chapter 1 remains readable legacy content, so the track
+  is intentionally mixed while one-source migration proceeds incrementally.
+- All 49 migrated lessons remain below five minutes. `IT-C17-mano` is the
+  tightest at 298 computed seconds; curriculum validation reports zero duration
+  violations and zero unknown or misordered prerequisites.
+- Sixteen deterministic generation targets now publish Chapters 2–17 from the
+  same lesson AST loaded by Language Ladder. Their manifest covers all 49
+  lessons, and app tests independently reproduce every chapter hash and lesson
+  count. Repository-wide missing book chapters fall from 252 to 236.
+- The generic renderer recognizes scoped “taken apart” headings and emits
+  portable TeX for the scholarly symbols `↔`, `ṓ`, `₁`, and `ʰ`, preserving the
+  app's precise Unicode while avoiding font-dependent gaps in generated PDFs.
+- A forced XeLaTeX build produces a 104-page book with zero missing glyphs,
+  duplicate destinations, or leaked generator metadata. All 104 rendered pages
+  were inspected; the cover, three-page contents, chapter openings, callouts,
+  dense tables, and final recall are unclipped, and the PDF outline contains
+  Preface, pronunciation, and all seventeen chapter destinations.
+- Four overfull boxes, ten underfull boxes, and the three pre-existing Chapter
+  1 Hyperref warnings remain. HL-B15 is next and now records the expanded,
+  measured clean-build debt rather than the old 13-page baseline.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -63,7 +63,7 @@ edition is authored.
 | [Spanish](./spanish/README.md) | Romance / Latin | Pilot — Chapters 1-3 authored (lessons + book); ~30 lessons |
 | [French](./french/README.md) | Romance / Latin | Chapters 1-2 authored (lessons + book) |
 | [German](./german/README.md) | Germanic / Latin | Chapters 1-2 authored (lessons + book) |
-| [Italian](./italian/README.md) | Romance / Latin | Chapter 1 (Greetings) authored (lessons + book) |
+| [Italian](./italian/README.md) | Romance / Latin | Chapters 1–17 authored; Chapters 2–17 canonical/generated for app + book |
 | [Portuguese](./portuguese/README.md) | Romance / Latin | Chapter 1 (Greetings) authored (lessons + book) |
 | [Arabic](./arabic/README.md) | Semitic / Arabic (vendored font) | Chapters 1-2 authored (script inline) |
 | [Hindi](./hindi/README.md) | Indo-Aryan / Devanagari | Chapters 1-2 authored (lessons + book) |

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -44,6 +44,118 @@
       "output": "spanish/book/chapters/ch06-first-verbs.tex"
     },
     {
+      "language": "italian",
+      "chapter": 2,
+      "title": "How Are You?",
+      "label": "ch:it-how-are-you",
+      "output": "italian/book/chapters/ch02-how-are-you.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 3,
+      "title": "Introducing Yourself",
+      "label": "ch:it-introductions",
+      "output": "italian/book/chapters/ch03-introductions.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 4,
+      "title": "Farewells",
+      "label": "ch:it-farewells",
+      "output": "italian/book/chapters/ch04-farewells.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 5,
+      "title": "The First Verbs",
+      "label": "ch:it-first-verbs",
+      "output": "italian/book/chapters/ch05-first-verbs.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 6,
+      "title": "Numbers One to Ten",
+      "label": "ch:it-numbers-one-to-ten",
+      "output": "italian/book/chapters/ch06-numbers-1-10.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 7,
+      "title": "Days of the Week",
+      "label": "ch:it-days-of-the-week",
+      "output": "italian/book/chapters/ch07-days-of-the-week.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 8,
+      "title": "Telling Time",
+      "label": "ch:it-telling-time",
+      "output": "italian/book/chapters/ch08-telling-time.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 9,
+      "title": "Months and Seasons",
+      "label": "ch:it-months-and-seasons",
+      "output": "italian/book/chapters/ch09-months-and-seasons.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 10,
+      "title": "Family",
+      "label": "ch:it-family",
+      "output": "italian/book/chapters/ch10-family.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 11,
+      "title": "Bread, Water, and Wine",
+      "label": "ch:it-bread-water-wine",
+      "output": "italian/book/chapters/ch11-bread-water-wine.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 12,
+      "title": "Numbers Eleven to Twenty",
+      "label": "ch:it-numbers-eleven-to-twenty",
+      "output": "italian/book/chapters/ch12-numbers-11-20.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 13,
+      "title": "Colours",
+      "label": "ch:it-colours",
+      "output": "italian/book/chapters/ch13-colours.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 14,
+      "title": "Having and Telling Your Age",
+      "label": "ch:it-having-and-age",
+      "output": "italian/book/chapters/ch14-having-and-age.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 15,
+      "title": "Two Italian Pasts",
+      "label": "ch:it-two-pasts",
+      "output": "italian/book/chapters/ch15-two-pasts.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 16,
+      "title": "Being, Going, and the Past with Essere",
+      "label": "ch:it-essere-andare-past",
+      "output": "italian/book/chapters/ch16-essere-andare-past.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 17,
+      "title": "Head and Hand",
+      "label": "ch:it-head-and-hand",
+      "output": "italian/book/chapters/ch17-head-and-hand.tex"
+    },
+    {
       "language": "bengali",
       "chapter": 6,
       "title": "Numbers One to Five",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -22,6 +22,183 @@
       "tex": "gujarati/book/chapters/ch06-numbers-1-5.tex"
     },
     {
+      "language": "italian",
+      "chapter": 2,
+      "sourceHash": "fnv1a64:03633dd64e873a05",
+      "lessonIds": [
+        "IT-C02-prego",
+        "IT-C02-come",
+        "IT-C02-stare",
+        "IT-C02-come-stai",
+        "IT-C02-come-sta",
+        "IT-C02-come-va",
+        "IT-C02-cosi-cosi",
+        "IT-C02-practice"
+      ],
+      "tex": "italian/book/chapters/ch02-how-are-you.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 3,
+      "sourceHash": "fnv1a64:aa27c60a3d656001",
+      "lessonIds": [
+        "IT-C03-io",
+        "IT-C03-mi-chiamo",
+        "IT-C03-come-ti-chiami",
+        "IT-C03-piacere",
+        "IT-C03-practice"
+      ],
+      "tex": "italian/book/chapters/ch03-introductions.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 4,
+      "sourceHash": "fnv1a64:ca5f394581f1d56b",
+      "lessonIds": [
+        "IT-C04-arrivederci",
+        "IT-C04-a-domani",
+        "IT-C04-a-presto",
+        "IT-C04-a-piu-tardi",
+        "IT-C04-practice"
+      ],
+      "tex": "italian/book/chapters/ch04-farewells.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 5,
+      "sourceHash": "fnv1a64:fc48d491a87398dc",
+      "lessonIds": [
+        "IT-C05-parlare",
+        "IT-C05-abitare",
+        "IT-C05-lavorare",
+        "IT-C05-parlo-italiano",
+        "IT-C05-practice"
+      ],
+      "tex": "italian/book/chapters/ch05-first-verbs.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 6,
+      "sourceHash": "fnv1a64:23d44140d0f55101",
+      "lessonIds": [
+        "IT-C06-numeri-1-5",
+        "IT-C06-numeri-6-10"
+      ],
+      "tex": "italian/book/chapters/ch06-numbers-1-10.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 7,
+      "sourceHash": "fnv1a64:e411e61a0e42f98e",
+      "lessonIds": [
+        "IT-C07-giorni-1",
+        "IT-C07-giorni-2"
+      ],
+      "tex": "italian/book/chapters/ch07-days-of-the-week.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 8,
+      "sourceHash": "fnv1a64:8c6f2fefca515e70",
+      "lessonIds": [
+        "IT-C08-ora",
+        "IT-C08-mezzogiorno-mezzanotte"
+      ],
+      "tex": "italian/book/chapters/ch08-telling-time.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 9,
+      "sourceHash": "fnv1a64:d030a0fa85b5678f",
+      "lessonIds": [
+        "IT-C09-mesi",
+        "IT-C09-stagioni"
+      ],
+      "tex": "italian/book/chapters/ch09-months-and-seasons.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 10,
+      "sourceHash": "fnv1a64:c6b580550c4c7454",
+      "lessonIds": [
+        "IT-C10-genitori",
+        "IT-C10-fratello-sorella"
+      ],
+      "tex": "italian/book/chapters/ch10-family.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 11,
+      "sourceHash": "fnv1a64:0ba39a1b7b3a0899",
+      "lessonIds": [
+        "IT-C11-pane",
+        "IT-C11-acqua-vino"
+      ],
+      "tex": "italian/book/chapters/ch11-bread-water-wine.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 12,
+      "sourceHash": "fnv1a64:e2431531c5358324",
+      "lessonIds": [
+        "IT-C12-numeri-11-16",
+        "IT-C12-numeri-17-20"
+      ],
+      "tex": "italian/book/chapters/ch12-numbers-11-20.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 13,
+      "sourceHash": "fnv1a64:d158e4e3576da88e",
+      "lessonIds": [
+        "IT-C13-nero-bianco",
+        "IT-C13-rosso-blu"
+      ],
+      "tex": "italian/book/chapters/ch13-colours.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 14,
+      "sourceHash": "fnv1a64:62fcc73207804a51",
+      "lessonIds": [
+        "IT-C14-avere",
+        "IT-C14-eta"
+      ],
+      "tex": "italian/book/chapters/ch14-having-and-age.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 15,
+      "sourceHash": "fnv1a64:9dfc5c16142e4a8d",
+      "lessonIds": [
+        "IT-C15-passato-prossimo",
+        "IT-C15-passato-remoto"
+      ],
+      "tex": "italian/book/chapters/ch15-two-pasts.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 16,
+      "sourceHash": "fnv1a64:46629a0359aec030",
+      "lessonIds": [
+        "IT-C16-essere",
+        "IT-C16-essere-stato",
+        "IT-C16-andare",
+        "IT-C16-passato-prossimo-essere"
+      ],
+      "tex": "italian/book/chapters/ch16-essere-andare-past.tex"
+    },
+    {
+      "language": "italian",
+      "chapter": 17,
+      "sourceHash": "fnv1a64:28edfc484982a197",
+      "lessonIds": [
+        "IT-C17-testa",
+        "IT-C17-mano"
+      ],
+      "tex": "italian/book/chapters/ch17-head-and-hand.tex"
+    },
+    {
       "language": "marathi",
       "chapter": 6,
       "sourceHash": "fnv1a64:d0addd66aaedf900",

--- a/code/learning/human-languages/italian/CHANGELOG.md
+++ b/code/learning/human-languages/italian/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Canonical book Chapters 2–17 — 2026-08-03
+
+- Migrated all 49 lessons in Chapters 2–17 to the strict schema-v2 shared-spine
+  contract with prerequisite-closed knowledge boundaries and sub-five-minute
+  duration budgets.
+- Added sixteen deterministic chapter targets and source hashes so Language
+  Ladder and the downloadable book consume and verify the same canonical lesson
+  AST instead of maintaining separate copies.
+- Expanded the book from 13 to 104 pages, added width-aware generated tables,
+  and taught the renderer portable TeX fallbacks for scholarly Unicode symbols.
+- Verified zero missing glyphs and duplicate destinations, inspected all 104
+  rendered pages, and retained the remaining layout/bookmark cleanup as HL-B15.
+
 ## Sub-five-minute remediation — 2026-08-02
 
 - Corrected seventeen declared five-minute estimates whose lesson bodies

--- a/code/learning/human-languages/italian/README.md
+++ b/code/learning/human-languages/italian/README.md
@@ -21,13 +21,20 @@ and Italian kept the final vowels French dropped. The showpiece etymology:
 
 - **Chapter 1 — Greetings** ([`lessons/IT-C01-*`](./lessons/)): ciao, buono,
   il/la/lo (gender), giorno, buongiorno, sera/buonasera, notte/buonanotte,
-  grazie, practice. In the book.
-- **Chapter 2 — Introducing Yourself** (planned): *mi chiamo…*, *tu* vs. *Lei*.
+  grazie, practice. Hand-authored in the book and still readable as legacy
+  curriculum content.
+- **Chapters 2–17**: 49 prerequisite-ordered lessons move from wellbeing and
+  introductions through farewells, the first verbs, numbers, calendar and time,
+  family, food, colours, age, two pasts, *essere/andare*, and the body. All are
+  strict schema-v2 lessons and generate the corresponding book chapters from
+  the same hashed AST that Language Ladder loads.
 
 ## Book
 
-Compiles with XeLaTeX (Latin Modern, no vendored font needed). `latexmk
--xelatex book.tex`.
+The 104-page volume compiles with XeLaTeX (Latin Modern, no vendored font
+needed): `latexmk -xelatex book.tex`. Chapters 2–17 are generated from the
+canonical lessons by `npm run generate:books` in the
+`human-language-data` package; do not edit those chapter files by hand.
 
 ## Files
 

--- a/code/learning/human-languages/italian/book/book.tex
+++ b/code/learning/human-languages/italian/book/book.tex
@@ -62,4 +62,21 @@ a gate. Released under CC~BY-SA~4.0.
 
 \input{chapters/ch01-greetings}
 
+\input{chapters/ch02-how-are-you}
+\input{chapters/ch03-introductions}
+\input{chapters/ch04-farewells}
+\input{chapters/ch05-first-verbs}
+\input{chapters/ch06-numbers-1-10}
+\input{chapters/ch07-days-of-the-week}
+\input{chapters/ch08-telling-time}
+\input{chapters/ch09-months-and-seasons}
+\input{chapters/ch10-family}
+\input{chapters/ch11-bread-water-wine}
+\input{chapters/ch12-numbers-11-20}
+\input{chapters/ch13-colours}
+\input{chapters/ch14-having-and-age}
+\input{chapters/ch15-two-pasts}
+\input{chapters/ch16-essere-andare-past}
+\input{chapters/ch17-head-and-hand}
+
 \end{document}

--- a/code/learning/human-languages/italian/book/chapters/ch02-how-are-you.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch02-how-are-you.tex
@@ -1,0 +1,414 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:03633dd64e873a05
+% canonical-lessons: IT-C02-prego, IT-C02-come, IT-C02-stare, IT-C02-come-stai, IT-C02-come-sta, IT-C02-come-va, IT-C02-cosi-cosi, IT-C02-practice
+
+\chapter{How Are You?}
+\label{ch:it-how-are-you}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[prego]{prego — "you're welcome," literally "I pray"}
+
+\label{lesson:IT-C02-prego}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The \emph{grazie} lesson already promised you this word. Someone says \textbf{grazie}; you reply \textbf{prego}. Like German \emph{bitte}, it's a small word that does several jobs — and it comes straight from \textbf{praying}.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{hard-g-before-o} — \textbf{prego} = \emph{PREH-go} with a \textbf{hard} g. (Italian g is soft only before \emph{e/i}; here the g is followed by \emph{o}, so it stays hard.)
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{prego} is "I pray" — the \emph{io} ("I") form of \textbf{pregare}, "to pray, to beg," from Latin \textbf{precārī}. When you answer \emph{grazie} with \emph{prego}, you're softly saying \emph{"I pray (it was nothing) / please, don't mention it."}
+
+That root \textbf{prec-} ("pray, entreat") gives English a surprising family:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{pray}, \textbf{prayer} — the direct line.
+  \item \textbf{precarious} — literally "held by \emph{prayer}," i.e. depending on someone's goodwill, therefore unstable.
+  \item \textbf{deprecate} ("pray \emph{away}, ward off") and \textbf{imprecation} ("a prayer \emph{against} — a curse").
+\end{itemize}
+
+Like German \textbf{bitte}, \emph{prego} stretches across situations, all of them a form of "I pray you":
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{you say \emph{prego} when…} & \textbf{it means} \\
+\midrule
+answering \emph{grazie} & \textbf{you're welcome} \\
+offering a seat / letting someone pass & \textbf{please, go ahead / after you} \\
+handing something over & \textbf{here you are} \\
+you didn't catch it & \textbf{sorry, come again?} \\
+\bottomrule
+\end{tabularx}
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "grazie" … "prego" — the full exchange{]}
+  \item {[}YOU SAY: "prego" then English "pray, precarious" — one family{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What verb is \emph{prego} the "I" form of? (\emph{pregare}, "to pray.") What English word means "held by prayer" and so "unstable"? (\emph{Precarious}.) Which German word does \emph{prego} behave like? (\emph{bitte} — one word, many courtesies.) Next: \textbf{come}, "how."
+\end{tcolorbox}
+\section[come]{come — "how," the third \emph{quomodo} cousin}
+
+\label{lesson:IT-C02-come}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} To ask \emph{how are you?} you need "how." In Italian it's \textbf{come} — and if you've seen the Spanish or French tracks, you already know its family.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{soft-c} — \textbf{come} = \emph{KOH-meh}. Here \emph{c} is before \emph{o}, so it's a \textbf{hard} \emph{k} (Italian \emph{c} only softens to \emph{ch} before \emph{e/i}). Final \emph{-e} is sounded: \emph{KOH-meh}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{come} = "how / like / as." Root: Latin \textbf{quōmodo}, "in what manner" — two words (\emph{quō} "in what way" + \emph{modo} "manner") fused and worn down. It is the \textbf{same source} as:
+
+\begin{itemize}
+\raggedright
+  \item Spanish \textbf{cómo} ("how")
+  \item French \textbf{comment} ("how")
+  \item and, doubling as "like/as," it matches Spanish \textbf{como} and French \textbf{comme}.
+\end{itemize}
+
+So one Latin \emph{quōmodo} became the "how" word in all three Romance sisters. The \emph{modo} piece ("manner, measure") also lives in English \textbf{mode}, \textbf{mod}el, \textbf{mod}erate — all about the \emph{way} something is done.
+
+Note Italian \emph{come} covers \textbf{both} jobs at once, and the written accent tells them apart only by context, not spelling: \emph{Come stai?} ("\textbf{How} are you?") vs \emph{bianco come la neve} ("white \textbf{as} snow").
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "come" — \emph{KOH-meh}{]}
+  \item {[}YOU SAY: come / cómo / comment — the three \emph{quomodo} siblings{]}
+  \item {[}YOU SAY: English \emph{mode, model} share the \emph{modo} piece{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What Latin word gives \emph{come}, and which Spanish and French words are its siblings? (\emph{quōmodo} $\to$ \emph{cómo}, \emph{comment}.) What two jobs does \emph{come} do? ("How?" and "like/as.") Next: the verb it pairs with — \textbf{stare}.
+\end{tcolorbox}
+\section[stare]{stare — "to be," the standing kind (Spanish's estar, undressed)}
+
+\label{lesson:IT-C02-stare}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Like Spanish, Italian has \textbf{two} verbs for "to be" — \textbf{essere} (identity) and \textbf{stare} (state). "How are you?" runs on \textbf{stare}. And if you did the Spanish track, this is \emph{estar} with its front \emph{e} taken off.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{st-clean} — Italian, unlike Spanish, is happy to start a word with \emph{st-}: no propping \emph{e}. \textbf{stare} = \emph{STAH-reh}, clean \emph{st}, final \emph{-e} sounded.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{stare} comes straight from Latin \textbf{stāre}, \emph{"to stand."} Spanish grew the same verb into \textbf{estar} (with a propping \emph{e-}); Italian kept it bare as \textbf{stare}. Same Latin root, same job: the \emph{temporary state} be-verb — how you \emph{stand} right now.
+
+That \textbf{stā-} root stands behind a wall of English words: \textbf{stay}, \textbf{stand}, \textbf{state}, \textbf{status}, \textbf{stable}, \textbf{station}, \textbf{stance}, \textbf{e-state}, \textbf{con-stant}, \textbf{circum-stance}. So \emph{Come stai?} is, at the root, \textbf{"how do you stand?"} — the very same picture as Spanish \emph{¿Cómo estás?}.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: essere vs stare, and the two forms you need}]
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{verb} & \textbf{from} & \textbf{job} \\
+\midrule
+\textbf{essere} & Latin \emph{esse} & identity — \emph{sono Marco}, "I am Marco" \\
+\textbf{stare} & Latin \emph{stāre} & state / how you are — \emph{sto bene}, "I'm well" \\
+\bottomrule
+\end{tabularx}
+
+For this chapter, just two forms of \emph{stare}:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{stai} — "you are" (informal, \emph{tu})
+  \item \textbf{sta} — "you are" (formal, \emph{Lei}) / "he/she is"
+\end{itemize}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "stare" — \emph{STAH-reh}, clean \emph{st}{]}
+  \item {[}YOU SAY: "stai" … "sta" — the two forms you'll ask with{]}
+  \item {[}YOU SAY: Italian \emph{stare} = Spanish \emph{estar}, same Latin \emph{stāre} "to stand"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What Latin verb is \emph{stare}, and which Spanish verb is its twin? ("To stand," \emph{stāre} — Spanish \emph{estar}.) Which Italian be-verb is for how you feel — \emph{essere} or \emph{stare}? (\emph{stare}.) Next: ask it — \textbf{Come stai?}
+\end{tcolorbox}
+\section[Come stai?]{Come stai? — “how are you?”}
+
+\label{lesson:IT-C02-come-stai}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Both pieces are ready: \textbf{come} (“how”) and \textbf{stare / stai} (“to be,” from \emph{stand}). Assemble Italian’s everyday question for a friend.
+\end{quote}
+
+\begin{cousinweb}
+\begin{quote}
+\textbf{Come stai?} = “How are you?” (informal) literally: \textbf{“How do you stand?”}
+\end{quote}
+
+\begin{itemize}
+\raggedright
+  \item \textbf{come} = “how”
+  \item \textbf{stai} = “you are / stand,” the \emph{tu} form of \emph{stare}
+\end{itemize}
+
+The subject \textbf{tu} (“you”) is already carried by \textbf{stai}, so Italian normally leaves it unspoken. Say \textbf{Come stai?}, not \emph{Come tu stai?}, unless you need to stress “you.” This is the same pro-drop habit you will use in later verb lessons.
+
+An everyday answer reuses the same verb:
+
+\begin{quote}
+\textbf{Come stai? — Sto bene, grazie.} “How are you? — I’m well, thanks.”
+\end{quote}
+
+\textbf{Sto} means “I am / stand.” The pair \textbf{stai / sto} lets the ending do the pronoun’s work: “you” in \emph{-ai}, “I” in \emph{-o}.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: “Come stai?” — informal, for a friend{]}
+  \item {[}YOU SAY: “Sto bene, grazie.”{]}
+  \item {[}YOU SAY: the two-part exchange — “Come stai? — Sto bene.”{]}
+\end{itemize}
+
+{[}REPEAT x2{]} “Come stai? — Sto bene, grazie.”
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} \emph{Come stai?} literally asks what? (“How do you \textbf{stand}?”) Which word means “how”? (\textbf{Come}.) Which form answers “I am”? (\textbf{Sto}.) Give the whole exchange: \textbf{Come stai? — Sto bene, grazie.} Next: formal speech and the “go” version.
+\end{tcolorbox}
+\section[Come sta?]{Come sta? — the formal question}
+
+\label{lesson:IT-C02-come-sta}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You can ask a friend \textbf{Come stai?} Change one ending when you speak to a stranger or elder.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: stai and sta}]
+\begin{quote}
+\textbf{Come sta?} = “How are you?” (formal)
+\end{quote}
+
+Italian uses \textbf{Lei} — literally “she,” often capitalized — as a polite “you.” Its verb therefore uses the third-person form \textbf{sta}, not informal \textbf{stai}:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{listener} & \textbf{question} \\
+\midrule
+a friend (\emph{tu}) & \textbf{Come stai?} \\
+a stranger or elder (\emph{Lei}) & \textbf{Come sta?} \\
+\bottomrule
+\end{tabularx}
+
+The politeness pattern has cousins in Spanish \emph{usted} and German \emph{Sie}, but you only need one Italian contrast here: \textbf{stai} for a friend, \textbf{sta} for formal respect.
+
+An answer can return the formal pronoun:
+
+\begin{quote}
+\textbf{Bene, grazie. E Lei?} — “Well, thank you. And you?”
+\end{quote}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: to a friend — “Come stai?”{]}
+  \item {[}YOU SAY: to a stranger — “Come sta?”{]}
+  \item {[}YOU SAY: “Bene, grazie. E Lei?”{]}
+\end{itemize}
+
+{[}REPEAT x2{]} “Stai — friend. Sta — formal.”
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which ending marks a friend? (\textbf{-i: stai}.) Which form is formal? (\textbf{Sta}.) What polite pronoun can follow \emph{e}, “and”? (\textbf{Lei}.) Next: keep the meaning but switch the picture from “stand” to “go.”
+\end{tcolorbox}
+\section[Come va?]{Come va? — “how is it going?”}
+
+\label{lesson:IT-C02-come-va}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} \textbf{Come stai?} pictures wellbeing as standing. Italian also has the same “going” picture as English.
+
+\begin{quote}
+\textbf{Come va?} = “How’s it going?”
+\end{quote}
+
+\textbf{Va} comes from \textbf{andare}, “to go.” Unlike \emph{stai / sta}, this question does not force you to choose an informal or formal ending, so it is useful in either setting.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: standing and going}]
+\begin{itemize}
+\raggedright
+  \item \textbf{Come stai?} — “How do you \textbf{stand}?”
+  \item \textbf{Come va?} — “How does it \textbf{go}?”
+\end{itemize}
+
+Spanish also uses the “stand” picture in \emph{¿cómo estás?}; French and German use a “go” picture. Italian keeps \textbf{both}, which makes it a bridge between them. The comparison is only a memory aid: in Italian, simply connect \textbf{stai} with \emph{stare} and \textbf{va} with \emph{andare}.
+
+You will learn all six forms of \emph{andare} much later. For now, \textbf{va} is one ready-made piece inside this question.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the standing question — “Come stai?”{]}
+  \item {[}YOU SAY: the going question — “Come va?”{]}
+  \item {[}YOU SAY: “Come va? — Bene, grazie.”{]}
+\end{itemize}
+
+{[}REPEAT x2{]} “Come stai? — Come va?”
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which question uses “stand”? (\textbf{Come stai?}) Which uses “go”? (\textbf{Come va?}) What infinitive owns \textbf{va}? (\textbf{Andare}.) Must \emph{Come va?} choose between \emph{tu} and \emph{Lei}? (\textbf{No}.) Next: answer with the original Italian “so-so.”
+\end{tcolorbox}
+\section[così così]{così così — the original "so-so"}
+
+\label{lesson:IT-C02-cosi-cosi}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} English "so-so" is a \textbf{loan translation of the Italian} \emph{così così}. Someone asks \emph{Come stai?}; you're middling; you wobble a hand and say \emph{così così} — "thus and thus," this way and that.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{soft-c} — \textbf{così} = \emph{koh-ZEE}: the \emph{c} is before \emph{o} (hard \emph{k}), and the single \emph{s} between vowels is \textbf{voiced}, a \emph{z} sound: \emph{koh-\textbf{ZEE}}. Stress the end (that's what the accent on \emph{ì} marks).
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{così} = "thus, so, in this way," from Latin \textbf{(ec)cum sīc}, "(behold) so." Doubled — \emph{così così} — it means "\textbf{so} and \textbf{so}," neither up nor down: a verbal shrug.
+
+The core piece \textbf{sīc} ("thus, so") is one you already write in English:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{sic} — the \emph{{[}sic{]}} you put after a quoted mistake means "\textbf{thus} it was written."
+  \item It's also the Latin behind Spanish/French/Italian \textbf{sì / si / sì} ("yes" — "it is \emph{so}"), and the \emph{-si} inside French \textbf{ain-si} ("thus").
+\end{itemize}
+
+So \emph{così così} is literally \textbf{"so, so"} — and English simply borrowed the shrug whole.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: your answer ladder for \emph{Come stai?}}]
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{answer} & \textbf{sense} \\
+\midrule
+\textbf{(Molto) bene, grazie} & (very) well, thanks \\
+\textbf{Così così} & so-so \\
+\textbf{Non c'è male} & "not bad" (lit. "there isn't bad") \\
+\bottomrule
+\end{tabularx}
+
+The cross-track shrug set, now five deep: Italian \textbf{così così} ("so, so"), French \textbf{comme ci comme ça} ("like this, like that"), Spanish \textbf{más o menos} ("more or less"), German \textbf{es geht} ("it goes").
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "così così" — \emph{koh-ZEE koh-ZEE}, with a hand-wobble{]}
+  \item {[}YOU SAY: answer "Come stai?" three ways — "Bene" / "Così così" / "Non c'è male"{]}
+  \item {[}YOU SAY: "sic" in English — "thus" — the same \emph{sīc}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \emph{così così} literally mean? ("Thus, thus / so, so.") What Latin word for "so" is inside it, and where do you still write it in English? (\emph{sīc} $\to$ \emph{{[}sic{]}}.) English "so-so" came from — which language? (Italian \emph{così così}.) Next: put the exchange together.
+\end{tcolorbox}
+\section[Practice]{Practice — "Come stai?", start to finish}
+
+\label{lesson:IT-C02-practice}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} No new words. This chapter's atoms — \emph{prego, come, stare, come stai?, così così} — assemble into a real exchange, formal and informal. It picks up from the Chapter 1 greetings.
+\end{quote}
+
+\subsection*{The exchange}
+\textbf{Formal} (a stranger, an elder — \emph{Lei}):
+
+\begin{quote}
+— Buongiorno. \textbf{Come sta?} — \textbf{Bene, grazie.} E Lei? — \textbf{Così così.} — {[}after a small favour{]} — Grazie! — \textbf{Prego.}
+\end{quote}
+
+\textbf{Informal} (a friend — \emph{tu}):
+
+\begin{quote}
+— Ciao! \textbf{Come stai?} — \textbf{Sto bene, e tu?} — Non c'è male.
+\end{quote}
+
+The glue is \textbf{e Lei? / e tu?} — "and you?" (\emph{e} = "and," Latin \emph{et}) — the Italian twin of Spanish \emph{¿y usted?} and French \emph{et toi?}.
+
+\begin{grammarlens}[title={What you've built this chapter}]
+\begin{itemize}
+\raggedright
+  \item \textbf{prego} — you're welcome / please ($\leftarrow$ \emph{pregare}, "to pray"; English \emph{precarious}).
+  \item \textbf{come} — how ($\leftarrow$ \emph{quōmodo}; sibling of \emph{cómo} / \emph{comment}).
+  \item \textbf{stare} — "to be" from \emph{stand} (= Spanish \emph{estar}); vs \emph{essere} (identity).
+  \item \textbf{Come stai? / sta? / va?} — informal, formal, and the "how's it going?" form (\emph{va} $\leftarrow$ \emph{andare}, "to go").
+  \item \textbf{così così} — so-so (English "so-so" borrowed it whole).
+\end{itemize}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the full \emph{formal} exchange, both voices{]}
+  \item {[}YOU SAY: the same \emph{informally} — \emph{sta $\to$ stai}, \emph{Lei $\to$ tu}{]}
+  \item {[}YOU SAY: all three questions — Come stai? / Come sta? / Come va?{]}
+\end{itemize}
+
+{[}REPEAT x2{]} "Come stai? — Sto bene, grazie, e tu?" until it's reflex.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which verb carries \emph{Come stai?}, and what does it literally ask? (\emph{stare}, "to stand" — "how do you stand?") What does \emph{prego} answer, and from what root? (\emph{grazie}; $\leftarrow$ \emph{pregare}, "to pray.") Italian can ask "how are you" two ways — which verbs? (\emph{stare}, stand; \emph{andare} $\to$ \emph{va}, go.) Next chapter: \textbf{introducing yourself} — mi chiamo, come ti chiami.
+\end{tcolorbox}

--- a/code/learning/human-languages/italian/book/chapters/ch03-introductions.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch03-introductions.tex
@@ -1,0 +1,266 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:aa27c60a3d656001
+% canonical-lessons: IT-C03-io, IT-C03-mi-chiamo, IT-C03-come-ti-chiami, IT-C03-piacere, IT-C03-practice
+
+\chapter{Introducing Yourself}
+\label{ch:it-introductions}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[io]{io — "I," the pronoun Italian loves to leave out}
+
+\label{lesson:IT-C03-io}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Before you introduce yourself, meet \textbf{io} — "I." It's a small word with a famous English cousin, and a surprising habit: Italian usually \textbf{drops it.}
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{io-glide} — \textbf{io} = \emph{EE-oh}, two quick vowels gliding together, stress the first: \emph{EE-oh}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{io} = "I," worn down from Latin \textbf{ego} — which English borrowed \emph{whole}:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{ego} — literally Latin "I" (your sense of self).
+  \item \textbf{egoist}, \textbf{egotist}, \textbf{egocentric} — all built on that "I."
+  \item Its Romance siblings: Spanish \textbf{yo}, Portuguese \textbf{eu}, French \textbf{je} — every one a child of \emph{ego}.
+\end{itemize}
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: the dropped subject (pro-drop)}]
+Here's the Italian habit worth learning now: \textbf{the verb ending already tells you who's speaking, so the pronoun is usually left out.} \emph{Sto bene} ("I'm well") needs no \emph{io} — the \emph{-o} of \emph{sto} is "I." You add \textbf{io} only for \textbf{emphasis} or \textbf{contrast}:
+
+\begin{quote}
+\emph{Io} sto bene — e tu? — "\emph{I'm} fine — and you?"
+\end{quote}
+
+Spanish (\emph{yo}) and Portuguese (\emph{eu}) do exactly the same. English can't: it must say "I" every time. So learning Italian means learning to \emph{trust the verb ending} and let the pronoun go.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "io" — \emph{EE-oh}{]}
+  \item {[}YOU SAY: "io" then English "ego, egoist" — the same Latin "I"{]}
+  \item {[}YOU SAY: "Sto bene" with no \emph{io} — the ending carries the "I"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What Latin word is \emph{io} from, and what English words share it? (\emph{Ego} — ego, egoist.) Why does Italian usually drop \emph{io}? (The verb ending already says who.) When do you keep it? (For emphasis/contrast.) Next: use it to introduce yourself — \textbf{mi chiamo}.
+\end{tcolorbox}
+\section[mi chiamo]{mi chiamo — "I call myself"}
+
+\label{lesson:IT-C03-mi-chiamo}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Like Spanish and French, Italian doesn't say "my name is." It says \textbf{"I call myself"} — \textbf{mi chiamo}. Same reflexive trick, same \emph{clāmāre} root as Spanish \emph{me llamo}.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{ch-hard-k} — Italian \textbf{ch} is a \textbf{hard k} (the opposite of English!): so \textbf{chiamo} = \emph{KYAH-moh}, not "chee-." (Italian softens \emph{c} to \emph{ch}-sound only before \emph{e/i}; the \emph{h} in \emph{chi} is there precisely to keep it hard.)
+  \item \textbf{mi chiamo} = \emph{mee KYAH-moh}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{mi chiamo} = \textbf{mi} ("myself") + \textbf{chiamo} ("I call") $\to$ \textbf{"I call myself."} Then the name: \emph{Mi chiamo Marco} — "I call myself Marco."
+
+The verb is \textbf{chiamarsi} ("to call oneself"), from Latin \textbf{clāmāre}, \emph{"to cry out, to call."} That root shouts through English:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{claim}, \textbf{exclaim}, \textbf{proclaim}, \textbf{acclaim}, \textbf{clamor} — all "calling out."
+  \item Its Romance siblings all name people the same way: Spanish \textbf{llamarse} (\emph{me llamo}), Portuguese \textbf{chamar-se} (\emph{me chamo}) — the \emph{cl-} softening to \emph{ll-} (Spanish) or \emph{ch-} (Italian/Portuguese). One Latin "call," three naming verbs.
+\end{itemize}
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: the reflexive, and the dropping of \emph{io}}]
+\emph{chiamo} alone is "I call {[}someone else{]}"; \textbf{mi} chiamo is "I call \textbf{myself}" — \textbf{reflexive}, the action looping back on you. The pronoun changes with the person: \textbf{mi} chiamo (I) $\to$ \textbf{ti} chiami (you) $\to$ \textbf{si} chiama (he/she/formal). And notice: no \emph{io} — the \emph{-o} ending already says "I." (You met that pro-drop last lesson.)
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "mi chiamo" — \emph{mee KYAH-moh}, hard \emph{k} in \emph{chiamo}{]}
+  \item {[}YOU SAY: "Mi chiamo …" with your own name{]}
+  \item {[}YOU SAY: "chiamo" then English "claim, exclaim, clamor" — the \emph{clāmāre} family{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \emph{mi chiamo} literally mean? ("I call myself.") What Latin verb is \emph{chiamarsi} from, and its English cousins? (\emph{clāmāre} — claim, exclaim, clamor.) How is Italian \emph{ch} pronounced? (A hard \emph{k}.) Next: ask it back — \textbf{Come ti chiami?}
+\end{tcolorbox}
+\section[Come ti chiami?]{Come ti chiami? — "what's your name?"}
+
+\label{lesson:IT-C03-come-ti-chiami}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You have both pieces: \textbf{come} ("how," from your how-are-you chapter) and \textbf{chiamarsi} ("to call oneself"). Like Spanish and French, Italian asks the name with \textbf{"how"}, not "what": \emph{how do you call yourself?}
+\end{quote}
+
+\begin{cousinweb}
+\begin{quote}
+\textbf{Come ti chiami?} = "What's your name?" (informal) literally: \textbf{"How do you call yourself?"}
+\end{quote}
+
+\begin{itemize}
+\raggedright
+  \item \textbf{come} = "how" ($\leftarrow$ \emph{quōmodo}; you met it in \emph{Come stai?}).
+  \item \textbf{ti} = "yourself" (the reflexive, matching \emph{mi} $\to$ \emph{ti}).
+  \item \textbf{chiami} = "you call" (the \emph{tu} form of \emph{chiamarsi}).
+\end{itemize}
+
+Two registers — the same \emph{tu / Lei} split you learned in Chapter 2:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{register} & \textbf{question} \\
+\midrule
+\textbf{informal} (\emph{tu}) & \textbf{Come ti chiami?} \\
+\textbf{formal} (\emph{Lei}) & \textbf{Come si chiama?} \\
+\bottomrule
+\end{tabularx}
+
+Only the reflexive pronoun and the ending move: \emph{ti chiami} $\to$ \emph{si chiama} — the identical pattern to \emph{mi chiamo $\to$ si chiama}. The whole exchange:
+
+\begin{quote}
+— Come ti chiami? — Mi chiamo Marco. E tu?
+\end{quote}
+
+Note Italian asks the name with \emph{come} ("how"), exactly like Spanish \emph{¿cómo se llama?} and French \emph{comment vous appelez-vous?} — the name is a matter of \emph{how} you're called, not \emph{what} you are.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "Come ti chiami?" — informal, for a peer{]}
+  \item {[}YOU SAY: "Come si chiama?" — formal, for a stranger (Lei){]}
+  \item {[}YOU SAY: the whole swap — "Come ti chiami? — Mi chiamo … E tu?"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \emph{Come ti chiami?} literally ask? ("How do you call yourself?") What changes for the formal \emph{Lei} version? (\emph{ti chiami} $\to$ \emph{si chiama}.) Which "how" word is it built on? (\emph{come} $\leftarrow$ \emph{quōmodo}.) Next: the reply when you meet — \textbf{piacere}.
+\end{tcolorbox}
+\section[piacere]{piacere — "pleased to meet you," i.e. "a pleasure"}
+
+\label{lesson:IT-C03-piacere}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Names exchanged, you close the introduction with one warm word: \textbf{piacere} — literally \emph{"a pleasure."} It's the twin of a word you'd say in Portuguese, and it's pure Latin \emph{please}.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{soft-c} — \textbf{piacere} = \emph{pya-\textbf{CHEH}-reh}: here \emph{c} is before \emph{e}, so it's soft (\emph{ch}), and the \emph{ia} glides: \emph{pya-CHE-re}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{piacere} = "a pleasure" (and, as a verb, "to please"), from Latin \textbf{placēre}, \emph{"to please, to be pleasing."} Said on meeting someone, it's short for \emph{"{[}it's{]} a pleasure {[}to meet you{]}."}
+
+That \textbf{placēre} root is thoroughly at home in English:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{please}, \textbf{pleasure}, \textbf{pleasant} — the direct line.
+  \item \textbf{complacent} ("pleased \emph{with} oneself"), \textbf{complaisant}, \textbf{placid} (pleased $\to$ calm).
+\end{itemize}
+
+And across the family, "pleased to meet you" is built from the \emph{same} idea nearly everywhere:
+
+\begin{itemize}
+\raggedright
+  \item Portuguese \textbf{prazer} ($\leftarrow$ \emph{placēre} too — its twin).
+  \item French \textbf{enchanté} (a different image — "enchanted").
+  \item Spanish \textbf{mucho gusto} ("much pleasure," but from \emph{gustus}, "taste" — a different Latin root).
+\end{itemize}
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: a one-word courtesy}]
+\emph{Piacere} stands alone — you just say it, with a small nod, as you shake hands. For a touch more you can say \emph{molto piacere} ("much pleasure") or \emph{piacere di conoscerti} ("pleasure to know you").
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "piacere" — \emph{pya-CHEH-reh}{]}
+  \item {[}YOU SAY: "piacere" then English "please, pleasure, placid" — the \emph{placēre} root{]}
+  \item {[}YOU SAY: Italian \emph{piacere} and Portuguese \emph{prazer} — twins from \emph{placēre}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \emph{piacere} literally mean, and from what? ("A pleasure," $\leftarrow$ \emph{placēre} "to please.") Its English cousins? (Please, pleasure, placid, complacent.) Which Portuguese word is its twin? (\emph{Prazer}.) Next: put the whole introduction together.
+\end{tcolorbox}
+\section[Practice]{Practice — introducing yourself in Italian}
+
+\label{lesson:IT-C03-practice}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} No new words. \emph{io, mi chiamo, come ti chiami, piacere} now assemble into a real first meeting — run it formally and informally until the register swap is automatic. This slots between your greetings (Ch. 1–2) and farewells (Ch. 4).
+\end{quote}
+
+\subsection*{The exchange}
+\textbf{Informal} (a peer):
+
+\begin{quote}
+— Ciao! \textbf{Come ti chiami?} — \textbf{Mi chiamo} Marco. E tu? — Giulia. \textbf{Piacere!} — Piacere!
+\end{quote}
+
+\textbf{Formal} (a stranger — \emph{Lei}):
+
+\begin{quote}
+— Buongiorno. \textbf{Come si chiama?} — Mi chiamo Marco Rossi. E Lei? — Rossi. \textbf{Molto piacere.}
+\end{quote}
+
+\begin{grammarlens}[title={What you've built this chapter}]
+\begin{itemize}
+\raggedright
+  \item \textbf{io} — "I" ($\leftarrow$ \emph{ego}), usually \textbf{dropped} — the verb ending carries it.
+  \item \textbf{mi chiamo} — "I call myself" (\emph{chiamarsi} $\leftarrow$ \emph{clāmāre}, "call out"; kin of Spanish \emph{me llamo}, Portuguese \emph{me chamo}).
+  \item \textbf{Come ti chiami? / Come si chiama?} — "how do you call yourself?", informal / formal.
+  \item \textbf{piacere} — "a pleasure" ($\leftarrow$ \emph{placēre}; twin of Portuguese \emph{prazer}).
+\end{itemize}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the full informal meeting, both voices{]}
+  \item {[}YOU SAY: the same formally — \emph{ti chiami $\to$ si chiama}, \emph{tu $\to$ Lei}{]}
+  \item {[}YOU SAY: chain it all — greet, name, ask, how-are-you, goodbye: "Ciao! Mi chiamo … Come ti chiami? … Come stai? … A domani!"{]}
+\end{itemize}
+
+{[}REPEAT x2{]} Run a whole first meeting start to finish.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Why does Italian usually drop \emph{io}? (The verb ending says who.) What does \emph{mi chiamo} literally mean, and its root? ("I call myself"; \emph{clāmāre}.) What does \emph{piacere} mean? ("A pleasure.") Italian now runs greet $\to$ introduce $\to$ how-are-you $\to$ goodbye, end to end.
+\end{tcolorbox}

--- a/code/learning/human-languages/italian/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch04-farewells.tex
@@ -1,0 +1,261 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:ca5f394581f1d56b
+% canonical-lessons: IT-C04-arrivederci, IT-C04-a-domani, IT-C04-a-presto, IT-C04-a-piu-tardi, IT-C04-practice
+
+\chapter{Farewells}
+\label{ch:it-farewells}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[arrivederci]{arrivederci — "goodbye," i.e. "until we meet again"}
+
+\label{lesson:IT-C04-arrivederci}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You can open a conversation in Italian and ask how someone is. Now, close it. The standard goodbye is \textbf{arrivederci} — and, like its French and German cousins, it doesn't say "goodbye" at all. It says \textbf{"until we see each other again."}
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \textbf{arrivederci} = \emph{ar-ree-veh-\textbf{DER}-chee}: a tapped double \emph{r}, and the final \emph{-ci} is soft (\emph{chee}, Italian \emph{c} before \emph{i}). Stress the \emph{-der-}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+Break it into four pieces you can almost read straight off:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{a} = "to / until" (Latin \emph{ad}).
+  \item \textbf{ri-} = "again" (Latin \emph{re-} — as in English \emph{re}-do, \emph{re}-view).
+  \item \textbf{vedere} = "to see" (Latin \emph{vidēre} $\to$ English \textbf{video}, \textbf{vision}, \textbf{evident}, \textbf{provide}).
+  \item \textbf{-ci} = "us / each other."
+\end{itemize}
+
+Glued: \emph{a-(ri)-vedere-ci} $\to$ \textbf{"to our seeing-one-another-again."} You don't say farewell; you promise the next meeting.
+
+\#\#\# The whole family says the same thing
+
+This "until re-seeing" idea is shared right across the languages you're learning — a lovely thing to notice:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{goodbye} & \textbf{literally} \\
+\midrule
+\textbf{Italian} & \emph{arrivederci} & "to our re-seeing" \\
+\textbf{French} & \emph{au revoir} & "to the re-seeing" (\emph{re} + \emph{voir}, see) \\
+\textbf{German} & \emph{auf Wiedersehen} & "on again-seeing" (\emph{wieder} + \emph{sehen}) \\
+\bottomrule
+\end{tabularx}
+
+Three languages, one gesture: part by pointing at the reunion, not the parting. (Italian keeps a heavier, final "to God" goodbye too — \textbf{addio}, \emph{a Dio} — the exact twin of Spanish \emph{adiós}; but for everyday partings it's \emph{arrivederci}.)
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "arrivederci" — \emph{ar-ree-veh-DER-chee}{]}
+  \item {[}YOU SAY: arrivederci / au revoir / auf Wiedersehen — all "until we see again"{]}
+  \item {[}YOU SAY: "vedere" then English "video, vision" — the \emph{see} root{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \emph{arrivederci} literally promise? ("Until we see each other again.") What French and German goodbyes share that exact idea? (\emph{au revoir}, \emph{auf Wiedersehen}.) Which heavier Italian goodbye means "to God," like Spanish \emph{adiós}? (\emph{addio}.) Next: "see you tomorrow" — \textbf{a domani}.
+\end{tcolorbox}
+\section[a domani]{a domani — "see you tomorrow"}
+
+\label{lesson:IT-C04-a-domani}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The "until re-seeing" pattern gives you a whole family of goodbyes: just name \textbf{when}. First: \textbf{a domani}, "to tomorrow."
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \textbf{a domani} = \emph{ah doh-\textbf{MAH}-nee}: clean open vowels, stress the \emph{-ma-}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{a} = "to / until" (the same \emph{a} from \emph{arrivederci}).
+  \item \textbf{domani} = "tomorrow," from Latin \textbf{dē māne}, \emph{"from the morning."}
+\end{itemize}
+
+That word \textbf{māne} ("morning") is quietly shared across the Romance family, and you may have already met its Spanish child:
+
+\begin{itemize}
+\raggedright
+  \item Italian \textbf{domani} ("tomorrow") $\leftarrow$ \emph{dē māne}.
+  \item Spanish \textbf{mañana} $\leftarrow$ \emph{(hōra) māneāna} — which means \textbf{both} "morning" \emph{and} "tomorrow," because tomorrow \emph{is} "the coming morning."
+\end{itemize}
+
+So \emph{a domani} literally says \textbf{"until the morning {[}to come{]}."} You part by pointing at daybreak.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "a domani" — \emph{ah doh-MAH-nee}{]}
+  \item {[}YOU SAY: Italian \emph{domani} and Spanish \emph{mañana} — both from \emph{māne}, "morning"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \emph{domani} come from, and what does it literally mean? (\emph{Dē māne} — "from the morning.") Which Spanish word shares that \emph{māne} root? (\emph{Mañana} — morning \emph{and} tomorrow.) Next: "see you soon" — \textbf{a presto}.
+\end{tcolorbox}
+\section[a presto]{a presto — "see you soon"}
+
+\label{lesson:IT-C04-a-presto}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Same frame, new "when": \textbf{a presto}, "to soon." And \emph{presto} is a word English already borrowed whole — from stage magic and music.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \textbf{a presto} = \emph{ah \textbf{PREH}-stoh}: clean \emph{st}, crisp open \emph{e}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{a} = "to / until."
+  \item \textbf{presto} = "soon, quickly," from Latin \textbf{praestō}, \emph{"at hand, ready, present"} (\emph{prae-} "before" + \emph{stō/stāre} "stand" — literally "standing before you," ready to hand).
+\end{itemize}
+
+English took \textbf{presto} straight from Italian:
+
+\begin{itemize}
+\raggedright
+  \item in \textbf{music}, \emph{presto} means "fast."
+  \item in stage magic, \emph{"presto!"} means "quick — and there it is!"
+  \item it shares that \emph{stō} ("stand") root with \emph{stare} from your how-are-you chapter, and with English \textbf{station}, \textbf{stable}, \textbf{status}.
+\end{itemize}
+
+So \emph{a presto} is \textbf{"until {[}it is{]} soon / at hand"} — see you before long.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "a presto" — \emph{ah PREH-stoh}{]}
+  \item {[}YOU SAY: "presto" as music ("fast") and magic ("presto!") — same word{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \emph{presto} mean, and where has English borrowed it? ("Soon / quickly" — in music and magic.) What "stand" root does it share with \emph{stare}? (Latin \emph{stō/stāre}.) Next: "see you later" — \textbf{a più tardi}.
+\end{tcolorbox}
+\section[a più tardi]{a più tardi — "see you later"}
+
+\label{lesson:IT-C04-a-piu-tardi}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The last "when" in the set: \textbf{a più tardi}, "to later" — literally "to \emph{more late}." Two small words, both alive in English.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{piu-glide} — \textbf{più} = \emph{pyoo}, one gliding syllable (the accent marks the stress).
+  \item \textbf{a più tardi} = \emph{ah pyoo \textbf{TAR}-dee}, tapped \emph{r}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{a} = "to / until."
+  \item \textbf{più} = "more," from Latin \textbf{plūs} — the very word English took for \textbf{plus}, and the root of \textbf{plural}, \textbf{surplus}.
+  \item \textbf{tardi} = "late," from Latin \textbf{tardus}, \emph{"slow, late"} $\to$ English \textbf{tardy}, \textbf{re-tard} ("to slow down"), \textbf{tardy} slip.
+\end{itemize}
+
+Together, \emph{più tardi} = \textbf{"more late"} = "later." So \emph{a più tardi} is "until {[}it's{]} more-late" — see you later on. (Italian builds "later" as \emph{more late}, just as English does with the comparative \emph{-er}.)
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "a più tardi" — \emph{ah pyoo TAR-dee}{]}
+  \item {[}YOU SAY: "più" \textasciitilde{} English \emph{plus}; "tardi" \textasciitilde{} English \emph{tardy} — both borrowed{]}
+  \item {[}YOU SAY: the four goodbyes — arrivederci / a domani / a presto / a più tardi{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What do \emph{più} and \emph{tardi} mean, and their English cousins? (\emph{Più} = "more" \textasciitilde{} plus; \emph{tardi} = "late" \textasciitilde{} tardy.) So \emph{a più tardi} literally says? ("To more-late" $\to$ see you later.) Next: put the farewells together.
+\end{tcolorbox}
+\section[Practice]{Practice — saying goodbye in Italian}
+
+\label{lesson:IT-C04-practice}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} No new words. You can now open a conversation, ask how someone is, and \textbf{close} it. Run the goodbyes until the right one comes automatically.
+\end{quote}
+
+\subsection*{You'll want to know: the closings}
+\textbf{Neutral / polite} (anyone):
+
+\begin{quote}
+— È stato un piacere. \textbf{Arrivederci!} — \textbf{Arrivederci!}
+\end{quote}
+
+\textbf{With a "when"} — pick the promise that fits:
+
+\begin{quote}
+— \textbf{A domani!} (see you tomorrow) — \textbf{A presto!} (see you soon) — \textbf{A più tardi!} (see you later — same day)
+\end{quote}
+
+\textbf{Casual} (a friend): the \emph{ciao} you learned in Chapter 1 doubles as "bye" —
+
+\begin{quote}
+— \textbf{Ciao, a presto!}
+\end{quote}
+
+\begin{grammarlens}[title={What you've built this chapter}]
+\begin{itemize}
+\raggedright
+  \item \textbf{arrivederci} — goodbye ("until we re-see each other"; the \emph{au revoir} / \emph{auf Wiedersehen} family). Heavier, final variant: \textbf{addio} ("to God," twin of \emph{adiós}).
+  \item \textbf{a domani} — see you tomorrow (\emph{domani} $\leftarrow$ \emph{dē māne}, "morning"; kin of Spanish \emph{mañana}).
+  \item \textbf{a presto} — see you soon (\emph{presto} $\leftarrow$ \emph{praestō}, "at hand" — the English music/magic word).
+  \item \textbf{a più tardi} — see you later (\emph{più} \textasciitilde{} plus, \emph{tardi} \textasciitilde{} tardy).
+\end{itemize}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: greet, ask, and close — "Ciao! Come stai? … A domani!"{]}
+  \item {[}YOU SAY: choose the right goodbye — leaving till tomorrow / in an hour / for good{]}
+  \item {[}YOU SAY: arrivederci / au revoir / auf Wiedersehen — the "re-seeing" trio{]}
+\end{itemize}
+
+{[}REPEAT x2{]} Open and close a whole tiny exchange without stopping.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which goodbye means "until we see each other again"? (\emph{Arrivederci}.) Which says "to the morning"? (\emph{A domani}.) Which Italian goodbye matches Spanish \emph{adiós} — "to God"? (\emph{Addio}.) You can now run an Italian conversation start to finish.
+\end{tcolorbox}

--- a/code/learning/human-languages/italian/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch05-first-verbs.tex
@@ -1,0 +1,302 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:fc48d491a87398dc
+% canonical-lessons: IT-C05-parlare, IT-C05-abitare, IT-C05-lavorare, IT-C05-parlo-italiano, IT-C05-practice
+
+\chapter{The First Verbs}
+\label{ch:it-first-verbs}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[parlare]{parlare — "to speak," the model -are verb}
+
+\label{lesson:IT-C05-parlare}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Until now you've assembled fixed phrases. \textbf{parlare} ("to speak") is your first real \textbf{verb} — and the model for Italian's biggest family, the \textbf{-are} verbs. Learn this one pattern and you drive thousands.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{r-tap} — a single tapped \emph{r}: \textbf{parlare} = \emph{par-LA-reh}.
+  \item \texttt{vowel-a-open} — clean open \emph{ah} vowels.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{parlare} comes from Late Latin \textbf{parabolāre}, \emph{"to tell parables, to discourse"} — from \textbf{parabola}, "a comparison, a speech" (Greek \emph{parabolē}). So to \emph{speak} is, at root, to \emph{tell parables}. The English family:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{parable}, \textbf{parole} (a word of honour), \textbf{palaver}, \textbf{parley}, \textbf{parliament} (a \emph{talking}-place).
+\end{itemize}
+
+And a lovely cross-link: \textbf{Italian \emph{parlare} and French \emph{parler} are the same word} — both from \emph{parabolāre}. \textbf{Spanish went a different way}: its "to speak," \emph{hablar}, is from \emph{fabulārī} ("to chat," $\leftarrow$ \emph{fābula} $\to$ fable). So Italy and France "tell parables"; Spain "tells fables."
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: the -are present tense (and pro-drop)}]
+Drop \textbf{-are} to get \emph{parl-}, then add the endings:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{person} & \textbf{ending} & \textbf{\emph{parlare} $\to$} \\
+\midrule
+(io) & \textbf{-o} & \textbf{parlo} (I speak) \\
+(tu) & \textbf{-i} & \textbf{parli} (you speak) \\
+(lui/lei) & \textbf{-a} & \textbf{parla} (he/she speaks) \\
+(noi) & -iamo & parliamo \\
+(voi) & -ate & parlate \\
+(loro) & -ano & parlano \\
+\bottomrule
+\end{tabularx}
+
+Like Spanish (\emph{hablo/hablas}), \textbf{Italian drops the subject pronoun} — \emph{parlo} already says "I," so you don't need \emph{io}. This closes a neat circle you've been building:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{Drop the pronoun}: Spanish (\emph{hablo}), \textbf{Italian (\emph{parlo})} — endings are distinct.
+  \item \textbf{Keep the pronoun}: French (\emph{je parle} — endings silent), German (\emph{ich wohne} — grammar needs a subject).
+\end{itemize}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "parlare" — \emph{par-LA-reh}{]}
+  \item {[}YOU SAY: "parlo, parli, parla" — no \emph{io} needed{]}
+  \item {[}YOU SAY: parlare / parler (same \emph{parabolāre}) vs Spanish \emph{hablar} (\emph{fabulārī}){]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What Latin word gives \emph{parlare}, and which French verb is its twin? (\emph{parabolāre} — French \emph{parler}.) Which Romance "speak" verb is from a \emph{different} root, and which? (Spanish \emph{hablar} $\leftarrow$ \emph{fabulārī}.) Does Italian keep or drop \emph{io}, and why? (Drops it — the endings are distinct.) Next: \textbf{abitare}, "to live."
+\end{tcolorbox}
+\section[abitare]{abitare — "to live," about \emph{having a place}}
+
+\label{lesson:IT-C05-abitare}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} A second \textbf{-are} verb — snap it into the endings you just learned. \textbf{abitare} ("to live, to dwell") lets you say \emph{where} you live — and it's the twin of French \emph{habiter}.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \textbf{abitare} = \emph{a-bee-TA-reh} (Italian dropped the Latin \emph{h-}, but the spelling and sense stayed). Clean open vowels, tapped \emph{r}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{abitare} comes from Latin \textbf{habitāre}, \emph{"to dwell, to keep having {[}a place{]}"} — the \textbf{frequentative} of \textbf{habēre}, "to have." To \emph{dwell} is to \emph{keep having} your place. The English family:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{habitat} — where a creature dwells; \textbf{inhabit}, \textbf{inhabitant}, \textbf{habitation}.
+  \item via \emph{habēre} ("have"): \textbf{habit} (what you keep having), \textbf{able}, \textbf{ability}.
+\end{itemize}
+
+French kept the \emph{h} in spelling (\emph{habiter}); Italian dropped it (\emph{abitare}) — same Latin verb, same meaning. Now you can answer a \emph{dove} ("where") question:
+
+\begin{quote}
+\textbf{Abito a Roma.} — "I live in Rome." (No \emph{io} — pro-drop.)
+\end{quote}
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: same -are template}]
+| (io) abito · (tu) abiti · (lui/lei) abita | (-o / -i / -a) |
+
+| abitiamo · abitate · abitano |  |
+
+Identical to \emph{parlare} — nothing new. That's the whole point of a regular pattern.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "abitare" — \emph{a-bee-TA-reh}{]}
+  \item {[}YOU SAY: "abito, abiti, abita" — same endings as \emph{parlo/parli/parla}{]}
+  \item {[}YOU SAY: "Abito a Roma"; and "abitare" $\leftrightarrow$ English \emph{habitat}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What Latin verb is \emph{abitare} from, and what does it literally involve? (\emph{habitāre} — "keep having a place," $\leftarrow$ \emph{habēre}, "to have.") English cousins? (Habitat, inhabit.) Say "I live in Rome." (\emph{Abito a Roma.}) Next: \textbf{lavorare}, "to work."
+\end{tcolorbox}
+\section[lavorare]{lavorare — "to work," the honest kind}
+
+\label{lesson:IT-C05-lavorare}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} A third \textbf{-are} verb — and a satisfying twist. Where Spanish and French built their word for "work" out of \textbf{torture}, \textbf{Italian took a different road entirely}: \emph{lavorare}, from plain Latin \emph{"to labour."}
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \textbf{lavorare} = \emph{la-vo-RA-reh}: clean vowels, tapped \emph{r}. (The \emph{v} is a real \emph{v}, unlike Spanish.)
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{lavorare} comes from Latin \textbf{labōrāre}, \emph{"to labour, to work, to strive"} — from \textbf{labor}, "toil, effort." No torture device here; just honest labour. The English family is large and dignified:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{labor / labour}, \textbf{laborious}, \textbf{laboratory} (a \emph{working}-place).
+  \item \textbf{elaborate} ("worked \emph{out}"), \textbf{collaborate} ("labour \emph{together}").
+\end{itemize}
+
+Here's the cross-language payoff — the same idea, \textbf{two very different roots}:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{"to work"} & \textbf{from} & \textbf{literal picture} \\
+\midrule
+\textbf{Italian} & \emph{lavorare} & \emph{labōrāre} & \textbf{labour, effort} \\
+\textbf{Spanish} & \emph{trabajar} & \emph{tripalium} & \textbf{a torture rack} \\
+\textbf{French} & \emph{travailler} & \emph{tripalium} & \textbf{a torture rack} \\
+\bottomrule
+\end{tabularx}
+
+Spain and France remember work as \emph{torture} ($\to$ \emph{travail/travel}); Italy remembers it as \emph{labour}. A single glance at three verbs, and you see two Roman attitudes to a day's work.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: same -are template}]
+| (io) lavoro · (tu) lavori · (lui/lei) lavora | (-o / -i / -a) |
+
+\begin{quote}
+\textbf{Lavoro a Milano.} — "I work in Milan."
+\end{quote}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "lavorare" — \emph{la-vo-RA-reh}{]}
+  \item {[}YOU SAY: "lavoro, lavori, lavora"{]}
+  \item {[}YOU SAY: Italian \emph{lavorare} (labour) vs Spanish \emph{trabajar} / French \emph{travailler} (torture){]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What Latin word is \emph{lavorare} from, and its English cousins? (\emph{labōrāre} — labor, laboratory, elaborate.) How does its root differ from Spanish \emph{trabajar} and French \emph{travailler}? (Those are from \emph{tripalium}, "torture"; Italian is from \emph{labor}, "toil.") Say "I work in Milan." (\emph{Lavoro a Milano.}) Next: your first sentence — \textbf{Parlo italiano}.
+\end{tcolorbox}
+\section[Parlo italiano]{Parlo italiano — your first real sentence}
+
+\label{lesson:IT-C05-parlo-italiano}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The moment it pays off: you take a \textbf{verb} you conjugated and a \textbf{noun}, and build a sentence no one handed you — \emph{Parlo italiano}, "I speak Italian." (Italian \emph{parlo} covers both "I speak" and "I am speaking.")
+\end{quote}
+
+\subsection*{You'll want to know: italiano}
+\textbf{italiano} = "Italian," from \textbf{Italia} — the ancient name of the peninsula itself. Its own origin is delightfully humble: many scholars trace \emph{Italia} to Oscan \textbf{víteliú}, \emph{"land of calves / young cattle"} (kin to Latin \emph{vitulus}, "calf," and perhaps English \emph{veal}). So \emph{Italia} may literally have meant \textbf{"Calf-land."} Say it \emph{ee-ta-LYA-no}.
+
+\subsection*{You'll want to know: the assembled sentence}
+Snap two things you own together:
+
+\begin{quote}
+\textbf{Parlo} (I speak, from \emph{parlare}) + \textbf{italiano} (Italian) = \textbf{Parlo italiano.}
+\end{quote}
+
+A complete, grammatical Italian sentence. Notice what's \emph{not} there:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{No \emph{io}.} Italian drops it (like Spanish \emph{hablo español}) — the \emph{-o} of \emph{parlo} already says "I". \emph{Io parlo italiano} is fine for emphasis only.
+  \item \textbf{No article} on the language: \emph{parlo italiano}.
+\end{itemize}
+
+This closes the \textbf{pronoun-rule circle} you've watched across five languages:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{pronoun} & \textbf{why} \\
+\midrule
+\textbf{Spanish} \emph{hablo} / \textbf{Italian} \emph{parlo} & \textbf{dropped} & endings are distinct \\
+\textbf{French} \emph{je parle} & kept & endings are silent \\
+\textbf{German} \emph{ich lerne} & kept & grammar needs an overt subject \\
+\bottomrule
+\end{tabularx}
+
+Swap the pieces: \textbf{Abito a Roma.} · \textbf{Lavoro a Milano.} · \textbf{Parli italiano?}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "Parlo italiano" — \emph{PAR-lo ee-ta-LYA-no}{]}
+  \item {[}YOU SAY: drop the \emph{io} — Italian doesn't need it (like Spanish, unlike French){]}
+  \item {[}YOU SAY: "italiano" $\leftarrow$ \emph{Italia}, maybe "calf-land" — a humble, farmerly name{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Where does \emph{italiano} come from, and what might \emph{Italia} have meant? (\emph{Italia}; perhaps "land of calves.") In \emph{Parlo italiano}, why no \emph{io} and no article? (The \emph{-o} ending is "I"; languages take no article.) Which two of the five languages \emph{drop} the pronoun? (Spanish and Italian.) Next: practice.
+\end{tcolorbox}
+\section[Practice]{Practice — making sentences with -are verbs}
+
+\label{lesson:IT-C05-practice}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} For the first time you're \textbf{building} Italian sentences from a pattern, not reciting phrases. Drill the three verbs until the endings are automatic — and remember, Italian drops the \emph{io}.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: conjugate on command}]
+{[}PAUSE 1s{]} Run each through \emph{io / tu / lui-lei} (pronoun dropped in speech):
+
+\begin{itemize}
+\raggedright
+  \item \textbf{parlare}: parlo · parli · parla
+  \item \textbf{abitare}: abito · abiti · abita
+  \item \textbf{lavorare}: lavoro · lavori · lavora
+\end{itemize}
+
+Same endings every time (\textbf{-o / -i / -a}), and no pronoun needed.
+\end{grammarlens}
+
+\begin{grammarlens}[title={Grammar Lens: say something real}]
+\begin{quote}
+— \textbf{Parli} italiano? — Sì, \textbf{parlo} un po'. E tu? — Anch'io. \textbf{Dove abiti}? — \textbf{Abito} a Roma, e \textbf{lavoro} a Milano. — Grazie! — Prego.
+\end{quote}
+\end{grammarlens}
+
+\begin{grammarlens}[title={What you've built this chapter}]
+\begin{itemize}
+\raggedright
+  \item \textbf{the regular -are present tense} — drop \emph{-are}, add \emph{-o/-i/-a/-iamo/-ate/-ano}; the pronoun is \textbf{dropped} (like Spanish).
+  \item \textbf{parlare} ($\leftarrow$ \emph{parabolāre} $\to$ parable; = French \emph{parler}, vs Spanish \emph{hablar}), \textbf{abitare} ($\leftarrow$ \emph{habitāre} $\to$ habitat; twin of \emph{habiter}), \textbf{lavorare} ($\leftarrow$ \emph{labōrāre} $\to$ labor/laboratory — the "labour" road, not Spanish/French "torture").
+  \item \textbf{Parlo italiano} — first self-assembled sentence (\emph{italiano} $\leftarrow$ \emph{Italia}, perhaps "calf-land").
+  \item \textbf{The pronoun circle across 5 languages}: ES \emph{hablo} + IT \emph{parlo} \textbf{drop}; FR \emph{je parle} (silent endings) + DE \emph{ich lerne} (grammar) \textbf{keep}.
+\end{itemize}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: conjugate all three verbs, io/tu/lui — no pronoun spoken{]}
+  \item {[}YOU SAY: answer about yourself — what you speak, where you live, where you work{]}
+  \item {[}YOU SAY: chain it — "Ciao! Parlo italiano. Parli italiano? … Arrivederci!"{]}
+\end{itemize}
+
+{[}REPEAT x2{]} "Parli italiano? — Sì, parlo un po'."
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What are the three singular \emph{-are} endings? (\emph{-o / -i / -a}.) Give the "I" forms of the three verbs. (\emph{Parlo, abito, lavoro}.) Which languages drop the subject pronoun, and which keep it, and why? (Drop: ES/IT — distinct endings; keep: FR — silent endings, DE — grammar.) Italian now moves in real sentences.
+\end{tcolorbox}

--- a/code/learning/human-languages/italian/book/chapters/ch06-numbers-1-10.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch06-numbers-1-10.tex
@@ -1,0 +1,112 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:23d44140d0f55101
+% canonical-lessons: IT-C06-numeri-1-5, IT-C06-numeri-6-10
+
+\chapter{Numbers One to Ten}
+\label{ch:it-numbers-one-to-ten}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[uno, due, tre, quattro, cinque]{uno, due, tre, quattro, cinque — counting to five}
+
+\label{lesson:IT-C06-numeri-1-5}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Of all the Romance sisters, \textbf{Italian kept the numbers closest to Latin} — it stayed in Italy, next to Rome, and wore the words down the least. Beside each you'll see the Spanish and French cousins for contrast.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{double-tt} — \textbf{quattro}: hold the double \emph{t} audibly, \emph{KWAT-tro} (Italian really doubles its consonants).
+  \item \texttt{c-before-i} — \textbf{cinque} = \emph{CHEEN-kweh}: \emph{c} before \emph{i/e} is a "ch" sound, but the \emph{-que} stays a hard \emph{kw}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Italian} & \textbf{$\leftarrow$ Latin} & \textbf{Spanish / French} & \textbf{English cousins} \\
+\midrule
+\textbf{uno} (1) & \emph{ūnus} & \emph{uno} / \emph{un} & \textbf{unit, union, unique} (and \emph{a/an}, \emph{one}) \\
+\textbf{due} (2) & \emph{duo} & \emph{dos} / \emph{deux} & \textbf{duo, dual, duet, double} \\
+\textbf{tre} (3) & \emph{trēs} & \emph{tres} / \emph{trois} & \textbf{trio, triple, triangle} \\
+\textbf{quattro} (4) & \emph{quattuor} & \emph{cuatro} / \emph{quatre} & \textbf{quart, quarter, quatrain} \\
+\textbf{cinque} (5) & \emph{quīnque} & \emph{cinco} / \emph{cinq} & \textbf{quintet, quintessence} \\
+\bottomrule
+\end{tabularx}
+
+Notice \textbf{cinque} — Italian kept Latin \emph{quīnque} almost whole (\emph{-que} and all), while Spanish softened it to \emph{cinco} and French clipped it to \emph{cinq}. And \textbf{quattro} is why a musical foursome is a \emph{quartet} and four singers make a \emph{quattro}-anything. Italian is the sister who changed her Latin the least.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: uno $\to$ un / uno / una}]
+\textbf{uno} is also "a/an," and it flexes by gender and the following sound: \textbf{un} (before most masc. nouns), \textbf{uno} (before tricky masc. clusters like \emph{s+consonant} or \emph{z-}), \textbf{una} (fem.). \emph{un caffè} "a/one coffee," \emph{una birra} "a/one beer." The others (\emph{due, tre…}) don't change.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "uno, due, tre, quattro, cinque" — count up{]}
+  \item {[}YOU SAY: each with its English cousin — "due/duo, tre/trio, quattro/quart, cinque/quintet"{]}
+  \item {[}YOU SAY: "un caffè, una birra" — \emph{uno} $\to$ un/una before a noun{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Give 1–5 in Italian. (\emph{Uno, due, tre, quattro, cinque}.) Which Italian number kept Latin \emph{quīnque} most intact, versus Spanish and French? (\emph{cinque}, vs \emph{cinco} / \emph{cinq}.) What does \emph{un/una} mean besides "one"? ("A/an.") Next: \textbf{6–10}, and the months hidden inside them.
+\end{tcolorbox}
+\section[sei, sette, otto, nove, dieci]{sei, sette, otto, nove, dieci — and the calendar's secret}
+
+\label{lesson:IT-C06-numeri-6-10}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The rest of the count — and, like Spanish and French, Italian hides the same calendar fact: \textbf{settembre–dicembre are Latin for 7, 8, 9, 10.} Italian even keeps the old Latin double consonants that show it.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{double-tt} — \textbf{sette} = \emph{SET-teh}, \textbf{otto} = \emph{OT-toh}: lean on the doubled \emph{t}, a giveaway that Latin's \emph{-pt-} and \emph{-ct-} both collapsed into \emph{-tt-}.
+  \item \texttt{c-before-i} — \textbf{dieci} = \emph{DYE-chee} (the \emph{c} before \emph{i} $\to$ "ch").
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Italian} & \textbf{$\leftarrow$ Latin} & \textbf{Spanish twin} & \textbf{English cousins} \\
+\midrule
+\textbf{sei} (6) & \emph{sex} & \emph{seis} & \textbf{sextet, sextant} \\
+\textbf{sette} (7) & \emph{septem} & \emph{siete} & \textbf{settembre} (the \emph{7th} month!), septet \\
+\textbf{otto} (8) & \emph{octō} & \emph{ocho} & \textbf{ottobre} (8th), \textbf{octave, octopus} \\
+\textbf{nove} (9) & \emph{novem} & \emph{nueve} & \textbf{novembre} (9th), novena \\
+\textbf{dieci} (10) & \emph{decem} & \emph{diez} & \textbf{dicembre} (10th), \textbf{decimal, decade} \\
+\bottomrule
+\end{tabularx}
+
+Watch the doubled consonants do historical work: Latin \emph{septem} had a \emph{-pt-} that Italian smoothed to \emph{-tt-} $\to$ \textbf{sette}; Latin \emph{octō} had a \emph{-ct-} that likewise became \emph{-tt-} $\to$ \textbf{otto}. Italian didn't drop those clusters (as French did in \emph{huit}) — it \textbf{assimilated} them into twins. So \emph{otto} and \emph{ottobre} still show the 8 side by side.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: why the months are "off by two"}]
+\emph{Settembre} means "7th," but it's the \textbf{9th} month. The old \textbf{Roman year began in March}, so \emph{September} really was the seventh; later \emph{luglio} and \emph{agosto} (July and August, for Julius and Augustus) pushed the counting months down two slots. The Latin numbers stuck to the labels. Every \emph{dicembre}, you say Roman "\textbf{ten}" — just as in Spanish \emph{diciembre} and French \emph{décembre}.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "sei, sette, otto, nove, dieci" — finish the count{]}
+  \item {[}YOU SAY: "sette/settembre, otto/ottobre, nove/novembre, dieci/dicembre"{]}
+  \item {[}YOU SAY: "octō $\to$ otto" — the \emph{-ct-} becoming a doubled \emph{-tt-}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Give 6–10 in Italian. (\emph{Sei, sette, otto, nove, dieci}.) What happened to Latin's \emph{-ct-} in \emph{octō $\to$ otto}? (It assimilated to a doubled \emph{-tt-}.) Why is \emph{dicembre} Latin for "ten"? (The Roman year began in March.) Next chapter builds on this toward time and days.
+\end{tcolorbox}

--- a/code/learning/human-languages/italian/book/chapters/ch07-days-of-the-week.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch07-days-of-the-week.tex
@@ -1,0 +1,99 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:e411e61a0e42f98e
+% canonical-lessons: IT-C07-giorni-1, IT-C07-giorni-2
+
+\chapter{Days of the Week}
+\label{ch:it-days-of-the-week}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[lunedì, martedì, mercoledì, giovedì, venerdì]{lunedì to venerdì — the planet-week, Italian-style}
+
+\label{lesson:IT-C07-giorni-1}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Italy sat at the centre of the Roman world, so its weekday names are the \textbf{planet-week} almost undisturbed — the same map of the sky French uses. The tell is the little accented \textbf{-dì} at the end of each.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{final-stress-i} — the \textbf{-dì} carries a \textbf{written accent} and the \textbf{stress}: \emph{lu-ne-DÌ}, \emph{mar-te-DÌ}. That accent marks "day" (\emph{diēs}) and where your voice lands.
+  \item \texttt{c-before-i} — \textbf{mercoledì} = \emph{mer-co-le-DÌ} (hard \emph{c} here, before \emph{o}).
+\end{itemize}
+\end{sounds}
+
+\begin{grammarlens}[title={Grammar Lens: {[}planet{]} + dì}]
+\textbf{dì} is Latin \textbf{diēs}, "day" — the same \emph{-di} you'd hear in French \emph{lundi}. Before it sits a \textbf{planet-god}:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Italian} & \textbf{$\leftarrow$ Latin} & \textbf{planet} & \textbf{Spanish twin} & \textbf{French twin} \\
+\midrule
+\textbf{lunedì} & \emph{lūnae diēs} & Moon & \emph{lunes} & \emph{lundi} \\
+\textbf{martedì} & \emph{Martis diēs} & Mars & \emph{martes} & \emph{mardi} \\
+\textbf{mercoledì} & \emph{Mercuriī diēs} & Mercury & \emph{miércoles} & \emph{mercredi} \\
+\textbf{giovedì} & \emph{Jovis diēs} & Jupiter (\emph{Giove}) & \emph{jueves} & \emph{jeudi} \\
+\textbf{venerdì} & \emph{Veneris diēs} & Venus (\emph{Venere}) & \emph{viernes} & \emph{vendredi} \\
+\bottomrule
+\end{tabularx}
+
+Line up the three sisters — \emph{lunedì / lunes / lundi} — and you're looking at one Roman word, \emph{lūnae diēs}, worn three ways. Italian and French keep the day-word at the \textbf{end} (\emph{lune-dì}, \emph{lun-di}); Spanish clipped it off entirely (\emph{lunes}). And \emph{giovedì} wears \textbf{Giove}, the Italian name of Jupiter — the same king-god English honours as Thor in \emph{Thursday}.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "lunedì, martedì, mercoledì, giovedì, venerdì" — mind the final stress{]}
+  \item {[}YOU SAY: the three-sister line — "lunedì / lunes / lundi", "martedì / martes / mardi"{]}
+  \item {[}YOU SAY: "-dì = diēs = day" — the accented tail{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What is the accented \emph{-dì}, and from what Latin word? ("Day," $\leftarrow$ \emph{diēs}.) Which planet is \emph{giovedì}? (Jupiter — \emph{Giove}.) How do Italian/French treat the day-word versus Spanish? (IT/FR keep it at the end, \emph{-dì/-di}; Spanish dropped it, \emph{lunes}.) Next: the \textbf{weekend} — \emph{sabato} and \emph{domenica}.
+\end{tcolorbox}
+\section[sabato, domenica]{sabato and domenica — the religious weekend}
+
+\label{lesson:IT-C07-giorni-2}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The five weekdays were planets; the two weekend days are \textbf{faith}. Here the accented \emph{-dì} disappears, because these names never came from \emph{diēs} + a god — they came from the Sabbath and the Lord.
+\end{quote}
+
+\begin{cousinweb}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Italian} & \textbf{$\leftarrow$ Latin} & \textbf{meaning} & \textbf{Spanish twin} \\
+\midrule
+\textbf{sabato} & \emph{Sabbatum} $\leftarrow$ Hebrew \emph{shabbāt} & the "\textbf{Sabbath}," the day of rest & \emph{sábado} \\
+\textbf{domenica} & \emph{(diēs) Dominica} $\leftarrow$ \emph{Dominus} & "the \textbf{Lord's} day" & \emph{domingo} \\
+\bottomrule
+\end{tabularx}
+
+\begin{itemize}
+\raggedright
+  \item \textbf{sabato} is the \textbf{Sabbath} — Latin \emph{Sabbatum} straight from Hebrew \emph{shabbāt}, "to cease, to rest." Where English kept the planet (\textbf{Satur}day = Saturn), Italian, Spanish, and French all took the Jewish rest-day instead (\emph{sabato / sábado / samedi}).
+  \item \textbf{domenica} is "the \textbf{Lord's} day," \emph{diēs Dominica}, from \emph{Dominus} "lord, master" ($\to$ English \emph{dominion, dominate, dame, don}). Christianity renamed the old "Sun's day": English still says \textbf{Sun}day, but Italian and Spanish point to the Lord (\emph{domenica / domingo}). Note \emph{domenica} is \textbf{feminine} (\emph{la domenica}) — \emph{diēs} went feminine here.
+\end{itemize}
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the full week — "lunedì … venerdì, sabato, domenica"{]}
+  \item {[}YOU SAY: "sabato = Sabbath, domenica = the Lord's day" — faith, not planets{]}
+  \item {[}YOU SAY: the sisters — "sabato / sábado", "domenica / domingo"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Give all seven Italian days. (\emph{Lunedì … domenica}.) Where does \emph{sabato} come from? (The \textbf{Sabbath}, \emph{Sabbatum} $\leftarrow$ Hebrew \emph{shabbāt}.) What does \emph{domenica} mean, and its Spanish twin? ("The \textbf{Lord's} day"; \emph{domingo}.) Next chapter builds on this toward telling the time.
+\end{tcolorbox}

--- a/code/learning/human-languages/italian/book/chapters/ch08-telling-time.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch08-telling-time.tex
@@ -1,0 +1,109 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:8c6f2fefca515e70
+% canonical-lessons: IT-C08-ora, IT-C08-mezzogiorno-mezzanotte
+
+\chapter{Telling Time}
+\label{ch:it-telling-time}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[ora]{ora — the hour, told with "le"}
+
+\label{lesson:IT-C08-ora}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Italian's word for "hour" is \textbf{ora}, straight from Latin \textbf{hōra} (which Rome took from Greek \emph{h\'{\={o}}rā}, "a time of day"). Telling the time in Italian has one neat twist: you use the \textbf{feminine article} and let \emph{ore} ("hours") stay implied.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{open-o} — \textbf{ora} = \emph{OH-ra}, open \emph{o}, single tapped \emph{r}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{ora} $\leftarrow$ Latin \textbf{hōra} $\leftarrow$ Greek \textbf{h\'{\={o}}rā}. It's the closest of the sisters to the Latin: French wore it to \emph{heure}, but Italian barely touched it — \emph{hōra $\to$ ora} (Italian dropped the silent Latin \emph{h-} in spelling, too). Same word as English \emph{hour}, and as German's borrowed \emph{Uhr}.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: "è l'una" but "sono le due"}]
+Here's the twist. Italian tells the time with the \textbf{feminine article} (because \emph{ora/ore} is feminine), and the verb agrees with the number:
+
+\begin{quote}
+\textbf{È l'una.} — "It is one o'clock." (singular: \emph{è} "it is" + \emph{l'una} = "the one {[}hour{]}") \textbf{Sono le due.} — "It is two o'clock." (plural: \emph{sono} "they are" + \emph{le due} = "the two {[}hours{]}") \textbf{Sono le dieci.} — "It is ten o'clock."
+\end{quote}
+
+Literally "\textbf{they are} the two {[}hours{]}" — Italian counts the hours as feminine things and drops the word \emph{ore} entirely; the article \textbf{le} carries it. Only \textbf{one o'clock} is singular (\emph{è l'una}); from two on, it's \emph{sono le …}.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "ora" — \emph{OH-ra}{]}
+  \item {[}YOU SAY: "è l'una … sono le due, sono le tre, sono le quattro"{]}
+  \item {[}YOU SAY: "ora / heure / Uhr / hour" — all Latin \emph{hōra}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What word is \emph{ora} from, and its sisters? (Latin \emph{hōra} $\leftarrow$ Greek \emph{h\'{\={o}}rā}; French \emph{heure}, German \emph{Uhr}, English \emph{hour}.) Why "\emph{sono le} due" but "\emph{è l'}una"? (Plural hours take \emph{sono le …}; one o'clock is singular \emph{è l'una}.) What word does the \emph{le} stand in for? (\emph{ore}, "hours" — feminine.) Next: \textbf{mezzogiorno} and \textbf{mezzanotte} — noon and midnight.
+\end{tcolorbox}
+\section[mezzogiorno, mezzanotte]{mezzogiorno and mezzanotte — Italy's noon and midnight}
+
+\label{lesson:IT-C08-mezzogiorno-mezzanotte}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The two unnumbered hours. \textbf{mezzogiorno} (noon) and \textbf{mezzanotte} (midnight) are, like their French cousins, the \textbf{middle} of the day and the night — built from \emph{mezzo} "half/middle" plus \emph{giorno} "day" and \emph{notte} "night."
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{double-zz} — \textbf{mezzo} = \emph{MED-dzo}, the doubled \emph{zz} a hard "ts/dz" — lean on it.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+The front piece is \textbf{mezzo/mezza}, "half, middle," from Latin \textbf{medius} (cousin of English \emph{medium, mid}, and of French \emph{mi-} in \emph{midi}):
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Italian} & \textbf{=} & \textbf{$\leftarrow$ Latin} & \textbf{literally} \\
+\midrule
+\textbf{mezzogiorno} & \emph{mezzo} + \emph{giorno} & \emph{medius} + \emph{diurnum} & "\textbf{mid}-\textbf{day}" (noon) \\
+\textbf{mezzanotte} & \emph{mezza} + \emph{notte} & \emph{media} + \emph{noctem} & "\textbf{mid}-\textbf{night}" (midnight) \\
+\bottomrule
+\end{tabularx}
+
+\begin{itemize}
+\raggedright
+  \item \textbf{mezzogiorno} = "mid-day." \emph{giorno} ("day") is from Latin \emph{diurnum} ("of the day") — the same root as English \emph{journal} and \emph{journey} (a day's travel). So noon is "the middle of the day-span."
+  \item \textbf{mezzanotte} = "mid-night." \emph{notte} ("night") $\leftarrow$ \emph{noctem}, twin of English \emph{night} and French \emph{nuit}. \emph{mezza} is the \textbf{feminine} "half" (agreeing with the feminine \emph{notte}), where \emph{mezzo} is masculine (with \emph{giorno}) — the article system you just met, again.
+\end{itemize}
+
+To use them, they \emph{are} the hour:
+
+\begin{quote}
+\textbf{È mezzogiorno.} — "It is noon." \textbf{È mezzanotte.} — "It is midnight."
+\end{quote}
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "mezzogiorno" (noon), "mezzanotte" (midnight){]}
+  \item {[}YOU SAY: break them — "mezzo (middle) + giorno (day)", "mezza + notte (night)"{]}
+  \item {[}YOU SAY: "È mezzogiorno. È mezzanotte." — singular \emph{è}, no number{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What do \emph{mezzogiorno} and \emph{mezzanotte} literally mean? ("Mid-day" and "mid-night.") What is \emph{mezzo/mezza} from, and its French cousin? (Latin \emph{medius}; French \emph{mi-} in \emph{midi/minuit}.) Why \emph{mezza}notte but \emph{mezzo}giorno? (\emph{mezza} is feminine for \emph{notte}, \emph{mezzo} masculine for \emph{giorno}.) Next chapter builds on this toward months and family.
+\end{tcolorbox}

--- a/code/learning/human-languages/italian/book/chapters/ch09-months-and-seasons.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch09-months-and-seasons.tex
@@ -1,0 +1,104 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:d030a0fa85b5678f
+% canonical-lessons: IT-C09-mesi, IT-C09-stagioni
+
+\chapter{Months and Seasons}
+\label{ch:it-months-and-seasons}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[i mesi]{i mesi — Rome's own months}
+
+\label{lesson:IT-C09-mesi}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Sitting next to Rome, Italian kept the month names \textbf{closest to Latin} of all the sisters — the same procession of gods and Caesars, barely worn. And two things you know pay off: \emph{marzo} is the war-god of \emph{martedì}, and \emph{settembre– dicembre} are the Latin numbers 7–10.
+\end{quote}
+
+\begin{cousinweb}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Italian} & \textbf{$\leftarrow$ Latin} & \textbf{who / what} & \textbf{Spanish twin} \\
+\midrule
+\textbf{gennaio} & \emph{Januarius} & \textbf{Janus}, god of beginnings & \emph{enero} \\
+\textbf{febbraio} & \emph{Februarius} & the \emph{Februa} purification & \emph{febrero} \\
+\textbf{marzo} & \emph{Martius} & \textbf{Mars} — the god of \textbf{martedì}! & \emph{marzo} \\
+\textbf{aprile} & \emph{Aprilis} & \emph{aperire} "to open" & \emph{abril} \\
+\textbf{maggio} & \emph{Maius} & \textbf{Maia}, growth-goddess & \emph{mayo} \\
+\textbf{giugno} & \emph{Junius} & \textbf{Juno}, queen of gods & \emph{junio} \\
+\textbf{luglio} & \emph{Julius} & \textbf{Julius Caesar} & \emph{julio} \\
+\textbf{agosto} & \emph{Augustus} & emperor \textbf{Augustus} & \emph{agosto} \\
+\textbf{settembre} & \emph{september} & "\textbf{7th}" (\emph{septem}) & \emph{septiembre} \\
+\textbf{ottobre} & \emph{october} & "\textbf{8th}" (\emph{octo}) & \emph{octubre} \\
+\textbf{novembre} & \emph{november} & "\textbf{9th}" (\emph{novem}) & \emph{noviembre} \\
+\textbf{dicembre} & \emph{december} & "\textbf{10th}" (\emph{decem}) & \emph{diciembre} \\
+\bottomrule
+\end{tabularx}
+
+The Italian tells: \emph{gennaio} kept the \emph{-aio} of \emph{Januarius}, and \emph{settembre/ottobre} keep the doubled/assimilated look (\emph{ottobre}, like \emph{otto}). And two payoffs land:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{marzo = Mars = martedì.} The month and Tuesday honour the \emph{same} war-god — \emph{Martius} and \emph{Martedì}. One unlocks the other.
+  \item \textbf{settembre…dicembre = 7…10.} Still the Latin numbers, because the Roman year began in \textbf{March}; then \emph{luglio} (Julius) and \emph{agosto} (Augustus) were inserted and shifted the count.
+\end{itemize}
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the twelve — "gennaio, febbraio, marzo … novembre, dicembre"{]}
+  \item {[}YOU SAY: "marzo / martedì — both Mars"{]}
+  \item {[}YOU SAY: "settembre = 7, dicembre = 10"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which god links \emph{marzo} and \emph{martedì}? (\textbf{Mars}.) Why is \emph{dicembre} Latin for "ten"? (The Roman year began in March.) Which two months honour real \textbf{people}? (\emph{Luglio} — Julius; \emph{agosto} — Augustus.) Next: the \textbf{stagioni}, the seasons.
+\end{tcolorbox}
+\section[le stagioni]{le stagioni — the four seasons}
+
+\label{lesson:IT-C09-stagioni}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The word for "season," \textbf{stagione}, is itself a small lesson: it's Latin \textbf{statiō}, a "standing" — a fixed \emph{station} of the year (cousin of English \emph{station, stage}). And the loveliest of the four, \textbf{primavera}, means the "\textbf{first green}."
+\end{quote}
+
+\begin{cousinweb}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Italian} & \textbf{$\leftarrow$ Latin} & \textbf{literally} \\
+\midrule
+\textbf{la primavera} (spring) & \emph{prīma vēra} & "\textbf{first spring / first green}" (\emph{prima} "first" + \emph{vera} $\leftarrow$ \emph{ver} "spring") \\
+\textbf{l'estate} (summer) & \emph{aestas / aestātem} & "the heat, the hot season" \\
+\textbf{l'autunno} (autumn) & \emph{autumnus} & "autumn" (twin of English \emph{autumn}) \\
+\textbf{l'inverno} (winter) & \emph{hibernum} & "the wintry season" (cousin of \emph{hibernate}) \\
+\bottomrule
+\end{tabularx}
+
+\begin{itemize}
+\raggedright
+  \item \textbf{primavera} = \emph{prima} + \emph{vera}: the "first spring." Latin \emph{vēr} was the word for spring; Italian (and Spanish, and Portuguese) built "prima-vera," the year's \emph{first} season — the same idea French once had in \emph{primevère}.
+  \item \textbf{estate} $\leftarrow$ \emph{aestas}, "heat." \textbf{autunno} $\leftarrow$ \emph{autumnus}, the same word English borrowed. \textbf{inverno} $\leftarrow$ \emph{hibernum} "wintry" — English \textbf{hibernate} is "to spend the \emph{inverno}."
+\end{itemize}
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "la primavera, l'estate, l'autunno, l'inverno"{]}
+  \item {[}YOU SAY: "primavera = prima + vera (first green)"; "inverno \textasciitilde{} hibernate"{]}
+  \item {[}YOU SAY: "stagione $\leftarrow$ statiō — a 'standing' of the year, like station"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Name the four Italian seasons. (\emph{Primavera, estate, autunno, inverno}.) What does \emph{primavera} literally mean? ("\textbf{First spring / first green}.") What Latin word is \emph{stagione} from, and its English cousin? (\emph{Statiō} "a standing"; \emph{station}.) Next chapter builds on this toward family and food.
+\end{tcolorbox}

--- a/code/learning/human-languages/italian/book/chapters/ch10-family.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch10-family.tex
@@ -1,0 +1,84 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:c6b580550c4c7454
+% canonical-lessons: IT-C10-genitori, IT-C10-fratello-sorella
+
+\chapter{Family}
+\label{ch:it-family}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[il padre, la madre]{il padre, la madre — closest to Latin}
+
+\label{lesson:IT-C10-genitori}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Italian, as ever, stays nearest to Rome. Its \textbf{padre} ("father") and \textbf{madre} ("mother") barely moved from Latin \textbf{pater} and \textbf{māter} — Latin just softened the \emph{-t-} to \emph{-d-}. If you know the Latin, you nearly know the Italian.
+\end{quote}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{il padre} ("father") $\leftarrow$ Latin \textbf{pater} (\emph{-t- $\to$ -d-}).
+  \item \textbf{la madre} ("mother") $\leftarrow$ Latin \textbf{māter} (\emph{-t- $\to$ -d-}).
+\end{itemize}
+
+Articles: \emph{il} padre (masculine), \emph{la} madre (feminine).
+
+\textbf{English already borrowed one of these whole:} a \textbf{padre} is what English (and Spanish-influenced) speakers call a priest or military chaplain — \emph{padre} itself, untouched.
+\end{cousinweb}
+
+\begin{cousinweb}
+Italian "parents" is \textbf{i genitori} — not from \emph{parens} but from Latin \textbf{genitor}, "the \textbf{begetter}," from \emph{gignere} "to beget/bring forth." That root \emph{gen-} "give birth to" is everywhere in English: \textbf{genital, progenitor, genesis, generate, genus, gene}. So \emph{i genitori} are literally "the begetters." (Beware the \textbf{false friend}: Italian \emph{parenti} means \textbf{relatives} in general, \emph{not} "parents"!)
+
+The Latin-through-English adjective family still comes from \emph{pater/māter}: \textbf{pat}ernal, \textbf{mat}ernal — the same roots as French \emph{père/mère} and, by Grimm's law, English \emph{father/mother}.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "il padre, la madre" — soft \emph{-d-} where Latin had \emph{-t-}{]}
+  \item {[}YOU SAY: "i genitori = the parents; \emph{genitor} = begetter $\to$ genesis, gene"{]}
+  \item {[}YOU SAY: the false-friend warning — "\emph{parenti} = relatives, NOT parents"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Give "father" and "mother" with articles. (\textbf{il padre, la madre}.) What single sound did Latin \emph{pater/māter} soften to? (The \emph{-t-} became \textbf{-d-}.) What does \textbf{genitori} literally mean, and name an English cousin. ("The \textbf{begetters}"; genesis/gene/progenitor.) What does the false friend \emph{parenti} mean? (\textbf{Relatives}, not parents.) Next: \textbf{fratello} and \textbf{sorella}.
+\end{tcolorbox}
+\section[il fratello, la sorella]{il fratello, la sorella — brother and sister, with a little-ending}
+
+\label{lesson:IT-C10-fratello-sorella}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Here Italian does something charming. Where French kept \emph{frère} and \emph{sœur} bare, Italian rebuilt "brother" and "sister" with its beloved \textbf{diminutive} endings — literally "\textbf{little brother}" and "\textbf{little sister}" — and those forms became the everyday words.
+\end{quote}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{il fratello} ("brother") $\leftarrow$ Latin \textbf{frāter} + the diminutive \textbf{-ellus} $\to$ \emph{fraterellus} $\to$ \emph{fratello}, once "little brother."
+  \item \textbf{la sorella} ("sister") $\leftarrow$ Latin \textbf{soror} + the diminutive \textbf{-ella} $\to$ \emph{sorella}, once "little sister."
+\end{itemize}
+
+The root still shows: \textbf{frat-} and \textbf{soror-}, the same roots English turns into \textbf{frat}ernal, \textbf{frat}ernity, \textbf{friar} and \textbf{soror}ity, \textbf{soror}al. Italian just wrapped them in the affectionate \emph{-ello/-ella} that also gives \emph{fratello}'s cousins across the language (\emph{-ello} on \emph{poverello} "poor little one," \emph{-ella} on countless names).
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: all four — "il padre, la madre, il fratello, la sorella"{]}
+  \item {[}YOU SAY: the build — "\emph{frater} + \emph{-ello} $\to$ fratello, 'little brother'"{]}
+  \item {[}YOU SAY: "fratello $\to$ fraternal; sorella $\to$ sorority"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Give "brother" and "sister" with articles. (\textbf{il fratello, la sorella}.) What did Italian \textbf{add} to Latin \emph{frāter/soror} to make them? (A \textbf{diminutive} ending, \emph{-ello / -ella} — "little brother/sister.") Name an English cousin of each root. (\emph{frat-} $\to$ fraternal/friar; \emph{soror-} $\to$ sorority.) Next chapter: sentences about the family.
+\end{tcolorbox}

--- a/code/learning/human-languages/italian/book/chapters/ch11-bread-water-wine.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch11-bread-water-wine.tex
@@ -1,0 +1,85 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:0ba39a1b7b3a0899
+% canonical-lessons: IT-C11-pane, IT-C11-acqua-vino
+
+\chapter{Bread, Water, and Wine}
+\label{ch:it-bread-water-wine}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[il pane]{il pane — bread, and its companions}
+
+\label{lesson:IT-C11-pane}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} \textbf{il pane} ("bread") — and, true to form, Italian keeps it \textbf{closest to Latin}: \emph{pānis $\to$ pane}, barely touched. Its root carries the same warm story as the French \emph{pain}: a \textbf{companion} is one you \textbf{share bread} with.
+\end{quote}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{il pane} ("bread") $\leftarrow$ Latin \textbf{pānis} — masculine, \emph{il} pane; the plural is \emph{i pani}.
+\end{itemize}
+\end{cousinweb}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{companion / company} $\leftarrow$ \emph{com-} ("with") + \emph{pānis} — "one you \textbf{break bread with}."
+  \item \textbf{pantry}, \textbf{pannier} (a bread-basket).
+  \item And a purely Italian gem: \textbf{companatico} — the word for "\textbf{whatever you eat with bread}" (cheese, salami, anything on it). The bread is the given; the \emph{companatico} is what joins it — the same \emph{com- + pānis} idea, alive in one Italian word.
+\end{itemize}
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "il pane" — open \emph{e}; plural "i pani"{]}
+  \item {[}YOU SAY: "pane $\to$ companion, companatico" — bread and what joins it{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Give "bread" with its article. (\textbf{il pane}.) What Latin word, and how much did Italian change it? (\emph{pānis} — barely: \emph{pānis $\to$ pane}.) What does \emph{companatico} mean, and how does it use the bread-root? ("What you eat \textbf{with} bread" — \emph{com-} "with" + \emph{pānis}.) Next: \textbf{l'acqua} and \textbf{il vino}.
+\end{tcolorbox}
+\section[l'acqua, il vino]{l'acqua, il vino — water and wine, close to the source}
+
+\label{lesson:IT-C11-acqua-vino}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The Italian table's two drinks — and a neat contrast with French. Where French dissolved Latin \emph{aqua} into a bare \textbf{eau} ("oh"), Italian kept it almost \textbf{whole}: \textbf{acqua}, with the \emph{aqua} still ringing in it.
+\end{quote}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{l'acqua} ("water") $\leftarrow$ Latin \textbf{aqua}. Italian barely moved it — it even \textbf{doubles} the sound with \textbf{-cq-} (\emph{AH-kwa}), holding onto the hard \emph{qu} that French threw away. Set them side by side: Latin \emph{aqua} $\to$ Italian \textbf{acqua} (kept) vs French \textbf{eau} (worn to a vowel). English borrowed the same loud original for \textbf{aquatic, aquarium, aqueduct}. Takes \emph{l'} before the vowel.
+\end{itemize}
+\end{cousinweb}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{il vino} ("wine") $\leftarrow$ Latin \textbf{vīnum} — clean and close, like everything Italian. The same word travelled into English as \textbf{wine}, and gives \textbf{vine, vinegar, vintage, vineyard, vinyl}. Masculine: \emph{il} vino.
+\end{itemize}
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "l'acqua, il vino" — \emph{acqua} with the doubled \emph{-cq-}{]}
+  \item {[}YOU SAY: the contrast — "Latin \emph{aqua} $\to$ Italian \textbf{acqua} (kept), French \textbf{eau} (worn away)"{]}
+  \item {[}YOU SAY: "acqua $\leftrightarrow$ aquarium; vino $\to$ wine, vinegar"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Give "water" and "wine" with articles. (\textbf{l'acqua, il vino}.) How does Italian \emph{acqua} differ from French \emph{eau}, from the same \emph{aqua}? (Italian \textbf{kept} it — even doubling \emph{-cq-}; French wore it to a single vowel.) Name an English cousin of each. (\emph{acqua} $\to$ aquatic/aquarium; \emph{vino} $\to$ wine/vinegar.) Next chapter: asking for these at a table.
+\end{tcolorbox}

--- a/code/learning/human-languages/italian/book/chapters/ch12-numbers-11-20.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch12-numbers-11-20.tex
@@ -1,0 +1,114 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:e2431531c5358324
+% canonical-lessons: IT-C12-numeri-11-16, IT-C12-numeri-17-20
+
+\chapter{Numbers Eleven to Twenty}
+\label{ch:it-numbers-eleven-to-twenty}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[undici — sedici]{undici $\to$ sedici — the ten you can still see}
+
+\label{lesson:IT-C12-numeri-11-16}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} True to form, Italian keeps the teens \textbf{closest to Latin} — so close that the word for "ten" is still sitting in plain sight inside each one. Where French wore \emph{decem} down to a bare \textbf{-ze}, Italian kept \textbf{-dici}.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: six fusions}]
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{Italian} & \textbf{$\leftarrow$ Latin} & \textbf{build} \\
+\midrule
+11 & \textbf{undici} & \emph{ūndecim} & un + dici \\
+12 & \textbf{dodici} & \emph{duodecim} & do + dici \\
+13 & \textbf{tredici} & \emph{trēdecim} & tre + dici \\
+14 & \textbf{quattordici} & \emph{quattuordecim} & quattor + dici \\
+15 & \textbf{quindici} & \emph{quīndecim} & quin + dici \\
+16 & \textbf{sedici} & \emph{sēdecim} & se + dici \\
+\bottomrule
+\end{tabularx}
+
+Every one is \textbf{digit + -dici}, and \textbf{-dici} is Latin \textbf{decem}, "ten" — the same ten you say as \textbf{dieci} (10). Compare the sisters and Italian's clarity jumps out:
+
+\begin{itemize}
+\raggedright
+  \item Latin \emph{sēdecim} $\to$ Italian \textbf{sedici} (ten still audible) · French \textbf{seize} (ten worn to a \emph{-ze}) · Portuguese \textbf{dezesseis} (rebuilt from scratch).
+\end{itemize}
+
+The digits are your Chapter 6 numbers barely changed: \emph{tre$\to$tre-}, \emph{quattro$\to$ quattor-}, \emph{cinque$\to$quin-}, \emph{sei$\to$se-}.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "undici, dodici, tredici, quattordici, quindici, sedici"{]}
+  \item {[}YOU SAY: the ten inside — "-dici = \emph{decem} = \textbf{dieci}"{]}
+  \item {[}YOU SAY: the three-sister line — "sedici / seize / dezesseis, one Latin word"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Count 11 to 16 in Italian. (\emph{Undici, dodici, tredici, quattordici, quindici, sedici}.) What is the \textbf{-dici} in every one? (Latin \textbf{decem}, "ten" — the same as \emph{dieci}.) Which order are they built in — digit first or ten first? (\textbf{Digit first}: \emph{tre}-dici = "three-ten".) Next: at \textbf{17}, Italian flips \emph{both} its strategy \textbf{and} its direction.
+\end{tcolorbox}
+\section[diciassette — venti]{diciassette $\to$ venti — the count turns around}
+
+\label{lesson:IT-C12-numeri-17-20}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Watch the language change direction. Through \textbf{sedici} (16), Italian put the \textbf{digit first} and the ten last. At \textbf{17}, it turns the whole thing around and puts the \textbf{ten first} — and it keeps the \emph{-dici} right there so you can see it happen.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: the reversal}]
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{Italian} & \textbf{build} & \textbf{order} \\
+\midrule
+16 & \textbf{sedici} & \emph{se} + \emph{dici} & \textbf{six-ten} \\
+\textbf{17} & \textbf{diciassette} & \emph{dici} + \emph{(a)} + \emph{sette} & \textbf{ten-and-seven} \\
+18 & \textbf{diciotto} & \emph{dici} + \emph{otto} & ten-eight \\
+19 & \textbf{diciannove} & \emph{dici} + \emph{(an)} + \emph{nove} & ten-nine \\
+20 & \textbf{venti} & $\leftarrow$ \emph{vīgintī} & — \\
+\bottomrule
+\end{tabularx}
+
+Same building blocks — \emph{dici} ("ten") and your Chapter 6 digits — but from 17 the \textbf{ten leads}. The little linking sounds (\emph{diciAssette}, \emph{diciANnove}) are just Italian smoothing the joint, the doubling it loves.
+\end{grammarlens}
+
+\begin{grammarlens}[title={What you've built: three different breaks}]
+This "give up fusing, go transparent" seam happens in every Romance sister, but \textbf{not at the same place}:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{fuses up to} & \textbf{goes transparent at} \\
+\midrule
+\textbf{Portuguese} & \emph{quinze} (15) & \textbf{16} — \emph{dezesseis} \\
+\textbf{French} & \emph{seize} (16) & \textbf{17} — \emph{dix-sept} \\
+\textbf{Italian} & \emph{sedici} (16) & \textbf{17} — \emph{diciassette} \\
+\bottomrule
+\end{tabularx}
+
+Three languages, one inherited Latin system, three different breaking points. (And German, you may recall, never breaks at all.)
+
+\textbf{venti} (20) $\leftarrow$ \emph{vīgintī}, the same root as French \emph{vingt} and English \textbf{vigesimal}.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: 16$\to$20 — "sedici, diciassette, diciotto, diciannove, venti"{]}
+  \item {[}YOU SAY: the turn — "\emph{se}-dici (six-ten) $\to$ \emph{dici}-assette (ten-seven)"{]}
+  \item {[}YOU SAY: the whole run, undici to venti{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What changes between \emph{sedici} and \emph{diciassette}? (The \textbf{order} — the \textbf{ten moves to the front}; digit-first becomes ten-first.) Where do the three Romance sisters break? (\textbf{Portuguese at 16}, \textbf{French and Italian at 17}.) What Latin word gives \emph{venti}? (\emph{vīgintī} — like French \emph{vingt}, English \emph{vigesimal}.) Next chapter: numbers in use.
+\end{tcolorbox}

--- a/code/learning/human-languages/italian/book/chapters/ch13-colours.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch13-colours.tex
@@ -1,0 +1,124 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:d158e4e3576da88e
+% canonical-lessons: IT-C13-nero-bianco, IT-C13-rosso-blu
+
+\chapter{Colours}
+\label{ch:it-colours}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[nero, bianco]{nero, bianco — one Roman, one Lombard}
+
+\label{lesson:IT-C13-nero-bianco}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Italy's two most basic colours came from \textbf{two different peoples}. One is Rome's own word. The other arrived with the Germanic tribes who settled the peninsula after Rome fell.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{nero} ("black") $\leftarrow$ Latin \emph{\textbf{niger}}. Straight inheritance, barely changed: \emph{niger} $\to$ \emph{nigrum} $\to$ \emph{nero}. The same \emph{niger} gives English \emph{denigrate}, "to blacken."
+\end{cousinweb}
+
+\begin{cousinweb}
+Latin's white was \emph{\textbf{albus}}. Italian doesn't use it. Instead: \textbf{bianco}, from Germanic \emph{\textbf{blank}} — "\textbf{shining, gleaming}" — most likely carried in by the \textbf{Lombards}, the Germanic people who ruled northern Italy for two centuries and left their name on \textbf{Lombardia}.
+
+The same word became French \emph{blanc} and Portuguese \emph{branco}. Germanic lending \textbf{into} Romance is the reverse of the usual direction, and here the loan won so completely that Latin's own word was pushed out of the colour slot altogether.
+\end{cousinweb}
+
+\begin{cousinweb}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{word} & \textbf{meaning} & \textbf{the white inside} \\
+\midrule
+\textbf{alba} & dawn & the sky turning white \\
+\textbf{albume} & egg white & the white part \\
+\textbf{Albania}, \emph{Alpi} & (place names) & "the white ones" \\
+\emph{album} (Eng.) & album & a blank white tablet \\
+\bottomrule
+\end{tabularx}
+
+Latin's white is still here — just doing other jobs.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "nero, bianco"{]}
+  \item {[}YOU SAY: "il vino bianco, il vino rosso" — Ch.11's wine, coloured{]}
+  \item {[}YOU SAY: "il pane bianco" — Ch.11's bread{]}
+  \item {[}YOU SAY: "l'\textbf{alba}" — and hear Latin's forgotten white{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which colour is Rome's own? (\textbf{Nero} $\leftarrow$ \emph{niger}.) Where does \textbf{bianco} come from? (\textbf{Germanic \emph{blank}}, "shining" — likely via the \textbf{Lombards}.) Why is that surprising? (Latin normally lends \textbf{to} Germanic, not the reverse.) Where did \emph{albus} survive? (In \textbf{alba}, "dawn," and \textbf{albume} — no longer a colour.) Next: \textbf{rosso} and \textbf{blu}, and one more traveller.
+\end{tcolorbox}
+\section[rosso, blu]{rosso, blu — and the blue Italy plays in}
+
+\label{lesson:IT-C13-rosso-blu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} One very old word, one more Germanic loan — and a third blue that came all the way from Persia by way of Arabic.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{rosso} $\leftarrow$ Latin \emph{\textbf{russus}} ("red"), from PIE \emph{\textbf{h\textsubscript{1}rewd\textsuperscript{h}-}}. That root is one of the oldest colour words we can reconstruct:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{word} \\
+\midrule
+Italian & \textbf{rosso} \\
+French & \textbf{rouge} ($\leftarrow$ \emph{rubeus}) \\
+English & \textbf{red}, \emph{rust}, \emph{ruby} \\
+German & \textbf{rot} \\
+\bottomrule
+\end{tabularx}
+
+\emph{Rosso} and \emph{red} are \textbf{cousins}, not borrowings — separated for millennia. Note the \textbf{double s}: hold it. \emph{Roso} and \emph{rosso} are different words.
+\end{cousinweb}
+
+\begin{cousinweb}
+\textbf{blu} $\leftarrow$ Germanic \emph{\textbf{blāo}}, exactly like French \emph{bleu}. Chapter pattern confirmed: \textbf{bianco} and \textbf{blu}, Italian's white and blue, are both \textbf{Germanic imports}.
+\end{cousinweb}
+
+\begin{cousinweb}
+Italian has a second blue, and it's the famous one: \textbf{azzurro}, from Arabic \emph{\textbf{lāzaward}} ("lapis lazuli"), itself from Persian \emph{\textbf{lāžward}}. The initial \emph{l-} was swallowed — heard as an article and dropped — leaving \emph{azur/azzurro}. The same journey gave Spanish and Portuguese \textbf{azul}, French \textbf{azur}, and English \textbf{azure}.
+
+Italy's national teams are \textbf{gli Azzurri}, "the blue ones" — named, at the end of a very long chain, after a \textbf{blue stone mined in Afghanistan}.
+\end{cousinweb}
+
+\begin{grammarlens}[title={What you've built: the colour paths}]
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Italian} & \textbf{source} \\
+\midrule
+nero & Latin \emph{niger} \\
+\textbf{bianco} & \textbf{Germanic} \emph{blank} \\
+rosso & Latin \emph{russus} (ancient PIE root) \\
+\textbf{blu} & \textbf{Germanic} \emph{blāo} \\
+\textbf{azzurro} & \textbf{Arabic} \emph{lāzaward} \\
+\bottomrule
+\end{tabularx}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "rosso, blu, azzurro"{]}
+  \item {[}YOU SAY: "il vino rosso" — Chapter 11's wine{]}
+  \item {[}YOU SAY: the cousins — "rosso · red · rot · rouge"{]}
+  \item {[}YOU SAY: "gli Azzurri" — and think of the stone{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Is \emph{rosso} related to English \emph{red} by borrowing or descent? (\textbf{Descent} — PIE \emph{\textbf{h\textsubscript{1}rewd\textsuperscript{h}-}}.) Which two Italian colours are Germanic loans? (\textbf{Bianco} and \textbf{blu}.) Where does \textbf{azzurro} come from? (\textbf{Arabic \emph{lāzaward}}, "lapis lazuli" — via Persian; the \emph{l-} was lost as if it were an article.) What are Italy's teams called? (\textbf{Gli Azzurri}.) Next chapter: attaching these colours to the nouns you know.
+\end{tcolorbox}

--- a/code/learning/human-languages/italian/book/chapters/ch14-having-and-age.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch14-having-and-age.tex
@@ -1,0 +1,141 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:62fcc73207804a51
+% canonical-lessons: IT-C14-avere, IT-C14-eta
+
+\chapter{Having and Telling Your Age}
+\label{ch:it-having-and-age}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[avere]{avere — "to have"}
+
+\label{lesson:IT-C14-avere}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Italian's workhorse verb — and the home of the language's \textbf{only silent letter}, which is there for a reason worth knowing.
+\end{quote}
+
+\subsection*{You'll want to know: the forms}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} & \textbf{} \\
+\midrule
+\textbf{ho} & \textbf{abbiamo} &  \\
+\textbf{hai} & \textbf{avete} &  \\
+\textbf{ha} & \textbf{hanno} &  \\
+\bottomrule
+\end{tabularx}
+
+Look at which forms carry an \textbf{h}: \emph{ho, hai, ha, hanno}. And which don't: \emph{abbiamo, avete}.
+
+\begin{grammarlens}[title={Grammar Lens: why silent h survives}]
+Italian threw the Latin \textbf{h} away almost completely — it is never pronounced, and \emph{uomo} ($\leftarrow$ \emph{homō}) and \emph{erba} ($\leftarrow$ \emph{herba}) simply dropped it.
+
+But in \emph{avere} it stayed, because without it these words would collide:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{with h} & \textbf{without h} & \textbf{meaning} \\
+\midrule
+\textbf{ho} — I have & \textbf{o} & "or" \\
+\textbf{hai} — you have & \textbf{ai} & "to the" \\
+\textbf{ha} — he/she has & \textbf{a} & "to" \\
+\textbf{hanno} — they have & \textbf{anno} & "\textbf{year}" \\
+\bottomrule
+\end{tabularx}
+
+Four minimal pairs, all extremely common. The \textbf{h} is silent, does nothing to the sound, and is kept \textbf{only so your eye can tell the words apart}. Spelling doing a job pronunciation can't — hold onto \emph{hanno} vs \emph{anno}; it comes back in the next lesson.
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{avere} $\leftarrow$ Latin \emph{\textbf{habēre}}, the same source as French \emph{avoir}. English took it as a whole family: \textbf{habit} (what you have regularly), \textbf{inhabit}, \textbf{exhibit} ("hold out"), \textbf{prohibit} ("hold back").
+
+Note \emph{abbiamo} — the \textbf{bb} is the old \emph{habē-} resurfacing in the \emph{noi} form, while \emph{ho} wore down to a single vowel.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "ho, hai, ha, abbiamo, avete, hanno"{]}
+  \item {[}YOU SAY: "Ho un fratello" ("I have a brother") — Ch. 10's family{]}
+  \item {[}YOU SAY: the pair — "\textbf{hanno} they have · \textbf{anno} a year"{]}
+  \item {[}YOU SAY: "Abbiamo pane e vino" — Ch. 11's food{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Give the six forms. (\emph{Ho, hai, ha, abbiamo, avete, hanno}.) Which carry an \textbf{h}? (\emph{Ho, hai, ha, hanno}.) Is it pronounced? (\textbf{No} — never.) Then why is it there? (To keep them apart from \textbf{o, ai, a, anno} in \textbf{writing}.) What root is \emph{avere} from? (Latin \emph{\textbf{habēre}} $\to$ \emph{habit/inhabit/exhibit}.) Next: \emph{anno} takes centre stage.
+\end{tcolorbox}
+\section[ho venti anni]{ho venti anni — having your years}
+
+\label{lesson:IT-C14-eta}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Italian states age with \textbf{avere}, not \emph{essere}. And the silent \textbf{h} from last lesson stops being trivia here — it becomes the difference between two real sentences.
+\end{quote}
+
+\subsection*{You'll want to know: the phrase}
+\begin{quote}
+\textbf{Quanti anni hai?} — "How many years do you \textbf{have}?" \textbf{Ho venti anni.} — "I \textbf{have} twenty years."
+\end{quote}
+
+\emph{Essere} is wrong here. \emph{Sono venti anni} does not mean "I am twenty."
+
+\begin{cousinweb}
+\textbf{anno} ("year") $\leftarrow$ Latin \emph{\textbf{annus}} $\to$ English \textbf{annual}, \textbf{anniversary}, \textbf{annals}, \emph{per annum}. Chapter 9's months and seasons came from the same calendar vocabulary.
+
+Note the \textbf{double n}: \emph{a-nno}, held. Italian's double consonants are real length, not decoration.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: h earns its keep}]
+Now put the last lesson to work:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{sentence} & \textbf{meaning} \\
+\midrule
+\textbf{Hanno venti anni.} & "\textbf{They have} twenty years." \\
+\textbf{anno} & "\textbf{year}" \\
+\bottomrule
+\end{tabularx}
+
+\emph{Hanno} and \emph{anno} sound \textbf{exactly the same}. Only the silent \textbf{h} tells them apart — and in a sentence about years, both words show up at once. That is precisely why Italian kept a letter it never pronounces.
+\end{grammarlens}
+
+\begin{grammarlens}[title={Grammar Lens: who has and who is}]
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{} \\
+\midrule
+Italian & \emph{h\textbf{o} venti anni} — \textbf{have} \\
+French & \emph{j'\textbf{ai} vingt ans} — \textbf{have} \\
+Spanish & \emph{t\textbf{engo} veinte años} — \textbf{have} \\
+Portuguese & \emph{t\textbf{enho} vinte anos} — \textbf{have} \\
+German & \emph{ich \textbf{bin} zwanzig Jahre alt} — \textbf{be} \\
+English & \emph{I \textbf{am} twenty} — \textbf{be} \\
+\bottomrule
+\end{tabularx}
+
+\textbf{Romance has its years; Germanic is its years.}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "Quanti anni hai?"{]}
+  \item {[}YOU SAY: "Ho venti anni" — hold the \textbf{nn}{]}
+  \item {[}YOU SAY: your own age, using Ch. 12's numbers{]}
+  \item {[}YOU SAY: the pair aloud — "\textbf{hanno} … \textbf{anno}" — identical sound{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which verb does Italian use for age? (\emph{\textbf{Avere}}, never \emph{essere}.) What does \emph{ho venti anni} literally say? ("I \textbf{have} twenty years.") Where does \emph{anno} come from? (Latin \emph{\textbf{annus}} $\to$ \emph{annual/anniversary}.) What separates \emph{hanno} from \emph{anno}? (\textbf{Only the silent h} — they sound identical.) Which two languages say "I \textbf{am}" instead? (\textbf{German and English}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/italian/book/chapters/ch15-two-pasts.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch15-two-pasts.tex
@@ -1,0 +1,170 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:9dfc5c16142e4a8d
+% canonical-lessons: IT-C15-passato-prossimo, IT-C15-passato-remoto
+
+\chapter{Two Italian Pasts}
+\label{ch:it-two-pasts}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[ho parlato]{ho parlato — the past built from "have"}
+
+\label{lesson:IT-C15-passato-prossimo}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Italy's everyday past tense, and you already own both halves: \textbf{avere} from last chapter, and Chapter 5's verbs.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: the compound-past recipe}]
+\begin{quote}
+\textbf{avere} (conjugated) + \textbf{past participle}
+\end{quote}
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{infinitive} & \textbf{ends in} & \textbf{participle} \\
+\midrule
+parl\textbf{are} & -are & parl\textbf{ato} \\
+lavor\textbf{are} & -are & lavor\textbf{ato} \\
+cred\textbf{ere} & -ere & cred\textbf{uto} \\
+dorm\textbf{ire} & -ire & dorm\textbf{ito} \\
+\bottomrule
+\end{tabularx}
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+\textbf{ho} parlato & I spoke / I have spoken \\
+\textbf{hai} parlato & you spoke \\
+\textbf{ha} parlato & he/she spoke \\
+\textbf{abbiamo} parlato & we spoke \\
+\textbf{hanno} parlato & they spoke \\
+\bottomrule
+\end{tabularx}
+
+The silent \textbf{h} from last chapter is doing its job again: \emph{ho parlato} on the page can't be misread as \emph{o parlato} ("or spoken").
+
+Note \textbf{parlato} keeps the \emph{-t-} that French wore away: Italian \emph{parlato}, French \emph{parlé}, both from Latin \emph{\textbf{-ātum}}. Italian is the more conservative sister — the same pattern as Chapter 11's \emph{acqua} against French \emph{eau}.
+\end{grammarlens}
+
+\begin{cousinweb}
+Latin could say:
+
+\begin{quote}
+\emph{\textbf{habeō litterās scriptās}} — "I \textbf{have} letters \textbf{written}."
+\end{quote}
+
+Not a past tense: \emph{avere} in its plain sense of \textbf{possessing}, with \emph{scriptās} as an \textbf{adjective} agreeing with \emph{litterās}. Over centuries "I possess a written thing" slid into simply "\textbf{I wrote}" — a possessive construction \textbf{hardened into a tense}.
+
+The fossil survives. When the object comes \textbf{before} the verb, the participle still agrees with it, exactly as an adjective would:
+
+\begin{quote}
+\textbf{Le ho vist\emph{e}.} — "I saw them {[}f. pl.{]}."
+\end{quote}
+
+That \emph{-e} is a Latin adjective ending, still agreeing after two thousand years.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "ho parlato, hai parlato, ha parlato, abbiamo parlato, hanno parlato"{]}
+  \item {[}YOU SAY: the conservative \emph{-t-} — "parla\textbf{t}o · French parlé"{]}
+  \item {[}YOU SAY: "Ho lavorato" ("I worked") — Ch. 5's verb{]}
+  \item {[}YOU SAY: the old meaning — "I \textbf{have} a thing \textbf{spoken}"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What two pieces make the \emph{passato prossimo}? (\textbf{Avere} + the \textbf{past participle}.) What is \emph{parlare}'s participle? (\textbf{Parlato} $\leftarrow$ \emph{-ātum}.) What did \emph{ho parlato} originally mean? ("I \textbf{have} {[}a thing{]} \textbf{spoken}" — a \textbf{possessive}.) Why can the participle agree? (It was an \textbf{adjective} describing the object.) Next: the other Italian past, and where it still lives.
+\end{tcolorbox}
+\section[parlò]{parlò — the past that depends where you are}
+
+\label{lesson:IT-C15-passato-remoto}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Italian's other past tense. Whether it sounds normal or bookish depends on \textbf{which part of Italy you are standing in} — the clearest case of geography deciding grammar in this course.
+\end{quote}
+
+\subsection*{You'll want to know: the remote past}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{passato remoto} & \textbf{passato prossimo} \\
+\midrule
+he spoke & \textbf{parlò} & ha parlato \\
+they spoke & \textbf{parlarono} & hanno parlato \\
+I spoke & \textbf{parlai} & ho parlato \\
+\bottomrule
+\end{tabularx}
+
+Note the final stress: \emph{parl\textbf{ò}}, with the accent written. Compare Chapter 12's numbers — Italian marks a stressed final vowel the same way.
+
+\begin{cousinweb}
+\textbf{parlò} $\leftarrow$ Vulgar Latin \textbf{\textbackslash{}\emph{parabolāvit\textbf{, the plain Latin perfect, handed straight down. Which makes it the }same tense\textbf{ as:}}}
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{"he spoke"} \\
+\midrule
+\textbf{Italian} & \emph{\textbf{parlò}} \\
+Spanish & \emph{habló} \\
+Portuguese & \emph{falou} \\
+French & \emph{il parla} \\
+\bottomrule
+\end{tabularx}
+
+One Latin ancestor, four descendants — and four different fates in daily life.
+\end{cousinweb}
+
+\begin{culture}
+This is what makes Italian interesting here:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{region} & \textbf{everyday past} \\
+\midrule
+\textbf{Sicily, much of the south} & \textbf{passato remoto} — \emph{parlò} is normal speech \\
+Tuscany & both, with a distinction of distance in time \\
+\textbf{North} & \textbf{passato prossimo} almost always; \emph{parlò} feels literary \\
+\bottomrule
+\end{tabularx}
+
+So the "correct" answer changes as you travel. In the north the \emph{passato remoto} has retreated to books, exactly as French's \emph{passé simple} and German's \emph{Präteritum} did. In the south it never left.
+\end{culture}
+
+\begin{grammarlens}[title={What you've built: three retreats and two holdouts}]
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{simple past} & \textbf{status in speech} \\
+\midrule
+French & \emph{passé simple} & \textbf{gone} — books only \\
+German & \emph{Präteritum} & \textbf{retreating}, especially in the south \\
+\textbf{Italian} & \emph{passato remoto} & \textbf{split by region} \\
+Spanish & \emph{habló} & \textbf{alive} (though Spain is drifting toward \emph{he hablado}) \\
+Portuguese & \emph{falou} & \textbf{alive} \\
+\bottomrule
+\end{tabularx}
+
+Three languages let a "have" compound push the inherited past out of conversation; Italian is the one caught \textbf{mid-process}, with the old tense still holding half the country.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the pair — "parl\textbf{ò} … \textbf{ha} parlato"{]}
+  \item {[}YOU SAY: the sisters — "parlò · habló · falou · il parla"{]}
+  \item {[}YOU SAY: the geography — "in \textbf{Palermo} ordinary; in \textbf{Milano} literary"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What is \emph{parlò} descended from? (Vulgar Latin \textbf{\textbackslash{}\emph{parabolāvit\textbf{.) What decides whether it sounds normal or bookish? (}Where in Italy you are\textbf{ — everyday in the south, literary in the north.) Which languages kept this tense fully alive? (}Spanish\textbf{ and }Portuguese\textbf{.) Which lost it entirely from speech? (}French\textbf{.) Next chapter: the verbs that take \emph{essere} instead of \emph{avere}.}}}
+\end{tcolorbox}

--- a/code/learning/human-languages/italian/book/chapters/ch16-essere-andare-past.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch16-essere-andare-past.tex
@@ -1,0 +1,250 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:46629a0359aec030
+% canonical-lessons: IT-C16-essere, IT-C16-essere-stato, IT-C16-andare, IT-C16-passato-prossimo-essere
+
+\chapter{Being, Going, and the Past with Essere}
+\label{ch:it-essere-andare-past}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[essere]{essere — “to be”}
+
+\label{lesson:IT-C16-essere}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You have known one Italian “to be” since Chapter 2: \textbf{stare}, from Latin \emph{stāre}, “to stand.” Now meet \textbf{essere}, from Latin \emph{esse}, “to be.”
+\end{quote}
+
+\subsection*{You'll want to know: the six forms}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+io \textbf{sono} & noi \textbf{siamo} \\
+tu \textbf{sei} & voi \textbf{siete} \\
+lui/lei \textbf{è} & loro \textbf{sono} \\
+\bottomrule
+\end{tabularx}
+
+Italian normally drops the subject pronoun because the ending identifies the person: \textbf{Sono italiano} means “I am Italian.” One collision needs care: \textbf{io sono} and \textbf{loro sono} are identical. Keep \emph{loro} when context would not make “they” clear.
+
+\begin{grammarlens}[title={Grammar Lens: one accent and two words}]
+\textbf{È} with the grave accent is the verb “is.” Plain \textbf{e} is “and”:
+
+\begin{itemize}
+\raggedright
+  \item Marco \textbf{è} italiano. — Marco \textbf{is} Italian.
+  \item Marco \textbf{e} Anna. — Marco \textbf{and} Anna.
+\end{itemize}
+
+The two words sound different enough in careful speech, but the accent makes the contrast unmistakable on the page. Never drop it from the verb.
+\end{grammarlens}
+
+\begin{cousinweb}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Latin} & \textbf{picture} & \textbf{Italian} \\
+\midrule
+\emph{esse} & being or identity & \textbf{essere} \\
+\emph{stāre} & standing or state & \textbf{stare} \\
+\bottomrule
+\end{tabularx}
+
+Italian kept both verbs. The next micro-lesson shows the surprising place where their histories overlap.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: “sono, sei, è, siamo, siete, sono”{]}
+  \item {[}YOU SAY: “Marco è italiano” — then “Marco e Anna”{]}
+  \item {[}YOU SAY: “essere — be; stare — stand/state”{]}
+\end{itemize}
+
+{[}REPEAT x2{]} “Sono, sei, è — siamo, siete, sono.”
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Give the six forms of \emph{essere}. (\textbf{Sono, sei, è, siamo, siete, sono}.) What does the accent distinguish? (\textbf{È}, “is,” from \textbf{e}, “and.”) Which older verbs became \emph{essere} and \emph{stare}? (Latin \emph{\textbf{esse}} and \emph{\textbf{stāre}}.) Next: why both verbs share \textbf{stato}.
+\end{tcolorbox}
+\section[essere to stato]{essere $\to$ stato — a borrowed piece}
+
+\label{lesson:IT-C16-essere-stato}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Italian kept both Latin “be” verbs as \textbf{essere} and \textbf{stare}. Now look at the piece they unexpectedly share.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: one participle for two verbs}]
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{verb} & \textbf{past participle} \\
+\midrule
+\textbf{stare} & \textbf{stato} \\
+\textbf{essere} & \textbf{stato} \\
+\bottomrule
+\end{tabularx}
+
+\emph{Essere}’s own participle did not survive. Latin \emph{esse} never supplied a useful one, so Italian filled the empty slot with \emph{stare}’s \textbf{stato}. A verb assembled from historically different roots is \textbf{suppletive}, like English \emph{go / went}.
+
+That shared piece creates a real ambiguity:
+
+\begin{quote}
+\textbf{sono stato} = “I have been” or “I have stayed”
+\end{quote}
+
+Only the surrounding sentence tells you which verb is meant.
+\end{grammarlens}
+
+\begin{grammarlens}[title={What you've built: three Romance solutions}]
+The same Latin material took a different shape in each sister language:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{result} \\
+\midrule
+Spanish & \emph{ser} and \emph{estar}: two verbs kept fully separate \\
+French & \emph{être}: one verb with old \emph{stāre} pieces inside its forms \\
+Italian & \emph{essere} and \emph{stare}: two verbs that share \textbf{stato} \\
+\bottomrule
+\end{tabularx}
+
+Italian sits between the other two: less separated than Spanish, less fused than French. You do not need either sister language to use Italian; the comparison simply makes the borrowed piece visible.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: “stare $\to$ stato”{]}
+  \item {[}YOU SAY: “essere $\to$ stato”{]}
+  \item {[}YOU SAY: “sono stato — I have been / I have stayed”{]}
+\end{itemize}
+
+{[}REPEAT x2{]} “Two verbs, one \textbf{stato}.”
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What is \emph{essere}’s participle? (\textbf{Stato}, borrowed from \emph{stare}.) What can \emph{sono stato} mean? (“I have \textbf{been}” or “I have \textbf{stayed}.”) Which language keeps the two verbs fully separate? (\textbf{Spanish}.) Which fuses them most? (\textbf{French}.) Next: the two-stem verb \textbf{andare}, “to go.”
+\end{tcolorbox}
+\section[andare]{andare — “to go,” on two stems}
+
+\label{lesson:IT-C16-andare}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Chapter 2 gave you \textbf{Come va?}, “How’s it going?” The \textbf{va} inside it belongs to \textbf{andare}, “to go.” Learn the whole verb before using it to build the past.
+\end{quote}
+
+\subsection*{You'll want to know: the forms}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+io \textbf{vado} & noi \textbf{andiamo} \\
+tu \textbf{vai} & voi \textbf{andate} \\
+lui/lei \textbf{va} & loro \textbf{vanno} \\
+\bottomrule
+\end{tabularx}
+
+Past participle: \textbf{andato}.
+
+The table has a visible seam:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{stem} & \textbf{forms} & \textbf{history} \\
+\midrule
+\textbf{vad- / va-} & vado, vai, va, \textbf{vanno} & Latin \emph{vādere}, “to stride” \\
+\textbf{and-} & andare, andiamo, andate, andato & disputed; probably \emph{ambitāre}, “go around” \\
+\bottomrule
+\end{tabularx}
+
+Notice that \textbf{vanno} belongs with \textbf{vado}, not with \emph{andiamo}. The split is not “singular versus plural.” It is two old verbs patched into one modern paradigm — another case of \textbf{suppletion}, like \emph{essere} borrowing \emph{stare}’s \textbf{stato}.
+
+Spanish shows the same kind of seam in \emph{voy} beside \emph{andar}. The comparison is a memory aid; the Italian forms above are the only ones you need here.
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: “vado, vai, va”{]}
+  \item {[}YOU SAY: “andiamo, andate, vanno”{]}
+  \item {[}YOU SAY: the infinitive and participle — “andare, andato”{]}
+  \item {[}YOU SAY: the Chapter 2 callback — “Come va?”{]}
+\end{itemize}
+
+{[}REPEAT x2{]} “Vado, vai, va — andiamo, andate, vanno.”
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Give the six present forms. (\textbf{Vado, vai, va, andiamo, andate, vanno}.) Which plural form belongs to the \emph{vad-} side? (\textbf{Vanno}.) What is the participle? (\textbf{Andato}.) Which familiar question already used \emph{va}? (\textbf{Come va?}) Next: combine \textbf{essere + andato} and make the ending agree.
+\end{tcolorbox}
+\section[sono andato]{sono andato — the past built on essere}
+
+\label{lesson:IT-C16-passato-prossimo-essere}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Chapter 15 built the past with \emph{avere}: \textbf{ho parlato}. You now know the other auxiliary, \textbf{essere}, plus the participles \textbf{stato} and \textbf{andato}. Combine them, then watch the participle’s ending change.
+\end{quote}
+
+\subsection*{You'll want to know: start with stato}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+\textbf{sono stato} & I have been / stayed \\
+\textbf{sei stato} & you have been / stayed \\
+\textbf{è stato} & he has been / stayed \\
+\textbf{siamo stati} & we have been / stayed \\
+\bottomrule
+\end{tabularx}
+
+The plural \textbf{stati} is the first clue: with \emph{essere}, the participle describes the subject and therefore agrees with it.
+
+\begin{grammarlens}[title={Grammar Lens: motion, change, and agreement}]
+Many verbs of motion or change of state take \textbf{essere}: \emph{andare} (go), \emph{venire} (come), \emph{arrivare} (arrive), \emph{partire} (leave), \emph{nascere} (be born), \emph{morire} (die), \emph{diventare} (become), plus \emph{essere} and \emph{stare}.
+
+Use the four adjective endings you already know:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{subject} & \textbf{sentence} \\
+\midrule
+Marco & Marco è \textbf{andato}. \\
+Anna & Anna è \textbf{andata}. \\
+the boys & I ragazzi sono \textbf{andati}. \\
+the girls & Le ragazze sono \textbf{andate}. \\
+\bottomrule
+\end{tabularx}
+
+A woman therefore says \textbf{sono andata}, not \emph{sono andato}. The ending agrees with the \textbf{subject}, in gender and number: \emph{-o, -a, -i, -e}.
+\end{grammarlens}
+
+\begin{culture}
+The participle began as an adjective: \textbf{Anna è andata} was “Anna is gone-away,” with \emph{andata} describing Anna just as \emph{stanca} (“tired”) would. French keeps the same agreement (\emph{elle est allée}); German uses a similar auxiliary split but no agreement (\emph{sie ist gegangen}). The systems developed alongside one another, but only the Romance sisters preserve this adjective fossil visibly.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: “sono stato, sei stato, siamo stati”{]}
+  \item {[}YOU SAY: “sono andato” — then, as a woman, “sono andata”{]}
+  \item {[}YOU SAY: “andato, andata, andati, andate”{]}
+  \item {[}YOU SAY: the contrast — “ho parlato; sono andato”{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which auxiliary do many motion and change verbs take? (\textbf{Essere}.) What does the participle agree with? (\textbf{The subject}.) Give all four endings. (\emph{\textbf{-o, -a, -i, -e}}.) How does a woman say “I went”? (\textbf{Sono andata}.) Why does agreement survive? (The participle began as an \textbf{adjective}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/italian/book/chapters/ch17-head-and-hand.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch17-head-and-hand.tex
@@ -1,0 +1,125 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:28edfc484982a197
+% canonical-lessons: IT-C17-testa, IT-C17-mano
+
+\chapter{Head and Hand}
+\label{ch:it-head-and-hand}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[la testa]{la testa — "the head"}
+
+\label{lesson:IT-C17-testa}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} If you have done the French chapter, you already know this word's story. What is worth seeing is how much \textbf{less} Italian did to it.
+\end{quote}
+
+\subsection*{You'll want to know: the word}
+\begin{quote}
+\textbf{la testa} — the head. Feminine.
+\end{quote}
+
+\begin{cousinweb}
+Latin \emph{\textbf{testa}} meant an \textbf{earthenware pot}, a shell, a shard. Roman soldiers' slang used it for the skull, and \textbf{across Gaul and Italy} the joke outlived the proper word \emph{caput}. (Only there — Iberia kept \emph{caput}, which is why Portuguese and Spanish still say \emph{cabeça} and \emph{cabeza}.)
+
+Put the two descendants side by side:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+Latin & \emph{\textbf{testa}} \\
+\textbf{Italian} & \emph{\textbf{testa}} — almost unchanged \\
+French & \emph{\textbf{tête}} — \emph{s} lost, vowels collapsed \\
+\bottomrule
+\end{tabularx}
+
+This is the conservative-sister pattern this course keeps meeting. Chapter 11 had \emph{acqua} against \emph{eau}; Chapter 15 had \emph{parlato} keeping the Latin \emph{-t-} that \emph{parlé} wore away. Italian holds its shape; French erodes.
+
+Say them one after the other: \emph{testa} … \emph{tête}. Same word, ten centuries apart.
+\end{cousinweb}
+
+\begin{cousinweb}
+French gave \emph{caput} away almost entirely, keeping it only in \emph{chef} and \emph{chapitre}. Italian kept it as a \textbf{live, common word}:
+
+\begin{quote}
+\textbf{il capo} — the head (of an organisation), the boss, the chief.
+\end{quote}
+
+So Italian has \textbf{both}: \emph{testa} for the thing on your shoulders, \emph{capo} for the person in charge. English borrowed the second one straight out of Italian — a \emph{capo} in a crime family is exactly this word.
+
+Also from \emph{caput}: \textbf{capitale}, \textbf{capitolo} (chapter), and \textbf{capitano}.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "la testa"{]}
+  \item {[}YOU SAY: "ho mal di testa" — "I have a headache"{]}
+  \item {[}YOU SAY: the erosion — "\textbf{testa} … \textbf{tête}"{]}
+  \item {[}YOU SAY: the pair — "la \textbf{testa} on your shoulders, il \textbf{capo} in charge"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Say "the head." (\emph{La testa} — feminine.) What did \emph{testa} mean in Latin? (An \textbf{earthenware pot} — soldiers' slang for the skull.) How does Italian compare with French here? (Italian kept it \textbf{almost unchanged} — the spelling is identical, the vowel opened; French wore it down to \emph{tête} — the conservative-sister pattern again, like \emph{acqua}/\emph{eau}.) What did Italian do with \emph{caput}? (Kept it as \emph{\textbf{il capo}}, "boss, chief" — a live everyday word, where French kept it only outside the head-slot.) Next: the hand.
+\end{tcolorbox}
+\section[la mano]{la mano — "the hand"}
+
+\label{lesson:IT-C17-mano}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Italian nouns \emph{tend} to announce their gender: \textbf{-o} is usually masculine, \textbf{-a} usually feminine. (Chapter 1 deliberately didn't give you that as a rule — it told you to learn each noun \textbf{with its article}, and this word is a good demonstration of why.)
+\end{quote}
+
+\subsection*{You'll want to know: the word}
+\begin{quote}
+\textbf{la mano} — the hand. \textbf{Feminine}, ending in \textbf{-o}. Plural: \textbf{le mani} — feminine, ending in \textbf{-i}.
+\end{quote}
+
+Both halves are irregular. A masculine \emph{-o} noun would pluralise in \emph{-i} (\emph{libro $\to$ libri}); a feminine noun usually ends \emph{-a} and pluralises in \emph{-e} (\emph{casa $\to$ case}). \emph{Mano} takes the feminine article and the masculine-looking endings.
+
+\begin{grammarlens}[title={Grammar Lens: five declensions}]
+Italian inherited a system with \textbf{five declensions} — five families of endings — and flattened it to \textbf{three} productive classes: \emph{-o}/\emph{-i} (\emph{libro/libri}), \emph{-a}/\emph{-e} (\emph{casa/case}), and \emph{-e}/\emph{-i} (\emph{notte/notti}, which Chapter 1 already gave you). \emph{Manus} belonged to the Latin \textbf{fourth}, whose nouns ended in \emph{-us} but could be \textbf{feminine}:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Latin} & \textbf{} & \textbf{Italian} \\
+\midrule
+\emph{manus} (4th decl., \textbf{fem.}) & $\to$ & \emph{la mano} \\
+\emph{manūs} (plural) & $\to$ & \emph{le mani} \\
+\bottomrule
+\end{tabularx}
+
+When Italian dropped the fourth declension, \emph{mano} was left with its old gender and an ending that now looks like it belongs to a different class. The word didn't change; \textbf{the system around it did.}
+
+That is the general lesson, and it recurs everywhere in this course: an "irregular" word is usually a \textbf{regular word from a system that no longer exists}.
+
+(A few others survive the same way: \emph{la radio}, \emph{la foto}, \emph{l'auto} — though those are short for \emph{radiofonia}, \emph{fotografia}, \emph{automobile}, which is a different reason for the same look.)
+\end{grammarlens}
+
+\begin{cousinweb}
+Latin \emph{manus} is inside a great many English words — \emph{manual}, \emph{manuscript}, \emph{manufacture} ("made by hand"), \emph{maintain} ("hold in the hand"). English took \textbf{manage} specifically from Italian \emph{\textbf{maneggiare}}, which meant to \textbf{handle a horse}. Every modern manager is, etymologically, working in a riding school.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "la mano, le mani"{]}
+  \item {[}YOU SAY: the breach — "\textbf{la} mano, feminine, ending in \textbf{-o}"{]}
+  \item {[}YOU SAY: the reason — "fourth declension, \emph{manus}, feminine"{]}
+  \item {[}YOU SAY: "manage $\leftarrow$ \textbf{maneggiare} — to handle a horse"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Say "the hand" and "the hands." (\emph{La mano} / \emph{le mani}.) What rule does it break? (The \textbf{tendency} that \emph{-o} is masculine — \emph{mano} is feminine.) Why? (Latin \emph{manus} was \textbf{fourth declension}, whose nouns ended \emph{-us} but could be feminine; Italian dropped that declension and left the word stranded.) What is the general lesson? (An \textbf{irregular} word is usually a \textbf{regular word from a lost system}.) Which English word came from Italian here, and what did it mean? (\textbf{Manage}, from \emph{maneggiare}, to \textbf{handle a horse}.) Next: the rest of the body.
+\end{tcolorbox}

--- a/code/learning/human-languages/italian/book/preamble.tex
+++ b/code/learning/human-languages/italian/book/preamble.tex
@@ -15,6 +15,7 @@
 \tcbuselibrary{skins,breakable}
 \usepackage{booktabs}
 \usepackage{longtable}
+\usepackage{tabularx}
 \usepackage{array}
 \usepackage[hidelinks]{hyperref}
 \usepackage{titlesec}
@@ -36,10 +37,10 @@
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
   fonttitle=\bfseries, title={Why it's said this way}
 }
-\newtcolorbox{grammarlens}{
+\newtcolorbox{grammarlens}[1][]{
   breakable, skin=enhanced, colback=blue!5, colframe=blue!35!black,
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
-  fonttitle=\bfseries, title={Grammar Lens}
+  fonttitle=\bfseries, title={Grammar Lens}, #1
 }
 \newtcolorbox{sounds}{
   breakable, skin=enhanced, colback=green!6, colframe=green!30!black,

--- a/code/learning/human-languages/italian/lessons/IT-C02-come-sta.md
+++ b/code/learning/human-languages/italian/lessons/IT-C02-come-sta.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C02-come-sta
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 140
 chapter: 2
 type: phrase
 headword: Come sta?
@@ -9,18 +12,31 @@ prerequisites: [IT-C02-come-stai]
 sounds: [open-a]
 roots: [stare-latin]
 etymology_hook: "Come sta? keeps the standing metaphor of Come stai? but changes the social register"
-est_minutes: 4
+duration:
+  max_seconds: 218
+requires:
+  knowledge: [IT-ETYMON-COME-STAI-02]
+introduces:
+  knowledge: [IT-GRAMMAR-COME-STA-02]
+practises:
+  knowledge: [IT-ETYMON-COME-STAI-02, IT-GRAMMAR-COME-STA-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: formal
+variety: standard-contemporary
 reviews_of: [IT-C02-come-stai, IT-C02-stare]
 ---
-
 # Come sta? — the formal question
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You can ask a friend **Come stai?** Change one ending when you speak
 to a stranger or elder.
 
-## From stai to sta
+## Grammar Lens: stai and sta
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-COME-STA-02]; assesses=[] -->
 
 > **Come sta?** = “How are you?” (formal)
 
@@ -41,6 +57,7 @@ An answer can return the formal pronoun:
 > **Bene, grazie. E Lei?** — “Well, thank you. And you?”
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-ETYMON-COME-STAI-02, IT-GRAMMAR-COME-STA-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: to a friend — “Come stai?”]
@@ -50,6 +67,7 @@ An answer can return the formal pronoun:
 [REPEAT x2] “Stai — friend. Sta — formal.”
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-ETYMON-COME-STAI-02, IT-GRAMMAR-COME-STA-02] -->
 
 [PAUSE 3s] Which ending marks a friend? (**-i: stai**.) Which form is formal?
 (**Sta**.) What polite pronoun can follow *e*, “and”? (**Lei**.) Next: keep the

--- a/code/learning/human-languages/italian/lessons/IT-C02-come-stai.md
+++ b/code/learning/human-languages/italian/lessons/IT-C02-come-stai.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C02-come-stai
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 130
 chapter: 2
 type: phrase
 headword: Come stai?
@@ -9,18 +12,31 @@ prerequisites: [IT-C02-stare, IT-C02-come]
 sounds: [ai-glide]
 roots: [stare-latin]
 etymology_hook: "come (← quōmodo) + stai (stare 'to stand'): Italian literally asks 'how do you stand?'"
-est_minutes: 4
+duration:
+  max_seconds: 242
+requires:
+  knowledge: [IT-SOUND-STARE-02, IT-ETYMON-STARE-03, IT-GRAMMAR-STARE-04, IT-SOUND-COME-02, IT-ETYMON-COME-03]
+introduces:
+  knowledge: [IT-ETYMON-COME-STAI-02]
+practises:
+  knowledge: [IT-SOUND-STARE-02, IT-ETYMON-STARE-03, IT-GRAMMAR-STARE-04, IT-SOUND-COME-02, IT-ETYMON-COME-03, IT-ETYMON-COME-STAI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C02-stare, IT-C02-come]
 ---
-
 # Come stai? — “how are you?”
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Both pieces are ready: **come** (“how”) and **stare / stai** (“to
 be,” from *stand*). Assemble Italian’s everyday question for a friend.
 
 ## The phrase, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-COME-STAI-02]; assesses=[] -->
 
 > **Come stai?** = “How are you?” (informal)
 > literally: **“How do you stand?”**
@@ -41,6 +57,7 @@ An everyday answer reuses the same verb:
 pronoun’s work: “you” in *-ai*, “I” in *-o*.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-STARE-02, IT-ETYMON-STARE-03, IT-GRAMMAR-STARE-04, IT-SOUND-COME-02, IT-ETYMON-COME-03, IT-ETYMON-COME-STAI-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: “Come stai?” — informal, for a friend]
@@ -50,6 +67,7 @@ pronoun’s work: “you” in *-ai*, “I” in *-o*.
 [REPEAT x2] “Come stai? — Sto bene, grazie.”
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-STARE-02, IT-ETYMON-STARE-03, IT-GRAMMAR-STARE-04, IT-SOUND-COME-02, IT-ETYMON-COME-03, IT-ETYMON-COME-STAI-02] -->
 
 [PAUSE 3s] *Come stai?* literally asks what? (“How do you **stand**?”) Which word
 means “how”? (**Come**.) Which form answers “I am”? (**Sto**.) Give the whole

--- a/code/learning/human-languages/italian/lessons/IT-C02-come-va.md
+++ b/code/learning/human-languages/italian/lessons/IT-C02-come-va.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C02-come-va
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 150
 chapter: 2
 type: phrase
 headword: Come va?
@@ -9,13 +12,25 @@ prerequisites: [IT-C02-come-sta]
 sounds: [open-a]
 roots: [andare-latin]
 etymology_hook: "Come va? changes the wellbeing metaphor from stare, 'stand', to andare, 'go'"
-est_minutes: 4
+duration:
+  max_seconds: 250
+requires:
+  knowledge: [IT-GRAMMAR-COME-STA-02]
+introduces:
+  knowledge: [IT-GRAMMAR-COME-VA-02]
+practises:
+  knowledge: [IT-GRAMMAR-COME-STA-02, IT-GRAMMAR-COME-VA-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C02-come-stai, IT-C02-come-sta]
 ---
-
 # Come va? — “how is it going?”
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] **Come stai?** pictures wellbeing as standing. Italian also has the
 same “going” picture as English.
@@ -26,7 +41,8 @@ same “going” picture as English.
 not force you to choose an informal or formal ending, so it is useful in either
 setting.
 
-## Two pictures
+## Grammar Lens: standing and going
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-COME-VA-02]; assesses=[] -->
 
 - **Come stai?** — “How do you **stand**?”
 - **Come va?** — “How does it **go**?”
@@ -40,6 +56,7 @@ You will learn all six forms of *andare* much later. For now, **va** is one
 ready-made piece inside this question.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-GRAMMAR-COME-STA-02, IT-GRAMMAR-COME-VA-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: the standing question — “Come stai?”]
@@ -49,6 +66,7 @@ ready-made piece inside this question.
 [REPEAT x2] “Come stai? — Come va?”
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-GRAMMAR-COME-STA-02, IT-GRAMMAR-COME-VA-02] -->
 
 [PAUSE 3s] Which question uses “stand”? (**Come stai?**) Which uses “go”?
 (**Come va?**) What infinitive owns **va**? (**Andare**.) Must *Come va?* choose

--- a/code/learning/human-languages/italian/lessons/IT-C02-come.md
+++ b/code/learning/human-languages/italian/lessons/IT-C02-come.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C02-come
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 110
 chapter: 2
 type: word
 headword: come
@@ -9,24 +12,38 @@ prerequisites: [IT-C01-ciao]
 sounds: [soft-c]
 roots: [quomodo-latin]
 etymology_hook: "come ← Latin quōmodo 'in what manner' — the same root as Spanish cómo and French comment"
-est_minutes: 3
+duration:
+  max_seconds: 186
+requires:
+  knowledge: []
+introduces:
+  knowledge: [IT-SOUND-COME-02, IT-ETYMON-COME-03]
+practises:
+  knowledge: [IT-SOUND-COME-02, IT-ETYMON-COME-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C02-prego]
 ---
-
 # come — "how," the third *quomodo* cousin
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] To ask *how are you?* you need "how." In Italian it's **come** — and
 if you've seen the Spanish or French tracks, you already know its family.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[IT-SOUND-COME-02]; assesses=[] -->
 
 - `soft-c` — **come** = *KOH-meh*. Here *c* is before *o*, so it's a **hard** *k*
   (Italian *c* only softens to *ch* before *e/i*). Final *-e* is sounded:
   *KOH-meh*.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-COME-03]; assesses=[] -->
 
 **come** = "how / like / as." Root: Latin **quōmodo**, "in what manner" — two
 words (*quō* "in what way" + *modo* "manner") fused and worn down. It is the
@@ -45,6 +62,7 @@ them apart only by context, not spelling: *Come stai?* ("**How** are you?") vs
 *bianco come la neve* ("white **as** snow").
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-COME-02, IT-ETYMON-COME-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "come" — *KOH-meh*]
@@ -52,6 +70,7 @@ them apart only by context, not spelling: *Come stai?* ("**How** are you?") vs
 - [YOU SAY: English *mode, model* share the *modo* piece]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-COME-02, IT-ETYMON-COME-03] -->
 
 [PAUSE 3s] What Latin word gives *come*, and which Spanish and French words are
 its siblings? (*quōmodo* → *cómo*, *comment*.) What two jobs does *come* do?

--- a/code/learning/human-languages/italian/lessons/IT-C02-cosi-cosi.md
+++ b/code/learning/human-languages/italian/lessons/IT-C02-cosi-cosi.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C02-cosi-cosi
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 160
 chapter: 2
 type: word
 headword: così così
@@ -9,25 +12,39 @@ prerequisites: [IT-C02-come-stai]
 sounds: [soft-c, s-voiced]
 roots: [eccum-sic-latin]
 etymology_hook: "così ← Latin (ec)cum sīc 'thus, so'; sīc is the 'sic' English still writes"
-est_minutes: 3
+duration:
+  max_seconds: 243
+requires:
+  knowledge: [IT-ETYMON-COME-STAI-02]
+introduces:
+  knowledge: [IT-SOUND-COSI-COSI-02, IT-ETYMON-COSI-COSI-03, IT-GRAMMAR-COSI-COSI-04]
+practises:
+  knowledge: [IT-ETYMON-COME-STAI-02, IT-SOUND-COSI-COSI-02, IT-ETYMON-COSI-COSI-03, IT-GRAMMAR-COSI-COSI-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C01-buono, IT-C02-come-stai]
 ---
-
 # così così — the original "so-so"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] English "so-so" is a **loan translation of the Italian** *così così*.
 Someone asks *Come stai?*; you're middling; you wobble a hand and say *così
 così* — "thus and thus," this way and that.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[IT-SOUND-COSI-COSI-02]; assesses=[] -->
 
 - `soft-c` — **così** = *koh-ZEE*: the *c* is before *o* (hard *k*), and the
   single *s* between vowels is **voiced**, a *z* sound: *koh-**ZEE***. Stress the
   end (that's what the accent on *ì* marks).
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-COSI-COSI-03]; assesses=[] -->
 
 **così** = "thus, so, in this way," from Latin **(ec)cum sīc**, "(behold) so."
 Doubled — *così così* — it means "**so** and **so**," neither up nor down: a
@@ -44,6 +61,7 @@ So *così così* is literally **"so, so"** — and English simply borrowed the s
 whole.
 
 ## Grammar Lens: your answer ladder for *Come stai?*
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-COSI-COSI-04]; assesses=[] -->
 
 | answer | sense |
 |---|---|
@@ -56,6 +74,7 @@ French **comme ci comme ça** ("like this, like that"), Spanish **más o menos**
 ("more or less"), German **es geht** ("it goes").
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-ETYMON-COME-STAI-02, IT-SOUND-COSI-COSI-02, IT-ETYMON-COSI-COSI-03, IT-GRAMMAR-COSI-COSI-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "così così" — *koh-ZEE koh-ZEE*, with a hand-wobble]
@@ -63,6 +82,7 @@ French **comme ci comme ça** ("like this, like that"), Spanish **más o menos**
 - [YOU SAY: "sic" in English — "thus" — the same *sīc*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-ETYMON-COME-STAI-02, IT-SOUND-COSI-COSI-02, IT-ETYMON-COSI-COSI-03, IT-GRAMMAR-COSI-COSI-04] -->
 
 [PAUSE 3s] What does *così così* literally mean? ("Thus, thus / so, so.") What
 Latin word for "so" is inside it, and where do you still write it in English?

--- a/code/learning/human-languages/italian/lessons/IT-C02-practice.md
+++ b/code/learning/human-languages/italian/lessons/IT-C02-practice.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C02-practice
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 170
 chapter: 2
 type: practice-mix
 headword: (practice)
@@ -8,19 +11,32 @@ concept_tag: CH2-PRACTICE
 prerequisites: [IT-C02-prego, IT-C02-come, IT-C02-stare, IT-C02-come-stai, IT-C02-come-sta, IT-C02-come-va, IT-C02-cosi-cosi]
 sounds: []
 roots: []
-est_minutes: 4
+duration:
+  max_seconds: 297
+requires:
+  knowledge: [IT-SOUND-PREGO-02, IT-ETYMON-PREGO-03, IT-SOUND-COME-02, IT-ETYMON-COME-03, IT-SOUND-STARE-02, IT-ETYMON-STARE-03, IT-GRAMMAR-STARE-04, IT-ETYMON-COME-STAI-02, IT-GRAMMAR-COME-STA-02, IT-GRAMMAR-COME-VA-02, IT-SOUND-COSI-COSI-02, IT-ETYMON-COSI-COSI-03, IT-GRAMMAR-COSI-COSI-04]
+introduces:
+  knowledge: [IT-LEX-PRACTICE-02, IT-NOTICE-PRACTICE-03]
+practises:
+  knowledge: [IT-SOUND-PREGO-02, IT-ETYMON-PREGO-03, IT-SOUND-COME-02, IT-ETYMON-COME-03, IT-SOUND-STARE-02, IT-ETYMON-STARE-03, IT-GRAMMAR-STARE-04, IT-ETYMON-COME-STAI-02, IT-GRAMMAR-COME-STA-02, IT-GRAMMAR-COME-VA-02, IT-SOUND-COSI-COSI-02, IT-ETYMON-COSI-COSI-03, IT-GRAMMAR-COSI-COSI-04, IT-LEX-PRACTICE-02, IT-NOTICE-PRACTICE-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C02-prego, IT-C02-come-stai, IT-C02-come-sta, IT-C02-come-va, IT-C02-cosi-cosi, IT-C01-practice]
 ---
-
 # Practice — "Come stai?", start to finish
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] No new words. This chapter's atoms — *prego, come, stare, come stai?,
 così così* — assemble into a real exchange, formal and informal. It picks up from
 the Chapter 1 greetings.
 
 ## The exchange
+<!-- hl-knowledge: introduces=[IT-LEX-PRACTICE-02]; assesses=[] -->
 
 **Formal** (a stranger, an elder — *Lei*):
 
@@ -39,6 +55,7 @@ The glue is **e Lei? / e tu?** — "and you?" (*e* = "and," Latin *et*) — the
 Italian twin of Spanish *¿y usted?* and French *et toi?*.
 
 ## What you've built this chapter
+<!-- hl-knowledge: introduces=[IT-NOTICE-PRACTICE-03]; assesses=[] -->
 
 - **prego** — you're welcome / please (← *pregare*, "to pray"; English
   *precarious*).
@@ -49,6 +66,7 @@ Italian twin of Spanish *¿y usted?* and French *et toi?*.
 - **così così** — so-so (English "so-so" borrowed it whole).
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-PREGO-02, IT-ETYMON-PREGO-03, IT-SOUND-COME-02, IT-ETYMON-COME-03, IT-SOUND-STARE-02, IT-ETYMON-STARE-03, IT-GRAMMAR-STARE-04, IT-ETYMON-COME-STAI-02, IT-GRAMMAR-COME-STA-02, IT-GRAMMAR-COME-VA-02, IT-SOUND-COSI-COSI-02, IT-ETYMON-COSI-COSI-03, IT-GRAMMAR-COSI-COSI-04, IT-LEX-PRACTICE-02, IT-NOTICE-PRACTICE-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: the full *formal* exchange, both voices]
@@ -58,6 +76,7 @@ Italian twin of Spanish *¿y usted?* and French *et toi?*.
 [REPEAT x2] "Come stai? — Sto bene, grazie, e tu?" until it's reflex.
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-PREGO-02, IT-ETYMON-PREGO-03, IT-SOUND-COME-02, IT-ETYMON-COME-03, IT-SOUND-STARE-02, IT-ETYMON-STARE-03, IT-GRAMMAR-STARE-04, IT-ETYMON-COME-STAI-02, IT-GRAMMAR-COME-STA-02, IT-GRAMMAR-COME-VA-02, IT-SOUND-COSI-COSI-02, IT-ETYMON-COSI-COSI-03, IT-GRAMMAR-COSI-COSI-04, IT-LEX-PRACTICE-02, IT-NOTICE-PRACTICE-03] -->
 
 [PAUSE 3s] Which verb carries *Come stai?*, and what does it literally ask?
 (*stare*, "to stand" — "how do you stand?") What does *prego* answer, and from

--- a/code/learning/human-languages/italian/lessons/IT-C02-prego.md
+++ b/code/learning/human-languages/italian/lessons/IT-C02-prego.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C02-prego
+spine_node: SPINE-COURTESY-THANK
+sequence: 100
 chapter: 2
 type: word
 headword: prego
@@ -9,24 +12,38 @@ prerequisites: [IT-C01-grazie]
 sounds: [hard-g-before-o]
 roots: [precari-latin]
 etymology_hook: "prego ← pregare 'to pray' (← Latin precārī) → English pray, precarious, deprecate"
-est_minutes: 3
+duration:
+  max_seconds: 198
+requires:
+  knowledge: []
+introduces:
+  knowledge: [IT-SOUND-PREGO-02, IT-ETYMON-PREGO-03]
+practises:
+  knowledge: [IT-SOUND-PREGO-02, IT-ETYMON-PREGO-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C01-grazie]
 ---
-
 # prego — "you're welcome," literally "I pray"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The *grazie* lesson already promised you this word. Someone says
 **grazie**; you reply **prego**. Like German *bitte*, it's a small word that does
 several jobs — and it comes straight from **praying**.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[IT-SOUND-PREGO-02]; assesses=[] -->
 
 - `hard-g-before-o` — **prego** = *PREH-go* with a **hard** g. (Italian g is soft
   only before *e/i*; here the g is followed by *o*, so it stays hard.)
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-PREGO-03]; assesses=[] -->
 
 **prego** is "I pray" — the *io* ("I") form of **pregare**, "to pray, to beg,"
 from Latin **precārī**. When you answer *grazie* with *prego*, you're softly
@@ -51,12 +68,14 @@ of "I pray you":
 | you didn't catch it | **sorry, come again?** |
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-PREGO-02, IT-ETYMON-PREGO-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "grazie" … "prego" — the full exchange]
 - [YOU SAY: "prego" then English "pray, precarious" — one family]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-PREGO-02, IT-ETYMON-PREGO-03] -->
 
 [PAUSE 3s] What verb is *prego* the "I" form of? (*pregare*, "to pray.") What
 English word means "held by prayer" and so "unstable"? (*Precarious*.) Which

--- a/code/learning/human-languages/italian/lessons/IT-C02-stare.md
+++ b/code/learning/human-languages/italian/lessons/IT-C02-stare.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C02-stare
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 120
 chapter: 2
 type: word
 headword: stare
@@ -9,24 +12,38 @@ prerequisites: []
 sounds: [st-clean]
 roots: [stare-latin]
 etymology_hook: "stare ← Latin stāre 'to stand' — the SAME verb as Spanish estar; come stai? = 'how do you stand?'"
-est_minutes: 4
+duration:
+  max_seconds: 214
+requires:
+  knowledge: []
+introduces:
+  knowledge: [IT-SOUND-STARE-02, IT-ETYMON-STARE-03, IT-GRAMMAR-STARE-04]
+practises:
+  knowledge: [IT-SOUND-STARE-02, IT-ETYMON-STARE-03, IT-GRAMMAR-STARE-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C02-come]
 ---
-
 # stare — "to be," the standing kind (Spanish's estar, undressed)
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Like Spanish, Italian has **two** verbs for "to be" — **essere**
 (identity) and **stare** (state). "How are you?" runs on **stare**. And if you
 did the Spanish track, this is *estar* with its front *e* taken off.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[IT-SOUND-STARE-02]; assesses=[] -->
 
 - `st-clean` — Italian, unlike Spanish, is happy to start a word with *st-*: no
   propping *e*. **stare** = *STAH-reh*, clean *st*, final *-e* sounded.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-STARE-03]; assesses=[] -->
 
 **stare** comes straight from Latin **stāre**, *"to stand."* Spanish grew the
 same verb into **estar** (with a propping *e-*); Italian kept it bare as
@@ -39,6 +56,7 @@ That **stā-** root stands behind a wall of English words: **stay**, **stand**,
 stand?"** — the very same picture as Spanish *¿Cómo estás?*.
 
 ## Grammar Lens: essere vs stare, and the two forms you need
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-STARE-04]; assesses=[] -->
 
 | verb | from | job |
 |---|---|---|
@@ -51,6 +69,7 @@ For this chapter, just two forms of *stare*:
 - **sta** — "you are" (formal, *Lei*) / "he/she is"
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-STARE-02, IT-ETYMON-STARE-03, IT-GRAMMAR-STARE-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "stare" — *STAH-reh*, clean *st*]
@@ -58,6 +77,7 @@ For this chapter, just two forms of *stare*:
 - [YOU SAY: Italian *stare* = Spanish *estar*, same Latin *stāre* "to stand"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-STARE-02, IT-ETYMON-STARE-03, IT-GRAMMAR-STARE-04] -->
 
 [PAUSE 3s] What Latin verb is *stare*, and which Spanish verb is its twin?
 ("To stand," *stāre* — Spanish *estar*.) Which Italian be-verb is for how you

--- a/code/learning/human-languages/italian/lessons/IT-C03-come-ti-chiami.md
+++ b/code/learning/human-languages/italian/lessons/IT-C03-come-ti-chiami.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C03-come-ti-chiami
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 200
 chapter: 3
 type: phrase
 headword: Come ti chiami?
@@ -9,19 +12,32 @@ prerequisites: [IT-C03-mi-chiamo, IT-C02-come]
 sounds: [ch-hard-k]
 roots: [quomodo-latin, clamare-latin]
 etymology_hook: "come (← quōmodo 'how') + ti chiami (chiamarsi) — 'how do you call yourself?'"
-est_minutes: 3
+duration:
+  max_seconds: 288
+requires:
+  knowledge: [IT-SOUND-MI-CHIAMO-02, IT-ETYMON-MI-CHIAMO-03, IT-GRAMMAR-MI-CHIAMO-04, IT-SOUND-COME-02, IT-ETYMON-COME-03]
+introduces:
+  knowledge: [IT-ETYMON-COME-TI-CHIAMI-02]
+practises:
+  knowledge: [IT-SOUND-MI-CHIAMO-02, IT-ETYMON-MI-CHIAMO-03, IT-GRAMMAR-MI-CHIAMO-04, IT-SOUND-COME-02, IT-ETYMON-COME-03, IT-ETYMON-COME-TI-CHIAMI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C03-mi-chiamo, IT-C02-come]
 ---
-
 # Come ti chiami? — "what's your name?"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You have both pieces: **come** ("how," from your how-are-you chapter)
 and **chiamarsi** ("to call oneself"). Like Spanish and French, Italian asks the
 name with **"how"**, not "what": *how do you call yourself?*
 
 ## The phrase, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-COME-TI-CHIAMI-02]; assesses=[] -->
 
 > **Come ti chiami?** = "What's your name?" (informal)
 > literally: **"How do you call yourself?"**
@@ -47,6 +63,7 @@ llama?* and French *comment vous appelez-vous?* — the name is a matter of *how
 you're called, not *what* you are.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-MI-CHIAMO-02, IT-ETYMON-MI-CHIAMO-03, IT-GRAMMAR-MI-CHIAMO-04, IT-SOUND-COME-02, IT-ETYMON-COME-03, IT-ETYMON-COME-TI-CHIAMI-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "Come ti chiami?" — informal, for a peer]
@@ -54,6 +71,7 @@ you're called, not *what* you are.
 - [YOU SAY: the whole swap — "Come ti chiami? — Mi chiamo … E tu?"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-MI-CHIAMO-02, IT-ETYMON-MI-CHIAMO-03, IT-GRAMMAR-MI-CHIAMO-04, IT-SOUND-COME-02, IT-ETYMON-COME-03, IT-ETYMON-COME-TI-CHIAMI-02] -->
 
 [PAUSE 3s] What does *Come ti chiami?* literally ask? ("How do you call
 yourself?") What changes for the formal *Lei* version? (*ti chiami* → *si

--- a/code/learning/human-languages/italian/lessons/IT-C03-io.md
+++ b/code/learning/human-languages/italian/lessons/IT-C03-io.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C03-io
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 180
 chapter: 3
 type: word
 headword: io
@@ -9,24 +12,38 @@ prerequisites: []
 sounds: [io-glide]
 roots: [ego-latin]
 etymology_hook: "io ← Latin ego 'I' → English ego, egoist; Italian usually drops it (pro-drop)"
-est_minutes: 3
+duration:
+  max_seconds: 206
+requires:
+  knowledge: []
+introduces:
+  knowledge: [IT-SOUND-IO-02, IT-ETYMON-IO-03, IT-GRAMMAR-IO-04]
+practises:
+  knowledge: [IT-SOUND-IO-02, IT-ETYMON-IO-03, IT-GRAMMAR-IO-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C04-arrivederci]
 ---
-
 # io — "I," the pronoun Italian loves to leave out
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Before you introduce yourself, meet **io** — "I." It's a small word
 with a famous English cousin, and a surprising habit: Italian usually **drops
 it.**
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[IT-SOUND-IO-02]; assesses=[] -->
 
 - `io-glide` — **io** = *EE-oh*, two quick vowels gliding together, stress the
   first: *EE-oh*.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-IO-03]; assesses=[] -->
 
 **io** = "I," worn down from Latin **ego** — which English borrowed *whole*:
 
@@ -36,6 +53,7 @@ it.**
   one a child of *ego*.
 
 ## Grammar Lens: the dropped subject (pro-drop)
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-IO-04]; assesses=[] -->
 
 Here's the Italian habit worth learning now: **the verb ending already tells you
 who's speaking, so the pronoun is usually left out.** *Sto bene* ("I'm well")
@@ -49,6 +67,7 @@ say "I" every time. So learning Italian means learning to *trust the verb ending
 and let the pronoun go.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-IO-02, IT-ETYMON-IO-03, IT-GRAMMAR-IO-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "io" — *EE-oh*]
@@ -56,6 +75,7 @@ and let the pronoun go.
 - [YOU SAY: "Sto bene" with no *io* — the ending carries the "I"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-IO-02, IT-ETYMON-IO-03, IT-GRAMMAR-IO-04] -->
 
 [PAUSE 3s] What Latin word is *io* from, and what English words share it? (*Ego*
 — ego, egoist.) Why does Italian usually drop *io*? (The verb ending already

--- a/code/learning/human-languages/italian/lessons/IT-C03-mi-chiamo.md
+++ b/code/learning/human-languages/italian/lessons/IT-C03-mi-chiamo.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C03-mi-chiamo
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 190
 chapter: 3
 type: phrase
 headword: mi chiamo
@@ -9,19 +12,32 @@ prerequisites: [IT-C03-io]
 sounds: [ch-hard-k]
 roots: [clamare-latin]
 etymology_hook: "chiamarsi ← Latin clāmāre 'to call out' → English claim, clamor, exclaim, proclaim"
-est_minutes: 4
+duration:
+  max_seconds: 218
+requires:
+  knowledge: [IT-SOUND-IO-02, IT-ETYMON-IO-03, IT-GRAMMAR-IO-04]
+introduces:
+  knowledge: [IT-SOUND-MI-CHIAMO-02, IT-ETYMON-MI-CHIAMO-03, IT-GRAMMAR-MI-CHIAMO-04]
+practises:
+  knowledge: [IT-SOUND-IO-02, IT-ETYMON-IO-03, IT-GRAMMAR-IO-04, IT-SOUND-MI-CHIAMO-02, IT-ETYMON-MI-CHIAMO-03, IT-GRAMMAR-MI-CHIAMO-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C03-io]
 ---
-
 # mi chiamo — "I call myself"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Like Spanish and French, Italian doesn't say "my name is." It says **"I
 call myself"** — **mi chiamo**. Same reflexive trick, same *clāmāre* root as
 Spanish *me llamo*.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[IT-SOUND-MI-CHIAMO-02]; assesses=[] -->
 
 - `ch-hard-k` — Italian **ch** is a **hard k** (the opposite of English!): so
   **chiamo** = *KYAH-moh*, not "chee-." (Italian softens *c* to *ch*-sound only
@@ -29,6 +45,7 @@ Spanish *me llamo*.
 - **mi chiamo** = *mee KYAH-moh*.
 
 ## The phrase, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-MI-CHIAMO-03]; assesses=[] -->
 
 **mi chiamo** = **mi** ("myself") + **chiamo** ("I call") → **"I call myself."**
 Then the name: *Mi chiamo Marco* — "I call myself Marco."
@@ -43,6 +60,7 @@ out, to call."* That root shouts through English:
   (Spanish) or *ch-* (Italian/Portuguese). One Latin "call," three naming verbs.
 
 ## Grammar Lens: the reflexive, and the dropping of *io*
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-MI-CHIAMO-04]; assesses=[] -->
 
 *chiamo* alone is "I call [someone else]"; **mi** chiamo is "I call **myself**" —
 **reflexive**, the action looping back on you. The pronoun changes with the
@@ -51,6 +69,7 @@ And notice: no *io* — the *-o* ending already says "I." (You met that pro-drop
 last lesson.)
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-IO-02, IT-ETYMON-IO-03, IT-GRAMMAR-IO-04, IT-SOUND-MI-CHIAMO-02, IT-ETYMON-MI-CHIAMO-03, IT-GRAMMAR-MI-CHIAMO-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "mi chiamo" — *mee KYAH-moh*, hard *k* in *chiamo*]
@@ -58,6 +77,7 @@ last lesson.)
 - [YOU SAY: "chiamo" then English "claim, exclaim, clamor" — the *clāmāre* family]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-IO-02, IT-ETYMON-IO-03, IT-GRAMMAR-IO-04, IT-SOUND-MI-CHIAMO-02, IT-ETYMON-MI-CHIAMO-03, IT-GRAMMAR-MI-CHIAMO-04] -->
 
 [PAUSE 3s] What does *mi chiamo* literally mean? ("I call myself.") What Latin
 verb is *chiamarsi* from, and its English cousins? (*clāmāre* — claim, exclaim,

--- a/code/learning/human-languages/italian/lessons/IT-C03-piacere.md
+++ b/code/learning/human-languages/italian/lessons/IT-C03-piacere.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C03-piacere
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 210
 chapter: 3
 type: word
 headword: piacere
@@ -9,24 +12,38 @@ prerequisites: [IT-C03-come-ti-chiami]
 sounds: [soft-c, ia-glide]
 roots: [placere-latin]
 etymology_hook: "piacere ← Latin placēre 'to please' → English please, pleasure, complacent; kin of Portuguese prazer"
-est_minutes: 3
+duration:
+  max_seconds: 188
+requires:
+  knowledge: [IT-ETYMON-COME-TI-CHIAMI-02]
+introduces:
+  knowledge: [IT-SOUND-PIACERE-02, IT-ETYMON-PIACERE-03, IT-GRAMMAR-PIACERE-04]
+practises:
+  knowledge: [IT-ETYMON-COME-TI-CHIAMI-02, IT-SOUND-PIACERE-02, IT-ETYMON-PIACERE-03, IT-GRAMMAR-PIACERE-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C03-mi-chiamo, IT-C03-come-ti-chiami]
 ---
-
 # piacere — "pleased to meet you," i.e. "a pleasure"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Names exchanged, you close the introduction with one warm word:
 **piacere** — literally *"a pleasure."* It's the twin of a word you'd say in
 Portuguese, and it's pure Latin *please*.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[IT-SOUND-PIACERE-02]; assesses=[] -->
 
 - `soft-c` — **piacere** = *pya-**CHEH**-reh*: here *c* is before *e*, so it's
   soft (*ch*), and the *ia* glides: *pya-CHE-re*.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-PIACERE-03]; assesses=[] -->
 
 **piacere** = "a pleasure" (and, as a verb, "to please"), from Latin **placēre**,
 *"to please, to be pleasing."* Said on meeting someone, it's short for *"[it's] a
@@ -47,12 +64,14 @@ everywhere:
   different Latin root).
 
 ## Grammar Lens: a one-word courtesy
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-PIACERE-04]; assesses=[] -->
 
 *Piacere* stands alone — you just say it, with a small nod, as you shake hands.
 For a touch more you can say *molto piacere* ("much pleasure") or *piacere di
 conoscerti* ("pleasure to know you").
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-ETYMON-COME-TI-CHIAMI-02, IT-SOUND-PIACERE-02, IT-ETYMON-PIACERE-03, IT-GRAMMAR-PIACERE-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "piacere" — *pya-CHEH-reh*]
@@ -60,6 +79,7 @@ conoscerti* ("pleasure to know you").
 - [YOU SAY: Italian *piacere* and Portuguese *prazer* — twins from *placēre*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-ETYMON-COME-TI-CHIAMI-02, IT-SOUND-PIACERE-02, IT-ETYMON-PIACERE-03, IT-GRAMMAR-PIACERE-04] -->
 
 [PAUSE 3s] What does *piacere* literally mean, and from what? ("A pleasure," ←
 *placēre* "to please.") Its English cousins? (Please, pleasure, placid,

--- a/code/learning/human-languages/italian/lessons/IT-C03-practice.md
+++ b/code/learning/human-languages/italian/lessons/IT-C03-practice.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C03-practice
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 220
 chapter: 3
 type: practice-mix
 headword: (practice)
@@ -8,13 +11,25 @@ concept_tag: CH3-PRACTICE
 prerequisites: [IT-C03-io, IT-C03-mi-chiamo, IT-C03-come-ti-chiami, IT-C03-piacere]
 sounds: []
 roots: []
-est_minutes: 4
+duration:
+  max_seconds: 237
+requires:
+  knowledge: [IT-SOUND-IO-02, IT-ETYMON-IO-03, IT-GRAMMAR-IO-04, IT-SOUND-MI-CHIAMO-02, IT-ETYMON-MI-CHIAMO-03, IT-GRAMMAR-MI-CHIAMO-04, IT-ETYMON-COME-TI-CHIAMI-02, IT-SOUND-PIACERE-02, IT-ETYMON-PIACERE-03, IT-GRAMMAR-PIACERE-04]
+introduces:
+  knowledge: [IT-LEX-C03-PRACTICE-02, IT-NOTICE-C03-PRACTICE-03]
+practises:
+  knowledge: [IT-SOUND-IO-02, IT-ETYMON-IO-03, IT-GRAMMAR-IO-04, IT-SOUND-MI-CHIAMO-02, IT-ETYMON-MI-CHIAMO-03, IT-GRAMMAR-MI-CHIAMO-04, IT-ETYMON-COME-TI-CHIAMI-02, IT-SOUND-PIACERE-02, IT-ETYMON-PIACERE-03, IT-GRAMMAR-PIACERE-04, IT-LEX-C03-PRACTICE-02, IT-NOTICE-C03-PRACTICE-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C03-mi-chiamo, IT-C03-come-ti-chiami, IT-C03-piacere, IT-C02-practice]
 ---
-
 # Practice — introducing yourself in Italian
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] No new words. *io, mi chiamo, come ti chiami, piacere* now assemble
 into a real first meeting — run it formally and informally until the register
@@ -22,6 +37,7 @@ swap is automatic. This slots between your greetings (Ch. 1–2) and farewells
 (Ch. 4).
 
 ## The exchange
+<!-- hl-knowledge: introduces=[IT-LEX-C03-PRACTICE-02]; assesses=[] -->
 
 **Informal** (a peer):
 
@@ -37,6 +53,7 @@ swap is automatic. This slots between your greetings (Ch. 1–2) and farewells
 > — Rossi. **Molto piacere.**
 
 ## What you've built this chapter
+<!-- hl-knowledge: introduces=[IT-NOTICE-C03-PRACTICE-03]; assesses=[] -->
 
 - **io** — "I" (← *ego*), usually **dropped** — the verb ending carries it.
 - **mi chiamo** — "I call myself" (*chiamarsi* ← *clāmāre*, "call out"; kin of
@@ -46,6 +63,7 @@ swap is automatic. This slots between your greetings (Ch. 1–2) and farewells
 - **piacere** — "a pleasure" (← *placēre*; twin of Portuguese *prazer*).
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-IO-02, IT-ETYMON-IO-03, IT-GRAMMAR-IO-04, IT-SOUND-MI-CHIAMO-02, IT-ETYMON-MI-CHIAMO-03, IT-GRAMMAR-MI-CHIAMO-04, IT-ETYMON-COME-TI-CHIAMI-02, IT-SOUND-PIACERE-02, IT-ETYMON-PIACERE-03, IT-GRAMMAR-PIACERE-04, IT-LEX-C03-PRACTICE-02, IT-NOTICE-C03-PRACTICE-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: the full informal meeting, both voices]
@@ -56,6 +74,7 @@ swap is automatic. This slots between your greetings (Ch. 1–2) and farewells
 [REPEAT x2] Run a whole first meeting start to finish.
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-IO-02, IT-ETYMON-IO-03, IT-GRAMMAR-IO-04, IT-SOUND-MI-CHIAMO-02, IT-ETYMON-MI-CHIAMO-03, IT-GRAMMAR-MI-CHIAMO-04, IT-ETYMON-COME-TI-CHIAMI-02, IT-SOUND-PIACERE-02, IT-ETYMON-PIACERE-03, IT-GRAMMAR-PIACERE-04, IT-LEX-C03-PRACTICE-02, IT-NOTICE-C03-PRACTICE-03] -->
 
 [PAUSE 3s] Why does Italian usually drop *io*? (The verb ending says who.) What
 does *mi chiamo* literally mean, and its root? ("I call myself"; *clāmāre*.) What

--- a/code/learning/human-languages/italian/lessons/IT-C04-a-domani.md
+++ b/code/learning/human-languages/italian/lessons/IT-C04-a-domani.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C04-a-domani
+spine_node: SPINE-TAKE-LEAVE
+sequence: 240
 chapter: 4
 type: phrase
 headword: a domani
@@ -9,22 +12,36 @@ prerequisites: [IT-C04-arrivederci]
 sounds: [vowel-a-open]
 roots: [de-mane-latin]
 etymology_hook: "domani ← Latin de mane 'from the morning' — same mane 'morning' as Spanish mañana"
-est_minutes: 3
+duration:
+  max_seconds: 128
+requires:
+  knowledge: [IT-SOUND-ARRIVEDERCI-02, IT-ETYMON-ARRIVEDERCI-03]
+introduces:
+  knowledge: [IT-SOUND-A-DOMANI-02, IT-ETYMON-A-DOMANI-03]
+practises:
+  knowledge: [IT-SOUND-ARRIVEDERCI-02, IT-ETYMON-ARRIVEDERCI-03, IT-SOUND-A-DOMANI-02, IT-ETYMON-A-DOMANI-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C04-arrivederci]
 ---
-
 # a domani — "see you tomorrow"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The "until re-seeing" pattern gives you a whole family of goodbyes:
 just name **when**. First: **a domani**, "to tomorrow."
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[IT-SOUND-A-DOMANI-02]; assesses=[] -->
 
 - **a domani** = *ah doh-**MAH**-nee*: clean open vowels, stress the *-ma-*.
 
 ## The phrase, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-A-DOMANI-03]; assesses=[] -->
 
 - **a** = "to / until" (the same *a* from *arrivederci*).
 - **domani** = "tomorrow," from Latin **dē māne**, *"from the morning."*
@@ -40,12 +57,14 @@ So *a domani* literally says **"until the morning [to come]."** You part by
 pointing at daybreak.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-ARRIVEDERCI-02, IT-ETYMON-ARRIVEDERCI-03, IT-SOUND-A-DOMANI-02, IT-ETYMON-A-DOMANI-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "a domani" — *ah doh-MAH-nee*]
 - [YOU SAY: Italian *domani* and Spanish *mañana* — both from *māne*, "morning"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-ARRIVEDERCI-02, IT-ETYMON-ARRIVEDERCI-03, IT-SOUND-A-DOMANI-02, IT-ETYMON-A-DOMANI-03] -->
 
 [PAUSE 3s] What does *domani* come from, and what does it literally mean? (*Dē
 māne* — "from the morning.") Which Spanish word shares that *māne* root? (*Mañana*

--- a/code/learning/human-languages/italian/lessons/IT-C04-a-piu-tardi.md
+++ b/code/learning/human-languages/italian/lessons/IT-C04-a-piu-tardi.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C04-a-piu-tardi
+spine_node: SPINE-TAKE-LEAVE
+sequence: 260
 chapter: 4
 type: phrase
 headword: a più tardi
@@ -9,24 +12,38 @@ prerequisites: [IT-C04-arrivederci]
 sounds: [piu-glide, r-tap]
 roots: [plus-latin, tardus-latin]
 etymology_hook: "più ← Latin plūs 'more'; tardi ← tardus 'slow, late' → English tardy, retard"
-est_minutes: 3
+duration:
+  max_seconds: 140
+requires:
+  knowledge: [IT-SOUND-ARRIVEDERCI-02, IT-ETYMON-ARRIVEDERCI-03]
+introduces:
+  knowledge: [IT-SOUND-A-PIU-TARDI-02, IT-ETYMON-A-PIU-TARDI-03]
+practises:
+  knowledge: [IT-SOUND-ARRIVEDERCI-02, IT-ETYMON-ARRIVEDERCI-03, IT-SOUND-A-PIU-TARDI-02, IT-ETYMON-A-PIU-TARDI-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C04-a-presto]
 ---
-
 # a più tardi — "see you later"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The last "when" in the set: **a più tardi**, "to later" — literally
 "to *more late*." Two small words, both alive in English.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[IT-SOUND-A-PIU-TARDI-02]; assesses=[] -->
 
 - `piu-glide` — **più** = *pyoo*, one gliding syllable (the accent marks the
   stress).
 - **a più tardi** = *ah pyoo **TAR**-dee*, tapped *r*.
 
 ## The phrase, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-A-PIU-TARDI-03]; assesses=[] -->
 
 - **a** = "to / until."
 - **più** = "more," from Latin **plūs** — the very word English took for
@@ -39,6 +56,7 @@ Together, *più tardi* = **"more late"** = "later." So *a più tardi* is "until
 just as English does with the comparative *-er*.)
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-ARRIVEDERCI-02, IT-ETYMON-ARRIVEDERCI-03, IT-SOUND-A-PIU-TARDI-02, IT-ETYMON-A-PIU-TARDI-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "a più tardi" — *ah pyoo TAR-dee*]
@@ -46,6 +64,7 @@ just as English does with the comparative *-er*.)
 - [YOU SAY: the four goodbyes — arrivederci / a domani / a presto / a più tardi]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-ARRIVEDERCI-02, IT-ETYMON-ARRIVEDERCI-03, IT-SOUND-A-PIU-TARDI-02, IT-ETYMON-A-PIU-TARDI-03] -->
 
 [PAUSE 3s] What do *più* and *tardi* mean, and their English cousins? (*Più* =
 "more" ~ plus; *tardi* = "late" ~ tardy.) So *a più tardi* literally says?

--- a/code/learning/human-languages/italian/lessons/IT-C04-a-presto.md
+++ b/code/learning/human-languages/italian/lessons/IT-C04-a-presto.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C04-a-presto
+spine_node: SPINE-TAKE-LEAVE
+sequence: 250
 chapter: 4
 type: phrase
 headword: a presto
@@ -9,22 +12,36 @@ prerequisites: [IT-C04-arrivederci]
 sounds: [s-clean]
 roots: [praesto-latin]
 etymology_hook: "presto ← Latin praestō 'at hand, ready' → English presto (music: fast)"
-est_minutes: 3
+duration:
+  max_seconds: 132
+requires:
+  knowledge: [IT-SOUND-ARRIVEDERCI-02, IT-ETYMON-ARRIVEDERCI-03]
+introduces:
+  knowledge: [IT-SOUND-A-PRESTO-02, IT-ETYMON-A-PRESTO-03]
+practises:
+  knowledge: [IT-SOUND-ARRIVEDERCI-02, IT-ETYMON-ARRIVEDERCI-03, IT-SOUND-A-PRESTO-02, IT-ETYMON-A-PRESTO-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C04-a-domani]
 ---
-
 # a presto — "see you soon"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Same frame, new "when": **a presto**, "to soon." And *presto* is a
 word English already borrowed whole — from stage magic and music.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[IT-SOUND-A-PRESTO-02]; assesses=[] -->
 
 - **a presto** = *ah **PREH**-stoh*: clean *st*, crisp open *e*.
 
 ## The phrase, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-A-PRESTO-03]; assesses=[] -->
 
 - **a** = "to / until."
 - **presto** = "soon, quickly," from Latin **praestō**, *"at hand, ready,
@@ -41,12 +58,14 @@ English took **presto** straight from Italian:
 So *a presto* is **"until [it is] soon / at hand"** — see you before long.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-ARRIVEDERCI-02, IT-ETYMON-ARRIVEDERCI-03, IT-SOUND-A-PRESTO-02, IT-ETYMON-A-PRESTO-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "a presto" — *ah PREH-stoh*]
 - [YOU SAY: "presto" as music ("fast") and magic ("presto!") — same word]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-ARRIVEDERCI-02, IT-ETYMON-ARRIVEDERCI-03, IT-SOUND-A-PRESTO-02, IT-ETYMON-A-PRESTO-03] -->
 
 [PAUSE 3s] What does *presto* mean, and where has English borrowed it? ("Soon /
 quickly" — in music and magic.) What "stand" root does it share with *stare*?

--- a/code/learning/human-languages/italian/lessons/IT-C04-arrivederci.md
+++ b/code/learning/human-languages/italian/lessons/IT-C04-arrivederci.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C04-arrivederci
+spine_node: SPINE-TAKE-LEAVE
+sequence: 230
 chapter: 4
 type: word
 headword: arrivederci
@@ -9,13 +12,25 @@ prerequisites: []
 sounds: [r-tap, soft-c]
 roots: [re-videre-latin]
 etymology_hook: "arrivederci = a + ri(re-) + vedere 'see' + ci 'us' — 'to our seeing-again', twin of au revoir / auf Wiedersehen"
-est_minutes: 4
+duration:
+  max_seconds: 239
+requires:
+  knowledge: []
+introduces:
+  knowledge: [IT-SOUND-ARRIVEDERCI-02, IT-ETYMON-ARRIVEDERCI-03]
+practises:
+  knowledge: [IT-SOUND-ARRIVEDERCI-02, IT-ETYMON-ARRIVEDERCI-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C02-practice]
 ---
-
 # arrivederci — "goodbye," i.e. "until we meet again"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You can open a conversation in Italian and ask how someone is. Now,
 close it. The standard goodbye is **arrivederci** — and, like its French and
@@ -23,11 +38,13 @@ German cousins, it doesn't say "goodbye" at all. It says **"until we see each
 other again."**
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[IT-SOUND-ARRIVEDERCI-02]; assesses=[] -->
 
 - **arrivederci** = *ar-ree-veh-**DER**-chee*: a tapped double *r*, and the final
   *-ci* is soft (*chee*, Italian *c* before *i*). Stress the *-der-*.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-ARRIVEDERCI-03]; assesses=[] -->
 
 Break it into four pieces you can almost read straight off:
 
@@ -56,6 +73,7 @@ Three languages, one gesture: part by pointing at the reunion, not the parting.
 exact twin of Spanish *adiós*; but for everyday partings it's *arrivederci*.)
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-ARRIVEDERCI-02, IT-ETYMON-ARRIVEDERCI-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "arrivederci" — *ar-ree-veh-DER-chee*]
@@ -63,6 +81,7 @@ exact twin of Spanish *adiós*; but for everyday partings it's *arrivederci*.)
 - [YOU SAY: "vedere" then English "video, vision" — the *see* root]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-ARRIVEDERCI-02, IT-ETYMON-ARRIVEDERCI-03] -->
 
 [PAUSE 3s] What does *arrivederci* literally promise? ("Until we see each other
 again.") What French and German goodbyes share that exact idea? (*au revoir*,

--- a/code/learning/human-languages/italian/lessons/IT-C04-practice.md
+++ b/code/learning/human-languages/italian/lessons/IT-C04-practice.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C04-practice
+spine_node: SPINE-TAKE-LEAVE
+sequence: 270
 chapter: 4
 type: practice-mix
 headword: (practice)
@@ -8,18 +11,31 @@ concept_tag: CH4-PRACTICE
 prerequisites: [IT-C04-arrivederci, IT-C04-a-domani, IT-C04-a-presto, IT-C04-a-piu-tardi]
 sounds: []
 roots: []
-est_minutes: 4
+duration:
+  max_seconds: 203
+requires:
+  knowledge: [IT-SOUND-ARRIVEDERCI-02, IT-ETYMON-ARRIVEDERCI-03, IT-SOUND-A-DOMANI-02, IT-ETYMON-A-DOMANI-03, IT-SOUND-A-PRESTO-02, IT-ETYMON-A-PRESTO-03, IT-SOUND-A-PIU-TARDI-02, IT-ETYMON-A-PIU-TARDI-03]
+introduces:
+  knowledge: [IT-LEX-C04-PRACTICE-02, IT-NOTICE-C04-PRACTICE-03]
+practises:
+  knowledge: [IT-SOUND-ARRIVEDERCI-02, IT-ETYMON-ARRIVEDERCI-03, IT-SOUND-A-DOMANI-02, IT-ETYMON-A-DOMANI-03, IT-SOUND-A-PRESTO-02, IT-ETYMON-A-PRESTO-03, IT-SOUND-A-PIU-TARDI-02, IT-ETYMON-A-PIU-TARDI-03, IT-LEX-C04-PRACTICE-02, IT-NOTICE-C04-PRACTICE-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C04-arrivederci, IT-C04-a-domani, IT-C04-a-presto, IT-C04-a-piu-tardi, IT-C02-practice]
 ---
-
 # Practice — saying goodbye in Italian
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] No new words. You can now open a conversation, ask how someone is, and
 **close** it. Run the goodbyes until the right one comes automatically.
 
-## The closings
+## You'll want to know: the closings
+<!-- hl-knowledge: introduces=[IT-LEX-C04-PRACTICE-02]; assesses=[] -->
 
 **Neutral / polite** (anyone):
 
@@ -37,6 +53,7 @@ reviews_of: [IT-C04-arrivederci, IT-C04-a-domani, IT-C04-a-presto, IT-C04-a-piu-
 > — **Ciao, a presto!**
 
 ## What you've built this chapter
+<!-- hl-knowledge: introduces=[IT-NOTICE-C04-PRACTICE-03]; assesses=[] -->
 
 - **arrivederci** — goodbye ("until we re-see each other"; the *au revoir* /
   *auf Wiedersehen* family). Heavier, final variant: **addio** ("to God," twin
@@ -48,6 +65,7 @@ reviews_of: [IT-C04-arrivederci, IT-C04-a-domani, IT-C04-a-presto, IT-C04-a-piu-
 - **a più tardi** — see you later (*più* ~ plus, *tardi* ~ tardy).
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-ARRIVEDERCI-02, IT-ETYMON-ARRIVEDERCI-03, IT-SOUND-A-DOMANI-02, IT-ETYMON-A-DOMANI-03, IT-SOUND-A-PRESTO-02, IT-ETYMON-A-PRESTO-03, IT-SOUND-A-PIU-TARDI-02, IT-ETYMON-A-PIU-TARDI-03, IT-LEX-C04-PRACTICE-02, IT-NOTICE-C04-PRACTICE-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: greet, ask, and close — "Ciao! Come stai? … A domani!"]
@@ -58,6 +76,7 @@ reviews_of: [IT-C04-arrivederci, IT-C04-a-domani, IT-C04-a-presto, IT-C04-a-piu-
 [REPEAT x2] Open and close a whole tiny exchange without stopping.
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-ARRIVEDERCI-02, IT-ETYMON-ARRIVEDERCI-03, IT-SOUND-A-DOMANI-02, IT-ETYMON-A-DOMANI-03, IT-SOUND-A-PRESTO-02, IT-ETYMON-A-PRESTO-03, IT-SOUND-A-PIU-TARDI-02, IT-ETYMON-A-PIU-TARDI-03, IT-LEX-C04-PRACTICE-02, IT-NOTICE-C04-PRACTICE-03] -->
 
 [PAUSE 3s] Which goodbye means "until we see each other again"? (*Arrivederci*.)
 Which says "to the morning"? (*A domani*.) Which Italian goodbye matches Spanish

--- a/code/learning/human-languages/italian/lessons/IT-C05-abitare.md
+++ b/code/learning/human-languages/italian/lessons/IT-C05-abitare.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C05-abitare
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 290
 chapter: 5
 type: word
 headword: abitare
@@ -9,24 +12,38 @@ prerequisites: [IT-C05-parlare]
 sounds: [r-tap, vowel-a-open]
 roots: [habitare-latin]
 etymology_hook: "abitare ← Latin habitāre 'to dwell' (frequentative of habēre 'to have') → English habitat, inhabit"
-est_minutes: 3
+duration:
+  max_seconds: 167
+requires:
+  knowledge: [IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04]
+introduces:
+  knowledge: [IT-SOUND-ABITARE-02, IT-ETYMON-ABITARE-03, IT-GRAMMAR-ABITARE-04]
+practises:
+  knowledge: [IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04, IT-SOUND-ABITARE-02, IT-ETYMON-ABITARE-03, IT-GRAMMAR-ABITARE-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C05-parlare]
 ---
-
 # abitare — "to live," about *having a place*
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] A second **-are** verb — snap it into the endings you just learned.
 **abitare** ("to live, to dwell") lets you say *where* you live — and it's the
 twin of French *habiter*.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[IT-SOUND-ABITARE-02]; assesses=[] -->
 
 - **abitare** = *a-bee-TA-reh* (Italian dropped the Latin *h-*, but the spelling
   and sense stayed). Clean open vowels, tapped *r*.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-ABITARE-03]; assesses=[] -->
 
 **abitare** comes from Latin **habitāre**, *"to dwell, to keep having [a
 place]"* — the **frequentative** of **habēre**, "to have." To *dwell* is to *keep
@@ -42,6 +59,7 @@ same Latin verb, same meaning. Now you can answer a *dove* ("where") question:
 > **Abito a Roma.** — "I live in Rome." (No *io* — pro-drop.)
 
 ## Grammar Lens: same -are template
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-ABITARE-04]; assesses=[] -->
 
 | (io) abito · (tu) abiti · (lui/lei) abita | (-o / -i / -a) |
 | abitiamo · abitate · abitano | |
@@ -50,6 +68,7 @@ Identical to *parlare* — nothing new. That's the whole point of a regular
 pattern.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04, IT-SOUND-ABITARE-02, IT-ETYMON-ABITARE-03, IT-GRAMMAR-ABITARE-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "abitare" — *a-bee-TA-reh*]
@@ -57,6 +76,7 @@ pattern.
 - [YOU SAY: "Abito a Roma"; and "abitare" ↔ English *habitat*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04, IT-SOUND-ABITARE-02, IT-ETYMON-ABITARE-03, IT-GRAMMAR-ABITARE-04] -->
 
 [PAUSE 3s] What Latin verb is *abitare* from, and what does it literally involve?
 (*habitāre* — "keep having a place," ← *habēre*, "to have.") English cousins?

--- a/code/learning/human-languages/italian/lessons/IT-C05-lavorare.md
+++ b/code/learning/human-languages/italian/lessons/IT-C05-lavorare.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C05-lavorare
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 300
 chapter: 5
 type: word
 headword: lavorare
@@ -9,24 +12,38 @@ prerequisites: [IT-C05-parlare]
 sounds: [r-tap, vowel-a-open]
 roots: [laborare-latin]
 etymology_hook: "lavorare ← Latin labōrāre 'to labour' → English labor, laboratory, elaborate, collaborate"
-est_minutes: 4
+duration:
+  max_seconds: 180
+requires:
+  knowledge: [IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04]
+introduces:
+  knowledge: [IT-SOUND-LAVORARE-02, IT-ETYMON-LAVORARE-03, IT-GRAMMAR-LAVORARE-04]
+practises:
+  knowledge: [IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04, IT-SOUND-LAVORARE-02, IT-ETYMON-LAVORARE-03, IT-GRAMMAR-LAVORARE-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C05-abitare]
 ---
-
 # lavorare — "to work," the honest kind
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] A third **-are** verb — and a satisfying twist. Where Spanish and
 French built their word for "work" out of **torture**, **Italian took a different
 road entirely**: *lavorare*, from plain Latin *"to labour."*
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[IT-SOUND-LAVORARE-02]; assesses=[] -->
 
 - **lavorare** = *la-vo-RA-reh*: clean vowels, tapped *r*. (The *v* is a real
   *v*, unlike Spanish.)
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-LAVORARE-03]; assesses=[] -->
 
 **lavorare** comes from Latin **labōrāre**, *"to labour, to work, to strive"* —
 from **labor**, "toil, effort." No torture device here; just honest labour. The
@@ -48,12 +65,14 @@ it as *labour*. A single glance at three verbs, and you see two Roman attitudes 
 a day's work.
 
 ## Grammar Lens: same -are template
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-LAVORARE-04]; assesses=[] -->
 
 | (io) lavoro · (tu) lavori · (lui/lei) lavora | (-o / -i / -a) |
 
 > **Lavoro a Milano.** — "I work in Milan."
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04, IT-SOUND-LAVORARE-02, IT-ETYMON-LAVORARE-03, IT-GRAMMAR-LAVORARE-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "lavorare" — *la-vo-RA-reh*]
@@ -62,6 +81,7 @@ a day's work.
   (torture)]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04, IT-SOUND-LAVORARE-02, IT-ETYMON-LAVORARE-03, IT-GRAMMAR-LAVORARE-04] -->
 
 [PAUSE 3s] What Latin word is *lavorare* from, and its English cousins?
 (*labōrāre* — labor, laboratory, elaborate.) How does its root differ from Spanish

--- a/code/learning/human-languages/italian/lessons/IT-C05-parlare.md
+++ b/code/learning/human-languages/italian/lessons/IT-C05-parlare.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C05-parlare
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 280
 chapter: 5
 type: word
 headword: parlare
@@ -9,24 +12,38 @@ prerequisites: [IT-C03-io, IT-C02-come]
 sounds: [r-tap, vowel-a-open]
 roots: [parabolare-latin]
 etymology_hook: "parlare ← Late Latin parabolāre 'to tell parables' (← parabola) → English parable, parole; = French parler"
-est_minutes: 4
+duration:
+  max_seconds: 219
+requires:
+  knowledge: [IT-SOUND-IO-02, IT-ETYMON-IO-03, IT-GRAMMAR-IO-04, IT-SOUND-COME-02, IT-ETYMON-COME-03]
+introduces:
+  knowledge: [IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04]
+practises:
+  knowledge: [IT-SOUND-IO-02, IT-ETYMON-IO-03, IT-GRAMMAR-IO-04, IT-SOUND-COME-02, IT-ETYMON-COME-03, IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C03-practice, IT-C04-practice]
 ---
-
 # parlare — "to speak," the model -are verb
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Until now you've assembled fixed phrases. **parlare** ("to speak") is
 your first real **verb** — and the model for Italian's biggest family, the
 **-are** verbs. Learn this one pattern and you drive thousands.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[IT-SOUND-PARLARE-02]; assesses=[] -->
 
 - `r-tap` — a single tapped *r*: **parlare** = *par-LA-reh*.
 - `vowel-a-open` — clean open *ah* vowels.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-PARLARE-03]; assesses=[] -->
 
 **parlare** comes from Late Latin **parabolāre**, *"to tell parables, to
 discourse"* — from **parabola**, "a comparison, a speech" (Greek *parabolē*). So
@@ -41,6 +58,7 @@ word** — both from *parabolāre*. **Spanish went a different way**: its "to sp
 "tell parables"; Spain "tells fables."
 
 ## Grammar Lens: the -are present tense (and pro-drop)
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-PARLARE-04]; assesses=[] -->
 
 Drop **-are** to get *parl-*, then add the endings:
 
@@ -63,6 +81,7 @@ building:
   wohne* — grammar needs a subject).
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-IO-02, IT-ETYMON-IO-03, IT-GRAMMAR-IO-04, IT-SOUND-COME-02, IT-ETYMON-COME-03, IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "parlare" — *par-LA-reh*]
@@ -70,6 +89,7 @@ building:
 - [YOU SAY: parlare / parler (same *parabolāre*) vs Spanish *hablar* (*fabulārī*)]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-IO-02, IT-ETYMON-IO-03, IT-GRAMMAR-IO-04, IT-SOUND-COME-02, IT-ETYMON-COME-03, IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04] -->
 
 [PAUSE 3s] What Latin word gives *parlare*, and which French verb is its twin?
 (*parabolāre* — French *parler*.) Which Romance "speak" verb is from a *different*

--- a/code/learning/human-languages/italian/lessons/IT-C05-parlo-italiano.md
+++ b/code/learning/human-languages/italian/lessons/IT-C05-parlo-italiano.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C05-parlo-italiano
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 310
 chapter: 5
 type: phrase
 headword: Parlo italiano
@@ -9,19 +12,32 @@ prerequisites: [IT-C05-parlare]
 sounds: [ia-glide, vowel-a-open]
 roots: [italia-latin]
 etymology_hook: "italiano ← Italia, the ancient name of the peninsula (perhaps Oscan víteliú, 'land of calves')"
-est_minutes: 4
+duration:
+  max_seconds: 213
+requires:
+  knowledge: [IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04]
+introduces:
+  knowledge: [IT-LEX-PARLO-ITALIANO-02, IT-LEX-PARLO-ITALIANO-03]
+practises:
+  knowledge: [IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04, IT-LEX-PARLO-ITALIANO-02, IT-LEX-PARLO-ITALIANO-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C05-parlare, IT-C03-io]
 ---
-
 # Parlo italiano — your first real sentence
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The moment it pays off: you take a **verb** you conjugated and a
 **noun**, and build a sentence no one handed you — *Parlo italiano*, "I speak
 Italian." (Italian *parlo* covers both "I speak" and "I am speaking.")
 
-## The new word: italiano
+## You'll want to know: italiano
+<!-- hl-knowledge: introduces=[IT-LEX-PARLO-ITALIANO-02]; assesses=[] -->
 
 **italiano** = "Italian," from **Italia** — the ancient name of the peninsula
 itself. Its own origin is delightfully humble: many scholars trace *Italia* to
@@ -29,7 +45,8 @@ Oscan **víteliú**, *"land of calves / young cattle"* (kin to Latin *vitulus*,
 "calf," and perhaps English *veal*). So *Italia* may literally have meant
 **"Calf-land."** Say it *ee-ta-LYA-no*.
 
-## The sentence, assembled
+## You'll want to know: the assembled sentence
+<!-- hl-knowledge: introduces=[IT-LEX-PARLO-ITALIANO-03]; assesses=[] -->
 
 Snap two things you own together:
 
@@ -53,6 +70,7 @@ This closes the **pronoun-rule circle** you've watched across five languages:
 Swap the pieces: **Abito a Roma.** · **Lavoro a Milano.** · **Parli italiano?**
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04, IT-LEX-PARLO-ITALIANO-02, IT-LEX-PARLO-ITALIANO-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "Parlo italiano" — *PAR-lo ee-ta-LYA-no*]
@@ -60,6 +78,7 @@ Swap the pieces: **Abito a Roma.** · **Lavoro a Milano.** · **Parli italiano?*
 - [YOU SAY: "italiano" ← *Italia*, maybe "calf-land" — a humble, farmerly name]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04, IT-LEX-PARLO-ITALIANO-02, IT-LEX-PARLO-ITALIANO-03] -->
 
 [PAUSE 3s] Where does *italiano* come from, and what might *Italia* have meant?
 (*Italia*; perhaps "land of calves.") In *Parlo italiano*, why no *io* and no

--- a/code/learning/human-languages/italian/lessons/IT-C05-practice.md
+++ b/code/learning/human-languages/italian/lessons/IT-C05-practice.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C05-practice
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 320
 chapter: 5
 type: practice-mix
 headword: (practice)
@@ -8,19 +11,32 @@ concept_tag: CH5-PRACTICE
 prerequisites: [IT-C05-parlare, IT-C05-abitare, IT-C05-lavorare, IT-C05-parlo-italiano]
 sounds: []
 roots: []
-est_minutes: 4
+duration:
+  max_seconds: 242
+requires:
+  knowledge: [IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04, IT-SOUND-ABITARE-02, IT-ETYMON-ABITARE-03, IT-GRAMMAR-ABITARE-04, IT-SOUND-LAVORARE-02, IT-ETYMON-LAVORARE-03, IT-GRAMMAR-LAVORARE-04, IT-LEX-PARLO-ITALIANO-02, IT-LEX-PARLO-ITALIANO-03]
+introduces:
+  knowledge: [IT-GRAMMAR-PRACTICE-02, IT-GRAMMAR-PRACTICE-03, IT-NOTICE-PRACTICE-04]
+practises:
+  knowledge: [IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04, IT-SOUND-ABITARE-02, IT-ETYMON-ABITARE-03, IT-GRAMMAR-ABITARE-04, IT-SOUND-LAVORARE-02, IT-ETYMON-LAVORARE-03, IT-GRAMMAR-LAVORARE-04, IT-LEX-PARLO-ITALIANO-02, IT-LEX-PARLO-ITALIANO-03, IT-GRAMMAR-PRACTICE-02, IT-GRAMMAR-PRACTICE-03, IT-NOTICE-PRACTICE-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C05-parlare, IT-C05-abitare, IT-C05-lavorare, IT-C05-parlo-italiano, IT-C03-practice]
 ---
-
 # Practice — making sentences with -are verbs
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] For the first time you're **building** Italian sentences from a
 pattern, not reciting phrases. Drill the three verbs until the endings are
 automatic — and remember, Italian drops the *io*.
 
-## Conjugate on command
+## Grammar Lens: conjugate on command
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-PRACTICE-02]; assesses=[] -->
 
 [PAUSE 1s] Run each through *io / tu / lui-lei* (pronoun dropped in speech):
 
@@ -30,13 +46,15 @@ automatic — and remember, Italian drops the *io*.
 
 Same endings every time (**-o / -i / -a**), and no pronoun needed.
 
-## Say something real
+## Grammar Lens: say something real
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-PRACTICE-03]; assesses=[] -->
 
 > — **Parli** italiano? — Sì, **parlo** un po'. E tu?
 > — Anch'io. **Dove abiti**? — **Abito** a Roma, e **lavoro** a Milano.
 > — Grazie! — Prego.
 
 ## What you've built this chapter
+<!-- hl-knowledge: introduces=[IT-NOTICE-PRACTICE-04]; assesses=[] -->
 
 - **the regular -are present tense** — drop *-are*, add *-o/-i/-a/-iamo/-ate/-ano*;
   the pronoun is **dropped** (like Spanish).
@@ -49,6 +67,7 @@ Same endings every time (**-o / -i / -a**), and no pronoun needed.
   FR *je parle* (silent endings) + DE *ich lerne* (grammar) **keep**.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04, IT-SOUND-ABITARE-02, IT-ETYMON-ABITARE-03, IT-GRAMMAR-ABITARE-04, IT-SOUND-LAVORARE-02, IT-ETYMON-LAVORARE-03, IT-GRAMMAR-LAVORARE-04, IT-LEX-PARLO-ITALIANO-02, IT-LEX-PARLO-ITALIANO-03, IT-GRAMMAR-PRACTICE-02, IT-GRAMMAR-PRACTICE-03, IT-NOTICE-PRACTICE-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: conjugate all three verbs, io/tu/lui — no pronoun spoken]
@@ -58,6 +77,7 @@ Same endings every time (**-o / -i / -a**), and no pronoun needed.
 [REPEAT x2] "Parli italiano? — Sì, parlo un po'."
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04, IT-SOUND-ABITARE-02, IT-ETYMON-ABITARE-03, IT-GRAMMAR-ABITARE-04, IT-SOUND-LAVORARE-02, IT-ETYMON-LAVORARE-03, IT-GRAMMAR-LAVORARE-04, IT-LEX-PARLO-ITALIANO-02, IT-LEX-PARLO-ITALIANO-03, IT-GRAMMAR-PRACTICE-02, IT-GRAMMAR-PRACTICE-03, IT-NOTICE-PRACTICE-04] -->
 
 [PAUSE 3s] What are the three singular *-are* endings? (*-o / -i / -a*.) Give the
 "I" forms of the three verbs. (*Parlo, abito, lavoro*.) Which languages drop the

--- a/code/learning/human-languages/italian/lessons/IT-C06-numeri-1-5.md
+++ b/code/learning/human-languages/italian/lessons/IT-C06-numeri-1-5.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C06-numeri-1-5
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 330
 chapter: 6
 type: word
 headword: uno, due, tre, quattro, cinque
@@ -9,19 +12,32 @@ prerequisites: []
 sounds: [double-tt, c-before-i]
 roots: [unus-duo-tres-latin]
 etymology_hook: "uno/due/tre/quattro/cinque ← ūnus/duo/trēs/quattuor/quīnque — Italian stays closest to Latin (cinque keeps the -que; = Spanish cinco, French cinq)"
-est_minutes: 4
+duration:
+  max_seconds: 214
+requires:
+  knowledge: []
+introduces:
+  knowledge: [IT-SOUND-NUMERI-1-5-02, IT-ETYMON-NUMERI-1-5-03, IT-GRAMMAR-NUMERI-1-5-04]
+practises:
+  knowledge: [IT-SOUND-NUMERI-1-5-02, IT-ETYMON-NUMERI-1-5-03, IT-GRAMMAR-NUMERI-1-5-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C05-practice]
 ---
-
 # uno, due, tre, quattro, cinque — counting to five
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Of all the Romance sisters, **Italian kept the numbers closest to
 Latin** — it stayed in Italy, next to Rome, and wore the words down the least.
 Beside each you'll see the Spanish and French cousins for contrast.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[IT-SOUND-NUMERI-1-5-02]; assesses=[] -->
 
 - `double-tt` — **quattro**: hold the double *t* audibly, *KWAT-tro* (Italian
   really doubles its consonants).
@@ -29,6 +45,7 @@ Beside each you'll see the Spanish and French cousins for contrast.
   the *-que* stays a hard *kw*.
 
 ## The numbers, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-NUMERI-1-5-03]; assesses=[] -->
 
 | Italian | ← Latin | Spanish / French | English cousins |
 |---|---|---|---|
@@ -44,6 +61,7 @@ while Spanish softened it to *cinco* and French clipped it to *cinq*. And
 *quattro*-anything. Italian is the sister who changed her Latin the least.
 
 ## Grammar Lens: uno → un / uno / una
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-NUMERI-1-5-04]; assesses=[] -->
 
 **uno** is also "a/an," and it flexes by gender and the following sound: **un**
 (before most masc. nouns), **uno** (before tricky masc. clusters like *s+consonant*
@@ -51,6 +69,7 @@ or *z-*), **una** (fem.). *un caffè* "a/one coffee," *una birra* "a/one beer." 
 others (*due, tre…*) don't change.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-NUMERI-1-5-02, IT-ETYMON-NUMERI-1-5-03, IT-GRAMMAR-NUMERI-1-5-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "uno, due, tre, quattro, cinque" — count up]
@@ -59,6 +78,7 @@ others (*due, tre…*) don't change.
 - [YOU SAY: "un caffè, una birra" — *uno* → un/una before a noun]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-NUMERI-1-5-02, IT-ETYMON-NUMERI-1-5-03, IT-GRAMMAR-NUMERI-1-5-04] -->
 
 [PAUSE 3s] Give 1–5 in Italian. (*Uno, due, tre, quattro, cinque*.) Which Italian
 number kept Latin *quīnque* most intact, versus Spanish and French? (*cinque*, vs

--- a/code/learning/human-languages/italian/lessons/IT-C06-numeri-6-10.md
+++ b/code/learning/human-languages/italian/lessons/IT-C06-numeri-6-10.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C06-numeri-6-10
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 340
 chapter: 6
 type: word
 headword: sei, sette, otto, nove, dieci
@@ -9,25 +12,39 @@ prerequisites: [IT-C06-numeri-1-5]
 sounds: [double-tt, c-before-i]
 roots: [sex-septem-octo-latin]
 etymology_hook: "sette/otto/nove/dieci ← septem/octō/novem/decem → settembre/ottobre/novembre/dicembre (= Spanish siete/ocho/nueve/diez)"
-est_minutes: 4
+duration:
+  max_seconds: 218
+requires:
+  knowledge: [IT-SOUND-NUMERI-1-5-02, IT-ETYMON-NUMERI-1-5-03, IT-GRAMMAR-NUMERI-1-5-04]
+introduces:
+  knowledge: [IT-SOUND-NUMERI-6-10-02, IT-ETYMON-NUMERI-6-10-03, IT-GRAMMAR-NUMERI-6-10-04]
+practises:
+  knowledge: [IT-SOUND-NUMERI-1-5-02, IT-ETYMON-NUMERI-1-5-03, IT-GRAMMAR-NUMERI-1-5-04, IT-SOUND-NUMERI-6-10-02, IT-ETYMON-NUMERI-6-10-03, IT-GRAMMAR-NUMERI-6-10-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C06-numeri-1-5]
 ---
-
 # sei, sette, otto, nove, dieci — and the calendar's secret
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The rest of the count — and, like Spanish and French, Italian hides the
 same calendar fact: **settembre–dicembre are Latin for 7, 8, 9, 10.** Italian even
 keeps the old Latin double consonants that show it.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[IT-SOUND-NUMERI-6-10-02]; assesses=[] -->
 
 - `double-tt` — **sette** = *SET-teh*, **otto** = *OT-toh*: lean on the doubled
   *t*, a giveaway that Latin's *-pt-* and *-ct-* both collapsed into *-tt-*.
 - `c-before-i` — **dieci** = *DYE-chee* (the *c* before *i* → "ch").
 
 ## The numbers, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-NUMERI-6-10-03]; assesses=[] -->
 
 | Italian | ← Latin | Spanish twin | English cousins |
 |---|---|---|---|
@@ -44,6 +61,7 @@ became *-tt-* → **otto**. Italian didn't drop those clusters (as French did in
 the 8 side by side.
 
 ## Grammar Lens: why the months are "off by two"
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-NUMERI-6-10-04]; assesses=[] -->
 
 *Settembre* means "7th," but it's the **9th** month. The old **Roman year began in
 March**, so *September* really was the seventh; later *luglio* and *agosto* (July
@@ -52,6 +70,7 @@ The Latin numbers stuck to the labels. Every *dicembre*, you say Roman "**ten**"
 just as in Spanish *diciembre* and French *décembre*.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-NUMERI-1-5-02, IT-ETYMON-NUMERI-1-5-03, IT-GRAMMAR-NUMERI-1-5-04, IT-SOUND-NUMERI-6-10-02, IT-ETYMON-NUMERI-6-10-03, IT-GRAMMAR-NUMERI-6-10-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "sei, sette, otto, nove, dieci" — finish the count]
@@ -59,6 +78,7 @@ just as in Spanish *diciembre* and French *décembre*.
 - [YOU SAY: "octō → otto" — the *-ct-* becoming a doubled *-tt-*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-NUMERI-1-5-02, IT-ETYMON-NUMERI-1-5-03, IT-GRAMMAR-NUMERI-1-5-04, IT-SOUND-NUMERI-6-10-02, IT-ETYMON-NUMERI-6-10-03, IT-GRAMMAR-NUMERI-6-10-04] -->
 
 [PAUSE 3s] Give 6–10 in Italian. (*Sei, sette, otto, nove, dieci*.) What happened
 to Latin's *-ct-* in *octō → otto*? (It assimilated to a doubled *-tt-*.) Why is

--- a/code/learning/human-languages/italian/lessons/IT-C07-giorni-1.md
+++ b/code/learning/human-languages/italian/lessons/IT-C07-giorni-1.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C07-giorni-1
+spine_node: SPINE-TIME-OF-DAY
+sequence: 350
 chapter: 7
 type: word
 headword: lunedì, martedì, mercoledì, giovedì, venerdì
@@ -9,26 +12,40 @@ prerequisites: [IT-C06-numeri-6-10]
 sounds: [final-stress-i, c-before-i]
 roots: [dies-latin, planet-gods]
 etymology_hook: "lunedì/martedì… = [planet] + dì (← diēs 'day'); same Roman planet-week as French, with the accented -dì kept audible; Spanish twins lunes/martes"
-est_minutes: 4
+duration:
+  max_seconds: 196
+requires:
+  knowledge: [IT-SOUND-NUMERI-6-10-02, IT-ETYMON-NUMERI-6-10-03, IT-GRAMMAR-NUMERI-6-10-04]
+introduces:
+  knowledge: [IT-SOUND-GIORNI-1-02, IT-GRAMMAR-GIORNI-1-03]
+practises:
+  knowledge: [IT-SOUND-NUMERI-6-10-02, IT-ETYMON-NUMERI-6-10-03, IT-GRAMMAR-NUMERI-6-10-04, IT-SOUND-GIORNI-1-02, IT-GRAMMAR-GIORNI-1-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C06-numeri-6-10]
 ---
-
 # lunedì to venerdì — the planet-week, Italian-style
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Italy sat at the centre of the Roman world, so its weekday names are
 the **planet-week** almost undisturbed — the same map of the sky French uses. The
 tell is the little accented **-dì** at the end of each.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[IT-SOUND-GIORNI-1-02]; assesses=[] -->
 
 - `final-stress-i` — the **-dì** carries a **written accent** and the **stress**:
   *lu-ne-DÌ*, *mar-te-DÌ*. That accent marks "day" (*diēs*) and where your voice
   lands.
 - `c-before-i` — **mercoledì** = *mer-co-le-DÌ* (hard *c* here, before *o*).
 
-## The pattern: [planet] + dì
+## Grammar Lens: [planet] + dì
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-GIORNI-1-03]; assesses=[] -->
 
 **dì** is Latin **diēs**, "day" — the same *-di* you'd hear in French *lundi*.
 Before it sits a **planet-god**:
@@ -48,6 +65,7 @@ And *giovedì* wears **Giove**, the Italian name of Jupiter — the same king-go
 English honours as Thor in *Thursday*.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-NUMERI-6-10-02, IT-ETYMON-NUMERI-6-10-03, IT-GRAMMAR-NUMERI-6-10-04, IT-SOUND-GIORNI-1-02, IT-GRAMMAR-GIORNI-1-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "lunedì, martedì, mercoledì, giovedì, venerdì" — mind the final stress]
@@ -56,6 +74,7 @@ English honours as Thor in *Thursday*.
 - [YOU SAY: "-dì = diēs = day" — the accented tail]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-NUMERI-6-10-02, IT-ETYMON-NUMERI-6-10-03, IT-GRAMMAR-NUMERI-6-10-04, IT-SOUND-GIORNI-1-02, IT-GRAMMAR-GIORNI-1-03] -->
 
 [PAUSE 3s] What is the accented *-dì*, and from what Latin word? ("Day," ← *diēs*.)
 Which planet is *giovedì*? (Jupiter — *Giove*.) How do Italian/French treat the

--- a/code/learning/human-languages/italian/lessons/IT-C07-giorni-2.md
+++ b/code/learning/human-languages/italian/lessons/IT-C07-giorni-2.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C07-giorni-2
+spine_node: SPINE-TIME-OF-DAY
+sequence: 360
 chapter: 7
 type: word
 headword: sabato, domenica
@@ -9,19 +12,32 @@ prerequisites: [IT-C07-giorni-1]
 sounds: [double-none, stress-first]
 roots: [sabbatum-latin, dominica-latin]
 etymology_hook: "sabato ← Sabbatum (Sabbath), domenica ← diēs Dominica ('the Lord's day') — Italy's weekend keeps the religious names, twins of Spanish sábado/domingo"
-est_minutes: 4
+duration:
+  max_seconds: 157
+requires:
+  knowledge: [IT-SOUND-GIORNI-1-02, IT-GRAMMAR-GIORNI-1-03]
+introduces:
+  knowledge: [IT-ETYMON-GIORNI-2-02]
+practises:
+  knowledge: [IT-SOUND-GIORNI-1-02, IT-GRAMMAR-GIORNI-1-03, IT-ETYMON-GIORNI-2-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C07-giorni-1, IT-C06-numeri-6-10]
 ---
-
 # sabato and domenica — the religious weekend
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The five weekdays were planets; the two weekend days are **faith**. Here
 the accented *-dì* disappears, because these names never came from *diēs* + a god
 — they came from the Sabbath and the Lord.
 
 ## The two days, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-GIORNI-2-02]; assesses=[] -->
 
 | Italian | ← Latin | meaning | Spanish twin |
 |---|---|---|---|
@@ -39,6 +55,7 @@ the accented *-dì* disappears, because these names never came from *diēs* + a 
   *diēs* went feminine here.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-GIORNI-1-02, IT-GRAMMAR-GIORNI-1-03, IT-ETYMON-GIORNI-2-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: the full week — "lunedì … venerdì, sabato, domenica"]
@@ -46,6 +63,7 @@ the accented *-dì* disappears, because these names never came from *diēs* + a 
 - [YOU SAY: the sisters — "sabato / sábado", "domenica / domingo"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-GIORNI-1-02, IT-GRAMMAR-GIORNI-1-03, IT-ETYMON-GIORNI-2-02] -->
 
 [PAUSE 3s] Give all seven Italian days. (*Lunedì … domenica*.) Where does *sabato*
 come from? (The **Sabbath**, *Sabbatum* ← Hebrew *shabbāt*.) What does *domenica*

--- a/code/learning/human-languages/italian/lessons/IT-C08-mezzogiorno-mezzanotte.md
+++ b/code/learning/human-languages/italian/lessons/IT-C08-mezzogiorno-mezzanotte.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C08-mezzogiorno-mezzanotte
+spine_node: SPINE-TIME-OF-DAY
+sequence: 380
 chapter: 8
 type: word
 headword: mezzogiorno, mezzanotte
@@ -9,23 +12,37 @@ prerequisites: [IT-C08-ora]
 sounds: [double-zz, gli-none]
 roots: [medius-latin, diurnum-noctem-latin]
 etymology_hook: "mezzogiorno = mezzo + giorno ('mid-day'), mezzanotte = mezza + notte ('mid-night'); mezzo ← medius, twin of French midi/minuit"
-est_minutes: 4
+duration:
+  max_seconds: 196
+requires:
+  knowledge: [IT-SOUND-ORA-02, IT-ETYMON-ORA-03, IT-GRAMMAR-ORA-04]
+introduces:
+  knowledge: [IT-SOUND-MEZZOGIORNO-MEZZANOTTE-02, IT-ETYMON-MEZZOGIORNO-MEZZANOTTE-03]
+practises:
+  knowledge: [IT-SOUND-ORA-02, IT-ETYMON-ORA-03, IT-GRAMMAR-ORA-04, IT-SOUND-MEZZOGIORNO-MEZZANOTTE-02, IT-ETYMON-MEZZOGIORNO-MEZZANOTTE-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C08-ora, IT-C07-giorni-2]
 ---
-
 # mezzogiorno and mezzanotte — Italy's noon and midnight
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The two unnumbered hours. **mezzogiorno** (noon) and **mezzanotte**
 (midnight) are, like their French cousins, the **middle** of the day and the night —
 built from *mezzo* "half/middle" plus *giorno* "day" and *notte* "night."
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[IT-SOUND-MEZZOGIORNO-MEZZANOTTE-02]; assesses=[] -->
 
 - `double-zz` — **mezzo** = *MED-dzo*, the doubled *zz* a hard "ts/dz" — lean on it.
 
 ## The two words, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-MEZZOGIORNO-MEZZANOTTE-03]; assesses=[] -->
 
 The front piece is **mezzo/mezza**, "half, middle," from Latin **medius** (cousin
 of English *medium, mid*, and of French *mi-* in *midi*):
@@ -48,6 +65,7 @@ To use them, they *are* the hour:
 > **È mezzogiorno.** — "It is noon." **È mezzanotte.** — "It is midnight."
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-ORA-02, IT-ETYMON-ORA-03, IT-GRAMMAR-ORA-04, IT-SOUND-MEZZOGIORNO-MEZZANOTTE-02, IT-ETYMON-MEZZOGIORNO-MEZZANOTTE-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "mezzogiorno" (noon), "mezzanotte" (midnight)]
@@ -55,6 +73,7 @@ To use them, they *are* the hour:
 - [YOU SAY: "È mezzogiorno. È mezzanotte." — singular *è*, no number]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-ORA-02, IT-ETYMON-ORA-03, IT-GRAMMAR-ORA-04, IT-SOUND-MEZZOGIORNO-MEZZANOTTE-02, IT-ETYMON-MEZZOGIORNO-MEZZANOTTE-03] -->
 
 [PAUSE 3s] What do *mezzogiorno* and *mezzanotte* literally mean? ("Mid-day" and
 "mid-night.") What is *mezzo/mezza* from, and its French cousin? (Latin *medius*;

--- a/code/learning/human-languages/italian/lessons/IT-C08-ora.md
+++ b/code/learning/human-languages/italian/lessons/IT-C08-ora.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C08-ora
+spine_node: SPINE-TIME-OF-DAY
+sequence: 370
 chapter: 8
 type: word
 headword: ora
@@ -9,23 +12,37 @@ prerequisites: [IT-C06-numeri-1-5]
 sounds: [open-o, r-single]
 roots: [hora-latin, hora-greek]
 etymology_hook: "ora ← Latin hōra ← Greek hṓrā → hour; time is told with the feminine article: 'sono le due' = 'it is the two [hours]'"
-est_minutes: 4
+duration:
+  max_seconds: 210
+requires:
+  knowledge: [IT-SOUND-NUMERI-1-5-02, IT-ETYMON-NUMERI-1-5-03, IT-GRAMMAR-NUMERI-1-5-04]
+introduces:
+  knowledge: [IT-SOUND-ORA-02, IT-ETYMON-ORA-03, IT-GRAMMAR-ORA-04]
+practises:
+  knowledge: [IT-SOUND-NUMERI-1-5-02, IT-ETYMON-NUMERI-1-5-03, IT-GRAMMAR-NUMERI-1-5-04, IT-SOUND-ORA-02, IT-ETYMON-ORA-03, IT-GRAMMAR-ORA-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C06-numeri-1-5, IT-C07-giorni-2]
 ---
-
 # ora — the hour, told with "le"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Italian's word for "hour" is **ora**, straight from Latin **hōra** (which
 Rome took from Greek *hṓrā*, "a time of day"). Telling the time in Italian has one
 neat twist: you use the **feminine article** and let *ore* ("hours") stay implied.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[IT-SOUND-ORA-02]; assesses=[] -->
 
 - `open-o` — **ora** = *OH-ra*, open *o*, single tapped *r*.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-ORA-03]; assesses=[] -->
 
 **ora** ← Latin **hōra** ← Greek **hṓrā**. It's the closest of the sisters to the
 Latin: French wore it to *heure*, but Italian barely touched it — *hōra → ora*
@@ -33,6 +50,7 @@ Latin: French wore it to *heure*, but Italian barely touched it — *hōra → o
 *hour*, and as German's borrowed *Uhr*.
 
 ## Grammar Lens: "è l'una" but "sono le due"
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-ORA-04]; assesses=[] -->
 
 Here's the twist. Italian tells the time with the **feminine article** (because
 *ora/ore* is feminine), and the verb agrees with the number:
@@ -48,6 +66,7 @@ things and drops the word *ore* entirely; the article **le** carries it. Only
 **one o'clock** is singular (*è l'una*); from two on, it's *sono le …*.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-NUMERI-1-5-02, IT-ETYMON-NUMERI-1-5-03, IT-GRAMMAR-NUMERI-1-5-04, IT-SOUND-ORA-02, IT-ETYMON-ORA-03, IT-GRAMMAR-ORA-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "ora" — *OH-ra*]
@@ -55,6 +74,7 @@ things and drops the word *ore* entirely; the article **le** carries it. Only
 - [YOU SAY: "ora / heure / Uhr / hour" — all Latin *hōra*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-NUMERI-1-5-02, IT-ETYMON-NUMERI-1-5-03, IT-GRAMMAR-NUMERI-1-5-04, IT-SOUND-ORA-02, IT-ETYMON-ORA-03, IT-GRAMMAR-ORA-04] -->
 
 [PAUSE 3s] What word is *ora* from, and its sisters? (Latin *hōra* ← Greek *hṓrā*;
 French *heure*, German *Uhr*, English *hour*.) Why "*sono le* due" but "*è l'*una"?

--- a/code/learning/human-languages/italian/lessons/IT-C09-mesi.md
+++ b/code/learning/human-languages/italian/lessons/IT-C09-mesi.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C09-mesi
+spine_node: SPINE-TIME-OF-DAY
+sequence: 390
 chapter: 9
 type: word
 headword: i mesi
@@ -9,13 +12,25 @@ prerequisites: [IT-C06-numeri-6-10, IT-C07-giorni-1]
 sounds: [double-gg, c-before-i]
 roots: [latin-months, roman-gods]
 etymology_hook: "Italy kept the months closest to Latin: gennaio←Januarius, marzo←Mars (= martedì!), settembre–dicembre = the Latin 7–10 you learned as numbers"
-est_minutes: 4
+duration:
+  max_seconds: 188
+requires:
+  knowledge: [IT-SOUND-NUMERI-6-10-02, IT-ETYMON-NUMERI-6-10-03, IT-GRAMMAR-NUMERI-6-10-04, IT-SOUND-GIORNI-1-02, IT-GRAMMAR-GIORNI-1-03]
+introduces:
+  knowledge: [IT-ETYMON-MESI-02]
+practises:
+  knowledge: [IT-SOUND-NUMERI-6-10-02, IT-ETYMON-NUMERI-6-10-03, IT-GRAMMAR-NUMERI-6-10-04, IT-SOUND-GIORNI-1-02, IT-GRAMMAR-GIORNI-1-03, IT-ETYMON-MESI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C06-numeri-6-10, IT-C07-giorni-1]
 ---
-
 # i mesi — Rome's own months
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Sitting next to Rome, Italian kept the month names **closest to Latin**
 of all the sisters — the same procession of gods and Caesars, barely worn. And two
@@ -23,6 +38,7 @@ things you know pay off: *marzo* is the war-god of *martedì*, and *settembre–
 dicembre* are the Latin numbers 7–10.
 
 ## The months, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-MESI-02]; assesses=[] -->
 
 | Italian | ← Latin | who / what | Spanish twin |
 |---|---|---|---|
@@ -49,6 +65,7 @@ keep the doubled/assimilated look (*ottobre*, like *otto*). And two payoffs land
   and shifted the count.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-NUMERI-6-10-02, IT-ETYMON-NUMERI-6-10-03, IT-GRAMMAR-NUMERI-6-10-04, IT-SOUND-GIORNI-1-02, IT-GRAMMAR-GIORNI-1-03, IT-ETYMON-MESI-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: the twelve — "gennaio, febbraio, marzo … novembre, dicembre"]
@@ -56,6 +73,7 @@ keep the doubled/assimilated look (*ottobre*, like *otto*). And two payoffs land
 - [YOU SAY: "settembre = 7, dicembre = 10"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-NUMERI-6-10-02, IT-ETYMON-NUMERI-6-10-03, IT-GRAMMAR-NUMERI-6-10-04, IT-SOUND-GIORNI-1-02, IT-GRAMMAR-GIORNI-1-03, IT-ETYMON-MESI-02] -->
 
 [PAUSE 3s] Which god links *marzo* and *martedì*? (**Mars**.) Why is *dicembre*
 Latin for "ten"? (The Roman year began in March.) Which two months honour real

--- a/code/learning/human-languages/italian/lessons/IT-C09-stagioni.md
+++ b/code/learning/human-languages/italian/lessons/IT-C09-stagioni.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C09-stagioni
+spine_node: SPINE-TIME-OF-DAY
+sequence: 400
 chapter: 9
 type: word
 headword: le stagioni
@@ -9,13 +12,25 @@ prerequisites: [IT-C09-mesi]
 sounds: [double-none, open-e]
 roots: [latin-seasons]
 etymology_hook: "primavera = prima vera 'first spring/green'; estate ← aestas; autunno ← autumnus; inverno ← hibernum; even 'stagione' is Latin statiō, a 'standing' of the year"
-est_minutes: 4
+duration:
+  max_seconds: 153
+requires:
+  knowledge: [IT-ETYMON-MESI-02]
+introduces:
+  knowledge: [IT-ETYMON-STAGIONI-02]
+practises:
+  knowledge: [IT-ETYMON-MESI-02, IT-ETYMON-STAGIONI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C09-mesi, IT-C08-ora]
 ---
-
 # le stagioni — the four seasons
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The word for "season," **stagione**, is itself a small lesson: it's Latin
 **statiō**, a "standing" — a fixed *station* of the year (cousin of English
@@ -23,6 +38,7 @@ reviews_of: [IT-C09-mesi, IT-C08-ora]
 green**."
 
 ## The four seasons, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-STAGIONI-02]; assesses=[] -->
 
 | Italian | ← Latin | literally |
 |---|---|---|
@@ -39,6 +55,7 @@ green**."
   the *inverno*."
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-ETYMON-MESI-02, IT-ETYMON-STAGIONI-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "la primavera, l'estate, l'autunno, l'inverno"]
@@ -46,6 +63,7 @@ green**."
 - [YOU SAY: "stagione ← statiō — a 'standing' of the year, like station"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-ETYMON-MESI-02, IT-ETYMON-STAGIONI-02] -->
 
 [PAUSE 3s] Name the four Italian seasons. (*Primavera, estate, autunno, inverno*.)
 What does *primavera* literally mean? ("**First spring / first green**.") What Latin

--- a/code/learning/human-languages/italian/lessons/IT-C10-fratello-sorella.md
+++ b/code/learning/human-languages/italian/lessons/IT-C10-fratello-sorella.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C10-fratello-sorella
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 420
 chapter: 10
 type: word
 headword: il fratello, la sorella
@@ -9,13 +12,25 @@ prerequisites: [IT-C10-genitori]
 sounds: [double-ll, r-tap]
 roots: [frater-latin, soror-latin]
 etymology_hook: "fratello ← frater + the diminutive -ellus, sorella ← soror + -ella; Italian rebuilt 'brother/sister' as 'little brother/little sister', keeping frat-/soror- (→ fraternal, sorority)"
-est_minutes: 4
+duration:
+  max_seconds: 136
+requires:
+  knowledge: [IT-ETYMON-GENITORI-02, IT-ETYMON-GENITORI-03]
+introduces:
+  knowledge: [IT-ETYMON-FRATELLO-SORELLA-02]
+practises:
+  knowledge: [IT-ETYMON-GENITORI-02, IT-ETYMON-GENITORI-03, IT-ETYMON-FRATELLO-SORELLA-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C10-genitori, IT-C09-stagioni]
 ---
-
 # il fratello, la sorella — brother and sister, with a little-ending
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Here Italian does something charming. Where French kept *frère* and
 *sœur* bare, Italian rebuilt "brother" and "sister" with its beloved
@@ -23,6 +38,7 @@ reviews_of: [IT-C10-genitori, IT-C09-stagioni]
 and those forms became the everyday words.
 
 ## Taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-FRATELLO-SORELLA-02]; assesses=[] -->
 
 - **il fratello** ("brother") ← Latin **frāter** + the diminutive **-ellus** →
   *fraterellus* → *fratello*, once "little brother."
@@ -36,6 +52,7 @@ cousins across the language (*-ello* on *poverello* "poor little one," *-ella* o
 countless names).
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-ETYMON-GENITORI-02, IT-ETYMON-GENITORI-03, IT-ETYMON-FRATELLO-SORELLA-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: all four — "il padre, la madre, il fratello, la sorella"]
@@ -43,6 +60,7 @@ countless names).
 - [YOU SAY: "fratello → fraternal; sorella → sorority"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-ETYMON-GENITORI-02, IT-ETYMON-GENITORI-03, IT-ETYMON-FRATELLO-SORELLA-02] -->
 
 [PAUSE 3s] Give "brother" and "sister" with articles. (**il fratello, la
 sorella**.) What did Italian **add** to Latin *frāter/soror* to make them?

--- a/code/learning/human-languages/italian/lessons/IT-C10-genitori.md
+++ b/code/learning/human-languages/italian/lessons/IT-C10-genitori.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C10-genitori
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 410
 chapter: 10
 type: word
 headword: il padre, la madre
@@ -9,19 +12,32 @@ prerequisites: [IT-C09-stagioni, IT-C01-ciao]
 sounds: [d-single, r-tap]
 roots: [pater-latin, mater-latin]
 etymology_hook: "padre/madre sit closest of the sisters to Latin pater/mater; padre is the very word English borrowed as 'padre'; genitori 'parents' ← genitor 'begetter' (→ genital, progenitor, genesis)"
-est_minutes: 4
+duration:
+  max_seconds: 182
+requires:
+  knowledge: [IT-ETYMON-STAGIONI-02]
+introduces:
+  knowledge: [IT-ETYMON-GENITORI-02, IT-ETYMON-GENITORI-03]
+practises:
+  knowledge: [IT-ETYMON-STAGIONI-02, IT-ETYMON-GENITORI-02, IT-ETYMON-GENITORI-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C09-stagioni, IT-C01-ciao]
 ---
-
 # il padre, la madre — closest to Latin
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Italian, as ever, stays nearest to Rome. Its **padre** ("father") and
 **madre** ("mother") barely moved from Latin **pater** and **māter** — Latin just
 softened the *-t-* to *-d-*. If you know the Latin, you nearly know the Italian.
 
 ## Taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-GENITORI-02]; assesses=[] -->
 
 - **il padre** ("father") ← Latin **pater** (*-t- → -d-*).
 - **la madre** ("mother") ← Latin **māter** (*-t- → -d-*).
@@ -32,7 +48,8 @@ Articles: *il* padre (masculine), *la* madre (feminine).
 Spanish-influenced) speakers call a priest or military chaplain — *padre* itself,
 untouched.
 
-## The word for "parents" — genitori
+## The word, taken apart: genitori
+<!-- hl-knowledge: introduces=[IT-ETYMON-GENITORI-03]; assesses=[] -->
 
 Italian "parents" is **i genitori** — not from *parens* but from Latin **genitor**,
 "the **begetter**," from *gignere* "to beget/bring forth." That root *gen-* "give
@@ -45,6 +62,7 @@ The Latin-through-English adjective family still comes from *pater/māter*:
 law, English *father/mother*.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-ETYMON-STAGIONI-02, IT-ETYMON-GENITORI-02, IT-ETYMON-GENITORI-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "il padre, la madre" — soft *-d-* where Latin had *-t-*]
@@ -52,6 +70,7 @@ law, English *father/mother*.
 - [YOU SAY: the false-friend warning — "*parenti* = relatives, NOT parents"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-ETYMON-STAGIONI-02, IT-ETYMON-GENITORI-02, IT-ETYMON-GENITORI-03] -->
 
 [PAUSE 3s] Give "father" and "mother" with articles. (**il padre, la madre**.)
 What single sound did Latin *pater/māter* soften to? (The *-t-* became **-d-**.)

--- a/code/learning/human-languages/italian/lessons/IT-C11-acqua-vino.md
+++ b/code/learning/human-languages/italian/lessons/IT-C11-acqua-vino.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C11-acqua-vino
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 440
 chapter: 11
 type: word
 headword: l'acqua, il vino
@@ -9,19 +12,32 @@ prerequisites: [IT-C11-pane]
 sounds: [double-cq, v-clear]
 roots: [aqua-latin, vinum-latin]
 etymology_hook: "acqua kept Latin aqua almost whole (the -cq- doubles the sound) — the loud original French wore down to eau; vino ← vīnum → wine/vine/vinegar/vintage"
-est_minutes: 4
+duration:
+  max_seconds: 152
+requires:
+  knowledge: [IT-ETYMON-PANE-02, IT-ETYMON-PANE-03]
+introduces:
+  knowledge: [IT-ETYMON-ACQUA-VINO-02, IT-ETYMON-ACQUA-VINO-03]
+practises:
+  knowledge: [IT-ETYMON-PANE-02, IT-ETYMON-PANE-03, IT-ETYMON-ACQUA-VINO-02, IT-ETYMON-ACQUA-VINO-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C11-pane, IT-C10-genitori]
 ---
-
 # l'acqua, il vino — water and wine, close to the source
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The Italian table's two drinks — and a neat contrast with French.
 Where French dissolved Latin *aqua* into a bare **eau** ("oh"), Italian kept it
 almost **whole**: **acqua**, with the *aqua* still ringing in it.
 
-## l'acqua (water) — Latin aqua, preserved
+## The word, taken apart: l'acqua
+<!-- hl-knowledge: introduces=[IT-ETYMON-ACQUA-VINO-02]; assesses=[] -->
 
 - **l'acqua** ("water") ← Latin **aqua**. Italian barely moved it — it even
   **doubles** the sound with **-cq-** (*AH-kwa*), holding onto the hard *qu* that
@@ -29,13 +45,15 @@ almost **whole**: **acqua**, with the *aqua* still ringing in it.
   vs French **eau** (worn to a vowel). English borrowed the same loud original for
   **aquatic, aquarium, aqueduct**. Takes *l'* before the vowel.
 
-## il vino (wine) — Latin vīnum
+## The word, taken apart: vino
+<!-- hl-knowledge: introduces=[IT-ETYMON-ACQUA-VINO-03]; assesses=[] -->
 
 - **il vino** ("wine") ← Latin **vīnum** — clean and close, like everything Italian.
   The same word travelled into English as **wine**, and gives **vine, vinegar,
   vintage, vineyard, vinyl**. Masculine: *il* vino.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-ETYMON-PANE-02, IT-ETYMON-PANE-03, IT-ETYMON-ACQUA-VINO-02, IT-ETYMON-ACQUA-VINO-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "l'acqua, il vino" — *acqua* with the doubled *-cq-*]
@@ -44,6 +62,7 @@ almost **whole**: **acqua**, with the *aqua* still ringing in it.
 - [YOU SAY: "acqua ↔ aquarium; vino → wine, vinegar"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-ETYMON-PANE-02, IT-ETYMON-PANE-03, IT-ETYMON-ACQUA-VINO-02, IT-ETYMON-ACQUA-VINO-03] -->
 
 [PAUSE 3s] Give "water" and "wine" with articles. (**l'acqua, il vino**.) How does
 Italian *acqua* differ from French *eau*, from the same *aqua*? (Italian **kept**

--- a/code/learning/human-languages/italian/lessons/IT-C11-pane.md
+++ b/code/learning/human-languages/italian/lessons/IT-C11-pane.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C11-pane
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 430
 chapter: 11
 type: word
 headword: il pane
@@ -9,24 +12,38 @@ prerequisites: [IT-C10-fratello-sorella, IT-C01-ciao]
 sounds: [e-open, n-single]
 roots: [panis-latin]
 etymology_hook: "pane sits closest to Latin pānis; the root gives companion (com + pānis, 'one you share bread with'), company, pantry; Italy's companatico is 'whatever you eat WITH bread'"
-est_minutes: 4
+duration:
+  max_seconds: 136
+requires:
+  knowledge: [IT-ETYMON-FRATELLO-SORELLA-02]
+introduces:
+  knowledge: [IT-ETYMON-PANE-02, IT-ETYMON-PANE-03]
+practises:
+  knowledge: [IT-ETYMON-FRATELLO-SORELLA-02, IT-ETYMON-PANE-02, IT-ETYMON-PANE-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C10-fratello-sorella, IT-C01-ciao]
 ---
-
 # il pane — bread, and its companions
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] **il pane** ("bread") — and, true to form, Italian keeps it **closest
 to Latin**: *pānis → pane*, barely touched. Its root carries the same warm story
 as the French *pain*: a **companion** is one you **share bread** with.
 
 ## Taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-PANE-02]; assesses=[] -->
 
 - **il pane** ("bread") ← Latin **pānis** — masculine, *il* pane; the plural is
   *i pani*.
 
-## The "bread" family
+## The word, taken apart: bread family
+<!-- hl-knowledge: introduces=[IT-ETYMON-PANE-03]; assesses=[] -->
 
 - **companion / company** ← *com-* ("with") + *pānis* — "one you **break bread
   with**."
@@ -37,12 +54,14 @@ as the French *pain*: a **companion** is one you **share bread** with.
   word.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-ETYMON-FRATELLO-SORELLA-02, IT-ETYMON-PANE-02, IT-ETYMON-PANE-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "il pane" — open *e*; plural "i pani"]
 - [YOU SAY: "pane → companion, companatico" — bread and what joins it]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-ETYMON-FRATELLO-SORELLA-02, IT-ETYMON-PANE-02, IT-ETYMON-PANE-03] -->
 
 [PAUSE 3s] Give "bread" with its article. (**il pane**.) What Latin word, and how
 much did Italian change it? (*pānis* — barely: *pānis → pane*.) What does

--- a/code/learning/human-languages/italian/lessons/IT-C12-numeri-11-16.md
+++ b/code/learning/human-languages/italian/lessons/IT-C12-numeri-11-16.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C12-numeri-11-16
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 450
 chapter: 12
 type: word
 headword: undici — sedici
@@ -9,19 +12,32 @@ prerequisites: [IT-C06-numeri-6-10, IT-C11-acqua-vino]
 sounds: [c-soft-dici, double-consonant]
 roots: [latin-decim]
 etymology_hook: "undici…sedici ← ūndecim…sēdecim, with -dici still visibly Latin decem ('ten') — clearer than French's worn-down -ze; and dieci (10) sits right there beside it"
-est_minutes: 4
+duration:
+  max_seconds: 163
+requires:
+  knowledge: [IT-SOUND-NUMERI-6-10-02, IT-ETYMON-NUMERI-6-10-03, IT-GRAMMAR-NUMERI-6-10-04, IT-ETYMON-ACQUA-VINO-02, IT-ETYMON-ACQUA-VINO-03]
+introduces:
+  knowledge: [IT-GRAMMAR-NUMERI-11-16-02]
+practises:
+  knowledge: [IT-SOUND-NUMERI-6-10-02, IT-ETYMON-NUMERI-6-10-03, IT-GRAMMAR-NUMERI-6-10-04, IT-ETYMON-ACQUA-VINO-02, IT-ETYMON-ACQUA-VINO-03, IT-GRAMMAR-NUMERI-11-16-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C06-numeri-6-10, IT-C11-acqua-vino]
 ---
-
 # undici → sedici — the ten you can still see
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] True to form, Italian keeps the teens **closest to Latin** — so close
 that the word for "ten" is still sitting in plain sight inside each one. Where
 French wore *decem* down to a bare **-ze**, Italian kept **-dici**.
 
-## The six fusions
+## Grammar Lens: six fusions
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-NUMERI-11-16-02]; assesses=[] -->
 
 | | Italian | ← Latin | build |
 |---|---|---|---|
@@ -43,6 +59,7 @@ The digits are your Chapter 6 numbers barely changed: *tre→tre-*, *quattro→
 quattor-*, *cinque→quin-*, *sei→se-*.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-NUMERI-6-10-02, IT-ETYMON-NUMERI-6-10-03, IT-GRAMMAR-NUMERI-6-10-04, IT-ETYMON-ACQUA-VINO-02, IT-ETYMON-ACQUA-VINO-03, IT-GRAMMAR-NUMERI-11-16-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "undici, dodici, tredici, quattordici, quindici, sedici"]
@@ -50,6 +67,7 @@ quattor-*, *cinque→quin-*, *sei→se-*.
 - [YOU SAY: the three-sister line — "sedici / seize / dezesseis, one Latin word"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-NUMERI-6-10-02, IT-ETYMON-NUMERI-6-10-03, IT-GRAMMAR-NUMERI-6-10-04, IT-ETYMON-ACQUA-VINO-02, IT-ETYMON-ACQUA-VINO-03, IT-GRAMMAR-NUMERI-11-16-02] -->
 
 [PAUSE 3s] Count 11 to 16 in Italian. (*Undici, dodici, tredici, quattordici,
 quindici, sedici*.) What is the **-dici** in every one? (Latin **decem**, "ten" —

--- a/code/learning/human-languages/italian/lessons/IT-C12-numeri-17-20.md
+++ b/code/learning/human-languages/italian/lessons/IT-C12-numeri-17-20.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C12-numeri-17-20
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 460
 chapter: 12
 type: word
 headword: diciassette — venti
@@ -9,20 +12,33 @@ prerequisites: [IT-C12-numeri-11-16]
 sounds: [double-ss, c-soft-dici]
 roots: [latin-decim, viginti-latin]
 etymology_hook: "at 17 Italian reverses itself — sedici is 'six-ten' but diciassette is 'ten-and-seven' (dici + e + sette); the same ten, moved to the front, mid-count; venti ← vīgintī"
-est_minutes: 4
+duration:
+  max_seconds: 194
+requires:
+  knowledge: [IT-GRAMMAR-NUMERI-11-16-02]
+introduces:
+  knowledge: [IT-GRAMMAR-NUMERI-17-20-02, IT-NOTICE-NUMERI-17-20-03]
+practises:
+  knowledge: [IT-GRAMMAR-NUMERI-11-16-02, IT-GRAMMAR-NUMERI-17-20-02, IT-NOTICE-NUMERI-17-20-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C12-numeri-11-16, IT-C06-numeri-6-10]
 ---
-
 # diciassette → venti — the count turns around
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Watch the language change direction. Through **sedici** (16), Italian
 put the **digit first** and the ten last. At **17**, it turns the whole thing
 around and puts the **ten first** — and it keeps the *-dici* right there so you
 can see it happen.
 
-## The reversal
+## Grammar Lens: the reversal
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-NUMERI-17-20-02]; assesses=[] -->
 
 | | Italian | build | order |
 |---|---|---|---|
@@ -36,7 +52,8 @@ Same building blocks — *dici* ("ten") and your Chapter 6 digits — but from 1
 **ten leads**. The little linking sounds (*diciAssette*, *diciANnove*) are just
 Italian smoothing the joint, the doubling it loves.
 
-## All three sisters break — at different numbers
+## What you've built: three different breaks
+<!-- hl-knowledge: introduces=[IT-NOTICE-NUMERI-17-20-03]; assesses=[] -->
 
 This "give up fusing, go transparent" seam happens in every Romance sister, but
 **not at the same place**:
@@ -54,6 +71,7 @@ German, you may recall, never breaks at all.)
 **vigesimal**.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-GRAMMAR-NUMERI-11-16-02, IT-GRAMMAR-NUMERI-17-20-02, IT-NOTICE-NUMERI-17-20-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: 16→20 — "sedici, diciassette, diciotto, diciannove, venti"]
@@ -61,6 +79,7 @@ German, you may recall, never breaks at all.)
 - [YOU SAY: the whole run, undici to venti]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-GRAMMAR-NUMERI-11-16-02, IT-GRAMMAR-NUMERI-17-20-02, IT-NOTICE-NUMERI-17-20-03] -->
 
 [PAUSE 3s] What changes between *sedici* and *diciassette*? (The **order** — the
 **ten moves to the front**; digit-first becomes ten-first.) Where do the three

--- a/code/learning/human-languages/italian/lessons/IT-C13-nero-bianco.md
+++ b/code/learning/human-languages/italian/lessons/IT-C13-nero-bianco.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C13-nero-bianco
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 470
 chapter: 13
 type: word
 headword: nero, bianco
@@ -9,25 +12,39 @@ prerequisites: [IT-C12-numeri-17-20]
 sounds: [open-e, palatal-bi]
 roots: [latin-niger, germanic-blank]
 etymology_hook: "nero ← niger, but bianco ← Germanic *blank 'shining' — brought by the Lombards and displacing Latin albus, which survives in alba ('dawn') and albume"
-est_minutes: 4
+duration:
+  max_seconds: 206
+requires:
+  knowledge: [IT-GRAMMAR-NUMERI-17-20-02, IT-NOTICE-NUMERI-17-20-03]
+introduces:
+  knowledge: [IT-ETYMON-NERO-BIANCO-02, IT-ETYMON-NERO-BIANCO-03, IT-ETYMON-NERO-BIANCO-04]
+practises:
+  knowledge: [IT-GRAMMAR-NUMERI-17-20-02, IT-NOTICE-NUMERI-17-20-03, IT-ETYMON-NERO-BIANCO-02, IT-ETYMON-NERO-BIANCO-03, IT-ETYMON-NERO-BIANCO-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C12-numeri-17-20, IT-C11-pane-acqua]
 ---
-
 # nero, bianco — one Roman, one Lombard
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Italy's two most basic colours came from **two different peoples**.
 One is Rome's own word. The other arrived with the Germanic tribes who settled
 the peninsula after Rome fell.
 
-## nero — Rome's own
+## The word, taken apart: nero
+<!-- hl-knowledge: introduces=[IT-ETYMON-NERO-BIANCO-02]; assesses=[] -->
 
 **nero** ("black") ← Latin ***niger***. Straight inheritance, barely changed:
 *niger* → *nigrum* → *nero*. The same *niger* gives English *denigrate*, "to
 blacken."
 
-## bianco — the newcomer
+## The word, taken apart: bianco
+<!-- hl-knowledge: introduces=[IT-ETYMON-NERO-BIANCO-03]; assesses=[] -->
 
 Latin's white was ***albus***. Italian doesn't use it. Instead: **bianco**, from
 Germanic ***blank*** — "**shining, gleaming**" — most likely carried in by the
@@ -38,7 +55,8 @@ The same word became French *blanc* and Portuguese *branco*. Germanic lending
 **into** Romance is the reverse of the usual direction, and here the loan won so
 completely that Latin's own word was pushed out of the colour slot altogether.
 
-## Where albus went
+## The word, taken apart: albus
+<!-- hl-knowledge: introduces=[IT-ETYMON-NERO-BIANCO-04]; assesses=[] -->
 
 | word | meaning | the white inside |
 |---|---|---|
@@ -50,6 +68,7 @@ completely that Latin's own word was pushed out of the colour slot altogether.
 Latin's white is still here — just doing other jobs.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-GRAMMAR-NUMERI-17-20-02, IT-NOTICE-NUMERI-17-20-03, IT-ETYMON-NERO-BIANCO-02, IT-ETYMON-NERO-BIANCO-03, IT-ETYMON-NERO-BIANCO-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "nero, bianco"]
@@ -58,6 +77,7 @@ Latin's white is still here — just doing other jobs.
 - [YOU SAY: "l'**alba**" — and hear Latin's forgotten white]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-GRAMMAR-NUMERI-17-20-02, IT-NOTICE-NUMERI-17-20-03, IT-ETYMON-NERO-BIANCO-02, IT-ETYMON-NERO-BIANCO-03, IT-ETYMON-NERO-BIANCO-04] -->
 
 [PAUSE 3s] Which colour is Rome's own? (**Nero** ← *niger*.) Where does **bianco**
 come from? (**Germanic *blank***, "shining" — likely via the **Lombards**.) Why is

--- a/code/learning/human-languages/italian/lessons/IT-C13-rosso-blu.md
+++ b/code/learning/human-languages/italian/lessons/IT-C13-rosso-blu.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C13-rosso-blu
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 480
 chapter: 13
 type: word
 headword: rosso, blu
@@ -9,18 +12,31 @@ prerequisites: [IT-C13-nero-bianco]
 sounds: [double-s, final-stress-u]
 roots: [pie-rewdh, germanic-blao, arabic-lazaward]
 etymology_hook: "rosso ← russus ← PIE *h₁rewdʰ-, cousin of English red and German rot; blu is a SECOND Germanic loan, while azzurro ← Arabic lāzaward 'lapis lazuli' → English azure — the colour Italy's teams are named for"
-est_minutes: 4
+duration:
+  max_seconds: 229
+requires:
+  knowledge: [IT-ETYMON-NERO-BIANCO-02, IT-ETYMON-NERO-BIANCO-03, IT-ETYMON-NERO-BIANCO-04]
+introduces:
+  knowledge: [IT-ETYMON-ROSSO-BLU-02, IT-ETYMON-ROSSO-BLU-03, IT-ETYMON-ROSSO-BLU-04, IT-NOTICE-ROSSO-BLU-05]
+practises:
+  knowledge: [IT-ETYMON-NERO-BIANCO-02, IT-ETYMON-NERO-BIANCO-03, IT-ETYMON-NERO-BIANCO-04, IT-ETYMON-ROSSO-BLU-02, IT-ETYMON-ROSSO-BLU-03, IT-ETYMON-ROSSO-BLU-04, IT-NOTICE-ROSSO-BLU-05]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C13-nero-bianco, IT-C12-numeri-17-20]
 ---
-
 # rosso, blu — and the blue Italy plays in
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] One very old word, one more Germanic loan — and a third blue that came
 all the way from Persia by way of Arabic.
 
-## rosso — very old indeed
+## The word, taken apart: rosso
+<!-- hl-knowledge: introduces=[IT-ETYMON-ROSSO-BLU-02]; assesses=[] -->
 
 **rosso** ← Latin ***russus*** ("red"), from PIE ***h₁rewdʰ-***. That root is one
 of the oldest colour words we can reconstruct:
@@ -35,13 +51,15 @@ of the oldest colour words we can reconstruct:
 *Rosso* and *red* are **cousins**, not borrowings — separated for millennia.
 Note the **double s**: hold it. *Roso* and *rosso* are different words.
 
-## blu — the second Germanic loan
+## The word, taken apart: blu
+<!-- hl-knowledge: introduces=[IT-ETYMON-ROSSO-BLU-03]; assesses=[] -->
 
 **blu** ← Germanic ***blāo***, exactly like French *bleu*. Chapter pattern
 confirmed: **bianco** and **blu**, Italian's white and blue, are both **Germanic
 imports**.
 
-## azzurro — the Arabic blue
+## The word, taken apart: azzurro
+<!-- hl-knowledge: introduces=[IT-ETYMON-ROSSO-BLU-04]; assesses=[] -->
 
 Italian has a second blue, and it's the famous one: **azzurro**, from Arabic
 ***lāzaward*** ("lapis lazuli"), itself from Persian ***lāžward***. The initial
@@ -52,7 +70,8 @@ English **azure**.
 Italy's national teams are **gli Azzurri**, "the blue ones" — named, at the end of
 a very long chain, after a **blue stone mined in Afghanistan**.
 
-## The chapter in one table
+## What you've built: the colour paths
+<!-- hl-knowledge: introduces=[IT-NOTICE-ROSSO-BLU-05]; assesses=[] -->
 
 | Italian | source |
 |---|---|
@@ -63,6 +82,7 @@ a very long chain, after a **blue stone mined in Afghanistan**.
 | **azzurro** | **Arabic** *lāzaward* |
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-ETYMON-NERO-BIANCO-02, IT-ETYMON-NERO-BIANCO-03, IT-ETYMON-NERO-BIANCO-04, IT-ETYMON-ROSSO-BLU-02, IT-ETYMON-ROSSO-BLU-03, IT-ETYMON-ROSSO-BLU-04, IT-NOTICE-ROSSO-BLU-05] -->
 
 [PAUSE 1s]
 - [YOU SAY: "rosso, blu, azzurro"]
@@ -71,6 +91,7 @@ a very long chain, after a **blue stone mined in Afghanistan**.
 - [YOU SAY: "gli Azzurri" — and think of the stone]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-ETYMON-NERO-BIANCO-02, IT-ETYMON-NERO-BIANCO-03, IT-ETYMON-NERO-BIANCO-04, IT-ETYMON-ROSSO-BLU-02, IT-ETYMON-ROSSO-BLU-03, IT-ETYMON-ROSSO-BLU-04, IT-NOTICE-ROSSO-BLU-05] -->
 
 [PAUSE 3s] Is *rosso* related to English *red* by borrowing or descent?
 (**Descent** — PIE ***h₁rewdʰ-***.) Which two Italian colours are Germanic loans?

--- a/code/learning/human-languages/italian/lessons/IT-C14-avere.md
+++ b/code/learning/human-languages/italian/lessons/IT-C14-avere.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C14-avere
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 490
 chapter: 14
 type: word
 headword: avere
@@ -9,18 +12,31 @@ prerequisites: [IT-C13-rosso-blu, IT-C05-parlare]
 sounds: [silent-h, double-n]
 roots: [latin-habere]
 etymology_hook: "avere ← habēre (→ habit/inhabit/exhibit/prohibit). Italian dropped the Latin h everywhere EXCEPT here: ho/hai/ha/hanno keep a silent h purely to distinguish them from o 'or', ai 'to the', a 'to', anno 'YEAR' — spelling doing a job sound can't"
-est_minutes: 4
+duration:
+  max_seconds: 219
+requires:
+  knowledge: [IT-ETYMON-ROSSO-BLU-02, IT-ETYMON-ROSSO-BLU-03, IT-ETYMON-ROSSO-BLU-04, IT-NOTICE-ROSSO-BLU-05, IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04]
+introduces:
+  knowledge: [IT-LEX-AVERE-02, IT-GRAMMAR-AVERE-03, IT-ETYMON-AVERE-04]
+practises:
+  knowledge: [IT-ETYMON-ROSSO-BLU-02, IT-ETYMON-ROSSO-BLU-03, IT-ETYMON-ROSSO-BLU-04, IT-NOTICE-ROSSO-BLU-05, IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04, IT-LEX-AVERE-02, IT-GRAMMAR-AVERE-03, IT-ETYMON-AVERE-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C13-rosso-blu, IT-C05-parlare, IT-C11-acqua-vino]
 ---
-
 # avere — "to have"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Italian's workhorse verb — and the home of the language's **only
 silent letter**, which is there for a reason worth knowing.
 
-## The forms
+## You'll want to know: the forms
+<!-- hl-knowledge: introduces=[IT-LEX-AVERE-02]; assesses=[] -->
 
 | | | |
 |---|---|---|
@@ -31,7 +47,8 @@ silent letter**, which is there for a reason worth knowing.
 Look at which forms carry an **h**: *ho, hai, ha, hanno*. And which don't:
 *abbiamo, avete*.
 
-## The silent h, and why it survives
+## Grammar Lens: why silent h survives
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-AVERE-03]; assesses=[] -->
 
 Italian threw the Latin **h** away almost completely — it is never pronounced,
 and *uomo* (← *homō*) and *erba* (← *herba*) simply dropped it.
@@ -50,7 +67,8 @@ the sound, and is kept **only so your eye can tell the words apart**. Spelling
 doing a job pronunciation can't — hold onto *hanno* vs *anno*; it comes back in
 the next lesson.
 
-## The root
+## The word, taken apart
+<!-- hl-knowledge: introduces=[IT-ETYMON-AVERE-04]; assesses=[] -->
 
 **avere** ← Latin ***habēre***, the same source as French *avoir*. English took
 it as a whole family: **habit** (what you have regularly), **inhabit**,
@@ -60,6 +78,7 @@ Note *abbiamo* — the **bb** is the old *habē-* resurfacing in the *noi* form,
 while *ho* wore down to a single vowel.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-ETYMON-ROSSO-BLU-02, IT-ETYMON-ROSSO-BLU-03, IT-ETYMON-ROSSO-BLU-04, IT-NOTICE-ROSSO-BLU-05, IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04, IT-LEX-AVERE-02, IT-GRAMMAR-AVERE-03, IT-ETYMON-AVERE-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "ho, hai, ha, abbiamo, avete, hanno"]
@@ -68,6 +87,7 @@ while *ho* wore down to a single vowel.
 - [YOU SAY: "Abbiamo pane e vino" — Ch. 11's food]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-ETYMON-ROSSO-BLU-02, IT-ETYMON-ROSSO-BLU-03, IT-ETYMON-ROSSO-BLU-04, IT-NOTICE-ROSSO-BLU-05, IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04, IT-LEX-AVERE-02, IT-GRAMMAR-AVERE-03, IT-ETYMON-AVERE-04] -->
 
 [PAUSE 3s] Give the six forms. (*Ho, hai, ha, abbiamo, avete, hanno*.) Which
 carry an **h**? (*Ho, hai, ha, hanno*.) Is it pronounced? (**No** — never.) Then

--- a/code/learning/human-languages/italian/lessons/IT-C14-eta.md
+++ b/code/learning/human-languages/italian/lessons/IT-C14-eta.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C14-eta
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 500
 chapter: 14
 type: phrase
 headword: ho venti anni
@@ -9,26 +12,40 @@ prerequisites: [IT-C14-avere, IT-C12-numeri-17-20]
 sounds: [double-n, final-stress-a]
 roots: [latin-annus, latin-aetas]
 etymology_hook: "ho venti anni = 'I HAVE twenty years' like French/Spanish/Portuguese, against German/English 'I AM'; anno ← annus → annual/anniversary — and here hanno ('they have') vs anno ('year') stops being a curiosity and becomes a sentence you must spell right"
-est_minutes: 4
+duration:
+  max_seconds: 252
+requires:
+  knowledge: [IT-LEX-AVERE-02, IT-GRAMMAR-AVERE-03, IT-ETYMON-AVERE-04, IT-GRAMMAR-NUMERI-17-20-02, IT-NOTICE-NUMERI-17-20-03]
+introduces:
+  knowledge: [IT-LEX-ETA-02, IT-ETYMON-ETA-03, IT-GRAMMAR-ETA-04, IT-GRAMMAR-ETA-05]
+practises:
+  knowledge: [IT-LEX-AVERE-02, IT-GRAMMAR-AVERE-03, IT-ETYMON-AVERE-04, IT-GRAMMAR-NUMERI-17-20-02, IT-NOTICE-NUMERI-17-20-03, IT-LEX-ETA-02, IT-ETYMON-ETA-03, IT-GRAMMAR-ETA-04, IT-GRAMMAR-ETA-05]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C14-avere, IT-C12-numeri-17-20, IT-C09-mesi]
 ---
-
 # ho venti anni — having your years
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Italian states age with **avere**, not *essere*. And the silent **h**
 from last lesson stops being trivia here — it becomes the difference between two
 real sentences.
 
-## The phrase
+## You'll want to know: the phrase
+<!-- hl-knowledge: introduces=[IT-LEX-ETA-02]; assesses=[] -->
 
 > **Quanti anni hai?** — "How many years do you **have**?"
 > **Ho venti anni.** — "I **have** twenty years."
 
 *Essere* is wrong here. *Sono venti anni* does not mean "I am twenty."
 
-## anno ← annus
+## The word, taken apart: anno
+<!-- hl-knowledge: introduces=[IT-ETYMON-ETA-03]; assesses=[] -->
 
 **anno** ("year") ← Latin ***annus*** → English **annual**, **anniversary**,
 **annals**, *per annum*. Chapter 9's months and seasons came from the same
@@ -37,7 +54,8 @@ calendar vocabulary.
 Note the **double n**: *a-nno*, held. Italian's double consonants are real
 length, not decoration.
 
-## The h earns its keep
+## Grammar Lens: h earns its keep
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-ETA-04]; assesses=[] -->
 
 Now put the last lesson to work:
 
@@ -50,7 +68,8 @@ Now put the last lesson to work:
 apart — and in a sentence about years, both words show up at once. That is
 precisely why Italian kept a letter it never pronounces.
 
-## Who has, who is
+## Grammar Lens: who has and who is
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-ETA-05]; assesses=[] -->
 
 | language | |
 |---|---|
@@ -64,6 +83,7 @@ precisely why Italian kept a letter it never pronounces.
 **Romance has its years; Germanic is its years.**
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-LEX-AVERE-02, IT-GRAMMAR-AVERE-03, IT-ETYMON-AVERE-04, IT-GRAMMAR-NUMERI-17-20-02, IT-NOTICE-NUMERI-17-20-03, IT-LEX-ETA-02, IT-ETYMON-ETA-03, IT-GRAMMAR-ETA-04, IT-GRAMMAR-ETA-05] -->
 
 [PAUSE 1s]
 - [YOU SAY: "Quanti anni hai?"]
@@ -72,6 +92,7 @@ precisely why Italian kept a letter it never pronounces.
 - [YOU SAY: the pair aloud — "**hanno** … **anno**" — identical sound]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-LEX-AVERE-02, IT-GRAMMAR-AVERE-03, IT-ETYMON-AVERE-04, IT-GRAMMAR-NUMERI-17-20-02, IT-NOTICE-NUMERI-17-20-03, IT-LEX-ETA-02, IT-ETYMON-ETA-03, IT-GRAMMAR-ETA-04, IT-GRAMMAR-ETA-05] -->
 
 [PAUSE 3s] Which verb does Italian use for age? (***Avere***, never *essere*.)
 What does *ho venti anni* literally say? ("I **have** twenty years.") Where does

--- a/code/learning/human-languages/italian/lessons/IT-C15-passato-prossimo.md
+++ b/code/learning/human-languages/italian/lessons/IT-C15-passato-prossimo.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C15-passato-prossimo
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 510
 chapter: 15
 type: word
 headword: ho parlato
@@ -9,18 +12,31 @@ prerequisites: [IT-C14-avere, IT-C05-parlare]
 sounds: [silent-h, double-t]
 roots: [latin-habere-participle]
 etymology_hook: "ho parlato was once literally 'I HAVE [a thing] spoken' — Latin habeō litterās scriptās, a possessive with the participle as an ADJECTIVE agreeing with the object; the agreement survives when the object comes first (le ho viste), a fossil of the lost meaning"
-est_minutes: 4
+duration:
+  max_seconds: 245
+requires:
+  knowledge: [IT-LEX-AVERE-02, IT-GRAMMAR-AVERE-03, IT-ETYMON-AVERE-04, IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04]
+introduces:
+  knowledge: [IT-GRAMMAR-PASSATO-PROSSIMO-02, IT-ETYMON-PASSATO-PROSSIMO-03]
+practises:
+  knowledge: [IT-LEX-AVERE-02, IT-GRAMMAR-AVERE-03, IT-ETYMON-AVERE-04, IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04, IT-GRAMMAR-PASSATO-PROSSIMO-02, IT-ETYMON-PASSATO-PROSSIMO-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C14-avere, IT-C05-parlare, IT-C05-lavorare]
 ---
-
 # ho parlato — the past built from "have"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Italy's everyday past tense, and you already own both halves: **avere**
 from last chapter, and Chapter 5's verbs.
 
-## The recipe
+## Grammar Lens: the compound-past recipe
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-PASSATO-PROSSIMO-02]; assesses=[] -->
 
 > **avere** (conjugated) + **past participle**
 
@@ -46,7 +62,8 @@ Note **parlato** keeps the *-t-* that French wore away: Italian *parlato*, Frenc
 *parlé*, both from Latin ***-ātum***. Italian is the more conservative sister —
 the same pattern as Chapter 11's *acqua* against French *eau*.
 
-## The buried possessive
+## The word, taken apart: the buried possessive
+<!-- hl-knowledge: introduces=[IT-ETYMON-PASSATO-PROSSIMO-03]; assesses=[] -->
 
 Latin could say:
 
@@ -65,6 +82,7 @@ still agrees with it, exactly as an adjective would:
 That *-e* is a Latin adjective ending, still agreeing after two thousand years.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-LEX-AVERE-02, IT-GRAMMAR-AVERE-03, IT-ETYMON-AVERE-04, IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04, IT-GRAMMAR-PASSATO-PROSSIMO-02, IT-ETYMON-PASSATO-PROSSIMO-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "ho parlato, hai parlato, ha parlato, abbiamo parlato, hanno parlato"]
@@ -73,6 +91,7 @@ That *-e* is a Latin adjective ending, still agreeing after two thousand years.
 - [YOU SAY: the old meaning — "I **have** a thing **spoken**"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-LEX-AVERE-02, IT-GRAMMAR-AVERE-03, IT-ETYMON-AVERE-04, IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04, IT-GRAMMAR-PASSATO-PROSSIMO-02, IT-ETYMON-PASSATO-PROSSIMO-03] -->
 
 [PAUSE 3s] What two pieces make the *passato prossimo*? (**Avere** + the **past
 participle**.) What is *parlare*'s participle? (**Parlato** ← *-ātum*.) What did

--- a/code/learning/human-languages/italian/lessons/IT-C15-passato-remoto.md
+++ b/code/learning/human-languages/italian/lessons/IT-C15-passato-remoto.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C15-passato-remoto
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 520
 chapter: 15
 type: word
 headword: parlò
@@ -9,19 +12,32 @@ prerequisites: [IT-C15-passato-prossimo]
 sounds: [final-stress-o]
 roots: [latin-perfect]
 etymology_hook: "parlò ← Vulgar Latin perfect *parabolāvit, the same inheritance as Spanish habló and Portuguese falou — but in Italian its survival is GEOGRAPHIC: everyday speech in Sicily and much of the south, literature-only in the north"
-est_minutes: 4
+duration:
+  max_seconds: 264
+requires:
+  knowledge: [IT-GRAMMAR-PASSATO-PROSSIMO-02, IT-ETYMON-PASSATO-PROSSIMO-03]
+introduces:
+  knowledge: [IT-LEX-PASSATO-REMOTO-02, IT-ETYMON-PASSATO-REMOTO-03, IT-PRAGMATICS-PASSATO-REMOTO-04, IT-NOTICE-PASSATO-REMOTO-05]
+practises:
+  knowledge: [IT-GRAMMAR-PASSATO-PROSSIMO-02, IT-ETYMON-PASSATO-PROSSIMO-03, IT-LEX-PASSATO-REMOTO-02, IT-ETYMON-PASSATO-REMOTO-03, IT-PRAGMATICS-PASSATO-REMOTO-04, IT-NOTICE-PASSATO-REMOTO-05]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C15-passato-prossimo, IT-C05-parlare]
 ---
-
 # parlò — the past that depends where you are
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Italian's other past tense. Whether it sounds normal or bookish
 depends on **which part of Italy you are standing in** — the clearest case of
 geography deciding grammar in this course.
 
-## What it looks like
+## You'll want to know: the remote past
+<!-- hl-knowledge: introduces=[IT-LEX-PASSATO-REMOTO-02]; assesses=[] -->
 
 | | passato remoto | passato prossimo |
 |---|---|---|
@@ -32,7 +48,8 @@ geography deciding grammar in this course.
 Note the final stress: *parl**ò***, with the accent written. Compare Chapter 12's
 numbers — Italian marks a stressed final vowel the same way.
 
-## The direct inheritance
+## The word, taken apart: the inherited past
+<!-- hl-knowledge: introduces=[IT-ETYMON-PASSATO-REMOTO-03]; assesses=[] -->
 
 **parlò** ← Vulgar Latin **\*parabolāvit**, the plain Latin perfect, handed straight down.
 Which makes it the **same tense** as:
@@ -46,7 +63,8 @@ Which makes it the **same tense** as:
 
 One Latin ancestor, four descendants — and four different fates in daily life.
 
-## Geography, not grammar
+## Why it's said this way: geography
+<!-- hl-knowledge: introduces=[IT-PRAGMATICS-PASSATO-REMOTO-04]; assesses=[] -->
 
 This is what makes Italian interesting here:
 
@@ -60,7 +78,8 @@ So the "correct" answer changes as you travel. In the north the *passato remoto*
 has retreated to books, exactly as French's *passé simple* and German's
 *Präteritum* did. In the south it never left.
 
-## The same retreat, three times — and two holdouts
+## What you've built: three retreats and two holdouts
+<!-- hl-knowledge: introduces=[IT-NOTICE-PASSATO-REMOTO-05]; assesses=[] -->
 
 | language | simple past | status in speech |
 |---|---|---|
@@ -75,6 +94,7 @@ conversation; Italian is the one caught **mid-process**, with the old tense stil
 holding half the country.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-GRAMMAR-PASSATO-PROSSIMO-02, IT-ETYMON-PASSATO-PROSSIMO-03, IT-LEX-PASSATO-REMOTO-02, IT-ETYMON-PASSATO-REMOTO-03, IT-PRAGMATICS-PASSATO-REMOTO-04, IT-NOTICE-PASSATO-REMOTO-05] -->
 
 [PAUSE 1s]
 - [YOU SAY: the pair — "parl**ò** … **ha** parlato"]
@@ -82,6 +102,7 @@ holding half the country.
 - [YOU SAY: the geography — "in **Palermo** ordinary; in **Milano** literary"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-GRAMMAR-PASSATO-PROSSIMO-02, IT-ETYMON-PASSATO-PROSSIMO-03, IT-LEX-PASSATO-REMOTO-02, IT-ETYMON-PASSATO-REMOTO-03, IT-PRAGMATICS-PASSATO-REMOTO-04, IT-NOTICE-PASSATO-REMOTO-05] -->
 
 [PAUSE 3s] What is *parlò* descended from? (Vulgar Latin **\*parabolāvit**.) What decides
 whether it sounds normal or bookish? (**Where in Italy you are** — everyday in the

--- a/code/learning/human-languages/italian/lessons/IT-C16-andare.md
+++ b/code/learning/human-languages/italian/lessons/IT-C16-andare.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C16-andare
+spine_node: SPINE-ASK-LOCATION
+sequence: 550
 chapter: 16
 type: word
 headword: andare
@@ -9,19 +12,32 @@ prerequisites: [IT-C16-essere-stato, IT-C02-come-va]
 sounds: [double-consonant, open-a]
 roots: [latin-vadere, disputed-ambitare]
 etymology_hook: "vado/vai/va/vanno continue Latin vadere, while andare/andiamo/andate/andato probably continue a different root"
-est_minutes: 4
+duration:
+  max_seconds: 195
+requires:
+  knowledge: [IT-GRAMMAR-ESSERE-STATO-02, IT-NOTICE-ESSERE-STATO-03, IT-GRAMMAR-COME-VA-02]
+introduces:
+  knowledge: [IT-LEX-ANDARE-02]
+practises:
+  knowledge: [IT-GRAMMAR-ESSERE-STATO-02, IT-NOTICE-ESSERE-STATO-03, IT-GRAMMAR-COME-VA-02, IT-LEX-ANDARE-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C16-essere-stato, IT-C02-come-va]
 ---
-
 # andare — “to go,” on two stems
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Chapter 2 gave you **Come va?**, “How’s it going?” The **va** inside
 it belongs to **andare**, “to go.” Learn the whole verb before using it to build
 the past.
 
-## The forms
+## You'll want to know: the forms
+<!-- hl-knowledge: introduces=[IT-LEX-ANDARE-02]; assesses=[] -->
 
 | | |
 |---|---|
@@ -46,6 +62,7 @@ Spanish shows the same kind of seam in *voy* beside *andar*. The comparison is
 a memory aid; the Italian forms above are the only ones you need here.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-GRAMMAR-ESSERE-STATO-02, IT-NOTICE-ESSERE-STATO-03, IT-GRAMMAR-COME-VA-02, IT-LEX-ANDARE-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: “vado, vai, va”]
@@ -56,6 +73,7 @@ a memory aid; the Italian forms above are the only ones you need here.
 [REPEAT x2] “Vado, vai, va — andiamo, andate, vanno.”
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-GRAMMAR-ESSERE-STATO-02, IT-NOTICE-ESSERE-STATO-03, IT-GRAMMAR-COME-VA-02, IT-LEX-ANDARE-02] -->
 
 [PAUSE 3s] Give the six present forms. (**Vado, vai, va, andiamo, andate,
 vanno**.) Which plural form belongs to the *vad-* side? (**Vanno**.) What is the

--- a/code/learning/human-languages/italian/lessons/IT-C16-essere-stato.md
+++ b/code/learning/human-languages/italian/lessons/IT-C16-essere-stato.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C16-essere-stato
+spine_node: SPINE-ASK-LOCATION
+sequence: 540
 chapter: 16
 type: etymology
 headword: essere → stato
@@ -9,18 +12,31 @@ prerequisites: [IT-C16-essere]
 sounds: [double-consonant]
 roots: [latin-esse, latin-stare]
 etymology_hook: "essere borrowed stare's participle, so sono stato can mean both 'I have been' and 'I have stayed'"
-est_minutes: 4
+duration:
+  max_seconds: 197
+requires:
+  knowledge: [IT-LEX-ESSERE-02, IT-GRAMMAR-ESSERE-03, IT-ETYMON-ESSERE-04]
+introduces:
+  knowledge: [IT-GRAMMAR-ESSERE-STATO-02, IT-NOTICE-ESSERE-STATO-03]
+practises:
+  knowledge: [IT-LEX-ESSERE-02, IT-GRAMMAR-ESSERE-03, IT-ETYMON-ESSERE-04, IT-GRAMMAR-ESSERE-STATO-02, IT-NOTICE-ESSERE-STATO-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C16-essere, IT-C02-stare]
 ---
-
 # essere → stato — a borrowed piece
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Italian kept both Latin “be” verbs as **essere** and **stare**. Now
 look at the piece they unexpectedly share.
 
-## One participle for two verbs
+## Grammar Lens: one participle for two verbs
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-ESSERE-STATO-02]; assesses=[] -->
 
 | verb | past participle |
 |---|---|
@@ -37,7 +53,8 @@ That shared piece creates a real ambiguity:
 
 Only the surrounding sentence tells you which verb is meant.
 
-## Three Romance solutions
+## What you've built: three Romance solutions
+<!-- hl-knowledge: introduces=[IT-NOTICE-ESSERE-STATO-03]; assesses=[] -->
 
 The same Latin material took a different shape in each sister language:
 
@@ -52,6 +69,7 @@ than French. You do not need either sister language to use Italian; the
 comparison simply makes the borrowed piece visible.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-LEX-ESSERE-02, IT-GRAMMAR-ESSERE-03, IT-ETYMON-ESSERE-04, IT-GRAMMAR-ESSERE-STATO-02, IT-NOTICE-ESSERE-STATO-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: “stare → stato”]
@@ -61,6 +79,7 @@ comparison simply makes the borrowed piece visible.
 [REPEAT x2] “Two verbs, one **stato**.”
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-LEX-ESSERE-02, IT-GRAMMAR-ESSERE-03, IT-ETYMON-ESSERE-04, IT-GRAMMAR-ESSERE-STATO-02, IT-NOTICE-ESSERE-STATO-03] -->
 
 [PAUSE 3s] What is *essere*’s participle? (**Stato**, borrowed from *stare*.)
 What can *sono stato* mean? (“I have **been**” or “I have **stayed**.”) Which

--- a/code/learning/human-languages/italian/lessons/IT-C16-essere.md
+++ b/code/learning/human-languages/italian/lessons/IT-C16-essere.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C16-essere
+spine_node: SPINE-ASK-LOCATION
+sequence: 530
 chapter: 16
 type: word
 headword: essere
@@ -9,18 +12,31 @@ prerequisites: [IT-C02-stare, IT-C14-avere, IT-C15-passato-prossimo]
 sounds: [double-consonant, open-e]
 roots: [latin-esse]
 etymology_hook: "essere continues Latin esse; its six present forms also teach the crucial è/e accent contrast"
-est_minutes: 4
+duration:
+  max_seconds: 180
+requires:
+  knowledge: [IT-SOUND-STARE-02, IT-ETYMON-STARE-03, IT-GRAMMAR-STARE-04, IT-LEX-AVERE-02, IT-GRAMMAR-AVERE-03, IT-ETYMON-AVERE-04, IT-GRAMMAR-PASSATO-PROSSIMO-02, IT-ETYMON-PASSATO-PROSSIMO-03]
+introduces:
+  knowledge: [IT-LEX-ESSERE-02, IT-GRAMMAR-ESSERE-03, IT-ETYMON-ESSERE-04]
+practises:
+  knowledge: [IT-SOUND-STARE-02, IT-ETYMON-STARE-03, IT-GRAMMAR-STARE-04, IT-LEX-AVERE-02, IT-GRAMMAR-AVERE-03, IT-ETYMON-AVERE-04, IT-GRAMMAR-PASSATO-PROSSIMO-02, IT-ETYMON-PASSATO-PROSSIMO-03, IT-LEX-ESSERE-02, IT-GRAMMAR-ESSERE-03, IT-ETYMON-ESSERE-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C02-stare, IT-C14-avere, IT-C05-parlare]
 ---
-
 # essere — “to be”
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You have known one Italian “to be” since Chapter 2: **stare**, from
 Latin *stāre*, “to stand.” Now meet **essere**, from Latin *esse*, “to be.”
 
-## The six forms
+## You'll want to know: the six forms
+<!-- hl-knowledge: introduces=[IT-LEX-ESSERE-02]; assesses=[] -->
 
 | | |
 |---|---|
@@ -33,7 +49,8 @@ person: **Sono italiano** means “I am Italian.” One collision needs care:
 **io sono** and **loro sono** are identical. Keep *loro* when context would not
 make “they” clear.
 
-## One accent, two words
+## Grammar Lens: one accent and two words
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-ESSERE-03]; assesses=[] -->
 
 **È** with the grave accent is the verb “is.” Plain **e** is “and”:
 
@@ -43,7 +60,8 @@ make “they” clear.
 The two words sound different enough in careful speech, but the accent makes
 the contrast unmistakable on the page. Never drop it from the verb.
 
-## Two roots, two living verbs
+## The word, taken apart: two living roots
+<!-- hl-knowledge: introduces=[IT-ETYMON-ESSERE-04]; assesses=[] -->
 
 | Latin | picture | Italian |
 |---|---|---|
@@ -54,6 +72,7 @@ Italian kept both verbs. The next micro-lesson shows the surprising place where
 their histories overlap.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-STARE-02, IT-ETYMON-STARE-03, IT-GRAMMAR-STARE-04, IT-LEX-AVERE-02, IT-GRAMMAR-AVERE-03, IT-ETYMON-AVERE-04, IT-GRAMMAR-PASSATO-PROSSIMO-02, IT-ETYMON-PASSATO-PROSSIMO-03, IT-LEX-ESSERE-02, IT-GRAMMAR-ESSERE-03, IT-ETYMON-ESSERE-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: “sono, sei, è, siamo, siete, sono”]
@@ -63,6 +82,7 @@ their histories overlap.
 [REPEAT x2] “Sono, sei, è — siamo, siete, sono.”
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-SOUND-STARE-02, IT-ETYMON-STARE-03, IT-GRAMMAR-STARE-04, IT-LEX-AVERE-02, IT-GRAMMAR-AVERE-03, IT-ETYMON-AVERE-04, IT-GRAMMAR-PASSATO-PROSSIMO-02, IT-ETYMON-PASSATO-PROSSIMO-03, IT-LEX-ESSERE-02, IT-GRAMMAR-ESSERE-03, IT-ETYMON-ESSERE-04] -->
 
 [PAUSE 3s] Give the six forms of *essere*. (**Sono, sei, è, siamo, siete,
 sono**.) What does the accent distinguish? (**È**, “is,” from **e**, “and.”)

--- a/code/learning/human-languages/italian/lessons/IT-C16-passato-prossimo-essere.md
+++ b/code/learning/human-languages/italian/lessons/IT-C16-passato-prossimo-essere.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C16-passato-prossimo-essere
+spine_node: SPINE-ASK-LOCATION
+sequence: 560
 chapter: 16
 type: phrase
 headword: sono andato
@@ -9,19 +12,32 @@ prerequisites: [IT-C16-andare, IT-C16-essere-stato, IT-C15-passato-prossimo]
 sounds: [double-consonant, final-vowel]
 roots: [latin-esse-participle, latin-andare]
 etymology_hook: "sono andato / sono andata preserves the participle's older job as an adjective describing the subject"
-est_minutes: 4
+duration:
+  max_seconds: 233
+requires:
+  knowledge: [IT-LEX-ANDARE-02, IT-GRAMMAR-ESSERE-STATO-02, IT-NOTICE-ESSERE-STATO-03, IT-GRAMMAR-PASSATO-PROSSIMO-02, IT-ETYMON-PASSATO-PROSSIMO-03]
+introduces:
+  knowledge: [IT-LEX-PASSATO-PROSSIMO-ESSERE-02, IT-GRAMMAR-PASSATO-PROSSIMO-ESSERE-03, IT-PRAGMATICS-PASSATO-PROSSIMO-ESSERE-04]
+practises:
+  knowledge: [IT-LEX-ANDARE-02, IT-GRAMMAR-ESSERE-STATO-02, IT-NOTICE-ESSERE-STATO-03, IT-GRAMMAR-PASSATO-PROSSIMO-02, IT-ETYMON-PASSATO-PROSSIMO-03, IT-LEX-PASSATO-PROSSIMO-ESSERE-02, IT-GRAMMAR-PASSATO-PROSSIMO-ESSERE-03, IT-PRAGMATICS-PASSATO-PROSSIMO-ESSERE-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C16-andare, IT-C16-essere-stato, IT-C15-passato-prossimo]
 ---
-
 # sono andato — the past built on essere
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Chapter 15 built the past with *avere*: **ho parlato**. You now know
 the other auxiliary, **essere**, plus the participles **stato** and **andato**.
 Combine them, then watch the participle’s ending change.
 
-## Start with stato
+## You'll want to know: start with stato
+<!-- hl-knowledge: introduces=[IT-LEX-PASSATO-PROSSIMO-ESSERE-02]; assesses=[] -->
 
 | | |
 |---|---|
@@ -33,7 +49,8 @@ Combine them, then watch the participle’s ending change.
 The plural **stati** is the first clue: with *essere*, the participle describes
 the subject and therefore agrees with it.
 
-## Motion, change, and agreement
+## Grammar Lens: motion, change, and agreement
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-PASSATO-PROSSIMO-ESSERE-03]; assesses=[] -->
 
 Many verbs of motion or change of state take **essere**: *andare* (go), *venire*
 (come), *arrivare* (arrive), *partire* (leave), *nascere* (be born), *morire*
@@ -51,7 +68,8 @@ Use the four adjective endings you already know:
 A woman therefore says **sono andata**, not *sono andato*. The ending agrees
 with the **subject**, in gender and number: *-o, -a, -i, -e*.
 
-## Why agreement survives
+## Why it's said this way: agreement
+<!-- hl-knowledge: introduces=[IT-PRAGMATICS-PASSATO-PROSSIMO-ESSERE-04]; assesses=[] -->
 
 The participle began as an adjective: **Anna è andata** was “Anna is
 gone-away,” with *andata* describing Anna just as *stanca* (“tired”) would.
@@ -61,6 +79,7 @@ alongside one another, but only the Romance sisters preserve this adjective
 fossil visibly.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-LEX-ANDARE-02, IT-GRAMMAR-ESSERE-STATO-02, IT-NOTICE-ESSERE-STATO-03, IT-GRAMMAR-PASSATO-PROSSIMO-02, IT-ETYMON-PASSATO-PROSSIMO-03, IT-LEX-PASSATO-PROSSIMO-ESSERE-02, IT-GRAMMAR-PASSATO-PROSSIMO-ESSERE-03, IT-PRAGMATICS-PASSATO-PROSSIMO-ESSERE-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: “sono stato, sei stato, siamo stati”]
@@ -69,6 +88,7 @@ fossil visibly.
 - [YOU SAY: the contrast — “ho parlato; sono andato”]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-LEX-ANDARE-02, IT-GRAMMAR-ESSERE-STATO-02, IT-NOTICE-ESSERE-STATO-03, IT-GRAMMAR-PASSATO-PROSSIMO-02, IT-ETYMON-PASSATO-PROSSIMO-03, IT-LEX-PASSATO-PROSSIMO-ESSERE-02, IT-GRAMMAR-PASSATO-PROSSIMO-ESSERE-03, IT-PRAGMATICS-PASSATO-PROSSIMO-ESSERE-04] -->
 
 [PAUSE 3s] Which auxiliary do many motion and change verbs take? (**Essere**.)
 What does the participle agree with? (**The subject**.) Give all four endings.

--- a/code/learning/human-languages/italian/lessons/IT-C17-mano.md
+++ b/code/learning/human-languages/italian/lessons/IT-C17-mano.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C17-mano
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 580
 chapter: 17
 type: word
 headword: la mano
@@ -9,20 +12,33 @@ prerequisites: [IT-C17-testa, IT-C01-il-la-lo]
 sounds: [final-vowel, open-o]
 roots: [latin-manus]
 etymology_hook: "la mano is FEMININE while ending in -o, and plural le mani — because Latin manus was a fourth-declension feminine, a class whose nouns ended in -us like the masculines; the gender is two thousand years old and the ending is a fossil of a declension Italian no longer has"
-est_minutes: 4
+duration:
+  max_seconds: 298
+requires:
+  knowledge: [IT-LEX-TESTA-02, IT-ETYMON-TESTA-03, IT-ETYMON-TESTA-04]
+introduces:
+  knowledge: [IT-LEX-MANO-02, IT-GRAMMAR-MANO-03, IT-ETYMON-MANO-04]
+practises:
+  knowledge: [IT-LEX-TESTA-02, IT-ETYMON-TESTA-03, IT-ETYMON-TESTA-04, IT-LEX-MANO-02, IT-GRAMMAR-MANO-03, IT-ETYMON-MANO-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C17-testa, IT-C01-il-la-lo]
 ---
-
 # la mano — "the hand"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Italian nouns *tend* to announce their gender: **-o** is usually
 masculine, **-a** usually feminine. (Chapter 1 deliberately didn't give you that
 as a rule — it told you to learn each noun **with its article**, and this word is
 a good demonstration of why.)
 
-## The word
+## You'll want to know: the word
+<!-- hl-knowledge: introduces=[IT-LEX-MANO-02]; assesses=[] -->
 
 > **la mano** — the hand. **Feminine**, ending in **-o**.
 > Plural: **le mani** — feminine, ending in **-i**.
@@ -31,7 +47,8 @@ Both halves are irregular. A masculine *-o* noun would pluralise in *-i* (*libro
 → libri*); a feminine noun usually ends *-a* and pluralises in *-e* (*casa →
 case*). *Mano* takes the feminine article and the masculine-looking endings.
 
-## Latin had more than two shapes
+## Grammar Lens: five declensions
+<!-- hl-knowledge: introduces=[IT-GRAMMAR-MANO-03]; assesses=[] -->
 
 Italian inherited a system with **five declensions** — five families of endings —
 and flattened it to **three** productive classes: *-o*/*-i* (*libro/libri*),
@@ -56,7 +73,8 @@ exists**.
 those are short for *radiofonia*, *fotografia*, *automobile*, which is a
 different reason for the same look.)
 
-## manus in English
+## The word, taken apart: manus
+<!-- hl-knowledge: introduces=[IT-ETYMON-MANO-04]; assesses=[] -->
 
 Latin *manus* is inside a great many English words — *manual*, *manuscript*,
 *manufacture* ("made by hand"), *maintain* ("hold in the hand"). English took
@@ -64,6 +82,7 @@ Latin *manus* is inside a great many English words — *manual*, *manuscript*,
 horse**. Every modern manager is, etymologically, working in a riding school.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-LEX-TESTA-02, IT-ETYMON-TESTA-03, IT-ETYMON-TESTA-04, IT-LEX-MANO-02, IT-GRAMMAR-MANO-03, IT-ETYMON-MANO-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "la mano, le mani"]
@@ -72,6 +91,7 @@ horse**. Every modern manager is, etymologically, working in a riding school.
 - [YOU SAY: "manage ← **maneggiare** — to handle a horse"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-LEX-TESTA-02, IT-ETYMON-TESTA-03, IT-ETYMON-TESTA-04, IT-LEX-MANO-02, IT-GRAMMAR-MANO-03, IT-ETYMON-MANO-04] -->
 
 [PAUSE 3s] Say "the hand" and "the hands." (*La mano* / *le mani*.) What rule
 does it break? (The **tendency** that *-o* is masculine — *mano* is feminine.)

--- a/code/learning/human-languages/italian/lessons/IT-C17-testa.md
+++ b/code/learning/human-languages/italian/lessons/IT-C17-testa.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: IT-C17-testa
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 570
 chapter: 17
 type: word
 headword: la testa
@@ -9,22 +12,36 @@ prerequisites: [IT-C01-il-la-lo]
 sounds: [double-consonant, open-e]
 roots: [latin-testa, latin-caput]
 etymology_hook: "Italian keeps the pot-word ALMOST UNCHANGED — Latin testa 'earthenware pot' is still testa — where French wore the same word down to tête; and unlike French, Italian ALSO kept caput as capo, so both the old head-word and its slang replacement are alive side by side"
-est_minutes: 4
+duration:
+  max_seconds: 257
+requires:
+  knowledge: []
+introduces:
+  knowledge: [IT-LEX-TESTA-02, IT-ETYMON-TESTA-03, IT-ETYMON-TESTA-04]
+practises:
+  knowledge: [IT-LEX-TESTA-02, IT-ETYMON-TESTA-03, IT-ETYMON-TESTA-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [IT-C01-il-la-lo, IT-C11-acqua-vino]
 ---
-
 # la testa — "the head"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] If you have done the French chapter, you already know this word's
 story. What is worth seeing is how much **less** Italian did to it.
 
-## The word
+## You'll want to know: the word
+<!-- hl-knowledge: introduces=[IT-LEX-TESTA-02]; assesses=[] -->
 
 > **la testa** — the head. Feminine.
 
-## The pot, again
+## The word, taken apart: testa
+<!-- hl-knowledge: introduces=[IT-ETYMON-TESTA-03]; assesses=[] -->
 
 Latin ***testa*** meant an **earthenware pot**, a shell, a shard. Roman soldiers'
 slang used it for the skull, and **across Gaul and Italy** the joke outlived the
@@ -45,7 +62,8 @@ This is the conservative-sister pattern this course keeps meeting. Chapter 11 ha
 
 Say them one after the other: *testa* … *tête*. Same word, ten centuries apart.
 
-## And Italian kept caput too
+## The word, taken apart: caput
+<!-- hl-knowledge: introduces=[IT-ETYMON-TESTA-04]; assesses=[] -->
 
 French gave *caput* away almost entirely, keeping it only in *chef* and
 *chapitre*. Italian kept it as a **live, common word**:
@@ -59,6 +77,7 @@ a *capo* in a crime family is exactly this word.
 Also from *caput*: **capitale**, **capitolo** (chapter), and **capitano**.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[IT-LEX-TESTA-02, IT-ETYMON-TESTA-03, IT-ETYMON-TESTA-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "la testa"]
@@ -67,6 +86,7 @@ Also from *caput*: **capitale**, **capitolo** (chapter), and **capitano**.
 - [YOU SAY: the pair — "la **testa** on your shoulders, il **capo** in charge"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[IT-LEX-TESTA-02, IT-ETYMON-TESTA-03, IT-ETYMON-TESTA-04] -->
 
 [PAUSE 3s] Say "the head." (*La testa* — feminine.) What did *testa* mean in
 Latin? (An **earthenware pot** — soldiers' slang for the skull.) How does Italian

--- a/code/packages/typescript/human-language-data/src/book.ts
+++ b/code/packages/typescript/human-language-data/src/book.ts
@@ -45,7 +45,11 @@ function escapeLatexCharacter(character: string): string {
     "]": "{]}",
     "←": "$\\leftarrow$",
     "→": "$\\to$",
+    "↔": "$\\leftrightarrow$",
     "≈": "$\\approx$",
+    "ṓ": "\\'{\\={o}}",
+    "₁": "\\textsubscript{1}",
+    "ʰ": "\\textsuperscript{h}",
   };
   return escaped[character] ?? character;
 }

--- a/code/packages/typescript/human-language-data/src/parse.ts
+++ b/code/packages/typescript/human-language-data/src/parse.ts
@@ -50,7 +50,7 @@ function classifyBlock(title: string): LessonBlockType {
   if (normalized.startsWith("you'll want to know")) return "input";
   if (normalized.startsWith("sounds you'll need")) return "pronunciation";
   if (normalized.startsWith("script")) return "script";
-  if (normalized.startsWith("the word, taken apart")) return "etymology";
+  if (normalized.includes("taken apart")) return "etymology";
   if (normalized.startsWith("why it's said this way")) return "culture-pragmatics";
   if (
     normalized.startsWith("grammar lens") ||

--- a/code/packages/typescript/human-language-data/tests/book.test.ts
+++ b/code/packages/typescript/human-language-data/tests/book.test.ts
@@ -92,6 +92,9 @@ describe("canonical LaTeX chapter rendering", () => {
       "\\textbf{A\\&B} costs \\$5 and uses \\texttt{x\\_y}",
     );
     expect(renderInlineMarkdown("favor ≈ fah-BOR")).toBe("favor $\\approx$ fah-BOR");
+    expect(renderInlineMarkdown("hṓrā ↔ h₁rewdʰ")).toBe(
+      "h\\'{\\={o}}rā $\\leftrightarrow$ h\\textsubscript{1}rewd\\textsuperscript{h}",
+    );
     expect(renderInlineMarkdown("*buen**os*** and ***Como** tú.*")).toBe(
       "\\emph{buen\\textbf{os}} and \\emph{\\textbf{Como} tú.}",
     );

--- a/code/packages/typescript/human-language-data/tests/parse.test.ts
+++ b/code/packages/typescript/human-language-data/tests/parse.test.ts
@@ -104,6 +104,17 @@ describe("parseLesson", () => {
     ]);
   });
 
+  it("recognizes scoped taken-apart headings as etymology blocks", () => {
+    const parsed = parseBodyBlocks([
+      "## The phrase, taken apart",
+      "A phrase history.",
+      "",
+      "## The four seasons, taken apart",
+      "Four word histories.",
+    ].join("\n"));
+    expect(parsed.blocks.map((block) => block.type)).toEqual(["etymology", "etymology"]);
+  });
+
   it("parses block-boundary knowledge without rendering the directive", () => {
     const parsed = parseBodyBlocks([
       "## Guided Practice",

--- a/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
@@ -35,6 +35,31 @@ describe("generated book source hashes", () => {
     },
   );
 
+  it.each([
+    [2, 8],
+    [3, 5],
+    [4, 5],
+    [5, 5],
+    [6, 2],
+    [7, 2],
+    [8, 2],
+    [9, 2],
+    [10, 2],
+    [11, 2],
+    [12, 2],
+    [13, 2],
+    [14, 2],
+    [15, 2],
+    [16, 4],
+    [17, 2],
+  ])("matches the browser-loaded Italian Chapter %i AST across %i lessons", (chapter, count) => {
+    const lessons = loadLessons();
+    const expected = expectedBookHash("italian", chapter);
+    expect(expected?.lessonIds).toHaveLength(count);
+    expect(actualChapterHash(lessons, "italian", chapter)).toBe(expected?.sourceHash);
+    expect(bookHashStatus(lessons, "italian", chapter)).toBe("synced");
+  });
+
   it("reports a generated chapter stale when one canonical lesson changes", () => {
     const lessons = loadLessons();
     const changed = lessons.map((lesson) =>


### PR DESCRIPTION
## Summary

- migrate all 49 Italian lessons in Chapters 2–17 to the strict shared-spine schema with explicit prerequisite-closed knowledge boundaries and sub-five-minute budgets
- generate sixteen downloadable book chapters and source-hash manifests from the same lesson AST loaded by Language Ladder
- add independent app hash/count checks, typed “taken apart” heading support, width-aware Italian tables, and portable TeX fallbacks for scholarly Unicode
- update the measured backlog: missing book chapters fall from 252 to 236, and HL-B15 is next for the remaining Italian layout/bookmark warnings

## Validation

- `human-language-data`: 81 tests passed; strict integration validation passed; generated-book check passed
- curriculum report: 0 duration violations, 0 unknown prerequisites, 236 missing book chapters
- `language-ladder`: 303 tests passed; production build passed
- forced XeLaTeX build: 104 pages, 0 missing glyphs, 0 duplicate destinations
- rendered and inspected all 104 pages; verified the 19 top-level outline destinations, cover, contents, dense tables, chapter openings, and final recall
- `git diff --check` passed

The forced PDF build still reports four overfull boxes, ten underfull boxes, and three pre-existing Chapter 1 Hyperref warnings. Those are explicitly measured under HL-B15 rather than hidden in this one-source publication tranche.