### PR TITLE
fix(spice): lower parser JFET gate-drain capacitance

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `CGD` and `CGD0` gate-drain capacitance
+  parameters instead of silently dropping them.
 - Validate and lower JFET model-card `CGS` and `CGS0` gate-source capacitance
   parameters instead of silently dropping them.
 - Validate MOS model-card `NSS` and `TPG` process parameters and derive missing

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1315,6 +1315,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             vto=model.params.get("VTO", -2.0 if model.kind == "NJF" else 2.0),
             lambda_=model.params.get("LAMBDA", 0.0),
             Cgs=model.params.get("CGS", model.params.get("CGS0", 0.0)),
+            Cgd=model.params.get("CGD", model.params.get("CGD0", 0.0)),
         )
     if prefix == "M":
         _require_min_fields(fields, 6, "MOSFET")
@@ -1913,6 +1914,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or gate_source_capacitance < 0.0
         ):
             raise NetlistParseError("JFET CGS must be finite and non-negative")
+        gate_drain_capacitance = params.get("CGD", params.get("CGD0"))
+        if gate_drain_capacitance is not None and (
+            not math.isfinite(gate_drain_capacitance)
+            or gate_drain_capacitance < 0.0
+        ):
+            raise NetlistParseError("JFET CGD must be finite and non-negative")
     if kind in {"NMOS", "PMOS"}:
         if "LEVEL" in params:
             level = params["LEVEL"]

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -906,6 +906,28 @@ def test_rejects_invalid_jfet_gate_source_capacitance(value: str) -> None:
         parse_netlist(f".model fast NJF(CGS={value})")
 
 
+@pytest.mark.parametrize("parameter", ["CGD", "CGD0"])
+def test_parse_jfet_gate_drain_capacitance_aliases(parameter: str) -> None:
+    parsed = parse_netlist(
+        f"""
+.model fast NJF({parameter}=4p)
+J1 drain gate source fast
+"""
+    )
+
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert isclose(jfet.Cgd, 4.0e-12)
+
+
+@pytest.mark.parametrize("value", ["-1p", "1e999"])
+def test_rejects_invalid_jfet_gate_drain_capacitance(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="JFET CGD must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NJF(CGD={value})")
+
+
 def test_parse_pjf_model_aliases_beta() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `CGD` and `CGD0` gate-drain capacitance
+  parameters instead of silently dropping them.
 - Validate and lower JFET model-card `CGS` and `CGS0` gate-source capacitance
   parameters instead of silently dropping them.
 - Validate MOS model-card `NSS` and `TPG` process parameters and derive missing

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1158,6 +1158,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("JFET CGS must be finite and non-negative");
   }
+  const gateDrainCapacitance = params.get("CGD") ?? params.get("CGD0");
+  if (
+    (kind === "NJF" || kind === "PJF") &&
+    gateDrainCapacitance !== undefined &&
+    (!Number.isFinite(gateDrainCapacitance) || gateDrainCapacitance < 0.0)
+  ) {
+    throw new NetlistParseError("JFET CGD must be finite and non-negative");
+  }
   const level = params.get("LEVEL");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1724,6 +1732,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("VTO") ?? (polarity === "NJF" ? -2.0 : 2.0),
       model.params.get("LAMBDA") ?? 0.0,
       model.params.get("CGS") ?? model.params.get("CGS0") ?? 0.0,
+      model.params.get("CGD") ?? model.params.get("CGD0") ?? 0.0,
     );
   }
   if (prefix === "M") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -892,6 +892,30 @@ J1 drain gate source fast
     },
   );
 
+  it.each(["CGD", "CGD0"])(
+    "parses the JFET %s gate-drain capacitance alias",
+    (parameter) => {
+      const parsed = parseNetlist(`
+.model fast NJF(${parameter}=4p)
+J1 drain gate source fast
+`);
+
+      expect(parsed.circuit.elements()[0]).toMatchObject({
+        kind: "jfet",
+        gateDrainCapacitance: 4.0e-12,
+      });
+    },
+  );
+
+  it.each(["-1p", "1e999"])(
+    "rejects invalid JFET gate-drain capacitance %s",
+    (value) => {
+      expect(() => parseNetlist(`.model fast NJF(CGD=${value})`)).toThrow(
+        "JFET CGD must be finite and non-negative",
+      );
+    },
+  );
+
   it("parses PJF model beta aliases", () => {
     const parsed = parseNetlist(`
 .model pslow PJF(B=750u)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4320,11 +4320,16 @@ the Rust, Python, and TypeScript surfaces together.
      normalizer to derive missing `KP`, `VT0`, `GAMMA`, and `PHI` values from
      process parameters while preserving explicit model and instance values.
 
+401. Python and TypeScript Berkeley SPICE JFET gate-source capacitance parity.
+   - Status: completed in PR 9731.
+   - Both parser facades validate non-negative finite `CGS` / `CGS0` values
+     and lower them into the shared engine gate-source capacitance field.
+
 ## Backlog
 
-1. Python and TypeScript Berkeley SPICE JFET remaining parameter-lowering parity.
-   - Validate and lower `CGD` / `CGD0` gate-drain capacitance instead of
-     silently dropping the shared engine parameter.
+1. Python and TypeScript Berkeley SPICE diode model-card alias parity.
+   - Align parser validation and lowering with the shared engine aliases,
+     starting with `JS` as the diode saturation-current alias for `IS`.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary
- validate finite, non-negative JFET `CGD` and `CGD0` model-card values in the Python and TypeScript parser facades
- lower the selected value into the engines' existing gate-drain capacitance field
- record PR #9731 in the SPICE plan and queue diode model-card alias parity next

## Verification
- Python `spice-netlist-parser`: `bash BUILD` (227 passed, 88.68% coverage)
- Python `spice-netlist-parser`: `.venv/bin/ruff check .`
- TypeScript `spice-engine`: `npm test` (448 passed)
- TypeScript `spice-netlist-parser`: `bash BUILD` (216 passed)
- TypeScript `spice-netlist-parser`: `npm run test:coverage` (216 passed, 85.49% line coverage)