### PR TITLE
Make the German human-languages book warning-free

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -6,7 +6,7 @@ discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
 Last prioritized: 2026-08-03. Current baseline after schema-v2 block-boundary
-validation: 20 registered tracks, 1,065 Markdown lessons, 20 downloadable LaTeX
+validation: 20 registered tracks, 1,066 Markdown lessons, 20 downloadable LaTeX
 books, and zero duration violations. HL-V01 keeps the remaining migration debt
 reproducible in both JSON and human-readable reports; the first 51 Spanish
 lessons now prove one typed, knowledge-closed source across Language Ladder and
@@ -69,6 +69,7 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-D01 | Complete (#9624) | Split or rewrite every lesson whose computed duration is at least 300 seconds. | The deterministic report now reaches zero effective-duration violations across all twenty tracks. |
 | HL-S02 | Complete (#9634) | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | All 27 lessons have typed blocks, unique sequence, transitive knowledge closure, and sub-five-minute duration guarantees. |
 | HL-G03 | Complete (#9646) | Generate Spanish Chapters 4–6 from their canonical schema-v2 lesson ASTs after HL-S02. | All six generated chapters now share lesson hashes with Language Ladder; Markdown tables retain their structure in print. |
+| HL-G04 | Queued | Normalize paired straight quotation marks when canonical prose is rendered into LaTeX. | Generated prose should use true opening and closing marks under every book's language rules without changing the canonical app text or code spans. |
 | HL-V02 | Complete (#9653) | Validate learner-facing target-language prompts against block-level knowledge declarations and prerequisite closure. | Schema-v2 production and recall blocks cannot ask for an undeclared form or a form absent from the lesson's transitive knowledge frontier. |
 | HL-V03 | Queued | Compile individual prompt, answer, accepted-variant, feedback, and response-time contracts from typed activity blocks. | Every compiled activity names a non-empty subset of its block's assessed atoms and resolves all answer variants without scraping prose. |
 | HL-B04 | Complete (#9661) | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
@@ -88,9 +89,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B17 | Complete (#9748) | Remove Portuguese's LaTeX layout warnings. | The forced 105-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
 | HL-B18 | Complete (#9752) | Publish French Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | Nine schema-v2 lessons now generate seven chapters whose source hashes are independently verified against the Language Ladder corpus. |
 | HL-B19 | Complete (#9761) | Remove French's LaTeX layout and Unicode bookmark warnings. | The forced 98-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
-| HL-B20 | Complete in this PR | Publish German Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | Ten schema-v2 lessons now generate seven chapters whose source hashes are independently verified against the Language Ladder corpus. |
-| HL-B21 | Next | Remove German's LaTeX layout and Unicode bookmark warnings. | The expanded forced build has no missing glyphs or duplicate destinations but reports eighteen overfull boxes, one underfull horizontal box, eleven underfull vertical boxes, and three Hyperref warnings; the clean-build signal is zero of each. |
-| HL-B22 | Queued | Publish Telugu Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Telugu PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
+| HL-B20 | Complete (#9765) | Publish German Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | Ten schema-v2 lessons now generate seven chapters whose source hashes are independently verified against the Language Ladder corpus. |
+| HL-B21 | Complete in this PR | Remove German's LaTeX layout and Unicode bookmark warnings. | The forced 104-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
+| HL-B22 | Next | Publish Telugu Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Telugu PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
 | HL-B23 | Queued | Remove Telugu's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports four overfull boxes, three underfull boxes, four duplicate practice labels, 27 Hyperref warnings, and a font-shape substitution warning; the clean-build signal is zero of each. |
 | HL-B24 | Queued | Publish Kannada Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Kannada PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
 | HL-B25 | Queued | Remove Kannada's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports four overfull boxes, five underfull boxes, four duplicate practice labels, 30 Hyperref warnings, and undefined bold/italic Kannada font shapes; the clean-build signal is zero of each. |
@@ -673,6 +674,31 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - The expanded warning baseline is eighteen overfull boxes, one underfull
   horizontal box, eleven underfull vertical boxes, and three Hyperref warnings.
   HL-B21 is next and records cleanup against the full 104-page artifact.
+
+## Findings from HL-B21
+
+- German now uses `\raggedbottom`, making intentionally short micro-lesson
+  pages explicit and removing eleven underfull vertical boxes without adding
+  filler or stretching learner content.
+- Concise running titles, one prose-only bookmark, a breakable practice path,
+  and three reflowed passages remove header, path, and paragraph overflow while
+  preserving the same grammar and etymology explanations.
+- Ten dense legacy tables now use responsive or explicitly bounded paragraph
+  columns. Every register, vocabulary, conjugation, weekday, and word-origin
+  comparison remains present and readable inside the text block.
+- The two canonical copy edits keep the generated German chapters and Language
+  Ladder hashes aligned: the `Kopf` recall reflows cleanly, while the shorter
+  visible `Entschuldigung` heading leaves its complete “un-guilting” etymology
+  in the lesson body.
+- Full-page inspection found that straight ASCII quotes elsewhere in generated
+  prose can become right-only quotation marks under German language rules.
+  HL-G04 records a cross-book generator fix; it follows the larger missing-book
+  gaps rather than expanding this focused layout tranche.
+- A forced XeLaTeX build produces 104 pages with zero missing glyphs, overfull
+  or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX
+  warnings. All 104 rendered pages were inspected; the outline retains the
+  Preface, pronunciation reference, and Chapters 1–23. HL-B22 is next: publish
+  Telugu Chapters 6–31 from canonical lessons.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -79,7 +79,7 @@
     {
       "language": "german",
       "chapter": 17,
-      "sourceHash": "fnv1a64:fdbd2e7e24d5d6f2",
+      "sourceHash": "fnv1a64:a529d960c10eae9c",
       "lessonIds": [
         "GE-C17-kopf",
         "GE-C17-kopf-haupt",
@@ -109,7 +109,7 @@
     {
       "language": "german",
       "chapter": 20,
-      "sourceHash": "fnv1a64:7f75baaef49241c0",
+      "sourceHash": "fnv1a64:2949289880ce15c7",
       "lessonIds": [
         "GE-C20-entschuldigung"
       ],

--- a/code/learning/human-languages/german/CHANGELOG.md
+++ b/code/learning/human-languages/german/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Warning-free 104-page book (2026-08-03)
+
+- Made intentionally short micro-lesson pages explicit with `\raggedbottom`,
+  removing eleven underfull vertical boxes without padding learner content.
+- Added concise running titles and a prose-only Chapter 12 bookmark, made the
+  Chapter 10 practice path breakable, and reflowed three dense explanations.
+- Replaced rigid legacy comparison tables with bounded paragraph columns while
+  preserving every vocabulary, grammar, register, and etymology comparison.
+- Shortened only the visible `Entschuldigung` heading and reflowed the canonical
+  `Kopf` recall; regenerated hashes keep the book and Language Ladder on the
+  same source while the full explanations remain intact.
+- A forced XeLaTeX build produces 104 pages with zero missing glyphs, overfull
+  or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX
+  warnings. All 104 rendered pages were inspected, and the outline retains the
+  Preface, pronunciation reference, and all twenty-three chapters.
+
 ## Canonical Chapters 17–23 (2026-08-03)
 
 - Migrated the ten lessons in Chapters 17–23 to schema version 2 with typed

--- a/code/learning/human-languages/german/README.md
+++ b/code/learning/human-languages/german/README.md
@@ -58,7 +58,9 @@ French *nuit* — one Indo-European word, split four ways.
 
 **All twenty-three chapters are authored and in the book (104 pages).** Chapters
 17–23 are generated from the same canonical lesson AST and source hashes that
-Language Ladder verifies independently.
+Language Ladder verifies independently. The forced XeLaTeX build is warning-free:
+zero missing glyphs, overfull or underfull boxes, duplicate destinations,
+Hyperref warnings, or LaTeX warnings.
 
 ## Files
 

--- a/code/learning/human-languages/german/book/chapters/appendix-pronunciation.tex
+++ b/code/learning/human-languages/german/book/chapters/appendix-pronunciation.tex
@@ -37,9 +37,9 @@ its word needs and points here for more.
   \item \textbf{Final devoicing} (above).
 \end{itemize}
 
-\section*{The High German Consonant Shift (a decoding tool)}
+\section*{The High German Consonant Shift}
 
-Not about \emph{saying} words but \emph{recognizing} them: German pushed
+A decoding tool rather than a rule for \emph{saying} words: German pushed
 certain consonants forward, so English and German cousins differ predictably.
 
 \begin{center}

--- a/code/learning/human-languages/german/book/chapters/ch03-how-are-you.tex
+++ b/code/learning/human-languages/german/book/chapters/ch03-how-are-you.tex
@@ -165,8 +165,8 @@ $=$ ``it'' $\cdot$ \textbf{dir} $=$ ``to you'' --- the dative of \emph{du}, the
 Two registers, and only the ``you'' changes --- the same move as the
 \emph{du}/\emph{Sie} split:
 
-\begin{center}
-\begin{tabular}{@{}ll@{}}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}p{0.27\linewidth}>{\raggedright\arraybackslash}X@{}}
 \toprule
 Register & Question \\
 \midrule
@@ -174,8 +174,7 @@ informal (friend, family) & \emph{Wie geht es dir?} (spoken \emph{Wie geht's
 dir?} / just \emph{Wie geht's?}) \\
 formal (stranger, elder) & \emph{Wie geht es Ihnen?} \\
 \bottomrule
-\end{tabular}
-\end{center}
+\end{tabularx}
 
 \emph{es} and \emph{dir} often crush together in speech into \emph{geht's} ---
 \emph{Wie geht's?} is the everyday form, and you can answer it with the
@@ -206,8 +205,8 @@ whole meaning.
 
 Your German answer ladder for \emph{Wie geht's?}:
 
-\begin{center}
-\begin{tabular}{@{}ll@{}}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}p{0.29\linewidth}>{\raggedright\arraybackslash}X@{}}
 \toprule
 Answer & Sense \\
 \midrule
@@ -216,8 +215,7 @@ Answer & Sense \\
 \emph{So lala} & so-so (a sing-song ``meh''; \emph{lala} is just filler) \\
 \emph{Nicht so gut} & not so well \\
 \bottomrule
-\end{tabular}
-\end{center}
+\end{tabularx}
 
 \begin{culture}
 The cross-track shrug collection, now four deep: German \textbf{es geht} (``it
@@ -260,8 +258,8 @@ takes the \textbf{dative} (\emph{dir} / \emph{Ihnen}), because it is short for
 ``how goes it \emph{to you}?''
 \end{grammarlens}
 
-\begin{center}
-\begin{tabular}{@{}ll@{}}
+\noindent
+\begin{tabular}{@{}>{\raggedright\arraybackslash}p{0.30\textwidth}>{\raggedright\arraybackslash}p{0.63\textwidth}@{}}
 \toprule
 Built this chapter & \\
 \midrule
@@ -271,12 +269,11 @@ Built this chapter & \\
 ask''; English \emph{bid}, \emph{bead}) \\
 \emph{gehen} / \emph{geht} & ``to go,'' the state-verb ($=$ English \emph{go})
 \\
-\emph{Wie geht es dir?} / \emph{Ihnen?} & how are you --- informal / formal \\
-\emph{gut} / \emph{es geht} / \emph{so lala} / \emph{nicht so gut} & the answer
+\emph{Wie geht es dir?}\slash{} \emph{Ihnen?} & how are you --- informal / formal \\
+\emph{gut}\slash{} \emph{es geht}\slash{} \emph{so lala}\slash{} \emph{nicht so gut} & the answer
 ladder \\
 \bottomrule
 \end{tabular}
-\end{center}
 
 Which verb carries German's ``how are you?'', and what English word is it?
 \emph{gehen} $=$ \emph{go}. Which two of our three tracks use ``to go,'' and

--- a/code/learning/human-languages/german/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/german/book/chapters/ch04-farewells.tex
@@ -184,8 +184,8 @@ soft-goodbye set --- \emph{bis bald} (soon), \emph{bis sp\"{a}ter} (later),
 No new words. The farewells now close a real conversation and fold back into
 everything since \emph{hallo}.
 
-\begin{center}
-\begin{tabular}{@{}ll@{}}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}p{0.30\linewidth}>{\raggedright\arraybackslash}X@{}}
 \toprule
 You're\ldots & Say \\
 \midrule
@@ -194,8 +194,7 @@ casual / to a friend & \emph{Tsch\"{u}ss.} \\
 meeting again soon & \emph{Bis bald.} \\
 leaving for the day & \emph{Bis morgen.} \\
 \bottomrule
-\end{tabular}
-\end{center}
+\end{tabularx}
 
 \noindent Everything from Chapters \ref{ch:greetings}--\ref{ch:farewells}, in
 one exchange:
@@ -212,8 +211,8 @@ one exchange:
 \noindent Between friends, that last line becomes \emph{Tsch\"{u}ss, bis
 morgen!}
 
-\begin{center}
-\begin{tabular}{@{}ll@{}}
+\noindent
+\begin{tabular}{@{}>{\raggedright\arraybackslash}p{0.30\textwidth}>{\raggedright\arraybackslash}p{0.63\textwidth}@{}}
 \toprule
 Built this chapter & \\
 \midrule
@@ -221,11 +220,10 @@ Built this chapter & \\
 \emph{sehen} $=$ \emph{see}; twin of \emph{au revoir}) \\
 \emph{tsch\"{u}ss} & casual bye (secretly \emph{adieu}, ``to God,'' cousin of
 \emph{adi\'{o}s}) \\
-\emph{bis bald} / \emph{sp\"{a}ter} / \emph{morgen} & soon / later / tomorrow
+\emph{bis bald}\slash{} \emph{sp\"{a}ter}\slash{} \emph{morgen} & soon / later / tomorrow
 --- \emph{bis} $+$ a time, like \emph{hasta} and \emph{\`{a}} \\
 \bottomrule
 \end{tabular}
-\end{center}
 
 Which German goodbye promises a ``re-seeing,'' and which language matches it?
 \emph{Auf Wiedersehen}; French \emph{au revoir}. What does the casual

--- a/code/learning/human-languages/german/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/german/book/chapters/ch05-first-verbs.tex
@@ -90,8 +90,8 @@ Was machst du? $=$ ``What are you doing?''
 nothing new to learn. That is the payoff of a regular pattern.
 \end{grammarlens}
 
-\begin{center}
-\begin{tabular}{@{}ll@{}}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}p{0.30\linewidth}>{\raggedright\arraybackslash}X@{}}
 \toprule
 Person & \emph{machen} $\to$ \\
 \midrule
@@ -102,8 +102,7 @@ Person & \emph{machen} $\to$ \\
 \emph{ihr} & \emph{macht} \\
 \emph{sie} / \emph{Sie} & \emph{machen} \\
 \bottomrule
-\end{tabular}
-\end{center}
+\end{tabularx}
 
 \section{\emph{lernen} --- ``to learn,'' and it \emph{is} English \emph{learn}}
 \label{lesson:lernen}
@@ -226,13 +225,13 @@ because German needs an overt subject.
 --- Danke! --- Bitte.
 \end{center}
 
-\begin{center}
-\begin{tabular}{@{}ll@{}}
+\noindent
+\begin{tabular}{@{}>{\raggedright\arraybackslash}p{0.30\textwidth}>{\raggedright\arraybackslash}p{0.63\textwidth}@{}}
 \toprule
 Built this chapter & \\
 \midrule
 the regular (weak) present & drop \emph{-en}, add
-\emph{-e}/\emph{-st}/\emph{-t}/\emph{-en}/\emph{-t}/\emph{-en}; the endings are
+\emph{-e}\slash{}\emph{-st}\slash{}\emph{-t}\slash{}\emph{-en}\slash{}\emph{-t}\slash{}\emph{-en}; the endings are
 \textbf{audible} \\
 \emph{wohnen} & $\leftarrow$ \emph{won\=en} $\to$ English \emph{wont} \\
 \emph{machen} & $\leftarrow$ \emph{mak\=on} $\to$ English \emph{make};
@@ -245,7 +244,6 @@ the pronoun rule & Spanish \textbf{drops} \emph{yo}; French \textbf{keeps}
 \emph{je} (silent endings); German \textbf{keeps} \emph{ich} (structure) \\
 \bottomrule
 \end{tabular}
-\end{center}
 
 What are the three singular weak endings, and are they audible? \emph{-e} /
 \emph{-st} / \emph{-t}; yes --- unlike French. Give the ``I'' forms of the

--- a/code/learning/human-languages/german/book/chapters/ch06-numbers-1-10.tex
+++ b/code/learning/human-languages/german/book/chapters/ch06-numbers-1-10.tex
@@ -52,7 +52,7 @@ counting form is \emph{eins}; the article drops the \emph{-s}. The other
 numbers do not change for the article.
 \end{grammarlens}
 
-\section{\emph{sechs, sieben, acht, neun, zehn} --- finishing the count}
+\section[\emph{sechs} to \emph{zehn}]{\emph{sechs, sieben, acht, neun, zehn} --- finishing the count}
 \label{lesson:zahlen-6-10}
 
 The rest of the way to ten --- and again, each is the twin of its English

--- a/code/learning/human-languages/german/book/chapters/ch07-days.tex
+++ b/code/learning/human-languages/german/book/chapters/ch07-days.tex
@@ -22,8 +22,8 @@ the \emph{ei} $=$ English ``eye.''\\[3pt]
 Germanic counterpart of the Roman planet.
 \end{morphologybox}
 
-\begin{center}
-\begin{tabular}{@{}llll@{}}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}p{0.16\linewidth}>{\raggedright\arraybackslash}p{0.22\linewidth}>{\raggedright\arraybackslash}p{0.21\linewidth}>{\raggedright\arraybackslash}X@{}}
 \toprule
 German & god & $=$ English & (Roman planet it replaced) \\
 \midrule
@@ -33,8 +33,7 @@ German & god & $=$ English & (Roman planet it replaced) \\
 \emph{Donnerstag} & \textbf{Donar} $=$ \textbf{Thor} (\emph{Donner} ``thunder'') & \textbf{Thurs}day & Jupiter \\
 \emph{Freitag} & \textbf{Frija/Frigg}, love-goddess & \textbf{Fri}day & Venus \\
 \bottomrule
-\end{tabular}
-\end{center}
+\end{tabularx}
 
 \begin{cousinweb}
 \textbf{\emph{Donnerstag} $\leftrightarrow$ Thursday.} \emph{Donner} is German
@@ -59,16 +58,15 @@ Two weekend days, and one more surprise: German's Saturday is \emph{not}
 Saturn's day --- it is the \textbf{Sabbath}, sharing its root with the Romance
 languages, not with English \emph{Saturday}. Sunday, though, stays the Sun's.
 
-\begin{center}
-\begin{tabular}{@{}llll@{}}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}p{0.14\linewidth}>{\raggedright\arraybackslash}p{0.31\linewidth}>{\raggedright\arraybackslash}p{0.20\linewidth}>{\raggedright\arraybackslash}X@{}}
 \toprule
 German & $\leftarrow$ & meaning & note \\
 \midrule
 \emph{Samstag} & \emph{Sabbat} $\leftarrow$ Greek \emph{s\'{a}bbaton} $\leftarrow$ Hebrew \emph{shabb\={a}t} & the ``\textbf{Sabbath}'' & \emph{not} Saturn! \\
 \emph{Sonntag} & \emph{Sun} $+$ \emph{Tag} (\emph{Sonne} ``sun'') & ``the \textbf{Sun's} day'' & $=$ English \textbf{Sun}day \\
 \bottomrule
-\end{tabular}
-\end{center}
+\end{tabularx}
 
 \begin{etymology}
 \textbf{Samstag} surprises everyone: where English kept the Roman planet

--- a/code/learning/human-languages/german/book/chapters/ch08-time.tex
+++ b/code/learning/human-languages/german/book/chapters/ch08-time.tex
@@ -27,8 +27,8 @@ word that became French \emph{heure}, Italian \emph{ora}, and English
 That is the striking part: three layers of the German day, three different
 origins.
 
-\begin{center}
-\begin{tabular}{@{}lll@{}}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}p{0.20\linewidth}>{\raggedright\arraybackslash}p{0.28\linewidth}>{\raggedright\arraybackslash}X@{}}
 \toprule
 what & German & origin \\
 \midrule
@@ -36,8 +36,7 @@ the \textbf{numbers} & \emph{eins, zwei, drei} & native Germanic (twins of Engli
 the \textbf{weekdays} & \emph{Montag, Donnerstag} & Germanic gods (Latin \emph{months}) \\
 the \textbf{clock} & \emph{Uhr} & Latin loan (\emph{h\={o}ra}) \\
 \bottomrule
-\end{tabular}
-\end{center}
+\end{tabularx}
 
 German kept its own numbers and gods, but for the \emph{machine that measures
 hours} it reached for Rome. German also has a native word, \textbf{Stunde},
@@ -54,7 +53,7 @@ it works like English \textbf{o'clock}: \emph{zwei Uhr} $=$ ``two o'clock.''
 (\emph{Uhren}, the plural, means ``clocks,'' the objects.)
 \end{grammarlens}
 
-\section{\emph{Mittag} and \emph{Mitternacht} --- the native middle of day and night}
+\section[\emph{Mittag} and \emph{Mitternacht}]{\emph{Mittag} and \emph{Mitternacht} --- the native middle of day and night}
 \label{lesson:mittag-mitternacht}
 
 The clock-word \emph{Uhr} was Latin. But noon and midnight swing back to

--- a/code/learning/human-languages/german/book/chapters/ch10-family.tex
+++ b/code/learning/human-languages/german/book/chapters/ch10-family.tex
@@ -5,7 +5,7 @@ The months were Latin tourists. Family is the opposite story: German's words
 for father, mother, brother and sister were never borrowed --- they are
 inherited, and they are blood cousins of the English ones. Along the way they
 put a famous sound-law on display.
-\emph{Practice lessons: \texttt{lessons/GE-C10-*.md}.}
+\emph{Practice lessons: \nolinkurl{lessons/GE-C10-*.md}.}
 
 \section{\emph{der Vater}, \emph{die Mutter} --- the pair that proves Grimm's law}
 \label{lesson:eltern}
@@ -56,7 +56,7 @@ French and Latin sit on the other side of Grimm's line. The month names were
 Latin tourists; \emph{Vater} and \emph{Mutter} are natives.
 \end{culture}
 
-\section{\emph{der Bruder}, \emph{die Schwester} --- and the word for ``siblings''}
+\section[\emph{Bruder}, \emph{Schwester}, \emph{Geschwister}]{\emph{der Bruder}, \emph{die Schwester} --- and the word for ``siblings''}
 \label{lesson:geschwister}
 
 \begin{sounds}

--- a/code/learning/human-languages/german/book/chapters/ch11-food.tex
+++ b/code/learning/human-languages/german/book/chapters/ch11-food.tex
@@ -38,7 +38,7 @@ German nouns are also always \textbf{Capitalized} --- \emph{Brot},
 \emph{Vater}, \emph{Wasser} --- a rule no other language in this book follows.
 \end{culture}
 
-\section{\emph{das Wasser}, \emph{der Wein} --- one word Germans always had, one Rome brought}
+\section[\emph{Wasser} and \emph{Wein}]{\emph{das Wasser}, \emph{der Wein} --- one word Germans always had, one Rome brought}
 \label{lesson:wasser-wein}
 
 Two drinks, two very different histories. \emph{Wasser} is a word Germanic

--- a/code/learning/human-languages/german/book/chapters/ch12-numbers-11-20.tex
+++ b/code/learning/human-languages/german/book/chapters/ch12-numbers-11-20.tex
@@ -1,10 +1,10 @@
 \chapter{Numbers Eleven to Twenty}
 \label{ch:numbers-11-20}
 
-Why are English \emph{eleven} and \emph{twelve} so strange --- why not
-``oneteen, twoteen''? German has the identical oddity, and because the two
-languages are Germanic twins, learning one \emph{explains} the other. Then, at
-thirteen, both settle into a rule that never breaks.
+Why are English \emph{eleven} and \emph{twelve} so strange? Why not ``oneteen,
+twoteen''? German has the same oddity. Because the two languages are Germanic
+twins, learning one \emph{explains} the other. At thirteen, both settle into a
+rule that never breaks.
 \emph{Practice lessons: \texttt{lessons/GE-C12-*.md}.}
 
 \section{\emph{elf} und \emph{zw\"{o}lf} --- ``one left over,'' ``two left over''}
@@ -43,7 +43,7 @@ numbers. From \textbf{13} on, German turns completely regular --- and so does
 English.
 \end{grammarlens}
 
-\section{\emph{dreizehn} $\to$ \emph{zwanzig} --- the pattern that never breaks}
+\section[\emph{dreizehn} to \emph{zwanzig}]{\emph{dreizehn} $\to$ \emph{zwanzig} --- the pattern that never breaks}
 \label{lesson:zahlen-13-20}
 
 After the two leftovers, German settles into a rule so regular you can generate

--- a/code/learning/human-languages/german/book/chapters/ch13-colours.tex
+++ b/code/learning/human-languages/german/book/chapters/ch13-colours.tex
@@ -71,7 +71,7 @@ Practise them on something you can already name: \emph{der Wein ist wei\ss{}}
 (``the wine is white''), and \emph{wei\ss{}} $\cdot$ \emph{white} said side by
 side, so you can hear that it is one word.
 
-\section{\emph{rot}, \emph{blau} --- an ancient cousin and a second emigrant}
+\section[\emph{rot} and \emph{blau}]{\emph{rot}, \emph{blau} --- an ancient cousin and a second emigrant}
 \label{lesson:rot-blau}
 
 Two more native German colours. One is related to the French word for red ---

--- a/code/learning/human-languages/german/book/chapters/ch15-perfekt.tex
+++ b/code/learning/human-languages/german/book/chapters/ch15-perfekt.tex
@@ -132,9 +132,9 @@ Tense & Where it lives \\
 \end{tabular}
 \end{center}
 
-In southern Germany, Austria and Switzerland the \emph{Pr\"{a}teritum} has
-largely vanished from conversation. Further north it survives better. And in
-books, it is the normal past tense. A few verbs resist everywhere: \emph{war},
+The \emph{Pr\"{a}teritum} has largely vanished from conversation in southern
+Germany, Austria and Switzerland. Further north it survives better; in books,
+it is the normal past tense. A few verbs resist everywhere: \emph{war},
 \emph{hatte}, and the modal verbs stay common even in speech.
 
 \subsection*{The same retreat, three times}

--- a/code/learning/human-languages/german/book/chapters/ch17-head-and-hand.tex
+++ b/code/learning/human-languages/german/book/chapters/ch17-head-and-hand.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:fdbd2e7e24d5d6f2
+% canonical-source-hash: fnv1a64:a529d960c10eae9c
 % canonical-lessons: GE-C17-kopf, GE-C17-kopf-haupt, GE-C17-hand
 
 \chapter{Head and Hand}
@@ -62,7 +62,7 @@ German’s older inherited head-word did not disappear completely. The next micr
 {[}REPEAT x2{]} “Der Kopf — masculine, capitalised.”
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
-{[}PAUSE 3s{]} Say “the head.” (\textbf{Der Kopf}.) What gender? (\textbf{Masculine}.) Why the capital? (It is a \textbf{noun}.) What did \emph{Kopf} first mean? (A \textbf{cup or bowl}.) Which English word is related? (\textbf{Cup}.) Next: find the inherited word \emph{Haupt}.
+{[}PAUSE 3s{]} Say “the head.” (\textbf{Der Kopf}.) Give its gender. (\textbf{Masculine}.) Why the capital? (It is a \textbf{noun}.) What did \emph{Kopf} first mean? (A \textbf{cup or bowl}.) Name the related English word. (\textbf{Cup}.) Next: find the inherited word \emph{Haupt}.
 \end{tcolorbox}
 \section[Kopf / Haupt]{Kopf / Haupt — two head-words}
 

--- a/code/learning/human-languages/german/book/chapters/ch20-sorry.tex
+++ b/code/learning/human-languages/german/book/chapters/ch20-sorry.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:7f75baaef49241c0
+% canonical-source-hash: fnv1a64:2949289880ce15c7
 % canonical-lessons: GE-C20-entschuldigung
 
 \chapter{Sorry}
@@ -8,7 +8,7 @@
 This chapter is generated from the canonical micro-lessons used by Language Ladder.
 Each section stays independently resumable and preserves the authored prerequisite order.
 
-\section[Entschuldigung]{Entschuldigung — "sorry" / "excuse me" (un-guilting)}
+\section[Entschuldigung]{Entschuldigung — “sorry” / “excuse me”}
 
 \label{lesson:GE-C20-entschuldigung}
 

--- a/code/learning/human-languages/german/book/preamble.tex
+++ b/code/learning/human-languages/german/book/preamble.tex
@@ -13,6 +13,7 @@
 \setmainfont{Latin Modern Roman}
 \setsansfont{Latin Modern Sans}
 \setmonofont{Latin Modern Mono}
+\raggedbottom
 
 \usepackage[table]{xcolor}
 \usepackage{tcolorbox}

--- a/code/learning/human-languages/german/lessons/GE-C17-kopf.md
+++ b/code/learning/human-languages/german/lessons/GE-C17-kopf.md
@@ -86,6 +86,6 @@ in French.
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-KOPF-02, GE-SOUND-KOPF-03, GE-COMPOUND-KOPFSCHMERZEN-04, GE-ETYMON-KOPF-05] -->
 
-[PAUSE 3s] Say “the head.” (**Der Kopf**.) What gender? (**Masculine**.) Why the
-capital? (It is a **noun**.) What did *Kopf* first mean? (A **cup or bowl**.)
-Which English word is related? (**Cup**.) Next: find the inherited word *Haupt*.
+[PAUSE 3s] Say “the head.” (**Der Kopf**.) Give its gender. (**Masculine**.) Why
+the capital? (It is a **noun**.) What did *Kopf* first mean? (A **cup or bowl**.)
+Name the related English word. (**Cup**.) Next: find the inherited word *Haupt*.

--- a/code/learning/human-languages/german/lessons/GE-C20-entschuldigung.md
+++ b/code/learning/human-languages/german/lessons/GE-C20-entschuldigung.md
@@ -28,7 +28,7 @@ variety: standard-contemporary
 reviews_of: [GE-C19-bitte-requests, GE-C03-bitte, GE-C03-danke]
 ---
 
-# Entschuldigung — "sorry" / "excuse me" (un-guilting)
+# Entschuldigung — “sorry” / “excuse me”
 
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[] -->


### PR DESCRIPTION
## Summary
- remove all German PDF layout, bookmark, glyph, and LaTeX warnings without dropping curriculum content
- replace rigid tables with responsive/bounded columns, add safe running titles and natural page bottoms
- keep the canonical German lessons, generated chapters, book hashes, and Language Ladder corpus aligned
- record HL-B21 complete, promote Telugu HL-B22, and log the cross-book quote-normalization follow-up

## Validation
- human-language-data: 81 tests passed; integration: 9 passed
- Language Ladder: 333 tests passed; production build passed
- forced German XeLaTeX build: 104 pages; zero missing glyphs, overfull/underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings
- rendered and inspected all 104 pages; outline is Preface + pronunciation + Chapters 1–23; no generator/schema/hash metadata leaks
- unified publication pass rebuilt all 20 PDFs and verified the 20-entry catalog plus JSON/text curriculum reports
- git diff --check