### PR TITLE
fix(spice): validate diode emission coefficient

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate positive finite diode model-card `N` emission coefficient.
 - Validate finite, non-negative diode model-card `TT` transit time.
 - Validate positive finite BJT model-card `IS` saturation current.
 - Validate finite, non-negative BJT model-card `TF` and `TR` transit times.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1929,6 +1929,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(thermal_voltage) or thermal_voltage <= 0.0
         ):
             raise NetlistParseError("diode VT must be finite and positive")
+        emission_coefficient = params.get("N")
+        if emission_coefficient is not None and (
+            not math.isfinite(emission_coefficient) or emission_coefficient <= 0.0
+        ):
+            raise NetlistParseError("diode N must be finite and positive")
         junction_capacitance = next(
             (params[name] for name in ("CJO", "CJ", "CJ0") if name in params),
             None,

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -842,6 +842,23 @@ def test_rejects_invalid_diode_thermal_voltage(parameter: str, value: str) -> No
         parse_netlist(f".model clamp D({parameter}={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0.5", 0.5), ("2", 2.0)])
+def test_accepts_valid_diode_emission_coefficient(
+    value: str, expected: float
+) -> None:
+    parsed = parse_netlist(f".model clamp D(N={value})\nD1 in out clamp")
+
+    diode = parsed.circuit.elements[0]
+    assert isinstance(diode, Diode)
+    assert expected == diode.N
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "1e999"])
+def test_rejects_invalid_diode_emission_coefficient(value: str) -> None:
+    with pytest.raises(NetlistParseError, match="diode N must be finite and positive"):
+        parse_netlist(f".model clamp D(N={value})")
+
+
 def test_parse_diode_junction_capacitance_alias() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate positive finite diode model-card `N` emission coefficient.
 - Validate finite, non-negative diode model-card `TT` transit time.
 - Validate positive finite BJT model-card `IS` saturation current.
 - Validate finite, non-negative BJT model-card `TF` and `TR` transit times.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1166,6 +1166,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("diode VT must be finite and positive");
   }
+  const diodeEmissionCoefficient = params.get("N");
+  if (
+    kind === "D" &&
+    diodeEmissionCoefficient !== undefined &&
+    (!Number.isFinite(diodeEmissionCoefficient) || diodeEmissionCoefficient <= 0.0)
+  ) {
+    throw new NetlistParseError("diode N must be finite and positive");
+  }
   const diodeJunctionCapacitance =
     params.get("CJO") ?? params.get("CJ") ?? params.get("CJ0");
   if (

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -868,6 +868,27 @@ D1 in out clamp
     );
   });
 
+  it.each([
+    ["0.5", 0.5],
+    ["2", 2.0],
+  ])("accepts valid diode N emission coefficient %s", (value, expected) => {
+    const parsed = parseNetlist(`.model clamp D(N=${value})\nD1 in out clamp`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "diode",
+      emissionCoefficient: expected,
+    });
+  });
+
+  it.each(["0", "-1", "1e999"])(
+    "rejects invalid diode N emission coefficient %s",
+    (value) => {
+      expect(() => parseNetlist(`.model clamp D(N=${value})`)).toThrow(
+        "diode N must be finite and positive",
+      );
+    },
+  );
+
   it("parses BJT models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NPN(IS=1e-14 BF=120 VT=25m CJE=2p CJC=3p TF=4n TR=5n)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4384,16 +4384,21 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine BJT saturation-current field.
 
 413. Python and TypeScript Berkeley SPICE diode transit-time validation parity.
-   - Status: completed in this diode transit-time validation slice.
+   - Status: completed in PR 9785.
    - Both parser facades validate finite non-negative `TT` values before
      lowering them into the shared engine diode transit-time field.
+
+414. Python and TypeScript Berkeley SPICE diode emission-coefficient validation parity.
+   - Status: completed in this diode emission-coefficient validation slice.
+   - Both parser facades validate positive finite `N` values before lowering
+     them into the shared engine diode emission-coefficient field.
 
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE model-card validation parity.
    - Continue the parser-to-engine validation audit with positive finite diode
-     emission coefficient `N`, followed by positive finite breakdown voltage
-     `BV` and breakdown current `IBV`.
+     breakdown voltage `BV`, followed by positive finite breakdown current
+     `IBV`.
    - Audit remaining directly lowerable diode fields before moving to model
      parameters that require new parser-to-engine lowering surfaces.
 


### PR DESCRIPTION
## Summary
- reject zero, negative, and non-finite diode model-card `N` values in the Python and TypeScript parser facades
- preserve positive emission coefficients when lowering into the shared engine diode fields
- reconcile the SPICE plan with PR #9785 and queue diode `BV` and `IBV` validation next

## Validation
- `code/packages/python/spice-netlist-parser`: `bash BUILD` (299 tests, 89.02% coverage)
- `code/packages/python/spice-netlist-parser`: `.venv/bin/ruff check src tests`
- `code/packages/typescript/spice-engine`: `bash BUILD` (448 tests)
- `code/packages/typescript/spice-netlist-parser`: `bash BUILD` (288 tests)
- `code/packages/typescript/spice-netlist-parser`: `npm run test:coverage` (85.98% line coverage)