### PR TITLE
feat(adj): recover interrupted CAS transactions

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/arithmetic_provenance_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/arithmetic_provenance_e2e.rs
@@ -42,6 +42,21 @@ fn lock_cas(root: &Path) -> File {
     file
 }
 
+fn refuse_pending_transaction(root: &Path) {
+    let journal = root.join("code/specs/data/adj-stdlib-provenance/cas/.transaction-journal.json");
+    match std::fs::symlink_metadata(&journal) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Ok(_) => panic!(
+            "pending CAS transaction journal requires Python recovery before Rust projection: {}",
+            journal.display()
+        ),
+        Err(error) => panic!(
+            "cannot inspect CAS transaction journal {}: {error}",
+            journal.display()
+        ),
+    }
+}
+
 fn read_bundle(root: &Path, digest: &str) -> serde_json::Value {
     serde_json::from_slice(&read_cas_object(root, digest)).expect("parse provenance bundle")
 }
@@ -79,6 +94,7 @@ fn collect_bundle_snapshots(
 
 fn project_bundle_snapshots(root: &Path, snapshots: &Path, bundle_id: &str) -> usize {
     let _cas_lock = lock_cas(root);
+    refuse_pending_transaction(root);
     let manifest_path = root.join("code/specs/data/adj-stdlib-provenance/manifest.json");
     let manifest: serde_json::Value =
         serde_json::from_slice(&std::fs::read(&manifest_path).expect("read provenance manifest"))
@@ -114,6 +130,68 @@ fn rust_reader_uses_the_repository_cas_lock() {
         .try_lock()
         .expect_err("a second reader must not bypass the CAS lock");
     assert!(matches!(error, std::fs::TryLockError::WouldBlock));
+}
+
+#[test]
+fn rust_reader_refuses_a_pending_transaction_journal() {
+    let root = std::env::temp_dir().join(format!(
+        "adj_pending_provenance_{}_{}",
+        std::process::id(),
+        std::thread::current().name().unwrap_or("unnamed")
+    ));
+    let cas_root = root.join("code/specs/data/adj-stdlib-provenance/cas");
+    let snapshots = root.join("snapshots");
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&cas_root).expect("create temporary CAS root");
+    std::fs::write(cas_root.join("lock"), b"").expect("create CAS lock");
+    std::fs::write(cas_root.join(".transaction-journal.json"), b"pending")
+        .expect("create pending journal");
+
+    let failure = std::panic::catch_unwind(|| {
+        project_bundle_snapshots(&root, &snapshots, "unreachable.bundle")
+    })
+    .expect_err("Rust projection must refuse a pending journal");
+    let message = failure
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| failure.downcast_ref::<&str>().copied())
+        .unwrap_or("");
+    assert!(message.contains("pending CAS transaction journal"));
+    std::fs::remove_dir_all(&root).expect("remove temporary CAS root");
+}
+
+#[cfg(unix)]
+#[test]
+fn rust_reader_refuses_a_dangling_transaction_journal_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let root = std::env::temp_dir().join(format!(
+        "adj_pending_symlink_{}_{}",
+        std::process::id(),
+        std::thread::current().name().unwrap_or("unnamed")
+    ));
+    let cas_root = root.join("code/specs/data/adj-stdlib-provenance/cas");
+    let snapshots = root.join("snapshots");
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&cas_root).expect("create temporary CAS root");
+    std::fs::write(cas_root.join("lock"), b"").expect("create CAS lock");
+    symlink(
+        "missing-transaction-journal",
+        cas_root.join(".transaction-journal.json"),
+    )
+    .expect("create dangling journal symlink");
+
+    let failure = std::panic::catch_unwind(|| {
+        project_bundle_snapshots(&root, &snapshots, "unreachable.bundle")
+    })
+    .expect_err("Rust projection must refuse a dangling journal symlink");
+    let message = failure
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| failure.downcast_ref::<&str>().copied())
+        .unwrap_or("");
+    assert!(message.contains("pending CAS transaction journal"));
+    std::fs::remove_dir_all(&root).expect("remove temporary CAS root");
 }
 
 #[test]

--- a/code/scripts/adj_stdlib_manifest.py
+++ b/code/scripts/adj_stdlib_manifest.py
@@ -91,6 +91,9 @@ def load_provenance_bundles(
     schema_path = root / adj_stdlib_provenance.DEFAULT_SCHEMA
     try:
         with adj_stdlib_provenance.CasRootLock(cas_root):
+            adj_stdlib_provenance._recover_transaction(
+                cas_root, expected_manifest_path=manifest_path
+            )
             adj_stdlib_provenance._validate_repository_unlocked(
                 cas_root,
                 manifest_path,

--- a/code/scripts/adj_stdlib_provenance.py
+++ b/code/scripts/adj_stdlib_provenance.py
@@ -10,6 +10,8 @@ flat hash directory consumed by ``adj-verify``.
 from __future__ import annotations
 
 import argparse
+import base64
+import binascii
 import ctypes
 import hashlib
 import html
@@ -36,6 +38,9 @@ DEFAULT_ROOT = Path("code/specs/data/adj-stdlib-provenance/cas")
 DEFAULT_MANIFEST = Path("code/specs/data/adj-stdlib-provenance/manifest.json")
 DEFAULT_SCHEMA = Path("code/specs/data/adj-stdlib-provenance/manifest.schema.json")
 MAX_OBJECT_BYTES = 64 * 1024 * 1024
+TRANSACTION_JOURNAL_CONTRACT = "adj-stdlib/cas-transaction-journal/v1"
+TRANSACTION_JOURNAL_NAME = ".transaction-journal.json"
+TRANSACTION_PRUNE_DIRECTORY = ".transaction-prune"
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 OBJECT_KINDS = {
     "execution_witness",
@@ -293,15 +298,39 @@ def _read_regular_file(path: Path, *, limit: int = MAX_OBJECT_BYTES) -> bytes:
 
 
 def _ensure_real_directory(path: Path) -> None:
+    missing: list[Path] = []
+    cursor = path
+    while not cursor.exists():
+        missing.append(cursor)
+        parent = cursor.parent
+        if parent == cursor:
+            raise ProvenanceError(
+                f"cannot create directory below unavailable filesystem root: {cursor}"
+            )
+        cursor = parent
     if path.exists():
         _reject_link_components(path)
     else:
         _reject_link_components(path, allow_missing_leaf=True)
     path.mkdir(parents=True, exist_ok=True)
+    for created in reversed(missing):
+        _sync_directory(created.parent)
     _reject_link_components(path)
     info = path.lstat()
     if _is_link_or_reparse(info) or not stat.S_ISDIR(info.st_mode):
         raise ProvenanceError(f"refusing non-directory CAS path: {path}")
+
+
+def _sync_directory(path: Path) -> None:
+    if os.name == "nt":
+        return
+    descriptor = os.open(
+        path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    )
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
 
 
 def _write_exclusive(path: Path, data: bytes) -> None:
@@ -326,6 +355,7 @@ def _write_exclusive(path: Path, data: bytes) -> None:
                 ) from None
         if _read_regular_file(path, limit=len(data)) != data:
             raise ProvenanceError(f"published bytes do not re-read exactly: {path}")
+        _sync_directory(path.parent)
     finally:
         temporary.unlink(missing_ok=True)
 
@@ -334,7 +364,9 @@ def _write_atomic(path: Path, data: bytes) -> None:
     _ensure_real_directory(path.parent)
     if path.exists():
         _reject_link_components(path)
-    descriptor, temporary_name = tempfile.mkstemp(prefix=".index-", dir=path.parent)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}-", dir=path.parent
+    )
     temporary = Path(temporary_name)
     try:
         with os.fdopen(descriptor, "wb") as output:
@@ -342,8 +374,25 @@ def _write_atomic(path: Path, data: bytes) -> None:
             output.flush()
             os.fsync(output.fileno())
         os.replace(temporary, path)
+        _sync_directory(path.parent)
     finally:
         temporary.unlink(missing_ok=True)
+
+
+def _encoded_bytes(data: bytes) -> str:
+    return base64.b64encode(data).decode("ascii")
+
+
+def _decoded_bytes(value: Any, field: str) -> bytes:
+    if not isinstance(value, str):
+        raise ProvenanceError(f"{field} must be base64 text")
+    try:
+        decoded = base64.b64decode(value, validate=True)
+    except (ValueError, binascii.Error) as error:
+        raise ProvenanceError(f"{field} must be canonical base64") from error
+    if _encoded_bytes(decoded) != value:
+        raise ProvenanceError(f"{field} must be canonical base64")
+    return decoded
 
 
 def _require_hash(value: Any, field: str) -> str:
@@ -3471,20 +3520,333 @@ class CasRootLock:
         return False
 
 
+def _transaction_paths(cas_root: Path) -> tuple[Path, Path]:
+    return (
+        cas_root / TRANSACTION_JOURNAL_NAME,
+        cas_root / TRANSACTION_PRUNE_DIRECTORY,
+    )
+
+
+def _cleanup_atomic_temporaries(path: Path) -> None:
+    if not path.parent.exists():
+        return
+    _ensure_real_directory(path.parent)
+    removed = False
+    for temporary in path.parent.glob(f".{path.name}-*"):
+        _read_regular_file(temporary)
+        temporary.unlink()
+        removed = True
+    if removed:
+        _sync_directory(path.parent)
+
+
+def _cleanup_cas_temporaries(cas_root: Path) -> None:
+    objects = cas_root / "objects"
+    if not objects.exists():
+        return
+    _ensure_real_directory(objects)
+    synced: set[Path] = set()
+    for temporary in objects.rglob(".cas-*"):
+        _read_regular_file(temporary)
+        temporary.unlink()
+        synced.add(temporary.parent)
+    for parent in synced:
+        _sync_directory(parent)
+
+
+def _scan_cas_object_files(cas_root: Path) -> dict[str, Path]:
+    objects = cas_root / "objects"
+    if not objects.exists():
+        return {}
+    _ensure_real_directory(objects)
+    result: dict[str, Path] = {}
+    for path in objects.rglob("*"):
+        if path.is_dir():
+            _reject_link_components(path)
+            continue
+        data = _read_regular_file(path)
+        relative = path.relative_to(objects)
+        if len(relative.parts) != 2:
+            raise ProvenanceError(f"non-canonical CAS object path: {path}")
+        digest = relative.parts[0] + relative.parts[1]
+        _require_hash(digest, "CAS object path hash")
+        if sha256_bytes(data) != digest:
+            raise ProvenanceError(f"CAS object bytes disagree with path: {path}")
+        result[digest] = path
+    return result
+
+
+def _manifest_journal_path(cas_root: Path, relative_value: Any) -> Path:
+    relative_text = _require_nonempty(relative_value, "journal manifest path")
+    relative = PurePosixPath(relative_text)
+    if (
+        relative.is_absolute()
+        or ".." in relative.parts
+        or "\\" in relative_text
+        or relative.as_posix() != relative_text
+    ):
+        raise ProvenanceError("journal manifest path must stay below the CAS parent")
+    parent = cas_root.resolve().parent
+    selected = parent.joinpath(*relative.parts)
+    _reject_link_components(selected)
+    try:
+        selected.resolve().relative_to(parent)
+    except ValueError as error:
+        raise ProvenanceError(
+            "journal manifest path escapes the CAS parent"
+        ) from error
+    return selected
+
+
+def _load_transaction_journal(cas_root: Path) -> dict[str, Any] | None:
+    journal_path, _backup_root = _transaction_paths(cas_root)
+    try:
+        info = journal_path.lstat()
+    except FileNotFoundError:
+        return None
+    if _is_link_or_reparse(info) or not stat.S_ISREG(info.st_mode):
+        raise ProvenanceError(
+            f"refusing non-file CAS transaction journal: {journal_path}"
+        )
+    raw = _read_regular_file(journal_path)
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ProvenanceError("CAS transaction journal must be UTF-8 JSON") from error
+    if raw != canonical_json_bytes(value):
+        raise ProvenanceError("CAS transaction journal must be canonical JSON")
+    if not isinstance(value, dict) or set(value) != {
+        "allowed_index_sha256s",
+        "allowed_manifest_sha256s",
+        "baseline_index_base64",
+        "baseline_manifest",
+        "baseline_object_sha256s",
+        "contract",
+        "pruned_sha256s",
+    }:
+        raise ProvenanceError("CAS transaction journal has unknown or missing fields")
+    if value["contract"] != TRANSACTION_JOURNAL_CONTRACT:
+        raise ProvenanceError("CAS transaction journal uses an unsupported contract")
+    for field in ("allowed_index_sha256s", "allowed_manifest_sha256s"):
+        values = value[field]
+        if not isinstance(values, list) or values != sorted(set(values)):
+            raise ProvenanceError(f"journal {field} must be sorted and unique")
+        for index, digest in enumerate(values):
+            _require_hash(digest, f"{field}[{index}]")
+    baseline = value["baseline_object_sha256s"]
+    pruned = value["pruned_sha256s"]
+    if not isinstance(baseline, list) or baseline != sorted(set(baseline)):
+        raise ProvenanceError(
+            "journal baseline_object_sha256s must be sorted and unique"
+        )
+    if not isinstance(pruned, list) or pruned != sorted(set(pruned)):
+        raise ProvenanceError("journal pruned_sha256s must be sorted and unique")
+    for index, digest in enumerate(baseline):
+        _require_hash(digest, f"baseline_object_sha256s[{index}]")
+    for index, digest in enumerate(pruned):
+        _require_hash(digest, f"pruned_sha256s[{index}]")
+    if not set(pruned).issubset(baseline):
+        raise ProvenanceError("journal pruned objects must belong to the baseline")
+    encoded_index = value["baseline_index_base64"]
+    if encoded_index is not None:
+        index_bytes = _decoded_bytes(encoded_index, "baseline_index_base64")
+        try:
+            index_value = json.loads(index_bytes.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ProvenanceError("journal baseline index must be UTF-8 JSON") from error
+        if index_bytes != canonical_json_bytes(index_value) or not isinstance(
+            index_value, dict
+        ):
+            raise ProvenanceError("journal baseline index must be canonical JSON")
+        if set(index_value) != set(baseline):
+            raise ProvenanceError(
+                "journal baseline object set disagrees with its CAS index"
+            )
+        if sha256_bytes(index_bytes) not in value["allowed_index_sha256s"]:
+            raise ProvenanceError("journal does not authorize its baseline CAS index")
+    elif baseline:
+        raise ProvenanceError("index-free journal cannot claim baseline CAS objects")
+    manifest = value["baseline_manifest"]
+    if manifest is not None:
+        if not isinstance(manifest, dict) or set(manifest) != {
+            "bytes_base64",
+            "path",
+        }:
+            raise ProvenanceError("journal baseline_manifest is malformed")
+        _manifest_journal_path(cas_root, manifest["path"])
+        manifest_bytes = _decoded_bytes(
+            manifest["bytes_base64"], "baseline_manifest.bytes_base64"
+        )
+        if sha256_bytes(manifest_bytes) not in value["allowed_manifest_sha256s"]:
+            raise ProvenanceError("journal does not authorize its baseline manifest")
+    elif value["allowed_manifest_sha256s"]:
+        raise ProvenanceError("manifest-free journal cannot authorize manifest bytes")
+    return value
+
+
+def _cleanup_transaction_backups(cas_root: Path) -> None:
+    _journal_path, backup_root = _transaction_paths(cas_root)
+    try:
+        info = backup_root.lstat()
+    except FileNotFoundError:
+        return
+    if _is_link_or_reparse(info) or not stat.S_ISDIR(info.st_mode):
+        raise ProvenanceError(
+            f"refusing non-directory transaction backup path: {backup_root}"
+        )
+    _reject_link_components(backup_root)
+    for path in backup_root.iterdir():
+        if not path.is_file():
+            raise ProvenanceError(f"unexpected transaction backup entry: {path}")
+        digest = _require_hash(path.name, "transaction backup hash")
+        if sha256_bytes(_read_regular_file(path)) != digest:
+            raise ProvenanceError(f"transaction backup bytes disagree: {path}")
+    for path in backup_root.iterdir():
+        path.unlink()
+    backup_root.rmdir()
+    _sync_directory(cas_root)
+
+
+def _recover_transaction(
+    cas_root: Path, *, expected_manifest_path: Path | None = None
+) -> bool:
+    journal_path, backup_root = _transaction_paths(cas_root)
+    _cleanup_atomic_temporaries(journal_path)
+    _cleanup_cas_temporaries(cas_root)
+    journal = _load_transaction_journal(cas_root)
+    if journal is None:
+        _cleanup_atomic_temporaries(cas_root / "index.json")
+        if expected_manifest_path is not None:
+            _cleanup_atomic_temporaries(expected_manifest_path)
+        _cleanup_transaction_backups(cas_root)
+        return False
+    manifest_record = journal["baseline_manifest"]
+    manifest_path: Path | None = None
+    manifest_bytes: bytes | None = None
+    if manifest_record is not None:
+        manifest_path = _manifest_journal_path(cas_root, manifest_record["path"])
+        if (
+            expected_manifest_path is not None
+            and manifest_path != expected_manifest_path.resolve()
+        ):
+            raise ProvenanceError(
+                "pending CAS journal belongs to a different provenance manifest"
+            )
+        manifest_bytes = _decoded_bytes(
+            manifest_record["bytes_base64"], "baseline_manifest.bytes_base64"
+        )
+        _cleanup_atomic_temporaries(manifest_path)
+    index_path = cas_root / "index.json"
+    _cleanup_atomic_temporaries(index_path)
+    if index_path.exists():
+        current_index_hash = sha256_bytes(_read_regular_file(index_path))
+        if current_index_hash not in journal["allowed_index_sha256s"]:
+            raise ProvenanceError(
+                "current CAS index is not authorized by the transaction journal"
+            )
+    elif journal["baseline_index_base64"] is not None:
+        raise ProvenanceError(
+            "transaction journal cannot account for a missing CAS index"
+        )
+    if manifest_path is not None:
+        if not manifest_path.exists():
+            raise ProvenanceError(
+                "transaction journal cannot account for a missing manifest"
+            )
+        current_manifest_hash = sha256_bytes(_read_regular_file(manifest_path))
+        if current_manifest_hash not in journal["allowed_manifest_sha256s"]:
+            raise ProvenanceError(
+                "current manifest is not authorized by the transaction journal"
+            )
+    for digest in journal["pruned_sha256s"]:
+        backup = backup_root / digest
+        data = _read_regular_file(backup)
+        if sha256_bytes(data) != digest:
+            raise ProvenanceError(f"transaction prune backup disagrees for {digest}")
+        destination = Cas(cas_root).object_path(digest)
+        if destination.exists():
+            if _read_regular_file(destination) != data:
+                raise ProvenanceError(
+                    f"cannot recover over mismatched CAS object {digest}"
+                )
+        else:
+            _ensure_real_directory(destination.parent)
+            _write_exclusive(destination, data)
+    if manifest_path is not None and manifest_bytes is not None:
+        _write_atomic(manifest_path, manifest_bytes)
+    encoded_index = journal["baseline_index_base64"]
+    if encoded_index is None:
+        if index_path.exists():
+            _reject_link_components(index_path)
+            index_path.unlink()
+            _sync_directory(cas_root)
+    else:
+        _write_atomic(
+            index_path, _decoded_bytes(encoded_index, "baseline_index_base64")
+        )
+    baseline = set(journal["baseline_object_sha256s"])
+    current = _scan_cas_object_files(cas_root)
+    for digest in sorted(set(current) - baseline):
+        current[digest].unlink()
+        _sync_directory(current[digest].parent)
+    objects = cas_root / "objects"
+    if objects.exists():
+        for path in sorted(objects.rglob("*"), reverse=True):
+            if path.is_dir():
+                try:
+                    path.rmdir()
+                except OSError:
+                    pass
+                else:
+                    _sync_directory(path.parent)
+    if (
+        manifest_path is not None
+        and manifest_bytes is not None
+        and _read_regular_file(manifest_path) != manifest_bytes
+    ):
+        raise ProvenanceError("recovered manifest bytes do not match the journal")
+    if encoded_index is not None:
+        recovered = Cas(cas_root)
+        recovered.load()
+        _validate_index(recovered)
+    elif _scan_cas_object_files(cas_root):
+        raise ProvenanceError("index-free recovery left CAS object bytes behind")
+    journal_path.unlink()
+    _sync_directory(cas_root)
+    _cleanup_transaction_backups(cas_root)
+    return True
+
+
 class CasMutationTransaction:
     """Serialize one CAS mutation and remove newly materialized bytes on failure."""
 
-    def __init__(self, cas_root: Path, *, blocking: bool = True) -> None:
+    def __init__(
+        self,
+        cas_root: Path,
+        *,
+        blocking: bool = True,
+        manifest_path: Path | None = None,
+    ) -> None:
         self.cas = Cas(cas_root)
         self._lock = CasRootLock(cas_root, blocking=blocking)
+        self._journal_path, self._prune_backup_root = _transaction_paths(cas_root)
+        self._journal_manifest_path = manifest_path
         self._baseline_index: bytes | None = None
+        self._baseline_manifest: bytes | None = None
         self._baseline_objects: set[Path] = set()
+        self._journal_pruned_digests: list[str] = []
+        self._allowed_index_sha256s: set[str] = set()
+        self._allowed_manifest_sha256s: set[str] = set()
         self._entered = False
         self._committed = False
 
     def __enter__(self):
         self._lock.__enter__()
         try:
+            _recover_transaction(
+                self.cas.root,
+                expected_manifest_path=self._journal_manifest_path,
+            )
             self.cas.load()
             if self.cas.index_path.exists():
                 _validate_index(self.cas)
@@ -3494,47 +3856,115 @@ class CasMutationTransaction:
             self._baseline_objects = {
                 path.resolve() for path in self.cas.objects.rglob("*") if path.is_file()
             }
+            if self._baseline_index is None and self._baseline_objects:
+                raise ProvenanceError("CAS objects exist without a baseline index")
+            if self._journal_manifest_path is not None:
+                self._baseline_manifest = _read_regular_file(
+                    self._journal_manifest_path
+                )
+            if self._baseline_index is not None:
+                self._allowed_index_sha256s.add(
+                    sha256_bytes(self._baseline_index)
+                )
+            if self._baseline_manifest is not None:
+                self._allowed_manifest_sha256s.add(
+                    sha256_bytes(self._baseline_manifest)
+                )
             self._entered = True
+            self._write_journal()
             return self
         except Exception:
+            if self._entered and self._journal_path.exists():
+                self._rollback()
             self._lock.__exit__(None, None, None)
+            self._entered = False
             raise
+
+    def _journal_manifest(self) -> dict[str, str] | None:
+        if self._journal_manifest_path is None:
+            return None
+        if self._baseline_manifest is None:
+            raise ProvenanceError("transaction manifest baseline is unavailable")
+        try:
+            relative = self._journal_manifest_path.resolve().relative_to(
+                self.cas.root.resolve().parent
+            )
+        except ValueError as error:
+            raise ProvenanceError(
+                "transaction manifest must stay below the CAS parent"
+            ) from error
+        return {
+            "bytes_base64": _encoded_bytes(self._baseline_manifest),
+            "path": relative.as_posix(),
+        }
+
+    def _write_journal(self) -> None:
+        baseline_digests = sorted(
+            path.parent.name + path.name for path in self._baseline_objects
+        )
+        journal = {
+            "allowed_index_sha256s": sorted(self._allowed_index_sha256s),
+            "allowed_manifest_sha256s": sorted(self._allowed_manifest_sha256s),
+            "baseline_index_base64": (
+                _encoded_bytes(self._baseline_index)
+                if self._baseline_index is not None
+                else None
+            ),
+            "baseline_manifest": self._journal_manifest(),
+            "baseline_object_sha256s": baseline_digests,
+            "contract": TRANSACTION_JOURNAL_CONTRACT,
+            "pruned_sha256s": sorted(self._journal_pruned_digests),
+        }
+        _write_atomic(self._journal_path, canonical_json_bytes(journal))
+
+    def _publish_index(self) -> None:
+        target = canonical_json_bytes(self.cas.index)
+        self._allowed_index_sha256s.add(sha256_bytes(target))
+        self._write_journal()
+        self.cas.write_index()
+
+    def _publish_manifest(self, data: bytes) -> None:
+        if self._journal_manifest_path is None:
+            raise ProvenanceError("transaction has no manifest publication target")
+        self._allowed_manifest_sha256s.add(sha256_bytes(data))
+        self._write_journal()
+        _write_atomic(self._journal_manifest_path, data)
+
+    def _finish_commit(self) -> None:
+        _reject_link_components(self._journal_path)
+        self._journal_path.unlink()
+        try:
+            _sync_directory(self.cas.root)
+        except OSError:
+            # Unlinking the journal is the process-termination commit point.
+            # Directory-flush failure cannot be reported as a rolled-back write.
+            pass
+        try:
+            _cleanup_transaction_backups(self.cas.root)
+        except (OSError, ProvenanceError):
+            # Journal removal is the commit point.  A suspicious backup must
+            # remain for fail-closed inspection, not turn a commit into rollback.
+            pass
 
     def commit(self) -> None:
         if not self._entered or self._committed:
             raise ProvenanceError("CAS mutation transaction is not open")
-        self.cas.write_index()
+        try:
+            self._publish_index()
+            _validate_index(self.cas)
+            self._finish_commit()
+        except Exception:
+            self._rollback()
+            raise
         self._committed = True
 
     def _rollback(self) -> None:
         if not self._entered:
             return
-        if self._baseline_index is None:
-            if self.cas.index_path.exists():
-                _reject_link_components(self.cas.index_path)
-                self.cas.index_path.unlink()
-        else:
-            _write_atomic(self.cas.index_path, self._baseline_index)
-        if self.cas.objects.exists():
-            for path in sorted(self.cas.objects.rglob("*"), reverse=True):
-                if not path.is_file() or path.resolve() in self._baseline_objects:
-                    continue
-                data = _read_regular_file(path)
-                relative = path.relative_to(self.cas.objects)
-                if len(relative.parts) != 2:
-                    raise ProvenanceError(
-                        f"refusing rollback of non-canonical CAS path {path}"
-                    )
-                digest = relative.parts[0] + relative.parts[1]
-                if sha256_bytes(data) != digest:
-                    raise ProvenanceError(
-                        f"refusing rollback of mismatched CAS object {path}"
-                    )
-                path.unlink()
-                try:
-                    path.parent.rmdir()
-                except OSError:
-                    pass
+        _recover_transaction(
+            self.cas.root,
+            expected_manifest_path=self._journal_manifest_path,
+        )
         self.cas.load()
 
     def __exit__(self, exc_type: object, exc: object, traceback: object) -> bool:
@@ -3565,7 +3995,11 @@ class BundleRegistrationTransaction(CasMutationTransaction):
         allow_unwitnessed_baseline: bool = False,
         allow_migration_formula_inputs_baseline: bool = False,
     ) -> None:
-        super().__init__(cas_root, blocking=False)
+        super().__init__(
+            cas_root,
+            blocking=False,
+            manifest_path=manifest_path,
+        )
         self.manifest_path = manifest_path
         self.expected_manifest_id = expected_manifest_id
         self.schema_path = schema_path
@@ -3576,7 +4010,6 @@ class BundleRegistrationTransaction(CasMutationTransaction):
         self.allow_migration_formula_inputs_baseline = (
             allow_migration_formula_inputs_baseline
         )
-        self._baseline_manifest = b""
 
     def __enter__(self):
         try:
@@ -3593,7 +4026,7 @@ class BundleRegistrationTransaction(CasMutationTransaction):
                     self.allow_migration_formula_inputs_baseline
                 ),
             )
-            self._baseline_manifest = _read_regular_file(self.manifest_path)
+            assert self._baseline_manifest is not None
             return self
         except Exception:
             super().__exit__(Exception, None, None)
@@ -3604,13 +4037,13 @@ class BundleRegistrationTransaction(CasMutationTransaction):
             raise ProvenanceError("registration transaction is not open")
         manifest, registered = _registered_manifest(
             self.cas,
-            self._baseline_manifest,
+            self._baseline_manifest or b"",
             registrations,
             self.expected_manifest_id,
         )
         try:
-            self.cas.write_index()
-            _write_atomic(self.manifest_path, canonical_json_bytes(manifest))
+            self._publish_index()
+            self._publish_manifest(canonical_json_bytes(manifest))
             _validate_repository_unlocked(
                 self.cas.root,
                 self.manifest_path,
@@ -3619,19 +4052,12 @@ class BundleRegistrationTransaction(CasMutationTransaction):
                 formula_inventory_command=self.formula_inventory_command,
                 formula_audit_command=self.formula_audit_command,
             )
+            self._finish_commit()
         except Exception:
             self._rollback()
             raise
         self._committed = True
         return registered
-
-    def _rollback(self) -> None:
-        if not self._entered:
-            return
-        if self._baseline_manifest:
-            _write_atomic(self.manifest_path, self._baseline_manifest)
-        super()._rollback()
-
 
 class BundleRootReplacementTransaction(BundleRegistrationTransaction):
     """Explicitly replace owned roots and prune only newly unreachable objects."""
@@ -3639,8 +4065,6 @@ class BundleRootReplacementTransaction(BundleRegistrationTransaction):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._baseline_digests: set[str] = set()
-        self._pruned_digests: list[str] = []
-        self._prune_backup: tempfile.TemporaryDirectory[str] | None = None
 
     def __enter__(self):
         super().__enter__()
@@ -3648,45 +4072,31 @@ class BundleRootReplacementTransaction(BundleRegistrationTransaction):
         return self
 
     def _stage_prune(self, digests: set[str]) -> None:
-        backup = tempfile.TemporaryDirectory(prefix="adj-provenance-prune-")
-        backup_root = Path(backup.name)
         try:
+            _ensure_real_directory(self._prune_backup_root)
             for digest in sorted(digests):
                 data = _read_regular_file(self.cas.object_path(digest))
                 if sha256_bytes(data) != digest:
                     raise ProvenanceError(
                         f"refusing to prune mismatched CAS object {digest}"
                     )
-                _write_exclusive(backup_root / digest, data)
+                _write_exclusive(self._prune_backup_root / digest, data)
+            self._journal_pruned_digests = sorted(digests)
+            self._write_journal()
             for digest in sorted(digests):
                 path = self.cas.object_path(digest)
                 _reject_link_components(path)
-                self._pruned_digests.append(digest)
                 path.unlink()
+                _sync_directory(path.parent)
                 try:
                     path.parent.rmdir()
                 except OSError:
                     pass
+                else:
+                    _sync_directory(path.parent.parent)
         except Exception:
-            self._prune_backup = backup
-            self._restore_pruned()
+            self._journal_pruned_digests = sorted(digests)
             raise
-        self._prune_backup = backup
-
-    def _restore_pruned(self) -> None:
-        if self._prune_backup is None:
-            return
-        backup_root = Path(self._prune_backup.name)
-        for digest in self._pruned_digests:
-            destination = self.cas.object_path(digest)
-            if destination.exists():
-                if sha256_bytes(_read_regular_file(destination)) != digest:
-                    raise ProvenanceError(
-                        f"cannot restore over mismatched CAS object {digest}"
-                    )
-                continue
-            _write_exclusive(destination, _read_regular_file(backup_root / digest))
-        self._pruned_digests.clear()
 
     def commit(self, registrations: dict[str, str]) -> list[str]:
         del registrations
@@ -3721,7 +4131,7 @@ class BundleRootReplacementTransaction(BundleRegistrationTransaction):
             )
         manifest, registered = _registered_manifest(
             self.cas,
-            self._baseline_manifest,
+            self._baseline_manifest or b"",
             new_roots,
             self.expected_manifest_id,
             allow_replacements=True,
@@ -3729,7 +4139,7 @@ class BundleRootReplacementTransaction(BundleRegistrationTransaction):
             expected_current=expected_current,
         )
         try:
-            self.cas.write_index()
+            self._publish_index()
             with tempfile.TemporaryDirectory(
                 prefix="adj-provenance-candidate-"
             ) as candidate_directory:
@@ -3758,8 +4168,8 @@ class BundleRootReplacementTransaction(BundleRegistrationTransaction):
                 for digest, record in self.cas.index.items()
                 if digest in reachable
             }
-            self.cas.write_index()
-            _write_atomic(self.manifest_path, canonical_json_bytes(manifest))
+            self._publish_index()
+            self._publish_manifest(canonical_json_bytes(manifest))
             _validate_repository_unlocked(
                 self.cas.root,
                 self.manifest_path,
@@ -3768,28 +4178,13 @@ class BundleRootReplacementTransaction(BundleRegistrationTransaction):
                 formula_inventory_command=self.formula_inventory_command,
                 formula_audit_command=self.formula_audit_command,
             )
+            self._finish_commit()
         except Exception:
             self._rollback()
             raise
         self._committed = True
         pruned = sorted(unreachable)
-        if self._prune_backup is not None:
-            try:
-                self._prune_backup.cleanup()
-            except OSError:
-                pass
-            self._prune_backup = None
         return {"bundle_hashes": registered, "pruned_sha256s": pruned}
-
-    def _rollback(self) -> None:
-        self._restore_pruned()
-        super()._rollback()
-        if self._prune_backup is not None:
-            try:
-                self._prune_backup.cleanup()
-            except OSError:
-                pass
-            self._prune_backup = None
 
 
 def _validate_index(cas: Cas) -> None:
@@ -4604,6 +4999,7 @@ def validate_repository(
     formula_audit_command: Sequence[str] | None = None,
 ) -> dict[str, Any]:
     with CasRootLock(cas_root):
+        _recover_transaction(cas_root, expected_manifest_path=manifest_path)
         return _validate_repository_unlocked(
             cas_root,
             manifest_path,
@@ -4624,6 +5020,7 @@ def project_snapshots(
     formula_audit_command: Sequence[str] | None = None,
 ) -> dict[str, Any]:
     with CasRootLock(cas_root):
+        _recover_transaction(cas_root, expected_manifest_path=manifest_path)
         result = _validate_repository_unlocked(
             cas_root,
             manifest_path,

--- a/code/scripts/adj_stdlib_report.py
+++ b/code/scripts/adj_stdlib_report.py
@@ -222,6 +222,9 @@ def build_report(
         cas_root = root / adj_stdlib_provenance.DEFAULT_ROOT
         manifest_path = root / adj_stdlib_provenance.DEFAULT_MANIFEST
         with adj_stdlib_provenance.CasRootLock(cas_root):
+            adj_stdlib_provenance._recover_transaction(
+                cas_root, expected_manifest_path=manifest_path
+            )
             adj_stdlib_provenance._validate_repository_unlocked(
                 cas_root,
                 manifest_path,

--- a/code/scripts/tests/test_adj_stdlib_provenance.py
+++ b/code/scripts/tests/test_adj_stdlib_provenance.py
@@ -48,6 +48,183 @@ def acquire_cas_lock_with_alternate_temp(
         release.wait(10)
 
 
+def crash_registration_transaction(
+    cas_root_text: str,
+    manifest_path_text: str,
+    workspace_root_text: str,
+    stage: str,
+) -> None:
+    cas_root = Path(cas_root_text)
+    manifest_path = Path(manifest_path_text)
+    workspace_root = Path(workspace_root_text)
+    original_write_index = provenance.Cas.write_index
+    original_write_atomic = provenance._write_atomic
+    original_replace = provenance.os.replace
+
+    def write_index_then_exit(cas: object) -> None:
+        original_write_index(cas)
+        if stage == "index":
+            os._exit(91)
+
+    def write_atomic_then_exit(path: Path, data: bytes) -> None:
+        original_write_atomic(path, data)
+        if stage == "manifest" and path == manifest_path:
+            os._exit(91)
+
+    def replace_or_exit(source: object, destination: object) -> None:
+        selected = Path(destination)
+        if stage == "index_temp" and selected == cas_root / "index.json":
+            os._exit(91)
+        if stage == "manifest_temp" and selected == manifest_path:
+            os._exit(91)
+        original_replace(source, destination)
+
+    with (
+        mock.patch.object(provenance.Cas, "write_index", write_index_then_exit),
+        mock.patch.object(provenance, "_write_atomic", write_atomic_then_exit),
+        mock.patch.object(provenance.os, "replace", replace_or_exit),
+        provenance.BundleRegistrationTransaction(
+            cas_root,
+            manifest_path,
+            expected_manifest_id="test.provenance.v1",
+            workspace_root=workspace_root,
+        ) as transaction,
+    ):
+        original_hash = json.loads(manifest_path.read_text(encoding="utf-8"))[
+            "bundle_hashes"
+        ][0]
+        added = provenance._json_object(
+            transaction.cas, original_hash, "provenance_bundle"
+        )
+        added["bundle_id"] = "test.crash.registration.v1"
+        added_hash = transaction.cas.put_json(
+            added,
+            kind="provenance_bundle",
+            label="crashing registration bundle",
+            links=provenance._bundle_declared_links(added),
+        )
+        if stage == "object":
+            os._exit(91)
+        transaction.commit({"test.crash.registration.v1": added_hash})
+
+
+def crash_index_only_transaction(cas_root_text: str, stage: str) -> None:
+    cas_root = Path(cas_root_text)
+    original_write_index = provenance.Cas.write_index
+    original_link = provenance.os.link
+
+    def write_index_then_exit(cas: object) -> None:
+        original_write_index(cas)
+        os._exit(91)
+
+    def link_or_exit(source: object, destination: object) -> None:
+        if stage == "object_temp":
+            os._exit(91)
+        original_link(source, destination)
+
+    with (
+        mock.patch.object(provenance.Cas, "write_index", write_index_then_exit),
+        mock.patch.object(provenance.os, "link", link_or_exit),
+        provenance.CasMutationTransaction(cas_root) as transaction,
+    ):
+        transaction.cas.put(
+            f"crashing index-only {stage}".encode(),
+            kind="raw_source",
+            label="crashing index-only object",
+        )
+        if stage == "object":
+            os._exit(91)
+        transaction.commit()
+
+
+def crash_journal_preparation(cas_root_text: str) -> None:
+    cas_root = Path(cas_root_text)
+    journal_path = cas_root / provenance.TRANSACTION_JOURNAL_NAME
+    original_replace = provenance.os.replace
+
+    def replace_or_exit(source: object, destination: object) -> None:
+        if Path(destination) == journal_path:
+            os._exit(91)
+        original_replace(source, destination)
+
+    with (
+        mock.patch.object(provenance.os, "replace", replace_or_exit),
+        provenance.CasMutationTransaction(cas_root),
+    ):
+        raise AssertionError("journal crash fixture reached its body")
+
+
+def crash_root_replacement_transaction(
+    cas_root_text: str,
+    manifest_path_text: str,
+    workspace_root_text: str,
+    stage: str,
+) -> None:
+    cas_root = Path(cas_root_text)
+    manifest_path = Path(manifest_path_text)
+    workspace_root = Path(workspace_root_text)
+    original_stage_prune = provenance.BundleRootReplacementTransaction._stage_prune
+    original_write_index = provenance.Cas.write_index
+    original_write_atomic = provenance._write_atomic
+    index_writes = 0
+
+    def prune_then_exit(transaction: object, digests: set[str]) -> None:
+        original_stage_prune(transaction, digests)
+        if stage == "prune":
+            os._exit(91)
+
+    def write_index_then_exit(cas: object) -> None:
+        nonlocal index_writes
+        original_write_index(cas)
+        index_writes += 1
+        if stage == "filtered_index" and index_writes == 2:
+            os._exit(91)
+
+    def write_atomic_then_exit(path: Path, data: bytes) -> None:
+        original_write_atomic(path, data)
+        if stage == "manifest" and path == manifest_path:
+            os._exit(91)
+
+    with (
+        mock.patch.object(
+            provenance.BundleRootReplacementTransaction,
+            "_stage_prune",
+            prune_then_exit,
+        ),
+        mock.patch.object(provenance.Cas, "write_index", write_index_then_exit),
+        mock.patch.object(provenance, "_write_atomic", write_atomic_then_exit),
+        provenance.BundleRootReplacementTransaction(
+            cas_root,
+            manifest_path,
+            expected_manifest_id="test.provenance.v1",
+            workspace_root=workspace_root,
+        ) as transaction,
+    ):
+        old_hash = json.loads(manifest_path.read_text(encoding="utf-8"))[
+            "bundle_hashes"
+        ][0]
+        changed = provenance._json_object(
+            transaction.cas, old_hash, "provenance_bundle"
+        )
+        changed["clauses"][0]["resolution"]["reason"] = (
+            f"crashing root replacement at {stage}"
+        )
+        changed_hash = transaction.cas.put_json(
+            changed,
+            kind="provenance_bundle",
+            label="crashing replacement bundle",
+            links=provenance._bundle_declared_links(changed),
+        )
+        transaction.replace_roots(
+            {
+                "test.arithmetic.v1": {
+                    "expected_old_sha256": old_hash,
+                    "new_sha256": changed_hash,
+                }
+            }
+        )
+
+
 class AdjStdlibProvenanceTests(unittest.TestCase):
     class FakePosixGuardian:
         CONTRACT = "adj-stdlib/process-guardian/v1"
@@ -4835,6 +5012,74 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             self.assertEqual(first, second)
             self.assertEqual(len(cas.index), 1)
 
+    def test_publication_helpers_sync_the_containing_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            atomic_path = root / "index.json"
+            exclusive_path = root / "object"
+            with mock.patch.object(provenance, "_sync_directory") as sync:
+                provenance._write_atomic(atomic_path, b"atomic")
+                provenance._write_exclusive(exclusive_path, b"exclusive")
+
+            self.assertEqual(sync.call_args_list, [mock.call(root), mock.call(root)])
+
+    def test_directory_creation_syncs_each_new_parent_entry(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            first = root / "first"
+            target = first / "second"
+
+            with mock.patch.object(provenance, "_sync_directory") as sync:
+                provenance._ensure_real_directory(target)
+
+            self.assertEqual(sync.call_args_list, [mock.call(root), mock.call(first)])
+
+    def test_directory_creation_rejects_an_unavailable_filesystem_root(self) -> None:
+        with (
+            mock.patch.object(Path, "exists", return_value=False),
+            self.assertRaisesRegex(
+                provenance.ProvenanceError, "unavailable filesystem root"
+            ),
+        ):
+            provenance._ensure_real_directory(Path("unavailable") / "child")
+
+    def test_commit_sync_failure_does_not_report_a_false_rollback(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, _manifest_path, _hashes = self.build_repository(root)
+            journal = cas_root / provenance.TRANSACTION_JOURNAL_NAME
+            sync_directory = provenance._sync_directory
+            failed = False
+
+            def fail_after_commit_point(path: Path) -> None:
+                nonlocal failed
+                if path == cas_root and not journal.exists() and not failed:
+                    failed = True
+                    raise OSError("injected commit directory sync failure")
+                sync_directory(path)
+
+            with (
+                mock.patch.object(
+                    provenance, "_sync_directory", fail_after_commit_point
+                ),
+                provenance.CasMutationTransaction(cas_root) as transaction,
+            ):
+                digest = transaction.cas.put(
+                    b"committed despite sync failure",
+                    kind="raw_source",
+                    label="commit-point fixture",
+                )
+                transaction.commit()
+
+            self.assertTrue(failed)
+            recovered = provenance.Cas(cas_root)
+            recovered.load()
+            self.assertIn(digest, recovered.index)
+            self.assertEqual(
+                recovered.object_path(digest).read_bytes(),
+                b"committed despite sync failure",
+            )
+
     def test_manifest_registration_preserves_unowned_bundle_roots(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -5375,6 +5620,406 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         for failure_stage in ("candidate index", "filtered index", "manifest"):
             with self.subTest(failure_stage=failure_stage):
                 self.assert_root_replacement_publication_failure(failure_stage)
+
+    def assert_process_crash_restores_repository(
+        self,
+        worker: object,
+        stage: str,
+        *,
+        replacement: bool = False,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, _hashes = self.build_repository(root)
+            baseline_index = (cas_root / "index.json").read_bytes()
+            baseline_manifest = manifest_path.read_bytes()
+            baseline_objects = {
+                path.relative_to(cas_root): path.read_bytes()
+                for path in (cas_root / "objects").rglob("*")
+                if path.is_file()
+            }
+            context = multiprocessing.get_context("spawn")
+            arguments = (
+                str(cas_root),
+                str(manifest_path),
+                str(root),
+                stage,
+            )
+            if not replacement:
+                arguments = arguments[:3] + (stage,)
+            process = context.Process(target=worker, args=arguments)
+            process.start()
+            process.join(30)
+            self.assertFalse(process.is_alive(), "crash worker did not terminate")
+            self.assertEqual(process.exitcode, 91)
+            self.assertTrue((cas_root / provenance.TRANSACTION_JOURNAL_NAME).exists())
+
+            result = provenance.validate_repository(
+                cas_root, manifest_path, workspace_root=root
+            )
+
+            restored_objects = {
+                path.relative_to(cas_root): path.read_bytes()
+                for path in (cas_root / "objects").rglob("*")
+                if path.is_file()
+            }
+            self.assertTrue(result["valid"])
+            self.assertEqual((cas_root / "index.json").read_bytes(), baseline_index)
+            self.assertEqual(manifest_path.read_bytes(), baseline_manifest)
+            self.assertEqual(restored_objects, baseline_objects)
+            self.assertFalse(
+                (cas_root / provenance.TRANSACTION_JOURNAL_NAME).exists()
+            )
+            self.assertFalse(
+                (cas_root / provenance.TRANSACTION_PRUNE_DIRECTORY).exists()
+            )
+
+    def test_registration_recovers_after_process_death_at_each_publication(
+        self,
+    ) -> None:
+        for stage in (
+            "object",
+            "index_temp",
+            "index",
+            "manifest_temp",
+            "manifest",
+        ):
+            with self.subTest(stage=stage):
+                self.assert_process_crash_restores_repository(
+                    crash_registration_transaction, stage
+                )
+
+    def test_index_only_mutation_recovers_after_process_death(self) -> None:
+        for stage in ("object_temp", "object", "index"):
+            with (
+                self.subTest(stage=stage),
+                tempfile.TemporaryDirectory() as directory,
+            ):
+                root = Path(directory)
+                cas_root, manifest_path, _hashes = self.build_repository(root)
+                baseline_index = (cas_root / "index.json").read_bytes()
+                baseline_manifest = manifest_path.read_bytes()
+                baseline_objects = {
+                    path.relative_to(cas_root): path.read_bytes()
+                    for path in (cas_root / "objects").rglob("*")
+                    if path.is_file()
+                }
+                context = multiprocessing.get_context("spawn")
+                process = context.Process(
+                    target=crash_index_only_transaction,
+                    args=(str(cas_root), stage),
+                )
+                process.start()
+                process.join(30)
+                self.assertEqual(process.exitcode, 91)
+
+                provenance.validate_repository(
+                    cas_root, manifest_path, workspace_root=root
+                )
+
+                restored_objects = {
+                    path.relative_to(cas_root): path.read_bytes()
+                    for path in (cas_root / "objects").rglob("*")
+                    if path.is_file()
+                }
+                self.assertEqual(
+                    (cas_root / "index.json").read_bytes(), baseline_index
+                )
+                self.assertEqual(manifest_path.read_bytes(), baseline_manifest)
+                self.assertEqual(restored_objects, baseline_objects)
+                self.assertFalse(
+                    (cas_root / provenance.TRANSACTION_JOURNAL_NAME).exists()
+                )
+
+    def test_first_index_publication_recovers_into_an_empty_cas(self) -> None:
+        for stage in ("object_temp", "object", "index"):
+            with (
+                self.subTest(stage=stage),
+                tempfile.TemporaryDirectory() as directory,
+            ):
+                cas_root = Path(directory) / "cas"
+                context = multiprocessing.get_context("spawn")
+                process = context.Process(
+                    target=crash_index_only_transaction,
+                    args=(str(cas_root), stage),
+                )
+                process.start()
+                process.join(30)
+                self.assertEqual(process.exitcode, 91)
+
+                with provenance.CasRootLock(cas_root):
+                    self.assertTrue(provenance._recover_transaction(cas_root))
+
+                self.assertFalse((cas_root / "index.json").exists())
+                self.assertFalse(
+                    (cas_root / provenance.TRANSACTION_JOURNAL_NAME).exists()
+                )
+                self.assertEqual(provenance._scan_cas_object_files(cas_root), {})
+
+    def test_index_free_journal_rejects_claimed_baseline_objects_before_mutation(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            cas_root = Path(directory) / "cas"
+            context = multiprocessing.get_context("spawn")
+            process = context.Process(
+                target=crash_index_only_transaction,
+                args=(str(cas_root), "index"),
+            )
+            process.start()
+            process.join(30)
+            self.assertEqual(process.exitcode, 91)
+            journal_path = cas_root / provenance.TRANSACTION_JOURNAL_NAME
+            journal = json.loads(journal_path.read_text(encoding="utf-8"))
+            objects = provenance._scan_cas_object_files(cas_root)
+            self.assertEqual(len(objects), 1)
+            digest = next(iter(objects))
+            journal["baseline_object_sha256s"] = [digest]
+            journal_path.write_bytes(provenance.canonical_json_bytes(journal))
+            before_index = (cas_root / "index.json").read_bytes()
+            before_object = objects[digest].read_bytes()
+
+            with provenance.CasRootLock(cas_root), self.assertRaisesRegex(
+                provenance.ProvenanceError,
+                "index-free journal cannot claim baseline CAS objects",
+            ):
+                provenance._recover_transaction(cas_root)
+
+            self.assertEqual((cas_root / "index.json").read_bytes(), before_index)
+            self.assertEqual(objects[digest].read_bytes(), before_object)
+            self.assertTrue(journal_path.exists())
+
+    def test_journal_preparation_crash_leaves_no_owned_temporary(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, _hashes = self.build_repository(root)
+            context = multiprocessing.get_context("spawn")
+            process = context.Process(
+                target=crash_journal_preparation,
+                args=(str(cas_root),),
+            )
+            process.start()
+            process.join(30)
+            self.assertEqual(process.exitcode, 91)
+            self.assertTrue(
+                list(
+                    cas_root.glob(
+                        f".{provenance.TRANSACTION_JOURNAL_NAME}-*"
+                    )
+                )
+            )
+
+            result = provenance.validate_repository(
+                cas_root, manifest_path, workspace_root=root
+            )
+
+            self.assertTrue(result["valid"])
+            self.assertFalse(
+                list(
+                    cas_root.glob(
+                        f".{provenance.TRANSACTION_JOURNAL_NAME}-*"
+                    )
+                )
+            )
+
+    def test_recovery_is_idempotent_after_interrupted_baseline_restore(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, _hashes = self.build_repository(root)
+            baseline_index = (cas_root / "index.json").read_bytes()
+            baseline_manifest = manifest_path.read_bytes()
+            context = multiprocessing.get_context("spawn")
+            process = context.Process(
+                target=crash_registration_transaction,
+                args=(str(cas_root), str(manifest_path), str(root), "index"),
+            )
+            process.start()
+            process.join(30)
+            self.assertEqual(process.exitcode, 91)
+            write_atomic = provenance._write_atomic
+            failed = False
+
+            def fail_after_index_restore(path: Path, data: bytes) -> None:
+                nonlocal failed
+                write_atomic(path, data)
+                if path == cas_root / "index.json" and not failed:
+                    failed = True
+                    raise OSError("injected recovery interruption")
+
+            with (
+                mock.patch.object(
+                    provenance, "_write_atomic", fail_after_index_restore
+                ),
+                self.assertRaisesRegex(OSError, "injected recovery interruption"),
+            ):
+                provenance.validate_repository(
+                    cas_root, manifest_path, workspace_root=root
+                )
+            self.assertTrue((cas_root / provenance.TRANSACTION_JOURNAL_NAME).exists())
+
+            result = provenance.validate_repository(
+                cas_root, manifest_path, workspace_root=root
+            )
+
+            self.assertTrue(result["valid"])
+            self.assertEqual((cas_root / "index.json").read_bytes(), baseline_index)
+            self.assertEqual(manifest_path.read_bytes(), baseline_manifest)
+            self.assertFalse(
+                (cas_root / provenance.TRANSACTION_JOURNAL_NAME).exists()
+            )
+
+    def test_recovery_refuses_unauthorized_canonical_publication_bytes(self) -> None:
+        for selected in ("index", "manifest"):
+            with (
+                self.subTest(selected=selected),
+                tempfile.TemporaryDirectory() as directory,
+            ):
+                root = Path(directory)
+                cas_root, manifest_path, _hashes = self.build_repository(root)
+                context = multiprocessing.get_context("spawn")
+                process = context.Process(
+                    target=crash_registration_transaction,
+                    args=(str(cas_root), str(manifest_path), str(root), "object"),
+                )
+                process.start()
+                process.join(30)
+                self.assertEqual(process.exitcode, 91)
+                if selected == "index":
+                    selected_path = cas_root / "index.json"
+                    selected_path.write_bytes(provenance.canonical_json_bytes({}))
+                else:
+                    selected_path = manifest_path
+                    selected_path.write_bytes(
+                        provenance.canonical_json_bytes(
+                            {
+                                "algorithm": "sha256",
+                                "bundle_hashes": [],
+                                "manifest_id": "unauthorized.v1",
+                                "schema_version": 1,
+                            }
+                        )
+                    )
+                before_index = (cas_root / "index.json").read_bytes()
+                before_manifest = manifest_path.read_bytes()
+                before_objects = {
+                    path.relative_to(cas_root): path.read_bytes()
+                    for path in (cas_root / "objects").rglob("*")
+                    if path.is_file()
+                }
+
+                with self.assertRaisesRegex(
+                    provenance.ProvenanceError, "not authorized"
+                ):
+                    provenance.validate_repository(
+                        cas_root, manifest_path, workspace_root=root
+                    )
+
+                after_objects = {
+                    path.relative_to(cas_root): path.read_bytes()
+                    for path in (cas_root / "objects").rglob("*")
+                    if path.is_file()
+                }
+                self.assertEqual((cas_root / "index.json").read_bytes(), before_index)
+                self.assertEqual(manifest_path.read_bytes(), before_manifest)
+                self.assertEqual(after_objects, before_objects)
+                self.assertTrue(
+                    (cas_root / provenance.TRANSACTION_JOURNAL_NAME).exists()
+                )
+
+    @unittest.skipIf(
+        os.name == "nt", "creating symlinks is not reliably permitted on Windows"
+    )
+    def test_recovery_rejects_a_symlinked_manifest_path(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, _hashes = self.build_repository(root)
+            context = multiprocessing.get_context("spawn")
+            process = context.Process(
+                target=crash_registration_transaction,
+                args=(str(cas_root), str(manifest_path), str(root), "object"),
+            )
+            process.start()
+            process.join(30)
+            self.assertEqual(process.exitcode, 91)
+            redirected = root / "redirected-manifest.json"
+            redirected.write_bytes(manifest_path.read_bytes())
+            manifest_path.unlink()
+            manifest_path.symlink_to(redirected)
+            before = redirected.read_bytes()
+
+            with self.assertRaisesRegex(
+                provenance.ProvenanceError, "link or reparse"
+            ):
+                provenance.validate_repository(
+                    cas_root, manifest_path, workspace_root=root
+                )
+
+            self.assertEqual(redirected.read_bytes(), before)
+            self.assertTrue(
+                (cas_root / provenance.TRANSACTION_JOURNAL_NAME).exists()
+            )
+
+    @unittest.skipIf(
+        os.name == "nt", "creating symlinks is not reliably permitted on Windows"
+    )
+    def test_recovery_rejects_dangling_journal_and_backup_symlinks(self) -> None:
+        for selected in ("journal", "backup"):
+            with (
+                self.subTest(selected=selected),
+                tempfile.TemporaryDirectory() as directory,
+            ):
+                root = Path(directory)
+                cas_root, manifest_path, _hashes = self.build_repository(root)
+                if selected == "journal":
+                    context = multiprocessing.get_context("spawn")
+                    process = context.Process(
+                        target=crash_registration_transaction,
+                        args=(
+                            str(cas_root),
+                            str(manifest_path),
+                            str(root),
+                            "object",
+                        ),
+                    )
+                    process.start()
+                    process.join(30)
+                    self.assertEqual(process.exitcode, 91)
+                    selected_path = (
+                        cas_root / provenance.TRANSACTION_JOURNAL_NAME
+                    )
+                    selected_path.unlink()
+                    expected_error = "non-file CAS transaction journal"
+                else:
+                    selected_path = (
+                        cas_root / provenance.TRANSACTION_PRUNE_DIRECTORY
+                    )
+                    expected_error = "non-directory transaction backup path"
+                selected_path.symlink_to(root / "missing-target")
+                baseline_index = (cas_root / "index.json").read_bytes()
+                baseline_manifest = manifest_path.read_bytes()
+
+                with self.assertRaisesRegex(
+                    provenance.ProvenanceError, expected_error
+                ):
+                    provenance.validate_repository(
+                        cas_root, manifest_path, workspace_root=root
+                    )
+
+                self.assertEqual(
+                    (cas_root / "index.json").read_bytes(), baseline_index
+                )
+                self.assertEqual(manifest_path.read_bytes(), baseline_manifest)
+
+    def test_root_replacement_recovers_pruned_bytes_after_process_death(
+        self,
+    ) -> None:
+        for stage in ("prune", "filtered_index", "manifest"):
+            with self.subTest(stage=stage):
+                self.assert_process_crash_restores_repository(
+                    crash_root_replacement_transaction,
+                    stage,
+                    replacement=True,
+                )
 
     def test_root_replacement_restores_bytes_after_partial_prune_failure(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/code/specs/ADJ-STDLIB-COVERAGE.md
+++ b/code/specs/ADJ-STDLIB-COVERAGE.md
@@ -277,8 +277,21 @@ option mapping, or judge/evaluation failure.
     graph, rejects staged stray objects and stale same-ID transitive roots, preserves
     nonconflicting shared dependencies, and reports the exact baseline objects pruned
     because no final root reaches them.
-7d. Add a write-ahead recovery journal for process termination between the
-    atomic CAS-index and manifest publications.
+7d. **Complete for process termination:** every index-only, additive-registration,
+    and root-replacement transaction writes a canonical journal under the CAS lock
+    before object mutation. The journal pins the exact baseline index and manifest
+    bytes, complete baseline object set, transaction-authorized publication hashes,
+    and every prune-backup hash. Pruned bytes live in a discoverable CAS-local backup,
+    not process temporary storage. Until the journal is durably removed, recovery has
+    one decision: restore the baseline byte for byte, remove only hash-checked
+    post-baseline objects, validate, then clear recovery state. Python readers and
+    writers recover before loading the index; the Rust projection reader refuses a
+    pending journal under the same lock. Spawned-process `os._exit` fixtures cover
+    journal preparation, object temporary and publication, index temporary and
+    publication, manifest temporary and publication, and post-prune publication.
+    Injected recovery interruption proves idempotence on retry. POSIX directory entries
+    are fsynced after creation, publication, and removal. This item proves process-
+    termination recovery on POSIX and Windows, not power-loss recovery.
 7e. **Complete:** scope native snapshot projection to a named bundle and its
     recursive dependency closure so adding an unrelated manifest root cannot
     perturb an already verified consumer.

--- a/code/specs/data/adj-stdlib-provenance/README.md
+++ b/code/specs/data/adj-stdlib-provenance/README.md
@@ -109,11 +109,31 @@ transaction protected by the tracked `cas/lock` file and an OS-released lock.
 Because the stable lock identity is inside the CAS, it cannot diverge with
 process-specific temporary-directory settings. Authoritative Python and Rust
 readers and every CLI writer participate in the same lock, so neither split
-publication nor a lost index update is externally visible. Registration
-validates both the old and proposed graphs, is additive and idempotent, and
-rolls back newly written objects on failure. A different hash for an already
-registered bundle ID fails closed until an explicit root-replacement migration
-can prune the old unreachable graph.
+publication nor a lost index update is externally visible. Python readers recover
+a pending journal before loading canonical state; the Rust projection reader fails
+closed until Python recovery completes. Before mutation, the
+writer publishes a canonical `adj-stdlib/cas-transaction-journal/v1` record under
+that lock. It stores the exact baseline index and manifest bytes, the complete
+baseline object set, every authorized publication hash, and the hash of each
+CAS-local prune backup. A journal that remains after process termination is a
+durable rollback decision: the next reader or writer restores the baseline byte
+for byte, removes only canonical post-baseline objects, validates the restored
+index, and clears the journal last. Unknown index or manifest bytes fail closed
+without canonical-state recovery mutation; owned temporary cleanup may already
+have occurred. Registration validates both the old and proposed
+graphs, is additive and idempotent, and rolls back newly written objects on
+ordinary failure or process death. A different hash for an already registered
+bundle ID fails closed until an explicit root-replacement migration can prune the
+old unreachable graph.
+
+New directory entries, object links, and atomic replacements fsync their containing
+directories on POSIX, as do journal, index, manifest, prune, and recovery removals.
+This release proves process-termination recovery, not recovery after storage or
+power failure. Windows exercises the same spawned-process termination matrix, but
+portable Python does not expose an equivalent directory-flush primitive.
+Atomic-write temporary files have path-specific names;
+recovery removes only those owned names and hash-checks every CAS temporary or
+backup before deletion.
 
 This separation prevents an untrusted source locator from turning the verifier
 into a network or SSRF primitive. Reads are bounded and reject links and Windows


### PR DESCRIPTION
## Summary
- add a canonical rollback journal for index-only, registration, and root-replacement CAS mutations
- recover exact baseline index, manifest, and object bytes after process termination while rejecting unauthorized canonical state
- make Python readers recover pending work and Rust projection readers fail closed under the shared CAS lock
- persist prune backups inside the CAS and fsync POSIX directory-entry changes without claiming power-loss recovery

## Why
Exception rollback protected ordinary failures, but process termination between object, index, manifest, and prune publication could leave split canonical state. The journal makes the unfinished transaction inspectable and recoverable byte for byte.

## Validation
- `python code/scripts/tests/test_adj_stdlib_provenance.py` (188 passed, 7 skipped)
- `cargo test --test arithmetic_provenance_e2e` (5 passed)
- Ruff and `py_compile`
- ADJ stdlib report with unreferenced-test gate
- coverage manifest JSON Schema validation (6 roots, 10 objectives)
- provenance verification (6 bundles, 84 objects, 9 snapshots)
- manifest tests (12 passed) and report tests (9 passed)
- `rustfmt --check` and `git diff --check`

## Review
Two independent adversarial reviews exercised empty-CAS first publication, interrupted commit semantics, lexical manifest paths, symlink and metadata-error handling, directory durability boundaries, and documentation claims. All findings were fixed and both reviewers cleared the final patch.