### PR TITLE
fix(human-languages): make Portuguese book warning-free

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -84,9 +84,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-I01 | Complete (#9715) | Reduce unified all-books workflow setup time without splitting the single publication bundle. | A focused, preflighted XeLaTeX dependency closure replaces `texlive-full`; the unchanged job still builds all 20 books, verifies one bundle, and publishes that bundle from `main`. |
 | HL-B14 | Complete (#9728) | Publish Italian Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Forty-nine schema-v2 lessons now generate sixteen chapters whose source hashes are independently verified against the Language Ladder corpus. |
 | HL-B15 | Complete (#9735) | Remove Italian's LaTeX layout and Unicode bookmark warnings. | The forced 104-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
-| HL-B16 | Complete in this PR | Publish Portuguese Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Fifty schema-v2 lessons now generate sixteen chapters whose source hashes are independently verified against the Language Ladder corpus. |
-| HL-B17 | Next | Remove Portuguese's LaTeX layout warnings. | The expanded 105-page build has zero missing glyphs, duplicate destinations, Hyperref warnings, or LaTeX warnings, but reports six overfull boxes and thirteen underfull boxes; the clean-build signal is zero of each. |
-| HL-B18 | Queued | Publish French Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | The French PDF reaches Chapter 16 while canonical app content continues through Chapter 23; schema-v2 migration plus generation should close that drift safely. |
+| HL-B16 | Complete (#9744) | Publish Portuguese Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Fifty schema-v2 lessons now generate sixteen chapters whose source hashes are independently verified against the Language Ladder corpus. |
+| HL-B17 | Complete in this PR | Remove Portuguese's LaTeX layout warnings. | The forced 105-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
+| HL-B18 | Next | Publish French Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | The French PDF reaches Chapter 16 while canonical app content continues through Chapter 23; schema-v2 migration plus generation should close that drift safely. |
 | HL-B19 | Queued | Remove French's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs or duplicate labels but reports sixteen overfull boxes, nine underfull boxes, and six Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B20 | Queued | Publish German Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | The German PDF reaches Chapter 16 while canonical app content continues through Chapter 23; schema-v2 migration plus generation should close that drift safely. |
 | HL-B21 | Queued | Remove German's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs or duplicate labels but reports seventeen overfull boxes, eleven underfull boxes, and three Hyperref warnings; the clean-build signal is zero of each. |
@@ -593,6 +593,25 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - Six overfull boxes and thirteen underfull boxes remain in the expanded book.
   HL-B17 is next and records this measured 105-page presentation debt rather
   than the old 13-page baseline.
+
+## Findings from HL-B17
+
+- Portuguese now uses `\raggedbottom`, making intentionally short micro-lesson
+  pages explicit and removing eleven underfull vertical boxes without padding
+  or stretching learner content.
+- Six canonical lessons received small copy-flow edits: shorter resumable
+  headings, clearer sentence boundaries, and two deliberate warm-up paragraph
+  breaks. The same meaning, vocabulary, grammar, and etymology remain in both
+  Language Ladder and the generated book.
+- Regeneration updates the six affected chapter fingerprints, which Language
+  Ladder independently reproduces from the canonical AST. All fifty migrated
+  lessons remain below five minutes and prerequisite-closed.
+- A forced XeLaTeX build produces 105 pages with zero missing glyphs, overfull
+  or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX
+  warnings. Every page was rendered and inspected; the outline retains Preface,
+  pronunciation, and Chapters 1–17, and no generator metadata leaks into text.
+- HL-B18 is next: close the smaller seven-chapter French app/book gap before its
+  measured presentation-cleanup follow-up.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -211,7 +211,7 @@
     {
       "language": "portuguese",
       "chapter": 2,
-      "sourceHash": "fnv1a64:b1f0b2f2afaf849c",
+      "sourceHash": "fnv1a64:d1d8358ae18c96af",
       "lessonIds": [
         "PT-C02-de-nada",
         "PT-C02-como",
@@ -227,7 +227,7 @@
     {
       "language": "portuguese",
       "chapter": 3,
-      "sourceHash": "fnv1a64:fe554312c9530dd0",
+      "sourceHash": "fnv1a64:cbeaa2b81cbf1c89",
       "lessonIds": [
         "PT-C03-eu",
         "PT-C03-me-chamo",
@@ -240,7 +240,7 @@
     {
       "language": "portuguese",
       "chapter": 4,
-      "sourceHash": "fnv1a64:5525ef6075d2060a",
+      "sourceHash": "fnv1a64:66911b57472a9ba2",
       "lessonIds": [
         "PT-C04-adeus",
         "PT-C04-ate-logo",
@@ -253,7 +253,7 @@
     {
       "language": "portuguese",
       "chapter": 5,
-      "sourceHash": "fnv1a64:fca2fd8fd1da3e96",
+      "sourceHash": "fnv1a64:dc1f079cde196fa2",
       "lessonIds": [
         "PT-C05-falar",
         "PT-C05-morar",
@@ -286,7 +286,7 @@
     {
       "language": "portuguese",
       "chapter": 8,
-      "sourceHash": "fnv1a64:074f8f7eba5b6b2a",
+      "sourceHash": "fnv1a64:bcad5cb560fb13f6",
       "lessonIds": [
         "PT-C08-hora",
         "PT-C08-meio-dia-meia-noite"
@@ -378,7 +378,7 @@
     {
       "language": "portuguese",
       "chapter": 17,
-      "sourceHash": "fnv1a64:dff69b7e6fc4d902",
+      "sourceHash": "fnv1a64:05efdf7fd1a723f5",
       "lessonIds": [
         "PT-C17-cabeca",
         "PT-C17-cabeca-caput",

--- a/code/learning/human-languages/portuguese/CHANGELOG.md
+++ b/code/learning/human-languages/portuguese/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Warning-free 105-page edition — 2026-08-03
+
+- Added `\raggedbottom` so deliberately short micro-lesson pages keep natural
+  bottoms instead of producing eleven underfull vertical boxes.
+- Refined copy flow in six canonical lessons, using clearer sentence boundaries,
+  a shorter resumable heading, and explicit warm-up paragraph breaks to remove
+  six overfull and two underfull horizontal boxes without dropping content.
+- Regenerated the affected chapters and app-verified source fingerprints. All
+  lessons remain prerequisite-closed and below five minutes.
+- The forced XeLaTeX build now reports zero missing glyphs, overfull or
+  underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings
+  across all 105 pages.
+
 ## Canonical book Chapters 2–17 — 2026-08-03
 
 - Migrated all 50 lessons in Chapters 2–17 to strict schema v2 with unique

--- a/code/learning/human-languages/portuguese/README.md
+++ b/code/learning/human-languages/portuguese/README.md
@@ -31,7 +31,9 @@ uniquely agrees with the **speaker**, not the listener.
 
 The 105-page edition compiles with XeLaTeX. It uses Latin Modern for Portuguese
 and the repository-vendored Noto Naskh Arabic only for preserved Arabic source
-forms in the etymology. Run `latexmk -xelatex book.tex`.
+forms in the etymology. The forced build is free of missing glyphs, layout
+boxes, duplicate destinations, Hyperref warnings, and LaTeX warnings. Run
+`latexmk -xelatex book.tex`.
 
 ## Files
 

--- a/code/learning/human-languages/portuguese/book/book.tex
+++ b/code/learning/human-languages/portuguese/book/book.tex
@@ -6,6 +6,7 @@
 \date{}
 
 \begin{document}
+\raggedbottom
 
 \frontmatter
 

--- a/code/learning/human-languages/portuguese/book/chapters/ch02-how-are-you.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch02-how-are-you.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:b1f0b2f2afaf849c
+% canonical-source-hash: fnv1a64:d1d8358ae18c96af
 % canonical-lessons: PT-C02-de-nada, PT-C02-como, PT-C02-tudo, PT-C02-tudo-bem, PT-C02-como-vai-esta, PT-C02-mais-ou-menos, PT-C02-practice, PT-C02-formal-practice
 
 \chapter{How Are You?}
@@ -225,7 +225,7 @@ You do not need either pronoun for the basic pair: \textbf{Tudo bem? — Tudo be
 
 
 \begin{quote}
-\textbf{Warm-up.} {[}PAUSE 2s{]} \textbf{Tudo bem?} needs no verb. Portuguese also offers two familiar metaphors, using the \textbf{como} (“how”) you already know.
+\textbf{Warm-up.} {[}PAUSE 2s{]} \textbf{Tudo bem?} needs no verb. \textbf{Como} (“how”) also builds two familiar metaphors.
 
 \noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}

--- a/code/learning/human-languages/portuguese/book/chapters/ch03-introductions.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch03-introductions.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:fe554312c9530dd0
+% canonical-source-hash: fnv1a64:cbeaa2b81cbf1c89
 % canonical-lessons: PT-C03-eu, PT-C03-me-chamo, PT-C03-como-se-chama, PT-C03-prazer, PT-C03-practice
 
 \chapter{Introducing Yourself}
@@ -8,7 +8,7 @@
 This chapter is generated from the canonical micro-lessons used by Language Ladder.
 Each section stays independently resumable and preserves the authored prerequisite order.
 
-\section[eu]{eu — "I," the pronoun Portuguese usually drops}
+\section[eu]{eu — “I,” often dropped in Portuguese}
 
 \label{lesson:PT-C03-eu}
 

--- a/code/learning/human-languages/portuguese/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch04-farewells.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:5525ef6075d2060a
+% canonical-source-hash: fnv1a64:66911b57472a9ba2
 % canonical-lessons: PT-C04-adeus, PT-C04-ate-logo, PT-C04-ate-amanha, PT-C04-ate-breve, PT-C04-practice
 
 \chapter{Farewells}
@@ -107,7 +107,7 @@ So \textbf{até logo} = "\textbf{until soon}" — the exact mirror of Spanish \t
 
 
 \begin{quote}
-\textbf{Warm-up.} {[}PAUSE 2s{]} Same frame — \emph{até} + a "when." \textbf{Até amanhã}, "until tomorrow." And \emph{amanhã} is the Portuguese cousin of a Spanish word you already know, wearing a heavy nasal ending.
+\textbf{Warm-up.} {[}PAUSE 2s{]} Same frame — \emph{até} + a “when.” \textbf{Até amanhã} means “until tomorrow.” Its second word is the Portuguese cousin of a Spanish word you already know, wearing a heavy nasal ending.
 \end{quote}
 
 \begin{sounds}

--- a/code/learning/human-languages/portuguese/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch05-first-verbs.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:fca2fd8fd1da3e96
+% canonical-source-hash: fnv1a64:dc1f079cde196fa2
 % canonical-lessons: PT-C05-falar, PT-C05-morar, PT-C05-trabalhar, PT-C05-falo-portugues, PT-C05-practice
 
 \chapter{The First Verbs}
@@ -15,7 +15,9 @@ Each section stays independently resumable and preserves the authored prerequisi
 
 
 \begin{quote}
-\textbf{Warm-up.} {[}PAUSE 2s{]} Until now you've assembled fixed phrases. \textbf{falar} ("to speak") is your first real \textbf{verb} — the model for the big \textbf{-ar} family — and it hides a beautiful contrast with Spanish, right at its first letter.
+\textbf{Warm-up.} {[}PAUSE 2s{]}
+
+Until now you've assembled fixed phrases. \textbf{Falar} (“to speak”) is your first real \textbf{verb} and the model for the large \textbf{-ar} family. Its first letter also hides a beautiful contrast with Spanish.
 \end{quote}
 
 \begin{sounds}

--- a/code/learning/human-languages/portuguese/book/chapters/ch08-telling-time.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch08-telling-time.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:074f8f7eba5b6b2a
+% canonical-source-hash: fnv1a64:bcad5cb560fb13f6
 % canonical-lessons: PT-C08-hora, PT-C08-meio-dia-meia-noite
 
 \chapter{Telling Time}
@@ -59,11 +59,11 @@ Literally "\textbf{they are} two \textbf{hours}." Two things to notice, both fro
 
 
 \begin{quote}
-\textbf{Warm-up.} {[}PAUSE 2s{]} The two named hours. \textbf{meio-dia} (noon) and \textbf{meia-noite} (midnight) are the \textbf{middle} of the day and the night — and \emph{meia-noite} hides a sound-shift you already met back in the numbers.
+\textbf{Warm-up.} {[}PAUSE 2s{]} Two named hours: \textbf{meio-dia} is noon; \textbf{meia-noite} is midnight. Each names the \textbf{middle} of the day or night, and \emph{meia-noite} hides a sound-shift you already met in the numbers.
 \end{quote}
 
 \begin{cousinweb}
-The front piece is \textbf{meio/meia}, "half, middle," from Latin \textbf{medius/media} (cousin of English \emph{mid, medium} and of Spanish \emph{medio}):
+Both phrases begin with \textbf{meio/meia}, “half, middle.” It comes from Latin \textbf{medius/media}, cousin of English \emph{mid, medium} and Spanish \emph{medio}:
 
 \noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}

--- a/code/learning/human-languages/portuguese/book/chapters/ch17-head-and-hand.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch17-head-and-hand.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:dff69b7e6fc4d902
+% canonical-source-hash: fnv1a64:05efdf7fd1a723f5
 % canonical-lessons: PT-C17-cabeca, PT-C17-cabeca-caput, PT-C17-mao
 
 \chapter{Head and Hand}
@@ -62,7 +62,9 @@ In Brazilian Portuguese you may hear \textbf{Minha cabeça está doendo}. Both b
 
 
 \begin{quote}
-\textbf{Warm-up.} {[}PAUSE 2s{]} \textbf{Cabeça} kept Latin \emph{caput}, “head.” Other languages replaced that everyday word with containers, which makes the Portuguese survival visible.
+\textbf{Warm-up.} {[}PAUSE 2s{]}
+
+\textbf{Cabeça} kept Latin \emph{caput}, “head.” Other languages used container words instead. That contrast makes the Portuguese survival visible.
 
 \noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
@@ -106,7 +108,7 @@ Portuguese therefore holds a \textbf{doublet}: one word inherited through genera
 {[}REPEAT x2{]} “Cabeça and capital — two routes from \emph{caput}.”
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
-{[}PAUSE 3s{]} Which languages kept the \emph{caput} head-word? (\textbf{Portuguese and Spanish}.) What did French, Italian, and German substitute? (\textbf{Container words}.) What is the doubling in \emph{cabeça / capital}? (One \textbf{inherited}, one \textbf{re-borrowed}.) Next: the hand and the disappearing \emph{n}.
+{[}PAUSE 3s{]} Which two languages kept \emph{caput} as their everyday head-word? (\textbf{Portuguese and Spanish}.) What did French, Italian, and German use instead? (\textbf{Container words}.) Why do \emph{cabeça} and \emph{capital} look different? (One is \textbf{inherited}; one is \textbf{re-borrowed}.) Next: the hand and the disappearing \emph{n}.
 \end{tcolorbox}
 \section[a mão]{a mão — "the hand"}
 

--- a/code/learning/human-languages/portuguese/lessons/PT-C02-como-vai-esta.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C02-como-vai-esta.md
@@ -33,8 +33,8 @@ reviews_of: [PT-C02-tudo-bem, PT-C02-como]
 ## Warm-up
 <!-- hl-knowledge: introduces=[PT-LEX-COMO-VAI-ESTA-01]; assesses=[] -->
 
-[PAUSE 2s] **Tudo bem?** needs no verb. Portuguese also offers two familiar
-metaphors, using the **como** (“how”) you already know.
+[PAUSE 2s] **Tudo bem?** needs no verb. **Como** (“how”) also builds two
+familiar metaphors.
 
 | question | literally | verb |
 |---|---|---|

--- a/code/learning/human-languages/portuguese/lessons/PT-C03-eu.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C03-eu.md
@@ -28,7 +28,7 @@ variety: standard-contemporary
 reviews_of: [PT-C04-adeus]
 ---
 
-# eu — "I," the pronoun Portuguese usually drops
+# eu — “I,” often dropped in Portuguese
 
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[] -->

--- a/code/learning/human-languages/portuguese/lessons/PT-C04-ate-amanha.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C04-ate-amanha.md
@@ -33,9 +33,9 @@ reviews_of: [PT-C04-ate-logo]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[] -->
 
-[PAUSE 2s] Same frame — *até* + a "when." **Até amanhã**, "until tomorrow." And
-*amanhã* is the Portuguese cousin of a Spanish word you already know, wearing a
-heavy nasal ending.
+[PAUSE 2s] Same frame — *até* + a “when.” **Até amanhã** means “until tomorrow.”
+Its second word is the Portuguese cousin of a Spanish word you already know,
+wearing a heavy nasal ending.
 
 ## Sounds you'll need
 <!-- hl-knowledge: introduces=[PT-SOUND-ATE-AMANHA-02]; assesses=[] -->

--- a/code/learning/human-languages/portuguese/lessons/PT-C05-falar.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C05-falar.md
@@ -33,9 +33,11 @@ reviews_of: [PT-C03-practice, PT-C04-practice]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[] -->
 
-[PAUSE 2s] Until now you've assembled fixed phrases. **falar** ("to speak") is
-your first real **verb** — the model for the big **-ar** family — and it hides a
-beautiful contrast with Spanish, right at its first letter.
+[PAUSE 2s]
+
+Until now you've assembled fixed phrases. **Falar** (“to speak”) is
+your first real **verb** and the model for the large **-ar** family. Its first
+letter also hides a beautiful contrast with Spanish.
 
 ## Sounds you'll need
 <!-- hl-knowledge: introduces=[PT-SOUND-FALAR-02]; assesses=[] -->

--- a/code/learning/human-languages/portuguese/lessons/PT-C08-meio-dia-meia-noite.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C08-meio-dia-meia-noite.md
@@ -33,15 +33,15 @@ reviews_of: [PT-C08-hora, PT-C06-numeros-6-10, PT-C07-dias-2]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[] -->
 
-[PAUSE 2s] The two named hours. **meio-dia** (noon) and **meia-noite** (midnight)
-are the **middle** of the day and the night — and *meia-noite* hides a sound-shift
-you already met back in the numbers.
+[PAUSE 2s] Two named hours: **meio-dia** is noon; **meia-noite** is midnight.
+Each names the **middle** of the day or night, and *meia-noite* hides a
+sound-shift you already met in the numbers.
 
 ## The two words, taken apart
 <!-- hl-knowledge: introduces=[PT-ETYMON-MEIO-DIA-MEIA-NOITE-02]; assesses=[] -->
 
-The front piece is **meio/meia**, "half, middle," from Latin **medius/media**
-(cousin of English *mid, medium* and of Spanish *medio*):
+Both phrases begin with **meio/meia**, “half, middle.” It comes from Latin
+**medius/media**, cousin of English *mid, medium* and Spanish *medio*:
 
 | Portuguese | = | ← Latin | literally |
 |---|---|---|---|

--- a/code/learning/human-languages/portuguese/lessons/PT-C17-cabeca-caput.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C17-cabeca-caput.md
@@ -33,8 +33,10 @@ reviews_of: [PT-C17-cabeca]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[] -->
 
-[PAUSE 2s] **Cabeça** kept Latin *caput*, “head.” Other languages replaced that
-everyday word with containers, which makes the Portuguese survival visible.
+[PAUSE 2s]
+
+**Cabeça** kept Latin *caput*, “head.” Other languages used container
+words instead. That contrast makes the Portuguese survival visible.
 
 | language | “head” | older picture |
 |---|---|---|
@@ -75,7 +77,7 @@ because each route changes it differently.
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[PT-SOUND-CABECA-02, PT-ETYMON-CABECA-03, PT-ETYMON-CABECA-CAPUT-02] -->
 
-[PAUSE 3s] Which languages kept the *caput* head-word? (**Portuguese and
-Spanish**.) What did French, Italian, and German substitute? (**Container
-words**.) What is the doubling in *cabeça / capital*? (One **inherited**, one
-**re-borrowed**.) Next: the hand and the disappearing *n*.
+[PAUSE 3s] Which two languages kept *caput* as their everyday head-word?
+(**Portuguese and Spanish**.) What did French, Italian, and German use instead?
+(**Container words**.) Why do *cabeça* and *capital* look different? (One is
+**inherited**; one is **re-borrowed**.) Next: the hand and the disappearing *n*.


### PR DESCRIPTION
## Summary

- make deliberately short Portuguese micro-lesson pages use natural bottoms instead of generating eleven underfull vertical boxes
- refine copy flow in six canonical lessons to remove six overfull and two underfull horizontal boxes without dropping vocabulary, grammar, or etymology
- regenerate the six affected chapter fingerprints shared by Language Ladder and the book
- reprioritize the backlog so French Chapters 17–23 are next

## Validation

- `npm test` — human-language-data: 81 tests
- `npm run validate` — 9 integration tests
- `npm run check:books`
- `npm test` — Language Ladder: 319 tests
- `npm run build` — Language Ladder production build
- forced XeLaTeX build: 105 pages, 0 missing glyphs, 0 overfull/underfull boxes, 0 duplicate destinations, 0 Hyperref warnings, 0 LaTeX warnings
- rendered and inspected all 105 pages; verified 19 top-level outline entries and no leaked generator metadata