### PR TITLE
fix(spice): lower diode saturation-current alias

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate diode model-card `IS` / `JS` saturation current and lower the `JS`
+  alias instead of silently dropping it.
 - Validate and lower JFET model-card `CGD` and `CGD0` gate-drain capacitance
   parameters instead of silently dropping them.
 - Validate and lower JFET model-card `CGS` and `CGS0` gate-source capacitance

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1265,7 +1265,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             name,
             fields[1],
             fields[2],
-            Is=model.params.get("IS", 1e-15),
+            Is=model.params.get("IS", model.params.get("JS", 1e-15)),
             Vt=model.params.get("VT", 0.02585),
             N=model.params.get("N", 1.0),
             BV=model.params.get("BV"),
@@ -1907,6 +1907,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
         if params_text.startswith("(") and params_text.endswith(")"):
             params_text = params_text[1:-1]
     params = _parse_model_params(params_text)
+    if kind == "D":
+        saturation_current = params.get("IS", params.get("JS"))
+        if saturation_current is not None and (
+            not math.isfinite(saturation_current) or saturation_current <= 0.0
+        ):
+            raise NetlistParseError("diode IS must be finite and positive")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -796,6 +796,30 @@ Rload out 0 1k
     assert 0.0 < result.node_voltages["out"] < 0.7
 
 
+def test_parse_diode_saturation_current_alias() -> None:
+    parsed = parse_netlist(
+        """
+.model clamp D(JS=2p)
+D1 in out clamp
+"""
+    )
+
+    diode = parsed.circuit.elements[0]
+    assert isinstance(diode, Diode)
+    assert diode.Is == 2.0e-12
+
+
+@pytest.mark.parametrize("parameter", ["IS", "JS"])
+@pytest.mark.parametrize("value", ["0", "-1p", "1e999"])
+def test_rejects_invalid_diode_saturation_current(
+    parameter: str, value: str
+) -> None:
+    with pytest.raises(
+        NetlistParseError, match="diode IS must be finite and positive"
+    ):
+        parse_netlist(f".model clamp D({parameter}={value})")
+
+
 def test_parse_bjt_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate diode model-card `IS` / `JS` saturation current and lower the `JS`
+  alias instead of silently dropping it.
 - Validate and lower JFET model-card `CGD` and `CGD0` gate-drain capacitance
   parameters instead of silently dropping them.
 - Validate and lower JFET model-card `CGS` and `CGS0` gate-source capacitance

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1150,6 +1150,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   }
   const kind = match[1].toUpperCase();
   const params = parseModelParams(paramsText);
+  const diodeSaturationCurrent = params.get("IS") ?? params.get("JS");
+  if (
+    kind === "D" &&
+    diodeSaturationCurrent !== undefined &&
+    (!Number.isFinite(diodeSaturationCurrent) || diodeSaturationCurrent <= 0.0)
+  ) {
+    throw new NetlistParseError("diode IS must be finite and positive");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -1671,7 +1679,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       name,
       fields[1],
       fields[2],
-      model.params.get("IS") ?? 1.0e-15,
+      model.params.get("IS") ?? model.params.get("JS") ?? 1.0e-15,
       model.params.get("VT") ?? 0.02585,
       model.params.get("N") ?? 1.0,
       model.params.get("BV"),

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -775,6 +775,31 @@ Rload out 0 1k
     expect(result.voltage("out")).toBeLessThan(0.7);
   });
 
+  it("parses the diode JS saturation-current alias", () => {
+    const parsed = parseNetlist(`
+.model clamp D(JS=2p)
+D1 in out clamp
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "diode",
+      saturationCurrent: 2.0e-12,
+    });
+  });
+
+  it.each([
+    ["IS", "0"],
+    ["IS", "-1p"],
+    ["IS", "1e999"],
+    ["JS", "0"],
+    ["JS", "-1p"],
+    ["JS", "1e999"],
+  ])("rejects invalid diode %s saturation current %s", (parameter, value) => {
+    expect(() => parseNetlist(`.model clamp D(${parameter}=${value})`)).toThrow(
+      "diode IS must be finite and positive",
+    );
+  });
+
   it("parses BJT models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NPN(IS=1e-14 BF=120 VT=25m CJE=2p CJC=3p TF=4n TR=5n)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4325,11 +4325,16 @@ the Rust, Python, and TypeScript surfaces together.
    - Both parser facades validate non-negative finite `CGS` / `CGS0` values
      and lower them into the shared engine gate-source capacitance field.
 
+402. Python and TypeScript Berkeley SPICE JFET gate-drain capacitance parity.
+   - Status: completed in PR 9734.
+   - Both parser facades validate non-negative finite `CGD` / `CGD0` values
+     and lower them into the shared engine gate-drain capacitance field.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE diode model-card alias parity.
    - Align parser validation and lowering with the shared engine aliases,
-     starting with `JS` as the diode saturation-current alias for `IS`.
+     starting with `V_T` as the diode thermal-voltage alias for `VT`.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary
- validate finite, positive diode `IS` and `JS` model-card values in the Python and TypeScript parser facades
- lower `JS` through the existing diode saturation-current field with canonical `IS` precedence
- record PR #9734 in the SPICE plan and queue diode `V_T` alias parity next

## Verification
- Python `spice-netlist-parser`: `bash BUILD` (234 passed, 88.72% coverage)
- Python `spice-netlist-parser`: `.venv/bin/ruff check .`
- TypeScript `spice-engine`: `npm test` (448 passed)
- TypeScript `spice-netlist-parser`: `bash BUILD` (223 passed)
- TypeScript `spice-netlist-parser`: `npm run test:coverage` (223 passed, 85.53% line coverage)
- Rebased onto current `origin/main` and reran both parser package gates