### PR TITLE
feat(chief): add fail-closed daemon scheduler

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -761,6 +761,7 @@ members = [
     "chief-of-staff-process-supervisor",
     "chief-of-staff-orchestrator-core",
     "chief-of-staff-daemon-api",
+    "chief-of-staff-daemon-runtime",
     "chief-of-staff-cli-core",
     "chief-of-staff-tool-api",
     "chief-of-staff-host-runtime",

--- a/code/packages/rust/chief-of-staff-daemon-api/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-api/CHANGELOG.md
@@ -8,3 +8,4 @@
 - Preserve separate durable and authoritative health evidence with precision-safe JSON encoding.
 - Add a typed blocking WebSocket client with strict response-ID and envelope validation.
 - Accept the owned lifetime-free orchestrator core at the threaded daemon boundary.
+- Add a local serialized reconciliation boundary for the fail-closed daemon scheduler.

--- a/code/packages/rust/chief-of-staff-daemon-api/README.md
+++ b/code/packages/rust/chief-of-staff-daemon-api/README.md
@@ -15,6 +15,10 @@ constructs typed host-lifecycle requests, checks response versions and IDs, and
 retains stable remote error codes without exposing remote details through its
 diagnostic display.
 
+`DaemonApi::reconcile_once` is the local scheduler boundary. It runs convergence
+through the same serialized control plane as authenticated requests without
+pretending that the daemon process is a remote session.
+
 ## Validation
 
 ```sh

--- a/code/packages/rust/chief-of-staff-daemon-api/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-api/src/lib.rs
@@ -215,6 +215,24 @@ impl<C, A> DaemonApi<C, A> {
     }
 }
 
+impl<C, A> DaemonApi<C, A>
+where
+    C: ChiefControlPlane,
+{
+    /// Run one local reconciliation tick through the same serialized control
+    /// plane used by authenticated WebSocket requests.
+    ///
+    /// This is the scheduler boundary for the outer daemon runtime. It does not
+    /// authenticate a remote session because it is invoked only by the process
+    /// that already owns the control plane.
+    pub fn reconcile_once(&self) -> Result<ReconcileReport, ControlPlaneError> {
+        self.control_plane
+            .lock()
+            .map_err(|_| ControlPlaneError::Internal)?
+            .reconcile_once()
+    }
+}
+
 /// Local API ownership failure.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DaemonApiError {
@@ -1694,6 +1712,12 @@ mod tests {
         fn deregister_host(&mut self, _host_name: &HostName) -> Result<(), ControlPlaneError> {
             Err(ControlPlaneError::Internal)
         }
+    }
+
+    #[test]
+    fn local_scheduler_reconciliation_uses_the_serialized_control_plane() {
+        let api = DaemonApi::new(EmptyControlPlane, TestAuthorizer::allowing());
+        assert_eq!(api.reconcile_once(), Err(ControlPlaneError::Internal));
     }
 
     #[cfg(any(

--- a/code/packages/rust/chief-of-staff-daemon-runtime/BUILD
+++ b/code/packages/rust/chief-of-staff-daemon-runtime/BUILD
@@ -1,0 +1,1 @@
+cargo test -p chief-of-staff-daemon-runtime -- --nocapture

--- a/code/packages/rust/chief-of-staff-daemon-runtime/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-runtime/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Add a mandatory startup reconciliation tick before the WebSocket listener serves.
+- Add non-zero periodic reconciliation through the daemon API's serialized control plane.
+- Stop serving and surface a stable error when background convergence fails.
+- Join the scheduler promptly during cooperative external shutdown.

--- a/code/packages/rust/chief-of-staff-daemon-runtime/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-daemon-runtime/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "chief-of-staff-daemon-runtime"
+version = "0.1.0"
+edition = "2021"
+description = "Fail-closed reconciliation scheduler and WebSocket serving runtime for D18 Chief"
+license = "MIT"
+
+[dependencies]
+chief-of-staff-daemon-api = { path = "../chief-of-staff-daemon-api" }
+transport-platform = { path = "../transport-platform" }
+websocket-runtime = { path = "../websocket-runtime" }
+
+[dev-dependencies]
+chief-of-staff-orchestrator-core = { path = "../chief-of-staff-orchestrator-core" }
+chief-of-staff-service-reconciler = { path = "../chief-of-staff-service-reconciler" }
+chief-of-staff-service-registry = { path = "../chief-of-staff-service-registry" }

--- a/code/packages/rust/chief-of-staff-daemon-runtime/README.md
+++ b/code/packages/rust/chief-of-staff-daemon-runtime/README.md
@@ -1,0 +1,18 @@
+# chief-of-staff-daemon-runtime
+
+`chief-of-staff-daemon-runtime` turns the authenticated D18 Chief WebSocket API
+into a continuously converging daemon. It runs one mandatory reconciliation
+tick before serving, schedules bounded ticks through the API's serialized
+control plane, and stops the listener if convergence fails.
+
+The package intentionally does not parse configuration, load identities or
+trusted keys, choose listener addresses, install OS services, or own secrets.
+Those remain outer composition adapters.
+
+## Validation
+
+```sh
+cargo test -p chief-of-staff-daemon-runtime -- --nocapture
+cargo clippy -p chief-of-staff-daemon-runtime --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-daemon-runtime --no-deps
+```

--- a/code/packages/rust/chief-of-staff-daemon-runtime/required_capabilities.json
+++ b/code/packages/rust/chief-of-staff-daemon-runtime/required_capabilities.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/chief-of-staff-daemon-runtime",
+  "capabilities": [
+    {
+      "category": "net",
+      "action": "listen",
+      "target": "*:*",
+      "justification": "Serves the authenticated Chief API on the caller-supplied WebSocket listener."
+    },
+    {
+      "category": "time",
+      "action": "read",
+      "target": "*",
+      "justification": "Measures the caller-supplied reconciliation interval using process-local monotonic waits."
+    },
+    {
+      "category": "time",
+      "action": "sleep",
+      "target": "*",
+      "justification": "Waits interruptibly between bounded reconciliation ticks."
+    }
+  ],
+  "justification": "Fail-closed daemon scheduling and serving over injected control-plane, transport, storage, process, identity, keyring, and authorization adapters."
+}

--- a/code/packages/rust/chief-of-staff-daemon-runtime/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-runtime/src/lib.rs
@@ -1,0 +1,480 @@
+//! Fail-closed scheduling and serving for the D18 Chief daemon.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use chief_of_staff_daemon_api::{
+    bind_daemon, BindAddress, ChiefControlPlane, ControlPlaneError, DaemonApi, DaemonSession,
+    SessionAuthorizer,
+};
+use core::fmt::{self, Display, Formatter};
+use std::net::SocketAddr;
+use std::panic::{self, AssertUnwindSafe};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+use transport_platform::TransportPlatform;
+use websocket_runtime::{
+    StopHandle, WebSocketRuntime, WebSocketRuntimeError, WebSocketServerOptions,
+};
+
+/// Validated cadence for bounded background reconciliation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReconcileSchedule {
+    interval: Duration,
+}
+
+impl ReconcileSchedule {
+    /// Construct a schedule with a non-zero interval.
+    pub fn new(interval: Duration) -> Result<Self, DaemonRuntimeError> {
+        if interval.is_zero() {
+            return Err(DaemonRuntimeError::InvalidSchedule);
+        }
+        Ok(Self { interval })
+    }
+
+    /// Return the interval between completed scheduling waits.
+    pub fn interval(self) -> Duration {
+        self.interval
+    }
+}
+
+/// Stable failure from daemon binding, scheduling, reconciliation, or serving.
+#[derive(Debug)]
+pub enum DaemonRuntimeError {
+    /// The reconciliation interval was zero.
+    InvalidSchedule,
+    /// Startup or background reconciliation failed.
+    Reconciliation(ControlPlaneError),
+    /// The operating system refused to create the scheduler thread.
+    SchedulerUnavailable,
+    /// The scheduler thread panicked.
+    SchedulerPanicked,
+    /// The WebSocket transport could not bind or serve.
+    Transport(WebSocketRuntimeError),
+}
+
+impl Display for DaemonRuntimeError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidSchedule => "chief daemon runtime: invalid reconciliation schedule",
+            Self::Reconciliation(_) => "chief daemon runtime: reconciliation failed",
+            Self::SchedulerUnavailable => "chief daemon runtime: scheduler unavailable",
+            Self::SchedulerPanicked => "chief daemon runtime: scheduler panicked",
+            Self::Transport(_) => "chief daemon runtime: transport failed",
+        })
+    }
+}
+
+impl std::error::Error for DaemonRuntimeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Transport(error) => Some(error),
+            Self::InvalidSchedule
+            | Self::Reconciliation(_)
+            | Self::SchedulerUnavailable
+            | Self::SchedulerPanicked => None,
+        }
+    }
+}
+
+impl From<WebSocketRuntimeError> for DaemonRuntimeError {
+    fn from(error: WebSocketRuntimeError) -> Self {
+        Self::Transport(error)
+    }
+}
+
+#[derive(Default)]
+struct SchedulerState {
+    stopped: bool,
+    failure: Option<ControlPlaneError>,
+}
+
+/// Authenticated WebSocket listener plus mandatory reconciliation scheduler.
+pub struct ChiefDaemonRuntime<P, C, A>
+where
+    A: SessionAuthorizer,
+{
+    websocket: WebSocketRuntime<P, DaemonSession<A::Session>>,
+    api: Arc<DaemonApi<C, A>>,
+    schedule: ReconcileSchedule,
+}
+
+impl<P, C, A> ChiefDaemonRuntime<P, C, A>
+where
+    P: TransportPlatform,
+    C: ChiefControlPlane + Send + 'static,
+    A: SessionAuthorizer + Send + Sync + 'static,
+    A::Session: Send + 'static,
+{
+    /// Bind the caller-supplied API and schedule to an explicit listener.
+    pub fn bind(
+        platform: P,
+        address: BindAddress,
+        options: WebSocketServerOptions,
+        api: Arc<DaemonApi<C, A>>,
+        schedule: ReconcileSchedule,
+    ) -> Result<Self, DaemonRuntimeError> {
+        let websocket = bind_daemon(platform, address, options, Arc::clone(&api))?;
+        Ok(Self {
+            websocket,
+            api,
+            schedule,
+        })
+    }
+
+    /// Return the concrete local address selected by the listener.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.websocket.local_addr()
+    }
+
+    /// Return a cooperative handle that stops serving and wakes the scheduler.
+    pub fn stop_handle(&self) -> StopHandle {
+        self.websocket.stop_handle()
+    }
+
+    /// Reconcile once before serving, then run periodic fail-closed convergence.
+    pub fn serve(&mut self) -> Result<(), DaemonRuntimeError> {
+        self.api
+            .reconcile_once()
+            .map_err(DaemonRuntimeError::Reconciliation)?;
+
+        let state = Arc::new((Mutex::new(SchedulerState::default()), Condvar::new()));
+        let scheduler = spawn_scheduler(
+            Arc::clone(&self.api),
+            self.schedule,
+            Arc::clone(&state),
+            self.websocket.stop_handle(),
+        )?;
+        let transport_result = self.websocket.serve();
+        request_scheduler_stop(&state);
+        if scheduler.join().is_err() {
+            return Err(DaemonRuntimeError::SchedulerPanicked);
+        }
+        let failure = lock_state(&state).failure;
+        if let Some(error) = failure {
+            return Err(DaemonRuntimeError::Reconciliation(error));
+        }
+        transport_result.map_err(DaemonRuntimeError::Transport)
+    }
+}
+
+fn spawn_scheduler<C, A>(
+    api: Arc<DaemonApi<C, A>>,
+    schedule: ReconcileSchedule,
+    state: Arc<(Mutex<SchedulerState>, Condvar)>,
+    server_stop: StopHandle,
+) -> Result<JoinHandle<()>, DaemonRuntimeError>
+where
+    C: ChiefControlPlane + Send + 'static,
+    A: SessionAuthorizer + Send + Sync + 'static,
+{
+    thread::Builder::new()
+        .name("chief-reconcile".to_string())
+        .spawn(move || {
+            let panic_state = Arc::clone(&state);
+            let panic_stop = server_stop.clone();
+            let result = panic::catch_unwind(AssertUnwindSafe(|| {
+                scheduler_loop(api, schedule, state, server_stop);
+            }));
+            if let Err(payload) = result {
+                request_scheduler_stop(&panic_state);
+                panic_stop.stop();
+                panic::resume_unwind(payload);
+            }
+        })
+        .map_err(|_| DaemonRuntimeError::SchedulerUnavailable)
+}
+
+fn scheduler_loop<C, A>(
+    api: Arc<DaemonApi<C, A>>,
+    schedule: ReconcileSchedule,
+    state: Arc<(Mutex<SchedulerState>, Condvar)>,
+    server_stop: StopHandle,
+) where
+    C: ChiefControlPlane,
+    A: SessionAuthorizer,
+{
+    let (lock, wake) = &*state;
+    loop {
+        let guard = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let (guard, _) = wake
+            .wait_timeout_while(guard, schedule.interval(), |state| !state.stopped)
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if guard.stopped {
+            return;
+        }
+        drop(guard);
+
+        if let Err(error) = api.reconcile_once() {
+            let mut guard = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+            guard.failure = Some(error);
+            guard.stopped = true;
+            wake.notify_all();
+            server_stop.stop();
+            return;
+        }
+    }
+}
+
+fn request_scheduler_stop(state: &Arc<(Mutex<SchedulerState>, Condvar)>) {
+    let (lock, wake) = &**state;
+    lock.lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .stopped = true;
+    wake.notify_all();
+}
+
+fn lock_state(
+    state: &Arc<(Mutex<SchedulerState>, Condvar)>,
+) -> std::sync::MutexGuard<'_, SchedulerState> {
+    state
+        .0
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chief_of_staff_daemon_api::Operation;
+    use chief_of_staff_orchestrator_core::HostHealth;
+    use chief_of_staff_service_reconciler::ReconcileReport;
+    use chief_of_staff_service_registry::{DesiredState, HostName, HostRegistration, LoadedHost};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Instant;
+
+    struct TestAuthorizer;
+
+    impl SessionAuthorizer for TestAuthorizer {
+        type Session = ();
+        type Error = ();
+
+        fn authenticate(&self, credential: &str) -> Result<Self::Session, Self::Error> {
+            if credential == "secret" {
+                Ok(())
+            } else {
+                Err(())
+            }
+        }
+
+        fn authorize(
+            &self,
+            _session: &Self::Session,
+            _operation: Operation,
+        ) -> Result<bool, Self::Error> {
+            Ok(true)
+        }
+    }
+
+    struct CountingControlPlane {
+        reconciliations: Arc<AtomicUsize>,
+        fail_at: usize,
+        panic_at: usize,
+    }
+
+    impl CountingControlPlane {
+        fn new(reconciliations: Arc<AtomicUsize>, fail_at: usize) -> Self {
+            Self {
+                reconciliations,
+                fail_at,
+                panic_at: usize::MAX,
+            }
+        }
+
+        fn panicking_at(reconciliations: Arc<AtomicUsize>, panic_at: usize) -> Self {
+            Self {
+                reconciliations,
+                fail_at: usize::MAX,
+                panic_at,
+            }
+        }
+    }
+
+    impl ChiefControlPlane for CountingControlPlane {
+        fn register_host(
+            &mut self,
+            _registration: HostRegistration,
+            _desired_state: DesiredState,
+        ) -> Result<LoadedHost, ControlPlaneError> {
+            Err(ControlPlaneError::Internal)
+        }
+
+        fn list_hosts(&mut self) -> Result<Vec<LoadedHost>, ControlPlaneError> {
+            Ok(Vec::new())
+        }
+
+        fn set_desired_state(
+            &mut self,
+            _host_name: &HostName,
+            _desired_state: DesiredState,
+        ) -> Result<LoadedHost, ControlPlaneError> {
+            Err(ControlPlaneError::NotFound)
+        }
+
+        fn reconcile_once(&mut self) -> Result<ReconcileReport, ControlPlaneError> {
+            let count = self.reconciliations.fetch_add(1, Ordering::SeqCst) + 1;
+            assert_ne!(count, self.panic_at, "deliberate scheduler panic");
+            if count == self.fail_at {
+                Err(ControlPlaneError::Internal)
+            } else {
+                Ok(ReconcileReport::empty())
+            }
+        }
+
+        fn health_check(&mut self, _host_name: &HostName) -> Result<HostHealth, ControlPlaneError> {
+            Err(ControlPlaneError::NotFound)
+        }
+
+        fn deregister_host(&mut self, _host_name: &HostName) -> Result<(), ControlPlaneError> {
+            Err(ControlPlaneError::NotFound)
+        }
+    }
+
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly"
+    ))]
+    type HostPlatform = transport_platform::bsd::KqueueTransportPlatform;
+    #[cfg(target_os = "linux")]
+    type HostPlatform = transport_platform::linux::EpollTransportPlatform;
+    #[cfg(target_os = "windows")]
+    type HostPlatform = transport_platform::windows::WindowsTransportPlatform;
+
+    fn host_platform() -> HostPlatform {
+        HostPlatform::new().expect("host platform")
+    }
+
+    fn runtime(
+        reconciliations: Arc<AtomicUsize>,
+        fail_at: usize,
+        interval: Duration,
+    ) -> ChiefDaemonRuntime<HostPlatform, CountingControlPlane, TestAuthorizer> {
+        runtime_for(
+            CountingControlPlane::new(reconciliations, fail_at),
+            interval,
+        )
+    }
+
+    fn runtime_for(
+        control_plane: CountingControlPlane,
+        interval: Duration,
+    ) -> ChiefDaemonRuntime<HostPlatform, CountingControlPlane, TestAuthorizer> {
+        let api = Arc::new(DaemonApi::new(control_plane, TestAuthorizer));
+        ChiefDaemonRuntime::bind(
+            host_platform(),
+            BindAddress::Ip("127.0.0.1:0".parse().unwrap()),
+            WebSocketServerOptions::default(),
+            api,
+            ReconcileSchedule::new(interval).unwrap(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn zero_schedule_is_rejected() {
+        assert!(matches!(
+            ReconcileSchedule::new(Duration::ZERO),
+            Err(DaemonRuntimeError::InvalidSchedule)
+        ));
+    }
+
+    #[test]
+    fn public_errors_have_stable_payload_blind_diagnostics() {
+        let cases = [
+            (
+                DaemonRuntimeError::InvalidSchedule,
+                "chief daemon runtime: invalid reconciliation schedule",
+            ),
+            (
+                DaemonRuntimeError::Reconciliation(ControlPlaneError::Internal),
+                "chief daemon runtime: reconciliation failed",
+            ),
+            (
+                DaemonRuntimeError::SchedulerUnavailable,
+                "chief daemon runtime: scheduler unavailable",
+            ),
+            (
+                DaemonRuntimeError::SchedulerPanicked,
+                "chief daemon runtime: scheduler panicked",
+            ),
+        ];
+        for (error, expected) in cases {
+            assert_eq!(error.to_string(), expected);
+            assert!(std::error::Error::source(&error).is_none());
+        }
+
+        let error = DaemonRuntimeError::from(WebSocketRuntimeError::InvalidOptions);
+        assert_eq!(error.to_string(), "chief daemon runtime: transport failed");
+        assert!(std::error::Error::source(&error).is_some());
+    }
+
+    #[test]
+    fn startup_reconciliation_failure_prevents_serving() {
+        let reconciliations = Arc::new(AtomicUsize::new(0));
+        let mut runtime = runtime(Arc::clone(&reconciliations), 1, Duration::from_millis(5));
+        assert!(runtime.local_addr().ip().is_loopback());
+
+        assert!(matches!(
+            runtime.serve(),
+            Err(DaemonRuntimeError::Reconciliation(
+                ControlPlaneError::Internal
+            ))
+        ));
+        assert_eq!(reconciliations.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn background_failure_stops_server_and_surfaces_error() {
+        let reconciliations = Arc::new(AtomicUsize::new(0));
+        let mut runtime = runtime(Arc::clone(&reconciliations), 2, Duration::from_millis(5));
+
+        assert!(matches!(
+            runtime.serve(),
+            Err(DaemonRuntimeError::Reconciliation(
+                ControlPlaneError::Internal
+            ))
+        ));
+        assert_eq!(reconciliations.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn periodic_ticks_and_external_stop_join_scheduler_promptly() {
+        let reconciliations = Arc::new(AtomicUsize::new(0));
+        let mut runtime = runtime(
+            Arc::clone(&reconciliations),
+            usize::MAX,
+            Duration::from_millis(5),
+        );
+        let stop = runtime.stop_handle();
+        let server = thread::spawn(move || runtime.serve());
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while reconciliations.load(Ordering::SeqCst) < 3 && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(1));
+        }
+        assert!(reconciliations.load(Ordering::SeqCst) >= 3);
+
+        let stopped_at = Instant::now();
+        stop.stop();
+        assert!(server.join().unwrap().is_ok());
+        assert!(stopped_at.elapsed() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn scheduler_panic_stops_server_and_is_reported() {
+        let reconciliations = Arc::new(AtomicUsize::new(0));
+        let mut runtime = runtime_for(
+            CountingControlPlane::panicking_at(Arc::clone(&reconciliations), 2),
+            Duration::from_millis(5),
+        );
+
+        assert!(matches!(
+            runtime.serve(),
+            Err(DaemonRuntimeError::SchedulerPanicked)
+        ));
+        assert_eq!(reconciliations.load(Ordering::SeqCst), 2);
+    }
+}

--- a/code/packages/rust/chief-of-staff-service-reconciler/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-service-reconciler/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Add authoritative supervisor observations with package identity and heartbeat validation.
 - Add first-launch, restart-policy, quarantine, and crash-recovery state transitions.
 - Claim one bounded start or stop mutation per host before invoking the supervisor.
+- Add an explicit empty-registry report constructor for adapters and deterministic tests.

--- a/code/packages/rust/chief-of-staff-service-reconciler/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-service-reconciler/src/lib.rs
@@ -326,6 +326,13 @@ pub struct ReconcileReport {
 }
 
 impl ReconcileReport {
+    /// Construct the report produced by reconciling an empty registry.
+    pub fn empty() -> Self {
+        Self {
+            outcomes: Vec::new(),
+        }
+    }
+
     /// Borrow every per-host outcome in registry order.
     pub fn outcomes(&self) -> &[HostReconcileOutcome] {
         &self.outcomes
@@ -899,6 +906,11 @@ mod tests {
     use storage_core::InMemoryStorageBackend;
 
     const NOW: u64 = 1_000;
+
+    #[test]
+    fn empty_report_has_no_outcomes() {
+        assert!(ReconcileReport::empty().outcomes().is_empty());
+    }
 
     #[derive(Clone, Debug, PartialEq, Eq)]
     struct FakeError(&'static str);

--- a/code/specs/chief-of-staff-daemon-runtime.md
+++ b/code/specs/chief-of-staff-daemon-runtime.md
@@ -1,0 +1,89 @@
+# D18 Chief Daemon Runtime
+
+## Status
+
+This document specifies the fail-closed scheduling and serving boundary for the
+D18 Chief daemon.
+
+The Rust implementation package is `chief-of-staff-daemon-runtime`.
+
+## Purpose
+
+The runtime binds the authenticated `chief-of-staff-daemon-api` WebSocket
+listener to the bounded reconciliation operation owned by the same serialized
+control plane. It turns the request-driven API into a continuously converging
+daemon without moving durable state, process authority, channel keys, message
+payloads, or trust decisions into the scheduler.
+
+Configuration-file parsing, concrete identity and trusted-key loading, the final
+executable, OS service installation, pipeline wiring, and streaming operations
+remain later adapters.
+
+## Construction
+
+The caller supplies:
+
+- a concrete `TransportPlatform`;
+- an explicit listener `BindAddress` and WebSocket options;
+- an owned `Arc<DaemonApi<C, A>>`; and
+- a validated non-zero reconciliation interval.
+
+Binding opens only the explicitly supplied listener. It does not select a
+wildcard address, read environment variables, discover a home directory, or
+load configuration.
+
+## Startup Ordering
+
+`serve` performs one synchronous reconciliation tick before accepting any
+WebSocket request. If that tick fails, the listener never serves and the exact
+failure category is returned to the caller.
+
+This startup tick is mandatory. Persisted PIDs, statuses, heartbeats, and
+control-channel identifiers are historical evidence, not live process
+authority after a daemon restart.
+
+## Background Scheduling
+
+After successful startup reconciliation, one scheduler thread waits for the
+configured interval and invokes the same serialized `DaemonApi::reconcile_once`
+boundary. WebSocket requests and scheduled ticks cannot concurrently mutate the
+control plane because both use its existing mutex.
+
+Each tick remains bounded by the orchestrator core. The scheduler never loops
+inside a reconciliation operation and does not inspect payloads or keys.
+
+## Failure and Shutdown
+
+A background reconciliation failure is fatal for the serving runtime. The
+scheduler requests cooperative WebSocket shutdown, the serving thread joins the
+scheduler, and `serve` returns a stable reconciliation error. Continuing to
+accept lifecycle commands while convergence is unavailable would present a
+misleadingly healthy control surface.
+
+An external WebSocket stop request also wakes and joins the scheduler without
+waiting for the full reconciliation interval. No detached scheduler thread may
+outlive `serve`.
+
+Transport failure, reconciliation failure, invalid configuration, and scheduler
+panic remain distinct stable error categories. Diagnostics contain no request
+contents, package bytes, credentials, key material, or message payloads.
+
+## Capabilities
+
+The runtime listens through the already-declared WebSocket transport and reads
+or waits on process-local time for scheduling. Concrete storage, process,
+randomness, identity, keyring, and authorization adapters retain their own
+capability declarations.
+
+## Required Tests
+
+The package must cover:
+
+- rejection of a zero reconciliation interval;
+- successful startup reconciliation before serving;
+- startup failure before any request is accepted;
+- periodic reconciliation through the shared serialized control plane;
+- fatal background failure stopping the listener and surfacing the failure; and
+- cooperative external shutdown joining the scheduler promptly.
+
+The package forbids unsafe code and targets at least 95 percent line coverage.


### PR DESCRIPTION
## Summary

- add a daemon runtime that performs mandatory reconciliation before serving authenticated WebSocket requests
- schedule periodic bounded convergence through the same serialized control plane used by remote lifecycle operations
- fail closed by stopping the listener when background reconciliation fails or the scheduler panics
- wake and join the scheduler during cooperative shutdown so no detached convergence thread survives the server
- add stable payload-blind errors, capability metadata, package documentation, and a governing spec

This is the scheduling prerequisite for the final config/composition binary and OS service installers.

## Validation

- 53 targeted and downstream tests across daemon runtime/API, reconciler, orchestrator core, and CLI core
- strict Clippy on all changed Rust packages
- warning-free rustdoc on all changed Rust packages
- 98.81% line coverage for `chief-of-staff-daemon-runtime`
- repository build planner: 3 changed packages, 55 affected, Rust only

Part of #128.
Advances #138.
