### PR TITLE
fix(spice): lower BJT HFE alias

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower the BJT model-card `HFE` forward-beta alias.
 - Validate BJT model-card `BF` / `BETA` / `BETA_F` forward beta and lower the
   `BETA` alias instead of silently dropping it.
 - Validate diode model-card `CJO` / `CJ` / `CJ0` junction capacitance and

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1292,7 +1292,10 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             polarity=model.kind,
             Is=model.params.get("IS", 1e-14),
             beta_f=model.params.get(
-                "BF", model.params.get("BETA", model.params.get("BETA_F", 100.0))
+                "BF",
+                model.params.get(
+                    "BETA", model.params.get("BETA_F", model.params.get("HFE", 100.0))
+                ),
             ),
             Vt=model.params.get("VT", 0.02585),
             Cje=model.params.get("CJE", model.params.get("CBE", 0.0)),
@@ -1932,7 +1935,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             raise NetlistParseError("diode CJO must be finite and non-negative")
     if kind in {"NPN", "PNP"}:
         forward_beta = next(
-            (params[name] for name in ("BF", "BETA", "BETA_F") if name in params),
+            (
+                params[name]
+                for name in ("BF", "BETA", "BETA_F", "HFE")
+                if name in params
+            ),
             None,
         )
         if forward_beta is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -931,21 +931,25 @@ Qp col base emit slow
 def test_parse_bjt_forward_beta_alias_with_canonical_precedence() -> None:
     parsed = parse_netlist(
         """
-.model fast NPN(BF=120 BETA=90 BETA_F=80)
+.model fast NPN(BF=120 BETA=90 BETA_F=80 HFE=70)
 Q1 col base emit fast
 .model slow PNP(BETA=75)
 Q2 col base emit slow
+.model legacy NPN(HFE=65)
+Q3 col base emit legacy
 """
     )
 
-    first, second = parsed.circuit.elements
+    first, second, third = parsed.circuit.elements
     assert isinstance(first, BJT)
     assert isinstance(second, BJT)
+    assert isinstance(third, BJT)
     assert first.beta_f == 120.0
     assert second.beta_f == 75.0
+    assert third.beta_f == 65.0
 
 
-@pytest.mark.parametrize("parameter", ["BF", "BETA", "BETA_F"])
+@pytest.mark.parametrize("parameter", ["BF", "BETA", "BETA_F", "HFE"])
 @pytest.mark.parametrize("value", ["0", "-1", "1e999"])
 def test_rejects_invalid_bjt_forward_beta(parameter: str, value: str) -> None:
     with pytest.raises(NetlistParseError, match="BJT BF must be finite and positive"):

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower the BJT model-card `HFE` forward-beta alias.
 - Validate BJT model-card `BF` / `BETA` / `BETA_F` forward beta and lower the
   `BETA` alias instead of silently dropping it.
 - Validate diode model-card `CJO` / `CJ` / `CJ0` junction capacitance and

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1176,7 +1176,10 @@ function parseModelCard(fields: readonly string[]): ModelCard {
     throw new NetlistParseError("diode CJO must be finite and non-negative");
   }
   const bjtForwardBeta =
-    params.get("BF") ?? params.get("BETA") ?? params.get("BETA_F");
+    params.get("BF") ??
+    params.get("BETA") ??
+    params.get("BETA_F") ??
+    params.get("HFE");
   if (
     (kind === "NPN" || kind === "PNP") &&
     bjtForwardBeta !== undefined &&
@@ -1737,6 +1740,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("BF") ??
         model.params.get("BETA") ??
         model.params.get("BETA_F") ??
+        model.params.get("HFE") ??
         100.0,
       model.params.get("VT") ?? 0.02585,
       model.params.get("CJE") ?? model.params.get("CBE") ?? 0.0,

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -917,10 +917,12 @@ Q2 out base emit slow
 
   it("parses the BJT BETA forward-beta alias with canonical precedence", () => {
     const parsed = parseNetlist(`
-.model fast NPN(BF=120 BETA=90 BETA_F=80)
+.model fast NPN(BF=120 BETA=90 BETA_F=80 HFE=70)
 Q1 col base emit fast
 .model slow PNP(BETA=75)
 Q2 col base emit slow
+.model legacy NPN(HFE=65)
+Q3 col base emit legacy
 `);
 
     expect(parsed.circuit.elements()[0]).toMatchObject({
@@ -930,6 +932,10 @@ Q2 col base emit slow
     expect(parsed.circuit.elements()[1]).toMatchObject({
       kind: "bjt",
       forwardBeta: 75.0,
+    });
+    expect(parsed.circuit.elements()[2]).toMatchObject({
+      kind: "bjt",
+      forwardBeta: 65.0,
     });
   });
 
@@ -943,6 +949,9 @@ Q2 col base emit slow
     ["BETA_F", "0"],
     ["BETA_F", "-1"],
     ["BETA_F", "1e999"],
+    ["HFE", "0"],
+    ["HFE", "-1"],
+    ["HFE", "1e999"],
   ])("rejects invalid BJT %s forward beta %s", (parameter, value) => {
     expect(() => parseNetlist(`.model fast NPN(${parameter}=${value})`)).toThrow(
       "BJT BF must be finite and positive",

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4346,11 +4346,16 @@ the Rust, Python, and TypeScript surfaces together.
      values and lower `CJ` into the shared engine diode junction-capacitance
      field.
 
+406. Python and TypeScript Berkeley SPICE BJT forward-beta alias parity.
+   - Status: completed in PR 9750.
+   - Both parser facades validate positive finite `BF` / `BETA` / `BETA_F`
+     values and lower `BETA` into the shared engine BJT forward-beta field.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE BJT model-card alias parity.
    - Align parser validation and lowering with the shared engine aliases,
-     continuing with `HFE` as a forward-beta alias for `BF` after `BETA`.
+     continuing with `V_T` as a thermal-voltage alias for `VT` after `HFE`.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary
- validate positive finite BJT `HFE` values alongside the existing forward-beta names
- lower `HFE` after canonical `BF`, `BETA`, and `BETA_F` precedence in Python and TypeScript
- record #9750 and advance the SPICE backlog to BJT `V_T` parity

## Verification
- Python spice-netlist-parser `bash BUILD`: 261 passed, 88.82% coverage
- Python spice-netlist-parser `.venv/bin/ruff check .`: passed
- TypeScript spice-engine `npm run build && npm test`: 448 passed
- TypeScript spice-netlist-parser `bash BUILD`: 250 passed
- TypeScript spice-netlist-parser `npm run test:coverage`: 250 passed, 85.67% line coverage