### PR TITLE
fix(spice): lower BJT CJC0 alias

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate BJT model-card `CJC` / `CJC0` / `CBC` base-collector capacitance and
+  lower the `CJC0` alias instead of silently dropping it.
 - Validate BJT model-card `CJE` / `CJE0` / `CBE` base-emitter capacitance and
   lower the `CJE0` alias instead of silently dropping it.
 - Validate BJT model-card `VT` / `V_T` thermal voltage and lower the `V_T`

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1301,7 +1301,9 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Cje=model.params.get(
                 "CJE", model.params.get("CJE0", model.params.get("CBE", 0.0))
             ),
-            Cjc=model.params.get("CJC", model.params.get("CBC", 0.0)),
+            Cjc=model.params.get(
+                "CJC", model.params.get("CJC0", model.params.get("CBC", 0.0))
+            ),
             Tf=model.params.get("TF", 0.0),
             Tr=model.params.get("TR", 0.0),
         )
@@ -1962,6 +1964,15 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or base_emitter_capacitance < 0.0
         ):
             raise NetlistParseError("BJT CJE must be finite and non-negative")
+        base_collector_capacitance = next(
+            (params[name] for name in ("CJC", "CJC0", "CBC") if name in params),
+            None,
+        )
+        if base_collector_capacitance is not None and (
+            not math.isfinite(base_collector_capacitance)
+            or base_collector_capacitance < 0.0
+        ):
+            raise NetlistParseError("BJT CJC must be finite and non-negative")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1008,6 +1008,34 @@ def test_rejects_invalid_bjt_base_emitter_capacitance(
         parse_netlist(f".model fast NPN({parameter}={value})")
 
 
+def test_parse_bjt_base_collector_capacitance_alias_with_canonical_precedence() -> None:
+    parsed = parse_netlist(
+        """
+.model fast NPN(CJC=2p CJC0=3p CBC=4p)
+Q1 col base emit fast
+.model slow PNP(CJC0=5p)
+Q2 col base emit slow
+"""
+    )
+
+    first, second = parsed.circuit.elements
+    assert isinstance(first, BJT)
+    assert isinstance(second, BJT)
+    assert first.Cjc == 2.0e-12
+    assert second.Cjc == 5.0e-12
+
+
+@pytest.mark.parametrize("parameter", ["CJC", "CJC0", "CBC"])
+@pytest.mark.parametrize("value", ["-1p", "1e999"])
+def test_rejects_invalid_bjt_base_collector_capacitance(
+    parameter: str, value: str
+) -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT CJC must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NPN({parameter}={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate BJT model-card `CJC` / `CJC0` / `CBC` base-collector capacitance and
+  lower the `CJC0` alias instead of silently dropping it.
 - Validate BJT model-card `CJE` / `CJE0` / `CBE` base-emitter capacitance and
   lower the `CJE0` alias instead of silently dropping it.
 - Validate BJT model-card `VT` / `V_T` thermal voltage and lower the `V_T`

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1204,6 +1204,15 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT CJE must be finite and non-negative");
   }
+  const bjtBaseCollectorCapacitance =
+    params.get("CJC") ?? params.get("CJC0") ?? params.get("CBC");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtBaseCollectorCapacitance !== undefined &&
+    (!Number.isFinite(bjtBaseCollectorCapacitance) || bjtBaseCollectorCapacitance < 0.0)
+  ) {
+    throw new NetlistParseError("BJT CJC must be finite and non-negative");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -1764,7 +1773,10 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
         model.params.get("CJE0") ??
         model.params.get("CBE") ??
         0.0,
-      model.params.get("CJC") ?? model.params.get("CBC") ?? 0.0,
+      model.params.get("CJC") ??
+        model.params.get("CJC0") ??
+        model.params.get("CBC") ??
+        0.0,
       model.params.get("TF") ?? 0.0,
       model.params.get("TR") ?? 0.0,
     );

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1020,6 +1020,37 @@ Q2 col base emit slow
     );
   });
 
+  it("parses the BJT CJC0 capacitance alias with canonical precedence", () => {
+    const parsed = parseNetlist(`
+.model fast NPN(CJC=2p CJC0=3p CBC=4p)
+Q1 col base emit fast
+.model slow PNP(CJC0=5p)
+Q2 col base emit slow
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      baseCollectorCapacitance: 2.0e-12,
+    });
+    expect(parsed.circuit.elements()[1]).toMatchObject({
+      kind: "bjt",
+      baseCollectorCapacitance: 5.0e-12,
+    });
+  });
+
+  it.each([
+    ["CJC", "-1p"],
+    ["CJC", "1e999"],
+    ["CJC0", "-1p"],
+    ["CJC0", "1e999"],
+    ["CBC", "-1p"],
+    ["CBC", "1e999"],
+  ])("rejects invalid BJT %s base-collector capacitance %s", (parameter, value) => {
+    expect(() => parseNetlist(`.model fast NPN(${parameter}=${value})`)).toThrow(
+      "BJT CJC must be finite and non-negative",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4361,12 +4361,18 @@ the Rust, Python, and TypeScript surfaces together.
    - Both parser facades validate positive finite `VT` / `V_T` values and
      lower `V_T` into the shared engine BJT thermal-voltage field.
 
+409. Python and TypeScript Berkeley SPICE BJT base-emitter capacitance alias parity.
+   - Status: completed in PR 9760.
+   - Both parser facades validate finite non-negative `CJE` / `CJE0` / `CBE`
+     values and lower `CJE0` into the shared engine base-emitter capacitance
+     field after canonical `CJE` and before legacy `CBE`.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE BJT model-card alias parity.
    - Align parser validation and lowering with the shared engine aliases,
-     continuing with `CJC0` as a base-collector capacitance alias for `CJC`
-     after `CJE0`.
+     then audit the remaining directly lowerable BJT fields, starting with
+     finite non-negative `TF` / `TR` transit-time validation after `CJC0`.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary

- validate finite, non-negative BJT CJC, CJC0, and CBC model-card capacitance values in Python and TypeScript
- lower CJC0 with canonical CJC precedence and legacy CBC fallback
- record merged BJT CJE0 parity and queue the remaining directly lowerable BJT parameter audit

## Verification

- Python spice-netlist-parser: `bash BUILD` (282 passed, 88.90% coverage)
- Python spice-netlist-parser: `.venv/bin/ruff check .`
- TypeScript spice-engine: `npm ci --quiet && npm run build && npm test` (448 passed)
- TypeScript spice-netlist-parser: `bash BUILD && npm run test:coverage` (271 passed, 85.80% line coverage)