### PR TITLE
feat(human-languages): publish canonical Portuguese chapters

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -83,9 +83,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B13 | Complete (#9711) | Remove Bengali's missing glyphs and LaTeX layout/bookmark warnings. | Main-font punctuation, stable recap labels, bookmark-safe Bengali, natural page bottoms, explicit static-font shapes, and a breakable long title make the forced six-chapter build warning-free. |
 | HL-I01 | Complete (#9715) | Reduce unified all-books workflow setup time without splitting the single publication bundle. | A focused, preflighted XeLaTeX dependency closure replaces `texlive-full`; the unchanged job still builds all 20 books, verifies one bundle, and publishes that bundle from `main`. |
 | HL-B14 | Complete (#9728) | Publish Italian Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Forty-nine schema-v2 lessons now generate sixteen chapters whose source hashes are independently verified against the Language Ladder corpus. |
-| HL-B15 | Complete in this PR | Remove Italian's LaTeX layout and Unicode bookmark warnings. | The forced 104-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
-| HL-B16 | Next | Publish Portuguese Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Portuguese has canonical app content through Chapter 17, but its downloadable PDF contains only Chapter 1; schema-v2 migration plus generation should close that drift safely. |
-| HL-B17 | Queued | Remove Portuguese's LaTeX layout warnings. | A forced build succeeds with no missing glyphs, overfull boxes, duplicate labels, or Hyperref warnings, but reports three underfull boxes; the clean-build signal is zero. |
+| HL-B15 | Complete (#9735) | Remove Italian's LaTeX layout and Unicode bookmark warnings. | The forced 104-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
+| HL-B16 | Complete in this PR | Publish Portuguese Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Fifty schema-v2 lessons now generate sixteen chapters whose source hashes are independently verified against the Language Ladder corpus. |
+| HL-B17 | Next | Remove Portuguese's LaTeX layout warnings. | The expanded 105-page build has zero missing glyphs, duplicate destinations, Hyperref warnings, or LaTeX warnings, but reports six overfull boxes and thirteen underfull boxes; the clean-build signal is zero of each. |
 | HL-B18 | Queued | Publish French Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | The French PDF reaches Chapter 16 while canonical app content continues through Chapter 23; schema-v2 migration plus generation should close that drift safely. |
 | HL-B19 | Queued | Remove French's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs or duplicate labels but reports sixteen overfull boxes, nine underfull boxes, and six Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B20 | Queued | Publish German Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | The German PDF reaches Chapter 16 while canonical app content continues through Chapter 23; schema-v2 migration plus generation should close that drift safely. |
@@ -568,6 +568,31 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   and no schema or source-hash metadata leaks into extracted text.
 - HL-B16 is next: migrate Portuguese Chapters 2–17 to the same strict schema-v2
   lesson AST and publish them through the shared book/app generation path.
+
+## Findings from HL-B16
+
+- Portuguese Chapters 2–17 now comprise 50 strict schema-v2 micro-lessons with
+  explicit shared-spine anchors, prerequisite-closed knowledge atoms, typed
+  teaching blocks, and authored skill, mode, strand, register, variety, and
+  duration contracts. Chapter 1 remains readable legacy content while the
+  one-source migration proceeds incrementally.
+- All 50 migrated lessons remain below five minutes: computed durations span
+  141–298 seconds, with `PT-C17-mao` the tightest. Curriculum validation reports
+  zero duration violations and zero unknown or misordered prerequisites.
+- Sixteen deterministic generation targets now publish Chapters 2–17 from the
+  same lesson AST loaded by Language Ladder. Their manifest covers all 50
+  lessons, and app tests independently reproduce every chapter hash and lesson
+  count. Repository-wide missing book chapters fall from 236 to 220.
+- Chapter 4 preserves Arabic `حتى` beside transliterated *ḥattā*. Its generated
+  run now uses the repository-vendored Noto Naskh Arabic font, preventing the
+  Latin-only PDF path from silently dropping source-script evidence.
+- A forced XeLaTeX build produces a 105-page book with zero missing glyphs,
+  duplicate destinations, Hyperref warnings, LaTeX warnings, or leaked
+  generator metadata. All pages were rendered and inspected; the outline
+  retains Preface, pronunciation, and Chapters 1–17.
+- Six overfull boxes and thirteen underfull boxes remain in the expanded book.
+  HL-B17 is next and records this measured 105-page presentation debt rather
+  than the old 13-page baseline.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -156,6 +156,120 @@
       "output": "italian/book/chapters/ch17-head-and-hand.tex"
     },
     {
+      "language": "portuguese",
+      "chapter": 2,
+      "title": "How Are You?",
+      "label": "ch:pt-how-are-you",
+      "output": "portuguese/book/chapters/ch02-how-are-you.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 3,
+      "title": "Introducing Yourself",
+      "label": "ch:pt-introductions",
+      "output": "portuguese/book/chapters/ch03-introductions.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 4,
+      "title": "Farewells",
+      "label": "ch:pt-farewells",
+      "output": "portuguese/book/chapters/ch04-farewells.tex",
+      "unicodeScript": "Arabic",
+      "scriptCommand": "ptar"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 5,
+      "title": "The First Verbs",
+      "label": "ch:pt-first-verbs",
+      "output": "portuguese/book/chapters/ch05-first-verbs.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 6,
+      "title": "Numbers One to Ten",
+      "label": "ch:pt-numbers-one-to-ten",
+      "output": "portuguese/book/chapters/ch06-numbers-1-10.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 7,
+      "title": "Days of the Week",
+      "label": "ch:pt-days-of-the-week",
+      "output": "portuguese/book/chapters/ch07-days-of-the-week.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 8,
+      "title": "Telling Time",
+      "label": "ch:pt-telling-time",
+      "output": "portuguese/book/chapters/ch08-telling-time.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 9,
+      "title": "Months and Seasons",
+      "label": "ch:pt-months-and-seasons",
+      "output": "portuguese/book/chapters/ch09-months-and-seasons.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 10,
+      "title": "Family",
+      "label": "ch:pt-family",
+      "output": "portuguese/book/chapters/ch10-family.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 11,
+      "title": "Bread, Water, and Wine",
+      "label": "ch:pt-bread-water-wine",
+      "output": "portuguese/book/chapters/ch11-bread-water-wine.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 12,
+      "title": "Numbers Eleven to Twenty",
+      "label": "ch:pt-numbers-eleven-to-twenty",
+      "output": "portuguese/book/chapters/ch12-numbers-11-20.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 13,
+      "title": "Colours",
+      "label": "ch:pt-colours",
+      "output": "portuguese/book/chapters/ch13-colours.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 14,
+      "title": "Having and Telling Your Age",
+      "label": "ch:pt-having-and-age",
+      "output": "portuguese/book/chapters/ch14-having-and-age.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 15,
+      "title": "The Past Portuguese Kept",
+      "label": "ch:pt-past-portuguese-kept",
+      "output": "portuguese/book/chapters/ch15-past-portuguese-kept.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 16,
+      "title": "Ser and Estar",
+      "label": "ch:pt-ser-and-estar",
+      "output": "portuguese/book/chapters/ch16-ser-and-estar.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 17,
+      "title": "Head and Hand",
+      "label": "ch:pt-head-and-hand",
+      "output": "portuguese/book/chapters/ch17-head-and-hand.tex"
+    },
+    {
       "language": "bengali",
       "chapter": 6,
       "title": "Numbers One to Five",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -209,6 +209,184 @@
       "tex": "marathi/book/chapters/ch06-numbers-1-5.tex"
     },
     {
+      "language": "portuguese",
+      "chapter": 2,
+      "sourceHash": "fnv1a64:b1f0b2f2afaf849c",
+      "lessonIds": [
+        "PT-C02-de-nada",
+        "PT-C02-como",
+        "PT-C02-tudo",
+        "PT-C02-tudo-bem",
+        "PT-C02-como-vai-esta",
+        "PT-C02-mais-ou-menos",
+        "PT-C02-practice",
+        "PT-C02-formal-practice"
+      ],
+      "tex": "portuguese/book/chapters/ch02-how-are-you.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 3,
+      "sourceHash": "fnv1a64:fe554312c9530dd0",
+      "lessonIds": [
+        "PT-C03-eu",
+        "PT-C03-me-chamo",
+        "PT-C03-como-se-chama",
+        "PT-C03-prazer",
+        "PT-C03-practice"
+      ],
+      "tex": "portuguese/book/chapters/ch03-introductions.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 4,
+      "sourceHash": "fnv1a64:5525ef6075d2060a",
+      "lessonIds": [
+        "PT-C04-adeus",
+        "PT-C04-ate-logo",
+        "PT-C04-ate-amanha",
+        "PT-C04-ate-breve",
+        "PT-C04-practice"
+      ],
+      "tex": "portuguese/book/chapters/ch04-farewells.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 5,
+      "sourceHash": "fnv1a64:fca2fd8fd1da3e96",
+      "lessonIds": [
+        "PT-C05-falar",
+        "PT-C05-morar",
+        "PT-C05-trabalhar",
+        "PT-C05-falo-portugues",
+        "PT-C05-practice"
+      ],
+      "tex": "portuguese/book/chapters/ch05-first-verbs.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 6,
+      "sourceHash": "fnv1a64:e500f5a113192fbf",
+      "lessonIds": [
+        "PT-C06-numeros-1-5",
+        "PT-C06-numeros-6-10"
+      ],
+      "tex": "portuguese/book/chapters/ch06-numbers-1-10.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 7,
+      "sourceHash": "fnv1a64:b504ffa532cad313",
+      "lessonIds": [
+        "PT-C07-dias-1",
+        "PT-C07-dias-2"
+      ],
+      "tex": "portuguese/book/chapters/ch07-days-of-the-week.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 8,
+      "sourceHash": "fnv1a64:074f8f7eba5b6b2a",
+      "lessonIds": [
+        "PT-C08-hora",
+        "PT-C08-meio-dia-meia-noite"
+      ],
+      "tex": "portuguese/book/chapters/ch08-telling-time.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 9,
+      "sourceHash": "fnv1a64:565993042600b26d",
+      "lessonIds": [
+        "PT-C09-meses",
+        "PT-C09-estacoes"
+      ],
+      "tex": "portuguese/book/chapters/ch09-months-and-seasons.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 10,
+      "sourceHash": "fnv1a64:756b61183a892e04",
+      "lessonIds": [
+        "PT-C10-pais",
+        "PT-C10-irmaos"
+      ],
+      "tex": "portuguese/book/chapters/ch10-family.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 11,
+      "sourceHash": "fnv1a64:45ea90ec38957e5b",
+      "lessonIds": [
+        "PT-C11-pao",
+        "PT-C11-agua-vinho"
+      ],
+      "tex": "portuguese/book/chapters/ch11-bread-water-wine.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 12,
+      "sourceHash": "fnv1a64:d62ea89555f0cfaf",
+      "lessonIds": [
+        "PT-C12-numeros-11-15",
+        "PT-C12-numeros-16-20"
+      ],
+      "tex": "portuguese/book/chapters/ch12-numbers-11-20.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 13,
+      "sourceHash": "fnv1a64:bde0638b592353e1",
+      "lessonIds": [
+        "PT-C13-preto-branco",
+        "PT-C13-vermelho-azul"
+      ],
+      "tex": "portuguese/book/chapters/ch13-colours.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 14,
+      "sourceHash": "fnv1a64:5dd21c93ee684761",
+      "lessonIds": [
+        "PT-C14-ter",
+        "PT-C14-idade"
+      ],
+      "tex": "portuguese/book/chapters/ch14-having-and-age.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 15,
+      "sourceHash": "fnv1a64:6126b552a3d85de0",
+      "lessonIds": [
+        "PT-C15-preterito-perfeito",
+        "PT-C15-tenho-falado"
+      ],
+      "tex": "portuguese/book/chapters/ch15-past-portuguese-kept.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 16,
+      "sourceHash": "fnv1a64:bc608ce25d6412a4",
+      "lessonIds": [
+        "PT-C16-ser",
+        "PT-C16-ser-roots",
+        "PT-C16-ser-vs-estar",
+        "PT-C16-ser-estar-meaning"
+      ],
+      "tex": "portuguese/book/chapters/ch16-ser-and-estar.tex"
+    },
+    {
+      "language": "portuguese",
+      "chapter": 17,
+      "sourceHash": "fnv1a64:dff69b7e6fc4d902",
+      "lessonIds": [
+        "PT-C17-cabeca",
+        "PT-C17-cabeca-caput",
+        "PT-C17-mao"
+      ],
+      "tex": "portuguese/book/chapters/ch17-head-and-hand.tex"
+    },
+    {
       "language": "punjabi",
       "chapter": 6,
       "sourceHash": "fnv1a64:f165e75f6db9bbe5",

--- a/code/learning/human-languages/portuguese/CHANGELOG.md
+++ b/code/learning/human-languages/portuguese/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Canonical book Chapters 2–17 — 2026-08-03
+
+- Migrated all 50 lessons in Chapters 2–17 to strict schema v2 with unique
+  sequence, shared-spine anchors, prerequisite-closed knowledge atoms, typed
+  blocks, explicit coverage metadata, and computed durations below five
+  minutes.
+- Added sixteen deterministic LaTeX generation targets and matching Language
+  Ladder hash tests. The downloadable book and app now consume the same lesson
+  AST and independently agree on every chapter's canonical source fingerprint.
+- Expanded the book from Chapter 1 to all seventeen chapters (105 pages) while
+  preserving the original vocabulary, grammar, usage, and etymological depth.
+- Preserved Arabic `حتى` beside *ḥattā* and render it with the same vendored
+  Noto Naskh Arabic font used by the Arabic-script tracks, eliminating a
+  learner-visible missing-glyph defect without weakening the canonical text.
+- Recorded the expanded layout baseline in HL-B17: six overfull and thirteen
+  underfull boxes remain, with no missing glyphs, duplicate destinations,
+  Hyperref warnings, or LaTeX warnings.
+
 ## Sub-five-minute remediation — 2026-08-02
 
 - Corrected eighteen declared five-minute estimates whose lesson bodies already

--- a/code/learning/human-languages/portuguese/README.md
+++ b/code/learning/human-languages/portuguese/README.md
@@ -20,14 +20,18 @@ uniquely agrees with the **speaker**, not the listener.
 
 - **Chapter 1 — Greetings** ([`lessons/PT-C01-*`](./lessons/)): olá, bom/boa,
   o/a (gender), dia, bom dia, tarde/boa tarde, noite/boa noite,
-  obrigado/obrigada, practice. In the book.
-- **Chapter 2 — Introducing Yourself** (planned): *o meu nome é… / chamo-me…*,
-  *tu* vs. *você*.
+  obrigado/obrigada, practice. Legacy canonical lessons; in the book.
+- **Chapters 2–17**: 50 prerequisite-ordered schema-v2 micro-lessons spanning
+  conversation, verbs, numbers, time, family, food, colours, possession, past
+  tense, *ser/estar*, and the body. Every lesson is below five minutes and every
+  chapter is generated from the same typed lesson AST consumed by Language
+  Ladder.
 
 ## Book
 
-Compiles with XeLaTeX (Latin Modern, no vendored font needed). `latexmk
--xelatex book.tex`.
+The 105-page edition compiles with XeLaTeX. It uses Latin Modern for Portuguese
+and the repository-vendored Noto Naskh Arabic only for preserved Arabic source
+forms in the etymology. Run `latexmk -xelatex book.tex`.
 
 ## Files
 

--- a/code/learning/human-languages/portuguese/book/book.tex
+++ b/code/learning/human-languages/portuguese/book/book.tex
@@ -59,4 +59,36 @@ under CC~BY-SA~4.0.
 
 \input{chapters/ch01-greetings}
 
+\input{chapters/ch02-how-are-you}
+
+\input{chapters/ch03-introductions}
+
+\input{chapters/ch04-farewells}
+
+\input{chapters/ch05-first-verbs}
+
+\input{chapters/ch06-numbers-1-10}
+
+\input{chapters/ch07-days-of-the-week}
+
+\input{chapters/ch08-telling-time}
+
+\input{chapters/ch09-months-and-seasons}
+
+\input{chapters/ch10-family}
+
+\input{chapters/ch11-bread-water-wine}
+
+\input{chapters/ch12-numbers-11-20}
+
+\input{chapters/ch13-colours}
+
+\input{chapters/ch14-having-and-age}
+
+\input{chapters/ch15-past-portuguese-kept}
+
+\input{chapters/ch16-ser-and-estar}
+
+\input{chapters/ch17-head-and-hand}
+
 \end{document}

--- a/code/learning/human-languages/portuguese/book/chapters/ch02-how-are-you.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch02-how-are-you.tex
@@ -1,0 +1,404 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:b1f0b2f2afaf849c
+% canonical-lessons: PT-C02-de-nada, PT-C02-como, PT-C02-tudo, PT-C02-tudo-bem, PT-C02-como-vai-esta, PT-C02-mais-ou-menos, PT-C02-practice, PT-C02-formal-practice
+
+\chapter{How Are You?}
+\label{ch:pt-how-are-you}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[de nada]{de nada — "you're welcome," or "it was nothing"}
+
+\label{lesson:PT-C02-de-nada}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You already say \textbf{obrigado / obrigada} ("I am obliged"). The reply that closes the exchange is \textbf{de nada} — "of nothing" — the very same phrase, word for word, as Spanish.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{final-a-reduces} — \textbf{de nada} $\approx$ \emph{dee NAH-duh}: unstressed final \emph{-a} softens toward \emph{uh}; the \emph{d} is soft.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{de} = "of / from" (Latin \textbf{dē}).
+  \item \textbf{nada} = "nothing" — and it has the same buried story as its Spanish twin.
+\end{itemize}
+
+\textbf{nada} comes from Latin \textbf{(rēs) nāta}, \emph{"a born thing"} — from \emph{nāscī}, "to be born" (English \textbf{nat}ive, \textbf{nat}ure, \textbf{nat}al, re-\textbf{nais-sance}). Latin \emph{nōn … rēs nāta}, "not a single born thing," wore down until the "born thing" word, \textbf{nada}, came to mean \textbf{nothing} by itself.
+
+Portuguese and Spanish inherited the identical word and the identical courtesy:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{"you're welcome"} & \textbf{the "nothing" word} \\
+\midrule
+\textbf{Portuguese} & \emph{de nada} & \emph{nada} $\leftarrow$ \emph{nāta}, "a born thing" \\
+\textbf{Spanish} & \emph{de nada} & \emph{nada} $\leftarrow$ \emph{nāta}, "a born thing" \\
+\textbf{French} & \emph{de rien} & \emph{rien} $\leftarrow$ \emph{rem}, "a thing" \\
+\bottomrule
+\end{tabularx}
+
+So Iberia says "of no \emph{born-thing}"; France says "of no \emph{thing}." Same shrug of the shoulders, one Latin idea.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "obrigado / obrigada" … "de nada" — the full exchange{]}
+  \item {[}YOU SAY: "de nada" then English "native, nature" — nada's true family{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What did \emph{nada} originally mean in Latin? (A \emph{born thing} — \emph{nāta}.) Which language shares \emph{de nada} exactly, and which uses \emph{de rien} instead? (Spanish; French.) Next: \textbf{como}, "how."
+\end{tcolorbox}
+\section[como]{como — "how," the fourth \emph{quomodo} cousin}
+
+\label{lesson:PT-C02-como}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} One of two everyday ways to ask \emph{how are you?} in Portuguese starts with \textbf{como}, "how." It's the same word you've met (or will meet) across the Romance family.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{final-o-is-u} — \textbf{como} = \emph{KOH-moo}: the final unstressed \emph{-o} is said like \emph{u}. (Portuguese does this to nearly every final \emph{-o}: \emph{obrigado} $\to$ \emph{-doo}.)
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{como} = "how / like / as." Root: Latin \textbf{quōmodo}, "in what manner" — \emph{quō} ("in what way") + \emph{modo} ("manner"). It is the \textbf{same source} as its siblings:
+
+\begin{itemize}
+\raggedright
+  \item Spanish \textbf{cómo}, Italian \textbf{come}, French \textbf{comment} — all "how."
+  \item Doubling as "like/as," it matches Spanish \emph{como}, Italian \emph{come}.
+\end{itemize}
+
+Notice Portuguese and Spanish look almost identical here — \emph{como} vs \emph{cómo} — the only visible difference is the Spanish written accent that marks the \emph{question}. Portuguese leans on context and the question mark instead. The \emph{modo} piece lives on in English \textbf{mode}, \textbf{mod}el, \textbf{mod}erate.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: the two Portuguese "how are you"s}]
+Portuguese asks after you \textbf{two} ways, and you'll assemble both next lesson:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{Como vai?} — "how do you \textbf{go}?" (verb \emph{ir}, "to go" — like French/German).
+  \item \textbf{Como está?} — "how do you \textbf{stand/are}?" (verb \emph{estar} — like Spanish).
+\end{itemize}
+
+Plus a third, verb-free favourite — \textbf{Tudo bem?} — coming up.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "como" — \emph{KOH-moo}{]}
+  \item {[}YOU SAY: como / cómo / come / comment — the four \emph{quomodo} siblings{]}
+  \item {[}YOU SAY: "Como vai?" and "Como está?" — go, and stand{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What Latin word gives \emph{como}, and name two siblings. (\emph{quōmodo} $\to$ \emph{cómo}, \emph{come}, \emph{comment}.) What's the only written difference between Portuguese \emph{como} and Spanish \emph{cómo}? (The Spanish accent that marks a question.) Next: the word behind Portuguese's favourite greeting — \textbf{tudo}.
+\end{tcolorbox}
+\section[tudo]{tudo — "everything," the heart of \emph{Tudo bem?}}
+
+\label{lesson:PT-C02-tudo}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The most Brazilian way to greet someone doesn't use a "you" or a "to be" at all — it just asks \textbf{Tudo bem?}, "everything well?" To own it, learn its first word: \textbf{tudo}, "everything."
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{final-o-is-u} — \textbf{tudo} = \emph{TOO-doo}: final \emph{-o} $\to$ \emph{u}, and the \emph{d} is soft.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{tudo} = "everything, all," from Latin \textbf{tōtus}, \emph{"whole, entire."} You ask whether the \textbf{whole} of someone's life is going well — \emph{is everything OK?}
+
+That root \textbf{tōtus} is completely at home in English:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{total}, \textbf{totally}, \textbf{totality} — the whole amount.
+  \item \textbf{teetotal} — "\textbf{total}ly" abstaining (a playful reduplication of \emph{total}).
+  \item Italian \textbf{tutto}, Spanish \textbf{todo}, French \textbf{tout} — the same \emph{tōtus} across the family (you'll hear Spanish \emph{todo} echoing this).
+\end{itemize}
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: pairing it with "well"}]
+Portuguese "well" is \textbf{bem} ($\leftarrow$ Latin \emph{bene}, "well" — the \emph{bene} of \emph{bene}fit, \emph{bene}volent; cousin of Spanish \emph{bien}, French \emph{bien}). Put them together:
+
+\begin{quote}
+\textbf{Tudo bem?} = "Everything well?" $\to$ "How are you? / You OK?"
+\end{quote}
+
+The magic: \textbf{no pronoun, no verb.} You skip the whole \emph{você / tu / o senhor} tangle. That's why \emph{Tudo bem?} is the friendliest, safest opener in Brazilian Portuguese — and you can answer with the very same two words: \textbf{Tudo bem.} ("Everything's well.") Or just \textbf{Tudo bom.}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "tudo" — \emph{TOO-doo}{]}
+  \item {[}YOU SAY: "Tudo bem?" — everything well?{]}
+  \item {[}YOU SAY: "tudo" then English "total, totally" — one family{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What Latin word gives \emph{tudo}, and its English cousins? (\emph{tōtus} $\to$ total, totally, teetotal.) Why is \emph{Tudo bem?} so easy to use? (No pronoun, no verb — it dodges the \emph{você/tu/senhor} choice.) What's Portuguese for "well"? (\emph{bem} $\leftarrow$ \emph{bene}.) Next: assemble all three "how are you"s.
+\end{tcolorbox}
+\section[Tudo bem?]{Tudo bem? — “everything well?”}
+
+\label{lesson:PT-C02-tudo-bem}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You know \textbf{tudo}, “everything.” Add \textbf{bem}, “well,” and Portuguese gives you an everyday check-in with no verb at all.
+
+\begin{quote}
+\textbf{Tudo bem?} — “Everything well?” / “How are you?”
+\end{quote}
+
+The friendly answer can be identical:
+
+\begin{quote}
+\textbf{Tudo bem.} — “Everything’s well.”
+\end{quote}
+
+Because the question contains no “you” and no verb, it avoids choosing a social register. That simplicity is exactly why it is everywhere.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: Add the listener only when useful}]
+To bounce the question back, say:
+
+\begin{quote}
+\textbf{Tudo bem, e você?} — “All well, and you?”
+\end{quote}
+
+Everyday \textbf{você} comes from \emph{vossa mercê}, “your mercy.” Centuries of fast speech wore a respectful title into the ordinary pronoun “you,” much as Spanish \emph{usted} grew from a form meaning “your grace.” For more explicit respect, Portuguese can use \textbf{o senhor / a senhora}, “the gentleman / the lady.”
+
+You do not need either pronoun for the basic pair: \textbf{Tudo bem? — Tudo bem.}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: “Tudo bem?”{]}
+  \item {[}YOU SAY: the answer — “Tudo bem.”{]}
+  \item {[}YOU SAY: “Tudo bem, e você?”{]}
+\end{itemize}
+
+{[}REPEAT x2{]} “Tudo bem? — Tudo bem!”
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \emph{Tudo bem?} literally ask? (“Everything well?”) Why can it fit almost any listener? (It has \textbf{no verb and no pronoun}.) How do you bounce it back? (\textbf{E você?}) Where did \emph{você} come from? (\emph{Vossa mercê}, “your mercy.”) Next: two questions that do use verbs.
+\end{tcolorbox}
+\section[Como vai? / Como está?]{Como vai? / Como está? — go and stand}
+
+\label{lesson:PT-C02-como-vai-esta}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} \textbf{Tudo bem?} needs no verb. Portuguese also offers two familiar metaphors, using the \textbf{como} (“how”) you already know.
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{question} & \textbf{literally} & \textbf{verb} \\
+\midrule
+\textbf{Como vai?} & “How does it \textbf{go}?” & \emph{ir}, to go \\
+\textbf{Como está?} & “How do you \textbf{stand}?” & \emph{estar}, to be / stand \\
+\bottomrule
+\end{tabularx}
+
+\textbf{Vai} comes from \emph{ir}, whose Latin ancestor \emph{īre} also sits inside English \emph{exit} and \emph{transit}. \textbf{Está} comes from Latin \emph{stāre}, “to stand.”
+
+Portuguese therefore keeps both pictures:
+
+\begin{itemize}
+\raggedright
+  \item the “go” family, like French and German;
+  \item the “stand” family, like Spanish and Italian.
+\end{itemize}
+
+Italian also keeps both. You do not need those languages to speak Portuguese; the map simply makes the two metaphors memorable.
+
+\textbf{Tudo bem?} remains the easiest default because it skips the verb and register choice altogether.
+\end{quote}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the verb-free question — “Tudo bem?”{]}
+  \item {[}YOU SAY: the “go” question — “Como vai?”{]}
+  \item {[}YOU SAY: the “stand” question — “Como está?”{]}
+\end{itemize}
+
+{[}REPEAT x2{]} “Tudo bem? — Como vai? — Como está?”
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which question has no verb? (\textbf{Tudo bem?}) Which uses “go”? (\textbf{Como vai?}, from \emph{ir}.) Which uses “stand”? (\textbf{Como está?}, from \emph{estar}.) Portuguese keeps how many metaphors? (\textbf{Both}.) Next: the “more or less” answer.
+\end{tcolorbox}
+\section[mais ou menos]{mais ou menos — the "more or less" shrug}
+
+\label{lesson:PT-C02-mais-ou-menos}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Someone asks \emph{Tudo bem?} You're okay-ish. The Portuguese shrug is \textbf{mais ou menos} — "more or less" — the same words, root for root, that Spanish uses.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{nasal-ai} — \textbf{mais} $\approx$ \emph{mais} with a nasal glide (\emph{maish} in Brazil, the \emph{s} a soft \emph{sh}).
+  \item \texttt{final-o-is-u} — \textbf{menos} $\approx$ \emph{MEH-noos}; \textbf{ou} = a closed \emph{oh}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{mais ou menos} = literally \textbf{"more or less."} Every piece is Latin at heart:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{mais} = "more," from Latin \textbf{magis} ("more") — cousin of \emph{major}, \emph{master}, \emph{maximum}, \emph{mayor}.
+  \item \textbf{ou} = "or," from Latin \textbf{aut}.
+  \item \textbf{menos} = "less," from Latin \textbf{minus} — the very word English borrowed for \emph{minus}, \emph{minor}, \emph{minimum}, \emph{minus}cule.
+\end{itemize}
+
+So \emph{mais ou menos} is a \textbf{word-for-word twin of Spanish \emph{más o menos}} — Iberia's shared shrug. (Portuguese \emph{mais} and Spanish \emph{más} are the same \emph{magis}; the nasal \emph{-ais} is just Portuguese's accent.)
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: your answer ladder for \emph{Tudo bem?}}]
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{answer} & \textbf{sense} \\
+\midrule
+\textbf{Tudo bem / Tudo ótimo} & all well / all great \\
+\textbf{Mais ou menos} & so-so \\
+\textbf{Mais ou menos} + a hand-wobble & "eh, could be better" \\
+\bottomrule
+\end{tabularx}
+
+The five-language shrug set is now complete: Portuguese/Spanish \textbf{mais/más o menos} ("more or less"), Italian \textbf{così così} ("so, so"), French \textbf{comme ci comme ça} ("like this, like that"), German \textbf{es geht} ("it goes").
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "mais ou menos" — with a little wobble{]}
+  \item {[}YOU SAY: answer "Tudo bem?" two ways — "Tudo bem!" / "Mais ou menos"{]}
+  \item {[}YOU SAY: Portuguese \emph{mais ou menos} = Spanish \emph{más o menos}, same Latin \emph{magis}/\emph{minus}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \emph{mais ou menos} literally mean? ("More or less.") What Latin words are \emph{mais} and \emph{menos} from, and their English cousins? (\emph{magis} $\to$ major/ maximum; \emph{minus} $\to$ minor/minus.) Which language's shrug is its exact twin? (Spanish \emph{más o menos}.) Next: put the whole exchange together.
+\end{tcolorbox}
+\section[Practice]{Practice — Tudo bem?, start to finish}
+
+\label{lesson:PT-C02-practice}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} No new words. Assemble the chapter’s atoms into one casual exchange before adding the formal version.
+\end{quote}
+
+\subsection*{The exchange}
+\begin{quote}
+— Olá! \textbf{Tudo bem?} — \textbf{Tudo bem, e você?} — \textbf{Mais ou menos.} — {[}after a small favour{]} Obrigado! — \textbf{De nada.}
+\end{quote}
+
+The glue is \textbf{e você?}, “and you?”: \textbf{e} continues Latin \emph{et}, while \emph{você} grew from the respectful title \emph{vossa mercê}.
+
+\begin{grammarlens}[title={What you've built: What you are retrieving}]
+\begin{itemize}
+\raggedright
+  \item \textbf{de nada} — “of nothing,” you’re welcome;
+  \item \textbf{tudo bem?} — the verb-free check-in;
+  \item \textbf{como vai? / como está?} — “go” and “stand” alternatives;
+  \item \textbf{mais ou menos} — “more or less,” so-so.
+\end{itemize}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the whole exchange, both voices{]}
+  \item {[}YOU SAY: answer with “Tudo bem”{]}
+  \item {[}YOU SAY: answer with “Mais ou menos”{]}
+\end{itemize}
+
+{[}REPEAT x2{]} “Tudo bem? — Tudo bem, e você?”
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Run the casual exchange without looking. Which phrase answers a small favour? (\textbf{De nada}.) Which answer means “so-so”? (\textbf{Mais ou menos}.) Which question is safest before choosing a register? (\textbf{Tudo bem?}) Next: rebuild the exchange with \textbf{o senhor / a senhora}.
+\end{tcolorbox}
+\section[Practice]{Formal practice — Como está o senhor?}
+
+\label{lesson:PT-C02-formal-practice}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The casual exchange is secure. Now replace ordinary \emph{você} with the respectful title \textbf{o senhor} or \textbf{a senhora}.
+\end{quote}
+
+\subsection*{The exchange}
+\begin{quote}
+— Bom dia. \textbf{Como está o senhor?} — \textbf{Bem, obrigado. E o senhor?} — Tudo bem.
+\end{quote}
+
+For a woman, use \textbf{a senhora}. The words continue Latin \emph{senior}, “older,” the same root as English \textbf{senior} and Spanish \emph{señor}.
+
+The verb stays \textbf{está} because the title is grammatically third person: “How is the gentleman/lady?” That respectful grammar is already packed into the phrase; do not switch it to informal second-person \emph{estás} here.
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: to a man — “Como está o senhor?”{]}
+  \item {[}YOU SAY: to a woman — “Como está a senhora?”{]}
+  \item {[}YOU SAY: “Bem, obrigado. E o senhor?”{]}
+\end{itemize}
+
+{[}REPEAT x2{]} “Como está o senhor? — Bem, obrigado.”
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which titles mean a respectful “you”? (\textbf{O senhor / a senhora}.) Which verb form follows them? (\textbf{Está}, third person.) Where does \emph{senhor} come from? (Latin \emph{\textbf{senior}}, “older.”) You can now run the Chapter 2 exchange casually or formally.
+\end{tcolorbox}

--- a/code/learning/human-languages/portuguese/book/chapters/ch03-introductions.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch03-introductions.tex
@@ -1,0 +1,262 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:fe554312c9530dd0
+% canonical-lessons: PT-C03-eu, PT-C03-me-chamo, PT-C03-como-se-chama, PT-C03-prazer, PT-C03-practice
+
+\chapter{Introducing Yourself}
+\label{ch:pt-introductions}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[eu]{eu — "I," the pronoun Portuguese usually drops}
+
+\label{lesson:PT-C03-eu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Before introducing yourself, meet \textbf{eu} — "I." Famous English cousin, and the same habit as its Romance sisters: Portuguese usually \textbf{leaves it out.}
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{nasal-eu} — \textbf{eu} = \emph{EH-oo}, a gliding vowel with a light nasal colour, one syllable.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{eu} = "I," from Latin \textbf{ego} — the same \emph{ego} English borrowed outright:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{ego}, \textbf{egoist}, \textbf{egocentric} — all Latin "I."
+  \item Romance siblings, all from \emph{ego}: Spanish \textbf{yo}, Italian \textbf{io}, French \textbf{je}.
+\end{itemize}
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: the dropped subject (pro-drop)}]
+The verb ending already names the speaker, so Portuguese usually \textbf{omits} the pronoun: \emph{chamo-me} ("I call myself") needs no \emph{eu} — the \emph{-o} of \emph{chamo} is "I." You add \textbf{eu} for \textbf{emphasis} or \textbf{contrast}:
+
+\begin{quote}
+\emph{Eu} estou bem, e você? — "\emph{I'm} fine, and you?"
+\end{quote}
+
+Spanish (\emph{yo}) and Italian (\emph{io}) do the same. It's one of the first real habits of a Romance language: trust the verb ending, drop the pronoun.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "eu" — \emph{EH-oo}{]}
+  \item {[}YOU SAY: "eu" then English "ego, egoist" — the same Latin "I"{]}
+  \item {[}YOU SAY: eu / yo / io / je — four children of \emph{ego}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What Latin word is \emph{eu} from? (\emph{Ego} — ego, egoist.) Why does Portuguese usually drop it? (The verb ending already says "I.") When do you keep it? (Emphasis / contrast.) Next: introduce yourself — \textbf{me chamo}.
+\end{tcolorbox}
+\section[me chamo / chamo-me]{me chamo — "I call myself"}
+
+\label{lesson:PT-C03-me-chamo}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Like its Iberian and Italian sisters, Portuguese introduces you as what you \textbf{call yourself} — \textbf{me chamo} — from the very same Latin \emph{clāmāre} that gave Spanish \emph{me llamo} and Italian \emph{mi chiamo}.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{ch-is-sh} — Portuguese \textbf{ch} = \textbf{"sh"}: \textbf{chamo} = \emph{SHAH-moo}. (A neat three-way split from one Latin \emph{cl-}: Spanish \emph{ll} = \emph{y} (\emph{llamo}), Italian \emph{ch} = hard \emph{k} (\emph{chiamo}), Portuguese \emph{ch} = \emph{sh} (\emph{chamo}).)
+  \item \texttt{final-o-is-u} — final \emph{-o} $\to$ \emph{u}: \emph{SHAH-moo}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{me chamo} = \textbf{me} ("myself") + \textbf{chamo} ("I call") $\to$ \textbf{"I call myself."} Brazilians often say \textbf{eu me chamo}; European Portuguese prefers \textbf{chamo-me} (same words, pronoun clipped to the back) — both fine. Then the name: \emph{Me chamo Ana} — "I call myself Ana."
+
+The verb \textbf{chamar-se} ("to call oneself") is from Latin \textbf{clāmāre}, \emph{"to cry out, to call"} — shouting through English as \textbf{claim}, \textbf{exclaim}, \textbf{proclaim}, \textbf{clamor}. Three Romance naming verbs, one Latin call:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{"I call myself"} & \textbf{\emph{cl-} became} \\
+\midrule
+\textbf{Portuguese} & \emph{me chamo} & \emph{ch} (= \emph{sh}) \\
+\textbf{Spanish} & \emph{me llamo} & \emph{ll} (= \emph{y}) \\
+\textbf{Italian} & \emph{mi chiamo} & \emph{ch} (= hard \emph{k}) \\
+\bottomrule
+\end{tabularx}
+
+\textbf{Another way to say it:} \emph{o meu nome é …} ("my name is …"), where \textbf{nome} $\leftarrow$ Latin \textbf{nōmen}, "name" — the root of English \textbf{noun}, \textbf{nominal}, \textbf{nomenclature}, \textbf{nominate}. Two routes to the same introduction: the \emph{verb} (call myself) or the \emph{noun} (my name is).
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: the reflexive}]
+\emph{chamo} alone = "I call {[}someone{]}"; \textbf{me} chamo = "I call \textbf{myself}" — reflexive. The pronoun shifts with the person: \textbf{me} chamo (I) $\to$ \textbf{se} chama (he/she/você). And \emph{eu} is dropped — the \emph{-o} ending already says "I."
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "me chamo" — \emph{muh SHAH-moo}, \emph{ch} = \emph{sh}{]}
+  \item {[}YOU SAY: "Me chamo …" with your own name{]}
+  \item {[}YOU SAY: me chamo / me llamo / mi chiamo — one \emph{clāmāre}, three sounds{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \emph{me chamo} literally mean, and its Latin root? ("I call myself"; \emph{clāmāre} — claim/clamor.) How is Portuguese \emph{ch} pronounced, vs Italian \emph{ch}? (Portuguese \emph{sh}; Italian hard \emph{k}.) What's the noun-route alternative? (\emph{O meu nome é …}, \emph{nome} $\leftarrow$ \emph{nōmen}.) Next: ask it back — \textbf{Como se chama?}
+\end{tcolorbox}
+\section[Como se chama?]{Como se chama? — "what's your name?"}
+
+\label{lesson:PT-C03-como-se-chama}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Both pieces are yours: \textbf{como} ("how," from your \emph{Tudo bem?} chapter) and \textbf{chamar-se} ("to call oneself"). Portuguese, like all its sisters, asks the name with \textbf{"how"}: \emph{how do you call yourself?}
+\end{quote}
+
+\begin{cousinweb}
+\begin{quote}
+\textbf{Como se chama?} = "What's your name?" literally: \textbf{"How do you call yourself?"}
+\end{quote}
+
+\begin{itemize}
+\raggedright
+  \item \textbf{como} = "how" ($\leftarrow$ \emph{quōmodo}).
+  \item \textbf{se} = "yourself" (the reflexive; \emph{me} $\to$ \emph{se}).
+  \item \textbf{chama} = "calls" (\emph{você}/he-she form of \emph{chamar-se}).
+\end{itemize}
+
+Portuguese register is friendly here — the everyday polite form uses \textbf{você}:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{form} & \textbf{question} \\
+\midrule
+polite / neutral (\emph{você}) & \textbf{Como (você) se chama?} \\
+very formal & \textbf{Como se chama o senhor / a senhora?} \\
+familiar (\emph{tu}, more in Portugal) & \textbf{Como te chamas?} \\
+\bottomrule
+\end{tabularx}
+
+The reply loops right back: \emph{Me chamo Ana. E você?} And just like Spanish \emph{¿cómo se llama?} and Italian \emph{come ti chiami?}, the name is a matter of \textbf{how} you're called — never \emph{what}.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "Como se chama?" — \emph{KOH-moo suh SHAH-mah}{]}
+  \item {[}YOU SAY: the whole loop — "Como se chama? — Me chamo … E você?"{]}
+  \item {[}YOU SAY: como se chama / cómo se llama / come ti chiami — the same question, three sisters{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \emph{Como se chama?} literally ask? ("How do you call yourself?") Which everyday pronoun does the polite form use? (\emph{Você}.) What "how" word is it built on? (\emph{Como} $\leftarrow$ \emph{quōmodo}.) Next: the warm reply — \textbf{prazer}.
+\end{tcolorbox}
+\section[prazer]{prazer — "pleased to meet you," i.e. "a pleasure"}
+
+\label{lesson:PT-C03-prazer}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Names traded, you close with \textbf{prazer} — "a pleasure." It's the twin of Italian \emph{piacere}, and, like it, straight from Latin \emph{please}.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{pr-cluster} — \textbf{prazer} = \emph{prah-\textbf{ZEHR}}: the \emph{z} is a true \emph{z}; stress the end. (The \emph{pr-} shows a Portuguese sound-law: Latin \emph{pl-} often became \emph{pr-} — \emph{placēre} $\to$ \emph{prazer}, \emph{plūs} $\to$ …)
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{prazer} = "pleasure" (and, as a verb, "to please"), from Latin \textbf{placēre}, \emph{"to please."} On meeting someone it's short for \emph{"{[}it's{]} a pleasure."}
+
+That \emph{placēre} root is deep in English — \textbf{please}, \textbf{pleasure}, \textbf{pleasant}, \textbf{complacent}, \textbf{placid} — and it names this courtesy across the family:
+
+\begin{itemize}
+\raggedright
+  \item Italian \textbf{piacere} — its exact twin (same \emph{placēre}).
+  \item Spanish \textbf{mucho gusto} — "much pleasure," but from \emph{gustus} ("taste"), a different root.
+  \item French \textbf{enchanté} — a different picture again ("enchanted").
+\end{itemize}
+
+Portuguese took \emph{placēre}'s \emph{pl-} to \emph{pr-} (a regular shift — compare \emph{branco} "white" $\leftarrow$ Germanic \emph{blank}, \emph{praia} "beach" $\leftarrow$ \emph{plagia}), so \emph{piacere} and \emph{prazer} look a little different but are the very same word.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: a one-word courtesy}]
+\emph{Prazer} stands alone, with a nod or handshake. Fuller forms: \textbf{muito prazer} ("much pleasure"), or \textbf{prazer em conhecê-lo/-la} ("a pleasure to know you").
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "prazer" — \emph{prah-ZEHR}{]}
+  \item {[}YOU SAY: "prazer" then English "please, pleasure, placid" — the \emph{placēre} root{]}
+  \item {[}YOU SAY: Portuguese \emph{prazer} and Italian \emph{piacere} — twins from \emph{placēre}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \emph{prazer} mean, and from what Latin verb? ("A pleasure," $\leftarrow$ \emph{placēre}.) Its Italian twin? (\emph{Piacere}.) What sound-shift turned \emph{pl-} into \emph{pr-}? (The Portuguese \emph{placēre} $\to$ \emph{prazer} change.) Next: put the whole introduction together.
+\end{tcolorbox}
+\section[Practice]{Practice — introducing yourself in Portuguese}
+
+\label{lesson:PT-C03-practice}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} No new words. \emph{eu, me chamo, como se chama, prazer} assemble into a real first meeting. This slots between your greetings (Ch. 1–2) and farewells (Ch. 4), so Portuguese now runs a whole conversation.
+\end{quote}
+
+\subsection*{The exchange}
+\textbf{Casual} (\emph{você}):
+
+\begin{quote}
+— Olá! \textbf{Como você se chama?} — \textbf{Me chamo} Ana. E você? — João. \textbf{Prazer!} — Prazer!
+\end{quote}
+
+\textbf{More formal} (o senhor / a senhora):
+
+\begin{quote}
+— Bom dia. \textbf{Como se chama a senhora?} — Chamo-me Ana Costa. E o senhor? — Costa. \textbf{Muito prazer.}
+\end{quote}
+
+\begin{grammarlens}[title={What you've built this chapter}]
+\begin{itemize}
+\raggedright
+  \item \textbf{eu} — "I" ($\leftarrow$ \emph{ego}), usually \textbf{dropped} — the verb ending carries it.
+  \item \textbf{me chamo / chamo-me} — "I call myself" (\emph{chamar-se} $\leftarrow$ \emph{clāmāre}; \emph{ch} = \emph{sh}; kin of \emph{me llamo}, \emph{mi chiamo}). Alt: \emph{o meu nome é} (\emph{nome} $\leftarrow$ \emph{nōmen}).
+  \item \textbf{Como se chama?} — "how do you call yourself?" (polite \emph{você}).
+  \item \textbf{prazer} — "a pleasure" ($\leftarrow$ \emph{placēre}; twin of Italian \emph{piacere}).
+\end{itemize}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the full casual meeting, both voices{]}
+  \item {[}YOU SAY: the same formally — with \emph{o senhor / a senhora}{]}
+  \item {[}YOU SAY: chain it all — greet, name, ask, how-are-you, goodbye: "Olá! Me chamo … Como se chama? … Tudo bem? … Até logo!"{]}
+\end{itemize}
+
+{[}REPEAT x2{]} Run a whole first meeting start to finish.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Why does Portuguese usually drop \emph{eu}? (The verb ending says who.) What does \emph{me chamo} literally mean, and its root? ("I call myself"; \emph{clāmāre}.) What does \emph{prazer} mean, and its Italian twin? ("A pleasure"; \emph{piacere}.) Portuguese now runs greet $\to$ introduce $\to$ how-are-you $\to$ goodbye, end to end — the fifth language to close the loop.
+\end{tcolorbox}

--- a/code/learning/human-languages/portuguese/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch04-farewells.tex
@@ -1,0 +1,255 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:5525ef6075d2060a
+% canonical-lessons: PT-C04-adeus, PT-C04-ate-logo, PT-C04-ate-amanha, PT-C04-ate-breve, PT-C04-practice
+
+\chapter{Farewells}
+\label{ch:pt-farewells}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[adeus]{adeus — "goodbye," i.e. "to God"}
+
+\label{lesson:PT-C04-adeus}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You can greet, ask \emph{tudo bem?}, and reply. Now close the conversation. The Portuguese goodbye is \textbf{adeus} — and it's a tiny prayer: \textbf{"to God."}
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{nasal-eu} — \textbf{adeus} $\approx$ \emph{ah-\textbf{DEH}-oosh}: the \emph{eu} is a gliding vowel; final \emph{-s} is a soft \emph{sh} in Portugal (\emph{-s} $\to$ \emph{ss} in Brazil). Stress the \emph{-deus}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{adeus} = \textbf{a} ("to") + \textbf{Deus} ("God"), from Latin \textbf{ad Deum}, \emph{"to God."} It's the fossil of a blessing — \emph{"{[}I commend you{]} to God"} — said at parting, exactly like the English \textbf{goodbye}, which is a worn-down \emph{"God be with ye."}
+
+This is one of the most beautiful family resemblances in the whole curriculum — five languages, one farewell prayer:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{goodbye} & \textbf{=} \\
+\midrule
+\textbf{Portuguese} & \emph{adeus} & a + Deus \\
+\textbf{Spanish} & \emph{adiós} & a + Dios \\
+\textbf{French} & \emph{adieu} & à + Dieu \\
+\textbf{Italian} & \emph{addio} & a + Dio \\
+\textbf{English} & \emph{goodbye} & "God be with ye" \\
+\bottomrule
+\end{tabularx}
+
+The \emph{Deus} here is the same one in English \textbf{deity}, \textbf{divine}, \textbf{adieu}, and Spanish \emph{Dios}. When you say \emph{adeus}, you're handing someone to God for safekeeping until next time.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "adeus" — \emph{ah-DEH-oosh}{]}
+  \item {[}YOU SAY: adeus / adiós / adieu / addio — one "to God" across four languages{]}
+  \item {[}YOU SAY: even English "goodbye" = "God be with ye"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \emph{adeus} literally mean, and from what? ("To God," $\leftarrow$ \emph{ad Deum}.) Name two sister-language goodbyes with the same "to God" origin. (\emph{adiós}, \emph{adieu}, \emph{addio}.) What English goodbye hides "God be with ye"? (\emph{Goodbye}.) Next: the softer "see you" goodbyes — starting with \textbf{até logo}.
+\end{tcolorbox}
+\section[até logo]{até logo — "see you later," and a word straight from Arabic}
+
+\label{lesson:PT-C04-ate-logo}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The everyday Portuguese goodbye isn't \emph{adeus} (that's a bit final) — it's \textbf{até logo}, "until soon." And its first word carries the same surprise Spanish's \emph{hasta} does: it came from \textbf{Arabic}.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \textbf{até} = \emph{ah-\textbf{TEH}}, stress the end (the accent on \emph{é}).
+  \item \texttt{final-o-is-u} — \textbf{logo} = \emph{LOH-goo}, final \emph{-o} $\to$ \emph{u}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{até} = "until, up to." Like Spanish \textbf{hasta}, it comes from \textbf{Arabic \emph{ḥattā} (\ptar{حتى})}, "until" — carried into Iberian speech across the \textbf{800 years of al-Andalus}. Both Iberian languages borrowed the \emph{same} Arabic word for this everyday preposition. That's remarkable: languages freely borrow \emph{nouns} (Portuguese has thousands from Arabic — \emph{almofada}, \emph{açúcar}, \emph{azeite}), but a \textbf{function word} like "until" almost never crosses. \emph{até} and \emph{hasta} are twin survivors of that deep Arabic layer under Iberian Romance.
+  \item \textbf{logo} = "soon, right away, then," from Latin \textbf{locō}, \emph{"in {[}that{]} place"} $\to$ "on the spot" $\to$ "soon." (Spanish did the identical thing: \textbf{luego} $\leftarrow$ \emph{locō}, and \emph{hasta luego} is the word-for-word twin of \emph{até logo}.)
+\end{itemize}
+
+So \textbf{até logo} = "\textbf{until soon}" — the exact mirror of Spanish \textbf{hasta luego}, Arabic preposition and all.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "até logo" — \emph{ah-TEH LOH-goo}{]}
+  \item {[}YOU SAY: Portuguese \emph{até} and Spanish \emph{hasta} — both from Arabic \emph{ḥattā}{]}
+  \item {[}YOU SAY: \emph{até logo} = \emph{hasta luego}, twin for twin{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Where does \emph{até} come from, and which Spanish word is its twin? (Arabic \emph{ḥattā} — Spanish \emph{hasta}.) Why is borrowing it surprising? (It's a \emph{function word}; languages rarely borrow those.) What does \emph{logo} share with Spanish \emph{luego}? (Both $\leftarrow$ Latin \emph{locō}, "in place" $\to$ "soon".) Next: \textbf{até amanhã}.
+\end{tcolorbox}
+\section[até amanhã]{até amanhã — "see you tomorrow"}
+
+\label{lesson:PT-C04-ate-amanha}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Same frame — \emph{até} + a "when." \textbf{Até amanhã}, "until tomorrow." And \emph{amanhã} is the Portuguese cousin of a Spanish word you already know, wearing a heavy nasal ending.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{nasal-anha} — \textbf{amanhã} = \emph{ah-mah-\textbf{NYÃ}}: the \textbf{nh} is the \emph{ny} of "canyon" (Portuguese spells the \emph{ñ} sound as \emph{nh}), and the final \textbf{-ã} is a strong \textbf{nasal} \emph{a} — air through the nose, no hard consonant. Stress the end.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{até} = "until" ($\leftarrow$ Arabic \emph{ḥattā}, from the last lesson).
+  \item \textbf{amanhã} = "tomorrow," from Latin \textbf{ad māneāna}, \emph{"to the morning {[}hour{]}."}
+\end{itemize}
+
+That \textbf{māne} ("morning") root is shared right across Romance — you've now met three of its children:
+
+\begin{itemize}
+\raggedright
+  \item Portuguese \textbf{amanhã} ("tomorrow") $\leftarrow$ \emph{ad māneāna}.
+  \item Spanish \textbf{mañana} — morning \emph{and} tomorrow (the \emph{ñ} spelled with the tilde).
+  \item Italian \textbf{domani} ("tomorrow") $\leftarrow$ \emph{dē māne}.
+\end{itemize}
+
+Same idea everywhere: tomorrow is \textbf{"the morning to come."} Portuguese writes the \emph{ny} sound as \textbf{nh} (\emph{amanhã}), where Spanish uses \textbf{ñ} (\emph{mañana}) — two spellings, one sound, both from that doubled-\emph{n}.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "até amanhã" — \emph{ah-TEH ah-mah-NYÃ}, nasal ending{]}
+  \item {[}YOU SAY: amanhã / mañana / domani — three children of \emph{māne}, "morning"{]}
+  \item {[}YOU SAY: Portuguese \emph{nh} = Spanish \emph{ñ} = the \emph{ny} sound{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \emph{amanhã} come from, and literally mean? (\emph{Ad māneāna} — "to the morning.") How does Portuguese spell the \emph{ny} sound that Spanish writes as \emph{ñ}? (As \emph{nh}.) Next: "see you soon" — \textbf{até breve}.
+\end{tcolorbox}
+\section[até breve]{até breve — "see you soon"}
+
+\label{lesson:PT-C04-ate-breve}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The last of the \emph{até} goodbyes: \textbf{até breve}, "until soon" — literally "until {[}a{]} \emph{short} {[}while{]}." \emph{Breve} is a word English wears in several coats.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \textbf{até breve} = \emph{ah-TEH \textbf{BREH}-vee}: open \emph{e} in \emph{breve}, final \emph{-e} softens toward \emph{ee}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{até} = "until" ($\leftarrow$ Arabic \emph{ḥattā}).
+  \item \textbf{breve} = "short, brief," from Latin \textbf{brevis}, \emph{"short."}
+\end{itemize}
+
+You already own \emph{brevis} in English, several times over:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{brief} — short (a \emph{brief} meeting; a legal \emph{brief}).
+  \item \textbf{brevity} — shortness ("brevity is the soul of wit").
+  \item \textbf{abbreviate}, \textbf{abridge} — to make short.
+  \item even the musical \textbf{breve} and the little \textbf{breve} mark ˘ over a short vowel.
+\end{itemize}
+
+So \emph{até breve} is \textbf{"until {[}a{]} short {[}while{]}"} — see you before long. It's a touch warmer and less fixed than \emph{até logo}; both mean "see you soon."
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "até breve" — \emph{ah-TEH BREH-vee}{]}
+  \item {[}YOU SAY: "breve" then English "brief, brevity, abbreviate" — one root{]}
+  \item {[}YOU SAY: the three \emph{até} goodbyes — até logo / até amanhã / até breve{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \emph{breve} mean, and its English cousins? ("Short" — brief, brevity, abbreviate.) So \emph{até breve} literally says? ("Until a short while" $\to$ see you soon.) Next: put the Portuguese goodbyes together.
+\end{tcolorbox}
+\section[Practice]{Practice — saying goodbye in Portuguese}
+
+\label{lesson:PT-C04-practice}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} No new words. You can now greet, ask \emph{tudo bem?}, and \textbf{close} the conversation. Run the goodbyes until the right one is automatic.
+\end{quote}
+
+\subsection*{You'll want to know: The closings}
+\textbf{Final / formal} — the "to God" goodbye:
+
+\begin{quote}
+— Foi um prazer. \textbf{Adeus!}
+\end{quote}
+
+\textbf{Everyday "see you"} — pick the \emph{até} that fits:
+
+\begin{quote}
+— \textbf{Até logo!} (see you later / soon) — \textbf{Até amanhã!} (see you tomorrow) — \textbf{Até breve!} (see you soon)
+\end{quote}
+
+\textbf{Casual chain} — greet and part:
+
+\begin{quote}
+— Olá! Tudo bem? … \textbf{Até logo!} — \textbf{Até!} (Brazilians often clip it to just \emph{"até!"})
+\end{quote}
+
+\begin{grammarlens}[title={What you've built this chapter}]
+\begin{itemize}
+\raggedright
+  \item \textbf{adeus} — goodbye ("to God"; the \emph{adiós / adieu / addio} family, and English \emph{goodbye} = "God be with ye").
+  \item \textbf{até logo} — see you later (\emph{até} $\leftarrow$ \textbf{Arabic \emph{ḥattā}}, twin of Spanish \emph{hasta}; \emph{logo} $\leftarrow$ \emph{locō}, kin of \emph{luego}). \emph{Até logo} = \emph{hasta luego}.
+  \item \textbf{até amanhã} — see you tomorrow (\emph{amanhã} $\leftarrow$ \emph{ad māneāna}, kin of \emph{mañana}; the \emph{nh} = Spanish \emph{ñ}).
+  \item \textbf{até breve} — see you soon (\emph{breve} $\leftarrow$ \emph{brevis}, "short" — brief/brevity).
+\end{itemize}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: greet, ask, and close — "Olá! Tudo bem? … Até amanhã!"{]}
+  \item {[}YOU SAY: choose the right goodbye — leaving for good / till tomorrow / soon{]}
+  \item {[}YOU SAY: \emph{até logo} and Spanish \emph{hasta luego} — twins, Arabic \emph{até/hasta} and all{]}
+\end{itemize}
+
+{[}REPEAT x2{]} Open and close a whole tiny exchange without stopping.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which Portuguese goodbye means "to God"? (\emph{Adeus}.) Which word inside the \emph{até} goodbyes came from Arabic, and what's its Spanish twin? (\emph{Até} $\leftarrow$ \emph{ḥattā} — Spanish \emph{hasta}.) You can now run a Portuguese conversation start to finish — that's the fifth language to reach the full greet-to-goodbye arc.
+\end{tcolorbox}

--- a/code/learning/human-languages/portuguese/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch05-first-verbs.tex
@@ -1,0 +1,291 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:fca2fd8fd1da3e96
+% canonical-lessons: PT-C05-falar, PT-C05-morar, PT-C05-trabalhar, PT-C05-falo-portugues, PT-C05-practice
+
+\chapter{The First Verbs}
+\label{ch:pt-first-verbs}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[falar]{falar — "to speak," and the \emph{f} that Spanish lost}
+
+\label{lesson:PT-C05-falar}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Until now you've assembled fixed phrases. \textbf{falar} ("to speak") is your first real \textbf{verb} — the model for the big \textbf{-ar} family — and it hides a beautiful contrast with Spanish, right at its first letter.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{final-r} — \textbf{falar} = \emph{fah-LAR}, tapped final \emph{r}. The stem is \emph{fal-}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{falar} comes from Latin \textbf{fabulārī}, \emph{"to chat, to tell tales"} — from \textbf{fābula}, "a story" ($\to$ English \textbf{fable}, \textbf{fabulous}, \textbf{confabulate}). The \textbf{same Latin verb as Spanish \emph{hablar}} — but here's the twist:
+
+\textbf{Portuguese kept the Latin \emph{f-}; Spanish turned \emph{f-} into \emph{h-}.} So the two "speak" verbs diverge at letter one, and the pattern runs through the whole vocabulary:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Latin (f-)} & \textbf{Portuguese (f-)} & \textbf{Spanish (h-, silent)} \\
+\midrule
+\emph{fabulārī} & \textbf{falar} & hablar \\
+\emph{farīna} & \textbf{farinha} (flour) & harina \\
+\emph{fīlius} & \textbf{filho} (son) & hijo \\
+\emph{facere} & \textbf{fazer} (to do) & hacer \\
+\emph{ferrum} & \textbf{ferro} (iron) & hierro \\
+\bottomrule
+\end{tabularx}
+
+So when a Spanish word starts with a silent \emph{h}, its Portuguese twin usually still has the honest Latin \emph{f} — \emph{hijo/filho}, \emph{hacer/fazer}. Portuguese is the more conservative sister here.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: the -ar present tense (pro-drop)}]
+Drop \textbf{-ar} to get \emph{fal-}, then add the endings:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{person} & \textbf{ending} & \textbf{\emph{falar} $\to$} \\
+\midrule
+(eu) & \textbf{-o} & \textbf{falo} (I speak) \\
+(tu) & \textbf{-as} & \textbf{falas} (you speak) \\
+(você/ele/ela) & \textbf{-a} & \textbf{fala} \\
+(nós) & -amos & falamos \\
+(vocês/eles) & -am & falam \\
+\bottomrule
+\end{tabularx}
+
+Like Spanish and Italian, \textbf{Portuguese drops the subject pronoun} — \emph{falo} already says "I," so no \emph{eu} needed. (Portuguese joins the \emph{drop} camp: ES, PT, IT drop; FR, DE keep.)
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "falar" — \emph{fah-LAR}{]}
+  \item {[}YOU SAY: "falo, falas, fala" — no \emph{eu} needed{]}
+  \item {[}YOU SAY: falar $\leftrightarrow$ hablar, filho $\leftrightarrow$ hijo — Portuguese keeps the \emph{f}, Spanish drops it to silent \emph{h}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What Latin verb is \emph{falar} from, and which Spanish verb is its twin? (\emph{fabulārī} — Spanish \emph{hablar}.) What sound-law separates them? (Portuguese kept \emph{f-}; Spanish shifted \emph{f- $\to$ h-}: \emph{filho/hijo}.) Does Portuguese keep or drop the pronoun? (Drops it.) Next: \textbf{morar}, "to live."
+\end{tcolorbox}
+\section[morar]{morar — "to live," i.e. to \emph{linger} somewhere}
+
+\label{lesson:PT-C05-morar}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} A second \textbf{-ar} verb — and a distinctive Portuguese choice. Where its sisters say "live" with \emph{habitāre} ("keep having a place"), everyday Portuguese uses \textbf{morar} — from a verb that means to \textbf{linger}.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \textbf{morar} = \emph{moh-RAR}, tapped final \emph{r}, clean vowels.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{morar} comes from Latin \textbf{morārī}, \emph{"to delay, to linger, to tarry, to stay a while."} To \emph{dwell} somewhere is, in Portuguese, to \emph{linger} there — a softer, more temporary image than "keeping" a place. That \emph{morārī} root survives in English in a couple of unexpected words:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{moratorium} — an official \emph{delay} (a pause on payments or actions).
+  \item \textbf{demur} — to \emph{linger / hesitate}, to raise an objection (\emph{without demur}).
+\end{itemize}
+
+(Portuguese does also have \emph{habitar} — the \emph{habitāre} verb its sisters use — but it's formal; \textbf{morar} is what you actually say: \emph{Onde você mora?}, "Where do you live?")
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: same -ar template}]
+| (eu) moro · (tu) moras · (você) mora | (-o / -as / -a) |
+
+| moramos · moram |  |
+
+\begin{quote}
+\textbf{Moro em Lisboa.} — "I live in Lisbon."
+\end{quote}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "morar" — \emph{moh-RAR}{]}
+  \item {[}YOU SAY: "moro, moras, mora"{]}
+  \item {[}YOU SAY: "Onde você mora?" — "Where do you live?"; "morar" $\leftrightarrow$ \emph{moratorium}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What Latin verb is \emph{morar} from, and what did it mean? (\emph{morārī} — "to delay / linger.") English cousins? (\emph{Moratorium}, \emph{demur}.) Say "I live in Lisbon." (\emph{Moro em Lisboa.}) Next: \textbf{trabalhar}, "to work."
+\end{tcolorbox}
+\section[trabalhar]{trabalhar — "to work," and the torture returns}
+
+\label{lesson:PT-C05-trabalhar}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} A third \textbf{-ar} verb — and Portuguese rejoins its Iberian sister on the darkest etymology in the curriculum. \textbf{trabalhar} ("to work"), like Spanish \emph{trabajar}, began as a word for \textbf{torture}.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{nasal-anha} — the \textbf{-lh-} is a \emph{ly} glide (as in Spanish \emph{ll}): \textbf{trabalhar} = \emph{tra-ba-\textbf{LYAR}}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{trabalhar} comes from Vulgar Latin \textbf{tripaliāre}, \emph{"to torture"} — from \textbf{tripalium}, a Roman instrument of torture made of \textbf{three stakes} (\emph{tri-} "three" + \emph{pālus} "stake" $\to$ English \emph{pale}, \emph{impale}). \emph{Torture $\to$ toil $\to$ work}, and English took the same road: \textbf{travail} (painful effort) $\to$ \textbf{travel} (a journey was an ordeal).
+
+So Portuguese and Spanish are \textbf{twins} here — \emph{trabalhar} and \emph{trabajar}, both from \emph{tripaliāre}. Only the middle consonant differs: Latin \emph{-li-} became Portuguese \textbf{-lh-} (\emph{trabalhar}) and Spanish \textbf{-j-} (\emph{trabajar}). And this puts the "work" verbs of the five languages into two neat camps:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{Torture} (\emph{tripalium}): Portuguese \emph{trabalhar}, Spanish \emph{trabajar}, French \emph{travailler}.
+  \item \textbf{Labour} (\emph{labor}): Italian \emph{lavorare}.
+\end{itemize}
+
+Three languages remember work as \emph{torture}; only Italy remembers it as \emph{labour}.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: same -ar template}]
+| (eu) trabalho · (tu) trabalhas · (você) trabalha | (-o / -as / -a) |
+
+\begin{quote}
+\textbf{Trabalho no Porto.} — "I work in Porto."
+\end{quote}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "trabalhar" — \emph{tra-ba-LYAR}{]}
+  \item {[}YOU SAY: "trabalho, trabalhas, trabalha"{]}
+  \item {[}YOU SAY: trabalhar $\leftrightarrow$ trabajar (twins) $\to$ travail $\to$ travel — torture to journey{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What did \emph{trabalhar} originally mean, and from what device? ("To torture," $\leftarrow$ \emph{tripalium}, three stakes.) Its Spanish twin, and the one difference? (\emph{trabajar}; Latin \emph{-li-} $\to$ PT \emph{-lh-} / ES \emph{-j-}.) Which language uses "labour" instead? (Italian, \emph{lavorare}.) Next: your first sentence — \textbf{Falo português}.
+\end{tcolorbox}
+\section[Falo português]{Falo português — your first real sentence}
+
+\label{lesson:PT-C05-falo-portugues}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The payoff: you take a \textbf{verb} you conjugated and a \textbf{noun}, and build a sentence no one handed you — \emph{Falo português}, "I speak Portuguese." (\emph{Falo} covers both "I speak" and "I'm speaking.")
+\end{quote}
+
+\subsection*{You'll want to know: The new word: português}
+\textbf{português} = "Portuguese," from \textbf{Portus Cale} — a Roman-era port at the mouth of the \textbf{Douro} river (today's \textbf{Porto} / \textbf{Oporto}). \emph{Portus} is Latin "port, harbour" ($\to$ English \textbf{port}, \textbf{portal}, \textbf{import}); \textbf{Cale} is older and debated — perhaps Celtic for "harbour/shelter," or Latin \emph{cālidus} "warm." So \emph{Portugal} began as a single \textbf{harbour town}, whose name spread to the whole country and its language. Say it \emph{por-too-\textbf{GESH}} (final \emph{-s} = \emph{sh} in Portugal).
+
+\subsection*{You'll want to know: The sentence, assembled}
+\begin{quote}
+\textbf{Falo} (I speak, from \emph{falar}) + \textbf{português} = \textbf{Falo português.}
+\end{quote}
+
+A complete, grammatical Portuguese sentence. As before:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{No \emph{eu}.} The \emph{-o} of \emph{falo} says "I" — Portuguese drops the pronoun (like Spanish and Italian).
+  \item \textbf{No article} on the language: \emph{falo português}.
+\end{itemize}
+
+With this, \textbf{all five languages} you've been building now cross the same line — from reciting phrases to \textbf{making sentences}:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{"I speak/learn {[}language{]}"} \\
+\midrule
+Spanish & \textbf{Hablo} español \\
+Portuguese & \textbf{Falo} português \\
+Italian & \textbf{Parlo} italiano \\
+French & \textbf{Je parle} français \\
+German & \textbf{Ich lerne} Deutsch \\
+\bottomrule
+\end{tabularx}
+
+Swap the pieces: \textbf{Moro em Lisboa.} · \textbf{Trabalho no Porto.} · \textbf{Você fala português?}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "Falo português" — \emph{FAH-loo por-too-GESH}{]}
+  \item {[}YOU SAY: drop the \emph{eu} — Portuguese doesn't need it{]}
+  \item {[}YOU SAY: "português" $\leftarrow$ \emph{Portus Cale}, a single harbour town that named a nation{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Where does \emph{português} come from? (\emph{Portus Cale}, a port at the Douro's mouth $\to$ Porto.) In \emph{Falo português}, why no \emph{eu} and no article? (The \emph{-o} is "I"; languages take no article.) Which three of the five languages drop the pronoun? (Spanish, Portuguese, Italian.) Next: practice.
+\end{tcolorbox}
+\section[Practice]{Practice — making sentences with -ar verbs}
+
+\label{lesson:PT-C05-practice}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} For the first time you're \textbf{building} Portuguese sentences from a pattern. Drill the three verbs until the endings are automatic — and remember, Portuguese drops the \emph{eu}.
+\end{quote}
+
+\subsection*{Guided Practice: conjugate on command}
+{[}PAUSE 1s{]} Run each through \emph{eu / tu / você} (pronoun dropped in speech):
+
+\begin{itemize}
+\raggedright
+  \item \textbf{falar}: falo · falas · fala
+  \item \textbf{morar}: moro · moras · mora
+  \item \textbf{trabalhar}: trabalho · trabalhas · trabalha
+\end{itemize}
+
+Same endings every time (\textbf{-o / -as / -a}), no pronoun needed.
+
+\subsection*{Guided Practice: say something real}
+\begin{quote}
+— \textbf{Você fala} português? — \textbf{Falo} um pouco. E você? — Também. \textbf{Onde} você \textbf{mora}? — \textbf{Moro} em Lisboa, e \textbf{trabalho} no Porto. — Obrigado! — De nada.
+\end{quote}
+
+\begin{grammarlens}[title={What you've built this chapter}]
+\begin{itemize}
+\raggedright
+  \item \textbf{the regular -ar present tense} — drop \emph{-ar}, add \emph{-o/-as/-a/-amos/-am}; pronoun \textbf{dropped} (like Spanish, Italian).
+  \item \textbf{falar} ($\leftarrow$ \emph{fabulārī} $\to$ fable; twin of Spanish \emph{hablar} but with the \emph{f} kept), \textbf{morar} ($\leftarrow$ \emph{morārī} "to linger" $\to$ moratorium — a root no sibling uses), \textbf{trabalhar} ($\leftarrow$ \emph{tripalium} "torture"; twin of \emph{trabajar}).
+  \item \textbf{Falo português} ($\leftarrow$ \emph{Portus Cale}, a harbour town) — first self-assembled sentence, and the \textbf{fifth language} to cross from phrases into sentences.
+\end{itemize}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: conjugate all three verbs, eu/tu/você — no pronoun spoken{]}
+  \item {[}YOU SAY: answer about yourself — what you speak, where you live, where you work{]}
+  \item {[}YOU SAY: chain it — "Olá! Falo português. Você fala português? … Até logo!"{]}
+\end{itemize}
+
+{[}REPEAT x2{]} "Você fala português? — Falo um pouco."
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What are the three singular \emph{-ar} endings? (\emph{-o / -as / -a}.) Give the "I" forms of the three verbs. (\emph{Falo, moro, trabalho}.) \emph{falar} vs Spanish \emph{hablar} — what's the sound-law difference? (Portuguese kept \emph{f-}; Spanish shifted \emph{f$\to$h}.) All five of your languages now move in real sentences — the course has handed over rules, not phrases.
+\end{tcolorbox}

--- a/code/learning/human-languages/portuguese/book/chapters/ch06-numbers-1-10.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch06-numbers-1-10.tex
@@ -1,0 +1,114 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:e500f5a113192fbf
+% canonical-lessons: PT-C06-numeros-1-5, PT-C06-numeros-6-10
+
+\chapter{Numbers One to Ten}
+\label{ch:pt-numbers-one-to-ten}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[um, dois, três, quatro, cinco]{um, dois, três, quatro, cinco — counting to five}
+
+\label{lesson:PT-C06-numeros-1-5}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Portuguese counts almost like its sister Spanish — but with two signature Portuguese twists: heavy \textbf{nasal vowels}, and a number that still \textbf{changes for gender} where Spanish long stopped. Spanish twins are beside each.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{nasal-um} — \textbf{um} is nasal: \emph{oong} said softly through the nose, no real \emph{m}. (The \emph{-m} is just the spelling for nasality, as in \emph{sim}, \emph{bom}.)
+  \item \texttt{open-e} — \textbf{três} = \emph{trehs} with an open \emph{e} and the circumflex marking it.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Portuguese} & \textbf{$\leftarrow$ Latin} & \textbf{Spanish twin} & \textbf{English cousins} \\
+\midrule
+\textbf{um} (1) & \emph{ūnus} & \emph{uno} & \textbf{unit, union, unique} (and \emph{a/an}, \emph{one}) \\
+\textbf{dois} (2) & \emph{duo} & \emph{dos} & \textbf{duo, dual, double} \\
+\textbf{três} (3) & \emph{trēs} & \emph{tres} & \textbf{trio, triple, triangle} \\
+\textbf{quatro} (4) & \emph{quattuor} & \emph{cuatro} & \textbf{quart, quarter, quadrant} \\
+\textbf{cinco} (5) & \emph{quīnque} & \emph{cinco} & \textbf{quintet, quintessence} \\
+\bottomrule
+\end{tabularx}
+
+\emph{Cinco} is spelled \textbf{identically} to Spanish — the two closest sisters. But watch \emph{two}.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: um/uma and the gendered "two" (dois/duas)}]
+\textbf{um} is also "a/an," gendered \textbf{um} (masc.) / \textbf{uma} (fem.): \emph{um café}, \emph{uma cerveja}. That much matches Spanish. The surprise is \textbf{two}: Portuguese still inflects it — \textbf{dois} (masc.) / \textbf{duas} (fem.) — a direct survival of Latin \emph{duo} (masc.) / \emph{duae} (fem.). So it's \emph{dois cafés} but \emph{duas cervejas}. Spanish levelled this to a single \emph{dos} centuries ago; Portuguese kept the old split. The rest (\emph{três, quatro, cinco}) don't change.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "um, dois, três, quatro, cinco" — count up{]}
+  \item {[}YOU SAY: the gendered two — "dois cafés" (masc.) / "duas cervejas" (fem.){]}
+  \item {[}YOU SAY: each with its English cousin — "dois/duo, três/trio, cinco/quintet"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Give 1–5 in Portuguese. (\emph{Um, dois, três, quatro, cinco}.) Which number still changes for gender, and how? (\emph{Two} — \emph{dois} / \emph{duas}, $\leftarrow$ Latin \emph{duo/duae}.) What does \emph{um/uma} mean besides "one"? ("A/an.") Next: \textbf{6–10}, where a Portuguese sound-shift is on full display.
+\end{tcolorbox}
+\section[seis, sete, oito, nove, dez]{seis, sete, oito, nove, dez — and the calendar's secret}
+
+\label{lesson:PT-C06-numeros-6-10}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The rest of the way to ten. Like Spanish, Portuguese hides the calendar fact — \textbf{setembro–dezembro are Latin for 7, 8, 9, 10} — and one number, \emph{oito}, puts a signature Portuguese sound-shift on full display.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{diphthong-oi} — \textbf{oito} = \emph{OY-too}, \textbf{dois} rhymes with it: the \emph{oi} glide.
+  \item \textbf{dez} = \emph{dehs} (open \emph{e}); the final \emph{-z} is a soft "sh"/"s" in Portugal, "s" in Brazil.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Portuguese} & \textbf{$\leftarrow$ Latin} & \textbf{Spanish twin} & \textbf{English cousins} \\
+\midrule
+\textbf{seis} (6) & \emph{sex} & \emph{seis} & \textbf{sextet, sextant} \\
+\textbf{sete} (7) & \emph{septem} & \emph{siete} & \textbf{setembro} (the \emph{7th} month!), septet \\
+\textbf{oito} (8) & \emph{octō} & \emph{ocho} & \textbf{outubro} (8th), \textbf{octave, octopus} \\
+\textbf{nove} (9) & \emph{novem} & \emph{nueve} & \textbf{novembro} (9th), novena \\
+\textbf{dez} (10) & \emph{decem} & \emph{diez} & \textbf{dezembro} (10th), \textbf{decimal, dízimo} \\
+\bottomrule
+\end{tabularx}
+
+The star is \textbf{oito}. Latin \emph{octō} had a \emph{-ct-} cluster, and Portuguese turned every Latin \emph{-ct-} into \emph{\textbf{-it-}}: \emph{octō $\to$ oito}, \emph{noctem $\to$ noite} ("night"), \emph{lactem $\to$ leite} ("milk"), \emph{factum $\to$ feito} ("done"). So \emph{oito}, \emph{noite}, and \emph{leite} all carry the same fingerprint — once you spot the \emph{-it-}, you can often guess the Latin word had a \emph{-ct-}. (Spanish took a different path: \emph{octō $\to$ ocho}, with \emph{-ct- $\to$ -ch-}. Same cluster, two sisters, two solutions — \emph{oito} vs \emph{ocho}.)
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: why the months are "off by two"}]
+\emph{Setembro} means "7th," yet sits \textbf{9th}. The old \textbf{Roman year began in March}, so \emph{September} really was the seventh; \emph{julho} and \emph{agosto} (July, August) were inserted later and shoved the counting months down. The Latin numbers stuck to the month names. Every \emph{dezembro}, you're saying Roman "\textbf{ten}" — and \emph{dez} also gave Portuguese \emph{dízimo}, a "tithe" (a tenth), the twin of English \emph{dime}.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "seis, sete, oito, nove, dez" — finish the count{]}
+  \item {[}YOU SAY: "sete/setembro, oito/outubro, nove/novembro, dez/dezembro"{]}
+  \item {[}YOU SAY: the \emph{-ct- $\to$ -it-} set — "oito, noite, leite" — then Spanish "ocho"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Give 6–10 in Portuguese. (\emph{Seis, sete, oito, nove, dez}.) What Latin cluster became \emph{-it-} in \emph{oito}, and one more example? (\emph{-ct-}; \emph{noite} $\leftarrow$ \emph{noctem} / \emph{leite} $\leftarrow$ \emph{lactem}.) Why is \emph{dezembro} Latin for "ten"? (The Roman year began in March.) Next chapter builds on this toward time and days.
+\end{tcolorbox}

--- a/code/learning/human-languages/portuguese/book/chapters/ch07-days-of-the-week.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch07-days-of-the-week.tex
@@ -1,0 +1,107 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:b504ffa532cad313
+% canonical-lessons: PT-C07-dias-1, PT-C07-dias-2
+
+\chapter{Days of the Week}
+\label{ch:pt-days-of-the-week}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[segunda, terça, quarta, quinta, sexta(-feira)]{segunda to sexta — the week that got numbered}
+
+\label{lesson:PT-C07-dias-1}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Here Portuguese does something \textbf{no other Romance language does}. French, Italian, and Spanish all name their weekdays for planet-gods (\emph{lundi}, \emph{lunedì}, \emph{lunes} = the Moon). Portuguese threw the pagan gods out and \textbf{numbered} the days instead — and the numbers are the very ones you just learned.
+\end{quote}
+
+\begin{culture}
+In the 6th century, \textbf{Martinho de Braga}, a bishop in what is now northern Portugal, refused to let Christians name days after \emph{Mars} and \emph{Jupiter}. Borrowing the Church's word for the numbered holy days of Easter week, he called them \textbf{feiras} — and Portuguese alone kept the system for \textbf{every} week.
+
+\textbf{feira} $\leftarrow$ Latin \textbf{fēria}, "a feast-day / a day free of work." (The same \emph{fēria} drifted, elsewhere, into "market/fair" — English \textbf{fair} is its cousin, because markets were held on feast-days.)
+\end{culture}
+
+\begin{grammarlens}[title={Grammar Lens: The pattern: {[}ordinal{]} + feira}]
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Portuguese} & \textbf{means} & \textbf{$\leftarrow$ ordinal of} & \textbf{(cardinal you learned)} \\
+\midrule
+\textbf{segunda}-feira (Mon) & "2nd feast-day" & \emph{secundus} "second" & \emph{dois} (2) \\
+\textbf{terça}-feira (Tue) & "3rd" & \emph{tertius} "third" & \emph{três} (3) \\
+\textbf{quarta}-feira (Wed) & "4th" & \emph{quartus} "fourth" & \emph{quatro} (4) \\
+\textbf{quinta}-feira (Thu) & "5th" & \emph{quintus} "fifth" & \emph{cinco} (5) \\
+\textbf{sexta}-feira (Fri) & "6th" & \emph{sextus} "sixth" & \emph{seis} (6) \\
+\bottomrule
+\end{tabularx}
+
+So \emph{quarta-feira} is literally "\textbf{fourth} feast-day," and you can hear \emph{quatro} (4) inside \emph{quarta}. In everyday speech the "-feira" is often dropped: "\emph{Até segunda!}" — "See you Monday!" (Why does Monday start at \textbf{two}, not one? Because Sunday is counted as the \emph{first} day — the next lesson closes that loop.)
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "segunda, terça, quarta, quinta, sexta" — Monday through Friday{]}
+  \item {[}YOU SAY: hear the number in each — "quarta $\leftarrow$ quatro (4), quinta $\leftarrow$ cinco (5), sexta $\leftarrow$ seis (6)"{]}
+  \item {[}YOU SAY: drop the tail — "Até sexta!" ("See you Friday!"){]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} How is Portuguese unique among Romance languages here? (It \textbf{numbers} its weekdays — \emph{feiras} — instead of naming planet-gods.) What does \emph{feira} mean, and its English cousin? ("Feast-day," $\leftarrow$ \emph{fēria}; English \emph{fair}.) What number hides in \emph{quinta-feira}? (Five — \emph{quinta} $\leftarrow$ \emph{quintus}, cousin of \emph{cinco}.) Next: the two days that \textbf{kept} their old names — \emph{sábado} and \emph{domingo}.
+\end{tcolorbox}
+\section[sábado, domingo]{sábado and domingo — and why Monday is "the second"}
+
+\label{lesson:PT-C07-dias-2}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Five weekdays got numbered — but two kept their names. \emph{Sábado} and \emph{domingo} are the \textbf{religious anchors} of the Portuguese week, and \emph{domingo} is the key that explains why the counting started where it did.
+\end{quote}
+
+\begin{cousinweb}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Portuguese} & \textbf{$\leftarrow$ Latin} & \textbf{meaning} & \textbf{shared with} \\
+\midrule
+\textbf{sábado} & \emph{Sabbatum} $\leftarrow$ Hebrew \emph{shabbāt} & the "\textbf{Sabbath}," rest-day & Spanish \emph{sábado}, Italian \emph{sabato}, French \emph{samedi} \\
+\textbf{domingo} & \emph{(diēs) Dominica} $\leftarrow$ \emph{Dominus} & "the \textbf{Lord's} day" & Spanish \emph{domingo}, Italian \emph{domenica} \\
+\bottomrule
+\end{tabularx}
+
+\begin{itemize}
+\raggedright
+  \item \textbf{sábado} is the \textbf{Sabbath}, from Hebrew \emph{shabbāt} "to rest" — the one weekend name every Romance language shares (even numbering-mad Portuguese kept it).
+  \item \textbf{domingo} is "the \textbf{Lord's} day," \emph{diēs Dominica}, from \emph{Dominus} "lord, master" ($\to$ English \emph{dominion, dominate, dame}).
+\end{itemize}
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: domingo is "day one" — so Monday is "day two"}]
+Now the loop closes. The Church counted \textbf{domingo (Sunday) as the \emph{first} day} of the week — \emph{prima feria}, the Lord's day, the start. That's why:
+
+\begin{quote}
+domingo = 1st $\to$ \textbf{segunda}-feira (Monday) = \textbf{2nd} $\to$ terça (3rd) $\to$ … $\to$ sexta (Friday) = 6th $\to$ sábado (Saturday) = 7th.
+\end{quote}
+
+Monday isn't the first weekday in this system — it's the day \textbf{after} the Lord's day, the \emph{second}. So \emph{segunda-feira} ("second feast-day") makes perfect sense once you know Sunday was counted first. The whole week is a countdown anchored on \emph{domingo}.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the full week — "domingo, segunda, terça, quarta, quinta, sexta, sábado"{]}
+  \item {[}YOU SAY: the anchors — "sábado = Sabbath, domingo = the Lord's day"{]}
+  \item {[}YOU SAY: the logic — "domingo is 1st, so segunda (Monday) is 2nd"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Give all seven Portuguese days. (\emph{Domingo, segunda … sábado}.) What does \emph{domingo} mean, and why does that make Monday "\emph{segunda}"? ("The \textbf{Lord's} day"; Sunday is counted \textbf{first}, so Monday is the \textbf{second}.) Which weekend name do all the Romance languages share? (\emph{Sábado} — the Sabbath.) Next chapter builds on this toward telling the time.
+\end{tcolorbox}

--- a/code/learning/human-languages/portuguese/book/chapters/ch08-telling-time.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch08-telling-time.tex
@@ -1,0 +1,103 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:074f8f7eba5b6b2a
+% canonical-lessons: PT-C08-hora, PT-C08-meio-dia-meia-noite
+
+\chapter{Telling Time}
+\label{ch:pt-telling-time}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[hora]{hora — the hour, said in full}
+
+\label{lesson:PT-C08-hora}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Portuguese "hour" is \textbf{hora}, from Latin \textbf{hōra} ($\leftarrow$ Greek \emph{h\'{\={o}}rā}) — the same word behind Spanish \emph{hora}, French \emph{heure}, and English \emph{hour}. And unlike Italian, which hides the word, Portuguese keeps \textbf{horas} right out loud.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{silent-h} — the \textbf{h} of \emph{hora} is silent (as everywhere in Portuguese): say \emph{OH-ra}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{hora} $\leftarrow$ Latin \textbf{hōra} $\leftarrow$ Greek \textbf{h\'{\={o}}rā}, "a time of day." Portuguese kept the Latin spelling's silent \emph{h-}, exactly as English \emph{hour} does. Line the sisters up: \emph{hora / hora / heure / Uhr / hour} — one Roman word (itself Greek-born) fanned across five languages.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: "é uma hora" but "são duas horas"}]
+Portuguese states the word \textbf{horas} in full, and the verb agrees with the number:
+
+\begin{quote}
+\textbf{É uma hora.} — "It is one o'clock." (singular: \emph{é} "it is" + \emph{uma hora}) \textbf{São duas horas.} — "It is two o'clock." (plural: \emph{são} "they are" + \emph{duas horas}) \textbf{São dez horas.} — "It is ten o'clock."
+\end{quote}
+
+Literally "\textbf{they are} two \textbf{hours}." Two things to notice, both from earlier chapters: the verb is \textbf{é} (one) vs \textbf{são} (two or more), like Italian \emph{è/sono}; and \textbf{two} still shows gender — \emph{duas} horas (feminine, agreeing with \emph{horas}), the \emph{dois/duas} split you met in the numbers.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "hora" — \emph{OH-ra}, silent h{]}
+  \item {[}YOU SAY: "é uma hora … são duas horas, são três horas"{]}
+  \item {[}YOU SAY: "duas horas" — feminine \emph{duas}, not \emph{dois}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What word is \emph{hora} from, and its Spanish twin? (Latin \emph{hōra} $\leftarrow$ Greek \emph{h\'{\={o}}rā}; Spanish \emph{hora}.) Why "\emph{são duas} horas" but "\emph{é uma} hora"? (Plural takes \emph{são}; one o'clock is singular \emph{é}.) Why \emph{duas} and not \emph{dois}? (\emph{Horas} is feminine — the \emph{dois/duas} gender split.) Next: \textbf{meio-dia} and \textbf{meia-noite} — noon and midnight.
+\end{tcolorbox}
+\section[meio-dia, meia-noite]{meio-dia and meia-noite — noon and midnight}
+
+\label{lesson:PT-C08-meio-dia-meia-noite}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The two named hours. \textbf{meio-dia} (noon) and \textbf{meia-noite} (midnight) are the \textbf{middle} of the day and the night — and \emph{meia-noite} hides a sound-shift you already met back in the numbers.
+\end{quote}
+
+\begin{cousinweb}
+The front piece is \textbf{meio/meia}, "half, middle," from Latin \textbf{medius/media} (cousin of English \emph{mid, medium} and of Spanish \emph{medio}):
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Portuguese} & \textbf{=} & \textbf{$\leftarrow$ Latin} & \textbf{literally} \\
+\midrule
+\textbf{meio-dia} & \emph{meio} + \emph{dia} & \emph{medius} + \emph{diēs} & "\textbf{mid}-\textbf{day}" (noon) \\
+\textbf{meia-noite} & \emph{meia} + \emph{noite} & \emph{media} + \emph{noctem} & "\textbf{mid}-\textbf{night}" (midnight) \\
+\bottomrule
+\end{tabularx}
+
+\begin{itemize}
+\raggedright
+  \item \textbf{meio-dia} = "mid-day." \emph{dia} ("day") $\leftarrow$ \emph{diēs}; \emph{meio} is masculine (agreeing with the masculine \emph{dia}).
+  \item \textbf{meia-noite} = "mid-night." \emph{meia} is \textbf{feminine} (for the feminine \emph{noite}) — the \emph{meio/meia} gender pair, like the \emph{dois/duas} you know. And look at \textbf{noite}: it comes from Latin \textbf{noctem}, and the \emph{-ct-} became \emph{-it-} — \emph{noctem $\to$ noite} — the \textbf{very same ct$\to$it shift} that turned \emph{octō} into \emph{oito} ("8") in the numbers chapter. Spot \emph{-it-} and you can often guess a Latin \emph{-ct-} underneath.
+\end{itemize}
+
+To use them, they \emph{are} the hour:
+
+\begin{quote}
+\textbf{É meio-dia.} — "It is noon." \textbf{É meia-noite.} — "It is midnight."
+\end{quote}
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "meio-dia" (noon), "meia-noite" (midnight){]}
+  \item {[}YOU SAY: break them — "meio (middle) + dia (day)", "meia + noite (night)"{]}
+  \item {[}YOU SAY: the shift — "noite $\leftarrow$ noctem, like oito $\leftarrow$ octō"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What do \emph{meio-dia} and \emph{meia-noite} literally mean? ("Mid-day" and "mid-night.") Why \emph{meia}-noite but \emph{meio}-dia? (\emph{meia} feminine for \emph{noite}, \emph{meio} masculine for \emph{dia}.) What earlier sound-shift is inside \emph{noite}? (\emph{ct$\to$it}: \emph{noctem $\to$ noite}, like \emph{octō $\to$ oito}.) Next chapter builds on this toward months and family.
+\end{tcolorbox}

--- a/code/learning/human-languages/portuguese/book/chapters/ch09-months-and-seasons.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch09-months-and-seasons.tex
@@ -1,0 +1,110 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:565993042600b26d
+% canonical-lessons: PT-C09-meses, PT-C09-estacoes
+
+\chapter{Months and Seasons}
+\label{ch:pt-months-and-seasons}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[os meses]{os meses — the gods and numbers of the calendar}
+
+\label{lesson:PT-C09-meses}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The Portuguese months are the Roman procession of gods and Caesars, worn down the Portuguese way. And two things you know pay off: \emph{março} is the war-god, and \emph{setembro–dezembro} are the Latin numbers 7–10.
+\end{quote}
+
+\begin{cousinweb}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Portuguese} & \textbf{$\leftarrow$ Latin} & \textbf{who / what} & \textbf{Spanish twin} \\
+\midrule
+\textbf{janeiro} & \emph{Januarius} & \textbf{Janus}, god of beginnings & \emph{enero} \\
+\textbf{fevereiro} & \emph{Februarius} & the \emph{Februa} purification & \emph{febrero} \\
+\textbf{março} & \emph{Martius} & \textbf{Mars}, the war-god & \emph{marzo} \\
+\textbf{abril} & \emph{Aprilis} & \emph{aperire} "to open" & \emph{abril} \\
+\textbf{maio} & \emph{Maius} & \textbf{Maia}, growth-goddess & \emph{mayo} \\
+\textbf{junho} & \emph{Junius} & \textbf{Juno}, queen of gods & \emph{junio} \\
+\textbf{julho} & \emph{Julius} & \textbf{Julius Caesar} & \emph{julio} \\
+\textbf{agosto} & \emph{Augustus} & emperor \textbf{Augustus} & \emph{agosto} \\
+\textbf{setembro} & \emph{september} & "\textbf{7th}" (\emph{septem}) & \emph{septiembre} \\
+\textbf{outubro} & \emph{october} & "\textbf{8th}" (\emph{octo}) & \emph{octubre} \\
+\textbf{novembro} & \emph{november} & "\textbf{9th}" (\emph{novem}) & \emph{noviembre} \\
+\textbf{dezembro} & \emph{december} & "\textbf{10th}" (\emph{decem}) & \emph{diciembre} \\
+\bottomrule
+\end{tabularx}
+
+Portuguese tells: \emph{janeiro/fevereiro} kept the \emph{-eiro} ending ($\leftarrow$ \emph{-arius}, the same suffix in \emph{feira}), and \emph{setembro/dezembro} echo the numbers \emph{sete/dez} you learned. Two payoffs:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{março = Mars.} The war-god's month, the same Mars behind English \emph{March}.
+  \item \textbf{setembro…dezembro = 7…10.} Still the Latin numbers, because the Roman year began in \textbf{March}; then \emph{julho} (Julius) and \emph{agosto} (Augustus) were inserted and pushed the count down two.
+\end{itemize}
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the twelve — "janeiro, fevereiro, março … novembro, dezembro"{]}
+  \item {[}YOU SAY: "março = Mars, the war-god"{]}
+  \item {[}YOU SAY: "setembro = 7 (sete), dezembro = 10 (dez)"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which god is \emph{março} named for? (\textbf{Mars}, the war-god.) Why is \emph{dezembro} Latin for "ten"? (The Roman year began in March.) Which two months honour real \textbf{people}? (\emph{Julho} — Julius; \emph{agosto} — Augustus.) Next: the \textbf{estações}, the seasons.
+\end{tcolorbox}
+\section[as estações]{as estações — the seasons, and a shifting summer}
+
+\label{lesson:PT-C09-estacoes}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Four seasons — and a small mystery in one of them. Portuguese's word for \textbf{summer}, \emph{verão}, didn't come from a "heat" word like French \emph{été}. It grew out of the word for \textbf{spring}. Here's how.
+\end{quote}
+
+\begin{cousinweb}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Portuguese} & \textbf{$\leftarrow$ Latin} & \textbf{literally} \\
+\midrule
+\textbf{a primavera} (spring) & \emph{prīma vēra} & "\textbf{first spring / first green}" (\emph{prima} + \emph{ver} "spring") \\
+\textbf{o verão} (summer) & \emph{vēranum (tempus)} & "the \textbf{spring-like / warm} season" ($\leftarrow$ \emph{vēr} "spring"!) \\
+\textbf{o outono} (autumn) & \emph{autumnus} & "autumn" (\emph{ct/tumn} $\to$ \emph{ut}: \emph{autumnus $\to$ outono}) \\
+\textbf{o inverno} (winter) & \emph{hibernum} & "the wintry season" (cousin of \emph{hibernate}) \\
+\bottomrule
+\end{tabularx}
+
+The twist is in the first two, both born from Latin \textbf{vēr}, "spring":
+
+\begin{itemize}
+\raggedright
+  \item \textbf{primavera} = \emph{prima} + \emph{ver}: "the \textbf{first} spring / first green" — the year's opening season (shared with Spanish and Italian).
+  \item \textbf{verão} $\leftarrow$ \emph{vēranum}, which meant "\textbf{spring-like}, of the growing season." Warmth crept forward on the calendar, and the word slid with it — so Portuguese's "summer" literally \emph{grew out of} "spring." (Spanish did the same: \emph{verano}.)
+\end{itemize}
+
+And \textbf{outono} $\leftarrow$ \emph{autumnus} shows a familiar Portuguese move: the \emph{au…t} smoothed to \textbf{ou}, the same softening you saw in \emph{oito} and \emph{noite}.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "a primavera, o verão, o outono, o inverno"{]}
+  \item {[}YOU SAY: the twist — "verão $\leftarrow$ veranum $\leftarrow$ ver (spring): summer from spring"{]}
+  \item {[}YOU SAY: "inverno \textasciitilde{} hibernate"; "outono $\leftarrow$ autumnus"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Name the four Portuguese seasons. (\emph{Primavera, verão, outono, inverno}.) What's surprising about \emph{verão}'s origin? (It comes from \emph{vēr} "\textbf{spring}" — the summer-word grew out of the spring-word.) What does \emph{primavera} literally mean? ("\textbf{First spring / first green}.") Next chapter builds on this toward family and food.
+\end{tcolorbox}

--- a/code/learning/human-languages/portuguese/book/chapters/ch10-family.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch10-family.tex
@@ -1,0 +1,95 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:756b61183a892e04
+% canonical-lessons: PT-C10-pais, PT-C10-irmaos
+
+\chapter{Family}
+\label{ch:pt-family}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[o pai, a mãe]{o pai, a mãe — the family words worn to the bone}
+
+\label{lesson:PT-C10-pais}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Every Romance sister descends from \emph{pater} and \emph{māter}, but \textbf{Portuguese wore them down the furthest}. Italian kept \emph{padre/madre}; French \emph{père/mère}; Portuguese dissolved the middle consonant entirely, leaving the one-syllable \textbf{pai} and the nasal \textbf{mãe}.
+\end{quote}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{o pai} ("father") $\leftarrow$ Latin \textbf{pater}. Portuguese dropped the intervocalic \textbf{-t-} completely: \emph{pater $\to$ pae $\to$ pai}. The same disappearing-\emph{-t-} you saw in Ch.1's \emph{noite} is here taken all the way to a bare diphthong.
+  \item \textbf{a mãe} ("mother") $\leftarrow$ Latin \textbf{māter}. Same loss of \emph{-t-}, and the \emph{a} soaked up a nasal from the lost \emph{-n-}/\emph{-m-} environment $\to$ the tilde vowel \textbf{ã} (\emph{mãe} = "mahng-ee," nasal).
+\end{itemize}
+
+Articles: \emph{o} pai (masculine), \emph{a} mãe (feminine).
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: The plural trick — os pais}]
+Portuguese says \textbf{os pais} for "\textbf{the parents}" — but literally it is "the \textbf{fathers}." Like Spanish \emph{los padres}, the masculine plural \textbf{covers a mixed group}: one father + one mother = \emph{os pais}. (And mind the spelling twin: \textbf{o país} — with an accent — means "the \textbf{country}"; \emph{os pais} / \emph{os países} are a classic pair to keep straight.)
+
+The learned adjectives, borrowed back from Latin, still show the old root: \textbf{pat}ernal, \textbf{mat}ernal — so \emph{pai} and \emph{paternal} are the worn-down and the dressed-up versions of the same word.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "o pai, a mãe" — \emph{mãe} fully nasal{]}
+  \item {[}YOU SAY: the erosion — "\emph{pater} $\to$ \emph{pae} $\to$ \textbf{pai}; the \emph{-t-} vanished"{]}
+  \item {[}YOU SAY: "os pais = the parents (lit. 'the fathers'); mind \emph{o país} = country"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Give "father" and "mother" with articles. (\textbf{o pai, a mãe}.) What happened to the \emph{-t-} of \emph{pater/māter} in Portuguese? (It \textbf{vanished} — \emph{pater $\to$ pae $\to$ pai}.) What does \textbf{os pais} mean literally and in use? (Literally "the fathers"; in use, "\textbf{the parents}.") What word does \emph{o país} (accented) mean? (The \textbf{country} — a spelling trap.) Next: \textbf{o irmão, a irmã} — and a surprise about where "brother" comes from.
+\end{tcolorbox}
+\section[o irmão, a irmã]{o irmão, a irmã — the brother who isn't a "frater"}
+
+\label{lesson:PT-C10-irmaos}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Every other track in this course builds "brother" from Latin \emph{frāter} (French \emph{frère}, Italian \emph{fratello}). Portuguese — and Spanish with it — does something completely different, and it is one of the best etymologies in the whole language.
+\end{quote}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{o irmão} ("brother") and \textbf{a irmã} ("sister") come \textbf{not} from \emph{frāter} but from Latin \textbf{germānus}, meaning "\textbf{genuine, of the same stock, born of the same parents.}"
+  \item The Romans said \textbf{frāter germānus} — a "\textbf{full} brother," one sharing both parents, as opposed to a half-brother. Over time Iberian speakers \textbf{dropped the \emph{frāter}} and kept the adjective: \emph{(frāter) germānus $\to$ irmão}. So a Portuguese brother is literally a "\textbf{full-blood} one."
+\end{itemize}
+
+Articles: \emph{o} irmão (masc.), \emph{a} irmã (fem.); the masculine plural \textbf{os irmãos} covers a mixed set ("siblings"), exactly as \emph{os pais} did for parents.
+\end{cousinweb}
+
+\begin{cousinweb}
+That same \emph{germānus} "of the same stock" fans out in English:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{germane} — "relevant, closely related" (originally "having the same parents").
+  \item \textbf{German} — the \textbf{people-name}! The Romans called the tribes across the Rhine \emph{Germani}, plausibly "the genuine/kindred ones." So \emph{irmão} ("brother") and \emph{German} (the nation) spring from one Latin word for \textbf{kinship}.
+\end{itemize}
+
+Spanish made the \textbf{identical} swap — \emph{hermano / hermana} — so Portuguese \emph{irmão} and Spanish \emph{hermano} are twins, both meaning "full-blood brother," both leaving \emph{frāter} behind (kept only in bookish \emph{fraternal / fraterno}).
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "o irmão, a irmã" — both nasal endings{]}
+  \item {[}YOU SAY: the origin — "\emph{frāter germānus} $\to$ drop \emph{frāter} $\to$ \textbf{irmão}, 'full brother'"{]}
+  \item {[}YOU SAY: the cousins — "germano $\to$ germane, and \emph{German} the people"{]}
+  \item {[}YOU SAY: the twin — "Portuguese \emph{irmão} = Spanish \emph{hermano}"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Give "brother" and "sister" with articles. (\textbf{o irmão, a irmã}.) What Latin word are they from — and what did it mean? (\textbf{germānus} — "genuine, of the same parents"; from \emph{frāter germānus}, "full brother.") Name two English cousins of \emph{germānus}. (\textbf{germane}; \textbf{German}, the people-name.) What is the Spanish twin of \emph{irmão}? (\emph{hermano}.) Next chapter: sentences about the whole family.
+\end{tcolorbox}

--- a/code/learning/human-languages/portuguese/book/chapters/ch11-bread-water-wine.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch11-bread-water-wine.tex
@@ -1,0 +1,81 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:45ea90ec38957e5b
+% canonical-lessons: PT-C11-pao, PT-C11-agua-vinho
+
+\chapter{Bread, Water, and Wine}
+\label{ch:pt-bread-water-wine}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[o pão]{o pão — bread, worn down to a hum}
+
+\label{lesson:PT-C11-pao}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} \textbf{o pão} ("bread") — and Portuguese does to it exactly what it did to "father." Just as \emph{pater} eroded to the one-syllable \textbf{pai}, Latin \emph{pānis} wore down to the single \textbf{nasal} syllable \textbf{pão} ("\textbf{powng}"). Same word as French \emph{pain} and Italian \emph{pane}, taken furthest.
+\end{quote}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{o pão} ("bread") $\leftarrow$ Latin \textbf{pānis}. The intervocalic \emph{-n-} dissolved and left its \textbf{nasality} behind on the vowel: \emph{pānis $\to$ pãe $\to$ pão}, the tilde marking the hum — the identical process behind \textbf{pai} ($\leftarrow$ \emph{pater}) and \textbf{mãe} ($\leftarrow$ \emph{māter}) from the family chapter. Masculine: \emph{o} pão; the plural is the tricky \textbf{pães}.
+\end{itemize}
+\end{cousinweb}
+
+\begin{cousinweb}
+Even worn to a hum, the root keeps its English relatives: \textbf{companion / company} (\emph{com-} + \emph{pānis}, "one you \textbf{share bread with}"), \textbf{pantry}, \textbf{pannier}. So \emph{pão} and \emph{companion} are the near-vanished and the well-preserved ends of one Latin word.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "o pão" — fully nasal, "powng"; plural "pães"{]}
+  \item {[}YOU SAY: the parallel — "\emph{pater} $\to$ \textbf{pai}, \emph{pānis} $\to$ \textbf{pão} — same nasal erosion"{]}
+  \item {[}YOU SAY: "pão $\to$ companion, pantry"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Give "bread" with its article. (\textbf{o pão}.) What Latin word is it from, and what happened to it? (\emph{pānis} — worn to a single \textbf{nasal} syllable, \emph{pānis $\to$ pão}.) Which family word followed the \emph{same} erosion? (\textbf{pai}, $\leftarrow$ \emph{pater} — and \emph{mãe} $\leftarrow$ \emph{māter}.) Next: \textbf{a água} and \textbf{o vinho} — water and wine.
+\end{tcolorbox}
+\section[a água, o vinho]{a água, o vinho — water and wine}
+
+\label{lesson:PT-C11-agua-vinho}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Two drinks, two more sound-stories. Portuguese kept \textbf{água} close to Latin \emph{aqua} (unlike French, which dissolved it to \emph{eau}), and it stamps \textbf{vinho} with its signature spelling — the \textbf{-nh-}.
+\end{quote}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{a água} ("water") $\leftarrow$ Latin \textbf{aqua}. Portuguese held its body — \emph{aqua $\to$ água} — where French wore it down to a single vowel (\emph{eau}). The accent on \textbf{á} marks the stress. It's \textbf{feminine}: \emph{a} água. English kept the loud original in \textbf{aquatic, aquarium, aqueduct}.
+\end{itemize}
+\end{cousinweb}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{o vinho} ("wine") $\leftarrow$ Latin \textbf{vīnum}. The \textbf{-nh-} is Portuguese's palatal \emph{ny} sound — the \textbf{same sound} as Spanish \textbf{ñ} (\emph{viño}$\to$\emph{vinho}), French/Italian \textbf{gn}, and the \emph{nh} you already met in \emph{amanhã} ("tomorrow"). One sound, four spellings across the sisters. The word still gives English \textbf{wine, vine, vinegar, vintage}. Masculine: \emph{o} vinho.
+\end{itemize}
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "a água, o vinho" — stress the \emph{á}; \emph{-nh-} = palatal \emph{ny}{]}
+  \item {[}YOU SAY: the contrast — "\emph{aqua} $\to$ \textbf{água} (kept), French \textbf{eau} (worn away)"{]}
+  \item {[}YOU SAY: "the \emph{nh} of \emph{vinho} = Spanish \emph{ñ}, met before in \emph{amanhã}"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Give "water" and "wine" with articles. (\textbf{a água, o vinho}.) How does \emph{água} compare with French \emph{eau}, from the same \emph{aqua}? (Portuguese \textbf{kept} the body; French wore it to a vowel.) What sound is the \textbf{-nh-} in \emph{vinho}, and its Spanish twin? (A palatal \emph{ny} — Spanish \textbf{ñ}.) Next chapter: asking for these at a table.
+\end{tcolorbox}

--- a/code/learning/human-languages/portuguese/book/chapters/ch12-numbers-11-20.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch12-numbers-11-20.tex
@@ -1,0 +1,116 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:d62ea89555f0cfaf
+% canonical-lessons: PT-C12-numeros-11-15, PT-C12-numeros-16-20
+
+\chapter{Numbers Eleven to Twenty}
+\label{ch:pt-numbers-eleven-to-twenty}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[onze — quinze]{onze $\to$ quinze — the short list}
+
+\label{lesson:PT-C12-numeros-11-15}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Portuguese inherited the same welded Latin teens as its sisters — but it kept \textbf{fewer of them than anyone}. Just \textbf{five}. After \emph{quinze} (15), it starts over with a completely different, much plainer method.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: The five fusions}]
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{Portuguese} & \textbf{$\leftarrow$ Latin} & \textbf{build} \\
+\midrule
+11 & \textbf{onze} & \emph{ūndecim} & "one-ten" \\
+12 & \textbf{doze} & \emph{duodecim} & "two-ten" \\
+13 & \textbf{treze} & \emph{trēdecim} & "three-ten" \\
+14 & \textbf{catorze} & \emph{quattuordecim} & "four-ten" \\
+15 & \textbf{quinze} & \emph{quīndecim} & "five-ten" \\
+\bottomrule
+\end{tabularx}
+
+The shared \textbf{-ze} is Latin \textbf{decem} ("ten") worn thin — the same ten inside \textbf{dez} (10) and \textbf{dezembro} (the old 10th month, from Chapter 9). The digit sits at the front: \emph{dois$\to$do-}, \emph{três$\to$tre-}, \emph{quatro$\to$cator-}, \emph{cinco$\to$quin-}.
+
+Note \textbf{catorze} — Portuguese kept the \emph{c-} where Spanish says \emph{catorce} and French \emph{quatorze}; three worn-down versions of one Latin \emph{quattuordecim}.
+\end{grammarlens}
+
+\begin{grammarlens}[title={What you've built: And that's where it stops}]
+\emph{Quinze} is the \textbf{last} fused number. From \textbf{16} Portuguese does something none of its sisters do so early — the next lesson.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "onze, doze, treze, catorze, quinze"{]}
+  \item {[}YOU SAY: the ten inside — "-ze = \emph{decem} = \textbf{dez}"{]}
+  \item {[}YOU SAY: the digit inside — "\textbf{três} $\to$ \textbf{tre}ze, \textbf{cinco} $\to$ \textbf{quin}ze"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Count 11 to 15. (\emph{Onze, doze, treze, catorze, quinze}.) What is the \textbf{-ze}? (Latin \textbf{decem}, "ten" — as in \emph{dez}, \emph{dezembro}.) How many fused teens does Portuguese keep, and is that more or fewer than its sisters? (\textbf{Five} — \textbf{fewer}; French and Italian keep six.) Next: \textbf{16}, where Portuguese starts building numbers a brand-new way.
+\end{tcolorbox}
+\section[dezesseis — vinte]{dezesseis $\to$ vinte — built from scratch, with the "and" still showing}
+
+\label{lesson:PT-C12-numeros-16-20}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} At \textbf{16}, Portuguese stops inheriting and starts \textbf{building}. And it does it more openly than any sister: it glues together the living words for "ten," "and," and the digit — and leaves the \textbf{and} right there in the middle where you can hear it.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: Ten AND six}]
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{Portuguese} & \textbf{build} & \textbf{literally} \\
+\midrule
+15 & \textbf{quinze} & (fused, inherited) & "five-ten" \\
+\textbf{16} & \textbf{dezesseis} & \textbf{dez + e + seis} & \textbf{"ten and six"} \\
+17 & \textbf{dezessete} & dez + e + sete & "ten and seven" \\
+18 & \textbf{dezoito} & dez + oito & "ten eight" \\
+19 & \textbf{dezenove} & dez + e + nove & "ten and nine" \\
+20 & \textbf{vinte} & $\leftarrow$ \emph{vīgintī} & — \\
+\bottomrule
+\end{tabularx}
+
+Every one begins with \textbf{dez} ("ten," Chapter 6) and most keep \textbf{e} ("and") — so \emph{dezesseis} is transparently a little sentence: \emph{ten-and-six}. (\emph{Dezoito} swallows the \emph{e} before the vowel of \emph{oito}.) You already know every ingredient; nothing here needs memorising, only assembling.
+\end{grammarlens}
+
+\begin{grammarlens}[title={What you've built: Portuguese breaks earliest}]
+All three Romance sisters give up fusing partway through the teens — but Portuguese gives up \textbf{first}:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{last fused} & \textbf{goes transparent at} \\
+\midrule
+\textbf{Portuguese} & \emph{quinze} (15) & \textbf{16} — \emph{dezesseis} \\
+French & \emph{seize} (16) & 17 — \emph{dix-sept} \\
+Italian & \emph{sedici} (16) & 17 — \emph{diciassette} \\
+\bottomrule
+\end{tabularx}
+
+One inherited Latin system, three different breaking points — and Portuguese is the boldest rebuilder. (German, by contrast, never breaks at all.)
+
+\textbf{vinte} (20) $\leftarrow$ \emph{vīgintī}, the same root as French \emph{vingt}, Italian \emph{venti}, and English \textbf{vigesimal}.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: 15$\to$20 — "quinze, dezesseis, dezessete, dezoito, dezenove, vinte"{]}
+  \item {[}YOU SAY: hear the sentence — "\emph{dez} \textbf{e} \emph{seis} — ten AND six"{]}
+  \item {[}YOU SAY: the whole run, onze to vinte{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \textbf{dezesseis} literally spell out? ("\textbf{Ten and six}" — \emph{dez} + \emph{e} + \emph{seis}.) At which number does Portuguese break, and how does that compare with French and Italian? (At \textbf{16} — \textbf{earlier}; they break at 17.) Why does \emph{dezoito} have no \emph{e}? (It's \textbf{swallowed} before the vowel of \emph{oito}.) Next chapter: numbers in use.
+\end{tcolorbox}

--- a/code/learning/human-languages/portuguese/book/chapters/ch13-colours.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch13-colours.tex
@@ -1,0 +1,129 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:bde0638b592353e1
+% canonical-lessons: PT-C13-preto-branco, PT-C13-vermelho-azul
+
+\chapter{Colours}
+\label{ch:pt-colours}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[preto, branco]{preto, branco — two blacks and a borrowed white}
+
+\label{lesson:PT-C13-preto-branco}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Portuguese does something the other Romance languages don't: it keeps \textbf{two words for black}, and the everyday one isn't the Latin one at all.
+\end{quote}
+
+\begin{cousinweb}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{word} & \textbf{source} & \textbf{use} \\
+\midrule
+\textbf{negro} & Latin \emph{\textbf{niger}} & literary, formal, fixed phrases \\
+\textbf{preto} & Latin \emph{\textbf{pressus}} "pressed, dense" & the \textbf{everyday} colour word \\
+\bottomrule
+\end{tabularx}
+
+\emph{Negro} is the expected inheritance — the same \emph{niger} that gave French \emph{noir} and Italian \emph{nero}. But day to day, Portuguese reaches for \textbf{preto}, from \emph{pressus} ("pressed together, compact"). Dense $\to$ thick $\to$ \textbf{dark}: a colour named for how \textbf{packed} it is, not for its shade.
+
+You already know \emph{pressus}'s English children: \emph{press}, \emph{pressure}, \emph{compress}.
+\end{cousinweb}
+
+\begin{cousinweb}
+Latin's white, \emph{\textbf{albus}}, lost here too. Portuguese says \textbf{branco}, from Germanic \emph{\textbf{blank}} ("shining") — the same loan that gave French \emph{blanc} and Italian \emph{bianco}, arriving with the Suevi and Visigoths who settled Iberia.
+
+Notice what Portuguese did to the shape: \emph{blanc-} $\to$ \textbf{branc-}. The \textbf{l $\to$ r} swap is a Portuguese signature (compare \emph{plaza} $\to$ \textbf{praça}, \emph{blando} $\to$ \emph{brando}).
+\end{cousinweb}
+
+\begin{cousinweb}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{word} & \textbf{meaning} \\
+\midrule
+\textbf{alvorada} & dawn (the sky going white) \\
+\textbf{alva} & white, dawn (poetic) \\
+\emph{albumina}, \emph{álbum} & (technical borrowings) \\
+\bottomrule
+\end{tabularx}
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "preto, branco"{]}
+  \item {[}YOU SAY: "o vinho branco" — Chapter 11's wine{]}
+  \item {[}YOU SAY: "o pão é branco" — Chapter 11's bread{]}
+  \item {[}YOU SAY: the l$\to$r swap — "blanc $\to$ \textbf{branco}"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What are Portuguese's two blacks? (\textbf{Negro} $\leftarrow$ \emph{niger}, literary; and \textbf{preto} $\leftarrow$ \emph{pressus} "pressed/dense," the everyday one.) Why would "pressed" mean black? (\textbf{Dense $\to$ thick $\to$ dark}.) Where does \textbf{branco} come from? (\textbf{Germanic \emph{blank}}, "shining" — borrowed \textbf{into} Romance.) What sound change shows in \emph{branco}? (\textbf{l $\to$ r}, as in \emph{praça}.) Next: \textbf{vermelho}, the strangest colour word in the language.
+\end{tcolorbox}
+\section[vermelho, azul]{vermelho, azul — a worm and a stone}
+
+\label{lesson:PT-C13-vermelho-azul}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} These two are the best etymologies in the whole chapter. Portuguese named its red after an \textbf{insect} and its blue after a \textbf{rock}.
+\end{quote}
+
+\begin{cousinweb}
+Every other Romance language builds "red" on the ancient root \emph{h\textsubscript{1}rewd\textsuperscript{h}-} (\emph{rouge}, \emph{rosso}, Spanish \emph{rojo}, and English \emph{red}, German \emph{rot}). Portuguese went its own way.
+
+\textbf{vermelho} $\leftarrow$ Latin \emph{\textbf{vermiculus}}, "\textbf{little worm}" — the diminutive of \emph{vermis}, "worm."
+
+Why? Because the finest red dye in the ancient Mediterranean came from \textbf{kermes}, a scale insect harvested off oak trees and crushed for its pigment. Dyers called the creature a "little worm," and eventually the \textbf{dye's name became the colour's name}.
+
+The same word gave English \textbf{vermilion}. And \emph{vermis} gave English \textbf{vermin}.
+
+Portuguese does still keep the old root — in \textbf{rubro} (literary "red") and \textbf{ruivo} ("red-haired") — but the everyday word for red is a bug.
+\end{cousinweb}
+
+\begin{cousinweb}
+\textbf{azul} $\leftarrow$ Arabic \emph{\textbf{lāzaward}} $\leftarrow$ Persian \emph{\textbf{lāžward}}: \textbf{lapis lazuli}, the deep-blue stone mined for millennia in Afghanistan and ground into the most expensive pigment in the medieval world.
+
+The initial \emph{\textbf{l-}} was lost — Spanish and Portuguese ears took it for the article \emph{l'} and dropped it — leaving \emph{azul}. The same journey produced French \textbf{azur}, Italian \textbf{azzurro}, and English \textbf{azure}.
+
+This is the \textbf{al-Andalus} thread again: eight centuries of Arabic in Iberia left Portuguese and Spanish thousands of words, and one of them is a basic colour.
+\end{cousinweb}
+
+\begin{grammarlens}[title={What you've built: The chapter in one table}]
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Portuguese} & \textbf{source} \\
+\midrule
+preto & Latin \emph{pressus} "pressed" \\
+\textbf{branco} & \textbf{Germanic} \emph{blank} "shining" \\
+\textbf{vermelho} & Latin \emph{vermiculus} "\textbf{little worm}" \\
+\textbf{azul} & \textbf{Arabic} \emph{lāzaward} "\textbf{lapis lazuli}" \\
+\bottomrule
+\end{tabularx}
+
+Not one of Portuguese's four basic colours is a plain inherited Latin colour word.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "vermelho, azul"{]}
+  \item {[}YOU SAY: "o vinho é vermelho… o vinho tinto" — note: \textbf{wine} is \emph{tinto}, "dyed"{]}
+  \item {[}YOU SAY: "vermelho — vermilion — vermin"{]}
+  \item {[}YOU SAY: all four — "preto, branco, vermelho, azul"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \textbf{vermelho} literally come from? (\emph{\textbf{Vermiculus}}, "\textbf{little worm}" — the \textbf{kermes} insect crushed for dye.) Which English word is its sibling? (\textbf{Vermilion}.) Where does \textbf{azul} come from? (\textbf{Arabic \emph{lāzaward}}, "\textbf{lapis lazuli}," via Persian — the \emph{l-} lost as if an article.) What's odd about all four Portuguese colours? (\textbf{None} is a plain inherited Latin colour word.) Next chapter: describing what you see.
+\end{tcolorbox}

--- a/code/learning/human-languages/portuguese/book/chapters/ch14-having-and-age.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch14-having-and-age.tex
@@ -1,0 +1,144 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:5dd21c93ee684761
+% canonical-lessons: PT-C14-ter, PT-C14-idade
+
+\chapter{Having and Telling Your Age}
+\label{ch:pt-having-and-age}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[ter]{ter — "to have"}
+
+\label{lesson:PT-C14-ter}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Every Romance language needs a word for "have." French and Italian took one from Latin; \textbf{Portuguese and Spanish took a different one entirely} — and it didn't originally mean "have" at all.
+\end{quote}
+
+\subsection*{You'll want to know: The forms}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+(eu) & \textbf{tenho} \\
+(tu) & \textbf{tens} \\
+(ele/ela/você) & \textbf{tem} \\
+(nós) & \textbf{temos} \\
+(vocês/eles) & \textbf{têm} \\
+\bottomrule
+\end{tabularx}
+
+Two things to watch:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{tenho} — the \textbf{-nh-} (Portuguese's palatal \emph{ny}, = Spanish \textbf{ñ}), already met in \emph{vinho} (Ch. 11) and \emph{amanhã}.
+  \item \textbf{tem} vs \textbf{têm} — "he has" vs "\textbf{they} have". They sound nearly alike; the \textbf{circumflex} marks the plural. An accent doing grammar, not sound.
+\end{itemize}
+
+\begin{cousinweb}
+\textbf{ter} $\leftarrow$ Latin \emph{\textbf{tenēre}}, "\textbf{to hold}" — not "to have."
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{"to have"} & \textbf{$\leftarrow$ Latin} \\
+\midrule
+French & \emph{avoir} & \emph{habēre} \\
+Italian & \emph{avere} & \emph{habēre} \\
+\textbf{Portuguese} & \textbf{ter} & \emph{\textbf{tenēre}} "to hold" \\
+\textbf{Spanish} & \textbf{tener} & \emph{\textbf{tenēre}} "to hold" \\
+\bottomrule
+\end{tabularx}
+
+Portuguese \emph{does} still have \textbf{haver} ($\leftarrow$ \emph{habēre}) — but it got demoted to an auxiliary and to \emph{há} ("there is"). So on the Iberian peninsula the two verbs \textbf{swapped jobs}: "hold" moved up to mean \emph{have}, and "have" moved down to a grammar word.
+
+English kept the \emph{tenēre} family as borrowings: \textbf{tenant} (one who \emph{holds} land), \textbf{retain}, \textbf{maintain}, \textbf{tenacious}, \textbf{tenure}, \textbf{contain}.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "tenho, tens, tem, temos, têm"{]}
+  \item {[}YOU SAY: the \textbf{-nh-} — "te\textbf{nh}o", like \emph{vi\textbf{nh}o}{]}
+  \item {[}YOU SAY: "Tenho um irmão" ("I have a brother") — Ch. 10's family{]}
+  \item {[}YOU SAY: the hold-family — "ter · tenant · retain · tenacious"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What did \emph{ter}'s Latin source mean? (\emph{\textbf{Tenēre}} — "to \textbf{hold}".) Which other language made the same swap? (\textbf{Spanish}, \emph{tener}.) What happened to Portuguese's \emph{habēre} verb? (It became \textbf{haver} — an auxiliary, and \emph{há} "there is".) What separates \emph{tem} from \emph{têm}? (The \textbf{circumflex} — singular vs plural.) Next: the question \emph{ter} is used for that English would never use "have" for.
+\end{tcolorbox}
+\section[tenho vinte anos]{tenho vinte anos — holding your years}
+
+\label{lesson:PT-C14-idade}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Portuguese states age with \textbf{ter}. And since \emph{ter} came from "to \textbf{hold}," the sentence is, at the root, "\textbf{I hold twenty years}" — the most physical version of this idea in any of the five languages.
+\end{quote}
+
+\subsection*{You'll want to know: The phrase}
+\begin{quote}
+\textbf{Quantos anos tens?} — "How many years do you \textbf{have}?" \textbf{Tenho vinte anos.} — "I \textbf{have} twenty years."
+\end{quote}
+
+\emph{Ser} is wrong here. And \textbf{anos} can't be dropped, unlike English "I'm twenty."
+
+\begin{cousinweb}
+\textbf{ano} ("year") $\leftarrow$ Latin \emph{\textbf{annus}} $\to$ English \textbf{annual}, \textbf{anniversary}, \textbf{annals}.
+
+Now compare the two Iberian sisters:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Latin} & \textbf{Portuguese} & \textbf{Spanish} \\
+\midrule
+\emph{annus} & \textbf{ano} & \textbf{año} \\
+\bottomrule
+\end{tabularx}
+
+The Latin \textbf{-nn-} went two ways: Portuguese \textbf{simplified} it to a plain \emph{n}, Spanish \textbf{palatalized} it into \textbf{ñ}. Same word, same peninsula, two outcomes — and this is exactly where Spanish's \emph{ñ} came from in the first place: doubled Latin \emph{n}.
+
+Careful: keep \emph{ano} distinct from \emph{ânus}. The stress and the circumflex do the work.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: Who has, who is}]
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{} & \textbf{literally} \\
+\midrule
+Portuguese & \emph{t\textbf{enho} vinte anos} & I \textbf{hold} … \\
+Spanish & \emph{t\textbf{engo} veinte años} & I \textbf{hold} … \\
+French & \emph{j'\textbf{ai} vingt ans} & I \textbf{have} … \\
+Italian & \emph{h\textbf{o} venti anni} & I \textbf{have} … \\
+German & \emph{ich \textbf{bin} zwanzig Jahre alt} & I \textbf{am} … \\
+English & \emph{I \textbf{am} twenty} & I \textbf{am} … \\
+\bottomrule
+\end{tabularx}
+
+Three layers: Germanic \textbf{is} its years, French and Italian \textbf{have} them, and Iberian Romance \textbf{holds} them.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "Quantos anos tens?"{]}
+  \item {[}YOU SAY: "Tenho vinte anos"{]}
+  \item {[}YOU SAY: your own age, using Ch. 12's numbers{]}
+  \item {[}YOU SAY: the sister pair — "\textbf{ano} … \textbf{año}" — one Latin \emph{annus}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which verb does Portuguese use for age? (\emph{\textbf{Ter}}, never \emph{ser}.) Given \emph{ter}'s root, what does the sentence literally say? ("I \textbf{hold} twenty years.") Where does \emph{ano} come from? (Latin \emph{\textbf{annus}}.) What did Portuguese and Spanish each do with the \textbf{-nn-}? (PT \textbf{simplified} it to \emph{n}; ES \textbf{palatalized} it to \textbf{ñ}.) Which two languages say "I \textbf{am}" instead? (\textbf{German and English}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/portuguese/book/chapters/ch15-past-portuguese-kept.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch15-past-portuguese-kept.tex
@@ -1,0 +1,157 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:6126b552a3d85de0
+% canonical-lessons: PT-C15-preterito-perfeito, PT-C15-tenho-falado
+
+\chapter{The Past Portuguese Kept}
+\label{ch:pt-past-portuguese-kept}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[falei]{falei — the past Portuguese kept}
+
+\label{lesson:PT-C15-preterito-perfeito}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Portuguese's everyday past tense. Its interest isn't its endings — it's that Portuguese still \textbf{has} it in daily speech, when several sisters do not.
+\end{quote}
+
+\subsection*{You'll want to know: The forms}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+(eu) & \textbf{falei} \\
+(tu) & \textbf{falaste} \\
+(ele/ela/você) & \textbf{falou} \\
+(nós) & \textbf{falámos} (Portugal) / \textbf{falamos} (Brazil) \\
+(vocês/eles) & \textbf{falaram} \\
+\bottomrule
+\end{tabularx}
+
+One word. No auxiliary, no participle — the verb carries the past by itself.
+
+The \emph{nós} form is worth a note: Portugal writes \textbf{falámos} with an accent to separate it from the present \emph{falamos}, while Brazil writes both \textbf{falamos} and lets context decide. Same word, one accent, two spelling conventions.
+
+\textbf{falei} $\leftarrow$ Vulgar Latin perfect \textbf{*fabulāvī}, the same source as Spanish \emph{hablé}. The Latin \emph{-āv-} dissolved and left a \textbf{stressed final vowel} behind, which is why \emph{falei} and \emph{falou} end where they do.
+
+\begin{culture}
+Now the point of the chapter:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{this tense} & \textbf{where it lives now} \\
+\midrule
+\textbf{Portuguese} & \emph{falou} & \textbf{everyday speech} \\
+\textbf{Spanish} & \emph{habló} & \textbf{everyday speech} \\
+Italian & \emph{parlò} & \textbf{south} yes, north literary \\
+German & \emph{sagte} & retreating, standard in \textbf{writing} \\
+French & \emph{il parla} & \textbf{literature only} \\
+\bottomrule
+\end{tabularx}
+
+All five inherited the same thing. French, German and northern Italy each built a compound past out of "have" and let it push the old simple past out of conversation. \textbf{Portuguese and Spanish, at the western edge of the map, didn't.}
+
+Portuguese has all the parts to build a compound — \emph{ter} from Chapter 14, and a participle (\emph{falado}). It simply doesn't use them for this job. The next lesson shows what it uses them for instead.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "falei, falaste, falou, falámos, falaram"{]}
+  \item {[}YOU SAY: "Ontem falei com a minha mãe" ("Yesterday I spoke with my mother"){]}
+  \item {[}YOU SAY: "Trabalhei" — Ch. 5's verb in the past{]}
+  \item {[}YOU SAY: the five fates — "falou · habló · parlò · sagte · il parla"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} How many words does the Portuguese past need? (\textbf{One} — no auxiliary.) Where does \emph{falei} come from? (Vulgar Latin perfect \textbf{*fabulāvī}, like Spanish \emph{hablé}.) Which two languages kept this tense in everyday speech? (\textbf{Portuguese} and \textbf{Spanish}.) Which one exiled it to literature? (\textbf{French}.) Next: what Portuguese does with \emph{ter} + participle, since it isn't this.
+\end{tcolorbox}
+\section[tenho falado]{tenho falado — the compound that means something else}
+
+\label{lesson:PT-C15-tenho-falado}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Portuguese \textbf{does} have \emph{ter} + participle. It looks exactly like the French and Italian compound past, and it means \textbf{something different}. This is one of the most common mistakes English speakers make in Portuguese.
+\end{quote}
+
+\subsection*{You'll want to know: The form}
+\begin{quote}
+\textbf{ter} (conjugated) + \textbf{past participle}
+\end{quote}
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{infinitive} & \textbf{participle} \\
+\midrule
+fal\textbf{ar} & fal\textbf{ado} \\
+com\textbf{er} & com\textbf{ido} \\
+part\textbf{ir} & part\textbf{ido} \\
+\bottomrule
+\end{tabularx}
+
+$\to$ \textbf{tenho falado}, \textbf{tens falado}, \textbf{tem falado}…
+
+\begin{grammarlens}[title={Grammar Lens: What it actually means}]
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Portuguese} & \textbf{English} \\
+\midrule
+\textbf{falei} & "I spoke" — one finished event \\
+\textbf{tenho falado} & "I \textbf{have been} speaking" — \textbf{repeatedly, lately} \\
+\bottomrule
+\end{tabularx}
+
+\emph{Tenho falado com ele} does \textbf{not} mean "I have spoken to him {[}once{]}." It means "I \textbf{have been} speaking to him" — \textbf{more than once, over a recent stretch of time, and it may still be going on}.
+
+For a single completed act, Portuguese uses the simple past from the last lesson:
+
+\begin{quote}
+\textbf{Falei com ele ontem.} — "I spoke with him yesterday."
+\end{quote}
+\end{grammarlens}
+
+\begin{culture}
+French and Italian let their compound take over the plain past, so \emph{j'ai parlé} and \emph{ho parlato} now just mean "I spoke."
+
+Portuguese never did — \emph{\textbf{falei}} was already occupying that slot and never left. So when Portuguese assembled the same \emph{have} + participle machinery, there was \textbf{no vacancy}, and the construction drifted into a different job: \textbf{repeated or continuing} action.
+
+Same parts, same era, same family. Different outcome, because of what was already in the way.
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{have + participle means} \\
+\midrule
+French & \emph{j'ai parlé} — \textbf{I spoke} \\
+Italian & \emph{ho parlato} — \textbf{I spoke} \\
+German & \emph{ich habe gesagt} — \textbf{I said} \\
+\textbf{Portuguese} & \emph{tenho falado} — \textbf{I have been speaking (repeatedly)} \\
+\bottomrule
+\end{tabularx}
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the contrast — "\textbf{falei} I spoke · \textbf{tenho falado} I've been speaking"{]}
+  \item {[}YOU SAY: "Falei com ele ontem" — one event{]}
+  \item {[}YOU SAY: "Tenho falado com ele" — repeatedly, lately{]}
+  \item {[}YOU SAY: the warning — "\emph{tenho falado} is \textbf{not} 'I have spoken'"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \emph{tenho falado} mean? ("I \textbf{have been} speaking" — \textbf{repeatedly}, over a recent stretch.) What do you use for one finished act? (The simple past — \emph{\textbf{falei}}.) Why doesn't Portuguese's compound mean "I spoke"? (Because \emph{\textbf{falei}} \textbf{never vacated} that slot, so the new construction took a different job.) Which languages let their compound take over the plain past? (\textbf{French, Italian, German}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/portuguese/book/chapters/ch16-ser-and-estar.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch16-ser-and-estar.tex
@@ -1,0 +1,237 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:bc608ce25d6412a4
+% canonical-lessons: PT-C16-ser, PT-C16-ser-roots, PT-C16-ser-vs-estar, PT-C16-ser-estar-meaning
+
+\chapter{Ser and Estar}
+\label{ch:pt-ser-and-estar}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[ser]{ser — “to be”}
+
+\label{lesson:PT-C16-ser}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Portuguese has two verbs for “to be.” Begin with \textbf{ser}, used for identity and what something is; the choice against \emph{estar} comes later.
+\end{quote}
+
+\subsection*{You'll want to know: Present}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+eu \textbf{sou} & nós \textbf{somos} \\
+tu \textbf{és} & \textasciitilde{}\textasciitilde{}vós \textbf{sois}\textasciitilde{}\textasciitilde{} \\
+ele/ela/você \textbf{é} & eles/elas/vocês \textbf{são} \\
+\bottomrule
+\end{tabularx}
+
+\emph{Tu és} is live in European Portuguese. \textbf{Vós} survives mainly in northern dialect and church language; everyday “you all” is \textbf{vocês}, with \textbf{são}.
+
+\subsection*{You'll want to know: Two past rows}
+Preterite, the completed past from Chapter 15:
+
+\begin{quote}
+\textbf{fui, foste, foi, fomos, foram}
+\end{quote}
+
+Imperfect, for background or ongoing past:
+
+\begin{quote}
+\textbf{era, eras, era, éramos, eram}
+\end{quote}
+
+The three anchors \textbf{sou — fui — era} look unrelated. That is a clue that several historical pieces have been welded together, which the next lesson will unpack. For now, retrieve each row as a usable pattern.
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: “sou, és, é, somos, são”{]}
+  \item {[}YOU SAY: “Eu sou português. Ela é médica.”{]}
+  \item {[}YOU SAY: “fui, foste, foi, fomos, foram”{]}
+  \item {[}YOU SAY: “era, éramos, eram”{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Give the present of \emph{ser}. (\textbf{Sou, és, é, somos, são}.) Which form goes with \emph{vocês}? (\textbf{São}.) Give the preterite row. (\textbf{Fui, foste, foi, fomos, foram}.) Which imperfect form means “I was”? (\textbf{Era}.) Next: why those rows look so different.
+\end{tcolorbox}
+\section[sou / era / fui / ser]{ser — two verbs, three stems}
+
+\label{lesson:PT-C16-ser-roots}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} \textbf{Sou, era, fui, ser} do not resemble one another because the modern verb preserves several older roots.
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Portuguese} & \textbf{source} \\
+\midrule
+\textbf{sou, és, é, somos, são} & Latin \emph{esse}, “to be” \\
+\textbf{era, éramos, eram} & \emph{esse}’s imperfect \\
+\textbf{fui, foi, foram} & \emph{esse}’s ancient perfect \emph{fuī} \\
+infinitive \textbf{ser} & Latin \emph{sedēre}, “to sit” \\
+\bottomrule
+\end{tabularx}
+
+That is \textbf{two Latin verbs} but \textbf{three stems}: \emph{esse} was already suppletive, using both its ordinary root and the older \emph{fuī} perfect. \emph{Sedēre} also gave English \textbf{sedentary} and \textbf{session}.
+\end{quote}
+
+\begin{cousinweb}
+The entire preterite is shared with \textbf{ir}, “to go”:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{person} & \textbf{ser} & \textbf{ir} \\
+\midrule
+eu & \textbf{fui} & \textbf{fui} \\
+tu & \textbf{foste} & \textbf{foste} \\
+ele & \textbf{foi} & \textbf{foi} \\
+nós & \textbf{fomos} & \textbf{fomos} \\
+eles & \textbf{foram} & \textbf{foram} \\
+\bottomrule
+\end{tabularx}
+
+\textbf{Fui professor} means “I was a teacher”; \textbf{fui ao Brasil} means “I went to Brazil.” What follows disambiguates them. \emph{Fuī} already belonged to \emph{ser}’s ancestor; \textbf{ir} borrowed the row after Latin \emph{īre}’s own perfect wore away. Spanish made the same Iberian choice.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: “ser $\leftarrow$ sedēre, to sit”{]}
+  \item {[}YOU SAY: “sou / era $\leftarrow$ esse”{]}
+  \item {[}YOU SAY: “fui professor; fui ao Brasil”{]}
+\end{itemize}
+
+{[}REPEAT x2{]} “Two verbs, three stems; \emph{fui} has two meanings.”
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which Latin verb gives the infinitive? (\emph{\textbf{Sedēre}, “sit.”}) Which gives \emph{sou} and \emph{era}? (\emph{\textbf{Esse}.) What two verbs share }fui\emph{? (\textbf{Ser} and \textbf{ir}.) Which borrowed it? (\textbf{Ir}.) Next: put }ser\emph{ beside }estar\emph{.}
+\end{tcolorbox}
+\section[ser vs. estar]{ser vs. estar — the core choice}
+
+\label{lesson:PT-C16-ser-vs-estar}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Chapter 2 used \textbf{Como está?} Now learn \emph{estar}’s forms and make the basic choice between Portuguese’s two verbs for “to be.”
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+eu \textbf{estou} & nós \textbf{estamos} \\
+tu \textbf{estás} & \textasciitilde{}\textasciitilde{}vós \textbf{estais}\textasciitilde{}\textasciitilde{} \\
+ele/ela/você \textbf{está} & eles/elas/vocês \textbf{estão} \\
+\bottomrule
+\end{tabularx}
+
+Say \textbf{vocês estão} in ordinary speech. You may hear shortened \emph{tou} and \emph{tá}; recognise them, but write the full forms.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: What something is; how it is}]
+\begin{quote}
+\textbf{ser} = what something is \textbf{estar} = its location or the condition it is in
+\end{quote}
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{ser} & \textbf{estar} \\
+\midrule
+Ele \textbf{é} médico. — He is a doctor. & Ele \textbf{está} doente. — He is ill. \\
+\textbf{Sou} português. — I’m Portuguese. & \textbf{Estou} em Lisboa. — I’m in Lisbon. \\
+A neve \textbf{é} branca. — Snow is white. & O café \textbf{está} frio. — The coffee is cold. \\
+\bottomrule
+\end{tabularx}
+
+Identity, origin, profession, and defining qualities use \textbf{ser}. Location, health, mood, weather, and resulting conditions use \textbf{estar}.
+
+Do not reduce this to “permanent versus temporary”: \textbf{ele está morto}, “he is dead,” uses \emph{estar}. Death is not temporary; it is a condition someone has ended up in.
+\end{grammarlens}
+
+\begin{grammarlens}[title={What you've built: A mnemonic, not the cause}]
+\emph{Ser} contains forms from Latin \emph{sedēre}, “sit”; \emph{estar} continues \emph{stāre}, “stand.” Picture \textbf{ser} as seated in identity and \textbf{estar} as standing in a condition. The history is a memory aid, not the cause: \emph{esse} supplied \emph{ser}’s identity meaning, while \emph{stāre} pulled toward place and resulting state.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: “estou, estás, está, estamos, estão”{]}
+  \item {[}YOU SAY: “Sou português; estou em Lisboa.”{]}
+  \item {[}YOU SAY: “Ele é médico; ele está doente.”{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which verb names identity? (\textbf{Ser}.) Which marks location or a resulting condition? (\textbf{Estar}.) How do you say “I’m in Lisbon”? (\textbf{Estou em Lisboa}.) Why does “he is dead” use \emph{estar}? (It is a \textbf{resulting condition}, so permanence is not the real test.) Next: use the choice to change meaning.
+\end{tcolorbox}
+\section[é bonita / está bonita]{é bonita / está bonita — a choice you can use}
+
+\label{lesson:PT-C16-ser-estar-meaning}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} \emph{Ser} and \emph{estar} are not competing answers where one is always a mistake. With many adjectives, swapping the verb deliberately changes meaning.
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{with ser} & \textbf{with estar} \\
+\midrule
+Ela \textbf{é} bonita. — She is beautiful. & Ela \textbf{está} bonita. — She looks beautiful now. \\
+A sopa \textbf{é} boa. — It is a good soup. & A sopa \textbf{está} boa. — This bowl tastes good. \\
+\bottomrule
+\end{tabularx}
+
+\textbf{Ser} presents the quality as part of what the subject is. \textbf{Estar} presents the quality as the current condition or impression. Context, not a mechanical “permanent” rule, decides what you mean.
+\end{quote}
+
+\begin{cousinweb}
+Portuguese and Spanish maintain this full two-verb choice. Italian keeps \emph{essere} and \emph{stare} but lets them overlap differently; French has one \emph{être} that absorbed old \emph{stāre} pieces. German \emph{sein} is a separate Germanic cousin.
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{broad result} \\
+\midrule
+Portuguese / Spanish & two verbs, chosen by meaning \\
+Italian & two verbs with overlap \\
+French & one fused verb \\
+German & one verb built from Germanic roots \\
+\bottomrule
+\end{tabularx}
+
+The Romance rows started with the same Latin material and reorganised it in three ways. That is why the Portuguese choice is systematic but not universal.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: “Ela é bonita” — a quality{]}
+  \item {[}YOU SAY: “Ela está bonita” — right now{]}
+  \item {[}YOU SAY: “A sopa é boa; a sopa está boa.”{]}
+\end{itemize}
+
+{[}REPEAT x2{]} “Ser: what it is. Estar: the condition it is in.”
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What changes between \emph{ela é bonita} and \emph{ela está bonita}? (A defining quality versus a \textbf{current impression}.) Is \emph{estar} automatically a mistake with \emph{bonita}? (\textbf{No}; it says something different.) Which Romance languages keep the full two-verb choice? (\textbf{Portuguese and Spanish}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/portuguese/book/chapters/ch17-head-and-hand.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch17-head-and-hand.tex
@@ -1,0 +1,167 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:dff69b7e6fc4d902
+% canonical-lessons: PT-C17-cabeca, PT-C17-cabeca-caput, PT-C17-mao
+
+\chapter{Head and Hand}
+\label{ch:pt-head-and-hand}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[a cabeça]{a cabeça — “the head”}
+
+\label{lesson:PT-C17-cabeca}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Learn one body word and one reading rule together.
+
+\begin{quote}
+\textbf{a cabeça} — the head, feminine
+\end{quote}
+\end{quote}
+
+\begin{sounds}
+The \textbf{ç} is a \textbf{cedilla}. It marks a \emph{c} pronounced \textbf{s} before \emph{a}, \emph{o}, or \emph{u}, where plain \emph{c} would normally be hard \textbf{k}. So \emph{cabeça} ends roughly “-essa,” not “-eka.”
+
+The mark began as a tiny \textbf{z} under the letter: medieval scribes used \emph{ç} as shorthand for \emph{cz}. Treat that as a recognition hook; this track has not yet asked you to write the mark by hand.
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{Cabeça} comes from Late Latin \emph{\textbf{capitia}}, built from \emph{\textbf{caput}}, “head.” Portuguese wore the word down in ordinary speech but kept the old root.
+
+A useful sentence is:
+
+\begin{quote}
+\textbf{Dói-me a cabeça.} — “My head hurts.” (European Portuguese)
+\end{quote}
+
+In Brazilian Portuguese you may hear \textbf{Minha cabeça está doendo}. Both begin with the same feminine noun \textbf{a cabeça}.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: “a cabeça” — make \textbf{ç} an \textbf{s}{]}
+  \item {[}YOU SAY: “Dói-me a cabeça.”{]}
+  \item {[}YOU SAY: “cabeça $\leftarrow$ caput”{]}
+\end{itemize}
+
+{[}REPEAT x2{]} “A cabeça — feminine; ç sounds s.”
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Say “the head.” (\textbf{A cabeça}.) What does the cedilla do? (Marks \emph{c} as \textbf{s} before \emph{a/o/u}.) What is the Latin root? (\emph{\textbf{Caput}}.) Next: compare the head-words and find that root a second time in learned vocabulary.
+\end{tcolorbox}
+\section[cabeça / capital]{cabeça / capital — one root, two arrivals}
+
+\label{lesson:PT-C17-cabeca-caput}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} \textbf{Cabeça} kept Latin \emph{caput}, “head.” Other languages replaced that everyday word with containers, which makes the Portuguese survival visible.
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{“head”} & \textbf{older picture} \\
+\midrule
+Portuguese & \textbf{cabeça} & Latin \emph{caput}, head \\
+Spanish & \emph{cabeza} & Latin \emph{caput}, head \\
+French & \emph{tête} & Latin \emph{testa}, pot \\
+Italian & \emph{testa} & Latin \emph{testa}, pot \\
+German & \emph{Kopf} & Germanic “cup” word \\
+\bottomrule
+\end{tabularx}
+
+French/Italian and German independently replaced “head” with a vessel. Iberian Romance kept \emph{caput}. Portuguese still has \textbf{testa}, but narrowed it to “forehead” instead of the whole head.
+\end{quote}
+
+\begin{cousinweb}
+The same \emph{caput} later entered learned vocabulary again:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{capital} — the head city or head sum;
+  \item \textbf{capítulo} — a “little head” of a text;
+  \item \textbf{capitão} — the head of a company.
+\end{itemize}
+
+Portuguese therefore holds a \textbf{doublet}: one word inherited through generations of speech (\textbf{cabeça}), another branch borrowed back from written Latin (\textbf{capital, capítulo, capitão}). One root can arrive twice and look different because each route changes it differently.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: “cabeça — inherited”{]}
+  \item {[}YOU SAY: “capital — re-borrowed”{]}
+  \item {[}YOU SAY: “tête/testa: pot; Kopf: cup”{]}
+\end{itemize}
+
+{[}REPEAT x2{]} “Cabeça and capital — two routes from \emph{caput}.”
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which languages kept the \emph{caput} head-word? (\textbf{Portuguese and Spanish}.) What did French, Italian, and German substitute? (\textbf{Container words}.) What is the doubling in \emph{cabeça / capital}? (One \textbf{inherited}, one \textbf{re-borrowed}.) Next: the hand and the disappearing \emph{n}.
+\end{tcolorbox}
+\section[a mão]{a mão — "the hand"}
+
+\label{lesson:PT-C17-mao}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Two things in one short word: a sound change that shaped half of Portuguese, and a gender that is two thousand years old.
+\end{quote}
+
+\subsection*{You'll want to know: The word}
+\begin{quote}
+\textbf{a mão} — the hand. \textbf{Feminine}. Plural: \textbf{as mãos}.
+\end{quote}
+
+\begin{cousinweb}
+Latin \emph{\textbf{manus}} $\to$ Portuguese \emph{\textbf{mão}}. The \textbf{-n-} vanished.
+
+That is not a one-off. Portuguese systematically \textbf{dropped n between vowels}, nasalising the vowel in front of it. What happened next depends on the word: the nasality \textbf{stayed} where the result was a nasal diphthong, and \textbf{faded again} where it left a plain vowel. The \textbf{til} (\textbf{\textasciitilde{}}) marks the ones that kept it.
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Latin} & \textbf{Portuguese} & \textbf{} \\
+\midrule
+\emph{manus} & \textbf{mão} & hand — \textbf{nasality kept} \\
+\emph{lūna} & \textbf{lua} & moon — nasality faded \\
+\emph{bona} & \textbf{boa} & good (f.) — nasality faded \\
+\emph{pānis} & \textbf{pão} & bread — \textbf{kept}; Chapter 11 told this one \\
+\bottomrule
+\end{tabularx}
+
+Compare Spanish, which kept the \emph{\textbf{n}} in all of them: \emph{mano}, \emph{luna}, \emph{buena}, \emph{pan}. This single change is a large part of why written Portuguese and Spanish look so similar and sound so different.
+
+Say the pair aloud: \emph{mano} … \emph{mão}. You can hear the \emph{n} becoming the nasal.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: Feminine, like Italian's}]
+\textbf{A mão} is feminine — and so is Italian \textbf{la mano}, for the same reason. Latin \emph{manus} belonged to the \textbf{fourth declension}, a class whose nouns ended in \emph{-us} but could be feminine. The declension is long gone; the gender outlived it.
+
+Portuguese is less startling about it than Italian, because \emph{mão} doesn't end in a giveaway \emph{-o}. But it is the same two-thousand-year-old fact underneath.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "a mão, as mãos"{]}
+  \item {[}YOU SAY: the change — "ma\textbf{n}us … mã\textbf{o}"{]}
+  \item {[}YOU SAY: the family — "lua, boa, pão — all lost an \textbf{n}"{]}
+  \item {[}YOU SAY: the contrast — "Spanish \emph{mano}, Portuguese \emph{mão}"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Say "the hand" and "the hands." (\emph{A mão} / \emph{as mãos}.) What happened to the \emph{n} of \emph{manus}? (It \textbf{dissolved between vowels}, leaving a nasal vowel — which the \textbf{til} marks.) Name two other words that did the same. (\emph{Lua} $\leftarrow$ \emph{lūna}, \emph{boa} $\leftarrow$ \emph{bona}, \emph{pão} — Ch. 11.) Did they all keep the nasality? (\textbf{No} — \emph{mão} and \emph{pão} did; \emph{lua} and \emph{boa} lost it again.) What did Spanish do? (\textbf{Kept the \emph{n}} in all — \emph{mano}, \emph{luna}, \emph{pan}.) Why is \emph{mão} feminine? (Latin \emph{manus} was \textbf{fourth-declension feminine} — the same reason Italian says \emph{la mano}.) Next: the rest of the body.
+\end{tcolorbox}

--- a/code/learning/human-languages/portuguese/book/preamble.tex
+++ b/code/learning/human-languages/portuguese/book/preamble.tex
@@ -2,22 +2,37 @@
 % XeLaTeX only. Mirrors the Spanish/French/Italian tracks (Latin script).
 
 \usepackage{fontspec}
-\usepackage{polyglossia}
-\setdefaultlanguage{english}
-\setotherlanguage{portuguese}
-
 \setmainfont{Latin Modern Roman}
 \setsansfont{Latin Modern Sans}
 \setmonofont{Latin Modern Mono}
 
+% polyglossia loads bidi for Arabic, so color-related packages must come first.
 \usepackage[table]{xcolor}
 \usepackage{tcolorbox}
 \tcbuselibrary{skins,breakable}
 \usepackage{booktabs}
 \usepackage{longtable}
+\usepackage{tabularx}
 \usepackage{array}
 \usepackage[hidelinks]{hyperref}
 \usepackage{titlesec}
+
+\usepackage{polyglossia}
+\setdefaultlanguage{english}
+\setotherlanguage{portuguese}
+\setotherlanguage{arabic}
+
+% Chapter 4 preserves the Arabic source of Portuguese ate. Use the same
+% vendored font as the Arabic, Persian, and Urdu books so local and CI output
+% are deterministic and no source-script glyph is dropped.
+\newfontfamily\arabicfont[
+  Path=../../_fonts/,
+  Script=Arabic,
+  BoldFont=NotoNaskhArabic-Static.ttf,
+  ItalicFont=NotoNaskhArabic-Static.ttf,
+  BoldItalicFont=NotoNaskhArabic-Static.ttf
+]{NotoNaskhArabic-Static.ttf}
+\newcommand{\ptar}[1]{\textarabic{#1}}
 
 \hypersetup{
   pdftitle={Portuguese, Step by Step, Root by Root},
@@ -36,10 +51,10 @@
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
   fonttitle=\bfseries, title={Why it's said this way}
 }
-\newtcolorbox{grammarlens}{
+\newtcolorbox{grammarlens}[1][]{
   breakable, skin=enhanced, colback=blue!5, colframe=blue!35!black,
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
-  fonttitle=\bfseries, title={Grammar Lens}
+  fonttitle=\bfseries, title={Grammar Lens}, #1
 }
 \newtcolorbox{sounds}{
   breakable, skin=enhanced, colback=green!6, colframe=green!30!black,

--- a/code/learning/human-languages/portuguese/lessons/PT-C02-como-vai-esta.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C02-como-vai-esta.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C02-como-vai-esta
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 140
 chapter: 2
 type: phrase
 headword: Como vai? / Como está?
@@ -9,13 +12,26 @@ prerequisites: [PT-C02-tudo-bem, PT-C02-como]
 sounds: [open-a]
 roots: [ire-latin, stare-latin]
 etymology_hook: "Como vai? pictures wellbeing as going; Como está? pictures it as standing"
-est_minutes: 4
+duration:
+  max_seconds: 236
+requires:
+  knowledge: [PT-GRAMMAR-TUDO-BEM-02, PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04]
+introduces:
+  knowledge: [PT-LEX-COMO-VAI-ESTA-01]
+practises:
+  knowledge: [PT-GRAMMAR-TUDO-BEM-02, PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04, PT-LEX-COMO-VAI-ESTA-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C02-tudo-bem, PT-C02-como]
 ---
 
 # Como vai? / Como está? — go and stand
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[PT-LEX-COMO-VAI-ESTA-01]; assesses=[] -->
 
 [PAUSE 2s] **Tudo bem?** needs no verb. Portuguese also offers two familiar
 metaphors, using the **como** (“how”) you already know.
@@ -40,6 +56,7 @@ the map simply makes the two metaphors memorable.
 choice altogether.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-GRAMMAR-TUDO-BEM-02, PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04, PT-LEX-COMO-VAI-ESTA-01] -->
 
 [PAUSE 1s]
 - [YOU SAY: the verb-free question — “Tudo bem?”]
@@ -49,6 +66,7 @@ choice altogether.
 [REPEAT x2] “Tudo bem? — Como vai? — Como está?”
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-GRAMMAR-TUDO-BEM-02, PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04, PT-LEX-COMO-VAI-ESTA-01] -->
 
 [PAUSE 3s] Which question has no verb? (**Tudo bem?**) Which uses “go”?
 (**Como vai?**, from *ir*.) Which uses “stand”? (**Como está?**, from *estar*.)

--- a/code/learning/human-languages/portuguese/lessons/PT-C02-como.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C02-como.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C02-como
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 110
 chapter: 2
 type: word
 headword: como
@@ -9,24 +12,39 @@ prerequisites: [PT-C01-ola]
 sounds: [final-o-is-u]
 roots: [quomodo-latin]
 etymology_hook: "como ← Latin quōmodo 'in what manner' — the same root as Spanish cómo, Italian come"
-est_minutes: 3
+duration:
+  max_seconds: 222
+requires:
+  knowledge: []
+introduces:
+  knowledge: [PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04]
+practises:
+  knowledge: [PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C02-de-nada]
 ---
 
 # como — "how," the fourth *quomodo* cousin
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] One of two everyday ways to ask *how are you?* in Portuguese starts
 with **como**, "how." It's the same word you've met (or will meet) across the
 Romance family.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[PT-SOUND-COMO-02]; assesses=[] -->
 
 - `final-o-is-u` — **como** = *KOH-moo*: the final unstressed *-o* is said like
   *u*. (Portuguese does this to nearly every final *-o*: *obrigado* → *-doo*.)
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-COMO-03]; assesses=[] -->
 
 **como** = "how / like / as." Root: Latin **quōmodo**, "in what manner" — *quō*
 ("in what way") + *modo* ("manner"). It is the **same source** as its siblings:
@@ -40,6 +58,7 @@ Portuguese leans on context and the question mark instead. The *modo* piece
 lives on in English **mode**, **mod**el, **mod**erate.
 
 ## Grammar Lens: the two Portuguese "how are you"s
+<!-- hl-knowledge: introduces=[PT-GRAMMAR-COMO-04]; assesses=[] -->
 
 Portuguese asks after you **two** ways, and you'll assemble both next lesson:
 
@@ -49,6 +68,7 @@ Portuguese asks after you **two** ways, and you'll assemble both next lesson:
 Plus a third, verb-free favourite — **Tudo bem?** — coming up.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "como" — *KOH-moo*]
@@ -56,6 +76,7 @@ Plus a third, verb-free favourite — **Tudo bem?** — coming up.
 - [YOU SAY: "Como vai?" and "Como está?" — go, and stand]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04] -->
 
 [PAUSE 3s] What Latin word gives *como*, and name two siblings. (*quōmodo* →
 *cómo*, *come*, *comment*.) What's the only written difference between Portuguese

--- a/code/learning/human-languages/portuguese/lessons/PT-C02-de-nada.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C02-de-nada.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C02-de-nada
+spine_node: SPINE-COURTESY-THANK
+sequence: 100
 chapter: 2
 type: phrase
 headword: de nada
@@ -9,24 +12,39 @@ prerequisites: [PT-C01-obrigado]
 sounds: [final-a-reduces]
 roots: [de-latin, nata-latin]
 etymology_hook: "nada ← Latin (rem) nāta 'a born thing' → 'nothing' — the same word as Spanish nada"
-est_minutes: 3
+duration:
+  max_seconds: 164
+requires:
+  knowledge: []
+introduces:
+  knowledge: [PT-SOUND-DE-NADA-02, PT-ETYMON-DE-NADA-03]
+practises:
+  knowledge: [PT-SOUND-DE-NADA-02, PT-ETYMON-DE-NADA-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C01-obrigado]
 ---
 
 # de nada — "you're welcome," or "it was nothing"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You already say **obrigado / obrigada** ("I am obliged"). The reply
 that closes the exchange is **de nada** — "of nothing" — the very same phrase,
 word for word, as Spanish.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[PT-SOUND-DE-NADA-02]; assesses=[] -->
 
 - `final-a-reduces` — **de nada** ≈ *dee NAH-duh*: unstressed final *-a* softens
   toward *uh*; the *d* is soft.
 
 ## The phrase, taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-DE-NADA-03]; assesses=[] -->
 
 - **de** = "of / from" (Latin **dē**).
 - **nada** = "nothing" — and it has the same buried story as its Spanish twin.
@@ -48,12 +66,14 @@ So Iberia says "of no *born-thing*"; France says "of no *thing*." Same shrug of
 the shoulders, one Latin idea.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-DE-NADA-02, PT-ETYMON-DE-NADA-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "obrigado / obrigada" … "de nada" — the full exchange]
 - [YOU SAY: "de nada" then English "native, nature" — nada's true family]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-DE-NADA-02, PT-ETYMON-DE-NADA-03] -->
 
 [PAUSE 3s] What did *nada* originally mean in Latin? (A *born thing* — *nāta*.)
 Which language shares *de nada* exactly, and which uses *de rien* instead?

--- a/code/learning/human-languages/portuguese/lessons/PT-C02-formal-practice.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C02-formal-practice.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C02-formal-practice
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 170
 chapter: 2
 type: practice-mix
 headword: Como está o senhor?
@@ -8,18 +11,32 @@ concept_tag: PT-CH2-FORMAL-PRACTICE
 prerequisites: [PT-C02-practice, PT-C02-como-vai-esta]
 sounds: []
 roots: [senior-latin]
-est_minutes: 4
+duration:
+  max_seconds: 214
+requires:
+  knowledge: [PT-LEX-C02-PRACTICE-02, PT-NOTICE-C02-PRACTICE-03, PT-LEX-COMO-VAI-ESTA-01]
+introduces:
+  knowledge: [PT-LEX-FORMAL-PRACTICE-02]
+practises:
+  knowledge: [PT-LEX-C02-PRACTICE-02, PT-NOTICE-C02-PRACTICE-03, PT-LEX-COMO-VAI-ESTA-01, PT-LEX-FORMAL-PRACTICE-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C02-practice, PT-C02-como-vai-esta]
 ---
 
 # Formal practice — Como está o senhor?
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The casual exchange is secure. Now replace ordinary *você* with the
 respectful title **o senhor** or **a senhora**.
 
 ## The exchange
+<!-- hl-knowledge: introduces=[PT-LEX-FORMAL-PRACTICE-02]; assesses=[] -->
 
 > — Bom dia. **Como está o senhor?**
 > — **Bem, obrigado. E o senhor?**
@@ -33,6 +50,7 @@ the gentleman/lady?” That respectful grammar is already packed into the phrase
 do not switch it to informal second-person *estás* here.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-LEX-C02-PRACTICE-02, PT-NOTICE-C02-PRACTICE-03, PT-LEX-COMO-VAI-ESTA-01, PT-LEX-FORMAL-PRACTICE-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: to a man — “Como está o senhor?”]
@@ -42,6 +60,7 @@ do not switch it to informal second-person *estás* here.
 [REPEAT x2] “Como está o senhor? — Bem, obrigado.”
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-LEX-C02-PRACTICE-02, PT-NOTICE-C02-PRACTICE-03, PT-LEX-COMO-VAI-ESTA-01, PT-LEX-FORMAL-PRACTICE-02] -->
 
 [PAUSE 3s] Which titles mean a respectful “you”? (**O senhor / a senhora**.)
 Which verb form follows them? (**Está**, third person.) Where does *senhor* come

--- a/code/learning/human-languages/portuguese/lessons/PT-C02-mais-ou-menos.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C02-mais-ou-menos.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C02-mais-ou-menos
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 150
 chapter: 2
 type: word
 headword: mais ou menos
@@ -9,25 +12,40 @@ prerequisites: [PT-C02-tudo-bem]
 sounds: [nasal-ai, final-o-is-u]
 roots: [magis-latin, minus-latin]
 etymology_hook: "mais ← Latin magis 'more'; menos ← minus 'less' — the same shrug as Spanish más o menos"
-est_minutes: 3
+duration:
+  max_seconds: 234
+requires:
+  knowledge: [PT-GRAMMAR-TUDO-BEM-02]
+introduces:
+  knowledge: [PT-SOUND-MAIS-OU-MENOS-02, PT-ETYMON-MAIS-OU-MENOS-03, PT-GRAMMAR-MAIS-OU-MENOS-04]
+practises:
+  knowledge: [PT-GRAMMAR-TUDO-BEM-02, PT-SOUND-MAIS-OU-MENOS-02, PT-ETYMON-MAIS-OU-MENOS-03, PT-GRAMMAR-MAIS-OU-MENOS-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C02-tudo, PT-C02-tudo-bem]
 ---
 
 # mais ou menos — the "more or less" shrug
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Someone asks *Tudo bem?* You're okay-ish. The Portuguese shrug is
 **mais ou menos** — "more or less" — the same words, root for root, that Spanish
 uses.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[PT-SOUND-MAIS-OU-MENOS-02]; assesses=[] -->
 
 - `nasal-ai` — **mais** ≈ *mais* with a nasal glide (*maish* in Brazil, the *s*
   a soft *sh*).
 - `final-o-is-u` — **menos** ≈ *MEH-noos*; **ou** = a closed *oh*.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-MAIS-OU-MENOS-03]; assesses=[] -->
 
 **mais ou menos** = literally **"more or less."** Every piece is Latin at heart:
 
@@ -42,6 +60,7 @@ shared shrug. (Portuguese *mais* and Spanish *más* are the same *magis*; the
 nasal *-ais* is just Portuguese's accent.)
 
 ## Grammar Lens: your answer ladder for *Tudo bem?*
+<!-- hl-knowledge: introduces=[PT-GRAMMAR-MAIS-OU-MENOS-04]; assesses=[] -->
 
 | answer | sense |
 |---|---|
@@ -54,6 +73,7 @@ menos** ("more or less"), Italian **così così** ("so, so"), French **comme ci
 comme ça** ("like this, like that"), German **es geht** ("it goes").
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-GRAMMAR-TUDO-BEM-02, PT-SOUND-MAIS-OU-MENOS-02, PT-ETYMON-MAIS-OU-MENOS-03, PT-GRAMMAR-MAIS-OU-MENOS-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "mais ou menos" — with a little wobble]
@@ -61,6 +81,7 @@ comme ça** ("like this, like that"), German **es geht** ("it goes").
 - [YOU SAY: Portuguese *mais ou menos* = Spanish *más o menos*, same Latin *magis*/*minus*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-GRAMMAR-TUDO-BEM-02, PT-SOUND-MAIS-OU-MENOS-02, PT-ETYMON-MAIS-OU-MENOS-03, PT-GRAMMAR-MAIS-OU-MENOS-04] -->
 
 [PAUSE 3s] What does *mais ou menos* literally mean? ("More or less.") What Latin
 words are *mais* and *menos* from, and their English cousins? (*magis* → major/

--- a/code/learning/human-languages/portuguese/lessons/PT-C02-practice.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C02-practice.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C02-practice
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 160
 chapter: 2
 type: practice-mix
 headword: (practice)
@@ -8,18 +11,32 @@ concept_tag: CH2-PRACTICE
 prerequisites: [PT-C02-de-nada, PT-C02-como, PT-C02-tudo, PT-C02-tudo-bem, PT-C02-como-vai-esta, PT-C02-mais-ou-menos]
 sounds: []
 roots: []
-est_minutes: 4
+duration:
+  max_seconds: 204
+requires:
+  knowledge: [PT-SOUND-DE-NADA-02, PT-ETYMON-DE-NADA-03, PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04, PT-SOUND-TUDO-02, PT-ETYMON-TUDO-03, PT-GRAMMAR-TUDO-04, PT-GRAMMAR-TUDO-BEM-02, PT-LEX-COMO-VAI-ESTA-01, PT-SOUND-MAIS-OU-MENOS-02, PT-ETYMON-MAIS-OU-MENOS-03, PT-GRAMMAR-MAIS-OU-MENOS-04]
+introduces:
+  knowledge: [PT-LEX-C02-PRACTICE-02, PT-NOTICE-C02-PRACTICE-03]
+practises:
+  knowledge: [PT-SOUND-DE-NADA-02, PT-ETYMON-DE-NADA-03, PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04, PT-SOUND-TUDO-02, PT-ETYMON-TUDO-03, PT-GRAMMAR-TUDO-04, PT-GRAMMAR-TUDO-BEM-02, PT-LEX-COMO-VAI-ESTA-01, PT-SOUND-MAIS-OU-MENOS-02, PT-ETYMON-MAIS-OU-MENOS-03, PT-GRAMMAR-MAIS-OU-MENOS-04, PT-LEX-C02-PRACTICE-02, PT-NOTICE-C02-PRACTICE-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C02-de-nada, PT-C02-tudo-bem, PT-C02-como-vai-esta, PT-C02-mais-ou-menos, PT-C01-practice]
 ---
 
 # Practice — Tudo bem?, start to finish
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] No new words. Assemble the chapter’s atoms into one casual exchange
 before adding the formal version.
 
 ## The exchange
+<!-- hl-knowledge: introduces=[PT-LEX-C02-PRACTICE-02]; assesses=[] -->
 
 > — Olá! **Tudo bem?**
 > — **Tudo bem, e você?**
@@ -29,7 +46,8 @@ before adding the formal version.
 The glue is **e você?**, “and you?”: **e** continues Latin *et*, while *você*
 grew from the respectful title *vossa mercê*.
 
-## What you are retrieving
+## What you've built: What you are retrieving
+<!-- hl-knowledge: introduces=[PT-NOTICE-C02-PRACTICE-03]; assesses=[] -->
 
 - **de nada** — “of nothing,” you’re welcome;
 - **tudo bem?** — the verb-free check-in;
@@ -37,6 +55,7 @@ grew from the respectful title *vossa mercê*.
 - **mais ou menos** — “more or less,” so-so.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-DE-NADA-02, PT-ETYMON-DE-NADA-03, PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04, PT-SOUND-TUDO-02, PT-ETYMON-TUDO-03, PT-GRAMMAR-TUDO-04, PT-GRAMMAR-TUDO-BEM-02, PT-LEX-COMO-VAI-ESTA-01, PT-SOUND-MAIS-OU-MENOS-02, PT-ETYMON-MAIS-OU-MENOS-03, PT-GRAMMAR-MAIS-OU-MENOS-04, PT-LEX-C02-PRACTICE-02, PT-NOTICE-C02-PRACTICE-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: the whole exchange, both voices]
@@ -46,6 +65,7 @@ grew from the respectful title *vossa mercê*.
 [REPEAT x2] “Tudo bem? — Tudo bem, e você?”
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-DE-NADA-02, PT-ETYMON-DE-NADA-03, PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04, PT-SOUND-TUDO-02, PT-ETYMON-TUDO-03, PT-GRAMMAR-TUDO-04, PT-GRAMMAR-TUDO-BEM-02, PT-LEX-COMO-VAI-ESTA-01, PT-SOUND-MAIS-OU-MENOS-02, PT-ETYMON-MAIS-OU-MENOS-03, PT-GRAMMAR-MAIS-OU-MENOS-04, PT-LEX-C02-PRACTICE-02, PT-NOTICE-C02-PRACTICE-03] -->
 
 [PAUSE 3s] Run the casual exchange without looking. Which phrase answers a
 small favour? (**De nada**.) Which answer means “so-so”? (**Mais ou menos**.)

--- a/code/learning/human-languages/portuguese/lessons/PT-C02-tudo-bem.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C02-tudo-bem.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C02-tudo-bem
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 130
 chapter: 2
 type: phrase
 headword: Tudo bem?
@@ -9,13 +12,26 @@ prerequisites: [PT-C02-tudo, PT-C02-como]
 sounds: [nasal-em]
 roots: [totus-latin]
 etymology_hook: "Tudo bem? literally asks 'everything well?' and needs neither a verb nor a pronoun"
-est_minutes: 4
+duration:
+  max_seconds: 234
+requires:
+  knowledge: [PT-SOUND-TUDO-02, PT-ETYMON-TUDO-03, PT-GRAMMAR-TUDO-04, PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04]
+introduces:
+  knowledge: [PT-GRAMMAR-TUDO-BEM-02]
+practises:
+  knowledge: [PT-SOUND-TUDO-02, PT-ETYMON-TUDO-03, PT-GRAMMAR-TUDO-04, PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04, PT-GRAMMAR-TUDO-BEM-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C02-tudo, PT-C02-como]
 ---
 
 # Tudo bem? — “everything well?”
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You know **tudo**, “everything.” Add **bem**, “well,” and Portuguese
 gives you an everyday check-in with no verb at all.
@@ -29,7 +45,8 @@ The friendly answer can be identical:
 Because the question contains no “you” and no verb, it avoids choosing a social
 register. That simplicity is exactly why it is everywhere.
 
-## Add the listener only when useful
+## Grammar Lens: Add the listener only when useful
+<!-- hl-knowledge: introduces=[PT-GRAMMAR-TUDO-BEM-02]; assesses=[] -->
 
 To bounce the question back, say:
 
@@ -43,6 +60,7 @@ Portuguese can use **o senhor / a senhora**, “the gentleman / the lady.”
 You do not need either pronoun for the basic pair: **Tudo bem? — Tudo bem.**
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-TUDO-02, PT-ETYMON-TUDO-03, PT-GRAMMAR-TUDO-04, PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04, PT-GRAMMAR-TUDO-BEM-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: “Tudo bem?”]
@@ -52,6 +70,7 @@ You do not need either pronoun for the basic pair: **Tudo bem? — Tudo bem.**
 [REPEAT x2] “Tudo bem? — Tudo bem!”
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-TUDO-02, PT-ETYMON-TUDO-03, PT-GRAMMAR-TUDO-04, PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04, PT-GRAMMAR-TUDO-BEM-02] -->
 
 [PAUSE 3s] What does *Tudo bem?* literally ask? (“Everything well?”) Why can it
 fit almost any listener? (It has **no verb and no pronoun**.) How do you bounce

--- a/code/learning/human-languages/portuguese/lessons/PT-C02-tudo.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C02-tudo.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C02-tudo
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 120
 chapter: 2
 type: word
 headword: tudo
@@ -9,23 +12,38 @@ prerequisites: []
 sounds: [final-o-is-u]
 roots: [totus-latin]
 etymology_hook: "tudo ← Latin tōtus 'whole, entire' → English total, totally, teetotal"
-est_minutes: 3
+duration:
+  max_seconds: 252
+requires:
+  knowledge: []
+introduces:
+  knowledge: [PT-SOUND-TUDO-02, PT-ETYMON-TUDO-03, PT-GRAMMAR-TUDO-04]
+practises:
+  knowledge: [PT-SOUND-TUDO-02, PT-ETYMON-TUDO-03, PT-GRAMMAR-TUDO-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C02-como]
 ---
 
 # tudo — "everything," the heart of *Tudo bem?*
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The most Brazilian way to greet someone doesn't use a "you" or a
 "to be" at all — it just asks **Tudo bem?**, "everything well?" To own it, learn
 its first word: **tudo**, "everything."
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[PT-SOUND-TUDO-02]; assesses=[] -->
 
 - `final-o-is-u` — **tudo** = *TOO-doo*: final *-o* → *u*, and the *d* is soft.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-TUDO-03]; assesses=[] -->
 
 **tudo** = "everything, all," from Latin **tōtus**, *"whole, entire."* You ask
 whether the **whole** of someone's life is going well — *is everything OK?*
@@ -38,6 +56,7 @@ That root **tōtus** is completely at home in English:
   the family (you'll hear Spanish *todo* echoing this).
 
 ## Grammar Lens: pairing it with "well"
+<!-- hl-knowledge: introduces=[PT-GRAMMAR-TUDO-04]; assesses=[] -->
 
 Portuguese "well" is **bem** (← Latin *bene*, "well" — the *bene* of *bene*fit,
 *bene*volent; cousin of Spanish *bien*, French *bien*). Put them together:
@@ -50,6 +69,7 @@ Portuguese — and you can answer with the very same two words: **Tudo bem.**
 ("Everything's well.") Or just **Tudo bom.**
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-TUDO-02, PT-ETYMON-TUDO-03, PT-GRAMMAR-TUDO-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "tudo" — *TOO-doo*]
@@ -57,6 +77,7 @@ Portuguese — and you can answer with the very same two words: **Tudo bem.**
 - [YOU SAY: "tudo" then English "total, totally" — one family]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-TUDO-02, PT-ETYMON-TUDO-03, PT-GRAMMAR-TUDO-04] -->
 
 [PAUSE 3s] What Latin word gives *tudo*, and its English cousins? (*tōtus* →
 total, totally, teetotal.) Why is *Tudo bem?* so easy to use? (No pronoun, no

--- a/code/learning/human-languages/portuguese/lessons/PT-C03-como-se-chama.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C03-como-se-chama.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C03-como-se-chama
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 200
 chapter: 3
 type: phrase
 headword: Como se chama?
@@ -9,19 +12,33 @@ prerequisites: [PT-C03-me-chamo, PT-C02-como]
 sounds: [ch-is-sh]
 roots: [quomodo-latin, clamare-latin]
 etymology_hook: "como (← quōmodo 'how') + se chama (chamar-se) — 'how do you call yourself?'"
-est_minutes: 3
+duration:
+  max_seconds: 273
+requires:
+  knowledge: [PT-SOUND-ME-CHAMO-02, PT-ETYMON-ME-CHAMO-03, PT-GRAMMAR-ME-CHAMO-04, PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04]
+introduces:
+  knowledge: [PT-ETYMON-COMO-SE-CHAMA-02]
+practises:
+  knowledge: [PT-SOUND-ME-CHAMO-02, PT-ETYMON-ME-CHAMO-03, PT-GRAMMAR-ME-CHAMO-04, PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04, PT-ETYMON-COMO-SE-CHAMA-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C03-me-chamo, PT-C02-como]
 ---
 
 # Como se chama? — "what's your name?"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Both pieces are yours: **como** ("how," from your *Tudo bem?* chapter)
 and **chamar-se** ("to call oneself"). Portuguese, like all its sisters, asks the
 name with **"how"**: *how do you call yourself?*
 
 ## The phrase, taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-COMO-SE-CHAMA-02]; assesses=[] -->
 
 > **Como se chama?** = "What's your name?"
 > literally: **"How do you call yourself?"**
@@ -43,6 +60,7 @@ se llama?* and Italian *come ti chiami?*, the name is a matter of **how** you're
 called — never *what*.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-ME-CHAMO-02, PT-ETYMON-ME-CHAMO-03, PT-GRAMMAR-ME-CHAMO-04, PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04, PT-ETYMON-COMO-SE-CHAMA-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "Como se chama?" — *KOH-moo suh SHAH-mah*]
@@ -51,6 +69,7 @@ called — never *what*.
   three sisters]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-ME-CHAMO-02, PT-ETYMON-ME-CHAMO-03, PT-GRAMMAR-ME-CHAMO-04, PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04, PT-ETYMON-COMO-SE-CHAMA-02] -->
 
 [PAUSE 3s] What does *Como se chama?* literally ask? ("How do you call
 yourself?") Which everyday pronoun does the polite form use? (*Você*.) What "how"

--- a/code/learning/human-languages/portuguese/lessons/PT-C03-eu.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C03-eu.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C03-eu
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 180
 chapter: 3
 type: word
 headword: eu
@@ -9,23 +12,38 @@ prerequisites: []
 sounds: [nasal-eu]
 roots: [ego-latin]
 etymology_hook: "eu ← Latin ego 'I' → English ego; Portuguese usually drops it (pro-drop)"
-est_minutes: 3
+duration:
+  max_seconds: 171
+requires:
+  knowledge: []
+introduces:
+  knowledge: [PT-SOUND-EU-02, PT-ETYMON-EU-03, PT-GRAMMAR-EU-04]
+practises:
+  knowledge: [PT-SOUND-EU-02, PT-ETYMON-EU-03, PT-GRAMMAR-EU-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C04-adeus]
 ---
 
 # eu — "I," the pronoun Portuguese usually drops
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Before introducing yourself, meet **eu** — "I." Famous English cousin,
 and the same habit as its Romance sisters: Portuguese usually **leaves it out.**
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[PT-SOUND-EU-02]; assesses=[] -->
 
 - `nasal-eu` — **eu** = *EH-oo*, a gliding vowel with a light nasal colour, one
   syllable.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-EU-03]; assesses=[] -->
 
 **eu** = "I," from Latin **ego** — the same *ego* English borrowed outright:
 
@@ -33,6 +51,7 @@ and the same habit as its Romance sisters: Portuguese usually **leaves it out.**
 - Romance siblings, all from *ego*: Spanish **yo**, Italian **io**, French **je**.
 
 ## Grammar Lens: the dropped subject (pro-drop)
+<!-- hl-knowledge: introduces=[PT-GRAMMAR-EU-04]; assesses=[] -->
 
 The verb ending already names the speaker, so Portuguese usually **omits** the
 pronoun: *chamo-me* ("I call myself") needs no *eu* — the *-o* of *chamo* is "I."
@@ -44,6 +63,7 @@ Spanish (*yo*) and Italian (*io*) do the same. It's one of the first real habits
 of a Romance language: trust the verb ending, drop the pronoun.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-EU-02, PT-ETYMON-EU-03, PT-GRAMMAR-EU-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "eu" — *EH-oo*]
@@ -51,6 +71,7 @@ of a Romance language: trust the verb ending, drop the pronoun.
 - [YOU SAY: eu / yo / io / je — four children of *ego*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-EU-02, PT-ETYMON-EU-03, PT-GRAMMAR-EU-04] -->
 
 [PAUSE 3s] What Latin word is *eu* from? (*Ego* — ego, egoist.) Why does
 Portuguese usually drop it? (The verb ending already says "I.") When do you keep

--- a/code/learning/human-languages/portuguese/lessons/PT-C03-me-chamo.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C03-me-chamo.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C03-me-chamo
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 190
 chapter: 3
 type: phrase
 headword: me chamo / chamo-me
@@ -9,19 +12,33 @@ prerequisites: [PT-C03-eu]
 sounds: [ch-is-sh, final-o-is-u]
 roots: [clamare-latin, nomen-latin]
 etymology_hook: "chamar-se ← Latin clāmāre 'to call out' (claim/clamor); alt. 'meu nome é' ← nōmen (name/noun)"
-est_minutes: 4
+duration:
+  max_seconds: 226
+requires:
+  knowledge: [PT-SOUND-EU-02, PT-ETYMON-EU-03, PT-GRAMMAR-EU-04]
+introduces:
+  knowledge: [PT-SOUND-ME-CHAMO-02, PT-ETYMON-ME-CHAMO-03, PT-GRAMMAR-ME-CHAMO-04]
+practises:
+  knowledge: [PT-SOUND-EU-02, PT-ETYMON-EU-03, PT-GRAMMAR-EU-04, PT-SOUND-ME-CHAMO-02, PT-ETYMON-ME-CHAMO-03, PT-GRAMMAR-ME-CHAMO-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C03-eu]
 ---
 
 # me chamo — "I call myself"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Like its Iberian and Italian sisters, Portuguese introduces you as
 what you **call yourself** — **me chamo** — from the very same Latin *clāmāre*
 that gave Spanish *me llamo* and Italian *mi chiamo*.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[PT-SOUND-ME-CHAMO-02]; assesses=[] -->
 
 - `ch-is-sh` — Portuguese **ch** = **"sh"**: **chamo** = *SHAH-moo*. (A neat
   three-way split from one Latin *cl-*: Spanish *ll* = *y* (*llamo*), Italian
@@ -29,6 +46,7 @@ that gave Spanish *me llamo* and Italian *mi chiamo*.
 - `final-o-is-u` — final *-o* → *u*: *SHAH-moo*.
 
 ## The phrase, taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-ME-CHAMO-03]; assesses=[] -->
 
 **me chamo** = **me** ("myself") + **chamo** ("I call") → **"I call myself."**
 Brazilians often say **eu me chamo**; European Portuguese prefers **chamo-me**
@@ -51,12 +69,14 @@ Latin **nōmen**, "name" — the root of English **noun**, **nominal**,
 (call myself) or the *noun* (my name is).
 
 ## Grammar Lens: the reflexive
+<!-- hl-knowledge: introduces=[PT-GRAMMAR-ME-CHAMO-04]; assesses=[] -->
 
 *chamo* alone = "I call [someone]"; **me** chamo = "I call **myself**" —
 reflexive. The pronoun shifts with the person: **me** chamo (I) → **se** chama
 (he/she/você). And *eu* is dropped — the *-o* ending already says "I."
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-EU-02, PT-ETYMON-EU-03, PT-GRAMMAR-EU-04, PT-SOUND-ME-CHAMO-02, PT-ETYMON-ME-CHAMO-03, PT-GRAMMAR-ME-CHAMO-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "me chamo" — *muh SHAH-moo*, *ch* = *sh*]
@@ -64,6 +84,7 @@ reflexive. The pronoun shifts with the person: **me** chamo (I) → **se** chama
 - [YOU SAY: me chamo / me llamo / mi chiamo — one *clāmāre*, three sounds]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-EU-02, PT-ETYMON-EU-03, PT-GRAMMAR-EU-04, PT-SOUND-ME-CHAMO-02, PT-ETYMON-ME-CHAMO-03, PT-GRAMMAR-ME-CHAMO-04] -->
 
 [PAUSE 3s] What does *me chamo* literally mean, and its Latin root? ("I call
 myself"; *clāmāre* — claim/clamor.) How is Portuguese *ch* pronounced, vs Italian

--- a/code/learning/human-languages/portuguese/lessons/PT-C03-practice.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C03-practice.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C03-practice
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 220
 chapter: 3
 type: practice-mix
 headword: (practice)
@@ -8,19 +11,33 @@ concept_tag: CH3-PRACTICE
 prerequisites: [PT-C03-eu, PT-C03-me-chamo, PT-C03-como-se-chama, PT-C03-prazer]
 sounds: []
 roots: []
-est_minutes: 4
+duration:
+  max_seconds: 245
+requires:
+  knowledge: [PT-SOUND-EU-02, PT-ETYMON-EU-03, PT-GRAMMAR-EU-04, PT-SOUND-ME-CHAMO-02, PT-ETYMON-ME-CHAMO-03, PT-GRAMMAR-ME-CHAMO-04, PT-ETYMON-COMO-SE-CHAMA-02, PT-SOUND-PRAZER-02, PT-ETYMON-PRAZER-03, PT-GRAMMAR-PRAZER-04]
+introduces:
+  knowledge: [PT-LEX-C03-PRACTICE-02, PT-NOTICE-C03-PRACTICE-03]
+practises:
+  knowledge: [PT-SOUND-EU-02, PT-ETYMON-EU-03, PT-GRAMMAR-EU-04, PT-SOUND-ME-CHAMO-02, PT-ETYMON-ME-CHAMO-03, PT-GRAMMAR-ME-CHAMO-04, PT-ETYMON-COMO-SE-CHAMA-02, PT-SOUND-PRAZER-02, PT-ETYMON-PRAZER-03, PT-GRAMMAR-PRAZER-04, PT-LEX-C03-PRACTICE-02, PT-NOTICE-C03-PRACTICE-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C03-me-chamo, PT-C03-como-se-chama, PT-C03-prazer, PT-C02-practice]
 ---
 
 # Practice — introducing yourself in Portuguese
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] No new words. *eu, me chamo, como se chama, prazer* assemble into a
 real first meeting. This slots between your greetings (Ch. 1–2) and farewells
 (Ch. 4), so Portuguese now runs a whole conversation.
 
 ## The exchange
+<!-- hl-knowledge: introduces=[PT-LEX-C03-PRACTICE-02]; assesses=[] -->
 
 **Casual** (*você*):
 
@@ -36,6 +53,7 @@ real first meeting. This slots between your greetings (Ch. 1–2) and farewells
 > — Costa. **Muito prazer.**
 
 ## What you've built this chapter
+<!-- hl-knowledge: introduces=[PT-NOTICE-C03-PRACTICE-03]; assesses=[] -->
 
 - **eu** — "I" (← *ego*), usually **dropped** — the verb ending carries it.
 - **me chamo / chamo-me** — "I call myself" (*chamar-se* ← *clāmāre*; *ch* = *sh*;
@@ -44,6 +62,7 @@ real first meeting. This slots between your greetings (Ch. 1–2) and farewells
 - **prazer** — "a pleasure" (← *placēre*; twin of Italian *piacere*).
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-EU-02, PT-ETYMON-EU-03, PT-GRAMMAR-EU-04, PT-SOUND-ME-CHAMO-02, PT-ETYMON-ME-CHAMO-03, PT-GRAMMAR-ME-CHAMO-04, PT-ETYMON-COMO-SE-CHAMA-02, PT-SOUND-PRAZER-02, PT-ETYMON-PRAZER-03, PT-GRAMMAR-PRAZER-04, PT-LEX-C03-PRACTICE-02, PT-NOTICE-C03-PRACTICE-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: the full casual meeting, both voices]
@@ -54,6 +73,7 @@ real first meeting. This slots between your greetings (Ch. 1–2) and farewells
 [REPEAT x2] Run a whole first meeting start to finish.
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-EU-02, PT-ETYMON-EU-03, PT-GRAMMAR-EU-04, PT-SOUND-ME-CHAMO-02, PT-ETYMON-ME-CHAMO-03, PT-GRAMMAR-ME-CHAMO-04, PT-ETYMON-COMO-SE-CHAMA-02, PT-SOUND-PRAZER-02, PT-ETYMON-PRAZER-03, PT-GRAMMAR-PRAZER-04, PT-LEX-C03-PRACTICE-02, PT-NOTICE-C03-PRACTICE-03] -->
 
 [PAUSE 3s] Why does Portuguese usually drop *eu*? (The verb ending says who.)
 What does *me chamo* literally mean, and its root? ("I call myself"; *clāmāre*.)

--- a/code/learning/human-languages/portuguese/lessons/PT-C03-prazer.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C03-prazer.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C03-prazer
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 210
 chapter: 3
 type: word
 headword: prazer
@@ -9,24 +12,39 @@ prerequisites: [PT-C03-como-se-chama]
 sounds: [pr-cluster, final-r]
 roots: [placere-latin]
 etymology_hook: "prazer ← Latin placēre 'to please' → English please, pleasure; twin of Italian piacere"
-est_minutes: 3
+duration:
+  max_seconds: 190
+requires:
+  knowledge: [PT-ETYMON-COMO-SE-CHAMA-02]
+introduces:
+  knowledge: [PT-SOUND-PRAZER-02, PT-ETYMON-PRAZER-03, PT-GRAMMAR-PRAZER-04]
+practises:
+  knowledge: [PT-ETYMON-COMO-SE-CHAMA-02, PT-SOUND-PRAZER-02, PT-ETYMON-PRAZER-03, PT-GRAMMAR-PRAZER-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C03-me-chamo, PT-C03-como-se-chama]
 ---
 
 # prazer — "pleased to meet you," i.e. "a pleasure"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Names traded, you close with **prazer** — "a pleasure." It's the twin
 of Italian *piacere*, and, like it, straight from Latin *please*.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[PT-SOUND-PRAZER-02]; assesses=[] -->
 
 - `pr-cluster` — **prazer** = *prah-**ZEHR***: the *z* is a true *z*; stress the
   end. (The *pr-* shows a Portuguese sound-law: Latin *pl-* often became *pr-* —
   *placēre* → *prazer*, *plūs* → …)
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-PRAZER-03]; assesses=[] -->
 
 **prazer** = "pleasure" (and, as a verb, "to please"), from Latin **placēre**,
 *"to please."* On meeting someone it's short for *"[it's] a pleasure."*
@@ -44,11 +62,13 @@ Portuguese took *placēre*'s *pl-* to *pr-* (a regular shift — compare *branco
 *prazer* look a little different but are the very same word.
 
 ## Grammar Lens: a one-word courtesy
+<!-- hl-knowledge: introduces=[PT-GRAMMAR-PRAZER-04]; assesses=[] -->
 
 *Prazer* stands alone, with a nod or handshake. Fuller forms: **muito prazer**
 ("much pleasure"), or **prazer em conhecê-lo/-la** ("a pleasure to know you").
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-ETYMON-COMO-SE-CHAMA-02, PT-SOUND-PRAZER-02, PT-ETYMON-PRAZER-03, PT-GRAMMAR-PRAZER-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "prazer" — *prah-ZEHR*]
@@ -56,6 +76,7 @@ Portuguese took *placēre*'s *pl-* to *pr-* (a regular shift — compare *branco
 - [YOU SAY: Portuguese *prazer* and Italian *piacere* — twins from *placēre*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-ETYMON-COMO-SE-CHAMA-02, PT-SOUND-PRAZER-02, PT-ETYMON-PRAZER-03, PT-GRAMMAR-PRAZER-04] -->
 
 [PAUSE 3s] What does *prazer* mean, and from what Latin verb? ("A pleasure," ←
 *placēre*.) Its Italian twin? (*Piacere*.) What sound-shift turned *pl-* into

--- a/code/learning/human-languages/portuguese/lessons/PT-C04-adeus.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C04-adeus.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C04-adeus
+spine_node: SPINE-TAKE-LEAVE
+sequence: 230
 chapter: 4
 type: word
 headword: adeus
@@ -9,23 +12,38 @@ prerequisites: []
 sounds: [nasal-eu, final-s-sh]
 roots: [ad-deum-latin]
 etymology_hook: "adeus ← a Deus 'to God' — the exact twin of Spanish adiós, French adieu, Italian addio"
-est_minutes: 3
+duration:
+  max_seconds: 180
+requires:
+  knowledge: []
+introduces:
+  knowledge: [PT-SOUND-ADEUS-02, PT-ETYMON-ADEUS-03]
+practises:
+  knowledge: [PT-SOUND-ADEUS-02, PT-ETYMON-ADEUS-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C02-practice]
 ---
 
 # adeus — "goodbye," i.e. "to God"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You can greet, ask *tudo bem?*, and reply. Now close the conversation.
 The Portuguese goodbye is **adeus** — and it's a tiny prayer: **"to God."**
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[PT-SOUND-ADEUS-02]; assesses=[] -->
 
 - `nasal-eu` — **adeus** ≈ *ah-**DEH**-oosh*: the *eu* is a gliding vowel; final
   *-s* is a soft *sh* in Portugal (*-s* → *ss* in Brazil). Stress the *-deus*.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-ADEUS-03]; assesses=[] -->
 
 **adeus** = **a** ("to") + **Deus** ("God"), from Latin **ad Deum**, *"to
 God."* It's the fossil of a blessing — *"[I commend you] to God"* — said at
@@ -48,6 +66,7 @@ Spanish *Dios*. When you say *adeus*, you're handing someone to God for
 safekeeping until next time.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-ADEUS-02, PT-ETYMON-ADEUS-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "adeus" — *ah-DEH-oosh*]
@@ -55,6 +74,7 @@ safekeeping until next time.
 - [YOU SAY: even English "goodbye" = "God be with ye"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-ADEUS-02, PT-ETYMON-ADEUS-03] -->
 
 [PAUSE 3s] What does *adeus* literally mean, and from what? ("To God," ← *ad
 Deum*.) Name two sister-language goodbyes with the same "to God" origin.

--- a/code/learning/human-languages/portuguese/lessons/PT-C04-ate-amanha.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C04-ate-amanha.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C04-ate-amanha
+spine_node: SPINE-TAKE-LEAVE
+sequence: 250
 chapter: 4
 type: phrase
 headword: até amanhã
@@ -9,25 +12,40 @@ prerequisites: [PT-C04-ate-logo]
 sounds: [nasal-anha, final-o-is-u]
 roots: [hatta-arabic, ad-maneana-latin]
 etymology_hook: "amanhã ← Latin ad māneāna 'to the morning' — kin of Spanish mañana; note the nasal -ã"
-est_minutes: 3
+duration:
+  max_seconds: 160
+requires:
+  knowledge: [PT-SOUND-ATE-LOGO-02, PT-ETYMON-ATE-LOGO-03]
+introduces:
+  knowledge: [PT-SOUND-ATE-AMANHA-02, PT-ETYMON-ATE-AMANHA-03]
+practises:
+  knowledge: [PT-SOUND-ATE-LOGO-02, PT-ETYMON-ATE-LOGO-03, PT-SOUND-ATE-AMANHA-02, PT-ETYMON-ATE-AMANHA-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C04-ate-logo]
 ---
 
 # até amanhã — "see you tomorrow"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Same frame — *até* + a "when." **Até amanhã**, "until tomorrow." And
 *amanhã* is the Portuguese cousin of a Spanish word you already know, wearing a
 heavy nasal ending.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[PT-SOUND-ATE-AMANHA-02]; assesses=[] -->
 
 - `nasal-anha` — **amanhã** = *ah-mah-**NYÃ***: the **nh** is the *ny* of
   "canyon" (Portuguese spells the *ñ* sound as *nh*), and the final **-ã** is a
   strong **nasal** *a* — air through the nose, no hard consonant. Stress the end.
 
 ## The phrase, taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-ATE-AMANHA-03]; assesses=[] -->
 
 - **até** = "until" (← Arabic *ḥattā*, from the last lesson).
 - **amanhã** = "tomorrow," from Latin **ad māneāna**, *"to the morning [hour]."*
@@ -44,6 +62,7 @@ the *ny* sound as **nh** (*amanhã*), where Spanish uses **ñ** (*mañana*) — 
 spellings, one sound, both from that doubled-*n*.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-ATE-LOGO-02, PT-ETYMON-ATE-LOGO-03, PT-SOUND-ATE-AMANHA-02, PT-ETYMON-ATE-AMANHA-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "até amanhã" — *ah-TEH ah-mah-NYÃ*, nasal ending]
@@ -51,6 +70,7 @@ spellings, one sound, both from that doubled-*n*.
 - [YOU SAY: Portuguese *nh* = Spanish *ñ* = the *ny* sound]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-ATE-LOGO-02, PT-ETYMON-ATE-LOGO-03, PT-SOUND-ATE-AMANHA-02, PT-ETYMON-ATE-AMANHA-03] -->
 
 [PAUSE 3s] What does *amanhã* come from, and literally mean? (*Ad māneāna* — "to
 the morning.") How does Portuguese spell the *ny* sound that Spanish writes as

--- a/code/learning/human-languages/portuguese/lessons/PT-C04-ate-breve.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C04-ate-breve.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C04-ate-breve
+spine_node: SPINE-TAKE-LEAVE
+sequence: 260
 chapter: 4
 type: phrase
 headword: até breve
@@ -9,23 +12,38 @@ prerequisites: [PT-C04-ate-logo]
 sounds: [nasal-em, final-e-reduces]
 roots: [hatta-arabic, brevis-latin]
 etymology_hook: "breve ← Latin brevis 'short' → English brief, brevity, abbreviate"
-est_minutes: 3
+duration:
+  max_seconds: 141
+requires:
+  knowledge: [PT-SOUND-ATE-LOGO-02, PT-ETYMON-ATE-LOGO-03]
+introduces:
+  knowledge: [PT-SOUND-ATE-BREVE-02, PT-ETYMON-ATE-BREVE-03]
+practises:
+  knowledge: [PT-SOUND-ATE-LOGO-02, PT-ETYMON-ATE-LOGO-03, PT-SOUND-ATE-BREVE-02, PT-ETYMON-ATE-BREVE-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C04-ate-amanha]
 ---
 
 # até breve — "see you soon"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The last of the *até* goodbyes: **até breve**, "until soon" — literally
 "until [a] *short* [while]." *Breve* is a word English wears in several coats.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[PT-SOUND-ATE-BREVE-02]; assesses=[] -->
 
 - **até breve** = *ah-TEH **BREH**-vee*: open *e* in *breve*, final *-e* softens
   toward *ee*.
 
 ## The phrase, taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-ATE-BREVE-03]; assesses=[] -->
 
 - **até** = "until" (← Arabic *ḥattā*).
 - **breve** = "short, brief," from Latin **brevis**, *"short."*
@@ -41,6 +59,7 @@ So *até breve* is **"until [a] short [while]"** — see you before long. It's a
 touch warmer and less fixed than *até logo*; both mean "see you soon."
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-ATE-LOGO-02, PT-ETYMON-ATE-LOGO-03, PT-SOUND-ATE-BREVE-02, PT-ETYMON-ATE-BREVE-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "até breve" — *ah-TEH BREH-vee*]
@@ -48,6 +67,7 @@ touch warmer and less fixed than *até logo*; both mean "see you soon."
 - [YOU SAY: the three *até* goodbyes — até logo / até amanhã / até breve]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-ATE-LOGO-02, PT-ETYMON-ATE-LOGO-03, PT-SOUND-ATE-BREVE-02, PT-ETYMON-ATE-BREVE-03] -->
 
 [PAUSE 3s] What does *breve* mean, and its English cousins? ("Short" — brief,
 brevity, abbreviate.) So *até breve* literally says? ("Until a short while" →

--- a/code/learning/human-languages/portuguese/lessons/PT-C04-ate-logo.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C04-ate-logo.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C04-ate-logo
+spine_node: SPINE-TAKE-LEAVE
+sequence: 240
 chapter: 4
 type: phrase
 headword: até logo
@@ -9,24 +12,39 @@ prerequisites: [PT-C04-adeus]
 sounds: [final-o-is-u]
 roots: [hatta-arabic, loco-latin]
 etymology_hook: "até ← Arabic ḥattā (the SAME Arabic loan as Spanish hasta); logo ← Latin locō 'in place' → 'soon'"
-est_minutes: 4
+duration:
+  max_seconds: 189
+requires:
+  knowledge: [PT-SOUND-ADEUS-02, PT-ETYMON-ADEUS-03]
+introduces:
+  knowledge: [PT-SOUND-ATE-LOGO-02, PT-ETYMON-ATE-LOGO-03]
+practises:
+  knowledge: [PT-SOUND-ADEUS-02, PT-ETYMON-ADEUS-03, PT-SOUND-ATE-LOGO-02, PT-ETYMON-ATE-LOGO-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C04-adeus]
 ---
 
 # até logo — "see you later," and a word straight from Arabic
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The everyday Portuguese goodbye isn't *adeus* (that's a bit final) —
 it's **até logo**, "until soon." And its first word carries the same surprise
 Spanish's *hasta* does: it came from **Arabic**.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[PT-SOUND-ATE-LOGO-02]; assesses=[] -->
 
 - **até** = *ah-**TEH***, stress the end (the accent on *é*).
 - `final-o-is-u` — **logo** = *LOH-goo*, final *-o* → *u*.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-ATE-LOGO-03]; assesses=[] -->
 
 - **até** = "until, up to." Like Spanish **hasta**, it comes from **Arabic
   *ḥattā* (حتى)**, "until" — carried into Iberian speech across the **800 years
@@ -43,6 +61,7 @@ So **até logo** = "**until soon**" — the exact mirror of Spanish **hasta lueg
 Arabic preposition and all.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-ADEUS-02, PT-ETYMON-ADEUS-03, PT-SOUND-ATE-LOGO-02, PT-ETYMON-ATE-LOGO-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "até logo" — *ah-TEH LOH-goo*]
@@ -50,6 +69,7 @@ Arabic preposition and all.
 - [YOU SAY: *até logo* = *hasta luego*, twin for twin]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-ADEUS-02, PT-ETYMON-ADEUS-03, PT-SOUND-ATE-LOGO-02, PT-ETYMON-ATE-LOGO-03] -->
 
 [PAUSE 3s] Where does *até* come from, and which Spanish word is its twin?
 (Arabic *ḥattā* — Spanish *hasta*.) Why is borrowing it surprising? (It's a

--- a/code/learning/human-languages/portuguese/lessons/PT-C04-practice.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C04-practice.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C04-practice
+spine_node: SPINE-TAKE-LEAVE
+sequence: 270
 chapter: 4
 type: practice-mix
 headword: (practice)
@@ -8,18 +11,32 @@ concept_tag: CH4-PRACTICE
 prerequisites: [PT-C04-adeus, PT-C04-ate-logo, PT-C04-ate-amanha, PT-C04-ate-breve]
 sounds: []
 roots: []
-est_minutes: 4
+duration:
+  max_seconds: 216
+requires:
+  knowledge: [PT-SOUND-ADEUS-02, PT-ETYMON-ADEUS-03, PT-SOUND-ATE-LOGO-02, PT-ETYMON-ATE-LOGO-03, PT-SOUND-ATE-AMANHA-02, PT-ETYMON-ATE-AMANHA-03, PT-SOUND-ATE-BREVE-02, PT-ETYMON-ATE-BREVE-03]
+introduces:
+  knowledge: [PT-LEX-C04-PRACTICE-02, PT-NOTICE-C04-PRACTICE-03]
+practises:
+  knowledge: [PT-SOUND-ADEUS-02, PT-ETYMON-ADEUS-03, PT-SOUND-ATE-LOGO-02, PT-ETYMON-ATE-LOGO-03, PT-SOUND-ATE-AMANHA-02, PT-ETYMON-ATE-AMANHA-03, PT-SOUND-ATE-BREVE-02, PT-ETYMON-ATE-BREVE-03, PT-LEX-C04-PRACTICE-02, PT-NOTICE-C04-PRACTICE-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C04-adeus, PT-C04-ate-logo, PT-C04-ate-amanha, PT-C04-ate-breve, PT-C02-practice]
 ---
 
 # Practice — saying goodbye in Portuguese
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] No new words. You can now greet, ask *tudo bem?*, and **close** the
 conversation. Run the goodbyes until the right one is automatic.
 
-## The closings
+## You'll want to know: The closings
+<!-- hl-knowledge: introduces=[PT-LEX-C04-PRACTICE-02]; assesses=[] -->
 
 **Final / formal** — the "to God" goodbye:
 
@@ -37,6 +54,7 @@ conversation. Run the goodbyes until the right one is automatic.
 > — **Até!** (Brazilians often clip it to just *"até!"*)
 
 ## What you've built this chapter
+<!-- hl-knowledge: introduces=[PT-NOTICE-C04-PRACTICE-03]; assesses=[] -->
 
 - **adeus** — goodbye ("to God"; the *adiós / adieu / addio* family, and English
   *goodbye* = "God be with ye").
@@ -47,6 +65,7 @@ conversation. Run the goodbyes until the right one is automatic.
 - **até breve** — see you soon (*breve* ← *brevis*, "short" — brief/brevity).
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-ADEUS-02, PT-ETYMON-ADEUS-03, PT-SOUND-ATE-LOGO-02, PT-ETYMON-ATE-LOGO-03, PT-SOUND-ATE-AMANHA-02, PT-ETYMON-ATE-AMANHA-03, PT-SOUND-ATE-BREVE-02, PT-ETYMON-ATE-BREVE-03, PT-LEX-C04-PRACTICE-02, PT-NOTICE-C04-PRACTICE-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: greet, ask, and close — "Olá! Tudo bem? … Até amanhã!"]
@@ -57,6 +76,7 @@ conversation. Run the goodbyes until the right one is automatic.
 [REPEAT x2] Open and close a whole tiny exchange without stopping.
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-ADEUS-02, PT-ETYMON-ADEUS-03, PT-SOUND-ATE-LOGO-02, PT-ETYMON-ATE-LOGO-03, PT-SOUND-ATE-AMANHA-02, PT-ETYMON-ATE-AMANHA-03, PT-SOUND-ATE-BREVE-02, PT-ETYMON-ATE-BREVE-03, PT-LEX-C04-PRACTICE-02, PT-NOTICE-C04-PRACTICE-03] -->
 
 [PAUSE 3s] Which Portuguese goodbye means "to God"? (*Adeus*.) Which word inside
 the *até* goodbyes came from Arabic, and what's its Spanish twin? (*Até* ← *ḥattā*

--- a/code/learning/human-languages/portuguese/lessons/PT-C05-falar.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C05-falar.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C05-falar
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 280
 chapter: 5
 type: word
 headword: falar
@@ -9,23 +12,38 @@ prerequisites: [PT-C03-eu, PT-C02-como]
 sounds: [final-r, final-a-reduces]
 roots: [fabulari-latin]
 etymology_hook: "falar ← Latin fabulārī 'to chat' (← fābula 'story' → fable); Portuguese KEPT the f- where Spanish shifted f→h"
-est_minutes: 4
+duration:
+  max_seconds: 222
+requires:
+  knowledge: [PT-SOUND-EU-02, PT-ETYMON-EU-03, PT-GRAMMAR-EU-04, PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04]
+introduces:
+  knowledge: [PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04]
+practises:
+  knowledge: [PT-SOUND-EU-02, PT-ETYMON-EU-03, PT-GRAMMAR-EU-04, PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04, PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C03-practice, PT-C04-practice]
 ---
 
 # falar — "to speak," and the *f* that Spanish lost
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Until now you've assembled fixed phrases. **falar** ("to speak") is
 your first real **verb** — the model for the big **-ar** family — and it hides a
 beautiful contrast with Spanish, right at its first letter.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[PT-SOUND-FALAR-02]; assesses=[] -->
 
 - `final-r` — **falar** = *fah-LAR*, tapped final *r*. The stem is *fal-*.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-FALAR-03]; assesses=[] -->
 
 **falar** comes from Latin **fabulārī**, *"to chat, to tell tales"* — from
 **fābula**, "a story" (→ English **fable**, **fabulous**, **confabulate**). The
@@ -48,6 +66,7 @@ still has the honest Latin *f* — *hijo/filho*, *hacer/fazer*. Portuguese is th
 more conservative sister here.
 
 ## Grammar Lens: the -ar present tense (pro-drop)
+<!-- hl-knowledge: introduces=[PT-GRAMMAR-FALAR-04]; assesses=[] -->
 
 Drop **-ar** to get *fal-*, then add the endings:
 
@@ -64,6 +83,7 @@ says "I," so no *eu* needed. (Portuguese joins the *drop* camp: ES, PT, IT drop;
 FR, DE keep.)
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-EU-02, PT-ETYMON-EU-03, PT-GRAMMAR-EU-04, PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04, PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "falar" — *fah-LAR*]
@@ -72,6 +92,7 @@ FR, DE keep.)
   drops it to silent *h*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-EU-02, PT-ETYMON-EU-03, PT-GRAMMAR-EU-04, PT-SOUND-COMO-02, PT-ETYMON-COMO-03, PT-GRAMMAR-COMO-04, PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04] -->
 
 [PAUSE 3s] What Latin verb is *falar* from, and which Spanish verb is its twin?
 (*fabulārī* — Spanish *hablar*.) What sound-law separates them? (Portuguese kept

--- a/code/learning/human-languages/portuguese/lessons/PT-C05-falo-portugues.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C05-falo-portugues.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C05-falo-portugues
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 310
 chapter: 5
 type: phrase
 headword: Falo português
@@ -9,19 +12,33 @@ prerequisites: [PT-C05-falar]
 sounds: [final-s-sh, nasal-em]
 roots: [portus-cale-latin]
 etymology_hook: "português ← Portus Cale, a port at the Douro's mouth ('warm/fair port') → Portugal, Oporto"
-est_minutes: 4
+duration:
+  max_seconds: 214
+requires:
+  knowledge: [PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04]
+introduces:
+  knowledge: [PT-LEX-FALO-PORTUGUES-02, PT-LEX-FALO-PORTUGUES-03]
+practises:
+  knowledge: [PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04, PT-LEX-FALO-PORTUGUES-02, PT-LEX-FALO-PORTUGUES-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C05-falar, PT-C03-eu]
 ---
 
 # Falo português — your first real sentence
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The payoff: you take a **verb** you conjugated and a **noun**, and
 build a sentence no one handed you — *Falo português*, "I speak Portuguese."
 (*Falo* covers both "I speak" and "I'm speaking.")
 
-## The new word: português
+## You'll want to know: The new word: português
+<!-- hl-knowledge: introduces=[PT-LEX-FALO-PORTUGUES-02]; assesses=[] -->
 
 **português** = "Portuguese," from **Portus Cale** — a Roman-era port at the mouth
 of the **Douro** river (today's **Porto** / **Oporto**). *Portus* is Latin "port,
@@ -31,7 +48,8 @@ debated — perhaps Celtic for "harbour/shelter," or Latin *cālidus* "warm." So
 country and its language. Say it *por-too-**GESH*** (final *-s* = *sh* in
 Portugal).
 
-## The sentence, assembled
+## You'll want to know: The sentence, assembled
+<!-- hl-knowledge: introduces=[PT-LEX-FALO-PORTUGUES-03]; assesses=[] -->
 
 > **Falo** (I speak, from *falar*) + **português** = **Falo português.**
 
@@ -56,6 +74,7 @@ Swap the pieces: **Moro em Lisboa.** · **Trabalho no Porto.** · **Você fala
 português?**
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04, PT-LEX-FALO-PORTUGUES-02, PT-LEX-FALO-PORTUGUES-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "Falo português" — *FAH-loo por-too-GESH*]
@@ -63,6 +82,7 @@ português?**
 - [YOU SAY: "português" ← *Portus Cale*, a single harbour town that named a nation]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04, PT-LEX-FALO-PORTUGUES-02, PT-LEX-FALO-PORTUGUES-03] -->
 
 [PAUSE 3s] Where does *português* come from? (*Portus Cale*, a port at the Douro's
 mouth → Porto.) In *Falo português*, why no *eu* and no article? (The *-o* is "I";

--- a/code/learning/human-languages/portuguese/lessons/PT-C05-morar.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C05-morar.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C05-morar
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 290
 chapter: 5
 type: word
 headword: morar
@@ -9,23 +12,38 @@ prerequisites: [PT-C05-falar]
 sounds: [final-r, final-a-reduces]
 roots: [morari-latin]
 etymology_hook: "morar ← Latin morārī 'to delay, to linger, to tarry' → English moratorium, demur"
-est_minutes: 3
+duration:
+  max_seconds: 186
+requires:
+  knowledge: [PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04]
+introduces:
+  knowledge: [PT-SOUND-MORAR-02, PT-ETYMON-MORAR-03, PT-GRAMMAR-MORAR-04]
+practises:
+  knowledge: [PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04, PT-SOUND-MORAR-02, PT-ETYMON-MORAR-03, PT-GRAMMAR-MORAR-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C05-falar]
 ---
 
 # morar — "to live," i.e. to *linger* somewhere
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] A second **-ar** verb — and a distinctive Portuguese choice. Where its
 sisters say "live" with *habitāre* ("keep having a place"), everyday Portuguese
 uses **morar** — from a verb that means to **linger**.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[PT-SOUND-MORAR-02]; assesses=[] -->
 
 - **morar** = *moh-RAR*, tapped final *r*, clean vowels.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-MORAR-03]; assesses=[] -->
 
 **morar** comes from Latin **morārī**, *"to delay, to linger, to tarry, to stay
 a while."* To *dwell* somewhere is, in Portuguese, to *linger* there — a softer,
@@ -40,6 +58,7 @@ it's formal; **morar** is what you actually say: *Onde você mora?*, "Where do y
 live?")
 
 ## Grammar Lens: same -ar template
+<!-- hl-knowledge: introduces=[PT-GRAMMAR-MORAR-04]; assesses=[] -->
 
 | (eu) moro · (tu) moras · (você) mora | (-o / -as / -a) |
 | moramos · moram | |
@@ -47,6 +66,7 @@ live?")
 > **Moro em Lisboa.** — "I live in Lisbon."
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04, PT-SOUND-MORAR-02, PT-ETYMON-MORAR-03, PT-GRAMMAR-MORAR-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "morar" — *moh-RAR*]
@@ -54,6 +74,7 @@ live?")
 - [YOU SAY: "Onde você mora?" — "Where do you live?"; "morar" ↔ *moratorium*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04, PT-SOUND-MORAR-02, PT-ETYMON-MORAR-03, PT-GRAMMAR-MORAR-04] -->
 
 [PAUSE 3s] What Latin verb is *morar* from, and what did it mean? (*morārī* — "to
 delay / linger.") English cousins? (*Moratorium*, *demur*.) Say "I live in

--- a/code/learning/human-languages/portuguese/lessons/PT-C05-practice.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C05-practice.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C05-practice
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 320
 chapter: 5
 type: practice-mix
 headword: (practice)
@@ -8,19 +11,33 @@ concept_tag: CH5-PRACTICE
 prerequisites: [PT-C05-falar, PT-C05-morar, PT-C05-trabalhar, PT-C05-falo-portugues]
 sounds: []
 roots: []
-est_minutes: 4
+duration:
+  max_seconds: 239
+requires:
+  knowledge: [PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04, PT-SOUND-MORAR-02, PT-ETYMON-MORAR-03, PT-GRAMMAR-MORAR-04, PT-SOUND-TRABALHAR-02, PT-ETYMON-TRABALHAR-03, PT-GRAMMAR-TRABALHAR-04, PT-LEX-FALO-PORTUGUES-02, PT-LEX-FALO-PORTUGUES-03]
+introduces:
+  knowledge: [PT-NOTICE-C05-PRACTICE-04]
+practises:
+  knowledge: [PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04, PT-SOUND-MORAR-02, PT-ETYMON-MORAR-03, PT-GRAMMAR-MORAR-04, PT-SOUND-TRABALHAR-02, PT-ETYMON-TRABALHAR-03, PT-GRAMMAR-TRABALHAR-04, PT-LEX-FALO-PORTUGUES-02, PT-LEX-FALO-PORTUGUES-03, PT-NOTICE-C05-PRACTICE-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C05-falar, PT-C05-morar, PT-C05-trabalhar, PT-C05-falo-portugues, PT-C03-practice]
 ---
 
 # Practice — making sentences with -ar verbs
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] For the first time you're **building** Portuguese sentences from a
 pattern. Drill the three verbs until the endings are automatic — and remember,
 Portuguese drops the *eu*.
 
-## Conjugate on command
+## Guided Practice: conjugate on command
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04, PT-SOUND-MORAR-02, PT-ETYMON-MORAR-03, PT-GRAMMAR-MORAR-04, PT-SOUND-TRABALHAR-02, PT-ETYMON-TRABALHAR-03, PT-GRAMMAR-TRABALHAR-04, PT-LEX-FALO-PORTUGUES-02, PT-LEX-FALO-PORTUGUES-03] -->
 
 [PAUSE 1s] Run each through *eu / tu / você* (pronoun dropped in speech):
 
@@ -30,13 +47,15 @@ Portuguese drops the *eu*.
 
 Same endings every time (**-o / -as / -a**), no pronoun needed.
 
-## Say something real
+## Guided Practice: say something real
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04, PT-SOUND-MORAR-02, PT-ETYMON-MORAR-03, PT-GRAMMAR-MORAR-04, PT-SOUND-TRABALHAR-02, PT-ETYMON-TRABALHAR-03, PT-GRAMMAR-TRABALHAR-04, PT-LEX-FALO-PORTUGUES-02, PT-LEX-FALO-PORTUGUES-03] -->
 
 > — **Você fala** português? — **Falo** um pouco. E você?
 > — Também. **Onde** você **mora**? — **Moro** em Lisboa, e **trabalho** no Porto.
 > — Obrigado! — De nada.
 
 ## What you've built this chapter
+<!-- hl-knowledge: introduces=[PT-NOTICE-C05-PRACTICE-04]; assesses=[] -->
 
 - **the regular -ar present tense** — drop *-ar*, add *-o/-as/-a/-amos/-am*;
   pronoun **dropped** (like Spanish, Italian).
@@ -47,6 +66,7 @@ Same endings every time (**-o / -as / -a**), no pronoun needed.
   sentence, and the **fifth language** to cross from phrases into sentences.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04, PT-SOUND-MORAR-02, PT-ETYMON-MORAR-03, PT-GRAMMAR-MORAR-04, PT-SOUND-TRABALHAR-02, PT-ETYMON-TRABALHAR-03, PT-GRAMMAR-TRABALHAR-04, PT-LEX-FALO-PORTUGUES-02, PT-LEX-FALO-PORTUGUES-03, PT-NOTICE-C05-PRACTICE-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: conjugate all three verbs, eu/tu/você — no pronoun spoken]
@@ -56,6 +76,7 @@ Same endings every time (**-o / -as / -a**), no pronoun needed.
 [REPEAT x2] "Você fala português? — Falo um pouco."
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04, PT-SOUND-MORAR-02, PT-ETYMON-MORAR-03, PT-GRAMMAR-MORAR-04, PT-SOUND-TRABALHAR-02, PT-ETYMON-TRABALHAR-03, PT-GRAMMAR-TRABALHAR-04, PT-LEX-FALO-PORTUGUES-02, PT-LEX-FALO-PORTUGUES-03, PT-NOTICE-C05-PRACTICE-04] -->
 
 [PAUSE 3s] What are the three singular *-ar* endings? (*-o / -as / -a*.) Give the
 "I" forms of the three verbs. (*Falo, moro, trabalho*.) *falar* vs Spanish

--- a/code/learning/human-languages/portuguese/lessons/PT-C05-trabalhar.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C05-trabalhar.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C05-trabalhar
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 300
 chapter: 5
 type: word
 headword: trabalhar
@@ -9,24 +12,39 @@ prerequisites: [PT-C05-falar]
 sounds: [nasal-anha, final-r]
 roots: [tripalium-latin]
 etymology_hook: "trabalhar ← Vulgar Latin tripaliāre 'to torture' (← tripalium) → English travail, travel; twin of Spanish trabajar"
-est_minutes: 3
+duration:
+  max_seconds: 184
+requires:
+  knowledge: [PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04]
+introduces:
+  knowledge: [PT-SOUND-TRABALHAR-02, PT-ETYMON-TRABALHAR-03, PT-GRAMMAR-TRABALHAR-04]
+practises:
+  knowledge: [PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04, PT-SOUND-TRABALHAR-02, PT-ETYMON-TRABALHAR-03, PT-GRAMMAR-TRABALHAR-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C05-morar]
 ---
 
 # trabalhar — "to work," and the torture returns
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] A third **-ar** verb — and Portuguese rejoins its Iberian sister on the
 darkest etymology in the curriculum. **trabalhar** ("to work"), like Spanish
 *trabajar*, began as a word for **torture**.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[PT-SOUND-TRABALHAR-02]; assesses=[] -->
 
 - `nasal-anha` — the **-lh-** is a *ly* glide (as in Spanish *ll*): **trabalhar**
   = *tra-ba-**LYAR***.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-TRABALHAR-03]; assesses=[] -->
 
 **trabalhar** comes from Vulgar Latin **tripaliāre**, *"to torture"* — from
 **tripalium**, a Roman instrument of torture made of **three stakes** (*tri-*
@@ -46,12 +64,14 @@ the "work" verbs of the five languages into two neat camps:
 Three languages remember work as *torture*; only Italy remembers it as *labour*.
 
 ## Grammar Lens: same -ar template
+<!-- hl-knowledge: introduces=[PT-GRAMMAR-TRABALHAR-04]; assesses=[] -->
 
 | (eu) trabalho · (tu) trabalhas · (você) trabalha | (-o / -as / -a) |
 
 > **Trabalho no Porto.** — "I work in Porto."
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04, PT-SOUND-TRABALHAR-02, PT-ETYMON-TRABALHAR-03, PT-GRAMMAR-TRABALHAR-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "trabalhar" — *tra-ba-LYAR*]
@@ -59,6 +79,7 @@ Three languages remember work as *torture*; only Italy remembers it as *labour*.
 - [YOU SAY: trabalhar ↔ trabajar (twins) → travail → travel — torture to journey]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04, PT-SOUND-TRABALHAR-02, PT-ETYMON-TRABALHAR-03, PT-GRAMMAR-TRABALHAR-04] -->
 
 [PAUSE 3s] What did *trabalhar* originally mean, and from what device? ("To
 torture," ← *tripalium*, three stakes.) Its Spanish twin, and the one difference?

--- a/code/learning/human-languages/portuguese/lessons/PT-C06-numeros-1-5.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C06-numeros-1-5.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C06-numeros-1-5
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 330
 chapter: 6
 type: word
 headword: um, dois, três, quatro, cinco
@@ -9,25 +12,40 @@ prerequisites: []
 sounds: [nasal-um, open-e]
 roots: [unus-duo-tres-latin]
 etymology_hook: "um/dois/três/quatro/cinco ← ūnus/duo/trēs/quattuor/quīnque; Portuguese uniquely keeps GENDER on 'two' (dois/duas). = Spanish uno/dos/tres/cuatro/cinco"
-est_minutes: 4
+duration:
+  max_seconds: 203
+requires:
+  knowledge: []
+introduces:
+  knowledge: [PT-SOUND-NUMEROS-1-5-02, PT-ETYMON-NUMEROS-1-5-03, PT-GRAMMAR-NUMEROS-1-5-04]
+practises:
+  knowledge: [PT-SOUND-NUMEROS-1-5-02, PT-ETYMON-NUMEROS-1-5-03, PT-GRAMMAR-NUMEROS-1-5-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C05-practice]
 ---
 
 # um, dois, três, quatro, cinco — counting to five
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Portuguese counts almost like its sister Spanish — but with two
 signature Portuguese twists: heavy **nasal vowels**, and a number that still
 **changes for gender** where Spanish long stopped. Spanish twins are beside each.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[PT-SOUND-NUMEROS-1-5-02]; assesses=[] -->
 
 - `nasal-um` — **um** is nasal: *oong* said softly through the nose, no real *m*.
   (The *-m* is just the spelling for nasality, as in *sim*, *bom*.)
 - `open-e` — **três** = *trehs* with an open *e* and the circumflex marking it.
 
 ## The numbers, taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-NUMEROS-1-5-03]; assesses=[] -->
 
 | Portuguese | ← Latin | Spanish twin | English cousins |
 |---|---|---|---|
@@ -41,6 +59,7 @@ signature Portuguese twists: heavy **nasal vowels**, and a number that still
 *two*.
 
 ## Grammar Lens: um/uma and the gendered "two" (dois/duas)
+<!-- hl-knowledge: introduces=[PT-GRAMMAR-NUMEROS-1-5-04]; assesses=[] -->
 
 **um** is also "a/an," gendered **um** (masc.) / **uma** (fem.): *um café*, *uma
 cerveja*. That much matches Spanish. The surprise is **two**: Portuguese still
@@ -50,6 +69,7 @@ levelled this to a single *dos* centuries ago; Portuguese kept the old split. Th
 rest (*três, quatro, cinco*) don't change.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-NUMEROS-1-5-02, PT-ETYMON-NUMEROS-1-5-03, PT-GRAMMAR-NUMEROS-1-5-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "um, dois, três, quatro, cinco" — count up]
@@ -57,6 +77,7 @@ rest (*três, quatro, cinco*) don't change.
 - [YOU SAY: each with its English cousin — "dois/duo, três/trio, cinco/quintet"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-NUMEROS-1-5-02, PT-ETYMON-NUMEROS-1-5-03, PT-GRAMMAR-NUMEROS-1-5-04] -->
 
 [PAUSE 3s] Give 1–5 in Portuguese. (*Um, dois, três, quatro, cinco*.) Which number
 still changes for gender, and how? (*Two* — *dois* / *duas*, ← Latin *duo/duae*.)

--- a/code/learning/human-languages/portuguese/lessons/PT-C06-numeros-6-10.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C06-numeros-6-10.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C06-numeros-6-10
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 340
 chapter: 6
 type: word
 headword: seis, sete, oito, nove, dez
@@ -9,25 +12,40 @@ prerequisites: [PT-C06-numeros-1-5]
 sounds: [diphthong-oi, open-e]
 roots: [sex-septem-octo-latin]
 etymology_hook: "sete/oito/nove/dez ← septem/octō/novem/decem → setembro/outubro/novembro/dezembro; oito shows the Portuguese ct→it shift (octō→oito, like noite/noctem)"
-est_minutes: 4
+duration:
+  max_seconds: 230
+requires:
+  knowledge: [PT-SOUND-NUMEROS-1-5-02, PT-ETYMON-NUMEROS-1-5-03, PT-GRAMMAR-NUMEROS-1-5-04]
+introduces:
+  knowledge: [PT-SOUND-NUMEROS-6-10-02, PT-ETYMON-NUMEROS-6-10-03, PT-GRAMMAR-NUMEROS-6-10-04]
+practises:
+  knowledge: [PT-SOUND-NUMEROS-1-5-02, PT-ETYMON-NUMEROS-1-5-03, PT-GRAMMAR-NUMEROS-1-5-04, PT-SOUND-NUMEROS-6-10-02, PT-ETYMON-NUMEROS-6-10-03, PT-GRAMMAR-NUMEROS-6-10-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C06-numeros-1-5]
 ---
 
 # seis, sete, oito, nove, dez — and the calendar's secret
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The rest of the way to ten. Like Spanish, Portuguese hides the calendar
 fact — **setembro–dezembro are Latin for 7, 8, 9, 10** — and one number, *oito*,
 puts a signature Portuguese sound-shift on full display.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[PT-SOUND-NUMEROS-6-10-02]; assesses=[] -->
 
 - `diphthong-oi` — **oito** = *OY-too*, **dois** rhymes with it: the *oi* glide.
 - **dez** = *dehs* (open *e*); the final *-z* is a soft "sh"/"s" in Portugal,
   "s" in Brazil.
 
 ## The numbers, taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-NUMEROS-6-10-03]; assesses=[] -->
 
 | Portuguese | ← Latin | Spanish twin | English cousins |
 |---|---|---|---|
@@ -45,6 +63,7 @@ guess the Latin word had a *-ct-*. (Spanish took a different path: *octō → oc
 with *-ct- → -ch-*. Same cluster, two sisters, two solutions — *oito* vs *ocho*.)
 
 ## Grammar Lens: why the months are "off by two"
+<!-- hl-knowledge: introduces=[PT-GRAMMAR-NUMEROS-6-10-04]; assesses=[] -->
 
 *Setembro* means "7th," yet sits **9th**. The old **Roman year began in March**,
 so *September* really was the seventh; *julho* and *agosto* (July, August) were
@@ -53,6 +72,7 @@ month names. Every *dezembro*, you're saying Roman "**ten**" — and *dez* also 
 Portuguese *dízimo*, a "tithe" (a tenth), the twin of English *dime*.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-NUMEROS-1-5-02, PT-ETYMON-NUMEROS-1-5-03, PT-GRAMMAR-NUMEROS-1-5-04, PT-SOUND-NUMEROS-6-10-02, PT-ETYMON-NUMEROS-6-10-03, PT-GRAMMAR-NUMEROS-6-10-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "seis, sete, oito, nove, dez" — finish the count]
@@ -60,6 +80,7 @@ Portuguese *dízimo*, a "tithe" (a tenth), the twin of English *dime*.
 - [YOU SAY: the *-ct- → -it-* set — "oito, noite, leite" — then Spanish "ocho"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-NUMEROS-1-5-02, PT-ETYMON-NUMEROS-1-5-03, PT-GRAMMAR-NUMEROS-1-5-04, PT-SOUND-NUMEROS-6-10-02, PT-ETYMON-NUMEROS-6-10-03, PT-GRAMMAR-NUMEROS-6-10-04] -->
 
 [PAUSE 3s] Give 6–10 in Portuguese. (*Seis, sete, oito, nove, dez*.) What Latin
 cluster became *-it-* in *oito*, and one more example? (*-ct-*; *noite* ← *noctem*

--- a/code/learning/human-languages/portuguese/lessons/PT-C07-dias-1.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C07-dias-1.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C07-dias-1
+spine_node: SPINE-TIME-OF-DAY
+sequence: 350
 chapter: 7
 type: word
 headword: segunda, terça, quarta, quinta, sexta(-feira)
@@ -9,20 +12,34 @@ prerequisites: [PT-C06-numeros-1-5]
 sounds: [nasal-none, open-e]
 roots: [feria-latin, ordinals-latin]
 etymology_hook: "Portuguese is the ONLY Romance language to drop the pagan planet-gods: its weekdays are numbered 'feiras' — segunda-feira '2nd feast-day', built from the ordinals of the numbers you just learned"
-est_minutes: 4
+duration:
+  max_seconds: 243
+requires:
+  knowledge: [PT-SOUND-NUMEROS-1-5-02, PT-ETYMON-NUMEROS-1-5-03, PT-GRAMMAR-NUMEROS-1-5-04]
+introduces:
+  knowledge: [PT-PRAGMATICS-DIAS-1-02, PT-GRAMMAR-DIAS-1-03]
+practises:
+  knowledge: [PT-SOUND-NUMEROS-1-5-02, PT-ETYMON-NUMEROS-1-5-03, PT-GRAMMAR-NUMEROS-1-5-04, PT-PRAGMATICS-DIAS-1-02, PT-GRAMMAR-DIAS-1-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C06-numeros-1-5, PT-C06-numeros-6-10]
 ---
 
 # segunda to sexta — the week that got numbered
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Here Portuguese does something **no other Romance language does**.
 French, Italian, and Spanish all name their weekdays for planet-gods (*lundi*,
 *lunedì*, *lunes* = the Moon). Portuguese threw the pagan gods out and **numbered**
 the days instead — and the numbers are the very ones you just learned.
 
-## The story: a bishop renames the week
+## Why it's said this way: The story: a bishop renames the week
+<!-- hl-knowledge: introduces=[PT-PRAGMATICS-DIAS-1-02]; assesses=[] -->
 
 In the 6th century, **Martinho de Braga**, a bishop in what is now northern
 Portugal, refused to let Christians name days after *Mars* and *Jupiter*. Borrowing
@@ -33,7 +50,8 @@ the Church's word for the numbered holy days of Easter week, he called them
 drifted, elsewhere, into "market/fair" — English **fair** is its cousin, because
 markets were held on feast-days.)
 
-## The pattern: [ordinal] + feira
+## Grammar Lens: The pattern: [ordinal] + feira
+<!-- hl-knowledge: introduces=[PT-GRAMMAR-DIAS-1-03]; assesses=[] -->
 
 | Portuguese | means | ← ordinal of | (cardinal you learned) |
 |---|---|---|---|
@@ -49,6 +67,7 @@ segunda!*" — "See you Monday!" (Why does Monday start at **two**, not one? Bec
 Sunday is counted as the *first* day — the next lesson closes that loop.)
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-NUMEROS-1-5-02, PT-ETYMON-NUMEROS-1-5-03, PT-GRAMMAR-NUMEROS-1-5-04, PT-PRAGMATICS-DIAS-1-02, PT-GRAMMAR-DIAS-1-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "segunda, terça, quarta, quinta, sexta" — Monday through Friday]
@@ -57,6 +76,7 @@ Sunday is counted as the *first* day — the next lesson closes that loop.)
 - [YOU SAY: drop the tail — "Até sexta!" ("See you Friday!")]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-NUMEROS-1-5-02, PT-ETYMON-NUMEROS-1-5-03, PT-GRAMMAR-NUMEROS-1-5-04, PT-PRAGMATICS-DIAS-1-02, PT-GRAMMAR-DIAS-1-03] -->
 
 [PAUSE 3s] How is Portuguese unique among Romance languages here? (It **numbers**
 its weekdays — *feiras* — instead of naming planet-gods.) What does *feira* mean,

--- a/code/learning/human-languages/portuguese/lessons/PT-C07-dias-2.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C07-dias-2.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C07-dias-2
+spine_node: SPINE-TIME-OF-DAY
+sequence: 360
 chapter: 7
 type: word
 headword: sábado, domingo
@@ -9,19 +12,33 @@ prerequisites: [PT-C07-dias-1]
 sounds: [nasal-o, open-a]
 roots: [sabbatum-latin, dominica-latin]
 etymology_hook: "sábado ← Sabbatum (Sabbath), domingo ← diēs Dominica ('the Lord's day') — and because domingo is the 'first' day, Monday becomes the 'second' (segunda)"
-est_minutes: 4
+duration:
+  max_seconds: 199
+requires:
+  knowledge: [PT-PRAGMATICS-DIAS-1-02, PT-GRAMMAR-DIAS-1-03]
+introduces:
+  knowledge: [PT-ETYMON-DIAS-2-02, PT-GRAMMAR-DIAS-2-03]
+practises:
+  knowledge: [PT-PRAGMATICS-DIAS-1-02, PT-GRAMMAR-DIAS-1-03, PT-ETYMON-DIAS-2-02, PT-GRAMMAR-DIAS-2-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C07-dias-1, PT-C06-numeros-1-5]
 ---
 
 # sábado and domingo — and why Monday is "the second"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Five weekdays got numbered — but two kept their names. *Sábado* and
 *domingo* are the **religious anchors** of the Portuguese week, and *domingo* is
 the key that explains why the counting started where it did.
 
 ## The two days, taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-DIAS-2-02]; assesses=[] -->
 
 | Portuguese | ← Latin | meaning | shared with |
 |---|---|---|---|
@@ -34,6 +51,7 @@ the key that explains why the counting started where it did.
   master" (→ English *dominion, dominate, dame*).
 
 ## Grammar Lens: domingo is "day one" — so Monday is "day two"
+<!-- hl-knowledge: introduces=[PT-GRAMMAR-DIAS-2-03]; assesses=[] -->
 
 Now the loop closes. The Church counted **domingo (Sunday) as the *first* day** of
 the week — *prima feria*, the Lord's day, the start. That's why:
@@ -47,6 +65,7 @@ you know Sunday was counted first. The whole week is a countdown anchored on
 *domingo*.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-PRAGMATICS-DIAS-1-02, PT-GRAMMAR-DIAS-1-03, PT-ETYMON-DIAS-2-02, PT-GRAMMAR-DIAS-2-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: the full week — "domingo, segunda, terça, quarta, quinta, sexta,
@@ -55,6 +74,7 @@ you know Sunday was counted first. The whole week is a countdown anchored on
 - [YOU SAY: the logic — "domingo is 1st, so segunda (Monday) is 2nd"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-PRAGMATICS-DIAS-1-02, PT-GRAMMAR-DIAS-1-03, PT-ETYMON-DIAS-2-02, PT-GRAMMAR-DIAS-2-03] -->
 
 [PAUSE 3s] Give all seven Portuguese days. (*Domingo, segunda … sábado*.) What does
 *domingo* mean, and why does that make Monday "*segunda*"? ("The **Lord's** day";

--- a/code/learning/human-languages/portuguese/lessons/PT-C08-hora.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C08-hora.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C08-hora
+spine_node: SPINE-TIME-OF-DAY
+sequence: 370
 chapter: 8
 type: word
 headword: hora
@@ -9,24 +12,39 @@ prerequisites: [PT-C06-numeros-1-5]
 sounds: [silent-h, open-o]
 roots: [hora-latin, hora-greek]
 etymology_hook: "hora ← Latin hōra ← Greek hṓrā → hour; 'são duas horas' keeps 'horas' explicit and plural"
-est_minutes: 4
+duration:
+  max_seconds: 201
+requires:
+  knowledge: [PT-SOUND-NUMEROS-1-5-02, PT-ETYMON-NUMEROS-1-5-03, PT-GRAMMAR-NUMEROS-1-5-04]
+introduces:
+  knowledge: [PT-SOUND-HORA-02, PT-ETYMON-HORA-03, PT-GRAMMAR-HORA-04]
+practises:
+  knowledge: [PT-SOUND-NUMEROS-1-5-02, PT-ETYMON-NUMEROS-1-5-03, PT-GRAMMAR-NUMEROS-1-5-04, PT-SOUND-HORA-02, PT-ETYMON-HORA-03, PT-GRAMMAR-HORA-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C06-numeros-1-5, PT-C07-dias-2]
 ---
 
 # hora — the hour, said in full
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Portuguese "hour" is **hora**, from Latin **hōra** (← Greek *hṓrā*) — the
 same word behind Spanish *hora*, French *heure*, and English *hour*. And unlike
 Italian, which hides the word, Portuguese keeps **horas** right out loud.
 
 ## Sounds you'll need
+<!-- hl-knowledge: introduces=[PT-SOUND-HORA-02]; assesses=[] -->
 
 - `silent-h` — the **h** of *hora* is silent (as everywhere in Portuguese): say
   *OH-ra*.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-HORA-03]; assesses=[] -->
 
 **hora** ← Latin **hōra** ← Greek **hṓrā**, "a time of day." Portuguese kept the
 Latin spelling's silent *h-*, exactly as English *hour* does. Line the sisters up:
@@ -34,6 +52,7 @@ Latin spelling's silent *h-*, exactly as English *hour* does. Line the sisters u
 five languages.
 
 ## Grammar Lens: "é uma hora" but "são duas horas"
+<!-- hl-knowledge: introduces=[PT-GRAMMAR-HORA-04]; assesses=[] -->
 
 Portuguese states the word **horas** in full, and the verb agrees with the number:
 
@@ -48,6 +67,7 @@ and **two** still shows gender — *duas* horas (feminine, agreeing with *horas*
 the *dois/duas* split you met in the numbers.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-NUMEROS-1-5-02, PT-ETYMON-NUMEROS-1-5-03, PT-GRAMMAR-NUMEROS-1-5-04, PT-SOUND-HORA-02, PT-ETYMON-HORA-03, PT-GRAMMAR-HORA-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "hora" — *OH-ra*, silent h]
@@ -55,6 +75,7 @@ the *dois/duas* split you met in the numbers.
 - [YOU SAY: "duas horas" — feminine *duas*, not *dois*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-NUMEROS-1-5-02, PT-ETYMON-NUMEROS-1-5-03, PT-GRAMMAR-NUMEROS-1-5-04, PT-SOUND-HORA-02, PT-ETYMON-HORA-03, PT-GRAMMAR-HORA-04] -->
 
 [PAUSE 3s] What word is *hora* from, and its Spanish twin? (Latin *hōra* ← Greek
 *hṓrā*; Spanish *hora*.) Why "*são duas* horas" but "*é uma* hora"? (Plural takes

--- a/code/learning/human-languages/portuguese/lessons/PT-C08-meio-dia-meia-noite.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C08-meio-dia-meia-noite.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C08-meio-dia-meia-noite
+spine_node: SPINE-TIME-OF-DAY
+sequence: 380
 chapter: 8
 type: word
 headword: meio-dia, meia-noite
@@ -9,19 +12,33 @@ prerequisites: [PT-C08-hora]
 sounds: [diphthong-ei, nasal-none]
 roots: [medius-latin, noctem-latin]
 etymology_hook: "meio-dia = meio + dia ('mid-day'), meia-noite = meia + noite ('mid-night'); noite ← noctem shows the ct→it shift from the numbers chapter (oito)"
-est_minutes: 4
+duration:
+  max_seconds: 183
+requires:
+  knowledge: [PT-SOUND-HORA-02, PT-ETYMON-HORA-03, PT-GRAMMAR-HORA-04]
+introduces:
+  knowledge: [PT-ETYMON-MEIO-DIA-MEIA-NOITE-02]
+practises:
+  knowledge: [PT-SOUND-HORA-02, PT-ETYMON-HORA-03, PT-GRAMMAR-HORA-04, PT-ETYMON-MEIO-DIA-MEIA-NOITE-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C08-hora, PT-C06-numeros-6-10, PT-C07-dias-2]
 ---
 
 # meio-dia and meia-noite — noon and midnight
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The two named hours. **meio-dia** (noon) and **meia-noite** (midnight)
 are the **middle** of the day and the night — and *meia-noite* hides a sound-shift
 you already met back in the numbers.
 
 ## The two words, taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-MEIO-DIA-MEIA-NOITE-02]; assesses=[] -->
 
 The front piece is **meio/meia**, "half, middle," from Latin **medius/media**
 (cousin of English *mid, medium* and of Spanish *medio*):
@@ -44,6 +61,7 @@ To use them, they *are* the hour:
 > **É meio-dia.** — "It is noon." **É meia-noite.** — "It is midnight."
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-HORA-02, PT-ETYMON-HORA-03, PT-GRAMMAR-HORA-04, PT-ETYMON-MEIO-DIA-MEIA-NOITE-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "meio-dia" (noon), "meia-noite" (midnight)]
@@ -51,6 +69,7 @@ To use them, they *are* the hour:
 - [YOU SAY: the shift — "noite ← noctem, like oito ← octō"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-HORA-02, PT-ETYMON-HORA-03, PT-GRAMMAR-HORA-04, PT-ETYMON-MEIO-DIA-MEIA-NOITE-02] -->
 
 [PAUSE 3s] What do *meio-dia* and *meia-noite* literally mean? ("Mid-day" and
 "mid-night.") Why *meia*-noite but *meio*-dia? (*meia* feminine for *noite*, *meio*

--- a/code/learning/human-languages/portuguese/lessons/PT-C09-estacoes.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C09-estacoes.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C09-estacoes
+spine_node: SPINE-TIME-OF-DAY
+sequence: 400
 chapter: 9
 type: word
 headword: as estações
@@ -9,19 +12,33 @@ prerequisites: [PT-C09-meses]
 sounds: [nasal-ao, open-e]
 roots: [latin-seasons]
 etymology_hook: "primavera = 'first green'; verão ← veranum 'spring-like' — Portuguese's word for SUMMER literally grew out of 'spring'; outono ← autumnus (ct→ut); inverno ← hibernum"
-est_minutes: 4
+duration:
+  max_seconds: 178
+requires:
+  knowledge: [PT-ETYMON-MESES-02]
+introduces:
+  knowledge: [PT-ETYMON-ESTACOES-02]
+practises:
+  knowledge: [PT-ETYMON-MESES-02, PT-ETYMON-ESTACOES-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C09-meses, PT-C08-hora]
 ---
 
 # as estações — the seasons, and a shifting summer
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Four seasons — and a small mystery in one of them. Portuguese's word for
 **summer**, *verão*, didn't come from a "heat" word like French *été*. It grew out
 of the word for **spring**. Here's how.
 
 ## The four seasons, taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-ESTACOES-02]; assesses=[] -->
 
 | Portuguese | ← Latin | literally |
 |---|---|---|
@@ -42,6 +59,7 @@ And **outono** ← *autumnus* shows a familiar Portuguese move: the *au…t* smo
 **ou**, the same softening you saw in *oito* and *noite*.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-ETYMON-MESES-02, PT-ETYMON-ESTACOES-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "a primavera, o verão, o outono, o inverno"]
@@ -49,6 +67,7 @@ And **outono** ← *autumnus* shows a familiar Portuguese move: the *au…t* smo
 - [YOU SAY: "inverno ~ hibernate"; "outono ← autumnus"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-ETYMON-MESES-02, PT-ETYMON-ESTACOES-02] -->
 
 [PAUSE 3s] Name the four Portuguese seasons. (*Primavera, verão, outono, inverno*.)
 What's surprising about *verão*'s origin? (It comes from *vēr* "**spring**" — the

--- a/code/learning/human-languages/portuguese/lessons/PT-C09-meses.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C09-meses.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C09-meses
+spine_node: SPINE-TIME-OF-DAY
+sequence: 390
 chapter: 9
 type: word
 headword: os meses
@@ -9,19 +12,33 @@ prerequisites: [PT-C06-numeros-6-10, PT-C07-dias-1]
 sounds: [nasal-none, open-e]
 roots: [latin-months, roman-gods]
 etymology_hook: "janeiro←Januarius (Janus), março←Mars, julho←Julius Caesar; setembro–dezembro still mean Latin 7–10 (the numbers you learned)"
-est_minutes: 4
+duration:
+  max_seconds: 183
+requires:
+  knowledge: [PT-SOUND-NUMEROS-6-10-02, PT-ETYMON-NUMEROS-6-10-03, PT-GRAMMAR-NUMEROS-6-10-04, PT-PRAGMATICS-DIAS-1-02, PT-GRAMMAR-DIAS-1-03]
+introduces:
+  knowledge: [PT-ETYMON-MESES-02]
+practises:
+  knowledge: [PT-SOUND-NUMEROS-6-10-02, PT-ETYMON-NUMEROS-6-10-03, PT-GRAMMAR-NUMEROS-6-10-04, PT-PRAGMATICS-DIAS-1-02, PT-GRAMMAR-DIAS-1-03, PT-ETYMON-MESES-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C06-numeros-6-10, PT-C07-dias-1]
 ---
 
 # os meses — the gods and numbers of the calendar
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The Portuguese months are the Roman procession of gods and Caesars,
 worn down the Portuguese way. And two things you know pay off: *março* is the
 war-god, and *setembro–dezembro* are the Latin numbers 7–10.
 
 ## The months, taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-MESES-02]; assesses=[] -->
 
 | Portuguese | ← Latin | who / what | Spanish twin |
 |---|---|---|---|
@@ -48,6 +65,7 @@ Two payoffs:
   and pushed the count down two.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-NUMEROS-6-10-02, PT-ETYMON-NUMEROS-6-10-03, PT-GRAMMAR-NUMEROS-6-10-04, PT-PRAGMATICS-DIAS-1-02, PT-GRAMMAR-DIAS-1-03, PT-ETYMON-MESES-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: the twelve — "janeiro, fevereiro, março … novembro, dezembro"]
@@ -55,6 +73,7 @@ Two payoffs:
 - [YOU SAY: "setembro = 7 (sete), dezembro = 10 (dez)"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-NUMEROS-6-10-02, PT-ETYMON-NUMEROS-6-10-03, PT-GRAMMAR-NUMEROS-6-10-04, PT-PRAGMATICS-DIAS-1-02, PT-GRAMMAR-DIAS-1-03, PT-ETYMON-MESES-02] -->
 
 [PAUSE 3s] Which god is *março* named for? (**Mars**, the war-god.) Why is
 *dezembro* Latin for "ten"? (The Roman year began in March.) Which two months honour

--- a/code/learning/human-languages/portuguese/lessons/PT-C10-irmaos.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C10-irmaos.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C10-irmaos
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 420
 chapter: 10
 type: word
 headword: o irmão, a irmã
@@ -9,13 +12,26 @@ prerequisites: [PT-C10-pais]
 sounds: [nasal-ao, nasal-a]
 roots: [germanus-latin]
 etymology_hook: "the Iberian surprise: irmão/irmã come NOT from frater but from Latin germanus 'genuine, of the same parents' (frater germanus 'full brother') — the same word as 'germane' and the people-name 'German'; Spanish did the identical swap (hermano/hermana)"
-est_minutes: 4
+duration:
+  max_seconds: 218
+requires:
+  knowledge: [PT-ETYMON-PAIS-02, PT-GRAMMAR-PAIS-03]
+introduces:
+  knowledge: [PT-ETYMON-IRMAOS-02, PT-ETYMON-IRMAOS-03]
+practises:
+  knowledge: [PT-ETYMON-PAIS-02, PT-GRAMMAR-PAIS-03, PT-ETYMON-IRMAOS-02, PT-ETYMON-IRMAOS-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C10-pais, PT-C09-estacoes]
 ---
 
 # o irmão, a irmã — the brother who isn't a "frater"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Every other track in this course builds "brother" from Latin *frāter*
 (French *frère*, Italian *fratello*). Portuguese — and Spanish with it — does
@@ -23,6 +39,7 @@ something completely different, and it is one of the best etymologies in the who
 language.
 
 ## Taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-IRMAOS-02]; assesses=[] -->
 
 - **o irmão** ("brother") and **a irmã** ("sister") come **not** from *frāter* but
   from Latin **germānus**, meaning "**genuine, of the same stock, born of the same
@@ -35,7 +52,8 @@ language.
 Articles: *o* irmão (masc.), *a* irmã (fem.); the masculine plural **os irmãos**
 covers a mixed set ("siblings"), exactly as *os pais* did for parents.
 
-## The astonishing cousins of germanus
+## The word, taken apart: The astonishing cousins of germanus
+<!-- hl-knowledge: introduces=[PT-ETYMON-IRMAOS-03]; assesses=[] -->
 
 That same *germānus* "of the same stock" fans out in English:
 
@@ -50,6 +68,7 @@ and Spanish *hermano* are twins, both meaning "full-blood brother," both leaving
 *frāter* behind (kept only in bookish *fraternal / fraterno*).
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-ETYMON-PAIS-02, PT-GRAMMAR-PAIS-03, PT-ETYMON-IRMAOS-02, PT-ETYMON-IRMAOS-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "o irmão, a irmã" — both nasal endings]
@@ -59,6 +78,7 @@ and Spanish *hermano* are twins, both meaning "full-blood brother," both leaving
 - [YOU SAY: the twin — "Portuguese *irmão* = Spanish *hermano*"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-ETYMON-PAIS-02, PT-GRAMMAR-PAIS-03, PT-ETYMON-IRMAOS-02, PT-ETYMON-IRMAOS-03] -->
 
 [PAUSE 3s] Give "brother" and "sister" with articles. (**o irmão, a irmã**.) What
 Latin word are they from — and what did it mean? (**germānus** — "genuine, of the

--- a/code/learning/human-languages/portuguese/lessons/PT-C10-pais.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C10-pais.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C10-pais
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 410
 chapter: 10
 type: word
 headword: o pai, a mãe
@@ -9,13 +12,26 @@ prerequisites: [PT-C09-estacoes, PT-C01-ola]
 sounds: [nasal-ae, diphthong-ai]
 roots: [pater-latin, mater-latin]
 etymology_hook: "Portuguese wore pater/māter down further than any sister — to one-syllable pai and nasal mãe (the intervocalic -t- vanished, pater→pae→pai); os pais means both 'the parents' and, literally, 'the fathers'"
-est_minutes: 4
+duration:
+  max_seconds: 219
+requires:
+  knowledge: [PT-ETYMON-ESTACOES-02]
+introduces:
+  knowledge: [PT-ETYMON-PAIS-02, PT-GRAMMAR-PAIS-03]
+practises:
+  knowledge: [PT-ETYMON-ESTACOES-02, PT-ETYMON-PAIS-02, PT-GRAMMAR-PAIS-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C09-estacoes, PT-C01-ola]
 ---
 
 # o pai, a mãe — the family words worn to the bone
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Every Romance sister descends from *pater* and *māter*, but
 **Portuguese wore them down the furthest**. Italian kept *padre/madre*; French
@@ -23,6 +39,7 @@ reviews_of: [PT-C09-estacoes, PT-C01-ola]
 one-syllable **pai** and the nasal **mãe**.
 
 ## Taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-PAIS-02]; assesses=[] -->
 
 - **o pai** ("father") ← Latin **pater**. Portuguese dropped the intervocalic
   **-t-** completely: *pater → pae → pai*. The same disappearing-*-t-* you saw in
@@ -33,7 +50,8 @@ one-syllable **pai** and the nasal **mãe**.
 
 Articles: *o* pai (masculine), *a* mãe (feminine).
 
-## The plural trick — os pais
+## Grammar Lens: The plural trick — os pais
+<!-- hl-knowledge: introduces=[PT-GRAMMAR-PAIS-03]; assesses=[] -->
 
 Portuguese says **os pais** for "**the parents**" — but literally it is "the
 **fathers**." Like Spanish *los padres*, the masculine plural **covers a mixed
@@ -46,6 +64,7 @@ The learned adjectives, borrowed back from Latin, still show the old root:
 dressed-up versions of the same word.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-ETYMON-ESTACOES-02, PT-ETYMON-PAIS-02, PT-GRAMMAR-PAIS-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "o pai, a mãe" — *mãe* fully nasal]
@@ -53,6 +72,7 @@ dressed-up versions of the same word.
 - [YOU SAY: "os pais = the parents (lit. 'the fathers'); mind *o país* = country"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-ETYMON-ESTACOES-02, PT-ETYMON-PAIS-02, PT-GRAMMAR-PAIS-03] -->
 
 [PAUSE 3s] Give "father" and "mother" with articles. (**o pai, a mãe**.) What
 happened to the *-t-* of *pater/māter* in Portuguese? (It **vanished** — *pater →

--- a/code/learning/human-languages/portuguese/lessons/PT-C11-agua-vinho.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C11-agua-vinho.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C11-agua-vinho
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 440
 chapter: 11
 type: word
 headword: a água, o vinho
@@ -9,26 +12,41 @@ prerequisites: [PT-C11-pao]
 sounds: [nasal-none, nh-palatal]
 roots: [aqua-latin, vinum-latin]
 etymology_hook: "água kept aqua's body (where French wore it to eau); vinho ← vīnum, with Portuguese's signature -nh- (= Spanish ñ, French/Italian gn) → wine/vine/vinegar"
-est_minutes: 4
+duration:
+  max_seconds: 171
+requires:
+  knowledge: [PT-ETYMON-PAO-02, PT-ETYMON-PAO-03]
+introduces:
+  knowledge: [PT-ETYMON-AGUA-VINHO-02, PT-ETYMON-AGUA-VINHO-03]
+practises:
+  knowledge: [PT-ETYMON-PAO-02, PT-ETYMON-PAO-03, PT-ETYMON-AGUA-VINHO-02, PT-ETYMON-AGUA-VINHO-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C11-pao, PT-C10-pais]
 ---
 
 # a água, o vinho — water and wine
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Two drinks, two more sound-stories. Portuguese kept **água** close to
 Latin *aqua* (unlike French, which dissolved it to *eau*), and it stamps **vinho**
 with its signature spelling — the **-nh-**.
 
-## a água (water) — Latin aqua, kept
+## The word, taken apart: a água (water) — Latin aqua, kept
+<!-- hl-knowledge: introduces=[PT-ETYMON-AGUA-VINHO-02]; assesses=[] -->
 
 - **a água** ("water") ← Latin **aqua**. Portuguese held its body — *aqua → água*
   — where French wore it down to a single vowel (*eau*). The accent on **á** marks
   the stress. It's **feminine**: *a* água. English kept the loud original in
   **aquatic, aquarium, aqueduct**.
 
-## o vinho (wine) — Latin vīnum, with -nh-
+## The word, taken apart: o vinho (wine) — Latin vīnum, with -nh-
+<!-- hl-knowledge: introduces=[PT-ETYMON-AGUA-VINHO-03]; assesses=[] -->
 
 - **o vinho** ("wine") ← Latin **vīnum**. The **-nh-** is Portuguese's palatal *ny*
   sound — the **same sound** as Spanish **ñ** (*viño*→*vinho*), French/Italian
@@ -37,6 +55,7 @@ with its signature spelling — the **-nh-**.
   vintage**. Masculine: *o* vinho.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-ETYMON-PAO-02, PT-ETYMON-PAO-03, PT-ETYMON-AGUA-VINHO-02, PT-ETYMON-AGUA-VINHO-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "a água, o vinho" — stress the *á*; *-nh-* = palatal *ny*]
@@ -44,6 +63,7 @@ with its signature spelling — the **-nh-**.
 - [YOU SAY: "the *nh* of *vinho* = Spanish *ñ*, met before in *amanhã*"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-ETYMON-PAO-02, PT-ETYMON-PAO-03, PT-ETYMON-AGUA-VINHO-02, PT-ETYMON-AGUA-VINHO-03] -->
 
 [PAUSE 3s] Give "water" and "wine" with articles. (**a água, o vinho**.) How does
 *água* compare with French *eau*, from the same *aqua*? (Portuguese **kept** the

--- a/code/learning/human-languages/portuguese/lessons/PT-C11-pao.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C11-pao.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C11-pao
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 430
 chapter: 11
 type: word
 headword: o pão
@@ -9,13 +12,26 @@ prerequisites: [PT-C10-irmaos, PT-C01-ola]
 sounds: [nasal-ao, p-clear]
 roots: [panis-latin]
 etymology_hook: "pão ← pānis, worn to one nasal syllable (pānis→pãe→pão) — the same nasalizing erosion that made pai from pater; the root still gives companion, pantry"
-est_minutes: 4
+duration:
+  max_seconds: 158
+requires:
+  knowledge: [PT-ETYMON-IRMAOS-02, PT-ETYMON-IRMAOS-03]
+introduces:
+  knowledge: [PT-ETYMON-PAO-02, PT-ETYMON-PAO-03]
+practises:
+  knowledge: [PT-ETYMON-IRMAOS-02, PT-ETYMON-IRMAOS-03, PT-ETYMON-PAO-02, PT-ETYMON-PAO-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C10-irmaos, PT-C10-pais]
 ---
 
 # o pão — bread, worn down to a hum
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] **o pão** ("bread") — and Portuguese does to it exactly what it did to
 "father." Just as *pater* eroded to the one-syllable **pai**, Latin *pānis* wore
@@ -23,13 +39,15 @@ down to the single **nasal** syllable **pão** ("**powng**"). Same word as Frenc
 *pain* and Italian *pane*, taken furthest.
 
 ## Taken apart
+<!-- hl-knowledge: introduces=[PT-ETYMON-PAO-02]; assesses=[] -->
 
 - **o pão** ("bread") ← Latin **pānis**. The intervocalic *-n-* dissolved and left
   its **nasality** behind on the vowel: *pānis → pãe → pão*, the tilde marking the
   hum — the identical process behind **pai** (← *pater*) and **mãe** (← *māter*)
   from the family chapter. Masculine: *o* pão; the plural is the tricky **pães**.
 
-## The "bread" family — still there
+## The word, taken apart: The "bread" family — still there
+<!-- hl-knowledge: introduces=[PT-ETYMON-PAO-03]; assesses=[] -->
 
 Even worn to a hum, the root keeps its English relatives: **companion / company**
 (*com-* + *pānis*, "one you **share bread with**"), **pantry**, **pannier**. So
@@ -37,6 +55,7 @@ Even worn to a hum, the root keeps its English relatives: **companion / company*
 Latin word.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-ETYMON-IRMAOS-02, PT-ETYMON-IRMAOS-03, PT-ETYMON-PAO-02, PT-ETYMON-PAO-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "o pão" — fully nasal, "powng"; plural "pães"]
@@ -45,6 +64,7 @@ Latin word.
 - [YOU SAY: "pão → companion, pantry"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-ETYMON-IRMAOS-02, PT-ETYMON-IRMAOS-03, PT-ETYMON-PAO-02, PT-ETYMON-PAO-03] -->
 
 [PAUSE 3s] Give "bread" with its article. (**o pão**.) What Latin word is it from,
 and what happened to it? (*pānis* — worn to a single **nasal** syllable, *pānis →

--- a/code/learning/human-languages/portuguese/lessons/PT-C12-numeros-11-15.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C12-numeros-11-15.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C12-numeros-11-15
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 450
 chapter: 12
 type: word
 headword: onze — quinze
@@ -9,19 +12,33 @@ prerequisites: [PT-C06-numeros-6-10, PT-C11-agua-vinho]
 sounds: [nasal-on, z-voiced]
 roots: [latin-decim]
 etymology_hook: "onze…quinze ← ūndecim…quīndecim, the -ze a worn-down decem ('ten'); Portuguese keeps only FIVE fused teens — fewer than any sister — then rebuilds from 16 on"
-est_minutes: 4
+duration:
+  max_seconds: 166
+requires:
+  knowledge: [PT-SOUND-NUMEROS-6-10-02, PT-ETYMON-NUMEROS-6-10-03, PT-GRAMMAR-NUMEROS-6-10-04, PT-ETYMON-AGUA-VINHO-02, PT-ETYMON-AGUA-VINHO-03]
+introduces:
+  knowledge: [PT-GRAMMAR-NUMEROS-11-15-02, PT-NOTICE-NUMEROS-11-15-03]
+practises:
+  knowledge: [PT-SOUND-NUMEROS-6-10-02, PT-ETYMON-NUMEROS-6-10-03, PT-GRAMMAR-NUMEROS-6-10-04, PT-ETYMON-AGUA-VINHO-02, PT-ETYMON-AGUA-VINHO-03, PT-GRAMMAR-NUMEROS-11-15-02, PT-NOTICE-NUMEROS-11-15-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C06-numeros-6-10, PT-C11-agua-vinho]
 ---
 
 # onze → quinze — the short list
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Portuguese inherited the same welded Latin teens as its sisters — but
 it kept **fewer of them than anyone**. Just **five**. After *quinze* (15), it
 starts over with a completely different, much plainer method.
 
-## The five fusions
+## Grammar Lens: The five fusions
+<!-- hl-knowledge: introduces=[PT-GRAMMAR-NUMEROS-11-15-02]; assesses=[] -->
 
 | | Portuguese | ← Latin | build |
 |---|---|---|---|
@@ -38,12 +55,14 @@ at the front: *dois→do-*, *três→tre-*, *quatro→cator-*, *cinco→quin-*.
 Note **catorze** — Portuguese kept the *c-* where Spanish says *catorce* and
 French *quatorze*; three worn-down versions of one Latin *quattuordecim*.
 
-## And that's where it stops
+## What you've built: And that's where it stops
+<!-- hl-knowledge: introduces=[PT-NOTICE-NUMEROS-11-15-03]; assesses=[] -->
 
 *Quinze* is the **last** fused number. From **16** Portuguese does something none
 of its sisters do so early — the next lesson.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-NUMEROS-6-10-02, PT-ETYMON-NUMEROS-6-10-03, PT-GRAMMAR-NUMEROS-6-10-04, PT-ETYMON-AGUA-VINHO-02, PT-ETYMON-AGUA-VINHO-03, PT-GRAMMAR-NUMEROS-11-15-02, PT-NOTICE-NUMEROS-11-15-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "onze, doze, treze, catorze, quinze"]
@@ -51,6 +70,7 @@ of its sisters do so early — the next lesson.
 - [YOU SAY: the digit inside — "**três** → **tre**ze, **cinco** → **quin**ze"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-NUMEROS-6-10-02, PT-ETYMON-NUMEROS-6-10-03, PT-GRAMMAR-NUMEROS-6-10-04, PT-ETYMON-AGUA-VINHO-02, PT-ETYMON-AGUA-VINHO-03, PT-GRAMMAR-NUMEROS-11-15-02, PT-NOTICE-NUMEROS-11-15-03] -->
 
 [PAUSE 3s] Count 11 to 15. (*Onze, doze, treze, catorze, quinze*.) What is the
 **-ze**? (Latin **decem**, "ten" — as in *dez*, *dezembro*.) How many fused teens

--- a/code/learning/human-languages/portuguese/lessons/PT-C12-numeros-16-20.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C12-numeros-16-20.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C12-numeros-16-20
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 460
 chapter: 12
 type: word
 headword: dezesseis — vinte
@@ -9,20 +12,34 @@ prerequisites: [PT-C12-numeros-11-15]
 sounds: [double-ss, nasal-in]
 roots: [latin-decem, viginti-latin]
 etymology_hook: "dezesseis = dez + e + seis, literally 'TEN AND SIX' — Portuguese rebuilt its upper teens from live words, keeping the 'and' (e) visible; it breaks at 16, earlier than any sister"
-est_minutes: 4
+duration:
+  max_seconds: 213
+requires:
+  knowledge: [PT-GRAMMAR-NUMEROS-11-15-02, PT-NOTICE-NUMEROS-11-15-03]
+introduces:
+  knowledge: [PT-GRAMMAR-NUMEROS-16-20-02, PT-NOTICE-NUMEROS-16-20-03]
+practises:
+  knowledge: [PT-GRAMMAR-NUMEROS-11-15-02, PT-NOTICE-NUMEROS-11-15-03, PT-GRAMMAR-NUMEROS-16-20-02, PT-NOTICE-NUMEROS-16-20-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C12-numeros-11-15, PT-C06-numeros-6-10]
 ---
 
 # dezesseis → vinte — built from scratch, with the "and" still showing
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] At **16**, Portuguese stops inheriting and starts **building**. And it
 does it more openly than any sister: it glues together the living words for "ten,"
 "and," and the digit — and leaves the **and** right there in the middle where you
 can hear it.
 
-## Ten AND six
+## Grammar Lens: Ten AND six
+<!-- hl-knowledge: introduces=[PT-GRAMMAR-NUMEROS-16-20-02]; assesses=[] -->
 
 | | Portuguese | build | literally |
 |---|---|---|---|
@@ -38,7 +55,8 @@ Every one begins with **dez** ("ten," Chapter 6) and most keep **e** ("and") —
 the *e* before the vowel of *oito*.) You already know every ingredient; nothing
 here needs memorising, only assembling.
 
-## Portuguese breaks earliest
+## What you've built: Portuguese breaks earliest
+<!-- hl-knowledge: introduces=[PT-NOTICE-NUMEROS-16-20-03]; assesses=[] -->
 
 All three Romance sisters give up fusing partway through the teens — but
 Portuguese gives up **first**:
@@ -56,6 +74,7 @@ the boldest rebuilder. (German, by contrast, never breaks at all.)
 English **vigesimal**.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-GRAMMAR-NUMEROS-11-15-02, PT-NOTICE-NUMEROS-11-15-03, PT-GRAMMAR-NUMEROS-16-20-02, PT-NOTICE-NUMEROS-16-20-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: 15→20 — "quinze, dezesseis, dezessete, dezoito, dezenove, vinte"]
@@ -63,6 +82,7 @@ English **vigesimal**.
 - [YOU SAY: the whole run, onze to vinte]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-GRAMMAR-NUMEROS-11-15-02, PT-NOTICE-NUMEROS-11-15-03, PT-GRAMMAR-NUMEROS-16-20-02, PT-NOTICE-NUMEROS-16-20-03] -->
 
 [PAUSE 3s] What does **dezesseis** literally spell out? ("**Ten and six**" — *dez*
 + *e* + *seis*.) At which number does Portuguese break, and how does that compare

--- a/code/learning/human-languages/portuguese/lessons/PT-C13-preto-branco.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C13-preto-branco.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C13-preto-branco
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 470
 chapter: 13
 type: word
 headword: preto, branco
@@ -9,18 +12,32 @@ prerequisites: [PT-C12-numeros-16-20]
 sounds: [closed-e, nasal-an]
 roots: [latin-pressus, latin-niger, germanic-blank]
 etymology_hook: "Portuguese keeps TWO blacks — negro ← niger and everyday preto ← Latin pressus 'pressed, dense' (dense → dark); branco is Germanic *blank 'shining', and Latin albus survives in alvorada ('dawn')"
-est_minutes: 4
+duration:
+  max_seconds: 203
+requires:
+  knowledge: [PT-GRAMMAR-NUMEROS-16-20-02, PT-NOTICE-NUMEROS-16-20-03]
+introduces:
+  knowledge: [PT-ETYMON-PRETO-BRANCO-02, PT-ETYMON-PRETO-BRANCO-03, PT-ETYMON-PRETO-BRANCO-04]
+practises:
+  knowledge: [PT-GRAMMAR-NUMEROS-16-20-02, PT-NOTICE-NUMEROS-16-20-03, PT-ETYMON-PRETO-BRANCO-02, PT-ETYMON-PRETO-BRANCO-03, PT-ETYMON-PRETO-BRANCO-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C12-numeros-16-20, PT-C11-pao-agua]
 ---
 
 # preto, branco — two blacks and a borrowed white
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Portuguese does something the other Romance languages don't: it keeps
 **two words for black**, and the everyday one isn't the Latin one at all.
 
-## The two blacks
+## The word, taken apart: The two blacks
+<!-- hl-knowledge: introduces=[PT-ETYMON-PRETO-BRANCO-02]; assesses=[] -->
 
 | word | source | use |
 |---|---|---|
@@ -34,7 +51,8 @@ Italian *nero*. But day to day, Portuguese reaches for **preto**, from *pressus*
 
 You already know *pressus*'s English children: *press*, *pressure*, *compress*.
 
-## branco — the Germanic import
+## The word, taken apart: branco — the Germanic import
+<!-- hl-knowledge: introduces=[PT-ETYMON-PRETO-BRANCO-03]; assesses=[] -->
 
 Latin's white, ***albus***, lost here too. Portuguese says **branco**, from
 Germanic ***blank*** ("shining") — the same loan that gave French *blanc* and
@@ -43,7 +61,8 @@ Italian *bianco*, arriving with the Suevi and Visigoths who settled Iberia.
 Notice what Portuguese did to the shape: *blanc-* → **branc-**. The **l → r**
 swap is a Portuguese signature (compare *plaza* → **praça**, *blando* → *brando*).
 
-## Where albus went
+## The word, taken apart: Where albus went
+<!-- hl-knowledge: introduces=[PT-ETYMON-PRETO-BRANCO-04]; assesses=[] -->
 
 | word | meaning |
 |---|---|
@@ -52,6 +71,7 @@ swap is a Portuguese signature (compare *plaza* → **praça**, *blando* → *br
 | *albumina*, *álbum* | (technical borrowings) |
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-GRAMMAR-NUMEROS-16-20-02, PT-NOTICE-NUMEROS-16-20-03, PT-ETYMON-PRETO-BRANCO-02, PT-ETYMON-PRETO-BRANCO-03, PT-ETYMON-PRETO-BRANCO-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "preto, branco"]
@@ -60,6 +80,7 @@ swap is a Portuguese signature (compare *plaza* → **praça**, *blando* → *br
 - [YOU SAY: the l→r swap — "blanc → **branco**"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-GRAMMAR-NUMEROS-16-20-02, PT-NOTICE-NUMEROS-16-20-03, PT-ETYMON-PRETO-BRANCO-02, PT-ETYMON-PRETO-BRANCO-03, PT-ETYMON-PRETO-BRANCO-04] -->
 
 [PAUSE 3s] What are Portuguese's two blacks? (**Negro** ← *niger*, literary; and
 **preto** ← *pressus* "pressed/dense," the everyday one.) Why would "pressed" mean

--- a/code/learning/human-languages/portuguese/lessons/PT-C13-vermelho-azul.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C13-vermelho-azul.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C13-vermelho-azul
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 480
 chapter: 13
 type: word
 headword: vermelho, azul
@@ -9,18 +12,32 @@ prerequisites: [PT-C13-preto-branco]
 sounds: [lh-palatal, final-l]
 roots: [latin-vermiculus, arabic-lazaward]
 etymology_hook: "vermelho ← vermiculus 'little worm' — the kermes insect crushed for scarlet dye (→ English vermilion), so PT alone doesn't use the ancient red root; azul ← Arabic lāzaward 'lapis lazuli' → English azure"
-est_minutes: 4
+duration:
+  max_seconds: 272
+requires:
+  knowledge: [PT-ETYMON-PRETO-BRANCO-02, PT-ETYMON-PRETO-BRANCO-03, PT-ETYMON-PRETO-BRANCO-04]
+introduces:
+  knowledge: [PT-ETYMON-VERMELHO-AZUL-02, PT-ETYMON-VERMELHO-AZUL-03, PT-NOTICE-VERMELHO-AZUL-04]
+practises:
+  knowledge: [PT-ETYMON-PRETO-BRANCO-02, PT-ETYMON-PRETO-BRANCO-03, PT-ETYMON-PRETO-BRANCO-04, PT-ETYMON-VERMELHO-AZUL-02, PT-ETYMON-VERMELHO-AZUL-03, PT-NOTICE-VERMELHO-AZUL-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C13-preto-branco, PT-C12-numeros-16-20]
 ---
 
 # vermelho, azul — a worm and a stone
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] These two are the best etymologies in the whole chapter. Portuguese
 named its red after an **insect** and its blue after a **rock**.
 
-## vermelho — the little worm
+## The word, taken apart: vermelho — the little worm
+<!-- hl-knowledge: introduces=[PT-ETYMON-VERMELHO-AZUL-02]; assesses=[] -->
 
 Every other Romance language builds "red" on the ancient root *h₁rewdʰ-*
 (*rouge*, *rosso*, Spanish *rojo*, and English *red*, German *rot*). Portuguese
@@ -39,7 +56,8 @@ The same word gave English **vermilion**. And *vermis* gave English **vermin**.
 Portuguese does still keep the old root — in **rubro** (literary "red") and
 **ruivo** ("red-haired") — but the everyday word for red is a bug.
 
-## azul — the stone from the mountains
+## The word, taken apart: azul — the stone from the mountains
+<!-- hl-knowledge: introduces=[PT-ETYMON-VERMELHO-AZUL-03]; assesses=[] -->
 
 **azul** ← Arabic ***lāzaward*** ← Persian ***lāžward***: **lapis lazuli**, the
 deep-blue stone mined for millennia in Afghanistan and ground into the most
@@ -52,7 +70,8 @@ article *l'* and dropped it — leaving *azul*. The same journey produced French
 This is the **al-Andalus** thread again: eight centuries of Arabic in Iberia left
 Portuguese and Spanish thousands of words, and one of them is a basic colour.
 
-## The chapter in one table
+## What you've built: The chapter in one table
+<!-- hl-knowledge: introduces=[PT-NOTICE-VERMELHO-AZUL-04]; assesses=[] -->
 
 | Portuguese | source |
 |---|---|
@@ -64,6 +83,7 @@ Portuguese and Spanish thousands of words, and one of them is a basic colour.
 Not one of Portuguese's four basic colours is a plain inherited Latin colour word.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-ETYMON-PRETO-BRANCO-02, PT-ETYMON-PRETO-BRANCO-03, PT-ETYMON-PRETO-BRANCO-04, PT-ETYMON-VERMELHO-AZUL-02, PT-ETYMON-VERMELHO-AZUL-03, PT-NOTICE-VERMELHO-AZUL-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "vermelho, azul"]
@@ -72,6 +92,7 @@ Not one of Portuguese's four basic colours is a plain inherited Latin colour wor
 - [YOU SAY: all four — "preto, branco, vermelho, azul"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-ETYMON-PRETO-BRANCO-02, PT-ETYMON-PRETO-BRANCO-03, PT-ETYMON-PRETO-BRANCO-04, PT-ETYMON-VERMELHO-AZUL-02, PT-ETYMON-VERMELHO-AZUL-03, PT-NOTICE-VERMELHO-AZUL-04] -->
 
 [PAUSE 3s] What does **vermelho** literally come from? (***Vermiculus***, "**little
 worm**" — the **kermes** insect crushed for dye.) Which English word is its

--- a/code/learning/human-languages/portuguese/lessons/PT-C14-idade.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C14-idade.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C14-idade
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 500
 chapter: 14
 type: phrase
 headword: tenho vinte anos
@@ -9,26 +12,41 @@ prerequisites: [PT-C14-ter, PT-C12-numeros-16-20]
 sounds: [nasal-anos, plural-s]
 roots: [latin-annus, latin-aetas]
 etymology_hook: "tenho vinte anos literally 'I HOLD twenty years' (ter ← tenēre), the strongest form of the Romance have-your-age idiom; ano ← annus simplified the -nn- where Spanish palatalized it to año — one Latin word, two Iberian outcomes"
-est_minutes: 4
+duration:
+  max_seconds: 259
+requires:
+  knowledge: [PT-LEX-TER-02, PT-ETYMON-TER-03, PT-GRAMMAR-NUMEROS-16-20-02, PT-NOTICE-NUMEROS-16-20-03]
+introduces:
+  knowledge: [PT-LEX-IDADE-02, PT-ETYMON-IDADE-03, PT-GRAMMAR-IDADE-04]
+practises:
+  knowledge: [PT-LEX-TER-02, PT-ETYMON-TER-03, PT-GRAMMAR-NUMEROS-16-20-02, PT-NOTICE-NUMEROS-16-20-03, PT-LEX-IDADE-02, PT-ETYMON-IDADE-03, PT-GRAMMAR-IDADE-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C14-ter, PT-C12-numeros-16-20, PT-C09-meses]
 ---
 
 # tenho vinte anos — holding your years
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Portuguese states age with **ter**. And since *ter* came from "to
 **hold**," the sentence is, at the root, "**I hold twenty years**" — the most
 physical version of this idea in any of the five languages.
 
-## The phrase
+## You'll want to know: The phrase
+<!-- hl-knowledge: introduces=[PT-LEX-IDADE-02]; assesses=[] -->
 
 > **Quantos anos tens?** — "How many years do you **have**?"
 > **Tenho vinte anos.** — "I **have** twenty years."
 
 *Ser* is wrong here. And **anos** can't be dropped, unlike English "I'm twenty."
 
-## ano ← annus, minus one n
+## The word, taken apart: ano ← annus, minus one n
+<!-- hl-knowledge: introduces=[PT-ETYMON-IDADE-03]; assesses=[] -->
 
 **ano** ("year") ← Latin ***annus*** → English **annual**, **anniversary**,
 **annals**.
@@ -47,7 +65,8 @@ Latin *n*.
 Careful: keep *ano* distinct from *ânus*. The stress and the circumflex do the
 work.
 
-## Who has, who is
+## Grammar Lens: Who has, who is
+<!-- hl-knowledge: introduces=[PT-GRAMMAR-IDADE-04]; assesses=[] -->
 
 | language | | literally |
 |---|---|---|
@@ -62,6 +81,7 @@ Three layers: Germanic **is** its years, French and Italian **have** them, and
 Iberian Romance **holds** them.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-LEX-TER-02, PT-ETYMON-TER-03, PT-GRAMMAR-NUMEROS-16-20-02, PT-NOTICE-NUMEROS-16-20-03, PT-LEX-IDADE-02, PT-ETYMON-IDADE-03, PT-GRAMMAR-IDADE-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "Quantos anos tens?"]
@@ -70,6 +90,7 @@ Iberian Romance **holds** them.
 - [YOU SAY: the sister pair — "**ano** … **año**" — one Latin *annus*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-LEX-TER-02, PT-ETYMON-TER-03, PT-GRAMMAR-NUMEROS-16-20-02, PT-NOTICE-NUMEROS-16-20-03, PT-LEX-IDADE-02, PT-ETYMON-IDADE-03, PT-GRAMMAR-IDADE-04] -->
 
 [PAUSE 3s] Which verb does Portuguese use for age? (***Ter***, never *ser*.)
 Given *ter*'s root, what does the sentence literally say? ("I **hold** twenty

--- a/code/learning/human-languages/portuguese/lessons/PT-C14-ter.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C14-ter.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C14-ter
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 490
 chapter: 14
 type: word
 headword: ter
@@ -9,19 +12,33 @@ prerequisites: [PT-C13-vermelho-azul, PT-C05-falar]
 sounds: [nasal-em, circumflex-tem]
 roots: [latin-tenere]
 etymology_hook: "PT and ES alone use tenēre 'to HOLD' (→ tenant/retain/tenacious) for 'have', while French/Italian kept habēre; Portuguese does have haver ← habēre, but demoted it to an auxiliary — two verbs swapped jobs on the Iberian peninsula"
-est_minutes: 4
+duration:
+  max_seconds: 216
+requires:
+  knowledge: [PT-ETYMON-VERMELHO-AZUL-02, PT-ETYMON-VERMELHO-AZUL-03, PT-NOTICE-VERMELHO-AZUL-04, PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04]
+introduces:
+  knowledge: [PT-LEX-TER-02, PT-ETYMON-TER-03]
+practises:
+  knowledge: [PT-ETYMON-VERMELHO-AZUL-02, PT-ETYMON-VERMELHO-AZUL-03, PT-NOTICE-VERMELHO-AZUL-04, PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04, PT-LEX-TER-02, PT-ETYMON-TER-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C13-vermelho-azul, PT-C05-falar, PT-C10-irmaos]
 ---
 
 # ter — "to have"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Every Romance language needs a word for "have." French and Italian
 took one from Latin; **Portuguese and Spanish took a different one entirely** —
 and it didn't originally mean "have" at all.
 
-## The forms
+## You'll want to know: The forms
+<!-- hl-knowledge: introduces=[PT-LEX-TER-02]; assesses=[] -->
 
 | | |
 |---|---|
@@ -38,7 +55,8 @@ Two things to watch:
 - **tem** vs **têm** — "he has" vs "**they** have". They sound nearly alike; the
   **circumflex** marks the plural. An accent doing grammar, not sound.
 
-## The Iberian swap
+## The word, taken apart: The Iberian swap
+<!-- hl-knowledge: introduces=[PT-ETYMON-TER-03]; assesses=[] -->
 
 **ter** ← Latin ***tenēre***, "**to hold**" — not "to have."
 
@@ -58,6 +76,7 @@ English kept the *tenēre* family as borrowings: **tenant** (one who *holds*
 land), **retain**, **maintain**, **tenacious**, **tenure**, **contain**.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-ETYMON-VERMELHO-AZUL-02, PT-ETYMON-VERMELHO-AZUL-03, PT-NOTICE-VERMELHO-AZUL-04, PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04, PT-LEX-TER-02, PT-ETYMON-TER-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "tenho, tens, tem, temos, têm"]
@@ -66,6 +85,7 @@ land), **retain**, **maintain**, **tenacious**, **tenure**, **contain**.
 - [YOU SAY: the hold-family — "ter · tenant · retain · tenacious"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-ETYMON-VERMELHO-AZUL-02, PT-ETYMON-VERMELHO-AZUL-03, PT-NOTICE-VERMELHO-AZUL-04, PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04, PT-LEX-TER-02, PT-ETYMON-TER-03] -->
 
 [PAUSE 3s] What did *ter*'s Latin source mean? (***Tenēre*** — "to **hold**".)
 Which other language made the same swap? (**Spanish**, *tener*.) What happened to

--- a/code/learning/human-languages/portuguese/lessons/PT-C15-preterito-perfeito.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C15-preterito-perfeito.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C15-preterito-perfeito
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 510
 chapter: 15
 type: word
 headword: falei
@@ -9,18 +12,32 @@ prerequisites: [PT-C14-ter, PT-C05-falar]
 sounds: [final-stress-ei, nasal-aram]
 roots: [latin-perfect]
 etymology_hook: "falei ← Vulgar Latin perfect **\*fabulāvī**, the direct inheritance — the SAME tense French exiled to literature (il parla), German pushed aside (sagte) and northern Italy dropped (parlò); Portuguese and Spanish, at the western edge, simply kept using it"
-est_minutes: 4
+duration:
+  max_seconds: 252
+requires:
+  knowledge: [PT-LEX-TER-02, PT-ETYMON-TER-03, PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04]
+introduces:
+  knowledge: [PT-LEX-PRETERITO-PERFEITO-02, PT-PRAGMATICS-PRETERITO-PERFEITO-03]
+practises:
+  knowledge: [PT-LEX-TER-02, PT-ETYMON-TER-03, PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04, PT-LEX-PRETERITO-PERFEITO-02, PT-PRAGMATICS-PRETERITO-PERFEITO-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C14-ter, PT-C05-falar, PT-C05-trabalhar]
 ---
 
 # falei — the past Portuguese kept
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Portuguese's everyday past tense. Its interest isn't its endings —
 it's that Portuguese still **has** it in daily speech, when several sisters do not.
 
-## The forms
+## You'll want to know: The forms
+<!-- hl-knowledge: introduces=[PT-LEX-PRETERITO-PERFEITO-02]; assesses=[] -->
 
 | | |
 |---|---|
@@ -40,7 +57,8 @@ lets context decide. Same word, one accent, two spelling conventions.
 Latin *-āv-* dissolved and left a **stressed final vowel** behind, which is why
 *falei* and *falou* end where they do.
 
-## The tense the others gave up
+## Why it's said this way: The tense the others gave up
+<!-- hl-knowledge: introduces=[PT-PRAGMATICS-PRETERITO-PERFEITO-03]; assesses=[] -->
 
 Now the point of the chapter:
 
@@ -61,6 +79,7 @@ participle (*falado*). It simply doesn't use them for this job. The next lesson
 shows what it uses them for instead.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-LEX-TER-02, PT-ETYMON-TER-03, PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04, PT-LEX-PRETERITO-PERFEITO-02, PT-PRAGMATICS-PRETERITO-PERFEITO-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "falei, falaste, falou, falámos, falaram"]
@@ -69,6 +88,7 @@ shows what it uses them for instead.
 - [YOU SAY: the five fates — "falou · habló · parlò · sagte · il parla"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-LEX-TER-02, PT-ETYMON-TER-03, PT-SOUND-FALAR-02, PT-ETYMON-FALAR-03, PT-GRAMMAR-FALAR-04, PT-LEX-PRETERITO-PERFEITO-02, PT-PRAGMATICS-PRETERITO-PERFEITO-03] -->
 
 [PAUSE 3s] How many words does the Portuguese past need? (**One** — no
 auxiliary.) Where does *falei* come from? (Vulgar Latin perfect **\*fabulāvī**, like

--- a/code/learning/human-languages/portuguese/lessons/PT-C15-tenho-falado.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C15-tenho-falado.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C15-tenho-falado
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 520
 chapter: 15
 type: phrase
 headword: tenho falado
@@ -9,19 +12,33 @@ prerequisites: [PT-C15-preterito-perfeito, PT-C14-ter]
 sounds: [nasal-am, participle-ado]
 roots: [latin-tenere-participle]
 etymology_hook: "Portuguese built the same have+participle machine as French and Italian, then gave it a DIFFERENT job: tenho falado means 'I have been speaking (repeatedly, lately)', not 'I spoke' — because the simple past falei never vacated the slot"
-est_minutes: 4
+duration:
+  max_seconds: 260
+requires:
+  knowledge: [PT-LEX-PRETERITO-PERFEITO-02, PT-PRAGMATICS-PRETERITO-PERFEITO-03, PT-LEX-TER-02, PT-ETYMON-TER-03]
+introduces:
+  knowledge: [PT-LEX-TENHO-FALADO-02, PT-GRAMMAR-TENHO-FALADO-03, PT-PRAGMATICS-TENHO-FALADO-04]
+practises:
+  knowledge: [PT-LEX-PRETERITO-PERFEITO-02, PT-PRAGMATICS-PRETERITO-PERFEITO-03, PT-LEX-TER-02, PT-ETYMON-TER-03, PT-LEX-TENHO-FALADO-02, PT-GRAMMAR-TENHO-FALADO-03, PT-PRAGMATICS-TENHO-FALADO-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C15-preterito-perfeito, PT-C14-ter, PT-C05-falar]
 ---
 
 # tenho falado — the compound that means something else
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Portuguese **does** have *ter* + participle. It looks exactly like the
 French and Italian compound past, and it means **something different**. This is
 one of the most common mistakes English speakers make in Portuguese.
 
-## The form
+## You'll want to know: The form
+<!-- hl-knowledge: introduces=[PT-LEX-TENHO-FALADO-02]; assesses=[] -->
 
 > **ter** (conjugated) + **past participle**
 
@@ -33,7 +50,8 @@ one of the most common mistakes English speakers make in Portuguese.
 
 → **tenho falado**, **tens falado**, **tem falado**…
 
-## What it actually means
+## Grammar Lens: What it actually means
+<!-- hl-knowledge: introduces=[PT-GRAMMAR-TENHO-FALADO-03]; assesses=[] -->
 
 | Portuguese | English |
 |---|---|
@@ -48,7 +66,8 @@ For a single completed act, Portuguese uses the simple past from the last lesson
 
 > **Falei com ele ontem.** — "I spoke with him yesterday."
 
-## Why the meanings diverged
+## Why it's said this way: Why the meanings diverged
+<!-- hl-knowledge: introduces=[PT-PRAGMATICS-TENHO-FALADO-04]; assesses=[] -->
 
 French and Italian let their compound take over the plain past, so *j'ai parlé*
 and *ho parlato* now just mean "I spoke."
@@ -69,6 +88,7 @@ in the way.
 | **Portuguese** | *tenho falado* — **I have been speaking (repeatedly)** |
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-LEX-PRETERITO-PERFEITO-02, PT-PRAGMATICS-PRETERITO-PERFEITO-03, PT-LEX-TER-02, PT-ETYMON-TER-03, PT-LEX-TENHO-FALADO-02, PT-GRAMMAR-TENHO-FALADO-03, PT-PRAGMATICS-TENHO-FALADO-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: the contrast — "**falei** I spoke · **tenho falado** I've been speaking"]
@@ -77,6 +97,7 @@ in the way.
 - [YOU SAY: the warning — "*tenho falado* is **not** 'I have spoken'"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-LEX-PRETERITO-PERFEITO-02, PT-PRAGMATICS-PRETERITO-PERFEITO-03, PT-LEX-TER-02, PT-ETYMON-TER-03, PT-LEX-TENHO-FALADO-02, PT-GRAMMAR-TENHO-FALADO-03, PT-PRAGMATICS-TENHO-FALADO-04] -->
 
 [PAUSE 3s] What does *tenho falado* mean? ("I **have been** speaking" —
 **repeatedly**, over a recent stretch.) What do you use for one finished act?

--- a/code/learning/human-languages/portuguese/lessons/PT-C16-ser-estar-meaning.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C16-ser-estar-meaning.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C16-ser-estar-meaning
+spine_node: SPINE-ASK-LOCATION
+sequence: 560
 chapter: 16
 type: grammar
 headword: é bonita / está bonita
@@ -9,13 +12,26 @@ prerequisites: [PT-C16-ser-vs-estar]
 sounds: []
 roots: [latin-esse, latin-stare]
 etymology_hook: "the Iberian ser/estar split turns one adjective into a defining quality or a current impression"
-est_minutes: 4
+duration:
+  max_seconds: 198
+requires:
+  knowledge: [PT-GRAMMAR-SER-VS-ESTAR-02, PT-NOTICE-SER-VS-ESTAR-03]
+introduces:
+  knowledge: [PT-ETYMON-SER-ESTAR-MEANING-02]
+practises:
+  knowledge: [PT-GRAMMAR-SER-VS-ESTAR-02, PT-NOTICE-SER-VS-ESTAR-03, PT-ETYMON-SER-ESTAR-MEANING-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C16-ser-vs-estar]
 ---
 
 # é bonita / está bonita — a choice you can use
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] *Ser* and *estar* are not competing answers where one is always a
 mistake. With many adjectives, swapping the verb deliberately changes meaning.
@@ -29,7 +45,8 @@ mistake. With many adjectives, swapping the verb deliberately changes meaning.
 the quality as the current condition or impression. Context, not a mechanical
 “permanent” rule, decides what you mean.
 
-## The wider family
+## The word, taken apart: The wider family
+<!-- hl-knowledge: introduces=[PT-ETYMON-SER-ESTAR-MEANING-02]; assesses=[] -->
 
 Portuguese and Spanish maintain this full two-verb choice. Italian keeps
 *essere* and *stare* but lets them overlap differently; French has one *être*
@@ -46,6 +63,7 @@ The Romance rows started with the same Latin material and reorganised it in
 three ways. That is why the Portuguese choice is systematic but not universal.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-GRAMMAR-SER-VS-ESTAR-02, PT-NOTICE-SER-VS-ESTAR-03, PT-ETYMON-SER-ESTAR-MEANING-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: “Ela é bonita” — a quality]
@@ -55,6 +73,7 @@ three ways. That is why the Portuguese choice is systematic but not universal.
 [REPEAT x2] “Ser: what it is. Estar: the condition it is in.”
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-GRAMMAR-SER-VS-ESTAR-02, PT-NOTICE-SER-VS-ESTAR-03, PT-ETYMON-SER-ESTAR-MEANING-02] -->
 
 [PAUSE 3s] What changes between *ela é bonita* and *ela está bonita*? (A
 defining quality versus a **current impression**.) Is *estar* automatically a

--- a/code/learning/human-languages/portuguese/lessons/PT-C16-ser-roots.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C16-ser-roots.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C16-ser-roots
+spine_node: SPINE-ASK-LOCATION
+sequence: 540
 chapter: 16
 type: etymology
 headword: sou / era / fui / ser
@@ -9,13 +12,26 @@ prerequisites: [PT-C16-ser]
 sounds: [open-e]
 roots: [latin-esse, latin-sedere, latin-fui]
 etymology_hook: "ser uses esse for sou/era, sedere 'sit' for the infinitive, and esse's ancient fui perfect; ir later borrowed that whole perfect"
-est_minutes: 4
+duration:
+  max_seconds: 173
+requires:
+  knowledge: [PT-LEX-SER-02, PT-LEX-SER-03]
+introduces:
+  knowledge: [PT-ETYMON-SER-ROOTS-02]
+practises:
+  knowledge: [PT-LEX-SER-02, PT-LEX-SER-03, PT-ETYMON-SER-ROOTS-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C16-ser, PT-C15-preterito-perfeito]
 ---
 
 # ser — two verbs, three stems
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] **Sou, era, fui, ser** do not resemble one another because the
 modern verb preserves several older roots.
@@ -31,7 +47,8 @@ That is **two Latin verbs** but **three stems**: *esse* was already suppletive,
 using both its ordinary root and the older *fuī* perfect. *Sedēre* also gave
 English **sedentary** and **session**.
 
-## fui means “was” and “went”
+## The word, taken apart: fui means “was” and “went”
+<!-- hl-knowledge: introduces=[PT-ETYMON-SER-ROOTS-02]; assesses=[] -->
 
 The entire preterite is shared with **ir**, “to go”:
 
@@ -49,6 +66,7 @@ ancestor; **ir** borrowed the row after Latin *īre*’s own perfect wore away.
 Spanish made the same Iberian choice.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-LEX-SER-02, PT-LEX-SER-03, PT-ETYMON-SER-ROOTS-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: “ser ← sedēre, to sit”]
@@ -58,6 +76,7 @@ Spanish made the same Iberian choice.
 [REPEAT x2] “Two verbs, three stems; *fui* has two meanings.”
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-LEX-SER-02, PT-LEX-SER-03, PT-ETYMON-SER-ROOTS-02] -->
 
 [PAUSE 3s] Which Latin verb gives the infinitive? (***Sedēre**, “sit.”*) Which
 gives *sou* and *era*? (***Esse**.) What two verbs share *fui*? (**Ser** and

--- a/code/learning/human-languages/portuguese/lessons/PT-C16-ser-vs-estar.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C16-ser-vs-estar.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C16-ser-vs-estar
+spine_node: SPINE-ASK-LOCATION
+sequence: 550
 chapter: 16
 type: phrase
 headword: ser vs. estar
@@ -9,13 +12,26 @@ prerequisites: [PT-C16-ser-roots, PT-C02-como-vai-esta, PT-C05-morar]
 sounds: [nasal-ao, unstressed-vowel-reduction]
 roots: [latin-sedere, latin-stare]
 etymology_hook: "ser's sit and estar's stand origins make a useful mnemonic, though esse versus stare caused the meaning split"
-est_minutes: 4
+duration:
+  max_seconds: 230
+requires:
+  knowledge: [PT-ETYMON-SER-ROOTS-02, PT-LEX-COMO-VAI-ESTA-01, PT-SOUND-MORAR-02, PT-ETYMON-MORAR-03, PT-GRAMMAR-MORAR-04]
+introduces:
+  knowledge: [PT-GRAMMAR-SER-VS-ESTAR-02, PT-NOTICE-SER-VS-ESTAR-03]
+practises:
+  knowledge: [PT-ETYMON-SER-ROOTS-02, PT-LEX-COMO-VAI-ESTA-01, PT-SOUND-MORAR-02, PT-ETYMON-MORAR-03, PT-GRAMMAR-MORAR-04, PT-GRAMMAR-SER-VS-ESTAR-02, PT-NOTICE-SER-VS-ESTAR-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C16-ser-roots, PT-C02-como-vai-esta, PT-C09-estacoes]
 ---
 
 # ser vs. estar — the core choice
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Chapter 2 used **Como está?** Now learn *estar*’s forms and make the
 basic choice between Portuguese’s two verbs for “to be.”
@@ -29,7 +45,8 @@ basic choice between Portuguese’s two verbs for “to be.”
 Say **vocês estão** in ordinary speech. You may hear shortened *tou* and *tá*;
 recognise them, but write the full forms.
 
-## What something is; how it is
+## Grammar Lens: What something is; how it is
+<!-- hl-knowledge: introduces=[PT-GRAMMAR-SER-VS-ESTAR-02]; assesses=[] -->
 
 > **ser** = what something is
 > **estar** = its location or the condition it is in
@@ -47,7 +64,8 @@ Do not reduce this to “permanent versus temporary”: **ele está morto**, “
 dead,” uses *estar*. Death is not temporary; it is a condition someone has
 ended up in.
 
-## A mnemonic, not the cause
+## What you've built: A mnemonic, not the cause
+<!-- hl-knowledge: introduces=[PT-NOTICE-SER-VS-ESTAR-03]; assesses=[] -->
 
 *Ser* contains forms from Latin *sedēre*, “sit”; *estar* continues *stāre*,
 “stand.” Picture **ser** as seated in identity and **estar** as standing in a
@@ -55,6 +73,7 @@ condition. The history is a memory aid, not the cause: *esse* supplied *ser*’s
 identity meaning, while *stāre* pulled toward place and resulting state.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-ETYMON-SER-ROOTS-02, PT-LEX-COMO-VAI-ESTA-01, PT-SOUND-MORAR-02, PT-ETYMON-MORAR-03, PT-GRAMMAR-MORAR-04, PT-GRAMMAR-SER-VS-ESTAR-02, PT-NOTICE-SER-VS-ESTAR-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: “estou, estás, está, estamos, estão”]
@@ -62,6 +81,7 @@ identity meaning, while *stāre* pulled toward place and resulting state.
 - [YOU SAY: “Ele é médico; ele está doente.”]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-ETYMON-SER-ROOTS-02, PT-LEX-COMO-VAI-ESTA-01, PT-SOUND-MORAR-02, PT-ETYMON-MORAR-03, PT-GRAMMAR-MORAR-04, PT-GRAMMAR-SER-VS-ESTAR-02, PT-NOTICE-SER-VS-ESTAR-03] -->
 
 [PAUSE 3s] Which verb names identity? (**Ser**.) Which marks location or a
 resulting condition? (**Estar**.) How do you say “I’m in Lisbon”? (**Estou em

--- a/code/learning/human-languages/portuguese/lessons/PT-C16-ser.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C16-ser.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C16-ser
+spine_node: SPINE-ASK-LOCATION
+sequence: 530
 chapter: 16
 type: word
 headword: ser
@@ -9,18 +12,32 @@ prerequisites: [PT-C14-ter, PT-C15-preterito-perfeito]
 sounds: [nasal-ao, open-e]
 roots: [latin-esse]
 etymology_hook: "sou, era, and fui expose three historical stems inside the everyday verb ser"
-est_minutes: 4
+duration:
+  max_seconds: 148
+requires:
+  knowledge: [PT-LEX-TER-02, PT-ETYMON-TER-03, PT-LEX-PRETERITO-PERFEITO-02, PT-PRAGMATICS-PRETERITO-PERFEITO-03]
+introduces:
+  knowledge: [PT-LEX-SER-02, PT-LEX-SER-03]
+practises:
+  knowledge: [PT-LEX-TER-02, PT-ETYMON-TER-03, PT-LEX-PRETERITO-PERFEITO-02, PT-PRAGMATICS-PRETERITO-PERFEITO-03, PT-LEX-SER-02, PT-LEX-SER-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C14-ter, PT-C15-preterito-perfeito, PT-C05-falar]
 ---
 
 # ser — “to be”
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Portuguese has two verbs for “to be.” Begin with **ser**, used for
 identity and what something is; the choice against *estar* comes later.
 
-## Present
+## You'll want to know: Present
+<!-- hl-knowledge: introduces=[PT-LEX-SER-02]; assesses=[] -->
 
 | | |
 |---|---|
@@ -31,7 +48,8 @@ identity and what something is; the choice against *estar* comes later.
 *Tu és* is live in European Portuguese. **Vós** survives mainly in northern
 dialect and church language; everyday “you all” is **vocês**, with **são**.
 
-## Two past rows
+## You'll want to know: Two past rows
+<!-- hl-knowledge: introduces=[PT-LEX-SER-03]; assesses=[] -->
 
 Preterite, the completed past from Chapter 15:
 
@@ -46,6 +64,7 @@ several historical pieces have been welded together, which the next lesson will
 unpack. For now, retrieve each row as a usable pattern.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-LEX-TER-02, PT-ETYMON-TER-03, PT-LEX-PRETERITO-PERFEITO-02, PT-PRAGMATICS-PRETERITO-PERFEITO-03, PT-LEX-SER-02, PT-LEX-SER-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: “sou, és, é, somos, são”]
@@ -54,6 +73,7 @@ unpack. For now, retrieve each row as a usable pattern.
 - [YOU SAY: “era, éramos, eram”]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-LEX-TER-02, PT-ETYMON-TER-03, PT-LEX-PRETERITO-PERFEITO-02, PT-PRAGMATICS-PRETERITO-PERFEITO-03, PT-LEX-SER-02, PT-LEX-SER-03] -->
 
 [PAUSE 3s] Give the present of *ser*. (**Sou, és, é, somos, são**.) Which form
 goes with *vocês*? (**São**.) Give the preterite row. (**Fui, foste, foi, fomos,

--- a/code/learning/human-languages/portuguese/lessons/PT-C17-cabeca-caput.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C17-cabeca-caput.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C17-cabeca-caput
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 580
 chapter: 17
 type: etymology
 headword: cabeça / capital
@@ -9,13 +12,26 @@ prerequisites: [PT-C17-cabeca]
 sounds: [cedilla-s]
 roots: [latin-caput, latin-testa]
 etymology_hook: "cabeça inherited caput through everyday speech, while capital and capítulo later re-borrowed the same root from written Latin"
-est_minutes: 4
+duration:
+  max_seconds: 180
+requires:
+  knowledge: [PT-SOUND-CABECA-02, PT-ETYMON-CABECA-03]
+introduces:
+  knowledge: [PT-ETYMON-CABECA-CAPUT-02]
+practises:
+  knowledge: [PT-SOUND-CABECA-02, PT-ETYMON-CABECA-03, PT-ETYMON-CABECA-CAPUT-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C17-cabeca]
 ---
 
 # cabeça / capital — one root, two arrivals
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] **Cabeça** kept Latin *caput*, “head.” Other languages replaced that
 everyday word with containers, which makes the Portuguese survival visible.
@@ -32,7 +48,8 @@ French/Italian and German independently replaced “head” with a vessel. Iberi
 Romance kept *caput*. Portuguese still has **testa**, but narrowed it to
 “forehead” instead of the whole head.
 
-## The root returned in books
+## The word, taken apart: The root returned in books
+<!-- hl-knowledge: introduces=[PT-ETYMON-CABECA-CAPUT-02]; assesses=[] -->
 
 The same *caput* later entered learned vocabulary again:
 
@@ -46,6 +63,7 @@ of speech (**cabeça**), another branch borrowed back from written Latin
 because each route changes it differently.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-CABECA-02, PT-ETYMON-CABECA-03, PT-ETYMON-CABECA-CAPUT-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: “cabeça — inherited”]
@@ -55,6 +73,7 @@ because each route changes it differently.
 [REPEAT x2] “Cabeça and capital — two routes from *caput*.”
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-CABECA-02, PT-ETYMON-CABECA-03, PT-ETYMON-CABECA-CAPUT-02] -->
 
 [PAUSE 3s] Which languages kept the *caput* head-word? (**Portuguese and
 Spanish**.) What did French, Italian, and German substitute? (**Container

--- a/code/learning/human-languages/portuguese/lessons/PT-C17-cabeca.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C17-cabeca.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C17-cabeca
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 570
 chapter: 17
 type: word
 headword: a cabeça
@@ -9,19 +12,33 @@ prerequisites: [PT-C01-o-a]
 sounds: [cedilla-s]
 roots: [latin-caput]
 etymology_hook: "cabeça continues Late Latin capitia from caput, so Portuguese kept the older head-word"
-est_minutes: 4
+duration:
+  max_seconds: 161
+requires:
+  knowledge: []
+introduces:
+  knowledge: [PT-SOUND-CABECA-02, PT-ETYMON-CABECA-03]
+practises:
+  knowledge: [PT-SOUND-CABECA-02, PT-ETYMON-CABECA-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C01-o-a, PT-C09-meses]
 ---
 
 # a cabeça — “the head”
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Learn one body word and one reading rule together.
 
 > **a cabeça** — the head, feminine
 
-## Read the cedilla
+## Sounds you'll need: Read the cedilla
+<!-- hl-knowledge: introduces=[PT-SOUND-CABECA-02]; assesses=[] -->
 
 The **ç** is a **cedilla**. It marks a *c* pronounced **s** before *a*, *o*, or
 *u*, where plain *c* would normally be hard **k**. So *cabeça* ends roughly
@@ -31,7 +48,8 @@ The mark began as a tiny **z** under the letter: medieval scribes used *ç* as
 shorthand for *cz*. Treat that as a recognition hook; this track has not yet
 asked you to write the mark by hand.
 
-## The inherited word
+## The word, taken apart: The inherited word
+<!-- hl-knowledge: introduces=[PT-ETYMON-CABECA-03]; assesses=[] -->
 
 **Cabeça** comes from Late Latin ***capitia***, built from ***caput***, “head.”
 Portuguese wore the word down in ordinary speech but kept the old root.
@@ -44,6 +62,7 @@ In Brazilian Portuguese you may hear **Minha cabeça está doendo**. Both begin
 with the same feminine noun **a cabeça**.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-CABECA-02, PT-ETYMON-CABECA-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: “a cabeça” — make **ç** an **s**]
@@ -53,6 +72,7 @@ with the same feminine noun **a cabeça**.
 [REPEAT x2] “A cabeça — feminine; ç sounds s.”
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-CABECA-02, PT-ETYMON-CABECA-03] -->
 
 [PAUSE 3s] Say “the head.” (**A cabeça**.) What does the cedilla do? (Marks *c*
 as **s** before *a/o/u*.) What is the Latin root? (***Caput***.) Next: compare

--- a/code/learning/human-languages/portuguese/lessons/PT-C17-mao.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C17-mao.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: PT-C17-mao
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 590
 chapter: 17
 type: word
 headword: a mão
@@ -9,23 +12,38 @@ prerequisites: [PT-C17-cabeca-caput, PT-C01-o-a]
 sounds: [nasal-ao, til]
 roots: [latin-manus]
 etymology_hook: "mão ← manus: the -n- between vowels DISSOLVED (a regular Portuguese change, cf. lua ← luna, boa ← bona) nasalising the vowel — nasality the til records in mão/pão but which faded again in lua/boa; and like Italian mano it stays FEMININE, because manus was a fourth-declension feminine"
-est_minutes: 4
+duration:
+  max_seconds: 298
+requires:
+  knowledge: [PT-ETYMON-CABECA-CAPUT-02]
+introduces:
+  knowledge: [PT-LEX-MAO-02, PT-ETYMON-MAO-03, PT-GRAMMAR-MAO-04]
+practises:
+  knowledge: [PT-ETYMON-CABECA-CAPUT-02, PT-LEX-MAO-02, PT-ETYMON-MAO-03, PT-GRAMMAR-MAO-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [PT-C17-cabeca, PT-C17-cabeca-caput, PT-C11-pao]
 ---
 
 # a mão — "the hand"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Two things in one short word: a sound change that shaped half of
 Portuguese, and a gender that is two thousand years old.
 
-## The word
+## You'll want to know: The word
+<!-- hl-knowledge: introduces=[PT-LEX-MAO-02]; assesses=[] -->
 
 > **a mão** — the hand. **Feminine**.
 > Plural: **as mãos**.
 
-## Where did the n go?
+## The word, taken apart: Where did the n go?
+<!-- hl-knowledge: introduces=[PT-ETYMON-MAO-03]; assesses=[] -->
 
 Latin ***manus*** → Portuguese ***mão***. The **-n-** vanished.
 
@@ -47,7 +65,8 @@ sound so different.
 
 Say the pair aloud: *mano* … *mão*. You can hear the *n* becoming the nasal.
 
-## Feminine, like Italian's
+## Grammar Lens: Feminine, like Italian's
+<!-- hl-knowledge: introduces=[PT-GRAMMAR-MAO-04]; assesses=[] -->
 
 **A mão** is feminine — and so is Italian **la mano**, for the same reason. Latin
 *manus* belonged to the **fourth declension**, a class whose nouns ended in *-us*
@@ -57,6 +76,7 @@ Portuguese is less startling about it than Italian, because *mão* doesn't end i
 a giveaway *-o*. But it is the same two-thousand-year-old fact underneath.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[PT-ETYMON-CABECA-CAPUT-02, PT-LEX-MAO-02, PT-ETYMON-MAO-03, PT-GRAMMAR-MAO-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "a mão, as mãos"]
@@ -65,6 +85,7 @@ a giveaway *-o*. But it is the same two-thousand-year-old fact underneath.
 - [YOU SAY: the contrast — "Spanish *mano*, Portuguese *mão*"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[PT-ETYMON-CABECA-CAPUT-02, PT-LEX-MAO-02, PT-ETYMON-MAO-03, PT-GRAMMAR-MAO-04] -->
 
 [PAUSE 3s] Say "the hand" and "the hands." (*A mão* / *as mãos*.) What happened
 to the *n* of *manus*? (It **dissolved between vowels**, leaving a nasal vowel —

--- a/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
@@ -60,6 +60,31 @@ describe("generated book source hashes", () => {
     expect(bookHashStatus(lessons, "italian", chapter)).toBe("synced");
   });
 
+  it.each([
+    [2, 8],
+    [3, 5],
+    [4, 5],
+    [5, 5],
+    [6, 2],
+    [7, 2],
+    [8, 2],
+    [9, 2],
+    [10, 2],
+    [11, 2],
+    [12, 2],
+    [13, 2],
+    [14, 2],
+    [15, 2],
+    [16, 4],
+    [17, 3],
+  ])("matches the browser-loaded Portuguese Chapter %i AST across %i lessons", (chapter, count) => {
+    const lessons = loadLessons();
+    const expected = expectedBookHash("portuguese", chapter);
+    expect(expected?.lessonIds).toHaveLength(count);
+    expect(actualChapterHash(lessons, "portuguese", chapter)).toBe(expected?.sourceHash);
+    expect(bookHashStatus(lessons, "portuguese", chapter)).toBe("synced");
+  });
+
   it("reports a generated chapter stale when one canonical lesson changes", () => {
     const lessons = loadLessons();
     const changed = lessons.map((lesson) =>


### PR DESCRIPTION
## Summary

- migrate all 50 Portuguese lessons in Chapters 2–17 to strict schema v2 with shared-spine anchors, prerequisite-closed knowledge, typed blocks, and sub-five-minute budgets
- generate sixteen LaTeX chapters from the same canonical lesson AST consumed by Language Ladder and independently verify all sixteen chapter hashes in the app
- expand the downloadable Portuguese book from Chapter 1 to all seventeen chapters (105 pages)
- preserve Arabic `حتى` in the Chapter 4 etymology using the repository-vendored Noto Naskh Arabic font
- update the measurable backlog: missing book chapters fall from 236 to 220; HL-B17 records the remaining layout-only warning debt

## Validation

- `npm test` — human-language-data: 81 tests
- `npm run validate` — 9 integration tests
- `npm run check:books`
- `npm test` — Language Ladder: 319 tests
- `npm run build` — Language Ladder production build
- forced XeLaTeX build: 105 pages, 0 missing glyphs, 0 duplicate destinations, 0 Hyperref warnings, 0 LaTeX warnings
- rendered and inspected all 105 pages; verified 19 top-level outline entries and no leaked generator metadata

## Follow-up

HL-B17 is intentionally next: remove the expanded book's six overfull and thirteen underfull boxes without mixing presentation cleanup into this one-source migration.