### PR TITLE
fix(spice): validate diode transit time

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate finite, non-negative diode model-card `TT` transit time.
 - Validate positive finite BJT model-card `IS` saturation current.
 - Validate finite, non-negative BJT model-card `TF` and `TR` transit times.
 - Validate BJT model-card `CJC` / `CJC0` / `CBC` base-collector capacitance and

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1937,6 +1937,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(junction_capacitance) or junction_capacitance < 0.0
         ):
             raise NetlistParseError("diode CJO must be finite and non-negative")
+        transit_time = params.get("TT")
+        if transit_time is not None and (
+            not math.isfinite(transit_time) or transit_time < 0.0
+        ):
+            raise NetlistParseError("diode TT must be finite and non-negative")
     if kind in {"NPN", "PNP"}:
         saturation_current = params.get("IS")
         if saturation_current is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -866,6 +866,23 @@ def test_rejects_invalid_diode_junction_capacitance(
         parse_netlist(f".model clamp D({parameter}={value})")
 
 
+@pytest.mark.parametrize("value", ["0", "4n"])
+def test_accepts_valid_diode_transit_time(value: str) -> None:
+    parsed = parse_netlist(f".model clamp D(TT={value})\nD1 in out clamp")
+
+    diode = parsed.circuit.elements[0]
+    assert isinstance(diode, Diode)
+    assert diode.Tt == parse_value(value)
+
+
+@pytest.mark.parametrize("value", ["-1n", "1e999"])
+def test_rejects_invalid_diode_transit_time(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="diode TT must be finite and non-negative"
+    ):
+        parse_netlist(f".model clamp D(TT={value})")
+
+
 def test_parse_bjt_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate finite, non-negative diode model-card `TT` transit time.
 - Validate positive finite BJT model-card `IS` saturation current.
 - Validate finite, non-negative BJT model-card `TF` and `TR` transit times.
 - Validate BJT model-card `CJC` / `CJC0` / `CBC` base-collector capacitance and

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1175,6 +1175,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("diode CJO must be finite and non-negative");
   }
+  const diodeTransitTime = params.get("TT");
+  if (
+    kind === "D" &&
+    diodeTransitTime !== undefined &&
+    (!Number.isFinite(diodeTransitTime) || diodeTransitTime < 0.0)
+  ) {
+    throw new NetlistParseError("diode TT must be finite and non-negative");
+  }
   const bjtForwardBeta =
     params.get("BF") ??
     params.get("BETA") ??

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -825,6 +825,24 @@ D1 in out clamp
     );
   });
 
+  it.each([
+    ["0", 0.0],
+    ["4n", 4.0e-9],
+  ])("accepts valid diode TT transit time %s", (value, expected) => {
+    const parsed = parseNetlist(`.model clamp D(TT=${value})\nD1 in out clamp`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "diode",
+      transitTime: expected,
+    });
+  });
+
+  it.each(["-1n", "1e999"])("rejects invalid diode TT transit time %s", (value) => {
+    expect(() => parseNetlist(`.model clamp D(TT=${value})`)).toThrow(
+      "diode TT must be finite and non-negative",
+    );
+  });
+
   it("parses the diode V_T thermal-voltage alias", () => {
     const parsed = parseNetlist(`
 .model clamp D(V_T=27m)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4378,12 +4378,24 @@ the Rust, Python, and TypeScript surfaces together.
    - Both parser facades validate finite non-negative `TF` / `TR` values before
      lowering them into the shared engine BJT transit-time fields.
 
+412. Python and TypeScript Berkeley SPICE BJT saturation-current validation parity.
+   - Status: completed in PR 9778.
+   - Both parser facades validate positive finite `IS` values before lowering
+     them into the shared engine BJT saturation-current field.
+
+413. Python and TypeScript Berkeley SPICE diode transit-time validation parity.
+   - Status: completed in this diode transit-time validation slice.
+   - Both parser facades validate finite non-negative `TT` values before
+     lowering them into the shared engine diode transit-time field.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE model-card validation parity.
-   - Complete a fresh parser-to-engine validation audit after the directly
-     lowerable BJT fields, starting with finite non-negative diode `TT` transit
-     time validation.
+   - Continue the parser-to-engine validation audit with positive finite diode
+     emission coefficient `N`, followed by positive finite breakdown voltage
+     `BV` and breakdown current `IBV`.
+   - Audit remaining directly lowerable diode fields before moving to model
+     parameters that require new parser-to-engine lowering surfaces.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary
- reject negative and non-finite diode model-card `TT` values in the Python and TypeScript parser facades
- preserve zero and positive transit times when lowering into the shared engine diode fields
- reconcile the SPICE implementation plan with PR #9778 and queue the next audited diode validation gaps

## Validation
- `code/packages/python/spice-netlist-parser`: `bash BUILD` (294 tests, 88.99% coverage)
- `code/packages/python/spice-netlist-parser`: `.venv/bin/ruff check src tests`
- `code/packages/typescript/spice-engine`: `bash BUILD` (448 tests)
- `code/packages/typescript/spice-netlist-parser`: `bash BUILD` (283 tests)
- `code/packages/typescript/spice-netlist-parser`: `npm run test:coverage` (85.94% line coverage)