### PR TITLE
fix(spice): validate diode breakdown current

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate positive finite diode model-card `IBV` breakdown current.
 - Validate positive finite diode model-card `BV` breakdown voltage.
 - Validate positive finite diode model-card `N` emission coefficient.
 - Validate finite, non-negative diode model-card `TT` transit time.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1939,6 +1939,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(breakdown_voltage) or breakdown_voltage <= 0.0
         ):
             raise NetlistParseError("diode BV must be finite and positive")
+        breakdown_current = params.get("IBV")
+        if breakdown_current is not None and (
+            not math.isfinite(breakdown_current) or breakdown_current <= 0.0
+        ):
+            raise NetlistParseError("diode IBV must be finite and positive")
         junction_capacitance = next(
             (params[name] for name in ("CJO", "CJ", "CJ0") if name in params),
             None,

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -874,6 +874,23 @@ def test_rejects_invalid_diode_breakdown_voltage(value: str) -> None:
         parse_netlist(f".model clamp D(BV={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("1u", 1.0e-6), ("2m", 2.0e-3)])
+def test_accepts_valid_diode_breakdown_current(value: str, expected: float) -> None:
+    parsed = parse_netlist(f".model clamp D(IBV={value})\nD1 in out clamp")
+
+    diode = parsed.circuit.elements[0]
+    assert isinstance(diode, Diode)
+    assert expected == diode.IBV
+
+
+@pytest.mark.parametrize("value", ["0", "-1u", "1e999"])
+def test_rejects_invalid_diode_breakdown_current(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="diode IBV must be finite and positive"
+    ):
+        parse_netlist(f".model clamp D(IBV={value})")
+
+
 def test_parse_diode_junction_capacitance_alias() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate positive finite diode model-card `IBV` breakdown current.
 - Validate positive finite diode model-card `BV` breakdown voltage.
 - Validate positive finite diode model-card `N` emission coefficient.
 - Validate finite, non-negative diode model-card `TT` transit time.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1182,6 +1182,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("diode BV must be finite and positive");
   }
+  const diodeBreakdownCurrent = params.get("IBV");
+  if (
+    kind === "D" &&
+    diodeBreakdownCurrent !== undefined &&
+    (!Number.isFinite(diodeBreakdownCurrent) || diodeBreakdownCurrent <= 0.0)
+  ) {
+    throw new NetlistParseError("diode IBV must be finite and positive");
+  }
   const diodeJunctionCapacitance =
     params.get("CJO") ?? params.get("CJ") ?? params.get("CJ0");
   if (

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -907,6 +907,24 @@ D1 in out clamp
     );
   });
 
+  it.each([
+    ["1u", 1.0e-6],
+    ["2m", 2.0e-3],
+  ])("accepts valid diode IBV breakdown current %s", (value, expected) => {
+    const parsed = parseNetlist(`.model clamp D(IBV=${value})\nD1 in out clamp`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "diode",
+      breakdownCurrent: expected,
+    });
+  });
+
+  it.each(["0", "-1u", "1e999"])("rejects invalid diode IBV %s", (value) => {
+    expect(() => parseNetlist(`.model clamp D(IBV=${value})`)).toThrow(
+      "diode IBV must be finite and positive",
+    );
+  });
+
   it("parses BJT models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NPN(IS=1e-14 BF=120 VT=25m CJE=2p CJC=3p TF=4n TR=5n)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4394,17 +4394,22 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine diode emission-coefficient field.
 
 415. Python and TypeScript Berkeley SPICE diode breakdown-voltage validation parity.
-   - Status: completed in this diode breakdown-voltage validation slice.
+   - Status: completed in PR 9805.
    - Both parser facades validate positive finite `BV` values before lowering
      them into the shared engine diode breakdown-voltage field.
+
+416. Python and TypeScript Berkeley SPICE diode breakdown-current validation parity.
+   - Status: completed in this diode breakdown-current validation slice.
+   - Both parser facades validate positive finite `IBV` values before lowering
+     them into the shared engine diode breakdown-current field.
 
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE model-card validation parity.
-   - Continue the parser-to-engine validation audit with positive finite diode
-     breakdown current `IBV`.
-   - Audit remaining directly lowerable diode fields before moving to model
-     parameters that require new parser-to-engine lowering surfaces.
+   - Audit remaining diode model-card parameters that require new lowering
+     surfaces, starting with finite non-negative series resistance `RS`, then
+     junction potential `VJ`, grading coefficient `M`, and depletion
+     coefficient `FC`.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary
- reject zero, negative, and non-finite diode model-card `IBV` values in the Python and TypeScript parser facades
- preserve positive breakdown currents when lowering into shared engine diode fields
- reconcile the SPICE plan with PR #9805 and queue the new-surface diode parameter audit

## Validation
- `code/packages/python/spice-netlist-parser`: `bash BUILD` (309 tests, 89.07% coverage)
- `code/packages/python/spice-netlist-parser`: `.venv/bin/ruff check src tests`
- `code/packages/typescript/spice-engine`: `bash BUILD` (448 tests)
- `code/packages/typescript/spice-netlist-parser`: `bash BUILD` (298 tests)
- `code/packages/typescript/spice-netlist-parser`: `npm run test:coverage` (86.06% line coverage)