### PR TITLE
fix(human-languages): make French book warning-free

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -86,9 +86,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B15 | Complete (#9735) | Remove Italian's LaTeX layout and Unicode bookmark warnings. | The forced 104-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
 | HL-B16 | Complete (#9744) | Publish Portuguese Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Fifty schema-v2 lessons now generate sixteen chapters whose source hashes are independently verified against the Language Ladder corpus. |
 | HL-B17 | Complete (#9748) | Remove Portuguese's LaTeX layout warnings. | The forced 105-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
-| HL-B18 | Complete in this PR | Publish French Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | Nine schema-v2 lessons now generate seven chapters whose source hashes are independently verified against the Language Ladder corpus. |
-| HL-B19 | Next | Remove French's LaTeX layout and Unicode bookmark warnings. | The expanded forced 98-page build has no missing glyphs or duplicate destinations but retains sixteen overfull boxes, nine underfull boxes, and six Hyperref warnings; the clean-build signal is zero of each. |
-| HL-B20 | Queued | Publish German Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | The German PDF reaches Chapter 16 while canonical app content continues through Chapter 23; schema-v2 migration plus generation should close that drift safely. |
+| HL-B18 | Complete (#9752) | Publish French Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | Nine schema-v2 lessons now generate seven chapters whose source hashes are independently verified against the Language Ladder corpus. |
+| HL-B19 | Complete in this PR | Remove French's LaTeX layout and Unicode bookmark warnings. | The forced 98-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
+| HL-B20 | Next | Publish German Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | The German PDF reaches Chapter 16 while canonical app content continues through Chapter 23; schema-v2 migration plus generation should close that drift safely. |
 | HL-B21 | Queued | Remove German's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs or duplicate labels but reports seventeen overfull boxes, eleven underfull boxes, and three Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B22 | Queued | Publish Telugu Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Telugu PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
 | HL-B23 | Queued | Remove Telugu's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports four overfull boxes, three underfull boxes, four duplicate practice labels, 27 Hyperref warnings, and a font-shape substitution warning; the clean-build signal is zero of each. |
@@ -634,6 +634,23 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - The expanded book retains the exact pre-existing warning baseline: sixteen
   overfull boxes, nine underfull boxes, and six Hyperref warnings. HL-B19 is
   next and records cleanup against the full 98-page artifact.
+
+## Findings from HL-B19
+
+- French now uses `\raggedbottom`, making intentionally short micro-lesson
+  pages explicit and removing nine underfull vertical boxes without padding or
+  stretching learner content.
+- Six concise optional section titles keep legacy running headers inside the
+  text block, while two prose-only Chapter 12 titles provide clean PDF
+  bookmarks without changing the visible mathematical arrows.
+- Three internal source paths can now break naturally. Five dense legacy tables
+  use a flexible final column, preserving every comparison while removing
+  horizontal overflow, and one pronominal-verb explanation has clearer sentence
+  boundaries for the same grammatical rule.
+- A forced XeLaTeX build produces 98 pages with zero missing glyphs, overfull or
+  underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings.
+- HL-B20 is next: close the seven-chapter German app/book gap before its measured
+  presentation-cleanup follow-up.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/french/CHANGELOG.md
+++ b/code/learning/human-languages/french/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Warning-free 98-page book — 2026-08-03
+
+- Added natural page bottoms for intentionally short micro-lessons and concise
+  optional running titles for six long legacy section headings.
+- Made two Chapter 12 bookmarks prose-only, allowed three internal source paths
+  to break naturally, and gave five dense comparison tables flexible final
+  columns without removing any vocabulary, grammar, or etymology.
+- Reflowed one pronominal-verb explanation into clearer sentence boundaries
+  while preserving its agreement rule and examples.
+- A forced XeLaTeX build now reports zero missing glyphs, overfull or underfull
+  boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings across
+  all 98 pages.
+
 ## Canonical Chapters 17–23 — 2026-08-03
 
 - Migrated the nine lessons in Chapters 17–23 to schema version 2 with typed

--- a/code/learning/human-languages/french/README.md
+++ b/code/learning/human-languages/french/README.md
@@ -58,7 +58,9 @@ is assumed: the text supplies every Spanish form in full, as enrichment, so the
 
 **All twenty-three chapters are authored and in the book (98 pages).** Chapters
 17–23 are generated from the same canonical lesson AST and source hashes that
-Language Ladder verifies independently.
+Language Ladder verifies independently. A forced XeLaTeX build is free of
+missing glyphs, layout boxes, duplicate destinations, Hyperref warnings, and
+LaTeX warnings.
 
 ## Files
 

--- a/code/learning/human-languages/french/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/french/book/chapters/ch01-greetings.tex
@@ -151,7 +151,7 @@ silent, heard only in \emph{les}).
 \emph{bon} stays masculine. The evening swap for \emph{bonjour}, and --- like
 Spanish \emph{buenas noches} --- usable both arriving and leaving.
 
-\section{\emph{nuit} --- ``night,'' and a sound-change mirroring Spanish}
+\section[\emph{nuit}]{\emph{nuit} --- ``night,'' and a sound-change mirroring Spanish}
 \label{lesson:nuit}
 
 \begin{cousinweb}

--- a/code/learning/human-languages/french/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/french/book/chapters/ch02-introductions.tex
@@ -82,7 +82,7 @@ That is how French says a name --- not ``my name is'' but ``I call myself.''
 (English has the same move, hidden in ``I call \emph{myself}.'')
 \end{grammarlens}
 
-\section{\emph{je m'appelle\ldots} --- ``my name is\ldots,'' literally ``I call myself''}
+\section[\emph{je m'appelle\ldots}]{\emph{je m'appelle\ldots} --- ``my name is\ldots,'' literally ``I call myself''}
 \label{lesson:je-mappelle}
 
 \emph{je} (I, \S\ref{lesson:je}) $+$ \emph{me} (myself, \S\ref{lesson:me},
@@ -155,7 +155,7 @@ appelez-\textbf{vous}?} (with a hyphen). The informal version simply swaps in
 exactly as \emph{me} became \emph{m'}.
 \end{grammarlens}
 
-\section{\emph{enchant\'{e}} --- ``delighted,'' i.e. ``pleased to meet you''}
+\section[\emph{enchant\'{e}}]{\emph{enchant\'{e}} --- ``delighted,'' i.e. ``pleased to meet you''}
 \label{lesson:enchante}
 
 \begin{sounds}

--- a/code/learning/human-languages/french/book/chapters/ch03-how-are-you.tex
+++ b/code/learning/human-languages/french/book/chapters/ch03-how-are-you.tex
@@ -12,7 +12,8 @@ asking how someone is doing. French asks that last question with a verb of
 \end{center}
 
 Each piece is taken apart first, then assembled.
-\emph{Practice lessons: \texttt{lessons/FR-C03-*.md}.}
+
+\emph{Practice lessons: \nolinkurl{lessons/FR-C03-*.md}.}
 
 \section{\emph{merci} --- ``thank you,'' and it means \emph{mercy}}
 \label{lesson:merci}
@@ -46,7 +47,7 @@ Same feeling, three quite different pictures --- French hands you a reward,
 Spanish hands you grace, Portuguese declares itself in your debt.
 \end{culture}
 
-\section{\emph{de rien} --- ``you're welcome,'' literally ``of nothing''}
+\section{\emph{de rien} --- ``you're welcome'': ``of nothing''}
 \label{lesson:de-rien}
 
 \begin{sounds}
@@ -145,7 +146,7 @@ formal. \emph{tu} is the familiar ``you'' (a friend, a peer); \emph{vous} is the
 formal or plural ``you'' (a stranger, an elder, a group).
 
 \begin{center}
-\begin{tabular}{@{}lll@{}}
+\begin{tabularx}{\linewidth}{@{}ll>{\raggedright\arraybackslash}X@{}}
 \toprule
 Register & Question & Literally \\
 \midrule
@@ -153,7 +154,7 @@ Casual, universal & \emph{Comment \c{c}a va?} (or \emph{\c{C}a va?}) & ``How doe
 Informal, one friend & \emph{Comment vas-tu?} & ``How go \emph{you}?'' \\
 Formal or plural & \emph{Comment allez-vous?} & ``How go \emph{you} (vous)?'' \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 \emph{vas} and \emph{allez} are simply the \emph{tu} and \emph{vous} forms of

--- a/code/learning/human-languages/french/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/french/book/chapters/ch05-first-verbs.tex
@@ -112,7 +112,7 @@ beginning with a vowel. With this verb you can answer an \emph{o\`{u}}
 (``where'') question: \emph{J'habite \`{a} Paris.} --- ``I live in Paris.''
 \end{grammarlens}
 
-\section{\emph{travailler} --- ``to work,'' and the torture behind \emph{travel}}
+\section[\emph{travailler}]{\emph{travailler} --- ``to work,'' and the torture behind \emph{travel}}
 \label{lesson:travailler}
 
 \begin{sounds}

--- a/code/learning/human-languages/french/book/chapters/ch06-numbers-1-10.tex
+++ b/code/learning/human-languages/french/book/chapters/ch06-numbers-1-10.tex
@@ -16,7 +16,7 @@ half-know them from English, and a \emph{Spanish twin} stands beside each one.
 \end{sounds}
 
 \begin{center}
-\begin{tabular}{@{}llll@{}}
+\begin{tabularx}{\linewidth}{@{}lll>{\raggedright\arraybackslash}X@{}}
 \toprule
 French & $\leftarrow$ Latin & Spanish twin & English cousins \\
 \midrule
@@ -26,7 +26,7 @@ French & $\leftarrow$ Latin & Spanish twin & English cousins \\
 \emph{quatre} (4) & \emph{quattuor} & \emph{cuatro} & \textbf{quart}, \textbf{quarter}, \textbf{quatrain}, \textbf{quadrant} \\
 \emph{cinq} (5) & \emph{qu\={\i}nque} & \emph{cinco} & \textbf{quintet}, \textbf{quintessence} \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 \begin{cousinweb}
@@ -47,7 +47,7 @@ exactly like Spanish \emph{un}/\emph{una}. The others (\emph{deux}, \emph{trois}
 \ldots) don't change.
 \end{grammarlens}
 
-\section{\emph{six, sept, huit, neuf, dix} --- and the calendar's secret}
+\section[six to ten]{\emph{six, sept, huit, neuf, dix} --- and the calendar's secret}
 \label{lesson:nombres-6-10}
 
 The rest of the way to ten. These four hide the same fact the English and

--- a/code/learning/human-languages/french/book/chapters/ch07-days.tex
+++ b/code/learning/human-languages/french/book/chapters/ch07-days.tex
@@ -21,7 +21,7 @@ Every French weekday ends in \emph{-di}, which is Latin \emph{di\={e}s},
 ``day.'' The first part is a planet-god. Read each one as ``[god]'s day'':
 
 \begin{center}
-\begin{tabular}{@{}llll@{}}
+\begin{tabularx}{\linewidth}{@{}lll>{\raggedright\arraybackslash}X@{}}
 \toprule
 French & $\leftarrow$ Latin & planet-god & English echo \\
 \midrule
@@ -31,7 +31,7 @@ French & $\leftarrow$ Latin & planet-god & English echo \\
 \emph{jeudi} & \emph{Jovis di\={e}s} & \textbf{Jupiter} (\emph{Jove}) & \emph{Thurs}day (\textbf{Thor} $=$ Jupiter) \\
 \emph{vendredi} & \emph{Veneris di\={e}s} & \textbf{Venus} & \emph{Fri}day (Frigg/Freya $=$ Venus) \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 \begin{cousinweb}

--- a/code/learning/human-languages/french/book/chapters/ch09-months-seasons.tex
+++ b/code/learning/human-languages/french/book/chapters/ch09-months-seasons.tex
@@ -4,7 +4,7 @@
 The French calendar is a procession of Roman gods and emperors, carried almost
 unchanged out of Latin --- and the four seasons are four small Latin poems about
 heat, sleep, and first things. \emph{Practice lessons:
-\texttt{lessons/FR-C09-*.md}.}
+\nolinkurl{lessons/FR-C09-*.md}.}
 
 \section{\emph{les mois} --- the calendar's gods and Caesars}
 \label{lesson:mois}
@@ -61,7 +61,7 @@ Four words for the turning year: \textbf{le printemps}, \textbf{l'\'{e}t\'{e}},
 a small poem --- \emph{printemps} means, almost literally, ``the first time.''
 
 \begin{center}
-\begin{tabular}{@{}lll@{}}
+\begin{tabularx}{\linewidth}{@{}ll>{\raggedright\arraybackslash}X@{}}
 \toprule
 French & $\leftarrow$ Latin & literally \\
 \midrule
@@ -70,7 +70,7 @@ French & $\leftarrow$ Latin & literally \\
 \emph{l'automne} (autumn) & \emph{autumnus} & ``autumn'' --- the word English borrowed \\
 \emph{l'hiver} (winter) & \emph{h\={\i}bernum (tempus)} & ``the \textbf{wintry} season'' \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 \begin{cousinweb}

--- a/code/learning/human-languages/french/book/chapters/ch12-numbers-11-20.tex
+++ b/code/learning/human-languages/french/book/chapters/ch12-numbers-11-20.tex
@@ -4,9 +4,9 @@
 The French teens are not built the way you would guess. Six of them came out of
 Latin already welded together; then, at exactly seventeen, the language changes
 its mind in front of you. \emph{Practice lessons:
-\texttt{lessons/FR-C12-*.md}.}
+\nolinkurl{lessons/FR-C12-*.md}.}
 
-\section{\emph{onze} $\to$ \emph{seize} --- six numbers welded together}
+\section[\emph{onze} to \emph{seize}]{\emph{onze} $\to$ \emph{seize} --- six numbers welded together}
 \label{lesson:nombres-11-16}
 
 French did not say ``ten-one, ten-two.'' It inherited six numbers already
@@ -34,6 +34,7 @@ Look at the ending they all share: \textbf{-ze}. That is Latin \emph{decem}
 three disguises.
 \end{cousinweb}
 
+\newpage
 \begin{grammarlens}
 \textbf{The digit is still in there.} The front of each word is the small
 number it is built on: \emph{un} $\to$ \emph{on-}, \emph{deux} $\to$
@@ -44,7 +45,7 @@ comes first and the \emph{ten} second --- \emph{tr\=edecim} is ``three-ten,''
 not ``ten-three.''
 \end{grammarlens}
 
-\section{\emph{dix-sept} $\to$ \emph{vingt} --- where French changes its mind}
+\section[\emph{dix-sept} to \emph{vingt}]{\emph{dix-sept} $\to$ \emph{vingt} --- where French changes its mind}
 \label{lesson:nombres-17-20}
 
 Here is something you can \emph{watch happen}. Up to \emph{seize} (16), French

--- a/code/learning/human-languages/french/book/chapters/ch13-colours.tex
+++ b/code/learning/human-languages/french/book/chapters/ch13-colours.tex
@@ -54,7 +54,7 @@ in your head --- \emph{noir} from Latin, \emph{blanc} from the Franks. Say
 \emph{l'aube} and hear the old Latin white still sitting inside it.
 \end{grammarlens}
 
-\section{\emph{rouge}, \emph{bleu} --- an ancient word and a borrowed one}
+\section[\emph{rouge} and \emph{bleu}]{\emph{rouge}, \emph{bleu} --- an ancient word and a borrowed one}
 \label{lesson:rouge-bleu}
 
 The last section gave one inherited colour and one borrowed. This one repeats

--- a/code/learning/human-languages/french/book/chapters/ch16-etre.tex
+++ b/code/learning/human-languages/french/book/chapters/ch16-etre.tex
@@ -189,14 +189,14 @@ agreed with her, and it still does.
 Compare the two halves of the system:
 
 \begin{center}
-\begin{tabular}{@{}lll@{}}
+\begin{tabularx}{\linewidth}{@{}ll>{\raggedright\arraybackslash}X@{}}
 \toprule
 Auxiliary & Participle agrees with & Because it was\ldots \\
 \midrule
 \emph{avoir} & a \textbf{preceding object} (\emph{les lettres que j'ai \'{e}crites}) & ``I have letters written'' \\
 \emph{\^{e}tre} & the \textbf{subject} (\emph{elle est all\'{e}e}) & ``she is gone'' \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 One rule underneath both: \textbf{the participle was an adjective, and it agrees
@@ -218,11 +218,11 @@ auxiliary looks like \emph{\^{e}tre}; the agreement behaves like \emph{avoir}.
 Don't let the first mislead you about the second.
 \end{grammarlens}
 
-One group in particular escapes even that. Verbs that exist \emph{only} in
-pronominal form --- \emph{se souvenir} (remember), \emph{s'enfuir} (flee),
-\emph{s'\'{e}vanouir} (faint) --- have no non-reflexive version for the pronoun
-to be an object \emph{of}, so they simply agree with the subject: \emph{elles se
-sont \textbf{souvenues}}.
+One group in particular escapes even that: verbs that exist \emph{only} in
+pronominal form. Examples include \emph{se souvenir} (remember), \emph{s'enfuir}
+(flee), and \emph{s'\'{e}vanouir} (faint). They have no non-reflexive version for
+the pronoun to be an object \emph{of}, so they simply agree with the subject:
+\emph{elles se sont \textbf{souvenues}}.
 
 \begin{sounds}
 \textbf{Practice.} Say \emph{je suis all\'{e}, il est all\'{e}, elle est

--- a/code/learning/human-languages/french/book/preamble.tex
+++ b/code/learning/human-languages/french/book/preamble.tex
@@ -57,3 +57,7 @@
 
 \titleformat{\chapter}[display]
   {\normalfont\Large\bfseries}{Chapter \thechapter}{10pt}{\huge}
+
+% Micro-lessons deliberately leave some pages short. Keep their natural
+% whitespace instead of stretching page content to force a flush bottom.
+\raggedbottom


### PR DESCRIPTION
## Summary
- remove the complete measured French PDF warning baseline from the full 98-page book
- keep long legacy running titles and Chapter 12 PDF bookmarks concise without changing visible lesson meaning
- make five dense comparison tables responsive to the text width, preserve natural micro-lesson page bottoms, and improve one awkward callout page break

## Measured result
- 98 pages and 25 expected top-level outline entries
- 0 missing glyphs
- 0 overfull or underfull boxes
- 0 duplicate destinations
- 0 Hyperref warnings
- 0 LaTeX warnings
- no schema, source-hash, or generator metadata leaked into extracted book text

## Validation
- `npm test` — human-language-data: 81 passed
- `npm run validate` — 9 passed
- `npm run check:books`
- `npm test` — Language Ladder: 326 passed
- `npm run build` — Language Ladder
- `npx vitest run tests/bookhashes.test.ts` — 51 passed after final rebase
- `latexmk -g -xelatex -interaction=nonstopmode -halt-on-error book.tex`
- rendered all 98 pages; inspected seven contact sheets and every changed page at full size
- verified page count, outline, intentional blank pages, warning counts, and extracted-text metadata
- `git diff --check`