### PR TITLE
feat(human-languages): publish canonical German chapters

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -87,9 +87,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B16 | Complete (#9744) | Publish Portuguese Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Fifty schema-v2 lessons now generate sixteen chapters whose source hashes are independently verified against the Language Ladder corpus. |
 | HL-B17 | Complete (#9748) | Remove Portuguese's LaTeX layout warnings. | The forced 105-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
 | HL-B18 | Complete (#9752) | Publish French Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | Nine schema-v2 lessons now generate seven chapters whose source hashes are independently verified against the Language Ladder corpus. |
-| HL-B19 | Complete in this PR | Remove French's LaTeX layout and Unicode bookmark warnings. | The forced 98-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
-| HL-B20 | Next | Publish German Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | The German PDF reaches Chapter 16 while canonical app content continues through Chapter 23; schema-v2 migration plus generation should close that drift safely. |
-| HL-B21 | Queued | Remove German's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs or duplicate labels but reports seventeen overfull boxes, eleven underfull boxes, and three Hyperref warnings; the clean-build signal is zero of each. |
+| HL-B19 | Complete (#9761) | Remove French's LaTeX layout and Unicode bookmark warnings. | The forced 98-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
+| HL-B20 | Complete in this PR | Publish German Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | Ten schema-v2 lessons now generate seven chapters whose source hashes are independently verified against the Language Ladder corpus. |
+| HL-B21 | Next | Remove German's LaTeX layout and Unicode bookmark warnings. | The expanded forced build has no missing glyphs or duplicate destinations but reports eighteen overfull boxes, one underfull horizontal box, eleven underfull vertical boxes, and three Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B22 | Queued | Publish Telugu Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Telugu PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
 | HL-B23 | Queued | Remove Telugu's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports four overfull boxes, three underfull boxes, four duplicate practice labels, 27 Hyperref warnings, and a font-shape substitution warning; the clean-build signal is zero of each. |
 | HL-B24 | Queued | Publish Kannada Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Kannada PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
@@ -651,6 +651,28 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings.
 - HL-B20 is next: close the seven-chapter German app/book gap before its measured
   presentation-cleanup follow-up.
+
+## Findings from HL-B20
+
+- German Chapters 17–23 now comprise ten strict schema-v2 micro-lessons with
+  explicit shared-spine anchors, prerequisite-closed knowledge atoms, typed
+  teaching blocks, and authored skill, mode, strand, register, variety, and
+  duration contracts. Their computed durations range from 164 to 262 seconds.
+- The audit found that `Entschuldigung` occupied Chapter 19 while no Chapter 20
+  lesson existed. A new Chapter 19 lesson now reviews `bitte` as “please” in
+  **Wasser, bitte** using only Chapters 3 and 11; the unchanged apology content
+  follows as prerequisite-dependent Chapter 20.
+- Seven generated chapters carry deterministic hashes and lesson ids that
+  Language Ladder independently reproduces from the canonical AST. The corpus
+  grows to 1,066 lessons, repository-wide missing book chapters fall from 213
+  to 207, and unknown prerequisites and duration violations remain at zero.
+- A forced XeLaTeX build produces 104 pages with zero missing glyphs, duplicate
+  destinations, LaTeX warnings, or leaked generator metadata. All pages were
+  rendered and inspected; the outline retains Preface, pronunciation, and
+  Chapters 1–23.
+- The expanded warning baseline is eighteen overfull boxes, one underfull
+  horizontal box, eleven underfull vertical boxes, and three Hyperref warnings.
+  HL-B21 is next and records cleanup against the full 104-page artifact.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -319,6 +319,55 @@
       "output": "french/book/chapters/ch23-green-and-yellow.tex"
     },
     {
+      "language": "german",
+      "chapter": 17,
+      "title": "Head and Hand",
+      "label": "ch:ge-head-and-hand",
+      "output": "german/book/chapters/ch17-head-and-hand.tex"
+    },
+    {
+      "language": "german",
+      "chapter": 18,
+      "title": "Yes and No",
+      "label": "ch:ge-yes-and-no",
+      "output": "german/book/chapters/ch18-yes-and-no.tex"
+    },
+    {
+      "language": "german",
+      "chapter": 19,
+      "title": "Please",
+      "label": "ch:ge-please",
+      "output": "german/book/chapters/ch19-please.tex"
+    },
+    {
+      "language": "german",
+      "chapter": 20,
+      "title": "Sorry",
+      "label": "ch:ge-sorry",
+      "output": "german/book/chapters/ch20-sorry.tex"
+    },
+    {
+      "language": "german",
+      "chapter": 21,
+      "title": "Weather",
+      "label": "ch:ge-weather",
+      "output": "german/book/chapters/ch21-weather.tex"
+    },
+    {
+      "language": "german",
+      "chapter": 22,
+      "title": "Dog and Cat",
+      "label": "ch:ge-dog-and-cat",
+      "output": "german/book/chapters/ch22-dog-and-cat.tex"
+    },
+    {
+      "language": "german",
+      "chapter": 23,
+      "title": "Green and Yellow",
+      "label": "ch:ge-green-and-yellow",
+      "output": "german/book/chapters/ch23-green-and-yellow.tex"
+    },
+    {
       "language": "bengali",
       "chapter": 6,
       "title": "Numbers One to Five",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -77,6 +77,72 @@
       "tex": "french/book/chapters/ch23-green-and-yellow.tex"
     },
     {
+      "language": "german",
+      "chapter": 17,
+      "sourceHash": "fnv1a64:fdbd2e7e24d5d6f2",
+      "lessonIds": [
+        "GE-C17-kopf",
+        "GE-C17-kopf-haupt",
+        "GE-C17-hand"
+      ],
+      "tex": "german/book/chapters/ch17-head-and-hand.tex"
+    },
+    {
+      "language": "german",
+      "chapter": 18,
+      "sourceHash": "fnv1a64:0fd5b6c217dea39e",
+      "lessonIds": [
+        "GE-C18-ja",
+        "GE-C18-nein"
+      ],
+      "tex": "german/book/chapters/ch18-yes-and-no.tex"
+    },
+    {
+      "language": "german",
+      "chapter": 19,
+      "sourceHash": "fnv1a64:56d533c514140e42",
+      "lessonIds": [
+        "GE-C19-bitte-requests"
+      ],
+      "tex": "german/book/chapters/ch19-please.tex"
+    },
+    {
+      "language": "german",
+      "chapter": 20,
+      "sourceHash": "fnv1a64:7f75baaef49241c0",
+      "lessonIds": [
+        "GE-C20-entschuldigung"
+      ],
+      "tex": "german/book/chapters/ch20-sorry.tex"
+    },
+    {
+      "language": "german",
+      "chapter": 21,
+      "sourceHash": "fnv1a64:e773a690ba617e60",
+      "lessonIds": [
+        "GE-C21-das-wetter"
+      ],
+      "tex": "german/book/chapters/ch21-weather.tex"
+    },
+    {
+      "language": "german",
+      "chapter": 22,
+      "sourceHash": "fnv1a64:d7f81c59cce27f45",
+      "lessonIds": [
+        "GE-C22-hund-katze"
+      ],
+      "tex": "german/book/chapters/ch22-dog-and-cat.tex"
+    },
+    {
+      "language": "german",
+      "chapter": 23,
+      "sourceHash": "fnv1a64:6fb7a16474f85d3e",
+      "lessonIds": [
+        "GE-C23-gruen-gelb"
+      ],
+      "tex": "german/book/chapters/ch23-green-and-yellow.tex"
+    },
+    {
       "language": "gujarati",
       "chapter": 6,
       "sourceHash": "fnv1a64:388a6950ab136cc1",

--- a/code/learning/human-languages/german/CHANGELOG.md
+++ b/code/learning/human-languages/german/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Canonical Chapters 17–23 (2026-08-03)
+
+- Migrated the ten lessons in Chapters 17–23 to schema version 2 with typed
+  blocks, explicit shared-spine concepts, prerequisite-closed knowledge atoms,
+  and honest sub-five-minute duration contracts.
+- Repaired the missing shared-spine step between yes/no and sorry: a new
+  164-second `bitte` lesson assembles only previously learned words into
+  **Wasser, bitte**, while `Entschuldigung` moves from Chapter 19 to Chapter 20.
+- Generated seven LaTeX chapters from those canonical lessons and added
+  independent Language Ladder source-hash and lesson-count assertions, so the
+  app and downloadable book now consume one source of truth through Chapter 23.
+- Expanded the book from 84 to 104 pages. A forced XeLaTeX build has no missing
+  glyphs, duplicate destinations, LaTeX warnings, or leaked generator metadata;
+  all 104 rendered pages and the complete outline were inspected.
+- Recorded eighteen overfull boxes, one underfull horizontal box, eleven
+  underfull vertical boxes, and three Hyperref warnings for the focused HL-B21
+  cleanup tranche.
+
 ## Sub-five-minute lesson remediation (2026-08-02)
 
 - All twenty-seven German duration violations are resolved. Twenty-two lessons

--- a/code/learning/human-languages/german/README.md
+++ b/code/learning/human-languages/german/README.md
@@ -48,8 +48,17 @@ French *nuit* — one Indo-European word, split four ways.
 - **Chapter 15 — The Two Past Tenses**: Perfekt, Präteritum.
 - **Chapter 16 — To Be, and the Past That Takes It**: sein (three ancient verbs
   in one paradigm), the Perfekt with *sein*.
+- **Chapter 17 — Head and Hand**: *der Kopf*, *Haupt*, *die Hand*.
+- **Chapter 18 — Yes and No**: *ja*, *nein*, and the negative-answer *doch*.
+- **Chapter 19 — Please**: *Wasser, bitte* from previously learned words.
+- **Chapter 20 — Sorry**: *Entschuldigung*, *es tut mir leid*.
+- **Chapter 21 — Weather**: *das Wetter*, *es ist heiß/kalt*, *es regnet*.
+- **Chapter 22 — Dog and Cat**: *Hund*, *Katze*.
+- **Chapter 23 — Green and Yellow**: *grün*, *gelb*.
 
-**All sixteen chapters are authored and in the book (84 pages).**
+**All twenty-three chapters are authored and in the book (104 pages).** Chapters
+17–23 are generated from the same canonical lesson AST and source hashes that
+Language Ladder verifies independently.
 
 ## Files
 

--- a/code/learning/human-languages/german/book/book.tex
+++ b/code/learning/human-languages/german/book/book.tex
@@ -85,5 +85,13 @@ gate. Released under CC~BY-SA~4.0.
 \input{chapters/ch15-perfekt}
 \input{chapters/ch16-sein}
 
+\input{chapters/ch17-head-and-hand}
+\input{chapters/ch18-yes-and-no}
+\input{chapters/ch19-please}
+\input{chapters/ch20-sorry}
+\input{chapters/ch21-weather}
+\input{chapters/ch22-dog-and-cat}
+\input{chapters/ch23-green-and-yellow}
+
 
 \end{document}

--- a/code/learning/human-languages/german/book/chapters/ch17-head-and-hand.tex
+++ b/code/learning/human-languages/german/book/chapters/ch17-head-and-hand.tex
@@ -1,0 +1,201 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:fdbd2e7e24d5d6f2
+% canonical-lessons: GE-C17-kopf, GE-C17-kopf-haupt, GE-C17-hand
+
+\chapter{Head and Hand}
+\label{ch:ge-head-and-hand}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[der Kopf]{Der Kopf — “the head”}
+
+\label{lesson:GE-C17-kopf}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Learn the first body part with its article and its characteristic final sound.
+\end{quote}
+
+\subsection*{You'll want to know: der Kopf}
+\begin{quote}
+\textbf{der Kopf} — the head
+\end{quote}
+
+It is masculine and capitalised because every German noun begins with a capital letter.
+
+\begin{sounds}
+At the end of \textbf{Kopf}, close for \emph{p} and release directly into \emph{f}. English has no identical native ending, so practise it slowly:
+
+\begin{quote}
+Ko-p-f $\to$ \textbf{Kopf}
+\end{quote}
+\end{sounds}
+
+\begin{grammarlens}[title={Grammar Lens: Kopf + Schmerzen}]
+A useful phrase is:
+
+\begin{quote}
+\textbf{Ich habe Kopfschmerzen.} — I have a headache.
+\end{quote}
+
+German compounds simply place nouns together: \textbf{Kopf} (head) + \textbf{Schmerzen} (pains).
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{Kopf} originally meant a \textbf{cup or bowl}. It is related to English \textbf{cup}; both were early borrowings of Late Latin \emph{\textbf{cuppa}}. A container word became slang for the skull and eventually took over the everyday job.
+
+German’s older inherited head-word did not disappear completely. The next micro-lesson follows it into compounds and compares the same container metaphor in French.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: “der Kopf” — release \emph{p} into \emph{f}{]}
+  \item {[}YOU SAY: “Ich habe Kopfschmerzen.”{]}
+  \item {[}YOU SAY: “Kopf — cup or bowl”{]}
+\end{itemize}
+
+{[}REPEAT x2{]} “Der Kopf — masculine, capitalised.”
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Say “the head.” (\textbf{Der Kopf}.) What gender? (\textbf{Masculine}.) Why the capital? (It is a \textbf{noun}.) What did \emph{Kopf} first mean? (A \textbf{cup or bowl}.) Which English word is related? (\textbf{Cup}.) Next: find the inherited word \emph{Haupt}.
+\end{tcolorbox}
+\section[Kopf / Haupt]{Kopf / Haupt — two head-words}
+
+\label{lesson:GE-C17-kopf-haupt}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} \textbf{Kopf} began as “cup.” German’s inherited word for “head” is \textbf{Haupt}, a cousin of English \emph{head} and Latin \emph{caput}.
+\end{quote}
+
+\begin{cousinweb}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{inherited form} \\
+\midrule
+Latin & \emph{caput} \\
+German & \textbf{Haupt} \\
+English & \textbf{head} \\
+\bottomrule
+\end{tabularx}
+
+The initial \emph{k $\to$ h} relationship reflects Grimm’s law, the same systematic Germanic sound shift seen in Latin \emph{pater} beside English \emph{father}. The later consonants have their own history; use the initial pair as the clear signal.
+
+\textbf{Haupt} survives in compounds and formal vocabulary:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{Hauptstadt} — capital, literally “head city”;
+  \item \textbf{Hauptbahnhof} — main station;
+  \item \textbf{Hauptsache} — main thing.
+\end{itemize}
+\end{cousinweb}
+
+\begin{culture}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{everyday word} & \textbf{older picture} \\
+\midrule
+German & \textbf{Kopf} & \emph{cuppa}, cup \\
+French & \emph{tête} & \emph{testa}, pot \\
+\bottomrule
+\end{tabularx}
+
+Both languages independently promoted a vessel-word to “head,” while keeping the older head-root in words for chiefs, capitals, or main things. The vocabulary sources are both Latin loans, but the \textbf{metaphor} was applied separately: heads look like bowls in many languages.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: “Kopf — everyday cup-word”{]}
+  \item {[}YOU SAY: “Haupt — inherited head-word”{]}
+  \item {[}YOU SAY: “Hauptstadt, Hauptbahnhof”{]}
+\end{itemize}
+
+{[}REPEAT x2{]} “Kopf took the job; Haupt stayed in compounds.”
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which word is everyday “head”? (\textbf{Kopf}.) Which inherited word survives in compounds? (\textbf{Haupt}.) Name two compounds. (\textbf{Hauptstadt, Hauptbahnhof}.) What parallel metaphor did French use? (\textbf{Tête}, originally a pot.) Next: the hand.
+\end{tcolorbox}
+\section[die Hand]{die Hand — "the hand"}
+
+\label{lesson:GE-C17-hand}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} After the tangle of \emph{Kopf} and \emph{Haupt}, here is the easiest word in the chapter — and a useful lesson about when languages \textbf{don't} match.
+\end{quote}
+
+\subsection*{You'll want to know: die Hand}
+\begin{quote}
+\textbf{die Hand} — the hand. \textbf{Feminine}, and spelled exactly like English.
+\end{quote}
+
+\begin{sounds}
+One pronunciation note: the final \textbf{d} is said as a \textbf{t}. German devoices a consonant at the end of a word, so \emph{Hand} \textbf{ends} like English \emph{hunt} — but with the open \emph{ah} of \emph{Tag}, not \emph{hunt}'s vowel. Add an ending and the \emph{d} comes back: \emph{die Hän\textbf{d}e} ("the hands").
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{Hand} is Germanic *\emph{handuz}, and English inherited it directly. Same word, same meaning, two thousand years apart. German and English are close relatives, and body parts are where you feel it most:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{German} & \textbf{English} \\
+\midrule
+\textbf{Hand} & hand \\
+\textbf{Arm} & arm \\
+\textbf{Finger} & finger \\
+\textbf{Fuß} & foot \\
+\textbf{Herz} & heart \\
+\bottomrule
+\end{tabularx}
+\end{cousinweb}
+
+\begin{culture}
+Now the interesting part. Every Romance language in this course builds "hand" on Latin \emph{\textbf{manus}}:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+French & \emph{la main} \\
+Italian & \emph{la mano} \\
+Portuguese & \emph{a mão} \\
+Spanish & \emph{la mano} \\
+\bottomrule
+\end{tabularx}
+
+And Germanic — German, English — has *\emph{handuz}, which is \textbf{not related to \emph{manus} at all}. The two families simply have different words here.
+
+That is worth noticing, because this course keeps finding connections, and it can start to feel as though everything must connect. It doesn't. Indo-European languages share a great deal, and then diverge, and "hand" is one of the places where they diverged early and completely.
+
+The Latin word did reach German — but only as \textbf{borrowed vocabulary}: \emph{Manuskript}, \emph{Maniküre}, \emph{manuell}. Learned imports, sitting beside the native word without displacing it.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "die Hand" — final \textbf{d} said as \textbf{t}{]}
+  \item {[}YOU SAY: the plural, and hear the \emph{d} return — "die Hän\textbf{d}e"{]}
+  \item {[}YOU SAY: the Germanic set — "Hand, Arm, Finger, Fuß, Herz"{]}
+  \item {[}YOU SAY: the gap — "\emph{main}, \emph{mano}, \emph{mão} … but \textbf{Hand}"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Say "the hand." (\emph{Die Hand} — \textbf{feminine}.) How is the final \textbf{d} pronounced, and why? (As a \textbf{t} — German \textbf{devoices} final consonants; the \emph{d} returns in \emph{Hände}.) Is \emph{Hand} related to French \emph{main}? (\textbf{No} — Germanic *\emph{handuz} against Latin \emph{manus}; the families differ here.) How did \emph{manus} reach German anyway? (As \textbf{borrowed} learned words — \emph{Manuskript}, \emph{manuell}.) Next: the rest of the body.
+\end{tcolorbox}

--- a/code/learning/human-languages/german/book/chapters/ch18-yes-and-no.tex
+++ b/code/learning/human-languages/german/book/chapters/ch18-yes-and-no.tex
@@ -1,0 +1,104 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:0fd5b6c217dea39e
+% canonical-lessons: GE-C18-ja, GE-C18-nein
+
+\chapter{Yes and No}
+\label{ch:ge-yes-and-no}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[ja]{ja — yes}
+
+\label{lesson:GE-C18-ja}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The easiest German word to say, and one English almost shares.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{ja} = \textbf{yes}. Said \emph{yah} — remember German \textbf{j} is pronounced like English \textbf{y}, never the English "j."
+
+It's an ancient \textbf{Germanic} word, and English kept the very same root in the one word that still clearly shows it:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{yea} — the old, formal "yes" (\emph{the yeas and the nays} in a vote) — this is \emph{ja}'s direct cousin, same Proto-Germanic root.
+  \item \textbf{aye} — the sailor's and parliament's "yes" (\emph{Aye, aye, captain}) — \emph{sounds} like a cousin, but its origin is actually \textbf{uncertain}; it may come from a different word entirely, so don't bank on it.
+\end{itemize}
+
+So German \emph{ja} and English \emph{yea} are the same little word, split between two cousin languages. (English's everyday \emph{yes} is a compound of that same \emph{yea} with an old "be it so.")
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: A German habit to file away}]
+German also has a \textbf{third} answer-word, \textbf{doch}, for one special job: contradicting a \textbf{negative} — exactly like French \emph{si}. If someone says something \emph{isn't} so and you insist it \emph{is}, you say \textbf{doch}, not \emph{ja}:
+
+\begin{quote}
+\emph{Du kommst nicht?} ("You're not coming?") — \emph{\textbf{Doch!}} ("Yes I am!")
+\end{quote}
+
+You'll drill \emph{doch} on its own later; for now, keep \emph{ja} for a plain yes and know \emph{doch} is waiting for the contradictions.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "ja" — \emph{yah}, the j like English y{]}
+  \item {[}YOU SAY: the English cousin — "yea… ja" (and maybe \emph{aye}){]}
+  \item {[}YOU SAY: the contradiction preview — "Du kommst nicht? — Doch!"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} How do you say yes in German? (\textbf{ja}, \emph{yah}.) How is the \textbf{j} pronounced? (Like English \textbf{y}.) Which English word is \emph{ja}'s firm direct cousin? (\textbf{yea} — \emph{aye} only looks like one; its origin is uncertain.) What German word answers \emph{yes} specifically to contradict a \textbf{negative}? (\textbf{doch}.)
+\end{tcolorbox}
+\section[nein]{nein — no}
+
+\label{lesson:GE-C18-nein}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} German's "no" is a tiny sentence with a number hidden inside it.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{nein} = \textbf{no}. Said to rhyme with English \emph{nine} (the \textbf{ei} in German is always \emph{eye}).
+
+Take it apart and it's two words fused: \textbf{ni + ein} — literally \textbf{"not one."} English did the \emph{exact same trick}: \textbf{ne + one $\to$ none}. So German \emph{nein} and English \emph{none} are the same idea — "not a single one" — hardened into a bare "no."
+\end{cousinweb}
+
+\begin{culture}
+That \textbf{n‑} at the front is not a coincidence. A single ancient sound — linguists write it \textbf{PIE *ne} — is the negator behind an astonishing sweep of languages you're learning:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{from PIE \emph{*ne}} & \textbf{} \\
+\midrule
+Latin & \emph{nōn} $\to$ Spanish \textbf{no}, French \textbf{non} \\
+German & \textbf{nein} (\emph{ni}-ein) \\
+Hindi & \textbf{nahīṃ} (from \emph{na}) \\
+English & \textbf{no, not, none} \\
+\bottomrule
+\end{tabularx}
+
+Learn \emph{nein} and you've really met the same "n‑of‑no" that will greet you again in Hindi, and that you already met in Spanish and French. One negative, half the world.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "nein" — rhymes with \emph{nine}{]}
+  \item {[}YOU SAY: taken apart — "ni + ein = not one", like English \emph{none}{]}
+  \item {[}YOU SAY: the family — "nōn… non… nein… nahīṃ" — all the PIE \emph{ne}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} How do you say no in German? (\textbf{nein}, rhymes with \emph{nine}.) What two words is it fused from, and what do they mean? (\emph{\textbf{ni + ein}} — "not one.") Which English word is built the same way? (\textbf{none} = \emph{ne + one}.) What ancient sound links German \emph{nein}, Latin \emph{nōn} and Hindi \emph{nahīṃ}? (\textbf{PIE *ne}, the negator.)
+\end{tcolorbox}

--- a/code/learning/human-languages/german/book/chapters/ch19-please.tex
+++ b/code/learning/human-languages/german/book/chapters/ch19-please.tex
@@ -1,0 +1,46 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:56d533c514140e42
+% canonical-lessons: GE-C19-bitte-requests
+
+\chapter{Please}
+\label{ch:ge-please}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[bitte]{bitte — turn a known word into a polite request}
+
+\label{lesson:GE-C19-bitte-requests}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You already use \textbf{bitte} after \textbf{danke} to mean “you’re welcome.” Now give that same small word its other everyday job: \textbf{please}.
+\end{quote}
+
+\subsection*{You'll want to know: A complete small request}
+\begin{quote}
+\textbf{Wasser, bitte.} — Water, please.
+\end{quote}
+
+Nothing here is new except the job \textbf{bitte} is doing. You learned \textbf{Wasser} in Chapter 11. Put \textbf{bitte} after the thing you want and the two known words become a complete, polite small request. The comma marks the little pause you will naturally hear before \textbf{bitte}.
+
+\begin{cousinweb}
+\textbf{Bitte} is the request form of \textbf{bitten}, “to ask, request, pray.” Its English cousins are \textbf{bid}—as in “I bid you welcome”—and \textbf{bead}, whose oldest meaning was a prayer. A prayer bead was first the object used to count those requests.
+
+So when you add \textbf{bitte}, the word itself is already doing the asking.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: “Wasser.” — water{]}
+  \item {[}YOU SAY: “Wasser, bitte.” — water, please{]}
+  \item {[}YOU SAY: the root family — “bitten, bitte, bid, bead”{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Ask politely for water. (\textbf{Wasser, bitte.}) What older lesson supplied both words? (\textbf{Bitte} came from the courtesy loop; \textbf{Wasser} came from the food chapter.) Which verb is \textbf{bitte} built from? (\textbf{Bitten}, “to ask or request.”) Name its two English cousins. (\textbf{Bid} and \textbf{bead}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/german/book/chapters/ch20-sorry.tex
+++ b/code/learning/human-languages/german/book/chapters/ch20-sorry.tex
@@ -1,0 +1,56 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:7f75baaef49241c0
+% canonical-lessons: GE-C20-entschuldigung
+
+\chapter{Sorry}
+\label{ch:ge-sorry}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[Entschuldigung]{Entschuldigung — "sorry" / "excuse me" (un-guilting)}
+
+\label{lesson:GE-C20-entschuldigung}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You already know \textbf{bitte} does triple duty for "please," "you're welcome," and "here you go." German's word for \textbf{sorry} is just as hard-working: \textbf{Entschuldigung} covers both "\textbf{excuse me}" and "\textbf{I'm sorry}."
+\end{quote}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{ent-} = a "removal / undoing" prefix — the same shape as in \textbf{ent}decken ("un-cover" $\to$ discover) or \textbf{ent}fernen ("un-distance" $\to$ remove).
+  \item \textbf{Schuld} = "\textbf{guilt, fault, blame}" (also, separately, "debt" — a \emph{Schuld} can be money owed or wrong done).
+  \item \textbf{-igung} = a noun-forming suffix, roughly "-ing/-ation."
+\end{itemize}
+
+So \textbf{Entschuldigung} is literally "\textbf{an un-guilting}" — the act of removing blame. Saying it hands the guilt back: \emph{I release you from any fault} (when getting someone's attention or brushing past) or \emph{I ask you to release me from mine} (when apologizing).
+
+\textbf{Schuld} has a striking cousin: it traces to the same ancient Germanic root as English \textbf{shall} and \textbf{should} — a verb that originally meant \textbf{"to owe."} \emph{Schuld} (what is owed, guilt) and \emph{shall} (what one is obliged to do) are, at root, the same idea of an obligation outstanding.
+\end{cousinweb}
+
+\begin{culture}
+For \textbf{deeper regret} — real sorrow, not a bump in the hallway — German often reaches for \textbf{es tut mir leid}, literally "\textbf{it does to-me sorrow}":
+
+\begin{itemize}
+\raggedright
+  \item \textbf{es} = "it," \textbf{tut} = "does" (from \textbf{tun}, "to do"), \textbf{mir} = "to me," \textbf{Leid} = "sorrow, suffering" (a cousin of English \textbf{loath}, both from a root meaning "hateful, painful").
+\end{itemize}
+
+Use \textbf{Entschuldigung} for the everyday sorry/excuse-me (stepping on a foot, interrupting), and \textbf{es tut mir leid} when you mean it more — condolences, a real regret. The two overlap; native speakers move between them by feel.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "Schuld" — guilt/fault — then "Entschuldigung," sorry / excuse me{]}
+  \item {[}YOU SAY: the deeper phrase — "es tut mir leid," it pains me / I'm so sorry{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \textbf{Entschuldigung} literally mean, piece by piece? (\textbf{"Un-guilting"} — \emph{ent-} "away" + \emph{Schuld} "guilt/fault.") What English word shares Schuld's ancient root? (\textbf{Shall/should} — both from a root meaning "to owe.") What's the deeper phrase for real regret? (\textbf{Es tut mir leid}, "it does to me sorrow.")
+\end{tcolorbox}

--- a/code/learning/human-languages/german/book/chapters/ch21-weather.tex
+++ b/code/learning/human-languages/german/book/chapters/ch21-weather.tex
@@ -1,0 +1,52 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:e773a690ba617e60
+% canonical-lessons: GE-C21-das-wetter
+
+\chapter{Weather}
+\label{ch:ge-weather}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[das Wetter, es regnet]{das Wetter, es regnet — German's own native words, English's own cousins}
+
+\label{lesson:GE-C21-das-wetter}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Every Romance language you've met so far shares the exact same Latin word for "weather" (\emph{tempus}). German breaks completely from that family — with a word that's actually a much closer cousin of English.
+\end{quote}
+
+\subsection*{The two words: das Wetter and weather}
+\textbf{das Wetter} = "\textbf{weather}" — from Proto-Germanic \emph{\textbf{wedrą}} — the \textbf{exact same word} as English \textbf{weather} itself (both descend from the same Germanic ancestor, not one borrowed from the other). Unlike Spanish's \emph{tiempo}, French's \emph{temps}, or Latin's own \emph{tempus}-family, German's weather word has \textbf{no connection to Latin at all} — it's a native Germanic inheritance, cousin to English rather than to Romance.
+
+\begin{grammarlens}[title={Grammar Lens: Es ist heiß / Es ist kalt}]
+\begin{quote}
+\textbf{Es ist heiß.} — "It's hot." — literally "it \textbf{is} hot." \textbf{Es ist kalt.} — "It's cold." — literally "it \textbf{is} cold."
+\end{quote}
+
+German uses \textbf{sein} ("to be") here — matching the same "\textbf{be}" pattern you already met in German's own AGE lesson (\emph{ich bin zwanzig}), not the Romance "make" periphrasis (\emph{hacer}/\emph{faire}).
+\end{grammarlens}
+
+\begin{cousinweb}
+\begin{quote}
+\textbf{Es regnet.} — "It's raining." — from \textbf{regnen} $\leftarrow$ Proto-Germanic
+\end{quote}
+
+\emph{\textbf{regnōną}} — the \textbf{same root} as English \textbf{rain}. Just like \emph{Wetter}/ "weather," this is a genuine Germanic cousin-pair, not a shared Latin borrowing the way Spanish's \emph{llueve} and French's \emph{pleut} are.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "Wetter" — weather, the same word as English "weather"{]}
+  \item {[}YOU SAY: "Es ist heiß. Es ist kalt." — it's hot/cold{]}
+  \item {[}YOU SAY: "Es regnet" — it's raining, same root as English "rain"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Does \textbf{Wetter} come from Latin, like the Romance languages' weather words? (\textbf{No} — it's native Germanic, the same word as English "weather.") What verb does German use for "it's hot/cold" — \emph{sein} ("be") or a \emph{hacer}-style "make"? (\emph{\textbf{Sein}}, "to be" — matching German's own AGE pattern.) What English word is \textbf{regnet} related to? (\textbf{Rain} — same Proto-Germanic root, \emph{regnōną}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/german/book/chapters/ch22-dog-and-cat.tex
+++ b/code/learning/human-languages/german/book/chapters/ch22-dog-and-cat.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:d7f81c59cce27f45
+% canonical-lessons: GE-C22-hund-katze
+
+\chapter{Dog and Cat}
+\label{ch:ge-dog-and-cat}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[Hund, Katze]{Hund, Katze — one native word, one surprising loan}
+
+\label{lesson:GE-C22-hund-katze}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Here's a real surprise to end this comparison on: German's word for "dog" is native and expected — but its word for "cat" secretly isn't native at all.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{Hund} ("\textbf{dog}") is native Germanic, from \textbf{Proto-Indo-European} \emph{\textbf{*kwon-}} — and it has a direct cousin sitting inside English itself: \textbf{hound}. Old English \textbf{hund} was the ordinary, everyday word for "dog" for centuries — until, for reasons nobody fully understands, \textbf{dog} (Old English \emph{docga}) pushed it out by the 16th century, leaving \emph{hound} to narrow down to just hunting dogs. English's \emph{dog} is, honestly, its \textbf{own} unexplained mystery word, with no confirmed cognates in any other language — the exact same \emph{shape} of story as Spanish's \emph{perro} displacing \emph{can}, just in a completely different language family.
+\end{cousinweb}
+
+\begin{cousinweb}
+Here's the twist: \textbf{Katze} ("\textbf{cat}") looks like it should be native Germanic too, sitting right next to native \emph{Hund} — but it isn't. \textbf{Katze} descends from Proto-Germanic \textbf{*kattuz}, which is itself a borrowing of the \textbf{same Late Latin cattus} you already met with French's \emph{chat} and Spanish's \emph{gato} — most likely ultimately \textbf{Afro-Asiatic}, traveling out of Egypt along Roman trade routes. Every Germanic language shows this \textbf{same} borrowing (Dutch \emph{kat}, Swedish \emph{katt}, Icelandic \emph{köttur}) — so unlike "dog" words, which go their own separate ways in nearly every language, "cat" words are remarkably \textbf{widespread} across both Germanic and Romance, because the word traveled \textbf{with the animal itself}. Be honest that this isn't a universal rule, though: \textbf{Romanian} (\emph{pisică}) and much of \textbf{South Slavic} (Serbian/Croatian \emph{mačka}) built their own onomatopoeic cat-words instead, imitating the sound of a cat's call rather than inheriting \emph{cattus} — so the spread is wide, but not without real exceptions.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "Hund" — dog, native Germanic, cousin of English "hound"{]}
+  \item {[}YOU SAY: the parallel — English replaced "hound" with the still-mysterious "dog," the same shape as Spanish's perro/can{]}
+  \item {[}YOU SAY: "Katze" — cat, surprisingly a Latin loanword, not native at all{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Is \textbf{Hund} native Germanic, and what's its English cousin? (\textbf{Yes} — cousin of English \textbf{hound}.) What word did English replace \emph{hound} with, and is that word's origin known? (\textbf{Dog} — genuinely \textbf{unexplained}, no confirmed cognates anywhere.) Is \textbf{Katze} native Germanic? (\textbf{No} — surprisingly, it's the same borrowed Late Latin \emph{cattus} behind French's \emph{chat} and Spanish's \emph{gato}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/german/book/chapters/ch23-green-and-yellow.tex
+++ b/code/learning/human-languages/german/book/chapters/ch23-green-and-yellow.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:6fb7a16474f85d3e
+% canonical-lessons: GE-C23-gruen-gelb
+
+\chapter{Green and Yellow}
+\label{ch:ge-green-and-yellow}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[grün, gelb]{grün, gelb — English's own cousin, and a secret cousin of French}
+
+\label{lesson:GE-C23-gruen-gelb}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} German's green word is a direct cousin of English's own word. Its yellow word has a cousin too — but a much more surprising one, sitting inside French.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{grün} ("\textbf{green}") is native Germanic, from Proto-Germanic \emph{\textbf{*grōniz}}, ultimately from \textbf{Proto-Indo-European} \emph{\textbf{*ǵ\textsuperscript{h}reh\textsubscript{1}-}}, "\textbf{to grow, to become green}" — the \textbf{exact same root} as English's own \textbf{green}. Be careful, though: this is a \textbf{completely different} root from Latin's \textbf{viridis} (source of Spanish's \emph{verde}, French's \emph{vert}), which traces to its own, separate "to grow/flourish" root, \emph{\textbf{*weis-}}. Two unrelated language families each independently built a "green" word out of a verb meaning "to grow" — a real coincidence of logic, not a shared word.
+\end{cousinweb}
+
+\begin{cousinweb}
+\textbf{gelb} ("\textbf{yellow}") is native too, from Proto-Germanic \emph{\textbf{*gelwaz}} — and the same word as English's \textbf{yellow}. Trace it back far enough, to \textbf{Proto-Indo-European} \emph{\textbf{*ghel-}} ("\textbf{to shine}," with derivatives covering yellow, green, and gold), and it is usually said to land on the \textbf{same ancient root} behind Latin's \textbf{galbus/galbinus} — the source of \textbf{French}'s \textbf{jaune}. Honesty check, though: that particular link is \textbf{less secure} than it looks — some modern Latin scholarship treats \emph{galbus}'s origin as genuinely unknown rather than confirming the \emph{*ghel-} connection. So \emph{gelb} and \emph{jaune} are \textbf{probably} PIE-level cousins, despite belonging to completely different language families and reaching German and French by entirely separate paths — just don't treat the link as airtight.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "grün" — green, direct cousin of English's own "green"{]}
+  \item {[}YOU SAY: "gelb" — yellow, probable hidden cousin of French's jaune{]}
+  \item {[}YOU SAY: the contrast — grün's root is unrelated to Latin's viridis, but gelb's root is PROBABLY shared with French's jaune{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Is \textbf{grün} related to Latin's \emph{viridis}? (\textbf{No} — a completely different root, though both independently mean "grow" $\to$ "green"; \emph{grün} IS a direct cousin of English's own "green.") What French word is \textbf{gelb}'s probable PIE cousin, and how solid is that link? (\textbf{Jaune} — both usually traced to PIE \emph{*ghel-}, "to shine," though modern Latin scholarship treats \emph{galbus}'s origin as genuinely unknown, so the connection is probable, not certain.)
+\end{tcolorbox}

--- a/code/learning/human-languages/german/book/preamble.tex
+++ b/code/learning/human-languages/german/book/preamble.tex
@@ -19,6 +19,7 @@
 \tcbuselibrary{skins,breakable}
 \usepackage{booktabs}
 \usepackage{longtable}
+\usepackage{tabularx}
 \usepackage{array}
 \usepackage[hidelinks]{hyperref}
 \usepackage{titlesec}
@@ -46,10 +47,10 @@
 }
 
 % Grammar Lens callout: plain-language grammar concept + English contrast.
-\newtcolorbox{grammarlens}{
+\newtcolorbox{grammarlens}[1][]{
   breakable, skin=enhanced, colback=blue!5, colframe=blue!35!black,
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
-  fonttitle=\bfseries, title={Grammar Lens}
+  fonttitle=\bfseries, title={Grammar Lens}, #1
 }
 
 % Sounds callout: the pronunciation facts a single word needs.

--- a/code/learning/human-languages/german/lessons/GE-C17-hand.md
+++ b/code/learning/human-languages/german/lessons/GE-C17-hand.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: GE-C17-hand
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 630
 chapter: 17
 type: word
 headword: die Hand
@@ -9,26 +12,44 @@ prerequisites: [GE-C17-kopf-haupt, GE-C01-der-die-das]
 sounds: [final-devoicing, vowel-a-german]
 roots: [germanic-handuz]
 etymology_hook: "die Hand IS English hand — Germanic *handuz, with no Latin relative at all; where French/Italian/Portuguese all continue manus, Germanic simply has a different word, so this is the body part where the two families do NOT meet"
-est_minutes: 4
+duration:
+  max_seconds: 262
+requires:
+  knowledge: [GE-LEX-HAUPT-02, GE-ETYMON-HAUPT-03, GE-SOUND-GRIMMS-LAW-04, GE-CULTURE-HEAD-CONTAINERS-05]
+introduces:
+  knowledge: [GE-LEX-HAND-02, GE-SOUND-HAND-03, GE-ETYMON-HAND-04, GE-ETYMON-HAND-MANUS-05]
+practises:
+  knowledge: [GE-LEX-HAND-02, GE-SOUND-HAND-03, GE-ETYMON-HAND-04, GE-ETYMON-HAND-MANUS-05]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [GE-C17-kopf, GE-C17-kopf-haupt, GE-C01-der-die-das]
 ---
 
 # die Hand — "the hand"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] After the tangle of *Kopf* and *Haupt*, here is the easiest word in
 the chapter — and a useful lesson about when languages **don't** match.
 
-## The word
+## You'll want to know: die Hand
+<!-- hl-knowledge: introduces=[GE-LEX-HAND-02]; assesses=[] -->
 
 > **die Hand** — the hand. **Feminine**, and spelled exactly like English.
+
+## Sounds you'll need: Final devoicing
+<!-- hl-knowledge: introduces=[GE-SOUND-HAND-03]; assesses=[] -->
 
 One pronunciation note: the final **d** is said as a **t**. German devoices a
 consonant at the end of a word, so *Hand* **ends** like English *hunt* — but with the open *ah* of *Tag*, not *hunt*'s vowel.
 Add an ending and the *d* comes back: *die Hän**d**e* ("the hands").
 
-## It is the English word
+## The word, taken apart: It is the English word
+<!-- hl-knowledge: introduces=[GE-ETYMON-HAND-04]; assesses=[] -->
 
 **Hand** is Germanic \**handuz*, and English inherited it directly. Same word,
 same meaning, two thousand years apart. German and English are close relatives,
@@ -42,7 +63,8 @@ and body parts are where you feel it most:
 | **Fuß** | foot |
 | **Herz** | heart |
 
-## Where the family tree stops
+## Why it's said this way: Where the family tree stops
+<!-- hl-knowledge: introduces=[GE-ETYMON-HAND-MANUS-05]; assesses=[] -->
 
 Now the interesting part. Every Romance language in this course builds "hand" on
 Latin ***manus***:
@@ -67,6 +89,7 @@ The Latin word did reach German — but only as **borrowed vocabulary**:
 word without displacing it.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-HAND-02, GE-SOUND-HAND-03, GE-ETYMON-HAND-04, GE-ETYMON-HAND-MANUS-05] -->
 
 [PAUSE 1s]
 - [YOU SAY: "die Hand" — final **d** said as **t**]
@@ -75,6 +98,7 @@ word without displacing it.
 - [YOU SAY: the gap — "*main*, *mano*, *mão* … but **Hand**"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-HAND-02, GE-SOUND-HAND-03, GE-ETYMON-HAND-04, GE-ETYMON-HAND-MANUS-05] -->
 
 [PAUSE 3s] Say "the hand." (*Die Hand* — **feminine**.) How is the final **d**
 pronounced, and why? (As a **t** — German **devoices** final consonants; the *d*

--- a/code/learning/human-languages/german/lessons/GE-C17-kopf-haupt.md
+++ b/code/learning/human-languages/german/lessons/GE-C17-kopf-haupt.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: GE-C17-kopf-haupt
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 620
 chapter: 17
 type: etymology
 headword: Kopf / Haupt
@@ -9,16 +12,32 @@ prerequisites: [GE-C17-kopf]
 sounds: []
 roots: [latin-cuppa, germanic-haubudam, pie-kaput]
 etymology_hook: "Kopf took the everyday job while inherited Haupt, cousin of head and caput, survived in compounds"
-est_minutes: 4
+duration:
+  max_seconds: 166
+requires:
+  knowledge: [GE-LEX-KOPF-02, GE-SOUND-KOPF-03, GE-COMPOUND-KOPFSCHMERZEN-04, GE-ETYMON-KOPF-05]
+introduces:
+  knowledge: [GE-LEX-HAUPT-02, GE-ETYMON-HAUPT-03, GE-SOUND-GRIMMS-LAW-04, GE-CULTURE-HEAD-CONTAINERS-05]
+practises:
+  knowledge: [GE-LEX-HAUPT-02, GE-ETYMON-HAUPT-03, GE-SOUND-GRIMMS-LAW-04, GE-CULTURE-HEAD-CONTAINERS-05]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [GE-C17-kopf]
 ---
 
 # Kopf / Haupt — two head-words
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] **Kopf** began as “cup.” German’s inherited word for “head” is
 **Haupt**, a cousin of English *head* and Latin *caput*.
+
+## The word, taken apart: inherited Haupt
+<!-- hl-knowledge: introduces=[GE-LEX-HAUPT-02, GE-ETYMON-HAUPT-03, GE-SOUND-GRIMMS-LAW-04]; assesses=[] -->
 
 | language | inherited form |
 |---|---|
@@ -36,7 +55,8 @@ consonants have their own history; use the initial pair as the clear signal.
 - **Hauptbahnhof** — main station;
 - **Hauptsache** — main thing.
 
-## Two container metaphors
+## Why it's said this way: Two container metaphors
+<!-- hl-knowledge: introduces=[GE-CULTURE-HEAD-CONTAINERS-05]; assesses=[] -->
 
 | language | everyday word | older picture |
 |---|---|---|
@@ -49,6 +69,7 @@ vocabulary sources are both Latin loans, but the **metaphor** was applied
 separately: heads look like bowls in many languages.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-HAUPT-02, GE-ETYMON-HAUPT-03, GE-SOUND-GRIMMS-LAW-04, GE-CULTURE-HEAD-CONTAINERS-05] -->
 
 [PAUSE 1s]
 - [YOU SAY: “Kopf — everyday cup-word”]
@@ -58,6 +79,7 @@ separately: heads look like bowls in many languages.
 [REPEAT x2] “Kopf took the job; Haupt stayed in compounds.”
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-HAUPT-02, GE-ETYMON-HAUPT-03, GE-SOUND-GRIMMS-LAW-04, GE-CULTURE-HEAD-CONTAINERS-05] -->
 
 [PAUSE 3s] Which word is everyday “head”? (**Kopf**.) Which inherited word
 survives in compounds? (**Haupt**.) Name two compounds. (**Hauptstadt,

--- a/code/learning/human-languages/german/lessons/GE-C17-kopf.md
+++ b/code/learning/human-languages/german/lessons/GE-C17-kopf.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: GE-C17-kopf
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 610
 chapter: 17
 type: word
 headword: der Kopf
@@ -9,28 +12,48 @@ prerequisites: [GE-C01-der-die-das]
 sounds: [final-devoicing]
 roots: [latin-cuppa]
 etymology_hook: "Kopf first meant cup or bowl, from the same Late Latin cuppa source as English cup"
-est_minutes: 4
+duration:
+  max_seconds: 175
+requires:
+  knowledge: []
+introduces:
+  knowledge: [GE-LEX-KOPF-02, GE-SOUND-KOPF-03, GE-COMPOUND-KOPFSCHMERZEN-04, GE-ETYMON-KOPF-05]
+practises:
+  knowledge: [GE-LEX-KOPF-02, GE-SOUND-KOPF-03, GE-COMPOUND-KOPFSCHMERZEN-04, GE-ETYMON-KOPF-05]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [GE-C01-der-die-das, GE-W03-capitalization]
 ---
 
 # Der Kopf — “the head”
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Learn the first body part with its article and its characteristic
 final sound.
+
+## You'll want to know: der Kopf
+<!-- hl-knowledge: introduces=[GE-LEX-KOPF-02]; assesses=[] -->
 
 > **der Kopf** — the head
 
 It is masculine and capitalised because every German noun begins with a capital
 letter.
 
-## Make the -pf sequence
+## Sounds you'll need: Make the -pf sequence
+<!-- hl-knowledge: introduces=[GE-SOUND-KOPF-03]; assesses=[] -->
 
 At the end of **Kopf**, close for *p* and release directly into *f*. English has
 no identical native ending, so practise it slowly:
 
 > Ko-p-f → **Kopf**
+
+## Grammar Lens: Kopf + Schmerzen
+<!-- hl-knowledge: introduces=[GE-COMPOUND-KOPFSCHMERZEN-04]; assesses=[] -->
 
 A useful phrase is:
 
@@ -39,7 +62,8 @@ A useful phrase is:
 German compounds simply place nouns together: **Kopf** (head) + **Schmerzen**
 (pains).
 
-## The old cup
+## The word, taken apart: The old cup
+<!-- hl-knowledge: introduces=[GE-ETYMON-KOPF-05]; assesses=[] -->
 
 **Kopf** originally meant a **cup or bowl**. It is related to English **cup**;
 both were early borrowings of Late Latin ***cuppa***. A container word became
@@ -50,6 +74,7 @@ micro-lesson follows it into compounds and compares the same container metaphor
 in French.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-KOPF-02, GE-SOUND-KOPF-03, GE-COMPOUND-KOPFSCHMERZEN-04, GE-ETYMON-KOPF-05] -->
 
 [PAUSE 1s]
 - [YOU SAY: “der Kopf” — release *p* into *f*]
@@ -59,6 +84,7 @@ in French.
 [REPEAT x2] “Der Kopf — masculine, capitalised.”
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-KOPF-02, GE-SOUND-KOPF-03, GE-COMPOUND-KOPFSCHMERZEN-04, GE-ETYMON-KOPF-05] -->
 
 [PAUSE 3s] Say “the head.” (**Der Kopf**.) What gender? (**Masculine**.) Why the
 capital? (It is a **noun**.) What did *Kopf* first mean? (A **cup or bowl**.)

--- a/code/learning/human-languages/german/lessons/GE-C18-ja.md
+++ b/code/learning/human-languages/german/lessons/GE-C18-ja.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: GE-C18-ja
+spine_node: SPINE-RESPOND-BASIC
+sequence: 640
 chapter: 18
 type: word
 headword: ja
@@ -9,17 +12,31 @@ prerequisites: [GE-C01-hallo]
 sounds: [vowel-a-long, j-as-y]
 roots: [ja-germanic]
 etymology_hook: "German ja is the old Germanic yes — the same word English keeps in the archaic yea (and, perhaps, the sailor's aye)"
-est_minutes: 3
+duration:
+  max_seconds: 236
+requires:
+  knowledge: []
+introduces:
+  knowledge: [GE-LEX-JA-02, GE-SOUND-JA-03, GE-ETYMON-JA-04, GE-PRAGMATICS-DOCH-05]
+practises:
+  knowledge: [GE-LEX-JA-02, GE-SOUND-JA-03, GE-ETYMON-JA-04, GE-PRAGMATICS-DOCH-05]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [GE-C01-hallo]
 ---
 
 # ja — yes
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The easiest German word to say, and one English almost shares.
 
-## The word
+## The word, taken apart
+<!-- hl-knowledge: introduces=[GE-LEX-JA-02, GE-SOUND-JA-03, GE-ETYMON-JA-04]; assesses=[] -->
 
 **ja** = **yes**. Said *yah* — remember German **j** is pronounced like English
 **y**, never the English "j."
@@ -37,7 +54,8 @@ So German *ja* and English *yea* are the same little word, split between two
 cousin languages. (English's everyday *yes* is a compound of that same *yea* with
 an old "be it so.")
 
-## A German habit to file away
+## Grammar Lens: A German habit to file away
+<!-- hl-knowledge: introduces=[GE-PRAGMATICS-DOCH-05]; assesses=[] -->
 
 German also has a **third** answer-word, **doch**, for one special job:
 contradicting a **negative** — exactly like French *si*. If someone says
@@ -49,6 +67,7 @@ You'll drill *doch* on its own later; for now, keep *ja* for a plain yes and kno
 *doch* is waiting for the contradictions.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-JA-02, GE-SOUND-JA-03, GE-ETYMON-JA-04, GE-PRAGMATICS-DOCH-05] -->
 
 [PAUSE 1s]
 - [YOU SAY: "ja" — *yah*, the j like English y]
@@ -56,6 +75,7 @@ You'll drill *doch* on its own later; for now, keep *ja* for a plain yes and kno
 - [YOU SAY: the contradiction preview — "Du kommst nicht? — Doch!"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-JA-02, GE-SOUND-JA-03, GE-ETYMON-JA-04, GE-PRAGMATICS-DOCH-05] -->
 
 [PAUSE 3s] How do you say yes in German? (**ja**, *yah*.) How is the **j**
 pronounced? (Like English **y**.) Which English word is *ja*'s firm direct

--- a/code/learning/human-languages/german/lessons/GE-C18-nein.md
+++ b/code/learning/human-languages/german/lessons/GE-C18-nein.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: GE-C18-nein
+spine_node: SPINE-RESPOND-BASIC
+sequence: 650
 chapter: 18
 type: word
 headword: nein
@@ -9,17 +12,31 @@ prerequisites: [GE-C18-ja]
 sounds: [diphthong-ei, n-consonant]
 roots: [ni-ein, pie-ne]
 etymology_hook: "nein is literally ni + ein, 'not one' — the same 'not-one' English froze into none, from the PIE *ne of no"
-est_minutes: 4
+duration:
+  max_seconds: 209
+requires:
+  knowledge: [GE-LEX-JA-02, GE-SOUND-JA-03, GE-ETYMON-JA-04, GE-PRAGMATICS-DOCH-05]
+introduces:
+  knowledge: [GE-LEX-NEIN-02, GE-SOUND-NEIN-03, GE-ETYMON-NEIN-04, GE-ETYMON-NEGATION-05]
+practises:
+  knowledge: [GE-LEX-JA-02, GE-LEX-NEIN-02, GE-SOUND-NEIN-03, GE-ETYMON-NEIN-04, GE-ETYMON-NEGATION-05]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [GE-C18-ja, GE-C01-hallo]
 ---
 
 # nein — no
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] German's "no" is a tiny sentence with a number hidden inside it.
 
-## The word
+## The word, taken apart
+<!-- hl-knowledge: introduces=[GE-LEX-NEIN-02, GE-SOUND-NEIN-03, GE-ETYMON-NEIN-04]; assesses=[] -->
 
 **nein** = **no**. Said to rhyme with English *nine* (the **ei** in German is
 always *eye*).
@@ -29,7 +46,8 @@ English did the *exact same trick*: **ne + one → none**. So German *nein* and
 English *none* are the same idea — "not a single one" — hardened into a bare
 "no."
 
-## One "no" runs across the whole chain
+## Why it's said this way: One "no" runs across the whole chain
+<!-- hl-knowledge: introduces=[GE-ETYMON-NEGATION-05]; assesses=[] -->
 
 That **n‑** at the front is not a coincidence. A single ancient sound — linguists
 write it **PIE \*ne** — is the negator behind an astonishing sweep of languages
@@ -47,6 +65,7 @@ in Hindi, and that you already met in Spanish and French. One negative, half the
 world.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-JA-02, GE-LEX-NEIN-02, GE-SOUND-NEIN-03, GE-ETYMON-NEIN-04, GE-ETYMON-NEGATION-05] -->
 
 [PAUSE 1s]
 - [YOU SAY: "nein" — rhymes with *nine*]
@@ -54,6 +73,7 @@ world.
 - [YOU SAY: the family — "nōn… non… nein… nahīṃ" — all the PIE *ne*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-JA-02, GE-LEX-NEIN-02, GE-SOUND-NEIN-03, GE-ETYMON-NEIN-04, GE-ETYMON-NEGATION-05] -->
 
 [PAUSE 3s] How do you say no in German? (**nein**, rhymes with *nine*.) What two
 words is it fused from, and what do they mean? (***ni + ein*** — "not one.") Which

--- a/code/learning/human-languages/german/lessons/GE-C19-bitte-requests.md
+++ b/code/learning/human-languages/german/lessons/GE-C19-bitte-requests.md
@@ -1,0 +1,72 @@
+---
+schema_version: 2
+id: GE-C19-bitte-requests
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 660
+chapter: 19
+type: phrase
+headword: bitte
+gloss: please — place the familiar courtesy word after a small request
+concept_tag: COURTESY-PLEASE
+prerequisites: [GE-C03-bitte, GE-C11-wasser-wein]
+sounds: []
+roots: [bitten-german]
+etymology_hook: "bitte is the request form of bitten 'to ask, request, pray,' cousin of English bid and bead"
+duration:
+  max_seconds: 164
+requires:
+  knowledge: []
+introduces:
+  knowledge: [GE-LEX-BITTE-PLEASE-02, GE-PHRASE-WASSER-BITTE-03, GE-ETYMON-BITTE-04]
+practises:
+  knowledge: [GE-LEX-BITTE-PLEASE-02, GE-PHRASE-WASSER-BITTE-03, GE-ETYMON-BITTE-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral-courtesy
+variety: standard-contemporary
+reviews_of: [GE-C03-bitte, GE-C11-wasser-wein]
+---
+
+# bitte — turn a known word into a polite request
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+[PAUSE 2s] You already use **bitte** after **danke** to mean “you’re welcome.”
+Now give that same small word its other everyday job: **please**.
+
+## You'll want to know: A complete small request
+<!-- hl-knowledge: introduces=[GE-LEX-BITTE-PLEASE-02, GE-PHRASE-WASSER-BITTE-03]; assesses=[] -->
+
+> **Wasser, bitte.** — Water, please.
+
+Nothing here is new except the job **bitte** is doing. You learned **Wasser**
+in Chapter 11. Put **bitte** after the thing you want and the two known words
+become a complete, polite small request. The comma marks the little pause you
+will naturally hear before **bitte**.
+
+## The word, taken apart: a request inside please
+<!-- hl-knowledge: introduces=[GE-ETYMON-BITTE-04]; assesses=[] -->
+
+**Bitte** is the request form of **bitten**, “to ask, request, pray.” Its English
+cousins are **bid**—as in “I bid you welcome”—and **bead**, whose oldest meaning
+was a prayer. A prayer bead was first the object used to count those requests.
+
+So when you add **bitte**, the word itself is already doing the asking.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-BITTE-PLEASE-02, GE-PHRASE-WASSER-BITTE-03, GE-ETYMON-BITTE-04] -->
+
+[PAUSE 1s]
+- [YOU SAY: “Wasser.” — water]
+- [YOU SAY: “Wasser, bitte.” — water, please]
+- [YOU SAY: the root family — “bitten, bitte, bid, bead”]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-BITTE-PLEASE-02, GE-PHRASE-WASSER-BITTE-03, GE-ETYMON-BITTE-04] -->
+
+[PAUSE 3s] Ask politely for water. (**Wasser, bitte.**) What older lesson
+supplied both words? (**Bitte** came from the courtesy loop; **Wasser** came
+from the food chapter.) Which verb is **bitte** built from? (**Bitten**, “to
+ask or request.”) Name its two English cousins. (**Bid** and **bead**.)

--- a/code/learning/human-languages/german/lessons/GE-C20-entschuldigung.md
+++ b/code/learning/human-languages/german/lessons/GE-C20-entschuldigung.md
@@ -1,21 +1,37 @@
 ---
-id: GE-C19-entschuldigung
-chapter: 19
+schema_version: 2
+id: GE-C20-entschuldigung
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 670
+chapter: 20
 type: word
 headword: Entschuldigung
 gloss: sorry / excuse me (literally "un-guilting," from Schuld "guilt/fault")
 concept_tag: COURTESY-SORRY
-prerequisites: [GE-C03-bitte]
+prerequisites: [GE-C19-bitte-requests]
 sounds: [ch-ach, u-umlaut-adjacent]
 roots: [schuld-german]
 etymology_hook: "Entschuldigung ← ent- 'away/un-' + Schuld 'guilt, fault' — Schuld shares its ancient root with English shall/should ('to owe')"
-est_minutes: 4
-reviews_of: [GE-C03-bitte, GE-C03-danke]
+duration:
+  max_seconds: 236
+requires:
+  knowledge: [GE-LEX-BITTE-PLEASE-02, GE-PHRASE-WASSER-BITTE-03, GE-ETYMON-BITTE-04]
+introduces:
+  knowledge: [GE-LEX-ENTSCHULDIGUNG-02, GE-ETYMON-ENTSCHULDIGUNG-03, GE-PRAGMATICS-SORRY-04]
+practises:
+  knowledge: [GE-LEX-ENTSCHULDIGUNG-02, GE-ETYMON-ENTSCHULDIGUNG-03, GE-PRAGMATICS-SORRY-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: contrastive-courtesy
+variety: standard-contemporary
+reviews_of: [GE-C19-bitte-requests, GE-C03-bitte, GE-C03-danke]
 ---
 
 # Entschuldigung — "sorry" / "excuse me" (un-guilting)
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You already know **bitte** does triple duty for "please," "you're
 welcome," and "here you go." German's word for **sorry** is just as
@@ -23,6 +39,7 @@ hard-working: **Entschuldigung** covers both "**excuse me**" and "**I'm
 sorry**."
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[GE-LEX-ENTSCHULDIGUNG-02, GE-ETYMON-ENTSCHULDIGUNG-03]; assesses=[] -->
 
 - **ent-** = a "removal / undoing" prefix — the same shape as in
   **ent**decken ("un-cover" → discover) or **ent**fernen ("un-distance" →
@@ -41,7 +58,8 @@ as English **shall** and **should** — a verb that originally meant **"to
 owe."** *Schuld* (what is owed, guilt) and *shall* (what one is obliged to do)
 are, at root, the same idea of an obligation outstanding.
 
-## Be honest about the other phrase: es tut mir leid
+## Why it's said this way: Everyday repair and deeper regret
+<!-- hl-knowledge: introduces=[GE-PRAGMATICS-SORRY-04]; assesses=[] -->
 
 For **deeper regret** — real sorrow, not a bump in the hallway — German often
 reaches for **es tut mir leid**, literally "**it does to-me sorrow**":
@@ -55,12 +73,14 @@ interrupting), and **es tut mir leid** when you mean it more — condolences, a
 real regret. The two overlap; native speakers move between them by feel.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-ENTSCHULDIGUNG-02, GE-ETYMON-ENTSCHULDIGUNG-03, GE-PRAGMATICS-SORRY-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "Schuld" — guilt/fault — then "Entschuldigung," sorry / excuse me]
 - [YOU SAY: the deeper phrase — "es tut mir leid," it pains me / I'm so sorry]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-ENTSCHULDIGUNG-02, GE-ETYMON-ENTSCHULDIGUNG-03, GE-PRAGMATICS-SORRY-04] -->
 
 [PAUSE 3s] What does **Entschuldigung** literally mean, piece by piece?
 (**"Un-guilting"** — *ent-* "away" + *Schuld* "guilt/fault.") What English word

--- a/code/learning/human-languages/german/lessons/GE-C21-das-wetter.md
+++ b/code/learning/human-languages/german/lessons/GE-C21-das-wetter.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: GE-C21-das-wetter
+spine_node: SPINE-TIME-OF-DAY
+sequence: 680
 chapter: 21
 type: phrase
 headword: das Wetter, es regnet
@@ -9,19 +12,33 @@ prerequisites: [GE-C14-alter]
 sounds: [w-as-v, umlaut-none]
 roots: [germanic-wetter-weather, germanic-regen-rain]
 etymology_hook: "das Wetter is a native Germanic word (Proto-Germanic *wedrą) — the SAME word as English 'weather' itself, not a Latin loan like every Romance language's tempus-based word; es regnet ('it's raining') is likewise native, from Proto-Germanic *regnōną — the SAME root as English 'rain'"
-est_minutes: 4
+duration:
+  max_seconds: 212
+requires:
+  knowledge: []
+introduces:
+  knowledge: [GE-LEX-WETTER-02, GE-ETYMON-WETTER-03, GE-GRAMMAR-WEATHER-SEIN-04, GE-LEX-REGNET-05, GE-ETYMON-REGNET-06]
+practises:
+  knowledge: [GE-LEX-WETTER-02, GE-ETYMON-WETTER-03, GE-GRAMMAR-WEATHER-SEIN-04, GE-LEX-REGNET-05, GE-ETYMON-REGNET-06]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [GE-C14-alter]
 ---
 
 # das Wetter, es regnet — German's own native words, English's own cousins
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Every Romance language you've met so far shares the exact same
 Latin word for "weather" (*tempus*). German breaks completely from that
 family — with a word that's actually a much closer cousin of English.
 
-## das Wetter — native Germanic, the same word as English "weather"
+## The two words: das Wetter and weather
+<!-- hl-knowledge: introduces=[GE-LEX-WETTER-02, GE-ETYMON-WETTER-03]; assesses=[] -->
 
 **das Wetter** = "**weather**" — from Proto-Germanic ***wedrą*** — the
 **exact same word** as English **weather** itself (both descend from the same
@@ -30,7 +47,8 @@ Germanic ancestor, not one borrowed from the other). Unlike Spanish's
 word has **no connection to Latin at all** — it's a native Germanic
 inheritance, cousin to English rather than to Romance.
 
-## Es ist heiß / Es ist kalt — sein, matching German's own pattern
+## Grammar Lens: Es ist heiß / Es ist kalt
+<!-- hl-knowledge: introduces=[GE-GRAMMAR-WEATHER-SEIN-04]; assesses=[] -->
 
 > **Es ist heiß.** — "It's hot." — literally "it **is** hot."
 > **Es ist kalt.** — "It's cold." — literally "it **is** cold."
@@ -39,7 +57,8 @@ German uses **sein** ("to be") here — matching the same "**be**" pattern you
 already met in German's own AGE lesson (*ich bin zwanzig*), not the Romance
 "make" periphrasis (*hacer*/*faire*).
 
-## es regnet — also native, the same root as English "rain"
+## The word, taken apart: es regnet
+<!-- hl-knowledge: introduces=[GE-LEX-REGNET-05, GE-ETYMON-REGNET-06]; assesses=[] -->
 
 > **Es regnet.** — "It's raining." — from **regnen** ← Proto-Germanic
   ***regnōną*** — the **same root** as English **rain**. Just like *Wetter*/
@@ -47,6 +66,7 @@ already met in German's own AGE lesson (*ich bin zwanzig*), not the Romance
   borrowing the way Spanish's *llueve* and French's *pleut* are.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-WETTER-02, GE-ETYMON-WETTER-03, GE-GRAMMAR-WEATHER-SEIN-04, GE-LEX-REGNET-05, GE-ETYMON-REGNET-06] -->
 
 [PAUSE 1s]
 - [YOU SAY: "Wetter" — weather, the same word as English "weather"]
@@ -54,6 +74,7 @@ already met in German's own AGE lesson (*ich bin zwanzig*), not the Romance
 - [YOU SAY: "Es regnet" — it's raining, same root as English "rain"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-WETTER-02, GE-ETYMON-WETTER-03, GE-GRAMMAR-WEATHER-SEIN-04, GE-LEX-REGNET-05, GE-ETYMON-REGNET-06] -->
 
 [PAUSE 3s] Does **Wetter** come from Latin, like the Romance languages'
 weather words? (**No** — it's native Germanic, the same word as English

--- a/code/learning/human-languages/german/lessons/GE-C22-hund-katze.md
+++ b/code/learning/human-languages/german/lessons/GE-C22-hund-katze.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: GE-C22-hund-katze
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 690
 chapter: 22
 type: word
 headword: Hund, Katze
@@ -9,22 +12,36 @@ prerequisites: [GE-C14-alter]
 sounds: [u-umlaut-none, tz-affricate]
 roots: [germanic-hund-dog, latin-cattus-afroasiatic]
 etymology_hook: "Hund is native Germanic (Proto-Indo-European *kwon-), cognate with English's OWN 'hound' — the word English ITSELF replaced with the still-unexplained 'dog,' the same shape of mystery as Spanish's perro; Katze, surprisingly, is NOT native Germanic at all — like French/Spanish/Italian, German borrowed the same Late Latin cattus, so 'cat' words are remarkably widespread across Germanic AND Romance (though NOT every European language: Romanian and much of South Slavic use their own onomatopoeic cat-words instead), while 'dog' words go their own separate ways almost everywhere"
-est_minutes: 4
+duration:
+  max_seconds: 260
+requires:
+  knowledge: []
+introduces:
+  knowledge: [GE-LEX-HUND-02, GE-ETYMON-HUND-03, GE-LEX-KATZE-04, GE-ETYMON-KATZE-05, GE-EVIDENCE-CAT-WORDS-06]
+practises:
+  knowledge: [GE-LEX-HUND-02, GE-ETYMON-HUND-03, GE-LEX-KATZE-04, GE-ETYMON-KATZE-05, GE-EVIDENCE-CAT-WORDS-06]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [GE-C14-alter]
 ---
 
 # Hund, Katze — one native word, one surprising loan
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Here's a real surprise to end this comparison on: German's word
 for "dog" is native and expected — but its word for "cat" secretly isn't
 native at all.
 
-## Hund — native Germanic, and English's own abandoned twin
+## The word, taken apart: Hund
+<!-- hl-knowledge: introduces=[GE-LEX-HUND-02, GE-ETYMON-HUND-03]; assesses=[] -->
 
 **Hund** ("**dog**") is native Germanic, from **Proto-Indo-European**
-***\*ḱwon-*** — and it has a direct cousin sitting inside English itself:
+***\*kwon-*** — and it has a direct cousin sitting inside English itself:
 **hound**. Old English **hund** was the ordinary, everyday word for "dog"
 for centuries — until, for reasons nobody fully understands, **dog**
 (Old English *docga*) pushed it out by the 16th century, leaving *hound* to
@@ -33,7 +50,8 @@ unexplained mystery word, with no confirmed cognates in any other
 language — the exact same *shape* of story as Spanish's *perro* displacing
 *can*, just in a completely different language family.
 
-## Katze — surprisingly NOT native
+## The word, taken apart: Katze
+<!-- hl-knowledge: introduces=[GE-LEX-KATZE-04, GE-ETYMON-KATZE-05, GE-EVIDENCE-CAT-WORDS-06]; assesses=[] -->
 
 Here's the twist: **Katze** ("**cat**") looks like it should be native
 Germanic too, sitting right next to native *Hund* — but it isn't. **Katze**
@@ -51,6 +69,7 @@ instead, imitating the sound of a cat's call rather than inheriting *cattus*
 — so the spread is wide, but not without real exceptions.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-HUND-02, GE-ETYMON-HUND-03, GE-LEX-KATZE-04, GE-ETYMON-KATZE-05, GE-EVIDENCE-CAT-WORDS-06] -->
 
 [PAUSE 1s]
 - [YOU SAY: "Hund" — dog, native Germanic, cousin of English "hound"]
@@ -59,6 +78,7 @@ instead, imitating the sound of a cat's call rather than inheriting *cattus*
 - [YOU SAY: "Katze" — cat, surprisingly a Latin loanword, not native at all]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-HUND-02, GE-ETYMON-HUND-03, GE-LEX-KATZE-04, GE-ETYMON-KATZE-05, GE-EVIDENCE-CAT-WORDS-06] -->
 
 [PAUSE 3s] Is **Hund** native Germanic, and what's its English cousin? (**Yes**
 — cousin of English **hound**.) What word did English replace *hound* with,

--- a/code/learning/human-languages/german/lessons/GE-C23-gruen-gelb.md
+++ b/code/learning/human-languages/german/lessons/GE-C23-gruen-gelb.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: GE-C23-gruen-gelb
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 700
 chapter: 23
 type: word
 headword: grün, gelb
@@ -9,19 +12,33 @@ prerequisites: [GE-C22-hund-katze]
 sounds: [umlaut-u, consonant-b-final]
 roots: [germanic-groeniz-grow, pie-ghel-shine]
 etymology_hook: "grün is native Germanic, the direct cousin of English's own 'green' (Proto-Germanic *grōniz, PIE *ǵʰreh₁-, 'to grow, become green') — a COMPLETELY DIFFERENT root from Latin's viridis, even though both independently mean 'grow' → 'green'; gelb is native too (Proto-Germanic *gelwaz), usually traced to the same ultimate PIE root, *ghel- ('to shine'), as French's jaune — though modern Latin scholarship treats jaune's Latin ancestor galbus as genuinely unknown in origin, so treat gelb/jaune as probable, not certain, cousins"
-est_minutes: 4
+duration:
+  max_seconds: 234
+requires:
+  knowledge: [GE-LEX-HUND-02, GE-ETYMON-HUND-03, GE-LEX-KATZE-04, GE-ETYMON-KATZE-05, GE-EVIDENCE-CAT-WORDS-06]
+introduces:
+  knowledge: [GE-LEX-GRUEN-02, GE-ETYMON-GRUEN-03, GE-LEX-GELB-04, GE-ETYMON-GELB-05, GE-EVIDENCE-GELB-JAUNE-06]
+practises:
+  knowledge: [GE-LEX-GRUEN-02, GE-ETYMON-GRUEN-03, GE-LEX-GELB-04, GE-ETYMON-GELB-05, GE-EVIDENCE-GELB-JAUNE-06]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
 reviews_of: [GE-C22-hund-katze]
 ---
 
 # grün, gelb — English's own cousin, and a secret cousin of French
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] German's green word is a direct cousin of English's own word.
 Its yellow word has a cousin too — but a much more surprising one, sitting
 inside French.
 
-## grün — English's own cousin, NOT Latin's
+## The word, taken apart: grün
+<!-- hl-knowledge: introduces=[GE-LEX-GRUEN-02, GE-ETYMON-GRUEN-03]; assesses=[] -->
 
 **grün** ("**green**") is native Germanic, from Proto-Germanic
 ***\*grōniz***, ultimately from **Proto-Indo-European** ***\*ǵʰreh₁-***,
@@ -32,7 +49,8 @@ traces to its own, separate "to grow/flourish" root, ***\*weis-***. Two
 unrelated language families each independently built a "green" word out of
 a verb meaning "to grow" — a real coincidence of logic, not a shared word.
 
-## gelb — a hidden cousin of French's jaune
+## The word, taken apart: gelb
+<!-- hl-knowledge: introduces=[GE-LEX-GELB-04, GE-ETYMON-GELB-05, GE-EVIDENCE-GELB-JAUNE-06]; assesses=[] -->
 
 **gelb** ("**yellow**") is native too, from Proto-Germanic ***\*gelwaz*** —
 and the same word as English's **yellow**. Trace it back far enough, to
@@ -48,6 +66,7 @@ German and French by entirely separate paths — just don't treat the link
 as airtight.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-GRUEN-02, GE-ETYMON-GRUEN-03, GE-LEX-GELB-04, GE-ETYMON-GELB-05, GE-EVIDENCE-GELB-JAUNE-06] -->
 
 [PAUSE 1s]
 - [YOU SAY: "grün" — green, direct cousin of English's own "green"]
@@ -56,6 +75,7 @@ as airtight.
   gelb's root is PROBABLY shared with French's jaune]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-GRUEN-02, GE-ETYMON-GRUEN-03, GE-LEX-GELB-04, GE-ETYMON-GELB-05, GE-EVIDENCE-GELB-JAUNE-06] -->
 
 [PAUSE 3s] Is **grün** related to Latin's *viridis*? (**No** — a completely
 different root, though both independently mean "grow" → "green"; *grün*

--- a/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
@@ -101,6 +101,22 @@ describe("generated book source hashes", () => {
     expect(bookHashStatus(lessons, "french", chapter)).toBe("synced");
   });
 
+  it.each([
+    [17, 3],
+    [18, 2],
+    [19, 1],
+    [20, 1],
+    [21, 1],
+    [22, 1],
+    [23, 1],
+  ])("matches the browser-loaded German Chapter %i AST across %i lessons", (chapter, count) => {
+    const lessons = loadLessons();
+    const expected = expectedBookHash("german", chapter);
+    expect(expected?.lessonIds).toHaveLength(count);
+    expect(actualChapterHash(lessons, "german", chapter)).toBe(expected?.sourceHash);
+    expect(bookHashStatus(lessons, "german", chapter)).toBe("synced");
+  });
+
   it("reports a generated chapter stale when one canonical lesson changes", () => {
     const lessons = loadLessons();
     const changed = lessons.map((lesson) =>


### PR DESCRIPTION
## Summary

- migrate all ten German lessons for Chapters 17–23 to schema v2 with shared-spine anchors, typed teaching blocks, prerequisite-closed knowledge atoms, and 164–262 second duration contracts
- repair the missing shared-spine step by adding a prerequisite-safe Chapter 19 `Wasser, bitte` lesson and moving the existing `Entschuldigung` lesson to Chapter 20
- generate seven LaTeX chapters from the canonical lesson AST, wire them into the German book, and independently verify their hashes and lesson counts in Language Ladder
- expand the downloadable German book from 84 to 104 pages and update the track documentation and human-languages backlog

## Validation

- `@coding-adventures/human-language-data`: 81 tests and 9 integration tests passed; generated-book check passed
- curriculum report: 20 tracks, 1,066 lessons, 20 books, 0 duration violations, 0 unknown prerequisites, 207 remaining missing book chapters
- Language Ladder: 333 full-suite tests passed; post-rebase 58 focused book-hash tests passed; production build passed
- forced XeLaTeX build: 104 pages, 0 missing glyphs, 0 duplicate destinations, 0 LaTeX warnings
- rendered and inspected all 104 pages; outline and extracted text contain Chapters 1–23 with no generator/schema/hash leakage
- one local unified pass built all 20 language PDFs successfully

## Follow-up

HL-B21 records the expanded German presentation baseline for focused cleanup: 18 overfull boxes, 1 underfull horizontal box, 11 underfull vertical boxes, and 3 Hyperref warnings.