### PR TITLE
fix(spice): lower BJT CJE0 alias

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate BJT model-card `CJE` / `CJE0` / `CBE` base-emitter capacitance and
+  lower the `CJE0` alias instead of silently dropping it.
 - Validate BJT model-card `VT` / `V_T` thermal voltage and lower the `V_T`
   alias instead of silently dropping it.
 - Validate and lower the BJT model-card `HFE` forward-beta alias.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1298,7 +1298,9 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
                 ),
             ),
             Vt=model.params.get("VT", model.params.get("V_T", 0.02585)),
-            Cje=model.params.get("CJE", model.params.get("CBE", 0.0)),
+            Cje=model.params.get(
+                "CJE", model.params.get("CJE0", model.params.get("CBE", 0.0))
+            ),
             Cjc=model.params.get("CJC", model.params.get("CBC", 0.0)),
             Tf=model.params.get("TF", 0.0),
             Tr=model.params.get("TR", 0.0),
@@ -1951,6 +1953,15 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(thermal_voltage) or thermal_voltage <= 0.0
         ):
             raise NetlistParseError("BJT VT must be finite and positive")
+        base_emitter_capacitance = next(
+            (params[name] for name in ("CJE", "CJE0", "CBE") if name in params),
+            None,
+        )
+        if base_emitter_capacitance is not None and (
+            not math.isfinite(base_emitter_capacitance)
+            or base_emitter_capacitance < 0.0
+        ):
+            raise NetlistParseError("BJT CJE must be finite and non-negative")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -980,6 +980,34 @@ def test_rejects_invalid_bjt_thermal_voltage(parameter: str, value: str) -> None
         parse_netlist(f".model fast NPN({parameter}={value})")
 
 
+def test_parse_bjt_base_emitter_capacitance_alias_with_canonical_precedence() -> None:
+    parsed = parse_netlist(
+        """
+.model fast NPN(CJE=2p CJE0=3p CBE=4p)
+Q1 col base emit fast
+.model slow PNP(CJE0=5p)
+Q2 col base emit slow
+"""
+    )
+
+    first, second = parsed.circuit.elements
+    assert isinstance(first, BJT)
+    assert isinstance(second, BJT)
+    assert first.Cje == 2.0e-12
+    assert second.Cje == 5.0e-12
+
+
+@pytest.mark.parametrize("parameter", ["CJE", "CJE0", "CBE"])
+@pytest.mark.parametrize("value", ["-1p", "1e999"])
+def test_rejects_invalid_bjt_base_emitter_capacitance(
+    parameter: str, value: str
+) -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT CJE must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NPN({parameter}={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate BJT model-card `CJE` / `CJE0` / `CBE` base-emitter capacitance and
+  lower the `CJE0` alias instead of silently dropping it.
 - Validate BJT model-card `VT` / `V_T` thermal voltage and lower the `V_T`
   alias instead of silently dropping it.
 - Validate and lower the BJT model-card `HFE` forward-beta alias.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1195,6 +1195,15 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT VT must be finite and positive");
   }
+  const bjtBaseEmitterCapacitance =
+    params.get("CJE") ?? params.get("CJE0") ?? params.get("CBE");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtBaseEmitterCapacitance !== undefined &&
+    (!Number.isFinite(bjtBaseEmitterCapacitance) || bjtBaseEmitterCapacitance < 0.0)
+  ) {
+    throw new NetlistParseError("BJT CJE must be finite and non-negative");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -1751,7 +1760,10 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
         model.params.get("HFE") ??
         100.0,
       model.params.get("VT") ?? model.params.get("V_T") ?? 0.02585,
-      model.params.get("CJE") ?? model.params.get("CBE") ?? 0.0,
+      model.params.get("CJE") ??
+        model.params.get("CJE0") ??
+        model.params.get("CBE") ??
+        0.0,
       model.params.get("CJC") ?? model.params.get("CBC") ?? 0.0,
       model.params.get("TF") ?? 0.0,
       model.params.get("TR") ?? 0.0,

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -989,6 +989,37 @@ Q2 col base emit slow
     );
   });
 
+  it("parses the BJT CJE0 capacitance alias with canonical precedence", () => {
+    const parsed = parseNetlist(`
+.model fast NPN(CJE=2p CJE0=3p CBE=4p)
+Q1 col base emit fast
+.model slow PNP(CJE0=5p)
+Q2 col base emit slow
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      baseEmitterCapacitance: 2.0e-12,
+    });
+    expect(parsed.circuit.elements()[1]).toMatchObject({
+      kind: "bjt",
+      baseEmitterCapacitance: 5.0e-12,
+    });
+  });
+
+  it.each([
+    ["CJE", "-1p"],
+    ["CJE", "1e999"],
+    ["CJE0", "-1p"],
+    ["CJE0", "1e999"],
+    ["CBE", "-1p"],
+    ["CBE", "1e999"],
+  ])("rejects invalid BJT %s base-emitter capacitance %s", (parameter, value) => {
+    expect(() => parseNetlist(`.model fast NPN(${parameter}=${value})`)).toThrow(
+      "BJT CJE must be finite and non-negative",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4356,12 +4356,17 @@ the Rust, Python, and TypeScript surfaces together.
    - Both parser facades validate positive finite `HFE` values and lower them
      into the shared engine BJT forward-beta field after canonical aliases.
 
+408. Python and TypeScript Berkeley SPICE BJT thermal-voltage alias parity.
+   - Status: completed in PR 9757.
+   - Both parser facades validate positive finite `VT` / `V_T` values and
+     lower `V_T` into the shared engine BJT thermal-voltage field.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE BJT model-card alias parity.
    - Align parser validation and lowering with the shared engine aliases,
-     continuing with `CJE0` as a base-emitter capacitance alias for `CJE` after
-     `V_T`.
+     continuing with `CJC0` as a base-collector capacitance alias for `CJC`
+     after `CJE0`.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary

- validate finite, non-negative BJT CJE, CJE0, and CBE model-card capacitance values in Python and TypeScript
- lower CJE0 with canonical CJE precedence and legacy CBE fallback
- record merged BJT thermal-voltage parity and advance the live backlog to CJC0

## Verification

- Python spice-netlist-parser: `bash BUILD` (275 passed, 88.87% coverage)
- Python spice-netlist-parser: `.venv/bin/ruff check .`
- TypeScript spice-engine: `npm ci --quiet && npm run build && npm test` (448 passed)
- TypeScript spice-netlist-parser: `bash BUILD && npm run test:coverage` (264 passed, 85.75% line coverage)