### PR TITLE
fix(spice): lower parser JFET gate-source capacitance

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `CGS` and `CGS0` gate-source capacitance
+  parameters instead of silently dropping them.
 - Validate MOS model-card `NSS` and `TPG` process parameters and derive missing
   `VT0`, `GAMMA`, and `PHI` values from `N_SUB` / `TOX` through shared engine semantics.
 - Validate and lower MOS model-card `CJS` and `CJD` aliases as canonical `CBS`

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1314,6 +1314,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             beta=model.params.get("BETA", model.params.get("B", 1.0e-4)),
             vto=model.params.get("VTO", -2.0 if model.kind == "NJF" else 2.0),
             lambda_=model.params.get("LAMBDA", 0.0),
+            Cgs=model.params.get("CGS", model.params.get("CGS0", 0.0)),
         )
     if prefix == "M":
         _require_min_fields(fields, 6, "MOSFET")
@@ -1905,6 +1906,13 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
         if params_text.startswith("(") and params_text.endswith(")"):
             params_text = params_text[1:-1]
     params = _parse_model_params(params_text)
+    if kind in {"NJF", "PJF"}:
+        gate_source_capacitance = params.get("CGS", params.get("CGS0"))
+        if gate_source_capacitance is not None and (
+            not math.isfinite(gate_source_capacitance)
+            or gate_source_capacitance < 0.0
+        ):
+            raise NetlistParseError("JFET CGS must be finite and non-negative")
     if kind in {"NMOS", "PMOS"}:
         if "LEVEL" in params:
             level = params["LEVEL"]

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -884,6 +884,28 @@ J1 drain gate source fast
     assert jfet.lambda_ == 0.02
 
 
+@pytest.mark.parametrize("parameter", ["CGS", "CGS0"])
+def test_parse_jfet_gate_source_capacitance_aliases(parameter: str) -> None:
+    parsed = parse_netlist(
+        f"""
+.model fast NJF({parameter}=3p)
+J1 drain gate source fast
+"""
+    )
+
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert isclose(jfet.Cgs, 3.0e-12)
+
+
+@pytest.mark.parametrize("value", ["-1p", "1e999"])
+def test_rejects_invalid_jfet_gate_source_capacitance(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="JFET CGS must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NJF(CGS={value})")
+
+
 def test_parse_pjf_model_aliases_beta() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `CGS` and `CGS0` gate-source capacitance
+  parameters instead of silently dropping them.
 - Validate MOS model-card `NSS` and `TPG` process parameters and derive missing
   `VT0`, `GAMMA`, and `PHI` values from `N_SUB` / `TOX` through shared engine semantics.
 - Validate and lower MOS model-card `CJS` and `CJD` aliases as canonical `CBS`

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1150,6 +1150,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   }
   const kind = match[1].toUpperCase();
   const params = parseModelParams(paramsText);
+  const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
+  if (
+    (kind === "NJF" || kind === "PJF") &&
+    gateSourceCapacitance !== undefined &&
+    (!Number.isFinite(gateSourceCapacitance) || gateSourceCapacitance < 0.0)
+  ) {
+    throw new NetlistParseError("JFET CGS must be finite and non-negative");
+  }
   const level = params.get("LEVEL");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1715,6 +1723,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("BETA") ?? model.params.get("B") ?? 1.0e-4,
       model.params.get("VTO") ?? (polarity === "NJF" ? -2.0 : 2.0),
       model.params.get("LAMBDA") ?? 0.0,
+      model.params.get("CGS") ?? model.params.get("CGS0") ?? 0.0,
     );
   }
   if (prefix === "M") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -868,6 +868,30 @@ J1 drain gate source fast
     });
   });
 
+  it.each(["CGS", "CGS0"])(
+    "parses the JFET %s gate-source capacitance alias",
+    (parameter) => {
+      const parsed = parseNetlist(`
+.model fast NJF(${parameter}=3p)
+J1 drain gate source fast
+`);
+
+      expect(parsed.circuit.elements()[0]).toMatchObject({
+        kind: "jfet",
+        gateSourceCapacitance: 3.0e-12,
+      });
+    },
+  );
+
+  it.each(["-1p", "1e999"])(
+    "rejects invalid JFET gate-source capacitance %s",
+    (value) => {
+      expect(() => parseNetlist(`.model fast NJF(CGS=${value})`)).toThrow(
+        "JFET CGS must be finite and non-negative",
+      );
+    },
+  );
+
   it("parses PJF model beta aliases", () => {
     const parsed = parseNetlist(`
 .model pslow PJF(B=750u)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4314,11 +4314,17 @@ the Rust, Python, and TypeScript surfaces together.
    - `CJS` and `CJD` are validated and lowered as canonical `CBS` and `CBD`
      bottom-junction capacitances in both parser facades.
 
+400. Python and TypeScript Berkeley SPICE MOS electrostatic defaults.
+   - Status: completed in PR 9729.
+   - Both parser facades validate `NSS` and `TPG`, then reuse the shared engine
+     normalizer to derive missing `KP`, `VT0`, `GAMMA`, and `PHI` values from
+     process parameters while preserving explicit model and instance values.
+
 ## Backlog
 
-1. Python and TypeScript Berkeley SPICE MOS electrostatic-default parity.
-   - Validate and consume `NSS` / `TPG`, then derive `VT0`, `GAMMA`, and `PHI`
-     from `N_SUB` / `TOX` with shared engine semantics.
+1. Python and TypeScript Berkeley SPICE JFET remaining parameter-lowering parity.
+   - Validate and lower `CGD` / `CGD0` gate-drain capacitance instead of
+     silently dropping the shared engine parameter.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary
- validate finite, non-negative JFET `CGS` and `CGS0` model-card values in the Python and TypeScript parser facades
- lower the selected value into the engines' existing gate-source capacitance field
- record PR #9729 in the SPICE plan and queue the remaining `CGD` parity gap

## Verification
- Python `spice-netlist-parser`: `bash BUILD` (223 passed, 88.66% coverage)
- Python `spice-netlist-parser`: `.venv/bin/ruff check .`
- TypeScript `spice-engine`: `npm test` (448 passed)
- TypeScript `spice-netlist-parser`: `bash BUILD` (212 passed)
- TypeScript `spice-netlist-parser`: `npm run test:coverage` (212 passed, 85.44% line coverage)