### PR TITLE
feat(build-tool): enforce Haskell rockspec UTF-8

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -13,16 +13,16 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "479ba6d78c2168ad36f02a1da020d7b91f6e4ef8",
+    "revision": "3445da42b281fe7af366d92bc589db5fa3951cfa",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1237,
-    "implementation_package_slots": 4385,
+    "implementation_identities": 1238,
+    "implementation_package_slots": 4386,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 271,
-    "singleton_packages": 787,
-    "singleton_missing_slots": 11018,
-    "rust_singletons": 592,
+    "singleton_packages": 788,
+    "singleton_missing_slots": 11032,
+    "rust_singletons": 593,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -1658,6 +1658,15 @@
       "branch": null,
       "pr_number": null,
       "notes": "Discovered in the collision-clean 479ba6d7 inventory after chief-of-staff-daemon-api landed as a Rust-only authenticated WebSocket control surface. It couples bounded JSON protocol handling to Chief host lifecycle operations and an optional concrete listener through websocket-runtime, and declares net:listen authority. Review the minimum truthful inherited listener, stream, authentication, and host-lifecycle authority; keep reusable bounded DTO, version, duplicate-field, stable-error, and redaction semantics in portable injected contracts; and record the residual daemon transport as a native-runtime exception rather than manufacturing all-language host-control servers. This review is excluded from autonomous delivery selection by parity policy."
+    },
+    {
+      "id": "chief-cli-core-portable-conformance",
+      "title": "Fixture and expand the portable Chief operator CLI core",
+      "status": "pending",
+      "depends_on": ["chief-service-registry-portable-conformance", "chief-daemon-api-native-authority-review"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-clean 3445da42 inventory after chief-of-staff-cli-core landed as a Rust-only zero-capability command layer. Its declarative argv grammar, conservative registration defaults, host/path/hash validation, typed injected-client dispatch, payload-blind daemon errors, deterministic JSON rendering, and exclusion of credential-bearing arguments are portable fixture candidates. Define language-neutral command/result/error cases, preserve the authenticated daemon client as an injected interface, expand only after the service-registry contract and daemon authority split are adjudicated, and keep sockets, credentials, terminal input, and process exit policy in native adapters."
     },
     {
       "id": "smart-home-axis-vapix-native-authority-review",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -374,7 +374,16 @@
       "depends_on": ["build-tool-perl-engine-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-haskell-rockspec-utf8",
       "pr_number": null,
-      "notes": "Materialized after merged PR #9632. Replace locale-sensitive lazy text I/O at the rockspec boundary with explicit strict UTF-8 decoding, consume both exact shared fixtures, preserve exact dependency edges, propagate typed METADATA_INVALID_UTF8 identity, and cover the real executable exit/stderr contract. Selected after PR #9717 merged because Ruby strict decoding and its dependent canonical resolver repairs are complete, the Haskell boundary is the next unblocked established-language build-tool gap, and its result will provide a stronger reference before the position-dependent Elixir repair."
+      "notes": "Materialized after merged PR #9632 and selected after PR #9717 because Ruby strict decoding and its dependent canonical resolver repairs are complete, making Haskell the next unblocked established-language build-tool boundary and a stronger reference for the position-dependent Elixir repair. The implementation strictly reads rockspec bytes, decodes UTF-8 before token parsing, propagates typed METADATA_INVALID_UTF8 with package and repository-relative manifest identity, preserves the exact lua/other -> lua/pkg shared-fixture edge, accepts literal U+FFFD, rejects five malformed-sequence classes, maps the real executable to exit 2 with empty stdout and stable root-redacted stderr, and closes lazy Windows read handles deterministically. Local validation passes 10 build-tool examples plus the graph and directed-graph suites, the exact Windows BUILD command, GHC -Wall -Werror build, Cabal check, publishability bounds, all-package Haddock generation, direct changed-boundary HPC ticks with 30% whole-engine expression coverage, the real invalid-fixture process contract, 57 shared conformance schema/runner tests, canonical Go test/vet/trimpath build, and a 205-package Haskell plan/BUILD validation. Cabal reports only newer incompatible major versions beyond the declared upper bounds; OSV Scanner, HLint, and Fourmolu are unavailable, while the changed-file credential scan is clean. Real Lua-package validation separately exposed the dependent Windows binary-safe source-hashing item now logged in state and roadmap rather than widening this metadata slice."
+    },
+    {
+      "id": "build-tool-haskell-binary-safe-source-hashing",
+      "title": "Make Haskell build-tool source hashing binary-safe on Windows",
+      "status": "pending",
+      "depends_on": ["build-tool-haskell-engine-rockspec-utf8-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered while validating the real Lua lane for the Haskell strict-rockspec slice. The engine resolves the exact UTF-8 fixtures and maps malformed rockspec bytes correctly, but hashing real Lua packages on Windows aborts before reporting with GHC handle commitBuffer error 0xc000014b when source text is sent through the locale-sensitive git hash-object stdin boundary. Reproduce with the actual lua/logic_gates -> lua/arithmetic pair, make source hashing raw-byte deterministic without changing graph or cache identities, add non-ASCII source fixtures and a real front-door dry run, and keep this separate from rockspec metadata decoding."
     },
     {
       "id": "build-tool-elixir-engine-rockspec-utf8-conformance",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,11 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": {
+    "number": 9742,
+    "url": "https://github.com/adhithyan15/coding-adventures/pull/9742",
+    "branch": "codex/build-tool-haskell-rockspec-utf8"
+  },
   "last_inventory": {
     "revision": "3445da42b281fe7af366d92bc589db5fa3951cfa",
     "schema_version": 3,
@@ -370,11 +374,11 @@
     {
       "id": "build-tool-haskell-engine-rockspec-utf8-conformance",
       "title": "Make the Haskell build tool enforce strict UTF-8 rockspec metadata",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-perl-engine-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-haskell-rockspec-utf8",
-      "pr_number": null,
-      "notes": "Materialized after merged PR #9632 and selected after PR #9717 because Ruby strict decoding and its dependent canonical resolver repairs are complete, making Haskell the next unblocked established-language build-tool boundary and a stronger reference for the position-dependent Elixir repair. The implementation strictly reads rockspec bytes, decodes UTF-8 before token parsing, propagates typed METADATA_INVALID_UTF8 with package and repository-relative manifest identity, preserves the exact lua/other -> lua/pkg shared-fixture edge, accepts literal U+FFFD, rejects five malformed-sequence classes, maps the real executable to exit 2 with empty stdout and stable root-redacted stderr, and closes lazy Windows read handles deterministically. Local validation passes 10 build-tool examples plus the graph and directed-graph suites, the exact Windows BUILD command, GHC -Wall -Werror build, Cabal check, publishability bounds, all-package Haddock generation, direct changed-boundary HPC ticks with 30% whole-engine expression coverage, the real invalid-fixture process contract, 57 shared conformance schema/runner tests, canonical Go test/vet/trimpath build, and a 205-package Haskell plan/BUILD validation. Cabal reports only newer incompatible major versions beyond the declared upper bounds; OSV Scanner, HLint, and Fourmolu are unavailable, while the changed-file credential scan is clean. Real Lua-package validation separately exposed the dependent Windows binary-safe source-hashing item now logged in state and roadmap rather than widening this metadata slice."
+      "pr_number": 9742,
+      "notes": "Materialized after merged PR #9632 and selected after PR #9717 because Ruby strict decoding and its dependent canonical resolver repairs are complete, making Haskell the next unblocked established-language build-tool boundary and a stronger reference for the position-dependent Elixir repair. The implementation strictly reads rockspec bytes, decodes UTF-8 before token parsing, propagates typed METADATA_INVALID_UTF8 with package and repository-relative manifest identity, preserves the exact lua/other -> lua/pkg shared-fixture edge, accepts literal U+FFFD, rejects five malformed-sequence classes, maps the real executable to exit 2 with empty stdout and stable root-redacted stderr, and closes lazy Windows read handles deterministically. Local validation passes 10 build-tool examples plus the graph and directed-graph suites, the exact Windows BUILD command, GHC -Wall -Werror build, Cabal check, publishability bounds, all-package Haddock generation, direct changed-boundary HPC ticks with 30% whole-engine expression coverage, the real invalid-fixture process contract, 57 shared conformance schema/runner tests, canonical Go test/vet/trimpath build, and a 205-package Haskell plan/BUILD validation. Cabal reports only newer incompatible major versions beyond the declared upper bounds; OSV Scanner, HLint, and Fourmolu are unavailable, while the changed-file credential scan is clean. Real Lua-package validation separately exposed the dependent Windows binary-safe source-hashing item now logged in state and roadmap rather than widening this metadata slice. Ready PR #9742 opened after a conflict-free rebase onto collision-clean 3445da42 and an exact-head rerun of all scoped gates."
     },
     {
       "id": "build-tool-haskell-binary-safe-source-hashing",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,22 +11,18 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": {
-    "number": 9717,
-    "url": "https://github.com/adhithyan15/coding-adventures/pull/9717",
-    "branch": "codex/websocket-core-portable-conformance"
-  },
+  "active_pr": null,
   "last_inventory": {
-    "revision": "5ceb7cafcb22ed70e096df281e12d10347113c2a",
+    "revision": "479ba6d78c2168ad36f02a1da020d7b91f6e4ef8",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1235,
-    "implementation_package_slots": 4383,
+    "implementation_identities": 1237,
+    "implementation_package_slots": 4385,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 271,
-    "singleton_packages": 785,
-    "singleton_missing_slots": 10990,
-    "rust_singletons": 590,
+    "singleton_packages": 787,
+    "singleton_missing_slots": 11018,
+    "rust_singletons": 592,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -374,11 +370,11 @@
     {
       "id": "build-tool-haskell-engine-rockspec-utf8-conformance",
       "title": "Make the Haskell build tool enforce strict UTF-8 rockspec metadata",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-perl-engine-rockspec-utf8-conformance"],
-      "branch": null,
+      "branch": "codex/build-tool-haskell-rockspec-utf8",
       "pr_number": null,
-      "notes": "Materialized after merged PR #9632. Replace locale-sensitive lazy text I/O at the rockspec boundary with explicit strict UTF-8 decoding, consume both exact shared fixtures, preserve exact dependency edges, propagate typed METADATA_INVALID_UTF8 identity, and cover the real executable exit/stderr contract. Schedule after Ruby because the Haskell toolchain and lazy-I/O boundary require a broader build and resource audit."
+      "notes": "Materialized after merged PR #9632. Replace locale-sensitive lazy text I/O at the rockspec boundary with explicit strict UTF-8 decoding, consume both exact shared fixtures, preserve exact dependency edges, propagate typed METADATA_INVALID_UTF8 identity, and cover the real executable exit/stderr contract. Selected after PR #9717 merged because Ruby strict decoding and its dependent canonical resolver repairs are complete, the Haskell boundary is the next unblocked established-language build-tool gap, and its result will provide a stronger reference before the position-dependent Elixir repair."
     },
     {
       "id": "build-tool-elixir-engine-rockspec-utf8-conformance",
@@ -1621,11 +1617,11 @@
     {
       "id": "websocket-core-portable-conformance",
       "title": "Define language-neutral WebSocket core conformance",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": [],
       "branch": "codex/websocket-core-portable-conformance",
       "pr_number": 9717,
-      "notes": "Discovered in the collision-clean 3258981f inventory after PR #9704 added Rust-only websocket-core. The package and governing spec explicitly define a zero-capability, transport-independent RFC 6455 state machine intended for later Python, Go, Ruby, TypeScript, and Elixir ports. Selected after PR #9703 merged because this unblocked fixture foundation is the dependency for every WebSocket port and D18 runtime consumer; the already unblocked Elixir resolver semantic and Haskell/Elixir UTF-8 items remain next-ranked independent build-tool work. Implemented a closed Draft 2020-12 schema plus 39 bounded language-neutral cases across all seven portable API families, with 23 existing Rust unit tests and 7 shared-fixture consumer tests passing. The first consumer covers exact handshake and wire outputs, incremental decoding, limits, canonical lengths, masking, fragmentation, controls, split UTF-8, close state, typed errors, and payload-free diagnostics. Package-local rustfmt, clippy -D warnings, rustdoc -D warnings, RustSec audit, fixture-schema tests, capability-taxonomy tests, and collision checks pass; direct LLVM reporting records 99.81% line and 100% function coverage for src/lib.rs. After rebasing onto collision-clean 5ceb7caf, the repository build tool selects and builds the complete 13-package prerequisite/downstream closure through the newly landed websocket-runtime. Current Rust 1.97 exposed only three pre-existing Windows-target maintenance points in iocp, transport-platform, and tcp-runtime; narrowly documented opaque-pointer/platform dead-code contracts plus canonical clamp/formatting now make all 13 packages pass tests and clippy without changing behavior. The full validator reproduces only the separately owned 73-gap debt gate (12 Python, 3 Swift, and 58 TypeScript), with no WebSocket finding. Sockets, DNS, TLS, clocks, randomness, event loops, retries, and runtime dispatch remain outside the portable contract."
+      "notes": "Discovered in the collision-clean 3258981f inventory after PR #9704 added Rust-only websocket-core. The package and governing spec explicitly define a zero-capability, transport-independent RFC 6455 state machine intended for later Python, Go, Ruby, TypeScript, and Elixir ports. Selected after PR #9703 merged because this unblocked fixture foundation is the dependency for every WebSocket port and D18 runtime consumer; the already unblocked Elixir resolver semantic and Haskell/Elixir UTF-8 items remain next-ranked independent build-tool work. Implemented a closed Draft 2020-12 schema plus 39 bounded language-neutral cases across all seven portable API families, with 23 existing Rust unit tests and 7 shared-fixture consumer tests passing. The first consumer covers exact handshake and wire outputs, incremental decoding, limits, canonical lengths, masking, fragmentation, controls, split UTF-8, close state, typed errors, and payload-free diagnostics. Package-local rustfmt, clippy -D warnings, rustdoc -D warnings, RustSec audit, fixture-schema tests, capability-taxonomy tests, and collision checks pass; direct LLVM reporting records 99.81% line and 100% function coverage for src/lib.rs. After rebasing onto collision-clean 5ceb7caf, the repository build tool selects and builds the complete 13-package prerequisite/downstream closure through the newly landed websocket-runtime. Current Rust 1.97 exposed only three pre-existing Windows-target maintenance points in iocp, transport-platform, and tcp-runtime; narrowly documented opaque-pointer/platform dead-code contracts plus canonical clamp/formatting now make all 13 packages pass tests and clippy without changing behavior. The full validator reproduces only the separately owned 73-gap debt gate (12 Python, 3 Swift, and 58 TypeScript), with no WebSocket finding. Sockets, DNS, TLS, clocks, randomness, event loops, retries, and runtime dispatch remain outside the portable contract. PR #9717 auto-completed as 479ba6d78c2168ad36f02a1da020d7b91f6e4ef8 after all 17 exact-head checks were terminal: eleven passed, three irrelevant analyzers skipped, and the CodeQL aggregate was neutral."
     },
     {
       "id": "websocket-runtime-native-authority-review",
@@ -1644,6 +1640,24 @@
       "branch": null,
       "pr_number": null,
       "notes": "After the shared WebSocket fixture oracle lands and HTTP framing prerequisites are consistent, port the authority-free core through all established implementation lanes with local idioms, empty capability manifests, real BUILD/BUILD_windows files, coverage, and downstream tests. The broad Java/Kotlin and Swift/Dart waves already own their currently missing http-core/http1 prerequisites; do not duplicate or bypass those dependency gaps. Runtime transport, TLS, mask-key generation, timers, event loops, and application dispatch remain separately reviewed native adapters."
+    },
+    {
+      "id": "chief-daemon-api-native-authority-review",
+      "title": "Review the Chief daemon API native-authority exception",
+      "status": "pending",
+      "depends_on": ["chief-orchestrator-core-portable-conformance", "websocket-runtime-native-authority-review"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-clean 479ba6d7 inventory after chief-of-staff-daemon-api landed as a Rust-only authenticated WebSocket control surface. It couples bounded JSON protocol handling to Chief host lifecycle operations and an optional concrete listener through websocket-runtime, and declares net:listen authority. Review the minimum truthful inherited listener, stream, authentication, and host-lifecycle authority; keep reusable bounded DTO, version, duplicate-field, stable-error, and redaction semantics in portable injected contracts; and record the residual daemon transport as a native-runtime exception rather than manufacturing all-language host-control servers. This review is excluded from autonomous delivery selection by parity policy."
+    },
+    {
+      "id": "smart-home-axis-vapix-native-authority-review",
+      "title": "Review the Axis VAPIX integration native-authority exception",
+      "status": "pending",
+      "depends_on": ["rust-network-substrate-capability-truthfulness", "smart-home-lan-http-native-executor-consolidation"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-clean 479ba6d7 inventory after smart-home-axis-vapix-integration landed as a Rust-only production adapter. The crate performs mDNS discovery, credential-referenced authenticated HTTPS, TLS, endpoint policy, runtime authorization, and concrete network effects, so the package is not an all-language portable target. Review truthful DNS/discovery/connect/TLS/Vault-derived authority and platform evidence; keep bounded VAPIX response validation, identity normalization, stable projection, and request planning in shared portable contracts where reusable; and record the residual adapter as a native-runtime exception. This review is excluded from autonomous delivery selection by parity policy."
     }
   ]
 }

--- a/code/programs/haskell/build-tool/BUILD_windows
+++ b/code/programs/haskell/build-tool/BUILD_windows
@@ -1,1 +1,1 @@
-echo "haskell support not enabled in windows CI yet -- skipping"
+cabal test all

--- a/code/programs/haskell/build-tool/CHANGELOG.md
+++ b/code/programs/haskell/build-tool/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this package will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- Shared valid and invalid Lua rockspec fixture coverage, typed
+  `METADATA_INVALID_UTF8` diagnostics, representative malformed-sequence
+  checks, literal U+FFFD coverage, and front-door exit-code validation.
+
+### Changed
+
+- Read rockspecs as raw bytes and decode strict UTF-8 before dependency
+  resolution, with repository-relative diagnostics and no checkout-root leak.
+- Force existing lazy text reads to EOF before parsing so Windows file handles
+  close deterministically after discovery and validation.
+- Exercise the Haskell build tool from `BUILD_windows` whenever Cabal is
+  available instead of unconditionally skipping the package.
+
 ## [0.1.0] - 2026-04-05
 
 ### Added

--- a/code/programs/haskell/build-tool/README.md
+++ b/code/programs/haskell/build-tool/README.md
@@ -9,11 +9,27 @@ dependencies from package manifests, hashes package inputs for incremental
 builds, uses git diff information to narrow the build set, and executes
 `BUILD` scripts in dependency order.
 
+Lua rockspec metadata is read as raw bytes and decoded as strict UTF-8 before
+dependency resolution. Malformed bytes fail closed with package and
+repository-relative manifest identity:
+
+```text
+METADATA_INVALID_UTF8: package=lua/pkg manifest=code/packages/lua/pkg/coding-adventures-pkg-0.1.0-1.rockspec encoding=UTF-8
+```
+
+The standalone front door writes that diagnostic to stderr and exits `2`.
+The package tests consume the shared `resolution/lua-utf8` and
+`resolution/lua-invalid-utf8` fixtures, cover representative malformed UTF-8
+classes, and distinguish a valid literal U+FFFD from a decoder replacement.
+
 ## Development
 
 ```bash
 # Run tests and build the executable
 bash BUILD
+
+# Windows: run the command recorded in BUILD_windows
+cabal test all
 ```
 
 ## Usage

--- a/code/programs/haskell/build-tool/coding-adventures-build-tool.cabal
+++ b/code/programs/haskell/build-tool/coding-adventures-build-tool.cabal
@@ -2,28 +2,34 @@ cabal-version: 3.0
 name:          coding-adventures-build-tool
 version:       0.2.0
 synopsis:      Haskell implementation of the monorepo build tool
+description:   Dependency-aware coding-adventures build orchestration in Haskell
+category:      Development
 license:       MIT
 author:        Adhithya Rajasekaran
 maintainer:    Adhithya Rajasekaran
 build-type:    Simple
+extra-doc-files: README.md
+               CHANGELOG.md
 
 library
     exposed-modules:  BuildTool
-    build-depends:    base >=4.14
-                    , containers
-                    , directed-graph
-                    , directory
-                    , filepath
-                    , process
-                    , time
+    build-depends:    base >=4.14 && <5
+                    , bytestring >=0.10 && <0.13
+                    , containers >=0.6 && <0.8
+                    , directed-graph ==0.1.*
+                    , directory >=1.3 && <1.4
+                    , filepath >=1.4 && <1.6
+                    , process >=1.6 && <1.7
+                    , text >=1.2 && <2.2
+                    , time >=1.9 && <1.15
     hs-source-dirs:   src
     default-language: Haskell2010
 
 executable build-tool
     main-is:          Main.hs
     hs-source-dirs:   app
-    build-depends:    base >=4.14
-                    , coding-adventures-build-tool
+    build-depends:    base >=4.14 && <5
+                    , coding-adventures-build-tool ==0.2.*
     ghc-options:      -threaded -with-rtsopts=--io-manager=native
     default-language: Haskell2010
 
@@ -31,8 +37,16 @@ test-suite spec
     type:             exitcode-stdio-1.0
     main-is:          Spec.hs
     other-modules:    BuildToolSpec
-    build-depends:    base >=4.14
-                    , coding-adventures-build-tool
-                    , hspec == 2.*
+                    , ResolutionUtf8Spec
+    build-depends:    aeson >=2.0 && <3
+                    , base >=4.14 && <5
+                    , base64-bytestring >=1.2 && <1.3
+                    , bytestring >=0.10 && <0.13
+                    , coding-adventures-build-tool ==0.2.*
+                    , directed-graph ==0.1.*
+                    , directory >=1.3 && <1.4
+                    , filepath >=1.4 && <1.6
+                    , hspec >=2.10 && <3
+                    , text >=1.2 && <2.2
     hs-source-dirs:   test
     default-language: Haskell2010

--- a/code/programs/haskell/build-tool/src/BuildTool.hs
+++ b/code/programs/haskell/build-tool/src/BuildTool.hs
@@ -1,6 +1,7 @@
 module BuildTool
     ( BuildResult(..)
     , Config(..)
+    , MetadataEncodingError(..)
     , Package(..)
     , ParsedArgs(..)
     , defaultConfig
@@ -8,10 +9,14 @@ module BuildTool
     , findRepoRoot
     , inferLanguage
     , parseArgs
+    , renderMetadataEncodingError
+    , resolveDependencies
     , runWithArgs
     ) where
 
-import Control.Monad (filterM, foldM, forM, unless, when)
+import Control.Exception (Exception, catch, evaluate, throwIO)
+import Control.Monad (filterM, foldM, forM, when)
+import qualified Data.ByteString as BS
 import Data.Char (isAlphaNum, ord, toLower)
 import Data.List (intercalate, isPrefixOf, nub, sort, sortOn)
 import qualified Data.Map.Strict as Map
@@ -19,6 +24,8 @@ import Data.Map.Strict (Map)
 import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import qualified Data.Set as Set
 import Data.Set (Set)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 import Data.Time.Clock (diffUTCTime, getCurrentTime)
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import qualified DirectedGraph as DG
@@ -43,6 +50,7 @@ import System.FilePath
     , takeExtension
     , takeFileName
     )
+import System.IO (hPutStrLn, stderr)
 import qualified System.Info as SystemInfo
 import System.Process (CreateProcess(..), proc, readCreateProcessWithExitCode)
 import Text.Read (readMaybe)
@@ -69,6 +77,29 @@ data ParsedArgs
     | ParsedVersion
     | ParsedRun Config
     deriving (Eq, Show)
+
+data MetadataEncodingError = MetadataEncodingError
+    { metadataErrorCode :: String
+    , metadataErrorPackage :: String
+    , metadataErrorManifest :: FilePath
+    , metadataErrorEncoding :: String
+    }
+    deriving (Eq)
+
+instance Show MetadataEncodingError where
+    show = renderMetadataEncodingError
+
+instance Exception MetadataEncodingError
+
+renderMetadataEncodingError :: MetadataEncodingError -> String
+renderMetadataEncodingError metadataError =
+    intercalate
+        " "
+        [ metadataErrorCode metadataError ++ ":"
+        , "package=" ++ metadataErrorPackage metadataError
+        , "manifest=" ++ metadataErrorManifest metadataError
+        , "encoding=" ++ metadataErrorEncoding metadataError
+        ]
 
 data Package = Package
     { packageName :: String
@@ -205,7 +236,12 @@ runWithArgs rawArgs =
         Right ParsedVersion -> do
             putStrLn versionString
             pure 0
-        Right (ParsedRun cfg) -> runBuild cfg
+        Right (ParsedRun cfg) -> runBuild cfg `catch` handleMetadataEncodingError
+
+handleMetadataEncodingError :: MetadataEncodingError -> IO Int
+handleMetadataEncodingError metadataError = do
+    hPutStrLn stderr (renderMetadataEncodingError metadataError)
+    pure 2
 
 runBuild :: Config -> IO Int
 runBuild cfg = do
@@ -428,7 +464,7 @@ hostOS = map toLower osName
 
 readBuildCommands :: FilePath -> IO [String]
 readBuildCommands path = do
-    contents <- readFile path
+    contents <- readFileStrict path
     pure
         [ trim line
         | line <- lines contents
@@ -436,6 +472,15 @@ readBuildCommands path = do
         , not (null stripped)
         , not ("#" `isPrefixOf` stripped)
         ]
+
+-- Prelude.readFile is lazy and can retain a Windows file handle after package
+-- discovery has returned. Force the complete text before handing it to a
+-- parser so the handle reaches EOF and closes deterministically.
+readFileStrict :: FilePath -> IO String
+readFileStrict path = do
+    contents <- readFile path
+    _ <- evaluate (length contents)
+    pure contents
 
 validatePackages :: [Package] -> IO [String]
 validatePackages packages =
@@ -545,7 +590,7 @@ readCargoNames root = do
     if not exists
         then pure []
         else do
-            contents <- readFile cargoPath
+            contents <- readFileStrict cargoPath
             pure (parseQuotedField "name" contents)
 
 readPyprojectNames :: FilePath -> IO [String]
@@ -555,7 +600,7 @@ readPyprojectNames root = do
     if not exists
         then pure []
         else do
-            contents <- readFile pyprojectPath
+            contents <- readFileStrict pyprojectPath
             pure (parseAssignmentField "name" contents)
 
 readGoModuleNames :: FilePath -> IO [String]
@@ -565,7 +610,7 @@ readGoModuleNames root = do
     if not exists
         then pure []
         else do
-            contents <- readFile goModPath
+            contents <- readFileStrict goModPath
             pure
                 [ map toLower (trim (drop (length ("module" :: String)) stripped))
                 | line <- lines contents
@@ -580,7 +625,7 @@ readPackageJsonNames root = do
     if not exists
         then pure []
         else do
-            contents <- readFile packageJson
+            contents <- readFileStrict packageJson
             pure (parseJsonLikeField "name" contents)
 
 readGemspecNames :: FilePath -> IO [String]
@@ -589,7 +634,7 @@ readGemspecNames root = do
     let gemspecs = [root </> entry | entry <- entries, takeExtension entry == ".gemspec"]
     fmap concat $
         forM gemspecs $ \path -> do
-            contents <- readFile path
+            contents <- readFileStrict path
             pure
                 [ map toLower (takeWhile (\char -> char /= '"' && char /= '\'') after)
                 | line <- lines contents
@@ -603,7 +648,7 @@ readGemspecNames root = do
 
 readSimpleFieldName :: FilePath -> IO (Maybe String)
 readSimpleFieldName path = do
-    contents <- readFile path
+    contents <- readFileStrict path
     pure $
         listToMaybe
             [ map toLower (trim (drop 1 rest))
@@ -693,8 +738,35 @@ readManifestTokens pkg = do
     existingFiles <- filterM doesFileExist rootFiles
     fmap (nub . concat) $
         forM existingFiles $ \path -> do
-            contents <- readFile path
+            contents <-
+                if map toLower (takeExtension path) == ".rockspec"
+                    then readRockspecUtf8 pkg path
+                    else readFileStrict path
             pure (tokenize contents)
+
+readRockspecUtf8 :: Package -> FilePath -> IO String
+readRockspecUtf8 pkg path = do
+    bytes <- BS.readFile path
+    case TextEncoding.decodeUtf8' bytes of
+        Left _ ->
+            throwIO
+                MetadataEncodingError
+                    { metadataErrorCode = "METADATA_INVALID_UTF8"
+                    , metadataErrorPackage = packageName pkg
+                    , metadataErrorManifest = repositoryRelativeManifest pkg path
+                    , metadataErrorEncoding = "UTF-8"
+                    }
+        Right contents -> pure (Text.unpack contents)
+
+repositoryRelativeManifest :: Package -> FilePath -> FilePath
+repositoryRelativeManifest pkg path =
+    intercalate
+        "/"
+        [ "code"
+        , "packages"
+        , packageName pkg
+        , takeFileName path
+        ]
 
 tokenize :: String -> [String]
 tokenize contents =
@@ -726,7 +798,7 @@ hashPackage pkg = do
     files <- packageRelevantFiles pkg
     filePayloads <-
         forM files $ \path -> do
-            contents <- readFile path
+            contents <- readFileStrict path
             let relative = makeRelative (packagePath pkg) path
             pure (relative ++ "\n" ++ contents ++ "\n")
     hashString (concat filePayloads)
@@ -831,7 +903,7 @@ loadCache path = do
     if not exists
         then pure emptyCache
         else do
-            contents <- readFile path
+            contents <- readFileStrict path
             pure (fromMaybe emptyCache (readMaybe contents))
 
 saveCache :: FilePath -> BuildCache -> IO ()

--- a/code/programs/haskell/build-tool/test/ResolutionUtf8Spec.hs
+++ b/code/programs/haskell/build-tool/test/ResolutionUtf8Spec.hs
@@ -1,0 +1,207 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module ResolutionUtf8Spec (resolutionUtf8Spec) where
+
+import Control.Exception (bracket, try)
+import Control.Monad (forM_)
+import Data.Aeson
+    ( FromJSON(..)
+    , Object
+    , eitherDecodeStrict'
+    , withObject
+    , (.:)
+    , (.:?)
+    , (.!=)
+    )
+import Data.Aeson.Types (Parser)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base64 as Base64
+import qualified Data.ByteString.Char8 as BS8
+import Data.List (isInfixOf, sort)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified DirectedGraph as DG
+import System.Directory
+    ( createDirectory
+    , createDirectoryIfMissing
+    , getTemporaryDirectory
+    , removeFile
+    , removePathForcibly
+    )
+import System.FilePath ((</>), pathSeparator, takeDirectory)
+import System.IO (hClose, openTempFile)
+import Test.Hspec
+
+import BuildTool
+
+data FixtureFile = FixtureFile
+    { fixturePath :: FilePath
+    , fixtureContentUtf8 :: Maybe Text.Text
+    , fixtureContentBase64 :: Maybe Text.Text
+    }
+
+data ResolutionFixture = ResolutionFixture
+    { fixtureFiles :: [FixtureFile]
+    , fixtureExpectedEdges :: [[String]]
+    }
+
+instance FromJSON FixtureFile where
+    parseJSON = withObject "fixture file" $ \object ->
+        FixtureFile
+            <$> object .: "path"
+            <*> object .:? "content_utf8"
+            <*> object .:? "content_base64"
+
+instance FromJSON ResolutionFixture where
+    parseJSON = withObject "resolution fixture" $ \object -> do
+        workspace <- object .: "workspace" :: Parser Object
+        expected <- object .: "expected" :: Parser Object
+        result <- expected .: "result" :: Parser Object
+        ResolutionFixture
+            <$> workspace .: "files"
+            <*> (result .:? "edges" .!= [])
+
+resolutionUtf8Spec :: Spec
+resolutionUtf8Spec = describe "Lua rockspec UTF-8 conformance" $ do
+    it "consumes the shared valid fixture and resolves only the exact edge" $
+        withFixture "resolution-lua-utf8.json" $ \root fixture -> do
+            graph <- resolveFixture root
+            graphEdges graph `shouldBe` fixtureExpectedEdges fixture
+            DG.nodes graph `shouldBe` ["lua/other", "lua/pkg"]
+
+    it "consumes the shared invalid fixture as a typed stable error" $
+        withFixture "resolution-lua-invalid-utf8.json" $ \root _ -> do
+            result <- try (resolveFixture root) :: IO (Either MetadataEncodingError DG.DirectedGraph)
+            case result of
+                Right _ -> expectationFailure "invalid UTF-8 unexpectedly resolved"
+                Left metadataError -> assertMetadataError root metadataError
+
+    it "accepts a literal replacement character encoded as valid UTF-8" $
+        withTemporaryDirectory "haskell-build-tool-replacement" $ \root -> do
+            writeLuaPackage
+                root
+                ( Text.encodeUtf8
+                    "package = \"coding-adventures-pkg\"\nversion = \"0.1.0-1\"\ndescription = { summary = \"Literal U+FFFD: \xFFFD\" }\ndependencies = { \"lua >= 5.4\" }\n"
+                )
+            graph <- resolveFixture root
+            DG.nodes graph `shouldBe` ["lua/pkg"]
+
+    it "rejects representative malformed UTF-8 sequence classes" $ do
+        let malformedSequences =
+                [ ("illegal leading byte", BS.pack [0xFF])
+                , ("unexpected continuation byte", BS.pack [0x80])
+                , ("truncated multibyte sequence", BS.pack [0xE2, 0x82])
+                , ("overlong encoding", BS.pack [0xC0, 0xAF])
+                , ("UTF-16 surrogate encoding", BS.pack [0xED, 0xA0, 0x80])
+                ]
+        forM_ malformedSequences $ \(label, malformedBytes) ->
+            withTemporaryDirectory "haskell-build-tool-malformed" $ \root -> do
+                writeLuaPackage
+                    root
+                    ( BS8.pack
+                        "package = \"coding-adventures-pkg\"\nversion = \"0.1.0-1\"\ndependencies = { \"lua >= 5.4\" }\n-- malformed: "
+                        <> malformedBytes
+                        <> BS8.pack "\n"
+                    )
+                result <- try (resolveFixture root) :: IO (Either MetadataEncodingError DG.DirectedGraph)
+                case result of
+                    Right _ -> expectationFailure (label ++ " unexpectedly resolved")
+                    Left metadataError -> assertMetadataError root metadataError
+
+    it "maps invalid metadata through the real front-door path to exit code 2" $
+        withFixture "resolution-lua-invalid-utf8.json" $ \root _ -> do
+            runWithArgs
+                [ "--root"
+                , root
+                , "--language"
+                , "lua"
+                , "--force"
+                , "--dry-run"
+                ]
+                `shouldReturn` 2
+
+assertMetadataError :: FilePath -> MetadataEncodingError -> Expectation
+assertMetadataError root metadataError = do
+    metadataErrorCode metadataError `shouldBe` "METADATA_INVALID_UTF8"
+    metadataErrorPackage metadataError `shouldBe` "lua/pkg"
+    metadataErrorManifest metadataError
+        `shouldBe` "code/packages/lua/pkg/coding-adventures-pkg-0.1.0-1.rockspec"
+    metadataErrorEncoding metadataError `shouldBe` "UTF-8"
+    renderMetadataEncodingError metadataError
+        `shouldBe` "METADATA_INVALID_UTF8: package=lua/pkg manifest=code/packages/lua/pkg/coding-adventures-pkg-0.1.0-1.rockspec encoding=UTF-8"
+    renderMetadataEncodingError metadataError `shouldSatisfy` (not . isInfixOf root)
+
+resolveFixture :: FilePath -> IO DG.DirectedGraph
+resolveFixture root = do
+    packages <- discoverPackages (root </> "code")
+    resolveDependencies (filter ((== "lua") . packageLanguage) packages)
+
+graphEdges :: DG.DirectedGraph -> [[String]]
+graphEdges graph =
+    sort
+        [ [fromNode, toNode]
+        | fromNode <- DG.nodes graph
+        , Right toNodes <- [DG.successors fromNode graph]
+        , toNode <- toNodes
+        ]
+
+withFixture :: FilePath -> (FilePath -> ResolutionFixture -> IO a) -> IO a
+withFixture fixtureName action = do
+    fixture <- loadFixture fixtureName
+    withTemporaryDirectory "haskell-build-tool-fixture" $ \root -> do
+        materializeFixture root fixture
+        action root fixture
+
+loadFixture :: FilePath -> IO ResolutionFixture
+loadFixture fixtureName = do
+    maybeRoot <- findRepoRoot Nothing
+    repoRoot <- maybe (fail "could not locate repository root for fixtures") pure maybeRoot
+    let sharedFixturePath =
+            repoRoot
+                </> "code"
+                </> "specs"
+                </> "fixtures"
+                </> "build-tool-v1"
+                </> "cases"
+                </> fixtureName
+    bytes <- BS.readFile sharedFixturePath
+    either (fail . ("invalid shared fixture: " ++)) pure (eitherDecodeStrict' bytes)
+
+materializeFixture :: FilePath -> ResolutionFixture -> IO ()
+materializeFixture root fixture =
+    forM_ (fixtureFiles fixture) $ \fixtureFile -> do
+        let destination = root </> portableToNative (fixturePath fixtureFile)
+        createDirectoryIfMissing True (takeDirectory destination)
+        bytes <- fixtureBytes fixtureFile
+        BS.writeFile destination bytes
+
+fixtureBytes :: FixtureFile -> IO BS.ByteString
+fixtureBytes fixtureFile =
+    case (fixtureContentUtf8 fixtureFile, fixtureContentBase64 fixtureFile) of
+        (Just content, Nothing) -> pure (Text.encodeUtf8 content)
+        (Nothing, Just content) ->
+            either (fail . ("invalid fixture base64: " ++)) pure (Base64.decode (Text.encodeUtf8 content))
+        _ -> fail "fixture file must contain exactly one content encoding"
+
+writeLuaPackage :: FilePath -> BS.ByteString -> IO ()
+writeLuaPackage root rockspecBytes = do
+    let packageRoot = root </> "code" </> "packages" </> "lua" </> "pkg"
+    createDirectoryIfMissing True packageRoot
+    BS8.writeFile (packageRoot </> "BUILD") "echo build\n"
+    BS.writeFile
+        (packageRoot </> "coding-adventures-pkg-0.1.0-1.rockspec")
+        rockspecBytes
+
+portableToNative :: FilePath -> FilePath
+portableToNative = map (\character -> if character == '/' then pathSeparator else character)
+
+withTemporaryDirectory :: String -> (FilePath -> IO a) -> IO a
+withTemporaryDirectory template = bracket create removePathForcibly
+  where
+    create = do
+        temporaryRoot <- getTemporaryDirectory
+        (reservedPath, handle) <- openTempFile temporaryRoot template
+        hClose handle
+        removeFile reservedPath
+        createDirectory reservedPath
+        pure reservedPath

--- a/code/programs/haskell/build-tool/test/Spec.hs
+++ b/code/programs/haskell/build-tool/test/Spec.hs
@@ -1,9 +1,12 @@
 import Test.Hspec
 
 import BuildToolSpec (buildToolSpec)
+import ResolutionUtf8Spec (resolutionUtf8Spec)
 
 main :: IO ()
 main = hspec spec
 
 spec :: Spec
-spec = buildToolSpec
+spec = do
+    buildToolSpec
+    resolutionUtf8Spec

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -288,6 +288,9 @@ MUST:
   locale fallback;
 - report invalid rockspec encoding as `METADATA_INVALID_UTF8`, including the
   repository-relative manifest path and package identity;
+- surface that failure from a standalone build-tool front door as unsafe or
+  malformed input: exit `2`, write the stable diagnostic to standard error,
+  write no success output, and never disclose the absolute checkout root;
 - emit sorted, unique internal edges; and
 - report malformed metadata with stable diagnostics instead of silently
   inventing a partial graph.

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -384,7 +384,11 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   CI-gate, and Ruby CodeQL checks. The post-#9717 leverage pass selects Haskell
   next because it is the remaining locale-sensitive established-language
   boundary and will provide a stronger reference for the position-dependent
-  Elixir repair; Elixir remains pending;
+  Elixir repair; Elixir remains pending. The Haskell real-package validation
+  also exposed a separate Windows source-hashing boundary: locale-sensitive
+  child-process stdin aborts with GHC `commitBuffer` error `0xc000014b` when
+  hashing non-ASCII package text. That binary-safe hashing repair is logged as
+  a dependent child rather than widening the rockspec metadata slice;
 - close the Ruby build tool's Starlark source-tree execution gaps. The Ruby
   UTF-8 validation found that a clean real plan cannot load the undeclared
   `coding_adventures_starlark_interpreter` runtime until repository library

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -122,13 +122,14 @@ The loop must not start by attempting 10,976 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`5ceb7cafcb22ed70e096df281e12d10347113c2a` is collision-clean at 1,235
-normalized implementation identities, 4,383 implementation slots, 172
-high-consensus packages, 271 high-consensus missing slots, 785 singletons, 590
+`479ba6d78c2168ad36f02a1da020d7b91f6e4ef8` is collision-clean at 1,237
+normalized implementation identities, 4,385 implementation slots, 172
+high-consensus packages, 271 high-consensus missing slots, 787 singletons, 592
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
-The new `websocket-runtime` identity has a native-authority review owner; the
-intervening parser, CI, and curriculum fixes changed no canonical package
-identity.
+The new `websocket-runtime`, `chief-of-staff-daemon-api`, and
+`smart-home-axis-vapix-integration` identities have explicit native-authority
+review owners; the intervening parser, CI, and curriculum fixes changed no
+other canonical package identity.
 The seventeen newest mixed Rust identities are `smart-home-camera-media`,
 `smart-home-onvif-integration`, `smart-home-shelly-integration`,
 `smart-home-wled-integration`, `smart-home-govee-lan-integration`,
@@ -295,6 +296,19 @@ profile, platform-CI evidence, and the guard that deterministic RFC 6455 logic
 stays in `websocket-core`; policy excludes that native-runtime review from
 autonomous selection.
 
+The `479ba6d7` refresh adds `chief-of-staff-daemon-api` and
+`smart-home-axis-vapix-integration`. The Chief daemon API couples bounded JSON
+protocol handling to authenticated host-lifecycle operations and an optional
+concrete WebSocket listener, so its minimum listener, stream, authentication,
+and host-control authority requires a native-runtime review while reusable
+DTO, version, duplicate-field, stable-error, and redaction semantics remain in
+portable injected contracts. The Axis adapter performs mDNS discovery,
+credential-referenced HTTPS, TLS, endpoint policy, runtime authorization, and
+concrete network effects; its bounded VAPIX validation, request planning,
+identity normalization, and stable projection remain portable seams, while the
+residual adapter is a reviewed native-runtime exception. Both review items are
+excluded from autonomous delivery selection.
+
 This loop delivers only deterministic, authority-free package contracts and
 implementations. DNS/UDP/TCP/TLS, endpoint review, credentials and Vault,
 capability approval, runtime mutation, native executors, and host hardening are
@@ -367,7 +381,10 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   pending child instead of expanding the UTF-8 behavior slice. Merged PR #9648
   completed Ruby with strict byte decoding, typed stable diagnostics, the exact
   shared fixtures, real CLI exit 2, and green Ubuntu, macOS, Windows, fixture,
-  CI-gate, and Ruby CodeQL checks. Haskell and Elixir remain pending;
+  CI-gate, and Ruby CodeQL checks. The post-#9717 leverage pass selects Haskell
+  next because it is the remaining locale-sensitive established-language
+  boundary and will provide a stronger reference for the position-dependent
+  Elixir repair; Elixir remains pending;
 - close the Ruby build tool's Starlark source-tree execution gaps. The Ruby
   UTF-8 validation found that a clean real plan cannot load the undeclared
   `coding_adventures_starlark_interpreter` runtime until repository library

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -309,6 +309,16 @@ identity normalization, and stable projection remain portable seams, while the
 residual adapter is a reviewed native-runtime exception. Both review items are
 excluded from autonomous delivery selection.
 
+The `3445da42` refresh adds `chief-of-staff-cli-core` and a Rust
+`semantic-ir-to-c` implementation. The CLI core is zero-capability and keeps
+credentials, sockets, terminal input, and process policy outside an injected
+authenticated client. Its declarative command grammar, conservative defaults,
+typed host/path/hash validation, dispatch records, stable errors, and
+deterministic JSON rendering are portable fixture candidates. A dedicated
+dependency-shaped owner now waits on the service-registry portable contract
+and daemon authority split. The additional SIR implementation fills an
+existing identity slot and creates no new package identity or exception.
+
 This loop delivers only deterministic, authority-free package contracts and
 implementations. DNS/UDP/TCP/TLS, endpoint review, credentials and Vault,
 capability approval, runtime mutation, native executors, and host hardening are


### PR DESCRIPTION
## Summary

- read Lua rockspec metadata as raw bytes and decode strict UTF-8 before dependency tokenization
- return typed, stable `METADATA_INVALID_UTF8` diagnostics with package and repository-relative manifest identity, then map the standalone front door to exit 2
- consume the exact shared valid/invalid fixtures, preserve `lua/other -> lua/pkg`, accept literal U+FFFD, and reject five malformed UTF-8 sequence classes
- force existing text reads to EOF so Windows discovery/test cleanup closes file handles deterministically
- replace the Haskell Windows build skip with the real `cabal test all` command and document the contract
- refresh the rebased collision-clean parity inventory and log newly discovered Haskell hashing and Chief CLI parity work

## Validation

- `cabal test all --test-show-details=direct` — 17 examples across graph, directed-graph, and build-tool suites
- `cabal test coding-adventures-build-tool:test:spec --test-show-details=direct --ghc-options=-Wall --ghc-options=-Werror` — 10/10
- `cabal build all --ghc-options=-Wall --ghc-options=-Werror`
- `cabal check` — no errors or warnings
- `cabal haddock all --haddock-all --haddock-hyperlink-source`
- HPC — strict decoder, renderer, and exit-2 handler ticked; 30% expression coverage for the pre-existing whole engine
- real executable invalid-fixture process — exit 2, empty stdout, exact stderr, no checkout-root disclosure
- `python -m unittest test_build_tool_conformance_schema test_build_tool_conformance_runner` — 57/57
- canonical Go build tool: `go test ./...`, `go vet ./...`, `go build -trimpath ./...`
- canonical Go Haskell-lane plan/BUILD validation — 205 packages, exit 0
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` — 1,238 identities, 4,386 slots, 15 established languages, zero collisions, zero unknown buckets
- `git diff --check`, JSON/state graph, generated-artifact, and changed-file credential checks

## Separately owned findings

- A broader `-Werror` probe over untouched graph tests reports five existing partial-pattern warnings; the changed build-tool suite is warning-clean and all suites pass normally.
- Real Lua-package hashing on Windows reaches a separate locale-sensitive `git hash-object` stdin failure (`commitBuffer` 0xc000014b). It is logged as `build-tool-haskell-binary-safe-source-hashing` rather than widening this metadata-decoding PR.
- The new Rust-only zero-capability `chief-of-staff-cli-core` is classified under a dependency-blocked portable-conformance owner; the new Rust SIR implementation fills an existing identity slot.