### PR TITLE
fix(spice): lower BJT forward-beta alias

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate BJT model-card `BF` / `BETA` / `BETA_F` forward beta and lower the
+  `BETA` alias instead of silently dropping it.
 - Validate diode model-card `CJO` / `CJ` / `CJ0` junction capacitance and
   lower the `CJ` alias instead of silently dropping it.
 - Validate diode model-card `VT` / `V_T` thermal voltage and lower the `V_T`

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1291,7 +1291,9 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             fields[3],
             polarity=model.kind,
             Is=model.params.get("IS", 1e-14),
-            beta_f=model.params.get("BETA_F", model.params.get("BF", 100.0)),
+            beta_f=model.params.get(
+                "BF", model.params.get("BETA", model.params.get("BETA_F", 100.0))
+            ),
             Vt=model.params.get("VT", 0.02585),
             Cje=model.params.get("CJE", model.params.get("CBE", 0.0)),
             Cjc=model.params.get("CJC", model.params.get("CBC", 0.0)),
@@ -1928,6 +1930,15 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(junction_capacitance) or junction_capacitance < 0.0
         ):
             raise NetlistParseError("diode CJO must be finite and non-negative")
+    if kind in {"NPN", "PNP"}:
+        forward_beta = next(
+            (params[name] for name in ("BF", "BETA", "BETA_F") if name in params),
+            None,
+        )
+        if forward_beta is not None and (
+            not math.isfinite(forward_beta) or forward_beta <= 0.0
+        ):
+            raise NetlistParseError("BJT BF must be finite and positive")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -928,6 +928,30 @@ Qp col base emit slow
     assert isclose(bjt.Vt, 26.0e-3)
 
 
+def test_parse_bjt_forward_beta_alias_with_canonical_precedence() -> None:
+    parsed = parse_netlist(
+        """
+.model fast NPN(BF=120 BETA=90 BETA_F=80)
+Q1 col base emit fast
+.model slow PNP(BETA=75)
+Q2 col base emit slow
+"""
+    )
+
+    first, second = parsed.circuit.elements
+    assert isinstance(first, BJT)
+    assert isinstance(second, BJT)
+    assert first.beta_f == 120.0
+    assert second.beta_f == 75.0
+
+
+@pytest.mark.parametrize("parameter", ["BF", "BETA", "BETA_F"])
+@pytest.mark.parametrize("value", ["0", "-1", "1e999"])
+def test_rejects_invalid_bjt_forward_beta(parameter: str, value: str) -> None:
+    with pytest.raises(NetlistParseError, match="BJT BF must be finite and positive"):
+        parse_netlist(f".model fast NPN({parameter}={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate BJT model-card `BF` / `BETA` / `BETA_F` forward beta and lower the
+  `BETA` alias instead of silently dropping it.
 - Validate diode model-card `CJO` / `CJ` / `CJ0` junction capacitance and
   lower the `CJ` alias instead of silently dropping it.
 - Validate diode model-card `VT` / `V_T` thermal voltage and lower the `V_T`

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1175,6 +1175,15 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("diode CJO must be finite and non-negative");
   }
+  const bjtForwardBeta =
+    params.get("BF") ?? params.get("BETA") ?? params.get("BETA_F");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtForwardBeta !== undefined &&
+    (!Number.isFinite(bjtForwardBeta) || bjtForwardBeta <= 0.0)
+  ) {
+    throw new NetlistParseError("BJT BF must be finite and positive");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -1725,7 +1734,10 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       fields[3],
       model.kind,
       model.params.get("IS") ?? 1.0e-14,
-      model.params.get("BF") ?? model.params.get("BETA_F") ?? 100.0,
+      model.params.get("BF") ??
+        model.params.get("BETA") ??
+        model.params.get("BETA_F") ??
+        100.0,
       model.params.get("VT") ?? 0.02585,
       model.params.get("CJE") ?? model.params.get("CBE") ?? 0.0,
       model.params.get("CJC") ?? model.params.get("CBC") ?? 0.0,

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -915,6 +915,40 @@ Q2 out base emit slow
     expect(element.thermalVoltage).toBeCloseTo(26.0e-3, 12);
   });
 
+  it("parses the BJT BETA forward-beta alias with canonical precedence", () => {
+    const parsed = parseNetlist(`
+.model fast NPN(BF=120 BETA=90 BETA_F=80)
+Q1 col base emit fast
+.model slow PNP(BETA=75)
+Q2 col base emit slow
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      forwardBeta: 120.0,
+    });
+    expect(parsed.circuit.elements()[1]).toMatchObject({
+      kind: "bjt",
+      forwardBeta: 75.0,
+    });
+  });
+
+  it.each([
+    ["BF", "0"],
+    ["BF", "-1"],
+    ["BF", "1e999"],
+    ["BETA", "0"],
+    ["BETA", "-1"],
+    ["BETA", "1e999"],
+    ["BETA_F", "0"],
+    ["BETA_F", "-1"],
+    ["BETA_F", "1e999"],
+  ])("rejects invalid BJT %s forward beta %s", (parameter, value) => {
+    expect(() => parseNetlist(`.model fast NPN(${parameter}=${value})`)).toThrow(
+      "BJT BF must be finite and positive",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4340,11 +4340,17 @@ the Rust, Python, and TypeScript surfaces together.
    - Both parser facades validate positive finite `VT` / `V_T` values and
      lower `V_T` into the shared engine diode thermal-voltage field.
 
+405. Python and TypeScript Berkeley SPICE diode junction-capacitance alias parity.
+   - Status: completed in PR 9745.
+   - Both parser facades validate non-negative finite `CJO` / `CJ` / `CJ0`
+     values and lower `CJ` into the shared engine diode junction-capacitance
+     field.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE BJT model-card alias parity.
    - Align parser validation and lowering with the shared engine aliases,
-     starting with `BETA` as a forward-beta alias for `BF`.
+     continuing with `HFE` as a forward-beta alias for `BF` after `BETA`.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary
- validate positive finite BJT forward beta across `BF`, `BETA`, and `BETA_F`
- lower `BETA` with synchronized canonical precedence in Python and TypeScript
- add parity tests, changelogs, and advance the SPICE backlog to `HFE`

## Verification
- Python spice-netlist-parser `bash BUILD`: 258 passed, 88.82% coverage
- Python spice-netlist-parser `.venv/bin/ruff check .`: passed
- TypeScript spice-engine `npm run build && npm test`: 448 passed
- TypeScript spice-netlist-parser `bash BUILD`: 247 passed
- TypeScript spice-netlist-parser `npm run test:coverage`: 247 passed, 85.67% line coverage