### PR TITLE
feat(sir-conformance): Collections cascade corpus + Linux -lm link fix

### DIFF
--- a/code/packages/rust/c-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/c-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Fixed (CI — Linux link failure)
+
+- Three C-compiling test helpers (`tests/three_way_conformance.rs`'s two,
+  plus `src/lib.rs`'s inline unit-test `run_c`) didn't link `-lm`. Harmless
+  until `semantic-ir-to-c`'s Numeric Collections slice
+  (0.31.0) made `floor`/`ceil`/`round`/`abs` the first `<math.h>` calls the
+  embedded runtime template makes — pasted into every generated `.c` file
+  regardless of source content, so any program compiled through this
+  crate's C round-trip now fails to link on Linux (`undefined reference to
+  'floor'`) without it. Fixed alongside the same gap in `sir-conformance`
+  and `sir-bench`.
+
 ### Milestone 11 — fixed-size arrays
 
 The first of the four aggregate axes (arrays → structs → pointers → strings).

--- a/code/packages/rust/c-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/c-to-semantic-ir/src/lib.rs
@@ -830,6 +830,7 @@ mod tests {
             .arg("-o")
             .arg(&exe)
             .arg(&cpath)
+            .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
             .output()
             .ok()?;
         assert!(

--- a/code/packages/rust/c-to-semantic-ir/tests/three_way_conformance.rs
+++ b/code/packages/rust/c-to-semantic-ir/tests/three_way_conformance.rs
@@ -119,6 +119,7 @@ fn run_reference(cc: &str, src: &str) -> String {
         .args(["-std=c99", "-fwrapv", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("reference compiler runs");
     assert!(
@@ -164,6 +165,7 @@ fn run_emitted_c(cc: &str, src: &str) -> String {
         .args(["-std=c99", "-o"])
         .arg(&exe)
         .arg(&cpath)
+        .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
         .output()
         .expect("emitted C compiler runs");
     assert!(

--- a/code/packages/rust/sir-bench/CHANGELOG.md
+++ b/code/packages/rust/sir-bench/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.1.1 — fix: Linux link failure benchmarking the C target
+
+The C-target compile step didn't link `-lm`. Harmless until
+`semantic-ir-to-c`'s Numeric Collections slice (0.31.0) made
+`floor`/`ceil`/`round`/`abs` the first `<math.h>` calls the embedded
+runtime template makes — pasted into every generated `.c` file regardless
+of source content, so benchmarking the C target now fails to link on
+Linux (`undefined reference to 'floor'`) without it. Fixed alongside the
+same gap in `sir-conformance` and `c-to-semantic-ir`.
+
 ## 0.1.0 — initial cross-backend performance benchmark harness
 
 First cut of `sir-bench`: measures how fast the code each backend *generates*

--- a/code/packages/rust/sir-bench/Cargo.toml
+++ b/code/packages/rust/sir-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sir-bench"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Cross-backend performance benchmark harness for the Semantic IR: lowers real Ruby source, emits to every backend, and times emit / compile / run so you can see how fast the GENERATED code is (Ruby → SIR → C / Rust / Go / Python / JS / Ruby)."
 

--- a/code/packages/rust/sir-bench/src/lib.rs
+++ b/code/packages/rust/sir-bench/src/lib.rs
@@ -326,6 +326,7 @@ fn compile_target(
                 .args(["-std=c99", "-O2", "-o"])
                 .arg(bin_path)
                 .arg(source_path)
+                .arg("-lm")  // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
                 .output()
         }
         Target::Rust => Command::new("rustc")

--- a/code/packages/rust/sir-conformance/CHANGELOG.md
+++ b/code/packages/rust/sir-conformance/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to the `sir-conformance` crate will be documented in this file.
 
+## [0.21.0] - Collections cascade corpus + Linux link fix
+
+Adds six new corpus programs proving the C-backend Collections slices
+(3-10: Array/Hash/String/Numeric/Symbol methods) agree across Python,
+JavaScript, Go, Rust, and C — `array_reduce` (a block method, proving
+closures round-trip identically through every backend's calling
+convention), `array_count_sum`, `hash_length_fetch`, `string_gsub_sub`,
+`numeric_abs_gcd`, `symbol_upcase_length`. All six print scalars only
+(never a bare Array/Hash) to sidestep a separate, real bug this batch
+surfaced: `puts` on an Array bracket-displays it on the C backend
+(`[1, 2, 3]`) but correctly unpacks one element per line on
+Python/JS/Go/Rust, matching real Ruby — tracked as its own follow-up, not
+fixed here. The Ruby target (as expected) skips every one of them: it has
+no Collections method dispatch at all yet, also tracked as its own
+follow-up.
+
+Also updates the `array_length` doc comment: the frontend bugs that used
+to block bracket-index (`a[1]`) from this corpus are now fixed (PR
+#9686), but bracket-index still isn't added here — Python/JS/Go/Rust's
+runtime catalogs have no `[]`/`[]=` dispatch yet, so it would fail (not
+skip) on four of six targets. Tracked as its own follow-up.
+
+### Fixed (CI — Linux link failure)
+
+- `run_c`'s compile command didn't link `-lm`. Harmless until
+  `semantic-ir-to-c`'s Numeric Collections slice (0.31.0) made
+  `floor`/`ceil`/`round`/`abs` the first `<math.h>` calls the embedded
+  runtime template makes — pasted into every generated `.c` file
+  regardless of source content, so every C-target conformance run failed
+  to link on Linux (`undefined reference to 'floor'`) without it. Fixed
+  alongside the same gap in `c-to-semantic-ir` and `sir-bench`.
+
 ## [0.20.0] - Comparison-operator frontier
 
 Adds `comparison_operators_match_ruby_on_every_backend`: `==`, `!=`, `<=`, `>=`

--- a/code/packages/rust/sir-conformance/Cargo.toml
+++ b/code/packages/rust/sir-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sir-conformance"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 description = "Cross-backend golden conformance harness for the Semantic IR: lowers real Ruby source and runs the emitted program through every backend's real toolchain, asserting identical output."
 

--- a/code/packages/rust/sir-conformance/README.md
+++ b/code/packages/rust/sir-conformance/README.md
@@ -69,6 +69,12 @@ across backends, a separate formatting concern). Current programs:
 | `multi_when` | multi-value `when 1, 2, 3` (folds through `or`) | `small\nbig` |
 | `string_case` | `String#upcase`/`#downcase`/`#strip` (Ruby→JS renames) | `HELLO\nworld\nhi` |
 | `seq_assign` | sequential assignment reading an earlier local (`b = a + 1`) | `5\n6\n11` |
+| `array_reduce` | Array block method (`reduce`) — closures across every backend | `10` |
+| `array_count_sum` | Array 0-arg query methods (`count`/`sum`) | `5\n6` |
+| `hash_length_fetch` | Hash non-block methods (`length`/`fetch`) | `2\n1` |
+| `string_gsub_sub` | remaining String methods (`gsub`/`sub`) | `bbb\nbaa` |
+| `numeric_abs_gcd` | Numeric methods (`abs`/`gcd`) | `5\n6` |
+| `symbol_upcase_length` | Symbol methods widened from String helpers | `HELLO\n5` |
 
 Adding a program is one `Program { name, ruby, expected }` entry in
 `tests/conformance.rs`.
@@ -80,11 +86,25 @@ backends" bug. Programs that hit an **unfixed** gap are kept *out* of the corpus
 (with a pointer to `lessons.md`) so the suite stays green while the gap stays
 visible. Currently tracked:
 
-- **Array/hash index reads** (`a[i]`, `h[k]`) — a frontend PARSER-precedence
-  gap: `a[1]` mis-parses as `a` followed by a bare `[1]` array literal
-  (`puts a[1]` → `(puts a)[1]`; `puts(a[1])` fails to parse). Needs a grammar
-  fix. (The *scoping* half — `x = a[1]` failing SIR validation — turned out to
-  be the general sequential-assignment bug and is now fixed; see `seq_assign`.)
+- **Array/hash index writes AND reads** (`a[i]`, `a[i] = v`, `h[k]`) — the
+  frontend parses and lowers both correctly now (PR #9686 fixed the
+  PARSER-precedence gap this section used to describe), but only the C
+  backend has a runtime `[]`/`[]=` dispatch implementation. Python/JS/Go/
+  Rust fail (not skip) at runtime. Needs a `[]`/`[]=` catalog entry on each
+  of those four runtimes.
+- **The `puts`-on-an-Array display convention** — `puts [1,2,3]` correctly
+  unpacks to `"1\n2\n3\n"` (real Ruby's rule) on Python/JS/Go/Rust, but the
+  C backend bracket-displays it (`"[1, 2, 3]\n"`) instead — the same
+  rendering `p`/`inspect` correctly use, just wrongly reused for `puts`
+  too. Needs a `puts`-specific Array-unpacking path in the C runtime,
+  distinct from its general display helper.
+- **Collections methods on the Ruby backend** — `semantic-ir-to-ruby`
+  rejects EVERY `__method__` dispatch to a built-in Collections method
+  across all ten slices; Python/JS/Go/Rust/C all handle the catalog
+  uniformly, Ruby has none of it yet. Every Collections-flavored corpus
+  program above (and several pre-existing ones) skips on the `ruby` target
+  for this reason — visible in the test's `--nocapture` output, not a
+  silent gap.
 
 Fixed since (now IN the suite):
 - The `or`/`and` builtin gap — `||`/`&&` and multi-value `when` threw

--- a/code/packages/rust/sir-conformance/src/lib.rs
+++ b/code/packages/rust/sir-conformance/src/lib.rs
@@ -402,6 +402,9 @@ fn run_c(name: &str, module: &Module) -> RunOutcome {
         .arg("-o")
         .arg(&bin)
         .arg(&src)
+        // Linux needs -lm to link floor/ceil/fabs (Numeric methods, slice 9);
+        // macOS's libSystem folds libm in, so this is a no-op there.
+        .arg("-lm")
         .output();
     match compiled {
         Ok(o) if o.status.success() => {

--- a/code/packages/rust/sir-conformance/tests/conformance.rs
+++ b/code/packages/rust/sir-conformance/tests/conformance.rs
@@ -60,14 +60,18 @@ const CORPUS: &[Program] = &[
     },
     // Array literal + `.length` (a method call, which lowers cleanly).
     //
-    // NOTE: index *reads* (`a[1]`, `h["k"]`) are deliberately NOT in the corpus
-    // yet — they hit two separate, currently-open Ruby-frontend gaps (see
-    // `lessons.md`): the paren-less `puts a[1]` mis-parses as `(puts a)[1]` and
-    // `puts(a[1])` fails to parse, while `x = a[1]` parses but fails SIR
-    // validation (`var-ref ... unknown name 'a'` — the index base is
-    // mis-scoped). Those are frontend bugs, tracked for a separate fix; adding a
-    // program that can't pass would only mask them. `.length` covers array
-    // construction end-to-end without tripping the index path.
+    // UPDATE: the frontend gaps that used to block index *reads* (`a[1]`,
+    // `h["k"]`) are now FIXED — `a[1]`/`h["k"] = v` parse and lower correctly
+    // on every backend (PR #9686, both the grammar and the shared
+    // `__method__("[]"/"[]=", ...)` lowering). Still NOT in this corpus,
+    // though, for a DIFFERENT reason: that lowering only has a runtime
+    // dispatch implementation on the C backend so far — Python/JS/Go/Rust's
+    // OOP runtime catalogs have no `[]`/`[]=` entries yet, so a bracket-index
+    // program fails at runtime (not a skip) on those four. Tracked as its own
+    // follow-up ("Python/JS/Go/Rust backends: implement []/[]= bracket-index
+    // runtime dispatch"); adding it here now would break the matrix rather
+    // than prove anything. `.length` covers array construction end-to-end
+    // without tripping the index path.
     Program {
         name: "array_length",
         ruby: "a = [10, 20, 30]\nputs a.length\n",
@@ -135,6 +139,55 @@ const CORPUS: &[Program] = &[
         name: "seq_assign",
         ruby: "a = 5\nb = a + 1\nc = b + a\nputs a\nputs b\nputs c\n",
         expected: "5\n6\n11",
+    },
+    // ── Collections cascade (C-backend slices 3-10) ──────────────────────
+    //
+    // The programs below all print SCALARS (never a bare Array/Hash), so
+    // they sidestep a separate, real display-convention bug this batch
+    // uncovered: `puts` on an Array bracket-displays it on the C backend
+    // (`[1, 2, 3]`) but correctly unpacks one element per line on
+    // Python/JS/Go/Rust, matching real Ruby (`puts [1,2,3]` → "1\n2\n3\n").
+    // Tracked as its own follow-up ("C backend: puts on an Array should
+    // unpack one-per-line") rather than fixed here — this corpus addition's
+    // job is proving the METHOD CATALOG agrees, not the display layer.
+    //
+    // A block method (`reduce`), proving closures round-trip identically
+    // through every backend's calling convention.
+    Program {
+        name: "array_reduce",
+        ruby: "puts [1, 2, 3, 4].reduce { |acc, x| acc + x }\n",
+        expected: "10",
+    },
+    // Two Array 0-arg query methods (slice 3).
+    Program {
+        name: "array_count_sum",
+        ruby: "puts [1, 2, 3, 4, 5].count\nputs [1, 2, 3].sum\n",
+        expected: "5\n6",
+    },
+    // Hash non-block methods (slice 6): `.length` and `.fetch`.
+    Program {
+        name: "hash_length_fetch",
+        ruby: "h = {\"a\" => 1, \"b\" => 2}\nputs h.length\nputs h.fetch(\"a\")\n",
+        expected: "2\n1",
+    },
+    // Remaining String methods (slice 8): literal `sub`/`gsub`.
+    Program {
+        name: "string_gsub_sub",
+        ruby: "puts \"aaa\".gsub(\"a\", \"b\")\nputs \"aaa\".sub(\"a\", \"b\")\n",
+        expected: "bbb\nbaa",
+    },
+    // Numeric methods (slice 9): `abs` and `gcd`.
+    Program {
+        name: "numeric_abs_gcd",
+        ruby: "puts((-5).abs)\nputs 12.gcd(18)\n",
+        expected: "5\n6",
+    },
+    // Symbol methods (slice 10): `upcase` widened from the String helper,
+    // `length` widened the same way.
+    Program {
+        name: "symbol_upcase_length",
+        ruby: "puts :hello.upcase\nputs :hello.length\n",
+        expected: "HELLO\n5",
     },
 ];
 


### PR DESCRIPTION
## Summary

- Adds 6 corpus programs to `sir-conformance`, proving the C-backend Collections slices (Array/Hash/String/Numeric/Symbol methods, slices 3–10) agree across Python/JavaScript/Go/Rust/C: `array_reduce` (a block method — proves closures round-trip identically through every backend's calling convention), `array_count_sum`, `hash_length_fetch`, `string_gsub_sub`, `numeric_abs_gcd`, `symbol_upcase_length`.
- All six print scalars only (never a bare Array/Hash) — this sidesteps a real bug the batch surfaced: `puts` on an Array bracket-displays it on the C backend (`[1, 2, 3]`) but correctly unpacks one element per line on Python/JS/Go/Rust, matching real Ruby. Filed separately, not fixed here.
- **Two more gaps discovered and filed** (out of scope for a corpus PR): Python/JS/Go/Rust have no `[]`/`[]=` runtime dispatch yet, even though the frontend now parses bracket-index correctly since #9686 (only C implements it); the Ruby backend (`semantic-ir-to-ruby`) has no Collections method dispatch at all — every Collections-flavored corpus program skips on the `ruby` target.
- **Linux CI fix**: `sir-conformance`'s `run_c`, `c-to-semantic-ir`'s three C-compiling test helpers, and `sir-bench`'s C-target benchmark step all lacked `-lm`. Harmless until `semantic-ir-to-c`'s Numeric slice (0.31.0, merged) made `floor`/`ceil`/`round`/`abs` the first `<math.h>` calls in the universally-embedded runtime template — every one of these now fails to link on Linux without it (same root cause already fixed in `semantic-ir-to-c`'s own tests, PR #9713).

`sir-conformance` 0.20.0 → 0.21.0, `sir-bench` 0.1.0 → 0.1.1.

## Test plan
- [x] `corpus_agrees_across_all_backends` and `corpus_all_lowers` — 21 corpus × 6 backends = 115 ran, 11 skipped (all skips are the Ruby target on Collections-flavored programs, the known gap above), 0 failures.
- [x] Full `sir-conformance` + `c-to-semantic-ir` + `sir-bench` regression suite — all green, pre- and post-rebase onto latest `origin/main`.
- [x] `cargo clippy` — clean.
- [x] Security review (sub-agent) — PASSED (low-risk diff: static test-data literals + a linker-flag addition to existing `Command` builders, no new injection surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)