### PR TITLE
Report HTML breakouts from foreign content

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,10 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- HTML start tags that force recovery from SVG or MathML foreign content now
+  report the foreign-content parse error, covering 15 previously silent
+  malformed corpus cases without changing DOM recovery or
+  undeclared-diagnostic coverage.
 - SVG and MathML start tags foster-parented out of table structure now report
   the table insertion-mode parse error, covering 26 previously silent malformed
   corpus cases without changing DOM recovery or undeclared-diagnostic coverage.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the specialized foster-parented foreign-start-tag diagnostic slice, 2,055
-of those cases emit at least one lexer or parser diagnostic and 128 remain
+After the foreign-content HTML-start-tag breakout diagnostic slice, 2,070 of
+those cases emit at least one lexer or parser diagnostic and 113 remain
 uncovered.
 Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
 These are reviewed rather than automatically removed: 89 are full-document
@@ -63,7 +63,7 @@ recovery closes a non-current list item, and a paragraph end tag reports when it
 breaks out of MathML foreign content. A formatting end tag also reports when an
 open table blocks adoption-agency recovery.
 
-The fresh 128-case residual inventory keeps the next concrete groups in the
+The fresh 113-case residual inventory keeps the next concrete groups in the
 existing priority order: remaining table foster-parenting and table-scope
 boundaries;
 select/template recovery; script-tokenizer EOF recovery; plaintext/frameset
@@ -83,7 +83,9 @@ Prioritized work items:
 3. **Adoption agency and active formatting.** Cover malformed formatting cases
    without changing their now-conforming DOM output.
 4. **Foreign content and fragment parsing.** Cover SVG/MathML integration
-   boundaries and context-sensitive fragment errors.
+   boundaries and context-sensitive fragment errors. HTML start tags that force
+   recovery from foreign content now report their parse error; remaining work
+   includes foreign end-tag and fragment-shell recovery.
 5. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4921,6 +4921,10 @@ impl HtmlParser {
             && !self.current_node_is_svg_html_integration_point()
             && exits_foreign_content_on_start_tag(&name, &attributes)
         {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-html-start-tag-in-foreign-content",
+                format!("HTML start tag `<{name}>` forced recovery from foreign content"),
+            ));
             if self.has_open_svg_html_integration_point() {
                 while self.current_namespace().is_some()
                     && !self.current_node_is_svg_html_integration_point()
@@ -33407,6 +33411,29 @@ mod tests {
     }
 
     #[test]
+    fn reports_html_start_tags_that_break_out_of_foreign_content() {
+        for source in [
+            "<!doctype html><svg><g><p>x",
+            "<!doctype html><math><mrow><div>x",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().any(|diagnostic| {
+                    diagnostic.code == "unexpected-html-start-tag-in-foreign-content"
+                }),
+                "source {source:?}"
+            );
+        }
+
+        let integration_point =
+            parse_html_with_diagnostics("<!doctype html><svg><foreignObject><p>x").unwrap();
+        assert!(integration_point
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "unexpected-html-start-tag-in-foreign-content"));
+    }
+
+    #[test]
     fn reports_fragment_eof_with_authored_disallowed_open_elements() {
         for (context, source) in [
             ("body", "<div>"),
@@ -33414,12 +33441,20 @@ mod tests {
             ("svg path", "<nobr>X"),
         ] {
             let output = parse_html_fragment_for_context_with_diagnostics(source, context).unwrap();
+            let mut expected = Vec::new();
+            if context == "svg path" {
+                expected.push(ParserDiagnostic::new(
+                    "unexpected-html-start-tag-in-foreign-content",
+                    "HTML start tag `<nobr>` forced recovery from foreign content",
+                ));
+            }
+            expected.push(ParserDiagnostic::new(
+                "eof-with-unclosed-elements",
+                "end of file was reached with disallowed open elements",
+            ));
             assert_eq!(
                 output.parser_diagnostics,
-                vec![ParserDiagnostic::new(
-                    "eof-with-unclosed-elements",
-                    "end of file was reached with disallowed open elements"
-                )],
+                expected,
                 "context {context:?}, source {source:?}"
             );
         }

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 128);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2055);
+    assert_eq!(missing_diagnostic_cases, 113);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2070);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report the WHATWG parse error when an HTML start tag forces recovery from SVG or MathML foreign content
- preserve HTML integration-point behavior and the existing DOM recovery
- ratchet malformed tree diagnostic coverage from 2,055 to 2,070 cases, leaving 113 silent cases, and reprioritize the backlog

## Validation
- cargo test -p coding-adventures-html-parser
- cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings
- cargo test -p coding-adventures-html-lexer
- cargo test -p state-machine-tokenizer
- exact pinned WPT/html5lib coverage audit: tree 1,934 upstream / 2,637 local / 0 missing; tokenizer 6,806 upstream / 7,015 raw / 7,242 normalized / 0 missing / 0 skipped
- generated fixture, audit coverage, audit manifest, and Rust-test guards