### PR TITLE
Report fostered table text recovery

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Non-whitespace character data foster-parented out of table structure now
+  reports the table-text parse error, covering 14 previously silent malformed
+  corpus cases without changing DOM recovery or undeclared-diagnostic coverage.
 - Obsolete `menuitem` end tags now report the in-body parse error when no
   matching `menuitem` is current, covering 4 previously silent malformed
   corpus cases without changing DOM recovery or undeclared-diagnostic coverage.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the specialized obsolete-`menuitem` end-tag diagnostic slice, 2,015 of
-those cases emit at least one lexer or parser diagnostic and 168 remain
+After the specialized foster-parented table-text diagnostic slice, 2,029 of
+those cases emit at least one lexer or parser diagnostic and 154 remain
 uncovered.
 Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
 These are reviewed rather than automatically removed: 89 are full-document
@@ -63,14 +63,20 @@ recovery closes a non-current list item, and a paragraph end tag reports when it
 breaks out of MathML foreign content. A formatting end tag also reports when an
 open table blocks adoption-agency recovery.
 
+The fresh 154-case residual inventory keeps the next concrete groups in the
+existing priority order: table foster-parenting and table-scope boundaries;
+select/template recovery; script-tokenizer EOF recovery; plaintext/frameset
+boundaries; and foreign-fragment stray tags plus MathML/SVG table integration.
+
 Prioritized work items:
 
 1. **In-body insertion mode.** Cover the remaining formatting-reconstruction
    and stray-tag diagnostics.
-2. **Table, select, and template insertion modes.** Cover foster parenting,
-   table scopes, select recovery, and template mode-stack errors. The remaining
-   fragment EOF inventory includes fostered-anchor `eof-in-table` rows and
-   MathML/SVG table-boundary scope recovery.
+2. **Table, select, and template insertion modes.** Cover the remaining foster
+   parenting, table scopes, select recovery, and template mode-stack errors.
+   Non-whitespace table text now reports when it is foster-parented. The
+   remaining fragment EOF inventory includes fostered-anchor `eof-in-table`
+   rows and MathML/SVG table-boundary scope recovery.
 3. **Adoption agency and active formatting.** Cover malformed formatting cases
    without changing their now-conforming DOM output.
 4. **Foreign content and fragment parsing.** Cover SVG/MathML integration

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5789,6 +5789,10 @@ impl HtmlParser {
                 return;
             }
             let pending = std::mem::take(&mut self.pending_table_text);
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-character-in-table",
+                "non-whitespace character data in a table context was foster parented",
+            ));
             if self.foster_text_before_open_table(pending) {
                 return;
             }
@@ -33340,6 +33344,33 @@ mod tests {
 
         let matching = parse_html_with_diagnostics("<!doctype html><menuitem></menuitem>").unwrap();
         assert!(matching.parser_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_non_whitespace_character_data_fostered_from_tables() {
+        for source in [
+            "<!doctype html><table> x</table>",
+            "<!doctype html><table><tr> x</table>",
+            "<!doctype html><div><table><a>foo</a> <tr><td>bar</td></tr></table></div>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().any(|diagnostic| {
+                    diagnostic
+                        == &ParserDiagnostic::new(
+                            "unexpected-character-in-table",
+                            "non-whitespace character data in a table context was foster parented",
+                        )
+                }),
+                "source {source:?}"
+            );
+        }
+
+        let whitespace = parse_html_with_diagnostics("<!doctype html><table> \n</table>").unwrap();
+        assert!(whitespace
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "unexpected-character-in-table"));
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 168);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2015);
+    assert_eq!(missing_diagnostic_cases, 154);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2029);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report a parser diagnostic when non-whitespace character data is foster-parented out of table structure
- cover 14 previously silent malformed tree-construction cases without changing DOM recovery or undeclared-diagnostic coverage
- refresh the concrete residual backlog and ratchet diagnostic coverage from 168 to 154 remaining cases

## Validation
- `cargo test -p coding-adventures-html-parser`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-lexer`
- `cargo test -p state-machine-tokenizer`
- pinned WPT/html5lib coverage audit: tree 1934/2637/missing 0; tokenizer 6806/7015/7242/skipped 0/missing 0
- all WHATWG audit metadata, manifest, coverage, and Rust-test checks

This is a bounded diagnostic-coverage slice; it does not claim full browser conformance.