### PR TITLE
fix(spice): validate BJT saturation current

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate positive finite BJT model-card `IS` saturation current.
 - Validate finite, non-negative BJT model-card `TF` and `TR` transit times.
 - Validate BJT model-card `CJC` / `CJC0` / `CBC` base-collector capacitance and
   lower the `CJC0` alias instead of silently dropping it.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1938,6 +1938,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
         ):
             raise NetlistParseError("diode CJO must be finite and non-negative")
     if kind in {"NPN", "PNP"}:
+        saturation_current = params.get("IS")
+        if saturation_current is not None and (
+            not math.isfinite(saturation_current) or saturation_current <= 0.0
+        ):
+            raise NetlistParseError("BJT IS must be finite and positive")
         forward_beta = next(
             (
                 params[name]

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -912,6 +912,14 @@ Q1 col base 0 fast
     assert 0.0 < result.node_voltages["col"] < 5.0
 
 
+@pytest.mark.parametrize("value", ["0", "-1p", "1e999"])
+def test_rejects_invalid_bjt_saturation_current(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT IS must be finite and positive"
+    ):
+        parse_netlist(f".model fast NPN(IS={value})")
+
+
 def test_parse_pnp_bjt_model_aliases_beta_f() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate positive finite BJT model-card `IS` saturation current.
 - Validate finite, non-negative BJT model-card `TF` and `TR` transit times.
 - Validate BJT model-card `CJC` / `CJC0` / `CBC` base-collector capacitance and
   lower the `CJC0` alias instead of silently dropping it.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1180,6 +1180,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
     params.get("BETA") ??
     params.get("BETA_F") ??
     params.get("HFE");
+  const bjtSaturationCurrent = params.get("IS");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtSaturationCurrent !== undefined &&
+    (!Number.isFinite(bjtSaturationCurrent) || bjtSaturationCurrent <= 0.0)
+  ) {
+    throw new NetlistParseError("BJT IS must be finite and positive");
+  }
   if (
     (kind === "NPN" || kind === "PNP") &&
     bjtForwardBeta !== undefined &&

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -894,6 +894,15 @@ Q1 col base 0 fast
     expect(result.voltage("col")).toBeLessThan(5.0);
   });
 
+  it.each(["0", "-1p", "1e999"])(
+    "rejects invalid BJT saturation current %s",
+    (value) => {
+      expect(() => parseNetlist(`.model fast NPN(IS=${value})`)).toThrow(
+        "BJT IS must be finite and positive",
+      );
+    },
+  );
+
   it("parses PNP BJT model aliases", () => {
     const parsed = parseNetlist(`
 .model slow PNP(IS=2e-14 BETA_F=80 VT=26m)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4373,12 +4373,17 @@ the Rust, Python, and TypeScript surfaces together.
      values and lower `CJC0` into the shared engine base-collector capacitance
      field after canonical `CJC` and before legacy `CBC`.
 
+411. Python and TypeScript Berkeley SPICE BJT transit-time validation parity.
+   - Status: completed in PR 9770.
+   - Both parser facades validate finite non-negative `TF` / `TR` values before
+     lowering them into the shared engine BJT transit-time fields.
+
 ## Backlog
 
-1. Python and TypeScript Berkeley SPICE BJT model-card alias parity.
-   - Align parser validation and lowering with the shared engine aliases,
-     then audit the remaining directly lowerable BJT fields, continuing with
-     positive finite saturation current `IS` validation after `TF` / `TR`.
+1. Python and TypeScript Berkeley SPICE model-card validation parity.
+   - Complete a fresh parser-to-engine validation audit after the directly
+     lowerable BJT fields, starting with finite non-negative diode `TT` transit
+     time validation.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary

- reject non-positive or non-finite BJT IS model-card saturation current in Python and TypeScript
- keep valid IS lowering aligned with shared engine requirements
- record merged BJT TF/TR validation and queue a fresh diode TT validation audit

## Verification

- Python spice-netlist-parser: `bash BUILD` (290 passed, 88.96% coverage)
- Python spice-netlist-parser: `.venv/bin/ruff check .`
- TypeScript spice-engine: `npm ci --quiet && npm run build && npm test` (448 passed)
- TypeScript spice-netlist-parser: `bash BUILD && npm run test:coverage` (279 passed, 85.90% line coverage)