### PR TITLE
fix(workspace): exclude os-kernel from cargo build --workspace

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -1,5 +1,12 @@
 [workspace]
 resolver = "2"
+# `os-kernel` is deliberately NOT a member (see `exclude` below): it targets
+# `x86_64-unknown-uefi` (no_std + a `panic_handler`) and cannot compile for the
+# host triple `cargo build --workspace`/`--all`/`clippy --workspace` use. It
+# still lives under this directory tree so the custom Go build-tool
+# (`code/programs/go/build-tool`) discovers it via its own `BUILD` file scan
+# (independent of this `members` list) and applies the documented SKIP.
+exclude = ["os-kernel"]
 members = [
     "adj-lang",
     "adj-lang-cli",
@@ -339,7 +346,6 @@ members = [
     "ml-framework-keras",
     "ml-framework-tf",
     "ml-framework-torch",
-    "os-kernel",
     "os-kernel-simulator",
     "parallel-execution-engine",
     "parser",


### PR DESCRIPTION
## Summary

- `os-kernel` targets `x86_64-unknown-uefi` (no_std + a `panic_handler`) and cannot compile for the host triple — confirmed by running `cargo build -p os-kernel`, which fails with `error: unwinding panics are not supported without std`.
- Its own `BUILD` file already documents this and SKIPs it for the custom Go build-tool, but raw `cargo build --workspace` (and `--all`/`clippy --workspace`) still tried to compile it and failed.
- Removes `os-kernel` from `[workspace] members` and adds it to `exclude`. The custom build-tool discovers packages by scanning for `BUILD` files directly (`DiscoverPackages` in `code/programs/go/build-tool`), independent of this `members` list, so its documented SKIP behavior is completely unaffected.
- No other crate path-depends on `os-kernel`. `os-kernel-simulator` (a normal `std` crate, unrelated) stays a member.

## Test plan

- [x] `cargo build -p os-kernel` reproduces the exact original failure (confirms this is a real, current issue, not stale)
- [x] `cargo metadata` confirms `os-kernel` is no longer a workspace member (and `os-kernel-simulator` still is)
- [x] `cargo build --workspace` no longer attempts to compile `os-kernel` (gets past it cleanly)
- [x] `/security-review` passed — pure workspace-membership bookkeeping; confirmed os-kernel was never actually built/tested/clippy-checked by CI even before this change (its own BUILD file already SKIPs it), and CodeQL doesn't scan Rust in this repo at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)