### PR TITLE
fix(adj): replace dead percent change source

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/fl4_percent_average_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/fl4_percent_average_e2e.rs
@@ -99,8 +99,8 @@ fn percent_change_composes_difference_and_quotient() {
         "percent_change(200, 250) = 25: {s}"
     );
     assert!(
-        s.contains("mathworld.wolfram.com/PercentageChange.html"),
-        "primary cites the percentage-change definition: {s}"
+        s.contains("www2.census.gov/programs-surveys/acs/tech_docs/accuracy/percchg.pdf"),
+        "primary cites the Census Bureau percentage-change definition: {s}"
     );
     assert!(
         s.contains("mathworld.wolfram.com/Difference.html"),

--- a/code/specs/ADJ-STDLIB-COVERAGE.md
+++ b/code/specs/ADJ-STDLIB-COVERAGE.md
@@ -308,8 +308,14 @@ option mapping, or judge/evaluation failure.
 7i. **Complete:** expose that parser inventory as canonical JSON with the exact input,
     declaration, and final-body SHA-256s so CAS tooling can consume a stable byte-level
     boundary without serializing `f64` AST literals as if they preserved source exactness.
-8. Replace the dead MathWorld `PercentageChange` locator before migrating
-   `percent.adj`; a source returning 404 cannot ground that clause.
+8. **Complete for source replacement:** `percent.adj` now cites the U.S. Census
+   Bureau `Percent Changes` PDF, verified reachable on 2026-08-03 instead of the
+   former MathWorld 404. Its displayed initial-to-final formula supports the
+   ordinary nonzero-baseline computation composed from `difference` and `quotient`.
+   This does not claim byte provenance or complete domain semantics: deterministic
+   PDF decomposition, explicit zero/negative-baseline policy review,
+   repository-input IR, parser inventory, derivations, witnesses, and CAS
+   registration remain part of the Wave 1 migration.
 9. Add executable formula preconditions or domain guards before migrating
    `proportion.adj`; `a/b=c/x` requires nonzero `a`, `b`, and `c`, while the
    current formula fails closed only on its final divisor.

--- a/code/specs/data/adj-formula-stdlib/arithmetic/percent.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/percent.adj
@@ -66,7 +66,7 @@ formulabook percentages {
     % share of the old amount, expressed per hundred. Composes `difference` and
     % `quotient` from arithmetic.adj.
     formula percent_change(old_amount, new_amount) = quotient(difference(new_amount, old_amount), old_amount) * 100
-        source "Percentage change is the difference between the final and initial value of a quantity, divided by the initial value, expressed as a percentage."
-        locator "https://mathworld.wolfram.com/PercentageChange.html"
+        source "Computing the Percent Change: %CHG = (EST final year - EST initial year) / EST initial year * 100."
+        locator "https://www2.census.gov/programs-surveys/acs/tech_docs/accuracy/percchg.pdf"
         trust authoritative
 }


### PR DESCRIPTION
## Summary
- replace the dead MathWorld percentage-change locator with the U.S. Census Bureau `Percent Changes` PDF
- update the executable CLI provenance assertion to require the replacement locator
- mark only the source-replacement backlog item complete while retaining PDF decomposition, domain review, and CAS migration as open work

## Why
The prior URL returns HTTP 404 and cannot ground a future byte-provenance bundle. The Census PDF was verified reachable on 2026-08-03 and states the initial-to-final percent-change formula used by `percent.adj`.

## Scope boundary
This PR does not add source bytes to CAS or claim `percent.adj` is byte verified. Zero/negative-baseline policy, deterministic PDF decomposition, repository-input IR, parser inventory, derivations, witnesses, and registration remain explicit Wave 1 work.

## Validation
- `cargo test --test fl4_percent_average_e2e` (4 passed)
- strict ADJ stdlib report with unreferenced-test gate
- coverage manifest JSON Schema validation (6 roots, 10 objectives)
- manifest tests (12 passed) and report tests (9 passed)
- `rustfmt --check` and `git diff --check`
- independent source and implementation-scope audits; final diff cleared