### PR TITLE
fix(spice): validate BJT transit times

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate finite, non-negative BJT model-card `TF` and `TR` transit times.
 - Validate BJT model-card `CJC` / `CJC0` / `CBC` base-collector capacitance and
   lower the `CJC0` alias instead of silently dropping it.
 - Validate BJT model-card `CJE` / `CJE0` / `CBE` base-emitter capacitance and

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1973,6 +1973,14 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or base_collector_capacitance < 0.0
         ):
             raise NetlistParseError("BJT CJC must be finite and non-negative")
+        for parameter_name in ("TF", "TR"):
+            transit_time = params.get(parameter_name)
+            if transit_time is not None and (
+                not math.isfinite(transit_time) or transit_time < 0.0
+            ):
+                raise NetlistParseError(
+                    f"BJT {parameter_name} must be finite and non-negative"
+                )
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1036,6 +1036,30 @@ def test_rejects_invalid_bjt_base_collector_capacitance(
         parse_netlist(f".model fast NPN({parameter}={value})")
 
 
+@pytest.mark.parametrize("parameter", ["TF", "TR"])
+@pytest.mark.parametrize("value", ["-1n", "1e999"])
+def test_rejects_invalid_bjt_transit_time(parameter: str, value: str) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match=f"BJT {parameter} must be finite and non-negative",
+    ):
+        parse_netlist(f".model fast NPN({parameter}={value})")
+
+
+def test_preserves_valid_bjt_transit_times() -> None:
+    parsed = parse_netlist(
+        """
+.model fast NPN(TF=4n TR=5n)
+Q1 col base emit fast
+"""
+    )
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Tf == 4.0e-9
+    assert transistor.Tr == 5.0e-9
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate finite, non-negative BJT model-card `TF` and `TR` transit times.
 - Validate BJT model-card `CJC` / `CJC0` / `CBC` base-collector capacitance and
   lower the `CJC0` alias instead of silently dropping it.
 - Validate BJT model-card `CJE` / `CJE0` / `CBE` base-emitter capacitance and

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1213,6 +1213,16 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT CJC must be finite and non-negative");
   }
+  for (const name of ["TF", "TR"] as const) {
+    const transitTime = params.get(name);
+    if (
+      (kind === "NPN" || kind === "PNP") &&
+      transitTime !== undefined &&
+      (!Number.isFinite(transitTime) || transitTime < 0.0)
+    ) {
+      throw new NetlistParseError(`BJT ${name} must be finite and non-negative`);
+    }
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1051,6 +1051,30 @@ Q2 col base emit slow
     );
   });
 
+  it.each([
+    ["TF", "-1n"],
+    ["TF", "1e999"],
+    ["TR", "-1n"],
+    ["TR", "1e999"],
+  ])("rejects invalid BJT %s transit time %s", (parameter, value) => {
+    expect(() => parseNetlist(`.model fast NPN(${parameter}=${value})`)).toThrow(
+      `BJT ${parameter} must be finite and non-negative`,
+    );
+  });
+
+  it("preserves valid BJT transit times", () => {
+    const parsed = parseNetlist(`
+.model fast NPN(TF=4n TR=5n)
+Q1 col base emit fast
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      forwardTransitTime: 4.0e-9,
+      reverseTransitTime: 5.0e-9,
+    });
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4367,12 +4367,18 @@ the Rust, Python, and TypeScript surfaces together.
      values and lower `CJE0` into the shared engine base-emitter capacitance
      field after canonical `CJE` and before legacy `CBE`.
 
+410. Python and TypeScript Berkeley SPICE BJT base-collector capacitance alias parity.
+   - Status: completed in PR 9763.
+   - Both parser facades validate finite non-negative `CJC` / `CJC0` / `CBC`
+     values and lower `CJC0` into the shared engine base-collector capacitance
+     field after canonical `CJC` and before legacy `CBC`.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE BJT model-card alias parity.
    - Align parser validation and lowering with the shared engine aliases,
-     then audit the remaining directly lowerable BJT fields, starting with
-     finite non-negative `TF` / `TR` transit-time validation after `CJC0`.
+     then audit the remaining directly lowerable BJT fields, continuing with
+     positive finite saturation current `IS` validation after `TF` / `TR`.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary

- reject negative or non-finite BJT TF and TR model-card transit times in Python and TypeScript
- preserve zero and positive TF/TR lowering into the shared engine BJT fields
- record merged CJC0 alias parity and queue BJT IS validation next

## Verification

- Python spice-netlist-parser: `bash BUILD` (287 passed, 88.93% coverage)
- Python spice-netlist-parser: `.venv/bin/ruff check .`
- TypeScript spice-engine: `npm ci --quiet && npm run build && npm test` (448 passed)
- TypeScript spice-netlist-parser: `bash BUILD && npm run test:coverage` (276 passed, 85.85% line coverage)