### PR TITLE
Report stray menuitem end tags

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Obsolete `menuitem` end tags now report the in-body parse error when no
+  matching `menuitem` is current, covering 4 previously silent malformed
+  corpus cases without changing DOM recovery or undeclared-diagnostic coverage.
 - A formatting end tag that cannot cross an open table scope now reports the
   Standard's parse error, covering 2 previously silent malformed corpus cases
   without changing DOM recovery.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the specialized formatting/table-scope diagnostic slice, 2,011 of those
-cases emit at least one lexer or parser diagnostic and 172 remain
+After the specialized obsolete-`menuitem` end-tag diagnostic slice, 2,015 of
+those cases emit at least one lexer or parser diagnostic and 168 remain
 uncovered.
 Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
 These are reviewed rather than automatically removed: 89 are full-document
@@ -55,7 +55,8 @@ original mode; synthetic text fragment contexts remain diagnostic-free.
 The in-body "any other end tag" parse error is now reported when implied end
 tags leave the matching open element non-current, including special-element
 scope stops and nested formatting recovery. Remaining in-body work covers
-formatting-reconstruction and stray-tag branches. Heading end tags report
+formatting-reconstruction and other stray-tag branches. Obsolete `menuitem`
+end tags now report when no matching element is current. Heading end tags report
 the specialized parse error when no heading is in scope or the current heading
 does not match the token. A `li` start tag reports when its implied-end-tag
 recovery closes a non-current list item, and a paragraph end tag reports when it
@@ -64,8 +65,8 @@ open table blocks adoption-agency recovery.
 
 Prioritized work items:
 
-1. **In-body insertion mode.** Cover specialized list-item, paragraph,
-   adoption-agency, formatting-reconstruction, and stray-tag diagnostics.
+1. **In-body insertion mode.** Cover the remaining formatting-reconstruction
+   and stray-tag diagnostics.
 2. **Table, select, and template insertion modes.** Cover foster parenting,
    table scopes, select recovery, and template mode-stack errors. The remaining
    fragment EOF inventory includes fostered-anchor `eof-in-table` rows and

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7342,8 +7342,18 @@ impl HtmlParser {
         let Some(index) = self.open_elements.iter().rposition(|path| {
             element_at_path(&self.document, path).is_some_and(|name| name == "menuitem")
         }) else {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-menuitem-end-tag",
+                "end tag `</menuitem>` did not match the current open element",
+            ));
             return;
         };
+        if index + 1 < self.open_elements.len() {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-menuitem-end-tag",
+                "end tag `</menuitem>` did not match the current open element",
+            ));
+        }
         if self
             .open_elements
             .iter()
@@ -33307,6 +33317,29 @@ mod tests {
                 "end tag `</font>` could not close a formatting element across table scope"
             )]
         );
+    }
+
+    #[test]
+    fn reports_menuitem_end_tags_without_a_matching_current_element() {
+        for source in [
+            "<!DOCTYPE html><menuitem><asdf></menuitem>x",
+            "<!DOCTYPE html></menuitem>",
+            "<!DOCTYPE html><html></menuitem>",
+            "<!DOCTYPE html><head></menuitem>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "unexpected-menuitem-end-tag",
+                    "end tag `</menuitem>` did not match the current open element"
+                )],
+                "source {source:?}"
+            );
+        }
+
+        let matching = parse_html_with_diagnostics("<!doctype html><menuitem></menuitem>").unwrap();
+        assert!(matching.parser_diagnostics.is_empty());
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 172);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2011);
+    assert_eq!(missing_diagnostic_cases, 168);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2015);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report a specialized parser diagnostic for obsolete `menuitem` end tags when no matching element is current
- cover four previously silent malformed tree-construction cases without changing DOM recovery
- update the conformance backlog and diagnostic ratchet from 172 to 168 remaining cases

## Validation
- `cargo test -p coding-adventures-html-parser`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-lexer`
- `cargo test -p state-machine-tokenizer`
- pinned WPT/html5lib coverage audit: tree 1934/2637/missing 0; tokenizer 6806/7015/7242/skipped 0/missing 0
- all WHATWG audit metadata, manifest, coverage, and Rust-test checks

This is a bounded diagnostic-coverage slice; it does not claim full browser conformance.