### PR TITLE
fix(spice): validate diode breakdown voltage

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate positive finite diode model-card `BV` breakdown voltage.
 - Validate positive finite diode model-card `N` emission coefficient.
 - Validate finite, non-negative diode model-card `TT` transit time.
 - Validate positive finite BJT model-card `IS` saturation current.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1934,6 +1934,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(emission_coefficient) or emission_coefficient <= 0.0
         ):
             raise NetlistParseError("diode N must be finite and positive")
+        breakdown_voltage = params.get("BV")
+        if breakdown_voltage is not None and (
+            not math.isfinite(breakdown_voltage) or breakdown_voltage <= 0.0
+        ):
+            raise NetlistParseError("diode BV must be finite and positive")
         junction_capacitance = next(
             (params[name] for name in ("CJO", "CJ", "CJ0") if name in params),
             None,

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -859,6 +859,21 @@ def test_rejects_invalid_diode_emission_coefficient(value: str) -> None:
         parse_netlist(f".model clamp D(N={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("1", 1.0), ("5.5", 5.5)])
+def test_accepts_valid_diode_breakdown_voltage(value: str, expected: float) -> None:
+    parsed = parse_netlist(f".model clamp D(BV={value})\nD1 in out clamp")
+
+    diode = parsed.circuit.elements[0]
+    assert isinstance(diode, Diode)
+    assert expected == diode.BV
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "1e999"])
+def test_rejects_invalid_diode_breakdown_voltage(value: str) -> None:
+    with pytest.raises(NetlistParseError, match="diode BV must be finite and positive"):
+        parse_netlist(f".model clamp D(BV={value})")
+
+
 def test_parse_diode_junction_capacitance_alias() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate positive finite diode model-card `BV` breakdown voltage.
 - Validate positive finite diode model-card `N` emission coefficient.
 - Validate finite, non-negative diode model-card `TT` transit time.
 - Validate positive finite BJT model-card `IS` saturation current.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1174,6 +1174,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("diode N must be finite and positive");
   }
+  const diodeBreakdownVoltage = params.get("BV");
+  if (
+    kind === "D" &&
+    diodeBreakdownVoltage !== undefined &&
+    (!Number.isFinite(diodeBreakdownVoltage) || diodeBreakdownVoltage <= 0.0)
+  ) {
+    throw new NetlistParseError("diode BV must be finite and positive");
+  }
   const diodeJunctionCapacitance =
     params.get("CJO") ?? params.get("CJ") ?? params.get("CJ0");
   if (

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -889,6 +889,24 @@ D1 in out clamp
     },
   );
 
+  it.each([
+    ["1", 1.0],
+    ["5.5", 5.5],
+  ])("accepts valid diode BV breakdown voltage %s", (value, expected) => {
+    const parsed = parseNetlist(`.model clamp D(BV=${value})\nD1 in out clamp`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "diode",
+      breakdownVoltage: expected,
+    });
+  });
+
+  it.each(["0", "-1", "1e999"])("rejects invalid diode BV %s", (value) => {
+    expect(() => parseNetlist(`.model clamp D(BV=${value})`)).toThrow(
+      "diode BV must be finite and positive",
+    );
+  });
+
   it("parses BJT models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NPN(IS=1e-14 BF=120 VT=25m CJE=2p CJC=3p TF=4n TR=5n)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4389,16 +4389,20 @@ the Rust, Python, and TypeScript surfaces together.
      lowering them into the shared engine diode transit-time field.
 
 414. Python and TypeScript Berkeley SPICE diode emission-coefficient validation parity.
-   - Status: completed in this diode emission-coefficient validation slice.
+   - Status: completed in PR 9799.
    - Both parser facades validate positive finite `N` values before lowering
      them into the shared engine diode emission-coefficient field.
+
+415. Python and TypeScript Berkeley SPICE diode breakdown-voltage validation parity.
+   - Status: completed in this diode breakdown-voltage validation slice.
+   - Both parser facades validate positive finite `BV` values before lowering
+     them into the shared engine diode breakdown-voltage field.
 
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE model-card validation parity.
    - Continue the parser-to-engine validation audit with positive finite diode
-     breakdown voltage `BV`, followed by positive finite breakdown current
-     `IBV`.
+     breakdown current `IBV`.
    - Audit remaining directly lowerable diode fields before moving to model
      parameters that require new parser-to-engine lowering surfaces.
 


### PR DESCRIPTION
## Summary
- reject zero, negative, and non-finite diode model-card `BV` values in the Python and TypeScript parser facades
- preserve positive breakdown voltages when lowering into shared engine diode fields
- reconcile the SPICE plan with PR #9799 and queue diode `IBV` validation next

## Validation
- `code/packages/python/spice-netlist-parser`: `bash BUILD` (304 tests, 89.04% coverage)
- `code/packages/python/spice-netlist-parser`: `.venv/bin/ruff check src tests`
- `code/packages/typescript/spice-engine`: `bash BUILD` (448 tests)
- `code/packages/typescript/spice-netlist-parser`: `bash BUILD` (293 tests)
- `code/packages/typescript/spice-netlist-parser`: `npm run test:coverage` (86.02% line coverage)