### PR TITLE
Report foreign starts fostered from tables

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- SVG and MathML start tags foster-parented out of table structure now report
+  the table insertion-mode parse error, covering 26 previously silent malformed
+  corpus cases without changing DOM recovery or undeclared-diagnostic coverage.
 - Non-whitespace character data foster-parented out of table structure now
   reports the table-text parse error, covering 14 previously silent malformed
   corpus cases without changing DOM recovery or undeclared-diagnostic coverage.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the specialized foster-parented table-text diagnostic slice, 2,029 of
-those cases emit at least one lexer or parser diagnostic and 154 remain
+After the specialized foster-parented foreign-start-tag diagnostic slice, 2,055
+of those cases emit at least one lexer or parser diagnostic and 128 remain
 uncovered.
 Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
 These are reviewed rather than automatically removed: 89 are full-document
@@ -63,8 +63,9 @@ recovery closes a non-current list item, and a paragraph end tag reports when it
 breaks out of MathML foreign content. A formatting end tag also reports when an
 open table blocks adoption-agency recovery.
 
-The fresh 154-case residual inventory keeps the next concrete groups in the
-existing priority order: table foster-parenting and table-scope boundaries;
+The fresh 128-case residual inventory keeps the next concrete groups in the
+existing priority order: remaining table foster-parenting and table-scope
+boundaries;
 select/template recovery; script-tokenizer EOF recovery; plaintext/frameset
 boundaries; and foreign-fragment stray tags plus MathML/SVG table integration.
 
@@ -75,6 +76,8 @@ Prioritized work items:
 2. **Table, select, and template insertion modes.** Cover the remaining foster
    parenting, table scopes, select recovery, and template mode-stack errors.
    Non-whitespace table text now reports when it is foster-parented. The
+   specialized SVG and MathML start-tag path now reports when table insertion
+   mode foster-parents foreign content. The
    remaining fragment EOF inventory includes fostered-anchor `eof-in-table`
    rows and MathML/SVG table-boundary scope recovery.
 3. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5240,6 +5240,10 @@ impl HtmlParser {
             && matches!(name.as_str(), "svg" | "math")
             && self.current_element_is_table_structure()
         {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-foreign-start-tag-in-table",
+                format!("start tag `<{name}>` in a table context was foster parented"),
+            ));
             let namespace = self.namespace_for_start_tag(&name);
             let name = adjusted_foreign_start_tag_name(name, namespace);
             let attributes = adjusted_foreign_attributes(attributes, namespace);
@@ -33371,6 +33375,35 @@ mod tests {
             .parser_diagnostics
             .iter()
             .all(|diagnostic| diagnostic.code != "unexpected-character-in-table"));
+    }
+
+    #[test]
+    fn reports_foreign_start_tags_fostered_from_tables() {
+        for (source, name) in [
+            ("<!doctype html><table><svg></svg></table>", "svg"),
+            ("<!doctype html><table><math></math></table>", "math"),
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().any(|diagnostic| {
+                    diagnostic
+                        == &ParserDiagnostic::new(
+                            "unexpected-foreign-start-tag-in-table",
+                            format!("start tag `<{name}>` in a table context was foster parented"),
+                        )
+                }),
+                "source {source:?}"
+            );
+        }
+
+        let cell = parse_html_with_diagnostics(
+            "<!doctype html><table><tr><td><svg></svg><math></math></td></tr></table>",
+        )
+        .unwrap();
+        assert!(cell
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "unexpected-foreign-start-tag-in-table"));
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 154);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2029);
+    assert_eq!(missing_diagnostic_cases, 128);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2055);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report the table insertion-mode parse error when SVG or MathML start tags are foster-parented out of table structure
- preserve the existing DOM recovery and avoid diagnostics for foreign starts inside table cells
- ratchet malformed tree diagnostic coverage from 2,029 to 2,055 cases, leaving 128 silent cases, and reprioritize the backlog

## Validation
- cargo test -p coding-adventures-html-parser
- cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings
- cargo test -p coding-adventures-html-lexer
- cargo test -p state-machine-tokenizer
- exact pinned WPT/html5lib coverage audit: tree 1,934 upstream / 2,637 local / 0 missing; tokenizer 6,806 upstream / 7,015 raw / 7,242 normalized / 0 missing / 0 skipped
- generated fixture, audit coverage, audit manifest, and Rust-test guards