### PR TITLE
fix(spice): lower BJT thermal-voltage alias

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate BJT model-card `VT` / `V_T` thermal voltage and lower the `V_T`
+  alias instead of silently dropping it.
 - Validate and lower the BJT model-card `HFE` forward-beta alias.
 - Validate BJT model-card `BF` / `BETA` / `BETA_F` forward beta and lower the
   `BETA` alias instead of silently dropping it.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1297,7 +1297,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
                     "BETA", model.params.get("BETA_F", model.params.get("HFE", 100.0))
                 ),
             ),
-            Vt=model.params.get("VT", 0.02585),
+            Vt=model.params.get("VT", model.params.get("V_T", 0.02585)),
             Cje=model.params.get("CJE", model.params.get("CBE", 0.0)),
             Cjc=model.params.get("CJC", model.params.get("CBC", 0.0)),
             Tf=model.params.get("TF", 0.0),
@@ -1946,6 +1946,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(forward_beta) or forward_beta <= 0.0
         ):
             raise NetlistParseError("BJT BF must be finite and positive")
+        thermal_voltage = params.get("VT", params.get("V_T"))
+        if thermal_voltage is not None and (
+            not math.isfinite(thermal_voltage) or thermal_voltage <= 0.0
+        ):
+            raise NetlistParseError("BJT VT must be finite and positive")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -956,6 +956,30 @@ def test_rejects_invalid_bjt_forward_beta(parameter: str, value: str) -> None:
         parse_netlist(f".model fast NPN({parameter}={value})")
 
 
+def test_parse_bjt_thermal_voltage_alias_with_canonical_precedence() -> None:
+    parsed = parse_netlist(
+        """
+.model fast NPN(VT=25m V_T=27m)
+Q1 col base emit fast
+.model slow PNP(V_T=28m)
+Q2 col base emit slow
+"""
+    )
+
+    first, second = parsed.circuit.elements
+    assert isinstance(first, BJT)
+    assert isinstance(second, BJT)
+    assert first.Vt == 25.0e-3
+    assert second.Vt == 28.0e-3
+
+
+@pytest.mark.parametrize("parameter", ["VT", "V_T"])
+@pytest.mark.parametrize("value", ["0", "-1m", "1e999"])
+def test_rejects_invalid_bjt_thermal_voltage(parameter: str, value: str) -> None:
+    with pytest.raises(NetlistParseError, match="BJT VT must be finite and positive"):
+        parse_netlist(f".model fast NPN({parameter}={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate BJT model-card `VT` / `V_T` thermal voltage and lower the `V_T`
+  alias instead of silently dropping it.
 - Validate and lower the BJT model-card `HFE` forward-beta alias.
 - Validate BJT model-card `BF` / `BETA` / `BETA_F` forward beta and lower the
   `BETA` alias instead of silently dropping it.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1187,6 +1187,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT BF must be finite and positive");
   }
+  const bjtThermalVoltage = params.get("VT") ?? params.get("V_T");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtThermalVoltage !== undefined &&
+    (!Number.isFinite(bjtThermalVoltage) || bjtThermalVoltage <= 0.0)
+  ) {
+    throw new NetlistParseError("BJT VT must be finite and positive");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -1742,7 +1750,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
         model.params.get("BETA_F") ??
         model.params.get("HFE") ??
         100.0,
-      model.params.get("VT") ?? 0.02585,
+      model.params.get("VT") ?? model.params.get("V_T") ?? 0.02585,
       model.params.get("CJE") ?? model.params.get("CBE") ?? 0.0,
       model.params.get("CJC") ?? model.params.get("CBC") ?? 0.0,
       model.params.get("TF") ?? 0.0,

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -958,6 +958,37 @@ Q3 col base emit legacy
     );
   });
 
+  it("parses the BJT V_T thermal-voltage alias with canonical precedence", () => {
+    const parsed = parseNetlist(`
+.model fast NPN(VT=25m V_T=27m)
+Q1 col base emit fast
+.model slow PNP(V_T=28m)
+Q2 col base emit slow
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      thermalVoltage: 25.0e-3,
+    });
+    expect(parsed.circuit.elements()[1]).toMatchObject({
+      kind: "bjt",
+      thermalVoltage: 28.0e-3,
+    });
+  });
+
+  it.each([
+    ["VT", "0"],
+    ["VT", "-1m"],
+    ["VT", "1e999"],
+    ["V_T", "0"],
+    ["V_T", "-1m"],
+    ["V_T", "1e999"],
+  ])("rejects invalid BJT %s thermal voltage %s", (parameter, value) => {
+    expect(() => parseNetlist(`.model fast NPN(${parameter}=${value})`)).toThrow(
+      "BJT VT must be finite and positive",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4351,11 +4351,17 @@ the Rust, Python, and TypeScript surfaces together.
    - Both parser facades validate positive finite `BF` / `BETA` / `BETA_F`
      values and lower `BETA` into the shared engine BJT forward-beta field.
 
+407. Python and TypeScript Berkeley SPICE BJT HFE alias parity.
+   - Status: completed in PR 9754.
+   - Both parser facades validate positive finite `HFE` values and lower them
+     into the shared engine BJT forward-beta field after canonical aliases.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE BJT model-card alias parity.
    - Align parser validation and lowering with the shared engine aliases,
-     continuing with `V_T` as a thermal-voltage alias for `VT` after `HFE`.
+     continuing with `CJE0` as a base-emitter capacitance alias for `CJE` after
+     `V_T`.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary
- validate positive finite BJT `VT` and `V_T` thermal-voltage parameters
- lower `V_T` after canonical `VT` precedence in Python and TypeScript
- record #9754 and advance the SPICE backlog to BJT `CJE0` parity

## Verification
- Python spice-netlist-parser `bash BUILD`: 268 passed, 88.84% coverage
- Python spice-netlist-parser `.venv/bin/ruff check .`: passed
- TypeScript spice-engine `npm run build && npm test`: 448 passed
- TypeScript spice-netlist-parser `bash BUILD`: 257 passed
- TypeScript spice-netlist-parser `npm run test:coverage`: 257 passed, 85.71% line coverage