### PR TITLE
feat(adj): enforce formula preconditions

### DIFF
--- a/code/grammars/adj_lang/adj_lang.grammar
+++ b/code/grammars/adj_lang/adj_lang.grammar
@@ -361,7 +361,7 @@ formulabook_decl = "formulabook" IDENT LBRACE { formulabook_item } RBRACE ;
 
 formulabook_item = use_decl | formula_decl ;
 
-formula_decl     = "formula" IDENT LPAREN [ formula_params ] RPAREN formula_body { annotation } ;
+formula_decl     = "formula" IDENT LPAREN [ formula_params ] RPAREN formula_body [ formula_requires ] { annotation } ;
 
 formula_params   = IDENT { COMMA IDENT } ;
 
@@ -379,6 +379,10 @@ formula_params   = IDENT { COMMA IDENT } ;
 formula_body     = EQUALS expr | LBRACE { formula_step } expr RBRACE ;
 
 formula_step     = "let" IDENT EQUALS expr ;
+
+formula_requires = "requires" formula_precondition { COMMA formula_precondition } ;
+
+formula_precondition = IDENT LPAREN [ expr { COMMA expr } ] RPAREN ;
 
 # ----------------------------------------------------------------
 # Table (ADJ-TABLES RS-5 — native tabular data as a first-class construct,

--- a/code/packages/rust/adj-constraint-solver/CHANGELOG.md
+++ b/code/packages/rust/adj-constraint-solver/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.17.0] - 2026-08-03 - exact computation literals
+
+- Every solver expression walker handles `ComputeExpr::ExactLit`. Solver backends retain their
+  existing numeric contracts while the execution engine preserves the literal's rational identity
+  for exact-first guards and audit output.
+
 ## [0.16.0] - 2026-07-23 — absorb `ComputeExpr::ToCurrency` (NUM-6c)
 
 ### Changed

--- a/code/packages/rust/adj-constraint-solver/Cargo.toml
+++ b/code/packages/rust/adj-constraint-solver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-constraint-solver"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "Solver bridge for the adj-lang constraint sublanguage. Takes an adj-lang ConstraintSystem (symbols + constrain/solve/check), classifies it, and dispatches the linear-equality case to cas-solve's exact rational Gaussian elimination — returning solved values traced back to the constraints. The first slice (B2a) of the ADJ constraint-solving arc; SAT / linear-integer / inequality feasibility and optimization follow."
 

--- a/code/packages/rust/adj-constraint-solver/src/lib.rs
+++ b/code/packages/rust/adj-constraint-solver/src/lib.rs
@@ -27,7 +27,7 @@ use cas_solve::frac::Frac;
 use cas_solve::{solve_cubic, solve_quadratic, solve_quartic, SolveResult};
 use constraint_core::Predicate;
 use constraint_engine::{lia::LiaTactic, sat::SatTactic, Model, SolverResult, Value};
-use logic_engine::{ComputeExpr, ComputeOp, KnowledgeBase};
+use logic_engine::{compute::ExactRational, ComputeExpr, ComputeOp, KnowledgeBase};
 use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, EQUAL, MUL, SUB};
 
 /// What solving a [`ConstraintSystem`] produced.
@@ -234,11 +234,12 @@ pub fn check(cs: &ConstraintSystem, kb: &KnowledgeBase) -> FeasibilityOutcome {
             // integer tactic *could* (e.g. `!=`), the integer verdict stands.
             SolverResult::Unsat => match real_feasibility(&subbed) {
                 FmResult::Sat(w) => return FeasibilityOutcome::SatReal { assignments: w },
-                FmResult::Unsat | FmResult::Unknown(_) => {
+                FmResult::Unsat => {
                     return FeasibilityOutcome::Unsat {
                         core: minimal_unsat_core(&subbed, &int_vars),
                     }
                 }
+                FmResult::Unknown(reason) => return FeasibilityOutcome::Unknown { reason },
             },
             // Integer tactic punted — let the real layer try.
             SolverResult::Unknown(_) => {}
@@ -337,7 +338,7 @@ fn expr_to_pred(e: &ComputeExpr) -> Option<Predicate> {
     match e {
         ComputeExpr::Ref(name) => Some(Predicate::Var(name.clone())),
         // A non-integer literal can't be expressed in LIA → None.
-        ComputeExpr::Lit(_) => int_const(e).map(Predicate::Int),
+        ComputeExpr::Lit(_) | ComputeExpr::ExactLit(_) => int_const(e).map(Predicate::Int),
         ComputeExpr::Bin(op, a, b) => {
             let pa = expr_to_pred(a)?;
             let pb = expr_to_pred(b)?;
@@ -384,8 +385,32 @@ fn int_const(e: &ComputeExpr) -> Option<i128> {
         ComputeExpr::Lit(x) if x.fract() == 0.0 && x.is_finite() && x.abs() < i128::MAX as f64 => {
             Some(*x as i128)
         }
+        ComputeExpr::ExactLit(exact) => exact_integer(exact),
         _ => None,
     }
+}
+
+/// Read an exact rational's parts without crossing a floating-point boundary.
+/// Fixed-width solver backends decline parts that do not fit rather than round.
+fn exact_parts_i128(exact: &ExactRational) -> Option<(i128, i128)> {
+    Some((
+        exact.numerator().to_string().parse().ok()?,
+        exact.denominator().to_string().parse().ok()?,
+    ))
+}
+
+fn exact_integer(exact: &ExactRational) -> Option<i128> {
+    let (num, den) = exact_parts_i128(exact)?;
+    (den == 1).then_some(num)
+}
+
+fn exact_to_rat(exact: &ExactRational) -> Option<Rat> {
+    let (num, den) = exact_parts_i128(exact)?;
+    Rat::new(num, den)
+}
+
+fn representable_exact_f64(exact: &ExactRational) -> Option<f64> {
+    exact.is_representable_as_f64().then(|| exact.to_f64())
 }
 
 // ===========================================================================
@@ -636,6 +661,7 @@ fn linearize(e: &ComputeExpr) -> Option<LinForm> {
     match e {
         ComputeExpr::Ref(name) => Some(LinForm::var(name)),
         ComputeExpr::Lit(x) => Some(LinForm::constant(f64_to_rat(*x)?)),
+        ComputeExpr::ExactLit(exact) => Some(LinForm::constant(exact_to_rat(exact)?)),
         ComputeExpr::Bin(op, a, b) => {
             let la = linearize(a)?;
             let lb = linearize(b)?;
@@ -1062,6 +1088,11 @@ pub enum OptimizeOutcome {
 /// - otherwise (the default: `: scalar`, `: money(...)`, …) solve the real-valued
 ///   (QF_LRA) LP via Fourier–Motzkin, byte-for-byte as before.
 pub fn optimize(cs: &ConstraintSystem, kb: &KnowledgeBase) -> OptimizeOutcome {
+    if optimization_requires_lossy_exact(cs, kb) {
+        return OptimizeOutcome::Unknown {
+            reason: "optimization would narrow a non-representable exact value".to_string(),
+        };
+    }
     if is_integer_program(cs) {
         if let Some(out) = optimize_integer(cs, kb) {
             return out;
@@ -1070,6 +1101,68 @@ pub fn optimize(cs: &ConstraintSystem, kb: &KnowledgeBase) -> OptimizeOutcome {
         // tactic punted) — the real solver still answers (or says Unknown).
     }
     optimize_real(cs, kb)
+}
+
+fn optimization_requires_lossy_exact(cs: &ConstraintSystem, kb: &KnowledgeBase) -> bool {
+    let variables: HashSet<&str> = cs.symbols.iter().map(|(name, _)| name.as_str()).collect();
+    fn expr_requires_loss(
+        expr: &ComputeExpr,
+        variables: &HashSet<&str>,
+        kb: &KnowledgeBase,
+    ) -> bool {
+        match expr {
+            ComputeExpr::ExactLit(value) => !value.is_representable_as_f64(),
+            ComputeExpr::Ref(name) if !variables.contains(name.as_str()) => {
+                kb.observed_numeric(name).is_some_and(|value| {
+                    value.precision_loss
+                        || value
+                            .exact
+                            .is_some_and(|exact| !exact.is_representable_as_f64())
+                })
+            }
+            ComputeExpr::Bin(_, left, right) => {
+                expr_requires_loss(left, variables, kb) || expr_requires_loss(right, variables, kb)
+            }
+            ComputeExpr::Unary(_, inner)
+            | ComputeExpr::Round { expr: inner, .. }
+            | ComputeExpr::ToScientific { expr: inner, .. }
+            | ComputeExpr::ToPercent { expr: inner, .. }
+            | ComputeExpr::ToCurrency { expr: inner, .. } => {
+                expr_requires_loss(inner, variables, kb)
+            }
+            ComputeExpr::Lit(_) | ComputeExpr::Ref(_) | ComputeExpr::Agg(_, _) => false,
+        }
+    }
+    fn mentions_variable(expr: &ComputeExpr, variables: &HashSet<&str>) -> bool {
+        match expr {
+            ComputeExpr::Ref(name) => variables.contains(name.as_str()),
+            ComputeExpr::Bin(_, left, right) => {
+                mentions_variable(left, variables) || mentions_variable(right, variables)
+            }
+            ComputeExpr::Unary(_, inner)
+            | ComputeExpr::Round { expr: inner, .. }
+            | ComputeExpr::ToScientific { expr: inner, .. }
+            | ComputeExpr::ToPercent { expr: inner, .. }
+            | ComputeExpr::ToCurrency { expr: inner, .. } => mentions_variable(inner, variables),
+            ComputeExpr::Lit(_) | ComputeExpr::ExactLit(_) | ComputeExpr::Agg(_, _) => false,
+        }
+    }
+    let root_requires_loss = |expr: &ComputeExpr| {
+        expr_requires_loss(expr, &variables, kb)
+            || (!mentions_variable(expr, &variables)
+                && logic_engine::compute("__optimization_exactness", expr, kb).is_ok_and(|value| {
+                    value.precision_loss
+                        || value
+                            .exact
+                            .is_some_and(|exact| !exact.is_representable_as_f64())
+                }))
+    };
+    cs.constraints.iter().any(|constraint| {
+        root_requires_loss(&constraint.lhs) || root_requires_loss(&constraint.rhs)
+    }) || cs
+        .objective
+        .as_ref()
+        .is_some_and(|(_, expr)| root_requires_loss(expr))
 }
 
 /// True iff this is an opted-in integer program: it has an objective, at least
@@ -1247,6 +1340,17 @@ fn optimize_integer(cs: &ConstraintSystem, kb: &KnowledgeBase) -> Option<Optimiz
         )?,
     };
 
+    if !ExactRational::from_i128(k_opt).is_representable_as_f64()
+        || !syms.iter().all(|name| match witness.get(name) {
+            Some(Value::Int(n)) => ExactRational::from_i128(*n).is_representable_as_f64(),
+            Some(Value::Bool(_)) => true,
+            _ => false,
+        })
+    {
+        return Some(OptimizeOutcome::Unknown {
+            reason: "integer optimum cannot be represented as f64".to_string(),
+        });
+    }
     let assignments: Vec<(String, f64)> = syms
         .iter()
         .filter_map(|v| match witness.get(v) {
@@ -1699,6 +1803,18 @@ fn solve_setcover_sat(
     let oracle = |k: i128| cover_sat(clauses, weights, syms, k);
     // smallest K in [0, feasible_obj] with Σwx ≤ K feasible
     let (raw, witness) = sat_min_feasible(&oracle, 0, feasible_obj)?;
+    let optimum = konst.checked_add(raw)?;
+    if !ExactRational::from_i128(optimum).is_representable_as_f64()
+        || !syms.iter().all(|name| match witness.get(name) {
+            Some(Value::Int(n)) => ExactRational::from_i128(*n).is_representable_as_f64(),
+            Some(Value::Bool(_)) => true,
+            _ => false,
+        })
+    {
+        return Some(OptimizeOutcome::Unknown {
+            reason: "set-cover optimum cannot be represented as f64".to_string(),
+        });
+    }
     let assignments: Vec<(String, f64)> = syms
         .iter()
         .filter_map(|v| match witness.get(v) {
@@ -1709,7 +1825,7 @@ fn solve_setcover_sat(
         .collect();
     let binding = binding_constraints(cs, kb, var_set, &assignments);
     Some(OptimizeOutcome::Optimal {
-        value: (konst + raw) as f64,
+        value: optimum as f64,
         assignments,
         binding,
     })
@@ -1883,6 +1999,13 @@ fn optimize_real(cs: &ConstraintSystem, kb: &KnowledgeBase) -> OptimizeOutcome {
             }
         },
     };
+    if !ExactRational::new(value_rat.num, value_rat.den)
+        .is_some_and(|value| value.is_representable_as_f64())
+    {
+        return OptimizeOutcome::Unknown {
+            reason: "optimal value cannot be represented as f64".to_string(),
+        };
+    }
 
     // Recover an achieving assignment: pin `max_obj = opt_internal` and run the
     // feasibility witness reconstruction over the original constraints.
@@ -2004,13 +2127,18 @@ fn substitute_observed(
         ComputeExpr::Ref(name) => {
             if variables.contains(name.as_str()) {
                 e.clone() // an unknown we are solving for — keep it symbolic
-            } else if let Some(v) = kb.observed_value(name) {
-                ComputeExpr::Lit(v) // a known observed fact — substitute its value
+            } else if let Some(numeric) = kb.observed_numeric(name) {
+                match numeric.exact {
+                    Some(exact) => ComputeExpr::ExactLit(exact),
+                    None if !numeric.precision_loss => ComputeExpr::Lit(numeric.value),
+                    // No faithful literal exists for a precision-lost value.
+                    None => e.clone(),
+                }
             } else {
                 e.clone() // neither — a free reference (likely makes it singular)
             }
         }
-        ComputeExpr::Lit(_) => e.clone(),
+        ComputeExpr::Lit(_) | ComputeExpr::ExactLit(_) => e.clone(),
         ComputeExpr::Bin(op, a, b) => ComputeExpr::Bin(
             *op,
             Box::new(substitute_observed(a, variables, kb)),
@@ -2077,6 +2205,7 @@ fn poly_of(e: &ComputeExpr, x: &str) -> Option<Poly> {
         ComputeExpr::Ref(name) if name == x => Some(vec![0.0, 1.0]),
         ComputeExpr::Ref(_) => None,
         ComputeExpr::Lit(c) => Some(vec![*c]),
+        ComputeExpr::ExactLit(exact) => Some(vec![representable_exact_f64(exact)?]),
         ComputeExpr::Bin(op, a, b) => {
             let pa = poly_of(a, x)?;
             let pb = poly_of(b, x)?;
@@ -2315,6 +2444,7 @@ fn expr_to_ir(e: &ComputeExpr) -> Option<IRNode> {
     match e {
         ComputeExpr::Ref(name) => Some(sym(name)),
         ComputeExpr::Lit(x) => num_to_ir(*x),
+        ComputeExpr::ExactLit(exact) => exact_to_ir(exact),
         ComputeExpr::Bin(op, a, b) => {
             let ia = expr_to_ir(a)?;
             let ib = expr_to_ir(b)?;
@@ -2335,11 +2465,7 @@ fn expr_to_ir(e: &ComputeExpr) -> Option<IRNode> {
                 // `a / c` (c a constant) is linear: rewrite as `a × (1/c)`.
                 // Division by a symbol is non-linear → None.
                 ComputeOp::Div => {
-                    let c = const_value(b)?;
-                    if c == 0.0 {
-                        return None;
-                    }
-                    let recip = num_to_ir(1.0 / c)?;
+                    let recip = reciprocal_to_ir(b)?;
                     Some(apply(sym(MUL), vec![ia, recip]))
                 }
                 // Aggregations reduce observed facts, not symbols — not part of
@@ -2364,10 +2490,26 @@ fn expr_to_ir(e: &ComputeExpr) -> Option<IRNode> {
     }
 }
 
-/// The constant value of an expr if it is a pure numeric literal, else `None`.
-fn const_value(e: &ComputeExpr) -> Option<f64> {
+/// Convert an exact literal to symbolic IR without narrowing it first. CAS IR
+/// stores i64 rational parts, so larger values are conservatively unsupported.
+fn exact_to_ir(exact: &ExactRational) -> Option<IRNode> {
+    let num: i64 = exact.numerator().to_string().parse().ok()?;
+    let den: i64 = exact.denominator().to_string().parse().ok()?;
+    if den == 1 {
+        Some(int(num))
+    } else {
+        Some(rat(num, den))
+    }
+}
+
+fn reciprocal_to_ir(e: &ComputeExpr) -> Option<IRNode> {
     match e {
-        ComputeExpr::Lit(x) => Some(*x),
+        ComputeExpr::Lit(c) if *c != 0.0 => num_to_ir(1.0 / c),
+        ComputeExpr::ExactLit(exact) => {
+            let num: i64 = exact.numerator().to_string().parse().ok()?;
+            let den: i64 = exact.denominator().to_string().parse().ok()?;
+            (num != 0).then(|| rat(den, num))
+        }
         _ => None,
     }
 }
@@ -2376,7 +2518,7 @@ fn const_value(e: &ComputeExpr) -> Option<f64> {
 /// constant) — used to keep multiplication/division linear.
 fn is_constant_expr(e: &ComputeExpr) -> bool {
     match e {
-        ComputeExpr::Lit(_) => true,
+        ComputeExpr::Lit(_) | ComputeExpr::ExactLit(_) => true,
         ComputeExpr::Ref(_) | ComputeExpr::Agg(_, _) => false,
         ComputeExpr::Bin(_, a, b) => is_constant_expr(a) && is_constant_expr(b),
         // `|c|` is constant iff its operand is (the absolute value of a constant
@@ -2433,11 +2575,12 @@ fn parse_rule(node: &IRNode) -> Option<(String, f64)> {
     let IRNode::Symbol(name) = &a.args[0] else {
         return None;
     };
-    let value = match &a.args[1] {
-        IRNode::Integer(n) => *n as f64,
-        IRNode::Rational(n, d) if *d != 0 => *n as f64 / *d as f64,
+    let exact = match &a.args[1] {
+        IRNode::Integer(n) => ExactRational::from_i128(*n as i128),
+        IRNode::Rational(n, d) if *d != 0 => ExactRational::new(*n as i128, *d as i128)?,
         _ => return None,
     };
+    let value = representable_exact_f64(&exact)?;
     if value.is_finite() {
         Some((name.clone(), value))
     } else {
@@ -2506,6 +2649,76 @@ mod tests {
             }
             other => panic!("expected Solved, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn lia_extracts_large_exact_integers_without_f64_narrowing() {
+        let value = 9_007_199_254_740_993_i128;
+        let expr = ComputeExpr::ExactLit(ExactRational::from_i128(value));
+        assert_eq!(int_const(&expr), Some(value));
+        assert!(matches!(expr_to_pred(&expr), Some(Predicate::Int(n)) if n == value));
+    }
+
+    #[test]
+    fn qf_lra_converts_large_exact_integers_directly_to_rat() {
+        let value = 9_007_199_254_740_993_i128;
+        let expr = ComputeExpr::ExactLit(ExactRational::from_i128(value));
+        let form = linearize(&expr).expect("large exact integer is within the Rat cap");
+        assert_eq!(form.constant, Rat::new(value, 1).unwrap());
+    }
+
+    #[test]
+    fn observed_substitution_preserves_the_exact_sidecar() {
+        let lowered = compile("observe large(9007199254740993)\n").unwrap();
+        let substituted = substitute_observed(
+            &ComputeExpr::Ref("large".into()),
+            &HashSet::new(),
+            &lowered.kb,
+        );
+        assert!(matches!(
+            substituted,
+            ComputeExpr::ExactLit(ref exact)
+                if exact_integer(exact) == Some(9_007_199_254_740_993)
+        ));
+    }
+
+    #[test]
+    fn cas_rejects_a_nonrepresentable_exact_assignment() {
+        let out = solve_src(
+            "symbol x : scalar\n\
+             constrain x = 9007199254740993\n\
+             solve for { x }\n",
+        );
+        assert!(matches!(out, SolveOutcome::Unsupported { .. }), "{out:?}");
+    }
+
+    #[test]
+    fn polynomial_solver_rejects_a_nonrepresentable_exact_coefficient() {
+        let out = solve_src(
+            "symbol x : scalar\n\
+             constrain x * x = 9007199254740993\n\
+             solve for { x }\n",
+        );
+        assert!(matches!(out, SolveOutcome::Unsupported { .. }), "{out:?}");
+    }
+
+    #[test]
+    fn tiny_exact_literal_is_unknown_or_unsupported_never_rounded_to_zero() {
+        let solved = solve_src(
+            "symbol x : scalar\n\
+             constrain x = 1e-400\n\
+             solve for { x }\n",
+        );
+        assert!(
+            matches!(solved, SolveOutcome::Unsupported { .. }),
+            "{solved:?}"
+        );
+
+        let checked = check_src("symbol x : scalar\nconstrain x = 1e-400\ncheck\n");
+        assert!(
+            matches!(checked, FeasibilityOutcome::Unknown { .. }),
+            "{checked:?}"
+        );
     }
 
     #[test]
@@ -3193,6 +3406,15 @@ mod tests {
         let out = optimize_src("symbol x : scalar\nconstrain x + x >= 3\nminimize x");
         let (value, _, _) = expect_optimal(&out);
         assert!((value - 1.5).abs() < 1e-9, "scalar stays real: {value}");
+    }
+
+    #[test]
+    fn optimization_rejects_a_nonrepresentable_exact_optimum() {
+        let out = optimize_src("symbol x : scalar\nconstrain x = 9007199254740993\nmaximize x");
+        assert!(
+            matches!(out, OptimizeOutcome::Unknown { .. }),
+            "got {out:?}"
+        );
     }
 
     // ---- SAT / pseudo-boolean set-cover scaling (B1b) ----------------------

--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.36.0] - 2026-08-03 - formula-domain abstentions and inventory v2
+
+- `adj-lang-cli` emits `formula_abstentions` for failed or unresolved formula preconditions,
+  including the withheld binding, nested formula identity, predicate result, and provenance.
+- Sensitive runs redact consumed fact terms as well as guard values and details while retaining
+  non-sensitive fact identity and provenance metadata.
+- `adj-formula-inventory` emits `adj-lang/formula_source_map/v2` only when a source contains
+  preconditions, with exact declaration and argument byte spans and hashes. Unguarded sources
+  retain byte-identical v1 output.
+- Formula audit identity includes preconditions when present, preventing guard bytes from being
+  dropped between parser inventory and execution evidence.
+- Derived JSON exposes `"precision_loss":true` and suppresses a misleading exact sidecar when an
+  authored exact value narrowed before reaching the output boundary.
+- Human explanations label precision loss, and formula audit results expose the marker while
+  withholding a misleading exact rational and retaining exact literals in the trusted plan IR.
+
 ## [0.35.0] - 2026-08-02 - NUM-7c: adj-verify rechecks the sqrt Real companion
 
 - No CLI code changes — `adj-verify` already walks every `DerivationNode` generically via

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/bin/adj-formula-inventory.rs
+++ b/code/packages/rust/adj-lang-cli/src/bin/adj-formula-inventory.rs
@@ -24,7 +24,16 @@ struct Formula<'a> {
     formula: &'a str,
     formulabook: &'a str,
     parameters: &'a [String],
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    preconditions: Vec<Precondition<'a>>,
     step_count: usize,
+}
+
+#[derive(Serialize)]
+struct Precondition<'a> {
+    arguments: Vec<Span>,
+    declaration: Span,
+    predicate: &'a str,
 }
 
 #[derive(Serialize)]
@@ -116,6 +125,7 @@ fn run() -> Result<(), Failure> {
     let inventory = adj_lang::formula_source_map(text)
         .map_err(|error| Failure::Input(format!("formula source map failed: {error:?}")))?;
 
+    let guarded = inventory.iter().any(|item| !item.preconditions.is_empty());
     let formulas = inventory
         .iter()
         .map(|item| Formula {
@@ -124,14 +134,32 @@ fn run() -> Result<(), Failure> {
             formula: &item.formula.name,
             formulabook: &item.formulabook,
             parameters: &item.formula.params,
+            preconditions: item
+                .preconditions
+                .iter()
+                .map(|precondition| Precondition {
+                    arguments: precondition
+                        .argument_spans
+                        .iter()
+                        .copied()
+                        .map(|value| span(&source, value))
+                        .collect(),
+                    declaration: span(&source, precondition.declaration_span),
+                    predicate: &precondition.precondition.predicate,
+                })
+                .collect(),
             step_count: item.formula.steps.len(),
         })
         .collect();
     let output = Inventory {
         formulas,
         kind: "formula_parser_inventory",
-        parser_contract: "adj-lang/formula_source_map/v1",
-        schema_version: 1,
+        parser_contract: if guarded {
+            "adj-lang/formula_source_map/v2"
+        } else {
+            "adj-lang/formula_source_map/v1"
+        },
+        schema_version: if guarded { 2 } else { 1 },
         scope: "source_file",
         source_sha256: sha256_hex(&source),
         source_size: source.len(),

--- a/code/packages/rust/adj-lang-cli/src/bin/adj-verify.rs
+++ b/code/packages/rust/adj-lang-cli/src/bin/adj-verify.rs
@@ -192,6 +192,8 @@ fn logic_json(status: &LogicStatus) -> String {
             LogicFailure::LogitDiffers { .. } => "logit_differs",
             LogicFailure::SlotNotObserved(_) => "slot_not_observed",
             LogicFailure::ThresholdNotEvaluable => "threshold_not_evaluable",
+            LogicFailure::PredicatePrecisionLoss { .. } => "predicate_precision_loss",
+            LogicFailure::PredicateOperandsDiffer => "predicate_operands_differ",
             LogicFailure::PredicateDoesNotHold { .. } => "predicate_does_not_hold",
         },
     };

--- a/code/packages/rust/adj-lang-cli/src/explain.rs
+++ b/code/packages/rust/adj-lang-cli/src/explain.rs
@@ -36,11 +36,14 @@
 //!   indented one level deeper, so a line in the prose maps back to exactly one
 //!   node in the derivation tree.
 
-use adj_lang::{LoweredStateMachine, StateMachineOutcome, StateMachineRun};
+use adj_lang::{FormulaAbstention, LoweredStateMachine, StateMachineOutcome, StateMachineRun};
 use logic_engine::compute::{DerivationNode, RoundSpec};
 use logic_engine::differential::{Differential, DifferentialDecision};
 use logic_engine::proof_dag::{DerivationOrigin, ProofStep};
-use logic_engine::{GovernStatus, GovernedResult, KnowledgeBase, Provenance, RoundingMode, TrustTier};
+use logic_engine::{
+    GovernStatus, GovernedResult, KnowledgeBase, LrAggregateWarning, Provenance, RoundingMode,
+    TrustTier,
+};
 
 /// Render the human-readable explanation of a decided query.
 ///
@@ -60,10 +63,15 @@ use logic_engine::{GovernStatus, GovernedResult, KnowledgeBase, Provenance, Roun
 pub fn explain(
     kb: &KnowledgeBase,
     diff: &Differential,
+    formula_abstentions: &[FormulaAbstention],
     state_machine_runs: &[(&LoweredStateMachine, StateMachineRun)],
     arguments: &[(logic_core::Term, GovernedResult)],
 ) -> String {
     let mut sections: Vec<String> = Vec::new();
+    let abstentions = render_formula_abstentions(formula_abstentions);
+    if !abstentions.is_empty() {
+        sections.push(abstentions);
+    }
     let derivations = render_derivations(kb);
     if !derivations.is_empty() {
         sections.push(derivations);
@@ -72,10 +80,13 @@ pub fn explain(
     // evidence (a prior or a contribution produced a proof step). A bare
     // computation / recall query has empty proofs and renders no differential —
     // so a `let`-only program stays derivations-only, unchanged from PR-E1.
-    let has_inference = diff
-        .ranked
-        .iter()
-        .any(|r| r.result.dag.proofs.first().is_some_and(|p| !p.steps.is_empty()));
+    let has_inference = diff.ranked.iter().any(|r| {
+        r.result
+            .dag
+            .proofs
+            .first()
+            .is_some_and(|p| !p.steps.is_empty())
+    });
     if has_inference {
         let inference = render_inference(kb, diff);
         if !inference.is_empty() {
@@ -104,6 +115,36 @@ pub fn explain(
         sections.push(runs);
     }
     sections.join("\n\n")
+}
+
+fn render_formula_abstentions(abstentions: &[FormulaAbstention]) -> String {
+    if abstentions.is_empty() {
+        return String::new();
+    }
+    let mut lines = vec!["FORMULA ABSTENTIONS".to_string()];
+    for abstention in abstentions {
+        let result = if adj_lang_cli::sensitive_input() {
+            "[redacted]".to_string()
+        } else if let Some(actual) = abstention.actual {
+            fmt_num(actual)
+        } else {
+            format!(
+                "unresolved ({})",
+                abstention.detail.as_deref().unwrap_or("unknown reason")
+            )
+        };
+        lines.push(format!(
+            "  {}: abstained because {}.{}[{}]({}) = {}   [{}]",
+            abstention.name,
+            abstention.formula,
+            abstention.predicate,
+            abstention.precondition_index,
+            abstention.parameter.as_deref().unwrap_or("expression"),
+            result,
+            fmt_prov(&abstention.provenance)
+        ));
+    }
+    lines.join("\n")
 }
 
 /// Render the state-machine run surface (ADJ-STATEMACHINE §3–§4, RS-3c) — for each
@@ -146,6 +187,14 @@ fn render_state_machines(runs: &[(&LoweredStateMachine, StateMachineRun)]) -> St
                 format!("  => NonTerminating (cycle at {state})")
             }
             StateMachineOutcome::Stuck { state } => format!("  => Stuck in {state}"),
+            StateMachineOutcome::PrecisionLoss { state, guard } => {
+                format!("  => Precision loss in {state}: {guard}")
+            }
+            StateMachineOutcome::ComputationError {
+                state,
+                phase,
+                detail,
+            } => format!("  => Computation error in {state} during {phase}: {detail}"),
         };
         out.push(outcome);
     }
@@ -174,11 +223,19 @@ fn render_derivations(kb: &KnowledgeBase) -> String {
         };
         // The exact-first display (NUM-5): all digits when the value has a finite
         // decimal expansion, else the labeled-lossy f64 — matching `value_json`.
-        let value = d
-            .exact
-            .as_ref()
-            .and_then(|e| e.to_exact_decimal_string())
-            .unwrap_or_else(|| fmt_num(d.value));
+        let value = if d.precision_loss {
+            fmt_num(d.value)
+        } else {
+            d.exact
+                .as_ref()
+                .and_then(|e| e.to_exact_decimal_string())
+                .unwrap_or_else(|| fmt_num(d.value))
+        };
+        let precision = if d.precision_loss {
+            " [precision loss]"
+        } else {
+            ""
+        };
         // P2: a value produced by applying a provenanced `formula` carries the
         // formula's citation (why the formula is trusted). A plain `let` has no
         // library claim; its audit trail is the derivation tree itself.
@@ -186,7 +243,14 @@ fn render_derivations(kb: &KnowledgeBase) -> String {
             Some(p) => format!("   <= {}", fmt_prov(p)),
             None => String::new(),
         };
-        out.push(format!("{} = {} [{}]{}", d.name, value, d.dim.tag(), cited));
+        out.push(format!(
+            "{} = {} [{}]{}{}",
+            d.name,
+            value,
+            d.dim.tag(),
+            precision,
+            cited
+        ));
         expand(&d.tree, 1, kb, &mut out);
         out.push(String::new()); // blank line between bindings
     }
@@ -296,9 +360,12 @@ fn render_inference(kb: &KnowledgeBase, diff: &Differential) -> String {
                 DerivationOrigin::FromPredicateContribution {
                     clause_id,
                     slot,
+                    observation_fact_id,
                     op,
                     threshold,
+                    threshold_exact,
                     observed,
+                    observed_exact,
                     logit_delta,
                 } => {
                     let via = predicates
@@ -306,12 +373,15 @@ fn render_inference(kb: &KnowledgeBase, diff: &Differential) -> String {
                         .find(|p| p.id == *clause_id)
                         .map(|p| format!(" via [{}]", fmt_prov(&p.provenance)))
                         .unwrap_or_default();
+                    let input = observation_fact_id
+                        .map(|id| format!(" input {}", cite_facts(kb, &[id])))
+                        .unwrap_or_default();
                     format!(
-                        "{ind}{} {} {} (observed {}) contributes logit {}{via}",
+                        "{ind}{} {} {} (observed {}) contributes logit {}{via}{input}",
                         slot,
                         op.symbol(),
-                        fmt_num(*threshold),
-                        fmt_num(*observed),
+                        fmt_exact_operand(*threshold, threshold_exact),
+                        fmt_exact_operand(*observed, observed_exact),
                         fmt_num(*logit_delta)
                     )
                 }
@@ -336,6 +406,18 @@ fn render_adjudication(kb: &KnowledgeBase, diff: &Differential) -> String {
             fmt_num(r.posterior),
             fmt_num(r.posterior_logit)
         ));
+        for warning in &r.result.warnings {
+            if let LrAggregateWarning::PredicatePrecisionLoss { slot, .. } = warning {
+                out.push(format!(
+                    "    warning: predicate for {slot} was not evaluated because its numeric value lost precision"
+                ));
+            }
+            if let LrAggregateWarning::PredicateEvaluationError { slot, detail, .. } = warning {
+                out.push(format!(
+                    "    warning: predicate for {slot} could not be evaluated: {detail}"
+                ));
+            }
+        }
     }
     match &diff.decision {
         DifferentialDecision::Empty => {
@@ -356,6 +438,16 @@ fn render_adjudication(kb: &KnowledgeBase, diff: &Differential) -> String {
                 trust
             ));
         }
+        DifferentialDecision::Indeterminate {
+            leader,
+            posterior,
+            reason,
+        } => out.push(format!(
+            "  => INDETERMINATE: {} (posterior {}) - {}",
+            leader,
+            fmt_num(*posterior),
+            reason
+        )),
         DifferentialDecision::Kickback {
             leader,
             runner_up,
@@ -401,7 +493,10 @@ fn render_adjudication(kb: &KnowledgeBase, diff: &Differential) -> String {
 /// **budget-truncated** search is never laundered into "no proof exists" — the
 /// two are reported distinctly (§proof_dag `truncated`). Returns "" when the
 /// program declared no binding query.
-fn render_arguments(kb: &KnowledgeBase, arguments: &[(logic_core::Term, GovernedResult)]) -> String {
+fn render_arguments(
+    kb: &KnowledgeBase,
+    arguments: &[(logic_core::Term, GovernedResult)],
+) -> String {
     if arguments.is_empty() {
         return String::new();
     }
@@ -414,9 +509,7 @@ fn render_arguments(kb: &KnowledgeBase, arguments: &[(logic_core::Term, Governed
             // absence) from "the search gave up" (a statement about budget, not
             // the world) — never collapse the two into a false claim.
             if dag.truncated {
-                out.push(
-                    "  (search truncated before a complete chain was found)".to_string(),
-                );
+                out.push("  (search truncated before a complete chain was found)".to_string());
             } else {
                 out.push("  abstained: no grounded chain derives this".to_string());
             }
@@ -462,7 +555,10 @@ fn render_arguments(kb: &KnowledgeBase, arguments: &[(logic_core::Term, Governed
 /// left exactly as ADR-6 rendered it. A defeated conclusion is named WITHDRAWN
 /// and cites its defeater plus the context precedence that withdrew it
 /// (`reanalysis outranks initial_report`); the surviving rival is GOVERNING.
-fn govern_suffix(conclusion: &logic_core::Term, answers: &[logic_engine::GovernedAnswer]) -> String {
+fn govern_suffix(
+    conclusion: &logic_core::Term,
+    answers: &[logic_engine::GovernedAnswer],
+) -> String {
     let contested = answers
         .iter()
         .any(|a| !matches!(a.status, GovernStatus::Governing));
@@ -714,7 +810,10 @@ fn expand(n: &DerivationNode, depth: usize, kb: &KnowledgeBase, out: &mut Vec<St
             out.push(format!("{ind}{slot} = {}   {}", fmt_num(*value), prov));
         }
         DerivationNode::DerivedRef { name, value } => {
-            out.push(format!("{ind}{name} = {}   (derived above)", fmt_num(*value)));
+            out.push(format!(
+                "{ind}{name} = {}   (derived above)",
+                fmt_num(*value)
+            ));
         }
         // A `Lit` operand never reaches here (guarded by `expands`); handled for
         // totality — a bare literal used as the whole tree just shows its value.
@@ -809,6 +908,17 @@ fn expand(n: &DerivationNode, depth: usize, kb: &KnowledgeBase, out: &mut Vec<St
 /// is exactly the stability P4 requires.
 fn fmt_num(v: f64) -> String {
     format!("{}", v)
+}
+
+fn fmt_exact_operand(value: f64, exact: &Option<logic_engine::compute::ExactRational>) -> String {
+    exact.as_ref().map_or_else(
+        || fmt_num(value),
+        |exact| {
+            exact
+                .to_exact_decimal_string()
+                .unwrap_or_else(|| format!("{}/{}", exact.numerator(), exact.denominator()))
+        },
+    )
 }
 
 /// The provenance of a leaf's grounding fact, or `[unattributed]`. P2: a fact

--- a/code/packages/rust/adj-lang-cli/src/formula_audit.rs
+++ b/code/packages/rust/adj-lang-cli/src/formula_audit.rs
@@ -10,8 +10,8 @@ use std::process::ExitCode;
 
 use adj_lang::ast::Term as AstTerm;
 use adj_lang::{
-    compile_with_imports, formula_provenance, program_source_map, ImportLimits, ImportProvider,
-    ProgramSourceMap, SourceSpan,
+    compile_with_imports, formula_provenance, program_source_map, CompileWithImportsError,
+    ImportLimits, ImportProvider, LowerError, ProgramSourceMap, SourceSpan,
 };
 use coding_adventures_sha256::sha256_hex;
 use logic_engine::compute::ExactRational;
@@ -107,7 +107,16 @@ struct FormulaIdentityDto {
     formulabook: String,
     name: String,
     parameters: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    preconditions: Vec<FormulaPreconditionIdentityDto>,
     source_sha256: String,
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct FormulaPreconditionIdentityDto {
+    arguments: Vec<SpanDto>,
+    declaration: SpanDto,
+    predicate: String,
 }
 
 #[derive(Serialize, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -193,6 +202,10 @@ enum PlanExprDto {
         right: Box<PlanExprDto>,
     },
     Literal {
+        f64_bits: String,
+    },
+    ExactLiteral {
+        exact_rational: RationalDto,
         f64_bits: String,
     },
     Reference {
@@ -494,6 +507,10 @@ fn plan_expr(value: &ComputeExpr) -> PlanExprDto {
         ComputeExpr::Lit(value) => PlanExprDto::Literal {
             f64_bits: bits(*value),
         },
+        ComputeExpr::ExactLit(value) => PlanExprDto::ExactLiteral {
+            exact_rational: rational(value),
+            f64_bits: bits(value.to_f64()),
+        },
         ComputeExpr::Bin(op, left, right) => PlanExprDto::Binary {
             left: Box::new(plan_expr(left)),
             operator: op.symbol(),
@@ -713,6 +730,7 @@ fn compute_error_reason(value: &ComputeError) -> &'static str {
         ComputeError::MalformedExpr { .. } => "malformed_expression",
         ComputeError::TooDeep { .. } => "too_deep",
         ComputeError::NonFinite { .. } => "non_finite",
+        ComputeError::PrecisionLoss { .. } => "precision_loss",
         ComputeError::DimensionMismatch { .. } => "dimension_mismatch",
     }
 }
@@ -852,6 +870,20 @@ fn build_exports(sources: &BTreeMap<String, LoadedSource>) -> Result<Vec<ExportR
                 formulabook: mapped.formulabook.clone(),
                 name: mapped.formula.name.clone(),
                 parameters: mapped.formula.params.clone(),
+                preconditions: mapped
+                    .preconditions
+                    .iter()
+                    .map(|precondition| FormulaPreconditionIdentityDto {
+                        arguments: precondition
+                            .argument_spans
+                            .iter()
+                            .copied()
+                            .map(|value| span(loaded.source.as_bytes(), value))
+                            .collect(),
+                        declaration: span(loaded.source.as_bytes(), precondition.declaration_span),
+                        predicate: precondition.precondition.predicate.clone(),
+                    })
+                    .collect(),
                 source_sha256: loaded.hash.clone(),
             };
             if !names.insert(identity.name.clone()) {
@@ -954,13 +986,34 @@ fn build_audit(
     provider: &RecordingProvider,
     snapshots: &dyn SnapshotStore,
 ) -> Result<AuditDto, Failure> {
-    let lowered = compile_with_imports(root_id, provider, ImportLimits::default())
-        .map_err(|error| Failure::Audit(format!("compile failed: {error:?}")))?;
+    let lowered =
+        compile_with_imports(root_id, provider, ImportLimits::default()).map_err(|error| {
+            match error {
+                CompileWithImportsError::Lower(LowerError::DuplicateFormula { formula }) => {
+                    Failure::Audit(format!("duplicate formula export name: {formula}"))
+                }
+                other => Failure::Audit(format!("compile failed: {other:?}")),
+            }
+        })?;
+    if !lowered.formula_abstentions.is_empty() {
+        return Err(Failure::Audit(
+            "formula abstention audit requires a versioned precondition witness contract"
+                .to_string(),
+        ));
+    }
     let sources = build_sources(provider.sources.borrow().clone())?;
     let root = sources
         .get(root_id)
         .ok_or_else(|| Failure::Audit("root source was not recorded".to_string()))?;
     let exports = build_exports(&sources)?;
+    if exports
+        .iter()
+        .any(|export| !export.identity.preconditions.is_empty())
+    {
+        return Err(Failure::Audit(
+            "guarded formula audit requires a versioned precondition witness contract".to_string(),
+        ));
+    }
     let imports = build_imports(&sources, &provider.imports.borrow())?;
 
     let mut derivations = Vec::new();
@@ -1022,6 +1075,12 @@ fn build_audit(
                 )))
             }
         };
+        if derived.precision_loss {
+            return Err(Failure::Audit(format!(
+                "formula query answer {} crossed a lossy numeric boundary",
+                derived.name
+            )));
+        }
 
         let checked = verify_derived(derived, &lowered.kb, snapshots);
         if checked.name != derived.name || checked.is_query_answer != plan.is_query_answer {

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -33,8 +33,8 @@ use adj_constraint_solver::{
     check, optimize, solve, FeasibilityOutcome, OptimizeOutcome, SolveOutcome,
 };
 use adj_lang::{
-    compile_with_imports, decide, run_state_machine, ImportLimits, LoweredRangeLookup,
-    LoweredStateMachine, StateMachineOutcome, StateMachineRun, YieldValue,
+    compile_with_imports, decide, run_state_machine, FormulaAbstention, ImportLimits,
+    LoweredRangeLookup, LoweredStateMachine, StateMachineOutcome, StateMachineRun, YieldValue,
 };
 use adj_lang_cli::{esc, payload, query_echo, sensitive_input, FsProvider};
 use logic_core::{atom, compound, var, LogicVar, Term};
@@ -42,7 +42,7 @@ use logic_engine::govern::Standing;
 use logic_engine::{
     enumerate_all, enumerate_governing, numeric_exact_magnitude, DerivationOrigin,
     DifferentialDecision, Fact, GovernStatus, GovernedResult, KnowledgeBase, LRAggregateResult,
-    Proof, Provenance, TrustTier,
+    LrAggregateWarning, Proof, Provenance, TrustTier,
 };
 
 mod explain;
@@ -70,6 +70,17 @@ fn jnum(x: f64) -> String {
     }
 }
 
+fn exact_operand_json(name: &str, exact: &Option<logic_engine::compute::ExactRational>) -> String {
+    exact.as_ref().map_or_else(String::new, |value| {
+        format!(
+            ",\"{}_exact\":{{\"num\":\"{}\",\"den\":\"{}\"}}",
+            name,
+            value.numerator(),
+            value.denominator()
+        )
+    })
+}
+
 /// Render a derived value's `"value"` field, **exact-first** (ADJ-EXACT-NUMBERS NX-4).
 ///
 /// When a computation stayed inside exact rational arithmetic (NX-3) *and* the result has a
@@ -82,9 +93,11 @@ fn jnum(x: f64) -> String {
 /// remain a JSON number literal, so the field's type is unchanged for every existing consumer;
 /// only its precision grows for values that were previously truncated.
 fn value_json(d: &logic_engine::compute::Derived) -> String {
-    if let Some(exact) = &d.exact {
-        if let Some(s) = exact.to_exact_decimal_string() {
-            return s;
+    if !d.precision_loss {
+        if let Some(exact) = &d.exact {
+            if let Some(s) = exact.to_exact_decimal_string() {
+                return s;
+            }
         }
     }
     jnum(d.value)
@@ -314,13 +327,18 @@ fn derived_json(kb: &KnowledgeBase) -> String {
             // numerator/denominator can exceed JSON's safe integer range — emit them as
             // **strings** so no precision is lost at the boundary (the whole point of the exact
             // channel). `BigInteger`'s `Display` is the plain decimal form.
-            let exact = match &d.exact {
-                Some(r) => format!(
+            let exact = match (&d.exact, d.precision_loss) {
+                (Some(r), false) => format!(
                     ",\"exact\":{{\"num\":\"{}\",\"den\":\"{}\"}}",
                     r.numerator(),
                     r.denominator()
                 ),
-                None => String::new(),
+                _ => String::new(),
+            };
+            let precision_loss = if d.precision_loss {
+                ",\"precision_loss\":true"
+            } else {
+                ""
             };
             // A value produced by APPLYING a provenanced `formula`
             // (ADJ-FORMULA-LIBRARIES rung-0) carries the formula's cited
@@ -338,17 +356,83 @@ fn derived_json(kb: &KnowledgeBase) -> String {
             // and here is the observed fact behind each operand."
             let derivation = format!(",\"derivation\":{}", derivation_tree_json(&d.tree, kb));
             format!(
-                "{{\"name\":\"{}\",\"value\":{},\"dim\":\"{}\"{}{}{}}}",
+                "{{\"name\":\"{}\",\"value\":{},\"dim\":\"{}\"{}{}{}{}}}",
                 esc(&d.name),
                 value_json(d),
                 esc(&d.dim.tag()),
                 exact,
+                precision_loss,
                 provenance,
                 derivation
             )
         })
         .collect();
     format!("[{}]", objs.join(","))
+}
+
+/// Render valid formula applications that declined to publish a value because
+/// a declared domain requirement failed or could not be resolved. The formula's
+/// provenance remains attached, while sensitive operand details follow the same
+/// redaction switch as query echoes.
+fn formula_abstention_json(abstention: &FormulaAbstention, kb: &KnowledgeBase) -> String {
+    let reason = if abstention.actual.is_some() {
+        "precondition_failed"
+    } else {
+        "precondition_unresolved"
+    };
+    let actual = if sensitive_input() {
+        "\"[redacted]\"".to_string()
+    } else {
+        abstention
+            .actual
+            .map(jnum)
+            .unwrap_or_else(|| "null".to_string())
+    };
+    let detail = match (&abstention.detail, sensitive_input()) {
+        (Some(_), true) => ",\"detail\":\"[redacted]\"".to_string(),
+        (Some(value), false) => format!(",\"detail\":\"{}\"", esc(value)),
+        (None, _) => String::new(),
+    };
+    let parameter = abstention
+        .parameter
+        .as_ref()
+        .map(|value| format!("\"{}\"", esc(value)))
+        .unwrap_or_else(|| "null".to_string());
+    format!(
+        "{{\"name\":\"{}\",\"formula\":\"{}\",\"outcome\":\"abstained\",\"reason\":\"{}\",\"precondition\":{{\"index\":{},\"predicate\":\"{}\",\"parameter\":{},\"actual\":{}{}}},\"inputs\":{},{}}}",
+        esc(&abstention.name),
+        esc(&abstention.formula),
+        reason,
+        abstention.precondition_index,
+        esc(&abstention.predicate),
+        parameter,
+        actual,
+        detail,
+        formula_input_citations_json(&abstention.fact_ids, kb),
+        prov(&abstention.provenance),
+    )
+}
+
+fn formula_input_citations_json(ids: &[logic_engine::FactId], kb: &KnowledgeBase) -> String {
+    let redact = sensitive_input();
+    let inputs = ids
+        .iter()
+        .filter_map(|id| kb.fact(*id))
+        .map(|fact| {
+            let term = if redact {
+                "[redacted]".to_string()
+            } else {
+                fact.term.to_string()
+            };
+            format!(
+                "{{\"fact_id\":{},\"term\":\"{}\",{}}}",
+                fact.id.0,
+                esc(&term),
+                prov(&fact.provenance)
+            )
+        })
+        .collect::<Vec<_>>();
+    format!("[{}]", inputs.join(","))
 }
 
 fn trust(t: &TrustTier) -> &'static str {
@@ -605,19 +689,28 @@ fn trace_steps_json(proof: &Proof, kb: &KnowledgeBase) -> String {
             DerivationOrigin::FromPredicateContribution {
                 clause_id,
                 slot,
+                observation_fact_id,
                 op,
                 threshold,
+                threshold_exact,
                 observed,
+                observed_exact,
                 logit_delta,
             } => {
                 format!(
-                    "\"kind\":\"predicate\",{head},\"clause_id\":{},\"slot\":\"{}\",\"op\":\"{}\",\"threshold\":{},\"observed\":{},\"logit_delta\":{}",
+                    "\"kind\":\"predicate\",{head},\"clause_id\":{},\"slot\":\"{}\",\"op\":\"{}\",\"threshold\":{}{},\"observed\":{}{},\"logit_delta\":{},\"observation\":{}",
                     clause_id.0,
                     esc(slot),
                     esc(op.symbol()),
                     jnum(*threshold),
+                    exact_operand_json("threshold", threshold_exact),
                     jnum(*observed),
-                    jnum(*logit_delta)
+                    exact_operand_json("observed", observed_exact),
+                    jnum(*logit_delta),
+                    observation_fact_id.map_or_else(
+                        || "[]".to_string(),
+                        |id| fact_citations_json(&[id], kb)
+                    )
                 )
             }
         };
@@ -742,9 +835,12 @@ fn proof_json(
                 DerivationOrigin::FromPredicateContribution {
                     clause_id,
                     slot,
+                    observation_fact_id,
                     op,
                     threshold,
+                    threshold_exact,
                     observed,
+                    observed_exact,
                     logit_delta,
                 } => {
                     let pv = predicates
@@ -756,12 +852,18 @@ fn proof_json(
                                 .to_string()
                         });
                     steps.push(format!(
-                        "{{\"kind\":\"predicate\",\"slot\":\"{}\",\"op\":\"{}\",\"threshold\":{},\"observed\":{},\"logit\":{},{}}}",
+                        "{{\"kind\":\"predicate\",\"slot\":\"{}\",\"op\":\"{}\",\"threshold\":{}{},\"observed\":{}{},\"logit\":{},\"observation\":{},{}}}",
                         esc(slot),
                         esc(op.symbol()),
                         jnum(*threshold),
+                        exact_operand_json("threshold", threshold_exact),
                         jnum(*observed),
+                        exact_operand_json("observed", observed_exact),
                         jnum(*logit_delta),
+                        observation_fact_id.map_or_else(
+                            || "[]".to_string(),
+                            |id| fact_citations_json(&[id], kb)
+                        ),
                         pv
                     ));
                 }
@@ -770,6 +872,42 @@ fn proof_json(
         }
     }
     format!("[{}]", steps.join(","))
+}
+
+fn aggregate_warnings_json(warnings: &[LrAggregateWarning]) -> String {
+    let items = warnings
+        .iter()
+        .map(|warning| match warning {
+            LrAggregateWarning::NoPriorDeclared { conclusion } => format!(
+                "{{\"type\":\"no_prior_declared\",\"conclusion\":\"{}\"}}",
+                esc(&format!("{conclusion}"))
+            ),
+            LrAggregateWarning::NoContributionsActive { conclusion } => format!(
+                "{{\"type\":\"no_contributions_active\",\"conclusion\":\"{}\"}}",
+                esc(&format!("{conclusion}"))
+            ),
+            LrAggregateWarning::DegenerateContribution { clause_id } => format!(
+                "{{\"type\":\"degenerate_contribution\",\"clause_id\":\"{}\"}}",
+                esc(&format!("{clause_id:?}"))
+            ),
+            LrAggregateWarning::PredicatePrecisionLoss { clause_id, slot } => format!(
+                "{{\"type\":\"predicate_precision_loss\",\"clause_id\":\"{}\",\"slot\":\"{}\"}}",
+                esc(&format!("{clause_id:?}")),
+                esc(slot)
+            ),
+            LrAggregateWarning::PredicateEvaluationError {
+                clause_id,
+                slot,
+                detail,
+            } => format!(
+                "{{\"type\":\"predicate_evaluation_error\",\"clause_id\":\"{}\",\"slot\":\"{}\",\"detail\":\"{}\"}}",
+                esc(&format!("{clause_id:?}")),
+                esc(slot),
+                esc(detail)
+            ),
+        })
+        .collect::<Vec<_>>();
+    format!("[{}]", items.join(","))
 }
 
 /// Map the constraint-engine outcomes to `(status atom, certificate JSON)` pairs
@@ -954,13 +1092,22 @@ fn main() -> ExitCode {
     let mut ranked: Vec<String> = Vec::new();
     for r in &diff.ranked {
         let proof = proof_json(&r.hypothesis, &lowered.kb, &r.result, &certs);
+        let warnings = if r.result.warnings.is_empty() {
+            String::new()
+        } else {
+            format!(
+                ",\"warnings\":{}",
+                aggregate_warnings_json(&r.result.warnings)
+            )
+        };
         ranked.push(format!(
-            "{{\"hypothesis\":\"{}\",\"posterior\":{},\"posterior_logit\":{},\"normalized_share\":{},\"proof\":{}}}",
+            "{{\"hypothesis\":\"{}\",\"posterior\":{},\"posterior_logit\":{},\"normalized_share\":{},\"proof\":{}{}}}",
             esc(&format!("{}", r.hypothesis)),
             jnum(r.posterior),
             jnum(r.posterior_logit),
             jnum(r.normalized_share),
-            proof
+            proof,
+            warnings
         ));
     }
 
@@ -975,6 +1122,16 @@ fn main() -> ExitCode {
                 jnum(*margin_logit)
             )
         }
+        DifferentialDecision::Indeterminate {
+            leader,
+            posterior,
+            reason,
+        } => format!(
+            "{{\"type\":\"indeterminate\",\"leader\":\"{}\",\"posterior\":{},\"reason\":\"{}\"}}",
+            esc(&format!("{}", leader)),
+            jnum(*posterior),
+            esc(reason)
+        ),
         DifferentialDecision::Kickback {
             leader, runner_up, margin_posterior, margin_logit, reason, ..
         } => format!(
@@ -1075,6 +1232,18 @@ fn main() -> ExitCode {
         format!(",\"derived\":{}", derived)
     };
 
+    let formula_abstentions_section = if lowered.formula_abstentions.is_empty() {
+        String::new()
+    } else {
+        let abstentions = lowered
+            .formula_abstentions
+            .iter()
+            .map(|abstention| formula_abstention_json(abstention, &lowered.kb))
+            .collect::<Vec<_>>()
+            .join(",");
+        format!(",\"formula_abstentions\":[{abstentions}]")
+    };
+
     // ADJ-STATEMACHINE RS-3c: the state-machine run section — each machine's typed
     // outcome, its ordered provenanced steps, and the machine's own citation.
     // Omitted (empty string) when the program declared no `statemachine`, so every
@@ -1112,13 +1281,19 @@ fn main() -> ExitCode {
             .collect();
         println!(
             "{}",
-            explain::explain(&lowered.kb, &diff, &state_machine_runs, &argument_chains)
+            explain::explain(
+                &lowered.kb,
+                &diff,
+                &lowered.formula_abstentions,
+                &state_machine_runs,
+                &argument_chains,
+            )
         );
         return ExitCode::SUCCESS;
     }
 
     println!(
-        "{{\"queries\":[{}],\"ranked\":[{}],\"decision\":{}{}{}{}{}{}{}{}{}}}",
+        "{{\"queries\":[{}],\"ranked\":[{}],\"decision\":{}{}{}{}{}{}{}{}{}{}}}",
         queries.join(","),
         ranked.join(","),
         decision,
@@ -1129,6 +1304,7 @@ fn main() -> ExitCode {
         governing_section,
         lookup_section,
         derived_section,
+        formula_abstentions_section,
         state_machines_section
     );
     ExitCode::SUCCESS
@@ -1196,6 +1372,21 @@ fn state_machine_outcome_json(outcome: &StateMachineOutcome, kb: &KnowledgeBase)
         StateMachineOutcome::Stuck { state } => {
             format!("{{\"type\":\"stuck\",\"state\":\"{}\"}}", esc(state))
         }
+        StateMachineOutcome::PrecisionLoss { state, guard } => format!(
+            "{{\"type\":\"precision_loss\",\"state\":\"{}\",\"guard\":\"{}\"}}",
+            esc(state),
+            esc(guard)
+        ),
+        StateMachineOutcome::ComputationError {
+            state,
+            phase,
+            detail,
+        } => format!(
+            "{{\"type\":\"computation_error\",\"state\":\"{}\",\"phase\":\"{}\",\"detail\":\"{}\"}}",
+            esc(state),
+            esc(phase),
+            esc(detail)
+        ),
     }
 }
 

--- a/code/packages/rust/adj-lang-cli/tests/cli_golden.rs
+++ b/code/packages/rust/adj-lang-cli/tests/cli_golden.rs
@@ -41,6 +41,32 @@ fn single_hypothesis_emits_cited_proof_dag() {
 }
 
 #[test]
+fn precision_lost_derived_value_is_explicit_and_not_labeled_exact() {
+    let (ok, s) = run(
+        "adjcli_precision_loss.adj",
+        r#"
+formulabook formulas {
+    formula sine(x) = latex "$\sin(x)$"
+        source "sine definition" trust authoritative
+}
+let narrowed = sine(1e-400)
+"#,
+    );
+
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(s.contains("\"name\":\"narrowed\""), "{s}");
+    assert!(s.contains("\"precision_loss\":true"), "{s}");
+    let narrowed = s
+        .split("\"name\":\"narrowed\"")
+        .nth(1)
+        .expect("narrowed binding")
+        .split("}")
+        .next()
+        .unwrap();
+    assert!(!narrowed.contains("\"exact\""), "{s}");
+}
+
+#[test]
 fn two_hypothesis_differential_ranks_and_decides() {
     // bacterial gets a strong observed LR, viral does not → bacterial leads.
     let (ok, s) = run(
@@ -146,14 +172,23 @@ fn let_derived_value_reports_its_inferred_dimension() {
          ? speed\n",
     );
     assert!(ok, "CLI exited non-zero: {s}");
-    assert!(s.contains("\"derived\":["), "expected a derived section: {s}");
+    assert!(
+        s.contains("\"derived\":["),
+        "expected a derived section: {s}"
+    );
     assert!(s.contains("\"name\":\"speed\""), "{s}");
     assert!(s.contains("\"value\":80"), "{s}");
-    assert!(s.contains("\"dim\":\"km/h\""), "expected inferred km/h: {s}");
+    assert!(
+        s.contains("\"dim\":\"km/h\""),
+        "expected inferred km/h: {s}"
+    );
     // Exact integer arithmetic is preserved alongside the f64.
     // NUM-5: the exact value is an arbitrary-precision BigRational, so num/den are emitted as
     // JSON strings (they can exceed JSON's safe integer range) rather than bare numbers.
-    assert!(s.contains("\"exact\":{\"num\":\"80\",\"den\":\"1\"}"), "{s}");
+    assert!(
+        s.contains("\"exact\":{\"num\":\"80\",\"den\":\"1\"}"),
+        "{s}"
+    );
 }
 
 #[test]
@@ -200,7 +235,10 @@ fn programs_without_a_let_omit_the_derived_section() {
          observe symptom(pressure)\n? acs\n",
     );
     assert!(ok, "CLI exited non-zero: {s}");
-    assert!(!s.contains("\"derived\""), "no let ⇒ no derived section: {s}");
+    assert!(
+        !s.contains("\"derived\""),
+        "no let ⇒ no derived section: {s}"
+    );
 }
 
 #[test]

--- a/code/packages/rust/adj-lang-cli/tests/fl4_proportion_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/fl4_proportion_e2e.rs
@@ -31,6 +31,24 @@ fn run(program: &Path) -> (bool, String) {
     (out.status.success(), String::from_utf8(out.stdout).unwrap())
 }
 
+fn run_explain(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg("--explain")
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli --explain");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn run_sensitive(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .env("ADJ_SENSITIVE_INPUT", "1")
+        .output()
+        .expect("run sensitive adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
 /// Copy a shipped `.adj` file (by relative path under the stdlib) into `dir`
 /// under its basename, so a consumer's relative `import` resolves.
 fn place(dir: &Path, rel: &str) {
@@ -71,11 +89,14 @@ fn fourth_proportional_composes_product_and_quotient_and_carries_all_citations()
         "fourth_proportional(2, 3, 4) = 6: {s}"
     );
     // Exact integer 6/1 — no f64 round-trip.
-    assert!(s.contains("\"num\":\"6\"") && s.contains("\"den\":\"1\""), "exact value 6/1: {s}");
-    // The primary cites the cross-multiplication rule of three.
     assert!(
-        s.contains("en.wikipedia.org/wiki/Cross-multiplication"),
-        "primary cites the rule-of-three source: {s}"
+        s.contains("\"num\":\"6\"") && s.contains("\"den\":\"1\""),
+        "exact value 6/1: {s}"
+    );
+    // The primary cites the proportion definition and its nonzero domain.
+    assert!(
+        s.contains("openstax.org/books/prealgebra-2e/pages/6-5-solve-proportions"),
+        "primary cites the proportion-domain source: {s}"
     );
     // BOTH composed primitives appear as corroborations.
     assert!(
@@ -123,13 +144,63 @@ fn the_derivation_tree_names_the_quotient_over_the_product() {
 }
 
 // ---------------------------------------------------------------------------
-// Honest edge case — a degenerate proportion 0/b = c/x has no finite fourth
-// proportional; the engine REFUSES (DivisionByZero), never fabricates a value.
+// Honest edge cases — every supplied term is part of the original equation's
+// domain. A zero in any position must abstain before body evaluation.
 // ---------------------------------------------------------------------------
 
 #[test]
-fn a_zero_first_term_is_refused_not_fabricated() {
-    let dir = scratch("zero");
+fn every_zero_input_abstains_without_evaluating_the_body() {
+    for (tag, first, second, third) in [("first", 0, 3, 4), ("second", 2, 0, 4), ("third", 2, 3, 0)]
+    {
+        let dir = scratch(&format!("zero_{tag}"));
+        with_lib(&dir);
+        std::fs::write(
+            dir.join("case.adj"),
+            format!(
+                "import \"proportion.adj\"\n\
+                 observe first_term({first})\n\
+                 observe second_term({second})\n\
+                 observe third_term({third})\n\
+                 ? fourth_proportional(first_term, second_term, third_term)\n"
+            ),
+        )
+        .unwrap();
+
+        let (ok, s) = run(&dir.join("case.adj"));
+        assert!(ok, "a false precondition is a successful abstention: {s}");
+        let json: serde_json::Value = serde_json::from_str(&s).expect("valid CLI JSON");
+        let abstentions = json["formula_abstentions"]
+            .as_array()
+            .expect("formula abstention array");
+        assert_eq!(abstentions.len(), 1, "one failed guard for {tag}: {s}");
+        assert_eq!(abstentions[0]["reason"], "precondition_failed");
+        assert_eq!(abstentions[0]["precondition"]["predicate"], "nonzero");
+        assert_eq!(
+            abstentions[0]["precondition"]["parameter"],
+            tag.to_string() + "_term"
+        );
+        assert_eq!(abstentions[0]["precondition"]["actual"], 0);
+        let inputs = abstentions[0]["inputs"]
+            .as_array()
+            .expect("guard input facts");
+        assert_eq!(inputs.len(), 1);
+        assert!(inputs[0]["term"].as_str().unwrap().contains(tag));
+        assert!(
+            json.get("derived").is_none(),
+            "no derived value for zero {tag}: {s}"
+        );
+        if tag == "first" {
+            let (explain_ok, explanation) = run_explain(&dir.join("case.adj"));
+            assert!(explain_ok, "abstention explanation exits successfully");
+            assert!(explanation.contains("FORMULA ABSTENTIONS"));
+            assert!(explanation.contains("fourth_proportional.nonzero[0](first_term) = 0"));
+        }
+    }
+}
+
+#[test]
+fn sensitive_formula_abstention_redacts_the_consumed_fact_term() {
+    let dir = scratch("sensitive_zero");
     with_lib(&dir);
     std::fs::write(
         dir.join("case.adj"),
@@ -141,9 +212,16 @@ fn a_zero_first_term_is_refused_not_fabricated() {
     )
     .unwrap();
 
-    let (_ok, s) = run(&dir.join("case.adj"));
-    // Dividing by the zero first term is refused: the engine reports
-    // DivisionByZero rather than inventing a fourth proportional.
-    assert!(s.contains("DivisionByZero"), "a zero first term must be refused, not fabricated: {s}");
-    assert!(!s.contains("\"value\":0"), "no fabricated value for a degenerate proportion: {s}");
+    let (ok, output) = run_sensitive(&dir.join("case.adj"));
+    assert!(ok, "sensitive abstention exits successfully: {output}");
+    assert!(output.contains("\"term\":\"[redacted]\""));
+    assert!(output.contains("\"fact_id\":0"));
+    assert!(
+        !output.contains("first_term(0)"),
+        "fact value leaked: {output}"
+    );
+    assert!(
+        !output.contains("\"actual\":0"),
+        "guard value leaked: {output}"
+    );
 }

--- a/code/packages/rust/adj-lang-cli/tests/formula_audit.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_audit.rs
@@ -85,6 +85,72 @@ fn formula_audit_rejects_duplicate_export_names_before_using_runtime_mapping() {
 }
 
 #[test]
+fn formula_audit_fails_closed_on_abstention_until_negative_witness_v2() {
+    let directory = std::env::temp_dir().join(format!(
+        "adj_formula_audit_abstention_{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&directory);
+    fs::create_dir_all(&directory).expect("create temporary source directory");
+    let program = directory.join("abstention.adj");
+    fs::write(
+        &program,
+        "formulabook guarded {\n\
+             formula quotient(a, b) = a / b\n\
+               requires nonzero(b)\n\
+               source \"division domain\" trust authoritative\n\
+         }\n\
+         observe numerator(8)\n\
+         observe denominator(0)\n\
+         ? quotient(numerator, denominator)\n",
+    )
+    .expect("write guarded program");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adj-formula-audit"))
+        .arg(&program)
+        .output()
+        .expect("run formula audit");
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("formula abstention audit requires a versioned precondition witness contract"));
+
+    fs::remove_dir_all(directory).expect("remove temporary source directory");
+}
+
+#[test]
+fn formula_audit_fails_closed_on_a_passing_guard_until_witness_v2() {
+    let directory = std::env::temp_dir().join(format!(
+        "adj_formula_audit_passing_guard_{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&directory);
+    fs::create_dir_all(&directory).expect("create temporary source directory");
+    let program = directory.join("passing_guard.adj");
+    fs::write(
+        &program,
+        "formulabook guarded {\n\
+             formula quotient(a, b) = a / b\n\
+               requires nonzero(b)\n\
+               source \"division domain\" trust authoritative\n\
+         }\n\
+         observe numerator(8)\n\
+         observe denominator(2)\n\
+         ? quotient(numerator, denominator)\n",
+    )
+    .expect("write guarded program");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adj-formula-audit"))
+        .arg(&program)
+        .output()
+        .expect("run formula audit");
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("guarded formula audit requires a versioned precondition witness contract"));
+
+    fs::remove_dir_all(directory).expect("remove temporary source directory");
+}
+
+#[test]
 fn formula_audit_rejects_provenance_that_maps_to_multiple_exports() {
     let directory = std::env::temp_dir().join(format!(
         "adj_formula_audit_ambiguous_{}",

--- a/code/packages/rust/adj-lang-cli/tests/formula_inventory_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_inventory_e2e.rs
@@ -56,6 +56,7 @@ fn emits_parser_order_and_exact_byte_hashes() {
     assert_eq!(formulas[0]["formula"], "total");
     assert_eq!(formulas[0]["parameters"], serde_json::json!(["a", "b"]));
     assert_eq!(formulas[0]["step_count"], 0);
+    assert!(formulas[0].get("preconditions").is_none());
     assert_eq!(formulas[1]["formula"], "scaled");
     assert_eq!(formulas[1]["step_count"], 1);
 
@@ -75,6 +76,46 @@ fn emits_parser_order_and_exact_byte_hashes() {
         &source[formulas[1]["body"]["start"].as_u64().unwrap() as usize
             ..formulas[1]["body"]["end"].as_u64().unwrap() as usize],
         "doubled / 10"
+    );
+}
+
+#[test]
+fn guarded_formula_emits_v2_with_exact_precondition_bytes() {
+    let dir = scratch("preconditions");
+    let path = dir.join("guarded.adj");
+    let source = concat!(
+        "formulabook guarded {\n",
+        "  formula divide(a, b) = a / b\n",
+        "    requires nonzero(b)\n",
+        "    source \"division domain\" trust authoritative\n",
+        "}\n",
+    );
+    fs::write(&path, source).unwrap();
+
+    let output = inventory(&path);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["parser_contract"], "adj-lang/formula_source_map/v2");
+    assert_eq!(value["schema_version"], 2);
+    let condition = &value["formulas"][0]["preconditions"][0];
+    assert_eq!(condition["predicate"], "nonzero");
+    for field in [&condition["declaration"], &condition["arguments"][0]] {
+        let start = field["start"].as_u64().unwrap() as usize;
+        let end = field["end"].as_u64().unwrap() as usize;
+        assert_eq!(
+            field["sha256"],
+            coding_adventures_sha256::sha256_hex(&source.as_bytes()[start..end])
+        );
+    }
+    let declaration = &condition["declaration"];
+    assert_eq!(
+        &source[declaration["start"].as_u64().unwrap() as usize
+            ..declaration["end"].as_u64().unwrap() as usize],
+        "nonzero(b)"
     );
 }
 

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [0.71.0] - 2026-08-03 - executable formula preconditions
+
+- Formulas can declare ordered, generic `requires` predicates; the first closed execution
+  predicate is `nonzero(expr)`, validated for name, arity, and parameter scope.
+- Preconditions execute before formula bodies at direct queries, `let` bindings, nested formula
+  calls, and deferred predicate branches. A failed or unresolved guard publishes no value and
+  produces a structured formula abstention instead of a compile error.
+- Native expression literals retain exact decimal identity through guard validation. A literal
+  consumed by a guard rejects any value-changing `f64` conversion, while unrelated arguments and
+  unguarded formulas retain their existing behavior. A persistent precision-loss marker follows
+  narrowed literals through later derived references, while observed or exact derived rationals
+  keep using the engine's rational sidecar for composed requirements.
+- Successful observations and rebinding clear stale abstentions; consumed-fact traversal follows
+  each derivation's predecessor scope, and deferred branches publish their LHS only after both
+  sides succeed through a one-binding transactional overlay rather than cloning the full KB.
+- Nested formula or built-in applications inside requirement expressions are rejected explicitly
+  in this first slice instead of being misreported as unresolved inputs.
+- Authored decimal literals lower into exact engine IR, and state machines terminate with a typed
+  precision-loss outcome when a comparison guard cannot be decided without narrowing exact input.
+- Formula source maps retain exact UTF-8 declaration and argument spans for every precondition.
+  Duplicate formula exports and top-level arity mismatches now fail closed instead of depending
+  on import order or falling through as ordinary queries.
+- The expression-walker depth cap is 96; boxing the structured abstention control-flow payload
+  keeps Windows debug frames small enough for that bound. Validation walks are iterative, and
+  adversarial deep-spine, deep-guard, and exponential-expansion tests cover both limits.
+
 ## [0.70.0] - 2026-08-02 - parser-backed formula source maps
 
 - `formula_source_map` inventories every parsed formulabook entry in source order and returns

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.70.0"
+version = "0.71.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/README.md
+++ b/code/packages/rust/adj-lang/README.md
@@ -91,6 +91,25 @@ formula-boundary, order, count, or name disagreement is an error rather than a b
 The source map is structural: import resolution, lowering, derivation replay, and execution
 coverage remain separate gates.
 
+### Formula domain requirements
+
+A formula may declare ordered requirements after its body and before its provenance annotations:
+
+```adj
+formula divide(dividend, divisor) = dividend / divisor
+    requires nonzero(divisor)
+    source "division definition" trust authoritative
+```
+
+Requirement predicates use a generic AST, but execution is a closed set: an unknown predicate,
+wrong arity, out-of-scope reference, or nested formula/built-in application is a compile error.
+The first slice accepts ordinary arithmetic expressions over bound parameters. `nonzero(expr)` is
+evaluated on the CPU after arguments are bound and before the body runs, including inside nested
+formula calls. Exact observed and derived values use rational sidecars; a literal consumed by a
+guard that cannot cross the current compute IR's `f64` boundary unchanged is rejected explicitly.
+A false or unresolved requirement emits a structured abstention and no derived value. Formula
+source maps expose the exact declaration and argument byte spans for every requirement.
+
 ### Constraints — `symbol` / `constrain` / `solve` / `check` (v0.7)
 
 The model extracts the policy's **unknowns and constraints**; the engine solves

--- a/code/packages/rust/adj-lang/src/_parser_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_parser_grammar.rs
@@ -579,6 +579,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"formula_params"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::RuleReference { name: r#"formula_body"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"formula_requires"#.to_string() }) },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
             line_number: 364,
@@ -621,6 +622,34 @@ pub fn parser_grammar() -> ParserGrammar {
             line_number: 381,
         },
         GrammarRule {
+            name: r#"formula_requires"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"requires"#.to_string() },
+                GrammarElement::RuleReference { name: r#"formula_precondition"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"formula_precondition"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 383,
+        },
+        GrammarRule {
+            name: r#"formula_precondition"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                        GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                                GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                            ] }) },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+            ] },
+            line_number: 385,
+        },
+        GrammarRule {
             name: r#"table_decl"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::Literal { value: r#"table"#.to_string() },
@@ -632,7 +661,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 415,
+            line_number: 419,
         },
         GrammarRule {
             name: r#"columns_decl"#.to_string(),
@@ -644,7 +673,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                     ] }) },
             ] },
-            line_number: 417,
+            line_number: 421,
         },
         GrammarRule {
             name: r#"table_row"#.to_string(),
@@ -663,7 +692,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
                     ] }) },
             ] },
-            line_number: 425,
+            line_number: 429,
         },
         GrammarRule {
             name: r#"row_item"#.to_string(),
@@ -672,7 +701,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 427,
+            line_number: 431,
         },
         GrammarRule {
             name: r#"statemachine_decl"#.to_string(),
@@ -691,7 +720,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 440,
+            line_number: 444,
         },
         GrammarRule {
             name: r#"sm_state"#.to_string(),
@@ -702,7 +731,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"sm_transition"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 449,
+            line_number: 453,
         },
         GrammarRule {
             name: r#"sm_transition"#.to_string(),
@@ -721,7 +750,7 @@ pub fn parser_grammar() -> ParserGrammar {
                             ] }) },
                     ] }) },
             ] },
-            line_number: 456,
+            line_number: 460,
         },
         GrammarRule {
             name: r#"sm_exit"#.to_string(),
@@ -732,7 +761,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"yield"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 458,
+            line_number: 462,
         },
         GrammarRule {
             name: r#"sm_guard"#.to_string(),
@@ -752,7 +781,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expr"#.to_string() },
                     ] }) },
             ] },
-            line_number: 460,
+            line_number: 464,
         },
         GrammarRule {
             name: r#"sm_action"#.to_string(),
@@ -760,7 +789,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"assert"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 462,
+            line_number: 466,
         },
         GrammarRule {
             name: r#"argument_decl"#.to_string(),
@@ -772,7 +801,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"arg_infer"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 480,
+            line_number: 484,
         },
         GrammarRule {
             name: r#"arg_premise"#.to_string(),
@@ -784,7 +813,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 482,
+            line_number: 486,
         },
         GrammarRule {
             name: r#"arg_infer"#.to_string(),
@@ -809,7 +838,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                     ] }) },
             ] },
-            line_number: 495,
+            line_number: 499,
         },
         GrammarRule {
             name: r#"arg_unless"#.to_string(),
@@ -821,12 +850,12 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 497,
+            line_number: 501,
         },
         GrammarRule {
             name: r#"arg_ref"#.to_string(),
             body: GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-            line_number: 499,
+            line_number: 503,
         },
         GrammarRule {
             name: r#"import_decl"#.to_string(),
@@ -834,7 +863,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"import"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 515,
+            line_number: 519,
         },
         GrammarRule {
             name: r#"annotation"#.to_string(),
@@ -845,7 +874,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"cites_annotation"#.to_string() },
                 GrammarElement::RuleReference { name: r#"quote_annotation"#.to_string() },
             ] },
-            line_number: 527,
+            line_number: 531,
         },
         GrammarRule {
             name: r#"source_annotation"#.to_string(),
@@ -853,7 +882,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"source"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 534,
+            line_number: 538,
         },
         GrammarRule {
             name: r#"locator_annotation"#.to_string(),
@@ -861,7 +890,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 535,
+            line_number: 539,
         },
         GrammarRule {
             name: r#"trust_annotation"#.to_string(),
@@ -869,7 +898,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"trust"#.to_string() },
                 GrammarElement::RuleReference { name: r#"trust_tier"#.to_string() },
             ] },
-            line_number: 536,
+            line_number: 540,
         },
         GrammarRule {
             name: r#"cites_annotation"#.to_string(),
@@ -879,7 +908,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 537,
+            line_number: 541,
         },
         GrammarRule {
             name: r#"quote_annotation"#.to_string(),
@@ -891,7 +920,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"snapshot"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 545,
+            line_number: 549,
         },
         GrammarRule {
             name: r#"trust_tier"#.to_string(),
@@ -902,7 +931,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"inferred"#.to_string() },
                 GrammarElement::Literal { value: r#"unattributed"#.to_string() },
             ] },
-            line_number: 547,
+            line_number: 551,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -926,7 +955,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 569,
+            line_number: 573,
         },
     ],
         version: 1,

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -105,6 +105,10 @@ pub enum AdapterError {
     /// LaTeX parsed successfully, but used math outside the ADJ arithmetic /
     /// constraint subset this surface can lower faithfully.
     UnsupportedLatexMath { source: String, detail: String },
+    /// A native arithmetic expression exceeded the construction-depth budget.
+    /// The adapter enforces this while folding operator spines so rejecting an
+    /// adversarial input never leaves a recursively dropped, unbounded AST.
+    ExpressionTooDeep { limit: usize },
 }
 
 /// Adapt the root `program` node.
@@ -289,7 +293,7 @@ fn adapt_predicate(node: &GrammarASTNode) -> Result<Evidence, AdapterError> {
             .iter()
             .find_map(|c| match c {
                 ASTNodeOrToken::Token(t) if t.type_ == TokenType::Number => {
-                    Some(parse_finite(&t.value, t.type_, "predicate").map(ExprAst::Lit))
+                    Some(parse_expr_numlit(&t.value, t.type_, "predicate").map(ExprAst::ExactLit))
                 }
                 _ => None,
             })
@@ -925,7 +929,8 @@ fn adapt_formulabook(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
 }
 
 fn adapt_formula(node: &GrammarASTNode) -> Result<FormulaDef, AdapterError> {
-    // formula_decl = "formula" IDENT LPAREN [ formula_params ] RPAREN EQUALS expr { annotation }
+    // formula_decl = "formula" IDENT LPAREN [ formula_params ] RPAREN
+    //                formula_body [ formula_requires ] { annotation }
     //
     // The name is the first Name token that isn't the `formula` keyword (the
     // parameter Name tokens live INSIDE the nested `formula_params` node, so they
@@ -991,6 +996,45 @@ fn adapt_formula(node: &GrammarASTNode) -> Result<FormulaDef, AdapterError> {
         position: "body expr",
     })?;
     let body = adapt_expr(expr_node)?;
+    // Preserve precondition and argument order exactly. Predicate semantics and
+    // arity are deliberately a lowering concern.
+    let mut preconditions = Vec::new();
+    if let Some(requires) = first_named_child(node, "formula_requires") {
+        for child in &requires.children {
+            let ASTNodeOrToken::Node(precondition) = child else {
+                continue;
+            };
+            if precondition.rule_name != "formula_precondition" {
+                continue;
+            }
+            let predicate = precondition
+                .children
+                .iter()
+                .find_map(|child| match child {
+                    ASTNodeOrToken::Token(token) if token.type_ == TokenType::Name => {
+                        Some(token.value.clone())
+                    }
+                    _ => None,
+                })
+                .ok_or(AdapterError::MissingChild {
+                    rule: "formula_precondition".into(),
+                    position: "predicate name",
+                })?;
+            let arguments = precondition
+                .children
+                .iter()
+                .filter_map(|child| match child {
+                    ASTNodeOrToken::Node(expr) if expr.rule_name == "expr" => Some(expr),
+                    _ => None,
+                })
+                .map(adapt_expr)
+                .collect::<Result<Vec<_>, _>>()?;
+            preconditions.push(crate::ast::FormulaPrecondition {
+                predicate,
+                arguments,
+            });
+        }
+    }
     // Same provenance envelope as every grounded clause (`{ annotation }`).
     let annotations = collect_annotations(node)?;
     Ok(FormulaDef {
@@ -998,6 +1042,7 @@ fn adapt_formula(node: &GrammarASTNode) -> Result<FormulaDef, AdapterError> {
         params,
         steps,
         body,
+        preconditions,
         annotations,
     })
 }
@@ -1525,6 +1570,7 @@ fn expr_ast_to_term(e: &ExprAst) -> Term {
             args: args.iter().map(expr_ast_to_term).collect(),
         },
         ExprAst::Lit(x) => Term::Num(NumLit::Int(*x as i64)),
+        ExprAst::ExactLit(x) => Term::Num(x.clone()),
         other => Term::Atom(format!("{other:?}")),
     }
 }
@@ -1614,6 +1660,44 @@ fn adapt_term_expr(node: &GrammarASTNode) -> Result<ExprAst, AdapterError> {
     fold_binary(node, "term_expr", "factor", adapt_factor)
 }
 
+const MAX_ADAPTED_EXPR_DEPTH: usize = 96;
+
+fn adapted_expr_depth(expr: &ExprAst) -> Result<usize, AdapterError> {
+    let mut maximum = 0;
+    let mut pending = vec![(expr, 1_usize)];
+    while let Some((node, depth)) = pending.pop() {
+        if depth > MAX_ADAPTED_EXPR_DEPTH {
+            return Err(AdapterError::ExpressionTooDeep {
+                limit: MAX_ADAPTED_EXPR_DEPTH,
+            });
+        }
+        maximum = maximum.max(depth);
+        let next = depth + 1;
+        match node {
+            ExprAst::Bin(_, left, right) | ExprAst::Call2(_, left, right) => {
+                pending.push((right, next));
+                pending.push((left, next));
+            }
+            ExprAst::Abs(inner)
+            | ExprAst::Floor(inner)
+            | ExprAst::Ceil(inner)
+            | ExprAst::Round(inner)
+            | ExprAst::RoundTo(inner, _)
+            | ExprAst::ToScientific(inner, _)
+            | ExprAst::ToPercent(inner, _)
+            | ExprAst::ToCurrency(inner, _, _)
+            | ExprAst::Trunc(inner)
+            | ExprAst::Sign(inner)
+            | ExprAst::Call(_, inner) => pending.push((inner, next)),
+            ExprAst::Apply(_, arguments) => {
+                pending.extend(arguments.iter().rev().map(|argument| (argument, next)));
+            }
+            ExprAst::Ref(_) | ExprAst::Lit(_) | ExprAst::ExactLit(_) | ExprAst::Agg(_, _) => {}
+        }
+    }
+    Ok(maximum)
+}
+
 /// Shared left-fold for the two binary-precedence levels: walk the
 /// node's children in source order, building `Bin(op, acc, rhs)` as each
 /// `(operator-token, operand)` pair appears. The operands are child
@@ -1625,14 +1709,28 @@ fn fold_binary(
     adapt_operand: fn(&GrammarASTNode) -> Result<ExprAst, AdapterError>,
 ) -> Result<ExprAst, AdapterError> {
     let mut acc: Option<ExprAst> = None;
+    let mut acc_depth = 0_usize;
     let mut pending_op: Option<ArithOp> = None;
     for c in &node.children {
         match c {
             ASTNodeOrToken::Node(n) if n.rule_name == operand_rule => {
                 let operand = adapt_operand(n)?;
+                let operand_depth = adapted_expr_depth(&operand)?;
                 acc = Some(match (acc.take(), pending_op.take()) {
-                    (None, _) => operand,
-                    (Some(lhs), Some(op)) => ExprAst::Bin(op, Box::new(lhs), Box::new(operand)),
+                    (None, _) => {
+                        acc_depth = operand_depth;
+                        operand
+                    }
+                    (Some(lhs), Some(op)) => {
+                        let combined_depth = 1 + acc_depth.max(operand_depth);
+                        if combined_depth > MAX_ADAPTED_EXPR_DEPTH {
+                            return Err(AdapterError::ExpressionTooDeep {
+                                limit: MAX_ADAPTED_EXPR_DEPTH,
+                            });
+                        }
+                        acc_depth = combined_depth;
+                        ExprAst::Bin(op, Box::new(lhs), Box::new(operand))
+                    }
                     (Some(lhs), None) => lhs, // defensive: two operands, no op
                 });
             }
@@ -1701,7 +1799,9 @@ fn adapt_factor(node: &GrammarASTNode) -> Result<ExprAst, AdapterError> {
     for c in &node.children {
         if let ASTNodeOrToken::Token(t) = c {
             if t.type_ == TokenType::Number {
-                return Ok(ExprAst::Lit(parse_finite(&t.value, t.type_, "factor")?));
+                return Ok(ExprAst::ExactLit(parse_expr_numlit(
+                    &t.value, t.type_, "factor",
+                )?));
             }
             if t.type_ == TokenType::Name {
                 return Ok(ExprAst::Ref(t.value.clone()));
@@ -3164,20 +3264,20 @@ fn trust_tier_from_node(node: &GrammarASTNode) -> Result<TrustTierName, AdapterE
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Parse a NUMBER lexeme to `f64`, rejecting non-finite values. Rust's
-/// `f64::from_str` accepts overflowing literals like `1e400` (→ `inf`);
-/// an infinite or NaN threshold is meaningless in a rulebook, so we
-/// reject it here with an accurate diagnostic rather than letting it
-/// silently flow downstream.
-fn parse_finite(raw: &str, kind: TokenType, rule: &str) -> Result<f64, AdapterError> {
-    match raw.parse::<f64>() {
-        Ok(x) if x.is_finite() => Ok(x),
-        _ => Err(AdapterError::BadToken {
+/// Parse a native arithmetic literal without discarding its decimal identity,
+/// while retaining the compute surface's historical finite-`f64` range gate.
+/// Underflow is allowed so a guarded application can diagnose the narrowing.
+fn parse_expr_numlit(raw: &str, kind: TokenType, rule: &str) -> Result<NumLit, AdapterError> {
+    let value = parse_numlit(raw, kind, rule)?;
+    if value.to_f64_lossy().is_finite() {
+        Ok(value)
+    } else {
+        Err(AdapterError::BadToken {
             rule: rule.to_string(),
             kind,
             value: raw.to_string(),
             reason: "not a finite f64",
-        }),
+        })
     }
 }
 
@@ -3223,9 +3323,10 @@ const MAX_NUMBER_TOKEN_SCALE: i64 = 4096;
 /// reject a hostile payload, never a real constant. (`BigDecimal::from_str` also enforces its own
 /// `MAX_SCALE`; these caps are the tighter, adj-lang-specific layer.)
 ///
-/// This replaces the old `f64` parse at the two **ground-term** sites (a table cell and a
-/// valued-fact argument). Compute leaves (`ExprAst::Lit`) still take an `f64` via `parse_finite`,
-/// because the compute layer is inherently `f64`.
+/// This replaces the old `f64` parse at ground-term sites and native arithmetic
+/// leaves. An [`ExprAst::ExactLit`] retains the source value until lowering; the
+/// compute layer still carries `f64`, so guarded calls reject value-changing
+/// narrowing before evaluation.
 fn parse_numlit(raw: &str, kind: TokenType, rule: &str) -> Result<NumLit, AdapterError> {
     // Reject an over-long token FIRST — before either the `i64` scan or the O(digits²) BigDecimal
     // parse — so no oversized mantissa can force superlinear work on any path. (A legitimate small
@@ -3531,7 +3632,7 @@ mod tests {
                     Evidence::Predicate { lhs, op, rhs } => {
                         assert!(matches!(lhs, ExprAst::Ref(ref s) if s == "gross_income"));
                         assert_eq!(op, CmpOp::Ge);
-                        assert!(matches!(rhs, ExprAst::Lit(v) if v == 14600.0));
+                        assert!(matches!(rhs, ExprAst::ExactLit(NumLit::Int(14600))));
                     }
                     other => panic!("expected predicate evidence, got {other:?}"),
                 }
@@ -3557,7 +3658,7 @@ mod tests {
                     ..
                 } => {
                     assert_eq!(op, *expected, "operator {sym}");
-                    assert!(matches!(rhs, ExprAst::Lit(v) if v == 18.0));
+                    assert!(matches!(rhs, ExprAst::ExactLit(NumLit::Int(18))));
                     assert!(matches!(lhs, ExprAst::Ref(ref s) if s == "age"));
                 }
                 other => panic!("expected predicate Contributes for {sym}, got {other:?}"),

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -35,7 +35,7 @@ impl NumLit {
     /// The **labeled lossy** `f64` view of this literal — the single sanctioned way to obtain an
     /// `f64` from a `NumLit`. `Int` widens with `as f64`; `Exact` narrows to the nearest `f64` via
     /// [`bignum_core::BigDecimal::to_f64`]. Used only where an `f64` is genuinely required (a
-    /// compute leaf or an approximate backend), never at parse time. The name is deliberately
+    /// retained AST leaf lowering or an approximate backend), never at parse time. The name is deliberately
     /// greppable so every lossy boundary is auditable, mirroring `logic_core::Number::to_f64_lossy`.
     pub fn to_f64_lossy(&self) -> f64 {
         match self {
@@ -209,6 +209,10 @@ pub enum ExprAst {
     Ref(String),
     /// A numeric literal written into the formula.
     Lit(f64),
+    /// A native numeric literal retained exactly until the lowering boundary.
+    /// Guarded formula applications reject this leaf if narrowing it to the
+    /// compute layer's `f64` literal would change its value.
+    ExactLit(NumLit),
     /// A binary arithmetic operation.
     Bin(ArithOp, Box<ExprAst>, Box<ExprAst>),
     /// An absolute value, `|x|` — a unary arithmetic form. Lowers to the native
@@ -633,11 +637,25 @@ pub struct FormulaDef {
     /// The formula body — the EXISTING `let` expression AST, reused verbatim.
     /// In the block form this is the final expression after the `let`-steps.
     pub body: ExprAst,
+    /// Domain requirements that must hold before this formula's body may be
+    /// evaluated. Predicates remain generic at the surface; lowering maps them
+    /// into a closed, typed execution set and rejects unknown names or arities.
+    pub preconditions: Vec<FormulaPrecondition>,
     /// The provenance envelope (`source` / `locator` / `trust`, plus any
     /// corroborating `cites`), reusing the shared [`Annotation`] set every
     /// grounded clause carries. Lowered via `annotations_to_provenance`; a
     /// shipped formula must carry a non-empty `source`.
     pub annotations: Vec<Annotation>,
+}
+
+/// One declared formula-domain requirement, preserving source order.
+///
+/// This is intentionally distinct from [`ExprAst::Apply`]: a precondition is a
+/// Boolean gate over bound arguments, not a numeric formula application.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FormulaPrecondition {
+    pub predicate: String,
+    pub arguments: Vec<ExprAst>,
 }
 
 /// A single `let`-step inside a multi-step formula body (ADJ-RULE-SUBSTRATE

--- a/code/packages/rust/adj-lang/src/lib.rs
+++ b/code/packages/rust/adj-lang/src/lib.rs
@@ -59,10 +59,14 @@ use logic_engine::Differential;
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode, GrammarParseError, GrammarParser};
 
 pub use adapter::{adapt_program, AdapterError};
-pub use ast::{Annotation, Define, DefineKind, OptDir, Program, RelOp, Statement, Term as AstTerm};
+pub use ast::{
+    Annotation, Define, DefineKind, FormulaPrecondition, OptDir, Program, RelOp, Statement,
+    Term as AstTerm,
+};
 pub use lower::{
-    lower, ConstraintSystem, LowerError, LoweredConstraint, LoweredExit, LoweredGuard,
-    LoweredProgram, LoweredRangeLookup, LoweredState, LoweredStateMachine, LoweredTransition,
+    lower, ConstraintSystem, FormulaAbstention, LowerError, LoweredConstraint, LoweredExit,
+    LoweredGuard, LoweredProgram, LoweredRangeLookup, LoweredState, LoweredStateMachine,
+    LoweredTransition,
 };
 pub use resolve::{resolve_imports, ImportError, ImportLimits, ImportProvider};
 pub use statemachine::{
@@ -98,6 +102,15 @@ pub struct FormulaSource {
     pub formula: ast::FormulaDef,
     pub declaration_span: SourceSpan,
     pub body_span: SourceSpan,
+    pub preconditions: Vec<FormulaPreconditionSource>,
+}
+
+/// One typed formula precondition paired with its exact authored bytes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FormulaPreconditionSource {
+    pub precondition: ast::FormulaPrecondition,
+    pub declaration_span: SourceSpan,
+    pub argument_spans: Vec<SourceSpan>,
 }
 
 /// One ordinary `? term` query and the exact bytes that declared it.
@@ -268,11 +281,44 @@ pub fn program_source_map(src: &str) -> Result<ProgramSourceMap, FormulaSourceMa
                         formula.name
                     ))
                 })?;
+            let precondition_nodes = direct_child(formula_node, "formula_requires")
+                .map(|requires| collect_nodes(requires, "formula_precondition"))
+                .unwrap_or_default();
+            if precondition_nodes.len() != formula.preconditions.len() {
+                return Err(FormulaSourceMapError::Inconsistent(format!(
+                    "formula {} has {} parsed preconditions but {} adapted preconditions",
+                    formula.name,
+                    precondition_nodes.len(),
+                    formula.preconditions.len()
+                )));
+            }
+            let preconditions = precondition_nodes
+                .into_iter()
+                .zip(&formula.preconditions)
+                .map(|(node, precondition)| {
+                    let argument_spans = node
+                        .children
+                        .iter()
+                        .filter_map(|child| match child {
+                            ASTNodeOrToken::Node(expr) if expr.rule_name == "expr" => {
+                                Some(locator.node_span(expr))
+                            }
+                            _ => None,
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    Ok(FormulaPreconditionSource {
+                        precondition: precondition.clone(),
+                        declaration_span: locator.node_span(node)?,
+                        argument_spans,
+                    })
+                })
+                .collect::<Result<Vec<_>, FormulaSourceMapError>>()?;
             inventory.push(FormulaSource {
                 formulabook: book_name.clone(),
                 formula: formula.clone(),
                 declaration_span: locator.node_span(formula_node)?,
                 body_span: locator.node_span(body_node)?,
+                preconditions,
             });
         }
     }

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -25,17 +25,17 @@ use logic_core::{
 };
 use logic_engine::{
     compute, BodyLiteral, Citation, CmpOp as EngineCmpOp, ComputeExpr, ComputeOp, ContentHash,
-    ContributionClause, Fact, JointContributionClause, KbError, KnowledgeBase,
-    PredicateContributionClause, PriorClause, Priority, Provenance, Rule, TrustTier,
+    ContributionClause, ExactRational, Fact, FactId, JointContributionClause, KbError,
+    KnowledgeBase, PredicateContributionClause, PriorClause, Priority, Provenance, Rule, TrustTier,
     UncertaintyMarker,
 };
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::ast::{
     AggOp, Annotation, ArithOp, BinFn, CmpOp, Define, DefineKind, Evidence, ExprAst, FormulaDef,
-    NamedFn, NumLit, OptDir, Program, RelOp, SmAction, SmGuard, Statement, Term as AstTerm,
-    TrustTierName,
+    FormulaPrecondition, NamedFn, NumLit, OptDir, Program, RelOp, SmAction, SmGuard, Statement,
+    Term as AstTerm, TrustTierName,
 };
 
 /// One lowered constraint: `lhs <op> rhs`, with both sides kept as
@@ -162,6 +162,39 @@ pub enum LowerError {
         formula: String,
         variable: String,
     },
+    /// Two imported formula books exported the same unqualified formula name.
+    /// Silent last-writer-wins resolution would make precondition enforcement
+    /// depend on import order, so duplicate exports are rejected.
+    DuplicateFormula {
+        formula: String,
+    },
+    /// A formula declared a precondition predicate outside the lowerer's closed,
+    /// typed execution set.
+    FormulaUnknownPrecondition {
+        formula: String,
+        predicate: String,
+    },
+    /// A known precondition predicate received the wrong number of arguments.
+    FormulaPreconditionArity {
+        formula: String,
+        predicate: String,
+        expected: usize,
+        got: usize,
+    },
+    /// The first precondition execution slice accepts arithmetic expressions
+    /// over parameters, but not nested formula/built-in applications. Reject
+    /// these explicitly rather than lowering an application to a poisoned slot
+    /// and misreporting a malformed guard as unresolved input.
+    FormulaPreconditionApplicationUnsupported {
+        formula: String,
+        predicate: String,
+    },
+    /// Internal control-flow carrier for a valid formula application that is
+    /// outside its declared domain. The top-level lowerer catches this and emits
+    /// a structured [`FormulaAbstention`] instead of failing compilation.
+    FormulaPreconditionAbstained {
+        abstention: Box<FormulaAbstention>,
+    },
     /// A shipped `formula` carried no `source` (the provenance-required lint,
     /// mirroring the recall-library adversarial write gate). A formula is a *claim
     /// about the world* ("BMI is mass ÷ height²") and may not enter a library
@@ -175,6 +208,13 @@ pub enum LowerError {
     /// rung-0, so it is rejected rather than silently mis-applied.
     FormulaBadArgument {
         formula: String,
+    },
+    /// An exact literal participating in a guarded formula could not cross the
+    /// compute layer's labeled `f64` boundary without changing value. Reject it
+    /// rather than making a guard decision or publishing a rounded result.
+    FormulaArgumentPrecisionLoss {
+        formula: String,
+        parameter: String,
     },
     /// A formula application `name(args)` in an expression named a formula that is
     /// not registered by any imported `formulabook` (ADJ-RULE-SUBSTRATE RS-1). A
@@ -379,6 +419,29 @@ pub enum LowerError {
     },
 }
 
+/// A formula application declined because a declared domain requirement failed
+/// or could not be resolved from the available facts.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FormulaAbstention {
+    /// The derived binding or query answer that was withheld.
+    pub name: String,
+    /// The formula whose requirement stopped evaluation (possibly a nested callee).
+    pub formula: String,
+    pub predicate: String,
+    /// Zero-based source order within the formula's `requires` clause.
+    pub precondition_index: usize,
+    /// The parameter named by a simple guard such as `nonzero(divisor)`.
+    pub parameter: Option<String>,
+    /// The evaluated argument for a false predicate. `None` means evaluation
+    /// could not resolve the requirement from the current KB.
+    pub actual: Option<f64>,
+    pub detail: Option<String>,
+    /// Ground facts consumed while evaluating the guard, preserving byte-level
+    /// input provenance for the CLI and future negative-witness replay.
+    pub fact_ids: Vec<FactId>,
+    pub provenance: Provenance,
+}
+
 /// One lowered RANGE / BRACKET lookup (ADJ-TABLES RS-5c) — the validated,
 /// index-resolved form of a `? lookup <table> <key_col> = <n> mode range give
 /// <value_col>` recall. The lowerer has already checked the table and columns
@@ -498,6 +561,9 @@ pub struct LoweredProgram {
     /// program with no dictionary. Used by the decomposer (surface forms) and
     /// enforced at compile time.
     pub dictionary: Vec<Define>,
+    /// Formula-domain refusals, in source execution order. A refusal publishes
+    /// no derived value and does not make an otherwise valid program fail to compile.
+    pub formula_abstentions: Vec<FormulaAbstention>,
 }
 
 /// Lower an [`ast::Program`] to a populated KB + queries + constraint system.
@@ -506,6 +572,8 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
     let mut queries = Vec::new();
     let mut constraints = ConstraintSystem::default();
     let mut dictionary: Vec<Define> = Vec::new();
+    let mut formula_abstentions = Vec::new();
+    let mut unavailable_bindings: HashMap<String, FormulaAbstention> = HashMap::new();
     // ADJ-STATEMACHINE RS-3b: each `statemachine` lowers to a validated,
     // provenance-stamped structure here (no driver yet — that is RS-3c).
     let mut state_machines: Vec<LoweredStateMachine> = Vec::new();
@@ -536,7 +604,11 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
         if let Statement::Formulabook { formulas: defs, .. } = stmt {
             for fd in defs {
                 validate_formula(fd)?;
-                formulas.insert(fd.name.as_str(), fd);
+                if formulas.insert(fd.name.as_str(), fd).is_some() {
+                    return Err(LowerError::DuplicateFormula {
+                        formula: fd.name.clone(),
+                    });
+                }
             }
         }
     }
@@ -663,6 +735,9 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
             }
             Statement::Observe { term, annotations } => {
                 let prov = annotations_to_provenance(annotations)?;
+                if let AstTerm::Compound { functor, .. } = term {
+                    unavailable_bindings.remove(functor);
+                }
                 kb.add_fact(Fact::certain(lower_term(term)).with_provenance(prov));
             }
             Statement::Relate { edge, annotations } => {
@@ -739,15 +814,42 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                 // importable, reusable `let`. The result is bound as a derived value
                 // named after the formula, carrying the formula's cited provenance so
                 // the computed answer is auditable back to WHY its formula is trusted.
-                if let Some(fd) = formula_for_query(conclusion, &formulas) {
-                    let substituted = apply_formula(fd, conclusion)?;
+                if let Some(fd) = formula_for_query(conclusion, &formulas)? {
+                    if let Some(mut abstention) =
+                        unavailable_query_argument(conclusion, &unavailable_bindings)
+                    {
+                        abstention.name = fd.name.clone();
+                        formula_abstentions.push(abstention);
+                        continue;
+                    }
+                    let substituted = match apply_formula(fd, conclusion, &kb) {
+                        Ok(value) => value,
+                        Err(LowerError::FormulaPreconditionAbstained { abstention }) => {
+                            let mut abstention = *abstention;
+                            abstention.name = fd.name.clone();
+                            unavailable_bindings.insert(fd.name.clone(), abstention.clone());
+                            formula_abstentions.push(abstention);
+                            continue;
+                        }
+                        Err(error) => return Err(error),
+                    };
                     // RS-1 composition: the substituted body may ITSELF apply other
                     // formulas (`ratio(n, d) = quotient(n, d)`). Expand every nested
                     // application recursively — with the depth guard — collecting the
                     // provenance chain of each applied formula, then lower the
                     // fully-expanded (application-free) expression through the SAME
                     // `compute` path a `let` uses.
-                    let (expanded, chain) = expand_applies(&substituted, &formulas, 0)?;
+                    let (expanded, chain) = match expand_applies(&substituted, &formulas, &kb, 0) {
+                        Ok(value) => value,
+                        Err(LowerError::FormulaPreconditionAbstained { abstention }) => {
+                            let mut abstention = *abstention;
+                            abstention.name = fd.name.clone();
+                            unavailable_bindings.insert(fd.name.clone(), abstention.clone());
+                            formula_abstentions.push(abstention);
+                            continue;
+                        }
+                        Err(error) => return Err(error),
+                    };
                     let cexpr = lower_expr(&expanded);
                     let derived = compute(fd.name.clone(), &cexpr, &kb).map_err(|e| {
                         LowerError::ComputationFailed {
@@ -765,6 +867,7 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                     let prov = compose_provenance(primary.clone(), &chain);
                     let mut formula_sources = vec![primary];
                     formula_sources.extend(chain.iter().cloned());
+                    unavailable_bindings.remove(&fd.name);
                     kb.add_derived(
                         derived
                             .with_formula_sources(prov, formula_sources)
@@ -867,7 +970,23 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                 // RS-1: a `let` may itself APPLY a library formula
                 // (`let r = ratio(a, b)`); expand every nested application first,
                 // collecting the applied-formula provenance chain.
-                let (expanded, chain) = expand_applies(expr, &formulas, 0)?;
+                if let Some(mut abstention) = unavailable_expression(expr, &unavailable_bindings) {
+                    abstention.name = name.clone();
+                    unavailable_bindings.insert(name.clone(), abstention.clone());
+                    formula_abstentions.push(abstention);
+                    continue;
+                }
+                let (expanded, chain) = match expand_applies(expr, &formulas, &kb, 0) {
+                    Ok(value) => value,
+                    Err(LowerError::FormulaPreconditionAbstained { abstention }) => {
+                        let mut abstention = *abstention;
+                        abstention.name = name.clone();
+                        unavailable_bindings.insert(name.clone(), abstention.clone());
+                        formula_abstentions.push(abstention);
+                        continue;
+                    }
+                    Err(error) => return Err(error),
+                };
                 let cexpr = lower_expr(&expanded);
                 let derived = compute(name.clone(), &cexpr, &kb).map_err(|e| {
                     LowerError::ComputationFailed {
@@ -882,6 +1001,7 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                     Some(prov) => derived.with_formula_sources(prov, chain.clone()),
                     None => derived,
                 };
+                unavailable_bindings.remove(name);
                 kb.add_derived(derived);
             }
             Statement::Uncertain {
@@ -1206,7 +1326,20 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
     for d in &deferred_formula_predicates {
         // Expand the application (recursively; formula-calls-formula supported),
         // collecting its provenance chain, then compute it against the full KB.
-        let (expanded, chain) = expand_applies(&d.lhs, &formulas, 0)?;
+        let (expanded, chain) = match expand_applies(&d.lhs, &formulas, &kb, 0) {
+            Ok(value) => value,
+            Err(LowerError::FormulaPreconditionAbstained { abstention }) => {
+                let mut abstention = *abstention;
+                abstention.name = match &d.lhs {
+                    ExprAst::Apply(name, _) => name.clone(),
+                    _ => "__branch_lhs".to_string(),
+                };
+                unavailable_bindings.insert(abstention.name.clone(), abstention.clone());
+                formula_abstentions.push(abstention);
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
         let slot_name = match &d.lhs {
             ExprAst::Apply(name, _) => name.clone(),
             // A compound LHS expression that merely *contains* an application gets a
@@ -1226,9 +1359,33 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
             Some(prov) => derived.with_formula_sources(prov, chain.clone()),
             None => derived,
         };
+        // Most RHS expressions do not refer to the staged LHS and expand against
+        // the original KB. A self-dependent RHS uses the engine's one-binding
+        // transactional overlay, which removes the candidate and its plan before
+        // returning instead of cloning the complete KB.
+        let mut rhs_refs = Vec::new();
+        collect_refs(&d.rhs, &mut rhs_refs);
+        let (derived, rhs_result) = if rhs_refs.iter().any(|name| name == &slot_name) {
+            kb.with_staged_derived(derived, |view| expand_applies(&d.rhs, &formulas, view, 0))
+        } else {
+            (derived, expand_applies(&d.rhs, &formulas, &kb, 0))
+        };
+        let (rhs_expanded, rhs_chain) = match rhs_result {
+            Ok(value) => value,
+            Err(LowerError::FormulaPreconditionAbstained { abstention }) => {
+                let mut abstention = *abstention;
+                abstention.name = match &d.rhs {
+                    ExprAst::Apply(name, _) => name.clone(),
+                    _ => "__branch_rhs".to_string(),
+                };
+                unavailable_bindings.insert(abstention.name.clone(), abstention.clone());
+                formula_abstentions.push(abstention);
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
+        unavailable_bindings.remove(&slot_name);
         kb.add_derived(derived);
-        // The RHS threshold may itself apply a formula; expand before lowering.
-        let (rhs_expanded, _) = expand_applies(&d.rhs, &formulas, 0)?;
         let clause = PredicateContributionClause::from_lr_expr(
             d.conclusion.clone(),
             slot_name,
@@ -1236,7 +1393,7 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
             lower_expr(&rhs_expanded),
             d.lr,
         )
-        .with_provenance(d.prov.clone());
+        .with_provenance(compose_provenance(d.prov.clone(), &rhs_chain));
         kb.add_predicate_contribution(clause);
     }
 
@@ -1304,6 +1461,7 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
         state_machines,
         constraints,
         dictionary,
+        formula_abstentions,
     })
 }
 
@@ -1587,6 +1745,12 @@ fn lower_expr(expr: &ExprAst) -> ComputeExpr {
     match expr {
         ExprAst::Ref(slot) => ComputeExpr::Ref(slot.clone()),
         ExprAst::Lit(x) => ComputeExpr::Lit(*x),
+        ExprAst::ExactLit(NumLit::Int(value)) => {
+            ComputeExpr::ExactLit(ExactRational::from_i128(*value as i128))
+        }
+        ExprAst::ExactLit(NumLit::Exact(value)) => {
+            ComputeExpr::ExactLit(ExactRational::from_ratio(value.to_rational()))
+        }
         ExprAst::Bin(op, a, b) => ComputeExpr::Bin(
             lower_arith_op(*op),
             Box::new(lower_expr(a)),
@@ -1933,6 +2097,7 @@ fn validate_formula(fd: &FormulaDef) -> Result<(), LowerError> {
     let mut in_scope: std::collections::HashSet<String> = fd.params.iter().cloned().collect();
     let check =
         |expr: &ExprAst, scope: &std::collections::HashSet<String>| -> Result<(), LowerError> {
+            validate_formula_expr_depth(expr)?;
             let mut refs = Vec::new();
             collect_refs(expr, &mut refs);
             for r in refs {
@@ -1950,6 +2115,40 @@ fn validate_formula(fd: &FormulaDef) -> Result<(), LowerError> {
         in_scope.insert(step.name.clone());
     }
     check(&fd.body, &in_scope)?;
+    // Preconditions are gates over CALLER-BOUND PARAMETERS. Formula-local
+    // `let` names do not exist until body materialization and therefore are not
+    // in scope here. The surface shape is generic; execution is deliberately a
+    // closed set so an unknown predicate can never be treated as truthy.
+    let parameter_scope: std::collections::HashSet<String> = fd.params.iter().cloned().collect();
+    for precondition in &fd.preconditions {
+        match precondition.predicate.as_str() {
+            "nonzero" => {
+                if precondition.arguments.len() != 1 {
+                    return Err(LowerError::FormulaPreconditionArity {
+                        formula: fd.name.clone(),
+                        predicate: precondition.predicate.clone(),
+                        expected: 1,
+                        got: precondition.arguments.len(),
+                    });
+                }
+            }
+            _ => {
+                return Err(LowerError::FormulaUnknownPrecondition {
+                    formula: fd.name.clone(),
+                    predicate: precondition.predicate.clone(),
+                })
+            }
+        }
+        for argument in &precondition.arguments {
+            check(argument, &parameter_scope)?;
+            if contains_formula_application(argument) {
+                return Err(LowerError::FormulaPreconditionApplicationUnsupported {
+                    formula: fd.name.clone(),
+                    predicate: precondition.predicate.clone(),
+                });
+            }
+        }
+    }
     // Reuse the shared provenance path (the same relate/rule/prior use), then
     // enforce that the primary `source` span is non-empty.
     let prov = annotations_to_provenance(&fd.annotations)?;
@@ -1961,42 +2160,140 @@ fn validate_formula(fd: &FormulaDef) -> Result<(), LowerError> {
     Ok(())
 }
 
+fn contains_formula_application(expr: &ExprAst) -> bool {
+    let mut pending = vec![expr];
+    while let Some(node) = pending.pop() {
+        match node {
+            ExprAst::Apply(_, _) => return true,
+            ExprAst::Bin(_, left, right) | ExprAst::Call2(_, left, right) => {
+                pending.push(right);
+                pending.push(left);
+            }
+            ExprAst::Abs(inner)
+            | ExprAst::Floor(inner)
+            | ExprAst::Ceil(inner)
+            | ExprAst::Round(inner)
+            | ExprAst::RoundTo(inner, _)
+            | ExprAst::ToScientific(inner, _)
+            | ExprAst::ToPercent(inner, _)
+            | ExprAst::ToCurrency(inner, _, _)
+            | ExprAst::Trunc(inner)
+            | ExprAst::Sign(inner)
+            | ExprAst::Call(_, inner) => pending.push(inner),
+            ExprAst::Ref(_) | ExprAst::Lit(_) | ExprAst::ExactLit(_) | ExprAst::Agg(_, _) => {}
+        }
+    }
+    false
+}
+
 /// Collect every identifier leaf of an [`ExprAst`] — a [`ExprAst::Ref`] name or
 /// an [`ExprAst::Agg`] slot — into `out`. Used by [`validate_formula`] to check
 /// parameter-scoping. Numbers and operators contribute no identifiers.
 fn collect_refs(expr: &ExprAst, out: &mut Vec<String>) {
-    match expr {
-        ExprAst::Ref(name) => out.push(name.clone()),
-        ExprAst::Agg(_, slot) => out.push(slot.clone()),
-        ExprAst::Lit(_) => {}
-        ExprAst::Bin(_, a, b) | ExprAst::Call2(_, a, b) => {
-            collect_refs(a, out);
-            collect_refs(b, out);
-        }
-        ExprAst::Abs(a)
-        | ExprAst::Floor(a)
-        | ExprAst::Ceil(a)
-        | ExprAst::Round(a)
-        | ExprAst::RoundTo(a, _)
-        | ExprAst::ToScientific(a, _)
-        | ExprAst::ToPercent(a, _)
-        | ExprAst::ToCurrency(a, _, _)
-        | ExprAst::Trunc(a)
-        | ExprAst::Sign(a)
-        | ExprAst::Call(_, a) => collect_refs(a, out),
-        // A formula application's callee NAME is a formula reference, not an
-        // identifier leaf — so it is NOT a candidate free variable (parameter
-        // scoping only constrains the value leaves). Only its ARGUMENTS carry
-        // identifier leaves that must resolve to declared parameters. (Whether the
-        // callee name resolves to a known formula is checked at APPLY time, not
-        // here, so a formula may legally reference a sibling declared later in the
-        // same book — forward references resolve in the expansion pass.)
-        ExprAst::Apply(_, args) => {
-            for a in args {
-                collect_refs(a, out);
+    let mut pending = vec![expr];
+    while let Some(expr) = pending.pop() {
+        match expr {
+            ExprAst::Ref(name) => out.push(name.clone()),
+            ExprAst::Agg(_, slot) => out.push(slot.clone()),
+            ExprAst::Lit(_) | ExprAst::ExactLit(_) => {}
+            ExprAst::Bin(_, a, b) | ExprAst::Call2(_, a, b) => {
+                pending.push(b);
+                pending.push(a);
+            }
+            ExprAst::Abs(a)
+            | ExprAst::Floor(a)
+            | ExprAst::Ceil(a)
+            | ExprAst::Round(a)
+            | ExprAst::RoundTo(a, _)
+            | ExprAst::ToScientific(a, _)
+            | ExprAst::ToPercent(a, _)
+            | ExprAst::ToCurrency(a, _, _)
+            | ExprAst::Trunc(a)
+            | ExprAst::Sign(a)
+            | ExprAst::Call(_, a) => pending.push(a),
+            // A formula application's callee NAME is a formula reference, not an
+            // identifier leaf — so it is NOT a candidate free variable (parameter
+            // scoping only constrains the value leaves). Only its ARGUMENTS carry
+            // identifier leaves that must resolve to declared parameters. (Whether the
+            // callee name resolves to a known formula is checked at APPLY time, not
+            // here, so a formula may legally reference a sibling declared later in the
+            // same book — forward references resolve in the expansion pass.)
+            ExprAst::Apply(_, args) => {
+                pending.extend(args.iter().rev());
             }
         }
     }
+}
+
+fn validate_formula_expr_depth(expr: &ExprAst) -> Result<(), LowerError> {
+    let mut pending = vec![(expr, 0_usize)];
+    while let Some((node, depth)) = pending.pop() {
+        let child_depth = match node {
+            ExprAst::Bin(_, _, _)
+            | ExprAst::Call2(_, _, _)
+            | ExprAst::Abs(_)
+            | ExprAst::Floor(_)
+            | ExprAst::Ceil(_)
+            | ExprAst::Round(_)
+            | ExprAst::RoundTo(_, _)
+            | ExprAst::ToScientific(_, _)
+            | ExprAst::ToPercent(_, _)
+            | ExprAst::ToCurrency(_, _, _)
+            | ExprAst::Trunc(_)
+            | ExprAst::Sign(_)
+            | ExprAst::Call(_, _)
+            | ExprAst::Apply(_, _) => Some(descend(depth)?),
+            ExprAst::Ref(_) | ExprAst::Lit(_) | ExprAst::ExactLit(_) | ExprAst::Agg(_, _) => None,
+        };
+        let Some(child_depth) = child_depth else {
+            continue;
+        };
+        match node {
+            ExprAst::Bin(_, left, right) | ExprAst::Call2(_, left, right) => {
+                pending.push((right, child_depth));
+                pending.push((left, child_depth));
+            }
+            ExprAst::Abs(inner)
+            | ExprAst::Floor(inner)
+            | ExprAst::Ceil(inner)
+            | ExprAst::Round(inner)
+            | ExprAst::RoundTo(inner, _)
+            | ExprAst::ToScientific(inner, _)
+            | ExprAst::ToPercent(inner, _)
+            | ExprAst::ToCurrency(inner, _, _)
+            | ExprAst::Trunc(inner)
+            | ExprAst::Sign(inner)
+            | ExprAst::Call(_, inner) => pending.push((inner, child_depth)),
+            ExprAst::Apply(_, arguments) => {
+                pending.extend(arguments.iter().rev().map(|arg| (arg, child_depth)));
+            }
+            ExprAst::Ref(_) | ExprAst::Lit(_) | ExprAst::ExactLit(_) | ExprAst::Agg(_, _) => {}
+        }
+    }
+    Ok(())
+}
+
+fn unavailable_expression(
+    expr: &ExprAst,
+    unavailable: &HashMap<String, FormulaAbstention>,
+) -> Option<FormulaAbstention> {
+    let mut refs = Vec::new();
+    collect_refs(expr, &mut refs);
+    refs.into_iter()
+        .find_map(|name| unavailable.get(&name).cloned())
+}
+
+fn unavailable_query_argument(
+    goal: &AstTerm,
+    unavailable: &HashMap<String, FormulaAbstention>,
+) -> Option<FormulaAbstention> {
+    let AstTerm::Compound { args, .. } = goal else {
+        return None;
+    };
+    args.iter().find_map(|argument| match argument {
+        AstTerm::Atom(name) => unavailable.get(name).cloned(),
+        _ => None,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -2032,6 +2329,20 @@ const FORMULA_MAX_EXPANSION_NODES: usize = 10_000;
 /// and any real measurement, so the cap constrains only pathological inputs.
 const MAX_ROUND_PLACES: u32 = 100;
 
+fn expression_literal_f64(expr: &ExprAst) -> Option<f64> {
+    match expr {
+        ExprAst::Lit(value) => Some(*value),
+        ExprAst::ExactLit(value) => Some(value.to_f64_lossy()),
+        _ => None,
+    }
+}
+
+fn bounded_precision_literal(expr: &ExprAst, minimum: f64) -> Option<u32> {
+    let value = expression_literal_f64(expr)?;
+    (value.fract() == 0.0 && value >= minimum && value <= MAX_ROUND_PLACES as f64)
+        .then_some(value as u32)
+}
+
 /// The significant-figure count `to_scientific(x)` uses when the surface omits it
 /// (NUM-6c). Six is the conventional default mantissa precision for scientific
 /// notation (`6.02214e23`) and comfortably inside [`MAX_ROUND_PLACES`]; an explicit
@@ -2064,7 +2375,7 @@ const DEFAULT_CURRENCY_PLACES: u32 = 2;
 /// could fire. This caps walker recursion so a pathological spine is a clean typed
 /// error, never a crash.
 ///
-/// The value (96) matches [`adapter`](crate::adapter)'s `SUBST_DEPTH_BUDGET`, chosen
+/// The value (96) stays below [`adapter`](crate::adapter)'s `SUBST_DEPTH_BUDGET`, chosen
 /// there for the identical reason: these walkers carry non-trivial per-frame state
 /// (a `HashMap` of substitutions, `Vec` accumulators), so a *few hundred* debug-build
 /// frames already approach the default ~2 MiB worker-thread stack. 96 keeps the walk
@@ -2121,7 +2432,9 @@ fn charged_clone(
     // frame cap (see [`FORMULA_MAX_NODE_DEPTH`]).
     let d = descend(node_depth)?;
     Ok(match expr {
-        ExprAst::Ref(_) | ExprAst::Lit(_) | ExprAst::Agg(_, _) => expr.clone(),
+        ExprAst::Ref(_) | ExprAst::Lit(_) | ExprAst::ExactLit(_) | ExprAst::Agg(_, _) => {
+            expr.clone()
+        }
         ExprAst::Bin(op, a, b) => ExprAst::Bin(
             *op,
             Box::new(charged_clone(a, budget, d)?),
@@ -2200,6 +2513,7 @@ struct DeferredFormulaPredicate {
 fn expand_applies(
     expr: &ExprAst,
     formulas: &HashMap<&str, &FormulaDef>,
+    kb: &KnowledgeBase,
     depth: usize,
 ) -> Result<(ExprAst, Vec<Provenance>), LowerError> {
     let mut chain = Vec::new();
@@ -2217,9 +2531,10 @@ fn expand_applies(
     // positions (`f(x) = g(x) + g(x)`) is popped off the path between the two uses,
     // so reuse is never mistaken for recursion.
     let mut active: Vec<String> = Vec::new();
+    let context = FormulaExpansionContext { formulas, kb };
     let expanded = expand_rec(
         expr,
-        formulas,
+        &context,
         depth,
         &mut chain,
         &mut active,
@@ -2229,14 +2544,20 @@ fn expand_applies(
     Ok((expanded, chain))
 }
 
+struct FormulaExpansionContext<'context, 'formula> {
+    formulas: &'context HashMap<&'formula str, &'formula FormulaDef>,
+    kb: &'context KnowledgeBase,
+}
+
 /// The recursive worker for [`expand_applies`]. Walks the expression; at an
 /// [`ExprAst::Apply`] it resolves the callee, checks arity, expands the arguments
 /// (siblings, same depth), records the callee's provenance, substitutes into the
 /// callee body, and expands THAT body at `depth + 1`. Every other node is rebuilt
 /// with its children expanded at the same depth.
+#[inline(never)]
 fn expand_rec(
     expr: &ExprAst,
-    formulas: &HashMap<&str, &FormulaDef>,
+    context: &FormulaExpansionContext<'_, '_>,
     depth: usize,
     chain: &mut Vec<Provenance>,
     active: &mut Vec<String>,
@@ -2280,24 +2601,17 @@ fn expand_rec(
                     });
                 }
                 let min = if name == "round_sig" { 1.0 } else { 0.0 };
-                let n = match &args[1] {
-                    ExprAst::Lit(v)
-                        if v.fract() == 0.0 && *v >= min && *v <= MAX_ROUND_PLACES as f64 =>
-                    {
-                        *v as u32
+                let n = bounded_precision_literal(&args[1], min).ok_or_else(|| {
+                    LowerError::FormulaBadArgument {
+                        formula: name.clone(),
                     }
-                    _ => {
-                        return Err(LowerError::FormulaBadArgument {
-                            formula: name.clone(),
-                        })
-                    }
-                };
+                })?;
                 let spec = if name == "round_sig" {
                     logic_engine::RoundSpec::SigFigures(n)
                 } else {
                     logic_engine::RoundSpec::Places(n)
                 };
-                let value = expand_rec(&args[0], formulas, depth, chain, active, budget, d)?;
+                let value = expand_rec(&args[0], context, depth, chain, active, budget, d)?;
                 return Ok(ExprAst::RoundTo(Box::new(value), spec));
             }
             // NUM-6c built-in: `to_scientific(x [, figures])` — the scientific-notation
@@ -2317,22 +2631,15 @@ fn expand_rec(
                     });
                 }
                 let figures = if args.len() == 2 {
-                    match &args[1] {
-                        ExprAst::Lit(v)
-                            if v.fract() == 0.0 && *v >= 1.0 && *v <= MAX_ROUND_PLACES as f64 =>
-                        {
-                            *v as u32
+                    bounded_precision_literal(&args[1], 1.0).ok_or_else(|| {
+                        LowerError::FormulaBadArgument {
+                            formula: name.clone(),
                         }
-                        _ => {
-                            return Err(LowerError::FormulaBadArgument {
-                                formula: name.clone(),
-                            })
-                        }
-                    }
+                    })?
                 } else {
                     DEFAULT_SCI_FIGURES
                 };
-                let value = expand_rec(&args[0], formulas, depth, chain, active, budget, d)?;
+                let value = expand_rec(&args[0], context, depth, chain, active, budget, d)?;
                 return Ok(ExprAst::ToScientific(Box::new(value), figures));
             }
             // NUM-6c built-in: `to_percent(x [, places])` — the percentage rendering.
@@ -2352,22 +2659,15 @@ fn expand_rec(
                     });
                 }
                 let places = if args.len() == 2 {
-                    match &args[1] {
-                        ExprAst::Lit(v)
-                            if v.fract() == 0.0 && *v >= 0.0 && *v <= MAX_ROUND_PLACES as f64 =>
-                        {
-                            *v as u32
+                    bounded_precision_literal(&args[1], 0.0).ok_or_else(|| {
+                        LowerError::FormulaBadArgument {
+                            formula: name.clone(),
                         }
-                        _ => {
-                            return Err(LowerError::FormulaBadArgument {
-                                formula: name.clone(),
-                            })
-                        }
-                    }
+                    })?
                 } else {
                     DEFAULT_PERCENT_PLACES
                 };
-                let value = expand_rec(&args[0], formulas, depth, chain, active, budget, d)?;
+                let value = expand_rec(&args[0], context, depth, chain, active, budget, d)?;
                 return Ok(ExprAst::ToPercent(Box::new(value), places));
             }
             // NUM-6c built-in: `to_currency(x, code [, places])` — the money rendering.
@@ -2401,29 +2701,23 @@ fn expand_rec(
                     }
                 };
                 let places = if args.len() == 3 {
-                    match &args[2] {
-                        ExprAst::Lit(v)
-                            if v.fract() == 0.0 && *v >= 0.0 && *v <= MAX_ROUND_PLACES as f64 =>
-                        {
-                            *v as u32
+                    bounded_precision_literal(&args[2], 0.0).ok_or_else(|| {
+                        LowerError::FormulaBadArgument {
+                            formula: name.clone(),
                         }
-                        _ => {
-                            return Err(LowerError::FormulaBadArgument {
-                                formula: name.clone(),
-                            })
-                        }
-                    }
+                    })?
                 } else {
                     DEFAULT_CURRENCY_PLACES
                 };
-                let value = expand_rec(&args[0], formulas, depth, chain, active, budget, d)?;
+                let value = expand_rec(&args[0], context, depth, chain, active, budget, d)?;
                 return Ok(ExprAst::ToCurrency(Box::new(value), code, places));
             }
             // Resolve the callee against the SAME registry the top-level query path
             // uses. An unknown name is a clean, specific error — distinct from an
             // aggregation or built-in call, which never reach here (they are separate
             // AST nodes recognised earlier in the grammar).
-            let fd = *formulas
+            let fd = *context
+                .formulas
                 .get(name.as_str())
                 .ok_or_else(|| LowerError::FormulaUnknown { name: name.clone() })?;
             if fd.params.len() != args.len() {
@@ -2440,9 +2734,10 @@ fn expand_rec(
             for (param, arg) in fd.params.iter().zip(args.iter()) {
                 subst.insert(
                     param.clone(),
-                    expand_rec(arg, formulas, depth, chain, active, budget, d)?,
+                    expand_rec(arg, context, depth, chain, active, budget, d)?,
                 );
             }
+            enforce_preconditions(fd, &subst, context.kb)?;
             // The cycle guard: if this formula is already OPEN on the expansion path,
             // re-entering it is (directly or mutually) recursive. ADJ formulas have
             // no base case, so a cycle can only diverge — reject it here, in O(1), at
@@ -2476,62 +2771,64 @@ fn expand_rec(
             let callee_body = effective_body(fd, budget, d)?;
             let substituted = substitute_expr(&callee_body, &subst, budget, d)?;
             active.push(name.clone());
-            let expanded = expand_rec(&substituted, formulas, depth + 1, chain, active, budget, d);
+            let expanded = expand_rec(&substituted, context, depth + 1, chain, active, budget, d);
             active.pop();
             expanded
         }
         // Leaves carry no application.
-        ExprAst::Ref(_) | ExprAst::Lit(_) | ExprAst::Agg(_, _) => Ok(expr.clone()),
+        ExprAst::Ref(_) | ExprAst::Lit(_) | ExprAst::ExactLit(_) | ExprAst::Agg(_, _) => {
+            Ok(expr.clone())
+        }
         // Binary nodes: expand both operands at the same depth.
         ExprAst::Bin(op, a, b) => Ok(ExprAst::Bin(
             *op,
-            Box::new(expand_rec(a, formulas, depth, chain, active, budget, d)?),
-            Box::new(expand_rec(b, formulas, depth, chain, active, budget, d)?),
+            Box::new(expand_rec(a, context, depth, chain, active, budget, d)?),
+            Box::new(expand_rec(b, context, depth, chain, active, budget, d)?),
         )),
         ExprAst::Call2(f, a, b) => Ok(ExprAst::Call2(
             *f,
-            Box::new(expand_rec(a, formulas, depth, chain, active, budget, d)?),
-            Box::new(expand_rec(b, formulas, depth, chain, active, budget, d)?),
+            Box::new(expand_rec(a, context, depth, chain, active, budget, d)?),
+            Box::new(expand_rec(b, context, depth, chain, active, budget, d)?),
         )),
         // Unary nodes: expand the single operand.
         ExprAst::Abs(a) => Ok(ExprAst::Abs(Box::new(expand_rec(
-            a, formulas, depth, chain, active, budget, d,
+            a, context, depth, chain, active, budget, d,
         )?))),
         ExprAst::Floor(a) => Ok(ExprAst::Floor(Box::new(expand_rec(
-            a, formulas, depth, chain, active, budget, d,
+            a, context, depth, chain, active, budget, d,
         )?))),
         ExprAst::Ceil(a) => Ok(ExprAst::Ceil(Box::new(expand_rec(
-            a, formulas, depth, chain, active, budget, d,
+            a, context, depth, chain, active, budget, d,
         )?))),
         ExprAst::Round(a) => Ok(ExprAst::Round(Box::new(expand_rec(
-            a, formulas, depth, chain, active, budget, d,
+            a, context, depth, chain, active, budget, d,
         )?))),
         ExprAst::RoundTo(a, n) => Ok(ExprAst::RoundTo(
-            Box::new(expand_rec(a, formulas, depth, chain, active, budget, d)?),
+            Box::new(expand_rec(a, context, depth, chain, active, budget, d)?),
             *n,
         )),
         ExprAst::ToScientific(a, n) => Ok(ExprAst::ToScientific(
-            Box::new(expand_rec(a, formulas, depth, chain, active, budget, d)?),
+            Box::new(expand_rec(a, context, depth, chain, active, budget, d)?),
             *n,
         )),
         ExprAst::ToPercent(a, n) => Ok(ExprAst::ToPercent(
-            Box::new(expand_rec(a, formulas, depth, chain, active, budget, d)?),
+            Box::new(expand_rec(a, context, depth, chain, active, budget, d)?),
             *n,
         )),
         ExprAst::ToCurrency(a, code, n) => Ok(ExprAst::ToCurrency(
-            Box::new(expand_rec(a, formulas, depth, chain, active, budget, d)?),
+            Box::new(expand_rec(a, context, depth, chain, active, budget, d)?),
             code.clone(),
             *n,
         )),
         ExprAst::Trunc(a) => Ok(ExprAst::Trunc(Box::new(expand_rec(
-            a, formulas, depth, chain, active, budget, d,
+            a, context, depth, chain, active, budget, d,
         )?))),
         ExprAst::Sign(a) => Ok(ExprAst::Sign(Box::new(expand_rec(
-            a, formulas, depth, chain, active, budget, d,
+            a, context, depth, chain, active, budget, d,
         )?))),
         ExprAst::Call(f, a) => Ok(ExprAst::Call(
             *f,
-            Box::new(expand_rec(a, formulas, depth, chain, active, budget, d)?),
+            Box::new(expand_rec(a, context, depth, chain, active, budget, d)?),
         )),
     }
 }
@@ -2574,15 +2871,20 @@ fn compose_chain(chain: &[Provenance]) -> Option<Provenance> {
 fn formula_for_query<'a>(
     goal: &AstTerm,
     formulas: &HashMap<&str, &'a FormulaDef>,
-) -> Option<&'a FormulaDef> {
+) -> Result<Option<&'a FormulaDef>, LowerError> {
     if let AstTerm::Compound { functor, args } = goal {
         if let Some(fd) = formulas.get(functor.as_str()) {
-            if fd.params.len() == args.len() {
-                return Some(fd);
+            if fd.params.len() != args.len() {
+                return Err(LowerError::FormulaArity {
+                    formula: functor.clone(),
+                    expected: fd.params.len(),
+                    got: args.len(),
+                });
             }
+            return Ok(Some(fd));
         }
     }
-    None
+    Ok(None)
 }
 
 /// APPLY a formula: bind each parameter to the correspondingly-positioned
@@ -2591,7 +2893,11 @@ fn formula_for_query<'a>(
 /// that is a plain identifier binds the parameter to a like-named slot
 /// (`ExprAst::Ref`); a number literal binds it to that constant (`ExprAst::Lit`).
 /// Any other argument shape is a [`LowerError::FormulaBadArgument`].
-fn apply_formula(fd: &FormulaDef, goal: &AstTerm) -> Result<ExprAst, LowerError> {
+fn apply_formula(
+    fd: &FormulaDef,
+    goal: &AstTerm,
+    kb: &KnowledgeBase,
+) -> Result<ExprAst, LowerError> {
     let args: &[AstTerm] = match goal {
         AstTerm::Compound { args, .. } => args,
         _ => &[],
@@ -2600,10 +2906,10 @@ fn apply_formula(fd: &FormulaDef, goal: &AstTerm) -> Result<ExprAst, LowerError>
     for (param, arg) in fd.params.iter().zip(args.iter()) {
         let bound = match arg {
             AstTerm::Atom(name) => ExprAst::Ref(name.clone()),
-            // A numeric formula argument feeds the (inherently `f64`) compute layer, so it
-            // takes the labeled-lossy export here — the exact literal is preserved on the
-            // ground-term paths (`lower_numlit`), not on this compute leaf.
-            AstTerm::Num(x) => ExprAst::Lit(x.to_f64_lossy()),
+            // Preserve a numeric argument through guard validation. The compute
+            // layer still consumes `f64`, so guarded calls reject a value-changing
+            // conversion before evaluation.
+            AstTerm::Num(x) => ExprAst::ExactLit(x.clone()),
             _ => {
                 return Err(LowerError::FormulaBadArgument {
                     formula: fd.name.clone(),
@@ -2612,6 +2918,7 @@ fn apply_formula(fd: &FormulaDef, goal: &AstTerm) -> Result<ExprAst, LowerError>
         };
         subst.insert(param.clone(), bound);
     }
+    enforce_preconditions(fd, &subst, kb)?;
     // A shallow, one-level substitution of leaf bindings (a query's args are atoms
     // or numbers) — its own local budget guards a body that reuses a parameter; the
     // deeper formula-calls-formula expansion of the resulting body runs later, in
@@ -2621,6 +2928,206 @@ fn apply_formula(fd: &FormulaDef, goal: &AstTerm) -> Result<ExprAst, LowerError>
     let mut budget: usize = 0;
     let effective = effective_body(fd, &mut budget, 0)?;
     substitute_expr(&effective, &subst, &mut budget, 0)
+}
+
+/// Evaluate a formula's declared requirements against its bound arguments before
+/// materializing the body. A false or unresolved requirement is carried upward
+/// as structured abstention control flow; malformed requirements were already
+/// rejected by [`validate_formula`].
+#[inline(never)]
+fn enforce_preconditions(
+    fd: &FormulaDef,
+    subst: &HashMap<String, ExprAst>,
+    kb: &KnowledgeBase,
+) -> Result<(), LowerError> {
+    for (
+        precondition_index,
+        FormulaPrecondition {
+            predicate,
+            arguments,
+        },
+    ) in fd.preconditions.iter().enumerate()
+    {
+        let parameter = match &arguments[0] {
+            ExprAst::Ref(name) => Some(name.clone()),
+            _ => None,
+        };
+        let mut budget = 0;
+        let argument = substitute_expr(&arguments[0], subst, &mut budget, 0)?;
+        let computed = match compute(
+            format!("__precondition_{}_{}", fd.name, predicate),
+            &lower_expr(&argument),
+            kb,
+        ) {
+            Ok(value) => value,
+            Err(error @ logic_engine::compute::ComputeError::UnknownSlot { .. })
+            | Err(error @ logic_engine::compute::ComputeError::EmptyAggregation { .. }) => {
+                return Err(LowerError::FormulaPreconditionAbstained {
+                    abstention: Box::new(FormulaAbstention {
+                        name: fd.name.clone(),
+                        formula: fd.name.clone(),
+                        predicate: predicate.clone(),
+                        precondition_index,
+                        parameter,
+                        actual: None,
+                        detail: Some(format!("{error:?}")),
+                        fact_ids: Vec::new(),
+                        provenance: annotations_to_provenance(&fd.annotations)?,
+                    }),
+                });
+            }
+            Err(error) => {
+                return Err(LowerError::ComputationFailed {
+                    name: format!("{} precondition {precondition_index}", fd.name),
+                    detail: format!("{error:?}"),
+                });
+            }
+        };
+        if computed.precision_loss {
+            return Err(LowerError::FormulaArgumentPrecisionLoss {
+                formula: fd.name.clone(),
+                parameter: parameter
+                    .clone()
+                    .unwrap_or_else(|| format!("precondition[{precondition_index}]")),
+            });
+        }
+        let is_zero = computed
+            .exact
+            .as_ref()
+            .map(|value| value.numerator().is_zero())
+            .unwrap_or(computed.value == 0.0);
+        if predicate == "nonzero" && is_zero {
+            return Err(LowerError::FormulaPreconditionAbstained {
+                abstention: Box::new(FormulaAbstention {
+                    name: fd.name.clone(),
+                    formula: fd.name.clone(),
+                    predicate: predicate.clone(),
+                    precondition_index,
+                    parameter,
+                    actual: Some(computed.value),
+                    detail: None,
+                    fact_ids: precondition_fact_ids(
+                        &computed.tree,
+                        computed.scope.fact_limit,
+                        computed.scope.derived_limit,
+                        kb,
+                    )
+                    .map_err(|detail| LowerError::ComputationFailed {
+                        name: format!("{} precondition {precondition_index}", fd.name),
+                        detail,
+                    })?,
+                    provenance: annotations_to_provenance(&fd.annotations)?,
+                }),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn precondition_fact_ids(
+    tree: &logic_engine::compute::DerivationNode,
+    fact_limit: u64,
+    derived_limit: usize,
+    kb: &KnowledgeBase,
+) -> Result<Vec<FactId>, String> {
+    fn collect_derived(
+        index: usize,
+        kb: &KnowledgeBase,
+        visiting: &mut HashSet<usize>,
+        output: &mut Vec<FactId>,
+    ) -> Result<(), String> {
+        if !visiting.insert(index) {
+            return Err("cycle in precondition derived references".to_string());
+        }
+        let derived = kb
+            .derived_bindings()
+            .get(index)
+            .ok_or_else(|| format!("precondition derived index {index} is outside the KB"))?;
+        let plan = kb.computation_plan_for(derived).ok_or_else(|| {
+            format!(
+                "precondition derived value {} has no trusted plan",
+                derived.name
+            )
+        })?;
+        collect(
+            &derived.tree,
+            plan.scope.fact_limit,
+            plan.scope.derived_limit,
+            kb,
+            visiting,
+            output,
+        )?;
+        visiting.remove(&index);
+        Ok(())
+    }
+
+    fn collect(
+        node: &logic_engine::compute::DerivationNode,
+        fact_limit: u64,
+        before: usize,
+        kb: &KnowledgeBase,
+        visiting: &mut HashSet<usize>,
+        output: &mut Vec<FactId>,
+    ) -> Result<(), String> {
+        use logic_engine::compute::DerivationNode as Node;
+        match node {
+            Node::Leaf { fact_id, .. } => {
+                if fact_id.0 >= fact_limit {
+                    return Err(format!(
+                        "precondition fact {} is outside computation scope {fact_limit}",
+                        fact_id.0
+                    ));
+                }
+                if kb.fact(*fact_id).is_none() {
+                    return Err(format!(
+                        "precondition fact {} is absent from the KB",
+                        fact_id.0
+                    ));
+                }
+                if !output.contains(fact_id) {
+                    output.push(*fact_id);
+                }
+            }
+            Node::Op { operands, .. } => {
+                for operand in operands {
+                    collect(operand, fact_limit, before, kb, visiting, output)?;
+                }
+            }
+            Node::Round { operand, .. }
+            | Node::ToScientific { operand, .. }
+            | Node::ToPercent { operand, .. }
+            | Node::ToCurrency { operand, .. } => {
+                collect(operand, fact_limit, before, kb, visiting, output)?;
+            }
+            Node::DerivedRef { name, .. } => {
+                let visible = kb.derived_bindings().get(..before).ok_or_else(|| {
+                    format!(
+                        "precondition derived scope {before} exceeds {} bindings",
+                        kb.derived_bindings().len()
+                    )
+                })?;
+                let dependency = visible
+                    .iter()
+                    .rposition(|candidate| candidate.name == *name)
+                    .ok_or_else(|| {
+                        format!("precondition derived reference {name} has no predecessor")
+                    })?;
+                collect_derived(dependency, kb, visiting, output)?;
+            }
+            Node::Lit { .. } => {}
+        }
+        Ok(())
+    }
+    let mut output = Vec::new();
+    collect(
+        tree,
+        fact_limit,
+        derived_limit,
+        kb,
+        &mut HashSet::new(),
+        &mut output,
+    )?;
+    Ok(output)
 }
 
 /// Fold a formula's multi-step `let`-bindings (RS-2) into a SINGLE effective
@@ -2682,7 +3189,7 @@ fn substitute_expr(
             Some(bound) => charged_clone(bound, budget, d)?,
             None => expr.clone(),
         },
-        ExprAst::Lit(_) => expr.clone(),
+        ExprAst::Lit(_) | ExprAst::ExactLit(_) => expr.clone(),
         ExprAst::Agg(op, slot) => match subst.get(slot) {
             Some(ExprAst::Ref(bound)) => ExprAst::Agg(*op, bound.clone()),
             _ => expr.clone(),
@@ -5721,11 +6228,47 @@ rule { head: r(a) when: x(t) }";
             spine = ExprAst::Bin(ArithOp::Add, Box::new(spine), Box::new(ExprAst::Lit(0.0)));
         }
         let formulas: HashMap<&str, &FormulaDef> = HashMap::new();
-        let result = expand_applies(&spine, &formulas, 0);
+        let result = expand_applies(&spine, &formulas, &KnowledgeBase::new(), 0);
         assert!(
             matches!(result, Err(LowerError::FormulaNestingTooDeep { limit }) if limit == FORMULA_MAX_NODE_DEPTH),
             "a deep operator spine must trip the nesting guard, got {result:?}"
         );
+    }
+
+    #[test]
+    fn source_operator_spine_is_rejected_during_adapter_construction() {
+        let expression = std::iter::repeat_n("0", 400)
+            .collect::<Vec<_>>()
+            .join(" + ");
+        let result = compile(&format!("let result = {expression}"));
+        assert!(
+            matches!(
+                result,
+                Err(crate::CompileError::Adapt(
+                    crate::adapter::AdapterError::ExpressionTooDeep { limit: 96 }
+                ))
+            ),
+            "a source spine must be bounded before a deep AST is constructed, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn precondition_fact_ids_reject_out_of_scope_and_absent_leaves() {
+        use logic_engine::compute::DerivationNode;
+
+        let leaf = DerivationNode::Leaf {
+            slot: "value".to_string(),
+            value: 1.0,
+            fact_id: FactId(0),
+        };
+        let kb = KnowledgeBase::new();
+        let out_of_scope =
+            precondition_fact_ids(&leaf, 0, 0, &kb).expect_err("the snapshot excludes fact zero");
+        assert!(out_of_scope.contains("outside computation scope"));
+
+        let absent = precondition_fact_ids(&leaf, 1, 0, &kb)
+            .expect_err("a visible ID still has to resolve to a stored fact");
+        assert!(absent.contains("absent from the KB"));
     }
 
     #[test]
@@ -5853,5 +6396,556 @@ rule { head: r(a) when: x(t) }";
             }
             other => panic!("expected LRAggregateResult, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn deferred_rhs_abstention_does_not_publish_the_lhs() {
+        let src = r#"
+            formulabook guarded {
+                formula identity(x) = x
+                    source "identity definition" trust authoritative
+                formula quotient(a, b) = a / b
+                    requires nonzero(b)
+                    source "division domain" trust authoritative
+            }
+            prior 0.1 for high
+            contributes 100 from identity(numerator) >= quotient(identity, denominator) to high
+                source "comparison rule" trust authoritative
+            observe numerator(8)
+            observe denominator(0)
+            ? high
+        "#;
+
+        let lowered = compile(src).expect("a failed RHS guard is a typed abstention");
+        assert!(
+            lowered.kb.derived_for("identity").is_none(),
+            "the staged LHS must not escape an incomplete branch"
+        );
+        assert_eq!(lowered.formula_abstentions.len(), 1);
+        assert_eq!(lowered.formula_abstentions[0].formula, "quotient");
+    }
+
+    #[test]
+    fn successful_deferred_rhs_formula_provenance_reaches_the_clause() {
+        let src = r#"
+            formulabook formulas {
+                formula identity(x) = x
+                    source "identity definition" trust authoritative
+                formula threshold_value(x) = x + 0
+                    source "threshold definition" trust authoritative
+            }
+            prior 0.1 for high
+            contributes 100 from identity(value) >= threshold_value(identity) to high
+                source "comparison rule" trust authoritative
+            observe value(8)
+            observe threshold(7.5)
+            ? high
+        "#;
+
+        let lowered = compile(src).expect("both deferred formula sides should expand");
+        let clauses = lowered.kb.predicate_contributions_for(&core_atom("high"));
+        assert_eq!(clauses.len(), 1);
+        assert_eq!(clauses[0].provenance.source, "comparison rule");
+        assert!(clauses[0]
+            .provenance
+            .corroborations
+            .iter()
+            .any(|citation| citation.source == "threshold definition"));
+    }
+
+    #[test]
+    fn formula_precondition_abstains_without_publishing_a_value() {
+        let src = r#"
+            formulabook guarded {
+                formula quotient(a, b) = a / b
+                    requires nonzero(b)
+                    source "division domain" trust authoritative
+            }
+            observe numerator(8)
+            observe denominator(0)
+            ? quotient(numerator, denominator)
+        "#;
+
+        let lowered = compile(src).expect("a false domain guard is not a compile error");
+        assert!(lowered.kb.derived_for("quotient").is_none());
+        assert_eq!(lowered.formula_abstentions.len(), 1);
+        let abstention = &lowered.formula_abstentions[0];
+        assert_eq!(abstention.formula, "quotient");
+        assert_eq!(abstention.predicate, "nonzero");
+        assert_eq!(abstention.actual, Some(0.0));
+    }
+
+    #[test]
+    fn unresolved_formula_precondition_abstains_distinctly() {
+        let src = r#"
+            formulabook guarded {
+                formula quotient(a, b) = a / b
+                    requires nonzero(b)
+                    source "division domain" trust authoritative
+            }
+            observe numerator(8)
+            ? quotient(numerator, denominator)
+        "#;
+
+        let lowered = compile(src).expect("an unresolved guard is a typed abstention");
+        let abstention = &lowered.formula_abstentions[0];
+        assert_eq!(abstention.actual, None);
+        assert!(abstention
+            .detail
+            .as_deref()
+            .is_some_and(|detail| detail.contains("UnknownSlot")));
+    }
+
+    #[test]
+    fn exact_nonzero_query_literal_uses_its_retained_rational_identity() {
+        let src = r#"
+            formulabook guarded {
+                formula identity(x) = x
+                    requires nonzero(x)
+                    source "identity domain" trust authoritative
+            }
+            ? identity(1e-400)
+        "#;
+
+        let lowered = compile(src).expect("an exact nonzero rational must not become zero");
+        let result = lowered.kb.derived_for("identity").unwrap();
+        assert_eq!(result.value, 0.0);
+        assert!(result
+            .exact
+            .as_ref()
+            .is_some_and(|value| !value.numerator().is_zero()));
+    }
+
+    #[test]
+    fn unguarded_formula_keeps_existing_literal_narrowing_behavior() {
+        let src = r#"
+            formulabook formulas {
+                formula identity(x) = x
+                    source "identity definition" trust authoritative
+            }
+            let result = identity(0.1)
+        "#;
+
+        let lowered = compile(src).expect("unguarded formulas do not run guard precision checks");
+        assert!((lowered.kb.derived_for("result").unwrap().value - 0.1).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn guard_precision_check_ignores_an_unconsumed_parameter() {
+        let src = r#"
+            formulabook formulas {
+                formula first(a, b) = a
+                    requires nonzero(a)
+                    source "first definition" trust authoritative
+            }
+            let result = first(1, 0.1)
+        "#;
+
+        let lowered = compile(src).expect("only literals consumed by a guard are checked");
+        assert_eq!(lowered.kb.derived_for("result").unwrap().value, 1.0);
+    }
+
+    #[test]
+    fn guard_accepts_exact_identity_carried_through_an_earlier_binding() {
+        let src = r#"
+            formulabook formulas {
+                formula identity(x) = x
+                    source "identity definition" trust authoritative
+                formula guarded(x) = x
+                    requires nonzero(x)
+                    source "guarded definition" trust authoritative
+            }
+            let narrowed = identity(1e-400)
+            let result = guarded(narrowed)
+        "#;
+
+        let lowered = compile(src).expect("identity preserves the exact rational sidecar");
+        assert!(lowered.formula_abstentions.is_empty());
+        assert!(lowered.kb.derived_for("result").is_some());
+    }
+
+    #[test]
+    fn guard_rejects_an_exact_observation_after_an_operation_discards_exactness() {
+        let src = r#"
+            formulabook formulas {
+                formula sine(x) = latex "$\sin(x)$"
+                    source "sine definition" trust authoritative
+                formula guarded(x) = x
+                    requires nonzero(x)
+                    source "guarded definition" trust authoritative
+            }
+            observe tiny(1e-400)
+            let transformed = sine(tiny)
+            let result = guarded(transformed)
+        "#;
+
+        assert!(matches!(
+            compile(src),
+            Err(crate::CompileError::Lower(
+                LowerError::FormulaArgumentPrecisionLoss { ref parameter, .. }
+            )) if parameter == "x"
+        ));
+    }
+
+    #[test]
+    fn observed_binding_shadows_an_unrelated_lossy_derived_marker() {
+        let src = r#"
+            formulabook formulas {
+                formula identity(x) = x
+                    source "identity definition" trust authoritative
+                formula guarded(x) = x
+                    requires nonzero(x)
+                    source "guarded definition" trust authoritative
+            }
+            let x = identity(1e-400)
+            observe x(1)
+            let result = guarded(x)
+        "#;
+
+        let lowered = compile(src).expect("guard resolution must match observed-first evaluation");
+        assert_eq!(lowered.kb.derived_for("result").unwrap().value, 1.0);
+    }
+
+    #[test]
+    fn exact_nonzero_expression_literal_uses_its_retained_rational_identity() {
+        let src = r#"
+            formulabook guarded {
+                formula identity(x) = x
+                    requires nonzero(x)
+                    source "identity domain" trust authoritative
+            }
+            let result = identity(1e-400)
+        "#;
+
+        let lowered = compile(src).expect("an exact nonzero rational must satisfy nonzero");
+        assert!(lowered.formula_abstentions.is_empty());
+        assert!(lowered.kb.derived_for("result").is_some());
+    }
+
+    #[test]
+    fn composed_guard_computes_from_exact_literals_before_narrowing() {
+        let src = r#"
+            formulabook guarded {
+                formula separation(x, y) = x
+                    requires nonzero(x - y)
+                    source "distinct values" trust authoritative
+            }
+            let result = separation(9007199254740993, 9007199254740992)
+        "#;
+
+        let lowered = compile(src).expect("exact subtraction is one, not rounded zero");
+        assert!(lowered.formula_abstentions.is_empty());
+        let result = lowered.kb.derived_for("result").unwrap();
+        assert_eq!(
+            result.exact.as_ref().unwrap().numerator().to_string(),
+            "9007199254740993"
+        );
+    }
+
+    #[test]
+    fn composed_guard_uses_exact_observed_values() {
+        let src = r#"
+            formulabook guarded {
+                formula separation(x, y) = x
+                    requires nonzero(x - y)
+                    source "distinct values" trust authoritative
+            }
+            observe x_value(9007199254740993)
+            observe y_value(9007199254740992)
+            let result = separation(x_value, y_value)
+        "#;
+
+        let lowered = compile(src).expect("observed exact values retain rational sidecars");
+        assert!(lowered.formula_abstentions.is_empty());
+        assert!(lowered.kb.derived_for("result").is_some());
+    }
+
+    #[test]
+    fn deeply_nested_precondition_hits_the_formula_depth_guard() {
+        let mut guard = ExprAst::Ref("x".to_string());
+        for _ in 0..150 {
+            guard = ExprAst::Bin(ArithOp::Add, Box::new(guard), Box::new(ExprAst::Lit(0.0)));
+        }
+        let formula = FormulaDef {
+            name: "identity".to_string(),
+            params: vec!["x".to_string()],
+            steps: Vec::new(),
+            body: ExprAst::Ref("x".to_string()),
+            preconditions: vec![FormulaPrecondition {
+                predicate: "nonzero".to_string(),
+                arguments: vec![guard],
+            }],
+            annotations: vec![
+                Annotation::Source("identity domain".to_string()),
+                Annotation::Trust(TrustTierName::Authoritative),
+            ],
+        };
+
+        assert!(matches!(
+            validate_formula(&formula),
+            Err(LowerError::FormulaNestingTooDeep { limit })
+                if limit == FORMULA_MAX_NODE_DEPTH
+        ));
+    }
+
+    #[test]
+    fn invalid_guard_arithmetic_is_an_execution_error_not_unresolved_input() {
+        let src = r#"
+            formulabook guarded {
+                formula identity(a, b) = a
+                    requires nonzero(a / b)
+                    source "guarded identity" trust authoritative
+            }
+            observe numerator(8)
+            observe denominator(0)
+            ? identity(numerator, denominator)
+        "#;
+
+        assert!(matches!(
+            compile(src),
+            Err(crate::CompileError::Lower(LowerError::ComputationFailed {
+                ref detail, ..
+            })) if detail.contains("DivisionByZero")
+        ));
+    }
+
+    #[test]
+    fn dependent_lets_propagate_the_original_formula_abstention() {
+        let src = r#"
+            formulabook guarded {
+                formula quotient(a, b) = a / b
+                    requires nonzero(b)
+                    source "division domain" trust authoritative
+            }
+            observe numerator(8)
+            observe denominator(0)
+            let first = quotient(numerator, denominator)
+            let second = first + 1
+        "#;
+
+        let lowered = compile(src).expect("dependent unavailable values remain abstentions");
+        assert!(lowered.kb.derived_for("first").is_none());
+        assert!(lowered.kb.derived_for("second").is_none());
+        assert_eq!(
+            lowered
+                .formula_abstentions
+                .iter()
+                .map(|value| value.name.as_str())
+                .collect::<Vec<_>>(),
+            ["first", "second"]
+        );
+        assert!(lowered
+            .formula_abstentions
+            .iter()
+            .all(|value| value.formula == "quotient"));
+    }
+
+    #[test]
+    fn successful_let_rebinding_clears_a_cached_abstention() {
+        let src = r#"
+            formulabook guarded {
+                formula quotient(a, b) = a / b
+                    requires nonzero(b)
+                    source "division domain" trust authoritative
+            }
+            observe numerator(8)
+            observe denominator(0)
+            let result = quotient(numerator, denominator)
+            let result = numerator + 1
+            let downstream = result + 1
+        "#;
+
+        let lowered = compile(src).expect("a successful rebind restores availability");
+        assert_eq!(lowered.kb.derived_for("result").unwrap().value, 9.0);
+        assert_eq!(lowered.kb.derived_for("downstream").unwrap().value, 10.0);
+        assert_eq!(lowered.formula_abstentions.len(), 1);
+    }
+
+    #[test]
+    fn later_observation_clears_a_cached_abstention() {
+        let src = r#"
+            formulabook guarded {
+                formula quotient(a, b) = a / b
+                    requires nonzero(b)
+                    source "division domain" trust authoritative
+            }
+            observe numerator(8)
+            observe denominator(0)
+            let result = quotient(numerator, denominator)
+            observe result(7)
+            let downstream = result + 1
+        "#;
+
+        let lowered = compile(src).expect("an observation supersedes stale unavailability");
+        assert_eq!(lowered.kb.derived_for("downstream").unwrap().value, 8.0);
+        assert_eq!(lowered.formula_abstentions.len(), 1);
+    }
+
+    #[test]
+    fn successful_direct_rebinding_clears_a_cached_abstention() {
+        let src = r#"
+            formulabook guarded {
+                formula quotient(a, b) = a / b
+                    requires nonzero(b)
+                    source "division domain" trust authoritative
+            }
+            observe numerator(8)
+            observe denominator(0)
+            ? quotient(numerator, denominator)
+            observe denominator(2)
+            ? quotient(numerator, denominator)
+            let downstream = quotient + 1
+        "#;
+
+        let lowered = compile(src).expect("a successful query rebind restores availability");
+        assert_eq!(lowered.kb.derived_for("quotient").unwrap().value, 4.0);
+        assert_eq!(lowered.kb.derived_for("downstream").unwrap().value, 5.0);
+        assert_eq!(lowered.formula_abstentions.len(), 1);
+    }
+
+    #[test]
+    fn guard_fact_ids_respect_each_derived_predecessor_scope() {
+        let src = r#"
+            formulabook guarded {
+                formula quotient(a, b) = a / b
+                    requires nonzero(b)
+                    source "division domain" trust authoritative
+            }
+            observe a(1)
+            observe b(0)
+            let x = a + b
+            let y = x + 1
+            let denominator = y - 2
+            let x = b + 2
+            ? quotient(a, denominator)
+        "#;
+
+        let lowered = compile(src).expect("a false guard remains a typed abstention");
+        assert_eq!(lowered.formula_abstentions.len(), 1);
+        assert_eq!(
+            lowered.formula_abstentions[0].fact_ids,
+            vec![FactId(0), FactId(1)],
+            "the old x binding consumed both a and b; the later x must not shadow it"
+        );
+    }
+
+    #[test]
+    fn nested_formula_precondition_propagates_to_the_outer_binding() {
+        let src = r#"
+            formulabook guarded {
+                formula quotient(a, b) = a / b
+                    requires nonzero(b)
+                    source "division domain" trust authoritative
+                formula ratio(a, b) = quotient(a, b)
+                    source "ratio definition" trust authoritative
+            }
+            observe numerator(8)
+            observe denominator(0)
+            let result = ratio(numerator, denominator)
+        "#;
+
+        let lowered = compile(src).expect("nested guard failure is an abstention");
+        assert!(lowered.kb.derived_for("result").is_none());
+        assert_eq!(lowered.formula_abstentions.len(), 1);
+        assert_eq!(lowered.formula_abstentions[0].name, "result");
+        assert_eq!(lowered.formula_abstentions[0].formula, "quotient");
+    }
+
+    #[test]
+    fn nonzero_accepts_negative_values() {
+        let src = r#"
+            formulabook guarded {
+                formula identity(x) = x
+                    requires nonzero(x)
+                    source "identity domain" trust authoritative
+            }
+            observe input(-2)
+            ? identity(input)
+        "#;
+
+        let lowered = compile(src).expect("negative values are nonzero");
+        assert_eq!(lowered.kb.derived_for("identity").unwrap().value, -2.0);
+        assert!(lowered.formula_abstentions.is_empty());
+    }
+
+    #[test]
+    fn malformed_formula_preconditions_are_typed_errors() {
+        let unknown = r#"
+            formulabook guarded {
+                formula identity(x) = x requires positive(x)
+                    source "identity domain" trust authoritative
+            }
+        "#;
+        assert!(matches!(
+            compile(unknown),
+            Err(crate::CompileError::Lower(LowerError::FormulaUnknownPrecondition {
+                ref predicate, ..
+            })) if predicate == "positive"
+        ));
+
+        let arity = r#"
+            formulabook guarded {
+                formula identity(x) = x requires nonzero()
+                    source "identity domain" trust authoritative
+            }
+        "#;
+        assert!(matches!(
+            compile(arity),
+            Err(crate::CompileError::Lower(
+                LowerError::FormulaPreconditionArity {
+                    expected: 1,
+                    got: 0,
+                    ..
+                }
+            ))
+        ));
+
+        let nested_application = r#"
+            formulabook guarded {
+                formula identity(x) = x requires nonzero(identity(x))
+                    source "identity domain" trust authoritative
+            }
+        "#;
+        assert!(matches!(
+            compile(nested_application),
+            Err(crate::CompileError::Lower(
+                LowerError::FormulaPreconditionApplicationUnsupported { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn duplicate_formula_exports_are_rejected() {
+        let src = r#"
+            formulabook first {
+                formula identity(x) = x source "first" trust authoritative
+            }
+            formulabook second {
+                formula identity(x) = x source "second" trust authoritative
+            }
+        "#;
+        assert!(matches!(
+            compile(src),
+            Err(crate::CompileError::Lower(LowerError::DuplicateFormula { ref formula }))
+                if formula == "identity"
+        ));
+    }
+
+    #[test]
+    fn top_level_formula_query_arity_mismatch_does_not_fall_through() {
+        let src = r#"
+            formulabook guarded {
+                formula quotient(a, b) = a / b
+                    source "division definition" trust authoritative
+            }
+            observe numerator(8)
+            ? quotient(numerator)
+        "#;
+        assert!(matches!(
+            compile(src),
+            Err(crate::CompileError::Lower(LowerError::FormulaArity {
+                ref formula, expected: 2, got: 1
+            })) if formula == "quotient"
+        ));
     }
 }

--- a/code/packages/rust/adj-lang/src/statemachine.rs
+++ b/code/packages/rust/adj-lang/src/statemachine.rs
@@ -28,8 +28,7 @@
 //!
 //! # Termination — total by construction (ADJ-STATEMACHINE §3–§4)
 //!
-//! The loop returns exactly one of four typed outcomes ([`StateMachineOutcome`]):
-//! `Halted` / `StepBudgetExceeded` / `NonTerminating` / `Stuck`. It **cannot hang**:
+//! The loop returns exactly one typed [`StateMachineOutcome`]. It **cannot hang**:
 //! the `steps >= budget` guard caps the loop at `budget + 1` iterations even if
 //! cycle detection never fires, and `budget` is the modeller's declared literal
 //! bound (a `u64`, but a fixed input value). A malicious or buggy machine therefore
@@ -55,14 +54,16 @@
 use std::collections::{BTreeSet, HashSet};
 
 use logic_core::Term as CoreTerm;
-use logic_engine::compute::Derived;
-use logic_engine::{compute, enumerate_all, CmpOp as EngineCmpOp, Fact, KnowledgeBase, Provenance};
+use logic_engine::compute::{ComputeError, Derived};
+use logic_engine::{
+    comparison_requires_lossy_fallback, compute, enumerate_all, CmpOp as EngineCmpOp, Fact,
+    KnowledgeBase, Provenance,
+};
 
 use crate::lower::{LoweredGuard, LoweredStateMachine};
 
-/// The outcome of a state-machine run — one of the four typed terminals of
-/// ADJ-STATEMACHINE §4. Total by construction: [`run_state_machine`] returns
-/// exactly one of these, always, and never hangs.
+/// The outcome of a state-machine run. Total by construction:
+/// [`run_state_machine`] returns exactly one of these, always, and never hangs.
 #[derive(Debug, Clone)]
 pub enum StateMachineOutcome {
     /// An exit criterion held; `result` is the yielded value (numeric with its
@@ -81,6 +82,17 @@ pub enum StateMachineOutcome {
     /// In `state`, no transition guard holds and no exit criterion holds — a dead
     /// end; a grounded abstention ("no transition applies in state …").
     Stuck { state: String },
+    /// A comparison guard could only be decided after discarding exact input
+    /// identity, so the machine abstained at that guard.
+    PrecisionLoss { state: String, guard: String },
+    /// A guard or yield expression failed in the shared computation engine.
+    /// `phase` identifies where evaluation stopped and `detail` preserves the
+    /// typed engine failure as a stable, human-readable diagnostic.
+    ComputationError {
+        state: String,
+        phase: String,
+        detail: String,
+    },
 }
 
 impl StateMachineOutcome {
@@ -92,6 +104,8 @@ impl StateMachineOutcome {
             StateMachineOutcome::StepBudgetExceeded { .. } => "step_budget_exceeded",
             StateMachineOutcome::NonTerminating { .. } => "non_terminating",
             StateMachineOutcome::Stuck { .. } => "stuck",
+            StateMachineOutcome::PrecisionLoss { .. } => "precision_loss",
+            StateMachineOutcome::ComputationError { .. } => "computation_error",
         }
     }
 }
@@ -178,15 +192,55 @@ pub fn run_state_machine(sm: &LoweredStateMachine, base_kb: &KnowledgeBase) -> S
     loop {
         // (1) Exit first: the FIRST exit (source order) whose guard holds halts the
         //     run, yielding its evaluated expression.
-        if let Some(exit) = sm.exits.iter().find(|e| guard_holds(&e.guard, &kb)) {
-            let result = eval_yield(&exit.yield_expr, &kb);
-            return StateMachineRun {
-                outcome: StateMachineOutcome::Halted {
-                    state: state.clone(),
-                    result,
-                },
-                steps: trace,
-            };
+        for exit in &sm.exits {
+            match evaluate_guard(&exit.guard, &kb) {
+                GuardEvaluation::Holds => {
+                    return match eval_yield(&exit.yield_expr, &kb) {
+                        YieldEvaluation::Value(result) => StateMachineRun {
+                            outcome: StateMachineOutcome::Halted {
+                                state: state.clone(),
+                                result,
+                            },
+                            steps: trace,
+                        },
+                        YieldEvaluation::PrecisionLoss => StateMachineRun {
+                            outcome: StateMachineOutcome::PrecisionLoss {
+                                state: state.clone(),
+                                guard: format!("yield {}", render_expr(&exit.yield_expr)),
+                            },
+                            steps: trace,
+                        },
+                        YieldEvaluation::ComputationError(detail) => StateMachineRun {
+                            outcome: StateMachineOutcome::ComputationError {
+                                state: state.clone(),
+                                phase: "yield".to_string(),
+                                detail,
+                            },
+                            steps: trace,
+                        },
+                    };
+                }
+                GuardEvaluation::PrecisionLoss => {
+                    return StateMachineRun {
+                        outcome: StateMachineOutcome::PrecisionLoss {
+                            state: state.clone(),
+                            guard: render_guard(&exit.guard),
+                        },
+                        steps: trace,
+                    };
+                }
+                GuardEvaluation::ComputationError(detail) => {
+                    return StateMachineRun {
+                        outcome: StateMachineOutcome::ComputationError {
+                            state: state.clone(),
+                            phase: "exit_guard".to_string(),
+                            detail,
+                        },
+                        steps: trace,
+                    };
+                }
+                GuardEvaluation::DoesNotHold => {}
+            }
         }
 
         // (2) Budget: the hard termination guarantee. At most `budget + 1`
@@ -231,7 +285,36 @@ pub fn run_state_machine(sm: &LoweredStateMachine, base_kb: &KnowledgeBase) -> S
                 steps: trace,
             };
         };
-        let Some(tr) = cur.transitions.iter().find(|t| guard_holds(&t.guard, &kb)) else {
+        let mut selected = None;
+        for transition in &cur.transitions {
+            match evaluate_guard(&transition.guard, &kb) {
+                GuardEvaluation::Holds => {
+                    selected = Some(transition);
+                    break;
+                }
+                GuardEvaluation::PrecisionLoss => {
+                    return StateMachineRun {
+                        outcome: StateMachineOutcome::PrecisionLoss {
+                            state: state.clone(),
+                            guard: render_guard(&transition.guard),
+                        },
+                        steps: trace,
+                    };
+                }
+                GuardEvaluation::ComputationError(detail) => {
+                    return StateMachineRun {
+                        outcome: StateMachineOutcome::ComputationError {
+                            state: state.clone(),
+                            phase: "transition_guard".to_string(),
+                            detail,
+                        },
+                        steps: trace,
+                    };
+                }
+                GuardEvaluation::DoesNotHold => {}
+            }
+        }
+        let Some(tr) = selected else {
             return StateMachineRun {
                 outcome: StateMachineOutcome::Stuck {
                     state: state.clone(),
@@ -266,7 +349,15 @@ pub fn run_state_machine(sm: &LoweredStateMachine, base_kb: &KnowledgeBase) -> S
 /// (ADJ-STATEMACHINE §3) lives in this function: a comparison guard is the
 /// predicate-gated-contribution comparison, a presence guard is an SLD "any proof?"
 /// check, and the bare atom `true` is the always-holds special case.
-fn guard_holds(g: &LoweredGuard, kb: &KnowledgeBase) -> bool {
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum GuardEvaluation {
+    Holds,
+    DoesNotHold,
+    PrecisionLoss,
+    ComputationError(String),
+}
+
+fn evaluate_guard(g: &LoweredGuard, kb: &KnowledgeBase) -> GuardEvaluation {
     match &g.comparison {
         // Comparison guard `subject <op> rhs`: read the subject's valued slot and
         // the (computed) rhs, then compare exact-first — mirroring exactly how
@@ -274,25 +365,44 @@ fn guard_holds(g: &LoweredGuard, kb: &KnowledgeBase) -> bool {
         // thr` predicate clause.
         Some((op, rhs)) => {
             let slot = subject_slot(&g.subject);
-            let Some((observed, observed_exact)) = kb.observed_numeric(&slot) else {
+            let Some(observed) = kb.observed_numeric(&slot) else {
                 // No value for the slot → the comparison cannot hold (it is not an
                 // error; the fact simply is not there yet).
-                return false;
+                return GuardEvaluation::DoesNotHold;
             };
-            let Ok(r) = compute("__sm_guard_rhs", rhs, kb) else {
-                // A malformed rhs is a non-firing guard, never a panic.
-                return false;
+            if observed.precision_loss {
+                return GuardEvaluation::PrecisionLoss;
+            }
+            let r = match compute("__sm_guard_rhs", rhs, kb) {
+                Ok(result) => result,
+                Err(error) => {
+                    return GuardEvaluation::ComputationError(compute_error_detail(&error));
+                }
             };
-            eval_cmp(*op, observed, r.value, observed_exact, r.exact)
+            if r.precision_loss {
+                return GuardEvaluation::PrecisionLoss;
+            }
+            if comparison_requires_lossy_fallback(&observed.exact, &r.exact) {
+                return GuardEvaluation::PrecisionLoss;
+            }
+            if eval_cmp(*op, observed.value, r.value, observed.exact, r.exact) {
+                GuardEvaluation::Holds
+            } else {
+                GuardEvaluation::DoesNotHold
+            }
         }
         // Presence guard: the bare atom `true` always holds (an unconditional
         // transition); any other atom holds iff it is present/derivable in the KB.
         None => {
             if is_true_atom(&g.subject) {
-                return true;
+                return GuardEvaluation::Holds;
             }
             let dag = enumerate_all(&g.subject, kb);
-            !dag.proofs.is_empty()
+            if dag.proofs.is_empty() {
+                GuardEvaluation::DoesNotHold
+            } else {
+                GuardEvaluation::Holds
+            }
         }
     }
 }
@@ -328,10 +438,37 @@ fn is_true_atom(subject: &CoreTerm) -> bool {
 /// result carries its derivation tree; a bare symbolic atom (whose slot has no
 /// numeric binding) is reported as a symbol — the engine's `UnknownSlot` on such
 /// an expression is the signal that the yield is symbolic, not a failure.
-fn eval_yield(expr: &logic_engine::ComputeExpr, kb: &KnowledgeBase) -> YieldValue {
+enum YieldEvaluation {
+    Value(YieldValue),
+    PrecisionLoss,
+    ComputationError(String),
+}
+
+fn eval_yield(expr: &logic_engine::ComputeExpr, kb: &KnowledgeBase) -> YieldEvaluation {
     match compute("__sm_yield", expr, kb) {
-        Ok(d) => YieldValue::Numeric(Box::new(d)),
-        Err(_) => YieldValue::Symbol(expr_symbol(expr)),
+        Ok(d) if d.precision_loss => YieldEvaluation::PrecisionLoss,
+        Ok(d) => YieldEvaluation::Value(YieldValue::Numeric(Box::new(d))),
+        Err(ComputeError::UnknownSlot { .. })
+            if matches!(expr, logic_engine::ComputeExpr::Ref(_)) =>
+        {
+            YieldEvaluation::Value(YieldValue::Symbol(expr_symbol(expr)))
+        }
+        Err(error) => YieldEvaluation::ComputationError(compute_error_detail(&error)),
+    }
+}
+
+fn compute_error_detail(error: &ComputeError) -> String {
+    match error {
+        ComputeError::UnknownSlot { slot } => format!("unknown slot: {slot}"),
+        ComputeError::EmptyAggregation { slot } => format!("empty aggregation: {slot}"),
+        ComputeError::DivisionByZero => "division by zero".to_string(),
+        ComputeError::MalformedExpr { detail } => format!("malformed expression: {detail}"),
+        ComputeError::TooDeep { limit } => format!("expression depth exceeds {limit}"),
+        ComputeError::NonFinite { op } => format!("non-finite result from {op:?}"),
+        ComputeError::PrecisionLoss { op } => format!("precision loss in {op:?}"),
+        ComputeError::DimensionMismatch { op, lhs, rhs } => {
+            format!("dimension mismatch for {op:?}: {lhs} versus {rhs}")
+        }
     }
 }
 
@@ -345,6 +482,7 @@ fn expr_symbol(expr: &logic_engine::ComputeExpr) -> String {
     match expr {
         E::Ref(slot) => slot.clone(),
         E::Lit(x) => format!("{x}"),
+        E::ExactLit(x) => format!("{}", x.to_f64()),
         _ => "<expr>".to_string(),
     }
 }
@@ -366,7 +504,211 @@ fn render_expr(expr: &logic_engine::ComputeExpr) -> String {
     match expr {
         E::Ref(slot) => slot.clone(),
         E::Lit(x) => format!("{x}"),
+        E::ExactLit(x) => format!("{}", x.to_f64()),
         E::Agg(_, slot) => slot.clone(),
         _ => "<expr>".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lower::{LoweredExit, LoweredState, LoweredTransition};
+    use logic_core::atom;
+    use logic_engine::{ComputeExpr, ComputeOp};
+
+    fn machine(
+        transitions: Vec<LoweredTransition>,
+        exit_guard: LoweredGuard,
+        yield_expr: ComputeExpr,
+    ) -> LoweredStateMachine {
+        LoweredStateMachine {
+            name: "test_machine".to_string(),
+            initial: "start".to_string(),
+            states: vec![LoweredState {
+                name: "start".to_string(),
+                transitions,
+            }],
+            exits: vec![LoweredExit {
+                guard: exit_guard,
+                yield_expr,
+            }],
+            budget: 1,
+            provenance: Provenance::default(),
+        }
+    }
+
+    fn division_by_zero() -> ComputeExpr {
+        ComputeExpr::Bin(
+            ComputeOp::Div,
+            Box::new(ComputeExpr::Lit(1.0)),
+            Box::new(ComputeExpr::Lit(0.0)),
+        )
+    }
+
+    #[test]
+    fn comparison_guard_fails_closed_on_precision_loss() {
+        let mut kb = KnowledgeBase::new();
+        let measurement = compute("measurement", &ComputeExpr::Lit(0.0), &kb)
+            .unwrap()
+            .with_precision_loss(true);
+        kb.add_derived(measurement);
+        let guard = LoweredGuard {
+            subject: atom("measurement"),
+            comparison: Some((EngineCmpOp::Ge, ComputeExpr::Lit(0.0))),
+        };
+
+        assert_eq!(evaluate_guard(&guard, &kb), GuardEvaluation::PrecisionLoss);
+    }
+
+    #[test]
+    fn comparison_guard_fails_closed_on_precision_lost_rhs() {
+        let mut kb = KnowledgeBase::new();
+        kb.add_fact(Fact::certain(logic_core::compound(
+            "measurement",
+            vec![logic_core::int(5)],
+        )));
+        let threshold = compute("threshold", &ComputeExpr::Lit(0.0), &kb)
+            .unwrap()
+            .with_precision_loss(true);
+        kb.add_derived(threshold);
+        let guard = LoweredGuard {
+            subject: atom("measurement"),
+            comparison: Some((EngineCmpOp::Ge, ComputeExpr::Ref("threshold".into()))),
+        };
+
+        assert_eq!(evaluate_guard(&guard, &kb), GuardEvaluation::PrecisionLoss);
+    }
+
+    #[test]
+    fn transition_guard_compute_error_does_not_fall_through() {
+        let mut kb = KnowledgeBase::new();
+        kb.add_fact(Fact::certain(logic_core::compound(
+            "measurement",
+            vec![logic_core::int(5)],
+        )));
+        let broken = LoweredTransition {
+            guard: LoweredGuard {
+                subject: atom("measurement"),
+                comparison: Some((EngineCmpOp::Ge, division_by_zero())),
+            },
+            target: "start".to_string(),
+            actions: vec![],
+        };
+        let fallback = LoweredTransition {
+            guard: LoweredGuard {
+                subject: atom("true"),
+                comparison: None,
+            },
+            target: "start".to_string(),
+            actions: vec![],
+        };
+        let sm = machine(
+            vec![broken, fallback],
+            LoweredGuard {
+                subject: atom("never"),
+                comparison: None,
+            },
+            ComputeExpr::Ref("unreachable".to_string()),
+        );
+
+        let run = run_state_machine(&sm, &kb);
+        match run.outcome {
+            StateMachineOutcome::ComputationError {
+                state,
+                phase,
+                detail,
+            } => {
+                assert_eq!(state, "start");
+                assert_eq!(phase, "transition_guard");
+                assert_eq!(detail, "division by zero");
+            }
+            other => panic!("expected typed computation error, got {other:?}"),
+        }
+        assert!(run.steps.is_empty());
+    }
+
+    #[test]
+    fn exit_guard_compute_error_does_not_fall_through() {
+        let mut kb = KnowledgeBase::new();
+        kb.add_fact(Fact::certain(logic_core::compound(
+            "measurement",
+            vec![logic_core::int(5)],
+        )));
+        let sm = machine(
+            vec![],
+            LoweredGuard {
+                subject: atom("measurement"),
+                comparison: Some((EngineCmpOp::Ge, division_by_zero())),
+            },
+            ComputeExpr::Ref("unreachable".to_string()),
+        );
+
+        let run = run_state_machine(&sm, &kb);
+        match run.outcome {
+            StateMachineOutcome::ComputationError {
+                state,
+                phase,
+                detail,
+            } => {
+                assert_eq!(state, "start");
+                assert_eq!(phase, "exit_guard");
+                assert_eq!(detail, "division by zero");
+            }
+            other => panic!("expected typed computation error, got {other:?}"),
+        }
+        assert!(run.steps.is_empty());
+    }
+
+    #[test]
+    fn yield_compute_error_is_not_symbolic_placeholder() {
+        let sm = machine(
+            vec![],
+            LoweredGuard {
+                subject: atom("true"),
+                comparison: None,
+            },
+            division_by_zero(),
+        );
+
+        let run = run_state_machine(&sm, &KnowledgeBase::new());
+        match run.outcome {
+            StateMachineOutcome::ComputationError {
+                state,
+                phase,
+                detail,
+            } => {
+                assert_eq!(state, "start");
+                assert_eq!(phase, "yield");
+                assert_eq!(detail, "division by zero");
+            }
+            other => panic!("expected typed computation error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn precision_lost_numeric_yield_abstains() {
+        let mut kb = KnowledgeBase::new();
+        let tainted = compute("tainted", &ComputeExpr::Lit(3.0), &kb)
+            .unwrap()
+            .with_precision_loss(true);
+        kb.add_derived(tainted);
+        let sm = machine(
+            vec![],
+            LoweredGuard {
+                subject: atom("true"),
+                comparison: None,
+            },
+            ComputeExpr::Ref("tainted".to_string()),
+        );
+
+        let run = run_state_machine(&sm, &kb);
+        match run.outcome {
+            StateMachineOutcome::PrecisionLoss { state, guard } => {
+                assert_eq!(state, "start");
+                assert_eq!(guard, "yield tainted");
+            }
+            other => panic!("expected typed precision loss, got {other:?}"),
+        }
     }
 }

--- a/code/packages/rust/adj-lang/tests/formula_source_map.rs
+++ b/code/packages/rust/adj-lang/tests/formula_source_map.rs
@@ -1,4 +1,4 @@
-use adj_lang::ast::{ArithOp, ExprAst};
+use adj_lang::ast::{ArithOp, ExprAst, NumLit};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -30,6 +30,34 @@ fn simple_formula_maps_exact_declaration_and_body_bytes() {
             if matches!(lhs.as_ref(), ExprAst::Ref(name) if name == "a")
                 && matches!(rhs.as_ref(), ExprAst::Ref(name) if name == "b")
     ));
+}
+
+#[test]
+fn preconditions_map_exact_declaration_and_argument_bytes() {
+    let src = "formulabook guarded {\n    formula divide(a, b) = a / b\n        requires nonzero(b), nonzero(a + b)\n        source \"division domain\"\n}\n";
+
+    let formulas = adj_lang::formula_source_map(src).expect("valid guarded formula");
+    let mapped = &formulas[0];
+
+    assert_eq!(span_text!(src, mapped.body_span), "a / b");
+    assert_eq!(mapped.preconditions.len(), 2);
+    assert_eq!(mapped.preconditions[0].precondition.predicate, "nonzero");
+    assert_eq!(
+        span_text!(src, mapped.preconditions[0].declaration_span),
+        "nonzero(b)"
+    );
+    assert_eq!(
+        span_text!(src, mapped.preconditions[0].argument_spans[0]),
+        "b"
+    );
+    assert_eq!(
+        span_text!(src, mapped.preconditions[1].declaration_span),
+        "nonzero(a + b)"
+    );
+    assert_eq!(
+        span_text!(src, mapped.preconditions[1].argument_spans[0]),
+        "a + b"
+    );
 }
 
 #[test]
@@ -88,7 +116,7 @@ fn multi_step_formula_body_span_selects_only_the_final_expression() {
         &mapped.formula.body,
         ExprAst::Bin(ArithOp::Div, lhs, rhs)
             if matches!(lhs.as_ref(), ExprAst::Ref(name) if name == "scaled")
-                && matches!(rhs.as_ref(), ExprAst::Lit(value) if *value == 2.0)
+                && matches!(rhs.as_ref(), ExprAst::ExactLit(NumLit::Int(2)))
     ));
 }
 

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.55.0] - 2026-08-03 - derived precision markers and transactional staging
+
+- `Derived` retains whether an exact source crossed a value-changing `f64` boundary, and that
+  marker now propagates through computations. Predicate contributions, state-machine guards,
+  and proof verification reject marked operands rather than making a discrete float decision.
+- Aggregations preserve rational sidecars when every observation is exact; mixed reductions are
+  marked when an exact source would otherwise be laundered through `f64`.
+- Recursive evaluation carries the marker through exact intermediates, exact source literals
+  remain rational in `ComputeExpr`, mixed comparisons reject unsafe float fallback, and LR emits
+  a typed warning when a predicate is withheld for precision loss.
+- `KnowledgeBase::with_staged_derived` exposes one candidate and its trusted computation plan to
+  an owned-result callback, then removes both on return. Deferred branches can evaluate a
+  self-dependent RHS without cloning the complete knowledge base or leaking a failed candidate.
+
 ## [0.54.0] - 2026-08-02 - NUM-7c: `adj-verify` recheck of the sqrt Real companion
 
 - `recheck_narrowing` gains two new `DerivationNode::Op` arms: `real: None` is not a narrowing

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -157,6 +157,19 @@ impl ExactRational {
         self.0.to_f64()
     }
 
+    /// Whether narrowing to `f64` and widening back reproduces this rational
+    /// exactly. This distinguishes an ordinary transcendental result from an
+    /// input whose identity was already lost at the floating-point boundary.
+    pub fn is_representable_as_f64(&self) -> bool {
+        let narrowed = self.to_f64();
+        if !narrowed.is_finite() {
+            return false;
+        }
+        BigDouble::from_f64(narrowed)
+            .to_decimal()
+            .is_some_and(|round_trip| round_trip.to_rational() == self.0)
+    }
+
     /// The **exact** base-10 expansion as a string, when the value terminates — the rendering
     /// side of ADJ-EXACT-NUMBERS NX-4. `1/4 → "0.25"`; a stored 39-digit π doubled → all 39
     /// fractional digits; `1/3 → None` (a repeating expansion no finite decimal can hold).
@@ -448,6 +461,9 @@ pub enum ComputeExpr {
     /// A numeric literal in the formula. The **no-magic-numbers** gate (step
     /// 3d) will require each of these to be a declared structural constant.
     Lit(f64),
+    /// An authored decimal/scientific literal whose rational identity survived
+    /// lowering. Its public magnitude is still the labeled-lossy `f64` view.
+    ExactLit(ExactRational),
     /// A binary operation: `Add`/`Sub`/`Mul`/`Div`/`Pow` only.
     Bin(ComputeOp, Box<ComputeExpr>, Box<ComputeExpr>),
     /// A unary operation: the rounding family (`Abs`/`Floor`/`Ceil`/`Round`) and
@@ -703,6 +719,10 @@ pub struct Derived {
     pub value: f64,
     /// Exact value when the expression stayed inside integer/rational arithmetic.
     pub exact: Option<ExactRational>,
+    /// True when an exact source crossed a value-changing `f64` boundary while
+    /// producing this binding. Consumers that make a discrete decision from the
+    /// value must reject or explicitly narrow that uncertainty.
+    pub precision_loss: bool,
     pub dim: Dimension,
     pub tree: DerivationNode,
     /// The compiler-produced expression that the verifier independently
@@ -728,6 +748,12 @@ pub struct Derived {
 }
 
 impl Derived {
+    /// Preserve a source-literal narrowing marker across later references.
+    pub fn with_precision_loss(mut self, precision_loss: bool) -> Self {
+        self.precision_loss |= precision_loss;
+        self
+    }
+
     /// Attach the applied formula's provenance (its cited `source`/`locator`/
     /// `trust`). Consumes and returns `self` so it composes with [`compute`]:
     /// `compute(name, expr, kb)?.with_provenance(prov)`.
@@ -783,6 +809,9 @@ pub enum ComputeError {
     /// silently make a predicate not fire (a quiet wrong answer). The whole
     /// point of provenance-through-math is that no number is silently wrong.
     NonFinite { op: ComputeOp },
+    /// An operation would require discarding a retained exact identity before
+    /// producing its result.
+    PrecisionLoss { op: ComputeOp },
     /// A binary operation mixed incompatible dimensions — `usd + days`,
     /// `usd + eur` without a conversion. The faithfulness gate (track A4): the
     /// engine, not the model, decides this is a category error. Carries the two
@@ -816,13 +845,14 @@ pub fn compute(
     expr: &ComputeExpr,
     kb: &KnowledgeBase,
 ) -> Result<Derived, ComputeError> {
-    let (tree, dim, exact) = eval(expr, kb, 0)?;
+    let (tree, dim, exact, precision_loss) = eval(expr, kb, 0)?;
     let value = tree.value();
     Ok(Derived {
         computation_id: None,
         name: name.into(),
         value,
         exact,
+        precision_loss,
         dim,
         tree,
         expr: expr.clone(),
@@ -915,7 +945,7 @@ fn eval(
     expr: &ComputeExpr,
     kb: &KnowledgeBase,
     depth: usize,
-) -> Result<(DerivationNode, Dimension, Option<ExactRational>), ComputeError> {
+) -> Result<(DerivationNode, Dimension, Option<ExactRational>, bool), ComputeError> {
     if depth >= MAX_EVAL_DEPTH {
         return Err(ComputeError::TooDeep {
             limit: MAX_EVAL_DEPTH,
@@ -928,6 +958,16 @@ fn eval(
             DerivationNode::Lit { value: *x },
             Dimension::Scalar,
             ExactRational::from_integer_f64(*x),
+            false,
+        )),
+
+        ComputeExpr::ExactLit(exact) => Ok((
+            DerivationNode::Lit {
+                value: exact.to_f64(),
+            },
+            Dimension::Scalar,
+            Some(exact.clone()),
+            false,
         )),
 
         ComputeExpr::Ref(slot) => {
@@ -949,6 +989,7 @@ fn eval(
                     },
                     d.dim,
                     exact,
+                    false,
                 ))
             } else if let Some(derived) = kb.derived_for(slot) {
                 Ok((
@@ -958,6 +999,7 @@ fn eval(
                     },
                     derived.dim.clone(),
                     derived.exact.clone(),
+                    derived.precision_loss,
                 ))
             } else {
                 Err(ComputeError::UnknownSlot { slot: slot.clone() })
@@ -965,8 +1007,8 @@ fn eval(
         }
 
         ComputeExpr::Bin(op, a, b) => {
-            let (lhs, dim_l, exact_l) = eval(a, kb, depth + 1)?;
-            let (rhs, dim_r, exact_r) = eval(b, kb, depth + 1)?;
+            let (lhs, dim_l, exact_l, loss_l) = eval(a, kb, depth + 1)?;
+            let (rhs, dim_r, exact_r, loss_r) = eval(b, kb, depth + 1)?;
             // Power is special: not a symmetric combine. The exponent must be
             // dimensionless and the result dimension is `base ^ exponent`
             // (`x^0 = scalar`, `x^2 = x·x`), so it bypasses the `dim_op` +
@@ -996,10 +1038,7 @@ fn eval(
                         ComputeError::DimensionMismatch { op: *op, lhs, rhs }
                     }
                 })?;
-                let result = base.powf(exponent);
-                if !result.is_finite() {
-                    return Err(ComputeError::NonFinite { op: *op });
-                }
+                let approximate_result = base.powf(exponent);
                 // A square root gets a correctly-rounded `BigDouble` "Real" audit companion
                 // (NUM-7). Detected on the *evaluated* exponent, bit-exactly `0.5` — not the
                 // exponent's exact sidecar, which is always `None` here: `ExactRational::
@@ -1038,19 +1077,51 @@ fn eval(
                 // `prec = 53` reproduces `f64::sqrt` bit-for-bit (bignum-core's own module doc),
                 // so this keeps the two audit-visible values from ever disagreeing in the last
                 // bit.
-                let result = if exponent == 0.5 { base.sqrt() } else { result };
+                let approximate_result = if exponent == 0.5 {
+                    base.sqrt()
+                } else {
+                    approximate_result
+                };
                 // Exact sidecar only for a non-negative integer exponent of an
                 // exact base — `(3/2)^2 = 9/4` stays exact; anything else keeps
                 // just the `f64` result.
+                let exact_source_would_narrow = exact_l
+                    .as_ref()
+                    .is_some_and(|value| !value.is_representable_as_f64())
+                    || exact_r
+                        .as_ref()
+                        .is_some_and(|value| !value.is_representable_as_f64());
+                let exact_integer_power = exact_l.is_some()
+                    && exact_r
+                        .as_ref()
+                        .is_some_and(|value| value.denominator() == &BigInteger::one());
                 let exact = match (exact_l, exact_r) {
                     (Some(a), Some(b)) if b.denominator() == &BigInteger::one() => b
                         .numerator()
                         .to_string()
                         .parse::<i128>()
                         .ok()
-                        .and_then(|e| a.powi(e)),
+                        .and_then(|e| {
+                            if e >= 0 {
+                                a.powi(e)
+                            } else {
+                                e.checked_neg().and_then(|positive| {
+                                    a.powi(positive)
+                                        .and_then(|power| ExactRational::from_i128(1).div(&power))
+                                })
+                            }
+                        }),
                     _ => None,
                 };
+                let result = exact
+                    .as_ref()
+                    .map_or(approximate_result, ExactRational::to_f64);
+                if !result.is_finite() {
+                    return Err(ComputeError::NonFinite { op: *op });
+                }
+                let precision_loss = loss_l
+                    || loss_r
+                    || (exact.is_none() && (exact_source_would_narrow || exact_integer_power));
                 return Ok((
                     DerivationNode::Op {
                         op: *op,
@@ -1060,6 +1131,7 @@ fn eval(
                     },
                     result_dim,
                     exact,
+                    precision_loss,
                 ));
             }
             // Dimensional check FIRST: usd + days is a category error regardless
@@ -1082,12 +1154,15 @@ fn eval(
             // (no arithmetic); a `NaN` operand would let `f64::min`/`max` silently
             // drop the NaN and return the finite side, so we produce `NaN`
             // explicitly and let the shared `is_finite` guard below reject it.
-            let result = match op {
+            let approximate_result = match op {
                 ComputeOp::Add => x + y,
                 ComputeOp::Sub => x - y,
                 ComputeOp::Mul => x * y,
                 ComputeOp::Div => {
-                    if y == 0.0 {
+                    let divisor_is_zero = exact_r
+                        .as_ref()
+                        .map_or(y == 0.0, |value| value.numerator().is_zero());
+                    if divisor_is_zero {
                         return Err(ComputeError::DivisionByZero);
                     }
                     x / y
@@ -1097,8 +1172,14 @@ fn eval(
                 // extra `eval` locals on the deeply-recursive path); a zero divisor is
                 // a clean error, never a `NaN`.
                 ComputeOp::Mod => {
-                    if y == 0.0 {
+                    let divisor_is_zero = exact_r
+                        .as_ref()
+                        .map_or(y == 0.0, |value| value.numerator().is_zero());
+                    if divisor_is_zero {
                         return Err(ComputeError::DivisionByZero);
+                    }
+                    if y == 0.0 {
+                        return Err(ComputeError::PrecisionLoss { op: *op });
                     }
                     x % y
                 }
@@ -1127,9 +1208,12 @@ fn eval(
                 ComputeOp::Gcd | ComputeOp::Lcm => int_gcd_lcm(*op, x, y)?,
                 _ => unreachable!("dim_op already rejected non-binary ops"),
             };
-            if !result.is_finite() {
-                return Err(ComputeError::NonFinite { op: *op });
-            }
+            let exact_source_would_narrow = exact_l
+                .as_ref()
+                .is_some_and(|value| !value.is_representable_as_f64())
+                || exact_r
+                    .as_ref()
+                    .is_some_and(|value| !value.is_representable_as_f64());
             let exact = match (exact_l, exact_r) {
                 (Some(a), Some(b)) => match op {
                     ComputeOp::Add => a.add(&b),
@@ -1138,12 +1222,23 @@ fn eval(
                     ComputeOp::Div => a.div(&b),
                     // min/max select an operand UNCHANGED, so the winner's exact
                     // rational carries through verbatim (ties pick the left).
-                    ComputeOp::Min2 => Some(if x <= y { a } else { b }),
-                    ComputeOp::Max2 => Some(if x >= y { a } else { b }),
+                    ComputeOp::Min2 => Some(if a.as_ratio() <= b.as_ratio() { a } else { b }),
+                    ComputeOp::Max2 => Some(if a.as_ratio() >= b.as_ratio() { a } else { b }),
                     _ => None,
                 },
                 _ => None,
             };
+            // Keep the public magnitude coherent with the exact identity. Computing
+            // these channels independently can otherwise turn `(2^53 + 1) - 2^53`
+            // into `value = 0, exact = 1`, after which every parent consumes the
+            // wrong magnitude despite the retained exact bytes.
+            let result = exact
+                .as_ref()
+                .map_or(approximate_result, ExactRational::to_f64);
+            if !result.is_finite() {
+                return Err(ComputeError::NonFinite { op: *op });
+            }
+            let precision_loss = loss_l || loss_r || (exact.is_none() && exact_source_would_narrow);
             Ok((
                 DerivationNode::Op {
                     op: *op,
@@ -1153,6 +1248,7 @@ fn eval(
                 },
                 result_dim,
                 exact,
+                precision_loss,
             ))
         }
 
@@ -1184,7 +1280,7 @@ fn eval(
         } => eval_to_currency(code, *places, *mode, expr, kb, depth),
 
         ComputeExpr::Agg(op, slot) => {
-            let observations = kb.observed_values_all(slot);
+            let observations = kb.observed_numerics_all(slot);
             // `count` is defined even when there are no observations (it's 0);
             // every other aggregation over an empty set is an error, not 0/NaN.
             if observations.is_empty() && *op != ComputeOp::Count {
@@ -1192,14 +1288,14 @@ fn eval(
             }
             let operands: Vec<DerivationNode> = observations
                 .iter()
-                .map(|(value, fact_id)| DerivationNode::Leaf {
+                .map(|(numeric, fact_id)| DerivationNode::Leaf {
                     slot: slot.clone(),
-                    value: *value,
+                    value: numeric.value,
                     fact_id: *fact_id,
                 })
                 .collect();
             let values: Vec<f64> = operands.iter().map(|n| n.value()).collect();
-            let result = match op {
+            let approximate_result = match op {
                 ComputeOp::Sum => values.iter().sum(),
                 ComputeOp::Count => values.len() as f64,
                 ComputeOp::Min => values.iter().cloned().fold(f64::INFINITY, f64::min),
@@ -1211,9 +1307,6 @@ fn eval(
                     })
                 }
             };
-            if !result.is_finite() {
-                return Err(ComputeError::NonFinite { op: *op });
-            }
             // `count` is a dimensionless tally; sum/min/max/avg keep the slot's
             // dimension (the magnitudes share it). Read it from the slot, or
             // Scalar if the slot has no dimensioned observation.
@@ -1224,6 +1317,21 @@ fn eval(
                     .map(|(d, _)| d.dim)
                     .unwrap_or(Dimension::Scalar)
             };
+            let exact = exact_aggregation(*op, &observations);
+            let result = exact
+                .as_ref()
+                .map_or(approximate_result, ExactRational::to_f64);
+            if !result.is_finite() {
+                return Err(ComputeError::NonFinite { op: *op });
+            }
+            let precision_loss = exact.is_none()
+                && observations.iter().any(|(numeric, _)| {
+                    numeric.precision_loss
+                        || numeric
+                            .exact
+                            .as_ref()
+                            .is_some_and(|value| !value.is_representable_as_f64())
+                });
             Ok((
                 DerivationNode::Op {
                     op: *op,
@@ -1232,9 +1340,46 @@ fn eval(
                     real: None,
                 },
                 result_dim,
-                None,
+                exact,
+                precision_loss,
             ))
         }
+    }
+}
+
+/// Reduce an all-exact observation set without routing its identity through
+/// `f64`. Mixed exact/inexact sets deliberately return no sidecar; `compute`
+/// then marks the result as precision-lost when any exact source participated.
+fn exact_aggregation(
+    op: ComputeOp,
+    observations: &[(crate::ResolvedNumeric, FactId)],
+) -> Option<ExactRational> {
+    if op == ComputeOp::Count {
+        return Some(ExactRational::from_i128(observations.len() as i128));
+    }
+    let exact: Option<Vec<ExactRational>> = observations
+        .iter()
+        .map(|(numeric, _)| numeric.exact.clone())
+        .collect();
+    let exact = exact?;
+    let first = exact.first()?.clone();
+    match op {
+        ComputeOp::Sum => exact
+            .iter()
+            .skip(1)
+            .try_fold(first, |total, value| total.add(value)),
+        ComputeOp::Min => exact
+            .into_iter()
+            .min_by(|left, right| left.as_ratio().cmp(right.as_ratio())),
+        ComputeOp::Max => exact
+            .into_iter()
+            .max_by(|left, right| left.as_ratio().cmp(right.as_ratio())),
+        ComputeOp::Avg => exact
+            .iter()
+            .skip(1)
+            .try_fold(first, |total, value| total.add(value))
+            .and_then(|total| total.div(&ExactRational::from_i128(exact.len() as i128))),
+        _ => None,
     }
 }
 
@@ -1253,8 +1398,11 @@ fn eval_unary(
     a: &ComputeExpr,
     kb: &KnowledgeBase,
     depth: usize,
-) -> Result<(DerivationNode, Dimension, Option<ExactRational>), ComputeError> {
-    let (operand, dim, exact) = eval(a, kb, depth + 1)?;
+) -> Result<(DerivationNode, Dimension, Option<ExactRational>, bool), ComputeError> {
+    let (operand, dim, exact, inherited_precision_loss) = eval(a, kb, depth + 1)?;
+    let exact_source_would_narrow = exact
+        .as_ref()
+        .is_some_and(|value| !value.is_representable_as_f64());
     // The **transcendental** functions are only defined on a pure number, so — like
     // `Pow`'s exponent — the operand must be dimensionless. `sin(3 dollars)` is a
     // category error, rejected here with the same `DimensionMismatch` the binary
@@ -1289,7 +1437,7 @@ fn eval_unary(
     // unit does not (`|−3 dollars| = 3 dollars`, `⌊3.7 mmol⌋ = 3 mmol`). The
     // transcendentals map a pure number to a pure number (`Scalar → Scalar`).
     let value = operand.value();
-    let result = match op {
+    let approximate_result = match op {
         ComputeOp::Abs => value.abs(),
         ComputeOp::Floor => value.floor(),
         ComputeOp::Ceil => value.ceil(),
@@ -1338,9 +1486,6 @@ fn eval_unary(
     // a `NaN` would otherwise compare `false` against every threshold and silently
     // suppress a predicate, exactly the quiet wrong answer provenance-through-math
     // forbids.
-    if !result.is_finite() {
-        return Err(ComputeError::NonFinite { op });
-    }
     // The exact result stays exact — now over unbounded `BigInteger`s. `BigRational` keeps
     // `den > 0`, and `BigInteger::div_rem` truncates toward zero with a remainder that takes
     // the numerator's sign (`num = q·den + rem`, `|rem| < den`), so from that one primitive:
@@ -1399,11 +1544,18 @@ fn eval_unary(
     // Rounding preserves the operand's dimension; a transcendental collapses to a
     // pure number (`Scalar`); `sgn` also collapses to `Scalar` (a sign is
     // dimensionless) but — unlike the transcendentals — accepts a dimensioned operand.
+    let result = exact
+        .as_ref()
+        .map_or(approximate_result, ExactRational::to_f64);
+    if !result.is_finite() {
+        return Err(ComputeError::NonFinite { op });
+    }
     let result_dim = if transcendental || op == ComputeOp::Sign {
         Dimension::Scalar
     } else {
         dim
     };
+    let precision_loss = inherited_precision_loss || (exact.is_none() && exact_source_would_narrow);
     Ok((
         DerivationNode::Op {
             op,
@@ -1413,6 +1565,7 @@ fn eval_unary(
         },
         result_dim,
         exact,
+        precision_loss,
     ))
 }
 
@@ -1437,8 +1590,8 @@ fn eval_round(
     expr: &ComputeExpr,
     kb: &KnowledgeBase,
     depth: usize,
-) -> Result<(DerivationNode, Dimension, Option<ExactRational>), ComputeError> {
-    let (operand, dim, exact) = eval(expr, kb, depth + 1)?;
+) -> Result<(DerivationNode, Dimension, Option<ExactRational>, bool), ComputeError> {
+    let (operand, dim, exact, precision_loss) = eval(expr, kb, depth + 1)?;
     // `round_to` is **dimension-preserving**, exactly like the unary round family:
     // narrowing `3.14159 mmol` to 2 places is `3.14 mmol`, still an amount.
     let exact_out = exact.as_ref().map(|r| round_rational(r, spec, mode));
@@ -1471,6 +1624,7 @@ fn eval_round(
         },
         dim,
         exact_out,
+        precision_loss,
     ))
 }
 
@@ -1540,8 +1694,8 @@ fn eval_to_scientific(
     expr: &ComputeExpr,
     kb: &KnowledgeBase,
     depth: usize,
-) -> Result<(DerivationNode, Dimension, Option<ExactRational>), ComputeError> {
-    let (operand, dim, exact) = eval(expr, kb, depth + 1)?;
+) -> Result<(DerivationNode, Dimension, Option<ExactRational>, bool), ComputeError> {
+    let (operand, dim, exact, precision_loss) = eval(expr, kb, depth + 1)?;
     // With an exact sidecar (every rational formula), the rendering and the narrowed
     // exact value are derived TOGETHER from one rounding, so the string and the audit
     // number can never disagree. A genuinely-inexact operand (a transcendental with no
@@ -1581,6 +1735,7 @@ fn eval_to_scientific(
         },
         dim,
         exact_out,
+        precision_loss,
     ))
 }
 
@@ -1673,8 +1828,8 @@ fn eval_to_percent(
     expr: &ComputeExpr,
     kb: &KnowledgeBase,
     depth: usize,
-) -> Result<(DerivationNode, Dimension, Option<ExactRational>), ComputeError> {
-    let (operand, dim, exact) = eval(expr, kb, depth + 1)?;
+) -> Result<(DerivationNode, Dimension, Option<ExactRational>, bool), ComputeError> {
+    let (operand, dim, exact, precision_loss) = eval(expr, kb, depth + 1)?;
     let (rendered, exact_out, result) = match &exact {
         Some(r) => {
             let (s, narrowed) = percent(r, places, mode);
@@ -1709,6 +1864,7 @@ fn eval_to_percent(
         },
         dim,
         exact_out,
+        precision_loss,
     ))
 }
 
@@ -1771,8 +1927,8 @@ fn eval_to_currency(
     expr: &ComputeExpr,
     kb: &KnowledgeBase,
     depth: usize,
-) -> Result<(DerivationNode, Dimension, Option<ExactRational>), ComputeError> {
-    let (operand, dim, exact) = eval(expr, kb, depth + 1)?;
+) -> Result<(DerivationNode, Dimension, Option<ExactRational>, bool), ComputeError> {
+    let (operand, dim, exact, precision_loss) = eval(expr, kb, depth + 1)?;
     let (rendered, exact_out, result) = match &exact {
         Some(r) => {
             let (amount, narrowed) = currency(r, places, mode);
@@ -1806,6 +1962,7 @@ fn eval_to_currency(
         },
         dim,
         exact_out,
+        precision_loss,
     ))
 }
 
@@ -1974,7 +2131,12 @@ pub fn recheck_narrowing(node: &DerivationNode) -> NarrowingCheck {
                 let (amount, narrowed) = currency(src, *places, *mode);
                 // The node's `rendered` is the code-prefixed form; reconstruct it the
                 // same way the emit path did (`"{code} {amount}"`).
-                check_rendered(&format!("{code} {amount}"), narrowed.to_f64(), rendered, *result)
+                check_rendered(
+                    &format!("{code} {amount}"),
+                    narrowed.to_f64(),
+                    rendered,
+                    *result,
+                )
             }
         },
         // NUM-7c: a sqrt's Real/BigDouble companion is technically a *widening* (exact →
@@ -1982,11 +2144,10 @@ pub fn recheck_narrowing(node: &DerivationNode) -> NarrowingCheck {
         // source + recorded spec/mode, re-derived and compared) for the identical reason: turn
         // the engine's own claim about its precision into independently-checked evidence.
         DerivationNode::Op { real: None, .. } => NarrowingCheck::NotANarrowing,
-        DerivationNode::Op {
-            real: Some(rc), ..
-        } => {
+        DerivationNode::Op { real: Some(rc), .. } => {
             let prec = rc.value.precision_bits();
-            let recomputed = BigDouble::from_rational(rc.source.as_ratio(), prec, rc.mode).sqrt(prec, rc.mode);
+            let recomputed =
+                BigDouble::from_rational(rc.source.as_ratio(), prec, rc.mode).sqrt(prec, rc.mode);
             if recomputed == *rc.value.as_big_double() {
                 NarrowingCheck::ReChecked
             } else {
@@ -2337,7 +2498,8 @@ mod tests {
             &kb_with(vec![]),
         )
         .unwrap();
-        let real = real_companion_of(&d).expect("sqrt of an exact base should get a real companion");
+        let real =
+            real_companion_of(&d).expect("sqrt of an exact base should get a real companion");
         assert_eq!(real.value.precision_bits(), 256);
         assert_eq!(real.value.to_decimal_string().unwrap(), "2");
     }
@@ -2352,7 +2514,10 @@ mod tests {
         .unwrap();
         let real = real_companion_of(&d).expect("sqrt of 2 should get a real companion");
         let rendered = real.value.to_decimal_string().unwrap();
-        assert!(rendered.starts_with("1.41421356237309504880168"), "got {rendered}");
+        assert!(
+            rendered.starts_with("1.41421356237309504880168"),
+            "got {rendered}"
+        );
     }
 
     #[test]
@@ -2375,11 +2540,18 @@ mod tests {
         // as a clean Err, never as a panic deep inside bignum-core.
         let err = compute(
             "root",
-            &bin(ComputeOp::Pow, ComputeExpr::Lit(-4.0), ComputeExpr::Lit(0.5)),
+            &bin(
+                ComputeOp::Pow,
+                ComputeExpr::Lit(-4.0),
+                ComputeExpr::Lit(0.5),
+            ),
             &kb_with(vec![]),
         )
         .unwrap_err();
-        assert!(matches!(err, ComputeError::NonFinite { op: ComputeOp::Pow }));
+        assert!(matches!(
+            err,
+            ComputeError::NonFinite { op: ComputeOp::Pow }
+        ));
     }
 
     #[test]
@@ -2396,10 +2568,17 @@ mod tests {
         // nesting levels, well under MAX_EVAL_DEPTH — then flip its sign with one more Mul.
         let mut magnitude = frac(1, 2);
         for _ in 0..11 {
-            magnitude = ComputeExpr::Bin(ComputeOp::Mul, Box::new(magnitude.clone()), Box::new(magnitude));
+            magnitude = ComputeExpr::Bin(
+                ComputeOp::Mul,
+                Box::new(magnitude.clone()),
+                Box::new(magnitude),
+            );
         }
-        let negative_underflowed =
-            ComputeExpr::Bin(ComputeOp::Mul, Box::new(magnitude), Box::new(ComputeExpr::Lit(-1.0)));
+        let negative_underflowed = ComputeExpr::Bin(
+            ComputeOp::Mul,
+            Box::new(magnitude),
+            Box::new(ComputeExpr::Lit(-1.0)),
+        );
         let expr = ComputeExpr::Bin(
             ComputeOp::Pow,
             Box::new(negative_underflowed),
@@ -2428,7 +2607,11 @@ mod tests {
         // and BigDouble has no cbrt: this must not be mistaken for a sqrt.
         let d = compute(
             "root",
-            &bin(ComputeOp::Pow, ComputeExpr::Lit(27.0), ComputeExpr::Lit(1.0 / 3.0)),
+            &bin(
+                ComputeOp::Pow,
+                ComputeExpr::Lit(27.0),
+                ComputeExpr::Lit(1.0 / 3.0),
+            ),
             &kb_with(vec![]),
         )
         .unwrap();
@@ -3227,6 +3410,158 @@ mod tests {
             }
             other => panic!("expected Op, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn aggregation_preserves_an_underflowing_exact_observation() {
+        use logic_core::{Number, Term};
+        use std::str::FromStr;
+
+        let tiny_text = format!("0.{}1", "0".repeat(399));
+        let tiny = BigDecimal::from_str(&tiny_text).unwrap();
+        let kb = kb_with(vec![Fact::certain(compound(
+            "tiny",
+            vec![Term::Num(Number::Exact(tiny.clone()))],
+        ))]);
+
+        let total = compute(
+            "total",
+            &ComputeExpr::Agg(ComputeOp::Sum, "tiny".into()),
+            &kb,
+        )
+        .unwrap();
+
+        assert_eq!(total.value, 0.0, "the public f64 magnitude underflows");
+        assert_eq!(
+            total.exact,
+            Some(ExactRational::from_ratio(tiny.to_rational())),
+            "the aggregate must retain the nonzero exact identity"
+        );
+        assert!(!total.precision_loss);
+    }
+
+    #[test]
+    fn compute_propagates_precision_loss_from_a_derived_reference() {
+        let mut kb = KnowledgeBase::new();
+        let narrowed = compute("narrowed", &ComputeExpr::Lit(0.0), &kb)
+            .unwrap()
+            .with_precision_loss(true);
+        kb.add_derived(narrowed);
+
+        let copied = compute("copied", &ComputeExpr::Ref("narrowed".into()), &kb).unwrap();
+        assert!(copied.precision_loss);
+    }
+
+    #[test]
+    fn nested_exact_intermediate_marks_loss_when_a_parent_discards_it() {
+        let kb = KnowledgeBase::new();
+        let tenth = bin(
+            ComputeOp::Div,
+            ComputeExpr::Lit(1.0),
+            ComputeExpr::Lit(10.0),
+        );
+        let tiny = bin(ComputeOp::Pow, tenth, ComputeExpr::Lit(400.0));
+        let result = compute(
+            "result",
+            &ComputeExpr::Unary(ComputeOp::Sin, Box::new(tiny)),
+            &kb,
+        )
+        .unwrap();
+
+        assert_eq!(result.value, 0.0);
+        assert!(result.precision_loss);
+    }
+
+    #[test]
+    fn exact_cancellation_keeps_public_magnitude_coherent_for_parent_ops() {
+        let kb = KnowledgeBase::new();
+        let one = bin(
+            ComputeOp::Sub,
+            ComputeExpr::ExactLit(ExactRational::from_i128(9_007_199_254_740_993)),
+            ComputeExpr::ExactLit(ExactRational::from_i128(9_007_199_254_740_992)),
+        );
+        let difference = compute("difference", &one, &kb).unwrap();
+        assert_eq!(difference.value, 1.0);
+        assert_eq!(difference.exact, Some(ExactRational::from_i128(1)));
+
+        let sine = compute(
+            "sine",
+            &ComputeExpr::Unary(ComputeOp::Sin, Box::new(one)),
+            &kb,
+        )
+        .unwrap();
+        assert_eq!(sine.value, 1.0_f64.sin());
+        assert!(!sine.precision_loss);
+    }
+
+    #[test]
+    fn negative_integer_power_preserves_the_exact_reciprocal() {
+        let result = compute(
+            "reciprocal",
+            &bin(
+                ComputeOp::Pow,
+                ComputeExpr::ExactLit(ExactRational::from_i128(10)),
+                ComputeExpr::ExactLit(ExactRational::from_i128(-1)),
+            ),
+            &KnowledgeBase::new(),
+        )
+        .unwrap();
+        assert_eq!(result.exact, ExactRational::new(1, 10));
+        assert!(!result.precision_loss);
+    }
+
+    #[test]
+    fn modulo_with_underflowing_exact_divisor_fails_as_precision_loss() {
+        let ten_to_400 = BigInteger::from_i128(10).pow(400);
+        let tiny = ExactRational::from_ratio(
+            BigRational::checked_new(BigInteger::one(), ten_to_400).unwrap(),
+        );
+        let error = compute(
+            "remainder",
+            &bin(
+                ComputeOp::Mod,
+                ComputeExpr::Lit(1.0),
+                ComputeExpr::ExactLit(tiny),
+            ),
+            &KnowledgeBase::new(),
+        )
+        .unwrap_err();
+        assert_eq!(error, ComputeError::PrecisionLoss { op: ComputeOp::Mod });
+    }
+
+    #[test]
+    fn exact_binary_min_max_order_underflowing_operands_by_rational_value() {
+        let kb = KnowledgeBase::new();
+        let ten_to_400 = BigInteger::from_i128(10).pow(400);
+        let tiny = ExactRational::from_ratio(
+            BigRational::checked_new(BigInteger::one(), ten_to_400.clone()).unwrap(),
+        );
+        let twice_tiny = ExactRational::from_ratio(
+            BigRational::checked_new(BigInteger::from_i128(2), ten_to_400).unwrap(),
+        );
+        let maximum = compute(
+            "maximum",
+            &bin(
+                ComputeOp::Max2,
+                ComputeExpr::ExactLit(tiny.clone()),
+                ComputeExpr::ExactLit(twice_tiny.clone()),
+            ),
+            &kb,
+        )
+        .unwrap();
+        let minimum = compute(
+            "minimum",
+            &bin(
+                ComputeOp::Min2,
+                ComputeExpr::ExactLit(tiny.clone()),
+                ComputeExpr::ExactLit(twice_tiny.clone()),
+            ),
+            &kb,
+        )
+        .unwrap();
+
+        assert_eq!(maximum.exact, Some(twice_tiny));
+        assert_eq!(minimum.exact, Some(tiny));
     }
 
     #[test]
@@ -4035,7 +4370,11 @@ mod tests {
         let expr = round_places(2, inner);
         let d = compute("r", &expr, &kb).unwrap();
         let checks = recheck_narrowings(&d.tree);
-        assert_eq!(checks.len(), 2, "expected the outer round and inner to_percent");
+        assert_eq!(
+            checks.len(),
+            2,
+            "expected the outer round and inner to_percent"
+        );
         assert_eq!(checks[0].0, 0); // outer round at the root
         assert_eq!(checks[1].0, 1); // inner to_percent one level down
         assert!(checks.iter().all(|(_, c)| c.is_rechecked()));

--- a/code/packages/rust/logic-engine/src/differential.rs
+++ b/code/packages/rust/logic-engine/src/differential.rs
@@ -52,7 +52,7 @@
 
 use logic_core::Term;
 
-use crate::lr_aggregate::{lr_aggregate, LRAggregateResult};
+use crate::lr_aggregate::{lr_aggregate, LRAggregateResult, LrAggregateWarning};
 use crate::KnowledgeBase;
 use crate::UncertaintyMarkerId;
 
@@ -88,6 +88,13 @@ pub enum DifferentialDecision {
         posterior: f64,
         margin_posterior: f64,
         margin_logit: f64,
+    },
+    /// A numeric predicate could not be evaluated without narrowing an exact
+    /// source. The ranking remains visible for audit, but it is not actionable.
+    Indeterminate {
+        leader: Term,
+        posterior: f64,
+        reason: String,
     },
     /// The leader's worst-case band and the runner-up's best-case band
     /// cross — an open uncertainty (or an exact tie) could flip the
@@ -191,6 +198,33 @@ pub fn differential(hypotheses: &[Term], kb: &KnowledgeBase) -> Differential {
 
     // Single hypothesis: nothing to compare against — determinate by
     // construction, infinite margin.
+    let predicate_failure_reason = ranked.iter().find_map(|ranked| {
+        ranked
+            .result
+            .warnings
+            .iter()
+            .find_map(|warning| match warning {
+                LrAggregateWarning::PredicatePrecisionLoss { .. } => {
+                    Some("a predicate depends on a precision-lost numeric value".to_string())
+                }
+                LrAggregateWarning::PredicateEvaluationError { detail, .. } => Some(format!(
+                    "a predicate threshold could not be evaluated: {detail}"
+                )),
+                _ => None,
+            })
+    });
+    if let Some(reason) = predicate_failure_reason {
+        let leader = &ranked[0];
+        return Differential {
+            decision: DifferentialDecision::Indeterminate {
+                leader: leader.hypothesis.clone(),
+                posterior: leader.posterior,
+                reason,
+            },
+            ranked,
+        };
+    }
+
     if ranked.len() == 1 {
         let leader = &ranked[0];
         return Differential {
@@ -260,7 +294,10 @@ pub fn differential(hypotheses: &[Term], kb: &KnowledgeBase) -> Differential {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lr_aggregate::{ContributionClause, PriorClause, UncertaintyMarker};
+    use crate::compute::{compute, ComputeExpr, ComputeOp};
+    use crate::lr_aggregate::{
+        CmpOp, ContributionClause, PredicateContributionClause, PriorClause, UncertaintyMarker,
+    };
     use crate::{Fact, KnowledgeBase};
     use logic_core::{atom, compound};
 
@@ -387,6 +424,63 @@ mod tests {
             }
             other => panic!("expected Determinate, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn predicate_precision_warning_makes_single_hypothesis_indeterminate() {
+        let mut kb = KnowledgeBase::new();
+        kb.add_prior(PriorClause::from_probability(atom("decision"), 0.10))
+            .unwrap();
+        kb.add_predicate_contribution(PredicateContributionClause::from_lr(
+            atom("decision"),
+            "measurement",
+            CmpOp::Ge,
+            0.0,
+            1e6,
+        ));
+        let measurement = compute("measurement", &ComputeExpr::Lit(0.0), &kb)
+            .unwrap()
+            .with_precision_loss(true);
+        kb.add_derived(measurement);
+
+        let diff = differential(&[atom("decision")], &kb);
+        assert!(matches!(
+            diff.decision,
+            DifferentialDecision::Indeterminate { .. }
+        ));
+    }
+
+    #[test]
+    fn predicate_threshold_error_makes_single_hypothesis_indeterminate() {
+        let mut kb = KnowledgeBase::new();
+        kb.add_prior(PriorClause::from_probability(atom("decision"), 0.10))
+            .unwrap();
+        kb.add_fact(Fact::certain(compound(
+            "measurement",
+            vec![logic_core::int(5)],
+        )));
+        kb.add_predicate_contribution(PredicateContributionClause::from_lr_expr(
+            atom("decision"),
+            "measurement",
+            CmpOp::Ge,
+            ComputeExpr::Bin(
+                ComputeOp::Div,
+                Box::new(ComputeExpr::Lit(1.0)),
+                Box::new(ComputeExpr::Lit(0.0)),
+            ),
+            1e6,
+        ));
+
+        let diff = differential(&[atom("decision")], &kb);
+        assert!(matches!(
+            diff.decision,
+            DifferentialDecision::Indeterminate { .. }
+        ));
+        assert!(diff.ranked[0]
+            .result
+            .warnings
+            .iter()
+            .any(|warning| matches!(warning, LrAggregateWarning::PredicateEvaluationError { .. })));
     }
 
     /// No hypotheses → Empty.

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -55,7 +55,7 @@ use logic_core::{unify, LogicVar, Number, Substitution, Term};
 pub use bignum_core::RoundingMode;
 pub use compute::{
     compute, recheck_narrowing, recheck_narrowings, ApproxReal, ComputationId, ComputationPlanRef,
-    ComputationScope, ComputeError, ComputeExpr, ComputeOp, DerivationNode, Derived,
+    ComputationScope, ComputeError, ComputeExpr, ComputeOp, DerivationNode, Derived, ExactRational,
     NarrowingCheck, RealCompanion, RoundSpec,
 };
 pub use conversion::{add_or_sub, convert_value, ConvError, Conversion, ConversionTable};
@@ -69,7 +69,7 @@ pub use govern::{
     enumerate_governing, ConflictStatus, GovernStatus, GovernedAnswer, GovernedResult,
 };
 pub use lr_aggregate::{
-    counterfactual, lr_aggregate, sigmoid, source_disagreements,
+    comparison_requires_lossy_fallback, counterfactual, lr_aggregate, sigmoid, source_disagreements,
     source_disagreements_with_threshold, CmpOp, ContributionClause, JointContributionClause,
     KbError, KickbackReport, LRAggregateResult, LrAggregateWarning, PredicateContributionClause,
     PriorClause, SourceDisagreementReport, SourceLogitDelta, UncertaintyMarker, UncertaintyReport,
@@ -421,6 +421,17 @@ impl RealPrecisionBits {
     pub fn get(self) -> u32 {
         self.0
     }
+}
+
+/// A numeric slot resolution together with the evidence needed by discrete
+/// consumers to decide whether the value is safe to compare.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedNumeric {
+    pub value: f64,
+    pub exact: Option<crate::compute::ExactRational>,
+    /// True when the value crossed a lossy boundary after originating from an
+    /// exact source. Predicate and state-machine guards must fail closed on it.
+    pub precision_loss: bool,
 }
 
 /// A collection of Facts and Rules, indexed for clause selection by
@@ -907,18 +918,25 @@ impl KnowledgeBase {
     /// rational sidecar when one is available. This is used by equality-heavy
     /// predicate gates such as `answer == 3 / 10`: the public magnitude remains
     /// `f64`, but exact integer/rational arithmetic can avoid float artifacts.
-    pub fn observed_numeric(
-        &self,
-        slot: &str,
-    ) -> Option<(f64, Option<crate::compute::ExactRational>)> {
+    pub fn observed_numeric(&self, slot: &str) -> Option<ResolvedNumeric> {
         self.observed_value_with_fact(slot)
             .map(|(v, id)| {
                 let exact = self
                     .observed_exact_value_with_fact(slot)
                     .and_then(|(x, exact_id)| if exact_id == id { Some(x) } else { None });
-                (v, exact)
+                ResolvedNumeric {
+                    value: v,
+                    exact,
+                    precision_loss: false,
+                }
             })
-            .or_else(|| self.derived_for(slot).map(|d| (d.value, d.exact.clone())))
+            .or_else(|| {
+                self.derived_for(slot).map(|d| ResolvedNumeric {
+                    value: d.value,
+                    exact: d.exact.clone(),
+                    precision_loss: d.precision_loss,
+                })
+            })
     }
 
     /// Like [`observed_value`](Self::observed_value) but also returns the
@@ -1005,19 +1023,75 @@ impl KnowledgeBase {
         out
     }
 
+    /// Every observed numeric value plus its exact sidecar, in fact-insertion
+    /// order. Aggregations use this paired view so exact observations cannot be
+    /// reduced through `f64` and then presented as untainted values.
+    pub fn observed_numerics_all(&self, slot: &str) -> Vec<(ResolvedNumeric, FactId)> {
+        let mut out: Vec<(ResolvedNumeric, FactId)> = self
+            .facts
+            .values()
+            .flatten()
+            .filter(|f| f.probability == Probability::Certain)
+            .filter_map(|f| match &f.term {
+                Term::Compound { functor, args } if functor == slot && args.len() == 1 => {
+                    numeric_magnitude(&args[0]).map(|value| {
+                        (
+                            ResolvedNumeric {
+                                value,
+                                exact: numeric_exact_magnitude(&args[0]),
+                                precision_loss: false,
+                            },
+                            f.id,
+                        )
+                    })
+                }
+                _ => None,
+            })
+            .collect();
+        out.sort_by_key(|(_, id)| id.0);
+        out
+    }
+
     /// Bind a `let`-computed [`Derived`](crate::compute::Derived) value into the
     /// KB. A later [`observed_value`](Self::observed_value) of its name returns
     /// the computed value, and a formula can reference it by name.
     pub fn add_derived(&mut self, mut derived: crate::compute::Derived) {
         let id = crate::compute::ComputationId(self.computation_plans.len());
         derived.computation_id = Some(id);
-        self.computation_plans.push(crate::compute::ComputationPlan {
-            expr: derived.expr.clone(),
-            scope: derived.scope,
-            formula_sources: derived.formula_sources.clone(),
-            is_query_answer: derived.is_query_answer,
-        });
+        self.computation_plans
+            .push(crate::compute::ComputationPlan {
+                expr: derived.expr.clone(),
+                scope: derived.scope,
+                formula_sources: derived.formula_sources.clone(),
+                is_query_answer: derived.is_query_answer,
+            });
         self.derived.push(derived);
+    }
+
+    /// Make one derived candidate visible for an owned-result computation, then
+    /// remove both the candidate and its trusted plan before returning. This is
+    /// the transactional overlay used when a branch RHS may refer to its staged
+    /// LHS; it avoids cloning the complete KB and removes the staging state even
+    /// when the callback unwinds.
+    pub fn with_staged_derived<R>(
+        &mut self,
+        derived: crate::compute::Derived,
+        operation: impl FnOnce(&KnowledgeBase) -> R,
+    ) -> (crate::compute::Derived, R) {
+        self.add_derived(derived);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| operation(self)));
+        let mut derived = self
+            .derived
+            .pop()
+            .expect("staged derived binding must remain present during callback");
+        self.computation_plans
+            .pop()
+            .expect("staged computation plan must remain paired with its binding");
+        derived.computation_id = None;
+        match result {
+            Ok(result) => (derived, result),
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
     }
 
     /// Look up a bound derived value by name (most-recently-bound wins, so a
@@ -1608,6 +1682,43 @@ mod tests {
 
         let clone = stored.clone();
         assert!(kb.computation_plan_for(&clone).is_none());
+    }
+
+    #[test]
+    fn staged_derived_is_visible_only_during_the_callback_and_can_be_committed() {
+        let mut kb = KnowledgeBase::new();
+        let candidate = compute::compute("candidate", &compute::ComputeExpr::Lit(7.0), &kb)
+            .expect("literal computes");
+
+        let (candidate, (visible, planned)) = kb.with_staged_derived(candidate, |view| {
+            let staged = view.derived_for("candidate").expect("candidate is staged");
+            (
+                staged.value == 7.0,
+                view.computation_plan_for(staged).is_some(),
+            )
+        });
+        assert!(visible);
+        assert!(planned);
+        assert!(kb.derived_for("candidate").is_none());
+        assert!(kb.derived_bindings().is_empty());
+
+        kb.add_derived(candidate);
+        let committed = kb.derived_for("candidate").expect("candidate commits");
+        assert!(kb.computation_plan_for(committed).is_some());
+    }
+
+    #[test]
+    fn staged_derived_is_removed_when_the_callback_unwinds() {
+        let mut kb = KnowledgeBase::new();
+        let candidate = compute::compute("candidate", &compute::ComputeExpr::Lit(7.0), &kb)
+            .expect("literal computes");
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            kb.with_staged_derived(candidate, |_view| panic!("deliberate callback failure"));
+        }));
+        assert!(result.is_err());
+        assert!(kb.derived_for("candidate").is_none());
+        assert!(kb.derived_bindings().is_empty());
     }
 
     #[test]

--- a/code/packages/rust/logic-engine/src/lr_aggregate.rs
+++ b/code/packages/rust/logic-engine/src/lr_aggregate.rs
@@ -227,6 +227,19 @@ impl CmpOp {
     }
 }
 
+/// Whether comparison would have to discard a non-round-trippable exact
+/// observed value because the threshold has no exact sidecar. An exact RHS is
+/// an explicitly authored threshold and may narrow to its stated decimal.
+pub fn comparison_requires_lossy_fallback(
+    lhs_exact: &Option<ExactRational>,
+    rhs_exact: &Option<ExactRational>,
+) -> bool {
+    matches!(
+        (lhs_exact, rhs_exact),
+        (Some(value), None) if !value.is_representable_as_f64()
+    )
+}
+
 /// Exact ordering of two rationals. `BigRational` is unbounded and totally ordered, so this is
 /// an exact comparison with no cross-multiplication overflow to guard against (the old `i128`
 /// sidecar needed an `f64` fallback; this never does).
@@ -758,6 +771,19 @@ pub enum LrAggregateWarning {
     /// `LR == 1.0`) fired. Permitted but a no-op; emitted once per
     /// such clause to surface likely modeller intent errors.
     DegenerateContribution { clause_id: ContributionClauseId },
+    /// A predicate contribution was not evaluated because doing so would make
+    /// a discrete decision from a precision-lost exact source.
+    PredicatePrecisionLoss {
+        clause_id: PredicateContributionClauseId,
+        slot: String,
+    },
+    /// A predicate threshold could not be evaluated, so the contribution was
+    /// not silently treated as absent.
+    PredicateEvaluationError {
+        clause_id: PredicateContributionClauseId,
+        slot: String,
+        detail: String,
+    },
 }
 
 /// Run LR aggregation for `query` against `kb`.
@@ -885,23 +911,60 @@ pub fn lr_aggregate(query: &Term, kb: &KnowledgeBase) -> LRAggregateResult {
     // value of its slot and evaluate the predicate on CPU; if true, apply its
     // logit_delta. A saturating logit_delta makes this a deterministic rule.
     for pc in kb.predicate_contributions_for(query) {
-        if let Some((observed, observed_exact)) = kb.observed_numeric(&pc.slot) {
-            let Ok(rhs) = compute("__predicate_rhs", &pc.rhs, kb) else {
+        if let Some(observed) = kb.observed_numeric(&pc.slot) {
+            if observed.precision_loss {
+                warnings.push(LrAggregateWarning::PredicatePrecisionLoss {
+                    clause_id: pc.id,
+                    slot: pc.slot.clone(),
+                });
                 continue;
+            }
+            let rhs = match compute("__predicate_rhs", &pc.rhs, kb) {
+                Ok(rhs) => rhs,
+                Err(error) => {
+                    warnings.push(LrAggregateWarning::PredicateEvaluationError {
+                        clause_id: pc.id,
+                        slot: pc.slot.clone(),
+                        detail: format!("{error:?}"),
+                    });
+                    continue;
+                }
             };
-            if pc
-                .op
-                .eval_values(observed, rhs.value, observed_exact, rhs.exact)
-            {
+            if rhs.precision_loss {
+                warnings.push(LrAggregateWarning::PredicatePrecisionLoss {
+                    clause_id: pc.id,
+                    slot: pc.slot.clone(),
+                });
+                continue;
+            }
+            if comparison_requires_lossy_fallback(&observed.exact, &rhs.exact) {
+                warnings.push(LrAggregateWarning::PredicatePrecisionLoss {
+                    clause_id: pc.id,
+                    slot: pc.slot.clone(),
+                });
+                continue;
+            }
+            if pc.op.eval_values(
+                observed.value,
+                rhs.value,
+                observed.exact.clone(),
+                rhs.exact.clone(),
+            ) {
                 any_contribution_active = true;
                 steps.push(ProofStep {
                     goal: query.clone(),
                     origin: DerivationOrigin::FromPredicateContribution {
                         clause_id: pc.id,
                         slot: pc.slot.clone(),
+                        observation_fact_id: kb
+                            .observed_numerics_all(&pc.slot)
+                            .last()
+                            .map(|(_, fact_id)| *fact_id),
                         op: pc.op,
                         threshold: rhs.value,
-                        observed,
+                        threshold_exact: rhs.exact,
+                        observed: observed.value,
+                        observed_exact: observed.exact,
                         logit_delta: pc.logit_delta,
                     },
                     depth: 0,
@@ -1196,6 +1259,24 @@ mod tests {
     }
 
     #[test]
+    fn mixed_comparison_rejects_a_non_round_trippable_exact_operand() {
+        let tenth = ExactRational::new(1, 10).unwrap();
+        assert!(comparison_requires_lossy_fallback(&Some(tenth), &None));
+        assert!(!comparison_requires_lossy_fallback(
+            &Some(ExactRational::from_i128(1)),
+            &None
+        ));
+        assert!(!comparison_requires_lossy_fallback(
+            &Some(ExactRational::new(1, 10).unwrap()),
+            &Some(ExactRational::from_i128(0))
+        ));
+        assert!(!comparison_requires_lossy_fallback(
+            &None,
+            &Some(ExactRational::new(1, 10).unwrap())
+        ));
+    }
+
+    #[test]
     #[should_panic(expected = "lr > 0.0")]
     fn predicate_contribution_with_negative_lr_panics() {
         let _ = PredicateContributionClause::from_lr(
@@ -1323,6 +1404,53 @@ mod tests {
             .steps
             .iter()
             .any(|s| matches!(s.origin, DerivationOrigin::FromPredicateContribution { .. })));
+    }
+
+    #[test]
+    fn predicate_does_not_fire_on_a_precision_lost_observation() {
+        let mut kb = KnowledgeBase::new();
+        kb.add_prior(PriorClause::from_probability(atom("decision"), 0.10))
+            .unwrap();
+        kb.add_predicate_contribution(PredicateContributionClause::from_lr(
+            atom("decision"),
+            "measurement",
+            CmpOp::Ge,
+            0.0,
+            1e6,
+        ));
+        let measurement = crate::compute("measurement", &ComputeExpr::Lit(0.0), &kb)
+            .unwrap()
+            .with_precision_loss(true);
+        kb.add_derived(measurement);
+
+        let result = lr_aggregate(&atom("decision"), &kb);
+        assert!(approx_eq(result.posterior, 0.10, 1e-12));
+        assert!(!result.dag.proofs[0].steps.iter().any(|step| matches!(
+            step.origin,
+            DerivationOrigin::FromPredicateContribution { .. }
+        )));
+    }
+
+    #[test]
+    fn predicate_does_not_fire_on_a_precision_lost_rhs() {
+        let mut kb = KnowledgeBase::new();
+        kb.add_prior(PriorClause::from_probability(atom("decision"), 0.10))
+            .unwrap();
+        kb.add_fact(Fact::certain(compound("measurement", vec![int(5)])));
+        let threshold = crate::compute("threshold", &ComputeExpr::Lit(0.0), &kb)
+            .unwrap()
+            .with_precision_loss(true);
+        kb.add_derived(threshold);
+        kb.add_predicate_contribution(PredicateContributionClause::from_lr_expr(
+            atom("decision"),
+            "measurement",
+            CmpOp::Ge,
+            ComputeExpr::Ref("threshold".into()),
+            1e6,
+        ));
+
+        let result = lr_aggregate(&atom("decision"), &kb);
+        assert!(approx_eq(result.posterior, 0.10, 1e-12));
     }
 
     #[test]

--- a/code/packages/rust/logic-engine/src/proof_dag.rs
+++ b/code/packages/rust/logic-engine/src/proof_dag.rs
@@ -110,12 +110,18 @@ pub enum DerivationOrigin {
         clause_id: PredicateContributionClauseId,
         /// The valued slot whose observation was compared.
         slot: String,
+        /// The winning observed fact, when the slot came directly from input.
+        observation_fact_id: Option<FactId>,
         /// The comparison operator (`>=`, `<=`, `>`, `<`, `==`).
         op: CmpOp,
         /// The right-hand threshold the clause was written against.
         threshold: f64,
+        /// Exact threshold identity when the evaluator retained one.
+        threshold_exact: Option<crate::compute::ExactRational>,
         /// The observed numeric value read from the valued fact `slot(V)`.
         observed: f64,
+        /// Exact observation identity when the input carried one.
+        observed_exact: Option<crate::compute::ExactRational>,
         /// log(LR) applied because the predicate held. Inline.
         logit_delta: f64,
     },
@@ -299,7 +305,10 @@ pub(crate) fn collect_ids(steps: &[ProofStep]) -> (Vec<FactId>, Vec<RuleId>) {
             // provenance carried inline on the step. They contribute no
             // probabilistic propositional variable to WMC, so they add no
             // FactId here.
-            DerivationOrigin::FromPredicateContribution { .. } => {}
+            DerivationOrigin::FromPredicateContribution {
+                observation_fact_id,
+                ..
+            } => facts.extend(observation_fact_id.iter().copied()),
         }
     }
     facts.sort();

--- a/code/packages/rust/logic-engine/src/verify.rs
+++ b/code/packages/rust/logic-engine/src/verify.rs
@@ -76,7 +76,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use logic_core::{unify, LogicVar, Substitution, Term};
 
 use crate::compute::{compute, ComputeError, DerivationNode, Derived};
-use crate::lr_aggregate::CmpOp;
+use crate::lr_aggregate::{comparison_requires_lossy_fallback, CmpOp};
 use crate::proof_dag::{DerivationOrigin, Proof, ProofStep};
 use crate::provenance::{ContentHash, Provenance, Quote};
 use crate::BodyLiteral;
@@ -373,6 +373,12 @@ pub enum LogicFailure {
     SlotNotObserved(String),
     /// The right-hand side of a predicate-gated clause could not be evaluated.
     ThresholdNotEvaluable,
+    /// A predicate operand crossed a lossy boundary after an exact source, so
+    /// re-running the discrete comparison would manufacture confidence.
+    PredicatePrecisionLoss { slot: String },
+    /// The proof's recorded predicate operands do not match recomputation from
+    /// the current exact input and rule expression.
+    PredicateOperandsDiffer,
     /// The comparison that fired no longer holds on the current observation.
     PredicateDoesNotHold {
         slot: String,
@@ -565,6 +571,14 @@ pub fn verify_quote(prov: &Provenance, snapshots: &dyn SnapshotStore) -> QuoteSt
     }
 }
 
+fn require_both_quotes(primary: QuoteStatus, input: QuoteStatus) -> QuoteStatus {
+    if matches!(input, QuoteStatus::Verified { .. }) {
+        primary
+    } else {
+        input
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Computed-answer verification
 // ---------------------------------------------------------------------------
@@ -663,6 +677,9 @@ fn recheck_derived_recursive(
     if fresh.exact != derived.exact {
         return ComputationStatus::Failed(ComputationFailure::ExactValueDiffers);
     }
+    if fresh.precision_loss && !derived.precision_loss {
+        return ComputationStatus::Failed(ComputationFailure::ArtifactDoesNotMatchPlan);
+    }
     if fresh.dim != derived.dim {
         return ComputationStatus::Failed(ComputationFailure::DimensionDiffers);
     }
@@ -707,7 +724,9 @@ fn recheck_derived_recursive(
         checked.insert(index);
     }
 
-    if has_inexact_narrowing(&fresh.tree) {
+    if derived.precision_loss {
+        ComputationStatus::Unverifiable("precision-lost exact source")
+    } else if has_inexact_narrowing(&fresh.tree) {
         ComputationStatus::Unverifiable("inexact narrowing source")
     } else {
         ComputationStatus::ReChecked
@@ -1149,6 +1168,12 @@ pub fn verify_step(
         DerivationOrigin::FromPredicateContribution {
             clause_id,
             slot,
+            observation_fact_id,
+            op: recorded_op,
+            threshold: recorded_threshold,
+            threshold_exact: recorded_threshold_exact,
+            observed: recorded_observed,
+            observed_exact: recorded_observed_exact,
             logit_delta,
             ..
         } => {
@@ -1165,6 +1190,23 @@ pub fn verify_step(
                 ),
                 Some(clause) => {
                     let prov = Some(clause.provenance.clone());
+                    let current_fact_id = kb
+                        .observed_numerics_all(&clause.slot)
+                        .last()
+                        .map(|(_, fact_id)| *fact_id);
+                    if slot != &clause.slot
+                        || recorded_op != &clause.op
+                        || observation_fact_id != &current_fact_id
+                    {
+                        return StepVerification {
+                            index,
+                            depth: step.depth,
+                            kind: "FromPredicateContribution",
+                            goal: step.goal.clone(),
+                            logic: LogicStatus::Failed(LogicFailure::PredicateOperandsDiffer),
+                            quote: verify_quote(&clause.provenance, snapshots),
+                        };
+                    }
                     // Re-read the observation and re-run the comparison on CPU.
                     // The trail's own `observed` / `threshold` numbers are
                     // deliberately NOT trusted as inputs here — they are the
@@ -1175,19 +1217,59 @@ pub fn verify_step(
                             LogicStatus::Failed(LogicFailure::SlotNotObserved(slot.clone())),
                             prov,
                         ),
-                        Some((observed, observed_exact)) => {
+                        Some(observed) if observed.precision_loss => (
+                            "FromPredicateContribution",
+                            LogicStatus::Failed(LogicFailure::PredicatePrecisionLoss {
+                                slot: slot.clone(),
+                            }),
+                            prov,
+                        ),
+                        Some(observed) => {
                             match compute("__verify_predicate_rhs", &clause.rhs, kb) {
                                 Err(_) => (
                                     "FromPredicateContribution",
                                     LogicStatus::Failed(LogicFailure::ThresholdNotEvaluable),
                                     prov,
                                 ),
+                                Ok(rhs) if rhs.precision_loss => (
+                                    "FromPredicateContribution",
+                                    LogicStatus::Failed(LogicFailure::PredicatePrecisionLoss {
+                                        slot: slot.clone(),
+                                    }),
+                                    prov,
+                                ),
+                                Ok(rhs)
+                                    if comparison_requires_lossy_fallback(
+                                        &observed.exact,
+                                        &rhs.exact,
+                                    ) =>
+                                {
+                                    (
+                                        "FromPredicateContribution",
+                                        LogicStatus::Failed(LogicFailure::PredicatePrecisionLoss {
+                                            slot: slot.clone(),
+                                        }),
+                                        prov,
+                                    )
+                                }
                                 Ok(rhs) => {
-                                    if !clause.op.eval_values(
-                                        observed,
+                                    if !close(*recorded_observed, observed.value)
+                                        || !close(*recorded_threshold, rhs.value)
+                                        || recorded_observed_exact != &observed.exact
+                                        || recorded_threshold_exact != &rhs.exact
+                                    {
+                                        (
+                                            "FromPredicateContribution",
+                                            LogicStatus::Failed(
+                                                LogicFailure::PredicateOperandsDiffer,
+                                            ),
+                                            prov,
+                                        )
+                                    } else if !clause.op.eval_values(
+                                        observed.value,
                                         rhs.value,
-                                        observed_exact,
-                                        rhs.exact,
+                                        observed.exact.clone(),
+                                        rhs.exact.clone(),
                                     ) {
                                         (
                                             "FromPredicateContribution",
@@ -1196,7 +1278,7 @@ pub fn verify_step(
                                                     slot: slot.clone(),
                                                     op: clause.op,
                                                     threshold: rhs.value,
-                                                    observed,
+                                                    observed: observed.value,
                                                 },
                                             ),
                                             prov,
@@ -1211,11 +1293,7 @@ pub fn verify_step(
                                             prov,
                                         )
                                     } else {
-                                        (
-                                            "FromPredicateContribution",
-                                            LogicStatus::ReChecked,
-                                            prov,
-                                        )
+                                        ("FromPredicateContribution", LogicStatus::ReChecked, prov)
                                     }
                                 }
                             }
@@ -1232,6 +1310,16 @@ pub fn verify_step(
         (DerivationOrigin::FromNegation { .. }, _) => QuoteStatus::NotApplicable,
         (_, Some(p)) => verify_quote(p, snapshots),
         (_, None) => QuoteStatus::Unverified(UnverifiedReason::NoProvenance),
+    };
+    let quote = match &step.origin {
+        DerivationOrigin::FromPredicateContribution {
+            observation_fact_id: Some(fact_id),
+            ..
+        } => match kb.fact(*fact_id) {
+            Some(fact) => require_both_quotes(quote, verify_quote(&fact.provenance, snapshots)),
+            None => QuoteStatus::Unverified(UnverifiedReason::NoProvenance),
+        },
+        _ => quote,
     };
 
     StepVerification {

--- a/code/packages/rust/logic-engine/tests/test_verify.rs
+++ b/code/packages/rust/logic-engine/tests/test_verify.rs
@@ -959,3 +959,20 @@ fn a_computed_answer_with_unavailable_source_bytes_is_not_fully_verified() {
     );
     assert!(!report.fully_verified());
 }
+
+#[test]
+fn precision_lost_computation_is_never_fully_verified() {
+    let mut kb = logic_engine::KnowledgeBase::new();
+    let derived = compute("narrowed", &ComputeExpr::Lit(0.0), &kb)
+        .unwrap()
+        .with_precision_loss(true);
+    kb.add_derived(derived);
+    let derived = kb.derived_for("narrowed").unwrap();
+
+    let report = verify_derived(derived, &kb, &NoSnapshots);
+    assert_eq!(
+        report.computation,
+        ComputationStatus::Unverifiable("precision-lost exact source")
+    );
+    assert!(!report.fully_verified());
+}

--- a/code/scripts/adj_stdlib_provenance.py
+++ b/code/scripts/adj_stdlib_provenance.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import base64
 import binascii
+import copy
 import ctypes
 import hashlib
 import html
@@ -894,11 +895,15 @@ def _validate_formula_inventory_value(
         "source_size",
     }:
         raise ProvenanceError("formula parser inventory has unknown or missing fields")
+    contract = (value.get("parser_contract"), value.get("schema_version"))
     if (
         value["kind"] != "formula_parser_inventory"
-        or value["parser_contract"] != "adj-lang/formula_source_map/v1"
+        or contract
+        not in {
+            ("adj-lang/formula_source_map/v1", 1),
+            ("adj-lang/formula_source_map/v2", 2),
+        }
         or not _is_integer(value["schema_version"])
-        or value["schema_version"] != 1
         or value["scope"] != "source_file"
         or _require_hash(
             value["source_sha256"], "formula parser inventory source_sha256"
@@ -915,15 +920,23 @@ def _validate_formula_inventory_value(
         raise ProvenanceError("formula parser inventory formulas must be an array")
     previous_end = 0
     seen_names: set[str] = set()
+    guarded = False
     for index, formula in enumerate(formulas):
         prefix = f"formula parser inventory formulas[{index}]"
-        if not isinstance(formula, dict) or set(formula) != {
+        base_fields = {
             "body",
             "declaration",
             "formula",
             "formulabook",
             "parameters",
             "step_count",
+        }
+        allowed_fields = base_fields | (
+            {"preconditions"} if contract[1] == 2 else set()
+        )
+        if not isinstance(formula, dict) or frozenset(formula) not in {
+            frozenset(base_fields),
+            frozenset(allowed_fields),
         }:
             raise ProvenanceError(f"{prefix} has unknown or missing fields")
         formula_name = _require_nonempty(formula["formula"], f"{prefix}.formula")
@@ -971,6 +984,86 @@ def _validate_formula_inventory_value(
                 f"{prefix} body/declaration containment or parser order disagrees"
             )
         previous_end = declaration_end
+        preconditions = formula.get("preconditions", [])
+        if not isinstance(preconditions, list):
+            raise ProvenanceError(f"{prefix}.preconditions must be an array")
+        if "preconditions" in formula and not preconditions:
+            raise ProvenanceError(
+                f"{prefix}.preconditions must not be empty when present"
+            )
+        guarded = guarded or bool(preconditions)
+        previous_precondition_end = body_end
+        for precondition_index, precondition in enumerate(preconditions):
+            condition_prefix = (
+                f"{prefix}.preconditions[{precondition_index}]"
+            )
+            if not isinstance(precondition, dict) or set(precondition) != {
+                "arguments",
+                "declaration",
+                "predicate",
+            }:
+                raise ProvenanceError(
+                    f"{condition_prefix} has unknown or missing fields"
+                )
+            _require_nonempty(
+                precondition["predicate"], f"{condition_prefix}.predicate"
+            )
+            declaration = precondition["declaration"]
+            if not isinstance(declaration, dict) or set(declaration) != {
+                "end",
+                "sha256",
+                "start",
+            }:
+                raise ProvenanceError(
+                    f"{condition_prefix}.declaration has the wrong schema"
+                )
+            condition_start = declaration["start"]
+            condition_end = declaration["end"]
+            if (
+                not _is_integer(condition_start)
+                or not _is_integer(condition_end)
+                or condition_start < previous_precondition_end
+                or condition_end <= condition_start
+                or condition_end > declaration_end
+                or _require_hash(
+                    declaration["sha256"],
+                    f"{condition_prefix}.declaration.sha256",
+                )
+                != sha256_bytes(source[condition_start:condition_end])
+            ):
+                raise ProvenanceError(
+                    f"{condition_prefix}.declaration byte span disagrees"
+                )
+            arguments = precondition["arguments"]
+            if not isinstance(arguments, list):
+                raise ProvenanceError(f"{condition_prefix}.arguments must be an array")
+            for argument_index, argument in enumerate(arguments):
+                argument_prefix = (
+                    f"{condition_prefix}.arguments[{argument_index}]"
+                )
+                if not isinstance(argument, dict) or set(argument) != {
+                    "end",
+                    "sha256",
+                    "start",
+                }:
+                    raise ProvenanceError(f"{argument_prefix} has the wrong schema")
+                argument_start = argument["start"]
+                argument_end = argument["end"]
+                if (
+                    not _is_integer(argument_start)
+                    or not _is_integer(argument_end)
+                    or argument_start < condition_start
+                    or argument_end <= argument_start
+                    or argument_end > condition_end
+                    or _require_hash(
+                        argument["sha256"], f"{argument_prefix}.sha256"
+                    )
+                    != sha256_bytes(source[argument_start:argument_end])
+                ):
+                    raise ProvenanceError(f"{argument_prefix} byte span disagrees")
+            previous_precondition_end = condition_end
+    if contract[1] == 2 and not guarded:
+        raise ProvenanceError("formula parser inventory v2 must contain a precondition")
 
 
 def put_formula_parser_inventory(
@@ -2864,13 +2957,17 @@ def _formula_reference(
     identity: Any,
     formula_bundles: list[tuple[str, dict[str, Any]]],
 ) -> tuple[dict[str, Any], set[str]]:
-    if not isinstance(identity, dict) or set(identity) != {
+    base_fields = {
         "body",
         "declaration",
         "formulabook",
         "name",
         "parameters",
         "source_sha256",
+    }
+    if not isinstance(identity, dict) or frozenset(identity) not in {
+        frozenset(base_fields),
+        frozenset(base_fields | {"preconditions"}),
     }:
         raise ProvenanceError("formula audit export identity has the wrong schema")
     source_hash = _require_hash(identity["source_sha256"], "formula identity source")
@@ -2887,6 +2984,8 @@ def _formula_reference(
                 and formula["formulabook"] == identity["formulabook"]
                 and formula["formula"] == identity["name"]
                 and formula["parameters"] == identity["parameters"]
+                and formula.get("preconditions", [])
+                == identity.get("preconditions", [])
             ):
                 matches.append((bundle_hash, bundle, inventory_hash, formula))
     if len(matches) != 1:
@@ -2913,6 +3012,8 @@ def _formula_reference(
         "source_ir_sha256": source_ir_hash,
         "source_sha256": source_hash,
     }
+    if identity.get("preconditions"):
+        reference["preconditions"] = identity["preconditions"]
     return reference, {
         bundle_hash,
         inventory_hash,
@@ -3074,6 +3175,15 @@ def _normalized_formula_evidence(
     legacy_input_references: bool = False,
 ) -> list[tuple[dict[str, Any], set[str], dict[str, Any], set[str]]]:
     by_source, formula_bundles = _execution_graph(cas, query_bundle)
+    for _bundle_hash, bundle in formula_bundles:
+        inventory = _json_object(
+            cas, bundle["formula_inventory_sha256"], "formula_parser_inventory"
+        )
+        if any(formula.get("preconditions") for formula in inventory["formulas"]):
+            raise ProvenanceError(
+                "guarded formula execution evidence requires a versioned "
+                "precondition witness contract"
+            )
     imports: list[dict[str, Any]] = []
     import_links: set[str] = set()
     for item in audit["imports"]:
@@ -3252,6 +3362,8 @@ def _normalized_formula_evidence(
             "parameters": formula["parameters"],
             "source_sha256": inventory["source_sha256"],
         }
+        if formula.get("preconditions"):
+            identity["preconditions"] = formula["preconditions"]
         reference, _links = _formula_reference(cas, identity, formula_bundles)
         if reference["bundle_sha256"] != direct_bundle_hash or reference["inventory_sha256"] != inventory_hash:
             raise ProvenanceError("direct parser export resolves outside its formula bundle")
@@ -3315,6 +3427,25 @@ def _validate_formula_execution_evidence(
     audit = _materialize_formula_audit(cas, query_bundle, audit_command)
     expected = _normalized_formula_evidence(cas, query_bundle, audit)
 
+    def legacy_v1_projection(
+        items: list[tuple[dict[str, Any], set[str], dict[str, Any], set[str]]],
+    ) -> list[tuple[dict[str, Any], set[str], dict[str, Any], set[str]]]:
+        """Project additive audit fields away for immutable pre-extension v1 bytes."""
+
+        def project_plan(expression: dict[str, Any]) -> None:
+            if expression.get("kind") == "exact_literal":
+                expression.pop("exact_rational", None)
+                expression["kind"] = "literal"
+            for key in ("left", "right", "expression"):
+                child = expression.get(key)
+                if isinstance(child, dict):
+                    project_plan(child)
+
+        projected = copy.deepcopy(items)
+        for derivation, _derivation_links, _witness, _witness_links in projected:
+            project_plan(derivation["plan"]["expression"])
+        return projected
+
     def expected_hashes(
         items: list[tuple[dict[str, Any], set[str], dict[str, Any], set[str]]],
     ) -> tuple[list[str], list[str]]:
@@ -3330,20 +3461,29 @@ def _validate_formula_execution_evidence(
             witnesses.append(sha256_bytes(canonical_json_bytes(normalized_witness)))
         return derivations, witnesses
 
-    expected_derivations, expected_witnesses = expected_hashes(expected)
-    if (
-        sorted(expected_derivations) != stored_derivations
-        or sorted(expected_witnesses) != stored_witnesses
-    ) and allow_migration_input_references:
-        expected = _normalized_formula_evidence(
+    candidates = [expected, legacy_v1_projection(expected)]
+    if allow_migration_input_references:
+        legacy_inputs = _normalized_formula_evidence(
             cas, query_bundle, audit, legacy_input_references=True
         )
-        expected_derivations, expected_witnesses = expected_hashes(expected)
-    if (
-        sorted(expected_derivations) != stored_derivations
-        or sorted(expected_witnesses) != stored_witnesses
-    ):
+        candidates.extend((legacy_inputs, legacy_v1_projection(legacy_inputs)))
+
+    selected = None
+    expected_derivations: list[str] = []
+    expected_witnesses: list[str] = []
+    for candidate in candidates:
+        candidate_derivations, candidate_witnesses = expected_hashes(candidate)
+        if (
+            sorted(candidate_derivations) == stored_derivations
+            and sorted(candidate_witnesses) == stored_witnesses
+        ):
+            selected = candidate
+            expected_derivations = candidate_derivations
+            expected_witnesses = candidate_witnesses
+            break
+    if selected is None:
         raise ProvenanceError("stored formula evidence set disagrees with replay")
+    expected = selected
 
     expected_links: set[str] = set()
     for (

--- a/code/scripts/tests/test_adj_stdlib_provenance.py
+++ b/code/scripts/tests/test_adj_stdlib_provenance.py
@@ -3994,6 +3994,107 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                     inventory, provenance.sha256_bytes(source), source
                 )
 
+    def test_formula_inventory_v2_binds_precondition_bytes(self) -> None:
+        source = (
+            b"formulabook guarded {\n"
+            b'  formula divide(a, b) = a / b requires nonzero(b) source "s" trust authoritative\n'
+            b"}\n"
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "guarded.adj"
+            path.write_bytes(source)
+            inventory = provenance._run_formula_inventory(
+                self.formula_inventory_command(), path
+            )
+            provenance._validate_formula_inventory_value(
+                inventory, provenance.sha256_bytes(source), source
+            )
+            self.assertEqual(inventory["schema_version"], 2)
+            self.assertEqual(
+                inventory["parser_contract"], "adj-lang/formula_source_map/v2"
+            )
+            condition = inventory["formulas"][0]["preconditions"][0]
+            self.assertEqual(condition["predicate"], "nonzero")
+            tampered = deepcopy(inventory)
+            tampered["formulas"][0]["preconditions"][0]["declaration"][
+                "sha256"
+            ] = "0" * 64
+            with self.assertRaisesRegex(
+                provenance.ProvenanceError,
+                "preconditions\\[0\\].declaration byte span disagrees",
+            ):
+                provenance._validate_formula_inventory_value(
+                    tampered, provenance.sha256_bytes(source), source
+                )
+
+            empty = deepcopy(inventory)
+            empty["formulas"][0]["preconditions"] = []
+            with self.assertRaisesRegex(
+                provenance.ProvenanceError,
+                "preconditions must not be empty when present",
+            ):
+                provenance._validate_formula_inventory_value(
+                    empty, provenance.sha256_bytes(source), source
+                )
+
+    def test_guarded_formula_execution_evidence_fails_closed_until_v2_witness(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            cas = provenance.Cas(Path(directory) / "cas")
+            inventory_hash = cas.put_json(
+                {
+                    "formulas": [
+                        {
+                            "body": {"end": 2, "sha256": "1" * 64, "start": 1},
+                            "declaration": {
+                                "end": 3,
+                                "sha256": "2" * 64,
+                                "start": 0,
+                            },
+                            "formula": "guarded",
+                            "formulabook": "demo",
+                            "parameters": ["x"],
+                            "preconditions": [
+                                {
+                                    "arguments": [
+                                        {"end": 2, "sha256": "3" * 64, "start": 1}
+                                    ],
+                                    "declaration": {
+                                        "end": 3,
+                                        "sha256": "4" * 64,
+                                        "start": 0,
+                                    },
+                                    "predicate": "nonzero",
+                                }
+                            ],
+                            "step_count": 0,
+                        }
+                    ],
+                    "kind": "formula_parser_inventory",
+                    "parser_contract": "adj-lang/formula_source_map/v2",
+                    "schema_version": 2,
+                    "scope": "source_file",
+                    "source_sha256": "5" * 64,
+                    "source_size": 3,
+                },
+                kind="formula_parser_inventory",
+                label="guarded fixture inventory",
+            )
+            formula_bundle = {
+                "formula_inventory_sha256": inventory_hash,
+            }
+            with (
+                mock.patch.object(
+                    provenance,
+                    "_execution_graph",
+                    return_value=({}, [("6" * 64, formula_bundle)]),
+                ),
+                self.assertRaisesRegex(
+                    provenance.ProvenanceError,
+                    "guarded formula execution evidence requires",
+                ),
+            ):
+                provenance._normalized_formula_evidence(cas, {}, {})
+
     def test_formula_execution_replay_requires_the_audit_binary(self) -> None:
         cas_root = formula_inventory_migration.REPO_ROOT / provenance.DEFAULT_ROOT
         manifest_path = formula_inventory_migration.REPO_ROOT / provenance.DEFAULT_MANIFEST

--- a/code/specs/ADJ-STDLIB-COVERAGE.md
+++ b/code/specs/ADJ-STDLIB-COVERAGE.md
@@ -316,9 +316,27 @@ option mapping, or judge/evaluation failure.
    PDF decomposition, explicit zero/negative-baseline policy review,
    repository-input IR, parser inventory, derivations, witnesses, and CAS
    registration remain part of the Wave 1 migration.
-9. Add executable formula preconditions or domain guards before migrating
-   `proportion.adj`; `a/b=c/x` requires nonzero `a`, `b`, and `c`, while the
-   current formula fails closed only on its final divisor.
+9a. **Complete for the language/runtime guard substrate:** formulas now support generic,
+   parser-backed `requires` predicates with exact byte spans, recursive execution,
+   typed validation, structured abstention, runtime consumed-fact IDs, and v2
+   parser inventory identity with source-byte spans.
+   `proportion.adj` requires nonzero `a`, `b`, and `c`, and E2E coverage proves
+   each zero position withholds the answer before body evaluation. CAS migration
+   remains separate until the worked query's observed inputs receive source IR.
+9b. Add versioned formula-audit guard outcomes and CAS execution witnesses that
+    independently replay both passed and failed guards, exact compared values,
+    consumed facts, guard source spans, and the presence or absence of the body
+    result. Every consumed fact must bind a stable owner source, source-IR claim,
+    and exact observation-byte span rather than relying on a runtime `FactId`.
+    The v2 contract must also encode exact-literal plans directly; v1 compatibility
+    must be selected by the declared contract rather than heuristic projection.
+    Guarded formulas must not migrate to CAS before this lands.
+9c. Bind predicate contributions over derived slots to their computation IDs,
+    transitive input facts, formula sources, and `verify_derived` results. Direct
+    observed predicate inputs are fact-bound and quote-checked now; derived inputs
+    must not claim equivalent byte completeness until this transitive proof lands.
+9d. Replace state-machine failure detail strings with a structured error
+    discriminant and typed phase on both guard and yield precision failures.
 10. Use the first-class derivation and execution-witness contract to execute every
     exported formula before migrating `average.adj`; prose cannot prove its `N=2`
     and `N=3` specializations.

--- a/code/specs/data/adj-formula-stdlib/arithmetic/proportion.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/proportion.adj
@@ -60,7 +60,10 @@ dictionary proportion_vocab {
 % The composed formula. For the proportion `a/b = c/x` (first/second = third/x),
 % the rule of three gives x = (b·c)/a. The body is a formula CALLING two cited
 % primitives: `product(second_term, third_term)` forms b·c, and `quotient(…,
-% first_term)` divides it by a. The engine resolves both applications on the
+% first_term)` divides it by a. The original relation and its solved form are
+% defined only when all three supplied terms are nonzero, so executable domain
+% requirements stop evaluation before denominator cancellation can fabricate 0.
+% The engine resolves both applications on the
 % CPU and carries their citations alongside this one. `fourth_proportional`
 % asserts its own claim about the world (how a missing proportional is found)
 % and so carries its own required source.
@@ -69,7 +72,8 @@ formulabook proportions {
     use proportion_vocab
 
     formula fourth_proportional(first_term, second_term, third_term) = quotient(product(second_term, third_term), first_term)
-        source "For an equation of the form a/b = c/x, where the variable to be evaluated is in the right-hand denominator, the rule of three states that x = bc/a."
-        locator "https://en.wikipedia.org/wiki/Cross-multiplication"
-        trust consensus
+        requires nonzero(first_term), nonzero(second_term), nonzero(third_term)
+        source "OpenStax defines a proportion a/b = c/x only where b and x are nonzero. Solving x = bc/a additionally requires nonzero a; with nonzero a and b, requiring nonzero c keeps the computed denominator x nonzero."
+        locator "https://openstax.org/books/prealgebra-2e/pages/6-5-solve-proportions-and-their-applications"
+        trust inferred
 }

--- a/code/specs/data/adj-formula-stdlib/arithmetic/proportion.query.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/proportion.query.adj
@@ -21,11 +21,10 @@ observe third_term(4)
 ? fourth_proportional(first_term, second_term, third_term)
 
 % ----------------------------------------------------------------------------
-% Honest edge case — a degenerate proportion 0/b = c/x has NO finite fourth
-% proportional (the rule of three would divide by zero). The formula makes no
-% special claim here; it applies the cited `quotient`, which REFUSES to divide by
-% zero. The engine returns a DivisionByZero error rather than inventing a value —
-% honest abstention, not a fabricated answer. (Uncomment to see it.)
+% Honest edge case — every supplied term must be nonzero for `a/b = c/x` and
+% its solved form to share a valid domain. The formula checks those requirements
+% before evaluating its body and returns a structured `precondition_failed`
+% abstention rather than inventing a value. (Uncomment to see it.)
 % ----------------------------------------------------------------------------
 % observe first_term(0)
 % ? fourth_proportional(first_term, second_term, third_term)

--- a/code/specs/data/adj-stdlib-provenance/manifest.schema.json
+++ b/code/specs/data/adj-stdlib-provenance/manifest.schema.json
@@ -264,6 +264,16 @@
         {
           "additionalProperties": false,
           "properties": {
+            "exact_rational": { "$ref": "#/$defs/formula_rational" },
+            "f64_bits": { "$ref": "#/$defs/f64_bits" },
+            "kind": { "const": "exact_literal" }
+          },
+          "required": ["exact_rational", "f64_bits", "kind"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
             "kind": { "const": "reference" },
             "name": { "minLength": 1, "type": "string" }
           },
@@ -379,6 +389,7 @@
         "formulabook": { "minLength": 1, "type": "string" },
         "inventory_sha256": { "$ref": "#/$defs/hash" },
         "parameters": { "items": { "minLength": 1, "type": "string" }, "type": "array" },
+        "preconditions": { "items": { "$ref": "#/$defs/formula_precondition" }, "minItems": 1, "type": "array" },
         "snapshot_sha256": { "$ref": "#/$defs/hash" },
         "source_ir_sha256": { "$ref": "#/$defs/hash" },
         "source_sha256": { "$ref": "#/$defs/hash" }
@@ -404,6 +415,26 @@
     "formula_rounding_mode": { "enum": ["down", "up", "floor", "ceiling", "half_up", "half_down", "half_even"] },
     "formula_parser_inventory": {
       "additionalProperties": false,
+      "allOf": [
+        {
+          "if": { "properties": { "parser_contract": { "const": "adj-lang/formula_source_map/v1" } }, "required": ["parser_contract"] },
+          "then": {
+            "properties": {
+              "formulas": { "items": { "not": { "required": ["preconditions"] } } },
+              "schema_version": { "const": 1 }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "parser_contract": { "const": "adj-lang/formula_source_map/v2" } }, "required": ["parser_contract"] },
+          "then": {
+            "properties": {
+              "formulas": { "contains": { "required": ["preconditions"] } },
+              "schema_version": { "const": 2 }
+            }
+          }
+        }
+      ],
       "properties": {
         "formulas": {
           "items": {
@@ -414,6 +445,7 @@
               "formula": { "minLength": 1, "type": "string" },
               "formulabook": { "minLength": 1, "type": "string" },
               "parameters": { "items": { "minLength": 1, "type": "string" }, "type": "array" },
+              "preconditions": { "items": { "$ref": "#/$defs/formula_precondition" }, "minItems": 1, "type": "array" },
               "step_count": { "minimum": 0, "type": "integer" }
             },
             "required": ["body", "declaration", "formula", "formulabook", "parameters", "step_count"],
@@ -422,13 +454,23 @@
           "type": "array"
         },
         "kind": { "const": "formula_parser_inventory" },
-        "parser_contract": { "const": "adj-lang/formula_source_map/v1" },
-        "schema_version": { "const": 1 },
+        "parser_contract": { "enum": ["adj-lang/formula_source_map/v1", "adj-lang/formula_source_map/v2"] },
+        "schema_version": { "enum": [1, 2] },
         "scope": { "const": "source_file" },
         "source_sha256": { "$ref": "#/$defs/hash" },
         "source_size": { "maximum": 67108864, "minimum": 0, "type": "integer" }
       },
       "required": ["formulas", "kind", "parser_contract", "schema_version", "scope", "source_sha256", "source_size"],
+      "type": "object"
+    },
+    "formula_precondition": {
+      "additionalProperties": false,
+      "properties": {
+        "arguments": { "items": { "$ref": "#/$defs/formula_span" }, "type": "array" },
+        "declaration": { "$ref": "#/$defs/formula_span" },
+        "predicate": { "minLength": 1, "type": "string" }
+      },
+      "required": ["arguments", "declaration", "predicate"],
       "type": "object"
     },
     "formula_span": {


### PR DESCRIPTION
## Summary
- add generic formula `requires` predicates with parser-backed ASTs, exact source spans, typed failures, and structured abstentions
- preserve exact numeric identity through formula evaluation, predicate proofs, verification, state-machine execution, and constraint solving so precision loss fails closed
- migrate `proportion.adj` to authoritative OpenStax provenance and require nonzero `a`, `b`, and `c`, with zero-domain E2E coverage
- version guarded formula inventory records while keeping legacy v1 records byte-identical
- record follow-up backlog items for CAS guard witnesses (9b), transitive derived-predicate evidence (9c), and richer state-machine failure discriminants (9d)

## Evidence boundary
This PR completes backlog 9a: the generic language/runtime substrate and the first guarded stdlib migration. Guarded formula CAS normalization and formula audit remain deliberately fail-closed until versioned positive/negative guard witnesses land in 9b. It does not claim that witness migration is complete.

## Validation
- `cargo test -p logic-engine -p adj-lang -p adj-constraint-solver -p adj-lang-cli --no-fail-fast`
- `cargo test -p adj-lang-cli --test fl4_proportion_e2e` after the final rebase
- `python -m unittest tests.test_adj_stdlib_provenance` (190 tests, 7 skipped)
- live CAS validation: 6 bundles, 84 objects, 9 snapshots, valid
- coverage manifest: 6 roots, 10 objectives, no errors, valid
- Ruff
- `git diff --check`