### PR TITLE
docs(human-languages): publish Telugu through Chapter 31

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -83,6 +83,7 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B12 | Complete (#9705) | Publish Bengali Chapter 6 from its canonical lesson rather than hand-copying another book chapter. | The schema-v2 lesson now generates the PDF chapter from the same source hash independently verified by Language Ladder. |
 | HL-B13 | Complete (#9711) | Remove Bengali's missing glyphs and LaTeX layout/bookmark warnings. | Main-font punctuation, stable recap labels, bookmark-safe Bengali, natural page bottoms, explicit static-font shapes, and a breakable long title make the forced six-chapter build warning-free. |
 | HL-I01 | Complete (#9715) | Reduce unified all-books workflow setup time without splitting the single publication bundle. | A focused, preflighted XeLaTeX dependency closure replaces `texlive-full`; the unchanged job still builds all 20 books, verifies one bundle, and publishes that bundle from `main`. |
+| HL-I02 | Queued | Update the human-language data package beyond the vulnerable PostCSS 8.5.19 transitive development dependency. | A clean install reports GHSA-fxqj-rqcc-2cmp through Vitest/Vite; PostCSS 8.5.25 is available, but this development-only moderate finding ranks behind HL-B23's reader-facing Telugu publication cleanup. |
 | HL-B14 | Complete (#9728) | Publish Italian Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Forty-nine schema-v2 lessons now generate sixteen chapters whose source hashes are independently verified against the Language Ladder corpus. |
 | HL-B15 | Complete (#9735) | Remove Italian's LaTeX layout and Unicode bookmark warnings. | The forced 104-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
 | HL-B16 | Complete (#9744) | Publish Portuguese Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Fifty schema-v2 lessons now generate sixteen chapters whose source hashes are independently verified against the Language Ladder corpus. |
@@ -90,9 +91,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B18 | Complete (#9752) | Publish French Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | Nine schema-v2 lessons now generate seven chapters whose source hashes are independently verified against the Language Ladder corpus. |
 | HL-B19 | Complete (#9761) | Remove French's LaTeX layout and Unicode bookmark warnings. | The forced 98-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
 | HL-B20 | Complete (#9765) | Publish German Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | Ten schema-v2 lessons now generate seven chapters whose source hashes are independently verified against the Language Ladder corpus. |
-| HL-B21 | Complete in this PR | Remove German's LaTeX layout and Unicode bookmark warnings. | The forced 104-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
-| HL-B22 | Next | Publish Telugu Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Telugu PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
-| HL-B23 | Queued | Remove Telugu's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports four overfull boxes, three underfull boxes, four duplicate practice labels, 27 Hyperref warnings, and a font-shape substitution warning; the clean-build signal is zero of each. |
+| HL-B21 | Complete (#9779) | Remove German's LaTeX layout and Unicode bookmark warnings. | The forced 104-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
+| HL-B22 | Complete in this PR | Publish Telugu Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | Thirty schema-v2 lessons now generate twenty-six chapters whose source hashes are independently verified against the Language Ladder corpus. |
+| HL-B23 | Next | Remove Telugu's LaTeX layout, duplicate-label, bookmark, and font warnings. | The expanded forced build has no missing glyphs or underfull horizontal boxes but reports eleven overfull boxes, nine underfull vertical boxes, four duplicate practice labels, 104 Hyperref warnings, and nine font warnings; visual inspection found no clipping, but the clean-build signal is zero of each. |
 | HL-B24 | Queued | Publish Kannada Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Kannada PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
 | HL-B25 | Queued | Remove Kannada's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports four overfull boxes, five underfull boxes, four duplicate practice labels, 30 Hyperref warnings, and undefined bold/italic Kannada font shapes; the clean-build signal is zero of each. |
 | HL-B26 | Queued | Publish Malayalam Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Malayalam PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
@@ -108,7 +109,7 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B36 | Queued | Publish Spanish Chapters 19–33 from canonical lessons rather than hand-copying another fifteen book chapters. | The Spanish PDF stops after Chapter 18 while canonical app content continues through Chapter 33; schema-v2 migration plus generation should raise book coverage from 55% to 100%. |
 | HL-B37 | Queued | Remove Spanish's remaining legacy LaTeX layout, bookmark, and font warnings. | After Chapters 4–6 generation, a forced build has no missing glyphs or duplicate labels but reports 50 overfull boxes, 14 underfull boxes, 14 Hyperref warnings, and one undefined small-caps shape; the clean-build signal is zero of each. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
-| HL-M02 | Queued | Extend Telugu's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the new register support step, needs a scheduled place. |
+| HL-M02 | Queued | Extend Telugu's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson needs a scheduled place, and the map must explicitly split or justify Chapter 20's numbers-and-weather topic collision. |
 | HL-M03 | Queued | Extend Kannada's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the new stacking support step, needs a scheduled place. |
 | HL-M04 | Queued | Extend Malayalam's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the four new support steps, needs a scheduled place. |
 | HL-M05 | Queued | Reconcile Arabic's roadmap and authoritative session map with canonical Chapters 1–27 and the sixteen-step writing sequence. | The roadmap details only Chapters 1–4 and still calls Chapter 5+ planned; the session map stops at Chapter 2 even though prerequisite-ordered canonical lessons continue through Chapter 27. |
@@ -699,6 +700,37 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   warnings. All 104 rendered pages were inspected; the outline retains the
   Preface, pronunciation reference, and Chapters 1–23. HL-B22 is next: publish
   Telugu Chapters 6–31 from canonical lessons.
+
+## Findings from HL-B22
+
+- All thirty canonical Telugu lessons after Chapter 5 now use schema v2 with
+  explicit spine nodes, prerequisite-safe sequences, honest sub-five-minute
+  duration budgets, typed knowledge boundaries, skills, modes, strands,
+  register, and variety metadata. The first thirty lessons remain schema v1,
+  so the track is intentionally mixed while migration proceeds incrementally.
+- Twenty-six generated chapters carry deterministic hashes and lesson ids that
+  Language Ladder independently reproduces from the canonical AST. Telugu book
+  coverage is now 100%, and the app and downloadable book share the same source
+  through Chapter 31.
+- The shared generator now supports named multi-script font sets. Telugu's
+  comparison passages can render Telugu, Tamil, Kannada, Malayalam, Devanagari,
+  and Arabic-script examples without hand-authored LaTeX or missing glyphs.
+- Chapter 20 currently combines the numbers 11–20 with an unrelated weather
+  lesson. HL-M02 records the need for the authoritative roadmap and session map
+  to split that progression or explain the grouping explicitly.
+- A forced XeLaTeX build produces 95 pages with zero missing glyphs or leaked
+  generator metadata. All pages were rendered and inspected; the outline keeps
+  Preface, the script reference, and Chapters 1–31 in order.
+- The expanded warning baseline is eleven overfull boxes, nine underfull
+  vertical boxes, four duplicate practice labels, 104 Hyperref warnings, and
+  nine font warnings. No visual clipping was found; HL-B23 is next and records
+  cleanup against the complete 95-page artifact.
+- The repository corpus contains 1,066 lessons with zero unknown prerequisites
+  and zero duration violations.
+- A clean data-package install surfaced the moderate, development-only
+  GHSA-fxqj-rqcc-2cmp advisory through Vitest, Vite, and PostCSS 8.5.19. A
+  non-breaking 8.5.25 resolution is available; HL-I02 records the lockfile
+  maintenance, behind the reader-facing Telugu build cleanup in HL-B23.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -1,5 +1,15 @@
 {
   "version": 1,
+  "scriptSets": {
+    "telugu-comparisons": [
+      { "unicodeScript": "Telugu", "scriptCommand": "te" },
+      { "unicodeScript": "Tamil", "scriptCommand": "ta" },
+      { "unicodeScript": "Kannada", "scriptCommand": "ka" },
+      { "unicodeScript": "Malayalam", "scriptCommand": "ml" },
+      { "unicodeScript": "Devanagari", "scriptCommand": "dv" },
+      { "unicodeScript": "Arabic", "scriptCommand": "ar" }
+    ]
+  },
   "targets": [
     {
       "language": "spanish",
@@ -366,6 +376,214 @@
       "title": "Green and Yellow",
       "label": "ch:ge-green-and-yellow",
       "output": "german/book/chapters/ch23-green-and-yellow.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 6,
+      "title": "Case Endings and Dative Subjects",
+      "label": "ch:te-dative-case",
+      "output": "telugu/book/chapters/ch06-dative-case.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 7,
+      "title": "Numbers One to Ten",
+      "label": "ch:te-numbers-one-to-ten",
+      "output": "telugu/book/chapters/ch07-numbers-1-10.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 8,
+      "title": "Please",
+      "label": "ch:te-please",
+      "output": "telugu/book/chapters/ch08-please.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 9,
+      "title": "Sorry",
+      "label": "ch:te-sorry",
+      "output": "telugu/book/chapters/ch09-sorry.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 10,
+      "title": "Days of the Week",
+      "label": "ch:te-days-of-the-week",
+      "output": "telugu/book/chapters/ch10-days.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 11,
+      "title": "Four Core Colours",
+      "label": "ch:te-core-colours",
+      "output": "telugu/book/chapters/ch11-colours.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 12,
+      "title": "Family",
+      "label": "ch:te-family",
+      "output": "telugu/book/chapters/ch12-family.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 13,
+      "title": "Head and Hand",
+      "label": "ch:te-head-and-hand",
+      "output": "telugu/book/chapters/ch13-head-and-hand.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 14,
+      "title": "Seasons",
+      "label": "ch:te-seasons",
+      "output": "telugu/book/chapters/ch14-seasons.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 15,
+      "title": "Water and Rice",
+      "label": "ch:te-water-and-rice",
+      "output": "telugu/book/chapters/ch15-water-and-rice.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 16,
+      "title": "The Traditional Months",
+      "label": "ch:te-traditional-months",
+      "output": "telugu/book/chapters/ch16-months.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 17,
+      "title": "Noon and Midnight",
+      "label": "ch:te-noon-and-midnight",
+      "output": "telugu/book/chapters/ch17-noon-and-midnight.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 18,
+      "title": "Telling Time",
+      "label": "ch:te-telling-time",
+      "output": "telugu/book/chapters/ch18-telling-time.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 19,
+      "title": "Asking Someone's Age",
+      "label": "ch:te-asking-age",
+      "output": "telugu/book/chapters/ch19-age.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 20,
+      "title": "Numbers Eleven to Twenty and Weather",
+      "label": "ch:te-numbers-and-weather",
+      "output": "telugu/book/chapters/ch20-numbers-and-weather.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 21,
+      "title": "Dog and Cat",
+      "label": "ch:te-dog-and-cat",
+      "output": "telugu/book/chapters/ch21-dog-and-cat.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 22,
+      "title": "Green and Yellow",
+      "label": "ch:te-green-and-yellow",
+      "output": "telugu/book/chapters/ch22-green-and-yellow.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 23,
+      "title": "Day",
+      "label": "ch:te-day",
+      "output": "telugu/book/chapters/ch23-day.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 24,
+      "title": "Night",
+      "label": "ch:te-night",
+      "output": "telugu/book/chapters/ch24-night.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 25,
+      "title": "Good Night",
+      "label": "ch:te-good-night",
+      "output": "telugu/book/chapters/ch25-good-night.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 26,
+      "title": "Morning",
+      "label": "ch:te-morning",
+      "output": "telugu/book/chapters/ch26-morning.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 27,
+      "title": "Evening",
+      "label": "ch:te-evening",
+      "output": "telugu/book/chapters/ch27-evening.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 28,
+      "title": "Afternoon",
+      "label": "ch:te-afternoon",
+      "output": "telugu/book/chapters/ch28-afternoon.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 29,
+      "title": "Good Morning",
+      "label": "ch:te-good-morning",
+      "output": "telugu/book/chapters/ch29-good-morning.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 30,
+      "title": "Good Evening",
+      "label": "ch:te-good-evening",
+      "output": "telugu/book/chapters/ch30-good-evening.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "telugu",
+      "chapter": 31,
+      "title": "Good Afternoon",
+      "label": "ch:te-good-afternoon",
+      "output": "telugu/book/chapters/ch31-good-afternoon.tex",
+      "scriptSet": "telugu-comparisons"
     },
     {
       "language": "bengali",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -636,6 +636,244 @@
         "ES-C06-practice"
       ],
       "tex": "spanish/book/chapters/ch06-first-verbs.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 6,
+      "sourceHash": "fnv1a64:6cb5796cbafe9026",
+      "lessonIds": [
+        "TE-C06-dative-ku",
+        "TE-C06-dative-subject"
+      ],
+      "tex": "telugu/book/chapters/ch06-dative-case.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 7,
+      "sourceHash": "fnv1a64:b740fb498ae7b163",
+      "lessonIds": [
+        "TE-C07-numbers-1-5",
+        "TE-C07-numbers-6-10"
+      ],
+      "tex": "telugu/book/chapters/ch07-numbers-1-10.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 8,
+      "sourceHash": "fnv1a64:88acff6378f254ad",
+      "lessonIds": [
+        "TE-C08-dayachesi"
+      ],
+      "tex": "telugu/book/chapters/ch08-please.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 9,
+      "sourceHash": "fnv1a64:a59621bd41d42067",
+      "lessonIds": [
+        "TE-C09-kshaminchandi"
+      ],
+      "tex": "telugu/book/chapters/ch09-sorry.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 10,
+      "sourceHash": "fnv1a64:10ee7dfe843f7b1a",
+      "lessonIds": [
+        "TE-C10-vaaram"
+      ],
+      "tex": "telugu/book/chapters/ch10-days.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 11,
+      "sourceHash": "fnv1a64:6edc3d8566fd18eb",
+      "lessonIds": [
+        "TE-C11-rangulu"
+      ],
+      "tex": "telugu/book/chapters/ch11-colours.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 12,
+      "sourceHash": "fnv1a64:21fe8857abf3df9c",
+      "lessonIds": [
+        "TE-C12-kutumbam"
+      ],
+      "tex": "telugu/book/chapters/ch12-family.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 13,
+      "sourceHash": "fnv1a64:83368e6f6cac4154",
+      "lessonIds": [
+        "TE-C13-sharira-bhagalu"
+      ],
+      "tex": "telugu/book/chapters/ch13-head-and-hand.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 14,
+      "sourceHash": "fnv1a64:ae3ab53969658ce4",
+      "lessonIds": [
+        "TE-C14-rutuvulu"
+      ],
+      "tex": "telugu/book/chapters/ch14-seasons.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 15,
+      "sourceHash": "fnv1a64:a75d12dfcd736972",
+      "lessonIds": [
+        "TE-C15-neellu-biyyam"
+      ],
+      "tex": "telugu/book/chapters/ch15-water-and-rice.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 16,
+      "sourceHash": "fnv1a64:8f0932ccb64f8552",
+      "lessonIds": [
+        "TE-C16-nelalu"
+      ],
+      "tex": "telugu/book/chapters/ch16-months.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 17,
+      "sourceHash": "fnv1a64:36b5b3c7a6c8324c",
+      "lessonIds": [
+        "TE-C17-madhyaahnam-ardharaatri"
+      ],
+      "tex": "telugu/book/chapters/ch17-noon-and-midnight.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 18,
+      "sourceHash": "fnv1a64:c703d071cc0d8e4b",
+      "lessonIds": [
+        "TE-C18-ganta"
+      ],
+      "tex": "telugu/book/chapters/ch18-telling-time.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 19,
+      "sourceHash": "fnv1a64:ecd0a47d80ab2c07",
+      "lessonIds": [
+        "TE-C19-vayasu"
+      ],
+      "tex": "telugu/book/chapters/ch19-age.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 20,
+      "sourceHash": "fnv1a64:a7a00722b8910236",
+      "lessonIds": [
+        "TE-C20-padakondu-iravai",
+        "TE-C20-vatavaranam"
+      ],
+      "tex": "telugu/book/chapters/ch20-numbers-and-weather.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 21,
+      "sourceHash": "fnv1a64:ac18c5895e380bad",
+      "lessonIds": [
+        "TE-C21-kukka-pilli"
+      ],
+      "tex": "telugu/book/chapters/ch21-dog-and-cat.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 22,
+      "sourceHash": "fnv1a64:07cbedbaa5b02653",
+      "lessonIds": [
+        "TE-C22-pacha-pasupu"
+      ],
+      "tex": "telugu/book/chapters/ch22-green-and-yellow.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 23,
+      "sourceHash": "fnv1a64:60f8859a49057808",
+      "lessonIds": [
+        "TE-C23-roju"
+      ],
+      "tex": "telugu/book/chapters/ch23-day.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 24,
+      "sourceHash": "fnv1a64:1d1695f2caa824c8",
+      "lessonIds": [
+        "TE-C24-ratri"
+      ],
+      "tex": "telugu/book/chapters/ch24-night.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 25,
+      "sourceHash": "fnv1a64:889282df4447ea86",
+      "lessonIds": [
+        "TE-C25-shubha-ratri"
+      ],
+      "tex": "telugu/book/chapters/ch25-good-night.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 26,
+      "sourceHash": "fnv1a64:3874dddb892a5b58",
+      "lessonIds": [
+        "TE-C26-udayam"
+      ],
+      "tex": "telugu/book/chapters/ch26-morning.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 27,
+      "sourceHash": "fnv1a64:504bda7b4b84a05c",
+      "lessonIds": [
+        "TE-C27-sayantram"
+      ],
+      "tex": "telugu/book/chapters/ch27-evening.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 28,
+      "sourceHash": "fnv1a64:7a9b4182b27fd1c7",
+      "lessonIds": [
+        "TE-C28-madhyahnam-widened"
+      ],
+      "tex": "telugu/book/chapters/ch28-afternoon.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 29,
+      "sourceHash": "fnv1a64:2a0449c46a95b7f2",
+      "lessonIds": [
+        "TE-C29-subhodayam"
+      ],
+      "tex": "telugu/book/chapters/ch29-good-morning.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 30,
+      "sourceHash": "fnv1a64:7adf548d83a059ec",
+      "lessonIds": [
+        "TE-C30-subha-sayantram"
+      ],
+      "tex": "telugu/book/chapters/ch30-good-evening.tex"
+    },
+    {
+      "language": "telugu",
+      "chapter": 31,
+      "sourceHash": "fnv1a64:a513a10b0723cd15",
+      "lessonIds": [
+        "TE-C31-subha-madhyahnam",
+        "TE-C31-subha-madhyahnam-register"
+      ],
+      "tex": "telugu/book/chapters/ch31-good-afternoon.tex"
     }
   ]
 }

--- a/code/learning/human-languages/telugu/CHANGELOG.md
+++ b/code/learning/human-languages/telugu/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Canonical Chapters 6–31 publication (2026-08-03)
+
+- Thirty later-track lessons now use schema v2 with explicit shared-spine
+  placement, prerequisite-safe sequences, typed knowledge boundaries, honest
+  sub-five-minute budgets, skills, modes, strands, register, and variety.
+- Twenty-six generated chapters extend the downloadable book through Chapter
+  31. Their source hashes and lesson ids are independently reproduced by
+  Language Ladder, keeping book and app content synchronized.
+- A reusable multi-script generator set selects the right vendored font for
+  Telugu, Tamil, Kannada, Malayalam, Devanagari, and Arabic-script comparisons.
+  The 95-page forced XeLaTeX build has zero missing glyphs; every page and the
+  complete outline were inspected.
+- The expanded book's remaining layout, duplicate-label, bookmark, and font
+  warnings are recorded in `HL-B23`; Telugu roadmap/session-map reconciliation,
+  including Chapter 20's numbers-and-weather grouping, remains in `HL-M02`.
+
 ## Sub-five-minute lesson remediation (2026-08-02)
 
 - All thirty-six Telugu duration violations are resolved. Thirty-five lessons

--- a/code/learning/human-languages/telugu/README.md
+++ b/code/learning/human-languages/telugu/README.md
@@ -45,6 +45,12 @@ book.
 - **Chapter 5 — First Verbs** ([`lessons/TE-C05-*`](./lessons/)): māṭlāḍu, **nēnu
   telugu māṭlāḍatānu**, uṇḍu, pani cēyu, practice. Stem + tense + person; no
   1st-person gender. In the book.
+- **Chapters 6–31 — Cases, numbers, courtesy, calendar, family, body, food,
+  time, weather, animals, colours, and greetings**
+  ([`lessons/TE-C{06..31}-*`](./lessons/)): thirty prerequisite-ordered
+  micro-lessons continue the same inline script, grammar, and etymology method.
+  All are schema v2, stay below five minutes, and generate twenty-six book
+  chapters from the exact canonical sources consumed by Language Ladder.
 
 ## Book / fonts
 
@@ -59,4 +65,6 @@ and in CI, no system-font dependency. `latexmk -xelatex book.tex`.
   · [`book/`](./book/)
 
 Lessons are slug-named (e.g. `TE-C01-namaskaram`); order lives in the book and
-`session-map.md`.
+canonical prerequisite metadata. The roadmap and authoritative session map
+currently stop before the full Chapter 31 sequence; that explicit metadata debt
+is tracked as `HL-M02` in the shared backlog.

--- a/code/learning/human-languages/telugu/book/book.tex
+++ b/code/learning/human-languages/telugu/book/book.tex
@@ -76,4 +76,31 @@ rule. Released under CC~BY-SA~4.0.
 
 \input{chapters/ch05-first-verbs}
 
+\input{chapters/ch06-dative-case}
+\input{chapters/ch07-numbers-1-10}
+\input{chapters/ch08-please}
+\input{chapters/ch09-sorry}
+\input{chapters/ch10-days}
+\input{chapters/ch11-colours}
+\input{chapters/ch12-family}
+\input{chapters/ch13-head-and-hand}
+\input{chapters/ch14-seasons}
+\input{chapters/ch15-water-and-rice}
+\input{chapters/ch16-months}
+\input{chapters/ch17-noon-and-midnight}
+\input{chapters/ch18-telling-time}
+\input{chapters/ch19-age}
+\input{chapters/ch20-numbers-and-weather}
+\input{chapters/ch21-dog-and-cat}
+\input{chapters/ch22-green-and-yellow}
+\input{chapters/ch23-day}
+\input{chapters/ch24-night}
+\input{chapters/ch25-good-night}
+\input{chapters/ch26-morning}
+\input{chapters/ch27-evening}
+\input{chapters/ch28-afternoon}
+\input{chapters/ch29-good-morning}
+\input{chapters/ch30-good-evening}
+\input{chapters/ch31-good-afternoon}
+
 \end{document}

--- a/code/learning/human-languages/telugu/book/chapters/ch06-dative-case.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch06-dative-case.tex
@@ -1,0 +1,148 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:6cb5796cbafe9026
+% canonical-lessons: TE-C06-dative-ku, TE-C06-dative-subject
+
+\chapter{Case Endings and Dative Subjects}
+\label{ch:te-dative-case}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[-ku]{-\te{కు} (-ku) — "to, for"}
+
+\label{lesson:TE-C06-dative-ku}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Your first \textbf{case ending}. English puts "to" in \textbf{front} as its own word. Telugu sticks it on the \textbf{back} — and that difference is the biggest structural fact about the language.
+\end{quote}
+
+\subsection*{You'll want to know: Adding it on}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{word} & \textbf{+ -ku} & \textbf{meaning} \\
+\midrule
+\te{పేరు} \emph{pēru} — name & \te{పేరు}\textbf{\te{కు}} \emph{pēru\textbf{ku}} & to/for the name \\
+\te{పని} \emph{pani} — work & \te{పని}\textbf{\te{కి}} \emph{pani\textbf{ki}} & for work \\
+\bottomrule
+\end{tabularx}
+
+Notice the suffix appears as \textbf{-\te{కు}} \emph{-ku} or \textbf{-\te{కి}} \emph{-ki} depending on the vowel before it. Same suffix, adjusted to fit — the seam still shows.
+
+And with "I", which changes its body first:
+
+\begin{quote}
+\textbf{\te{నేను}} \emph{nēnu} ("I") $\to$ \textbf{\te{నాకు}} \emph{nāku} ("to me")
+\end{quote}
+
+\emph{Nēnu} becomes \emph{nā-} before the ending. Nouns don't do this; they just take the suffix.
+
+\begin{grammarlens}[title={Grammar Lens: Why this matters}]
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{Telugu \textbf{-ku}} & \textbf{a Latin ending like \textbf{-īs}} \\
+\midrule
+pins down the case? & \textbf{yes} — dative, always & \textbf{no} — \emph{-īs} is dative \textbf{or} ablative \\
+carries number? & \textbf{no} — a separate suffix does & yes — plural, baked in \\
+carries declension class? & \textbf{no} & yes — 1st/2nd only \\
+can you see the seam? & \textbf{yes}: \emph{pēru} + \emph{ku} & no — one fused lump \\
+\bottomrule
+\end{tabularx}
+
+Telugu \textbf{stacks}: each suffix means one thing and sits in a fixed order, so you can point at every piece of a long word. Latin \textbf{fuses} — \emph{-īs} is case \emph{and} plural \emph{and} declension, indivisible, and it doesn't even settle \emph{which} case. Telugu's \emph{-ku} is never ambiguous.
+
+That's what "\textbf{agglutinative}" means, and it's why Telugu words grow long without growing hard: they are \textbf{built}, not memorised.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "\emph{pēru} … \emph{pēruku}"{]}
+  \item {[}YOU SAY: "\emph{nēnu} … \emph{nāku}" — "I" … "to me"{]}
+  \item {[}YOU SAY: "\emph{paniki}" — "for work," from Ch. 5's \te{పని}{]}
+  \item {[}YOU SAY: the principle — "one suffix, one meaning, visible seam"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \textbf{-\te{కు}} mean? ("\textbf{To}" or "\textbf{for}.") Where does it go? (\textbf{On the end} of the noun.) What is "to me"? (\textbf{\te{నాకు}} \emph{nāku} — \emph{nēnu} shrinks to \emph{nā-} first.) Why does it sometimes appear as \textbf{-\te{కి}}? (It \textbf{adjusts to the preceding vowel} — same suffix.) How does that differ from Latin? (Latin \textbf{fuses} case+number+declension into one ending — and \emph{-īs} doesn't even fix \emph{which} case; Telugu's carries \textbf{one} meaning, unambiguously, with the \textbf{seam visible}.) Next: the sentence where Telugu leaves out the subject entirely.
+\end{tcolorbox}
+\section[nāku telugu vaccu]{\te{నాకు} \te{తెలుగు} \te{వచ్చు} — "I know Telugu"}
+
+\label{lesson:TE-C06-dative-subject}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Chapter 5 gave you \textbf{\te{నేను} \te{తెలుగు} \te{మాట్లాడతాను}} — "\textbf{I} speak Telugu." Now say "I \textbf{know} Telugu." Telugu won't let you use \emph{nēnu} — and the verb it uses instead will surprise you.
+\end{quote}
+
+\subsection*{You'll want to know: The sentence}
+\begin{quote}
+\textbf{\te{నాకు} \te{తెలుగు} \te{వచ్చు}.} \emph{nāku telugu vaccu.} literally: "\textbf{to-me} Telugu \textbf{comes}."
+\end{quote}
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{piece} & \textbf{} \\
+\midrule
+\textbf{\te{నాకు}} \emph{nāku} & "to me" — the dative from the last lesson \\
+\textbf{\te{తెలుగు}} \emph{telugu} & Telugu (Ch. 5) \\
+\textbf{\te{వచ్చు}} \emph{vaccu} & "\textbf{comes}" — the very verb you learned in Ch. 4 \\
+\bottomrule
+\end{tabularx}
+
+Two things at once. \textbf{You are not the subject} — \emph{nēnu} is gone, moved into the dative, and what's left unmarked is \emph{telugu}. And the verb is literally "\textbf{to come}": a language you know is a thing that \textbf{comes to you}.
+
+\begin{grammarlens}[title={Grammar Lens: Why: things that happen \emph{to} you}]
+Telugu sorts experiences from actions. Speaking is something you \textbf{do}, so Ch. 5 used \emph{nēnu}. But knowing, liking, wanting, being hungry — these \textbf{arrive} at you. Telugu marks that by putting the person in the \textbf{dative}.
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{English frames it as} & \textbf{Telugu frames it as} \\
+\midrule
+I \textbf{know} Telugu & Telugu \textbf{comes to me} \\
+I \textbf{like} it & it is pleasing \textbf{to me} \\
+I \textbf{am} cold & cold is \textbf{to me} \\
+\bottomrule
+\end{tabularx}
+
+English keeps one fossil of exactly this: "\textbf{methinks}" — \emph{me} is a dative, "it seems \textbf{to me}." Telugu made it the rule.
+\end{grammarlens}
+
+\begin{cousinweb}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{"I know {[}the language{]}"} & \textbf{the dative} \\
+\midrule
+Telugu & \emph{nāku telugu vaccu} & \textbf{-ku} \\
+Tamil & \emph{enakku tamiḻ teriyum} & \textbf{-ukku} \\
+Kannada & \emph{nanage kannaḍa gottu} & \textbf{-ge} \\
+Malayalam & \emph{enikku malayāḷam aṟiyām} & \textbf{-ikku} \\
+\bottomrule
+\end{tabularx}
+
+One construction across four languages, with four suffixes that are visibly the \textbf{same suffix} — \emph{-ku / -ukku / -ge / -ikku}. The Dravidian family showing its bones, just as \emph{blanc/bianco/branco} did for Romance.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "\emph{nāku telugu vaccu}"{]}
+  \item {[}YOU SAY: the contrast — "\emph{nēnu telugu māṭlāḍatānu}" (I speak) … "\emph{nāku telugu vaccu}" (comes to me){]}
+  \item {[}YOU SAY: the literal — "to-me Telugu comes"{]}
+  \item {[}YOU SAY: the four cousins — "\emph{-ku · -ukku · -ge · -ikku}"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \textbf{\te{నాకు} \te{తెలుగు} \te{వచ్చు}} literally say? ("\textbf{To-me} Telugu \textbf{comes}.") Which verb is doing the work, and where did you meet it? (\textbf{\te{వచ్చు}} "to come" — Chapter 4.) What has English got that Telugu hasn't? (A nominative "\textbf{I}" — \emph{nēnu} is replaced by the dative \emph{nāku}.) Why the dative? (Knowing \textbf{happens to} you.) Which English word keeps the same idea? (\textbf{Methinks}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch07-numbers-1-10.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch07-numbers-1-10.tex
@@ -1,0 +1,131 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:b740fb498ae7b163
+% canonical-lessons: TE-C07-numbers-1-5, TE-C07-numbers-6-10
+
+\chapter{Numbers One to Ten}
+\label{ch:te-numbers-one-to-ten}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{ఒకటి} \te{రెండు} \te{మూడు} \te{నాలుగు} \te{ఐదు}]{\te{ఒకటి}, \te{రెండు}, \te{మూడు}, \te{నాలుగు}, \te{ఐదు} — one to five}
+
+\label{lesson:TE-C07-numbers-1-5}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Four of these five are old Dravidian friends. The very first one is Telugu going its own way.
+\end{quote}
+
+\subsection*{You'll want to know: The five}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{numeral} & \textbf{word} & \textbf{said} \\
+\midrule
+1 & \textbf{\te{౧}} & \textbf{\te{ఒకటి}} & \emph{okaṭi} \\
+2 & \textbf{\te{౨}} & \textbf{\te{రెండు}} & \emph{reṇḍu} \\
+3 & \textbf{\te{౩}} & \textbf{\te{మూడు}} & \emph{mūḍu} \\
+4 & \textbf{\te{౪}} & \textbf{\te{నాలుగు}} & \emph{nālugu} \\
+5 & \textbf{\te{౫}} & \textbf{\te{ఐదు}} & \emph{aidu} \\
+\bottomrule
+\end{tabularx}
+
+The symbols \textbf{\te{౧} \te{౨} \te{౩} \te{౪} \te{౫}} are Telugu's own digits.
+
+\begin{cousinweb}
+\textbf{One} is where Telugu leaves the family. Its cousins agree — Tamil \emph{oṉṟu}, Kannada \emph{ondu}, Malayalam \emph{onnu}, all from an old \emph{oṉ-} — but Telugu says \textbf{okaṭi}, a different formation altogether. It's the number to memorise fresh rather than reason across from Tamil.
+
+From two onward, the family closes ranks again:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{Tamil} & \textbf{Telugu} \\
+\midrule
+2 & \emph{iraṇṭu} & \textbf{reṇḍu} \\
+3 & \emph{mūṉṟu} & \textbf{mūḍu} \\
+4 & \emph{nāṉku} & \textbf{nālugu} \\
+5 & \emph{aintu} & \textbf{aidu} \\
+\bottomrule
+\end{tabularx}
+
+\emph{Reṇḍu} has simply dropped the opening vowel of \emph{iraṇṭu}; \emph{mūḍu} is \emph{mūṉṟu} with its cluster smoothed to a single \textbf{ḍ}. Same numbers, a Telugu polish.
+\end{cousinweb}
+
+\subsection*{Script you'll notice: A Telugu shape to notice}
+Nearly every Telugu word here ends in \textbf{‑u} (\emph{reṇḍu, mūḍu, nālugu}) — the language's strong preference for open, vowel-final syllables. Even where Tamil ends hard, Telugu tends to round the word off with a vowel.
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "okaṭi, reṇḍu, mūḍu, nālugu, aidu"{]}
+  \item {[}YOU SAY: the maverick — "okaṭi", NOT the oṉṟu/ondu/onnu of its cousins{]}
+  \item {[}YOU SAY: the family — "iraṇṭu $\to$ reṇḍu", the opening vowel dropped{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Count to five in Telugu. (\emph{Okaṭi, reṇḍu, mūḍu, nālugu, aidu}.) Which number does Telugu form unlike the rest of the family, and what do the others say? (\textbf{One} — Telugu \emph{okaṭi} vs \emph{oṉṟu / ondu / onnu}.) How does \emph{reṇḍu} relate to Tamil \emph{iraṇṭu}? (The opening vowel was dropped.) What vowel do most Telugu words here end in? (\textbf{‑u}.) Next: six to ten.
+\end{tcolorbox}
+\section[\te{ఆరు} \te{ఏడు} \te{ఎనిమిది} \te{తొమ్మిది} \te{పది}]{\te{ఆరు}, \te{ఏడు}, \te{ఎనిమిది}, \te{తొమ్మిది}, \te{పది} — six to ten}
+
+\label{lesson:TE-C07-numbers-6-10}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The top of the count is where Telugu is least like its cousins — two of these you simply learn on their own.
+\end{quote}
+
+\subsection*{You'll want to know: The five}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{numeral} & \textbf{word} & \textbf{said} \\
+\midrule
+6 & \textbf{\te{౬}} & \textbf{\te{ఆరు}} & \emph{āru} \\
+7 & \textbf{\te{౭}} & \textbf{\te{ఏడు}} & \emph{ēḍu} \\
+8 & \textbf{\te{౮}} & \textbf{\te{ఎనిమిది}} & \emph{enimidi} \\
+9 & \textbf{\te{౯}} & \textbf{\te{తొమ్మిది}} & \emph{tommidi} \\
+10 & \textbf{\te{౧౦}} & \textbf{\te{పది}} & \emph{padi} \\
+\bottomrule
+\end{tabularx}
+
+\begin{cousinweb}
+Six is an easy cousin (Tamil \emph{āṟu} $\to$ Telugu \emph{āru}). \textbf{Seven} is more interesting: Tamil \emph{ēḻu} carries the rare \textbf{ḻ} (the \emph{zh} of \emph{Tamiḻ}); Kannada hardened it to \textbf{ḷ} (\emph{ēḷu}); \textbf{Telugu went further still} and turned it into a plain \textbf{ḍ} — \emph{ēḍu}. One inherited sound, three fates across the three scripts.
+\end{cousinweb}
+
+\begin{cousinweb}
+Here Telugu strays furthest from its cousins —
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{Tamil} & \textbf{Malayalam} & \textbf{Telugu} \\
+\midrule
+8 & \emph{eṭṭu} & \emph{eṭṭu} & \textbf{enimidi} \\
+9 & \emph{oṉpatu} & \emph{onpatu} & \textbf{tommidi} \\
+\bottomrule
+\end{tabularx}
+
+You can't reach \emph{enimidi} and \emph{tommidi} from Tamil by regular sound-change the way you can \emph{reṇḍu} from \emph{iraṇṭu}: \emph{tommidi} is a different word entirely, and \emph{enimidi} — though it shares the ancient \emph{eṇ-} root behind \emph{eṭṭu} — has drifted too far to derive. So unlike 2–7, learn these two \textbf{fresh}.
+
+\textbf{Ten} comes partly back into the fold — Telugu \emph{padi} is a worn-down relative of the \emph{pat‑} in Tamil \emph{pattu} (and the \emph{‑patu} hiding inside \emph{tommidi} and Tamil \emph{oṉpatu}, "one-to-ten").
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "āru, ēḍu, enimidi, tommidi, padi"{]}
+  \item {[}YOU SAY: seven's three fates — "Tamil ēḻu, Kannada ēḷu, Telugu ēḍu"{]}
+  \item {[}YOU SAY: the two you learn fresh — "enimidi, tommidi"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Count six to ten in Telugu. (\emph{Āru, ēḍu, enimidi, tommidi, padi}.) What became of Tamil's \textbf{ḻ} (in \emph{ēḻu}) by the time it reached Telugu \emph{ēḍu}? (It hardened all the way to \textbf{ḍ}.) Which two numbers can't you derive from Tamil by regular correspondence? (\textbf{Eight and nine} — learn \emph{enimidi, tommidi} fresh.) How does \emph{padi} relate to Tamil \emph{pattu}? (A worn-down relative of the same \emph{pat‑} "ten".)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch08-please.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch08-please.tex
@@ -1,0 +1,65 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:88acff6378f254ad
+% canonical-lessons: TE-C08-dayachesi
+
+\chapter{Please}
+\label{ch:te-please}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{దయచేసి}]{\te{దయచేసి} (dayacēsi) — please (having done compassion)}
+
+\label{lesson:TE-C08-dayachesi}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Telugu's "please" carries a whole small sentence inside it: "having \textbf{done} (me) a compassion."
+\end{quote}
+
+\subsection*{You'll want to know: The word}
+\textbf{\te{దయచేసి}} = \textbf{please}, literally "\textbf{having done kindness / compassion}." Two pieces:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\te{దయ}} (\emph{daya}) = \textbf{compassion, kindness, grace} — from Sanskrit \textbf{daya}.
+  \item \textbf{\te{చేసి}} (\emph{cēsi}) = "\textbf{having done}," from the verb \textbf{\te{చేయు}} (\emph{cēyu}) "to do."
+\end{itemize}
+
+So \emph{dayacēsi} is \emph{having done (a) kindness} — you ask by crediting the listener with the grace you hope they'll show.
+
+It is the twin of \textbf{Tamil} \emph{tayavu seytu} ("\textbf{do} the kindness") — both use a "do" verb — and cousins with \textbf{Kannada} \emph{dayaviṭṭu} ("having \textbf{placed} compassion"). Further off, \textbf{Arabic} \emph{min faḍlik} ("from your \textbf{grace}") and \textbf{Hindi} \emph{kṛpayā} (from \emph{kṛpā}, "\textbf{compassion}") ask in the very same spirit.
+
+\begin{cousinweb}
+\textbf{daya} + a light verb, four ways:
+
+\begin{itemize}
+\raggedright
+  \item Telugu \textbf{\te{దయచేసి}} \emph{daya\textbf{cēsi}} — compassion \textbf{+ having done}
+  \item Tamil \textbf{\ta{தயவுசெய்து}} \emph{tayavu \textbf{sey}tu} — kindness \textbf{+ do}
+  \item Kannada \textbf{\ka{ದಯವಿಟ್ಟು}} \emph{daya\textbf{viṭṭu}} — compassion \textbf{+ having placed}
+  \item Malayalam \textbf{\ml{ദയവായി}} \emph{daya\textbf{vāyi}} — compassion \textbf{+ as / having become}
+\end{itemize}
+\end{cousinweb}
+
+\begin{culture}
+Honestly: the standalone word is somewhat \textbf{formal / emphatic}. Day-to-day, Telugu politeness rides on the \textbf{respectful command} ending \textbf{‑\te{ండి}} (\emph{-aṇḍi}): \textbf{\te{కూర్చోండి}} (\emph{kūrcōṇḍi}) "please sit," \textbf{\te{చెప్పండి}} (\emph{ceppaṇḍi}) "please tell me." That \emph{-aṇḍi} is already "please." Put \textbf{\te{దయచేసి}} in front to warm it further.
+\end{culture}
+
+\subsection*{Script you'll notice: Sound \& structure point}
+The middle syllable \textbf{\te{చే}} is \emph{ca} wearing the \textbf{long‑ē} sign \textbf{‑\te{ే}} (the counterpart of the short‑e sign \textbf{‑\te{ె}}), giving \emph{cē}; then \textbf{\te{సి}} is \emph{sa} + the \emph{i} sign (\textbf{‑\te{ి}}). Telugu marks a vowel's length and quality by the little sign riding on the consonant — the consonant stays put, the vowel-sign changes the tune.
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "daya" — compassion — then "cēsi," having done{]}
+  \item {[}YOU SAY: the whole word — "dayacēsi" = please{]}
+  \item {[}YOU SAY: the everyday way — the verb ending: "kūrcōṇḍi" = please sit{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What is the Telugu word for please? (\textbf{\te{దయచేసి}} \emph{dayacēsi}.) What do its pieces mean? ("\textbf{Compassion}" \emph{daya} + "\textbf{having done}" \emph{cēsi}.) Which cousins ask the same way? (\textbf{Tamil, Kannada, Malayalam} with \emph{daya} — plus \textbf{Arabic} \emph{faḍl}, \textbf{Hindi} \emph{kṛpā}.) What carries "please" in ordinary speech? (\textbf{The respectful verb ending ‑\te{ండి}} \emph{-aṇḍi}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch09-sorry.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch09-sorry.tex
@@ -1,0 +1,58 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:a59621bd41d42067
+% canonical-lessons: TE-C09-kshaminchandi
+
+\chapter{Sorry}
+\label{ch:te-sorry}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{క్షమించండి}]{\te{క్షమించండి} (kṣamin̄caṇḍi) — please forgive / sorry}
+
+\label{lesson:TE-C09-kshaminchandi}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You already know \textbf{\te{దయచేసి}} and its respectful \textbf{‑\te{ండి}} ending (\emph{kūrcōṇḍi}, "please sit"). Telugu's "sorry" hands you that very ending again, riding a brand-new verb.
+\end{quote}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{\te{క్షమా}} (\emph{kṣamā}) = "\textbf{forgiveness, patience}" — the Sanskrit noun, borrowed whole.
+  \item \textbf{‑\te{ఇంచు}} (\emph{‑in̄cu}) = a \textbf{verb-making suffix}: \emph{kṣamā} + \emph{‑in̄cu} $\to$ \textbf{\te{క్షమించు}} (\emph{kṣamin̄cu}), "\textbf{to forgive}." (The same pattern gives \te{ప్రారంభించు} \emph{prārambhin̄cu}, "to begin," from Sanskrit \emph{prārambha}.)
+  \item \textbf{‑\te{ండి}} (\emph{‑aṇḍi}) = the \textbf{respectful imperative} ending — exactly the one you already met on \emph{kūrcōṇḍi} "please sit" and \emph{ceppaṇḍi} "please tell me."
+\end{itemize}
+
+So \textbf{\te{క్షమించండి}} is "\textbf{please forgive}" — the same polite mold you already know, filled with a new verb.
+\end{cousinweb}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item Telugu \textbf{\te{క్షమించండి}} \emph{kṣamin̄\textbf{caṇḍi}} — Sanskrit \emph{kṣamā} + \textbf{‑in̄cu} (verb) + \textbf{‑aṇḍi} (imperative)
+  \item Kannada \textbf{\ka{ಕ್ಷಮಿಸಿ}} \emph{kṣami\textbf{si}} — Sanskrit \emph{kṣamā} + \textbf{‑isu} (verb) + \textbf{‑i} (imperative)
+  \item Malayalam \textbf{\ml{ക്ഷമിക്കണം}} \emph{kṣami\textbf{kkaṇaṁ}} — Sanskrit \emph{kṣama} + \textbf{‑ikkuka} (verb) + \textbf{‑aṇaṁ} (necessitative)
+  \item Tamil \textbf{\ta{மன்னிக்கவும்}} \emph{maṉṉi\textbf{kkavum}} — its \textbf{own} native root \emph{maṉṉi}, not Sanskrit at all
+\end{itemize}
+\end{cousinweb}
+
+\begin{culture}
+\textbf{\te{క్షమించండి}} is a real, everyday "sorry / please forgive me" — not stiffly formal — though in quick, casual exchanges Telugu speakers just as often reach for the borrowed English \textbf{"sorry."}
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "kṣamā" — the Sanskrit noun, forgiveness{]}
+  \item {[}YOU SAY: the verb — "kṣamin̄cu," to forgive — then "kṣamin̄caṇḍi," please forgive{]}
+  \item {[}YOU SAY: the ending you already know — "‑aṇḍi," same as kūrcōṇḍi{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What is \textbf{\te{క్షమించండి}} built from? (\textbf{Sanskrit kṣamā} + the verb-making suffix \textbf{‑in̄cu} + the respectful ending \textbf{‑aṇḍi}, which you already met on \emph{kūrcōṇḍi}.) Which cousins also verb-ify \emph{kṣamā}, and which doesn't? (\textbf{Kannada and Malayalam} do too; \textbf{Tamil} uses its own root \emph{maṉṉi}.) What's the casual alternative? (\textbf{Borrowed English "sorry."})
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch10-days.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch10-days.tex
@@ -1,0 +1,54 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:10ee7dfe843f7b1a
+% canonical-lessons: TE-C10-vaaram
+
+\chapter{Days of the Week}
+\label{ch:te-days-of-the-week}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{సోమవారం} \te{మంగళవారం} \te{బుధవారం} \te{గురువారం} \te{శుక్రవారం} \te{శనివారం} \te{ఆదివారం}]{\te{సోమవారం} to \te{ఆదివారం} — Telugu's week, with a twist on Sunday}
+
+\label{lesson:TE-C10-vaaram}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Like Kannada, Telugu's week runs on Sanskrit deity-names — but its Sunday breaks the "planet" pattern entirely, in a way even Kannada's doesn't.
+\end{quote}
+
+\begin{cousinweb}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Telugu} & \textbf{deity/planet} & \textbf{day} \\
+\midrule
+\textbf{\te{సోమవారం}} (\emph{Somavāram}) & \textbf{Moon} (Soma) & Monday \\
+\textbf{\te{మంగళవారం}} (\emph{Maṅgaḷavāram}) & \textbf{Mars} (Maṅgala) & Tuesday \\
+\textbf{\te{బుధవారం}} (\emph{Budhavāram}) & \textbf{Mercury} (Budha) & Wednesday \\
+\textbf{\te{గురువారం}} (\emph{Guruvāram}) & \textbf{Jupiter} (Guru/Bṛhaspati) & Thursday \\
+\textbf{\te{శుక్రవారం}} (\emph{Śukravāram}) & \textbf{Venus} (Śukra) & Friday \\
+\textbf{\te{శనివారం}} (\emph{Śanivāram}) & \textbf{Saturn} (Śani) & Saturday \\
+\textbf{\te{ఆదివారం}} (\emph{Ādivāram}) & — not a planet at all & Sunday \\
+\bottomrule
+\end{tabularx}
+\end{cousinweb}
+
+\begin{culture}
+Five days match the familiar planet-deity pattern — but \textbf{\te{ఆదివారం}} (\emph{Ādivāram}) doesn't name the Sun at all. \textbf{\te{ఆది}} (\emph{ādi}) is Sanskrit for "\textbf{the beginning, the first}." So Telugu's Sunday literally means "\textbf{the first day}" — a \textbf{positional} name, like Arabic's numbered weekdays, sitting right next to six planet-names that don't work that way. Even within one single week, a language can mix completely different naming strategies.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "Somavāram, Maṅgaḷavāram, Budhavāram, Guruvāram, Śukravāram, Śanivāram" — Monday through Saturday{]}
+  \item {[}YOU SAY: the odd one — "Ādivāram" — not a planet, "the first day"{]}
+  \item {[}YOU SAY: the parallel — like Arabic's numbered days, one Telugu day is positional too{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \textbf{\te{ఆదివారం}} literally mean, and is it a planet-name? (\textbf{"The first day"} — \textbf{ādi} "beginning" — \textbf{not} a planet-name, unlike the other six.) What ending do the other six Telugu weekdays share? (\textbf{‑\te{వారం}} \emph{-vāram}, Sanskrit "day," each paired with a planet-deity.)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch11-colours.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch11-colours.tex
@@ -1,0 +1,45 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:6edc3d8566fd18eb
+% canonical-lessons: TE-C11-rangulu
+
+\chapter{Four Core Colours}
+\label{ch:te-core-colours}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{నలుపు} \te{తెలుపు} \te{ఎరుపు} \te{నీలం}]{\te{నలుపు}, \te{తెలుపు}, \te{ఎరుపు}, \te{నీలం} — the pattern completes itself}
+
+\label{lesson:TE-C11-rangulu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} By now the shape should feel familiar: native colors for black, white, and red — and one shared Sanskrit word for blue. Telugu confirms it a fourth time.
+\end{quote}
+
+\subsection*{You'll want to know: Three native colors}
+\begin{itemize}
+\raggedright
+  \item \textbf{\te{నలుపు}} (\emph{nalupu}) = "\textbf{black}" — native Dravidian.
+  \item \textbf{\te{తెలుపు}} (\emph{telupu}) = "\textbf{white}" — native Dravidian.
+  \item \textbf{\te{ఎరుపు}} (\emph{erupu}) = "\textbf{red}" — native Dravidian.
+\end{itemize}
+
+\begin{cousinweb}
+\textbf{\te{నీలం}} (\emph{nīlam}) = "\textbf{blue}" — the identical Sanskrit \textbf{\te{నీల}} (\emph{nīla}) loan you've now seen in Tamil (\emph{nīlam}), Malayalam (\emph{nīla}), Kannada (\emph{nīli}), and Hindi (\emph{nīlā}). Four Dravidian languages plus Hindi, all independently keeping their own native black/white/red, and all reaching for the \textbf{exact same} borrowed word the moment it comes to blue.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "nalupu, telupu, erupu" — black, white, red{]}
+  \item {[}YOU SAY: "nīlam" — blue, the word every language in this course now shares{]}
+  \item {[}YOU SAY: the whole pattern, one more time — native, native, native, \textbf{borrowed}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What's the pattern across Tamil, Malayalam, Kannada, and Telugu's basic colors? (\textbf{Black, white, and red are native Dravidian words in every one of them; blue is a shared Sanskrit loan (nīla) in every one of them.})
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch12-family.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch12-family.tex
@@ -1,0 +1,56 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:21fe8857abf3df9c
+% canonical-lessons: TE-C12-kutumbam
+
+\chapter{Family}
+\label{ch:te-family}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{నాన్న} \te{అమ్మ} \te{అన్న} \te{తమ్ముడు} \te{అక్క} \te{చెల్లి}]{\te{నాన్న}, \te{అమ్మ}, and four sibling words — Telugu's own twist}
+
+\label{lesson:TE-C12-kutumbam}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Telugu shares the Dravidian family's age-first sibling system — but its words for "father" and "younger sister" go their own way.
+\end{quote}
+
+\subsection*{You'll want to know: Parents — one matches, one is Telugu's own}
+\begin{itemize}
+\raggedright
+  \item \textbf{\te{నాన్న}} (\emph{nānna}) = "\textbf{father}" — \textbf{Telugu's own word}, unlike Tamil/ Kannada's \emph{appā/appa}.
+  \item \textbf{\te{అమ్మ}} (\emph{amma}) = "\textbf{mother}" — matches Tamil/Kannada's \emph{ammā/amma} closely.
+\end{itemize}
+
+\begin{cousinweb}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Telugu} & \textbf{meaning} & \textbf{compare Tamil/Kannada} \\
+\midrule
+\textbf{\te{అన్న}} (\emph{anna}) & \textbf{older} brother & \emph{aṇṇaṉ/aṇṇa} — near match \\
+\textbf{\te{తమ్ముడు}} (\emph{tammuḍu}) & \textbf{younger} brother & \emph{tambi/tamma} — near match \\
+\textbf{\te{అక్క}} (\emph{akka}) & \textbf{older} sister & \emph{akkā/akka} — near match \\
+\textbf{\te{చెల్లి}} (\emph{celli}) & \textbf{younger} sister & \emph{tangai/tangi} — \textbf{Telugu's own word here} \\
+\bottomrule
+\end{tabularx}
+
+So the \emph{system} — four words, split by relative age rather than just gender — is shared across Tamil, Kannada, and Telugu. But the exact words aren't identical everywhere: Telugu keeps its own \textbf{\te{నాన్న}} for father and \textbf{\te{చెల్లి}} for "younger sister," even while three of the six words line up closely with its cousins.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "nānna, amma" — father, mother{]}
+  \item {[}YOU SAY: "anna, tammuḍu" — older/younger brother{]}
+  \item {[}YOU SAY: "akka, celli" — older/younger sister — celli is Telugu's own{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which two Telugu family words are its own, rather than matching Tamil/Kannada? (\textbf{\te{నాన్న}} \emph{nānna}, "father," and \textbf{\te{చెల్లి}} \emph{celli}, "younger sister.") Does Telugu still split siblings by age the same way? (\textbf{Yes} — the four-way age-before-gender system is shared across the whole Dravidian family, even where the exact words differ.)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch13-head-and-hand.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch13-head-and-hand.tex
@@ -1,0 +1,42 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:83368e6f6cac4154
+% canonical-lessons: TE-C13-sharira-bhagalu
+
+\chapter{Head and Hand}
+\label{ch:te-head-and-hand}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{తల} \te{చెయ్యి}]{\te{తల}, \te{చెయ్యి} — head shared outright, hand shared in disguise}
+
+\label{lesson:TE-C13-sharira-bhagalu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Head matches its cousins plainly. Hand looks, at first glance, like Telugu went its own way — but look closer, and it's the same word after all, just heavily reshaped.
+\end{quote}
+
+\subsection*{You'll want to know: The words}
+\begin{itemize}
+\raggedright
+  \item \textbf{\te{తల}} (\emph{tala}) = "\textbf{head}" — native Dravidian, matching Tamil \emph{talai}, Malayalam \emph{thala}, and Kannada \emph{tale} closely and plainly.
+  \item \textbf{\te{చెయ్యి}} (\emph{ceyyi}) = "\textbf{hand}" — also native Dravidian, and \textbf{the very same root} as Tamil/Malayalam/Kannada's \emph{kai}: Proto-Dravidian \emph{\textbf{kay-}}. Telugu's own regular sound change turned that ancient \textbf{k-} into \textbf{c-}, and reshaped the rest of the word alongside it — so \emph{ceyyi} only \emph{looks} unrelated to \emph{kai}. It's a cognate in disguise, not a different word.
+\end{itemize}
+
+So all four Dravidian languages actually \textbf{agree} on both "head" and "hand" at the root level — Telugu's hand-word has simply drifted further in sound than its cousins have, thanks to a sound change that reshaped many Telugu words the same way.
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "tala" — head, matching its cousins plainly{]}
+  \item {[}YOU SAY: "ceyyi" — hand, the SAME root as kai, reshaped by sound change{]}
+  \item {[}YOU SAY: the lesson — looks different, is actually the same word{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Does Telugu's word for "head" match its cousins? (\textbf{Yes} — \emph{tala}, like Tamil/Malayalam/Kannada.) Is its word for "hand," \emph{ceyyi}, truly a different word from \emph{kai}? (\textbf{No} — it's the \textbf{same Proto-Dravidian root} \emph{kay-}, reshaped by Telugu's own regular k$\to$c sound change — a cognate in disguise, not an unrelated word.)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch14-seasons.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch14-seasons.tex
@@ -1,0 +1,51 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:ae3ab53969658ce4
+% canonical-lessons: TE-C14-rutuvulu
+
+\chapter{Seasons}
+\label{ch:te-seasons}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{వసంత} \te{ఋతువు} \te{వేసవి} \te{వానాకాలం} \te{శీతాకాలం}]{\te{వసంత} \te{ఋతువు}, \te{వేసవి}, \te{వానాకాలం}, \te{శీతాకాలం} — the pattern completes itself}
+
+\label{lesson:TE-C14-rutuvulu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Telugu closes out the Dravidian season words the same way Kannada did: native words for summer/rain/cold, and a spring-word borrowed twice over from Sanskrit.
+\end{quote}
+
+\subsection*{You'll want to know: The words}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Telugu} & \textbf{meaning} & \textbf{source} \\
+\midrule
+\textbf{\te{వసంత} \te{ఋతువు}} (\emph{vasanta ṛtuvu}) & "spring" & both \emph{vasanta} and \textbf{\te{ఋతువు}} \emph{ṛtuvu} ("season") are Sanskrit, like Kannada's pair \\
+\textbf{\te{వేసవి}} (\emph{vēsavi}) & "summer" & native Dravidian — cousin of Kannada's \emph{bēsige} \\
+\textbf{\te{వానాకాలం}} (\emph{vānākālam}) & "rainy season" & \textbf{\te{వాన}} \emph{vāna} ("rain," native) + \emph{kālam} ("time," itself Sanskrit-derived but long assimilated) \\
+\textbf{\te{శీతాకాలం}} (\emph{śītākālam}) & "winter/cold season" & \emph{śīta} ("cold") leans Sanskrit-flavored here, unlike Tamil/Kannada's fully native cold-words \\
+\bottomrule
+\end{tabularx}
+
+\begin{culture}
+Telugu's \emph{vēsavi} and Kannada's \emph{bēsige} are close enough in shape to be genuine cousins — the same native Dravidian summer-word wearing two languages' sound changes. And once again, it's \textbf{\te{వానాకాలం}} (\emph{vānākālam}, the rains) that actually organizes Andhra/Telangana's agricultural year, not a clean four-way Western split — the same honest point every language in this arc has made.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "vēsavi" — summer, cousin of Kannada's bēsige{]}
+  \item {[}YOU SAY: "vānākālam" — the rains, the real central season{]}
+  \item {[}YOU SAY: "śītākālam" — the cold season{]}
+  \item {[}YOU SAY: the double Sanskrit loan — "vasanta ṛtuvu," like Kannada{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What's the relationship between Telugu's \emph{vēsavi} and Kannada's \emph{bēsige}? (\textbf{Cousins} — the same native Dravidian summer-word.) Which Dravidian languages borrow BOTH halves of their spring-word from Sanskrit (the season-name AND the word for "season" itself)? (\textbf{Kannada and Telugu} — \emph{vasanta ṛtu(vu)} — unlike Tamil/Malayalam's single \emph{vasantham} loan plus the long-assimilated \emph{kaalam}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch15-water-and-rice.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch15-water-and-rice.tex
@@ -1,0 +1,47 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:a75d12dfcd736972
+% canonical-lessons: TE-C15-neellu-biyyam
+
+\chapter{Water and Rice}
+\label{ch:te-water-and-rice}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{నీళ్ళు} \te{బియ్యం} \te{అన్నం}]{\te{నీళ్ళు}, \te{బియ్యం}, \te{అన్నం} — water matching its cousins, rice going its own way}
+
+\label{lesson:TE-C15-neellu-biyyam}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Water closes out 3-against-1 against Malayalam. Rice, though, turns out to have its own twist here.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\te{నీళ్ళు}} (\emph{nīḷḷu}) = "\textbf{water}" — matching Tamil's \emph{nīr} and Kannada's \emph{nīru}. Malayalam's \emph{veḷḷam} is the odd one out among all four Dravidian languages for water, not Telugu.
+\end{cousinweb}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{\te{బియ్యం}} (\emph{biyyam}) = "\textbf{rice}" (raw grain) — \textbf{Telugu's own word}, unlike the shared \emph{ari/arisi/akki} found in Malayalam, Tamil, and Kannada.
+  \item \textbf{\te{అన్నం}} (\emph{annam}) = "\textbf{cooked rice}" (the meal) — matching Kannada's \emph{anna} closely, both likely Sanskrit-influenced.
+\end{itemize}
+
+So the pattern flips between water and rice: for \textbf{water}, Telugu joins the majority (Tamil/Kannada) against Malayalam; for \textbf{raw rice}, Telugu is itself the odd one out against the other three.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "nīḷḷu" — water, matching Tamil/Kannada{]}
+  \item {[}YOU SAY: "biyyam" — raw rice, Telugu's own word{]}
+  \item {[}YOU SAY: "annam" — cooked rice, matching Kannada's anna{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which language is the odd one out for water, and which for raw rice? (\textbf{Malayalam} is the odd one out for water (\emph{veḷḷam}); \textbf{Telugu} is the odd one out for raw rice (\emph{biyyam}, unlike the shared \emph{ari/arisi/akki} elsewhere).)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch16-months.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch16-months.tex
@@ -1,0 +1,40 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:8f0932ccb64f8552
+% canonical-lessons: TE-C16-nelalu
+
+\chapter{The Traditional Months}
+\label{ch:te-traditional-months}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{చైత్రం} \te{వైశాఖం} \te{జ్యేష్ఠం} \te{ఆషాఢం} \te{శ్రావణం} \te{భాద్రపదం} \te{ఆశ్వయుజం} \te{కార్తీకం} \te{మార్గశిరం} \te{పుష్యం} \te{మాఘం} \te{ఫాల్గుణం}]{\te{చైత్రం} to \te{ఫాల్గుణం} — completing the split}
+
+\label{lesson:TE-C16-nelalu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The pattern across all four Dravidian languages is now complete: Telugu, like Kannada, shares its calendar with Hindi rather than building its own.
+\end{quote}
+
+\subsection*{You'll want to know: The twelve months}
+\textbf{\te{చైత్రం}, \te{వైశాఖం}, \te{జ్యేష్ఠం}, \te{ఆషాఢం}, \te{శ్రావణం}, \te{భాద్రపదం}, \te{ఆశ్వయుజం}, \te{కార్తీకం}, \te{మార్గశిరం}, \te{పుష్యం}, \te{మాఘం}, \te{ఫాల్గుణం}} (\emph{Caitraṁ, Vaiśākhaṁ, Jyēṣṭhaṁ, Āṣāḍhaṁ, Śrāvaṇaṁ, Bhādrapadaṁ, Āśvayujaṁ, Kārtīkaṁ, Mārgaśiraṁ, Puṣyaṁ, Māghaṁ, Phālguṇaṁ}).
+
+\begin{cousinweb}
+This closes out a genuine, clean split across the four Dravidian languages: \textbf{Tamil} and \textbf{Malayalam} each built their \textbf{own} solar calendar (nakshatra-named and zodiac-named, respectively) — while \textbf{Kannada} and \textbf{Telugu} instead share the \textbf{same pan-Indian Sanskritic lunisolar calendar} as Hindi's Vikram Samvat. Telugu's New Year, \textbf{Ugadi}, falls on the very same day as Kannada's — \emph{Chaitra Śuddha Pādyami}, the first day of Chaitra's bright fortnight.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the twelve — "Caitraṁ, Vaiśākhaṁ, Jyēṣṭhaṁ, Āṣāḍhaṁ, Śrāvaṇaṁ, Bhādrapadaṁ, Āśvayujaṁ, Kārtīkaṁ, Mārgaśiraṁ, Puṣyaṁ, Māghaṁ, Phālguṇaṁ"{]}
+  \item {[}YOU SAY: "Ugadi — Chaitra Śuddha Pādyami"{]}
+  \item {[}YOU SAY: the whole family split — Tamil/Malayalam their own; Kannada/ Telugu shared with Hindi{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} How does the four-language Dravidian calendar picture split? (\textbf{Tamil and Malayalam} each have their \textbf{own} solar calendar; \textbf{Kannada and Telugu} share the \textbf{same pan-Indian lunisolar calendar} as Hindi.) What is Telugu's New Year, and when does it fall? (\textbf{Ugadi}, on \emph{Chaitra Śuddha Pādyami} — the same day as Kannada's Ugadi.)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch17-noon-and-midnight.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch17-noon-and-midnight.tex
@@ -1,0 +1,45 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:36b5b3c7a6c8324c
+% canonical-lessons: TE-C17-madhyaahnam-ardharaatri
+
+\chapter{Noon and Midnight}
+\label{ch:te-noon-and-midnight}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{మధ్యాహ్నం} \te{అర్ధరాత్రి}]{\te{మధ్యాహ్నం}, \te{అర్ధరాత్రి} — the same noon word, a different midnight word}
+
+\label{lesson:TE-C17-madhyaahnam-ardharaatri}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Telugu and Kannada share the exact same Sanskrit word for noon — but then quietly part ways on midnight.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\te{మధ్యాహ్నం}} (\emph{madhyāhnam}) = "\textbf{noon, midday}" — the same Sanskrit \emph{tatsama} compound as Kannada's \emph{madhyāhna}: \textbf{\te{మధ్య}} (\emph{madhya}, "\textbf{middle}") + \textbf{\te{అహ్న}} (\emph{ahna}, "\textbf{day}"), plus Telugu's own \textbf{-\te{ం}} (\emph{anusvāra}) ending. Same root, same meaning, same everyday register in both languages.
+\end{cousinweb}
+
+\begin{cousinweb}
+\textbf{\te{అర్ధరాత్రి}} (\emph{ardharātri}) = "\textbf{midnight}" — but here Telugu reaches for a \textbf{different} Sanskrit root: \textbf{\te{అర్ధ}} (\emph{ardha}, "\textbf{half}"), not \emph{madhya} ("middle"). Paired with \textbf{\te{రాత్రి}} (\emph{rātri}, "\textbf{night}"), it literally means "\textbf{half-night}" — structurally the same shape as Hindi's colloquial \emph{ādhī rāt} ("half night") and Latin's transparent \emph{media nox} pattern, but built from Sanskrit's own dedicated "half" word rather than "middle."
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: Be honest: two different "middle-ish" ideas, side by side}]
+Don't assume \emph{madhya} and \emph{ardha} are the same word wearing different clothes — they're genuinely \textbf{separate Sanskrit roots} ("middle" vs. "half") that happen to land on the same meaning here, the way English "midday" and "half the day gone" would both point at noon without sharing a root. Telugu's noon word keeps Kannada's "middle" logic; its midnight word switches to "half" logic instead.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "madhyāhnam" — noon, same root as Kannada{]}
+  \item {[}YOU SAY: "ardharātri" — midnight, literally "half-night"{]}
+  \item {[}YOU SAY: the contrast — "madhya" (middle) for noon, "ardha" (half) for midnight — two different Sanskrit roots{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Does Telugu's noon word match Kannada's? (\textbf{Yes} — both \emph{madhyāhna(m)}, from \emph{madhya}, "middle.") Does Telugu's midnight word use the same root? (\textbf{No} — \emph{ardharātri} uses \textbf{ardha}, "half," a different Sanskrit root.) What does \emph{ardharātri} literally mean? ("\textbf{Half-night}" — the same shape as Hindi's \emph{ādhī rāt}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch18-telling-time.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch18-telling-time.tex
@@ -1,0 +1,50 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:c703d071cc0d8e4b
+% canonical-lessons: TE-C18-ganta
+
+\chapter{Telling Time}
+\label{ch:te-telling-time}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{గంట}]{\te{గంట} — matching Kannada and Hindi's "bell" word exactly}
+
+\label{lesson:TE-C18-ganta}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Telugu completes a clean three-way match: Hindi, Kannada, and now Telugu all use the same Sanskrit "bell" word for "hour."
+\end{quote}
+
+\subsection*{You'll want to know: \te{గంట} — bell AND hour, a third time}
+\textbf{\te{గంట}} (\emph{ganṭa}) = "\textbf{hour}" — and, exactly like Hindi's \emph{ghanṭā} and Kannada's \emph{gaṇṭe}, it means "\textbf{bell, clapper}" just as commonly, from the same Sanskrit \textbf{\dv{घण्टा}} (\emph{ghaṇṭā}). Same word, same bell-strikes-the-hour logic, three languages in a row.
+
+\begin{culture}
+So on this concept, the split isn't "Hindi vs. all four Dravidian languages" — \textbf{Hindi, Kannada, and Telugu} all share the Sanskrit \emph{ghaṇṭā} ("bell") root. \textbf{Tamil} most likely goes its own way with a native Dravidian word instead (though even specialists don't call this fully settled). \textbf{Malayalam} is the genuinely surprising one: its cognate word, \emph{mani}, is ALSO Sanskrit-derived per its own dictionaries — just from a \textbf{different} Sanskrit word, \emph{maṇi} ("gem"), not \emph{ghaṇṭā}. So three of these four languages likely trace their hour-word to Sanskrit, just not all to the \emph{same} Sanskrit word — worth remembering that a Sanskrit/native split isn't fixed per language, and isn't always a clean binary either.
+\end{culture}
+
+\begin{grammarlens}[title={Grammar Lens: telling the time}]
+\begin{quote}
+\textbf{\te{ఒక} \te{గంట}.} — "One o'clock." (\emph{oka ganṭa}, "one hour/bell") \textbf{\te{రెండు} \te{గంటలు}.} — "Two o'clock." (\emph{reṇḍu ganṭalu} — \emph{ganṭa} takes its plural
+\end{quote}
+
+form, \emph{ganṭalu}, once the count passes one)
+
+Notice Telugu's \emph{ganṭa} pluralizes to \emph{ganṭalu} for "two o'clock" onward — a small grammatical wrinkle Kannada's \emph{gaṇṭe} didn't show you.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "ganṭa" — hour, also "bell"{]}
+  \item {[}YOU SAY: "oka ganṭa" — one o'clock{]}
+  \item {[}YOU SAY: "reṇḍu ganṭalu" — two o'clock, plural \emph{ganṭalu}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What Sanskrit word do \textbf{\te{గంట}}, Kannada's \emph{gaṇṭe}, and Hindi's \emph{ghanṭā} all share? (\textbf{\dv{घण्टा}}, \emph{ghaṇṭā}, "bell.") Which Dravidian language most likely does NOT use this Sanskrit word for "hour"? (\textbf{Tamil} — most likely a native Dravidian word instead.) Does Malayalam's cognate word skip Sanskrit entirely too? (\textbf{No} — it's Sanskrit-derived too, per its own dictionaries, just from a \emph{different} Sanskrit word, \emph{maṇi}, "gem.") What happens to \emph{ganṭa} for "two o'clock"? (It \textbf{pluralizes} to \emph{ganṭalu}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch19-age.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch19-age.tex
@@ -1,0 +1,53 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:ecd0a47d80ab2c07
+% canonical-lessons: TE-C19-vayasu
+
+\chapter{Asking Someone's Age}
+\label{ch:te-asking-age}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{నీ} \te{వయసెంత}?]{\te{నీ} \te{వయసెంత}? — matching Kannada's simple possessive exactly}
+
+\label{lesson:TE-C19-vayasu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Telugu matches Kannada closely here — same Sanskrit word, same verbless grammar, just fused together by ordinary Telugu vowel sandhi.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\te{వయస్సు}} (\emph{vayasu}) = "\textbf{age}" — the exact same Sanskrit \textbf{\dv{वयस्}} (\emph{vayas}, "age, vigor, strength," PIE cousin of Latin \textbf{vīs}) you just met in Kannada.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: fused by sandhi, still verbless}]
+\begin{quote}
+\textbf{\te{నీ} \te{వయసెంత}?} — "How old are you?" — literally "\textbf{your age how-much}?"
+\end{quote}
+
+(\emph{nī vayas-enta?} — from \emph{nī vayasu} + \emph{enta}, "how much," fused by regular vowel sandhi into \emph{vayasenta}.)
+
+\begin{quote}
+\textbf{\te{నా} \te{వయస్సు} \te{ఇరవై}.} — "I am twenty years old." — literally "\textbf{my age}
+\end{quote}
+
+{[}is{]} \textbf{twenty}." (\emph{nā vayasu iravai.})
+
+Same shape as Kannada: a plain possessive ("your/my age") sitting next to the number, \textbf{no verb at all}. The only wrinkle is surface-level: everyday spoken Telugu often \textbf{fuses} \emph{vayasu} + \emph{enta} into one word, \emph{vayasenta}, the same kind of vowel sandhi you'd see fusing any two Telugu words in fast speech — the underlying grammar is identical to Kannada's, just written closer together.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "vayasu" — age{]}
+  \item {[}YOU SAY: "nī vayasenta?" — how old are you?{]}
+  \item {[}YOU SAY: "nā vayasu iravai" — I am twenty, "my age {[}is{]} twenty"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Is Telugu's \textbf{\te{వయస్సు}} the same Sanskrit word as Kannada's \emph{vayassu}? (\textbf{Yes} — both from \emph{vayas}, PIE cousin of Latin \emph{vīs}.) What happens to \emph{vayasu} + \emph{enta} in "\emph{nī vayasenta}?"? (They \textbf{fuse} by ordinary vowel sandhi.) Does Telugu use a verb to state age, like Kannada? (\textbf{No} — same verbless possessive shape.)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch20-numbers-and-weather.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch20-numbers-and-weather.tex
@@ -1,0 +1,84 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:a7a00722b8910236
+% canonical-lessons: TE-C20-padakondu-iravai, TE-C20-vatavaranam
+
+\chapter{Numbers Eleven to Twenty and Weather}
+\label{ch:te-numbers-and-weather}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{పదకొండు} — \te{ఇరవై}]{\te{పదకొండు}, \te{ఇరవై} — the same pattern, worn down one step further}
+
+\label{lesson:TE-C20-padakondu-iravai}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You just watched Kannada's twenty split cleanly into "two" + "ten." Telugu most likely comes from the exact same pattern — but centuries of extra erosion have worn it past the point of being visible today.
+\end{quote}
+
+\begin{cousinweb}
+Telugu's teens echo \textbf{\te{పది}} (\emph{padi}, "\textbf{ten}") plus each digit — \textbf{\te{పదకొండు}} (\emph{padakoṇḍu}, 11), \textbf{\te{పన్నెండు}} (\emph{panneṇḍu}, 12), and onward through \textbf{\te{పందొమ్మిది}} (\emph{paṅdommidi}, 19) — the same "digit + ten-echo" compounding you just saw in Kannada.
+\end{cousinweb}
+
+\begin{cousinweb}
+\textbf{\te{ఇరవై}} (\emph{iravai}, "\textbf{twenty}") most likely continues the \textbf{same} pan-Dravidian pattern as Kannada's \emph{ippattu} — an old \textbf{*iru-}/\textbf{*renḍu} ("two") root fused with an old "ten" root — but here's the honest difference: centuries of sound change have worn \emph{iravai} down far enough that it no longer visibly splits into "two" and "ten" on the surface, the way Kannada's \emph{ippattu} still does today. Telugu's own word for "two," \textbf{\te{రెండు}} (\emph{renḍu}), doesn't obviously show up inside \emph{iravai} anymore — treat this as the most likely comparative-Dravidian account rather than a transparent, easily re-derivable compound.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "padakoṇḍu, panneṇḍu" — 11, 12{]}
+  \item {[}YOU SAY: "padi" — ten{]}
+  \item {[}YOU SAY: "iravai" — twenty, most likely the same "two-tens" idea as Kannada, just worn down further{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} How are Telugu's teens built? (\textbf{\te{పది}} (ten) + a digit, compounded.) Does \textbf{\te{ఇరవై}} visibly split into "two" + "ten" today, the way Kannada's \emph{ippattu} does? (\textbf{No} — it most likely continues the same pan-Dravidian pattern, but erosion has worn away the visible split.) What's Telugu's word for "two"? (\textbf{\te{రెండు}}, \emph{renḍu}.)
+\end{tcolorbox}
+\section[\te{వాతావరణం}]{\te{వాతావరణం} — "the covering of air," pure Sanskrit this time}
+
+\label{lesson:TE-C20-vatavaranam}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Kannada's weather word mixed a Persian loan with a Sanskrit one. Telugu's is different again — a single, unmixed Sanskrit compound.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\te{వాతావరణం}} (\emph{vātāvaraṇam}) = "\textbf{weather, atmosphere}" — built entirely from Sanskrit:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\te{వాత}} (\emph{vāta}, "\textbf{wind, air}") — the same Sanskrit root behind \textbf{\te{వాయువు}} (\emph{vāyuvu}, "wind," and the wind-god Vāyu).
+  \item \textbf{\te{ఆవరణ}} (\emph{āvaraṇa}, "\textbf{covering, layer, enclosure}").
+\end{itemize}
+
+So \emph{vātāvaraṇam} literally means "\textbf{the covering of air}" — the layer of air surrounding everything, i.e., the atmosphere/weather. Unlike Kannada's \emph{havāmāna} (Persian \emph{hava} + Sanskrit \emph{māna}), \textbf{both} pieces here are Sanskrit — no Perso-Arabic loan involved at all.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: \te{వర్షం} \te{పడుతోంది} — "rain is falling"}]
+\begin{quote}
+\textbf{\te{వర్షం} \te{పడుతోంది}.} — "It's raining." — literally "\textbf{rain is falling}."
+\end{quote}
+
+(\emph{varṣaṁ paḍutōndi.}) — \textbf{\te{వర్షం}} (\emph{varṣaṁ}, "rain") is the same Sanskrit root, \emph{varṣā}, you'll see again in the Dravidian arc.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "vātāvaraṇam" — weather, "the covering of air"{]}
+  \item {[}YOU SAY: "vāta" — wind/air, "āvaraṇa" — covering{]}
+  \item {[}YOU SAY: "varṣaṁ paḍutōndi" — it's raining, "rain is falling"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What are the two Sanskrit pieces of \textbf{\te{వాతావరణం}}, and what does the whole word literally mean? (\textbf{\te{వాత}}, "air," + \textbf{\te{ఆవరణ}}, "covering" — "\textbf{the covering of air}.") Is either piece a Persian/Arabic loan, like part of Kannada's word? (\textbf{No} — both pieces are Sanskrit.) What word does Telugu use for "rain"? (\textbf{\te{వర్షం}}, \emph{varṣaṁ}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch21-dog-and-cat.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch21-dog-and-cat.tex
@@ -1,0 +1,40 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:ac18c5895e380bad
+% canonical-lessons: TE-C21-kukka-pilli
+
+\chapter{Dog and Cat}
+\label{ch:te-dog-and-cat}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{కుక్క}, \te{పిల్లి}]{\te{కుక్క}, \te{పిల్లి} — the odd one out, and the word that most likely closes the loop}
+
+\label{lesson:TE-C21-kukka-pilli}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Kannada just gave you a rock-solid native dog-word. Telugu breaks from that pattern — but its cat-word may be the single most important word in this whole arc.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\te{కుక్క}} (\emph{kukka}, "\textbf{dog}") does \textbf{not} clearly continue the same \textbf{\te{నాయి}}-family root shared by Kannada, Malayalam, and Tamil. Its origin is honestly debated: some linguists propose it's \textbf{onomatopoeic}, imitating the sound of a bark; others propose a borrowing from \textbf{Sanskrit} \textbf{\dv{कुक्कुर}} (\emph{kukkura}, itself a similarly-shaped word for dog). Neither is settled — but either way, Telugu's everyday dog-word genuinely doesn't match its closest cousins.
+\end{cousinweb}
+
+\begin{cousinweb}
+\textbf{\te{పిల్లి}} (\emph{pilli}, "\textbf{cat}") is a real, documented \textbf{Proto-Dravidian} root, \emph{\textbf{*pillV}} — with cognates surviving as \textbf{rarer, alternate} words for cat in both Tamil and Kannada. Here's why this word matters for the \textbf{whole} arc: Sanskrit's word for cat, \textbf{\dv{बिडाल}} (\emph{biḍāla}) — the word behind Hindi's \textbf{\dv{बिल्ली}} (\emph{billī}), which you met as "most likely" borrowed from Dravidian, without a confirmed specific source — most likely traces back to \textbf{this exact root}. So Telugu's everyday word for "cat" is most likely the closest living relative of the very word Sanskrit borrowed, tying together Latin's \emph{cattus}/Arabic's \emph{qiṭṭ} story on one side and Hindi's \emph{billī} story on the other, all within this single course.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "kukka" — dog, genuinely different from its Dravidian cousins{]}
+  \item {[}YOU SAY: "pilli" — cat, most likely the source behind Hindi's billī{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Does \textbf{\te{కుక్క}} continue the same root as Kannada's \emph{nāyi}? (\textbf{No} — genuinely different, debated between onomatopoeia and a Sanskrit loan.) What is \textbf{\te{పిల్లి}} most likely the source of? (\textbf{Sanskrit's \dv{बिडाल}}, \emph{biḍāla} — and so Hindi's \textbf{\dv{बिल्ली}}, \emph{billī}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch22-green-and-yellow.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch22-green-and-yellow.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:07cbedbaa5b02653
+% canonical-lessons: TE-C22-pacha-pasupu
+
+\chapter{Green and Yellow}
+\label{ch:te-green-and-yellow}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{పచ్చ}, \te{పసుపు}]{\te{పచ్చ}, \te{పసుపు} — two colors, one Dravidian root}
+
+\label{lesson:TE-C22-pacha-pasupu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} In Kannada, green stayed native but yellow got borrowed from Sanskrit. Telugu tells a tighter story: its green word and its yellow word turn out to be \textbf{doublets of the same root}, wearing two different faces.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\te{పచ్చ}} (\textbf{pacca}, "\textbf{green}") comes from \textbf{Proto-Dravidian} \emph{\textbf{*pac-}} — the same root already behind Tamil's \textbf{\ta{பச்சை}} (\emph{paccai}) and Kannada's \textbf{\ka{ಹಸಿರು}} (\emph{hasiru}, via Old Kannada \emph{pasir}). No surprise here; this is the same pan-Dravidian green family from the last lesson.
+\end{cousinweb}
+
+\begin{cousinweb}
+\textbf{\te{పసుపు}} (\textbf{pasupu}, "\textbf{yellow, turmeric}") is, remarkably, \textbf{also} a direct descendant of that \textbf{same} Proto-Dravidian \emph{\textbf{*pac-}} root — a true \textbf{doublet} of \emph{pacca} itself, not a separate borrowing the way Kannada's \emph{haḷadi} was. Tamil even keeps a matching cognate, \textbf{\ta{பசுப்பு}} (\emph{pacuppu}), sitting alongside its own \emph{paccai}. So where Kannada split green and yellow into two unrelated families (native Dravidian vs. a Sanskrit turmeric-loan), Telugu kept \textbf{both} colors inside the same native word-family — \emph{pacca} and \emph{pasupu} are, at root, doublets of the same word, one settling on "green" and the other on "yellow, turmeric-colored."
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "\te{పచ్చ}" — green, from Proto-Dravidian \emph{pac-{]}}
+  \item {[}YOU SAY: "\te{పసుపు}" — yellow/turmeric, a true doublet of pacca, same root{]}
+  \item {[}YOU SAY: the contrast with Kannada — Telugu kept both colors in one native family; Kannada's yellow broke away as a Sanskrit loan{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Are \textbf{\te{పచ్చ}} and \textbf{\te{పసుపు}} two unrelated words, or doublets of the same root? (\textbf{Doublets} — both from Proto-Dravidian \emph{*pac-}.) Does Telugu's yellow word follow the same pattern as Kannada's \emph{haḷadi} (a Sanskrit loan)? (\textbf{No} — Telugu kept its yellow word native, unlike Kannada.) What Tamil word is \emph{pasupu}'s direct cognate? (\textbf{\ta{பசுப்பு}}, \emph{pacuppu}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch23-day.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch23-day.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:60f8859a49057808
+% canonical-lessons: TE-C23-roju
+
+\chapter{Day}
+\label{ch:te-day}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{రోజు}]{\te{రోజు} (rōju) — "day," a genuine Persian surprise}
+
+\label{lesson:TE-C23-roju}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You might expect Telugu's word for "day" to be Sanskrit, like Kannada's \emph{dina}, or native Dravidian. It's neither — it's Persian.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\te{రోజు}} (\textbf{rōju}) — "\textbf{day}" — is Telugu's everyday, ordinary word for "a day." Here's the real surprise: it's \textbf{borrowed from Classical Persian} \textbf{\ar{روز}} (\emph{rōz}) — the same root, ultimately, as the Persian day names hiding in words like "Nowruz" ("new day"). Persian \emph{rōz} itself traces to a Proto-Indo-European root, \emph{\textbf{*lewk-}} ("\textbf{bright}") — a \textbf{completely different} PIE root from the \emph{\textbf{*dyew-}} family behind Latin's \emph{diēs}, Hindi's \emph{din}, and Kannada's \emph{dina}. Both roots independently mean something like "shining, bright" — but they are \textbf{not} cousins; this is convergent meaning, not shared ancestry.
+\end{cousinweb}
+
+\begin{culture}
+Telugu also has \textbf{\te{దినము}} (\textbf{dinamu}) — the same Sanskrit \textbf{tatsama} word as Kannada's \emph{dina}. But here's the honest twist: unlike Kannada, where \emph{dina} is the plain, everyday word, Telugu's \textbf{\te{దినము}} is the more \textbf{formal, literary} alternate — \emph{rōju} does the everyday work instead. Telugu's formal/everyday split runs the \textbf{opposite direction} from Kannada's.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "rōju" — "day," a genuine Persian loanword{]}
+  \item {[}YOU SAY: the honest surprise — from Persian rōz, PIE \emph{lewk-, NOT the same root as diēs/din/dina{]}}
+  \item {[}YOU SAY: the reversed pattern — dinamu is Telugu's FORMAL word, unlike Kannada's plain dina{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What language does Telugu's everyday \textbf{\te{రోజు}} (\emph{rōju}) come from? (\textbf{Persian} — \emph{rōz}.) Is Persian \emph{rōz}'s PIE root the same as Latin \emph{diēs}/Hindi \emph{din}/Kannada \emph{dina}'s root? (\textbf{No} — a completely different PIE root, \emph{*lewk-}, "bright," vs. \emph{*dyew-} — related in meaning, not in ancestry.) Is Telugu's Sanskrit word, \emph{\te{దినము}} (\emph{dinamu}), the everyday word or the formal one? (\textbf{The formal one} — the opposite of Kannada, where \emph{dina} is plain and everyday.)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch24-night.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch24-night.tex
@@ -1,0 +1,50 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:1d1695f2caa824c8
+% canonical-lessons: TE-C24-ratri
+
+\chapter{Night}
+\label{ch:te-night}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{రాత్రి}]{\te{రాత్రి} (rātri) — "night," this time matching the expected pattern}
+
+\label{lesson:TE-C24-ratri}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Last lesson's \emph{rōju} broke every expectation. This one is more straightforward — but still worth checking honestly, not assuming.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\te{రాత్రి}} (\textbf{rātri}) — "\textbf{night}" — is a Sanskrit \textbf{tatsama} word, already hiding inside \textbf{\te{అర్ధరాత్రి}} (\emph{ardharātri}, "midnight," Chapter 17). Unlike \emph{rōju}'s Persian surprise, \emph{rātri} really \textbf{is} Telugu's ordinary, everyday word for "night" — matching Kannada's own pattern this time, not breaking it.
+\end{cousinweb}
+
+\begin{cousinweb}
+Telugu \textbf{does} have native words here — but be honest: it's a \textbf{messier} picture than Kannada's clean two-word story, not a tidy mirror of it.
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\te{రేయి}} (\textbf{rēyi}) — attested in older Telugu literature; most sources treat it as inherited Dravidian, though some grammars instead link it to \emph{rātri} itself, so its native status is less than fully settled.
+  \item \textbf{\te{మాపు}} (\textbf{māpu}) — its \textbf{primary} sense is actually "\textbf{evening, dusk}" (as in \textbf{\te{రేపుమాపు}}, "morning and evening"), with "night" only a secondary, extended sense — not a clean synonym for \emph{rātri}.
+  \item \textbf{\te{ఇరులు}} (\textbf{irulu}) — a genuine cognate of Kannada's \textbf{\ka{ಇರುಳು}} (\emph{iruḷu}), but its primary modern sense is "\textbf{darkness}," archaic even in that use.
+\end{itemize}
+
+All three have been effectively pushed aside by the Sanskrit loan — but unlike Kannada's single native competitor, Telugu's "native" side is split across three words in three different, overlapping senses.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "rātri" — "night," already met inside ardharātri{]}
+  \item {[}YOU SAY: rēyi, māpu, irulu — three native words, three overlapping senses, all pushed aside{]}
+  \item {[}YOU SAY: the contrast with last lesson — day broke the pattern, night matches it{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Where have you already met \textbf{\te{రాత్రి}} before this lesson? (\textbf{\te{అర్ధరాత్రి}}, \emph{ardharātri}, "midnight.") Does \emph{rātri} follow the same "Sanskrit-as-everyday" pattern as Kannada's \emph{rātri}, or does it break the pattern the way \emph{rōju} did for "day"? (\textbf{It matches} — \emph{rātri} really is Telugu's everyday word.) Does Telugu's native-word story cleanly mirror Kannada's single-word \emph{iruḷu}? (\textbf{No} — it's messier: three words, \textbf{\te{రేయి}}/\textbf{\te{మాపు}}/\textbf{\te{ఇరులు}}, in three overlapping senses, not one clean replacement.)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch25-good-night.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch25-good-night.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:889282df4447ea86
+% canonical-lessons: TE-C25-shubha-ratri
+
+\chapter{Good Night}
+\label{ch:te-good-night}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{శుభ} \te{రాత్రి}]{\te{శుభ} \te{రాత్రి} (śubha rātri) — the standard translation, honestly checked against real speech}
+
+\label{lesson:TE-C25-shubha-ratri}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You have both pieces already: \emph{rātri} from last lesson, and one more Sanskrit word. But this lesson's honest twist is about who actually says the result out loud.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\te{శుభ} \te{రాత్రి}} (\textbf{śubha rātri}) — "\textbf{good night}" — literally "\textbf{auspicious night}." Both pieces are Sanskrit \textbf{tatsama}: \textbf{\te{రాత్రి}} (\emph{rātri}, "night," already met) plus \textbf{\te{శుభ}} (\emph{śubha}, "\textbf{auspicious}," from root \textbf{śubh}, "to be beautiful," ultimately PIE \emph{\textbf{*ḱewb\textsuperscript{h}-}}).
+\end{cousinweb}
+
+\begin{culture}
+Here's a genuinely interesting wrinkle, hedged appropriately: some sources describe modern Telugu speakers, especially casually, often \textbf{code- switching to English} "\textbf{good night}" rather than saying \textbf{\te{శుభ} \te{రాత్రి}} aloud — treating it more as the standard written/dictionary translation than an everyday spoken phrase. Be careful with this claim, though: the evidence for it comes mainly from informal language-learning blogs and forum posts, not rigorous sociolinguistic sources, and the same "code-switch to English for casual farewells" pattern plausibly shows up across other South Asian languages too — it isn't clearly something unique to Telugu, just something the available sources happened to mention for Telugu specifically. Either way, \emph{śubha rātri} itself is perfectly correct and understood Telugu, whatever its actual spoken frequency turns out to be.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "śubha rātri" — "good night," literally "auspicious night"{]}
+  \item {[}YOU SAY: śubha's own root — śubh, "to be beautiful" $\to$ "auspicious"{]}
+  \item {[}YOU SAY: the honest twist — the standard translation, but many speakers code-switch to English instead{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \textbf{\te{శుభ} \te{రాత్రి}} literally mean? ("\textbf{Auspicious night}.") Is \emph{śubha rātri} actually the phrase most Telugu speakers say aloud for "good night"? (\textbf{Often not} — many code-switch to English "good night" in casual speech; \emph{śubha rātri} is the standard written/ formal translation.) Does this mean \emph{śubha rātri} is wrong or ungrammatical? (\textbf{No} — perfectly correct, just less commonly spoken than expected.)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch26-morning.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch26-morning.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:3874dddb892a5b58
+% canonical-lessons: TE-C26-udayam
+
+\chapter{Morning}
+\label{ch:te-morning}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{ఉదయం}]{\te{ఉదయం} (udayam) — the same Sanskrit root, a different job than in Kannada}
+
+\label{lesson:TE-C26-udayam}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Last lesson's \te{రోజు} was a genuine Persian surprise. This lesson's word for "morning" goes the other way — straight Sanskrit, doing double duty in a way its Kannada cousin doesn't.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\te{ఉదయం}} (\textbf{udayam}) — "\textbf{morning}" — is a Sanskrit \textbf{tatsama}: from \textbf{\te{ఉదయ}} (\emph{udaya}, "\textbf{rise, appearance}") plus Telugu's own \textbf{-\te{ము}} (\emph{-mu}) nominal suffix. This is Telugu's most common, general everyday word for "morning" — but be honest: it doesn't have the field entirely to itself. \textbf{\te{పొద్దు}}/\textbf{\te{పొద్దున}} (\emph{poddu}/\emph{podduna}) is genuine \textbf{Proto-Dravidian} vocabulary — cognate with Tamil \textbf{pozhudu} and Kannada \textbf{hottu} — and does real everyday work too ("\textbf{\te{పొద్దున్నే} \te{లేచాను}}," "I woke up in the morning"). \textbf{\te{వేకువ}} (\emph{vēkuva}, "dawn, early morning") is labeled \textbf{colloquial}, not archaic or purely poetic. \te{ఉదయం} is the broadest, most general word — but not an uncontested one.
+\end{cousinweb}
+
+\begin{culture}
+Here's the honest cross-language twist. Kannada also has this \textbf{exact} Sanskrit root, \textbf{\te{ఉదయ}} (\emph{udaya}) — but only inside its \textbf{greeting}, \textbf{\ka{ಶುಭೋದಯ}} (\emph{śubhōdaya}, "good morning"). Kannada's actual everyday \textbf{noun} for "morning" is a completely unrelated \textbf{native} word, \textbf{\ka{ಬೆಳಗ್ಗೆ}} (\emph{beḷagge}, "the shining"). Telugu doesn't split the job that way: \textbf{\te{ఉదయం}} covers both the everyday noun AND, in \textbf{\te{శుభోదయం}}, the greeting root — one word, doing what Kannada spreads across two unrelated ones. And unlike \textbf{\te{రోజు}} (last lesson's genuine Persian surprise for "day"), Telugu's morning word holds no such twist — straightforwardly Sanskrit, start to finish.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "udayam" — "morning," Sanskrit tatsama, the broadest word, though poddu/podduna and vēkuva are real native alternatives too{]}
+  \item {[}YOU SAY: the cross-language twist — Kannada's \te{ఉదయ} root only shows up in ITS greeting; Telugu uses \te{ఉదయం} for both the noun and the greeting{]}
+  \item {[}YOU SAY: the contrast with \te{రోజు} — no Persian surprise here, just straightforward Sanskrit{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Is \te{ఉదయం} the ONLY word Telugu speakers use for "morning"? (\textbf{No} — it's the broadest, most common one, but \te{పొద్దు}/\te{పొద్దున} and \te{వేకువ}, both genuinely native, do real everyday work too.) Does Kannada's everyday morning-noun share \te{ఉదయం}'s root? (\textbf{No} — Kannada's \ka{ಬೆಳಗ್ಗೆ} is native; the shared root, udaya, shows up only inside Kannada's GREETING, \ka{ಶುಭೋದಯ}.) Does \te{ఉదయం} hold a surprise the way \te{రోజు} did? (\textbf{No} — straightforwardly Sanskrit throughout.)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch27-evening.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch27-evening.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:504bda7b4b84a05c
+% canonical-lessons: TE-C27-sayantram
+
+\chapter{Evening}
+\label{ch:te-evening}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{సాయంత్రం}]{\te{సాయంత్రం} (sāyantram) — a distant cousin of French "soir"}
+
+\label{lesson:TE-C27-sayantram}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} This lesson's word for "evening" reaches back to a PIE root you've technically already met — in a completely different language, on a completely different continent's language family.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\te{సాయంత్రం}} (\textbf{sāyantram}) — "\textbf{evening}" — is a Sanskrit \textbf{tatsama}: from \textbf{\te{సాయం}} (\emph{sāyam}, "\textbf{in the evening}") plus a Sanskrit \textbf{-tana} suffix that turns time-adverbs into adjectives — the same suffix pattern behind Sanskrit \textbf{divātana} ("of the day") and \textbf{sanātana} ("eternal, lasting").
+\end{cousinweb}
+
+\begin{cousinweb}
+Here's the striking part, checked directly against primary sources rather than assumed: \textbf{\te{సాయం}} itself traces to \textbf{Proto-Indo-European} \emph{\textbf{*seh\textsubscript{1}-}} ("\textbf{long, lasting}") — and this is \textbf{explicitly} documented as "distantly related to \textbf{Latin sērus}" ("late"), itself confirmed independently to trace to the very same \emph{*seh\textsubscript{1}-} root (via Proto-Italic \emph{*sēros}). You've technically already met \emph{sērus}: it's the Latin root already established in this course as the source of \textbf{French soir} and \textbf{Italian sera} — French and Italian's own everyday "evening" words. That makes \textbf{\te{సాయంత్రం}} and \textbf{soir}/\textbf{sera} genuine distant cognates — one route through Sanskrit tatsama borrowing into Telugu, one route through centuries of Vulgar Latin erosion into French and Italian, both ultimately the same Proto-Indo-European idea of something "long, lasting" stretching into "late in the day."
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "sāyantram" — "evening," sāyam + the -tana time-suffix{]}
+  \item {[}YOU SAY: the deep root — PIE \emph{seh\textsubscript{1}-, "long, lasting"{]}}
+  \item {[}YOU SAY: the cross-family cognate — the same root behind French soir and Italian sera, via Latin sērus{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What is \te{సాయంత్రం} built from? (\textbf{\te{సాయం}}, "in the evening," + a Sanskrit "-tana" time-adjective suffix.) What PIE root does \te{సాయం} trace to? (\emph{\textbf{*seh\textsubscript{1}-}}, "long, lasting.") What two Romance words are genuine distant cognates of \te{సాయంత్రం}, and through which Latin word? (\textbf{French soir and Italian sera} — both through Latin \textbf{sērus}, "late," which traces to the same \emph{*seh\textsubscript{1}-} root.)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch28-afternoon.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch28-afternoon.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:7a9b4182b27fd1c7
+% canonical-lessons: TE-C28-madhyahnam-widened
+
+\chapter{Afternoon}
+\label{ch:te-afternoon}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{మధ్యాహ్నం}]{\te{మధ్యాహ్నం} — the same "noon" word, now also "afternoon"}
+
+\label{lesson:TE-C28-madhyahnam-widened}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You already know \te{మధ్యాహ్నం} means "noon" — precisely, "middle of the day." This lesson's honest twist: the word doesn't stay that precise in modern use.
+\end{quote}
+
+\begin{culture}
+\textbf{\te{మధ్యాహ్నం}} (\textbf{madhyāhnam}) is the exact word from Chapter 17, still literally "middle" + "day" — but a source fetched directly (not just a search summary) confirms it now covers "\textbf{the time between noon and evening}" in modern usage — a genuine widened sense, not just the precise midday instant its etymology points to. This mirrors what this course already found for Hindi's \textbf{\dv{दोपहर}} (clearly, well- confirmed widened from "noon" to "afternoon") and, more thinly, for Kannada's own \textbf{\te{మధ్యాహ్న}} (a hedged, single-source impression of the same kind of stretch).
+\end{culture}
+
+\begin{cousinweb}
+Telugu also has \textbf{\te{అపరాహ్నం}} (\textbf{aparāhnam}), from the same classical \textbf{five-part Sanskrit day division} already found behind Kannada's \textbf{\te{అపరాహ్న}} — \emph{prāta/udaya} (sunrise), \emph{saṅgava}, \emph{madhyāhna} (noon), \emph{aparāhna} ("later afternoon" specifically), \emph{sāyāhna} (evening). Be honest about the sourcing here, echoing the same hedge already applied to Kannada's \emph{aparāhna} in KA-C28: thin, informal evidence — a native-speaker forum discussion, general dictionary usage notes — points toward \textbf{\te{మధ్యాహ్నం} winning colloquially}, with \textbf{\te{అపరాహ్నం}} staying the more \textbf{formally precise} term. Real, but not corpus-linguistics-grade sourcing — treat it the same cautious way KA-C28 treated its own equivalent finding, not as fully settled.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "madhyāhnam" — the same word from Chapter 17, "middle of the day"{]}
+  \item {[}YOU SAY: the confirmed widening — now also covers "the time between noon and evening"{]}
+  \item {[}YOU SAY: "aparāhnam" — the more precise classical word for later afternoon, staying the more formal term per thin but real evidence{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Is \te{మధ్యాహ్నం} a new word, or the same one from Chapter 17? (\textbf{The same word} — "middle" + "day.") Does modern usage confirm \te{మధ్యాహ్నం} covers only the exact instant of noon? (\textbf{No} — a directly- fetched source confirms it now covers "the time between noon and evening" too.) Is it confirmed whether \te{అపరాహ్నం} or widened \te{మధ్యాహ్నం} is more common today? (\textbf{Thin but real evidence} points to \te{మధ్యాహ్నం} winning colloquially, \te{అపరాహ్నం} staying formally precise — not fully settled, but not silent either.)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch29-good-morning.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch29-good-morning.tex
@@ -1,0 +1,43 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:2a0449c46a95b7f2
+% canonical-lessons: TE-C29-subhodayam
+
+\chapter{Good Morning}
+\label{ch:te-good-morning}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{శుభోదయం}]{\te{శుభోదయం} (śubhōdayam) — a claim worth real skepticism, not a settled fact}
+
+\label{lesson:TE-C29-subhodayam}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You already have \te{ఉదయం}. This lesson's honest twist is about a dramatic-sounding claim — and about being skeptical of it, even though it came from a source fetched directly.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\te{శుభోదయం}} (\textbf{śubhōdayam}) — "\textbf{good morning}" — is built from \textbf{\te{శుభ}} ("good") plus \textbf{\te{ఉదయం}} (already met, Chapter 26). Grammatically and etymologically, this is the straightforward, traditional Telugu "good morning."
+\end{cousinweb}
+
+\begin{culture}
+Here's the twist, and the honesty this time cuts against the source itself: one directly-fetched page describes \textbf{\te{శుభోదయం}} as \textbf{out of trend}, displaced by \textbf{English} "good morning," with children taught the English phrase from \textbf{preschool}. That's a vivid, quotable claim — but "fetched directly" doesn't make a source authoritative. This is the \textbf{same genre} of Telugu/Kannada/Hindi-learning content blog already found \textbf{overstated} for Hindi's \dv{सुप्रभात} and Kannada's own \textbf{\ka{ಶುಭೋದಯ}} (a single uncredentialed listicle, no sociolinguistic methodology, no citations) — treat this claim the same skeptical way, not as settled.
+
+Genuinely worth separating from that dramatic claim: \textbf{\te{సుప్రభాతం}} (\emph{suprabhātam}) also exists — built on \textbf{\te{ప్రభాత}} (\emph{prabhāta}), a \textbf{completely different} Sanskrit root from \textbf{\te{ఉదయ}} (\emph{udaya}). This is \textbf{not} the same root behind Kannada's \textbf{\ka{ಶುಭೋದಯ}}, which itself uses \emph{udaya} — don't conflate the two Sanskrit "morning" roots. A third option, \textbf{\te{ప్రొద్దుటి} \te{వందనాలు}} ("morning greetings," built on \textbf{\te{పొద్దు}}, Chapter 26's genuine native competitor to \te{ఉదయం}), also exists but isn't confirmed common either. \textbf{\te{నమస్కారం}} is the safer bet for everyday use — matching the same \te{నమస్కార}/\dv{नमस्ते} pattern already found doing the real everyday work for both Kannada and Hindi.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "śubhōdayam" — "good morning," śubha + udayam{]}
+  \item {[}YOU SAY: the honest twist — one low-authority source claims it's out of trend, displaced by English; treat with real skepticism{]}
+  \item {[}YOU SAY: \te{నమస్కారం} — the safer everyday-greeting bet{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What is \te{శుభోదయం} built from? (\textbf{\te{శుభ}} + \textbf{\te{ఉదయం}}.) Is the claim that \te{శుభోదయం} has been displaced by English a confirmed, well-sourced fact? (\textbf{No} — it comes from one low-authority content-blog source, the same genre already found overstated for Hindi/Kannada; treat it skeptically, not as settled.) Does \te{సుప్రభాతం} share \te{ఉదయం}'s root, or Kannada's \ka{ಶುಭೋದಯ}'s root? (\textbf{Neither} — its own root, \te{ప్రభాత}/prabhāta, is a genuinely different Sanskrit word.)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch30-good-evening.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch30-good-evening.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:7adf548d83a059ec
+% canonical-lessons: TE-C30-subha-sayantram
+
+\chapter{Good Evening}
+\label{ch:te-good-evening}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{శుభ} \te{సాయంత్రం}]{\te{శుభ} \te{సాయంత్రం} (śubha sāyantram) — a claim that actually holds up on checking}
+
+\label{lesson:TE-C30-subha-sayantram}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Last lesson's morning greeting rested on one dramatic, shaky source. This one is different — and the difference itself is worth noticing.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\te{శుభ} \te{సాయంత్రం}} (\textbf{śubha sāyantram}) — "\textbf{good evening}" — pairs \textbf{\te{శుభ}} ("good") with \textbf{\te{సాయంత్రం}} (already met, Chapter 27 — the word whose PIE root, \emph{seh\textsubscript{1}-, turned out to be a genuine distant cognate of Latin's }sērus\emph{, and so of French \textbf{soir} and Italian \textbf{sera}).}
+\end{cousinweb}
+
+\begin{culture}
+Here's the honest contrast worth drawing explicitly: last lesson's \textbf{\te{శుభోదయం}} rested on \textbf{one} dramatic, low-authority source claiming it had been displaced by English entirely. This time, \textbf{two} independently fetched sources — not just search-engine summaries — \textbf{agree}: \textbf{\te{శుభ} \te{సాయంత్రం}} is genuinely, commonly used, in \textbf{both} formal and informal contexts, appropriate for greeting people after work or arriving at an evening gathering. Neither source flags it as archaic or displaced. This doesn't mean these sources are beyond question — they're still the same general genre of language-learning content that's needed hedging elsewhere in this arc — but \textbf{being independently cross-corroborated} is a real, meaningful difference in evidence quality from a single dramatic claim, and it's worth being just as honest about a claim holding up as about one that doesn't. \textbf{\te{నమస్కారం}}, as before, remains a genuine time-independent alternative — but nothing here suggests it has \textbf{displaced} this greeting the way English reportedly displaced \te{శుభోదయం}.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "śubha sāyantram" — "good evening," śubha + sāyantram{]}
+  \item {[}YOU SAY: the honest contrast — this claim is cross-corroborated by two sources, unlike last lesson's single dramatic one{]}
+  \item {[}YOU SAY: \te{నమస్కారం} — a time-independent alternative, not a replacement here{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What word does \te{శుభ} \te{సాయంత్రం} pair with, and what's that word's own striking cross-language story? (\textbf{\te{సాయంత్రం}} — a genuine distant PIE cognate of Latin sērus/French soir/Italian sera.) Is the "genuinely commonly used" claim for \te{శుభ} \te{సాయంత్రం} as thinly sourced as \te{శుభోదయం}'s "displaced by English" claim was? (\textbf{No} — two independent sources agree here, versus one dramatic claim last lesson — a real difference in evidence quality.)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/chapters/ch31-good-afternoon.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch31-good-afternoon.tex
@@ -1,0 +1,78 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:a513a10b0723cd15
+% canonical-lessons: TE-C31-subha-madhyahnam, TE-C31-subha-madhyahnam-register
+
+\chapter{Good Afternoon}
+\label{ch:te-good-afternoon}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\te{శుభ} \te{మధ్యాహ్నం}]{\te{శుభ} \te{మధ్యాహ్నం} (śubha madhyāhnam) — good afternoon}
+
+\label{lesson:TE-C31-subha-madhyahnam}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You already know \textbf{\te{శుభ}} from the morning and evening greetings and \textbf{\te{మధ్యాహ్నం}} from the parts-of-day lessons. Put them together.
+\end{quote}
+
+\subsection*{You'll want to know: \te{శుభ} + \te{మధ్యాహ్నం}}
+\textbf{\te{శుభ} \te{మధ్యాహ్నం}} (\textbf{śubha madhyāhnam}) means “\textbf{good afternoon}.” The second word originally centres on “midday” or “noon,” but you learned in Chapter 28 that modern use widens it into the stretch between noon and evening.
+
+Telugu could instead have built the phrase on \textbf{\te{అపరాహ్నం}} (\emph{aparāhnam}), the more classically precise word for later afternoon. It did not. Kannada made the same choice in \textbf{\ka{ಶುಭ} \ka{ಮಧ್ಯಾಹ್ನ}} (\emph{śubha madhyāhna}): both languages chose the everyday “noon, widened” word from two available classical terms.
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "śubha madhyāhnam" — "good afternoon," śubha + madhyāhnam{]}
+  \item {[}YOU SAY: the word choice — built on \te{మధ్యాహ్నం}, not \te{అపరాహ్నం}, matching Kannada's exact same choice{]}
+  \item {[}YOU SAY: Kannada \textbf{\ka{ಶುಭ} \ka{ಮಧ್ಯಾಹ್ನ}} — the same word-building choice{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Is \te{శుభ} \te{మధ్యాహ్నం} built on \te{మధ్యాహ్నం} or \te{అపరాహ్నం}? (\textbf{\te{మధ్యాహ్నం}} — the “noon, widened” word.) Which sister language made the same choice? (\textbf{Kannada}, in \ka{ಶುಭ} \ka{ಮಧ್ಯಾಹ್ನ}.)
+\end{tcolorbox}
+\section[\te{శుభ} \te{మధ్యాహ్నం} — register]{\te{శుభ} \te{మధ్యాహ్నం} — register and evidence}
+
+\label{lesson:TE-C31-subha-madhyahnam-register}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You can now build \textbf{\te{శుభ} \te{మధ్యాహ్నం}}. The next question is when it sounds natural—and how strongly the available evidence answers that question.
+\end{quote}
+
+\begin{culture}
+Two independently fetched language-learning sources confirm that \textbf{\te{శుభ} \te{మధ్యాహ్నం}} is a real, correctly formed greeting for \textbf{formal or workplace} use around noon and early afternoon.
+
+Keep the claims separate, though. Talkpal explicitly ranks the greeting as \textbf{less common} in everyday conversation than morning or evening greetings. Preply independently supports its timing and formal register, but does not make that frequency comparison. So there are two sources for “real and formal,” but only one for “less common.” A second source must not be counted as evidence for a claim it never made.
+\end{culture}
+
+\begin{culture}
+\begin{itemize}
+\raggedright
+  \item \textbf{\te{శుభోదయం}} — the morning lesson found one low-authority claim of displacement by English; treat that dramatic claim skeptically.
+  \item \textbf{\te{శుభ} \te{సాయంత్రం}} — two sources supported common formal and informal use.
+  \item \textbf{\te{శుభ} \te{మధ్యాహ్నం}} — real and workplace-timed, with narrower support for its lower everyday frequency.
+\end{itemize}
+
+The three phrases do not need one uniform usage story. For a time-independent everyday greeting, \textbf{\te{నమస్కారం}} remains the safer choice.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the two-source claim — real, formal, and workplace-timed{]}
+  \item {[}YOU SAY: the one-source claim — less common than morning or evening{]}
+  \item {[}YOU SAY: \te{నమస్కారం} — the time-independent everyday alternative{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Do both sources rank \te{శుభ} \te{మధ్యాహ్నం} as less common? (\textbf{No.} Both support its formal use; only Talkpal makes the frequency comparison.) What is the safer all-day greeting? (\textbf{\te{నమస్కారం}}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/telugu/book/preamble.tex
+++ b/code/learning/human-languages/telugu/book/preamble.tex
@@ -19,21 +19,34 @@
 \newunicodechar{ṟ}{\b{r}}
 \newunicodechar{ṁ}{\.{m}}
 \newunicodechar{ḻ}{\b{l}}
+\newunicodechar{ḱ}{\'{k}}
 
 \usepackage[table]{xcolor}
 \usepackage{tcolorbox}
 \tcbuselibrary{skins,breakable}
 \usepackage{booktabs}
 \usepackage{longtable}
+\usepackage{tabularx}
 \usepackage{array}
 \usepackage[hidelinks]{hyperref}
 \usepackage{titlesec}
 
 \usepackage{polyglossia}
 \setmainlanguage{english}
+\setotherlanguage{arabic}
 
 \newfontfamily\telugufont[Path=../../_fonts/, Script=Telugu]{NotoSansTelugu-Static.ttf}
 \newcommand{\te}[1]{{\telugufont #1}}
+\newfontfamily\tamilfont[Path=../../_fonts/, Script=Tamil]{NotoSansTamil-Static.ttf}
+\newcommand{\ta}[1]{{\tamilfont #1}}
+\newfontfamily\kannadafont[Path=../../_fonts/, Script=Kannada]{NotoSansKannada-Static.ttf}
+\newcommand{\ka}[1]{{\kannadafont #1}}
+\newfontfamily\malayalamfont[Path=../../_fonts/, Script=Malayalam]{NotoSansMalayalam-Static.ttf}
+\newcommand{\ml}[1]{{\malayalamfont #1}}
+\newfontfamily\devanagarifont[Path=../../_fonts/, Script=Devanagari]{NotoSansDevanagari-Static.ttf}
+\newcommand{\dv}[1]{{\devanagarifont #1}}
+\newfontfamily\arabicfont[Path=../../_fonts/, Script=Arabic]{NotoNaskhArabic-Static.ttf}
+\newcommand{\ar}[1]{\textarabic{#1}}
 
 \hypersetup{
   pdftitle={Telugu, Step by Step, Root by Root},
@@ -52,10 +65,10 @@
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
   fonttitle=\bfseries, title={Why it's said this way}
 }
-\newtcolorbox{grammarlens}{
+\newtcolorbox{grammarlens}[1][]{
   breakable, skin=enhanced, colback=blue!5, colframe=blue!35!black,
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
-  fonttitle=\bfseries, title={Grammar Lens}
+  fonttitle=\bfseries, title={Grammar Lens}, #1
 }
 \newtcolorbox{sounds}{
   breakable, skin=enhanced, colback=green!6, colframe=green!30!black,

--- a/code/learning/human-languages/telugu/lessons/TE-C06-dative-ku.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C06-dative-ku.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C06-dative-ku
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 310
 chapter: 6
 type: word
 headword: -కు
@@ -10,19 +13,33 @@ prerequisites: [TE-C05-practice, TE-C03-nenu, TE-C02-peru]
 sounds: [retroflex-contrast]
 roots: [dravidian-dative-ku]
 etymology_hook: "Dravidian marks case by ADDING a suffix that means one thing and stays visible at the seam — unlike Latin, where a fused ending like -īs carries case AND number AND declension together and doesn't even settle which case (dative or ablative); -ku is the shared Dravidian dative, cousin of Tamil -ukku, Kannada -ge, Malayalam -ikku"
-est_minutes: 4
+duration:
+  max_seconds: 290
+requires:
+  knowledge: []
+introduces:
+  knowledge: [TE-LEX-C06-DATIVE-KU-01, TE-GRAMMAR-C06-DATIVE-KU-02]
+practises:
+  knowledge: [TE-LEX-C06-DATIVE-KU-01, TE-GRAMMAR-C06-DATIVE-KU-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C03-nenu, TE-C02-peru, TE-C05-practice]
 ---
 
 # -కు (-ku) — "to, for"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Your first **case ending**. English puts "to" in **front** as its own
 word. Telugu sticks it on the **back** — and that difference is the biggest
 structural fact about the language.
 
-## Adding it on
+## You'll want to know: Adding it on
+<!-- hl-knowledge: introduces=[TE-LEX-C06-DATIVE-KU-01]; assesses=[] -->
 
 | word | + -ku | meaning |
 |---|---|---|
@@ -39,7 +56,8 @@ And with "I", which changes its body first:
 *Nēnu* becomes *nā-* before the ending. Nouns don't do this; they just take the
 suffix.
 
-## Why this matters
+## Grammar Lens: Why this matters
+<!-- hl-knowledge: introduces=[TE-GRAMMAR-C06-DATIVE-KU-02]; assesses=[] -->
 
 | | Telugu **-ku** | a Latin ending like **-īs** |
 |---|---|---|
@@ -57,6 +75,7 @@ That's what "**agglutinative**" means, and it's why Telugu words grow long witho
 growing hard: they are **built**, not memorised.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C06-DATIVE-KU-01, TE-GRAMMAR-C06-DATIVE-KU-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "*pēru* … *pēruku*"]
@@ -65,6 +84,7 @@ growing hard: they are **built**, not memorised.
 - [YOU SAY: the principle — "one suffix, one meaning, visible seam"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C06-DATIVE-KU-01, TE-GRAMMAR-C06-DATIVE-KU-02] -->
 
 [PAUSE 3s] What does **-కు** mean? ("**To**" or "**for**.") Where does it go? (**On
 the end** of the noun.) What is "to me"? (**నాకు** *nāku* — *nēnu* shrinks to *nā-*

--- a/code/learning/human-languages/telugu/lessons/TE-C06-dative-subject.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C06-dative-subject.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C06-dative-subject
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 320
 chapter: 6
 type: phrase
 headword: నాకు తెలుగు వచ్చు
@@ -10,19 +13,33 @@ prerequisites: [TE-C06-dative-ku, TE-C05-nenu-telugu-maatlaadataanu]
 sounds: [gemination-cc]
 roots: [dravidian-dative-ku]
 etymology_hook: "Telugu says knowing a language literally as 'to me it COMES' (vaccu, the verb already taught for 'come') — the experiencer goes in the dative because knowing happens TO you; the same dative-subject construction runs through Tamil, Kannada and Malayalam"
-est_minutes: 4
+duration:
+  max_seconds: 285
+requires:
+  knowledge: [TE-LEX-C06-DATIVE-KU-01, TE-GRAMMAR-C06-DATIVE-KU-02]
+introduces:
+  knowledge: [TE-LEX-C06-DATIVE-SUBJECT-01, TE-GRAMMAR-C06-DATIVE-SUBJECT-02, TE-ETYMON-C06-DATIVE-SUBJECT-03]
+practises:
+  knowledge: [TE-LEX-C06-DATIVE-KU-01, TE-GRAMMAR-C06-DATIVE-KU-02, TE-LEX-C06-DATIVE-SUBJECT-01, TE-GRAMMAR-C06-DATIVE-SUBJECT-02, TE-ETYMON-C06-DATIVE-SUBJECT-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C06-dative-ku, TE-C05-nenu-telugu-maatlaadataanu, TE-C04-vellu]
 ---
 
 # నాకు తెలుగు వచ్చు — "I know Telugu"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C06-DATIVE-KU-01, TE-GRAMMAR-C06-DATIVE-KU-02] -->
 
 [PAUSE 2s] Chapter 5 gave you **నేను తెలుగు మాట్లాడతాను** — "**I** speak Telugu."
 Now say "I **know** Telugu." Telugu won't let you use *nēnu* — and the verb it
 uses instead will surprise you.
 
-## The sentence
+## You'll want to know: The sentence
+<!-- hl-knowledge: introduces=[TE-LEX-C06-DATIVE-SUBJECT-01]; assesses=[] -->
 
 > **నాకు తెలుగు వచ్చు.**
 > *nāku telugu vaccu.*
@@ -38,7 +55,8 @@ Two things at once. **You are not the subject** — *nēnu* is gone, moved into 
 dative, and what's left unmarked is *telugu*. And the verb is literally "**to
 come**": a language you know is a thing that **comes to you**.
 
-## Why: things that happen *to* you
+## Grammar Lens: Why: things that happen *to* you
+<!-- hl-knowledge: introduces=[TE-GRAMMAR-C06-DATIVE-SUBJECT-02]; assesses=[] -->
 
 Telugu sorts experiences from actions. Speaking is something you **do**, so Ch. 5
 used *nēnu*. But knowing, liking, wanting, being hungry — these **arrive** at you.
@@ -53,7 +71,8 @@ Telugu marks that by putting the person in the **dative**.
 English keeps one fossil of exactly this: "**methinks**" — *me* is a dative, "it
 seems **to me**." Telugu made it the rule.
 
-## All four sisters do it
+## The word, taken apart - All four sisters do it
+<!-- hl-knowledge: introduces=[TE-ETYMON-C06-DATIVE-SUBJECT-03]; assesses=[] -->
 
 | language | "I know [the language]" | the dative |
 |---|---|---|
@@ -67,6 +86,7 @@ One construction across four languages, with four suffixes that are visibly the
 bones, just as *blanc/bianco/branco* did for Romance.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C06-DATIVE-KU-01, TE-GRAMMAR-C06-DATIVE-KU-02, TE-LEX-C06-DATIVE-SUBJECT-01, TE-GRAMMAR-C06-DATIVE-SUBJECT-02, TE-ETYMON-C06-DATIVE-SUBJECT-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "*nāku telugu vaccu*"]
@@ -75,6 +95,7 @@ bones, just as *blanc/bianco/branco* did for Romance.
 - [YOU SAY: the four cousins — "*-ku · -ukku · -ge · -ikku*"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C06-DATIVE-KU-01, TE-GRAMMAR-C06-DATIVE-KU-02, TE-LEX-C06-DATIVE-SUBJECT-01, TE-GRAMMAR-C06-DATIVE-SUBJECT-02, TE-ETYMON-C06-DATIVE-SUBJECT-03] -->
 
 [PAUSE 3s] What does **నాకు తెలుగు వచ్చు** literally say? ("**To-me** Telugu
 **comes**.") Which verb is doing the work, and where did you meet it? (**వచ్చు**

--- a/code/learning/human-languages/telugu/lessons/TE-C07-numbers-1-5.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C07-numbers-1-5.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C07-numbers-1-5
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 330
 chapter: 7
 type: word
 headword: ఒకటి రెండు మూడు నాలుగు ఐదు
@@ -9,18 +12,32 @@ prerequisites: [TE-C01-namaskaram]
 sounds: [telugu-inherent-a, retroflex-series, telugu-u-ending]
 roots: [proto-dravidian-numbers]
 etymology_hook: "Telugu shares the family's 2–5 (iraṇṭu ↔ reṇḍu) but strikes out alone on ONE — okaṭi, not oṉṟu/ondu/onnu"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [TE-LEX-C07-NUMBERS-1-5-01, TE-ETYMON-C07-NUMBERS-1-5-02, TE-SCRIPT-C07-NUMBERS-1-5-03]
+practises:
+  knowledge: [TE-LEX-C07-NUMBERS-1-5-01, TE-ETYMON-C07-NUMBERS-1-5-02, TE-SCRIPT-C07-NUMBERS-1-5-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C01-namaskaram]
 ---
 
 # ఒకటి, రెండు, మూడు, నాలుగు, ఐదు — one to five
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Four of these five are old Dravidian friends. The very first one is
 Telugu going its own way.
 
-## The five
+## You'll want to know: The five
+<!-- hl-knowledge: introduces=[TE-LEX-C07-NUMBERS-1-5-01]; assesses=[] -->
 
 | | numeral | word | said |
 |---|---|---|---|
@@ -32,7 +49,8 @@ Telugu going its own way.
 
 The symbols **౧ ౨ ౩ ౪ ౫** are Telugu's own digits.
 
-## The odd one, then the family
+## The word, taken apart - The odd one, then the family
+<!-- hl-knowledge: introduces=[TE-ETYMON-C07-NUMBERS-1-5-02]; assesses=[] -->
 
 **One** is where Telugu leaves the family. Its cousins agree — Tamil *oṉṟu*,
 Kannada *ondu*, Malayalam *onnu*, all from an old *oṉ-* — but Telugu says
@@ -51,13 +69,15 @@ From two onward, the family closes ranks again:
 *Reṇḍu* has simply dropped the opening vowel of *iraṇṭu*; *mūḍu* is *mūṉṟu* with
 its cluster smoothed to a single **ḍ**. Same numbers, a Telugu polish.
 
-## A Telugu shape to notice
+## Script you'll notice: A Telugu shape to notice
+<!-- hl-knowledge: introduces=[TE-SCRIPT-C07-NUMBERS-1-5-03]; assesses=[] -->
 
 Nearly every Telugu word here ends in **‑u** (*reṇḍu, mūḍu, nālugu*) — the
 language's strong preference for open, vowel-final syllables. Even where Tamil
 ends hard, Telugu tends to round the word off with a vowel.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C07-NUMBERS-1-5-01, TE-ETYMON-C07-NUMBERS-1-5-02, TE-SCRIPT-C07-NUMBERS-1-5-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "okaṭi, reṇḍu, mūḍu, nālugu, aidu"]
@@ -65,6 +85,7 @@ ends hard, Telugu tends to round the word off with a vowel.
 - [YOU SAY: the family — "iraṇṭu → reṇḍu", the opening vowel dropped]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C07-NUMBERS-1-5-01, TE-ETYMON-C07-NUMBERS-1-5-02, TE-SCRIPT-C07-NUMBERS-1-5-03] -->
 
 [PAUSE 3s] Count to five in Telugu. (*Okaṭi, reṇḍu, mūḍu, nālugu, aidu*.) Which
 number does Telugu form unlike the rest of the family, and what do the others

--- a/code/learning/human-languages/telugu/lessons/TE-C07-numbers-6-10.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C07-numbers-6-10.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C07-numbers-6-10
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 340
 chapter: 7
 type: word
 headword: ఆరు ఏడు ఎనిమిది తొమ్మిది పది
@@ -9,18 +12,32 @@ prerequisites: [TE-C07-numbers-1-5]
 sounds: [telugu-inherent-a, retroflex-da, telugu-u-ending]
 roots: [proto-dravidian-numbers]
 etymology_hook: "eight and nine — enimidi, tommidi — you can't derive from Tamil's eṭṭu/oṉpatu; seven ēḍu shows Telugu's ḻ→ḍ"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TE-LEX-C07-NUMBERS-1-5-01, TE-ETYMON-C07-NUMBERS-1-5-02, TE-SCRIPT-C07-NUMBERS-1-5-03]
+introduces:
+  knowledge: [TE-LEX-C07-NUMBERS-6-10-01, TE-ETYMON-C07-NUMBERS-6-10-02, TE-ETYMON-C07-NUMBERS-6-10-03]
+practises:
+  knowledge: [TE-LEX-C07-NUMBERS-1-5-01, TE-ETYMON-C07-NUMBERS-1-5-02, TE-SCRIPT-C07-NUMBERS-1-5-03, TE-LEX-C07-NUMBERS-6-10-01, TE-ETYMON-C07-NUMBERS-6-10-02, TE-ETYMON-C07-NUMBERS-6-10-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C07-numbers-1-5]
 ---
 
 # ఆరు, ఏడు, ఎనిమిది, తొమ్మిది, పది — six to ten
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C07-NUMBERS-1-5-01, TE-ETYMON-C07-NUMBERS-1-5-02, TE-SCRIPT-C07-NUMBERS-1-5-03] -->
 
 [PAUSE 2s] The top of the count is where Telugu is least like its cousins — two
 of these you simply learn on their own.
 
-## The five
+## You'll want to know: The five
+<!-- hl-knowledge: introduces=[TE-LEX-C07-NUMBERS-6-10-01]; assesses=[] -->
 
 | | numeral | word | said |
 |---|---|---|---|
@@ -30,14 +47,16 @@ of these you simply learn on their own.
 | 9 | **౯** | **తొమ్మిది** | *tommidi* |
 | 10 | **౧౦** | **పది** | *padi* |
 
-## Seven, and a lost sound
+## The word, taken apart - Seven, and a lost sound
+<!-- hl-knowledge: introduces=[TE-ETYMON-C07-NUMBERS-6-10-02]; assesses=[] -->
 
 Six is an easy cousin (Tamil *āṟu* → Telugu *āru*). **Seven** is more
 interesting: Tamil *ēḻu* carries the rare **ḻ** (the *zh* of *Tamiḻ*); Kannada
 hardened it to **ḷ** (*ēḷu*); **Telugu went further still** and turned it into a
 plain **ḍ** — *ēḍu*. One inherited sound, three fates across the three scripts.
 
-## Eight and nine strike out alone
+## The word, taken apart - Eight and nine strike out alone
+<!-- hl-knowledge: introduces=[TE-ETYMON-C07-NUMBERS-6-10-03]; assesses=[] -->
 
 Here Telugu strays furthest from its cousins —
 
@@ -56,6 +75,7 @@ of the *pat‑* in Tamil *pattu* (and the *‑patu* hiding inside *tommidi* and
 Tamil *oṉpatu*, "one-to-ten").
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C07-NUMBERS-1-5-01, TE-ETYMON-C07-NUMBERS-1-5-02, TE-SCRIPT-C07-NUMBERS-1-5-03, TE-LEX-C07-NUMBERS-6-10-01, TE-ETYMON-C07-NUMBERS-6-10-02, TE-ETYMON-C07-NUMBERS-6-10-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "āru, ēḍu, enimidi, tommidi, padi"]
@@ -63,6 +83,7 @@ Tamil *oṉpatu*, "one-to-ten").
 - [YOU SAY: the two you learn fresh — "enimidi, tommidi"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C07-NUMBERS-1-5-01, TE-ETYMON-C07-NUMBERS-1-5-02, TE-SCRIPT-C07-NUMBERS-1-5-03, TE-LEX-C07-NUMBERS-6-10-01, TE-ETYMON-C07-NUMBERS-6-10-02, TE-ETYMON-C07-NUMBERS-6-10-03] -->
 
 [PAUSE 3s] Count six to ten in Telugu. (*Āru, ēḍu, enimidi, tommidi, padi*.)
 What became of Tamil's **ḻ** (in *ēḻu*) by the time it reached Telugu *ēḍu*? (It

--- a/code/learning/human-languages/telugu/lessons/TE-C08-dayachesi.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C08-dayachesi.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C08-dayachesi
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 350
 chapter: 8
 type: word
 headword: దయచేసి
@@ -9,18 +12,32 @@ prerequisites: [TE-C01-avunu]
 sounds: [telugu-vowel-sign-ee, telugu-vowel-sign-i, telugu-ca]
 roots: [daya-compassion]
 etymology_hook: "దయచేసి = 'having done compassion' — Telugu asks please with daya, like Tamil, Kannada, Arabic faḍl and Hindi kṛpā"
-est_minutes: 4
+duration:
+  max_seconds: 255
+requires:
+  knowledge: []
+introduces:
+  knowledge: [TE-LEX-C08-DAYACHESI-01, TE-ETYMON-C08-DAYACHESI-02, TE-PRAGMATICS-C08-DAYACHESI-03, TE-SCRIPT-C08-DAYACHESI-04]
+practises:
+  knowledge: [TE-LEX-C08-DAYACHESI-01, TE-ETYMON-C08-DAYACHESI-02, TE-PRAGMATICS-C08-DAYACHESI-03, TE-SCRIPT-C08-DAYACHESI-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: polite
+variety: standard-colloquial
 reviews_of: [TE-C01-avunu]
 ---
 
 # దయచేసి (dayacēsi) — please (having done compassion)
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Telugu's "please" carries a whole small sentence inside it: "having
 **done** (me) a compassion."
 
-## The word
+## You'll want to know: The word
+<!-- hl-knowledge: introduces=[TE-LEX-C08-DAYACHESI-01]; assesses=[] -->
 
 **దయచేసి** = **please**, literally "**having done kindness / compassion**." Two
 pieces:
@@ -36,7 +53,8 @@ It is the twin of **Tamil** *tayavu seytu* ("**do** the kindness") — both use 
 compassion"). Further off, **Arabic** *min faḍlik* ("from your **grace**") and
 **Hindi** *kṛpayā* (from *kṛpā*, "**compassion**") ask in the very same spirit.
 
-## The Dravidian family, side by side
+## The word, taken apart - The Dravidian family, side by side
+<!-- hl-knowledge: introduces=[TE-ETYMON-C08-DAYACHESI-02]; assesses=[] -->
 
 **daya** + a light verb, four ways:
 
@@ -45,14 +63,16 @@ compassion"). Further off, **Arabic** *min faḍlik* ("from your **grace**") and
 - Kannada **ದಯವಿಟ್ಟು** *daya**viṭṭu*** — compassion **+ having placed**
 - Malayalam **ദയവായി** *daya**vāyi*** — compassion **+ as / having become**
 
-## Be honest about how it's used
+## Why it's said this way: Be honest about how it's used
+<!-- hl-knowledge: introduces=[TE-PRAGMATICS-C08-DAYACHESI-03]; assesses=[] -->
 
 Honestly: the standalone word is somewhat **formal / emphatic**. Day-to-day,
 Telugu politeness rides on the **respectful command** ending **‑ండి** (*-aṇḍi*):
 **కూర్చోండి** (*kūrcōṇḍi*) "please sit," **చెప్పండి** (*ceppaṇḍi*) "please tell me."
 That *-aṇḍi* is already "please." Put **దయచేసి** in front to warm it further.
 
-## Sound & structure point
+## Script you'll notice: Sound & structure point
+<!-- hl-knowledge: introduces=[TE-SCRIPT-C08-DAYACHESI-04]; assesses=[] -->
 
 The middle syllable **చే** is *ca* wearing the **long‑ē** sign **‑ే** (the
 counterpart of the short‑e sign **‑ె**), giving *cē*; then **సి** is *sa* + the
@@ -61,6 +81,7 @@ vowel's length and quality by the little sign riding on the consonant — the
 consonant stays put, the vowel-sign changes the tune.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C08-DAYACHESI-01, TE-ETYMON-C08-DAYACHESI-02, TE-PRAGMATICS-C08-DAYACHESI-03, TE-SCRIPT-C08-DAYACHESI-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "daya" — compassion — then "cēsi," having done]
@@ -68,6 +89,7 @@ consonant stays put, the vowel-sign changes the tune.
 - [YOU SAY: the everyday way — the verb ending: "kūrcōṇḍi" = please sit]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C08-DAYACHESI-01, TE-ETYMON-C08-DAYACHESI-02, TE-PRAGMATICS-C08-DAYACHESI-03, TE-SCRIPT-C08-DAYACHESI-04] -->
 
 [PAUSE 3s] What is the Telugu word for please? (**దయచేసి** *dayacēsi*.) What do
 its pieces mean? ("**Compassion**" *daya* + "**having done**" *cēsi*.) Which

--- a/code/learning/human-languages/telugu/lessons/TE-C09-kshaminchandi.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C09-kshaminchandi.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C09-kshaminchandi
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 360
 chapter: 9
 type: word
 headword: క్షమించండి
@@ -9,19 +12,33 @@ prerequisites: [TE-C08-dayachesi]
 sounds: [telugu-conjunct-kssa, telugu-anusvara]
 roots: [kshama-sanskrit]
 etymology_hook: "క్షమించండి kṣamin̄caṇḍi ← Sanskrit kṣamā 'forgiveness' + Telugu verb-making -in̄cu + the SAME respectful -aṇḍi ending from దయచేసి...ండి"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TE-LEX-C08-DAYACHESI-01, TE-ETYMON-C08-DAYACHESI-02, TE-PRAGMATICS-C08-DAYACHESI-03, TE-SCRIPT-C08-DAYACHESI-04]
+introduces:
+  knowledge: [TE-ETYMON-C09-KSHAMINCHANDI-01, TE-ETYMON-C09-KSHAMINCHANDI-02, TE-PRAGMATICS-C09-KSHAMINCHANDI-03]
+practises:
+  knowledge: [TE-LEX-C08-DAYACHESI-01, TE-ETYMON-C08-DAYACHESI-02, TE-PRAGMATICS-C08-DAYACHESI-03, TE-SCRIPT-C08-DAYACHESI-04, TE-ETYMON-C09-KSHAMINCHANDI-01, TE-ETYMON-C09-KSHAMINCHANDI-02, TE-PRAGMATICS-C09-KSHAMINCHANDI-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: polite-repair
+variety: standard-colloquial
 reviews_of: [TE-C08-dayachesi]
 ---
 
 # క్షమించండి (kṣamin̄caṇḍi) — please forgive / sorry
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C08-DAYACHESI-01, TE-ETYMON-C08-DAYACHESI-02, TE-PRAGMATICS-C08-DAYACHESI-03, TE-SCRIPT-C08-DAYACHESI-04] -->
 
 [PAUSE 2s] You already know **దయచేసి** and its respectful **‑ండి** ending
 (*kūrcōṇḍi*, "please sit"). Telugu's "sorry" hands you that very ending
 again, riding a brand-new verb.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[TE-ETYMON-C09-KSHAMINCHANDI-01]; assesses=[] -->
 
 - **క్షమా** (*kṣamā*) = "**forgiveness, patience**" — the Sanskrit noun,
   borrowed whole.
@@ -34,7 +51,8 @@ again, riding a brand-new verb.
 So **క్షమించండి** is "**please forgive**" — the same polite mold you already
 know, filled with a new verb.
 
-## The Dravidian family, side by side
+## The word, taken apart - The Dravidian family, side by side
+<!-- hl-knowledge: introduces=[TE-ETYMON-C09-KSHAMINCHANDI-02]; assesses=[] -->
 
 - Telugu **క్షమించండి** *kṣamin̄**caṇḍi*** — Sanskrit *kṣamā* + **‑in̄cu**
   (verb) + **‑aṇḍi** (imperative)
@@ -45,13 +63,15 @@ know, filled with a new verb.
 - Tamil **மன்னிக்கவும்** *maṉṉi**kkavum*** — its **own** native root *maṉṉi*,
   not Sanskrit at all
 
-## Be honest about how it's used
+## Why it's said this way: Be honest about how it's used
+<!-- hl-knowledge: introduces=[TE-PRAGMATICS-C09-KSHAMINCHANDI-03]; assesses=[] -->
 
 **క్షమించండి** is a real, everyday "sorry / please forgive me" — not
 stiffly formal — though in quick, casual exchanges Telugu speakers just as
 often reach for the borrowed English **"sorry."**
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C08-DAYACHESI-01, TE-ETYMON-C08-DAYACHESI-02, TE-PRAGMATICS-C08-DAYACHESI-03, TE-SCRIPT-C08-DAYACHESI-04, TE-ETYMON-C09-KSHAMINCHANDI-01, TE-ETYMON-C09-KSHAMINCHANDI-02, TE-PRAGMATICS-C09-KSHAMINCHANDI-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "kṣamā" — the Sanskrit noun, forgiveness]
@@ -60,6 +80,7 @@ often reach for the borrowed English **"sorry."**
 - [YOU SAY: the ending you already know — "‑aṇḍi," same as kūrcōṇḍi]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C08-DAYACHESI-01, TE-ETYMON-C08-DAYACHESI-02, TE-PRAGMATICS-C08-DAYACHESI-03, TE-SCRIPT-C08-DAYACHESI-04, TE-ETYMON-C09-KSHAMINCHANDI-01, TE-ETYMON-C09-KSHAMINCHANDI-02, TE-PRAGMATICS-C09-KSHAMINCHANDI-03] -->
 
 [PAUSE 3s] What is **క్షమించండి** built from? (**Sanskrit kṣamā** +
 the verb-making suffix **‑in̄cu** + the respectful ending **‑aṇḍi**, which you

--- a/code/learning/human-languages/telugu/lessons/TE-C10-vaaram.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C10-vaaram.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C10-vaaram
+spine_node: SPINE-TIME-OF-DAY
+sequence: 370
 chapter: 10
 type: word
 headword: సోమవారం మంగళవారం బుధవారం గురువారం శుక్రవారం శనివారం ఆదివారం
@@ -9,18 +12,32 @@ prerequisites: [TE-C09-kshaminchandi]
 sounds: [telugu-anusvara, telugu-conjunct-kra]
 roots: [sanskrit-planet-words]
 etymology_hook: "Telugu's week is Sanskritic like Hindi's, but Sunday is Ādivāram — 'the FIRST day' (Sanskrit ādi 'beginning'), not a sun-name at all"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TE-ETYMON-C09-KSHAMINCHANDI-01, TE-ETYMON-C09-KSHAMINCHANDI-02, TE-PRAGMATICS-C09-KSHAMINCHANDI-03]
+introduces:
+  knowledge: [TE-ETYMON-C10-VAARAM-01, TE-PRAGMATICS-C10-VAARAM-02]
+practises:
+  knowledge: [TE-ETYMON-C09-KSHAMINCHANDI-01, TE-ETYMON-C09-KSHAMINCHANDI-02, TE-PRAGMATICS-C09-KSHAMINCHANDI-03, TE-ETYMON-C10-VAARAM-01, TE-PRAGMATICS-C10-VAARAM-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C09-kshaminchandi]
 ---
 
 # సోమవారం to ఆదివారం — Telugu's week, with a twist on Sunday
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C09-KSHAMINCHANDI-01, TE-ETYMON-C09-KSHAMINCHANDI-02, TE-PRAGMATICS-C09-KSHAMINCHANDI-03] -->
 
 [PAUSE 2s] Like Kannada, Telugu's week runs on Sanskrit deity-names — but its
 Sunday breaks the "planet" pattern entirely, in a way even Kannada's doesn't.
 
-## The pattern: [deity] + వారం, "day"
+## The word, taken apart - The pattern: [deity] + వారం, "day"
+<!-- hl-knowledge: introduces=[TE-ETYMON-C10-VAARAM-01]; assesses=[] -->
 
 | Telugu | deity/planet | day |
 |---|---|---|
@@ -32,7 +49,8 @@ Sunday breaks the "planet" pattern entirely, in a way even Kannada's doesn't.
 | **శనివారం** (*Śanivāram*) | **Saturn** (Śani) | Saturday |
 | **ఆదివారం** (*Ādivāram*) | — not a planet at all | Sunday |
 
-## Be honest: Sunday isn't a planet-name here
+## Why it's said this way: Be honest: Sunday isn't a planet-name here
+<!-- hl-knowledge: introduces=[TE-PRAGMATICS-C10-VAARAM-02]; assesses=[] -->
 
 Five days match the familiar planet-deity pattern — but **ఆదివారం**
 (*Ādivāram*) doesn't name the Sun at all. **ఆది** (*ādi*) is Sanskrit for
@@ -42,6 +60,7 @@ sitting right next to six planet-names that don't work that way. Even within
 one single week, a language can mix completely different naming strategies.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C09-KSHAMINCHANDI-01, TE-ETYMON-C09-KSHAMINCHANDI-02, TE-PRAGMATICS-C09-KSHAMINCHANDI-03, TE-ETYMON-C10-VAARAM-01, TE-PRAGMATICS-C10-VAARAM-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "Somavāram, Maṅgaḷavāram, Budhavāram, Guruvāram, Śukravāram,
@@ -51,6 +70,7 @@ one single week, a language can mix completely different naming strategies.
   positional too]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C09-KSHAMINCHANDI-01, TE-ETYMON-C09-KSHAMINCHANDI-02, TE-PRAGMATICS-C09-KSHAMINCHANDI-03, TE-ETYMON-C10-VAARAM-01, TE-PRAGMATICS-C10-VAARAM-02] -->
 
 [PAUSE 3s] What does **ఆదివారం** literally mean, and is it a planet-name?
 (**"The first day"** — **ādi** "beginning" — **not** a planet-name, unlike

--- a/code/learning/human-languages/telugu/lessons/TE-C11-rangulu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C11-rangulu.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C11-rangulu
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 380
 chapter: 11
 type: word
 headword: నలుపు తెలుపు ఎరుపు నీలం
@@ -9,25 +12,40 @@ prerequisites: [TE-C10-vaaram]
 sounds: [telugu-anusvara, telugu-short-vowels]
 roots: [dravidian-native-colors, sanskrit-nila]
 etymology_hook: "నలుపు/తెలుపు/ఎరుపు (black/white/red) are native Dravidian, matching a pattern across all four languages — నీలం (blue) closes the set as the one shared Sanskrit loan, everywhere"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TE-ETYMON-C10-VAARAM-01, TE-PRAGMATICS-C10-VAARAM-02]
+introduces:
+  knowledge: [TE-LEX-C11-RANGULU-01, TE-ETYMON-C11-RANGULU-02]
+practises:
+  knowledge: [TE-ETYMON-C10-VAARAM-01, TE-PRAGMATICS-C10-VAARAM-02, TE-LEX-C11-RANGULU-01, TE-ETYMON-C11-RANGULU-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C10-vaaram]
 ---
 
 # నలుపు, తెలుపు, ఎరుపు, నీలం — the pattern completes itself
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C10-VAARAM-01, TE-PRAGMATICS-C10-VAARAM-02] -->
 
 [PAUSE 2s] By now the shape should feel familiar: native colors for black,
 white, and red — and one shared Sanskrit word for blue. Telugu confirms it a
 fourth time.
 
-## Three native colors
+## You'll want to know: Three native colors
+<!-- hl-knowledge: introduces=[TE-LEX-C11-RANGULU-01]; assesses=[] -->
 
 - **నలుపు** (*nalupu*) = "**black**" — native Dravidian.
 - **తెలుపు** (*telupu*) = "**white**" — native Dravidian.
 - **ఎరుపు** (*erupu*) = "**red**" — native Dravidian.
 
-## The same shared blue, one more time
+## The word, taken apart - The same shared blue, one more time
+<!-- hl-knowledge: introduces=[TE-ETYMON-C11-RANGULU-02]; assesses=[] -->
 
 **నీలం** (*nīlam*) = "**blue**" — the identical Sanskrit **నీల** (*nīla*)
 loan you've now seen in Tamil (*nīlam*), Malayalam (*nīla*), Kannada
@@ -36,6 +54,7 @@ independently keeping their own native black/white/red, and all reaching for
 the **exact same** borrowed word the moment it comes to blue.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C10-VAARAM-01, TE-PRAGMATICS-C10-VAARAM-02, TE-LEX-C11-RANGULU-01, TE-ETYMON-C11-RANGULU-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "nalupu, telupu, erupu" — black, white, red]
@@ -45,6 +64,7 @@ the **exact same** borrowed word the moment it comes to blue.
   **borrowed**]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C10-VAARAM-01, TE-PRAGMATICS-C10-VAARAM-02, TE-LEX-C11-RANGULU-01, TE-ETYMON-C11-RANGULU-02] -->
 
 [PAUSE 3s] What's the pattern across Tamil, Malayalam, Kannada, and Telugu's
 basic colors? (**Black, white, and red are native Dravidian words in every

--- a/code/learning/human-languages/telugu/lessons/TE-C12-kutumbam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C12-kutumbam.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C12-kutumbam
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 390
 chapter: 12
 type: word
 headword: నాన్న అమ్మ అన్న తమ్ముడు అక్క చెల్లి
@@ -9,25 +12,40 @@ prerequisites: [TE-C11-rangulu]
 sounds: [telugu-retroflex-dda, telugu-geminate-nna]
 roots: [dravidian-appa-amma, dravidian-age-graded-siblings]
 etymology_hook: "నాన్న naanna (father) and చెల్లి chelli (younger sister) are Telugu's OWN forms, unlike Tamil/Kannada's appa/tangi — but the age-before-gender sibling system is the same across the family"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TE-LEX-C11-RANGULU-01, TE-ETYMON-C11-RANGULU-02]
+introduces:
+  knowledge: [TE-LEX-C12-KUTUMBAM-01, TE-ETYMON-C12-KUTUMBAM-02]
+practises:
+  knowledge: [TE-LEX-C11-RANGULU-01, TE-ETYMON-C11-RANGULU-02, TE-LEX-C12-KUTUMBAM-01, TE-ETYMON-C12-KUTUMBAM-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C11-rangulu]
 ---
 
 # నాన్న, అమ్మ, and four sibling words — Telugu's own twist
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C11-RANGULU-01, TE-ETYMON-C11-RANGULU-02] -->
 
 [PAUSE 2s] Telugu shares the Dravidian family's age-first sibling system —
 but its words for "father" and "younger sister" go their own way.
 
-## Parents — one matches, one is Telugu's own
+## You'll want to know: Parents — one matches, one is Telugu's own
+<!-- hl-knowledge: introduces=[TE-LEX-C12-KUTUMBAM-01]; assesses=[] -->
 
 - **నాన్న** (*nānna*) = "**father**" — **Telugu's own word**, unlike Tamil/
   Kannada's *appā/appa*.
 - **అమ్మ** (*amma*) = "**mother**" — matches Tamil/Kannada's *ammā/amma*
   closely.
 
-## Four sibling words, mostly shared — with one exception
+## The word, taken apart - Four sibling words, mostly shared — with one exception
+<!-- hl-knowledge: introduces=[TE-ETYMON-C12-KUTUMBAM-02]; assesses=[] -->
 
 | Telugu | meaning | compare Tamil/Kannada |
 |---|---|---|
@@ -43,6 +61,7 @@ aren't identical everywhere: Telugu keeps its own **నాన్న** for father
 closely with its cousins.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C11-RANGULU-01, TE-ETYMON-C11-RANGULU-02, TE-LEX-C12-KUTUMBAM-01, TE-ETYMON-C12-KUTUMBAM-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "nānna, amma" — father, mother]
@@ -50,6 +69,7 @@ closely with its cousins.
 - [YOU SAY: "akka, celli" — older/younger sister — celli is Telugu's own]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C11-RANGULU-01, TE-ETYMON-C11-RANGULU-02, TE-LEX-C12-KUTUMBAM-01, TE-ETYMON-C12-KUTUMBAM-02] -->
 
 [PAUSE 3s] Which two Telugu family words are its own, rather than matching
 Tamil/Kannada? (**నాన్న** *nānna*, "father," and **చెల్లి** *celli*,

--- a/code/learning/human-languages/telugu/lessons/TE-C13-sharira-bhagalu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C13-sharira-bhagalu.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C13-sharira-bhagalu
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 400
 chapter: 13
 type: word
 headword: తల చెయ్యి
@@ -9,19 +12,33 @@ prerequisites: [TE-C12-kutumbam]
 sounds: [telugu-geminate-yya]
 roots: [dravidian-tala-kay]
 etymology_hook: "చెయ్యి ceyyi (hand) LOOKS unrelated to Tamil/Kannada/Malayalam's kai — but it's the same Proto-Dravidian root *kay-, reshaped by Telugu's own regular k-to-c sound change"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TE-LEX-C12-KUTUMBAM-01, TE-ETYMON-C12-KUTUMBAM-02]
+introduces:
+  knowledge: [TE-LEX-C13-SHARIRA-BHAGALU-01]
+practises:
+  knowledge: [TE-LEX-C12-KUTUMBAM-01, TE-ETYMON-C12-KUTUMBAM-02, TE-LEX-C13-SHARIRA-BHAGALU-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C12-kutumbam]
 ---
 
 # తల, చెయ్యి — head shared outright, hand shared in disguise
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C12-KUTUMBAM-01, TE-ETYMON-C12-KUTUMBAM-02] -->
 
 [PAUSE 2s] Head matches its cousins plainly. Hand looks, at first glance,
 like Telugu went its own way — but look closer, and it's the same word
 after all, just heavily reshaped.
 
-## The words
+## You'll want to know: The words
+<!-- hl-knowledge: introduces=[TE-LEX-C13-SHARIRA-BHAGALU-01]; assesses=[] -->
 
 - **తల** (*tala*) = "**head**" — native Dravidian, matching Tamil *talai*,
   Malayalam *thala*, and Kannada *tale* closely and plainly.
@@ -37,6 +54,7 @@ in sound than its cousins have, thanks to a sound change that reshaped many
 Telugu words the same way.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C12-KUTUMBAM-01, TE-ETYMON-C12-KUTUMBAM-02, TE-LEX-C13-SHARIRA-BHAGALU-01] -->
 
 [PAUSE 1s]
 - [YOU SAY: "tala" — head, matching its cousins plainly]
@@ -44,6 +62,7 @@ Telugu words the same way.
 - [YOU SAY: the lesson — looks different, is actually the same word]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C12-KUTUMBAM-01, TE-ETYMON-C12-KUTUMBAM-02, TE-LEX-C13-SHARIRA-BHAGALU-01] -->
 
 [PAUSE 3s] Does Telugu's word for "head" match its cousins? (**Yes** —
 *tala*, like Tamil/Malayalam/Kannada.) Is its word for "hand," *ceyyi*, truly

--- a/code/learning/human-languages/telugu/lessons/TE-C14-rutuvulu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C14-rutuvulu.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C14-rutuvulu
+spine_node: SPINE-TIME-OF-DAY
+sequence: 410
 chapter: 14
 type: word
 headword: వసంత ఋతువు వేసవి వానాకాలం శీతాకాలం
@@ -9,19 +12,33 @@ prerequisites: [TE-C13-sharira-bhagalu]
 sounds: [telugu-vocalic-r, telugu-anusvara]
 roots: [dravidian-vesavi-vaana, sanskrit-vasanta-rutu]
 etymology_hook: "వేసవి vesavi (summer) is native Dravidian, cousin of Kannada's besige — వసంత ఋతువు vasanta rutuvu (spring) borrows both vasanta AND rutu from Sanskrit, like Kannada, not just Tamil/Malayalam's single vasantham loan"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TE-LEX-C13-SHARIRA-BHAGALU-01]
+introduces:
+  knowledge: [TE-LEX-C14-RUTUVULU-01, TE-PRAGMATICS-C14-RUTUVULU-02]
+practises:
+  knowledge: [TE-LEX-C13-SHARIRA-BHAGALU-01, TE-LEX-C14-RUTUVULU-01, TE-PRAGMATICS-C14-RUTUVULU-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C13-sharira-bhagalu]
 ---
 
 # వసంత ఋతువు, వేసవి, వానాకాలం, శీతాకాలం — the pattern completes itself
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C13-SHARIRA-BHAGALU-01] -->
 
 [PAUSE 2s] Telugu closes out the Dravidian season words the same way
 Kannada did: native words for summer/rain/cold, and a spring-word borrowed
 twice over from Sanskrit.
 
-## The words
+## You'll want to know: The words
+<!-- hl-knowledge: introduces=[TE-LEX-C14-RUTUVULU-01]; assesses=[] -->
 
 | Telugu | meaning | source |
 |---|---|---|
@@ -30,7 +47,8 @@ twice over from Sanskrit.
 | **వానాకాలం** (*vānākālam*) | "rainy season" | **వాన** *vāna* ("rain," native) + *kālam* ("time," itself Sanskrit-derived but long assimilated) |
 | **శీతాకాలం** (*śītākālam*) | "winter/cold season" | *śīta* ("cold") leans Sanskrit-flavored here, unlike Tamil/Kannada's fully native cold-words |
 
-## Be honest about the pattern, one more time
+## Why it's said this way: Be honest about the pattern, one more time
+<!-- hl-knowledge: introduces=[TE-PRAGMATICS-C14-RUTUVULU-02]; assesses=[] -->
 
 Telugu's *vēsavi* and Kannada's *bēsige* are close enough in shape to be
 genuine cousins — the same native Dravidian summer-word wearing two
@@ -40,6 +58,7 @@ not a clean four-way Western split — the same honest point every language
 in this arc has made.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C13-SHARIRA-BHAGALU-01, TE-LEX-C14-RUTUVULU-01, TE-PRAGMATICS-C14-RUTUVULU-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "vēsavi" — summer, cousin of Kannada's bēsige]
@@ -48,6 +67,7 @@ in this arc has made.
 - [YOU SAY: the double Sanskrit loan — "vasanta ṛtuvu," like Kannada]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C13-SHARIRA-BHAGALU-01, TE-LEX-C14-RUTUVULU-01, TE-PRAGMATICS-C14-RUTUVULU-02] -->
 
 [PAUSE 3s] What's the relationship between Telugu's *vēsavi* and Kannada's
 *bēsige*? (**Cousins** — the same native Dravidian summer-word.) Which

--- a/code/learning/human-languages/telugu/lessons/TE-C15-neellu-biyyam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C15-neellu-biyyam.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C15-neellu-biyyam
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 420
 chapter: 15
 type: word
 headword: నీళ్ళు బియ్యం అన్నం
@@ -9,24 +12,39 @@ prerequisites: [TE-C14-rutuvulu]
 sounds: [telugu-geminate-lla, telugu-anusvara]
 roots: [neellu-water-dravidian, biyyam-rice-dravidian]
 etymology_hook: "నీళ్ళు neellu (water) matches Tamil/Kannada's neer/niiru, completing the 3-against-1 pattern against Malayalam's vellam; బియ్యం biyyam (raw rice) is Telugu's own word, unlike Tamil/Kannada/Malayalam's shared ari/arisi/akki"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TE-LEX-C14-RUTUVULU-01, TE-PRAGMATICS-C14-RUTUVULU-02]
+introduces:
+  knowledge: [TE-ETYMON-C15-NEELLU-BIYYAM-01, TE-ETYMON-C15-NEELLU-BIYYAM-02]
+practises:
+  knowledge: [TE-LEX-C14-RUTUVULU-01, TE-PRAGMATICS-C14-RUTUVULU-02, TE-ETYMON-C15-NEELLU-BIYYAM-01, TE-ETYMON-C15-NEELLU-BIYYAM-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C14-rutuvulu]
 ---
 
 # నీళ్ళు, బియ్యం, అన్నం — water matching its cousins, rice going its own way
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C14-RUTUVULU-01, TE-PRAGMATICS-C14-RUTUVULU-02] -->
 
 [PAUSE 2s] Water closes out 3-against-1 against Malayalam. Rice, though,
 turns out to have its own twist here.
 
-## నీళ్ళు — matching the majority
+## The word, taken apart - నీళ్ళు — matching the majority
+<!-- hl-knowledge: introduces=[TE-ETYMON-C15-NEELLU-BIYYAM-01]; assesses=[] -->
 
 **నీళ్ళు** (*nīḷḷu*) = "**water**" — matching Tamil's *nīr* and Kannada's
 *nīru*. Malayalam's *veḷḷam* is the odd one out among all four Dravidian
 languages for water, not Telugu.
 
-## బియ్యం, అన్నం — rice, with a twist
+## The word, taken apart - బియ్యం, అన్నం — rice, with a twist
+<!-- hl-knowledge: introduces=[TE-ETYMON-C15-NEELLU-BIYYAM-02]; assesses=[] -->
 
 - **బియ్యం** (*biyyam*) = "**rice**" (raw grain) — **Telugu's own word**,
   unlike the shared *ari/arisi/akki* found in Malayalam, Tamil, and
@@ -39,6 +57,7 @@ the majority (Tamil/Kannada) against Malayalam; for **raw rice**, Telugu is
 itself the odd one out against the other three.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C14-RUTUVULU-01, TE-PRAGMATICS-C14-RUTUVULU-02, TE-ETYMON-C15-NEELLU-BIYYAM-01, TE-ETYMON-C15-NEELLU-BIYYAM-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "nīḷḷu" — water, matching Tamil/Kannada]
@@ -46,6 +65,7 @@ itself the odd one out against the other three.
 - [YOU SAY: "annam" — cooked rice, matching Kannada's anna]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C14-RUTUVULU-01, TE-PRAGMATICS-C14-RUTUVULU-02, TE-ETYMON-C15-NEELLU-BIYYAM-01, TE-ETYMON-C15-NEELLU-BIYYAM-02] -->
 
 [PAUSE 3s] Which language is the odd one out for water, and which for raw
 rice? (**Malayalam** is the odd one out for water (*veḷḷam*); **Telugu** is

--- a/code/learning/human-languages/telugu/lessons/TE-C16-nelalu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C16-nelalu.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C16-nelalu
+spine_node: SPINE-TIME-OF-DAY
+sequence: 430
 chapter: 16
 type: word
 headword: చైత్రం వైశాఖం జ్యేష్ఠం ఆషాఢం శ్రావణం భాద్రపదం ఆశ్వయుజం కార్తీకం మార్గశిరం పుష్యం మాఘం ఫాల్గుణం
@@ -9,26 +12,41 @@ prerequisites: [TE-C15-neellu-biyyam]
 sounds: [telugu-conjunct-shtha, telugu-anusvara]
 roots: [sanskrit-lunisolar-chaitra-system]
 etymology_hook: "Telugu shares the same pan-Indian Sanskritic lunisolar calendar as Kannada and Hindi (Ugadi falls the SAME day, Chaitra Shudda Padyami) — completing a clean split: Tamil and Malayalam built their OWN solar calendars, Kannada and Telugu share the pan-Indian one"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TE-ETYMON-C15-NEELLU-BIYYAM-01, TE-ETYMON-C15-NEELLU-BIYYAM-02]
+introduces:
+  knowledge: [TE-LEX-C16-NELALU-01, TE-ETYMON-C16-NELALU-02]
+practises:
+  knowledge: [TE-ETYMON-C15-NEELLU-BIYYAM-01, TE-ETYMON-C15-NEELLU-BIYYAM-02, TE-LEX-C16-NELALU-01, TE-ETYMON-C16-NELALU-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C15-neellu-biyyam]
 ---
 
 # చైత్రం to ఫాల్గుణం — completing the split
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C15-NEELLU-BIYYAM-01, TE-ETYMON-C15-NEELLU-BIYYAM-02] -->
 
 [PAUSE 2s] The pattern across all four Dravidian languages is now
 complete: Telugu, like Kannada, shares its calendar with Hindi rather than
 building its own.
 
-## The twelve months
+## You'll want to know: The twelve months
+<!-- hl-knowledge: introduces=[TE-LEX-C16-NELALU-01]; assesses=[] -->
 
 **చైత్రం, వైశాఖం, జ్యేష్ఠం, ఆషాఢం, శ్రావణం, భాద్రపదం, ఆశ్వయుజం, కార్తీకం,
 మార్గశిరం, పుష్యం, మాఘం, ఫాల్గుణం** (*Caitraṁ, Vaiśākhaṁ, Jyēṣṭhaṁ,
 Āṣāḍhaṁ, Śrāvaṇaṁ, Bhādrapadaṁ, Āśvayujaṁ, Kārtīkaṁ, Mārgaśiraṁ, Puṣyaṁ,
 Māghaṁ, Phālguṇaṁ*).
 
-## The whole Dravidian family, in one honest picture
+## The word, taken apart - The whole Dravidian family, in one honest picture
+<!-- hl-knowledge: introduces=[TE-ETYMON-C16-NELALU-02]; assesses=[] -->
 
 This closes out a genuine, clean split across the four Dravidian
 languages: **Tamil** and **Malayalam** each built their **own** solar
@@ -39,6 +57,7 @@ falls on the very same day as Kannada's — *Chaitra Śuddha Pādyami*, the
 first day of Chaitra's bright fortnight.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C15-NEELLU-BIYYAM-01, TE-ETYMON-C15-NEELLU-BIYYAM-02, TE-LEX-C16-NELALU-01, TE-ETYMON-C16-NELALU-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: the twelve — "Caitraṁ, Vaiśākhaṁ, Jyēṣṭhaṁ, Āṣāḍhaṁ, Śrāvaṇaṁ,
@@ -49,6 +68,7 @@ first day of Chaitra's bright fortnight.
   Telugu shared with Hindi]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C15-NEELLU-BIYYAM-01, TE-ETYMON-C15-NEELLU-BIYYAM-02, TE-LEX-C16-NELALU-01, TE-ETYMON-C16-NELALU-02] -->
 
 [PAUSE 3s] How does the four-language Dravidian calendar picture split?
 (**Tamil and Malayalam** each have their **own** solar calendar; **Kannada

--- a/code/learning/human-languages/telugu/lessons/TE-C17-madhyaahnam-ardharaatri.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C17-madhyaahnam-ardharaatri.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C17-madhyaahnam-ardharaatri
+spine_node: SPINE-TIME-OF-DAY
+sequence: 440
 chapter: 17
 type: word
 headword: మధ్యాహ్నం అర్ధరాత్రి
@@ -9,25 +12,40 @@ prerequisites: [TE-C16-nelalu]
 sounds: [telugu-conjunct-rdha, telugu-anusvara]
 roots: [sanskrit-madhya-middle, sanskrit-ardha-half]
 etymology_hook: "Telugu's మధ్యాహ్నం (madhyāhnam, noon) matches Kannada's madhya ('middle') root exactly — but its midnight word, అర్ధరాత్రి (ardharātri), switches to a DIFFERENT Sanskrit root, ardha ('half'), echoing Hindi's colloquial 'half night' pattern instead of Kannada's 'middle night'"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TE-LEX-C16-NELALU-01, TE-ETYMON-C16-NELALU-02]
+introduces:
+  knowledge: [TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03]
+practises:
+  knowledge: [TE-LEX-C16-NELALU-01, TE-ETYMON-C16-NELALU-02, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C16-nelalu]
 ---
 
 # మధ్యాహ్నం, అర్ధరాత్రి — the same noon word, a different midnight word
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C16-NELALU-01, TE-ETYMON-C16-NELALU-02] -->
 
 [PAUSE 2s] Telugu and Kannada share the exact same Sanskrit word for noon —
 but then quietly part ways on midnight.
 
-## మధ్యాహ్నం — matching Kannada exactly
+## The word, taken apart - మధ్యాహ్నం — matching Kannada exactly
+<!-- hl-knowledge: introduces=[TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01]; assesses=[] -->
 
 **మధ్యాహ్నం** (*madhyāhnam*) = "**noon, midday**" — the same Sanskrit
 *tatsama* compound as Kannada's *madhyāhna*: **మధ్య** (*madhya*, "**middle**")
 + **అహ్న** (*ahna*, "**day**"), plus Telugu's own **-ం** (*anusvāra*)
 ending. Same root, same meaning, same everyday register in both languages.
 
-## అర్ధరాత్రి — a DIFFERENT Sanskrit root: "half," not "middle"
+## The word, taken apart - అర్ధరాత్రి — a DIFFERENT Sanskrit root: "half," not "middle"
+<!-- hl-knowledge: introduces=[TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02]; assesses=[] -->
 
 **అర్ధరాత్రి** (*ardharātri*) = "**midnight**" — but here Telugu reaches for
 a **different** Sanskrit root: **అర్ధ** (*ardha*, "**half**"), not *madhya*
@@ -36,7 +54,8 @@ means "**half-night**" — structurally the same shape as Hindi's colloquial
 *ādhī rāt* ("half night") and Latin's transparent *media nox* pattern, but
 built from Sanskrit's own dedicated "half" word rather than "middle."
 
-## Be honest: two different "middle-ish" ideas, side by side
+## Grammar Lens: Be honest: two different "middle-ish" ideas, side by side
+<!-- hl-knowledge: introduces=[TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03]; assesses=[] -->
 
 Don't assume *madhya* and *ardha* are the same word wearing different
 clothes — they're genuinely **separate Sanskrit roots** ("middle" vs.
@@ -46,6 +65,7 @@ a root. Telugu's noon word keeps Kannada's "middle" logic; its midnight
 word switches to "half" logic instead.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C16-NELALU-01, TE-ETYMON-C16-NELALU-02, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "madhyāhnam" — noon, same root as Kannada]
@@ -54,6 +74,7 @@ word switches to "half" logic instead.
   midnight — two different Sanskrit roots]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C16-NELALU-01, TE-ETYMON-C16-NELALU-02, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03] -->
 
 [PAUSE 3s] Does Telugu's noon word match Kannada's? (**Yes** — both
 *madhyāhna(m)*, from *madhya*, "middle.") Does Telugu's midnight word use

--- a/code/learning/human-languages/telugu/lessons/TE-C18-ganta.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C18-ganta.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C18-ganta
+spine_node: SPINE-TIME-OF-DAY
+sequence: 450
 chapter: 18
 type: word
 headword: గంట
@@ -9,25 +12,40 @@ prerequisites: [TE-C17-madhyaahnam-ardharaatri]
 sounds: [telugu-anusvara, telugu-retroflex-tta]
 roots: [sanskrit-ghanta-bell]
 etymology_hook: "గంట (ganṭa, 'hour') is the same Sanskrit ghaṇṭā ('bell') word as Kannada's gaṇṭe and Hindi's ghanṭā — Telugu completes a clean 3-way match on this concept, contrasting with Tamil's most-likely-native maṇi (Malayalam's cognate mani, interestingly, traces to a DIFFERENT Sanskrit word, maṇi 'gem,' per its own dictionaries)"
-est_minutes: 4
+duration:
+  max_seconds: 250
+requires:
+  knowledge: [TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03]
+introduces:
+  knowledge: [TE-LEX-C18-GANTA-01, TE-PRAGMATICS-C18-GANTA-02, TE-GRAMMAR-C18-GANTA-03]
+practises:
+  knowledge: [TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03, TE-LEX-C18-GANTA-01, TE-PRAGMATICS-C18-GANTA-02, TE-GRAMMAR-C18-GANTA-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C17-madhyaahnam-ardharaatri]
 ---
 
 # గంట — matching Kannada and Hindi's "bell" word exactly
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03] -->
 
 [PAUSE 2s] Telugu completes a clean three-way match: Hindi, Kannada, and now
 Telugu all use the same Sanskrit "bell" word for "hour."
 
-## గంట — bell AND hour, a third time
+## You'll want to know: గంట — bell AND hour, a third time
+<!-- hl-knowledge: introduces=[TE-LEX-C18-GANTA-01]; assesses=[] -->
 
 **గంట** (*ganṭa*) = "**hour**" — and, exactly like Hindi's *ghanṭā* and Kannada's
 *gaṇṭe*, it means "**bell, clapper**" just as commonly, from the same Sanskrit
 **घण्टा** (*ghaṇṭā*). Same word, same bell-strikes-the-hour logic, three
 languages in a row.
 
-## Be honest: the split isn't a clean "Dravidian vs. Hindi" line
+## Why it's said this way: Be honest: the split isn't a clean "Dravidian vs. Hindi" line
+<!-- hl-knowledge: introduces=[TE-PRAGMATICS-C18-GANTA-02]; assesses=[] -->
 
 So on this concept, the split isn't "Hindi vs. all four Dravidian languages" —
 **Hindi, Kannada, and Telugu** all share the Sanskrit *ghaṇṭā* ("bell") root.
@@ -41,6 +59,7 @@ Sanskrit/native split isn't fixed per language, and isn't always a clean binary
 either.
 
 ## Grammar Lens: telling the time
+<!-- hl-knowledge: introduces=[TE-GRAMMAR-C18-GANTA-03]; assesses=[] -->
 
 > **ఒక గంట.** — "One o'clock." (*oka ganṭa*, "one hour/bell")
 > **రెండు గంటలు.** — "Two o'clock." (*reṇḍu ganṭalu* — *ganṭa* takes its plural
@@ -50,6 +69,7 @@ Notice Telugu's *ganṭa* pluralizes to *ganṭalu* for "two o'clock" onward —
 small grammatical wrinkle Kannada's *gaṇṭe* didn't show you.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03, TE-LEX-C18-GANTA-01, TE-PRAGMATICS-C18-GANTA-02, TE-GRAMMAR-C18-GANTA-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "ganṭa" — hour, also "bell"]
@@ -57,6 +77,7 @@ small grammatical wrinkle Kannada's *gaṇṭe* didn't show you.
 - [YOU SAY: "reṇḍu ganṭalu" — two o'clock, plural *ganṭalu*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03, TE-LEX-C18-GANTA-01, TE-PRAGMATICS-C18-GANTA-02, TE-GRAMMAR-C18-GANTA-03] -->
 
 [PAUSE 3s] What Sanskrit word do **గంట**, Kannada's *gaṇṭe*, and Hindi's *ghanṭā*
 all share? (**घण्टा**, *ghaṇṭā*, "bell.") Which Dravidian language most likely does

--- a/code/learning/human-languages/telugu/lessons/TE-C19-vayasu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C19-vayasu.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C19-vayasu
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 460
 chapter: 19
 type: phrase
 headword: నీ వయసెంత?
@@ -9,23 +12,38 @@ prerequisites: [TE-C18-ganta]
 sounds: [telugu-anusvara, telugu-vowel-sandhi]
 roots: [sanskrit-vayas-vigor-age]
 etymology_hook: "వయస్సు (vayasu, 'age') is the same Sanskrit वयस् (vayas, 'vigor, age') as Kannada's vayassu — PIE cousin of Latin vīs — and Telugu asks it the same simple, verbless way: 'నీ వయసెంత?' (nī vayasenta?, 'your age how-much?'), where వయస్సు+ఎంత fuse into vayas-enta by regular vowel sandhi"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TE-LEX-C18-GANTA-01, TE-PRAGMATICS-C18-GANTA-02, TE-GRAMMAR-C18-GANTA-03]
+introduces:
+  knowledge: [TE-ETYMON-C19-VAYASU-01, TE-GRAMMAR-C19-VAYASU-02]
+practises:
+  knowledge: [TE-LEX-C18-GANTA-01, TE-PRAGMATICS-C18-GANTA-02, TE-GRAMMAR-C18-GANTA-03, TE-ETYMON-C19-VAYASU-01, TE-GRAMMAR-C19-VAYASU-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C18-ganta]
 ---
 
 # నీ వయసెంత? — matching Kannada's simple possessive exactly
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C18-GANTA-01, TE-PRAGMATICS-C18-GANTA-02, TE-GRAMMAR-C18-GANTA-03] -->
 
 [PAUSE 2s] Telugu matches Kannada closely here — same Sanskrit word, same
 verbless grammar, just fused together by ordinary Telugu vowel sandhi.
 
-## వయస్సు — the same Sanskrit "vigor/age" word
+## The word, taken apart - వయస్సు — the same Sanskrit "vigor/age" word
+<!-- hl-knowledge: introduces=[TE-ETYMON-C19-VAYASU-01]; assesses=[] -->
 
 **వయస్సు** (*vayasu*) = "**age**" — the exact same Sanskrit **वयस्** (*vayas*,
 "age, vigor, strength," PIE cousin of Latin **vīs**) you just met in Kannada.
 
 ## Grammar Lens: fused by sandhi, still verbless
+<!-- hl-knowledge: introduces=[TE-GRAMMAR-C19-VAYASU-02]; assesses=[] -->
 
 > **నీ వయసెంత?** — "How old are you?" — literally "**your age how-much**?"
   (*nī vayas-enta?* — from *nī vayasu* + *enta*, "how much," fused by regular
@@ -40,6 +58,7 @@ kind of vowel sandhi you'd see fusing any two Telugu words in fast speech — th
 underlying grammar is identical to Kannada's, just written closer together.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C18-GANTA-01, TE-PRAGMATICS-C18-GANTA-02, TE-GRAMMAR-C18-GANTA-03, TE-ETYMON-C19-VAYASU-01, TE-GRAMMAR-C19-VAYASU-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "vayasu" — age]
@@ -47,6 +66,7 @@ underlying grammar is identical to Kannada's, just written closer together.
 - [YOU SAY: "nā vayasu iravai" — I am twenty, "my age [is] twenty"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C18-GANTA-01, TE-PRAGMATICS-C18-GANTA-02, TE-GRAMMAR-C18-GANTA-03, TE-ETYMON-C19-VAYASU-01, TE-GRAMMAR-C19-VAYASU-02] -->
 
 [PAUSE 3s] Is Telugu's **వయస్సు** the same Sanskrit word as Kannada's
 *vayassu*? (**Yes** — both from *vayas*, PIE cousin of Latin *vīs*.) What

--- a/code/learning/human-languages/telugu/lessons/TE-C20-padakondu-iravai.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C20-padakondu-iravai.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C20-padakondu-iravai
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 470
 chapter: 20
 type: word
 headword: పదకొండు — ఇరవై
@@ -9,26 +12,41 @@ prerequisites: [TE-C19-vayasu]
 sounds: [telugu-vowel-sign-ai, telugu-geminate-none]
 roots: [dravidian-padi-ten, dravidian-rendu-two]
 etymology_hook: "పదకొండు-పందొమ్మిది (11-19) echo పది (padi, 'ten') + a digit — ఇరవై (iravai, 'twenty') most likely continues the same pan-Dravidian *iru-/*renḍu ('two') + *pad- ('ten') pattern as Kannada's transparent ippattu, but centuries of erosion have worn iravai down further, so it doesn't visibly split into 'two' + 'ten' on the surface the way Kannada's does today"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TE-ETYMON-C19-VAYASU-01, TE-GRAMMAR-C19-VAYASU-02]
+introduces:
+  knowledge: [TE-ETYMON-C20-PADAKONDU-IRAVAI-01, TE-ETYMON-C20-PADAKONDU-IRAVAI-02]
+practises:
+  knowledge: [TE-ETYMON-C19-VAYASU-01, TE-GRAMMAR-C19-VAYASU-02, TE-ETYMON-C20-PADAKONDU-IRAVAI-01, TE-ETYMON-C20-PADAKONDU-IRAVAI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C19-vayasu]
 ---
 
 # పదకొండు, ఇరవై — the same pattern, worn down one step further
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C19-VAYASU-01, TE-GRAMMAR-C19-VAYASU-02] -->
 
 [PAUSE 2s] You just watched Kannada's twenty split cleanly into "two" +
 "ten." Telugu most likely comes from the exact same pattern — but centuries
 of extra erosion have worn it past the point of being visible today.
 
-## పదకొండు–పందొమ్మిది — "ten" + digit
+## The word, taken apart - పదకొండు–పందొమ్మిది — "ten" + digit
+<!-- hl-knowledge: introduces=[TE-ETYMON-C20-PADAKONDU-IRAVAI-01]; assesses=[] -->
 
 Telugu's teens echo **పది** (*padi*, "**ten**") plus each digit — **పదకొండు**
 (*padakoṇḍu*, 11), **పన్నెండు** (*panneṇḍu*, 12), and onward through
 **పందొమ్మిది** (*paṅdommidi*, 19) — the same "digit + ten-echo" compounding
 you just saw in Kannada.
 
-## ఇరవై — most likely the same "two-tens," just worn further
+## The word, taken apart - ఇరవై — most likely the same "two-tens," just worn further
+<!-- hl-knowledge: introduces=[TE-ETYMON-C20-PADAKONDU-IRAVAI-02]; assesses=[] -->
 
 **ఇరవై** (*iravai*, "**twenty**") most likely continues the **same**
 pan-Dravidian pattern as Kannada's *ippattu* — an old **\*iru-**/**\*renḍu**
@@ -41,6 +59,7 @@ likely comparative-Dravidian account rather than a transparent, easily
 re-derivable compound.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C19-VAYASU-01, TE-GRAMMAR-C19-VAYASU-02, TE-ETYMON-C20-PADAKONDU-IRAVAI-01, TE-ETYMON-C20-PADAKONDU-IRAVAI-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "padakoṇḍu, panneṇḍu" — 11, 12]
@@ -49,6 +68,7 @@ re-derivable compound.
   Kannada, just worn down further]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C19-VAYASU-01, TE-GRAMMAR-C19-VAYASU-02, TE-ETYMON-C20-PADAKONDU-IRAVAI-01, TE-ETYMON-C20-PADAKONDU-IRAVAI-02] -->
 
 [PAUSE 3s] How are Telugu's teens built? (**పది** (ten) + a digit,
 compounded.) Does **ఇరవై** visibly split into "two" + "ten" today, the way

--- a/code/learning/human-languages/telugu/lessons/TE-C20-vatavaranam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C20-vatavaranam.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C20-vatavaranam
+spine_node: SPINE-TIME-OF-DAY
+sequence: 480
 chapter: 20
 type: phrase
 headword: వాతావరణం
@@ -9,18 +12,32 @@ prerequisites: [TE-C18-ganta]
 sounds: [telugu-anusvara, telugu-compound-word]
 roots: [sanskrit-vata-wind, sanskrit-avarana-covering]
 etymology_hook: "వాతావరణం (vātāvaraṇam, 'weather, atmosphere') is a PURE Sanskrit compound — వాత (vāta, 'wind, air') + ఆవరణ (āvaraṇa, 'covering, layer') — literally 'the covering of air,' unlike Kannada's Persian+Sanskrit hybrid havāmāna for the same concept"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TE-LEX-C18-GANTA-01, TE-PRAGMATICS-C18-GANTA-02, TE-GRAMMAR-C18-GANTA-03]
+introduces:
+  knowledge: [TE-ETYMON-C20-VATAVARANAM-01, TE-GRAMMAR-C20-VATAVARANAM-02]
+practises:
+  knowledge: [TE-LEX-C18-GANTA-01, TE-PRAGMATICS-C18-GANTA-02, TE-GRAMMAR-C18-GANTA-03, TE-ETYMON-C20-VATAVARANAM-01, TE-GRAMMAR-C20-VATAVARANAM-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C18-ganta]
 ---
 
 # వాతావరణం — "the covering of air," pure Sanskrit this time
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C18-GANTA-01, TE-PRAGMATICS-C18-GANTA-02, TE-GRAMMAR-C18-GANTA-03] -->
 
 [PAUSE 2s] Kannada's weather word mixed a Persian loan with a Sanskrit one.
 Telugu's is different again — a single, unmixed Sanskrit compound.
 
-## వాతావరణం — vāta + āvaraṇa
+## The word, taken apart - వాతావరణం — vāta + āvaraṇa
+<!-- hl-knowledge: introduces=[TE-ETYMON-C20-VATAVARANAM-01]; assesses=[] -->
 
 **వాతావరణం** (*vātāvaraṇam*) = "**weather, atmosphere**" — built entirely
 from Sanskrit:
@@ -34,13 +51,15 @@ surrounding everything, i.e., the atmosphere/weather. Unlike Kannada's
 *havāmāna* (Persian *hava* + Sanskrit *māna*), **both** pieces here are
 Sanskrit — no Perso-Arabic loan involved at all.
 
-## వర్షం పడుతోంది — "rain is falling"
+## Grammar Lens: వర్షం పడుతోంది — "rain is falling"
+<!-- hl-knowledge: introduces=[TE-GRAMMAR-C20-VATAVARANAM-02]; assesses=[] -->
 
 > **వర్షం పడుతోంది.** — "It's raining." — literally "**rain is falling**."
   (*varṣaṁ paḍutōndi.*) — **వర్షం** (*varṣaṁ*, "rain") is the same Sanskrit
   root, *varṣā*, you'll see again in the Dravidian arc.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C18-GANTA-01, TE-PRAGMATICS-C18-GANTA-02, TE-GRAMMAR-C18-GANTA-03, TE-ETYMON-C20-VATAVARANAM-01, TE-GRAMMAR-C20-VATAVARANAM-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "vātāvaraṇam" — weather, "the covering of air"]
@@ -48,6 +67,7 @@ Sanskrit — no Perso-Arabic loan involved at all.
 - [YOU SAY: "varṣaṁ paḍutōndi" — it's raining, "rain is falling"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C18-GANTA-01, TE-PRAGMATICS-C18-GANTA-02, TE-GRAMMAR-C18-GANTA-03, TE-ETYMON-C20-VATAVARANAM-01, TE-GRAMMAR-C20-VATAVARANAM-02] -->
 
 [PAUSE 3s] What are the two Sanskrit pieces of **వాతావరణం**, and what does the
 whole word literally mean? (**వాత**, "air," + **ఆవరణ**, "covering" — "**the

--- a/code/learning/human-languages/telugu/lessons/TE-C21-kukka-pilli.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C21-kukka-pilli.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C21-kukka-pilli
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 490
 chapter: 21
 type: word
 headword: కుక్క, పిల్లి
@@ -9,19 +12,33 @@ prerequisites: [TE-C20-padakondu-iravai]
 sounds: [telugu-geminate-kk, telugu-geminate-ll]
 roots: [uncertain-kukka, dravidian-pillu-cat]
 etymology_hook: "కుక్క (kukka, 'dog') genuinely breaks from Kannada/Malayalam/Tamil's shared naayi root — debated between an onomatopoeic origin (imitating a bark) and a Sanskrit loan (कुक्कुर, kukkura); పిల్లి (pilli, 'cat') is Proto-Dravidian *pillV, and most likely closes this WHOLE arc's cat-word loop — the probable Dravidian source Sanskrit borrowed as बिडाल (biḍāla), giving Hindi's बिल्ली (billī)"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TE-ETYMON-C20-PADAKONDU-IRAVAI-01, TE-ETYMON-C20-PADAKONDU-IRAVAI-02]
+introduces:
+  knowledge: [TE-ETYMON-C21-KUKKA-PILLI-01, TE-ETYMON-C21-KUKKA-PILLI-02]
+practises:
+  knowledge: [TE-ETYMON-C20-PADAKONDU-IRAVAI-01, TE-ETYMON-C20-PADAKONDU-IRAVAI-02, TE-ETYMON-C21-KUKKA-PILLI-01, TE-ETYMON-C21-KUKKA-PILLI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C20-padakondu-iravai]
 ---
 
 # కుక్క, పిల్లి — the odd one out, and the word that most likely closes the loop
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C20-PADAKONDU-IRAVAI-01, TE-ETYMON-C20-PADAKONDU-IRAVAI-02] -->
 
 [PAUSE 2s] Kannada just gave you a rock-solid native dog-word. Telugu breaks
 from that pattern — but its cat-word may be the single most important word
 in this whole arc.
 
-## కుక్క — genuinely the odd one out
+## The word, taken apart - కుక్క — genuinely the odd one out
+<!-- hl-knowledge: introduces=[TE-ETYMON-C21-KUKKA-PILLI-01]; assesses=[] -->
 
 **కుక్క** (*kukka*, "**dog**") does **not** clearly continue the same
 **నాయి**-family root shared by Kannada, Malayalam, and Tamil. Its origin is
@@ -31,7 +48,8 @@ the sound of a bark; others propose a borrowing from **Sanskrit**
 settled — but either way, Telugu's everyday dog-word genuinely doesn't
 match its closest cousins.
 
-## పిల్లి — most likely closing the whole arc's loop
+## The word, taken apart - పిల్లి — most likely closing the whole arc's loop
+<!-- hl-knowledge: introduces=[TE-ETYMON-C21-KUKKA-PILLI-02]; assesses=[] -->
 
 **పిల్లి** (*pilli*, "**cat**") is a real, documented **Proto-Dravidian**
 root, ***\*pillV*** — with cognates surviving as **rarer, alternate** words
@@ -45,12 +63,14 @@ tying together Latin's *cattus*/Arabic's *qiṭṭ* story on one side and
 Hindi's *billī* story on the other, all within this single course.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C20-PADAKONDU-IRAVAI-01, TE-ETYMON-C20-PADAKONDU-IRAVAI-02, TE-ETYMON-C21-KUKKA-PILLI-01, TE-ETYMON-C21-KUKKA-PILLI-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "kukka" — dog, genuinely different from its Dravidian cousins]
 - [YOU SAY: "pilli" — cat, most likely the source behind Hindi's billī]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C20-PADAKONDU-IRAVAI-01, TE-ETYMON-C20-PADAKONDU-IRAVAI-02, TE-ETYMON-C21-KUKKA-PILLI-01, TE-ETYMON-C21-KUKKA-PILLI-02] -->
 
 [PAUSE 3s] Does **కుక్క** continue the same root as Kannada's *nāyi*? (**No**
 — genuinely different, debated between onomatopoeia and a Sanskrit loan.)

--- a/code/learning/human-languages/telugu/lessons/TE-C22-pacha-pasupu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C22-pacha-pasupu.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C22-pacha-pasupu
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 500
 chapter: 22
 type: word
 headword: పచ్చ, పసుపు
@@ -9,26 +12,41 @@ prerequisites: [TE-C11-rangulu, TE-C21-kukka-pilli]
 sounds: [telugu-short-vowels, telugu-virama-geminate]
 roots: [proto-dravidian-pac-green]
 etymology_hook: "పచ్చ (pacca, 'green') and పసుపు (pasupu, 'yellow, turmeric') are both descendants of the SAME Proto-Dravidian root, *pac- — true doublets of each other, not two separate word families; పచ్చ also shares that root with Tamil's பச்சை (paccai) and Kannada's ಹಸಿರು (hasiru), while Tamil's பசுப்பு (pacuppu) is a direct cognate of పసుపు itself"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TE-LEX-C11-RANGULU-01, TE-ETYMON-C11-RANGULU-02, TE-ETYMON-C21-KUKKA-PILLI-01, TE-ETYMON-C21-KUKKA-PILLI-02]
+introduces:
+  knowledge: [TE-ETYMON-C22-PACHA-PASUPU-01, TE-ETYMON-C22-PACHA-PASUPU-02]
+practises:
+  knowledge: [TE-LEX-C11-RANGULU-01, TE-ETYMON-C11-RANGULU-02, TE-ETYMON-C21-KUKKA-PILLI-01, TE-ETYMON-C21-KUKKA-PILLI-02, TE-ETYMON-C22-PACHA-PASUPU-01, TE-ETYMON-C22-PACHA-PASUPU-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C21-kukka-pilli]
 ---
 
 # పచ్చ, పసుపు — two colors, one Dravidian root
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C11-RANGULU-01, TE-ETYMON-C11-RANGULU-02, TE-ETYMON-C21-KUKKA-PILLI-01, TE-ETYMON-C21-KUKKA-PILLI-02] -->
 
 [PAUSE 2s] In Kannada, green stayed native but yellow got borrowed from
 Sanskrit. Telugu tells a tighter story: its green word and its yellow word
 turn out to be **doublets of the same root**, wearing two different faces.
 
-## పచ్చ — the native Dravidian green, again
+## The word, taken apart - పచ్చ — the native Dravidian green, again
+<!-- hl-knowledge: introduces=[TE-ETYMON-C22-PACHA-PASUPU-01]; assesses=[] -->
 
 **పచ్చ** (**pacca**, "**green**") comes from **Proto-Dravidian** ***\*pac-***
 — the same root already behind Tamil's **பச்சை** (*paccai*) and Kannada's
 **ಹಸಿರು** (*hasiru*, via Old Kannada *pasir*). No surprise here; this is the
 same pan-Dravidian green family from the last lesson.
 
-## పసుపు — a genuine doublet of pacca, not a separate word
+## The word, taken apart - పసుపు — a genuine doublet of pacca, not a separate word
+<!-- hl-knowledge: introduces=[TE-ETYMON-C22-PACHA-PASUPU-02]; assesses=[] -->
 
 **పసుపు** (**pasupu**, "**yellow, turmeric**") is, remarkably, **also** a
 direct descendant of that **same** Proto-Dravidian ***\*pac-*** root — a
@@ -42,6 +60,7 @@ of the same word, one settling on "green" and the other on "yellow,
 turmeric-colored."
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C11-RANGULU-01, TE-ETYMON-C11-RANGULU-02, TE-ETYMON-C21-KUKKA-PILLI-01, TE-ETYMON-C21-KUKKA-PILLI-02, TE-ETYMON-C22-PACHA-PASUPU-01, TE-ETYMON-C22-PACHA-PASUPU-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "పచ్చ" — green, from Proto-Dravidian *pac-]
@@ -50,6 +69,7 @@ turmeric-colored."
   native family; Kannada's yellow broke away as a Sanskrit loan]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C11-RANGULU-01, TE-ETYMON-C11-RANGULU-02, TE-ETYMON-C21-KUKKA-PILLI-01, TE-ETYMON-C21-KUKKA-PILLI-02, TE-ETYMON-C22-PACHA-PASUPU-01, TE-ETYMON-C22-PACHA-PASUPU-02] -->
 
 [PAUSE 3s] Are **పచ్చ** and **పసుపు** two unrelated words, or doublets of
 the same root? (**Doublets** — both from Proto-Dravidian *\*pac-*.) Does

--- a/code/learning/human-languages/telugu/lessons/TE-C23-roju.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C23-roju.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C23-roju
+spine_node: SPINE-TIME-OF-DAY
+sequence: 510
 chapter: 23
 type: word
 headword: రోజు
@@ -9,18 +12,32 @@ prerequisites: [TE-C17-madhyaahnam-ardharaatri]
 sounds: [telugu-vowel-sign-oo, telugu-ja]
 roots: [persian-roz-day, sanskrit-dinamu]
 etymology_hook: "రోజు (rōju, 'day') is genuinely borrowed from Classical Persian روز (rōz), itself from PIE *lewk- ('bright') — a completely different route and root from Latin diēs/Hindi din/Kannada dina's *dyew- family, though both ultimately trace to 'shining, bright' senses independently; దినము (dinamu) is the Sanskrit tatsama word (same root as Kannada's dina), but here it's the more FORMAL alternate — Telugu's everyday/formal split runs the OPPOSITE way from Kannada's"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03]
+introduces:
+  knowledge: [TE-ETYMON-C23-ROJU-01, TE-PRAGMATICS-C23-ROJU-02]
+practises:
+  knowledge: [TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03, TE-ETYMON-C23-ROJU-01, TE-PRAGMATICS-C23-ROJU-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C17-madhyaahnam-ardharaatri]
 ---
 
 # రోజు (rōju) — "day," a genuine Persian surprise
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03] -->
 
 [PAUSE 2s] You might expect Telugu's word for "day" to be Sanskrit, like
 Kannada's *dina*, or native Dravidian. It's neither — it's Persian.
 
-## రోజు — a genuine Persian loanword
+## The word, taken apart - రోజు — a genuine Persian loanword
+<!-- hl-knowledge: introduces=[TE-ETYMON-C23-ROJU-01]; assesses=[] -->
 
 **రోజు** (**rōju**) — "**day**" — is Telugu's everyday, ordinary word for
 "a day." Here's the real surprise: it's **borrowed from Classical
@@ -32,7 +49,8 @@ Latin's *diēs*, Hindi's *din*, and Kannada's *dina*. Both roots
 independently mean something like "shining, bright" — but they are **not**
 cousins; this is convergent meaning, not shared ancestry.
 
-## దినము — Sanskrit tatsama, but the FORMAL alternate here
+## Why it's said this way: దినము — Sanskrit tatsama, but the FORMAL alternate here
+<!-- hl-knowledge: introduces=[TE-PRAGMATICS-C23-ROJU-02]; assesses=[] -->
 
 Telugu also has **దినము** (**dinamu**) — the same Sanskrit **tatsama**
 word as Kannada's *dina*. But here's the honest twist: unlike Kannada,
@@ -42,6 +60,7 @@ Telugu's formal/everyday split runs the **opposite direction** from
 Kannada's.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03, TE-ETYMON-C23-ROJU-01, TE-PRAGMATICS-C23-ROJU-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "rōju" — "day," a genuine Persian loanword]
@@ -51,6 +70,7 @@ Kannada's.
   Kannada's plain dina]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03, TE-ETYMON-C23-ROJU-01, TE-PRAGMATICS-C23-ROJU-02] -->
 
 [PAUSE 3s] What language does Telugu's everyday **రోజు** (*rōju*) come
 from? (**Persian** — *rōz*.) Is Persian *rōz*'s PIE root the same as

--- a/code/learning/human-languages/telugu/lessons/TE-C24-ratri.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C24-ratri.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C24-ratri
+spine_node: SPINE-TIME-OF-DAY
+sequence: 520
 chapter: 24
 type: word
 headword: రాత్రి
@@ -9,18 +12,32 @@ prerequisites: [TE-C17-madhyaahnam-ardharaatri, TE-C23-roju]
 sounds: [telugu-conjunct-tra, telugu-vowel-sign-i]
 roots: [sanskrit-ratri, telugu-native-reyi-maapu]
 etymology_hook: "రాత్రి (rātri, 'night') is a Sanskrit tatsama word, already hiding inside అర్ధరాత్రి (ardharātri, 'midnight'), and — unlike rōju's genuine Persian surprise last lesson — it really is Telugu's everyday word for night; genuine native Telugu words exist too — రేయి (rēyi, most sources treat it as inherited Dravidian, though some grammars link it to rātri itself), మాపు (māpu, whose primary sense is actually 'evening/dusk,' as in రేపుమాపు, 'morning and evening'), and ఇరులు (irulu, cognate with Kannada's ಇರುಳು/iruḷu, primarily 'darkness') — a messier, three-way version of Kannada's cleaner two-word replacement story, not a tidy mirror of it"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03, TE-ETYMON-C23-ROJU-01, TE-PRAGMATICS-C23-ROJU-02]
+introduces:
+  knowledge: [TE-ETYMON-C24-RATRI-01, TE-ETYMON-C24-RATRI-02]
+practises:
+  knowledge: [TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03, TE-ETYMON-C23-ROJU-01, TE-PRAGMATICS-C23-ROJU-02, TE-ETYMON-C24-RATRI-01, TE-ETYMON-C24-RATRI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C17-madhyaahnam-ardharaatri, TE-C23-roju]
 ---
 
 # రాత్రి (rātri) — "night," this time matching the expected pattern
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03, TE-ETYMON-C23-ROJU-01, TE-PRAGMATICS-C23-ROJU-02] -->
 
 [PAUSE 2s] Last lesson's *rōju* broke every expectation. This one is more
 straightforward — but still worth checking honestly, not assuming.
 
-## రాత్రి — Telugu's genuine everyday word
+## The word, taken apart - రాత్రి — Telugu's genuine everyday word
+<!-- hl-knowledge: introduces=[TE-ETYMON-C24-RATRI-01]; assesses=[] -->
 
 **రాత్రి** (**rātri**) — "**night**" — is a Sanskrit **tatsama** word,
 already hiding inside **అర్ధరాత్రి** (*ardharātri*, "midnight," Chapter 17).
@@ -28,7 +45,8 @@ Unlike *rōju*'s Persian surprise, *rātri* really **is** Telugu's ordinary,
 everyday word for "night" — matching Kannada's own pattern this time, not
 breaking it.
 
-## A messier story than Kannada's — three words, not one
+## The word, taken apart - A messier story than Kannada's — three words, not one
+<!-- hl-knowledge: introduces=[TE-ETYMON-C24-RATRI-02]; assesses=[] -->
 
 Telugu **does** have native words here — but be honest: it's a **messier**
 picture than Kannada's clean two-word story, not a tidy mirror of it.
@@ -47,6 +65,7 @@ unlike Kannada's single native competitor, Telugu's "native" side is split
 across three words in three different, overlapping senses.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03, TE-ETYMON-C23-ROJU-01, TE-PRAGMATICS-C23-ROJU-02, TE-ETYMON-C24-RATRI-01, TE-ETYMON-C24-RATRI-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "rātri" — "night," already met inside ardharātri]
@@ -56,6 +75,7 @@ across three words in three different, overlapping senses.
   matches it]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03, TE-ETYMON-C23-ROJU-01, TE-PRAGMATICS-C23-ROJU-02, TE-ETYMON-C24-RATRI-01, TE-ETYMON-C24-RATRI-02] -->
 
 [PAUSE 3s] Where have you already met **రాత్రి** before this lesson?
 (**అర్ధరాత్రి**, *ardharātri*, "midnight.") Does *rātri* follow the same

--- a/code/learning/human-languages/telugu/lessons/TE-C25-shubha-ratri.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C25-shubha-ratri.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C25-shubha-ratri
+spine_node: SPINE-TIME-OF-DAY
+sequence: 530
 chapter: 25
 type: phrase
 headword: శుభ రాత్రి
@@ -9,26 +12,41 @@ prerequisites: [TE-C24-ratri]
 sounds: [telugu-sha, telugu-bha]
 roots: [sanskrit-shubha-beautiful, sanskrit-ratri]
 etymology_hook: "శుభ రాత్రి (śubha rātri), 'good night,' literally 'auspicious night' — both pieces Sanskrit tatsama: రాత్రి (already met last lesson) plus శుభ (śubha, 'auspicious,' from root śubh, 'to be beautiful,' PIE *ḱewbʰ-); some sources describe modern Telugu speakers often code-switching to English 'good night' in casual conversation instead of saying śubha rātri aloud — though this same code-switching pattern for farewells plausibly shows up across other South Asian languages too, so it's honestly unclear whether this is Telugu-specific or just where the available sources happened to comment on it"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TE-ETYMON-C24-RATRI-01, TE-ETYMON-C24-RATRI-02]
+introduces:
+  knowledge: [TE-ETYMON-C25-SHUBHA-RATRI-01, TE-PRAGMATICS-C25-SHUBHA-RATRI-02]
+practises:
+  knowledge: [TE-ETYMON-C24-RATRI-01, TE-ETYMON-C24-RATRI-02, TE-ETYMON-C25-SHUBHA-RATRI-01, TE-PRAGMATICS-C25-SHUBHA-RATRI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral-parting
+variety: standard-colloquial
 reviews_of: [TE-C24-ratri]
 ---
 
 # శుభ రాత్రి (śubha rātri) — the standard translation, honestly checked against real speech
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C24-RATRI-01, TE-ETYMON-C24-RATRI-02] -->
 
 [PAUSE 2s] You have both pieces already: *rātri* from last lesson, and one
 more Sanskrit word. But this lesson's honest twist is about who actually
 says the result out loud.
 
-## శుభ రాత్రి — "auspicious night"
+## The word, taken apart - శుభ రాత్రి — "auspicious night"
+<!-- hl-knowledge: introduces=[TE-ETYMON-C25-SHUBHA-RATRI-01]; assesses=[] -->
 
 **శుభ రాత్రి** (**śubha rātri**) — "**good night**" — literally
 "**auspicious night**." Both pieces are Sanskrit **tatsama**: **రాత్రి**
 (*rātri*, "night," already met) plus **శుభ** (*śubha*, "**auspicious**,"
 from root **śubh**, "to be beautiful," ultimately PIE ***\*ḱewbʰ-***).
 
-## Be honest: a claim worth flagging, not overstating
+## Why it's said this way: Be honest: a claim worth flagging, not overstating
+<!-- hl-knowledge: introduces=[TE-PRAGMATICS-C25-SHUBHA-RATRI-02]; assesses=[] -->
 
 Here's a genuinely interesting wrinkle, hedged appropriately: some sources
 describe modern Telugu speakers, especially casually, often **code-
@@ -45,6 +63,7 @@ correct and understood Telugu, whatever its actual spoken frequency turns
 out to be.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C24-RATRI-01, TE-ETYMON-C24-RATRI-02, TE-ETYMON-C25-SHUBHA-RATRI-01, TE-PRAGMATICS-C25-SHUBHA-RATRI-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "śubha rātri" — "good night," literally "auspicious night"]
@@ -53,6 +72,7 @@ out to be.
   code-switch to English instead]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C24-RATRI-01, TE-ETYMON-C24-RATRI-02, TE-ETYMON-C25-SHUBHA-RATRI-01, TE-PRAGMATICS-C25-SHUBHA-RATRI-02] -->
 
 [PAUSE 3s] What does **శుభ రాత్రి** literally mean? ("**Auspicious
 night**.") Is *śubha rātri* actually the phrase most Telugu speakers say

--- a/code/learning/human-languages/telugu/lessons/TE-C26-udayam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C26-udayam.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C26-udayam
+spine_node: SPINE-TIME-OF-DAY
+sequence: 540
 chapter: 26
 type: word
 headword: ఉదయం
@@ -9,19 +12,33 @@ prerequisites: [TE-C17-madhyaahnam-ardharaatri, TE-C23-roju]
 sounds: [telugu-anusvara, telugu-da]
 roots: [sanskrit-udaya-rise]
 etymology_hook: "ఉదయం (udayam, 'morning') is a Sanskrit tatsama — from ఉదయ (udaya, 'rise, appearance') + Telugu's own -ము (-mu) suffix — and it's genuinely Telugu's most common, general everyday word for 'morning'; be honest, though: it doesn't have the field entirely to itself — పొద్దు/పొద్దున (poddu/podduna), genuine Proto-Dravidian vocabulary cognate with Tamil pozhudu and Kannada hottu, does real everyday work too, and వేకువ (vēkuva, 'dawn, early morning') is labeled colloquial, not archaic; be honest also about the contrast with Kannada: Kannada has this exact Sanskrit root (udaya), but only inside its GREETING, ಶುಭೋದಯ (śubhōdaya) — Kannada's everyday morning noun is the unrelated native ಬೆಳಗ್ಗೆ; Telugu's ఉదయం, by contrast, covers BOTH the everyday-noun and greeting-root jobs at once — no such twist here, unlike the Persian-loan surprise already found for Telugu's 'day' word (rōju, TE-C23)"
-est_minutes: 4
+duration:
+  max_seconds: 275
+requires:
+  knowledge: [TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03, TE-ETYMON-C23-ROJU-01, TE-PRAGMATICS-C23-ROJU-02]
+introduces:
+  knowledge: [TE-ETYMON-C26-UDAYAM-01, TE-PRAGMATICS-C26-UDAYAM-02]
+practises:
+  knowledge: [TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03, TE-ETYMON-C23-ROJU-01, TE-PRAGMATICS-C23-ROJU-02, TE-ETYMON-C26-UDAYAM-01, TE-PRAGMATICS-C26-UDAYAM-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C17-madhyaahnam-ardharaatri, TE-C23-roju]
 ---
 
 # ఉదయం (udayam) — the same Sanskrit root, a different job than in Kannada
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03, TE-ETYMON-C23-ROJU-01, TE-PRAGMATICS-C23-ROJU-02] -->
 
 [PAUSE 2s] Last lesson's రోజు was a genuine Persian surprise. This
 lesson's word for "morning" goes the other way — straight Sanskrit,
 doing double duty in a way its Kannada cousin doesn't.
 
-## ఉదయం — Sanskrit, and genuinely everyday
+## The word, taken apart - ఉదయం — Sanskrit, and genuinely everyday
+<!-- hl-knowledge: introduces=[TE-ETYMON-C26-UDAYAM-01]; assesses=[] -->
 
 **ఉదయం** (**udayam**) — "**morning**" — is a Sanskrit **tatsama**: from
 **ఉదయ** (*udaya*, "**rise, appearance**") plus Telugu's own **-ము**
@@ -35,7 +52,8 @@ early morning") is labeled **colloquial**, not archaic or purely
 poetic. ఉదయం is the broadest, most general word — but not an
 uncontested one.
 
-## Be honest: the same root, doing a different job than in Kannada
+## Why it's said this way: Be honest: the same root, doing a different job than in Kannada
+<!-- hl-knowledge: introduces=[TE-PRAGMATICS-C26-UDAYAM-02]; assesses=[] -->
 
 Here's the honest cross-language twist. Kannada also has this **exact**
 Sanskrit root, **ఉదయ** (*udaya*) — but only inside its **greeting**,
@@ -49,6 +67,7 @@ Persian surprise for "day"), Telugu's morning word holds no such twist —
 straightforwardly Sanskrit, start to finish.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03, TE-ETYMON-C23-ROJU-01, TE-PRAGMATICS-C23-ROJU-02, TE-ETYMON-C26-UDAYAM-01, TE-PRAGMATICS-C26-UDAYAM-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "udayam" — "morning," Sanskrit tatsama, the broadest word,
@@ -59,6 +78,7 @@ straightforwardly Sanskrit, start to finish.
   straightforward Sanskrit]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03, TE-ETYMON-C23-ROJU-01, TE-PRAGMATICS-C23-ROJU-02, TE-ETYMON-C26-UDAYAM-01, TE-PRAGMATICS-C26-UDAYAM-02] -->
 
 [PAUSE 3s] Is ఉదయం the ONLY word Telugu speakers use for "morning"?
 (**No** — it's the broadest, most common one, but పొద్దు/పొద్దున and

--- a/code/learning/human-languages/telugu/lessons/TE-C27-sayantram.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C27-sayantram.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C27-sayantram
+spine_node: SPINE-TIME-OF-DAY
+sequence: 550
 chapter: 27
 type: word
 headword: సాయంత్రం
@@ -9,19 +12,33 @@ prerequisites: [TE-C26-udayam]
 sounds: [telugu-anusvara, telugu-conjunct-tra]
 roots: [sanskrit-sayam-evening]
 etymology_hook: "సాయంత్రం (sāyantram, 'evening') is a Sanskrit tatsama — from సాయం (sāyam, 'in the evening') plus a Sanskrit '-tana' suffix that turns time-adverbs into adjectives (cf. divātana, 'of the day'; sanātana, 'eternal'); సాయం itself, per Wiktionary, traces to PIE *seh₁- ('long, lasting') — and Wiktionary explicitly states this root is 'distantly related to Latin sērus,' independently confirmed on sērus's own Wiktionary page (Proto-Italic *sēros ← PIE *seh₁-, 'to be long, lasting, slow'); sērus is already established in this course as the root of French soir and Italian sera (LA-C33-vesper) — meaning Telugu's everyday evening word and the Romance family's everyday evening word are genuine, if very distant, cognates, one route through Sanskrit tatsama borrowing, one through Vulgar Latin erosion"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TE-ETYMON-C26-UDAYAM-01, TE-PRAGMATICS-C26-UDAYAM-02]
+introduces:
+  knowledge: [TE-ETYMON-C27-SAYANTRAM-01, TE-ETYMON-C27-SAYANTRAM-02]
+practises:
+  knowledge: [TE-ETYMON-C26-UDAYAM-01, TE-PRAGMATICS-C26-UDAYAM-02, TE-ETYMON-C27-SAYANTRAM-01, TE-ETYMON-C27-SAYANTRAM-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C26-udayam]
 ---
 
 # సాయంత్రం (sāyantram) — a distant cousin of French "soir"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C26-UDAYAM-01, TE-PRAGMATICS-C26-UDAYAM-02] -->
 
 [PAUSE 2s] This lesson's word for "evening" reaches back to a PIE root
 you've technically already met — in a completely different language,
 on a completely different continent's language family.
 
-## సాయంత్రం — Sanskrit, built from "evening" plus a time-suffix
+## The word, taken apart - సాయంత్రం — Sanskrit, built from "evening" plus a time-suffix
+<!-- hl-knowledge: introduces=[TE-ETYMON-C27-SAYANTRAM-01]; assesses=[] -->
 
 **సాయంత్రం** (**sāyantram**) — "**evening**" — is a Sanskrit
 **tatsama**: from **సాయం** (*sāyam*, "**in the evening**") plus a
@@ -29,7 +46,8 @@ Sanskrit **-tana** suffix that turns time-adverbs into adjectives — the
 same suffix pattern behind Sanskrit **divātana** ("of the day") and
 **sanātana** ("eternal, lasting").
 
-## A genuine distant cousin: the same PIE root as Latin's sērus
+## The word, taken apart - A genuine distant cousin: the same PIE root as Latin's sērus
+<!-- hl-knowledge: introduces=[TE-ETYMON-C27-SAYANTRAM-02]; assesses=[] -->
 
 Here's the striking part, checked directly against primary sources
 rather than assumed: **సాయం** itself traces to **Proto-Indo-European**
@@ -46,6 +64,7 @@ and Italian, both ultimately the same Proto-Indo-European idea of
 something "long, lasting" stretching into "late in the day."
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C26-UDAYAM-01, TE-PRAGMATICS-C26-UDAYAM-02, TE-ETYMON-C27-SAYANTRAM-01, TE-ETYMON-C27-SAYANTRAM-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "sāyantram" — "evening," sāyam + the -tana time-suffix]
@@ -54,6 +73,7 @@ something "long, lasting" stretching into "late in the day."
   and Italian sera, via Latin sērus]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C26-UDAYAM-01, TE-PRAGMATICS-C26-UDAYAM-02, TE-ETYMON-C27-SAYANTRAM-01, TE-ETYMON-C27-SAYANTRAM-02] -->
 
 [PAUSE 3s] What is సాయంత్రం built from? (**సాయం**, "in the evening," +
 a Sanskrit "-tana" time-adjective suffix.) What PIE root does సాయం trace

--- a/code/learning/human-languages/telugu/lessons/TE-C28-madhyahnam-widened.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C28-madhyahnam-widened.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C28-madhyahnam-widened
+spine_node: SPINE-TIME-OF-DAY
+sequence: 560
 chapter: 28
 type: word
 headword: మధ్యాహ్నం
@@ -9,19 +12,33 @@ prerequisites: [TE-C17-madhyaahnam-ardharaatri, TE-C27-sayantram]
 sounds: [telugu-conjunct-dhya, telugu-vowel-sign-aa]
 roots: [sanskrit-madhya-middle]
 etymology_hook: "మధ్యాహ్నం (madhyāhnam) is the SAME word already met in TE-C17 meaning precisely 'noon' ('middle' + 'day') — but a directly-fetched source confirms it also covers 'the time between noon and evening' in modern usage, the same kind of widening already found for Hindi's दोपहर (well-confirmed) and Kannada's మధ్యాహ్న (more thinly hedged); a separate, more precise word for 'later afternoon' specifically, అపరాహ్నం (aparāhnam, from the same classical five-part Sanskrit day division as Kannada's అపరాహ్న), also exists; thin, informal evidence (native-speaker forum discussion, dictionary usage notes) converges on మధ్యాహ్నం winning colloquially while అపరాహ్నం stays the formally precise term — a hedged, KA-C28-style parallel, not a fully settled comparison"
-est_minutes: 4
+duration:
+  max_seconds: 270
+requires:
+  knowledge: [TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03, TE-ETYMON-C27-SAYANTRAM-01, TE-ETYMON-C27-SAYANTRAM-02]
+introduces:
+  knowledge: [TE-PRAGMATICS-C28-MADHYAHNAM-WIDENED-01, TE-ETYMON-C28-MADHYAHNAM-WIDENED-02]
+practises:
+  knowledge: [TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03, TE-ETYMON-C27-SAYANTRAM-01, TE-ETYMON-C27-SAYANTRAM-02, TE-PRAGMATICS-C28-MADHYAHNAM-WIDENED-01, TE-ETYMON-C28-MADHYAHNAM-WIDENED-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TE-C17-madhyaahnam-ardharaatri, TE-C27-sayantram]
 ---
 
 # మధ్యాహ్నం — the same "noon" word, now also "afternoon"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03, TE-ETYMON-C27-SAYANTRAM-01, TE-ETYMON-C27-SAYANTRAM-02] -->
 
 [PAUSE 2s] You already know మధ్యాహ్నం means "noon" — precisely, "middle
 of the day." This lesson's honest twist: the word doesn't stay that
 precise in modern use.
 
-## మధ్యాహ్నం — same word, a genuinely wider modern meaning
+## Why it's said this way: మధ్యాహ్నం — same word, a genuinely wider modern meaning
+<!-- hl-knowledge: introduces=[TE-PRAGMATICS-C28-MADHYAHNAM-WIDENED-01]; assesses=[] -->
 
 **మధ్యాహ్నం** (**madhyāhnam**) is the exact word from Chapter 17,
 still literally "middle" + "day" — but a source fetched directly (not
@@ -33,7 +50,8 @@ confirmed widened from "noon" to "afternoon") and, more thinly, for
 Kannada's own **మధ్యాహ్న** (a hedged, single-source impression of the
 same kind of stretch).
 
-## A more precise word exists too — a thin but real comparison
+## The word, taken apart - A more precise word exists too — a thin but real comparison
+<!-- hl-knowledge: introduces=[TE-ETYMON-C28-MADHYAHNAM-WIDENED-02]; assesses=[] -->
 
 Telugu also has **అపరాహ్నం** (**aparāhnam**), from the same classical
 **five-part Sanskrit day division** already found behind Kannada's
@@ -48,6 +66,7 @@ sourcing — treat it the same cautious way KA-C28 treated its own
 equivalent finding, not as fully settled.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03, TE-ETYMON-C27-SAYANTRAM-01, TE-ETYMON-C27-SAYANTRAM-02, TE-PRAGMATICS-C28-MADHYAHNAM-WIDENED-01, TE-ETYMON-C28-MADHYAHNAM-WIDENED-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "madhyāhnam" — the same word from Chapter 17, "middle of
@@ -58,6 +77,7 @@ equivalent finding, not as fully settled.
   afternoon, staying the more formal term per thin but real evidence]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01, TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02, TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03, TE-ETYMON-C27-SAYANTRAM-01, TE-ETYMON-C27-SAYANTRAM-02, TE-PRAGMATICS-C28-MADHYAHNAM-WIDENED-01, TE-ETYMON-C28-MADHYAHNAM-WIDENED-02] -->
 
 [PAUSE 3s] Is మధ్యాహ్నం a new word, or the same one from Chapter 17?
 (**The same word** — "middle" + "day.") Does modern usage confirm

--- a/code/learning/human-languages/telugu/lessons/TE-C29-subhodayam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C29-subhodayam.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C29-subhodayam
+spine_node: SPINE-TIME-OF-DAY
+sequence: 570
 chapter: 29
 type: phrase
 headword: శుభోదయం
@@ -9,26 +12,41 @@ prerequisites: [TE-C26-udayam]
 sounds: [telugu-sha, telugu-conjunct-bha]
 roots: [su-good, sanskrit-udaya-rise]
 etymology_hook: "శుభోదయం (śubhōdayam, 'good morning') = శుభ ('good') + ఉదయం (already met, TE-C26); be honest about sourcing here: one directly-fetched source — a Telugu-learning content blog, the SAME low-authority genre already found overstated for Hindi's सुप्रभात and Kannada's ಶುಭೋದಯ — claims this is OUT OF TREND, displaced by ENGLISH 'good morning,' with children taught the English phrase from preschool; treat this with real skepticism, since a directly-fetched page isn't automatically an authoritative source; the same page also calls a SEPARATE alternative, సుప్రభాతం (suprabhātam, built on ప్రభాత/prabhāta — a genuinely DIFFERENT Sanskrit root from ఉదయ/udaya, NOT the same root as Kannada's ಶುಭೋದಯ, which itself uses udaya) 'archaic'; a third option, ప్రొద్దుటి వందనాలు ('morning greetings,' built on పొద్దు, TE-C26's genuine native competitor), also exists but isn't confirmed common; నమస్కారం is the safer everyday-greeting bet, matching the నమస్కార/नमस्ते pattern already found for Kannada and Hindi"
-est_minutes: 4
+duration:
+  max_seconds: 280
+requires:
+  knowledge: [TE-ETYMON-C26-UDAYAM-01, TE-PRAGMATICS-C26-UDAYAM-02]
+introduces:
+  knowledge: [TE-ETYMON-C29-SUBHODAYAM-01, TE-PRAGMATICS-C29-SUBHODAYAM-02]
+practises:
+  knowledge: [TE-ETYMON-C26-UDAYAM-01, TE-PRAGMATICS-C26-UDAYAM-02, TE-ETYMON-C29-SUBHODAYAM-01, TE-PRAGMATICS-C29-SUBHODAYAM-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: formal-traditional
+variety: standard-colloquial
 reviews_of: [TE-C26-udayam]
 ---
 
 # శుభోదయం (śubhōdayam) — a claim worth real skepticism, not a settled fact
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C26-UDAYAM-01, TE-PRAGMATICS-C26-UDAYAM-02] -->
 
 [PAUSE 2s] You already have ఉదయం. This lesson's honest twist is about
 a dramatic-sounding claim — and about being skeptical of it, even
 though it came from a source fetched directly.
 
-## శుభోదయం — శుభ + ఉదయం, the traditional phrase
+## The word, taken apart - శుభోదయం — శుభ + ఉదయం, the traditional phrase
+<!-- hl-knowledge: introduces=[TE-ETYMON-C29-SUBHODAYAM-01]; assesses=[] -->
 
 **శుభోదయం** (**śubhōdayam**) — "**good morning**" — is built from
 **శుభ** ("good") plus **ఉదయం** (already met, Chapter 26). Grammatically
 and etymologically, this is the straightforward, traditional Telugu
 "good morning."
 
-## Be honest: a dramatic claim, from a source worth real skepticism
+## Why it's said this way: Be honest: a dramatic claim, from a source worth real skepticism
+<!-- hl-knowledge: introduces=[TE-PRAGMATICS-C29-SUBHODAYAM-02]; assesses=[] -->
 
 Here's the twist, and the honesty this time cuts against the source
 itself: one directly-fetched page describes **శుభోదయం** as **out of
@@ -53,6 +71,7 @@ for everyday use — matching the same నమస్కార/नमस्ते 
 found doing the real everyday work for both Kannada and Hindi.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C26-UDAYAM-01, TE-PRAGMATICS-C26-UDAYAM-02, TE-ETYMON-C29-SUBHODAYAM-01, TE-PRAGMATICS-C29-SUBHODAYAM-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "śubhōdayam" — "good morning," śubha + udayam]
@@ -61,6 +80,7 @@ found doing the real everyday work for both Kannada and Hindi.
 - [YOU SAY: నమస్కారం — the safer everyday-greeting bet]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C26-UDAYAM-01, TE-PRAGMATICS-C26-UDAYAM-02, TE-ETYMON-C29-SUBHODAYAM-01, TE-PRAGMATICS-C29-SUBHODAYAM-02] -->
 
 [PAUSE 3s] What is శుభోదయం built from? (**శుభ** + **ఉదయం**.) Is the
 claim that శుభోదయం has been displaced by English a confirmed,

--- a/code/learning/human-languages/telugu/lessons/TE-C30-subha-sayantram.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C30-subha-sayantram.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C30-subha-sayantram
+spine_node: SPINE-TIME-OF-DAY
+sequence: 580
 chapter: 30
 type: phrase
 headword: శుభ సాయంత్రం
@@ -9,26 +12,41 @@ prerequisites: [TE-C27-sayantram]
 sounds: [telugu-sha, telugu-anusvara]
 roots: [su-good, sanskrit-sayam-evening]
 etymology_hook: "శుభ సాయంత్రం (śubha sāyantram, 'good evening') pairs శుభ with సాయంత్రం (TE-C27's word with the striking distant cognate to Latin sērus/French soir); unlike GREETING-MORNING's శుభోదయం, which rested on ONE dramatic, low-authority source claiming displacement by English, TWO independently fetched sources here agree it's genuinely, commonly used in BOTH formal and informal contexts — a real difference in evidence quality, worth noting explicitly rather than treating every 'good ___' greeting in this arc the same way; నమస్కారం remains confirmed as a time-independent, any-occasion alternative rather than something that has displaced this specific greeting"
-est_minutes: 4
+duration:
+  max_seconds: 255
+requires:
+  knowledge: [TE-ETYMON-C27-SAYANTRAM-01, TE-ETYMON-C27-SAYANTRAM-02]
+introduces:
+  knowledge: [TE-ETYMON-C30-SUBHA-SAYANTRAM-01, TE-PRAGMATICS-C30-SUBHA-SAYANTRAM-02]
+practises:
+  knowledge: [TE-ETYMON-C27-SAYANTRAM-01, TE-ETYMON-C27-SAYANTRAM-02, TE-ETYMON-C30-SUBHA-SAYANTRAM-01, TE-PRAGMATICS-C30-SUBHA-SAYANTRAM-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: formal-and-neutral
+variety: standard-colloquial
 reviews_of: [TE-C27-sayantram]
 ---
 
 # శుభ సాయంత్రం (śubha sāyantram) — a claim that actually holds up on checking
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C27-SAYANTRAM-01, TE-ETYMON-C27-SAYANTRAM-02] -->
 
 [PAUSE 2s] Last lesson's morning greeting rested on one dramatic,
 shaky source. This one is different — and the difference itself is
 worth noticing.
 
-## శుభ సాయంత్రం — paired with సాయంత్రం's own striking story
+## The word, taken apart - శుభ సాయంత్రం — paired with సాయంత్రం's own striking story
+<!-- hl-knowledge: introduces=[TE-ETYMON-C30-SUBHA-SAYANTRAM-01]; assesses=[] -->
 
 **శుభ సాయంత్రం** (**śubha sāyantram**) — "**good evening**" — pairs
 **శుభ** ("good") with **సాయంత్రం** (already met, Chapter 27 — the word
 whose PIE root, *seh₁-, turned out to be a genuine distant cognate of
 Latin's *sērus*, and so of French **soir** and Italian **sera**).
 
-## Be honest: this claim actually checked out, unlike the last one
+## Why it's said this way: Be honest: this claim actually checked out, unlike the last one
+<!-- hl-knowledge: introduces=[TE-PRAGMATICS-C30-SUBHA-SAYANTRAM-02]; assesses=[] -->
 
 Here's the honest contrast worth drawing explicitly: last lesson's
 **శుభోదయం** rested on **one** dramatic, low-authority source claiming
@@ -48,6 +66,7 @@ just as honest about a claim holding up as about one that doesn't.
 English reportedly displaced శుభోదయం.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C27-SAYANTRAM-01, TE-ETYMON-C27-SAYANTRAM-02, TE-ETYMON-C30-SUBHA-SAYANTRAM-01, TE-PRAGMATICS-C30-SUBHA-SAYANTRAM-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "śubha sāyantram" — "good evening," śubha + sāyantram]
@@ -57,6 +76,7 @@ English reportedly displaced శుభోదయం.
   replacement here]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-ETYMON-C27-SAYANTRAM-01, TE-ETYMON-C27-SAYANTRAM-02, TE-ETYMON-C30-SUBHA-SAYANTRAM-01, TE-PRAGMATICS-C30-SUBHA-SAYANTRAM-02] -->
 
 [PAUSE 3s] What word does శుభ సాయంత్రం pair with, and what's that
 word's own striking cross-language story? (**సాయంత్రం** — a genuine

--- a/code/learning/human-languages/telugu/lessons/TE-C31-subha-madhyahnam-register.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C31-subha-madhyahnam-register.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C31-subha-madhyahnam-register
+spine_node: SPINE-TIME-OF-DAY
+sequence: 600
 chapter: 31
 type: culture
 headword: శుభ మధ్యాహ్నం — register
@@ -9,18 +12,32 @@ prerequisites: [TE-C31-subha-madhyahnam]
 sounds: []
 roots: []
 etymology_hook: "source claims must stay separate: two sources support the formal timing, while only one ranks the greeting as less common"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TE-LEX-C31-SUBHA-MADHYAHNAM-01]
+introduces:
+  knowledge: [TE-PRAGMATICS-C31-SUBHA-MADHYAHNAM-REGISTER-01, TE-PRAGMATICS-C31-SUBHA-MADHYAHNAM-REGISTER-02]
+practises:
+  knowledge: [TE-LEX-C31-SUBHA-MADHYAHNAM-01, TE-PRAGMATICS-C31-SUBHA-MADHYAHNAM-REGISTER-01, TE-PRAGMATICS-C31-SUBHA-MADHYAHNAM-REGISTER-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: formal-workplace
+variety: standard-colloquial
 reviews_of: [TE-C29-subhodayam, TE-C30-subha-sayantram, TE-C31-subha-madhyahnam]
 ---
 
 # శుభ మధ్యాహ్నం — register and evidence
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C31-SUBHA-MADHYAHNAM-01] -->
 
 [PAUSE 2s] You can now build **శుభ మధ్యాహ్నం**. The next question is when it
 sounds natural—and how strongly the available evidence answers that question.
 
-## Real and formal; frequency is a narrower claim
+## Why it's said this way: Real and formal; frequency is a narrower claim
+<!-- hl-knowledge: introduces=[TE-PRAGMATICS-C31-SUBHA-MADHYAHNAM-REGISTER-01]; assesses=[] -->
 
 Two independently fetched language-learning sources confirm that
 **శుభ మధ్యాహ్నం** is a real, correctly formed greeting for **formal or
@@ -33,7 +50,8 @@ that frequency comparison. So there are two sources for “real and formal,” b
 only one for “less common.” A second source must not be counted as evidence for
 a claim it never made.
 
-## The honest three-way greeting map
+## Why it's said this way: The honest three-way greeting map
+<!-- hl-knowledge: introduces=[TE-PRAGMATICS-C31-SUBHA-MADHYAHNAM-REGISTER-02]; assesses=[] -->
 
 - **శుభోదయం** — the morning lesson found one low-authority claim of
   displacement by English; treat that dramatic claim skeptically.
@@ -45,6 +63,7 @@ The three phrases do not need one uniform usage story. For a time-independent
 everyday greeting, **నమస్కారం** remains the safer choice.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C31-SUBHA-MADHYAHNAM-01, TE-PRAGMATICS-C31-SUBHA-MADHYAHNAM-REGISTER-01, TE-PRAGMATICS-C31-SUBHA-MADHYAHNAM-REGISTER-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: the two-source claim — real, formal, and workplace-timed]
@@ -52,6 +71,7 @@ everyday greeting, **నమస్కారం** remains the safer choice.
 - [YOU SAY: నమస్కారం — the time-independent everyday alternative]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C31-SUBHA-MADHYAHNAM-01, TE-PRAGMATICS-C31-SUBHA-MADHYAHNAM-REGISTER-01, TE-PRAGMATICS-C31-SUBHA-MADHYAHNAM-REGISTER-02] -->
 
 [PAUSE 3s] Do both sources rank శుభ మధ్యాహ్నం as less common? (**No.** Both
 support its formal use; only Talkpal makes the frequency comparison.) What is

--- a/code/learning/human-languages/telugu/lessons/TE-C31-subha-madhyahnam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C31-subha-madhyahnam.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TE-C31-subha-madhyahnam
+spine_node: SPINE-TIME-OF-DAY
+sequence: 590
 chapter: 31
 type: phrase
 headword: శుభ మధ్యాహ్నం
@@ -9,18 +12,32 @@ prerequisites: [TE-C28-madhyahnam-widened, TE-C29-subhodayam, TE-C30-subha-sayan
 sounds: [telugu-conjunct-dhya, telugu-anusvara]
 roots: [su-good, sanskrit-madhya-middle]
 etymology_hook: "శుభ మధ్యాహ్నం pairs శుభ with the widened modern మధ్యాహ్నం, not the more classically precise అపరాహ్నం, exactly as Kannada does"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TE-PRAGMATICS-C28-MADHYAHNAM-WIDENED-01, TE-ETYMON-C28-MADHYAHNAM-WIDENED-02, TE-ETYMON-C29-SUBHODAYAM-01, TE-PRAGMATICS-C29-SUBHODAYAM-02, TE-ETYMON-C30-SUBHA-SAYANTRAM-01, TE-PRAGMATICS-C30-SUBHA-SAYANTRAM-02]
+introduces:
+  knowledge: [TE-LEX-C31-SUBHA-MADHYAHNAM-01]
+practises:
+  knowledge: [TE-PRAGMATICS-C28-MADHYAHNAM-WIDENED-01, TE-ETYMON-C28-MADHYAHNAM-WIDENED-02, TE-ETYMON-C29-SUBHODAYAM-01, TE-PRAGMATICS-C29-SUBHODAYAM-02, TE-ETYMON-C30-SUBHA-SAYANTRAM-01, TE-PRAGMATICS-C30-SUBHA-SAYANTRAM-02, TE-LEX-C31-SUBHA-MADHYAHNAM-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: formal-workplace
+variety: standard-colloquial
 reviews_of: [TE-C28-madhyahnam-widened, TE-C29-subhodayam, TE-C30-subha-sayantram]
 ---
 
 # శుభ మధ్యాహ్నం (śubha madhyāhnam) — good afternoon
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TE-PRAGMATICS-C28-MADHYAHNAM-WIDENED-01, TE-ETYMON-C28-MADHYAHNAM-WIDENED-02, TE-ETYMON-C29-SUBHODAYAM-01, TE-PRAGMATICS-C29-SUBHODAYAM-02, TE-ETYMON-C30-SUBHA-SAYANTRAM-01, TE-PRAGMATICS-C30-SUBHA-SAYANTRAM-02] -->
 
 [PAUSE 2s] You already know **శుభ** from the morning and evening greetings and
 **మధ్యాహ్నం** from the parts-of-day lessons. Put them together.
 
-## శుభ + మధ్యాహ్నం
+## You'll want to know: శుభ + మధ్యాహ్నం
+<!-- hl-knowledge: introduces=[TE-LEX-C31-SUBHA-MADHYAHNAM-01]; assesses=[] -->
 
 **శుభ మధ్యాహ్నం** (**śubha madhyāhnam**) means “**good afternoon**.”
 The second word originally centres on “midday” or “noon,” but you learned in
@@ -33,6 +50,7 @@ both languages chose the everyday “noon, widened” word from two available
 classical terms.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TE-PRAGMATICS-C28-MADHYAHNAM-WIDENED-01, TE-ETYMON-C28-MADHYAHNAM-WIDENED-02, TE-ETYMON-C29-SUBHODAYAM-01, TE-PRAGMATICS-C29-SUBHODAYAM-02, TE-ETYMON-C30-SUBHA-SAYANTRAM-01, TE-PRAGMATICS-C30-SUBHA-SAYANTRAM-02, TE-LEX-C31-SUBHA-MADHYAHNAM-01] -->
 
 [PAUSE 1s]
 - [YOU SAY: "śubha madhyāhnam" — "good afternoon," śubha + madhyāhnam]
@@ -41,6 +59,7 @@ classical terms.
 - [YOU SAY: Kannada **ಶುಭ ಮಧ್ಯಾಹ್ನ** — the same word-building choice]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TE-PRAGMATICS-C28-MADHYAHNAM-WIDENED-01, TE-ETYMON-C28-MADHYAHNAM-WIDENED-02, TE-ETYMON-C29-SUBHODAYAM-01, TE-PRAGMATICS-C29-SUBHODAYAM-02, TE-ETYMON-C30-SUBHA-SAYANTRAM-01, TE-PRAGMATICS-C30-SUBHA-SAYANTRAM-02, TE-LEX-C31-SUBHA-MADHYAHNAM-01] -->
 
 [PAUSE 3s] Is శుభ మధ్యాహ్నం built on మధ్యాహ్నం or అపరాహ్నం?
 (**మధ్యాహ్నం** — the “noon, widened” word.) Which sister language made the

--- a/code/packages/typescript/human-language-data/src/book-cli.ts
+++ b/code/packages/typescript/human-language-data/src/book-cli.ts
@@ -1,12 +1,22 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, normalize, relative as pathRelative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
-import { renderBookChapter, type BookGenerationTarget } from "./book.js";
+import {
+  renderBookChapter,
+  type BookGenerationTarget,
+  type InlineRenderOptions,
+} from "./book.js";
 import { defaultCurriculumRoot, loadLessons } from "./loader.js";
+
+interface ConfiguredBookGenerationTarget extends BookGenerationTarget {
+  /** Named reusable mapping from the config's scriptSets table. */
+  scriptSet?: string;
+}
 
 interface BookGenerationConfig {
   version: 1;
-  targets: BookGenerationTarget[];
+  scriptSets?: Record<string, InlineRenderOptions[]>;
+  targets: ConfiguredBookGenerationTarget[];
 }
 
 interface GeneratedBookHashManifest {
@@ -51,7 +61,27 @@ export function generatedBookOutputs(root = defaultCurriculumRoot()): Map<string
   const lessons = loadLessons(root);
   const outputs = new Map<string, string>();
   const manifest: GeneratedBookHashManifest = { version: 1, algorithm: "fnv1a64", chapters: [] };
-  for (const target of config.targets) {
+  for (const configuredTarget of config.targets) {
+    const { scriptSet, ...plainTarget } = configuredTarget;
+    let target: BookGenerationTarget = plainTarget;
+    if (scriptSet !== undefined) {
+      if (
+        target.inlineScripts !== undefined ||
+        target.unicodeScript !== undefined ||
+        target.scriptCommand !== undefined
+      ) {
+        throw new Error(
+          `${target.language} chapter ${target.chapter}: scriptSet cannot be combined with inline script options`,
+        );
+      }
+      const inlineScripts = config.scriptSets?.[scriptSet];
+      if (!inlineScripts) {
+        throw new Error(
+          `${target.language} chapter ${target.chapter}: unknown scriptSet '${scriptSet}'`,
+        );
+      }
+      target = { ...target, inlineScripts };
+    }
     const generated = renderBookChapter(target, lessons);
     safeOutput(root, target.output);
     outputs.set(target.output, generated.tex);

--- a/code/packages/typescript/human-language-data/src/book.ts
+++ b/code/packages/typescript/human-language-data/src/book.ts
@@ -12,12 +12,16 @@ export interface BookGenerationTarget {
   unicodeScript?: string;
   /** LaTeX command name, without the leading backslash, used for those runs. */
   scriptCommand?: string;
+  /** Multiple script/font mappings for lessons that compare writing systems inline. */
+  inlineScripts?: InlineRenderOptions[];
 }
 
 export interface InlineRenderOptions {
   unicodeScript: string;
   scriptCommand: string;
 }
+
+type InlineRenderOptionsInput = InlineRenderOptions | readonly InlineRenderOptions[];
 
 export interface GeneratedBookChapter {
   tex: string;
@@ -54,25 +58,39 @@ function escapeLatexCharacter(character: string): string {
   return escaped[character] ?? character;
 }
 
-function scriptMatcher(options: InlineRenderOptions | undefined): RegExp | undefined {
-  if (!options) return undefined;
-  if (!/^[A-Za-z_]+$/.test(options.unicodeScript)) {
-    throw new Error(`invalid Unicode script '${options.unicodeScript}'`);
-  }
-  if (!/^[A-Za-z@]+$/.test(options.scriptCommand)) {
-    throw new Error(`invalid LaTeX script command '${options.scriptCommand}'`);
-  }
-  return new RegExp(`^\\p{Script_Extensions=${options.unicodeScript}}$`, "u");
+function scriptMatchers(options: InlineRenderOptionsInput | undefined): Array<{
+  matcher: RegExp;
+  scriptCommand: string;
+}> {
+  if (!options) return [];
+  const mappings = Array.isArray(options) ? options : [options];
+  const seen = new Set<string>();
+  return mappings.map((mapping) => {
+    if (!/^[A-Za-z_]+$/.test(mapping.unicodeScript)) {
+      throw new Error(`invalid Unicode script '${mapping.unicodeScript}'`);
+    }
+    if (!/^[A-Za-z@]+$/.test(mapping.scriptCommand)) {
+      throw new Error(`invalid LaTeX script command '${mapping.scriptCommand}'`);
+    }
+    if (seen.has(mapping.unicodeScript)) {
+      throw new Error(`duplicate Unicode script '${mapping.unicodeScript}'`);
+    }
+    seen.add(mapping.unicodeScript);
+    return {
+      matcher: new RegExp(`^\\p{Script_Extensions=${mapping.unicodeScript}}$`, "u"),
+      scriptCommand: mapping.scriptCommand,
+    };
+  });
 }
 
 /** Render the deliberately small inline subset used by schema-v2 lessons. */
 export function renderInlineMarkdown(
   markdown: string,
-  options?: InlineRenderOptions,
+  options?: InlineRenderOptionsInput,
 ): string {
   const output: string[] = [];
   const emphasis: Array<"italic" | "bold"> = [];
-  const script = scriptMatcher(options);
+  const scripts = scriptMatchers(options);
   let cursor = 0;
   const open = (kind: "italic" | "bold"): void => {
     output.push(kind === "italic" ? "\\emph{" : "\\textbf{");
@@ -93,16 +111,17 @@ export function renderInlineMarkdown(
         continue;
       }
     }
-    if (script?.test(character)) {
+    const script = scripts.find((candidate) => candidate.matcher.test(character));
+    if (script) {
       const run: string[] = [];
       while (cursor < markdown.length) {
         const nextCodePoint = markdown.codePointAt(cursor);
         const next = nextCodePoint === undefined ? "" : String.fromCodePoint(nextCodePoint);
-        if (!script.test(next)) break;
+        if (!script.matcher.test(next)) break;
         run.push(escapeLatexCharacter(next));
         cursor += next.length;
       }
-      output.push(`\\${options!.scriptCommand}{${run.join("")}}`);
+      output.push(`\\${script.scriptCommand}{${run.join("")}}`);
       continue;
     }
     if (markdown[cursor] === "`") {
@@ -159,7 +178,7 @@ export function renderInlineMarkdown(
   return output.join("");
 }
 
-function renderMarkdown(markdown: string, options?: InlineRenderOptions): string {
+function renderMarkdown(markdown: string, options?: InlineRenderOptionsInput): string {
   const output: string[] = [];
   const paragraph: string[] = [];
   const quote: string[] = [];
@@ -290,7 +309,7 @@ function renderMarkdown(markdown: string, options?: InlineRenderOptions): string
   return output.join("\n").trimEnd();
 }
 
-function renderBlock(block: LessonBodyBlock, options?: InlineRenderOptions): string {
+function renderBlock(block: LessonBodyBlock, options?: InlineRenderOptionsInput): string {
   const content = renderMarkdown(block.markdown, options);
   const title = renderInlineMarkdown(block.title, options);
   if (block.type === "pronunciation") return `\\begin{sounds}\n${content}\n\\end{sounds}`;
@@ -321,7 +340,7 @@ function lessonSequence(lesson: ParsedLesson): number {
   return Number(stringValue(lesson.frontmatter.sequence));
 }
 
-function sectionShortTitle(lesson: ParsedLesson, options?: InlineRenderOptions): string {
+function sectionShortTitle(lesson: ParsedLesson, options?: InlineRenderOptionsInput): string {
   const title = lesson.realization.type.startsWith("practice")
     ? "Practice"
     : options && stringValue(lesson.frontmatter.romanization).trim() !== ""
@@ -333,7 +352,18 @@ function sectionShortTitle(lesson: ParsedLesson, options?: InlineRenderOptions):
   );
 }
 
-function targetRenderOptions(target: BookGenerationTarget): InlineRenderOptions | undefined {
+function targetRenderOptions(target: BookGenerationTarget): InlineRenderOptionsInput | undefined {
+  if (target.inlineScripts !== undefined) {
+    if (target.unicodeScript !== undefined || target.scriptCommand !== undefined) {
+      throw new Error(
+        `${target.language} chapter ${target.chapter}: inlineScripts cannot be combined with unicodeScript or scriptCommand`,
+      );
+    }
+    if (target.inlineScripts.length === 0) {
+      throw new Error(`${target.language} chapter ${target.chapter}: inlineScripts must not be empty`);
+    }
+    return target.inlineScripts;
+  }
   if (target.unicodeScript === undefined && target.scriptCommand === undefined) return undefined;
   if (target.unicodeScript === undefined || target.scriptCommand === undefined) {
     throw new Error(

--- a/code/packages/typescript/human-language-data/tests/book-cli.test.ts
+++ b/code/packages/typescript/human-language-data/tests/book-cli.test.ts
@@ -85,6 +85,45 @@ describe("canonical book generator filesystem shell", () => {
     expect(() => generatedBookOutputs(root)).toThrow(/unsafe generated book output/);
   });
 
+  it("resolves reusable script sets for cross-script comparison chapters", () => {
+    const root = fixture();
+    const lesson = join(root, "test", "lessons", "hello.md");
+    writeFileSync(lesson, readFileSync(lesson, "utf8").replaceAll("hello", "తెలుగు தமிழ்"));
+    writeFileSync(
+      join(root, "core", "book-generation.json"),
+      `${JSON.stringify({
+        version: 1,
+        scriptSets: {
+          comparisons: [
+            { unicodeScript: "Telugu", scriptCommand: "te" },
+            { unicodeScript: "Tamil", scriptCommand: "ta" },
+          ],
+        },
+        targets: [{
+          language: "test",
+          chapter: 1,
+          title: "Hello",
+          label: "ch:hello",
+          output: "test/book/chapters/ch01-first.tex",
+          scriptSet: "comparisons",
+        }],
+      })}\n`,
+    );
+
+    const chapter = generatedBookOutputs(root).get("test/book/chapters/ch01-first.tex");
+    expect(chapter).toContain("\\te{తెలుగు} \\ta{தமிழ்}");
+  });
+
+  it("fails closed on an unknown reusable script set", () => {
+    const root = fixture();
+    const config = join(root, "core", "book-generation.json");
+    writeFileSync(
+      config,
+      readFileSync(config, "utf8").replace('"output":"test/book/chapters/ch01-first.tex"', '"output":"test/book/chapters/ch01-first.tex","scriptSet":"missing"'),
+    );
+    expect(() => generatedBookOutputs(root)).toThrow(/unknown scriptSet 'missing'/);
+  });
+
   it("rejects an empty generation config and unsupported CLI modes", () => {
     const root = fixture();
     writeFileSync(

--- a/code/packages/typescript/human-language-data/tests/book.test.ts
+++ b/code/packages/typescript/human-language-data/tests/book.test.ts
@@ -111,6 +111,17 @@ describe("canonical LaTeX chapter rendering", () => {
     );
   });
 
+  it("wraps comparisons across multiple configured writing systems", () => {
+    const options = [
+      { unicodeScript: "Telugu", scriptCommand: "te" },
+      { unicodeScript: "Tamil", scriptCommand: "ta" },
+      { unicodeScript: "Kannada", scriptCommand: "ka" },
+    ];
+    expect(renderInlineMarkdown("తెలుగు / தமிழ் / ಕನ್ನಡ", options)).toBe(
+      "\\te{తెలుగు} / \\ta{தமிழ்} / \\ka{ಕನ್ನಡ}",
+    );
+  });
+
   it("uses authored romanization for a non-Latin section bookmark", () => {
     const lesson = parseLesson(
       source("A", 10, "दोन").replace("gloss: दोन", "gloss: two\nromanization: don"),
@@ -128,6 +139,20 @@ describe("canonical LaTeX chapter rendering", () => {
     expect(() => renderBookChapter({ ...target, unicodeScript: "Devanagari" }, [lesson])).toThrow(
       /unicodeScript and scriptCommand must be declared together/,
     );
+    expect(() => renderBookChapter({ ...target, inlineScripts: [] }, [lesson])).toThrow(
+      /inlineScripts must not be empty/,
+    );
+    expect(() =>
+      renderBookChapter(
+        {
+          ...target,
+          unicodeScript: "Devanagari",
+          scriptCommand: "mr",
+          inlineScripts: [{ unicodeScript: "Tamil", scriptCommand: "ta" }],
+        },
+        [lesson],
+      ),
+    ).toThrow(/inlineScripts cannot be combined/);
   });
 
   it("fails closed when a target includes a legacy lesson", () => {

--- a/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
@@ -117,6 +117,41 @@ describe("generated book source hashes", () => {
     expect(bookHashStatus(lessons, "german", chapter)).toBe("synced");
   });
 
+  it.each([
+    [6, 2],
+    [7, 2],
+    [8, 1],
+    [9, 1],
+    [10, 1],
+    [11, 1],
+    [12, 1],
+    [13, 1],
+    [14, 1],
+    [15, 1],
+    [16, 1],
+    [17, 1],
+    [18, 1],
+    [19, 1],
+    [20, 2],
+    [21, 1],
+    [22, 1],
+    [23, 1],
+    [24, 1],
+    [25, 1],
+    [26, 1],
+    [27, 1],
+    [28, 1],
+    [29, 1],
+    [30, 1],
+    [31, 2],
+  ])("matches the browser-loaded Telugu Chapter %i AST across %i lessons", (chapter, count) => {
+    const lessons = loadLessons();
+    const expected = expectedBookHash("telugu", chapter);
+    expect(expected?.lessonIds).toHaveLength(count);
+    expect(actualChapterHash(lessons, "telugu", chapter)).toBe(expected?.sourceHash);
+    expect(bookHashStatus(lessons, "telugu", chapter)).toBe("synced");
+  });
+
   it("reports a generated chapter stale when one canonical lesson changes", () => {
     const lessons = loadLessons();
     const changed = lessons.map((lesson) =>


### PR DESCRIPTION
## Summary
- migrate Telugu Chapters 6-31 to prerequisite-safe schema-v2 micro-lessons with explicit spine and knowledge metadata
- generate 26 downloadable-book chapters from the same canonical sources consumed by Language Ladder
- add reusable multi-script rendering for Telugu cross-language comparisons and extend the 95-page Telugu book through Chapter 31
- record the next Telugu layout cleanup, roadmap reconciliation, and newly discovered PostCSS audit work in the shared backlog

## Validation
- human-language-data: 84 tests passed; TypeScript build and generated-book drift check passed
- Language Ladder: 359 tests passed; production build passed
- corpus: 1,066 lessons, zero duration violations, zero unknown prerequisites, Telugu book coverage 100 percent
- forced Telugu XeLaTeX: 95 pages, zero missing glyphs; all pages and outline inspected
- unified publication: all 20 books compiled; 20 non-empty PDFs and 20 catalog entries verified

## Known debt
- HL-B23 tracks the expanded Telugu layout, duplicate-label, bookmark, and font warning baseline; visual inspection found no clipping
- the existing Vite large-chunk advisory remains unchanged