### PR TITLE
fix(elixir/zstd): correct FSE sequences-codec + add real zstd CLI interop test (CMP07)

### DIFF
--- a/code/packages/elixir/zstd/CHANGELOG.md
+++ b/code/packages/elixir/zstd/CHANGELOG.md
@@ -82,6 +82,15 @@ Lesson 96 (FSE codec) and Lesson 95 (FHD checksum-flag bit) for full detail.
   `code/specs/CMP07-zstd.md`, TC-9 is Cross-language / interoperability;
   the old label collided with the spec's numbering.
 
+### Security
+
+- Hardened the new TC-9 tests' temp-file names (`unique_tmp_name/1`): mixes
+  `:crypto.strong_rand_bytes/1` output in alongside the monotonic counter,
+  so a co-resident local user can't pre-guess the path and symlink-race it
+  between `File.write!/2` and the `zstd` CLI's read. Flagged as LOW severity
+  in security review (test-only temp files, no sensitive content); fixed
+  anyway since the change was cheap.
+
 ## [0.1.2] — 2026-07-12
 
 ### Fixed

--- a/code/packages/elixir/zstd/CHANGELOG.md
+++ b/code/packages/elixir/zstd/CHANGELOG.md
@@ -5,6 +5,83 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.1.3] — 2026-08-03
+
+Repo-wide audit follow-up: a sibling effort fixing `java/zstd` (PR #9780,
+rescuing it from a stale branch and running it against the real `zstd` CLI
+for the first time) discovered a real RFC 8878 conformance bug in the
+sequences-section FSE codec, later confirmed also present in `rust/zstd`.
+This release audits and fixes the same bug class here. See lessons.md
+Lesson 96 (FSE codec) and Lesson 95 (FHD checksum-flag bit) for full detail.
+
+### Fixed
+
+- **Three compounding bugs in the sequences-section FSE codec**, found by
+  cross-checking against the real `zstd` CLI (new TC-9 test below) and the
+  reference C source (`fse.h` / `fse_decompress.c` /
+  `zstd_decompress_block.c` from github.com/facebook/zstd). All three were
+  invisible to every prior test in this package, because encoder and
+  decoder were wrong in the same self-consistent way — internal round-trip
+  tests can never catch a systematic, symmetric protocol deviation, only an
+  independent reference implementation can:
+  1. `build_decode_table/2` and `build_encode_sym/2` used a fabricated
+     two-pass symbol-table spread ("count > 1 first, then count == 1")
+     instead of the real single pass over symbols in ascending index order
+     (`FSE_buildDTable_internal`'s actual algorithm). There is no
+     correctness reason for the count>1-vs-count==1 split — it was a
+     spurious deterministic-looking convention with no basis in the
+     reference algorithm.
+  2. Per-sequence field order was wrong on both sides. The real decoder:
+     PEEKS all 3 FSE symbols (LL, ML, OF) from the current states first
+     (a bare table lookup — consumes NO bits), THEN reads extra bits in
+     order Offset, Match_Length, Literals_Length, THEN updates FSE states
+     (consuming bits) in order Literals_Length, Match_Length, Offset. The
+     initial states (read once, before any sequences) are read in order LL,
+     OF, ML — a DIFFERENT order from the per-sequence update order; RFC
+     8878 is asymmetric here. This package previously fused "peek" and
+     "state update" into one step (in the wrong order, LL/OF/ML) and read
+     extra bits before doing so, corrupting the bitstream position for
+     every stream that followed the first sequence.
+  3. The FSE state-transition update must be SKIPPED for the LAST sequence
+     in a block — there is no "next" sequence to prepare a state for, and
+     symmetrically the encoder must never flush bits for that non-existent
+     transition. Added `fse_init_state/3` (mirrors the real zstd reference's
+     `FSE_initCState2`), which derives the encoder's starting state directly
+     from a symbol via a rounding formula (`(delta_nb + 2^15) >>> 16`)
+     instead of the normal `(state + delta_nb) >>> 16` transition, writing
+     no bits. `apply_sequences/11` now skips the state-update read on the
+     decode side's last iteration (`remaining == 1`) to match.
+  - Confirmed this bug class also reproduced against `rust/zstd` with the
+    same minimal repro (`compress("ababababab" * 3)`, one sequence:
+    ll=2, ml=28, offset=2) before this fix — not an Elixir-specific porting
+    mistake. Flagged as a follow-up for the remaining `zstd` ports.
+- **Frame Header Descriptor `Content_Checksum_Flag` bit position**: the
+  comment above the encoder's fixed FHD byte (`0xE0`) mislabelled bit 4 as
+  `Content_Checksum_Flag` (it is actually `Unused_bit`; the real checksum
+  flag is bit 2, per RFC 8878 §3.1.1.1 and verified empirically —
+  `zstd -c file` emits FHD `0x64`, `zstd -c --no-check file` emits FHD
+  `0x60`, differing at bit 2). Since `0xE0` already has both bits clear,
+  this was comment-only and never caused a wire-format bug in this package;
+  fixed the documentation to prevent the mistake from spreading if
+  checksum support is ever added. No functional change.
+
+### Added
+
+- **TC-9 (CLI interoperability)**: two new tests exercise the real `zstd`
+  CLI binary via `System.cmd/3`, in both directions (compress here,
+  decompress with `zstd -d`; and compress with `zstd`, decompress here),
+  gracefully skipped when `zstd` isn't found on `PATH`. This is the test
+  that would have caught (and, once written, did catch) the FSE bug above —
+  every existing test in this package only ever round-tripped through our
+  own encoder/decoder pair. Covers the exact minimal repro from the bug
+  report, prose text, and a ~9 KB high-sequence-count input (to also
+  exercise the `Number_of_Sequences` 2-byte wire form past the 128-sequence
+  boundary).
+- The previous "TC-9: bad magic returns error" test is renamed to
+  "bad magic returns error" (dropping the TC-9 label) — per
+  `code/specs/CMP07-zstd.md`, TC-9 is Cross-language / interoperability;
+  the old label collided with the spec's numbering.
+
 ## [0.1.2] — 2026-07-12
 
 ### Fixed

--- a/code/packages/elixir/zstd/lib/coding_adventures/zstd.ex
+++ b/code/packages/elixir/zstd/lib/coding_adventures/zstd.ex
@@ -164,16 +164,26 @@ defmodule CodingAdventures.Zstd do
   #   nb   = number of extra bits to read for the next state transition
   #   base = added to those extra bits to form the next state
   #
-  # Construction (must mirror the Rust implementation exactly):
+  # Construction (must mirror the real zstd C reference — fse.h /
+  # fse_decompress.c's FSE_buildDTable_internal — exactly):
   #
   # Phase 1: symbols with norm[s] == -1 (prob = 1/sz) go at the HIGH end of the
   #   table (indices sz-1, sz-2, ...). These get exactly one slot.
   #
   # Phase 2: remaining symbols are spread across the LOW portion using a
-  #   deterministic step function. This ensures each symbol occupies the
-  #   correct fraction of slots proportional to its normalised count.
-  #   Two-pass: first symbols with count > 1, then count == 1.
-  #   This matches the reference implementation ordering.
+  #   deterministic step function, in a SINGLE pass over symbols in ascending
+  #   order 0..maxSymbolValue, placing each symbol's full count immediately
+  #   when encountered. This ensures each symbol occupies the correct
+  #   fraction of slots proportional to its normalised count.
+  #
+  #   An earlier revision of this codec used a fabricated two-pass split
+  #   (all count>1 symbols first, then all count==1 symbols) instead. That
+  #   produces a DIFFERENT table layout — internally self-consistent (our
+  #   own decoder mirrored our own encoder, so round-trip tests passed) but
+  #   not the real wire format, so output was rejected by the real `zstd`
+  #   CLI with "Data corruption detected". There is no correctness reason to
+  #   special-case cnt>1 vs cnt==1 — that was a spurious convention with no
+  #   basis in the reference algorithm. See lessons.md Lesson 96.
   #
   # Phase 3: assign nb and base to each slot.
   #   For symbol s with sym_next counter ns:
@@ -203,36 +213,29 @@ defmodule CodingAdventures.Zstd do
     # Phase 2: spread remaining symbols.
     # The step function step = (sz>>1) + (sz>>3) + 3 is co-prime to sz
     # (which is always a power of two), so it visits every slot in [0..high] exactly once.
-    {tbl1, sym_next1} =
-      Enum.reduce(0..1, {tbl0, sym_next0, 0}, fn pass, {tbl, sn, pos} ->
-        {new_tbl, new_sn, new_pos} =
-          norm
-          |> Enum.with_index()
-          |> Enum.reduce({tbl, sn, pos}, fn {c, s}, {tbl_acc, sn_acc, pos_acc} ->
-            if c <= 0 do
-              {tbl_acc, sn_acc, pos_acc}
-            else
-              cnt = c
-              skip = if pass == 0, do: cnt <= 1, else: cnt != 1
-              if skip do
-                {tbl_acc, sn_acc, pos_acc}
-              else
-                new_sn = Map.put(sn_acc, s, cnt)
-                # Spread cnt occurrences of symbol s across the table
-                {final_tbl, final_pos} =
-                  Enum.reduce(1..cnt, {tbl_acc, pos_acc}, fn _, {t, p} ->
-                    t2 = Map.put(t, p, {s, 0, 0})
-                    # Advance pos using the step, skipping slots above `high`
-                    next_p = advance_pos(p, step, sz, high)
-                    {t2, next_p}
-                  end)
-                {final_tbl, new_sn, final_pos}
-              end
-            end
-          end)
-        {new_tbl, new_sn, new_pos}
+    #
+    # SINGLE pass over symbols in ascending index order — see the module doc
+    # above for why a two-pass split is wrong.
+    {tbl1, sym_next1, _pos} =
+      norm
+      |> Enum.with_index()
+      |> Enum.reduce({tbl0, sym_next0, 0}, fn {c, s}, {tbl_acc, sn_acc, pos_acc} ->
+        if c <= 0 do
+          {tbl_acc, sn_acc, pos_acc}
+        else
+          cnt = c
+          new_sn = Map.put(sn_acc, s, cnt)
+          # Spread cnt occurrences of symbol s across the table
+          {final_tbl, final_pos} =
+            Enum.reduce(1..cnt, {tbl_acc, pos_acc}, fn _, {t, p} ->
+              t2 = Map.put(t, p, {s, 0, 0})
+              # Advance pos using the step, skipping slots above `high`
+              next_p = advance_pos(p, step, sz, high)
+              {t2, next_p}
+            end)
+          {final_tbl, new_sn, final_pos}
+        end
       end)
-      |> then(fn {tbl, sn, _pos} -> {tbl, sn} end)
 
     # Phase 3: assign nb and base using sym_next counters.
     # We iterate slots in ascending index order, tracking which occurrence
@@ -311,33 +314,25 @@ defmodule CodingAdventures.Zstd do
     # = sz - 1 - (count of -1 symbols). We compute it as the minimum free slot.
     idx_limit = find_idx_limit(spread0, sz)
 
-    {spread1, _} =
-      Enum.reduce(0..1, {spread0, 0}, fn pass, {sp, pos} ->
-        {new_sp, new_pos} =
-          norm
-          |> Enum.with_index()
-          |> Enum.reduce({sp, pos}, fn {c, s}, {sp_acc, pos_acc} ->
-            if c <= 0 do
-              {sp_acc, pos_acc}
-            else
-              cnt = c
-              skip = if pass == 0, do: cnt <= 1, else: cnt != 1
-              if skip do
-                {sp_acc, pos_acc}
-              else
-                {final_sp, final_pos} =
-                  Enum.reduce(1..cnt, {sp_acc, pos_acc}, fn _, {sp2, p} ->
-                    sp3 = Map.put(sp2, p, s)
-                    next_p = advance_pos(p, step, sz, idx_limit)
-                    {sp3, next_p}
-                  end)
-                {final_sp, final_pos}
-              end
-            end
+    # SINGLE pass over symbols in ascending index order — must mirror
+    # build_decode_table's Phase 2 exactly (the real algorithm has no
+    # count>1-vs-count==1 split; see Lesson 96 / the module doc above
+    # build_decode_table).
+    {spread1, _pos} =
+      norm
+      |> Enum.with_index()
+      |> Enum.reduce({spread0, 0}, fn {c, s}, {sp_acc, pos_acc} ->
+        if c <= 0 do
+          {sp_acc, pos_acc}
+        else
+          cnt = c
+          Enum.reduce(1..cnt, {sp_acc, pos_acc}, fn _, {sp2, p} ->
+            sp3 = Map.put(sp2, p, s)
+            next_p = advance_pos(p, step, sz, idx_limit)
+            {sp3, next_p}
           end)
-        {new_sp, new_pos}
+        end
       end)
-      |> then(fn {sp, pos} -> {sp, pos} end)
 
     _ = high  # suppress unused warning
 
@@ -532,15 +527,23 @@ defmodule CodingAdventures.Zstd do
   # ─── FSE encode/decode operations ─────────────────────────────────────────────
   #
   # The encoder and decoder both maintain FSE state in [sz, 2*sz).
-  # Encoding symbol `sym` from state E:
+  #
+  # DECODING a symbol from state S is a two-STEP process that the real
+  # zstd decoder keeps separate (see apply_sequences/11 below for why this
+  # matters — a compounding bug in an earlier revision fused these steps
+  # together in the wrong order relative to the three parallel LL/ML/OF
+  # streams):
+  #   1. PEEK: decode_table[S] → {sym, nb, base}. A bare lookup — consumes
+  #      NO bits. The state itself already IS the decode-table index.
+  #   2. UPDATE (only when another sequence follows): new_S = base +
+  #      read(nb bits). This prepares the state the NEXT sequence's peek
+  #      will use; it is never performed after the LAST sequence in a block.
+  #
+  # ENCODING mirrors this. Encoding symbol `sym` from state E (the normal
+  # case — see fse_init_state/3 below for the exception):
   #   1. Compute nb = (E + delta_nb) >>> 16   (bits to emit)
   #   2. Write low nb bits of E to the bitstream
   #   3. new_E = st[(E >>> nb) + delta_fs]
-  #
-  # Decoding symbol from state S:
-  #   1. Look up decode_table[S] → {sym, nb, base}
-  #   2. new_S = base + read(nb bits)
-  #   3. Return sym
 
   defp fse_encode_sym(state, sym, ee, st) do
     # ee is a map: symbol -> {delta_nb, delta_fs}
@@ -552,12 +555,41 @@ defmodule CodingAdventures.Zstd do
     {nb, state, new_state}
   end
 
-  defp fse_decode_sym(state, dt, br_state) do
-    # dt is a list of {sym, nb, base} indexed by state
-    {sym, nb, base} = Enum.at(dt, state)
-    {bits, new_br} = rbr_read_bits(br_state, nb)
-    new_state = base + bits
-    {sym, new_state, new_br}
+  # Initialise an FSE encoder state DIRECTLY from a symbol, with no bits
+  # written to the stream. Mirrors the real zstd reference's
+  # FSE_initCState2 (fse_compress.c).
+  #
+  # Sequences are encoded in reverse order (last sequence first), so the
+  # FIRST symbol this encoder ever processes is semantically the LAST
+  # sequence in the block. There is no "previous" state to transition FROM
+  # for that symbol — symmetrically, the decoder never performs a state
+  # UPDATE after decoding the last sequence (see apply_sequences/11) — so
+  # encoding it via the normal fse_encode_sym/4 transition (which always
+  # flushes nb bits) would write bits the decoder will never read,
+  # corrupting the alignment of every stream that follows.
+  #
+  # The formula uses `(delta_nb + 2^15) >>> 16` (a rounding shift) in place
+  # of the usual `(state + delta_nb) >>> 16` — there is no real "state" yet
+  # to add.
+  defp fse_init_state(sym, ee, st) do
+    {delta_nb, delta_fs} = Map.fetch!(ee, sym)
+    nb_bits_out = (delta_nb + (1 <<< 15)) >>> 16
+    value = (nb_bits_out <<< 16) - delta_nb
+    slot_i = (value >>> nb_bits_out) + delta_fs
+    slot = max(slot_i, 0)
+    Enum.at(st, slot)
+  end
+
+  # PEEK the symbol at the given FSE state — a bare decode-table lookup.
+  # Consumes NO bits. dt is a list of {sym, nb, base} indexed by state.
+  defp fse_peek(dt, state), do: Enum.at(dt, state)
+
+  # UPDATE an FSE state: consumes `nb` bits from the bitstream and returns
+  # the new state plus the advanced reader. Must be skipped entirely for the
+  # last sequence in a block (see apply_sequences/11).
+  defp fse_update_state({_sym, nb, base}, br) do
+    {bits, new_br} = rbr_read_bits(br, nb)
+    {base + bits, new_br}
   end
 
   # ─── LL / ML code number computation ─────────────────────────────────────────
@@ -762,29 +794,40 @@ defmodule CodingAdventures.Zstd do
   #   [symbol_compression_modes: 1 byte]  (0x00 = all Predefined)
   #   [FSE bitstream: variable]
   #
-  # The FSE bitstream is a backward bit stream (reverse bit writer):
-  #   Sequences are encoded in REVERSE ORDER (last first).
-  #   For each sequence (in reverse):
-  #     OF extra bits, ML extra bits, LL extra bits (in this order)
-  #     FSE encode: ML symbol, then OF symbol, then LL symbol
-  #   After all sequences, flush final FSE states:
-  #     (state_of - sz_of) as OF_ACC_LOG bits
-  #     (state_ml - sz_ml) as ML_ACC_LOG bits
-  #     (state_ll - sz_ll) as LL_ACC_LOG bits
-  #   Add sentinel and flush.
+  # The FSE bitstream is a backward bit stream (reverse bit writer): the LAST
+  # bits `RevBitWriter.add_bits/3` call writes are the FIRST bits a forward
+  # reader consumes. This function encodes sequences in REVERSE ORDER (last
+  # sequence first), so per-call write order is naturally the reverse of the
+  # decoder's per-sequence read order described in apply_sequences/11.
   #
-  # The decoder does the mirror:
-  #   1. Read LL_ACC_LOG bits → initial state_ll
-  #   2. Read ML_ACC_LOG bits → initial state_ml
-  #   3. Read OF_ACC_LOG bits → initial state_of
-  #   4. For each sequence:
-  #       decode LL symbol (state transition)
-  #       decode OF symbol
-  #       decode ML symbol
-  #       read LL extra bits → final ll value
-  #       read ML extra bits → final ml value
-  #       read OF extra bits → final offset value
-  #   5. Apply sequence to output buffer
+  # This must mirror RFC 8878 §3.1.1.3.2.1.2, cross-checked against the real
+  # `zstd` CLI and the reference C source (ZSTD_decodeSequence /
+  # FSE_encodeSymbol / FSE_initCState2). The decoder's FORWARD per-sequence
+  # order is:
+  #   1. PEEK all 3 symbols (LL, ML, OF) from the current states — free, no
+  #      bits consumed.
+  #   2. Read extra bits, order OF, ML, LL.
+  #   3. UPDATE states (consumes bits), order LL, ML, OF — but ONLY if
+  #      another sequence follows. The LAST sequence's states are never
+  #      updated (there is no "next" peek to prepare for).
+  # Reversing that per-sequence order gives this function's write order
+  # for every sequence except the very first one processed (semantically
+  # the LAST sequence, which has no incoming transition to encode — see
+  # fse_init_state/3): updates OF, ML, LL, then extras LL, ML, OF.
+  #
+  # Before any of that, the decoder reads the INITIAL states — in order LL,
+  # OF, ML (RFC 8878 is asymmetric here: this is a DIFFERENT order from the
+  # per-sequence update order above). Since these are the very LAST bits
+  # written overall (they become the FIRST bits a forward reader sees), we
+  # write them in reverse: ML, OF, LL.
+  #
+  # An earlier revision of this codec (a) got the extras/updates relative
+  # order backwards, (b) got the OF/ML update order backwards, and (c)
+  # always flushed a transition for every sequence instead of special-casing
+  # the last one — internally self-consistent (our own decoder mirrored our
+  # own encoder) but not the real wire format, so output was rejected by
+  # `zstd -d` with "Data corruption detected" even though our own
+  # round-trip tests passed. See lessons.md Lesson 96.
 
   defp encode_sequences_section(seqs) do
     {ee_ll, st_ll} = build_encode_sym(@ll_norm, @ll_acc_log)
@@ -795,18 +838,15 @@ defmodule CodingAdventures.Zstd do
     sz_ml = 1 <<< @ml_acc_log
     sz_of = 1 <<< @of_acc_log
 
-    # FSE encoder states start at table_size (= sz). The state range [sz, 2*sz)
-    # maps to slot range [0, sz) in the state table.
-    init_state_ll = sz_ll
-    init_state_ml = sz_ml
-    init_state_of = sz_of
-
-    # Encode sequences in reverse order into a RevBitWriter.
+    # Encode sequences in reverse order into a RevBitWriter. `first?` tracks
+    # whether we're on the very first iteration (= the LAST real sequence),
+    # which needs a direct-formula state init (fse_init_state/3) rather than
+    # a normal bit-flushing transition (fse_encode_sym/4) — see module doc.
     {bw, state_ll, state_ml, state_of} =
       Enum.reverse(seqs)
       |> Enum.reduce(
-        {RevBitWriter.new(), init_state_ll, init_state_ml, init_state_of},
-        fn {ll, ml, off}, {bw, s_ll, s_ml, s_of} ->
+        {RevBitWriter.new(), 0, 0, 0, true},
+        fn {ll, ml, off}, {bw, s_ll, s_ml, s_of, first?} ->
           ll_code = ll_to_code(ll)
           ml_code = ml_to_code(ml)
 
@@ -817,33 +857,54 @@ defmodule CodingAdventures.Zstd do
             if raw_off <= 1, do: 0, else: floor_log2(raw_off)
           of_extra = raw_off - (1 <<< of_code)
 
-          # Write extra bits (OF, ML, LL in this order for the backward stream).
-          bw = RevBitWriter.add_bits(bw, of_extra, of_code)
           {_ml_base, ml_extra_bits} = Enum.at(@ml_codes, ml_code)
           ml_extra = ml - elem(Enum.at(@ml_codes, ml_code), 0)
-          bw = RevBitWriter.add_bits(bw, ml_extra, ml_extra_bits)
           {_ll_base, ll_extra_bits} = Enum.at(@ll_codes, ll_code)
           ll_extra = ll - elem(Enum.at(@ll_codes, ll_code), 0)
+
+          {bw, new_s_ll, new_s_ml, new_s_of} =
+            if first? do
+              # Last real sequence: no incoming transition to flush.
+              # Initialise state directly from the symbol (no bits written).
+              new_s_of = fse_init_state(of_code, ee_of, st_of)
+              new_s_ml = fse_init_state(ml_code, ee_ml, st_ml)
+              new_s_ll = fse_init_state(ll_code, ee_ll, st_ll)
+              {bw, new_s_ll, new_s_ml, new_s_of}
+            else
+              # Transition state FROM "state used to peek the sequence
+              # processed in the PREVIOUS iteration" TO "state used to peek
+              # THIS sequence" — write order OF, ML, LL (a forward decoder
+              # will consume this, in order LL, ML, OF, as the update AFTER
+              # decoding this sequence).
+              {nb_of, val_of, new_s_of} = fse_encode_sym(s_of, of_code, ee_of, st_of)
+              bw = RevBitWriter.add_bits(bw, val_of, nb_of)
+
+              {nb_ml, val_ml, new_s_ml} = fse_encode_sym(s_ml, ml_code, ee_ml, st_ml)
+              bw = RevBitWriter.add_bits(bw, val_ml, nb_ml)
+
+              {nb_ll, val_ll, new_s_ll} = fse_encode_sym(s_ll, ll_code, ee_ll, st_ll)
+              bw = RevBitWriter.add_bits(bw, val_ll, nb_ll)
+
+              {bw, new_s_ll, new_s_ml, new_s_of}
+            end
+
+          # Extra bits, write order LL, ML, OF (a forward decoder reads these
+          # in order OF, ML, LL immediately after peeking symbols).
           bw = RevBitWriter.add_bits(bw, ll_extra, ll_extra_bits)
+          bw = RevBitWriter.add_bits(bw, ml_extra, ml_extra_bits)
+          bw = RevBitWriter.add_bits(bw, of_extra, of_code)
 
-          # FSE encode symbols. Decode order is LL, OF, ML; encode order (reversed
-          # for backward stream) is ML, OF, LL.
-          {nb_ml, val_ml, new_s_ml} = fse_encode_sym(s_ml, ml_code, ee_ml, st_ml)
-          bw = RevBitWriter.add_bits(bw, val_ml, nb_ml)
-
-          {nb_of, val_of, new_s_of} = fse_encode_sym(s_of, of_code, ee_of, st_of)
-          bw = RevBitWriter.add_bits(bw, val_of, nb_of)
-
-          {nb_ll, val_ll, new_s_ll} = fse_encode_sym(s_ll, ll_code, ee_ll, st_ll)
-          bw = RevBitWriter.add_bits(bw, val_ll, nb_ll)
-
-          {bw, new_s_ll, new_s_ml, new_s_of}
+          {bw, new_s_ll, new_s_ml, new_s_of, false}
         end
       )
+      |> then(fn {bw, s_ll, s_ml, s_of, _first?} -> {bw, s_ll, s_ml, s_of} end)
 
-    # Flush final FSE states (low acc_log bits of state - sz).
-    bw = RevBitWriter.add_bits(bw, state_of - sz_of, @of_acc_log)
+    # Flush initial states (the state used to peek the FIRST real sequence).
+    # A forward-reading decoder reads these FIRST, in order LL, OF, ML. Since
+    # these are the very LAST bits written overall, we write the reverse:
+    # ML, OF, LL.
     bw = RevBitWriter.add_bits(bw, state_ml - sz_ml, @ml_acc_log)
+    bw = RevBitWriter.add_bits(bw, state_of - sz_of, @of_acc_log)
     bw = RevBitWriter.add_bits(bw, state_ll - sz_ll, @ll_acc_log)
 
     # Flush with sentinel bit and return byte list.
@@ -943,10 +1004,16 @@ defmodule CodingAdventures.Zstd do
             dt_ml = build_decode_table(@ml_norm, @ml_acc_log)
             dt_of = build_decode_table(@of_norm, @of_acc_log)
 
-            # Read initial FSE states.
+            # Read initial FSE states. RFC 8878 §3.1.1.3.2.1.2: the initial
+            # states are read in order LL, OF, ML — note this is a DIFFERENT
+            # order from the per-sequence symbol decode below (LL, ML, OF);
+            # the RFC is asymmetric here. Verified against the RFC text and
+            # cross-checked against the real `zstd` CLI (see lessons.md
+            # Lesson 96). An earlier revision of this codec read LL, ML, OF
+            # here, misaligning every bit read that follows.
             {s_ll, br} = rbr_read_bits(br, @ll_acc_log)
-            {s_ml, br} = rbr_read_bits(br, @ml_acc_log)
             {s_of, br} = rbr_read_bits(br, @of_acc_log)
+            {s_ml, br} = rbr_read_bits(br, @ml_acc_log)
 
             # Use binaries for the output buffer so back-references can use
             # binary_part/3 (O(1)) instead of Enum.at/2 (O(n)).
@@ -974,10 +1041,14 @@ defmodule CodingAdventures.Zstd do
   end
 
   defp apply_sequences(remaining, lits_bin, lit_pos, out, s_ll, s_ml, s_of, br, dt_ll, dt_ml, dt_of) do
-    # Decode LL symbol, then OF symbol, then ML symbol.
-    {ll_code, new_s_ll, br} = fse_decode_sym(s_ll, dt_ll, br)
-    {of_code, new_s_of, br} = fse_decode_sym(s_of, dt_of, br)
-    {ml_code, new_s_ml, br} = fse_decode_sym(s_ml, dt_ml, br)
+    # Step 1 — PEEK all 3 symbols (LL, ML, OF) from the CURRENT states. This
+    # is a bare table lookup (dt[state]) and consumes NO bits — the FSE
+    # state itself already IS the decode-table index. Only the subsequent
+    # state UPDATE (step 3 below) reads bits. See fse_peek/2 and the "FSE
+    # encode/decode operations" module doc above.
+    {ll_code, _ll_nb, _ll_base} = ll_entry = fse_peek(dt_ll, s_ll)
+    {ml_code, _ml_nb, _ml_base} = ml_entry = fse_peek(dt_ml, s_ml)
+    {of_code, _of_nb, _of_base} = of_entry = fse_peek(dt_of, s_of)
 
     if ll_code >= length(@ll_codes) do
       {:error, "invalid LL code #{ll_code}"}
@@ -988,15 +1059,43 @@ defmodule CodingAdventures.Zstd do
         {ll_base, ll_extra_bits} = Enum.at(@ll_codes, ll_code)
         {ml_base, ml_extra_bits} = Enum.at(@ml_codes, ml_code)
 
-        {ll_extra, br} = rbr_read_bits(br, ll_extra_bits)
-        {ml_extra, br} = rbr_read_bits(br, ml_extra_bits)
+        # Step 2 — read the VALUE extra bits, order OF, ML, LL (RFC 8878
+        # §3.1.1.3.2.1.2: "Decoding starts by reading the Number_of_Bits
+        # required to decode offset. It does the same for Match_Length and
+        # then for Literals_Length."). An earlier revision of this codec
+        # read these LL, ML, OF (and interleaved with the state updates
+        # below in the wrong relative order) — see lessons.md Lesson 96.
         {of_extra, br} = rbr_read_bits(br, of_code)
+        {ml_extra, br} = rbr_read_bits(br, ml_extra_bits)
+        {ll_extra, br} = rbr_read_bits(br, ll_extra_bits)
 
         ll = ll_base + ll_extra
         ml = ml_base + ml_extra
         # Offset: of_raw = (1 << of_code) | of_extra; offset = of_raw - 3
         of_raw = (1 <<< of_code) ||| of_extra
         offset = of_raw - 3
+
+        # Step 3 — UPDATE states (consumes bits), order LL, ML, OF (RFC 8878
+        # §3.1.1.3.2.1.2: "Literals_Length_State is updated, followed by
+        # Match_Length_State, and then Offset_State"), preparing the states
+        # the NEXT sequence's peek (step 1) will use.
+        #
+        # Per the reference decoder (ZSTD_decodeSequence), this update is
+        # skipped entirely for the LAST sequence — there is no "next"
+        # sequence to prepare a state for, and (symmetrically) the encoder
+        # never flushed any bits for that non-existent transition (see
+        # fse_init_state/3). Performing this read unconditionally, as an
+        # earlier revision of this codec did, consumes bits that were never
+        # written, corrupting the position of every stream that follows.
+        {new_s_ll, new_s_ml, new_s_of, br} =
+          if remaining != 1 do
+            {upd_s_ll, br} = fse_update_state(ll_entry, br)
+            {upd_s_ml, br} = fse_update_state(ml_entry, br)
+            {upd_s_of, br} = fse_update_state(of_entry, br)
+            {upd_s_ll, upd_s_ml, upd_s_of, br}
+          else
+            {s_ll, s_ml, s_of, br}
+          end
 
         # Emit `ll` literal bytes from the literals binary.
         lit_end = lit_pos + ll
@@ -1106,13 +1205,23 @@ defmodule CodingAdventures.Zstd do
       (@magic >>> 24) &&& 0xFF
     ]
 
-    # Frame Header Descriptor (FHD):
+    # Frame Header Descriptor (FHD), per RFC 8878 §3.1.1.1:
     #   bit 7-6: FCS_Field_Size flag = 11 → 8-byte FCS
     #   bit 5:   Single_Segment_Flag = 1 (no Window_Descriptor follows)
-    #   bit 4:   Content_Checksum_Flag = 0
-    #   bit 3-2: reserved = 0
+    #   bit 4:   Unused_bit = 0
+    #   bit 3:   Reserved_bit = 0
+    #   bit 2:   Content_Checksum_Flag = 0 (we never emit a trailing checksum)
     #   bit 1-0: Dict_ID_Flag = 0
     # = 0b1110_0000 = 0xE0
+    #
+    # NOTE: an earlier revision of this comment mislabelled bit 4 as
+    # Content_Checksum_Flag (it is actually Unused_bit; the real checksum
+    # flag is bit 2). Verified empirically against the real `zstd` CLI:
+    # `zstd -c file` (checksum on by default) emits FHD 0x64, `zstd -c
+    # --no-check file` emits FHD 0x60 — the differing bit is bit 2. This
+    # constant (0xE0) already has both bit 4 and bit 2 clear, so the
+    # mislabelling was comment-only and never caused a wire-format bug here
+    # — but see lessons.md Lesson 95 for the repo-wide pattern.
     fhd = [0xE0]
 
     # Frame_Content_Size: 8 bytes LE (uncompressed size).

--- a/code/packages/elixir/zstd/mix.exs
+++ b/code/packages/elixir/zstd/mix.exs
@@ -4,7 +4,7 @@ defmodule CodingAdventures.Zstd.MixProject do
   def project do
     [
       app: :coding_adventures_zstd,
-      version: "0.1.2",
+      version: "0.1.3",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/code/packages/elixir/zstd/test/zstd_test.exs
+++ b/code/packages/elixir/zstd/test/zstd_test.exs
@@ -128,12 +128,126 @@ defmodule CodingAdventures.ZstdTest do
       "300KB repetitive text: compressed #{byte_size(compressed)}, expected < #{threshold}"
   end
 
-  # ── TC-9: bad magic → {:error, _} ───────────────────────────────────────────
+  # ── TC-9: Cross-language / interoperability (real `zstd` CLI) ──────────────
+  #
+  # code/specs/CMP07-zstd.md designates TC-9 as cross-implementation
+  # round-trip against the real `zstd` CLI, in BOTH directions:
+  #
+  #   1. Compress with `Zstd.compress/1`, decompress with `zstd -d`.
+  #   2. Compress with `zstd`, decompress with `Zstd.decompress/1`.
+  #
+  # This is the ONLY kind of test that can catch a systematic, symmetric
+  # protocol deviation: a same-codebase round-trip test (`rt/1` above) is
+  # necessary but never sufficient, because if the encoder and decoder agree
+  # with each other on a WRONG convention, every internal round-trip still
+  # passes. That is exactly what happened here — three compounding bugs in
+  # the FSE sequences-section codec (a fabricated two-pass symbol-table
+  # spread, a wrong per-sequence field order, and an unconditional final
+  # state-transition flush that should have been skipped for the block's
+  # last sequence) survived undetected because this package had no
+  # independent, spec-conformant interop check. See lessons.md Lesson 96.
+  #
+  # `previously_broken_fse_repro/0` below is the minimal case from that bug
+  # report (`compress("ababababab" * 3)`, one sequence: ll=2, ml=28,
+  # offset=2) — it alone is enough to reproduce the "Data corruption
+  # detected" failure against a pre-fix build of this codec.
+  #
+  # Skipped (not failed) when the `zstd` binary isn't on PATH, since CI/dev
+  # environments vary — mirrors the approach taken in the java/zstd and
+  # rust/zstd ports of this same test.
+  #
+  # Repeat-offset inputs (where the SAME 8-byte pattern recurs at a FIXED
+  # distance) are deliberately avoided here: per code/specs/CMP07-zstd.md's
+  # "Educational Simplification" note, this implementation's decoder does
+  # not resolve the real zstd Repeat_Offset_1/2/3 mechanism, so a frame the
+  # real `zstd` CLI compresses USING repeat-offset shortcuts cannot be
+  # decoded by `Zstd.decompress/1` — that is a pre-existing, spec-documented
+  # limitation shared by every language port in this repo, not part of the
+  # FSE-codec bug this test targets.
+
+  defp zstd_cli_available? do
+    case System.cmd("zstd", ["--version"], stderr_to_stdout: true) do
+      {_, 0} -> true
+      _ -> false
+    end
+  rescue
+    ErlangError -> false
+  end
+
+  defp previously_broken_fse_repro, do: String.duplicate("ababababab", 3)
+
+  @tag :cli_interop
+  test "TC-9: CLI interoperability — compress ours, decompress with real `zstd -d`" do
+    if zstd_cli_available?() do
+      for input <- [
+            previously_broken_fse_repro(),
+            String.duplicate("the quick brown fox jumps over the lazy dog ", 25),
+            # ~9 KB of a repeating 6-byte cycle: comfortably pushes the
+            # single-block sequence count past 128, the exact boundary where
+            # Number_of_Sequences switches from its 1-byte to 2-byte wire
+            # form (RFC 8878 §3.1.1.3.1) — regression coverage for the
+            # sequence-count byte-order bug noted elsewhere in this file.
+            String.duplicate("ABCDEF", 1500) |> binary_part(0, 9000)
+          ] do
+        compressed = Zstd.compress(input)
+        tmp_zst = Path.join(System.tmp_dir!(), "ex-zstd-tc9-#{:erlang.unique_integer([:positive])}.zst")
+        File.write!(tmp_zst, compressed)
+
+        try do
+          {output, exit_code} = System.cmd("zstd", ["-d", "-q", "-c", tmp_zst], stderr_to_stdout: true)
+          assert exit_code == 0,
+            "real `zstd -d` failed to decode our compressed output (#{byte_size(input)} bytes): #{output}"
+          assert output == input,
+            "real `zstd -d` decoded our output but got different bytes back"
+        after
+          File.rm(tmp_zst)
+        end
+      end
+    else
+      IO.puts(:stderr, "zstd CLI not found on PATH — skipping TC-9 interop test")
+    end
+  end
+
+  @tag :cli_interop
+  test "TC-9: CLI interoperability — compress with real `zstd`, decompress ours" do
+    if zstd_cli_available?() do
+      for input <- [
+            previously_broken_fse_repro(),
+            String.duplicate("the quick brown fox jumps over the lazy dog ", 25),
+            String.duplicate("ABCDEF", 1500) |> binary_part(0, 9000)
+          ] do
+        unique = :erlang.unique_integer([:positive])
+        tmp_txt = Path.join(System.tmp_dir!(), "ex-zstd-tc9-#{unique}.txt")
+        tmp_zst = Path.join(System.tmp_dir!(), "ex-zstd-tc9-#{unique}.zst")
+        File.write!(tmp_txt, input)
+
+        try do
+          {_output, exit_code} = System.cmd("zstd", ["-q", "-f", "-o", tmp_zst, tmp_txt], stderr_to_stdout: true)
+          assert exit_code == 0, "real `zstd` CLI failed to compress the test input"
+
+          cli_compressed = File.read!(tmp_zst)
+          assert {:ok, ^input} = Zstd.decompress(cli_compressed),
+            "our decompress/1 failed to decode real `zstd`'s compressed output (#{byte_size(input)} bytes)"
+        after
+          File.rm(tmp_txt)
+          File.rm(tmp_zst)
+        end
+      end
+    else
+      IO.puts(:stderr, "zstd CLI not found on PATH — skipping TC-9 interop test")
+    end
+  end
+
+  # ── Error handling: bad magic → {:error, _} ─────────────────────────────────
   #
   # Any input that does not start with the ZStd magic 0xFD2FB528 must return
   # {:error, _}. We test several common cases.
+  #
+  # (Not one of the spec's 10 mandatory TCs — TC-9 is Cross-language /
+  # interoperability, above. An earlier revision of this file mislabelled
+  # this test "TC-9", which collided with the spec's numbering.)
 
-  test "TC-9: bad magic returns error" do
+  test "bad magic returns error" do
     assert {:error, msg} = Zstd.decompress("not a zstd frame")
     assert String.contains?(msg, "bad magic") or String.contains?(msg, "frame too short")
 

--- a/code/packages/elixir/zstd/test/zstd_test.exs
+++ b/code/packages/elixir/zstd/test/zstd_test.exs
@@ -176,6 +176,18 @@ defmodule CodingAdventures.ZstdTest do
 
   defp previously_broken_fse_repro, do: String.duplicate("ababababab", 3)
 
+  # Unique, hard-to-predict temp-file name: mixes a monotonic counter (for
+  # human-readable ordering) with 8 bytes of CSPRNG output, so a co-resident
+  # local user can't pre-guess the path and race it with a symlink between
+  # our File.write!/2 and the `zstd` CLI's read (or vice versa). This is
+  # belt-and-suspenders for test-only temp files with no sensitive content —
+  # not a defense against a privileged attacker.
+  defp unique_tmp_name(prefix) do
+    counter = :erlang.unique_integer([:positive])
+    rand = :crypto.strong_rand_bytes(8) |> Base.encode16(case: :lower)
+    "#{prefix}-#{counter}-#{rand}"
+  end
+
   @tag :cli_interop
   test "TC-9: CLI interoperability — compress ours, decompress with real `zstd -d`" do
     if zstd_cli_available?() do
@@ -190,7 +202,7 @@ defmodule CodingAdventures.ZstdTest do
             String.duplicate("ABCDEF", 1500) |> binary_part(0, 9000)
           ] do
         compressed = Zstd.compress(input)
-        tmp_zst = Path.join(System.tmp_dir!(), "ex-zstd-tc9-#{:erlang.unique_integer([:positive])}.zst")
+        tmp_zst = Path.join(System.tmp_dir!(), "#{unique_tmp_name("ex-zstd-tc9")}.zst")
         File.write!(tmp_zst, compressed)
 
         try do
@@ -216,9 +228,9 @@ defmodule CodingAdventures.ZstdTest do
             String.duplicate("the quick brown fox jumps over the lazy dog ", 25),
             String.duplicate("ABCDEF", 1500) |> binary_part(0, 9000)
           ] do
-        unique = :erlang.unique_integer([:positive])
-        tmp_txt = Path.join(System.tmp_dir!(), "ex-zstd-tc9-#{unique}.txt")
-        tmp_zst = Path.join(System.tmp_dir!(), "ex-zstd-tc9-#{unique}.zst")
+        unique = unique_tmp_name("ex-zstd-tc9")
+        tmp_txt = Path.join(System.tmp_dir!(), "#{unique}.txt")
+        tmp_zst = Path.join(System.tmp_dir!(), "#{unique}.zst")
         File.write!(tmp_txt, input)
 
         try do


### PR DESCRIPTION
## Summary

Repo-wide audit follow-up. A sibling effort fixing `java/zstd` (PR #9780,
rescued from a stale branch and run against the real `zstd` CLI for the
first time) discovered a real RFC 8878 conformance bug in the
sequences-section FSE codec, later confirmed also present in `rust/zstd`
(#9774 tracks the same audit for other language ports). This PR audits and
fixes the same bug class in `elixir/zstd`.

Confirmed the bug via a minimal repro (`compress("ababababab" * 3)`)
against the real `zstd -d` CLI before the fix (`Decoding error (36): Data
corruption detected`), and confirmed the fix resolves it, in both
directions, across several inputs.

- **Three compounding bugs in the sequences-section FSE codec**, all
  invisible to prior tests because encoder and decoder were wrong in the
  same self-consistent way (round-trip-only testing can't catch a
  systematic, symmetric protocol deviation):
  1. `build_decode_table/2` / `build_encode_sym/2` used a fabricated
     two-pass symbol-table spread (count>1 symbols first, then count==1)
     instead of the real single pass over symbols in ascending index order.
  2. Per-sequence field order was wrong: the real decoder PEEKS all 3 FSE
     symbols first (no bits consumed), THEN reads extra bits in order
     Offset/MatchLength/LiteralsLength, THEN updates states in order
     LiteralsLength/MatchLength/Offset. Initial states are read in order
     LL/OF/ML — asymmetric vs. the per-sequence update order. This codec
     previously fused peek+update into one step in the wrong order.
  3. The FSE state-transition update must be skipped for the last sequence
     in a block. Added `fse_init_state/3` (mirrors zstd's `FSE_initCState2`)
     to initialise the encoder's starting state directly from a symbol with
     no bits flushed, matching the decoder never reading an update after
     the last sequence.
- **FHD `Content_Checksum_Flag` bit**: fixed a mislabelled comment (bit 4 →
  bit 2, per RFC 8878 §3.1.1.1 and Lesson 95). The fixed FHD constant
  (`0xE0`) already had both bits clear, so this was comment-only and never
  a functional bug in this package.
- **TC-9 (CLI interoperability)**: added two tests exercising the real
  `zstd` CLI via `System.cmd/3`, in both directions, gracefully skipped if
  `zstd` isn't on `PATH`. This is the test that would have caught the bug
  above. Renamed the old "TC-9: bad magic returns error" test (spec's TC-9
  is Cross-language / interoperability) to avoid the numbering collision.
- Hardened the new tests' temp-file names against local symlink races
  (LOW-severity security-review finding — test-only, no sensitive data).

## Test plan

- [x] `mix test` — 27 tests pass (25 existing + 2 new TC-9), 0 failures
- [x] `mix test --cover` — 89.74% coverage (threshold 80%)
- [x] Manual repro: `compress("ababababab" * 3)` decoded correctly by real
      `zstd -d` CLI (failed with "Data corruption detected" before the fix)
- [x] Manual bidirectional interop across prose text, a ~9 KB
      high-sequence-count input, and binary data
- [x] Security review passed (one LOW, non-blocking, finding — fixed anyway)
- [x] `BUILD` script (`mix deps.get --quiet && mix test --cover`) passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)