### PR TITLE
feat(human-languages): publish canonical French chapters

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -85,9 +85,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B14 | Complete (#9728) | Publish Italian Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Forty-nine schema-v2 lessons now generate sixteen chapters whose source hashes are independently verified against the Language Ladder corpus. |
 | HL-B15 | Complete (#9735) | Remove Italian's LaTeX layout and Unicode bookmark warnings. | The forced 104-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
 | HL-B16 | Complete (#9744) | Publish Portuguese Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Fifty schema-v2 lessons now generate sixteen chapters whose source hashes are independently verified against the Language Ladder corpus. |
-| HL-B17 | Complete in this PR | Remove Portuguese's LaTeX layout warnings. | The forced 105-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
-| HL-B18 | Next | Publish French Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | The French PDF reaches Chapter 16 while canonical app content continues through Chapter 23; schema-v2 migration plus generation should close that drift safely. |
-| HL-B19 | Queued | Remove French's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs or duplicate labels but reports sixteen overfull boxes, nine underfull boxes, and six Hyperref warnings; the clean-build signal is zero of each. |
+| HL-B17 | Complete (#9748) | Remove Portuguese's LaTeX layout warnings. | The forced 105-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
+| HL-B18 | Complete in this PR | Publish French Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | Nine schema-v2 lessons now generate seven chapters whose source hashes are independently verified against the Language Ladder corpus. |
+| HL-B19 | Next | Remove French's LaTeX layout and Unicode bookmark warnings. | The expanded forced 98-page build has no missing glyphs or duplicate destinations but retains sixteen overfull boxes, nine underfull boxes, and six Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B20 | Queued | Publish German Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | The German PDF reaches Chapter 16 while canonical app content continues through Chapter 23; schema-v2 migration plus generation should close that drift safely. |
 | HL-B21 | Queued | Remove German's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs or duplicate labels but reports seventeen overfull boxes, eleven underfull boxes, and three Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B22 | Queued | Publish Telugu Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Telugu PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
@@ -612,6 +612,28 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   pronunciation, and Chapters 1–17, and no generator metadata leaks into text.
 - HL-B18 is next: close the smaller seven-chapter French app/book gap before its
   measured presentation-cleanup follow-up.
+
+## Findings from HL-B18
+
+- French Chapters 17–23 now comprise nine strict schema-v2 micro-lessons with
+  explicit shared-spine anchors, prerequisite-closed knowledge atoms, typed
+  teaching blocks, and authored skill, mode, strand, register, variety, and
+  duration contracts. Chapters 1–16 remain readable legacy content while the
+  one-source migration proceeds incrementally.
+- All nine migrated lessons remain below five minutes: computed durations span
+  194–287 seconds. Curriculum validation reports zero duration violations and
+  zero unknown or misordered prerequisites.
+- Seven deterministic generation targets now publish Chapters 17–23 from the
+  same lesson AST loaded by Language Ladder. Their manifest covers all nine
+  lessons, and app tests independently reproduce every chapter hash and lesson
+  count. Repository-wide missing book chapters fall from 220 to 213.
+- A forced XeLaTeX build produces a 98-page book with zero missing glyphs,
+  duplicate destinations, LaTeX warnings, or leaked generator metadata. All
+  pages were rendered and inspected; the outline retains Preface,
+  pronunciation, and Chapters 1–23.
+- The expanded book retains the exact pre-existing warning baseline: sixteen
+  overfull boxes, nine underfull boxes, and six Hyperref warnings. HL-B19 is
+  next and records cleanup against the full 98-page artifact.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -270,6 +270,55 @@
       "output": "portuguese/book/chapters/ch17-head-and-hand.tex"
     },
     {
+      "language": "french",
+      "chapter": 17,
+      "title": "Head and Hand",
+      "label": "ch:fr-head-and-hand",
+      "output": "french/book/chapters/ch17-head-and-hand.tex"
+    },
+    {
+      "language": "french",
+      "chapter": 18,
+      "title": "Yes and No",
+      "label": "ch:fr-yes-and-no",
+      "output": "french/book/chapters/ch18-yes-and-no.tex"
+    },
+    {
+      "language": "french",
+      "chapter": 19,
+      "title": "Please",
+      "label": "ch:fr-please",
+      "output": "french/book/chapters/ch19-please.tex"
+    },
+    {
+      "language": "french",
+      "chapter": 20,
+      "title": "Sorry",
+      "label": "ch:fr-sorry",
+      "output": "french/book/chapters/ch20-sorry.tex"
+    },
+    {
+      "language": "french",
+      "chapter": 21,
+      "title": "Weather",
+      "label": "ch:fr-weather",
+      "output": "french/book/chapters/ch21-weather.tex"
+    },
+    {
+      "language": "french",
+      "chapter": 22,
+      "title": "Dog and Cat",
+      "label": "ch:fr-dog-and-cat",
+      "output": "french/book/chapters/ch22-dog-and-cat.tex"
+    },
+    {
+      "language": "french",
+      "chapter": 23,
+      "title": "Green and Yellow",
+      "label": "ch:fr-green-and-yellow",
+      "output": "french/book/chapters/ch23-green-and-yellow.tex"
+    },
+    {
       "language": "bengali",
       "chapter": 6,
       "title": "Numbers One to Five",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -12,6 +12,71 @@
       "tex": "bengali/book/chapters/ch06-numbers-1-5.tex"
     },
     {
+      "language": "french",
+      "chapter": 17,
+      "sourceHash": "fnv1a64:bb8682839ab17ed4",
+      "lessonIds": [
+        "FR-C17-tete",
+        "FR-C17-main"
+      ],
+      "tex": "french/book/chapters/ch17-head-and-hand.tex"
+    },
+    {
+      "language": "french",
+      "chapter": 18,
+      "sourceHash": "fnv1a64:52b8d81257884801",
+      "lessonIds": [
+        "FR-C18-oui",
+        "FR-C18-non"
+      ],
+      "tex": "french/book/chapters/ch18-yes-and-no.tex"
+    },
+    {
+      "language": "french",
+      "chapter": 19,
+      "sourceHash": "fnv1a64:bed21c4a10769e2e",
+      "lessonIds": [
+        "FR-C19-sil-vous-plait"
+      ],
+      "tex": "french/book/chapters/ch19-please.tex"
+    },
+    {
+      "language": "french",
+      "chapter": 20,
+      "sourceHash": "fnv1a64:aaf2e4df4218e86b",
+      "lessonIds": [
+        "FR-C20-je-suis-desole"
+      ],
+      "tex": "french/book/chapters/ch20-sorry.tex"
+    },
+    {
+      "language": "french",
+      "chapter": 21,
+      "sourceHash": "fnv1a64:5a4d6c65cd441e86",
+      "lessonIds": [
+        "FR-C21-le-temps"
+      ],
+      "tex": "french/book/chapters/ch21-weather.tex"
+    },
+    {
+      "language": "french",
+      "chapter": 22,
+      "sourceHash": "fnv1a64:023629163e002b64",
+      "lessonIds": [
+        "FR-C22-chien-chat"
+      ],
+      "tex": "french/book/chapters/ch22-dog-and-cat.tex"
+    },
+    {
+      "language": "french",
+      "chapter": 23,
+      "sourceHash": "fnv1a64:cb3845fade53c6da",
+      "lessonIds": [
+        "FR-C23-vert-jaune"
+      ],
+      "tex": "french/book/chapters/ch23-green-and-yellow.tex"
+    },
+    {
       "language": "gujarati",
       "chapter": 6,
       "sourceHash": "fnv1a64:388a6950ab136cc1",

--- a/code/learning/human-languages/french/CHANGELOG.md
+++ b/code/learning/human-languages/french/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Canonical Chapters 17–23 — 2026-08-03
+
+- Migrated the nine lessons in Chapters 17–23 to schema version 2 with typed
+  blocks, explicit shared-spine concepts, prerequisite-closed knowledge atoms,
+  and honest sub-five-minute duration contracts.
+- Generated seven LaTeX chapters from those canonical lessons and added
+  independent Language Ladder source-hash and lesson-count assertions, so the
+  app and downloadable book now consume one source of truth through Chapter 23.
+- Expanded the book from 79 to 98 pages. A forced XeLaTeX build has no missing
+  glyphs, duplicate destinations, LaTeX warnings, or leaked generator metadata;
+  all 98 rendered pages and the 25-entry outline were inspected.
+- Recorded the unchanged baseline of sixteen overfull boxes, nine underfull
+  boxes, and six Hyperref warnings for the focused HL-B19 cleanup tranche.
+
 ## Sub-five-minute remediation — 2026-08-02
 
 - Corrected twenty-two declared five- or six-minute estimates whose lesson

--- a/code/learning/human-languages/french/README.md
+++ b/code/learning/human-languages/french/README.md
@@ -48,8 +48,17 @@ is assumed: the text supplies every Spanish form in full, as enrichment, so the
 - **Chapter 15 — The Compound Past**: passé composé, passé simple.
 - **Chapter 16 — To Be, and the Past That Takes It**: être, passé composé with
   *être*.
+- **Chapter 17 — Head and Hand**: *la tête*, *la main*.
+- **Chapter 18 — Yes and No**: *oui*, *non*.
+- **Chapter 19 — Please**: *s'il vous plaît*.
+- **Chapter 20 — Sorry**: *je suis désolé(e)*.
+- **Chapter 21 — Weather**: *le temps*, *il pleut*.
+- **Chapter 22 — Dog and Cat**: *chien*, *chat*.
+- **Chapter 23 — Green and Yellow**: *vert*, *jaune*.
 
-**All sixteen chapters are authored and in the book (79 pages).**
+**All twenty-three chapters are authored and in the book (98 pages).** Chapters
+17–23 are generated from the same canonical lesson AST and source hashes that
+Language Ladder verifies independently.
 
 ## Files
 

--- a/code/learning/human-languages/french/book/book.tex
+++ b/code/learning/human-languages/french/book/book.tex
@@ -82,5 +82,13 @@ a gate. Released under CC~BY-SA~4.0.
 \input{chapters/ch15-passe-compose}
 \input{chapters/ch16-etre}
 
+\input{chapters/ch17-head-and-hand}
+\input{chapters/ch18-yes-and-no}
+\input{chapters/ch19-please}
+\input{chapters/ch20-sorry}
+\input{chapters/ch21-weather}
+\input{chapters/ch22-dog-and-cat}
+\input{chapters/ch23-green-and-yellow}
+
 
 \end{document}

--- a/code/learning/human-languages/french/book/chapters/ch17-head-and-hand.tex
+++ b/code/learning/human-languages/french/book/chapters/ch17-head-and-hand.tex
@@ -1,0 +1,136 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:bb8682839ab17ed4
+% canonical-lessons: FR-C17-tete, FR-C17-main
+
+\chapter{Head and Hand}
+\label{ch:fr-head-and-hand}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[la tête]{la tête — "the head"}
+
+\label{lesson:FR-C17-tete}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The first body part, and one of the best etymologies in French. The word for \emph{head} is not the Latin word for head.
+\end{quote}
+
+\subsection*{You'll want to know: The word}
+\begin{quote}
+\textbf{la tête} — the head. Feminine, so \textbf{la}.
+\end{quote}
+
+\begin{cousinweb}
+Latin's word for "head" was \emph{\textbf{caput}}. You can see it surviving all over Europe:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+Portuguese & \emph{cabeça} \\
+Spanish & \emph{cabeza} \\
+Italian & \emph{capo} (now "chief, boss") \\
+English & \textbf{cap}tain, \textbf{cap}ital, de\textbf{cap}itate \\
+\bottomrule
+\end{tabularx}
+
+French has \emph{caput} too, and in two layers. \textbf{Inherited}, worn down by use: \textbf{chef} ("chief," originally "head"), \textbf{chapitre}, \textbf{cap} (a headland), \textbf{achever} ("to finish" — to bring to a head). \textbf{Re-borrowed} later, straight from written Latin: \textbf{capital}, \textbf{capitaine}, \textbf{décapiter}.
+
+What French does \emph{not} use it for is the thing on your shoulders.
+
+\textbf{Tête} comes from Latin \emph{\textbf{testa}}: an \textbf{earthenware pot}, a shell, a potsherd.
+\end{cousinweb}
+
+\begin{culture}
+Soldiers' slang. Roman troops called the skull a \emph{testa} the way English speakers say someone got hit on the \textbf{noggin} — a noggin being a small mug. It was a joke, it spread, and eventually the joke \emph{replaced the real word} in Gaul and Italy.
+
+So a French speaker saying \emph{j'ai mal à la tête} is, historically, saying "my pot hurts."
+
+\emph{Testa} is still visible in English \textbf{test} — which began as the shallow pot an alchemist used to assay metals.
+\end{culture}
+
+\begin{sounds}
+Look at the accent: \textbf{tê}te. Chapter W01 taught what a circumflex records — a letter that used to be there, almost always an \textbf{s}.
+
+\begin{quote}
+\emph{testa} $\to$ Old French \textbf{teste} $\to$ modern \textbf{tête}
+\end{quote}
+
+The \emph{s} stopped being pronounced, and the accent was put in to mark the grave. That is why English, which borrowed from Old French \emph{before} the \emph{s} fell, still has it in \textbf{test}.
+\end{sounds}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "la tête"{]}
+  \item {[}YOU SAY: "j'ai mal à la tête" — "my head hurts"{]}
+  \item {[}YOU SAY: the joke — "\emph{testa} = a \textbf{pot}"{]}
+  \item {[}YOU SAY: the receipt — "te\textbf{s}te $\to$ tê-te"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Say "the head." (\emph{La tête} — feminine.) Does it come from Latin \emph{caput}? (\textbf{No} — from \emph{\textbf{testa}}, an \textbf{earthenware pot}.) Why a pot? (Roman soldiers' \textbf{slang} for the skull, which replaced the proper word.) Where did \emph{caput} survive in French? (\textbf{Inherited} in \emph{chef}, \emph{chapitre}, \emph{cap}, \emph{achever}; \textbf{re-borrowed} in \emph{capital}, \emph{capitaine}, \emph{décapiter} — just never for the head itself.) What does the circumflex on \emph{tête} record? (\textbf{A lost \emph{s}} — \emph{teste}, still visible in English \textbf{test}.) Next: the hand.
+\end{tcolorbox}
+\section[la main]{la main — "the hand"}
+
+\label{lesson:FR-C17-main}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Where \emph{tête} abandoned its Latin ancestor, this one kept it — and then lent it to English several dozen times over.
+\end{quote}
+
+\subsection*{You'll want to know: The word}
+\begin{quote}
+\textbf{la main} — the hand. \textbf{Feminine}, and worth flagging: it ends in a consonant and still takes \emph{la}. French gender is not predictable from the ending, which is why this course always gives you the article.
+\end{quote}
+
+The \emph{-ain} is the nasal vowel from Chapter 11's \emph{pain} — say them together: \emph{pain}, \emph{main}.
+
+\begin{cousinweb}
+\textbf{Main} comes from Latin \emph{\textbf{manus}}, "hand." That word is inside an enormous number of English words, and once you see it you cannot unsee it:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{English} & \textbf{literally} \\
+\midrule
+\textbf{manual} & done by hand \\
+\textbf{manufacture} & made by hand (\emph{manus} + \emph{facere} "to make") \\
+\textbf{manuscript} & written by hand (\emph{manus} + \emph{scrībere}) \\
+\textbf{maintain} & hold in the hand (\emph{manū tenēre}) \\
+\textbf{manage} & to handle — via Italian \emph{maneggiare}, of horses \\
+\textbf{manoeuvre} & work by hand (\emph{manū operārī}) \\
+\bottomrule
+\end{tabularx}
+
+\textbf{Manufacture} is the one worth pausing on. It means "made by hand" — and it now names precisely the thing that \emph{isn't}.
+\end{cousinweb}
+
+\begin{cousinweb}
+\textbf{Maintenir} / English \textbf{maintain} is Latin \emph{manū tenēre}, "to hold in the hand" — a hand, plus the verb \emph{tenēre}, "to hold."
+
+So \emph{maintenance} — the least romantic word in any office — is literally \textbf{keeping something in hand}.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "la main" — and hear \emph{pain}, \emph{main}{]}
+  \item {[}YOU SAY: "j'ai mal à la main"{]}
+  \item {[}YOU SAY: the family — "manual, manuscript, maintain — all a \textbf{hand}"{]}
+  \item {[}YOU SAY: the irony — "\textbf{manufacture} = made by hand"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Say "the hand." (\emph{La main} — \textbf{feminine}, despite the consonant ending.) What Latin word is it from? (\emph{\textbf{Manus}}.) Give three English words built on it. (\emph{Manual}, \emph{manufacture}, \emph{manuscript}, \emph{maintain}, \emph{manage}, \emph{manoeuvre}.) What does \emph{manufacture} literally mean? ("\textbf{Made by hand}" — now the name for the opposite.) And \emph{maintenir}? (\emph{Manū tenēre}, "\textbf{hold in the hand}".) Next: the rest of the body.
+\end{tcolorbox}

--- a/code/learning/human-languages/french/book/chapters/ch18-yes-and-no.tex
+++ b/code/learning/human-languages/french/book/chapters/ch18-yes-and-no.tex
@@ -1,0 +1,117 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:52b8d81257884801
+% canonical-lessons: FR-C18-oui, FR-C18-non
+
+\chapter{Yes and No}
+\label{ch:fr-yes-and-no}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[oui]{oui — yes}
+
+\label{lesson:FR-C18-oui}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Where Spanish kept Latin's word for yes, French built a brand-new one — and named half a country after it.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{oui} = \textbf{yes}. Just two sounds, \emph{wee}.
+
+Its Romance cousins (Spanish \emph{sí}, Italian \emph{sì}) come from Latin \emph{sīc} "thus." \textbf{French took a different road entirely.} \emph{oui} comes from Old French \textbf{oïl}, and \emph{oïl} is a squeezed-down Latin phrase:
+
+\begin{quote}
+\textbf{hoc ille} ("this {[}is{]} it") $\to$ \emph{o-ïl} $\to$ \textbf{oui}
+\end{quote}
+
+You answered "yes" by saying, in effect, "\emph{that's the one}."
+\end{cousinweb}
+
+\begin{culture}
+This mattered so much it became a map. In the Middle Ages France was divided by how people said \emph{yes}:
+
+\begin{itemize}
+\raggedright
+  \item the \textbf{north} said \emph{oïl} $\to$ the \textbf{langue d'oïl} (which became modern French)
+  \item the \textbf{south} said \emph{oc} $\to$ the \textbf{langue d'oc} — still visible in the region name \textbf{Languedoc}, and in the language \textbf{Occitan}
+\end{itemize}
+
+One little answer-word, drawn as a border.
+\end{culture}
+
+\begin{grammarlens}[title={Grammar Lens: The other “yes,” si}]
+French keeps a \textbf{second} yes — \textbf{si} — for one special job: contradicting a \textbf{negative}. When someone says something \emph{isn't} so and you insist it \emph{is}, you answer \textbf{si}, not \emph{oui}:
+
+\begin{quote}
+\emph{Tu ne viens pas ?} ("You're not coming?") — \emph{\textbf{Si !}} ("Yes I am!")
+\end{quote}
+
+(That \emph{si} is the Latin \emph{sīc} the Spanish \emph{sí} also comes from — French kept it only for this contradicting move.)
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "oui" — \emph{wee}{]}
+  \item {[}YOU SAY: the origin — "hoc ille $\to$ oïl $\to$ oui": \emph{that's the one}{]}
+  \item {[}YOU SAY: the contradiction — "Tu ne viens pas ? — Si !"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} How do you say yes in French? (\textbf{oui}.) What Latin phrase is it worn down from? (\textbf{hoc ille}, "this is it," via \emph{oïl}.) What were the \emph{langue d'oïl} and \emph{langue d'oc} named after? (The two medieval words for \textbf{yes}.) When do you answer \textbf{si} instead of \emph{oui}? (To \textbf{contradict a negative} — \emph{Tu ne viens pas? — Si!})
+\end{tcolorbox}
+\section[non]{non — no / not}
+
+\label{lesson:FR-C18-non}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} After French's home-grown \emph{oui}, its \textbf{no} is the family word, shared straight with Spanish — but said the French way, through the nose.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{non} = \textbf{no}. It comes from Latin \textbf{nōn}, the same source as Spanish \emph{no} and Italian \emph{no}:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Latin \emph{nōn}} & \textbf{$\to$} \\
+\midrule
+Spanish & no \\
+Italian & no \\
+\textbf{French} & \textbf{non} \\
+\bottomrule
+\end{tabularx}
+
+Spanish dropped the \emph{n} and left a clean \emph{no}. French \textbf{kept} the \emph{n} — but turned it into a \textbf{nasal vowel}: you don't quite touch your tongue to say the final \emph{n}, you send the vowel through your nose. That's the sound written \textbf{‑on} in \emph{non}, \emph{bon}, \emph{bonjour} — you've met it before.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: The seed of French negation}]
+The word that actually carries negation inside a French sentence isn't \emph{non} but its \textbf{unstressed twin, ne} — both worn down from the same Latin \emph{nōn}. Modern French usually reinforces \emph{ne} with a second word, giving the pair \emph{ne … pas}:
+
+\begin{quote}
+\emph{Je \textbf{ne} parle \textbf{pas} français} = "I do \textbf{not} speak French."
+\end{quote}
+
+For now, \textbf{non} on its own is your answer-word. In \emph{ne … pas}, the \textbf{ne} is \emph{non}'s cousin from \emph{nōn}; the \textbf{pas} was added later — it originally meant "a step" (Latin \emph{passus}), as in "not walk a \emph{step}" — and simply stuck. That fuller sentence negation is something you'll build later.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "non" — nasal, through the nose, like the \emph{-on} in \emph{bon}{]}
+  \item {[}YOU SAY: the pair with yes — "oui / non"{]}
+  \item {[}YOU SAY: the family — Latin \emph{nōn} $\to$ Spanish \emph{no}, French \emph{non}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} How do you say no in French? (\textbf{non}.) What Latin word is it from, and which Spanish word is its twin? (\textbf{nōn}; Spanish \textbf{no}.) What did French do to the \emph{n} that Spanish dropped? (Kept it as a \textbf{nasal vowel} — the \emph{-on} sound.) What pair does full French negation usually wrap around the verb? (\emph{\textbf{ne … pas}}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/french/book/chapters/ch19-please.tex
+++ b/code/learning/human-languages/french/book/chapters/ch19-please.tex
@@ -1,0 +1,57 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:bed21c4a10769e2e
+% canonical-lessons: FR-C19-sil-vous-plait
+
+\chapter{Please}
+\label{ch:fr-please}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[s'il vous plaît]{s'il vous plaît — please}
+
+\label{lesson:FR-C19-sil-vous-plait}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} French doesn't order you to do things — it asks, very politely, \emph{if it would please you.}
+\end{quote}
+
+\begin{cousinweb}
+\textbf{s'il vous plaît} = \textbf{please} — but taken apart it's a tiny sentence:
+
+\begin{quote}
+\textbf{s'} (\emph{si}, "if") + \textbf{il} ("it") + \textbf{vous} ("you") + \textbf{plaît} ("pleases") $\to$ "\textbf{if it pleases you.}"
+\end{quote}
+
+You're not demanding; you're checking whether the favour would please them. It's the polite indirectness Spanish also uses in \emph{por favor} ("for a favour") — same courtesy, built a different way.
+
+The verb \textbf{plaît} is from Latin \textbf{placēre}, "to please" — which English borrowed wholesale: \textbf{please}, \textbf{pleasure}, \textbf{pleasant}, and (via "calm, pleasing") even \textbf{placid}.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: Formal and familiar}]
+French chooses the word for "you" by who you're talking to — and \emph{please} comes in both:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{s'il vous plaît} — \emph{vous}, the \textbf{formal / plural} you (a stranger, an elder, a room). Often written \textbf{SVP}.
+  \item \textbf{s'il te plaît} — \emph{te}, the \textbf{familiar} you (a friend, a child).
+\end{itemize}
+
+Two sounds to respect: the final \textbf{‑t} of \emph{plaît} is \textbf{silent} (\emph{pleh}), and \emph{plaît} itself carries the \emph{ai} = \emph{eh} you've met.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "s'il vous plaît" — final t silent, \emph{see voo pleh}{]}
+  \item {[}YOU SAY: taken apart — "if it pleases you"{]}
+  \item {[}YOU SAY: familiar — "s'il te plaît" to a friend{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} How do you say please in French? (\textbf{s'il vous plaît}.) What does it literally mean? ("\textbf{If it pleases you.}") Which Latin verb is \emph{plaît} from, and what English words come from it? (\textbf{placēre} — \emph{please, pleasure, placid}.) When do you say \textbf{s'il te plaît} instead? (To someone you address as \textbf{tu} — a friend or child.)
+\end{tcolorbox}

--- a/code/learning/human-languages/french/book/chapters/ch20-sorry.tex
+++ b/code/learning/human-languages/french/book/chapters/ch20-sorry.tex
@@ -1,0 +1,55 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:aaf2e4df4218e86b
+% canonical-lessons: FR-C20-je-suis-desole
+
+\chapter{Sorry}
+\label{ch:fr-sorry}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[je suis désolé(e)]{je suis désolé(e) — "I'm sorry" (literally "I am desolate")}
+
+\label{lesson:FR-C20-je-suis-desole}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You already know \textbf{s'il vous plaît}, "please" — "if it pleases you." French's "sorry" is, secretly, a much bigger word than it sounds: \textbf{désolé} is the same word as English \textbf{desolate}.
+\end{quote}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{je suis} = "\textbf{I am}."
+  \item \textbf{désolé} (feminine \textbf{désolée}) = "\textbf{sorry}," but literally "\textbf{made utterly alone / devastated.}" It comes from Latin \textbf{dēsōlāre}, "to make solitary" — \textbf{dē-} ("thoroughly, completely") + \textbf{sōlus} ("alone"), the very root of English \textbf{sole}, \textbf{solo}, \textbf{solitary}, and \textbf{desolate} itself.
+\end{itemize}
+
+So \textbf{je suis désolé(e)} literally says "\textbf{I am desolate}" — French reaches for a word of real devastation to say a plain "sorry," the way English keeps "terribly sorry" as an option rather than a requirement.
+\end{cousinweb}
+
+\begin{culture}
+French keeps two more courtesy words for different jobs:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{pardon} — a quick, all-purpose "sorry / pardon me" (bumping someone, a small slip). It comes from \textbf{pardonner}, Latin \textbf{per-} ("thoroughly") + \textbf{dōnāre} ("to give") — "to give completely," i.e. to forgive. The neat part isn't that French and Spanish coined this separately — it's that they \textbf{didn't have to}: \textbf{perdōnāre} was already one word in Late Latin, so French \emph{pardonner} and Spanish \emph{perdón/perdonar} are simply two children of the \emph{same} inherited word, not two languages independently landing on the same idea.
+  \item \textbf{excusez-moi} — "\textbf{excuse me}," from \textbf{excuser} < Latin \textbf{ex-} ("out of, free from") + \textbf{causa} ("cause, charge") — literally "to free from a charge." Reach for this to get someone's \textbf{attention}, not to apologize for a real fault.
+\end{itemize}
+
+\textbf{Je suis désolé(e)} carries the most \textbf{regret}; \textbf{pardon} is the quick, light reflex; \textbf{excusez-moi} is for getting attention. Native speakers slide between all three by feel.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "désolé" — sorry / desolate — then "je suis désolé," I am sorry{]}
+  \item {[}YOU SAY: the quick one — "pardon"{]}
+  \item {[}YOU SAY: the attention one — "excusez-moi"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \textbf{désolé} literally mean, and what English word is it identical to? (\textbf{"Made utterly alone"} — the same word as English \textbf{desolate}.) What is \textbf{pardon} built from, and why does \textbf{Spanish perdón} look just like it? (\textbf{Per- "thoroughly" + dōnāre "to give"} — both simply inherited the \emph{same} already-formed Latin word, \textbf{perdōnāre}.) What's \textbf{excusez-moi} for? (\textbf{Getting someone's attention}, not apologizing for a real fault.)
+\end{tcolorbox}

--- a/code/learning/human-languages/french/book/chapters/ch21-weather.tex
+++ b/code/learning/human-languages/french/book/chapters/ch21-weather.tex
@@ -1,0 +1,52 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:5a4d6c65cd441e86
+% canonical-lessons: FR-C21-le-temps
+
+\chapter{Weather}
+\label{ch:fr-weather}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[le temps, il pleut]{le temps, il pleut — the same Latin word, a different fate for "rain"}
+
+\label{lesson:FR-C21-le-temps}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You've seen Spanish's \emph{tiempo} mean both "time" and "weather" at once, from Latin \emph{tempus}. French has the exact same word, the exact same double meaning — because this widening happened within Latin itself, before French and Spanish went their separate ways.
+\end{quote}
+
+\subsection*{The two words: le temps — time and weather}
+\textbf{le temps} = both "\textbf{time}" and "\textbf{weather}" — from Latin \textbf{tempus}, same as Spanish's \emph{tiempo} (English kept only the "time" half: \textbf{temporal, tempo}). So \textbf{quel temps fait-il ?} ("what's the weather like?") is literally "\textbf{what time does it make}?" — the identical construction you met in Spanish's \emph{¿qué tiempo hace?}.
+
+\begin{grammarlens}[title={Grammar Lens: il fait chaud / il fait froid}]
+\begin{quote}
+\textbf{Il fait chaud.} — "It's hot." — literally "it \textbf{makes} hot." \textbf{Il fait froid.} — "It's cold." — literally "it \textbf{makes} cold."
+\end{quote}
+
+Same \emph{hacer}-style periphrasis as Spanish, just with French's own \textbf{faire} ("to make/do").
+\end{grammarlens}
+
+\begin{cousinweb}
+\begin{quote}
+\textbf{Il pleut.} — "It's raining." — from \textbf{pleuvoir} $\leftarrow$ Latin \textbf{pluere}, "to
+\end{quote}
+
+rain" — the \textbf{same} Latin verb behind Spanish's \emph{llueve}. But here's the honest difference: Spanish underwent the \textbf{pl- $\to$ ll-} shift (\emph{pluere} $\to$ \emph{llover}), while French kept the \textbf{pl-} cluster fully intact — \emph{pleuvoir} still visibly starts with \emph{pl-}, just like the Latin original. So the same Latin verb took two different sound-change paths in its two daughters: one eroded the cluster, one preserved it.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "le temps" — time, or weather, depending on context{]}
+  \item {[}YOU SAY: "il fait chaud. il fait froid." — it's hot/cold{]}
+  \item {[}YOU SAY: "il pleut" — it's raining, pl- kept intact from Latin{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What two things does \textbf{le temps} mean, and where does this polysemy come from? (\textbf{"Time"} and \textbf{"weather"} — from Latin \emph{tempus}, already double-sensed before French/Spanish split apart.) Does French's \emph{il pleut} show the same \emph{pl- $\to$ ll-} shift as Spanish's \emph{llueve}? (\textbf{No} — French kept the \emph{pl-} cluster intact; only Spanish underwent that shift.)
+\end{tcolorbox}

--- a/code/learning/human-languages/french/book/chapters/ch22-dog-and-cat.tex
+++ b/code/learning/human-languages/french/book/chapters/ch22-dog-and-cat.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:023629163e002b64
+% canonical-lessons: FR-C22-chien-chat
+
+\chapter{Dog and Cat}
+\label{ch:fr-dog-and-cat}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[chien, chat]{chien, chat — the regular one, and the well-traveled one}
+
+\label{lesson:FR-C22-chien-chat}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You've met Spanish's \emph{perro}, a genuine unsolved mystery, and Latin's own \emph{canis}/\emph{fēlēs}$\to$\emph{cattus} history. French's two animal words tell a cleaner story: one is perfectly regular, the other is the same well- documented word you already know.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{chien} ("\textbf{dog}") comes straight from Latin \textbf{canis} (accusative \emph{canem}) — and unlike Spanish, French kept it. Two separate, regular changes are stacked here: the initial \textbf{c}$\to$\textbf{ch} is the same \textbf{ca- $\to$ cha-} palatalization you can check against other Latin words — \textbf{campus} $\to$ \textbf{champ} ("field"), \textbf{cantāre} $\to$ \textbf{chanter} ("to sing"); the \textbf{a}$\to$\textbf{ie} in the middle is a different, later shift specific to words like \emph{canem} (known as Bartsch's Law — the outcome is completely regular and undisputed, even though the precise phonetic trigger is still debated). Put together, \emph{chien} is a fully \textbf{regular} sound change, following French's own rules predictably — a genuinely different story from Spanish, where the expected descendant (\emph{can}) got pushed aside by the still-unexplained \emph{perro}.
+\end{cousinweb}
+
+\begin{cousinweb}
+\textbf{chat} ("\textbf{cat}") continues \textbf{cattus}, the same Late Latin word — most likely ultimately \textbf{Afro-Asiatic} (compare Nubian \emph{kadis}) — that spread along Roman trade routes as domestic cats themselves spread out of \textbf{Egypt}. This is the identical word behind Spanish's \emph{gato} and Italian's \emph{gatto} — French, Spanish, and Italian all independently inherited the exact same Late Latin replacement for Classical \emph{fēlēs}.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "chien" — dog, the regular descendant of canis{]}
+  \item {[}YOU SAY: "champ, chanter" — the same ca- $\to$ cha- shift, in field and to sing{]}
+  \item {[}YOU SAY: "chat" — cat, the same word as Spanish's gato, from Egypt via Rome{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Is \emph{chien} a regular or irregular descendant of Latin \emph{canis}? (\textbf{Regular} — the same \emph{ca- $\to$ cha-} shift as \emph{champ} and \emph{chanter}.) Does French show the same \emph{perro}-style mystery Spanish does for "dog"? (\textbf{No} — French kept the expected Latin word.) What word does \emph{chat} continue, and where did that word most likely originate? (\textbf{Cattus}, most likely \textbf{Afro-Asiatic}, traveling with the cat out of \textbf{Egypt}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/french/book/chapters/ch23-green-and-yellow.tex
+++ b/code/learning/human-languages/french/book/chapters/ch23-green-and-yellow.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:cb3845fade53c6da
+% canonical-lessons: FR-C23-vert-jaune
+
+\chapter{Green and Yellow}
+\label{ch:fr-green-and-yellow}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[vert, jaune]{vert, jaune — the expected inheritance, and a hidden PIE-level cousin}
+
+\label{lesson:FR-C23-vert-jaune}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} French's green word is exactly what you'd expect. Its yellow word hides something you won't expect at all — a secret cousin sitting inside German.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{vert} ("\textbf{green}") $\leftarrow$ Latin \textbf{viridis} — and this is genuinely the \textbf{standard} source of "green" across nearly every Romance language: Spanish \emph{verde}, Italian \emph{verde}, Portuguese \emph{verde}, Catalan \emph{verd}. No surprise here — a clean, shared inheritance.
+\end{cousinweb}
+
+\begin{cousinweb}
+\textbf{jaune} ("\textbf{yellow}") $\leftarrow$ Latin \textbf{galbinus}, which literally meant "\textbf{yellow-green}" — an extended form of \textbf{galbus}, from \textbf{Proto-Indo- European} \emph{\textbf{*ghel-}}, "\textbf{to shine}" (with derivatives covering green, yellow, and gold alike — the same root gives Greek \emph{khlōros}, "greenish- yellow"). Here's the genuinely surprising part: this \textbf{same PIE root}, \emph{\textbf{*ghel-}}, is also usually cited as the source of \textbf{German}'s \textbf{gelb} and English's \textbf{yellow} — by a completely separate, Germanic path (Proto- Germanic \emph{\textbf{*gelwaz}}). Honesty check, though: the \emph{galbus}$\to$\emph{*ghel-} link itself is \textbf{less secure} than it looks — some modern Latin scholarship treats \emph{galbus}'s origin as unknown rather than confirming the connection. So \emph{jaune} and \emph{gelb} are \textbf{probably} cousins at the Proto-Indo-European level, despite one reaching French through Latin and the other reaching German directly through Germanic — just don't treat that link as airtight.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "vert" — green, the standard Romance word{]}
+  \item {[}YOU SAY: "jaune" — yellow, literally "yellow-green"{]}
+  \item {[}YOU SAY: the probable cousin — "jaune, gelb" — likely the same ancient PIE root, two completely different paths, though the link isn't airtight{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Is \textbf{vert} a typical or unusual Romance word for "green"? (\textbf{Typical} — the standard source across nearly all Romance languages.) What did Latin \textbf{galbinus}, the source of \emph{jaune}, literally mean? ("\textbf{Yellow-green}.") What German word is usually called \emph{jaune}'s deep PIE cousin, and how solid is that link? (\textbf{Gelb} — both usually traced to PIE \emph{*ghel-}, "to shine," though modern Latin scholarship treats \emph{galbus}'s origin as genuinely unknown, so the connection is probable, not certain.)
+\end{tcolorbox}

--- a/code/learning/human-languages/french/book/preamble.tex
+++ b/code/learning/human-languages/french/book/preamble.tex
@@ -15,6 +15,7 @@
 \tcbuselibrary{skins,breakable}
 \usepackage{booktabs}
 \usepackage{longtable}
+\usepackage{tabularx}
 \usepackage{array}
 \usepackage[hidelinks]{hyperref}
 \usepackage{titlesec}
@@ -41,10 +42,10 @@
 }
 
 % Grammar Lens callout: plain-language grammar concept + English contrast.
-\newtcolorbox{grammarlens}{
+\newtcolorbox{grammarlens}[1][]{
   breakable, skin=enhanced, colback=blue!5, colframe=blue!35!black,
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
-  fonttitle=\bfseries, title={Grammar Lens}
+  fonttitle=\bfseries, title={Grammar Lens}, #1
 }
 
 % Sounds callout: the pronunciation facts a single word needs.

--- a/code/learning/human-languages/french/lessons/FR-C17-main.md
+++ b/code/learning/human-languages/french/lessons/FR-C17-main.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: FR-C17-main
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 630
 chapter: 17
 type: word
 headword: la main
@@ -9,18 +12,32 @@ prerequisites: [FR-C17-tete, FR-C01-le-la]
 sounds: [nasal-in, silent-final]
 roots: [latin-manus]
 etymology_hook: "main ← Latin manus, the root behind MANUAL, MANUFACTURE ('made by hand'), MANUSCRIPT ('written by hand'), MAINTAIN ('hold in the hand') and MANAGE — one Latin hand is doing the work inside dozens of English words"
-est_minutes: 4
+duration:
+  max_seconds: 216
+requires:
+  knowledge: [FR-LEX-TETE-02, FR-ETYMON-TETE-03, FR-CULTURE-TETE-04, FR-SOUND-TETE-05]
+introduces:
+  knowledge: [FR-LEX-MAIN-02, FR-SOUND-MAIN-03, FR-ETYMON-MAIN-04, FR-ETYMON-MAINTENIR-05]
+practises:
+  knowledge: [FR-LEX-MAIN-02, FR-SOUND-MAIN-03, FR-ETYMON-MAIN-04, FR-ETYMON-MAINTENIR-05]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [FR-C17-tete, FR-C01-le-la]
 ---
 
 # la main — "the hand"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Where *tête* abandoned its Latin ancestor, this one kept it — and then
 lent it to English several dozen times over.
 
-## The word
+## You'll want to know: The word
+<!-- hl-knowledge: introduces=[FR-LEX-MAIN-02, FR-SOUND-MAIN-03]; assesses=[] -->
 
 > **la main** — the hand. **Feminine**, and worth flagging: it ends in a
 > consonant and still takes *la*. French gender is not predictable from the
@@ -29,7 +46,8 @@ lent it to English several dozen times over.
 The *-ain* is the nasal vowel from Chapter 11's *pain* — say them together:
 *pain*, *main*.
 
-## manus — the most productive hand in English
+## The word, taken apart: manus in English
+<!-- hl-knowledge: introduces=[FR-ETYMON-MAIN-04]; assesses=[] -->
 
 **Main** comes from Latin ***manus***, "hand." That word is inside an enormous
 number of English words, and once you see it you cannot unsee it:
@@ -46,7 +64,8 @@ number of English words, and once you see it you cannot unsee it:
 **Manufacture** is the one worth pausing on. It means "made by hand" — and it now
 names precisely the thing that *isn't*.
 
-## And French kept the phrase too
+## The phrase, taken apart: French kept it too
+<!-- hl-knowledge: introduces=[FR-ETYMON-MAINTENIR-05]; assesses=[] -->
 
 **Maintenir** / English **maintain** is Latin *manū tenēre*, "to hold in the
 hand" — a hand, plus the verb *tenēre*, "to hold."
@@ -55,6 +74,7 @@ So *maintenance* — the least romantic word in any office — is literally
 **keeping something in hand**.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-MAIN-02, FR-SOUND-MAIN-03, FR-ETYMON-MAIN-04, FR-ETYMON-MAINTENIR-05] -->
 
 [PAUSE 1s]
 - [YOU SAY: "la main" — and hear *pain*, *main*]
@@ -63,6 +83,7 @@ So *maintenance* — the least romantic word in any office — is literally
 - [YOU SAY: the irony — "**manufacture** = made by hand"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-MAIN-02, FR-SOUND-MAIN-03, FR-ETYMON-MAIN-04, FR-ETYMON-MAINTENIR-05] -->
 
 [PAUSE 3s] Say "the hand." (*La main* — **feminine**, despite the consonant
 ending.) What Latin word is it from? (***Manus***.) Give three English words

--- a/code/learning/human-languages/french/lessons/FR-C17-tete.md
+++ b/code/learning/human-languages/french/lessons/FR-C17-tete.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: FR-C17-tete
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 620
 chapter: 17
 type: word
 headword: la tête
@@ -9,22 +12,37 @@ prerequisites: [FR-C01-le-la]
 sounds: [vowel-e-grave, accent-marks]
 roots: [latin-testa]
 etymology_hook: "tête does NOT come from Latin caput 'head' — it comes from testa, 'earthenware pot, shell'; Roman soldiers' slang for the skull replaced the proper word entirely, and the circumflex marks the s that testa lost (teste → tête)"
-est_minutes: 4
+duration:
+  max_seconds: 287
+requires:
+  knowledge: []
+introduces:
+  knowledge: [FR-LEX-TETE-02, FR-ETYMON-TETE-03, FR-CULTURE-TETE-04, FR-SOUND-TETE-05]
+practises:
+  knowledge: [FR-LEX-TETE-02, FR-ETYMON-TETE-03, FR-CULTURE-TETE-04, FR-SOUND-TETE-05]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [FR-C01-le-la, FR-W01-accents]
 ---
 
 # la tête — "the head"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The first body part, and one of the best etymologies in French. The
 word for *head* is not the Latin word for head.
 
-## The word
+## You'll want to know: The word
+<!-- hl-knowledge: introduces=[FR-LEX-TETE-02]; assesses=[] -->
 
 > **la tête** — the head. Feminine, so **la**.
 
-## Latin had a perfectly good word, and French threw it away
+## The word, taken apart: Latin had a perfectly good word
+<!-- hl-knowledge: introduces=[FR-ETYMON-TETE-03]; assesses=[] -->
 
 Latin's word for "head" was ***caput***. You can see it surviving all over
 Europe:
@@ -46,7 +64,8 @@ What French does *not* use it for is the thing on your shoulders.
 **Tête** comes from Latin ***testa***: an **earthenware pot**, a shell, a
 potsherd.
 
-## Why a pot?
+## Why it's said this way: Why a pot?
+<!-- hl-knowledge: introduces=[FR-CULTURE-TETE-04]; assesses=[] -->
 
 Soldiers' slang. Roman troops called the skull a *testa* the way English speakers
 say someone got hit on the **noggin** — a noggin being a small mug. It was a
@@ -59,7 +78,8 @@ hurts."
 *Testa* is still visible in English **test** — which began as the shallow pot an
 alchemist used to assay metals.
 
-## The circumflex is a receipt
+## Sounds you'll need: The circumflex is a receipt
+<!-- hl-knowledge: introduces=[FR-SOUND-TETE-05]; assesses=[] -->
 
 Look at the accent: **tê**te. Chapter W01 taught what a circumflex records — a
 letter that used to be there, almost always an **s**.
@@ -71,6 +91,7 @@ That is why English, which borrowed from Old French *before* the *s* fell,
 still has it in **test**.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-TETE-02, FR-ETYMON-TETE-03, FR-CULTURE-TETE-04, FR-SOUND-TETE-05] -->
 
 [PAUSE 1s]
 - [YOU SAY: "la tête"]
@@ -79,6 +100,7 @@ still has it in **test**.
 - [YOU SAY: the receipt — "te**s**te → tê-te"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-TETE-02, FR-ETYMON-TETE-03, FR-CULTURE-TETE-04, FR-SOUND-TETE-05] -->
 
 [PAUSE 3s] Say "the head." (*La tête* — feminine.) Does it come from Latin
 *caput*? (**No** — from ***testa***, an **earthenware pot**.) Why a pot? (Roman

--- a/code/learning/human-languages/french/lessons/FR-C18-non.md
+++ b/code/learning/human-languages/french/lessons/FR-C18-non.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: FR-C18-non
+spine_node: SPINE-RESPOND-BASIC
+sequence: 650
 chapter: 18
 type: word
 headword: non
@@ -9,18 +12,32 @@ prerequisites: [FR-C18-oui]
 sounds: [nasal-vowel-on]
 roots: [non]
 etymology_hook: "non is Latin nōn — Spanish dropped the n to make no, French kept it as a nasal vowel: the vowel itself carries the n"
-est_minutes: 3
+duration:
+  max_seconds: 219
+requires:
+  knowledge: [FR-LEX-OUI-02, FR-ETYMON-OUI-03, FR-CULTURE-OUI-04, FR-PRAGMATICS-SI-05]
+introduces:
+  knowledge: [FR-LEX-NON-02, FR-SOUND-NON-03, FR-GRAMMAR-NEGATION-04]
+practises:
+  knowledge: [FR-LEX-OUI-02, FR-LEX-NON-02, FR-SOUND-NON-03, FR-GRAMMAR-NEGATION-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [FR-C18-oui, FR-C01-bonjour]
 ---
 
 # non — no / not
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] After French's home-grown *oui*, its **no** is the family word,
 shared straight with Spanish — but said the French way, through the nose.
 
-## The word
+## The word, taken apart
+<!-- hl-knowledge: introduces=[FR-LEX-NON-02, FR-SOUND-NON-03]; assesses=[] -->
 
 **non** = **no**. It comes from Latin **nōn**, the same source as Spanish *no*
 and Italian *no*:
@@ -36,7 +53,8 @@ turned it into a **nasal vowel**: you don't quite touch your tongue to say the
 final *n*, you send the vowel through your nose. That's the sound written **‑on**
 in *non*, *bon*, *bonjour* — you've met it before.
 
-## The seed of French negation
+## Grammar Lens: The seed of French negation
+<!-- hl-knowledge: introduces=[FR-GRAMMAR-NEGATION-04]; assesses=[] -->
 
 The word that actually carries negation inside a French sentence isn't *non* but
 its **unstressed twin, ne** — both worn down from the same Latin *nōn*. Modern
@@ -50,6 +68,7 @@ step" (Latin *passus*), as in "not walk a *step*" — and simply stuck. That ful
 sentence negation is something you'll build later.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-OUI-02, FR-LEX-NON-02, FR-SOUND-NON-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "non" — nasal, through the nose, like the *-on* in *bon*]
@@ -57,6 +76,7 @@ sentence negation is something you'll build later.
 - [YOU SAY: the family — Latin *nōn* → Spanish *no*, French *non*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-NON-02, FR-SOUND-NON-03, FR-GRAMMAR-NEGATION-04] -->
 
 [PAUSE 3s] How do you say no in French? (**non**.) What Latin word is it from,
 and which Spanish word is its twin? (**nōn**; Spanish **no**.) What did French do

--- a/code/learning/human-languages/french/lessons/FR-C18-oui.md
+++ b/code/learning/human-languages/french/lessons/FR-C18-oui.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: FR-C18-oui
+spine_node: SPINE-RESPOND-BASIC
+sequence: 640
 chapter: 18
 type: word
 headword: oui
@@ -9,18 +12,32 @@ prerequisites: [FR-C01-bonjour]
 sounds: [semivowel-w, vowel-i]
 roots: [hoc-ille]
 etymology_hook: "oui is Latin hoc ille 'this is it' worn through oïl — the whole north of France was named for it: the langue d'oïl"
-est_minutes: 4
+duration:
+  max_seconds: 251
+requires:
+  knowledge: []
+introduces:
+  knowledge: [FR-LEX-OUI-02, FR-ETYMON-OUI-03, FR-CULTURE-OUI-04, FR-PRAGMATICS-SI-05]
+practises:
+  knowledge: [FR-LEX-OUI-02, FR-ETYMON-OUI-03, FR-CULTURE-OUI-04, FR-PRAGMATICS-SI-05]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [FR-C01-bonjour]
 ---
 
 # oui — yes
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Where Spanish kept Latin's word for yes, French built a brand-new one
 — and named half a country after it.
 
-## The word
+## The word, taken apart
+<!-- hl-knowledge: introduces=[FR-LEX-OUI-02, FR-ETYMON-OUI-03]; assesses=[] -->
 
 **oui** = **yes**. Just two sounds, *wee*.
 
@@ -32,7 +49,8 @@ and *oïl* is a squeezed-down Latin phrase:
 
 You answered "yes" by saying, in effect, "*that's the one*."
 
-## A word that split a country
+## Why it's said this way: A word that split a country
+<!-- hl-knowledge: introduces=[FR-CULTURE-OUI-04]; assesses=[] -->
 
 This mattered so much it became a map. In the Middle Ages France was divided by
 how people said *yes*:
@@ -43,7 +61,8 @@ how people said *yes*:
 
 One little answer-word, drawn as a border.
 
-## The other "yes": si
+## Grammar Lens: The other “yes,” si
+<!-- hl-knowledge: introduces=[FR-PRAGMATICS-SI-05]; assesses=[] -->
 
 French keeps a **second** yes — **si** — for one special job: contradicting a
 **negative**. When someone says something *isn't* so and you insist it *is*, you
@@ -55,6 +74,7 @@ answer **si**, not *oui*:
 only for this contradicting move.)
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-OUI-02, FR-ETYMON-OUI-03, FR-CULTURE-OUI-04, FR-PRAGMATICS-SI-05] -->
 
 [PAUSE 1s]
 - [YOU SAY: "oui" — *wee*]
@@ -62,6 +82,7 @@ only for this contradicting move.)
 - [YOU SAY: the contradiction — "Tu ne viens pas ? — Si !"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-OUI-02, FR-ETYMON-OUI-03, FR-CULTURE-OUI-04, FR-PRAGMATICS-SI-05] -->
 
 [PAUSE 3s] How do you say yes in French? (**oui**.) What Latin phrase is it worn
 down from? (**hoc ille**, "this is it," via *oïl*.) What were the *langue d'oïl*

--- a/code/learning/human-languages/french/lessons/FR-C19-sil-vous-plait.md
+++ b/code/learning/human-languages/french/lessons/FR-C19-sil-vous-plait.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: FR-C19-sil-vous-plait
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 660
 chapter: 19
 type: phrase
 headword: s'il vous plaît
@@ -9,18 +12,32 @@ prerequisites: [FR-C01-bonjour]
 sounds: [liaison, nasal-vowel, silent-final-t]
 roots: [placere]
 etymology_hook: "s'il vous plaît is literally 'if it pleases you' — plaît ← Latin placēre, root of English please, pleasure, placid"
-est_minutes: 4
+duration:
+  max_seconds: 194
+requires:
+  knowledge: []
+introduces:
+  knowledge: [FR-LEX-PLEASE-02, FR-ETYMON-PLAIRE-03, FR-GRAMMAR-PLEASE-REGISTER-04]
+practises:
+  knowledge: [FR-LEX-PLEASE-02, FR-ETYMON-PLAIRE-03, FR-GRAMMAR-PLEASE-REGISTER-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: contrastive-formal-informal
+variety: standard-contemporary
 reviews_of: [FR-C01-bonjour]
 ---
 
 # s'il vous plaît — please
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] French doesn't order you to do things — it asks, very politely, *if
 it would please you.*
 
-## The phrase
+## The phrase, taken apart
+<!-- hl-knowledge: introduces=[FR-LEX-PLEASE-02, FR-ETYMON-PLAIRE-03]; assesses=[] -->
 
 **s'il vous plaît** = **please** — but taken apart it's a tiny sentence:
 
@@ -35,7 +52,8 @@ The verb **plaît** is from Latin **placēre**, "to please" — which English
 borrowed wholesale: **please**, **pleasure**, **pleasant**, and (via "calm,
 pleasing") even **placid**.
 
-## Formal and familiar
+## Grammar Lens: Formal and familiar
+<!-- hl-knowledge: introduces=[FR-GRAMMAR-PLEASE-REGISTER-04]; assesses=[] -->
 
 French chooses the word for "you" by who you're talking to — and *please* comes
 in both:
@@ -48,6 +66,7 @@ Two sounds to respect: the final **‑t** of *plaît* is **silent** (*pleh*), an
 *plaît* itself carries the *ai* = *eh* you've met.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-PLEASE-02, FR-ETYMON-PLAIRE-03, FR-GRAMMAR-PLEASE-REGISTER-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "s'il vous plaît" — final t silent, *see voo pleh*]
@@ -55,6 +74,7 @@ Two sounds to respect: the final **‑t** of *plaît* is **silent** (*pleh*), an
 - [YOU SAY: familiar — "s'il te plaît" to a friend]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-PLEASE-02, FR-ETYMON-PLAIRE-03, FR-GRAMMAR-PLEASE-REGISTER-04] -->
 
 [PAUSE 3s] How do you say please in French? (**s'il vous plaît**.) What does it
 literally mean? ("**If it pleases you.**") Which Latin verb is *plaît* from, and

--- a/code/learning/human-languages/french/lessons/FR-C20-je-suis-desole.md
+++ b/code/learning/human-languages/french/lessons/FR-C20-je-suis-desole.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: FR-C20-je-suis-desole
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 670
 chapter: 20
 type: phrase
 headword: je suis désolé(e)
@@ -9,19 +12,33 @@ prerequisites: [FR-C19-sil-vous-plait]
 sounds: [nasal-vowel, silent-final-e, liaison]
 roots: [desolare-latin]
 etymology_hook: "désolé ← Latin dēsōlāre 'to make utterly alone' (dē- + sōlus 'alone') — cousin of English desolate, solo, sole, solitary"
-est_minutes: 4
+duration:
+  max_seconds: 250
+requires:
+  knowledge: [FR-LEX-PLEASE-02, FR-ETYMON-PLAIRE-03, FR-GRAMMAR-PLEASE-REGISTER-04]
+introduces:
+  knowledge: [FR-LEX-DESOLE-02, FR-ETYMON-DESOLE-03, FR-PRAGMATICS-SORRY-04]
+practises:
+  knowledge: [FR-LEX-DESOLE-02, FR-ETYMON-DESOLE-03, FR-PRAGMATICS-SORRY-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: contrastive-courtesy
+variety: standard-contemporary
 reviews_of: [FR-C19-sil-vous-plait]
 ---
 
 # je suis désolé(e) — "I'm sorry" (literally "I am desolate")
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You already know **s'il vous plaît**, "please" — "if it pleases
 you." French's "sorry" is, secretly, a much bigger word than it sounds:
 **désolé** is the same word as English **desolate**.
 
 ## The phrase, taken apart
+<!-- hl-knowledge: introduces=[FR-LEX-DESOLE-02, FR-ETYMON-DESOLE-03]; assesses=[] -->
 
 - **je suis** = "**I am**."
 - **désolé** (feminine **désolée**) = "**sorry**," but literally "**made utterly
@@ -33,7 +50,8 @@ So **je suis désolé(e)** literally says "**I am desolate**" — French reaches
 a word of real devastation to say a plain "sorry," the way English keeps
 "terribly sorry" as an option rather than a requirement.
 
-## Be honest about the other words: pardon and excusez-moi
+## Why it's said this way: pardon and excusez-moi
+<!-- hl-knowledge: introduces=[FR-PRAGMATICS-SORRY-04]; assesses=[] -->
 
 French keeps two more courtesy words for different jobs:
 
@@ -55,6 +73,7 @@ light reflex; **excusez-moi** is for getting attention. Native speakers slide
 between all three by feel.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-DESOLE-02, FR-ETYMON-DESOLE-03, FR-PRAGMATICS-SORRY-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "désolé" — sorry / desolate — then "je suis désolé," I am sorry]
@@ -62,6 +81,7 @@ between all three by feel.
 - [YOU SAY: the attention one — "excusez-moi"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-DESOLE-02, FR-ETYMON-DESOLE-03, FR-PRAGMATICS-SORRY-04] -->
 
 [PAUSE 3s] What does **désolé** literally mean, and what English word is it
 identical to? (**"Made utterly alone"** — the same word as English

--- a/code/learning/human-languages/french/lessons/FR-C21-le-temps.md
+++ b/code/learning/human-languages/french/lessons/FR-C21-le-temps.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: FR-C21-le-temps
+spine_node: SPINE-TIME-OF-DAY
+sequence: 680
 chapter: 21
 type: phrase
 headword: le temps, il pleut
@@ -9,20 +12,34 @@ prerequisites: [FR-C14-age]
 sounds: [nasal-en, silent-final]
 roots: [tempus-latin, pluere-latin]
 etymology_hook: "le temps means BOTH 'time' and 'weather' — the exact same Latin tempus double sense as Spanish's tiempo (this widening happened within Latin itself, shared by both languages, not a Spanish-only development); il fait chaud/froid reuse faire ('to make'), just like Spanish's hacer; il pleut ('it's raining') KEEPS Latin pluere's pl- unchanged, unlike Spanish's llueve, which underwent the pl-→ll- shift"
-est_minutes: 4
+duration:
+  max_seconds: 243
+requires:
+  knowledge: []
+introduces:
+  knowledge: [FR-LEX-TEMPS-02, FR-GRAMMAR-IL-FAIT-03, FR-LEX-IL-PLEUT-04, FR-ETYMON-PLEUVOIR-05]
+practises:
+  knowledge: [FR-LEX-TEMPS-02, FR-GRAMMAR-IL-FAIT-03, FR-LEX-IL-PLEUT-04, FR-ETYMON-PLEUVOIR-05]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [FR-C14-age]
 ---
 
 # le temps, il pleut — the same Latin word, a different fate for "rain"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You've seen Spanish's *tiempo* mean both "time" and "weather" at
 once, from Latin *tempus*. French has the exact same word, the exact same
 double meaning — because this widening happened within Latin itself, before
 French and Spanish went their separate ways.
 
-## le temps — time AND weather, again
+## The two words: le temps — time and weather
+<!-- hl-knowledge: introduces=[FR-LEX-TEMPS-02]; assesses=[] -->
 
 **le temps** = both "**time**" and "**weather**" — from Latin **tempus**,
 same as Spanish's *tiempo* (English kept only the "time" half: **temporal,
@@ -30,7 +47,8 @@ tempo**). So **quel temps fait-il ?** ("what's the weather like?") is
 literally "**what time does it make**?" — the identical construction you met
 in Spanish's *¿qué tiempo hace?*.
 
-## il fait chaud / il fait froid — reusing faire, like Spanish's hacer
+## Grammar Lens: il fait chaud / il fait froid
+<!-- hl-knowledge: introduces=[FR-GRAMMAR-IL-FAIT-03]; assesses=[] -->
 
 > **Il fait chaud.** — "It's hot." — literally "it **makes** hot."
 > **Il fait froid.** — "It's cold." — literally "it **makes** cold."
@@ -38,7 +56,8 @@ in Spanish's *¿qué tiempo hace?*.
 Same *hacer*-style periphrasis as Spanish, just with French's own **faire**
 ("to make/do").
 
-## il pleut — Latin's pl- kept intact, unlike Spanish's llueve
+## The word, taken apart: il pleut
+<!-- hl-knowledge: introduces=[FR-LEX-IL-PLEUT-04, FR-ETYMON-PLEUVOIR-05]; assesses=[] -->
 
 > **Il pleut.** — "It's raining." — from **pleuvoir** ← Latin **pluere**, "to
   rain" — the **same** Latin verb behind Spanish's *llueve*. But here's the
@@ -49,6 +68,7 @@ Same *hacer*-style periphrasis as Spanish, just with French's own **faire**
   eroded the cluster, one preserved it.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-TEMPS-02, FR-GRAMMAR-IL-FAIT-03, FR-LEX-IL-PLEUT-04, FR-ETYMON-PLEUVOIR-05] -->
 
 [PAUSE 1s]
 - [YOU SAY: "le temps" — time, or weather, depending on context]
@@ -56,6 +76,7 @@ Same *hacer*-style periphrasis as Spanish, just with French's own **faire**
 - [YOU SAY: "il pleut" — it's raining, pl- kept intact from Latin]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-TEMPS-02, FR-LEX-IL-PLEUT-04, FR-ETYMON-PLEUVOIR-05] -->
 
 [PAUSE 3s] What two things does **le temps** mean, and where does this
 polysemy come from? (**"Time"** and **"weather"** — from Latin *tempus*,

--- a/code/learning/human-languages/french/lessons/FR-C22-chien-chat.md
+++ b/code/learning/human-languages/french/lessons/FR-C22-chien-chat.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: FR-C22-chien-chat
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 690
 chapter: 22
 type: word
 headword: chien, chat
@@ -9,20 +12,34 @@ prerequisites: [FR-C14-age]
 sounds: [ca-to-cha-shift, nasal-en]
 roots: [latin-canis-dog, latin-cattus-afroasiatic]
 etymology_hook: "chien is the fully REGULAR French descendant of Latin canis — the same ca- → cha- palatalization that also gives champ (← campus) and chanter (← cantāre) — unlike Spanish, which replaced canis-derived can with the still-unexplained perro; chat continues cattus, the same word (probably Afro-Asiatic, traveling with the cat out of Egypt) behind Spanish's gato and Italian's gatto"
-est_minutes: 4
+duration:
+  max_seconds: 233
+requires:
+  knowledge: []
+introduces:
+  knowledge: [FR-LEX-CHIEN-02, FR-ETYMON-CHIEN-03, FR-LEX-CHAT-04, FR-ETYMON-CHAT-05]
+practises:
+  knowledge: [FR-LEX-CHIEN-02, FR-ETYMON-CHIEN-03, FR-LEX-CHAT-04, FR-ETYMON-CHAT-05]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [FR-C14-age]
 ---
 
 # chien, chat — the regular one, and the well-traveled one
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You've met Spanish's *perro*, a genuine unsolved mystery, and
 Latin's own *canis*/*fēlēs*→*cattus* history. French's two animal words tell
 a cleaner story: one is perfectly regular, the other is the same well-
 documented word you already know.
 
-## chien — the regular, expected descendant of canis
+## The word, taken apart: chien
+<!-- hl-knowledge: introduces=[FR-LEX-CHIEN-02, FR-ETYMON-CHIEN-03]; assesses=[] -->
 
 **chien** ("**dog**") comes straight from Latin **canis** (accusative
 *canem*) — and unlike Spanish, French kept it. Two separate, regular changes
@@ -36,7 +53,8 @@ even though the precise phonetic trigger is still debated). Put together,
 predictably — a genuinely different story from Spanish, where the expected
 descendant (*can*) got pushed aside by the still-unexplained *perro*.
 
-## chat — the same well-traveled word as gato
+## The word, taken apart: chat
+<!-- hl-knowledge: introduces=[FR-LEX-CHAT-04, FR-ETYMON-CHAT-05]; assesses=[] -->
 
 **chat** ("**cat**") continues **cattus**, the same Late Latin word — most
 likely ultimately **Afro-Asiatic** (compare Nubian *kadis*) — that spread
@@ -46,6 +64,7 @@ French, Spanish, and Italian all independently inherited the exact same Late
 Latin replacement for Classical *fēlēs*.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-CHIEN-02, FR-ETYMON-CHIEN-03, FR-LEX-CHAT-04, FR-ETYMON-CHAT-05] -->
 
 [PAUSE 1s]
 - [YOU SAY: "chien" — dog, the regular descendant of canis]
@@ -55,6 +74,7 @@ Latin replacement for Classical *fēlēs*.
   Rome]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-CHIEN-02, FR-ETYMON-CHIEN-03, FR-LEX-CHAT-04, FR-ETYMON-CHAT-05] -->
 
 [PAUSE 3s] Is *chien* a regular or irregular descendant of Latin *canis*?
 (**Regular** — the same *ca- → cha-* shift as *champ* and *chanter*.) Does

--- a/code/learning/human-languages/french/lessons/FR-C23-vert-jaune.md
+++ b/code/learning/human-languages/french/lessons/FR-C23-vert-jaune.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: FR-C23-vert-jaune
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 700
 chapter: 23
 type: word
 headword: vert, jaune
@@ -9,26 +12,41 @@ prerequisites: [FR-C22-chien-chat]
 sounds: [nasal-en, diphthong-au]
 roots: [latin-viridis-vireo, latin-galbinus-shine]
 etymology_hook: "vert ← Latin viridis, the standard source of 'green' across nearly every Romance language (Spanish verde, Italian verde, Portuguese verde); jaune ← Latin galbinus, literally 'yellow-GREEN' — an extended form of galbus, usually traced to PIE *ghel-, 'to shine,' the same root claimed for German's gelb — though modern Latin scholarship treats galbus's origin as genuinely unknown, so treat jaune/gelb as probable, not certain, cousins"
-est_minutes: 4
+duration:
+  max_seconds: 226
+requires:
+  knowledge: [FR-LEX-CHIEN-02, FR-ETYMON-CHIEN-03, FR-LEX-CHAT-04, FR-ETYMON-CHAT-05]
+introduces:
+  knowledge: [FR-LEX-VERT-02, FR-ETYMON-VERT-03, FR-LEX-JAUNE-04, FR-ETYMON-JAUNE-05, FR-EVIDENCE-JAUNE-GELB-06]
+practises:
+  knowledge: [FR-LEX-VERT-02, FR-ETYMON-VERT-03, FR-LEX-JAUNE-04, FR-ETYMON-JAUNE-05, FR-EVIDENCE-JAUNE-GELB-06]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [FR-C22-chien-chat]
 ---
 
 # vert, jaune — the expected inheritance, and a hidden PIE-level cousin
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] French's green word is exactly what you'd expect. Its yellow word
 hides something you won't expect at all — a secret cousin sitting inside
 German.
 
-## vert — the standard Romance inheritance
+## The word, taken apart: vert
+<!-- hl-knowledge: introduces=[FR-LEX-VERT-02, FR-ETYMON-VERT-03]; assesses=[] -->
 
 **vert** ("**green**") ← Latin **viridis** — and this is genuinely the
 **standard** source of "green" across nearly every Romance language:
 Spanish *verde*, Italian *verde*, Portuguese *verde*, Catalan *verd*. No
 surprise here — a clean, shared inheritance.
 
-## jaune — literally "yellow-GREEN," and a secret cousin of German's gelb
+## The word, taken apart: jaune
+<!-- hl-knowledge: introduces=[FR-LEX-JAUNE-04, FR-ETYMON-JAUNE-05, FR-EVIDENCE-JAUNE-GELB-06]; assesses=[] -->
 
 **jaune** ("**yellow**") ← Latin **galbinus**, which literally meant
 "**yellow-green**" — an extended form of **galbus**, from **Proto-Indo-
@@ -45,6 +63,7 @@ level, despite one reaching French through Latin and the other reaching
 German directly through Germanic — just don't treat that link as airtight.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-VERT-02, FR-ETYMON-VERT-03, FR-LEX-JAUNE-04, FR-ETYMON-JAUNE-05, FR-EVIDENCE-JAUNE-GELB-06] -->
 
 [PAUSE 1s]
 - [YOU SAY: "vert" — green, the standard Romance word]
@@ -53,6 +72,7 @@ German directly through Germanic — just don't treat that link as airtight.
   PIE root, two completely different paths, though the link isn't airtight]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-VERT-02, FR-ETYMON-VERT-03, FR-LEX-JAUNE-04, FR-ETYMON-JAUNE-05, FR-EVIDENCE-JAUNE-GELB-06] -->
 
 [PAUSE 3s] Is **vert** a typical or unusual Romance word for "green"?
 (**Typical** — the standard source across nearly all Romance languages.)

--- a/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
@@ -85,6 +85,22 @@ describe("generated book source hashes", () => {
     expect(bookHashStatus(lessons, "portuguese", chapter)).toBe("synced");
   });
 
+  it.each([
+    [17, 2],
+    [18, 2],
+    [19, 1],
+    [20, 1],
+    [21, 1],
+    [22, 1],
+    [23, 1],
+  ])("matches the browser-loaded French Chapter %i AST across %i lessons", (chapter, count) => {
+    const lessons = loadLessons();
+    const expected = expectedBookHash("french", chapter);
+    expect(expected?.lessonIds).toHaveLength(count);
+    expect(actualChapterHash(lessons, "french", chapter)).toBe(expected?.sourceHash);
+    expect(bookHashStatus(lessons, "french", chapter)).toBe("synced");
+  });
+
   it("reports a generated chapter stale when one canonical lesson changes", () => {
     const lessons = loadLessons();
     const changed = lessons.map((lesson) =>


### PR DESCRIPTION
## Summary
- migrate all nine French lessons in Chapters 17–23 to schema v2 with shared-spine anchors, typed blocks, prerequisite-closed knowledge, and sub-five-minute contracts
- generate seven LaTeX chapters from the canonical lesson AST and verify their source hashes independently in Language Ladder
- expand the downloadable French book from 79 to 98 pages and record the unchanged legacy warning baseline for HL-B19

## Measured result
- 20 tracks, 1,065 lessons, 20 books
- 0 lessons at or above 300 effective seconds
- 0 unknown prerequisites
- missing lesson/book chapters: 220 → 213
- French PDF: 98 pages, 25 top-level outline entries
- no missing glyphs, duplicate destinations, LaTeX warnings, or leaked generator metadata
- unchanged pre-existing debt: 16 overfull boxes, 9 underfull boxes, 6 Hyperref warnings

## Validation
- `npm test` — human-language-data: 81 passed
- `npm run validate` — 9 passed
- `npm run check:books`
- `npm run report`
- `npm test` — Language Ladder: 326 passed
- `npm run build` — Language Ladder
- `latexmk -g -xelatex -interaction=nonstopmode -halt-on-error book.tex`
- rendered and visually inspected all 98 PDF pages
- verified page count, outline, blank-page set, warning counts, and extracted-text metadata
- `git diff --check`