### PR TITLE
feat(toml-parser): add fallible parse API

### DIFF
--- a/code/packages/rust/toml-parser/CHANGELOG.md
+++ b/code/packages/rust/toml-parser/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2] - 2026-08-03
+
+### Added
+
+- Add `try_create_toml_parser` and `try_parse_toml` so malformed TOML returns typed lexical or syntax errors instead of panicking.
+- Keep fallible error diagnostics payload-blind: source text and token values are never retained or displayed.
+
 ## [0.1.1] - 2026-07-18
 
 ### Fixed

--- a/code/packages/rust/toml-parser/Cargo.toml
+++ b/code/packages/rust/toml-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-toml-parser"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "TOML parser — parses TOML source text into an AST using the grammar-driven parser and the toml.grammar file"
 

--- a/code/packages/rust/toml-parser/README.md
+++ b/code/packages/rust/toml-parser/README.md
@@ -44,6 +44,19 @@ inline_table       = LBRACE [ keyval { COMMA keyval } ] RBRACE ;
 
 ## Usage
 
+Production callers should use the fallible entrypoint. Its error categories do
+not echo source text or token values:
+
+```rust
+use coding_adventures_toml_parser::try_parse_toml;
+
+let ast = try_parse_toml("[server]\nport = 8080")?;
+assert_eq!(ast.rule_name, "document");
+# Ok::<(), coding_adventures_toml_parser::TomlParseError>(())
+```
+
+The original panic-on-error convenience remains available for trusted fixtures:
+
 ```rust
 use coding_adventures_toml_parser::parse_toml;
 
@@ -59,6 +72,9 @@ use coding_adventures_toml_parser::create_toml_parser;
 let mut parser = create_toml_parser("key = 42");
 let ast = parser.parse().expect("parse failed");
 ```
+
+Use `try_create_toml_parser` when fine-grained control also needs lexical errors
+to remain recoverable.
 
 ## Key differences from json-parser
 

--- a/code/packages/rust/toml-parser/src/lib.rs
+++ b/code/packages/rust/toml-parser/src/lib.rs
@@ -1,6 +1,7 @@
 //! TOML parser backed by compiled parser grammar.
 
-use coding_adventures_toml_lexer::tokenize_toml;
+use coding_adventures_toml_lexer::create_toml_lexer;
+use core::fmt::{self, Display, Formatter};
 use parser::grammar_parser::{GrammarASTNode, GrammarParser};
 
 mod _grammar;
@@ -46,17 +47,48 @@ mod _grammar;
 /// thousands of levels past the cap (see this crate's tests).
 const MAX_RULE_DEPTH: usize = 165;
 
-pub fn create_toml_parser(source: &str) -> GrammarParser {
-    let tokens = tokenize_toml(source);
+/// Stable payload-blind failure from TOML tokenization or parsing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TomlParseError {
+    /// The source could not be tokenized as TOML.
+    Lexical,
+    /// The token stream did not satisfy the TOML grammar.
+    Syntax,
+}
+
+impl Display for TomlParseError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Lexical => "TOML tokenization failed",
+            Self::Syntax => "TOML parsing failed",
+        })
+    }
+}
+
+impl std::error::Error for TomlParseError {}
+
+/// Create a depth-capped TOML parser without panicking on lexical failure.
+pub fn try_create_toml_parser(source: &str) -> Result<GrammarParser, TomlParseError> {
+    let tokens = create_toml_lexer(source)
+        .tokenize()
+        .map_err(|_| TomlParseError::Lexical)?;
     let grammar = _grammar::parser_grammar();
-    GrammarParser::new(tokens, grammar).with_max_depth(MAX_RULE_DEPTH)
+    Ok(GrammarParser::new(tokens, grammar).with_max_depth(MAX_RULE_DEPTH))
+}
+
+pub fn create_toml_parser(source: &str) -> GrammarParser {
+    try_create_toml_parser(source).unwrap_or_else(|error| panic!("{error}"))
+}
+
+/// Parse TOML into a grammar AST without panicking on malformed input.
+pub fn try_parse_toml(source: &str) -> Result<GrammarASTNode, TomlParseError> {
+    try_create_toml_parser(source)?
+        .parse()
+        .map_err(|_| TomlParseError::Syntax)
 }
 
 pub fn parse_toml(source: &str) -> GrammarASTNode {
-    let mut parser = create_toml_parser(source);
-    parser
-        .parse()
-        .unwrap_or_else(|e| panic!("TOML parse failed: {e}"))
+    try_parse_toml(source).unwrap_or_else(|error| panic!("{error}"))
 }
 
 #[cfg(test)]
@@ -121,6 +153,34 @@ mod tests {
         assert!(has_keyval, "Expected 'keyval' rule in AST");
         assert!(has_key, "Expected 'key' rule in AST");
         assert!(has_value, "Expected 'value' rule in AST");
+    }
+
+    #[test]
+    fn fallible_api_distinguishes_lexical_and_syntax_errors_without_source_echo() {
+        let lexical_source = "secret = \"unterminated";
+        let lexical = try_parse_toml(lexical_source).unwrap_err();
+        assert_eq!(lexical, TomlParseError::Lexical);
+        assert_eq!(lexical.to_string(), "TOML tokenization failed");
+        assert!(!lexical.to_string().contains("secret"));
+
+        let syntax_source = "secret =";
+        let syntax = try_parse_toml(syntax_source).unwrap_err();
+        assert_eq!(syntax, TomlParseError::Syntax);
+        assert_eq!(syntax.to_string(), "TOML parsing failed");
+        assert!(!syntax.to_string().contains("secret"));
+    }
+
+    #[test]
+    fn fallible_factory_and_parser_preserve_valid_ast_shape_and_depth_cap() {
+        let ast = try_create_toml_parser("[server]\nport = 8080")
+            .unwrap()
+            .parse()
+            .unwrap();
+        assert_document_root(&ast);
+        assert_eq!(
+            try_parse_toml(&nested_array_source(5000)),
+            Err(TomlParseError::Syntax)
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -530,4 +590,3 @@ role = \"user\"
         assert!(try_parse(&nested_inline_table_source(10)).is_ok());
     }
 }
-


### PR DESCRIPTION
## Summary

- add `try_create_toml_parser` and `try_parse_toml` entrypoints for recoverable lexical and syntax failure
- preserve the measured TOML recursion-depth cap on both fallible paths
- keep error values and displays payload-blind: source text and token values are not retained or echoed
- retain the existing panic-on-error helpers for trusted fixtures and compatibility
- document the production-safe entrypoint and release it as parser version 0.1.2

This removes the malformed-config panic path blocking the Chief daemon configuration loader.

## Validation

- 26 TOML parser tests, including lexical, syntax, depth-cap, and valid-AST cases
- strict Clippy
- warning-free rustdoc
- 100% package line coverage
- repository build planner: 1 changed package, 7 affected, Rust only

Part of #128.
Unblocks the next #138 daemon-config slice.
