### PR TITLE
Report formatting recovery across table scope

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- A formatting end tag that cannot cross an open table scope now reports the
+  Standard's parse error, covering 2 previously silent malformed corpus cases
+  without changing DOM recovery.
 - A paragraph end tag that breaks out of MathML foreign content now reports
   the Standard's parse error, covering 2 previously silent malformed corpus
   cases without changing DOM recovery.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -22,7 +22,7 @@ exact upstream commits used for the latest completed audit.
 ## Prioritized Queue
 
 The 2026-08-03 upstream audit at WPT
-`a73cf1e91a6a95e4c5c39494d8fbfdab0b38cae1` and html5lib-tests
+`82c3d9069cf2e93e5528a1f428fa122bd9af651d` and html5lib-tests
 `224991ec10db04f056a89eed8b0bd8695fd2950e` covered all 1,934 WPT
 tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the specialized paragraph foreign-content diagnostic slice, 2,009 of
-those cases emit at least one lexer or parser diagnostic and 174 remain
+After the specialized formatting/table-scope diagnostic slice, 2,011 of those
+cases emit at least one lexer or parser diagnostic and 172 remain
 uncovered.
 Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
 These are reviewed rather than automatically removed: 89 are full-document
@@ -55,11 +55,12 @@ original mode; synthetic text fragment contexts remain diagnostic-free.
 The in-body "any other end tag" parse error is now reported when implied end
 tags leave the matching open element non-current, including special-element
 scope stops and nested formatting recovery. Remaining in-body work covers
-adoption-agency and formatting-reconstruction branches. Heading end tags report
+formatting-reconstruction and stray-tag branches. Heading end tags report
 the specialized parse error when no heading is in scope or the current heading
 does not match the token. A `li` start tag reports when its implied-end-tag
 recovery closes a non-current list item, and a paragraph end tag reports when it
-breaks out of MathML foreign content.
+breaks out of MathML foreign content. A formatting end tag also reports when an
+open table blocks adoption-agency recovery.
 
 Prioritized work items:
 

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -6986,6 +6986,12 @@ impl HtmlParser {
                 return;
             }
             if is_formatting_element(name) && self.has_table_context_above(index) {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-formatting-end-tag-in-table",
+                    format!(
+                        "end tag `</{name}>` could not close a formatting element across table scope"
+                    ),
+                ));
                 if self.open_element_is_fostered_before_open_table(index) {
                     self.capture_formatting_above(index);
                     self.open_elements.truncate(index);
@@ -33285,6 +33291,20 @@ mod tests {
             vec![ParserDiagnostic::new(
                 "unexpected-p-end-tag-in-foreign-content",
                 "end tag `</p>` in MathML foreign content forced HTML recovery"
+            )]
+        );
+    }
+
+    #[test]
+    fn reports_formatting_end_tag_recovery_across_table_scope() {
+        let output =
+            parse_html_with_diagnostics("<!DOCTYPE html><font><table></font></table></font>")
+                .unwrap();
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-formatting-end-tag-in-table",
+                "end tag `</font>` could not close a formatting element across table scope"
             )]
         );
     }

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
@@ -14,7 +14,7 @@
     "missing": 0,
     "missing_sources": [],
     "upstream_cases": 1934,
-    "upstream_revision": "a73cf1e91a6a95e4c5c39494d8fbfdab0b38cae1",
+    "upstream_revision": "82c3d9069cf2e93e5528a1f428fa122bd9af651d",
     "upstream_source": "wpt/html/syntax/parsing/resources"
   }
 }

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 174);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2009);
+    assert_eq!(missing_diagnostic_cases, 172);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2011);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report the HTML Standard parse error when a formatting end tag cannot cross an open table scope
- cover the two duplicated retained `font` recovery cases without changing DOM recovery
- ratchet diagnostic coverage from 2,009 to 2,011 cases and reprioritize the remaining backlog

## Evidence
- WPT `82c3d9069cf2e93e5528a1f428fa122bd9af651d`: 1,934/1,934 tree signatures, zero missing
- html5lib-tests `224991ec10db04f056a89eed8b0bd8695fd2950e`: 6,806/6,806 tokenizer signatures, zero missing and zero normalized skips
- 2,637/2,637 checked DOM outputs preserved
- silent declared-error cases: 174 to 172
- covered declared-error cases: 2,009 to 2,011
- undeclared diagnostics remain 139

## Validation
- `cargo test -p coding-adventures-html-parser --test tree_construction_test`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- WHATWG audit manifest/Rust-test/coverage checks
- generated fixture and README inventory checks
- `git diff --check`

This is a bounded diagnostic-conformance slice; it does not claim full browser conformance.