### PR TITLE
feat(chief): add operator CLI core

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -761,6 +761,7 @@ members = [
     "chief-of-staff-process-supervisor",
     "chief-of-staff-orchestrator-core",
     "chief-of-staff-daemon-api",
+    "chief-of-staff-cli-core",
     "chief-of-staff-tool-api",
     "chief-of-staff-host-runtime",
     "chief-of-staff-smart-home-tools",

--- a/code/packages/rust/chief-of-staff-cli-core/BUILD
+++ b/code/packages/rust/chief-of-staff-cli-core/BUILD
@@ -1,0 +1,1 @@
+cargo test -p chief-of-staff-cli-core -- --nocapture

--- a/code/packages/rust/chief-of-staff-cli-core/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-cli-core/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Add a declarative host-lifecycle command surface over an authenticated Chief daemon client.
+- Validate host identity and package hashes before dispatch.
+- Keep credentials, endpoints, terminal access, and connection setup outside argv parsing.
+- Add deterministic pretty-JSON result rendering.

--- a/code/packages/rust/chief-of-staff-cli-core/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-cli-core/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "chief-of-staff-cli-core"
+version = "0.1.0"
+edition = "2021"
+description = "Declarative operator command core for the D18 Chief daemon"
+license = "MIT"
+
+[dependencies]
+chief-of-staff-daemon-api = { path = "../chief-of-staff-daemon-api" }
+chief-of-staff-service-registry = { path = "../chief-of-staff-service-registry" }
+cli-builder = { path = "../cli-builder" }
+coding-adventures-json-serializer = { path = "../json-serializer" }
+coding-adventures-json-value = { path = "../json-value" }

--- a/code/packages/rust/chief-of-staff-cli-core/README.md
+++ b/code/packages/rust/chief-of-staff-cli-core/README.md
@@ -1,0 +1,19 @@
+# chief-of-staff-cli-core
+
+`chief-of-staff-cli-core` is the transport-free operator command layer for the
+D18 Chief daemon. It parses a small declarative `cli-builder` command tree and
+dispatches host lifecycle operations through an injected, already-authenticated
+daemon client.
+
+The current commands are `agents`, `doctor`, `register`, `start`, `stop`,
+`reconcile`, and `deregister`. Credentials and socket endpoints are deliberately
+absent from argv; a later executable adapter will acquire credentials through a
+secure terminal boundary and provide the connected client.
+
+## Validation
+
+```sh
+cargo test -p chief-of-staff-cli-core -- --nocapture
+cargo clippy -p chief-of-staff-cli-core --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-cli-core --no-deps
+```

--- a/code/packages/rust/chief-of-staff-cli-core/required_capabilities.json
+++ b/code/packages/rust/chief-of-staff-cli-core/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/chief-of-staff-cli-core",
+  "capabilities": [],
+  "justification": "Pure argv parsing and dispatch through an injected client. The package directly performs no filesystem, network, process, environment, terminal, clock, randomness, or secret-store access."
+}

--- a/code/packages/rust/chief-of-staff-cli-core/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-cli-core/src/lib.rs
@@ -1,0 +1,622 @@
+//! Declarative operator command core for the authenticated D18 Chief daemon.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use chief_of_staff_daemon_api::{DaemonClient, DaemonClientError};
+use chief_of_staff_service_registry::{
+    DesiredState, HostName, HostRegistration, PackagePath, RegistryError, RestartPolicy,
+};
+use cli_builder::{load_spec_from_str, CliBuilderError, ParseResult, Parser, ParserOutput};
+use coding_adventures_json_serializer::{serialize_pretty, JsonSerializerError, SerializerConfig};
+use coding_adventures_json_value::JsonValue;
+use core::fmt::{self, Display, Formatter};
+
+const CLI_SPEC: &str = r#"{
+  "cli_builder_spec_version": "1.0",
+  "name": "chief",
+  "description": "Operate the local D18 Chief daemon.",
+  "version": "0.1.0",
+  "commands": [
+    {
+      "id": "agents",
+      "name": "agents",
+      "description": "List registered host agents."
+    },
+    {
+      "id": "doctor",
+      "name": "doctor",
+      "description": "Inspect durable and authoritative host health.",
+      "arguments": [
+        {"id": "host", "name": "HOST", "description": "Registered host name.", "type": "string", "required": true}
+      ]
+    },
+    {
+      "id": "register",
+      "name": "register",
+      "description": "Register immutable host package identity.",
+      "arguments": [
+        {"id": "host", "name": "HOST", "description": "Stable host name.", "type": "string", "required": true},
+        {"id": "package_path", "name": "PACKAGE_PATH", "description": "Portable package path.", "type": "string", "required": true},
+        {"id": "package_hash", "name": "PACKAGE_HASH", "description": "Lowercase SHA-256 package hash.", "type": "string", "required": true}
+      ],
+      "flags": [
+        {"id": "restart", "long": "restart", "description": "Durable restart policy.", "type": "enum", "enum_values": ["always", "on_failure", "never"], "default": "never", "value_name": "POLICY"},
+        {"id": "state", "long": "state", "description": "Initial desired state.", "type": "enum", "enum_values": ["running", "stopped"], "default": "stopped", "value_name": "STATE"}
+      ]
+    },
+    {
+      "id": "start",
+      "name": "start",
+      "description": "Set one host's desired state to running.",
+      "arguments": [
+        {"id": "host", "name": "HOST", "description": "Registered host name.", "type": "string", "required": true}
+      ]
+    },
+    {
+      "id": "stop",
+      "name": "stop",
+      "description": "Set one host's desired state to stopped.",
+      "arguments": [
+        {"id": "host", "name": "HOST", "description": "Registered host name.", "type": "string", "required": true}
+      ]
+    },
+    {
+      "id": "reconcile",
+      "name": "reconcile",
+      "description": "Run one bounded host reconciliation tick."
+    },
+    {
+      "id": "deregister",
+      "name": "deregister",
+      "description": "Remove stopped, inactive host intent.",
+      "arguments": [
+        {"id": "host", "name": "HOST", "description": "Registered host name.", "type": "string", "required": true}
+      ]
+    }
+  ]
+}"#;
+
+/// One complete successful parser outcome.
+#[derive(Debug)]
+pub enum CliAction {
+    /// Generated help text; no daemon connection is needed.
+    Help(String),
+    /// Generated version text; no daemon connection is needed.
+    Version(String),
+    /// One validated operation for an already-authenticated daemon client.
+    Command(CliCommand),
+}
+
+/// One typed operator command supported by the current daemon API.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CliCommand {
+    /// List all durable host registrations.
+    Agents,
+    /// Inspect durable intent and authoritative health for one host.
+    Doctor(HostName),
+    /// Register immutable package identity and initial operator intent.
+    Register {
+        /// Validated immutable host registration.
+        registration: HostRegistration,
+        /// Conservative initial lifecycle intent.
+        desired_state: DesiredState,
+    },
+    /// Set one host's desired state to running.
+    Start(HostName),
+    /// Set one host's desired state to stopped.
+    Stop(HostName),
+    /// Run one bounded reconciliation tick.
+    Reconcile,
+    /// Remove stopped, inactive host intent.
+    Deregister(HostName),
+}
+
+/// Host-control calls required by the CLI dispatcher.
+///
+/// Implementations must already be authenticated before [`execute`] is called.
+/// Keeping connection and authentication outside this trait prevents secrets
+/// and endpoints from entering the argv model.
+pub trait AuthenticatedDaemonClient {
+    /// Register immutable package identity and initial intent.
+    fn register_host(
+        &mut self,
+        registration: &HostRegistration,
+        desired_state: DesiredState,
+    ) -> Result<JsonValue, DaemonClientError>;
+
+    /// List durable hosts.
+    fn list_hosts(&mut self) -> Result<JsonValue, DaemonClientError>;
+
+    /// Change durable desired lifecycle state.
+    fn set_desired_state(
+        &mut self,
+        host_name: &HostName,
+        desired_state: DesiredState,
+    ) -> Result<JsonValue, DaemonClientError>;
+
+    /// Run one bounded reconciliation tick.
+    fn reconcile_once(&mut self) -> Result<JsonValue, DaemonClientError>;
+
+    /// Inspect durable and authoritative host health.
+    fn health_check(&mut self, host_name: &HostName) -> Result<JsonValue, DaemonClientError>;
+
+    /// Remove stopped, inactive host intent.
+    fn deregister_host(&mut self, host_name: &HostName) -> Result<JsonValue, DaemonClientError>;
+}
+
+impl AuthenticatedDaemonClient for DaemonClient {
+    fn register_host(
+        &mut self,
+        registration: &HostRegistration,
+        desired_state: DesiredState,
+    ) -> Result<JsonValue, DaemonClientError> {
+        DaemonClient::register_host(self, registration, desired_state)
+    }
+
+    fn list_hosts(&mut self) -> Result<JsonValue, DaemonClientError> {
+        DaemonClient::list_hosts(self)
+    }
+
+    fn set_desired_state(
+        &mut self,
+        host_name: &HostName,
+        desired_state: DesiredState,
+    ) -> Result<JsonValue, DaemonClientError> {
+        DaemonClient::set_desired_state(self, host_name, desired_state)
+    }
+
+    fn reconcile_once(&mut self) -> Result<JsonValue, DaemonClientError> {
+        DaemonClient::reconcile_once(self)
+    }
+
+    fn health_check(&mut self, host_name: &HostName) -> Result<JsonValue, DaemonClientError> {
+        DaemonClient::health_check(self, host_name)
+    }
+
+    fn deregister_host(&mut self, host_name: &HostName) -> Result<JsonValue, DaemonClientError> {
+        DaemonClient::deregister_host(self, host_name)
+    }
+}
+
+/// Parse one complete argv vector, including `argv[0]`.
+///
+/// Help and version are returned as local actions and never require a daemon
+/// connection. Normal commands are fully validated before being returned.
+pub fn parse_argv(argv: &[String]) -> Result<CliAction, CliError> {
+    let spec = load_spec_from_str(CLI_SPEC).map_err(CliError::Parse)?;
+    let parser = Parser::new(spec);
+    match parser.parse(argv).map_err(CliError::Parse)? {
+        ParserOutput::Help(help) => Ok(CliAction::Help(help.text)),
+        ParserOutput::Version(version) => Ok(CliAction::Version(version.version)),
+        ParserOutput::Parse(result) => parse_command(&result).map(CliAction::Command),
+    }
+}
+
+/// Execute one validated command through an already-authenticated client.
+pub fn execute(
+    client: &mut impl AuthenticatedDaemonClient,
+    command: CliCommand,
+) -> Result<JsonValue, CliError> {
+    match command {
+        CliCommand::Agents => client.list_hosts(),
+        CliCommand::Doctor(host_name) => client.health_check(&host_name),
+        CliCommand::Register {
+            registration,
+            desired_state,
+        } => client.register_host(&registration, desired_state),
+        CliCommand::Start(host_name) => client.set_desired_state(&host_name, DesiredState::Running),
+        CliCommand::Stop(host_name) => client.set_desired_state(&host_name, DesiredState::Stopped),
+        CliCommand::Reconcile => client.reconcile_once(),
+        CliCommand::Deregister(host_name) => client.deregister_host(&host_name),
+    }
+    .map_err(CliError::Daemon)
+}
+
+/// Render one successful daemon result as deterministic pretty JSON.
+pub fn render_result(result: &JsonValue) -> Result<String, CliError> {
+    let config = SerializerConfig {
+        sort_keys: true,
+        trailing_newline: true,
+        ..SerializerConfig::default()
+    };
+    serialize_pretty(result, &config).map_err(CliError::Serialize)
+}
+
+fn parse_command(result: &ParseResult) -> Result<CliCommand, CliError> {
+    match result.command_path.last().map(String::as_str) {
+        Some("agents") => Ok(CliCommand::Agents),
+        Some("doctor") => Ok(CliCommand::Doctor(host_name(result)?)),
+        Some("register") => parse_register(result),
+        Some("start") => Ok(CliCommand::Start(host_name(result)?)),
+        Some("stop") => Ok(CliCommand::Stop(host_name(result)?)),
+        Some("reconcile") => Ok(CliCommand::Reconcile),
+        Some("deregister") => Ok(CliCommand::Deregister(host_name(result)?)),
+        _ => Err(CliError::InvalidInput {
+            field: "command",
+            message: "a supported subcommand is required",
+        }),
+    }
+}
+
+fn parse_register(result: &ParseResult) -> Result<CliCommand, CliError> {
+    let host_name = host_name(result)?;
+    let package_path =
+        PackagePath::new(argument(result, "package_path")?).map_err(CliError::Registry)?;
+    let package_hash = decode_package_hash(argument(result, "package_hash")?)?;
+    let restart_policy = match flag(result, "restart")? {
+        "always" => RestartPolicy::Always,
+        "on_failure" => RestartPolicy::OnFailure,
+        "never" => RestartPolicy::Never,
+        _ => return Err(invalid_spec_value("restart")),
+    };
+    let desired_state = match flag(result, "state")? {
+        "running" => DesiredState::Running,
+        "stopped" => DesiredState::Stopped,
+        _ => return Err(invalid_spec_value("state")),
+    };
+    Ok(CliCommand::Register {
+        registration: HostRegistration::new(host_name, package_path, package_hash, restart_policy),
+        desired_state,
+    })
+}
+
+fn host_name(result: &ParseResult) -> Result<HostName, CliError> {
+    HostName::new(argument(result, "host")?).map_err(CliError::Registry)
+}
+
+fn argument<'a>(result: &'a ParseResult, id: &'static str) -> Result<&'a str, CliError> {
+    result
+        .arguments
+        .get(id)
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| invalid_spec_value(id))
+}
+
+fn flag<'a>(result: &'a ParseResult, id: &'static str) -> Result<&'a str, CliError> {
+    result
+        .flags
+        .get(id)
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| invalid_spec_value(id))
+}
+
+fn invalid_spec_value(field: &'static str) -> CliError {
+    CliError::InvalidInput {
+        field,
+        message: "declarative parser returned an unexpected value",
+    }
+}
+
+fn decode_package_hash(value: &str) -> Result<[u8; 32], CliError> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(CliError::InvalidInput {
+            field: "package_hash",
+            message: "must be exactly 64 lowercase hexadecimal characters",
+        });
+    }
+    let mut hash = [0_u8; 32];
+    for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
+        hash[index] = (hex_nibble(pair[0]) << 4) | hex_nibble(pair[1]);
+    }
+    Ok(hash)
+}
+
+fn hex_nibble(byte: u8) -> u8 {
+    match byte {
+        b'0'..=b'9' => byte - b'0',
+        b'a'..=b'f' => byte - b'a' + 10,
+        _ => unreachable!("package hash was validated before decoding"),
+    }
+}
+
+/// Stable failure categories from parsing, validation, dispatch, or rendering.
+#[derive(Debug)]
+pub enum CliError {
+    /// Declarative specification or argv parsing failed.
+    Parse(CliBuilderError),
+    /// A parsed value violated a typed CLI boundary.
+    InvalidInput {
+        /// Stable input field name.
+        field: &'static str,
+        /// Payload-independent validation message.
+        message: &'static str,
+    },
+    /// Shared registry identity validation failed.
+    Registry(RegistryError),
+    /// The authenticated daemon client rejected or could not complete the call.
+    Daemon(DaemonClientError),
+    /// A successful JSON result could not be represented.
+    Serialize(JsonSerializerError),
+}
+
+impl Display for CliError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Parse(error) => write!(formatter, "{error}"),
+            Self::InvalidInput { field, message } => {
+                write!(formatter, "invalid {field}: {message}")
+            }
+            Self::Registry(error) => write!(formatter, "{error}"),
+            Self::Daemon(error) => write!(formatter, "{error}"),
+            Self::Serialize(_) => formatter.write_str("chief CLI could not serialize the result"),
+        }
+    }
+}
+
+impl std::error::Error for CliError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Parse(error) => Some(error),
+            Self::Registry(error) => Some(error),
+            Self::Daemon(error) => Some(error),
+            Self::Serialize(error) => Some(error),
+            Self::InvalidInput { .. } => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coding_adventures_json_value::JsonNumber;
+
+    fn argv(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    fn command(values: &[&str]) -> CliCommand {
+        match parse_argv(&argv(values)).unwrap() {
+            CliAction::Command(command) => command,
+            other => panic!("expected command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn help_and_version_are_local_actions_without_secret_flags() {
+        let CliAction::Help(help) = parse_argv(&argv(&["chief", "--help"])).unwrap() else {
+            panic!("expected help");
+        };
+        assert!(help.contains("agents"));
+        assert!(help.contains("doctor"));
+        for forbidden in ["credential", "password", "passphrase", "token", "endpoint"] {
+            assert!(!help.to_ascii_lowercase().contains(forbidden));
+        }
+        assert!(matches!(
+            parse_argv(&argv(&["chief", "agents", "--token", "secret"])),
+            Err(CliError::Parse(_))
+        ));
+
+        let CliAction::Version(version) = parse_argv(&argv(&["chief", "--version"])).unwrap()
+        else {
+            panic!("expected version");
+        };
+        assert_eq!(version, "0.1.0");
+    }
+
+    #[test]
+    fn parses_every_host_lifecycle_command() {
+        assert_eq!(command(&["chief", "agents"]), CliCommand::Agents);
+        assert!(matches!(
+            command(&["chief", "doctor", "alpha-host"]),
+            CliCommand::Doctor(host) if host.as_str() == "alpha-host"
+        ));
+        assert!(matches!(
+            command(&["chief", "start", "alpha-host"]),
+            CliCommand::Start(host) if host.as_str() == "alpha-host"
+        ));
+        assert!(matches!(
+            command(&["chief", "stop", "alpha-host"]),
+            CliCommand::Stop(host) if host.as_str() == "alpha-host"
+        ));
+        assert_eq!(command(&["chief", "reconcile"]), CliCommand::Reconcile);
+        assert!(matches!(
+            command(&["chief", "deregister", "alpha-host"]),
+            CliCommand::Deregister(host) if host.as_str() == "alpha-host"
+        ));
+    }
+
+    #[test]
+    fn register_uses_conservative_defaults_and_decodes_hash() {
+        let hash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let CliCommand::Register {
+            registration,
+            desired_state,
+        } = command(&["chief", "register", "alpha-host", "pkg/alpha", hash])
+        else {
+            panic!("expected register");
+        };
+        assert_eq!(registration.host_name().as_str(), "alpha-host");
+        assert_eq!(registration.package_path().as_str(), "pkg/alpha");
+        assert_eq!(registration.package_hash()[..4], [0x01, 0x23, 0x45, 0x67]);
+        assert_eq!(registration.restart_policy(), RestartPolicy::Never);
+        assert_eq!(desired_state, DesiredState::Stopped);
+
+        let CliCommand::Register {
+            registration,
+            desired_state,
+        } = command(&[
+            "chief",
+            "register",
+            "alpha-host",
+            "pkg/alpha",
+            hash,
+            "--restart",
+            "on_failure",
+            "--state",
+            "running",
+        ])
+        else {
+            panic!("expected register");
+        };
+        assert_eq!(registration.restart_policy(), RestartPolicy::OnFailure);
+        assert_eq!(desired_state, DesiredState::Running);
+    }
+
+    #[test]
+    fn typed_boundaries_reject_invalid_identity_before_dispatch() {
+        assert!(matches!(
+            parse_argv(&argv(&["chief", "doctor", "UPPER"])),
+            Err(CliError::Registry(_))
+        ));
+        assert!(matches!(
+            parse_argv(&argv(&[
+                "chief",
+                "register",
+                "alpha-host",
+                "pkg/alpha",
+                "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789"
+            ])),
+            Err(CliError::InvalidInput {
+                field: "package_hash",
+                ..
+            })
+        ));
+        assert!(matches!(
+            parse_argv(&argv(&[
+                "chief",
+                "register",
+                "alpha-host",
+                "bad\npath",
+                &"0".repeat(64)
+            ])),
+            Err(CliError::Registry(_))
+        ));
+    }
+
+    struct RecordingClient {
+        calls: Vec<String>,
+        fail_next: bool,
+    }
+
+    impl RecordingClient {
+        fn record(&mut self, call: String) -> Result<JsonValue, DaemonClientError> {
+            self.calls.push(call);
+            if self.fail_next {
+                self.fail_next = false;
+                Err(DaemonClientError::Remote {
+                    code: "forbidden".to_string(),
+                    message: "sensitive adapter detail".to_string(),
+                })
+            } else {
+                Ok(JsonValue::String("ok".to_string()))
+            }
+        }
+    }
+
+    impl AuthenticatedDaemonClient for RecordingClient {
+        fn register_host(
+            &mut self,
+            registration: &HostRegistration,
+            desired_state: DesiredState,
+        ) -> Result<JsonValue, DaemonClientError> {
+            self.record(format!(
+                "register:{}:{desired_state:?}",
+                registration.host_name()
+            ))
+        }
+
+        fn list_hosts(&mut self) -> Result<JsonValue, DaemonClientError> {
+            self.record("agents".to_string())
+        }
+
+        fn set_desired_state(
+            &mut self,
+            host_name: &HostName,
+            desired_state: DesiredState,
+        ) -> Result<JsonValue, DaemonClientError> {
+            self.record(format!("state:{host_name}:{desired_state:?}"))
+        }
+
+        fn reconcile_once(&mut self) -> Result<JsonValue, DaemonClientError> {
+            self.record("reconcile".to_string())
+        }
+
+        fn health_check(&mut self, host_name: &HostName) -> Result<JsonValue, DaemonClientError> {
+            self.record(format!("doctor:{host_name}"))
+        }
+
+        fn deregister_host(
+            &mut self,
+            host_name: &HostName,
+        ) -> Result<JsonValue, DaemonClientError> {
+            self.record(format!("deregister:{host_name}"))
+        }
+    }
+
+    #[test]
+    fn execute_routes_every_command_and_preserves_typed_daemon_errors() {
+        let mut client = RecordingClient {
+            calls: Vec::new(),
+            fail_next: false,
+        };
+        let hash = "0".repeat(64);
+        let invocations = vec![
+            argv(&["chief", "agents"]),
+            argv(&["chief", "doctor", "alpha-host"]),
+            argv(&["chief", "register", "alpha-host", "pkg/alpha", &hash]),
+            argv(&["chief", "start", "alpha-host"]),
+            argv(&["chief", "stop", "alpha-host"]),
+            argv(&["chief", "reconcile"]),
+            argv(&["chief", "deregister", "alpha-host"]),
+        ];
+        for invocation in invocations {
+            let CliAction::Command(command) = parse_argv(&invocation).unwrap() else {
+                panic!("expected command");
+            };
+            assert_eq!(
+                execute(&mut client, command).unwrap(),
+                JsonValue::String("ok".into())
+            );
+        }
+        assert_eq!(
+            client.calls,
+            [
+                "agents",
+                "doctor:alpha-host",
+                "register:alpha-host:Stopped",
+                "state:alpha-host:Running",
+                "state:alpha-host:Stopped",
+                "reconcile",
+                "deregister:alpha-host",
+            ]
+        );
+
+        client.fail_next = true;
+        let error = execute(&mut client, CliCommand::Agents).unwrap_err();
+        assert!(matches!(
+            &error,
+            CliError::Daemon(DaemonClientError::Remote { code, message })
+                if code == "forbidden" && message == "sensitive adapter detail"
+        ));
+        assert_eq!(error.to_string(), "chief daemon rejected the request");
+        assert!(!error.to_string().contains("sensitive"));
+    }
+
+    #[test]
+    fn result_rendering_is_sorted_pretty_json_with_newline() {
+        let value = JsonValue::Object(vec![
+            ("z".to_string(), JsonValue::Number(JsonNumber::Integer(2))),
+            ("a".to_string(), JsonValue::Bool(true)),
+        ]);
+        assert_eq!(
+            render_result(&value).unwrap(),
+            "{\n  \"a\": true,\n  \"z\": 2\n}\n"
+        );
+    }
+
+    #[test]
+    fn root_invocation_requires_a_supported_subcommand() {
+        assert!(matches!(
+            parse_argv(&argv(&["chief"])),
+            Err(CliError::InvalidInput {
+                field: "command",
+                ..
+            })
+        ));
+    }
+}

--- a/code/specs/chief-of-staff-cli-core.md
+++ b/code/specs/chief-of-staff-cli-core.md
@@ -1,0 +1,84 @@
+# D18 Chief Operator CLI Core
+
+## Status
+
+This document specifies the first operator command surface for the D18 Chief
+daemon. The Rust implementation package is `chief-of-staff-cli-core`.
+
+## Purpose
+
+The CLI core converts declaratively parsed argv into typed calls on the
+authenticated Chief daemon client. This slice exposes only the host lifecycle
+operations already implemented by `chief-of-staff-daemon-api`:
+
+- `agents` lists durable host records;
+- `doctor HOST` returns durable intent and fresh supervisor evidence;
+- `register HOST PACKAGE_PATH PACKAGE_HASH` registers immutable package
+  identity and initial desired state;
+- `start HOST` and `stop HOST` update durable desired state;
+- `reconcile` runs one bounded convergence tick; and
+- `deregister HOST` removes stopped, inactive intent.
+
+Pipeline control, interactive agent conversations, approvals, vault unlock,
+daemon installation, and background scheduling remain later slices because the
+daemon does not expose those capabilities yet.
+
+## Trust Boundary
+
+The core never accepts credentials, tokens, passphrases, or socket endpoints in
+argv. It executes against an already connected and authenticated client supplied
+by the outer process adapter. Secure terminal input, credential lifetime,
+loopback connection policy, and process exit codes therefore remain outside the
+parser and dispatcher.
+
+The public client trait is implemented for `chief_of_staff_daemon_api::DaemonClient`.
+Tests may inject an in-memory client without opening sockets.
+
+## Declarative Syntax
+
+The command tree is embedded as a `cli-builder` 1.0 JSON specification. The
+parser owns help, version output, subcommand routing, required argument checks,
+and enum validation.
+
+`register` accepts these flags:
+
+- `--restart always|on_failure|never`, defaulting to `never`;
+- `--state running|stopped`, defaulting to `stopped`.
+
+The conservative defaults prevent an omitted option from creating an automatic
+restart loop or immediately launching a newly registered package.
+
+Host names and package paths are validated by `chief-of-staff-service-registry`.
+Package hashes must be exactly 64 lowercase hexadecimal characters and are
+decoded into 32 bytes before any daemon call. The CLI introduces no second
+host-identity grammar.
+
+## Output and Errors
+
+Successful daemon results remain `JsonValue` values and can be rendered as
+deterministic two-space-indented JSON with a trailing newline. This preserves
+the daemon's precision-safe string representation for revisions and timestamps.
+
+Errors distinguish declarative parse failures, invalid typed input, daemon
+client failures, and local result-serialization failures. Daemon failures keep
+their typed source; their payload-blind `Display` behavior is not weakened by
+the CLI core.
+
+## Capabilities
+
+The package performs no filesystem, network, process, environment, clock,
+randomness, terminal, or secret-store access. Network and credential authority
+belong to the injected authenticated client and the future executable adapter.
+
+## Required Tests
+
+The package must cover:
+
+- declarative help and version behavior;
+- parsing every supported command;
+- conservative registration defaults and explicit enum overrides;
+- host-name, package-path, and lowercase SHA-256 validation;
+- dispatch of every command through an injected client;
+- preservation of typed daemon failures;
+- deterministic JSON result rendering; and
+- absence of credential-bearing argv flags or help text.


### PR DESCRIPTION
## Summary

- specify and add the dependency-free operator command layer for the current Chief daemon host-lifecycle API
- parse `agents`, `doctor`, `register`, `start`, `stop`, `reconcile`, and `deregister` through the repository `cli-builder`
- dispatch through the typed `DaemonClient` behind an injected already-authenticated client boundary
- validate shared host identity, portable package paths, and lowercase SHA-256 hashes before any daemon call
- render successful results as deterministic precision-preserving JSON

## Security boundary

Credentials, passphrases, tokens, endpoints, terminal access, and connection setup are deliberately absent from argv and this package. Credential-like flags are rejected. The outer executable adapter will own secure terminal acquisition and pass an authenticated client into this core.

## Validation

- `cargo fmt -p chief-of-staff-cli-core -- --check`
- `cargo test -p chief-of-staff-cli-core -- --nocapture`
- `cargo clippy -p chief-of-staff-cli-core --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p chief-of-staff-cli-core --no-deps`
- repository build planner: 1 changed package, 54 affected, Rust only

Advances #128 and #140. This intentionally does not claim pipeline, approval, vault-unlock, install-daemon, or interactive agent commands before those daemon capabilities exist.
