### PR TITLE
fix(spice): derive parser MOS electrostatic defaults

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate MOS model-card `NSS` and `TPG` process parameters and derive missing
+  `VT0`, `GAMMA`, and `PHI` values from `N_SUB` / `TOX` through shared engine semantics.
 - Validate and lower MOS model-card `CJS` and `CJD` aliases as canonical `CBS`
   and `CBD` junction capacitances.
 - Reject negative and non-finite MOS model-card `AF` values before lowering

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1912,6 +1912,20 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
                 raise NetlistParseError("only MOS LEVEL=1 model cards are supported")
         if "TOX" in params and (not math.isfinite(params["TOX"]) or params["TOX"] <= 0.0):
             raise NetlistParseError("MOSFET TOX must be finite and positive")
+        substrate_doping = next(
+            (params[name] for name in ("N_SUB", "NSUB", "N") if name in params),
+            None,
+        )
+        if substrate_doping is not None and (
+            not math.isfinite(substrate_doping) or substrate_doping <= 0.0
+        ):
+            raise NetlistParseError("MOSFET NSUB must be finite and positive")
+        if "NSS" in params and (
+            not math.isfinite(params["NSS"]) or params["NSS"] < 0.0
+        ):
+            raise NetlistParseError("MOSFET NSS must be finite and non-negative")
+        if "TPG" in params and params["TPG"] not in {-1.0, 0.0, 1.0}:
+            raise NetlistParseError("MOSFET TPG must be -1, 0, or 1")
         mobility = params.get("U0", params.get("UO"))
         if mobility is not None and (not math.isfinite(mobility) or mobility < 0.0):
             raise NetlistParseError("MOSFET U0 must be finite and non-negative")
@@ -2081,13 +2095,15 @@ def _build_mosfet_model(model: ModelCard, instance_params: dict[str, float]) -> 
         param_name = _LEVEL1_PARAM_ALIASES.get(name, name)
         if param_name in values and not isinstance(values[param_name], bool):
             values[param_name] = value
-    if "KP" not in params and "TOX" in model.params:
-        derivation_params = {"TOX": model.params["TOX"]}
-        if "U0" in values:
-            derivation_params["U0"] = values["U0"]
+    canonical_params = {_LEVEL1_PARAM_ALIASES.get(name, name) for name in params}
+    if "TOX" in model.params:
+        derivation_params = dict(model.params)
+        derivation_params["U0"] = values["U0"]
         normalized = normalize_model_card(model.name, model.kind, derivation_params)
         derived = mosfet_from_model_card("M", "d", "g", "s", "b", normalized)
-        values["KP"] = derived.model.model.params.KP
+        for field_name in ("KP", "VT0", "GAMMA", "PHI"):
+            if field_name not in canonical_params:
+                values[field_name] = getattr(derived.model.model.params, field_name)
     return MOSFET(
         type=MosfetType[model.kind],
         model=Level1Model(Level1Params(**values)),

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -2060,6 +2060,38 @@ def test_lowers_mosfet_junction_capacitance_aliases(
     assert isclose(getattr(mosfet.model.model.params, canonical), 2.0e-12)
 
 
+@pytest.mark.parametrize("parameter", ["NSS=-1", "NSS=1e999", "TPG=0.5"])
+def test_rejects_invalid_mosfet_electrostatic_process_parameters(
+    parameter: str,
+) -> None:
+    message = (
+        "MOSFET NSS must be finite and non-negative"
+        if parameter.startswith("NSS")
+        else "MOSFET TPG must be -1, 0, or 1"
+    )
+    with pytest.raises(NetlistParseError, match=message):
+        parse_netlist(f".model nfast NMOS({parameter})\nM1 d g s b nfast\n")
+
+
+def test_derives_mosfet_electrostatic_defaults_with_explicit_precedence() -> None:
+    derived = parse_netlist(
+        ".model nfast NMOS(NSUB=4e15 TOX=100n NSS=1e10 TPG=-1)\n"
+        "M1 d g s b nfast\n"
+    ).circuit.elements[0]
+    explicit = parse_netlist(
+        ".model nfast NMOS(NSUB=4e15 TOX=100n NSS=1e10 TPG=-1 "
+        "VT0=0.61 GAMMA=0.42 PHI=0.73)\nM1 d g s b nfast\n"
+    ).circuit.elements[0]
+    assert isinstance(derived, Mosfet)
+    assert derived.model.model.params.GAMMA > 0.0
+    assert derived.model.model.params.PHI > 0.0
+    assert not isclose(derived.model.model.params.VT0, 0.7)
+    assert isinstance(explicit, Mosfet)
+    assert isclose(explicit.model.model.params.VT0, 0.61)
+    assert isclose(explicit.model.model.params.GAMMA, 0.42)
+    assert isclose(explicit.model.model.params.PHI, 0.73)
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate MOS model-card `NSS` and `TPG` process parameters and derive missing
+  `VT0`, `GAMMA`, and `PHI` values from `N_SUB` / `TOX` through shared engine semantics.
 - Validate and lower MOS model-card `CJS` and `CJD` aliases as canonical `CBS`
   and `CBD` junction capacitances.
 - Reject negative and non-finite MOS model-card `AF` values and lower valid

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1166,6 +1166,32 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET TOX must be finite and positive");
   }
+  const substrateDoping = params.get("N_SUB") ?? params.get("NSUB") ?? params.get("N");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    substrateDoping !== undefined &&
+    (!Number.isFinite(substrateDoping) || substrateDoping <= 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET NSUB must be finite and positive");
+  }
+  const surfaceStateDensity = params.get("NSS");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    surfaceStateDensity !== undefined &&
+    (!Number.isFinite(surfaceStateDensity) || surfaceStateDensity < 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET NSS must be finite and non-negative");
+  }
+  const gateType = params.get("TPG");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    gateType !== undefined &&
+    gateType !== -1.0 &&
+    gateType !== 0.0 &&
+    gateType !== 1.0
+  ) {
+    throw new NetlistParseError("MOSFET TPG must be -1, 0, or 1");
+  }
   const surfaceMobility = params.get("U0") ?? params.get("UO");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1435,13 +1461,17 @@ function mosfetParams(
       params[key] = value;
     }
   }
-  if (!modelParams.has("KP") && !instanceParams.has("KP") && modelParams.has("TOX")) {
-    const derivationParams: Record<string, number> = { TOX: modelParams.get("TOX")! };
-    if (params.U0 !== undefined) {
-      derivationParams.U0 = params.U0;
-    }
+  const canonicalParams = new Set(
+    [...modelParams, ...instanceParams].map(([name]) => MOSFET_PARAM_ALIASES.get(name) ?? name),
+  );
+  if (modelParams.has("TOX")) {
+    const derivationParams = Object.fromEntries(modelParams);
+    derivationParams.U0 = params.U0 ?? 600.0;
     const normalized = normalizeModelCard(model.name, model.kind, derivationParams);
-    params.KP = mosfetFromModelCard("M", "d", "g", "s", "b", normalized).params.KP;
+    const derived = mosfetFromModelCard("M", "d", "g", "s", "b", normalized).params;
+    for (const key of ["KP", "VT0", "GAMMA", "PHI"] as const) {
+      if (!canonicalParams.has(key)) params[key] = derived[key];
+    }
   }
   return params;
 }

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1879,6 +1879,37 @@ Xright c d load
     expect(element.params[canonical]).toBeCloseTo(2.0e-12, 18);
   });
 
+  it.each([
+    ["NSS=-1", "MOSFET NSS must be finite and non-negative"],
+    ["NSS=1e999", "MOSFET NSS must be finite and non-negative"],
+    ["TPG=0.5", "MOSFET TPG must be -1, 0, or 1"],
+  ])("rejects invalid MOSFET process parameter %s", (parameter, message) => {
+    expect(() =>
+      parseNetlist(`.model nfast NMOS(${parameter})\nM1 d g s b nfast\n`),
+    ).toThrow(message);
+  });
+
+  it("derives MOSFET electrostatic defaults with explicit precedence", () => {
+    const derived = parseNetlist(
+      ".model nfast NMOS(NSUB=4e15 TOX=100n NSS=1e10 TPG=-1)\nM1 d g s b nfast\n",
+    ).circuit.elements()[0];
+    const explicit = parseNetlist(
+      ".model nfast NMOS(NSUB=4e15 TOX=100n NSS=1e10 TPG=-1 " +
+        "VT0=0.61 GAMMA=0.42 PHI=0.73)\nM1 d g s b nfast\n",
+    ).circuit.elements()[0];
+    expect(derived.kind).toBe("mosfet");
+    expect(explicit.kind).toBe("mosfet");
+    if (derived.kind !== "mosfet" || explicit.kind !== "mosfet") {
+      throw new Error("unexpected element kind");
+    }
+    expect(derived.params.GAMMA).toBeGreaterThan(0.0);
+    expect(derived.params.PHI).toBeGreaterThan(0.0);
+    expect(derived.params.VT0).not.toBeCloseTo(0.7, 12);
+    expect(explicit.params.VT0).toBeCloseTo(0.61, 15);
+    expect(explicit.params.GAMMA).toBeCloseTo(0.42, 15);
+    expect(explicit.params.PHI).toBeCloseTo(0.73, 15);
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4309,17 +4309,18 @@ the Rust, Python, and TypeScript surfaces together.
      shared diagnostic while zero and positive flicker-noise exponents lower
      into Level-1 parameters.
 
+399. Python and TypeScript Berkeley SPICE MOS junction-capacitance aliases.
+   - Status: completed in PR 9723.
+   - `CJS` and `CJD` are validated and lowered as canonical `CBS` and `CBD`
+     bottom-junction capacitances in both parser facades.
+
 ## Backlog
 
-1. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
-   - Align the `CJS` and `CJD` aliases with canonical `CBS` and `CBD` in both
-     facades.
-
-2. Python and TypeScript Berkeley SPICE MOS electrostatic-default parity.
+1. Python and TypeScript Berkeley SPICE MOS electrostatic-default parity.
    - Validate and consume `NSS` / `TPG`, then derive `VT0`, `GAMMA`, and `PHI`
      from `N_SUB` / `TOX` with shared engine semantics.
 
-3. Grammar-backed parser and app facade.
+2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust
      syntax facade as the grammar evolves, even if that breaks current
      pre-release parser APIs.
@@ -4327,7 +4328,7 @@ the Rust, Python, and TypeScript surfaces together.
      toward packaging, WebAssembly embedding, and product integration backed by
      the same public parser contract.
 
-4. Deck compatibility follow-up.
+3. Deck compatibility follow-up.
    - Expand deck-owned output compatibility beyond source-order analysis
      execution and stable artifact exports toward nested sweeps, raw-format
      interoperability, and remaining vendor-style output controls.
@@ -4338,7 +4339,7 @@ the Rust, Python, and TypeScript surfaces together.
      command routing, including control flow, variables, and script execution
      policy.
 
-5. Production solver core follow-up.
+4. Production solver core follow-up.
    - Sparse real/complex matrix paths now have cross-language native coverage,
      and Python real DC solves now use an optional SciPy sparse-LU backend with
      structured native fallback metadata.
@@ -4349,14 +4350,14 @@ the Rust, Python, and TypeScript surfaces together.
      damping, device limiting, tolerance policy, and additional convergence
      diagnostics for difficult transistor decks.
 
-6. Device model depth.
+5. Device model depth.
    - Audit diode, BJT, JFET, and MOS Level 1 behavior against reference decks.
    - Decide whether Level 2/3 MOS is in scope before BSIM; if BSIM lands, make
      Rust the first fast path and port stable semantics outward.
    - Expand temperature behavior, capacitance, noise, charge conservation, model
      card aliases, and error messages.
 
-7. Analysis completion.
+6. Analysis completion.
    - Generalize pole-zero beyond constrained fixture helpers.
    - Expand nonlinear distortion coverage.
    - Expand parsed `.FOUR` / `.MEASURE` integration across output plans and
@@ -4365,14 +4366,14 @@ the Rust, Python, and TypeScript surfaces together.
      Carlo trials.
    - Stabilize raw, CSV, JSON, and browser-friendly result formats.
 
-8. Mixed-signal integration.
+7. Mixed-signal integration.
    - Connect SPICE transient stepping to the hardware VM scheduler.
    - Support bidirectional analog/digital thresholds, event scheduling,
      breakpoint coordination, and VCD correlation.
    - Keep mixed-signal coupling deterministic across Python, Rust, and
      TypeScript.
 
-9. Verilog-A and custom models.
+8. Verilog-A and custom models.
    - Specify the accepted model subset and residual/Jacobian hooks.
    - Add parser or compiler support with sandboxing for TypeScript/web usage.
    - Provide a Rust-native fast path for compiled models.


### PR DESCRIPTION
## Summary

- validate MOS `N_SUB` / `NSUB`, `NSS`, and `TPG` process parameters in Python and TypeScript parser facades
- reuse shared engine normalization to derive missing `KP`, `VT0`, `GAMMA`, and `PHI` values while preserving explicit model and instance precedence
- reconcile the SPICE plan with merged CJS/CJD alias parity

## Verification

- Python `spice-netlist-parser`: `bash BUILD` (219 tests, 88.62% coverage)
- Python `spice-netlist-parser`: `.venv/bin/ruff check .`
- TypeScript `spice-engine`: `bash BUILD` (448 tests)
- TypeScript `spice-netlist-parser`: `bash BUILD` (208 tests)
- TypeScript `spice-netlist-parser`: `npm run test:coverage` (208 tests, 85.40% line coverage)
- post-rebase Python and TypeScript parser suites