### PR TITLE
fix(spice): lower diode series resistance

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower finite, non-negative diode model-card `RS` series resistance.
 - Validate positive finite diode model-card `IBV` breakdown current.
 - Validate positive finite diode model-card `BV` breakdown voltage.
 - Validate positive finite diode model-card `N` emission coefficient.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1274,6 +1274,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
                 "CJO", model.params.get("CJ", model.params.get("CJ0", 0.0))
             ),
             Tt=model.params.get("TT", 0.0),
+            Rs=model.params.get("RS", 0.0),
         )
     if prefix == "Q":
         _require_fields(fields, 5, "BJT")
@@ -1957,6 +1958,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(transit_time) or transit_time < 0.0
         ):
             raise NetlistParseError("diode TT must be finite and non-negative")
+        series_resistance = params.get("RS")
+        if series_resistance is not None and (
+            not math.isfinite(series_resistance) or series_resistance < 0.0
+        ):
+            raise NetlistParseError("diode RS must be finite and non-negative")
     if kind in {"NPN", "PNP"}:
         saturation_current = params.get("IS")
         if saturation_current is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -756,7 +756,7 @@ Rload out 0 500
 def test_parse_diode_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """
-.model fast D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u CJO=2p TT=4n)
+.model fast D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u CJO=2p TT=4n RS=3)
 V1 in 0 DC 0.7
 D1 in out fast
 Rload out 0 1k
@@ -776,6 +776,7 @@ Rload out 0 1k
                 "IBV": 1.0e-6,
                 "CJO": 2.0e-12,
                 "TT": 4.0e-9,
+                "RS": 3.0,
             },
         )
     }
@@ -790,6 +791,7 @@ Rload out 0 1k
     assert diode.IBV == 1.0e-6
     assert diode.Cjo == 2.0e-12
     assert diode.Tt == 4.0e-9
+    assert diode.Rs == 3.0
 
     result = dc_op(parsed.circuit)
     assert result.converged
@@ -889,6 +891,23 @@ def test_rejects_invalid_diode_breakdown_current(value: str) -> None:
         NetlistParseError, match="diode IBV must be finite and positive"
     ):
         parse_netlist(f".model clamp D(IBV={value})")
+
+
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("2.5", 2.5)])
+def test_accepts_valid_diode_series_resistance(value: str, expected: float) -> None:
+    parsed = parse_netlist(f".model clamp D(RS={value})\nD1 in out clamp")
+
+    diode = parsed.circuit.elements[0]
+    assert isinstance(diode, Diode)
+    assert expected == diode.Rs
+
+
+@pytest.mark.parametrize("value", ["-1", "1e999"])
+def test_rejects_invalid_diode_series_resistance(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="diode RS must be finite and non-negative"
+    ):
+        parse_netlist(f".model clamp D(RS={value})")
 
 
 def test_parse_diode_junction_capacitance_alias() -> None:

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower finite, non-negative diode model-card `RS` series resistance.
 - Validate positive finite diode model-card `IBV` breakdown current.
 - Validate positive finite diode model-card `BV` breakdown voltage.
 - Validate positive finite diode model-card `N` emission coefficient.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1207,6 +1207,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("diode TT must be finite and non-negative");
   }
+  const diodeSeriesResistance = params.get("RS");
+  if (
+    kind === "D" &&
+    diodeSeriesResistance !== undefined &&
+    (!Number.isFinite(diodeSeriesResistance) || diodeSeriesResistance < 0.0)
+  ) {
+    throw new NetlistParseError("diode RS must be finite and non-negative");
+  }
   const bjtForwardBeta =
     params.get("BF") ??
     params.get("BETA") ??
@@ -1780,18 +1788,21 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
         `model ${JSON.stringify(model.name)} has kind ${JSON.stringify(model.kind)}, expected "D"`,
       );
     }
-    return diode(
-      name,
-      fields[1],
-      fields[2],
-      model.params.get("IS") ?? model.params.get("JS") ?? 1.0e-15,
-      model.params.get("VT") ?? model.params.get("V_T") ?? 0.02585,
-      model.params.get("N") ?? 1.0,
-      model.params.get("BV"),
-      model.params.get("IBV") ?? 1.0e-3,
-      model.params.get("CJO") ?? model.params.get("CJ") ?? model.params.get("CJ0") ?? 0.0,
-      model.params.get("TT") ?? 0.0,
-    );
+    return {
+      ...diode(
+        name,
+        fields[1],
+        fields[2],
+        model.params.get("IS") ?? model.params.get("JS") ?? 1.0e-15,
+        model.params.get("VT") ?? model.params.get("V_T") ?? 0.02585,
+        model.params.get("N") ?? 1.0,
+        model.params.get("BV"),
+        model.params.get("IBV") ?? 1.0e-3,
+        model.params.get("CJO") ?? model.params.get("CJ") ?? model.params.get("CJ0") ?? 0.0,
+        model.params.get("TT") ?? 0.0,
+      ),
+      seriesResistance: model.params.get("RS") ?? 0.0,
+    };
   }
   if (prefix === "Q") {
     requireFields(fields, 5, "BJT");

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -736,7 +736,7 @@ Rload out 0 500
 
   it("parses diode models into operating-point circuits", () => {
     const parsed = parseNetlist(`
-.model fast D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u CJO=2p TT=4n)
+.model fast D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u CJO=2p TT=4n RS=3)
 V1 in 0 DC 0.7
 D1 in out fast
 Rload out 0 1k
@@ -754,6 +754,7 @@ Rload out 0 1k
         ["IBV", 1.0e-6],
         ["CJO", 2.0e-12],
         ["TT", 4.0e-9],
+        ["RS", 3.0],
       ]),
     });
     expect(parsed.circuit.elements()[1]).toMatchObject({
@@ -768,6 +769,7 @@ Rload out 0 1k
       breakdownCurrent: 1.0e-6,
       junctionCapacitance: 2.0e-12,
       transitTime: 4.0e-9,
+      seriesResistance: 3.0,
     });
 
     const result = dcOp(parsed.circuit);
@@ -922,6 +924,24 @@ D1 in out clamp
   it.each(["0", "-1u", "1e999"])("rejects invalid diode IBV %s", (value) => {
     expect(() => parseNetlist(`.model clamp D(IBV=${value})`)).toThrow(
       "diode IBV must be finite and positive",
+    );
+  });
+
+  it.each([
+    ["0", 0.0],
+    ["2.5", 2.5],
+  ])("accepts valid diode RS series resistance %s", (value, expected) => {
+    const parsed = parseNetlist(`.model clamp D(RS=${value})\nD1 in out clamp`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "diode",
+      seriesResistance: expected,
+    });
+  });
+
+  it.each(["-1", "1e999"])("rejects invalid diode RS %s", (value) => {
+    expect(() => parseNetlist(`.model clamp D(RS=${value})`)).toThrow(
+      "diode RS must be finite and non-negative",
     );
   });
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4399,17 +4399,21 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine diode breakdown-voltage field.
 
 416. Python and TypeScript Berkeley SPICE diode breakdown-current validation parity.
-   - Status: completed in this diode breakdown-current validation slice.
+   - Status: completed in PR 9809.
    - Both parser facades validate positive finite `IBV` values before lowering
      them into the shared engine diode breakdown-current field.
+
+417. Python and TypeScript Berkeley SPICE diode series-resistance parity.
+   - Status: completed in this diode series-resistance parity slice.
+   - Both parser facades validate finite non-negative `RS` values and lower
+     them into the shared engine diode series-resistance field.
 
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE model-card validation parity.
-   - Audit remaining diode model-card parameters that require new lowering
-     surfaces, starting with finite non-negative series resistance `RS`, then
-     junction potential `VJ`, grading coefficient `M`, and depletion
-     coefficient `FC`.
+   - Continue the audited diode model-card lowering surfaces with junction
+     potential `VJ`, grading coefficient `M`, and depletion coefficient `FC`,
+     followed by `XTI`, `EG`, `KF`, and `AF` validation and lowering parity.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary
- validate finite, non-negative diode model-card `RS` values in Python and TypeScript
- lower valid `RS` values into the existing engine diode series-resistance field
- add cross-language coverage and update the SPICE completion backlog

## Verification
- Python `spice-netlist-parser`: `bash BUILD` (313 tests), Ruff clean
- TypeScript `spice-engine`: `bash BUILD` (448 tests)
- TypeScript `spice-netlist-parser`: `bash BUILD` (302 tests)
- TypeScript parser coverage: 86.1% lines