### PR TITLE
refactor(chief): own daemon control-plane resources

### DIFF
--- a/code/packages/rust/chief-of-staff-daemon-api/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-api/CHANGELOG.md
@@ -7,3 +7,4 @@
 - Bind the protocol to `chief-of-staff-orchestrator-core` and the repository WebSocket runtime.
 - Preserve separate durable and authoritative health evidence with precision-safe JSON encoding.
 - Add a typed blocking WebSocket client with strict response-ID and envelope validation.
+- Accept the owned lifetime-free orchestrator core at the threaded daemon boundary.

--- a/code/packages/rust/chief-of-staff-daemon-api/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-api/src/lib.rs
@@ -109,7 +109,7 @@ pub trait ChiefControlPlane {
     fn deregister_host(&mut self, host_name: &HostName) -> Result<(), ControlPlaneError>;
 }
 
-impl<S, A> ChiefControlPlane for OrchestratorCore<'_, S, A>
+impl<S, A> ChiefControlPlane for OrchestratorCore<S, A>
 where
     S: HostSupervisor,
     A: ChannelWiringAuthorizer,
@@ -1336,6 +1336,13 @@ mod tests {
         }
     }
 
+    #[test]
+    fn owned_process_core_satisfies_threaded_daemon_handler_bounds() {
+        fn assert_control_plane<C: ChiefControlPlane + Send + 'static>() {}
+        type OwnedCore = chief_of_staff_orchestrator_core::ProcessOrchestratorCore<NoopWiring>;
+        assert_control_plane::<OwnedCore>();
+    }
+
     #[derive(Clone)]
     struct TestAuthorizer {
         accept_credential: bool,
@@ -1391,9 +1398,7 @@ mod tests {
         }
     }
 
-    fn core<'a>(
-        backend: &'a InMemoryStorageBackend,
-    ) -> OrchestratorCore<'a, FakeSupervisor, NoopWiring> {
+    fn core(backend: Arc<InMemoryStorageBackend>) -> OrchestratorCore<FakeSupervisor, NoopWiring> {
         OrchestratorCore::new(
             backend,
             FakeSupervisor::default(),
@@ -1419,11 +1424,11 @@ mod tests {
 
     #[test]
     fn authenticated_host_lifecycle_round_trips_all_core_operations() {
-        let backend = InMemoryStorageBackend::new();
+        let backend = Arc::new(InMemoryStorageBackend::new());
         let authorizer = TestAuthorizer::allowing();
         let operations = Arc::clone(&authorizer.operations);
         let seen = Arc::clone(&authorizer.seen_credentials);
-        let api = DaemonApi::new(core(&backend), authorizer);
+        let api = DaemonApi::new(core(Arc::clone(&backend)), authorizer);
         let mut session = DaemonSession::default();
 
         let authenticated = authenticate(&api, &mut session);
@@ -1503,10 +1508,10 @@ mod tests {
 
     #[test]
     fn requests_require_authentication_and_each_authorization_decision() {
-        let backend = InMemoryStorageBackend::new();
+        let backend = Arc::new(InMemoryStorageBackend::new());
         let mut denied = TestAuthorizer::allowing();
         denied.allow_operation = false;
-        let api = DaemonApi::new(core(&backend), denied);
+        let api = DaemonApi::new(core(Arc::clone(&backend)), denied);
         let mut session = DaemonSession::default();
 
         let unauthenticated = api.handle_text(&mut session, &request("1", "list_hosts", "{}"));
@@ -1515,10 +1520,10 @@ mod tests {
         let forbidden = api.handle_text(&mut session, &request("2", "list_hosts", "{}"));
         assert!(forbidden.contains(r#""code":"forbidden""#));
 
-        let backend = InMemoryStorageBackend::new();
+        let backend = Arc::new(InMemoryStorageBackend::new());
         let mut failed = TestAuthorizer::allowing();
         failed.fail_authorize = true;
-        let api = DaemonApi::new(core(&backend), failed);
+        let api = DaemonApi::new(core(Arc::clone(&backend)), failed);
         let mut session = DaemonSession::default();
         authenticate(&api, &mut session);
         let internal = api.handle_text(&mut session, &request("3", "list_hosts", "{}"));
@@ -1527,10 +1532,10 @@ mod tests {
 
     #[test]
     fn authentication_is_bounded_connection_local_and_never_echoed() {
-        let backend = InMemoryStorageBackend::new();
+        let backend = Arc::new(InMemoryStorageBackend::new());
         let mut authorizer = TestAuthorizer::allowing();
         authorizer.accept_credential = false;
-        let api = DaemonApi::new(core(&backend), authorizer);
+        let api = DaemonApi::new(core(Arc::clone(&backend)), authorizer);
         let mut first = DaemonSession::default();
         let failed = api.handle_text(
             &mut first,
@@ -1540,8 +1545,8 @@ mod tests {
         assert!(!failed.contains("do-not-echo"));
         assert!(!first.is_authenticated());
 
-        let backend = InMemoryStorageBackend::new();
-        let api = DaemonApi::new(core(&backend), TestAuthorizer::allowing());
+        let backend = Arc::new(InMemoryStorageBackend::new());
+        let api = DaemonApi::new(core(Arc::clone(&backend)), TestAuthorizer::allowing());
         let mut first = DaemonSession::default();
         authenticate(&api, &mut first);
         let repeated = authenticate(&api, &mut first);
@@ -1568,8 +1573,8 @@ mod tests {
 
     #[test]
     fn untrusted_json_and_envelopes_are_strictly_bounded() {
-        let backend = InMemoryStorageBackend::new();
-        let api = DaemonApi::new(core(&backend), TestAuthorizer::allowing());
+        let backend = Arc::new(InMemoryStorageBackend::new());
+        let api = DaemonApi::new(core(Arc::clone(&backend)), TestAuthorizer::allowing());
         let cases = [
             "not json".to_string(),
             "[]".to_string(),
@@ -1603,8 +1608,8 @@ mod tests {
 
     #[test]
     fn parameter_validation_and_control_plane_errors_are_stable() {
-        let backend = InMemoryStorageBackend::new();
-        let api = DaemonApi::new(core(&backend), TestAuthorizer::allowing());
+        let backend = Arc::new(InMemoryStorageBackend::new());
+        let api = DaemonApi::new(core(Arc::clone(&backend)), TestAuthorizer::allowing());
         let mut session = DaemonSession::default();
         authenticate(&api, &mut session);
 
@@ -1644,8 +1649,8 @@ mod tests {
 
     #[test]
     fn websocket_events_are_text_only_and_control_events_are_runtime_owned() {
-        let backend = InMemoryStorageBackend::new();
-        let api = DaemonApi::new(core(&backend), TestAuthorizer::allowing());
+        let backend = Arc::new(InMemoryStorageBackend::new());
+        let api = DaemonApi::new(core(Arc::clone(&backend)), TestAuthorizer::allowing());
         let mut session = DaemonSession::default();
         assert!(
             api.handle(&mut session, MessageEvent::Binary(vec![1, 2]))

--- a/code/packages/rust/chief-of-staff-orchestrator-core/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-orchestrator-core/CHANGELOG.md
@@ -7,3 +7,4 @@
 - Add authorized durable channel-definition create, load, and destroy operations.
 - Preserve separate durable intent and authoritative process health evidence.
 - Reject monotonic clock regression without advancing failed reconciliation state.
+- Own the shared storage handle and production trust resources so the complete core is `Send + 'static` for daemon composition.

--- a/code/packages/rust/chief-of-staff-orchestrator-core/README.md
+++ b/code/packages/rust/chief-of-staff-orchestrator-core/README.md
@@ -5,6 +5,11 @@ layer for the D18 Chief daemon. It composes durable host intent, deterministic
 reconciliation, authoritative process supervision, and authorized channel
 topology behind bounded calls suitable for a later WebSocket server and CLI.
 
+The core owns its shared storage handle, and the production process composition
+owns shared keyring and zeroizing identity handles. It can therefore move into
+the threaded daemon API as a `Send + 'static` control plane without leaked or
+self-referential process-lifetime allocations.
+
 The core is keyless and payload-blind. Verified child processes own host-runtime
 execution and channel endpoint keys; the parent stores topology and coordinates
 lifecycle without reading agent messages or vault secrets.

--- a/code/packages/rust/chief-of-staff-orchestrator-core/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-orchestrator-core/src/lib.rs
@@ -145,19 +145,19 @@ where
 }
 
 /// Bounded application core parameterized by process and authorization adapters.
-pub struct OrchestratorCore<'a, S, A> {
-    backend: &'a dyn StorageBackend,
-    reconciler: ServiceReconciler<'a>,
+pub struct OrchestratorCore<S, A> {
+    backend: Arc<dyn StorageBackend>,
+    reconcile_config: ReconcileConfig,
     supervisor: S,
     authorizer: A,
     clock: Arc<dyn MonotonicClock>,
     last_reconcile_ns: Option<u64>,
 }
 
-impl<'a, S, A> OrchestratorCore<'a, S, A> {
+impl<S, A> OrchestratorCore<S, A> {
     /// Bind storage, reconciliation, process authority, authorization, and time.
     pub fn new(
-        backend: &'a dyn StorageBackend,
+        backend: Arc<dyn StorageBackend>,
         supervisor: S,
         authorizer: A,
         clock: Arc<dyn MonotonicClock>,
@@ -165,7 +165,7 @@ impl<'a, S, A> OrchestratorCore<'a, S, A> {
     ) -> Self {
         Self {
             backend,
-            reconciler: ServiceReconciler::new(ServiceRegistry::new(backend), reconcile_config),
+            reconcile_config,
             supervisor,
             authorizer,
             clock,
@@ -184,7 +184,7 @@ impl<'a, S, A> OrchestratorCore<'a, S, A> {
     }
 }
 
-impl<S, A> OrchestratorCore<'_, S, A>
+impl<S, A> OrchestratorCore<S, A>
 where
     S: HostSupervisor,
     A: ChannelWiringAuthorizer,
@@ -195,7 +195,7 @@ where
         registration: HostRegistration,
         desired_state: DesiredState,
     ) -> Result<LoadedHost, OrchestratorCoreError<S::Error, A::Error>> {
-        ServiceRegistry::new(self.backend)
+        ServiceRegistry::new(self.backend.as_ref())
             .register(&HostEntry::registered(registration, desired_state))
             .map_err(OrchestratorCoreError::Registry)
     }
@@ -205,14 +205,14 @@ where
         &self,
         host_name: &HostName,
     ) -> Result<Option<LoadedHost>, OrchestratorCoreError<S::Error, A::Error>> {
-        ServiceRegistry::new(self.backend)
+        ServiceRegistry::new(self.backend.as_ref())
             .load(host_name)
             .map_err(OrchestratorCoreError::Registry)
     }
 
     /// List durable hosts in stable host-name order.
     pub fn list_hosts(&self) -> Result<Vec<LoadedHost>, OrchestratorCoreError<S::Error, A::Error>> {
-        ServiceRegistry::new(self.backend)
+        ServiceRegistry::new(self.backend.as_ref())
             .list()
             .map_err(OrchestratorCoreError::Registry)
     }
@@ -223,7 +223,7 @@ where
         host_name: &HostName,
         desired_state: DesiredState,
     ) -> Result<LoadedHost, OrchestratorCoreError<S::Error, A::Error>> {
-        let registry = ServiceRegistry::new(self.backend);
+        let registry = ServiceRegistry::new(self.backend.as_ref());
         let loaded = registry
             .load(host_name)
             .map_err(OrchestratorCoreError::Registry)?
@@ -250,10 +250,12 @@ where
         {
             return Err(OrchestratorCoreError::ClockRegressed);
         }
-        let report = self
-            .reconciler
-            .reconcile_all(&mut self.supervisor, now_ns)
-            .map_err(OrchestratorCoreError::Reconciliation)?;
+        let report = ServiceReconciler::new(
+            ServiceRegistry::new(self.backend.as_ref()),
+            self.reconcile_config,
+        )
+        .reconcile_all(&mut self.supervisor, now_ns)
+        .map_err(OrchestratorCoreError::Reconciliation)?;
         self.last_reconcile_ns = Some(now_ns);
         Ok(report)
     }
@@ -263,7 +265,7 @@ where
         &mut self,
         host_name: &HostName,
     ) -> Result<HostHealth, OrchestratorCoreError<S::Error, A::Error>> {
-        let durable = ServiceRegistry::new(self.backend)
+        let durable = ServiceRegistry::new(self.backend.as_ref())
             .load(host_name)
             .map_err(OrchestratorCoreError::Registry)?
             .ok_or_else(|| {
@@ -287,7 +289,7 @@ where
         &mut self,
         host_name: &HostName,
     ) -> Result<(), OrchestratorCoreError<S::Error, A::Error>> {
-        let registry = ServiceRegistry::new(self.backend);
+        let registry = ServiceRegistry::new(self.backend.as_ref());
         let loaded = registry
             .load(host_name)
             .map_err(OrchestratorCoreError::Registry)?
@@ -324,7 +326,7 @@ where
         self.authorizer
             .authorize(ChannelWiringRequest::Create(definition))
             .map_err(OrchestratorCoreError::Authorization)?;
-        ChannelDefinitionStore::new(self.backend)
+        ChannelDefinitionStore::new(self.backend.as_ref())
             .create(definition)
             .map_err(OrchestratorCoreError::Channel)
     }
@@ -334,7 +336,7 @@ where
         &self,
         channel_id: ChannelId,
     ) -> Result<Option<ChannelDefinition>, OrchestratorCoreError<S::Error, A::Error>> {
-        ChannelDefinitionStore::new(self.backend)
+        ChannelDefinitionStore::new(self.backend.as_ref())
             .load(channel_id)
             .map_err(OrchestratorCoreError::Channel)
     }
@@ -344,7 +346,7 @@ where
         &mut self,
         channel_id: ChannelId,
     ) -> Result<ChannelDefinition, OrchestratorCoreError<S::Error, A::Error>> {
-        let store = ChannelDefinitionStore::new(self.backend);
+        let store = ChannelDefinitionStore::new(self.backend.as_ref());
         let definition = store
             .load(channel_id)
             .map_err(OrchestratorCoreError::Channel)?
@@ -361,16 +363,16 @@ where
 }
 
 /// Production process-supervised specialization of the transport-independent core.
-pub type ProcessOrchestratorCore<'a, A> = OrchestratorCore<'a, ProcessHostSupervisor<'a>, A>;
+pub type ProcessOrchestratorCore<A> = OrchestratorCore<ProcessHostSupervisor, A>;
 
-impl<'a, A> OrchestratorCore<'a, ProcessHostSupervisor<'a>, A> {
+impl<A> OrchestratorCore<ProcessHostSupervisor, A> {
     /// Compose package trust, X3DH identity, process authority, storage, and time.
     #[allow(clippy::too_many_arguments)]
     pub fn with_process_supervisor(
-        backend: &'a dyn StorageBackend,
+        backend: Arc<dyn StorageBackend>,
         process_config: ProcessSupervisorConfig,
-        keyring: &'a PackageKeyring,
-        identity: &'a IdentityKeyPair,
+        keyring: Arc<PackageKeyring>,
+        identity: Arc<IdentityKeyPair>,
         clock: Arc<dyn MonotonicClock>,
         sessions: Box<dyn SessionIdSource>,
         reconcile_config: ReconcileConfig,
@@ -577,12 +579,12 @@ mod tests {
         .expect("valid channel definition")
     }
 
-    fn core<'a>(
-        backend: &'a InMemoryStorageBackend,
+    fn core(
+        backend: Arc<InMemoryStorageBackend>,
         supervisor: FakeSupervisor,
         authorizer: FakeAuthorizer,
         clock: Arc<TestClock>,
-    ) -> OrchestratorCore<'a, FakeSupervisor, FakeAuthorizer> {
+    ) -> OrchestratorCore<FakeSupervisor, FakeAuthorizer> {
         OrchestratorCore::new(
             backend,
             supervisor,
@@ -594,11 +596,11 @@ mod tests {
 
     #[test]
     fn host_registration_listing_and_desired_state_are_idempotent() {
-        let backend = InMemoryStorageBackend::new();
+        let backend = Arc::new(InMemoryStorageBackend::new());
         let supervisor = FakeSupervisor::default();
         let events = Arc::new(Mutex::new(Vec::new()));
         let core = core(
-            &backend,
+            Arc::clone(&backend),
             supervisor,
             FakeAuthorizer::allowing(events),
             Arc::new(TestClock::new([])),
@@ -640,10 +642,10 @@ mod tests {
 
     #[test]
     fn conflicting_registration_and_unknown_host_updates_are_typed() {
-        let backend = InMemoryStorageBackend::new();
+        let backend = Arc::new(InMemoryStorageBackend::new());
         let events = Arc::new(Mutex::new(Vec::new()));
         let core = core(
-            &backend,
+            Arc::clone(&backend),
             FakeSupervisor::default(),
             FakeAuthorizer::allowing(events),
             Arc::new(TestClock::new([])),
@@ -668,13 +670,13 @@ mod tests {
 
     #[test]
     fn reconciliation_samples_time_once_and_tracks_only_success() {
-        let backend = InMemoryStorageBackend::new();
+        let backend = Arc::new(InMemoryStorageBackend::new());
         let supervisor = FakeSupervisor::default();
         let supervisor_state = Arc::clone(&supervisor.0);
         let clock = Arc::new(TestClock::new([1_000, 1_001, 1_002]));
         let events = Arc::new(Mutex::new(Vec::new()));
         let mut core = core(
-            &backend,
+            Arc::clone(&backend),
             supervisor,
             FakeAuthorizer::allowing(events),
             Arc::clone(&clock),
@@ -719,12 +721,12 @@ mod tests {
 
     #[test]
     fn reconciliation_drives_start_observe_stop_and_restart() {
-        let backend = InMemoryStorageBackend::new();
+        let backend = Arc::new(InMemoryStorageBackend::new());
         let supervisor = FakeSupervisor::default();
         let state = Arc::clone(&supervisor.0);
         let events = Arc::new(Mutex::new(Vec::new()));
         let mut core = core(
-            &backend,
+            Arc::clone(&backend),
             supervisor,
             FakeAuthorizer::allowing(events),
             Arc::new(TestClock::new([100, 110, 120, 130])),
@@ -785,12 +787,12 @@ mod tests {
 
     #[test]
     fn reconciliation_rejects_clock_regression_before_supervisor_io() {
-        let backend = InMemoryStorageBackend::new();
+        let backend = Arc::new(InMemoryStorageBackend::new());
         let supervisor = FakeSupervisor::default();
         let state = Arc::clone(&supervisor.0);
         let events = Arc::new(Mutex::new(Vec::new()));
         let mut core = core(
-            &backend,
+            Arc::clone(&backend),
             supervisor,
             FakeAuthorizer::allowing(events),
             Arc::new(TestClock::new([20, 19])),
@@ -810,12 +812,12 @@ mod tests {
 
     #[test]
     fn health_keeps_cached_state_separate_from_fresh_authority() {
-        let backend = InMemoryStorageBackend::new();
+        let backend = Arc::new(InMemoryStorageBackend::new());
         let supervisor = FakeSupervisor::default();
         let state = Arc::clone(&supervisor.0);
         let events = Arc::new(Mutex::new(Vec::new()));
         let mut core = core(
-            &backend,
+            Arc::clone(&backend),
             supervisor,
             FakeAuthorizer::allowing(events),
             Arc::new(TestClock::new([])),
@@ -856,12 +858,12 @@ mod tests {
 
     #[test]
     fn deregistration_requires_stopped_intent_and_absent_or_exited_authority() {
-        let backend = InMemoryStorageBackend::new();
+        let backend = Arc::new(InMemoryStorageBackend::new());
         let supervisor = FakeSupervisor::default();
         let state = Arc::clone(&supervisor.0);
         let events = Arc::new(Mutex::new(Vec::new()));
         let mut core = core(
-            &backend,
+            Arc::clone(&backend),
             supervisor,
             FakeAuthorizer::allowing(events),
             Arc::new(TestClock::new([])),
@@ -915,11 +917,11 @@ mod tests {
 
     #[test]
     fn channel_mutations_are_authorized_before_storage_changes() {
-        let backend = InMemoryStorageBackend::new();
+        let backend = Arc::new(InMemoryStorageBackend::new());
         let supervisor = FakeSupervisor::default();
         let events = Arc::new(Mutex::new(Vec::new()));
         let mut core = core(
-            &backend,
+            Arc::clone(&backend),
             supervisor,
             FakeAuthorizer::allowing(Arc::clone(&events)),
             Arc::new(TestClock::new([])),
@@ -968,10 +970,10 @@ mod tests {
 
     #[test]
     fn denied_channel_mutations_leave_storage_unchanged() {
-        let backend = InMemoryStorageBackend::new();
+        let backend = Arc::new(InMemoryStorageBackend::new());
         let events = Arc::new(Mutex::new(Vec::new()));
         let mut core = core(
-            &backend,
+            Arc::clone(&backend),
             FakeSupervisor::default(),
             FakeAuthorizer::denying(Arc::clone(&events)),
             Arc::new(TestClock::new([])),
@@ -987,7 +989,7 @@ mod tests {
             None
         );
 
-        ChannelDefinitionStore::new(&backend)
+        ChannelDefinitionStore::new(backend.as_ref())
             .create(&definition)
             .expect("seed definition");
         assert!(matches!(
@@ -1035,9 +1037,9 @@ mod tests {
 
     #[test]
     fn production_constructor_composes_an_empty_process_supervised_core() {
-        let backend = InMemoryStorageBackend::new();
-        let keyring = PackageKeyring::new();
-        let identity = generate_identity_keypair();
+        let backend = Arc::new(InMemoryStorageBackend::new());
+        let keyring = Arc::new(PackageKeyring::new());
+        let identity = Arc::new(generate_identity_keypair());
         let executable = std::env::current_exe().expect("current executable");
         let config = ProcessSupervisorConfig::new(
             HostProgram::new(executable, std::iter::empty::<&str>()).expect("host program"),
@@ -1048,15 +1050,17 @@ mod tests {
         let clock = Arc::new(TestClock::new([1]));
         let events = Arc::new(Mutex::new(Vec::new()));
         let mut core = ProcessOrchestratorCore::with_process_supervisor(
-            &backend,
+            backend,
             config,
-            &keyring,
-            &identity,
+            keyring,
+            identity,
             clock,
             Box::<UuidV7SessionIdSource>::default(),
             ReconcileConfig::new(100).expect("reconcile config"),
             FakeAuthorizer::allowing(events),
         );
+        fn assert_send_static<T: Send + 'static>(_: &T) {}
+        assert_send_static(&core);
         assert!(core
             .reconcile_once()
             .expect("empty production tick")

--- a/code/packages/rust/chief-of-staff-process-supervisor/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-process-supervisor/CHANGELOG.md
@@ -7,3 +7,4 @@
 - Add authenticated readiness, heartbeat, and graceful termination handling.
 - Add owned child reaping with hard-kill fallback and drop cleanup.
 - Implement the D18 service reconciler's authoritative supervisor contract.
+- Own shared keyring and zeroizing identity handles and require movable session sources for daemon composition.

--- a/code/packages/rust/chief-of-staff-process-supervisor/README.md
+++ b/code/packages/rust/chief-of-staff-process-supervisor/README.md
@@ -5,6 +5,10 @@ D18 Chief hosts. It re-verifies a registered signed package immediately before
 each spawn, owns and reaps the child, bootstraps a fresh UUID-v7 secure channel,
 and reports readiness and heartbeat only after authenticated control messages.
 
+Its keyring and X3DH identity are shared through owned `Arc` handles, and its
+session source is `Send`, so the complete supervisor can move with the daemon's
+threaded control plane without copying secret key material.
+
 The crate implements the dependency-light service reconciler's
 `HostSupervisor` interface. It deliberately leaves durable restart policy,
 scheduling, backoff, and registry updates to the reconciler and runnable

--- a/code/packages/rust/chief-of-staff-process-supervisor/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/src/lib.rs
@@ -194,7 +194,7 @@ impl MonotonicClock for SystemMonotonicClock {
 }
 
 /// Source of fresh valid UUID-v7 secure-session identities.
-pub trait SessionIdSource {
+pub trait SessionIdSource: Send {
     /// Return the next per-spawn session.
     fn next_session(&mut self) -> Result<SessionId, ProcessSupervisorError>;
 }
@@ -362,21 +362,21 @@ impl OwnedInstance {
 }
 
 /// Concrete verified process authority for the D18 service reconciler.
-pub struct ProcessHostSupervisor<'a> {
+pub struct ProcessHostSupervisor {
     config: ProcessSupervisorConfig,
-    keyring: &'a PackageKeyring,
-    identity: &'a IdentityKeyPair,
+    keyring: Arc<PackageKeyring>,
+    identity: Arc<IdentityKeyPair>,
     clock: Arc<dyn MonotonicClock>,
     sessions: Box<dyn SessionIdSource>,
     instances: BTreeMap<String, OwnedInstance>,
 }
 
-impl<'a> ProcessHostSupervisor<'a> {
+impl ProcessHostSupervisor {
     /// Construct a supervisor around injected package trust, identity, time, and sessions.
     pub fn new(
         config: ProcessSupervisorConfig,
-        keyring: &'a PackageKeyring,
-        identity: &'a IdentityKeyPair,
+        keyring: Arc<PackageKeyring>,
+        identity: Arc<IdentityKeyPair>,
         clock: Arc<dyn MonotonicClock>,
         sessions: Box<dyn SessionIdSource>,
     ) -> Self {
@@ -395,7 +395,7 @@ impl<'a> ProcessHostSupervisor<'a> {
         registration: &HostRegistration,
     ) -> Result<OwnedInstance, ProcessSupervisorError> {
         let package_path = Path::new(registration.package_path().as_str());
-        let package = verify_agent_package(package_path, self.keyring)
+        let package = verify_agent_package(package_path, self.keyring.as_ref())
             .map_err(|_| ProcessSupervisorError::PackageVerification)?;
         if package.digest() != *registration.package_hash() {
             return Err(ProcessSupervisorError::PackageMismatch);
@@ -404,7 +404,7 @@ impl<'a> ProcessHostSupervisor<'a> {
         let session = self.sessions.next_session()?;
         let host = HostId::new(registration.host_name().as_str().to_owned())
             .map_err(|_| ProcessSupervisorError::Bootstrap)?;
-        let bootstrap = OrchestratorBootstrap::new(self.identity, host, session)
+        let bootstrap = OrchestratorBootstrap::new(self.identity.as_ref(), host, session)
             .map_err(|_| ProcessSupervisorError::Bootstrap)?;
         let offer = bootstrap
             .offer()
@@ -510,7 +510,7 @@ impl<'a> ProcessHostSupervisor<'a> {
     }
 }
 
-impl HostSupervisor for ProcessHostSupervisor<'_> {
+impl HostSupervisor for ProcessHostSupervisor {
     type Error = ProcessSupervisorError;
 
     fn inspect(
@@ -593,7 +593,7 @@ impl HostSupervisor for ProcessHostSupervisor<'_> {
     }
 }
 
-impl Drop for ProcessHostSupervisor<'_> {
+impl Drop for ProcessHostSupervisor {
     fn drop(&mut self) {
         for instance in self.instances.values_mut() {
             if instance.is_active() {

--- a/code/packages/rust/chief-of-staff-process-supervisor/tests/process_supervisor.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/tests/process_supervisor.rs
@@ -151,12 +151,12 @@ impl SessionIdSource for TestSessions {
     }
 }
 
-fn new_supervisor<'a>(
-    keyring: &'a PackageKeyring,
-    identity: &'a coding_adventures_x3dh::IdentityKeyPair,
+fn new_supervisor(
+    keyring: Arc<PackageKeyring>,
+    identity: Arc<coding_adventures_x3dh::IdentityKeyPair>,
     bootstrap_timeout: Duration,
     graceful_timeout: Duration,
-) -> ProcessHostSupervisor<'a> {
+) -> ProcessHostSupervisor {
     let program = HostProgram::new(
         env!("CARGO_BIN_EXE_process-supervisor-test-child"),
         std::iter::empty::<&str>(),
@@ -174,7 +174,7 @@ fn new_supervisor<'a>(
 }
 
 fn await_phase(
-    supervisor: &mut ProcessHostSupervisor<'_>,
+    supervisor: &mut ProcessHostSupervisor,
     registration: &HostRegistration,
     expected: SupervisorPhase,
 ) -> chief_of_staff_service_reconciler::SupervisorInstance {
@@ -199,11 +199,11 @@ fn await_phase(
 fn real_child_reaches_running_and_stops_gracefully() {
     let package = TestPackage::new("graceful", None);
     let registration = package.registration("fixture-host");
-    let keyring = keyring();
-    let identity = generate_identity_keypair();
+    let keyring = Arc::new(keyring());
+    let identity = Arc::new(generate_identity_keypair());
     let mut supervisor = new_supervisor(
-        &keyring,
-        &identity,
+        Arc::clone(&keyring),
+        Arc::clone(&identity),
         Duration::from_secs(3),
         Duration::from_secs(1),
     );
@@ -235,11 +235,11 @@ fn real_child_reaches_running_and_stops_gracefully() {
 fn exact_hash_is_checked_before_spawn_and_active_hash_cannot_change() {
     let package = TestPackage::new("identity", None);
     let mut registration = package.registration("identity-host");
-    let keyring = keyring();
-    let identity = generate_identity_keypair();
+    let keyring = Arc::new(keyring());
+    let identity = Arc::new(generate_identity_keypair());
     let mut supervisor = new_supervisor(
-        &keyring,
-        &identity,
+        Arc::clone(&keyring),
+        Arc::clone(&identity),
         Duration::from_secs(3),
         Duration::from_millis(200),
     );
@@ -290,10 +290,9 @@ fn bootstrap_timeout_and_oversized_record_are_cleaned_up() {
     ] {
         let package = TestPackage::new(label, Some(marker));
         let registration = package.registration(&format!("{label}-host"));
-        let keyring = keyring();
-        let identity = generate_identity_keypair();
-        let mut supervisor =
-            new_supervisor(&keyring, &identity, timeout, Duration::from_millis(100));
+        let keyring = Arc::new(keyring());
+        let identity = Arc::new(generate_identity_keypair());
+        let mut supervisor = new_supervisor(keyring, identity, timeout, Duration::from_millis(100));
         assert_eq!(supervisor.start(&registration), Err(expected));
         assert_eq!(
             supervisor.inspect(&registration).unwrap(),
@@ -318,11 +317,11 @@ fn wrong_ready_and_exit_before_ready_fail_closed() {
     ] {
         let package = TestPackage::new(label, Some(marker));
         let registration = package.registration(&format!("{label}-host"));
-        let keyring = keyring();
-        let identity = generate_identity_keypair();
+        let keyring = Arc::new(keyring());
+        let identity = Arc::new(generate_identity_keypair());
         let mut supervisor = new_supervisor(
-            &keyring,
-            &identity,
+            keyring,
+            identity,
             Duration::from_secs(3),
             Duration::from_millis(100),
         );
@@ -349,11 +348,11 @@ fn wrong_ready_and_exit_before_ready_fail_closed() {
 fn graceful_timeout_hard_kills_and_drop_reaps() {
     let package = TestPackage::new("hard-kill", Some("IGNORE_TERMINATE"));
     let registration = package.registration("hard-kill-host");
-    let keyring = keyring();
-    let identity = generate_identity_keypair();
+    let keyring = Arc::new(keyring());
+    let identity = Arc::new(generate_identity_keypair());
     let mut supervisor = new_supervisor(
-        &keyring,
-        &identity,
+        Arc::clone(&keyring),
+        Arc::clone(&identity),
         Duration::from_secs(3),
         Duration::from_millis(100),
     );
@@ -371,8 +370,8 @@ fn graceful_timeout_hard_kills_and_drop_reaps() {
     let second = TestPackage::new("drop", None);
     let second_registration = second.registration("drop-host");
     let mut dropped = new_supervisor(
-        &keyring,
-        &identity,
+        keyring,
+        identity,
         Duration::from_secs(3),
         Duration::from_millis(100),
     );
@@ -391,11 +390,11 @@ fn invalid_package_fails_before_process_creation() {
         [0; 32],
         RestartPolicy::Never,
     );
-    let keyring = keyring();
-    let identity = generate_identity_keypair();
+    let keyring = Arc::new(keyring());
+    let identity = Arc::new(generate_identity_keypair());
     let mut supervisor = new_supervisor(
-        &keyring,
-        &identity,
+        keyring,
+        identity,
         Duration::from_secs(1),
         Duration::from_secs(1),
     );

--- a/code/specs/process-host-supervisor.md
+++ b/code/specs/process-host-supervisor.md
@@ -65,9 +65,11 @@ The child independently verifies its package before sending
 control endpoint and terminates the child.
 
 Every launch receives a fresh non-zero UUID-v7 `SessionId` from an injected
-source. The session ID becomes the registry `ChannelId`; the adapter never mints
-a second channel identity. The orchestrator X3DH identity is borrowed rather
-than copied, preserving its zeroizing key ownership.
+`Send` source. The session ID becomes the registry `ChannelId`; the adapter never
+mints a second channel identity. The supervisor owns shared `Arc` handles to the
+trusted package keyring and orchestrator X3DH identity. This permits the complete
+process authority to move into the daemon's WebSocket handler without copying
+zeroizing identity material or constructing a self-referential owner.
 
 ## Process Authority
 
@@ -122,7 +124,8 @@ The package exposes:
 
 - validated `ProcessSupervisorConfig` and `HostProgram` values;
 - `MonotonicClock` and `SessionIdSource` interfaces plus production adapters;
-- `ProcessHostSupervisor`, implementing the reconciler `HostSupervisor` trait;
+- owned, movable `ProcessHostSupervisor`, implementing the reconciler
+  `HostSupervisor` trait;
 - `ChildProcessControl<R, W>` for host-runtime integration; and
 - bounded, input-independent `ProcessSupervisorError` diagnostics.
 
@@ -143,6 +146,8 @@ The package must cover:
 - real cross-platform child bootstrap, matching readiness, heartbeat, and
   graceful termination;
 - idempotent same-hash start and refusal of an active different-hash launch;
+- compile-time `Send + 'static` production composition with shared trust and
+  identity ownership;
 - bootstrap timeout, malformed bootstrap, wrong readiness, and exit-before-ready
   cleanup;
 - graceful-stop timeout with hard-kill fallback;

--- a/code/specs/runnable-orchestrator-core.md
+++ b/code/specs/runnable-orchestrator-core.md
@@ -32,14 +32,18 @@ The generic core receives:
 - validated reconciliation configuration; and
 - one channel-wiring authorizer.
 
-A production constructor composes the core with `ProcessHostSupervisor`, its
-trusted package keyring, long-lived X3DH identity, fixed absolute child program,
-fresh UUID-v7 session source, and the same monotonic clock used for authenticated
-receipt evidence.
+A production constructor composes the core with `ProcessHostSupervisor`, owned
+shared handles to its trusted package keyring and long-lived X3DH identity, a
+fixed absolute child program, fresh UUID-v7 session source, and the same
+monotonic clock used for authenticated receipt evidence.
 
-The backend and cryptographic trust objects are borrowed from the runnable
-daemon owner. The core does not create a self-referential filesystem backend or
-copy zeroizing identity material.
+The core owns an `Arc<dyn StorageBackend>` and the process supervisor owns
+`Arc` handles to its cryptographic trust objects. The complete control plane is
+therefore `Send + 'static` when its injected authorizer is, as required by the
+threaded WebSocket runtime. Shared ownership does not copy zeroizing identity
+material, leak process-lifetime allocations, or require a self-referential
+daemon owner. Registry and reconciliation handles borrow the owned backend only
+for the duration of each bounded operation.
 
 ## Host Intent API
 
@@ -107,8 +111,8 @@ CAS contract.
 
 The package exposes:
 
-- `OrchestratorCore<S, A>` for injected supervisors and authorizers;
-- `ProcessOrchestratorCore<A>` plus a production process-composition
+- owned `OrchestratorCore<S, A>` for injected supervisors and authorizers;
+- `ProcessOrchestratorCore<A>` plus a movable production process-composition
   constructor;
 - `ChannelWiringAuthorizer` and exact create/destroy request values;
 - `HostHealth`, preserving durable and authoritative views;
@@ -143,6 +147,8 @@ The package must cover:
 - authorization denial proving no channel mutation;
 - stable payload-free error diagnostics; and
 - production process-composition construction without spawning until a tick
-  actually requests start.
+  actually requests start; and
+- compile-time proof that production composition can cross the daemon's
+  `Send + 'static` handler boundary without leaks.
 
 The package forbids unsafe code and targets at least 95 percent line coverage.


### PR DESCRIPTION
## Summary

- make the production Chief control plane own its storage backend and host identity resources
- require session ID sources to be `Send`, allowing the process supervisor to cross the daemon task boundary safely
- construct bounded registry/reconciler borrows from owned resources without leaks, key copies, or self-referential owners
- compile-test the exact `ChiefControlPlane + Send + 'static` boundary required by the WebSocket daemon
- update the governing specs, READMEs, and changelogs

This removes the ownership blocker for composing a real long-lived Chief daemon process.

## Validation

- `cargo fmt -p chief-of-staff-process-supervisor -p chief-of-staff-orchestrator-core -p chief-of-staff-daemon-api -- --check`
- `cargo test -p chief-of-staff-process-supervisor -p chief-of-staff-orchestrator-core -p chief-of-staff-daemon-api -p chief-of-staff-cli-core` (42 tests)
- `cargo clippy -p chief-of-staff-process-supervisor -p chief-of-staff-orchestrator-core -p chief-of-staff-daemon-api --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p chief-of-staff-process-supervisor -p chief-of-staff-orchestrator-core -p chief-of-staff-daemon-api --no-deps`
- repository build planner: 3 changed packages, 54 affected, Rust only

Part of #128.
Advances #138.
