### PR TITLE
fix(human-languages): make Italian book warning-free

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -82,9 +82,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B12 | Complete (#9705) | Publish Bengali Chapter 6 from its canonical lesson rather than hand-copying another book chapter. | The schema-v2 lesson now generates the PDF chapter from the same source hash independently verified by Language Ladder. |
 | HL-B13 | Complete (#9711) | Remove Bengali's missing glyphs and LaTeX layout/bookmark warnings. | Main-font punctuation, stable recap labels, bookmark-safe Bengali, natural page bottoms, explicit static-font shapes, and a breakable long title make the forced six-chapter build warning-free. |
 | HL-I01 | Complete (#9715) | Reduce unified all-books workflow setup time without splitting the single publication bundle. | A focused, preflighted XeLaTeX dependency closure replaces `texlive-full`; the unchanged job still builds all 20 books, verifies one bundle, and publishes that bundle from `main`. |
-| HL-B14 | Complete in this PR | Publish Italian Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Forty-nine schema-v2 lessons now generate sixteen chapters whose source hashes are independently verified against the Language Ladder corpus. |
-| HL-B15 | Next | Remove Italian's LaTeX layout and Unicode bookmark warnings. | The expanded 104-page build has zero missing glyphs or duplicate destinations but reports four overfull boxes, ten underfull boxes, and three Hyperref warnings; the clean-build signal is zero of each. |
-| HL-B16 | Queued | Publish Portuguese Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Portuguese has canonical app content through Chapter 17, but its downloadable PDF contains only Chapter 1; schema-v2 migration plus generation should close that drift safely. |
+| HL-B14 | Complete (#9728) | Publish Italian Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Forty-nine schema-v2 lessons now generate sixteen chapters whose source hashes are independently verified against the Language Ladder corpus. |
+| HL-B15 | Complete in this PR | Remove Italian's LaTeX layout and Unicode bookmark warnings. | The forced 104-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
+| HL-B16 | Next | Publish Portuguese Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Portuguese has canonical app content through Chapter 17, but its downloadable PDF contains only Chapter 1; schema-v2 migration plus generation should close that drift safely. |
 | HL-B17 | Queued | Remove Portuguese's LaTeX layout warnings. | A forced build succeeds with no missing glyphs, overfull boxes, duplicate labels, or Hyperref warnings, but reports three underfull boxes; the clean-build signal is zero. |
 | HL-B18 | Queued | Publish French Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | The French PDF reaches Chapter 16 while canonical app content continues through Chapter 23; schema-v2 migration plus generation should close that drift safely. |
 | HL-B19 | Queued | Remove French's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs or duplicate labels but reports sixteen overfull boxes, nine underfull boxes, and six Hyperref warnings; the clean-build signal is zero of each. |
@@ -518,8 +518,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   20-book loop, one verified artifact, and one `main`-only Pages publication.
   The exact merged-main run installed the focused toolchain in 87 seconds,
   built all books in 93 seconds, verified the bundle, and published Pages.
-  HL-B14 is next: close the learner-visible Italian app/book drift through the
-  same canonical generation path.
+  HL-B14 and HL-B15 have since closed the Italian app/book drift and its measured
+  presentation debt. HL-B16 is next: apply the same canonical generation path
+  to Portuguese Chapters 2–17.
 
 ## Findings from HL-B14
 
@@ -546,6 +547,27 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - Four overfull boxes, ten underfull boxes, and the three pre-existing Chapter
   1 Hyperref warnings remain. HL-B15 is next and now records the expanded,
   measured clean-build debt rather than the old 13-page baseline.
+
+## Findings from HL-B15
+
+- The inline renderer now honors backslash escapes for Markdown punctuation, so
+  an etymological reconstruction such as `**\*parabolāvit**` becomes one bold
+  literal form rather than malformed nested emphasis. A focused regression test
+  keeps the canonical app text and generated TeX aligned.
+- Generated tables now begin without paragraph indentation. This removes the
+  otherwise invisible 17-point width excess while preserving full-width,
+  ragged-right columns for every generated language chapter.
+- Italian's legacy Chapter 1 heading now supplies a bookmark-safe short title,
+  and `\raggedbottom` makes deliberately short lesson pages explicit. Targeted
+  canonical copy and table-cell edits remove the remaining horizontal layout
+  warnings without dropping any vocabulary, grammar, or etymology.
+- A forced XeLaTeX build produces 104 pages with zero missing glyphs, overfull
+  or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX
+  warnings. All pages were rendered and inspected with no clipping or
+  collisions; the outline retains Preface, pronunciation, and Chapters 1–17,
+  and no schema or source-hash metadata leaks into extracted text.
+- HL-B16 is next: migrate Portuguese Chapters 2–17 to the same strict schema-v2
+  lesson AST and publish them through the shared book/app generation path.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/bengali/book/chapters/ch06-numbers-1-5.tex
+++ b/code/learning/human-languages/bengali/book/chapters/ch06-numbers-1-5.tex
@@ -19,6 +19,7 @@ Each section stays independently resumable and preserves the authored prerequisi
 \end{quote}
 
 \subsection*{You'll want to know: the five}
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{} & \textbf{Bengali} & \textbf{said} \\
@@ -34,6 +35,7 @@ Each section stays independently resumable and preserves the authored prerequisi
 The \textbf{\bn{ঁ}} on \emph{pā̃ch} is the \textbf{chandrabindu}, the same moon-dot Hindi uses, nasalising the vowel.
 
 \begin{cousinweb}
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{language} & \textbf{2} \\

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -66,7 +66,7 @@
     {
       "language": "italian",
       "chapter": 5,
-      "sourceHash": "fnv1a64:fc48d491a87398dc",
+      "sourceHash": "fnv1a64:428b548f8b6d4ad0",
       "lessonIds": [
         "IT-C05-parlare",
         "IT-C05-abitare",
@@ -79,7 +79,7 @@
     {
       "language": "italian",
       "chapter": 6,
-      "sourceHash": "fnv1a64:23d44140d0f55101",
+      "sourceHash": "fnv1a64:e98372b21a44469a",
       "lessonIds": [
         "IT-C06-numeri-1-5",
         "IT-C06-numeri-6-10"
@@ -119,7 +119,7 @@
     {
       "language": "italian",
       "chapter": 10,
-      "sourceHash": "fnv1a64:c6b580550c4c7454",
+      "sourceHash": "fnv1a64:408622844a141e06",
       "lessonIds": [
         "IT-C10-genitori",
         "IT-C10-fratello-sorella"
@@ -169,7 +169,7 @@
     {
       "language": "italian",
       "chapter": 15,
-      "sourceHash": "fnv1a64:9dfc5c16142e4a8d",
+      "sourceHash": "fnv1a64:0b856b51ba3decfd",
       "lessonIds": [
         "IT-C15-passato-prossimo",
         "IT-C15-passato-remoto"
@@ -179,7 +179,7 @@
     {
       "language": "italian",
       "chapter": 16,
-      "sourceHash": "fnv1a64:46629a0359aec030",
+      "sourceHash": "fnv1a64:bea08cde852eca81",
       "lessonIds": [
         "IT-C16-essere",
         "IT-C16-essere-stato",
@@ -191,7 +191,7 @@
     {
       "language": "italian",
       "chapter": 17,
-      "sourceHash": "fnv1a64:28edfc484982a197",
+      "sourceHash": "fnv1a64:8f8245bda887a5a8",
       "lessonIds": [
         "IT-C17-testa",
         "IT-C17-mano"

--- a/code/learning/human-languages/gujarati/book/chapters/ch06-numbers-1-5.tex
+++ b/code/learning/human-languages/gujarati/book/chapters/ch06-numbers-1-5.tex
@@ -19,6 +19,7 @@ Each section stays independently resumable and preserves the authored prerequisi
 \end{quote}
 
 \subsection*{You'll want to know: the five}
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{} & \textbf{Gujarati} & \textbf{said} \\
@@ -65,6 +66,7 @@ Do not carry both histories while the count is still new. Make the five forms au
 \begin{cousinweb}
 Sanskrit had gendered forms of “two,” and its daughters selected different parts of that paradigm:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{language} & \textbf{“two”} & \textbf{route} \\
@@ -83,6 +85,7 @@ The initial cluster changed too. In \emph{dv-}, the dental \emph{d} adopted the 
 \end{cousinweb}
 
 \begin{cousinweb}
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{stage} & \textbf{“three”} \\

--- a/code/learning/human-languages/italian/CHANGELOG.md
+++ b/code/learning/human-languages/italian/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Warning-free 104-page book — 2026-08-03
+
+- Taught the shared inline renderer to preserve backslash-escaped Markdown
+  punctuation, repairing the reconstructed `*parabolāvit` form in Chapter 15,
+  and added regression coverage for the exact bold form.
+- Removed paragraph indentation before generated tables, added a bookmark-safe
+  Chapter 1 title, and made intentionally short lesson pages ragged-bottom.
+- Tightened only the canonical prose and table cells responsible for horizontal
+  layout warnings, then recalculated their sub-five-minute duration budgets.
+- Forced a clean XeLaTeX build with zero missing glyphs, overfull or underfull
+  boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. All 104
+  rendered pages and the complete Preface/pronunciation/Chapter 1–17 outline
+  were inspected successfully.
+
 ## Canonical book Chapters 2–17 — 2026-08-03
 
 - Migrated all 49 lessons in Chapters 2–17 to the strict schema-v2 shared-spine
@@ -24,7 +38,7 @@
   each register, metaphor, suppletive stem, and grammar rule independently
   learnable in under five minutes. The shared report now measures zero Italian
   duration violations.
-- `IT-C02-practice` at 297 computed seconds and `IT-C17-mano` at 296 are the
+- `IT-C02-practice` at 297 computed seconds and `IT-C17-mano` at 298 are the
   tightest remaining Italian lessons and should be watched during copy edits.
 
 ## Chapter 17 — The body: the pot kept whole, and a noun that breaks the rule

--- a/code/learning/human-languages/italian/README.md
+++ b/code/learning/human-languages/italian/README.md
@@ -34,7 +34,9 @@ and Italian kept the final vowels French dropped. The showpiece etymology:
 The 104-page volume compiles with XeLaTeX (Latin Modern, no vendored font
 needed): `latexmk -xelatex book.tex`. Chapters 2–17 are generated from the
 canonical lessons by `npm run generate:books` in the
-`human-language-data` package; do not edit those chapter files by hand.
+`human-language-data` package; do not edit those chapter files by hand. A
+forced clean build reports zero missing glyphs, layout boxes, duplicate
+destinations, Hyperref warnings, or LaTeX warnings.
 
 ## Files
 

--- a/code/learning/human-languages/italian/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch01-greetings.tex
@@ -123,7 +123,7 @@ afternoon, when it gives way to \emph{buonasera}.
 feminine.
 \end{cousinweb}
 
-\section{\emph{notte} --- ``night,'' and the \emph{-ct-} $\to$ \emph{-tt-} rule}
+\section[notte --- night, and the -ct- to -tt- rule]{\emph{notte} --- ``night,'' and the \emph{-ct-} $\to$ \emph{-tt-} rule}
 \label{lesson:notte}
 
 \begin{cousinweb}

--- a/code/learning/human-languages/italian/book/chapters/ch02-how-are-you.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch02-how-are-you.tex
@@ -39,6 +39,7 @@ That root \textbf{prec-} ("pray, entreat") gives English a surprising family:
 
 Like German \textbf{bitte}, \emph{prego} stretches across situations, all of them a form of "I pray you":
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{you say \emph{prego} when…} & \textbf{it means} \\
@@ -132,6 +133,7 @@ That \textbf{stā-} root stands behind a wall of English words: \textbf{stay}, \
 \end{cousinweb}
 
 \begin{grammarlens}[title={Grammar Lens: essere vs stare, and the two forms you need}]
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{verb} & \textbf{from} & \textbf{job} \\
@@ -227,6 +229,7 @@ An everyday answer reuses the same verb:
 
 Italian uses \textbf{Lei} — literally “she,” often capitalized — as a polite “you.” Its verb therefore uses the third-person form \textbf{sta}, not informal \textbf{stai}:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{listener} & \textbf{question} \\
@@ -335,6 +338,7 @@ So \emph{così così} is literally \textbf{"so, so"} — and English simply borr
 \end{cousinweb}
 
 \begin{grammarlens}[title={Grammar Lens: your answer ladder for \emph{Come stai?}}]
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{answer} & \textbf{sense} \\

--- a/code/learning/human-languages/italian/book/chapters/ch03-introductions.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch03-introductions.tex
@@ -130,6 +130,7 @@ The verb is \textbf{chiamarsi} ("to call oneself"), from Latin \textbf{clāmāre
 
 Two registers — the same \emph{tu / Lei} split you learned in Chapter 2:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{register} & \textbf{question} \\

--- a/code/learning/human-languages/italian/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch04-farewells.tex
@@ -42,6 +42,7 @@ Glued: \emph{a-(ri)-vedere-ci} $\to$ \textbf{"to our seeing-one-another-again."}
 
 This "until re-seeing" idea is shared right across the languages you're learning — a lovely thing to notice:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{language} & \textbf{goodbye} & \textbf{literally} \\

--- a/code/learning/human-languages/italian/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch05-first-verbs.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:fc48d491a87398dc
+% canonical-source-hash: fnv1a64:428b548f8b6d4ad0
 % canonical-lessons: IT-C05-parlare, IT-C05-abitare, IT-C05-lavorare, IT-C05-parlo-italiano, IT-C05-practice
 
 \chapter{The First Verbs}
@@ -15,7 +15,9 @@ Each section stays independently resumable and preserves the authored prerequisi
 
 
 \begin{quote}
-\textbf{Warm-up.} {[}PAUSE 2s{]} Until now you've assembled fixed phrases. \textbf{parlare} ("to speak") is your first real \textbf{verb} — and the model for Italian's biggest family, the \textbf{-are} verbs. Learn this one pattern and you drive thousands.
+\textbf{Warm-up.} {[}PAUSE 2s{]}
+
+Until now you've assembled fixed phrases. \textbf{parlare} ("to speak") is your first real \textbf{verb} and the model for Italian's largest \textbf{-are} family. Learn this pattern and you drive thousands.
 \end{quote}
 
 \begin{sounds}
@@ -40,6 +42,7 @@ And a lovely cross-link: \textbf{Italian \emph{parlare} and French \emph{parler}
 \begin{grammarlens}[title={Grammar Lens: the -are present tense (and pro-drop)}]
 Drop \textbf{-are} to get \emph{parl-}, then add the endings:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{person} & \textbf{ending} & \textbf{\emph{parlare} $\to$} \\
@@ -157,6 +160,7 @@ Identical to \emph{parlare} — nothing new. That's the whole point of a regular
 
 Here's the cross-language payoff — the same idea, \textbf{two very different roots}:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{language} & \textbf{"to work"} & \textbf{from} & \textbf{literal picture} \\
@@ -221,11 +225,12 @@ A complete, grammatical Italian sentence. Notice what's \emph{not} there:
 
 This closes the \textbf{pronoun-rule circle} you've watched across five languages:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{} & \textbf{pronoun} & \textbf{why} \\
 \midrule
-\textbf{Spanish} \emph{hablo} / \textbf{Italian} \emph{parlo} & \textbf{dropped} & endings are distinct \\
+Spanish / Italian & \textbf{dropped} & \emph{hablo/parlo}: distinct endings \\
 \textbf{French} \emph{je parle} & kept & endings are silent \\
 \textbf{German} \emph{ich lerne} & kept & grammar needs an overt subject \\
 \bottomrule

--- a/code/learning/human-languages/italian/book/chapters/ch06-numbers-1-10.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch06-numbers-1-10.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:23d44140d0f55101
+% canonical-source-hash: fnv1a64:e98372b21a44469a
 % canonical-lessons: IT-C06-numeri-1-5, IT-C06-numeri-6-10
 
 \chapter{Numbers One to Ten}
@@ -27,6 +27,7 @@ Each section stays independently resumable and preserves the authored prerequisi
 \end{sounds}
 
 \begin{cousinweb}
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{Italian} & \textbf{$\leftarrow$ Latin} & \textbf{Spanish / French} & \textbf{English cousins} \\
@@ -66,7 +67,7 @@ Notice \textbf{cinque} — Italian kept Latin \emph{quīnque} almost whole (\emp
 
 
 \begin{quote}
-\textbf{Warm-up.} {[}PAUSE 2s{]} The rest of the count — and, like Spanish and French, Italian hides the same calendar fact: \textbf{settembre–dicembre are Latin for 7, 8, 9, 10.} Italian even keeps the old Latin double consonants that show it.
+\textbf{Warm-up.} {[}PAUSE 2s{]} The rest of the count hides a calendar fact: \textbf{settembre–dicembre are Latin for 7, 8, 9, 10.} Italian even keeps the old Latin double consonants that show it.
 \end{quote}
 
 \begin{sounds}
@@ -78,6 +79,7 @@ Notice \textbf{cinque} — Italian kept Latin \emph{quīnque} almost whole (\emp
 \end{sounds}
 
 \begin{cousinweb}
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{Italian} & \textbf{$\leftarrow$ Latin} & \textbf{Spanish twin} & \textbf{English cousins} \\

--- a/code/learning/human-languages/italian/book/chapters/ch07-days-of-the-week.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch07-days-of-the-week.tex
@@ -29,6 +29,7 @@ Each section stays independently resumable and preserves the authored prerequisi
 \begin{grammarlens}[title={Grammar Lens: {[}planet{]} + dì}]
 \textbf{dì} is Latin \textbf{diēs}, "day" — the same \emph{-di} you'd hear in French \emph{lundi}. Before it sits a \textbf{planet-god}:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{Italian} & \textbf{$\leftarrow$ Latin} & \textbf{planet} & \textbf{Spanish twin} & \textbf{French twin} \\
@@ -68,6 +69,7 @@ Line up the three sisters — \emph{lunedì / lunes / lundi} — and you're look
 \end{quote}
 
 \begin{cousinweb}
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{Italian} & \textbf{$\leftarrow$ Latin} & \textbf{meaning} & \textbf{Spanish twin} \\

--- a/code/learning/human-languages/italian/book/chapters/ch08-telling-time.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch08-telling-time.tex
@@ -72,6 +72,7 @@ Literally "\textbf{they are} the two {[}hours{]}" — Italian counts the hours a
 \begin{cousinweb}
 The front piece is \textbf{mezzo/mezza}, "half, middle," from Latin \textbf{medius} (cousin of English \emph{medium, mid}, and of French \emph{mi-} in \emph{midi}):
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{Italian} & \textbf{=} & \textbf{$\leftarrow$ Latin} & \textbf{literally} \\

--- a/code/learning/human-languages/italian/book/chapters/ch09-months-and-seasons.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch09-months-and-seasons.tex
@@ -19,6 +19,7 @@ Each section stays independently resumable and preserves the authored prerequisi
 \end{quote}
 
 \begin{cousinweb}
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{Italian} & \textbf{$\leftarrow$ Latin} & \textbf{who / what} & \textbf{Spanish twin} \\
@@ -71,6 +72,7 @@ The Italian tells: \emph{gennaio} kept the \emph{-aio} of \emph{Januarius}, and 
 \end{quote}
 
 \begin{cousinweb}
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{Italian} & \textbf{$\leftarrow$ Latin} & \textbf{literally} \\

--- a/code/learning/human-languages/italian/book/chapters/ch10-family.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch10-family.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:c6b580550c4c7454
+% canonical-source-hash: fnv1a64:408622844a141e06
 % canonical-lessons: IT-C10-genitori, IT-C10-fratello-sorella
 
 \chapter{Family}
@@ -33,7 +33,7 @@ Articles: \emph{il} padre (masculine), \emph{la} madre (feminine).
 \begin{cousinweb}
 Italian "parents" is \textbf{i genitori} — not from \emph{parens} but from Latin \textbf{genitor}, "the \textbf{begetter}," from \emph{gignere} "to beget/bring forth." That root \emph{gen-} "give birth to" is everywhere in English: \textbf{genital, progenitor, genesis, generate, genus, gene}. So \emph{i genitori} are literally "the begetters." (Beware the \textbf{false friend}: Italian \emph{parenti} means \textbf{relatives} in general, \emph{not} "parents"!)
 
-The Latin-through-English adjective family still comes from \emph{pater/māter}: \textbf{pat}ernal, \textbf{mat}ernal — the same roots as French \emph{père/mère} and, by Grimm's law, English \emph{father/mother}.
+The Latin-through-English adjectives still come from \emph{pater/māter}: \textbf{paternal} and \textbf{maternal} — the same roots as French \emph{père/mère} and, by Grimm's law, English \emph{father/mother}.
 \end{cousinweb}
 
 \subsection*{Guided Practice}

--- a/code/learning/human-languages/italian/book/chapters/ch12-numbers-11-20.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch12-numbers-11-20.tex
@@ -19,6 +19,7 @@ Each section stays independently resumable and preserves the authored prerequisi
 \end{quote}
 
 \begin{grammarlens}[title={Grammar Lens: six fusions}]
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{} & \textbf{Italian} & \textbf{$\leftarrow$ Latin} & \textbf{build} \\
@@ -66,6 +67,7 @@ The digits are your Chapter 6 numbers barely changed: \emph{tre$\to$tre-}, \emph
 \end{quote}
 
 \begin{grammarlens}[title={Grammar Lens: the reversal}]
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{} & \textbf{Italian} & \textbf{build} & \textbf{order} \\
@@ -84,6 +86,7 @@ Same building blocks — \emph{dici} ("ten") and your Chapter 6 digits — but f
 \begin{grammarlens}[title={What you've built: three different breaks}]
 This "give up fusing, go transparent" seam happens in every Romance sister, but \textbf{not at the same place}:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{language} & \textbf{fuses up to} & \textbf{goes transparent at} \\

--- a/code/learning/human-languages/italian/book/chapters/ch13-colours.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch13-colours.tex
@@ -29,6 +29,7 @@ The same word became French \emph{blanc} and Portuguese \emph{branco}. Germanic 
 \end{cousinweb}
 
 \begin{cousinweb}
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{word} & \textbf{meaning} & \textbf{the white inside} \\
@@ -70,6 +71,7 @@ Latin's white is still here — just doing other jobs.
 \begin{cousinweb}
 \textbf{rosso} $\leftarrow$ Latin \emph{\textbf{russus}} ("red"), from PIE \emph{\textbf{h\textsubscript{1}rewd\textsuperscript{h}-}}. That root is one of the oldest colour words we can reconstruct:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{language} & \textbf{word} \\
@@ -95,6 +97,7 @@ Italy's national teams are \textbf{gli Azzurri}, "the blue ones" — named, at t
 \end{cousinweb}
 
 \begin{grammarlens}[title={What you've built: the colour paths}]
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{Italian} & \textbf{source} \\

--- a/code/learning/human-languages/italian/book/chapters/ch14-having-and-age.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch14-having-and-age.tex
@@ -19,6 +19,7 @@ Each section stays independently resumable and preserves the authored prerequisi
 \end{quote}
 
 \subsection*{You'll want to know: the forms}
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{} & \textbf{} & \textbf{} \\
@@ -36,6 +37,7 @@ Italian threw the Latin \textbf{h} away almost completely — it is never pronou
 
 But in \emph{avere} it stayed, because without it these words would collide:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{with h} & \textbf{without h} & \textbf{meaning} \\
@@ -96,6 +98,7 @@ Note the \textbf{double n}: \emph{a-nno}, held. Italian's double consonants are 
 \begin{grammarlens}[title={Grammar Lens: h earns its keep}]
 Now put the last lesson to work:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{sentence} & \textbf{meaning} \\
@@ -109,6 +112,7 @@ Now put the last lesson to work:
 \end{grammarlens}
 
 \begin{grammarlens}[title={Grammar Lens: who has and who is}]
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{language} & \textbf{} \\

--- a/code/learning/human-languages/italian/book/chapters/ch15-two-pasts.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch15-two-pasts.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:9dfc5c16142e4a8d
+% canonical-source-hash: fnv1a64:0b856b51ba3decfd
 % canonical-lessons: IT-C15-passato-prossimo, IT-C15-passato-remoto
 
 \chapter{Two Italian Pasts}
@@ -23,6 +23,7 @@ Each section stays independently resumable and preserves the authored prerequisi
 \textbf{avere} (conjugated) + \textbf{past participle}
 \end{quote}
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{infinitive} & \textbf{ends in} & \textbf{participle} \\
@@ -34,6 +35,7 @@ dorm\textbf{ire} & -ire & dorm\textbf{ito} \\
 \bottomrule
 \end{tabularx}
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{} & \textbf{} \\
@@ -94,6 +96,7 @@ That \emph{-e} is a Latin adjective ending, still agreeing after two thousand ye
 \end{quote}
 
 \subsection*{You'll want to know: the remote past}
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{} & \textbf{passato remoto} & \textbf{passato prossimo} \\
@@ -107,8 +110,9 @@ I spoke & \textbf{parlai} & ho parlato \\
 Note the final stress: \emph{parl\textbf{ò}}, with the accent written. Compare Chapter 12's numbers — Italian marks a stressed final vowel the same way.
 
 \begin{cousinweb}
-\textbf{parlò} $\leftarrow$ Vulgar Latin \textbf{\textbackslash{}\emph{parabolāvit\textbf{, the plain Latin perfect, handed straight down. Which makes it the }same tense\textbf{ as:}}}
+\textbf{parlò} $\leftarrow$ Vulgar Latin \textbf{*parabolāvit}, the plain Latin perfect, handed straight down. Which makes it the \textbf{same tense} as:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{language} & \textbf{"he spoke"} \\
@@ -126,6 +130,7 @@ One Latin ancestor, four descendants — and four different fates in daily life.
 \begin{culture}
 This is what makes Italian interesting here:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{region} & \textbf{everyday past} \\
@@ -140,6 +145,7 @@ So the "correct" answer changes as you travel. In the north the \emph{passato re
 \end{culture}
 
 \begin{grammarlens}[title={What you've built: three retreats and two holdouts}]
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{language} & \textbf{simple past} & \textbf{status in speech} \\
@@ -166,5 +172,5 @@ Three languages let a "have" compound push the inherited past out of conversatio
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
-{[}PAUSE 3s{]} What is \emph{parlò} descended from? (Vulgar Latin \textbf{\textbackslash{}\emph{parabolāvit\textbf{.) What decides whether it sounds normal or bookish? (}Where in Italy you are\textbf{ — everyday in the south, literary in the north.) Which languages kept this tense fully alive? (}Spanish\textbf{ and }Portuguese\textbf{.) Which lost it entirely from speech? (}French\textbf{.) Next chapter: the verbs that take \emph{essere} instead of \emph{avere}.}}}
+{[}PAUSE 3s{]} What is the ancestor of \emph{parlò}? (\textbf{*parabolāvit}.) What decides whether it sounds normal or bookish? (\textbf{Where in Italy you are} — everyday in the south, literary in the north.) Which languages kept this tense fully alive? (\textbf{Spanish} and \textbf{Portuguese}.) Which lost it entirely from speech? (\textbf{French}.) Next chapter: the verbs that take \emph{essere} instead of \emph{avere}.
 \end{tcolorbox}

--- a/code/learning/human-languages/italian/book/chapters/ch16-essere-andare-past.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch16-essere-andare-past.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:46629a0359aec030
+% canonical-source-hash: fnv1a64:bea08cde852eca81
 % canonical-lessons: IT-C16-essere, IT-C16-essere-stato, IT-C16-andare, IT-C16-passato-prossimo-essere
 
 \chapter{Being, Going, and the Past with Essere}
@@ -19,6 +19,7 @@ Each section stays independently resumable and preserves the authored prerequisi
 \end{quote}
 
 \subsection*{You'll want to know: the six forms}
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{} & \textbf{} \\
@@ -44,6 +45,7 @@ The two words sound different enough in careful speech, but the accent makes the
 \end{grammarlens}
 
 \begin{cousinweb}
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{Latin} & \textbf{picture} & \textbf{Italian} \\
@@ -82,6 +84,7 @@ Italian kept both verbs. The next micro-lesson shows the surprising place where 
 \end{quote}
 
 \begin{grammarlens}[title={Grammar Lens: one participle for two verbs}]
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{verb} & \textbf{past participle} \\
@@ -105,6 +108,7 @@ Only the surrounding sentence tells you which verb is meant.
 \begin{grammarlens}[title={What you've built: three Romance solutions}]
 The same Latin material took a different shape in each sister language:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{language} & \textbf{result} \\
@@ -144,6 +148,7 @@ Italian sits between the other two: less separated than Spanish, less fused than
 \end{quote}
 
 \subsection*{You'll want to know: the forms}
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{} & \textbf{} \\
@@ -158,12 +163,13 @@ Past participle: \textbf{andato}.
 
 The table has a visible seam:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{stem} & \textbf{forms} & \textbf{history} \\
 \midrule
 \textbf{vad- / va-} & vado, vai, va, \textbf{vanno} & Latin \emph{vādere}, “to stride” \\
-\textbf{and-} & andare, andiamo, andate, andato & disputed; probably \emph{ambitāre}, “go around” \\
+\textbf{and-} & andare, andiamo, andate, andato & origin disputed; perhaps \emph{ambitāre} \\
 \bottomrule
 \end{tabularx}
 
@@ -198,6 +204,7 @@ Spanish shows the same kind of seam in \emph{voy} beside \emph{andar}. The compa
 \end{quote}
 
 \subsection*{You'll want to know: start with stato}
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{} & \textbf{} \\
@@ -216,6 +223,7 @@ Many verbs of motion or change of state take \textbf{essere}: \emph{andare} (go)
 
 Use the four adjective endings you already know:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{subject} & \textbf{sentence} \\

--- a/code/learning/human-languages/italian/book/chapters/ch17-head-and-hand.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch17-head-and-hand.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:28edfc484982a197
+% canonical-source-hash: fnv1a64:8f8245bda887a5a8
 % canonical-lessons: IT-C17-testa, IT-C17-mano
 
 \chapter{Head and Hand}
@@ -28,6 +28,7 @@ Latin \emph{\textbf{testa}} meant an \textbf{earthenware pot}, a shell, a shard.
 
 Put the two descendants side by side:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{} & \textbf{} \\
@@ -89,6 +90,7 @@ Both halves are irregular. A masculine \emph{-o} noun would pluralise in \emph{-
 \begin{grammarlens}[title={Grammar Lens: five declensions}]
 Italian inherited a system with \textbf{five declensions} — five families of endings — and flattened it to \textbf{three} productive classes: \emph{-o}/\emph{-i} (\emph{libro/libri}), \emph{-a}/\emph{-e} (\emph{casa/case}), and \emph{-e}/\emph{-i} (\emph{notte/notti}, which Chapter 1 already gave you). \emph{Manus} belonged to the Latin \textbf{fourth}, whose nouns ended in \emph{-us} but could be \textbf{feminine}:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{Latin} & \textbf{} & \textbf{Italian} \\
@@ -106,7 +108,16 @@ That is the general lesson, and it recurs everywhere in this course: an "irregul
 \end{grammarlens}
 
 \begin{cousinweb}
-Latin \emph{manus} is inside a great many English words — \emph{manual}, \emph{manuscript}, \emph{manufacture} ("made by hand"), \emph{maintain} ("hold in the hand"). English took \textbf{manage} specifically from Italian \emph{\textbf{maneggiare}}, which meant to \textbf{handle a horse}. Every modern manager is, etymologically, working in a riding school.
+Latin \emph{manus} is inside many English words:
+
+\begin{itemize}
+\raggedright
+  \item \emph{manual} and \emph{manuscript}
+  \item \emph{manufacture} ("made by hand")
+  \item \emph{maintain} ("hold in the hand")
+\end{itemize}
+
+English took \textbf{manage} specifically from Italian \emph{\textbf{maneggiare}}, which meant to \textbf{handle a horse}. Every modern manager is, etymologically, working in a riding school.
 \end{cousinweb}
 
 \subsection*{Guided Practice}

--- a/code/learning/human-languages/italian/book/preamble.tex
+++ b/code/learning/human-languages/italian/book/preamble.tex
@@ -27,6 +27,9 @@
   pdfkeywords={Italian, etymology, Latin, language learning}
 }
 
+% Keep intentionally short lesson pages ragged rather than stretching vertical gaps.
+\raggedbottom
+
 \newtcolorbox{cousinweb}{
   breakable, skin=enhanced, colback=yellow!8, colframe=yellow!45!black,
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,

--- a/code/learning/human-languages/italian/lessons/IT-C05-parlare.md
+++ b/code/learning/human-languages/italian/lessons/IT-C05-parlare.md
@@ -13,7 +13,7 @@ sounds: [r-tap, vowel-a-open]
 roots: [parabolare-latin]
 etymology_hook: "parlare ← Late Latin parabolāre 'to tell parables' (← parabola) → English parable, parole; = French parler"
 duration:
-  max_seconds: 219
+  max_seconds: 217
 requires:
   knowledge: [IT-SOUND-IO-02, IT-ETYMON-IO-03, IT-GRAMMAR-IO-04, IT-SOUND-COME-02, IT-ETYMON-COME-03]
 introduces:
@@ -32,9 +32,11 @@ reviews_of: [IT-C03-practice, IT-C04-practice]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[] -->
 
-[PAUSE 2s] Until now you've assembled fixed phrases. **parlare** ("to speak") is
-your first real **verb** — and the model for Italian's biggest family, the
-**-are** verbs. Learn this one pattern and you drive thousands.
+[PAUSE 2s]
+
+Until now you've assembled fixed phrases. **parlare** ("to speak") is
+your first real **verb** and the model for Italian's largest **-are** family.
+Learn this pattern and you drive thousands.
 
 ## Sounds you'll need
 <!-- hl-knowledge: introduces=[IT-SOUND-PARLARE-02]; assesses=[] -->

--- a/code/learning/human-languages/italian/lessons/IT-C05-parlo-italiano.md
+++ b/code/learning/human-languages/italian/lessons/IT-C05-parlo-italiano.md
@@ -13,7 +13,7 @@ sounds: [ia-glide, vowel-a-open]
 roots: [italia-latin]
 etymology_hook: "italiano ← Italia, the ancient name of the peninsula (perhaps Oscan víteliú, 'land of calves')"
 duration:
-  max_seconds: 213
+  max_seconds: 212
 requires:
   knowledge: [IT-SOUND-PARLARE-02, IT-ETYMON-PARLARE-03, IT-GRAMMAR-PARLARE-04]
 introduces:
@@ -63,7 +63,7 @@ This closes the **pronoun-rule circle** you've watched across five languages:
 
 | | pronoun | why |
 |---|---|---|
-| **Spanish** *hablo* / **Italian** *parlo* | **dropped** | endings are distinct |
+| Spanish / Italian | **dropped** | *hablo/parlo*: distinct endings |
 | **French** *je parle* | kept | endings are silent |
 | **German** *ich lerne* | kept | grammar needs an overt subject |
 

--- a/code/learning/human-languages/italian/lessons/IT-C06-numeri-6-10.md
+++ b/code/learning/human-languages/italian/lessons/IT-C06-numeri-6-10.md
@@ -13,7 +13,7 @@ sounds: [double-tt, c-before-i]
 roots: [sex-septem-octo-latin]
 etymology_hook: "sette/otto/nove/dieci ← septem/octō/novem/decem → settembre/ottobre/novembre/dicembre (= Spanish siete/ocho/nueve/diez)"
 duration:
-  max_seconds: 218
+  max_seconds: 214
 requires:
   knowledge: [IT-SOUND-NUMERI-1-5-02, IT-ETYMON-NUMERI-1-5-03, IT-GRAMMAR-NUMERI-1-5-04]
 introduces:
@@ -32,9 +32,9 @@ reviews_of: [IT-C06-numeri-1-5]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[] -->
 
-[PAUSE 2s] The rest of the count — and, like Spanish and French, Italian hides the
-same calendar fact: **settembre–dicembre are Latin for 7, 8, 9, 10.** Italian even
-keeps the old Latin double consonants that show it.
+[PAUSE 2s] The rest of the count hides a calendar fact:
+**settembre–dicembre are Latin for 7, 8, 9, 10.** Italian even keeps the old
+Latin double consonants that show it.
 
 ## Sounds you'll need
 <!-- hl-knowledge: introduces=[IT-SOUND-NUMERI-6-10-02]; assesses=[] -->

--- a/code/learning/human-languages/italian/lessons/IT-C10-genitori.md
+++ b/code/learning/human-languages/italian/lessons/IT-C10-genitori.md
@@ -13,7 +13,7 @@ sounds: [d-single, r-tap]
 roots: [pater-latin, mater-latin]
 etymology_hook: "padre/madre sit closest of the sisters to Latin pater/mater; padre is the very word English borrowed as 'padre'; genitori 'parents' ← genitor 'begetter' (→ genital, progenitor, genesis)"
 duration:
-  max_seconds: 182
+  max_seconds: 181
 requires:
   knowledge: [IT-ETYMON-STAGIONI-02]
 introduces:
@@ -57,9 +57,9 @@ birth to" is everywhere in English: **genital, progenitor, genesis, generate,
 genus, gene**. So *i genitori* are literally "the begetters." (Beware the **false
 friend**: Italian *parenti* means **relatives** in general, *not* "parents"!)
 
-The Latin-through-English adjective family still comes from *pater/māter*:
-**pat**ernal, **mat**ernal — the same roots as French *père/mère* and, by Grimm's
-law, English *father/mother*.
+The Latin-through-English adjectives still come from *pater/māter*:
+**paternal** and **maternal** — the same roots as French *père/mère* and, by
+Grimm's law, English *father/mother*.
 
 ## Guided Practice
 <!-- hl-knowledge: introduces=[]; assesses=[IT-ETYMON-STAGIONI-02, IT-ETYMON-GENITORI-02, IT-ETYMON-GENITORI-03] -->

--- a/code/learning/human-languages/italian/lessons/IT-C15-passato-remoto.md
+++ b/code/learning/human-languages/italian/lessons/IT-C15-passato-remoto.md
@@ -13,7 +13,7 @@ sounds: [final-stress-o]
 roots: [latin-perfect]
 etymology_hook: "parlò ← Vulgar Latin perfect *parabolāvit, the same inheritance as Spanish habló and Portuguese falou — but in Italian its survival is GEOGRAPHIC: everyday speech in Sicily and much of the south, literature-only in the north"
 duration:
-  max_seconds: 264
+  max_seconds: 263
 requires:
   knowledge: [IT-GRAMMAR-PASSATO-PROSSIMO-02, IT-ETYMON-PASSATO-PROSSIMO-03]
 introduces:
@@ -104,7 +104,7 @@ holding half the country.
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[IT-GRAMMAR-PASSATO-PROSSIMO-02, IT-ETYMON-PASSATO-PROSSIMO-03, IT-LEX-PASSATO-REMOTO-02, IT-ETYMON-PASSATO-REMOTO-03, IT-PRAGMATICS-PASSATO-REMOTO-04, IT-NOTICE-PASSATO-REMOTO-05] -->
 
-[PAUSE 3s] What is *parlò* descended from? (Vulgar Latin **\*parabolāvit**.) What decides
+[PAUSE 3s] What is the ancestor of *parlò*? (**\*parabolāvit**.) What decides
 whether it sounds normal or bookish? (**Where in Italy you are** — everyday in the
 south, literary in the north.) Which languages kept this tense fully alive?
 (**Spanish** and **Portuguese**.) Which lost it entirely from speech?

--- a/code/learning/human-languages/italian/lessons/IT-C16-andare.md
+++ b/code/learning/human-languages/italian/lessons/IT-C16-andare.md
@@ -13,7 +13,7 @@ sounds: [double-consonant, open-a]
 roots: [latin-vadere, disputed-ambitare]
 etymology_hook: "vado/vai/va/vanno continue Latin vadere, while andare/andiamo/andate/andato probably continue a different root"
 duration:
-  max_seconds: 195
+  max_seconds: 194
 requires:
   knowledge: [IT-GRAMMAR-ESSERE-STATO-02, IT-NOTICE-ESSERE-STATO-03, IT-GRAMMAR-COME-VA-02]
 introduces:
@@ -52,7 +52,7 @@ The table has a visible seam:
 | stem | forms | history |
 |---|---|---|
 | **vad- / va-** | vado, vai, va, **vanno** | Latin *vādere*, “to stride” |
-| **and-** | andare, andiamo, andate, andato | disputed; probably *ambitāre*, “go around” |
+| **and-** | andare, andiamo, andate, andato | origin disputed; perhaps *ambitāre* |
 
 Notice that **vanno** belongs with **vado**, not with *andiamo*. The split is not
 “singular versus plural.” It is two old verbs patched into one modern paradigm —

--- a/code/learning/human-languages/italian/lessons/IT-C17-mano.md
+++ b/code/learning/human-languages/italian/lessons/IT-C17-mano.md
@@ -76,10 +76,15 @@ different reason for the same look.)
 ## The word, taken apart: manus
 <!-- hl-knowledge: introduces=[IT-ETYMON-MANO-04]; assesses=[] -->
 
-Latin *manus* is inside a great many English words — *manual*, *manuscript*,
-*manufacture* ("made by hand"), *maintain* ("hold in the hand"). English took
-**manage** specifically from Italian ***maneggiare***, which meant to **handle a
-horse**. Every modern manager is, etymologically, working in a riding school.
+Latin *manus* is inside many English words:
+
+- *manual* and *manuscript*
+- *manufacture* ("made by hand")
+- *maintain* ("hold in the hand")
+
+English took **manage** specifically from Italian ***maneggiare***, which meant
+to **handle a horse**. Every modern manager is, etymologically, working in a
+riding school.
 
 ## Guided Practice
 <!-- hl-knowledge: introduces=[]; assesses=[IT-LEX-TESTA-02, IT-ETYMON-TESTA-03, IT-ETYMON-TESTA-04, IT-LEX-MANO-02, IT-GRAMMAR-MANO-03, IT-ETYMON-MANO-04] -->

--- a/code/learning/human-languages/marathi/book/chapters/ch06-numbers-1-5.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch06-numbers-1-5.tex
@@ -19,6 +19,7 @@ Each section stays independently resumable and preserves the authored prerequisi
 \end{quote}
 
 \subsection*{You'll want to know: the five}
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{} & \textbf{Marathi} & \textbf{said} \\
@@ -34,6 +35,7 @@ Each section stays independently resumable and preserves the authored prerequisi
 \begin{grammarlens}[title={What you've built: three Marathi tells}]
 Set them against Hindi. Two differences are visible and one is audible:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{number} & \textbf{Hindi} & \textbf{Marathi} \\

--- a/code/learning/human-languages/punjabi/book/chapters/ch06-numbers-1-5.tex
+++ b/code/learning/human-languages/punjabi/book/chapters/ch06-numbers-1-5.tex
@@ -19,6 +19,7 @@ Each section stays independently resumable and preserves the authored prerequisi
 \end{quote}
 
 \subsection*{You'll want to know: the five}
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{} & \textbf{Punjabi} & \textbf{said} \\
@@ -75,6 +76,7 @@ The next prerequisite-ordered lesson explains an important twist: Punjabi's nume
 \end{quote}
 
 \begin{grammarlens}[title={What you've built: the surprising family comparison}]
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{language} & \textbf{“five”} \\
@@ -100,6 +102,7 @@ Punjabi \textbf{panjāh} “fifty” (from Sanskrit \emph{pañcāśat}) makes th
 \begin{cousinweb}
 Persian independently voiced ancestral \emph{č} to \emph{j}: Iranian \emph{panč} became \emph{panj}. Two Indo-Iranian branches therefore reached the same shape separately:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{branch} & \textbf{path} \\

--- a/code/learning/human-languages/sanskrit/book/chapters/ch06-numbers-1-5.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch06-numbers-1-5.tex
@@ -19,6 +19,7 @@ Each section stays independently resumable and preserves the authored prerequisi
 \end{quote}
 
 \subsection*{You'll want to know: the five}
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{} & \textbf{stem} & \textbf{masculine} & \textbf{\textbf{neuter}} \\
@@ -67,6 +68,7 @@ These five forms point in two directions. The next lesson lines them up with Lat
 \end{quote}
 
 \begin{grammarlens}[title={What you've built: one family, not borrowing}]
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{Sanskrit} & \textbf{Latin} & \textbf{English} \\
@@ -81,12 +83,13 @@ These five forms point in two directions. The next lesson lines them up with Lat
 
 Sanskrit, Latin, and English inherited these from one family. Numbers resist replacement, so their relationship remains audible after millennia.
 
-The first row needs one caveat: \emph{éka-} and \emph{ūnus/one} use the same root with different suffixes, PIE \textbackslash{}\textbf{oy-ko-\emph{ versus \textbackslash{}\textbf{óynos\emph{. They are relatives rather than the same complete word. The other four rows continue the same word.}}}}
+The first row needs one caveat: \emph{éka-} and \emph{ūnus/one} use the same root with different suffixes, PIE *\emph{oy-ko-} versus *\emph{óynos}. They are relatives rather than the same complete word. The other four rows continue the same word.
 \end{grammarlens}
 
 \begin{cousinweb}
-PIE \textbackslash{}\textbf{kʷ\emph{ was a }k\emph{ with rounded lips. In \textbackslash{}\textbf{kʷetwóres\emph{ “four,” three branches treated it differently:}}}}
+PIE *\emph{kʷ} was a \emph{k} with rounded lips. In *\emph{kʷetwóres} “four,” three branches treated it differently:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{branch} & \textbf{outcome} & \textbf{example} \\
@@ -101,7 +104,7 @@ Sanskrit \emph{c-} is therefore a regular result, not a random replacement. The 
 \end{cousinweb}
 
 \begin{cousinweb}
-The \textbf{f-} of \emph{five} does not come from \textbackslash{}\textbf{kʷ\emph{. It comes from initial \textbackslash{}\textbf{p\emph{, changed to }f\emph{ by \textbf{Grimm's law}, as in }pater $\to$ father\emph{ and }pēs $\to$ foot\emph{.}}}}
+The \textbf{f-} of \emph{five} does not come from *\emph{kʷ}. It comes from initial *\emph{p}, changed to \emph{f} by \textbf{Grimm's law}, as in \emph{pater $\to$ father} and \emph{pēs $\to$ foot}.
 
 English \emph{four} is irregular. By the sound rule it should begin \emph{hw-} like \emph{what}. Its \emph{f-} is usually explained as analogy with neighbouring \emph{five}. Counting words can reshape one another.
 \end{cousinweb}
@@ -118,7 +121,7 @@ English \emph{four} is irregular. By the sound rule it should begin \emph{hw-} l
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
-{[}PAUSE 3s{]} Are the Latin and Sanskrit forms borrowed from one another? (No: they are inherited cousins.) What are the three outcomes of \textbackslash{}\textbf{kʷ\emph{? (Latin }qu-\emph{, Indo-Iranian }c-\emph{ after merger and palatalisation, Germanic }hw-\emph{.) Where does }five\emph{'s initial }f\emph{ come from? (PIE }p\emph{ by Grimm's law.) What is the usual explanation for }four\emph{ also beginning with }f\emph{? (Analogy with neighbouring }five\emph{.)}}
+{[}PAUSE 3s{]} Are the Latin and Sanskrit forms borrowed from one another? (No: they are inherited cousins.) What are the three outcomes of *\emph{kʷ}? (Latin \emph{qu-}, Indo-Iranian \emph{c-} after merger and palatalisation, Germanic \emph{hw-}.) Where does \emph{five}'s initial \emph{f} come from? (PIE \emph{p} by Grimm's law.) What is the usual explanation for \emph{four} also beginning with \emph{f}? (Analogy with neighbouring \emph{five}.)
 \end{tcolorbox}
 \section[pañca]{\emph{Pañca} hiding in familiar words}
 

--- a/code/learning/human-languages/spanish/book/chapters/ch03-introductions.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch03-introductions.tex
@@ -298,6 +298,7 @@ English has no such marker — it relies on word order and context. Spanish puts
 \begin{cousinweb}
 Latin used a recurring \emph{qu-} stem in questions. Spanish preserves that family, although centuries of sound change gave the modern forms different shapes:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{Spanish clue} & \textbf{$\leftarrow$ Latin} & \textbf{future meaning} \\

--- a/code/learning/human-languages/spanish/book/chapters/ch04-how-are-you.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch04-how-are-you.tex
@@ -208,6 +208,7 @@ Note the \textbf{¿} — Spanish opens a question with an upside-down mark so yo
 \end{quote}
 
 \begin{grammarlens}[title={Grammar Lens: one question, two relationships}]
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{register} & \textbf{question} \\
@@ -267,6 +268,7 @@ So \emph{más o menos} is literally \textbf{"more or less"} — the exact phrase
 \begin{grammarlens}[title={Grammar Lens: a small answer set}]
 You now have a scale to answer \emph{¿cómo estás?}:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{answer} & \textbf{sense} \\
@@ -381,6 +383,7 @@ The accent appears \textbf{only when a word breaks that rule} — it marks the e
 \begin{grammarlens}[title={Grammar Lens: one mark, two grammatical jobs}]
 The \textbf{tilde diacrítica} separates words that otherwise look alike:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{no accent} & \textbf{with accent} \\

--- a/code/learning/human-languages/spanish/book/chapters/ch05-farewells.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch05-farewells.tex
@@ -30,6 +30,7 @@ Each section stays independently resumable and preserves the authored prerequisi
 
 Every Romance sister kept the same farewell-prayer:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{language} & \textbf{goodbye} & \textbf{literally} \\
@@ -183,6 +184,7 @@ A nice contrast: \textbf{hasta luego} fuses an \textbf{Arabic} word and a \textb
 \begin{grammarlens}[title={Grammar Lens: the "hasta …" family}]
 \emph{hasta} + a time word is Spanish's whole toolkit of soft goodbyes. You'll build the other two this chapter:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{phrase} & \textbf{"until …"} & \textbf{when} \\
@@ -289,6 +291,7 @@ You already know its English twin: \textbf{prompt} (on time; to bring out a resp
 \begin{grammarlens}[title={Grammar Lens: the "hasta …" trio, complete}]
 You now have Spanish's three soft goodbyes, sharpest to vaguest in time:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{phrase} & \textbf{until…} & \textbf{nuance} \\
@@ -328,6 +331,7 @@ You now have Spanish's three soft goodbyes, sharpest to vaguest in time:
 \begin{grammarlens}[title={Grammar Lens: choosing the right goodbye}]
 The choice is about \textbf{when you'll meet again}:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{you're…} & \textbf{say} \\

--- a/code/learning/human-languages/spanish/book/chapters/ch06-first-verbs.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch06-first-verbs.tex
@@ -120,6 +120,7 @@ The initial Latin \textbf{f-} weakened and eventually disappeared in this word, 
 \begin{grammarlens}[title={Grammar Lens: the -ar present tense (the big one)}]
 \textbf{Hablar} belongs to the \textbf{-ar} family. To conjugate the three singular forms you need now, \textbf{drop -ar} and add the ending for the person:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{person} & \textbf{ending} & \textbf{\emph{hablar} $\to$} & \textbf{meaning} \\
@@ -183,6 +184,7 @@ So even plain \textbf{trabajo}, “I work,” hides the old idea of toil as torm
 \begin{grammarlens}[title={Grammar Lens: same -ar template}]
 Drop \textbf{-ar}, add the ending — identical to \emph{hablar}:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{person} & \textbf{form} & \textbf{meaning} \\
@@ -245,6 +247,7 @@ So \emph{Estudio español} is "I \emph{devote myself eagerly} to Spanish" — a 
 \begin{grammarlens}[title={Grammar Lens: the template holds}]
 Drop \textbf{-ar}, add the ending — for the third time:
 
+\noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{person} & \textbf{form} & \textbf{meaning} \\

--- a/code/packages/typescript/human-language-data/src/book.ts
+++ b/code/packages/typescript/human-language-data/src/book.ts
@@ -85,6 +85,14 @@ export function renderInlineMarkdown(
   while (cursor < markdown.length) {
     const codePoint = markdown.codePointAt(cursor);
     const character = codePoint === undefined ? "" : String.fromCodePoint(codePoint);
+    if (character === "\\" && cursor + 1 < markdown.length) {
+      const escaped = markdown[cursor + 1] ?? "";
+      if (`!"#$%&'()*+,-./:;<=>?@[\\]^_\`{|}~`.includes(escaped)) {
+        output.push(escapeLatexCharacter(escaped));
+        cursor += 2;
+        continue;
+      }
+    }
     if (script?.test(character)) {
       const run: string[] = [];
       while (cursor < markdown.length) {
@@ -211,6 +219,7 @@ function renderMarkdown(markdown: string, options?: InlineRenderOptions): string
         renderInlineMarkdown(row[index] ?? "", options),
       );
     output.push(
+      "\\noindent",
       `\\begin{tabularx}{\\linewidth}{@{}${columns}@{}}`,
       "\\toprule",
       `${cells(header)

--- a/code/packages/typescript/human-language-data/tests/book.test.ts
+++ b/code/packages/typescript/human-language-data/tests/book.test.ts
@@ -82,6 +82,7 @@ describe("canonical LaTeX chapter rendering", () => {
       "test",
     );
     const generated = renderBookChapter(target, [lesson]);
+    expect(generated.tex).toContain("\\noindent\n\\begin{tabularx}{\\linewidth}");
     expect(generated.tex).toContain("\\begin{tabularx}{\\linewidth}");
     expect(generated.tex).toContain("\\textbf{person} & \\textbf{form} \\\\");
     expect(generated.tex).toContain("I & \\textbf{hablo} \\\\");
@@ -97,6 +98,9 @@ describe("canonical LaTeX chapter rendering", () => {
     );
     expect(renderInlineMarkdown("*buen**os*** and ***Como** tú.*")).toBe(
       "\\emph{buen\\textbf{os}} and \\emph{\\textbf{Como} tú.}",
+    );
+    expect(renderInlineMarkdown("**\\*parabolāvit**")).toBe(
+      "\\textbf{*parabolāvit}",
     );
   });
 


### PR DESCRIPTION
## Summary

- make the 104-page Italian book warning-free without dropping curriculum content
- preserve backslash-escaped Markdown punctuation and prevent paragraph-indented generated tables
- add bookmark-safe legacy metadata, deliberate ragged page bottoms, honest duration updates, and regenerated book hashes/chapters
- record HL-B15 as complete and promote Portuguese canonical book generation as HL-B16

## Validation

- `npm test` — human-language-data: 81 passed
- `npm run validate` — 9 integration tests passed
- `npm run check:books` and `npm run report` — 20 tracks, 1,065 lessons, 0 duration violations, 0 unknown prerequisites, 236 missing lesson chapters
- Language Ladder: 303 tests passed and production build succeeded
- unified local XeLaTeX loop: all 20 books compiled
- forced Italian XeLaTeX build: 104 pages; 0 missing glyphs, overfull boxes, underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings
- rendered and inspected all 104 pages; verified the 19-entry PDF outline and absence of leaked generator metadata