### PR TITLE
fix(spice): lower diode junction-capacitance alias

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate diode model-card `CJO` / `CJ` / `CJ0` junction capacitance and
+  lower the `CJ` alias instead of silently dropping it.
 - Validate diode model-card `VT` / `V_T` thermal voltage and lower the `V_T`
   alias instead of silently dropping it.
 - Validate diode model-card `IS` / `JS` saturation current and lower the `JS`

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1270,7 +1270,9 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             N=model.params.get("N", 1.0),
             BV=model.params.get("BV"),
             IBV=model.params.get("IBV", 1e-3),
-            Cjo=model.params.get("CJO", model.params.get("CJ0", 0.0)),
+            Cjo=model.params.get(
+                "CJO", model.params.get("CJ", model.params.get("CJ0", 0.0))
+            ),
             Tt=model.params.get("TT", 0.0),
         )
     if prefix == "Q":
@@ -1918,6 +1920,14 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(thermal_voltage) or thermal_voltage <= 0.0
         ):
             raise NetlistParseError("diode VT must be finite and positive")
+        junction_capacitance = next(
+            (params[name] for name in ("CJO", "CJ", "CJ0") if name in params),
+            None,
+        )
+        if junction_capacitance is not None and (
+            not math.isfinite(junction_capacitance) or junction_capacitance < 0.0
+        ):
+            raise NetlistParseError("diode CJO must be finite and non-negative")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -842,6 +842,30 @@ def test_rejects_invalid_diode_thermal_voltage(parameter: str, value: str) -> No
         parse_netlist(f".model clamp D({parameter}={value})")
 
 
+def test_parse_diode_junction_capacitance_alias() -> None:
+    parsed = parse_netlist(
+        """
+.model clamp D(CJ=3p)
+D1 in out clamp
+"""
+    )
+
+    diode = parsed.circuit.elements[0]
+    assert isinstance(diode, Diode)
+    assert diode.Cjo == 3.0e-12
+
+
+@pytest.mark.parametrize("parameter", ["CJO", "CJ", "CJ0"])
+@pytest.mark.parametrize("value", ["-1p", "1e999"])
+def test_rejects_invalid_diode_junction_capacitance(
+    parameter: str, value: str
+) -> None:
+    with pytest.raises(
+        NetlistParseError, match="diode CJO must be finite and non-negative"
+    ):
+        parse_netlist(f".model clamp D({parameter}={value})")
+
+
 def test_parse_bjt_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate diode model-card `CJO` / `CJ` / `CJ0` junction capacitance and
+  lower the `CJ` alias instead of silently dropping it.
 - Validate diode model-card `VT` / `V_T` thermal voltage and lower the `V_T`
   alias instead of silently dropping it.
 - Validate diode model-card `IS` / `JS` saturation current and lower the `JS`

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1166,6 +1166,15 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("diode VT must be finite and positive");
   }
+  const diodeJunctionCapacitance =
+    params.get("CJO") ?? params.get("CJ") ?? params.get("CJ0");
+  if (
+    kind === "D" &&
+    diodeJunctionCapacitance !== undefined &&
+    (!Number.isFinite(diodeJunctionCapacitance) || diodeJunctionCapacitance < 0.0)
+  ) {
+    throw new NetlistParseError("diode CJO must be finite and non-negative");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -1692,7 +1701,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("N") ?? 1.0,
       model.params.get("BV"),
       model.params.get("IBV") ?? 1.0e-3,
-      model.params.get("CJO") ?? model.params.get("CJ0") ?? 0.0,
+      model.params.get("CJO") ?? model.params.get("CJ") ?? model.params.get("CJ0") ?? 0.0,
       model.params.get("TT") ?? 0.0,
     );
   }

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -800,6 +800,31 @@ D1 in out clamp
     );
   });
 
+  it("parses the diode CJ junction-capacitance alias", () => {
+    const parsed = parseNetlist(`
+.model clamp D(CJ=3p)
+D1 in out clamp
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "diode",
+      junctionCapacitance: 3.0e-12,
+    });
+  });
+
+  it.each([
+    ["CJO", "-1p"],
+    ["CJO", "1e999"],
+    ["CJ", "-1p"],
+    ["CJ", "1e999"],
+    ["CJ0", "-1p"],
+    ["CJ0", "1e999"],
+  ])("rejects invalid diode %s junction capacitance %s", (parameter, value) => {
+    expect(() => parseNetlist(`.model clamp D(${parameter}=${value})`)).toThrow(
+      "diode CJO must be finite and non-negative",
+    );
+  });
+
   it("parses the diode V_T thermal-voltage alias", () => {
     const parsed = parseNetlist(`
 .model clamp D(V_T=27m)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4335,11 +4335,16 @@ the Rust, Python, and TypeScript surfaces together.
    - Both parser facades validate positive finite `IS` / `JS` values and lower
      `JS` into the shared engine diode saturation-current field.
 
+404. Python and TypeScript Berkeley SPICE diode thermal-voltage alias parity.
+   - Status: completed in PR 9740.
+   - Both parser facades validate positive finite `VT` / `V_T` values and
+     lower `V_T` into the shared engine diode thermal-voltage field.
+
 ## Backlog
 
-1. Python and TypeScript Berkeley SPICE diode model-card alias parity.
+1. Python and TypeScript Berkeley SPICE BJT model-card alias parity.
    - Align parser validation and lowering with the shared engine aliases,
-     starting with `CJ` as the diode junction-capacitance alias for `CJO`.
+     starting with `BETA` as a forward-beta alias for `BF`.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary
- validate finite, non-negative diode `CJO`, `CJ`, and `CJ0` model-card values in the Python and TypeScript parser facades
- lower `CJ` through the existing diode junction-capacitance field with canonical `CJO` precedence
- record PR #9740 in the SPICE plan and queue BJT `BETA` alias parity next

## Verification
- Python `spice-netlist-parser`: `bash BUILD` (248 passed, 88.78% coverage)
- Python `spice-netlist-parser`: `.venv/bin/ruff check .`
- TypeScript `spice-engine`: `npm test` (448 passed)
- TypeScript `spice-netlist-parser`: `bash BUILD` (237 passed)
- TypeScript `spice-netlist-parser`: `npm run test:coverage` (237 passed, 85.62% line coverage)