### PR TITLE
Report table end tags exiting foreign content

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,10 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Table-context end tags that force recovery from SVG or MathML foreign
+  content now report the foreign-content parse error, covering 4 previously
+  silent malformed corpus cases without changing DOM recovery or
+  undeclared-diagnostic coverage.
 - HTML start tags that force recovery from SVG or MathML foreign content now
   report the foreign-content parse error, covering 15 previously silent
   malformed corpus cases without changing DOM recovery or

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the foreign-content HTML-start-tag breakout diagnostic slice, 2,070 of
-those cases emit at least one lexer or parser diagnostic and 113 remain
+After the foreign-content table-end-tag breakout diagnostic slice, 2,074 of
+those cases emit at least one lexer or parser diagnostic and 109 remain
 uncovered.
 Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
 These are reviewed rather than automatically removed: 89 are full-document
@@ -63,7 +63,7 @@ recovery closes a non-current list item, and a paragraph end tag reports when it
 breaks out of MathML foreign content. A formatting end tag also reports when an
 open table blocks adoption-agency recovery.
 
-The fresh 113-case residual inventory keeps the next concrete groups in the
+The fresh 109-case residual inventory keeps the next concrete groups in the
 existing priority order: remaining table foster-parenting and table-scope
 boundaries;
 select/template recovery; script-tokenizer EOF recovery; plaintext/frameset
@@ -77,7 +77,8 @@ Prioritized work items:
    parenting, table scopes, select recovery, and template mode-stack errors.
    Non-whitespace table text now reports when it is foster-parented. The
    specialized SVG and MathML start-tag path now reports when table insertion
-   mode foster-parents foreign content. The
+   mode foster-parents foreign content, and table-context end tags now report
+   when they force recovery from foreign content. The
    remaining fragment EOF inventory includes fostered-anchor `eof-in-table`
    rows and MathML/SVG table-boundary scope recovery.
 3. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -6721,7 +6721,12 @@ impl HtmlParser {
                 || self.current_namespace() == Some("svg")
                 || (self.current_namespace() == Some("math") && name == "p"))
         {
-            if self.current_namespace() == Some("math") && name == "p" {
+            if is_table_context_element(name) {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-table-end-tag-in-foreign-content",
+                    format!("end tag `</{name}>` forced table recovery from foreign content"),
+                ));
+            } else if self.current_namespace() == Some("math") && name == "p" {
                 self.diagnostics.push(ParserDiagnostic::new(
                     "unexpected-p-end-tag-in-foreign-content",
                     "end tag `</p>` in MathML foreign content forced HTML recovery",
@@ -33431,6 +33436,34 @@ mod tests {
             .parser_diagnostics
             .iter()
             .all(|diagnostic| diagnostic.code != "unexpected-html-start-tag-in-foreign-content"));
+    }
+
+    #[test]
+    fn reports_table_end_tags_that_break_out_of_foreign_content() {
+        for source in [
+            "<!doctype html><table><caption><svg><g>x</table>",
+            "<!doctype html><table><caption><math><mrow>x</table>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().any(|diagnostic| {
+                    diagnostic
+                        == &ParserDiagnostic::new(
+                            "unexpected-table-end-tag-in-foreign-content",
+                            "end tag `</table>` forced table recovery from foreign content",
+                        )
+                }),
+                "source {source:?}"
+            );
+        }
+
+        let closed_foreign = parse_html_with_diagnostics(
+            "<!doctype html><table><caption><svg></svg></caption></table>",
+        )
+        .unwrap();
+        assert!(closed_foreign.parser_diagnostics.iter().all(|diagnostic| {
+            diagnostic.code != "unexpected-table-end-tag-in-foreign-content"
+        }));
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 113);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2070);
+    assert_eq!(missing_diagnostic_cases, 109);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2074);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report the WHATWG foreign-content parse error when table-context end tags force recovery from SVG or MathML
- preserve the existing DOM recovery path and avoid diagnostics after foreign content is explicitly closed
- ratchet checked malformed-case diagnostic coverage from 2,070 to 2,074 cases, leaving 109 silent cases and 139 undeclared-diagnostic cases

## Evidence
- current WPT tree construction at `844f550c6bc1b604bc5aed82bfcd9048ea5cc339`: 1,934/1,934 signatures, zero missing
- html5lib tokenizer tests at `224991ec10db04f056a89eed8b0bd8695fd2950e`: 6,806/6,806 signatures, zero missing; 7,242 normalized cases, zero skips
- checked tree corpus: all 2,637 DOM outputs preserved

## Validation
- `cargo test -p coding-adventures-html-parser --test tree_construction_test`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- live upstream coverage audit with pinned counts and zero missing/skips
- parser audit manifest, Rust-test, coverage, and smoke checks
- generated HTML fixture and README inventory checks
- `git diff --check`
