### PR TITLE
fix(spice): lower diode thermal-voltage alias

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate diode model-card `VT` / `V_T` thermal voltage and lower the `V_T`
+  alias instead of silently dropping it.
 - Validate diode model-card `IS` / `JS` saturation current and lower the `JS`
   alias instead of silently dropping it.
 - Validate and lower JFET model-card `CGD` and `CGD0` gate-drain capacitance

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1266,7 +1266,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             fields[1],
             fields[2],
             Is=model.params.get("IS", model.params.get("JS", 1e-15)),
-            Vt=model.params.get("VT", 0.02585),
+            Vt=model.params.get("VT", model.params.get("V_T", 0.02585)),
             N=model.params.get("N", 1.0),
             BV=model.params.get("BV"),
             IBV=model.params.get("IBV", 1e-3),
@@ -1913,6 +1913,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(saturation_current) or saturation_current <= 0.0
         ):
             raise NetlistParseError("diode IS must be finite and positive")
+        thermal_voltage = params.get("VT", params.get("V_T"))
+        if thermal_voltage is not None and (
+            not math.isfinite(thermal_voltage) or thermal_voltage <= 0.0
+        ):
+            raise NetlistParseError("diode VT must be finite and positive")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -820,6 +820,28 @@ def test_rejects_invalid_diode_saturation_current(
         parse_netlist(f".model clamp D({parameter}={value})")
 
 
+def test_parse_diode_thermal_voltage_alias() -> None:
+    parsed = parse_netlist(
+        """
+.model clamp D(V_T=27m)
+D1 in out clamp
+"""
+    )
+
+    diode = parsed.circuit.elements[0]
+    assert isinstance(diode, Diode)
+    assert isclose(diode.Vt, 27.0e-3)
+
+
+@pytest.mark.parametrize("parameter", ["VT", "V_T"])
+@pytest.mark.parametrize("value", ["0", "-1m", "1e999"])
+def test_rejects_invalid_diode_thermal_voltage(parameter: str, value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="diode VT must be finite and positive"
+    ):
+        parse_netlist(f".model clamp D({parameter}={value})")
+
+
 def test_parse_bjt_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate diode model-card `VT` / `V_T` thermal voltage and lower the `V_T`
+  alias instead of silently dropping it.
 - Validate diode model-card `IS` / `JS` saturation current and lower the `JS`
   alias instead of silently dropping it.
 - Validate and lower JFET model-card `CGD` and `CGD0` gate-drain capacitance

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1158,6 +1158,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("diode IS must be finite and positive");
   }
+  const diodeThermalVoltage = params.get("VT") ?? params.get("V_T");
+  if (
+    kind === "D" &&
+    diodeThermalVoltage !== undefined &&
+    (!Number.isFinite(diodeThermalVoltage) || diodeThermalVoltage <= 0.0)
+  ) {
+    throw new NetlistParseError("diode VT must be finite and positive");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -1680,7 +1688,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       fields[1],
       fields[2],
       model.params.get("IS") ?? model.params.get("JS") ?? 1.0e-15,
-      model.params.get("VT") ?? 0.02585,
+      model.params.get("VT") ?? model.params.get("V_T") ?? 0.02585,
       model.params.get("N") ?? 1.0,
       model.params.get("BV"),
       model.params.get("IBV") ?? 1.0e-3,

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -800,6 +800,31 @@ D1 in out clamp
     );
   });
 
+  it("parses the diode V_T thermal-voltage alias", () => {
+    const parsed = parseNetlist(`
+.model clamp D(V_T=27m)
+D1 in out clamp
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "diode",
+      thermalVoltage: 27.0e-3,
+    });
+  });
+
+  it.each([
+    ["VT", "0"],
+    ["VT", "-1m"],
+    ["VT", "1e999"],
+    ["V_T", "0"],
+    ["V_T", "-1m"],
+    ["V_T", "1e999"],
+  ])("rejects invalid diode %s thermal voltage %s", (parameter, value) => {
+    expect(() => parseNetlist(`.model clamp D(${parameter}=${value})`)).toThrow(
+      "diode VT must be finite and positive",
+    );
+  });
+
   it("parses BJT models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NPN(IS=1e-14 BF=120 VT=25m CJE=2p CJC=3p TF=4n TR=5n)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4330,11 +4330,16 @@ the Rust, Python, and TypeScript surfaces together.
    - Both parser facades validate non-negative finite `CGD` / `CGD0` values
      and lower them into the shared engine gate-drain capacitance field.
 
+403. Python and TypeScript Berkeley SPICE diode saturation-current alias parity.
+   - Status: completed in PR 9738.
+   - Both parser facades validate positive finite `IS` / `JS` values and lower
+     `JS` into the shared engine diode saturation-current field.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE diode model-card alias parity.
    - Align parser validation and lowering with the shared engine aliases,
-     starting with `V_T` as the diode thermal-voltage alias for `VT`.
+     starting with `CJ` as the diode junction-capacitance alias for `CJO`.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary
- validate finite, positive diode `VT` and `V_T` model-card values in the Python and TypeScript parser facades
- lower `V_T` through the existing diode thermal-voltage field with canonical `VT` precedence
- record PR #9738 in the SPICE plan and queue diode `CJ` alias parity next

## Verification
- Python `spice-netlist-parser`: `bash BUILD` (241 passed, 88.75% coverage)
- Python `spice-netlist-parser`: `.venv/bin/ruff check .`
- TypeScript `spice-engine`: `npm test` (448 passed)
- TypeScript `spice-netlist-parser`: `bash BUILD` (230 passed)
- TypeScript `spice-netlist-parser`: `npm run test:coverage` (230 passed, 85.58% line coverage)