### PR TITLE
feat(smart-home): add Blue Iris camera controls

### DIFF
--- a/code/packages/rust/smart-home-blue-iris-integration/CHANGELOG.md
+++ b/code/packages/rust/smart-home-blue-iris-integration/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.2.0
+
+- Add permission-probed manual-recording control through the typed D23 camera
+  command with exact `camlist.isManRec` readback verification.
+- Add PTZ preset recall and five-second-bounded directional movement when both
+  the session and camera expose native PTZ support.
+- Add explicit native stop, fresh login/logout lifecycle, human approval, and
+  loopback protocol coverage for every control path.
+
 ## 0.1.0
 
 - Add manual local-HTTPS endpoint intake and Vault-backed Blue Iris credentials.

--- a/code/packages/rust/smart-home-blue-iris-integration/Cargo.toml
+++ b/code/packages/rust/smart-home-blue-iris-integration/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "smart-home-blue-iris-integration"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "Authenticated local Blue Iris NVR inspection"
+description = "Authenticated local Blue Iris NVR inspection and bounded camera controls"
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/smart-home-blue-iris-integration/README.md
+++ b/code/packages/rust/smart-home-blue-iris-integration/README.md
@@ -1,18 +1,27 @@
 # smart-home-blue-iris-integration
 
-Production-facing, read-only Blue Iris NVR inspection for D23.
+Production-facing Blue Iris NVR inspection and bounded camera control for D23.
 
 The integration accepts a manually configured local HTTPS origin and a Vault
 credential reference. After D23 authorizes `smart_home.read`, the production
 transport performs Blue Iris's documented `/json` challenge-response login and
-requests `camlist`. Credentials, the MD5 challenge response, and the resulting
-session stay inside the transport. The normalized result includes the server
-identity and each camera's enabled, online, signal, motion, trigger, alert, and
-recording state.
+requests `camlist`. Credentials, the MD5 challenge response, and each fresh
+session stay inside the transport, and every successful operation explicitly
+logs out. The normalized result includes the server identity and each camera's
+enabled, online, signal, motion, trigger, alert, and recording state.
+
+When login grants `clipcreate`, camera entities expose the typed
+`camera.recording` command. The transport changes only Blue Iris manual
+recording and confirms the result through exact `camlist.isManRec` readback.
+When login grants `ptz` and `camlist` marks a camera as PTZ-capable, entities
+also expose preset recall for presets 1 through 20 and directional movement
+with a 1-100 speed and a duration bounded to five seconds. Movement always ends
+with Blue Iris's native Stop command; an ambiguous start response also triggers
+a best-effort stop. All controls retain the existing D23 human-approval tier.
 
 Plain HTTP is accepted only for loopback transport tests. The runtime does not
-expose snapshots, streams, clips, PTZ, recording controls, configuration
-mutation, or administrative commands in this slice.
+expose snapshots, streams, clips, media transfer, general camera configuration,
+or administrative commands in this slice.
 
 Protocol reference:
 

--- a/code/packages/rust/smart-home-blue-iris-integration/src/lib.rs
+++ b/code/packages/rust/smart-home-blue-iris-integration/src/lib.rs
@@ -8,10 +8,10 @@ use http1::{parse_response_head, Http1ParseError};
 use http_core::BodyKind;
 use serde_json::{json, Map as JsonMap, Value as JsonValue};
 use smart_home_core::{
-    AgentId, Bridge, BridgeId, BridgeTransport, Capability, CapabilityId, CapabilityMode, Device,
-    DeviceId, Entity, EntityId, EntityKind, Health, IntegrationId, Metadata, ProtocolFamily,
-    ProtocolIdentifier, SmartHomeTool, StateConfidence, StateSnapshot, StateSource, Value,
-    ValueKind, VaultRef,
+    AgentId, Bridge, BridgeId, BridgeTransport, Capability, CapabilityId, CapabilityMode,
+    CommandResult, CommandType, Device, DeviceControlCommandType, DeviceId, Entity, EntityId,
+    EntityKind, Health, IntegrationId, Metadata, ProtocolFamily, ProtocolIdentifier, SmartHomeTool,
+    StateConfidence, StateSnapshot, StateSource, Value, ValueKind, VaultRef,
 };
 use smart_home_discovery::{
     DiscoveryConfidence, DiscoveryRecord, DiscoverySource, PairingRequirement,
@@ -20,21 +20,29 @@ use smart_home_local_http::{
     LocalHttpAuth, LocalHttpEndpoint, LocalHttpError, LocalHttpMethod, LocalHttpRequestPlan,
     LocalHttpRequestTemplate, LocalHttpScheme,
 };
-use smart_home_runtime::{RuntimeError, SmartHomeRuntime};
-use std::collections::BTreeSet;
+use smart_home_runtime::{RuntimeCommandToolRequest, RuntimeError, SmartHomeRuntime};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::io::{self, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
+use std::thread;
 use std::time::Duration;
 use tls_platform::{default_connector, TlsConfig, TlsConnector};
 use url_parser::{Url, UrlError};
 
-pub const VERSION: &str = "0.1.0";
+pub const VERSION: &str = "0.2.0";
 pub const INTEGRATION_ID: &str = "blue_iris";
 pub const PROTOCOL_ID: &str = "blue_iris_json";
 pub const JSON_PATH: &str = "/json";
 pub const DEFAULT_MAX_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
+pub const MIN_PTZ_SPEED: u32 = 1;
+pub const MAX_PTZ_SPEED: u32 = 100;
+pub const MAX_PTZ_DURATION_MS: u64 = 5_000;
+pub const MIN_PTZ_PRESET: u32 = 1;
+pub const MAX_PTZ_PRESET: u32 = 20;
 const MAX_SESSION_BYTES: usize = 512;
+const RECORDING_READBACK_ATTEMPTS: usize = 3;
+const RECORDING_READBACK_DELAY: Duration = Duration::from_millis(50);
 
 #[derive(Debug)]
 pub enum BlueIrisError {
@@ -58,6 +66,14 @@ pub enum BlueIrisError {
         reason: String,
     },
     MissingField(&'static str),
+    UnknownEntity(EntityId),
+    UnsupportedCommand(CommandType),
+    InvalidCommandArguments {
+        command_type: CommandType,
+        expected: &'static str,
+    },
+    PermissionDenied(&'static str),
+    VerificationFailed(String),
     Runtime(RuntimeError),
 }
 
@@ -85,6 +101,31 @@ impl fmt::Display for BlueIrisError {
                 write!(formatter, "Blue Iris {command} failed: {reason}")
             }
             Self::MissingField(field) => write!(formatter, "Blue Iris response is missing {field}"),
+            Self::UnknownEntity(entity_id) => {
+                write!(formatter, "unknown Blue Iris entity {}", entity_id.as_str())
+            }
+            Self::UnsupportedCommand(command_type) => {
+                write!(formatter, "unsupported Blue Iris command {command_type:?}")
+            }
+            Self::InvalidCommandArguments {
+                command_type,
+                expected,
+            } => write!(
+                formatter,
+                "invalid arguments for Blue Iris command {command_type:?}; expected {expected}"
+            ),
+            Self::PermissionDenied(permission) => {
+                write!(
+                    formatter,
+                    "Blue Iris session does not grant {permission} permission"
+                )
+            }
+            Self::VerificationFailed(message) => {
+                write!(
+                    formatter,
+                    "Blue Iris postcondition was not verified: {message}"
+                )
+            }
             Self::Runtime(error) => error.fmt(formatter),
         }
     }
@@ -258,12 +299,77 @@ pub struct BlueIrisSnapshot {
     pub cameras: Vec<BlueIrisCamera>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlueIrisPtzDirection {
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
+impl BlueIrisPtzDirection {
+    fn from_label(label: &str) -> Option<Self> {
+        match label {
+            "left" => Some(Self::Left),
+            "right" => Some(Self::Right),
+            "up" => Some(Self::Up),
+            "down" => Some(Self::Down),
+            _ => None,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Left => "left",
+            Self::Right => "right",
+            Self::Up => "up",
+            Self::Down => "down",
+        }
+    }
+
+    fn joystick(self, speed: u32) -> u32 {
+        let native_speed = speed.saturating_mul(15).div_ceil(100).clamp(1, 15);
+        match self {
+            Self::Left => (1 << 10) | (native_speed << 4),
+            Self::Right => (1 << 9) | (native_speed << 4),
+            Self::Up => (1 << 11) | native_speed,
+            Self::Down => (1 << 12) | native_speed,
+        }
+    }
+}
+
 pub trait BlueIrisTransport {
     fn inspect(
         &mut self,
         plan: &LocalHttpRequestPlan,
         credentials: &BlueIrisCredentials,
     ) -> Result<BlueIrisSnapshot, BlueIrisError>;
+
+    fn set_manual_recording(
+        &mut self,
+        plan: &LocalHttpRequestPlan,
+        credentials: &BlueIrisCredentials,
+        camera: &str,
+        enabled: bool,
+    ) -> Result<BlueIrisCamera, BlueIrisError>;
+
+    fn recall_ptz_preset(
+        &mut self,
+        plan: &LocalHttpRequestPlan,
+        credentials: &BlueIrisCredentials,
+        camera: &str,
+        preset: u32,
+    ) -> Result<(), BlueIrisError>;
+
+    fn move_ptz_bounded(
+        &mut self,
+        plan: &LocalHttpRequestPlan,
+        credentials: &BlueIrisCredentials,
+        camera: &str,
+        direction: BlueIrisPtzDirection,
+        speed: u32,
+        duration_ms: u64,
+    ) -> Result<(), BlueIrisError>;
 }
 
 pub struct BlueIrisLanTransport {
@@ -341,14 +447,12 @@ impl BlueIrisLanTransport {
             self.maximum_response_bytes,
         )?)?)
     }
-}
 
-impl BlueIrisTransport for BlueIrisLanTransport {
-    fn inspect(
+    fn login(
         &mut self,
         plan: &LocalHttpRequestPlan,
         credentials: &BlueIrisCredentials,
-    ) -> Result<BlueIrisSnapshot, BlueIrisError> {
+    ) -> Result<(Zeroizing<String>, BlueIrisServer), BlueIrisError> {
         let challenge = self.post_json(plan, &json!({"cmd":"login"}))?;
         let session = parse_login_challenge(&challenge)?;
         let response = challenge_response(credentials, session.as_str());
@@ -360,11 +464,151 @@ impl BlueIrisTransport for BlueIrisLanTransport {
                 "response":response.as_str(),
             }),
         )?;
-        let server = parse_login_success(&login)?;
-        let cameras = self.post_json(plan, &json!({"cmd":"camlist","session":session.as_str()}))?;
-        Ok(BlueIrisSnapshot {
-            server,
-            cameras: parse_camera_list(&cameras)?,
+        Ok((session, parse_login_success(&login)?))
+    }
+
+    fn authenticated<R>(
+        &mut self,
+        plan: &LocalHttpRequestPlan,
+        credentials: &BlueIrisCredentials,
+        operation: impl FnOnce(&mut Self, &str, &BlueIrisServer) -> Result<R, BlueIrisError>,
+    ) -> Result<R, BlueIrisError> {
+        let (session, server) = self.login(plan, credentials)?;
+        let result = operation(self, session.as_str(), &server);
+        let logout = self
+            .post_json(plan, &json!({"cmd":"logout","session":session.as_str()}))
+            .and_then(|value| require_success("logout", &value));
+        match (result, logout) {
+            (Err(error), _) => Err(error),
+            (Ok(_), Err(error)) => Err(error),
+            (Ok(value), Ok(())) => Ok(value),
+        }
+    }
+
+    fn camera_list(
+        &mut self,
+        plan: &LocalHttpRequestPlan,
+        session: &str,
+    ) -> Result<Vec<BlueIrisCamera>, BlueIrisError> {
+        let cameras = self.post_json(plan, &json!({"cmd":"camlist","session":session}))?;
+        parse_camera_list(&cameras)
+    }
+
+    fn stop_ptz(
+        &mut self,
+        plan: &LocalHttpRequestPlan,
+        session: &str,
+        camera: &str,
+    ) -> Result<(), BlueIrisError> {
+        let stop = self.post_json(
+            plan,
+            &json!({"cmd":"ptz","session":session,"camera":camera,"button":64,"updown":0}),
+        )?;
+        require_success("ptz stop", &stop)
+    }
+}
+
+impl BlueIrisTransport for BlueIrisLanTransport {
+    fn inspect(
+        &mut self,
+        plan: &LocalHttpRequestPlan,
+        credentials: &BlueIrisCredentials,
+    ) -> Result<BlueIrisSnapshot, BlueIrisError> {
+        self.authenticated(plan, credentials, |transport, session, server| {
+            Ok(BlueIrisSnapshot {
+                server: server.clone(),
+                cameras: transport.camera_list(plan, session)?,
+            })
+        })
+    }
+
+    fn set_manual_recording(
+        &mut self,
+        plan: &LocalHttpRequestPlan,
+        credentials: &BlueIrisCredentials,
+        camera: &str,
+        enabled: bool,
+    ) -> Result<BlueIrisCamera, BlueIrisError> {
+        self.authenticated(plan, credentials, |transport, session, server| {
+            if !server.clip_create_allowed {
+                return Err(BlueIrisError::PermissionDenied("clip-create"));
+            }
+            let response = transport.post_json(
+                plan,
+                &json!({"cmd":"camconfig","session":session,"camera":camera,"manrec":enabled}),
+            )?;
+            require_success("camconfig", &response)?;
+            for attempt in 0..RECORDING_READBACK_ATTEMPTS {
+                let observed = transport
+                    .camera_list(plan, session)?
+                    .into_iter()
+                    .find(|candidate| candidate.short_name == camera)
+                    .ok_or_else(|| {
+                        BlueIrisError::VerificationFailed(format!(
+                            "camera `{camera}` disappeared from camlist"
+                        ))
+                    })?;
+                if observed.manual_recording == enabled {
+                    return Ok(observed);
+                }
+                if attempt + 1 < RECORDING_READBACK_ATTEMPTS {
+                    thread::sleep(RECORDING_READBACK_DELAY);
+                }
+            }
+            Err(BlueIrisError::VerificationFailed(format!(
+                "camera `{camera}` manual recording did not become {enabled}"
+            )))
+        })
+    }
+
+    fn recall_ptz_preset(
+        &mut self,
+        plan: &LocalHttpRequestPlan,
+        credentials: &BlueIrisCredentials,
+        camera: &str,
+        preset: u32,
+    ) -> Result<(), BlueIrisError> {
+        self.authenticated(plan, credentials, |transport, session, server| {
+            if !server.ptz_allowed {
+                return Err(BlueIrisError::PermissionDenied("PTZ"));
+            }
+            let response = transport.post_json(
+                plan,
+                &json!({"cmd":"ptz","session":session,"camera":camera,"button":100 + preset}),
+            )?;
+            require_success("ptz", &response)
+        })
+    }
+
+    fn move_ptz_bounded(
+        &mut self,
+        plan: &LocalHttpRequestPlan,
+        credentials: &BlueIrisCredentials,
+        camera: &str,
+        direction: BlueIrisPtzDirection,
+        speed: u32,
+        duration_ms: u64,
+    ) -> Result<(), BlueIrisError> {
+        self.authenticated(plan, credentials, |transport, session, server| {
+            if !server.ptz_allowed {
+                return Err(BlueIrisError::PermissionDenied("PTZ"));
+            }
+            let start = transport.post_json(
+                plan,
+                &json!({
+                    "cmd":"ptz",
+                    "session":session,
+                    "camera":camera,
+                    "joystick":direction.joystick(speed),
+                    "updown":1,
+                }),
+            );
+            if let Err(error) = start.and_then(|value| require_success("ptz", &value)) {
+                let _ = transport.stop_ptz(plan, session, camera);
+                return Err(error);
+            }
+            thread::sleep(Duration::from_millis(duration_ms));
+            transport.stop_ptz(plan, session, camera)
         })
     }
 }
@@ -401,6 +645,50 @@ impl<T: BlueIrisTransport> BlueIrisClient<T> {
     pub fn inspect(&mut self) -> Result<BlueIrisSnapshot, BlueIrisError> {
         self.transport.inspect(&self.plan, &self.credentials)
     }
+
+    pub fn set_manual_recording_and_verify(
+        &mut self,
+        camera: &str,
+        enabled: bool,
+    ) -> Result<BlueIrisCamera, BlueIrisError> {
+        self.transport
+            .set_manual_recording(&self.plan, &self.credentials, camera, enabled)
+    }
+
+    pub fn recall_ptz_preset(&mut self, camera: &str, preset: u32) -> Result<(), BlueIrisError> {
+        if !(MIN_PTZ_PRESET..=MAX_PTZ_PRESET).contains(&preset) {
+            return Err(BlueIrisError::Validation(format!(
+                "PTZ preset must be between {MIN_PTZ_PRESET} and {MAX_PTZ_PRESET}"
+            )));
+        }
+        self.transport
+            .recall_ptz_preset(&self.plan, &self.credentials, camera, preset)
+    }
+
+    pub fn move_ptz_bounded(
+        &mut self,
+        camera: &str,
+        direction: BlueIrisPtzDirection,
+        speed: u32,
+        duration_ms: u64,
+    ) -> Result<(), BlueIrisError> {
+        if !(MIN_PTZ_SPEED..=MAX_PTZ_SPEED).contains(&speed)
+            || !(1..=MAX_PTZ_DURATION_MS).contains(&duration_ms)
+        {
+            return Err(BlueIrisError::Validation(
+                "PTZ movement requires speed 1 through 100 and duration_ms 1 through 5000"
+                    .to_string(),
+            ));
+        }
+        self.transport.move_ptz_bounded(
+            &self.plan,
+            &self.credentials,
+            camera,
+            direction,
+            speed,
+            duration_ms,
+        )
+    }
 }
 
 impl<T> fmt::Debug for BlueIrisClient<T> {
@@ -428,11 +716,22 @@ pub struct InstalledBlueIrisNvr {
 
 pub struct BlueIrisRuntimeIntegration<T> {
     client: BlueIrisClient<T>,
+    command_entities: BTreeMap<EntityId, BlueIrisCommandSupport>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BlueIrisCommandSupport {
+    camera: String,
+    recording: bool,
+    ptz: bool,
 }
 
 impl<T: BlueIrisTransport> BlueIrisRuntimeIntegration<T> {
     pub fn new(client: BlueIrisClient<T>) -> Self {
-        Self { client }
+        Self {
+            client,
+            command_entities: BTreeMap::new(),
+        }
     }
 
     pub fn inspect_and_install_authorized(
@@ -443,7 +742,108 @@ impl<T: BlueIrisTransport> BlueIrisRuntimeIntegration<T> {
     ) -> Result<InstalledBlueIrisNvr, BlueIrisError> {
         authorize_read(runtime, principal_id, observed_at_ms)?;
         let snapshot = self.client.inspect()?;
-        install_snapshot(runtime, &self.client.config, &snapshot, observed_at_ms)
+        let installed = install_snapshot(runtime, &self.client.config, &snapshot, observed_at_ms)?;
+        self.command_entities = installed
+            .cameras
+            .iter()
+            .zip(snapshot.cameras.iter())
+            .map(|(installed, camera)| {
+                (
+                    installed.camera_entity_id.clone(),
+                    BlueIrisCommandSupport {
+                        camera: camera.short_name.clone(),
+                        recording: snapshot.server.clip_create_allowed,
+                        ptz: snapshot.server.ptz_allowed && camera.ptz,
+                    },
+                )
+            })
+            .collect();
+        Ok(installed)
+    }
+
+    pub fn dispatch_command_authorized(
+        &mut self,
+        runtime: &mut SmartHomeRuntime,
+        principal_id: AgentId,
+        request: RuntimeCommandToolRequest,
+        now_ms: u64,
+    ) -> Result<CommandResult, BlueIrisError> {
+        let support = self
+            .command_entities
+            .get(&request.entity_id)
+            .cloned()
+            .ok_or_else(|| BlueIrisError::UnknownEntity(request.entity_id.clone()))?;
+        match request.command_type {
+            CommandType::DeviceControl(DeviceControlCommandType::SetCameraRecording) => {
+                if !support.recording {
+                    return Err(BlueIrisError::PermissionDenied("clip-create"));
+                }
+                let Value::Bool(enabled) = request.arguments else {
+                    return invalid_command_arguments(
+                        request.command_type,
+                        "a manual-recording boolean",
+                    );
+                };
+                let entity_id = request.entity_id.clone();
+                let command = runtime.authorize_command_tool(principal_id, request, now_ms)?;
+                let mut result = runtime.submit_command(command, now_ms)?;
+                let observed = self
+                    .client
+                    .set_manual_recording_and_verify(&support.camera, enabled)?;
+                let mut entity = runtime
+                    .registry()
+                    .entity(&entity_id)
+                    .cloned()
+                    .ok_or_else(|| BlueIrisError::UnknownEntity(entity_id.clone()))?;
+                entity.state = Some(StateSnapshot {
+                    entity_id: entity_id.clone(),
+                    value: camera_value(&observed),
+                    source: StateSource::Poll,
+                    observed_at_ms: now_ms,
+                    received_at_ms: now_ms,
+                    expires_at_ms: None,
+                    confidence: StateConfidence::Confirmed,
+                });
+                runtime.upsert_entity(entity)?;
+                result.message = Some(format!(
+                    "Blue Iris confirmed camera {} manual recording {}",
+                    support.camera,
+                    if enabled { "started" } else { "stopped" }
+                ));
+                Ok(result)
+            }
+            CommandType::DeviceControl(DeviceControlCommandType::RecallCameraPtzPreset) => {
+                if !support.ptz {
+                    return Err(BlueIrisError::PermissionDenied("PTZ"));
+                }
+                let preset = ptz_preset_argument(&request)?;
+                let command = runtime.authorize_command_tool(principal_id, request, now_ms)?;
+                let mut result = runtime.submit_command(command, now_ms)?;
+                self.client.recall_ptz_preset(&support.camera, preset)?;
+                result.message = Some(format!(
+                    "Blue Iris camera {} accepted PTZ preset {preset}",
+                    support.camera
+                ));
+                Ok(result)
+            }
+            CommandType::DeviceControl(DeviceControlCommandType::MoveCameraPtz) => {
+                if !support.ptz {
+                    return Err(BlueIrisError::PermissionDenied("PTZ"));
+                }
+                let (direction, speed, duration_ms) = ptz_move_arguments(&request)?;
+                let command = runtime.authorize_command_tool(principal_id, request, now_ms)?;
+                let mut result = runtime.submit_command(command, now_ms)?;
+                self.client
+                    .move_ptz_bounded(&support.camera, direction, speed, duration_ms)?;
+                result.message = Some(format!(
+                    "Blue Iris camera {} completed bounded PTZ {} movement",
+                    support.camera,
+                    direction.label()
+                ));
+                Ok(result)
+            }
+            command_type => Err(BlueIrisError::UnsupportedCommand(command_type)),
+        }
     }
 }
 
@@ -526,23 +926,29 @@ pub fn install_snapshot(
                 camera.short_name.clone(),
             )],
         })?;
+        let mut capabilities = vec![Capability::new(
+            CapabilityId::trusted("camera.health"),
+            CapabilityMode::Observe,
+            ValueKind::Object,
+        )];
+        if snapshot.server.clip_create_allowed {
+            capabilities.push(Capability::camera_recording());
+        } else {
+            capabilities.push(Capability::new(
+                CapabilityId::trusted("camera.recording"),
+                CapabilityMode::Observe,
+                ValueKind::Boolean,
+            ));
+        }
+        if snapshot.server.ptz_allowed && camera.ptz {
+            capabilities.push(Capability::camera_ptz());
+        }
         runtime.upsert_entity(Entity {
             entity_id: camera_entity_id.clone(),
             device_id: device_id.clone(),
             kind: EntityKind::Camera,
             name: camera.name.clone(),
-            capabilities: vec![
-                Capability::new(
-                    CapabilityId::trusted("camera.health"),
-                    CapabilityMode::Observe,
-                    ValueKind::Object,
-                ),
-                Capability::new(
-                    CapabilityId::trusted("camera.recording"),
-                    CapabilityMode::Observe,
-                    ValueKind::Boolean,
-                ),
-            ],
+            capabilities,
             state: Some(StateSnapshot {
                 entity_id: camera_entity_id.clone(),
                 value: camera_value(camera),
@@ -749,6 +1155,78 @@ fn camera_value(camera: &BlueIrisCamera) -> Value {
         fields.push(("number".to_string(), Value::Integer(number)));
     }
     Value::Object(fields)
+}
+
+fn ptz_preset_argument(request: &RuntimeCommandToolRequest) -> Result<u32, BlueIrisError> {
+    let preset = object_u32(&request.arguments, "preset_id");
+    match preset {
+        Some(preset) if (MIN_PTZ_PRESET..=MAX_PTZ_PRESET).contains(&preset) => Ok(preset),
+        _ => invalid_command_arguments(
+            request.command_type,
+            "an object with preset_id from 1 through 20",
+        ),
+    }
+}
+
+fn ptz_move_arguments(
+    request: &RuntimeCommandToolRequest,
+) -> Result<(BlueIrisPtzDirection, u32, u64), BlueIrisError> {
+    let direction =
+        object_text(&request.arguments, "direction").and_then(BlueIrisPtzDirection::from_label);
+    let speed = object_u32(&request.arguments, "speed");
+    let duration_ms = object_u64(&request.arguments, "duration_ms");
+    match (direction, speed, duration_ms) {
+        (Some(direction), Some(speed), Some(duration_ms))
+            if (MIN_PTZ_SPEED..=MAX_PTZ_SPEED).contains(&speed)
+                && (1..=MAX_PTZ_DURATION_MS).contains(&duration_ms) =>
+        {
+            Ok((direction, speed, duration_ms))
+        }
+        _ => invalid_command_arguments(
+            request.command_type,
+            "an object with direction left/right/up/down, speed 1 through 100, and duration_ms 1 through 5000",
+        ),
+    }
+}
+
+fn object_field<'a>(value: &'a Value, field: &str) -> Option<&'a Value> {
+    let Value::Object(fields) = value else {
+        return None;
+    };
+    fields
+        .iter()
+        .find_map(|(name, value)| (name == field).then_some(value))
+}
+
+fn object_u32(value: &Value, field: &str) -> Option<u32> {
+    let Value::Integer(value) = object_field(value, field)? else {
+        return None;
+    };
+    u32::try_from(*value).ok()
+}
+
+fn object_u64(value: &Value, field: &str) -> Option<u64> {
+    let Value::Integer(value) = object_field(value, field)? else {
+        return None;
+    };
+    u64::try_from(*value).ok()
+}
+
+fn object_text<'a>(value: &'a Value, field: &str) -> Option<&'a str> {
+    let Value::Text(value) = object_field(value, field)? else {
+        return None;
+    };
+    Some(value)
+}
+
+fn invalid_command_arguments<T>(
+    command_type: CommandType,
+    expected: &'static str,
+) -> Result<T, BlueIrisError> {
+    Err(BlueIrisError::InvalidCommandArguments {
+        command_type,
+        expected,
+    })
 }
 
 fn protocol_identifier(kind: &str, value: &str) -> Result<ProtocolIdentifier, BlueIrisError> {
@@ -993,6 +1471,13 @@ mod tests {
         }
     }
 
+    fn commandable_snapshot() -> BlueIrisSnapshot {
+        let mut snapshot = snapshot();
+        snapshot.server.clip_create_allowed = true;
+        snapshot.cameras[0].ptz = true;
+        snapshot
+    }
+
     fn authorize(runtime: &mut SmartHomeRuntime, principal: AgentId) {
         let _ = runtime.registry_mut().upsert_capability_grant(
             CapabilityGrant::for_all_smart_home(
@@ -1004,6 +1489,64 @@ mod tests {
             )
             .with_expiry(20_000),
         );
+    }
+
+    fn authorize_commands(runtime: &mut SmartHomeRuntime, principal: AgentId) {
+        let _ = runtime.registry_mut().upsert_capability_grant(
+            CapabilityGrant::for_all_smart_home(
+                CapabilityGrantId::trusted("grant:blue-iris-command-test"),
+                principal,
+                PrivilegeTier::HumanApproval,
+                "test",
+                1_000,
+            )
+            .with_expiry(20_000),
+        );
+    }
+
+    fn start_json_server(
+        responses: Vec<JsonValue>,
+    ) -> (u16, Arc<Mutex<Vec<String>>>, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let server_requests = Arc::clone(&requests);
+        let handle = thread::spawn(move || {
+            for response in responses {
+                let (stream, _) = listener.accept().unwrap();
+                let mut reader = BufReader::new(stream);
+                let mut head = String::new();
+                loop {
+                    let mut line = String::new();
+                    reader.read_line(&mut line).unwrap();
+                    if line == "\r\n" {
+                        break;
+                    }
+                    head.push_str(&line);
+                }
+                let length = head
+                    .lines()
+                    .find_map(|line| line.strip_prefix("Content-Length: "))
+                    .unwrap()
+                    .parse::<usize>()
+                    .unwrap();
+                let mut body = vec![0u8; length];
+                reader.read_exact(&mut body).unwrap();
+                server_requests
+                    .lock()
+                    .unwrap()
+                    .push(String::from_utf8(body).unwrap());
+                let body = serde_json::to_vec(&response).unwrap();
+                let reply = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                let stream = reader.get_mut();
+                stream.write_all(reply.as_bytes()).unwrap();
+                stream.write_all(&body).unwrap();
+            }
+        });
+        (port, requests, handle)
     }
 
     #[derive(Debug)]
@@ -1020,6 +1563,50 @@ mod tests {
         ) -> Result<BlueIrisSnapshot, BlueIrisError> {
             self.calls.fetch_add(1, Ordering::SeqCst);
             Ok(self.snapshot.clone())
+        }
+
+        fn set_manual_recording(
+            &mut self,
+            _plan: &LocalHttpRequestPlan,
+            _credentials: &BlueIrisCredentials,
+            camera: &str,
+            enabled: bool,
+        ) -> Result<BlueIrisCamera, BlueIrisError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let mut camera = self
+                .snapshot
+                .cameras
+                .iter()
+                .find(|candidate| candidate.short_name == camera)
+                .cloned()
+                .ok_or_else(|| BlueIrisError::VerificationFailed("camera missing".to_string()))?;
+            camera.manual_recording = enabled;
+            camera.recording = enabled;
+            Ok(camera)
+        }
+
+        fn recall_ptz_preset(
+            &mut self,
+            _plan: &LocalHttpRequestPlan,
+            _credentials: &BlueIrisCredentials,
+            _camera: &str,
+            _preset: u32,
+        ) -> Result<(), BlueIrisError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn move_ptz_bounded(
+            &mut self,
+            _plan: &LocalHttpRequestPlan,
+            _credentials: &BlueIrisCredentials,
+            _camera: &str,
+            _direction: BlueIrisPtzDirection,
+            _speed: u32,
+            _duration_ms: u64,
+        ) -> Result<(), BlueIrisError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
         }
     }
 
@@ -1119,6 +1706,125 @@ mod tests {
     }
 
     #[test]
+    fn runtime_authorizes_validates_and_confirms_blue_iris_controls() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let client = BlueIrisClient::new(
+            config(81),
+            credentials(),
+            FixedTransport {
+                snapshot: commandable_snapshot(),
+                calls: Arc::clone(&calls),
+            },
+        )
+        .unwrap();
+        let mut integration = BlueIrisRuntimeIntegration::new(client);
+        let mut runtime = SmartHomeRuntime::new();
+        let principal = AgentId::trusted("agent:controls");
+        authorize(&mut runtime, principal.clone());
+        authorize_commands(&mut runtime, principal.clone());
+        let installed = integration
+            .inspect_and_install_authorized(&mut runtime, principal.clone(), 2_000)
+            .unwrap();
+        let entity_id = installed.cameras[0].camera_entity_id.clone();
+        let entity = runtime.registry().entity(&entity_id).unwrap();
+        assert!(entity.capabilities.iter().any(
+            |capability| capability.capability_id == CapabilityId::trusted("camera.recording")
+        ));
+        assert!(entity
+            .capabilities
+            .iter()
+            .any(|capability| capability.capability_id == CapabilityId::trusted("camera.ptz")));
+
+        let recording = RuntimeCommandToolRequest::new(
+            entity_id.clone(),
+            CommandType::DeviceControl(DeviceControlCommandType::SetCameraRecording),
+            Value::Bool(true),
+        );
+        assert!(matches!(
+            integration.dispatch_command_authorized(
+                &mut runtime,
+                AgentId::trusted("agent:denied-control"),
+                recording.clone(),
+                2_500,
+            ),
+            Err(BlueIrisError::Runtime(_))
+        ));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        let invalid_move = RuntimeCommandToolRequest::new(
+            entity_id.clone(),
+            CommandType::DeviceControl(DeviceControlCommandType::MoveCameraPtz),
+            Value::Object(vec![
+                ("direction".to_string(), Value::Text("right".to_string())),
+                ("speed".to_string(), Value::Integer(50)),
+                ("duration_ms".to_string(), Value::Integer(5_001)),
+            ]),
+        );
+        assert!(matches!(
+            integration.dispatch_command_authorized(
+                &mut runtime,
+                principal.clone(),
+                invalid_move,
+                2_600,
+            ),
+            Err(BlueIrisError::InvalidCommandArguments { .. })
+        ));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        let recording_result = integration
+            .dispatch_command_authorized(&mut runtime, principal.clone(), recording, 3_000)
+            .unwrap();
+        let preset_result = integration
+            .dispatch_command_authorized(
+                &mut runtime,
+                principal.clone(),
+                RuntimeCommandToolRequest::new(
+                    entity_id.clone(),
+                    CommandType::DeviceControl(DeviceControlCommandType::RecallCameraPtzPreset),
+                    Value::Object(vec![("preset_id".to_string(), Value::Integer(4))]),
+                ),
+                4_000,
+            )
+            .unwrap();
+        let move_result = integration
+            .dispatch_command_authorized(
+                &mut runtime,
+                principal,
+                RuntimeCommandToolRequest::new(
+                    entity_id.clone(),
+                    CommandType::DeviceControl(DeviceControlCommandType::MoveCameraPtz),
+                    Value::Object(vec![
+                        ("direction".to_string(), Value::Text("right".to_string())),
+                        ("speed".to_string(), Value::Integer(50)),
+                        ("duration_ms".to_string(), Value::Integer(1)),
+                    ]),
+                ),
+                5_000,
+            )
+            .unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 4);
+        assert!(recording_result
+            .message
+            .as_deref()
+            .is_some_and(|message| message.contains("manual recording started")));
+        assert!(preset_result
+            .message
+            .as_deref()
+            .is_some_and(|message| message.contains("preset 4")));
+        assert!(move_result
+            .message
+            .as_deref()
+            .is_some_and(|message| message.contains("bounded PTZ right")));
+        let state = &runtime.registry().state(&entity_id).unwrap().value;
+        assert!(matches!(
+            state,
+            Value::Object(fields)
+                if fields.iter().any(|(field, value)|
+                    field == "manual_recording" && *value == Value::Bool(true))
+        ));
+    }
+
+    #[test]
     fn parser_skips_groups_and_sorts_cameras() {
         let value = json!({"result":"success","data":[
             {"optionDisplay":"All cameras","optionValue":"index","group":["back","front"]},
@@ -1155,6 +1861,7 @@ mod tests {
             json!({"result":"fail","session":"abc123"}),
             json!({"result":"success","session":"abc123","data":{"system name":"Home NVR","version":"6.0.9.8","admin":false,"ptz":true,"clipcreate":false,"tzone":420,"license":"must-not-persist"}}),
             json!({"result":"success","data":[{"optionDisplay":"Front Door","optionValue":"front","number":1,"isEnabled":true,"isOnline":true,"isNoSignal":false,"isRecording":true,"ptz":false,"audio":true}]}),
+            json!({"result":"success"}),
         ];
         let handle = thread::spawn(move || {
             for response in responses {
@@ -1196,14 +1903,95 @@ mod tests {
         assert_eq!(observed.server.name, "Home NVR");
         assert_eq!(observed.cameras[0].short_name, "front");
         let requests = requests.lock().unwrap();
-        assert_eq!(requests.len(), 3);
+        assert_eq!(requests.len(), 4);
         assert_eq!(requests[0], r#"{"cmd":"login"}"#);
         assert!(requests[1].contains(r#""session":"abc123""#));
         assert!(requests[1].contains(r#""response":""#));
         assert!(!requests[1].contains("operator"));
         assert!(!requests[1].contains("secret"));
         assert!(requests[2].contains(r#""cmd":"camlist""#));
+        assert!(requests[3].contains(r#""cmd":"logout""#));
         assert!(!format!("{observed:?}").contains("must-not-persist"));
+    }
+
+    #[test]
+    fn loopback_transport_proves_recording_readback_and_bounded_ptz_exchange() {
+        let login = |session: &str, clip_create: bool| {
+            vec![
+                json!({"result":"fail","session":session}),
+                json!({"result":"success","session":session,"data":{"system name":"Home NVR","version":"6.0.9.8","ptz":true,"clipcreate":clip_create}}),
+            ]
+        };
+        let mut responses = login("recording", true);
+        responses.extend([
+            json!({"result":"success","data":{"manrec":true}}),
+            json!({"result":"success","data":[{"optionDisplay":"Front Door","optionValue":"front","isEnabled":true,"isOnline":true,"isRecording":true,"isManRec":true,"ptz":true}]}),
+            json!({"result":"success"}),
+        ]);
+        responses.extend(login("preset", false));
+        responses.extend([json!({"result":"success"}), json!({"result":"success"})]);
+        responses.extend(login("move", false));
+        responses.extend([
+            json!({"result":"success"}),
+            json!({"result":"success"}),
+            json!({"result":"success"}),
+        ]);
+        let (port, requests, handle) = start_json_server(responses);
+        let mut client =
+            BlueIrisClient::new(config(port), credentials(), BlueIrisLanTransport::default())
+                .unwrap();
+        let observed = client
+            .set_manual_recording_and_verify("front", true)
+            .unwrap();
+        client.recall_ptz_preset("front", 4).unwrap();
+        client
+            .move_ptz_bounded("front", BlueIrisPtzDirection::Right, 50, 1)
+            .unwrap();
+        handle.join().unwrap();
+
+        assert!(observed.manual_recording);
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 14);
+        assert!(requests[2].contains(r#""cmd":"camconfig""#));
+        assert!(requests[2].contains(r#""camera":"front""#));
+        assert!(requests[2].contains(r#""manrec":true"#));
+        assert!(requests[3].contains(r#""cmd":"camlist""#));
+        assert!(requests[4].contains(r#""cmd":"logout""#));
+        assert!(requests[7].contains(r#""button":104"#));
+        assert!(requests[8].contains(r#""cmd":"logout""#));
+        assert!(requests[11].contains(r#""joystick":640"#));
+        assert!(requests[11].contains(r#""updown":1"#));
+        assert!(requests[12].contains(r#""button":64"#));
+        assert!(requests[12].contains(r#""updown":0"#));
+        assert!(requests[13].contains(r#""cmd":"logout""#));
+        assert!(requests.iter().all(|request| !request.contains("secret")));
+    }
+
+    #[test]
+    fn failed_ptz_start_attempts_stop_before_logout() {
+        let responses = vec![
+            json!({"result":"fail","session":"move-failure"}),
+            json!({"result":"success","session":"move-failure","data":{"system name":"Home NVR","version":"6.0.9.8","ptz":true,"clipcreate":false}}),
+            json!({"result":"fail","data":{"reason":"response lost after dispatch"}}),
+            json!({"result":"success"}),
+            json!({"result":"success"}),
+        ];
+        let (port, requests, handle) = start_json_server(responses);
+        let mut client =
+            BlueIrisClient::new(config(port), credentials(), BlueIrisLanTransport::default())
+                .unwrap();
+        assert!(matches!(
+            client.move_ptz_bounded("front", BlueIrisPtzDirection::Left, 25, 1),
+            Err(BlueIrisError::Api { command: "ptz", .. })
+        ));
+        handle.join().unwrap();
+
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 5);
+        assert!(requests[2].contains(r#""updown":1"#));
+        assert!(requests[3].contains(r#""button":64"#));
+        assert!(requests[3].contains(r#""updown":0"#));
+        assert!(requests[4].contains(r#""cmd":"logout""#));
     }
 
     #[test]

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Upgrade Blue Iris with permission-probed, readback-verified manual recording
+  and bounded PTZ controls over the authenticated local JSON session host.
 - Add first-party Blue Iris local HTTPS challenge-response authentication and
   read-only NVR/camera health inspection.
 - Record capability-probed, queue-aware Axis preset recall and bounded PTZ

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -45233,14 +45233,14 @@ pub fn first_party_catalog() -> Vec<IntegrationCatalogEntry> {
         base_entry(
             "blue_iris",
             "Blue Iris",
-            "Authenticated local Blue Iris NVR and managed-camera health inspection.",
+            "Authenticated local Blue Iris NVR inspection with verified manual recording and bounded PTZ control.",
             IntegrationCategory::CameraMedia,
             ConnectivityClass::LocalPolling,
             ImplementationStatus::FirstPartyRuntime,
             3,
             "blue_iris_json",
         )
-        .with_capabilities(&["smart_home.read"])
+        .with_capabilities(&["smart_home.read", "smart_home.command.device"])
         .with_entities(&[EntityKind::Camera])
         .with_discovery(&[DiscoveryMechanism::Manual])
         .with_auth(&[AuthMode::UsernamePassword])
@@ -45256,7 +45256,8 @@ pub fn first_party_catalog() -> Vec<IntegrationCatalogEntry> {
         .with_notes(&[
             "Production inspection uses the documented JSON challenge-response login over local HTTPS; plain HTTP is test-only on loopback.",
             "Credentials, challenge hashes, sessions, and the server license value remain outside normalized state and request-plan debug output.",
-            "PTZ, recording changes, snapshots, clips, media transfer, alerts, and administrative configuration remain separate permission-specific work.",
+            "Session permissions and camera capability gate readback-verified manual recording plus preset and bounded directional PTZ control.",
+            "Snapshots, clips, media transfer, broader camera configuration, and administrative changes remain separate permission-specific work.",
         ]),
         base_entry(
             "reolink",
@@ -81051,7 +81052,7 @@ mod tests {
     }
 
     #[test]
-    fn blue_iris_entry_exposes_authenticated_json_inspection_primitives() {
+    fn blue_iris_entry_exposes_authenticated_json_control_primitives() {
         let catalog = first_party_catalog();
         let blue_iris = find_entry(&catalog, &IntegrationId::trusted("blue_iris")).unwrap();
 
@@ -81065,6 +81066,9 @@ mod tests {
             vec![ProtocolFamily::Vendor("blue_iris_json".to_string())]
         );
         assert_eq!(blue_iris.auth_modes, vec![AuthMode::UsernamePassword]);
+        assert!(blue_iris
+            .required_capabilities
+            .contains(&CapabilityId::trusted("smart_home.command.device")));
         assert_eq!(blue_iris.target_entity_kinds, vec![EntityKind::Camera]);
         assert_eq!(blue_iris.discovery_mechanisms, vec![DiscoveryMechanism::Manual]);
         assert!(blue_iris

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -947,6 +947,28 @@ camera control while preserving the device's native arbitration boundary:
   test proves probing, denial and argument rejection before I/O, queue-cookie
   isolation, preset recall, bounded start/stop movement, and queue release.
 
+## Current Blue Iris Inspection and Control Slice
+
+This slice adds an authenticated local NVR host and the bounded camera controls
+that its documented JSON interface can verify:
+
+- Explicit local HTTPS configuration and Vault-backed credentials feed Blue
+  Iris's `/json` challenge-response login. Credentials, hashes, sessions, and
+  the returned license value remain transport-private, and each operation uses
+  a fresh session with explicit logout.
+- Authorized `camlist` inspection installs confirmed camera health, activity,
+  recording, and PTZ-support state. Plain HTTP remains loopback-test-only.
+- A session granting `clipcreate` exposes the existing typed
+  `camera.recording` command. Manual recording changes remain unconfirmed until
+  exact `camlist.isManRec` readback matches the request.
+- A session granting `ptz` plus a PTZ-capable camera exposes preset recall for
+  IDs 1-20 and left/right/up/down movement with 1-100 speed and at most five
+  seconds of duration. Movement ends with native Stop, including a best-effort
+  stop after an ambiguous start response.
+- D23 human approval occurs before control transport I/O. Runtime and real
+  loopback tests prove denied and malformed requests stop before transport,
+  recording readback, preset recall, bounded movement, Stop, and logout.
+
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
@@ -958,52 +980,49 @@ and then by prerequisite readiness:
    credential-bearing values use Vault leasing and destination validation.
 3. Add authenticated HEOS source browsing and queue insertion only after the
    account/session and Vault-leasing prerequisites are concrete.
-4. Add capability-probed Blue Iris PTZ preset and bounded movement controls only
-   when the authenticated session grants PTZ permission and the native command
-   has an explicit stop or equivalent bounded completion contract.
-5. Add Blue Iris manual-recording control only through the existing typed
-   camera-recording command, a session with clip-create permission, and exact
-   `camlist` readback verification.
-6. Add Blue Iris snapshots, alert/clip search, export, and playback only through
+4. Add Blue Iris snapshots, alert/clip search, export, and playback only through
    the camera-media lease and a concrete media executor.
-7. Add broader Blue Iris `camconfig` or administrative mutations only with
+5. Add broader Blue Iris `camconfig` or administrative mutations only with
    operation-specific D23 contracts, least-privilege permissions, and readable
    postcondition verification; do not persist the license value returned at
    login.
-8. Add automatic Blue Iris discovery only if the server exposes a documented,
+6. Add automatic Blue Iris discovery only if the server exposes a documented,
    stable LAN advertisement; the current production path is explicit local
    HTTPS endpoint configuration.
-9. Add Axis event streaming only after the existing WebSocket protocol core has
+7. Add Blue Iris focus, iris, digital-I/O, preset-setting, or broader PTZ
+   controls only when each operation has a specific native capability probe,
+   bounded semantics, and readable verification where the device exposes it.
+8. Add Axis event streaming only after the existing WebSocket protocol core has
    a concrete authenticated host, digest or short-lived session-token lifecycle,
    and subscription supervision.
-10. Add Axis snapshots and media transfer only through the camera-media lease and
+9. Add Axis snapshots and media transfer only through the camera-media lease and
    a concrete media executor.
-11. Add reusable HTTP Digest authentication before supporting Axis devices that
+10. Add reusable HTTP Digest authentication before supporting Axis devices that
    cannot expose the preferred HTTPS Basic-auth path.
-12. Enumerate Axis video sources/channels before extending PTZ beyond the current
+11. Enumerate Axis video sources/channels before extending PTZ beyond the current
    capability-probed VAPIX camera 1 boundary.
-13. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
+12. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
    only when each operation has a specific capability probe and readable state.
-14. Add Reolink snapshot, recording search/download, and playback operations only
+13. Add Reolink snapshot, recording search/download, and playback operations only
    through the existing camera-media lease and a concrete media executor.
-15. Add Reolink current-position, zoom, guard-point, or patrol controls only when
+14. Add Reolink current-position, zoom, guard-point, or patrol controls only when
    each operation has a capability-specific probe and the firmware exposes the
    native state needed to avoid invented orientation claims.
-16. Add Reolink push events only after a concrete webhook or event-stream host
+15. Add Reolink push events only after a concrete webhook or event-stream host
    and subscription lifecycle exist.
-17. Add authenticated KLAP/Tapo devices and other broader-device families only
+16. Add authenticated KLAP/Tapo devices and other broader-device families only
    after their authentication and session prerequisites are concrete.
-18. Add ONVIF PullPoint events once a concrete event host and subscription
+17. Add ONVIF PullPoint events once a concrete event host and subscription
    lifecycle exist.
-19. Add RTSP media transfer and recording once concrete media transfer and
+18. Add RTSP media transfer and recording once concrete media transfer and
    recorder host primitives exist.
-20. Add a production Matter commissioning, secure-session, and network host only
+19. Add a production Matter commissioning, secure-session, and network host only
    after certificate, fabric, Interaction Model encoding, subscription, and
    transport prerequisites exist.
-21. Add a Thread border-router host only after an actual host transport exists.
-22. Add a production Zigbee coordinator, join, and security host only after
+20. Add a Thread border-router host only after an actual host transport exists.
+21. Add a production Zigbee coordinator, join, and security host only after
    concrete coordinator transport and security primitives exist.
-23. Add production Z-Wave inclusion and S2 only after concrete host transport
+22. Add production Z-Wave inclusion and S2 only after concrete host transport
    and security primitives exist.
 
 ## End-To-End Definition


### PR DESCRIPTION
## Summary

- add capability-probed Blue Iris manual-recording control through the existing typed D23 camera command with exact `camlist.isManRec` readback
- add human-approved PTZ preset recall and five-second-bounded directional movement with native Stop and best-effort Stop after ambiguous starts
- keep credentials, challenge hashes, sessions, and logout lifecycle inside the production HTTPS transport while updating the catalog and D18-D23 completion inventory

## Validation

- `bash smart-home-blue-iris-integration/BUILD` (11 tests)
- `bash smart-home-integration-catalog/BUILD` (329 tests)
- `cargo clippy -p smart-home-blue-iris-integration -p smart-home-integration-catalog --all-targets -- -D warnings`
- post-rebase focused package, catalog capability, and strict Clippy gates

## Boundaries

- snapshots, clips, media transfer, broader camera/admin mutations, and undocumented discovery remain prerequisite-gated follow-up work
- no generated `code/packages/rust/Cargo.lock` is included