### PR TITLE
fix(csharp/zstd): correct FSE sequences-codec conformance + FHD checksum-flag bit

### DIFF
--- a/code/packages/csharp/zstd/CHANGELOG.md
+++ b/code/packages/csharp/zstd/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.1.1] - 2026-08-03
+
+### Fixed
+
+- **Sequences-section FSE codec was not RFC 8878 conformant**, despite passing
+  every internal round-trip test. This package was added independently
+  (months after `code/packages/rust/zstd`), but audited alongside a
+  repo-wide sweep (see `gh pr diff 9780`, `code/packages/java/zstd`) after the
+  same bug pattern was confirmed in the Rust reference implementation. Three
+  compounding bugs, each individually self-cancelling in a same-codebase
+  round-trip test (encoder and decoder always agreed with each other) but
+  fatal against the real `zstd` CLI:
+  1. `BuildDecodeTable`/`BuildEncodeTables` spread FSE table symbols using a
+     fabricated two-pass split (all `count>1` symbols first, then all
+     `count==1` symbols). The real algorithm (verified against
+     `FSE_buildDTable_internal` in `github.com/facebook/zstd`'s
+     `fse_decompress.c`) is a single pass over symbols in ascending order,
+     placing each symbol's full count immediately.
+  2. Per-sequence field order was wrong: a conformant decoder peeks all
+     three symbols (LL/OF/ML) from the current states first (zero bits),
+     then reads extra value bits in order OF, ML, LL, then updates FSE
+     states in order LL, ML, OF. This package combined peek-and-update into
+     one step and read extra bits in the wrong order.
+  3. The FSE state-transition update was performed for every sequence
+     uniformly, including the last one. A real decoder never updates state
+     after the final sequence in a block (there is no "next" sequence to
+     prepare a state for); the encoder must mirror this by computing the
+     first-processed (semantically last) sequence's starting state directly
+     via the `FSE_initCState2` formula, writing zero bits, instead of a
+     normal bit-flushing transition. Added `FseInitState` alongside the
+     renamed `FseEncodeTransition` (previously the single overloaded
+     `EncodeSymbol`) to implement this.
+- **Frame Header Descriptor `Content_Checksum_Flag` was read from bit 4
+  instead of bit 2**, and the reserved-bit rejection mask (`0x0C`) incorrectly
+  included bit 2 — meaning any real-world frame with a trailing content
+  checksum (the default for the `zstd` CLI) was rejected outright as having
+  "reserved frame-header bits set" before checksum parsing was ever reached.
+  Verified empirically: `zstd -c` emits FHD `0x64`; `zstd -c --no-check`
+  emits FHD `0x60`. RFC 8878 §3.1.1.1: bit 4 is `Unused_bit` (must be
+  ignored, not rejected), bit 2 is `Content_Checksum_Flag`.
+- Added a real TC-9 CLI-interoperability test (`Tc9CliInterop`,
+  `RepeatingPatternCliInterop`) that shells out to the actual `zstd` binary
+  in both directions (compress-here/decompress-there and the reverse).
+  Confirmed the pre-fix code failed `Tc9CliInterop` with the real CLI's
+  "Data corruption detected" error; the fix passes cleanly. This is the only
+  kind of test that can catch this bug class — a same-codebase round-trip
+  test cannot, since encoder and decoder always agreed with each other on
+  the same wrong convention.
+
 ## [0.1.0] - 2026-07-18
 
 ### Added

--- a/code/packages/csharp/zstd/CodingAdventures.Zstd.csproj
+++ b/code/packages/csharp/zstd/CodingAdventures.Zstd.csproj
@@ -6,7 +6,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <PackageId>CodingAdventures.Zstd.CSharp</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
     <Authors>Adhithya Rajasekaran</Authors>
     <Description>Pure C# educational Zstandard codec</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/code/packages/csharp/zstd/README.md
+++ b/code/packages/csharp/zstd/README.md
@@ -14,6 +14,14 @@ This package follows the repository's established CMP07 teaching format. It is
 an educational RFC 8878 subset: it does not decode arbitrary Zstandard streams
 that use compressed literals or custom/repeat FSE tables.
 
+The predefined-FSE sequences codec (table construction, per-sequence field
+order, and the last-sequence state-init special case) is verified against the
+real `zstd` CLI via `dotnet test` (see `Tc9CliInterop` and
+`RepeatingPatternCliInterop` in the test project) — a same-codebase
+round-trip test alone cannot catch a systematic, symmetric protocol
+deviation, since the encoder and decoder would simply agree with each other
+on the wrong convention. See `CHANGELOG.md` and lessons.md Lesson 96.
+
 ## Example
 
 ```csharp

--- a/code/packages/csharp/zstd/Zstd.cs
+++ b/code/packages/csharp/zstd/Zstd.cs
@@ -231,14 +231,28 @@ public static class Zstd
 
         var position = 4;
         var descriptor = data[position++];
-        if ((descriptor & 0x0C) != 0)
+
+        // Frame_Header_Descriptor bit layout (RFC 8878 §3.1.1.1):
+        //   bit 7-6: Frame_Content_Size_Flag
+        //   bit 5:   Single_Segment_Flag
+        //   bit 4:   Unused_bit (decoders MUST ignore it, not reject it)
+        //   bit 3:   Reserved (must be 0)
+        //   bit 2:   Content_Checksum_Flag
+        //   bit 1-0: Dictionary_ID_Flag
+        // An earlier revision of this decoder read the checksum flag from
+        // bit 4 and rejected any frame with bit 2 set as "reserved" — both
+        // backwards from the RFC. Verified empirically against the real
+        // `zstd` CLI: `zstd -c` (checksum on by default) emits FHD 0x64;
+        // `zstd -c --no-check` emits FHD 0x60 — the differing bit is bit 2.
+        // See lessons.md Lesson 95.
+        if ((descriptor & 0x08) != 0)
         {
             throw new InvalidDataException("reserved frame-header bits are set");
         }
 
         var contentSizeFlag = descriptor >> 6;
         var singleSegment = (descriptor & 0x20) != 0;
-        var checksum = (descriptor & 0x10) != 0;
+        var checksum = (descriptor & 0x04) != 0;
         var dictionaryFlag = descriptor & 3;
 
         if (!singleSegment)
@@ -384,31 +398,60 @@ public static class Zstd
         var literalTable = BuildDecodeTable(LiteralLengthNorm, LiteralLengthAccuracyLog);
         var matchTable = BuildDecodeTable(MatchLengthNorm, MatchLengthAccuracyLog);
         var offsetTable = BuildDecodeTable(OffsetNorm, OffsetAccuracyLog);
+
+        // Initial states are read LL, OF, ML — RFC 8878 §3.1.1.3.2.1.2. This
+        // is a DIFFERENT order from the per-sequence update order below
+        // (LL, ML, OF); the RFC is genuinely asymmetric here.
         var literalState = reader.ReadBits(LiteralLengthAccuracyLog);
-        var matchState = reader.ReadBits(MatchLengthAccuracyLog);
         var offsetState = reader.ReadBits(OffsetAccuracyLog);
+        var matchState = reader.ReadBits(MatchLengthAccuracyLog);
         var literalPosition = 0;
 
         for (var sequenceIndex = 0; sequenceIndex < sequenceCount; sequenceIndex++)
         {
-            var (literalCode, nextLiteralState) = DecodeSymbol(literalState, literalTable, reader);
-            var (offsetCode, nextOffsetState) = DecodeSymbol(offsetState, offsetTable, reader);
-            var (matchCode, nextMatchState) = DecodeSymbol(matchState, matchTable, reader);
-            literalState = nextLiteralState;
-            offsetState = nextOffsetState;
-            matchState = nextMatchState;
+            // Step 1 — peek all three symbols from the CURRENT states. This
+            // is a bare table lookup (the FSE state IS the decode-table
+            // index); it consumes zero bits. Only the state UPDATE in step 3
+            // reads bits.
+            if ((uint)literalState >= literalTable.Length
+                || (uint)offsetState >= offsetTable.Length
+                || (uint)matchState >= matchTable.Length)
+            {
+                throw new InvalidDataException("invalid FSE decoder state");
+            }
+
+            var literalEntry = literalTable[literalState];
+            var offsetEntry = offsetTable[offsetState];
+            var matchEntry = matchTable[matchState];
+            var literalCode = literalEntry.Symbol;
+            var offsetCode = offsetEntry.Symbol;
+            var matchCode = matchEntry.Symbol;
 
             if ((uint)literalCode >= LiteralLengthCodes.Length || (uint)matchCode >= MatchLengthCodes.Length)
             {
                 throw new InvalidDataException("invalid sequence code");
             }
 
-            var literalLength = LiteralLengthCodes[literalCode].Baseline
-                + reader.ReadBits(LiteralLengthCodes[literalCode].ExtraBits);
+            // Step 2 — read extra value bits, in order OF, ML, LL.
+            var rawOffset = (1 << offsetCode) | reader.ReadBits(offsetCode);
             var matchLength = MatchLengthCodes[matchCode].Baseline
                 + reader.ReadBits(MatchLengthCodes[matchCode].ExtraBits);
-            var rawOffset = (1 << offsetCode) | reader.ReadBits(offsetCode);
+            var literalLength = LiteralLengthCodes[literalCode].Baseline
+                + reader.ReadBits(LiteralLengthCodes[literalCode].ExtraBits);
             var matchOffset = rawOffset - 3;
+
+            // Step 3 — update FSE states (consumes bits), in order LL, ML,
+            // OF, preparing the states the NEXT sequence's peek will use —
+            // but only if this is not the last sequence. There is no "next"
+            // sequence to prepare a state for after the last one, and a
+            // conformant encoder never wrote any bits for that non-existent
+            // transition (see FseInitState in EncodeSequences).
+            if (sequenceIndex != sequenceCount - 1)
+            {
+                literalState = literalEntry.Baseline + reader.ReadBits(literalEntry.Bits);
+                matchState = matchEntry.Baseline + reader.ReadBits(matchEntry.Bits);
+                offsetState = offsetEntry.Baseline + reader.ReadBits(offsetEntry.Bits);
+            }
 
             if (literalLength < 0 || literalPosition + literalLength > literals.Length)
             {
@@ -542,6 +585,34 @@ public static class Zstd
         return (0x7F00 + data[1] + (data[2] << 8), 3);
     }
 
+    // Per RFC 8878 §3.1.1.3.2.1.2, verified against the reference C source
+    // (ZSTD_decodeSequence / FSE_encodeSymbol / FSE_initCState2 in
+    // github.com/facebook/zstd), a forward decoder processes each sequence
+    // in three strictly ordered steps:
+    //   1. Peek all three symbols (LL, OF, ML) from the CURRENT states —
+    //      a bare table lookup that consumes zero bits.
+    //   2. Read extra value bits, in order OF, ML, LL.
+    //   3. Update the FSE states (consumes bits), in order LL, ML, OF — but
+    //      ONLY if this is not the last sequence in the block. There is no
+    //      "next" sequence to prepare a state for after the last one.
+    // The very first read of all (the initial states, before sequence 1) is
+    // a separate, differently-ordered step: LL, OF, ML.
+    //
+    // The encoder mirrors this in exact reverse, since the bitstream is
+    // written backward: it processes sequences from last to first. The
+    // FIRST sequence it processes (the semantically LAST real sequence) has
+    // no incoming bit-consuming transition — mirroring step 3 being skipped
+    // on the decode side — so its starting state must be computed directly
+    // via FseInitState (zstd's FSE_initCState2), writing zero bits, rather
+    // than a normal FseEncodeTransition.
+    //
+    // An earlier revision of this codec combined peek-and-update into one
+    // step (in the wrong LL/OF/ML order), wrote extra bits in the wrong
+    // LL/ML/OF order, and flushed a state transition for every sequence
+    // uniformly instead of special-casing the last one. All three bugs were
+    // self-cancelling in this package's own round-trip tests (encoder and
+    // decoder agreed with each other) but produced output the real `zstd`
+    // CLI rejected as corrupt. See lessons.md Lesson 96.
     private static byte[] EncodeSequences(IReadOnlyList<Sequence> sequences)
     {
         var (literalEntries, literalStates) = BuildEncodeTables(LiteralLengthNorm, LiteralLengthAccuracyLog);
@@ -550,10 +621,11 @@ public static class Zstd
         var literalSize = 1 << LiteralLengthAccuracyLog;
         var matchSize = 1 << MatchLengthAccuracyLog;
         var offsetSize = 1 << OffsetAccuracyLog;
-        var literalState = literalSize;
-        var matchState = matchSize;
-        var offsetState = offsetSize;
+        var literalState = 0;
+        var matchState = 0;
+        var offsetState = 0;
         var writer = new ReverseBitWriter();
+        var first = true;
 
         for (var index = sequences.Count - 1; index >= 0; index--)
         {
@@ -563,28 +635,56 @@ public static class Zstd
             var rawOffset = sequence.Offset + 3;
             var offsetCode = BitOperations.Log2((uint)rawOffset);
             var offsetExtra = rawOffset - (1 << offsetCode);
-            writer.AddBits((uint)offsetExtra, offsetCode);
-            writer.AddBits(
-                (uint)(sequence.MatchLength - MatchLengthCodes[matchCode].Baseline),
-                MatchLengthCodes[matchCode].ExtraBits);
-            writer.AddBits(
-                (uint)(sequence.LiteralLength - LiteralLengthCodes[literalCode].Baseline),
-                LiteralLengthCodes[literalCode].ExtraBits);
+            var matchExtra = sequence.MatchLength - MatchLengthCodes[matchCode].Baseline;
+            var literalExtra = sequence.LiteralLength - LiteralLengthCodes[literalCode].Baseline;
 
-            (matchState, var bits, var value) = EncodeSymbol(matchState, matchCode, matchEntries, matchStates);
-            writer.AddBits((uint)value, bits);
-            (offsetState, bits, value) = EncodeSymbol(offsetState, offsetCode, offsetEntries, offsetStates);
-            writer.AddBits((uint)value, bits);
-            (literalState, bits, value) = EncodeSymbol(literalState, literalCode, literalEntries, literalStates);
-            writer.AddBits((uint)value, bits);
+            if (first)
+            {
+                // Last real sequence: no incoming transition to flush. The
+                // starting state is derived directly from the symbol, with
+                // zero bits written (mirrors FSE_initCState2).
+                offsetState = FseInitState(offsetCode, offsetEntries, offsetStates);
+                matchState = FseInitState(matchCode, matchEntries, matchStates);
+                literalState = FseInitState(literalCode, literalEntries, literalStates);
+                first = false;
+            }
+            else
+            {
+                // Transition write order OF, ML, LL — a forward decoder
+                // consumes these in reverse (LL, ML, OF) as the state
+                // UPDATE immediately after decoding this same sequence.
+                offsetState = FseEncodeTransition(offsetState, offsetCode, offsetEntries, offsetStates, writer);
+                matchState = FseEncodeTransition(matchState, matchCode, matchEntries, matchStates, writer);
+                literalState = FseEncodeTransition(literalState, literalCode, literalEntries, literalStates, writer);
+            }
+
+            // Extra bits, write order LL, ML, OF — a forward decoder reads
+            // these in order OF, ML, LL immediately after peeking symbols.
+            writer.AddBits((uint)literalExtra, LiteralLengthCodes[literalCode].ExtraBits);
+            writer.AddBits((uint)matchExtra, MatchLengthCodes[matchCode].ExtraBits);
+            writer.AddBits((uint)offsetExtra, offsetCode);
         }
 
-        writer.AddBits((uint)(offsetState - offsetSize), OffsetAccuracyLog);
+        // Flush the initial states (the states used to peek the FIRST real
+        // sequence). A forward decoder reads these first, in order LL, OF,
+        // ML. Since these are the very last bits written and the stream is
+        // read backward, write them in reverse: ML, OF, LL.
         writer.AddBits((uint)(matchState - matchSize), MatchLengthAccuracyLog);
+        writer.AddBits((uint)(offsetState - offsetSize), OffsetAccuracyLog);
         writer.AddBits((uint)(literalState - literalSize), LiteralLengthAccuracyLog);
         return writer.Finish();
     }
 
+    // Real FSE table-spread algorithm, verified against the reference C
+    // source (FSE_buildDTable_internal's low-probability branch in
+    // fse_decompress.c): a SINGLE pass over symbols 0..maxSymbolValue in
+    // ascending order, placing each symbol's full count immediately when
+    // encountered. There is no "count>1 symbols first, then count==1
+    // symbols" split — an earlier revision of this codec used exactly that
+    // fabricated two-pass convention, which produces a different table
+    // layout that is internally self-consistent (this package's own
+    // encoder/decoder agreed with each other) but is rejected as corrupt by
+    // the real `zstd` CLI. See lessons.md Lesson 96.
     private static DecodeEntry[] BuildDecodeTable(IReadOnlyList<int> normalized, int accuracyLog)
     {
         var size = 1 << accuracyLog;
@@ -598,32 +698,34 @@ public static class Zstd
         {
             if (normalized[symbol] == -1)
             {
-                symbols[high--] = symbol;
+                symbols[high] = symbol;
+                if (high > 0)
+                {
+                    high--;
+                }
+
                 symbolNext[symbol] = 1;
             }
         }
 
         var position = 0;
-        for (var pass = 0; pass < 2; pass++)
+        for (var symbol = 0; symbol < normalized.Count; symbol++)
         {
-            for (var symbol = 0; symbol < normalized.Count; symbol++)
+            var count = normalized[symbol];
+            if (count <= 0)
             {
-                var count = normalized[symbol];
-                if (count <= 0 || ((pass == 0) != (count > 1)))
-                {
-                    continue;
-                }
+                continue;
+            }
 
-                symbolNext[symbol] = count;
-                for (var occurrence = 0; occurrence < count; occurrence++)
+            symbolNext[symbol] = count;
+            for (var occurrence = 0; occurrence < count; occurrence++)
+            {
+                symbols[position] = symbol;
+                do
                 {
-                    symbols[position] = symbol;
-                    do
-                    {
-                        position = (position + step) & (size - 1);
-                    }
-                    while (position > high);
+                    position = (position + step) & (size - 1);
                 }
+                while (position > high);
             }
         }
 
@@ -661,30 +763,33 @@ public static class Zstd
         {
             if (normalized[symbol] == -1)
             {
-                spread[high--] = symbol;
+                spread[high] = symbol;
+                if (high > 0)
+                {
+                    high--;
+                }
             }
         }
 
+        // Single pass over symbols in ascending order — must mirror
+        // BuildDecodeTable's spread exactly (see comment there).
         var position = 0;
-        for (var pass = 0; pass < 2; pass++)
+        for (var symbol = 0; symbol < normalized.Count; symbol++)
         {
-            for (var symbol = 0; symbol < normalized.Count; symbol++)
+            var count = normalized[symbol];
+            if (count <= 0)
             {
-                var count = normalized[symbol];
-                if (count <= 0 || ((pass == 0) != (count > 1)))
-                {
-                    continue;
-                }
+                continue;
+            }
 
-                for (var occurrence = 0; occurrence < count; occurrence++)
+            for (var occurrence = 0; occurrence < count; occurrence++)
+            {
+                spread[position] = symbol;
+                do
                 {
-                    spread[position] = symbol;
-                    do
-                    {
-                        position = (position + step) & (size - 1);
-                    }
-                    while (position > high);
+                    position = (position + step) & (size - 1);
                 }
+                while (position > high);
             }
         }
 
@@ -714,8 +819,46 @@ public static class Zstd
         return (entries, states);
     }
 
-    private static (int State, int Bits, int Value) EncodeSymbol(
+    /// <summary>
+    /// Performs a normal FSE encode transition (mirrors real zstd's
+    /// <c>FSE_encodeSymbol</c>): flushes the bits needed to move from
+    /// <paramref name="state"/> to the next state that will decode as
+    /// <paramref name="symbol"/>, and returns that next state.
+    /// </summary>
+    private static int FseEncodeTransition(
         int state,
+        int symbol,
+        IReadOnlyList<EncodeEntry> entries,
+        IReadOnlyList<int> states,
+        ReverseBitWriter writer)
+    {
+        if ((uint)symbol >= entries.Count)
+        {
+            throw new InvalidDataException("FSE symbol is outside the predefined table");
+        }
+
+        var entry = entries[symbol];
+        var bits = (state + entry.DeltaBits) >> 16;
+        var value = state & ((1 << bits) - 1);
+        writer.AddBits((uint)value, bits);
+        var slot = (state >> bits) + entry.DeltaFindState;
+        if ((uint)slot >= states.Count)
+        {
+            throw new InvalidDataException("invalid FSE encoder state");
+        }
+
+        return states[slot];
+    }
+
+    /// <summary>
+    /// Computes an FSE encoder's starting state directly from a symbol,
+    /// writing zero bits (mirrors real zstd's <c>FSE_initCState2</c>). Used
+    /// for the first symbol processed in the reverse encode loop — the
+    /// semantically LAST real sequence — which has no incoming bit-consuming
+    /// transition, because a real decoder never performs a state update
+    /// after decoding the final sequence in a block.
+    /// </summary>
+    private static int FseInitState(
         int symbol,
         IReadOnlyList<EncodeEntry> entries,
         IReadOnlyList<int> states)
@@ -726,29 +869,15 @@ public static class Zstd
         }
 
         var entry = entries[symbol];
-        var bits = (state + entry.DeltaBits) >> 16;
-        var value = state & ((1 << bits) - 1);
-        var slot = (state >> bits) + entry.DeltaFindState;
+        var bits = (entry.DeltaBits + (1 << 15)) >> 16;
+        var value = (bits << 16) - entry.DeltaBits;
+        var slot = (value >> bits) + entry.DeltaFindState;
         if ((uint)slot >= states.Count)
         {
             throw new InvalidDataException("invalid FSE encoder state");
         }
 
-        return (states[slot], bits, value);
-    }
-
-    private static (int Symbol, int State) DecodeSymbol(
-        int state,
-        IReadOnlyList<DecodeEntry> table,
-        ReverseBitReader reader)
-    {
-        if ((uint)state >= table.Count)
-        {
-            throw new InvalidDataException("invalid FSE decoder state");
-        }
-
-        var entry = table[state];
-        return (entry.Symbol, entry.Baseline + reader.ReadBits(entry.Bits));
+        return states[slot];
     }
 
     private static int ValueToCode(int value, IReadOnlyList<CodeRange> codes)

--- a/code/packages/csharp/zstd/tests/CodingAdventures.Zstd.Tests/ZstdTests.cs
+++ b/code/packages/csharp/zstd/tests/CodingAdventures.Zstd.Tests/ZstdTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text;
 using Xunit;
 
@@ -130,12 +131,30 @@ public sealed class ZstdTests
     [Fact]
     public void MultiSegmentHeadersAndChecksumsAreConsumed()
     {
+        // Descriptor 0x04 sets ONLY Content_Checksum_Flag (bit 2, per RFC
+        // 8878 §3.1.1.1 — see lessons.md Lesson 95). Bit 5 (Single_Segment)
+        // is unset, so a 1-byte window descriptor follows.
+        byte[] frame =
+        [
+            0x28, 0xB5, 0x2F, 0xFD,
+            0x04, 0x00,
+            0x09, 0, 0, (byte)'x',
+            1, 2, 3, 4,
+        ];
+        Assert.Equal([(byte)'x'], Zstd.Decompress(frame));
+    }
+
+    [Fact]
+    public void Bit4IsUnusedAndMustNotBeTreatedAsChecksumOrReserved()
+    {
+        // Descriptor 0x10 sets only bit 4 (Unused_bit). A conformant decoder
+        // must ignore it entirely: no checksum trailer, no rejection. This
+        // guards against reintroducing the Lesson 95 bit-4/bit-2 mixup.
         byte[] frame =
         [
             0x28, 0xB5, 0x2F, 0xFD,
             0x10, 0x00,
             0x09, 0, 0, (byte)'x',
-            1, 2, 3, 4,
         ];
         Assert.Equal([(byte)'x'], Zstd.Decompress(frame));
     }
@@ -181,6 +200,158 @@ public sealed class ZstdTests
         new byte[] { 0x28, 0xB5, 0x2F, 0xFD, 0x20, 0, 0x01, 0, 0, 0xFF },
         new byte[] { 0x28, 0xB5, 0x2F, 0xFD, 0x20, 0, 0x05, 0, 0 },
     };
+
+    // ─── TC-9: real `zstd` CLI interoperability ────────────────────────────
+    //
+    // Every prior test in this file only ever round-trips through OUR OWN
+    // encoder/decoder pair. That is necessary but never sufficient: an
+    // encoder and decoder that systematically agree with each other on a
+    // WRONG wire-format convention (bit order, table-construction algorithm)
+    // pass every internal round-trip test while producing output no other
+    // implementation can read. That is exactly the shape of the bug fixed
+    // alongside this test — see lessons.md Lesson 96 and CHANGELOG.md.
+    // Skipped (not failed) when the `zstd` binary isn't on PATH, since dev/CI
+    // environments vary.
+    [Fact]
+    public void Tc9CliInterop()
+    {
+        if (!IsZstdCliAvailable())
+        {
+            return;
+        }
+
+        var text = string.Concat(Enumerable.Repeat("the quick brown fox jumps over the lazy dog ", 25));
+        var original = Encoding.UTF8.GetBytes(text);
+
+        // Direction 1: compress with ours, decompress with the real `zstd -d`.
+        var ourCompressed = Zstd.Compress(original);
+        var oursZst = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(oursZst, ourCompressed);
+            var decodedByCli = RunZstd(["-d", "-q", "-c", oursZst]);
+            Assert.Equal(original, decodedByCli);
+        }
+        finally
+        {
+            File.Delete(oursZst);
+        }
+
+        // Direction 2: compress with real `zstd`, decompress with ours.
+        var theirsInput = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(theirsInput, original);
+            var theirCompressed = RunZstd(["-q", "-c", theirsInput]);
+            var decodedByUs = Zstd.Decompress(theirCompressed);
+            Assert.Equal(original, decodedByUs);
+        }
+        finally
+        {
+            File.Delete(theirsInput);
+        }
+    }
+
+    /// <summary>
+    /// Real `zstd` CLI interop on an input large enough to push the
+    /// compressor's single-block sequence count well past a handful of
+    /// sequences, exercising the FSE sequences codec across many
+    /// state-transition steps (not just the boundary case). A codec that
+    /// gets the per-sequence field order or last-sequence special-case wrong
+    /// (Lesson 96) fails on multi-sequence input even though a
+    /// one-or-two-sequence smoke test can pass by coincidence.
+    /// </summary>
+    [Fact]
+    public void RepeatingPatternCliInterop()
+    {
+        if (!IsZstdCliAvailable())
+        {
+            return;
+        }
+
+        var cycle = "ABCDEF"u8.ToArray();
+        var original = new byte[9000];
+        for (var index = 0; index < original.Length; index++)
+        {
+            original[index] = cycle[index % cycle.Length];
+        }
+
+        var ourCompressed = Zstd.Compress(original);
+        var oursZst = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(oursZst, ourCompressed);
+            var decodedByCli = RunZstd(["-d", "-q", "-c", oursZst]);
+            Assert.Equal(original, decodedByCli);
+        }
+        finally
+        {
+            File.Delete(oursZst);
+        }
+    }
+
+    private static bool IsZstdCliAvailable()
+    {
+        try
+        {
+            using var process = Process.Start(new ProcessStartInfo("zstd", "--version")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            });
+            if (process is null)
+            {
+                return false;
+            }
+
+            return process.WaitForExit(10_000) && process.ExitCode == 0;
+        }
+        catch (Exception ex) when (ex is System.ComponentModel.Win32Exception or InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    private static byte[] RunZstd(IEnumerable<string> args)
+    {
+        var startInfo = new ProcessStartInfo("zstd")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        foreach (var arg in args)
+        {
+            startInfo.ArgumentList.Add(arg);
+        }
+
+        using var process = Process.Start(startInfo) ?? throw new InvalidOperationException("failed to start zstd");
+
+        // Both stdout and stderr are redirected, so both must be drained
+        // concurrently with (not after) WaitForExit: if `zstd` writes enough
+        // to stderr to fill the OS pipe buffer while nothing is reading it,
+        // the child blocks on that write and the parent deadlocks blocked on
+        // reading stdout. Draining both asynchronously up front avoids that.
+        using var stdout = new MemoryStream();
+        var stdoutTask = process.StandardOutput.BaseStream.CopyToAsync(stdout);
+        var stderrTask = process.StandardError.ReadToEndAsync();
+
+        if (!process.WaitForExit(30_000))
+        {
+            process.Kill();
+            throw new InvalidOperationException("zstd CLI timed out");
+        }
+
+        stdoutTask.GetAwaiter().GetResult();
+        var stderr = stderrTask.GetAwaiter().GetResult();
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"zstd CLI failed (exit {process.ExitCode}): {stderr}");
+        }
+
+        return stdout.ToArray();
+    }
 
     private static List<int> BlockTypes(byte[] frame)
     {


### PR DESCRIPTION
## Summary

Audits `code/packages/csharp/zstd` as part of the repo-wide sweep following the `java/zstd` rescue (#9780) and the confirmed `rust/zstd` reproduction of the same bug pattern. This package was added independently (PR #8570, months after the buggy Rust reference), so it was genuinely possible it was unaffected — the audit confirms it was **not**: it inherited the identical 3-bug FSE sequences-codec pattern, plus the FHD checksum-flag-bit bug.

Verified the bug is real (not theoretical) by stashing the fix and re-running the new TC-9 CLI-interop test against the pre-fix code: it fails against the real `zstd -d` binary with "Data corruption detected" (exit 1). The same test passes cleanly with the fix applied.

### The three compounding FSE sequences-codec bugs (all self-cancelling in same-codebase round-trip tests, all fatal against the real `zstd` CLI)

1. **Fabricated two-pass table-spread.** `BuildDecodeTable`/`BuildEncodeTables` spread FSE table symbols using an invented "all count>1 symbols first, then all count==1 symbols" convention. The real algorithm (`FSE_buildDTable_internal` in `github.com/facebook/zstd`'s `fse_decompress.c`) is a single pass over symbols 0..maxSymbolValue, placing each symbol's full count immediately.
2. **Wrong per-sequence field order.** A conformant decoder peeks all three symbols (LL/OF/ML) from the current states first (zero bits consumed), then reads extra value bits in order OF, ML, LL, then updates FSE states in order LL, ML, OF. This package combined peek-and-update into one step and read extra bits in the wrong order.
3. **Missing last-sequence update skip.** A real decoder never updates FSE state after the final sequence in a block. The encoder's first-processed (semantically last) sequence must derive its starting state directly via the `FSE_initCState2` formula (new `FseInitState`), writing zero bits — not via a normal bit-flushing transition (`FseEncodeTransition`, the renamed/split former `EncodeSymbol`).

### Also fixed: FHD `Content_Checksum_Flag` bit position (Lesson 95 pattern)

The frame-header descriptor read the checksum flag from bit 4 instead of bit 2, **and** the reserved-bit rejection mask (`0x0C`) incorrectly included bit 2 — so any real-world frame with a trailing content checksum (the `zstd` CLI's default) was rejected outright as "reserved frame-header bits are set" before checksum parsing was ever reached. Verified empirically: `zstd -c` emits FHD `0x64`; `zstd -c --no-check` emits FHD `0x60`. RFC 8878 §3.1.1.1: bit 4 is `Unused_bit` (must be ignored, not rejected), bit 2 is `Content_Checksum_Flag`.

### Testing

- Added `Tc9CliInterop` and `RepeatingPatternCliInterop` — real interop tests that shell out to the actual `zstd` binary in both directions (compress-here/decompress-there and the reverse). This is the only test class that can catch this bug shape; same-codebase round-trip tests cannot, because encoder and decoder always agree with each other on the same wrong convention.
- Added regression tests for the corrected FHD bit semantics (`MultiSegmentHeadersAndChecksumsAreConsumed` updated to use the correct bit 2; new `Bit4IsUnusedAndMustNotBeTreatedAsChecksumOrReserved`).
- All 32 tests pass. Line coverage 90.67% (gate: 80%, `/p:Threshold=80`).
- Security review: 1 round with a LOW finding (latent stdout/stderr pipe-deadlock hang risk in the new `RunZstd` test helper), fixed by draining both streams concurrently via `CopyToAsync`/`ReadToEndAsync` before `WaitForExit`; re-reviewed clean.

Same repo-wide audit as #9780 (`java/zstd`) and #9774.

## Test plan

- [x] `dotnet test` — 32/32 passing
- [x] `dotnet test /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line` — 90.67% line coverage, passes the 80% gate
- [x] `Tc9CliInterop` / `RepeatingPatternCliInterop` exercise the real `zstd` binary both directions
- [x] Confirmed regression: stashed the fix and re-ran `Tc9CliInterop` against pre-fix code — fails with real `zstd -d`'s "Data corruption detected"
- [x] Security review: 1 LOW finding, fixed, re-reviewed clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)