### PR TITLE
fix(human-languages): make Telugu book warning-free

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -83,7 +83,7 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B12 | Complete (#9705) | Publish Bengali Chapter 6 from its canonical lesson rather than hand-copying another book chapter. | The schema-v2 lesson now generates the PDF chapter from the same source hash independently verified by Language Ladder. |
 | HL-B13 | Complete (#9711) | Remove Bengali's missing glyphs and LaTeX layout/bookmark warnings. | Main-font punctuation, stable recap labels, bookmark-safe Bengali, natural page bottoms, explicit static-font shapes, and a breakable long title make the forced six-chapter build warning-free. |
 | HL-I01 | Complete (#9715) | Reduce unified all-books workflow setup time without splitting the single publication bundle. | A focused, preflighted XeLaTeX dependency closure replaces `texlive-full`; the unchanged job still builds all 20 books, verifies one bundle, and publishes that bundle from `main`. |
-| HL-I02 | Queued | Update the human-language data package beyond the vulnerable PostCSS 8.5.19 transitive development dependency. | A clean install reports GHSA-fxqj-rqcc-2cmp through Vitest/Vite; PostCSS 8.5.25 is available, but this development-only moderate finding ranks behind HL-B23's reader-facing Telugu publication cleanup. |
+| HL-I02 | Queued | Update the human-language data package beyond the vulnerable PostCSS 8.5.19 transitive development dependency. | A clean install reports GHSA-fxqj-rqcc-2cmp through Vitest/Vite; PostCSS 8.5.25 is available, but this development-only moderate finding remains behind reader-facing book and app gaps. |
 | HL-B14 | Complete (#9728) | Publish Italian Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Forty-nine schema-v2 lessons now generate sixteen chapters whose source hashes are independently verified against the Language Ladder corpus. |
 | HL-B15 | Complete (#9735) | Remove Italian's LaTeX layout and Unicode bookmark warnings. | The forced 104-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
 | HL-B16 | Complete (#9744) | Publish Portuguese Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Fifty schema-v2 lessons now generate sixteen chapters whose source hashes are independently verified against the Language Ladder corpus. |
@@ -92,9 +92,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B19 | Complete (#9761) | Remove French's LaTeX layout and Unicode bookmark warnings. | The forced 98-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
 | HL-B20 | Complete (#9765) | Publish German Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | Ten schema-v2 lessons now generate seven chapters whose source hashes are independently verified against the Language Ladder corpus. |
 | HL-B21 | Complete (#9779) | Remove German's LaTeX layout and Unicode bookmark warnings. | The forced 104-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
-| HL-B22 | Complete in this PR | Publish Telugu Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | Thirty schema-v2 lessons now generate twenty-six chapters whose source hashes are independently verified against the Language Ladder corpus. |
-| HL-B23 | Next | Remove Telugu's LaTeX layout, duplicate-label, bookmark, and font warnings. | The expanded forced build has no missing glyphs or underfull horizontal boxes but reports eleven overfull boxes, nine underfull vertical boxes, four duplicate practice labels, 104 Hyperref warnings, and nine font warnings; visual inspection found no clipping, but the clean-build signal is zero of each. |
-| HL-B24 | Queued | Publish Kannada Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Kannada PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
+| HL-B22 | Complete (#9803) | Publish Telugu Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | Thirty schema-v2 lessons now generate twenty-six chapters whose source hashes are independently verified against the Language Ladder corpus. |
+| HL-B23 | Complete in this PR | Remove Telugu's LaTeX layout, duplicate-label, bookmark, and font warnings. | The forced 95-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings. |
+| HL-B24 | Next | Publish Kannada Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Kannada PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
 | HL-B25 | Queued | Remove Kannada's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports four overfull boxes, five underfull boxes, four duplicate practice labels, 30 Hyperref warnings, and undefined bold/italic Kannada font shapes; the clean-build signal is zero of each. |
 | HL-B26 | Queued | Publish Malayalam Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Malayalam PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
 | HL-B27 | Queued | Remove Malayalam's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports seven overfull boxes, eight underfull boxes, four duplicate practice labels, 28 Hyperref warnings, and undefined bold/italic Malayalam font shapes; the clean-build signal is zero of each. |
@@ -730,7 +730,30 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - A clean data-package install surfaced the moderate, development-only
   GHSA-fxqj-rqcc-2cmp advisory through Vitest, Vite, and PostCSS 8.5.19. A
   non-breaking 8.5.25 resolution is available; HL-I02 records the lockfile
-  maintenance, behind the reader-facing Telugu build cleanup in HL-B23.
+  maintenance behind the remaining reader-facing book and app gaps.
+
+## Findings from HL-B23
+
+- Explicit regular, bold, italic, and bold-italic faces for every vendored
+  comparison font remove nine substitution warnings while keeping Telugu,
+  Tamil, Kannada, Malayalam, Devanagari, and Arabic-script examples available.
+- Bookmark-safe definitions preserve the visible script while removing font
+  presentation commands from PDF strings. All 104 Hyperref warnings disappear,
+  and the outline retains Preface, the script reference, and Chapters 1–31.
+- Five legacy practice sections now have chapter-specific labels. `\raggedbottom`
+  makes natural micro-lesson page endings explicit, removing four duplicate
+  destinations and nine underfull vertical boxes without adding filler.
+- Concise visible headings, one responsive table, a three-part month list, and
+  a shorter Chapter 20 title remove eleven overfull lines while preserving every
+  vocabulary item, grammar explanation, comparison, and etymology in the body.
+- Full-page review caught a long Section 4.4 running header touching its page
+  number even after the build log was clean. A prose-only running title fixes
+  that collision while retaining the complete Telugu heading in the lesson.
+- A forced XeLaTeX build produces 95 pages with zero missing glyphs, overfull or
+  underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings,
+  or font warnings. All pages were rendered and inspected; metadata, 33
+  top-level bookmarks, 93 total outline entries, and generator-leak checks pass.
+- HL-B24 is next: publish Kannada Chapters 6–31 from canonical lessons.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -492,7 +492,7 @@
     {
       "language": "telugu",
       "chapter": 20,
-      "title": "Numbers Eleven to Twenty and Weather",
+      "title": "Numbers 11–20 and Weather",
       "label": "ch:te-numbers-and-weather",
       "output": "telugu/book/chapters/ch20-numbers-and-weather.tex",
       "scriptSet": "telugu-comparisons"

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -640,7 +640,7 @@
     {
       "language": "telugu",
       "chapter": 6,
-      "sourceHash": "fnv1a64:6cb5796cbafe9026",
+      "sourceHash": "fnv1a64:a0d2c6d28e4fa358",
       "lessonIds": [
         "TE-C06-dative-ku",
         "TE-C06-dative-subject"
@@ -669,7 +669,7 @@
     {
       "language": "telugu",
       "chapter": 9,
-      "sourceHash": "fnv1a64:a59621bd41d42067",
+      "sourceHash": "fnv1a64:012d9dd03b6465c1",
       "lessonIds": [
         "TE-C09-kshaminchandi"
       ],
@@ -696,7 +696,7 @@
     {
       "language": "telugu",
       "chapter": 12,
-      "sourceHash": "fnv1a64:21fe8857abf3df9c",
+      "sourceHash": "fnv1a64:54fc86cc71a291ff",
       "lessonIds": [
         "TE-C12-kutumbam"
       ],
@@ -705,7 +705,7 @@
     {
       "language": "telugu",
       "chapter": 13,
-      "sourceHash": "fnv1a64:83368e6f6cac4154",
+      "sourceHash": "fnv1a64:1debf26c0657eade",
       "lessonIds": [
         "TE-C13-sharira-bhagalu"
       ],
@@ -723,7 +723,7 @@
     {
       "language": "telugu",
       "chapter": 15,
-      "sourceHash": "fnv1a64:a75d12dfcd736972",
+      "sourceHash": "fnv1a64:54bde29911714c6e",
       "lessonIds": [
         "TE-C15-neellu-biyyam"
       ],
@@ -732,7 +732,7 @@
     {
       "language": "telugu",
       "chapter": 16,
-      "sourceHash": "fnv1a64:8f0932ccb64f8552",
+      "sourceHash": "fnv1a64:a9b000a2c411482d",
       "lessonIds": [
         "TE-C16-nelalu"
       ],

--- a/code/learning/human-languages/telugu/CHANGELOG.md
+++ b/code/learning/human-languages/telugu/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Warning-free 95-page book (2026-08-03)
+
+- Explicit static font faces and bookmark-safe script commands remove all font
+  substitution and Hyperref warnings across Telugu and its five comparison
+  scripts without dropping any inline examples.
+- Chapter-specific legacy practice labels and natural `\raggedbottom` page
+  endings remove duplicate destinations and underfull-page warnings.
+- Concise headings, a responsive family table, a reflowed traditional-month
+  list, and a shorter Chapter 20 title remove every remaining overfull line.
+  The full vocabulary, grammar, comparison, and etymology content remains in the
+  lesson bodies shared with Language Ladder.
+- The forced 95-page XeLaTeX build now reports zero missing glyphs, box warnings,
+  duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings.
+  All pages and the complete 93-entry outline were inspected; a visual-only
+  running-header collision found during that review is fixed as well.
+
 ## Canonical Chapters 6–31 publication (2026-08-03)
 
 - Thirty later-track lessons now use schema v2 with explicit shared-spine

--- a/code/learning/human-languages/telugu/README.md
+++ b/code/learning/human-languages/telugu/README.md
@@ -56,7 +56,10 @@ book.
 
 The book compiles with XeLaTeX using the **vendored** Noto Sans Telugu font
 (`../../_fonts/`), loaded by relative path — so it builds identically locally
-and in CI, no system-font dependency. `latexmk -xelatex book.tex`.
+and in CI, no system-font dependency. A forced build produces 95 visually
+inspected pages with zero missing glyphs, layout warnings, duplicate
+destinations, bookmark warnings, or font warnings.
+`latexmk -xelatex book.tex`.
 
 ## Files
 

--- a/code/learning/human-languages/telugu/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch01-greetings.tex
@@ -7,7 +7,7 @@ the Dravidian family. Each lesson introduces the letters its word needs, so you
 learn to read the word and understand it at once. \emph{Practice lessons:
 \texttt{lessons/TE-C01-*.md}.}
 
-\section{\te{నమస్కారం} \emph{(namaskāram)} --- ``greetings,'' a making of a bow}
+\section{\te{నమస్కారం} \emph{(namaskāram)} --- ``greetings''}
 \label{lesson:namaskaram}
 
 \begin{sounds}
@@ -52,7 +52,7 @@ Said with the palms pressed together and a small bow --- the gesture \emph{is}
 the word. Both \textbf{hello and goodbye}, any time, to almost anyone.
 \end{culture}
 
-\section{\te{ధన్యవాదములు} \emph{(dhanyavādamulu)} --- ``thank you''}
+\section{\te{ధన్యవాదములు} --- ``thank you''}
 \label{lesson:dhanyavadamulu}
 
 \begin{sounds}
@@ -78,7 +78,7 @@ stem, not by separate little words. Later endings mark case (``to,'' ``from,''
 
 \begin{cognates}
 \begin{center}
-\begin{tabular}{@{}lll@{}}
+\begin{tabularx}{\linewidth}{@{}llX@{}}
 \toprule
 Language & ``Thanks'' & Note \\
 \midrule
@@ -88,7 +88,7 @@ Hindi & \emph{dhanyavād} & Sanskrit --- same stem \\
 Tamil & \emph{naṉṟi} & \textbf{native} (``goodness'') \\
 Malayalam & \emph{nandi} & \textbf{native} \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 \end{cognates}
 
@@ -180,7 +180,7 @@ family --- and the whole point of learning these four side by side.
 \end{grammarlens}
 
 \section{Recap, and how Telugu says goodbye}
-\label{lesson:practice}
+\label{lesson:te-c01-practice}
 
 \begin{center}
 \begin{tabular}{@{}llll@{}}

--- a/code/learning/human-languages/telugu/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch02-introductions.tex
@@ -73,7 +73,7 @@ Telugu sets ``my name'' beside ``Arun'' and lets the ``is'' be understood --- th
 literally ``my name Arun.''
 \end{grammarlens}
 
-\section{\te{నువ్వు} / \te{మీరు} \emph{(nuvvu / m\=\i ru)} --- ``you,'' familiar and respectful}
+\section[Nuvvu / mīru]{\te{నువ్వు} / \te{మీరు} \emph{(nuvvu / m\=\i ru)} --- ``you,'' familiar and respectful}
 \label{lesson:nuvvu-miiru}
 
 \begin{sounds}
@@ -134,7 +134,7 @@ most Sanskritised of the four, does so most readily of all.
 \end{cousinweb}
 
 \section{The whole exchange}
-\label{lesson:practice}
+\label{lesson:te-c02-practice}
 
 \begin{center}
 \begin{tabular}{@{}lll@{}}

--- a/code/learning/human-languages/telugu/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch03-responding.tex
@@ -96,7 +96,7 @@ together --- ``there is'' and ``there is not.''
 \end{grammarlens}
 
 \section{The whole exchange}
-\label{lesson:practice}
+\label{lesson:te-c03-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/telugu/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch04-farewells.tex
@@ -68,7 +68,7 @@ meet.'' The \te{-దాం} (\emph{-d\d{d}\=am}) ending is Telugu's ``let's \ldo
 \emph{ve\d{l}\d{l}d\d{d}\=am} (``let's go''), \emph{tind\=am} (``let's eat'').
 \end{cousinweb}
 
-\section{\te{మళ్ళీ కలుద్దాం} \emph{(ma\d{l}\d{l}\=\i\ kalud\d{d}\=am)} --- ``we'll meet again''}
+\section[Malli kaluddam]{\te{మళ్ళీ కలుద్దాం} \emph{(ma\d{l}\d{l}\=\i\ kalud\d{d}\=am)} --- ``we'll meet again''}
 \label{lesson:malli-kaluddaam}
 
 \begin{cousinweb}
@@ -80,7 +80,7 @@ Telugu keeps the native \emph{kalu} --- the same phrase, from different stock.
 \end{cousinweb}
 
 \section{The farewells}
-\label{lesson:practice}
+\label{lesson:te-c04-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/telugu/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch05-first-verbs.tex
@@ -92,7 +92,7 @@ them from unrelated families, all landed on the same trick.
 \end{grammarlens}
 
 \section{Sentences about yourself}
-\label{lesson:practice}
+\label{lesson:te-c05-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/telugu/book/chapters/ch06-dative-case.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch06-dative-case.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:6cb5796cbafe9026
+% canonical-source-hash: fnv1a64:a0d2c6d28e4fa358
 % canonical-lessons: TE-C06-dative-ku, TE-C06-dative-subject
 
 \chapter{Case Endings and Dative Subjects}
@@ -78,7 +78,7 @@ That's what "\textbf{agglutinative}" means, and it's why Telugu words grow long 
 
 
 \begin{quote}
-\textbf{Warm-up.} {[}PAUSE 2s{]} Chapter 5 gave you \textbf{\te{నేను} \te{తెలుగు} \te{మాట్లాడతాను}} — "\textbf{I} speak Telugu." Now say "I \textbf{know} Telugu." Telugu won't let you use \emph{nēnu} — and the verb it uses instead will surprise you.
+\textbf{Warm-up.} {[}PAUSE 2s{]} Chapter 5 taught you how to say "\textbf{I} speak Telugu." Now say "I \textbf{know} Telugu." Telugu won't let you use \emph{nēnu} — and the verb it uses instead will surprise you.
 \end{quote}
 
 \subsection*{You'll want to know: The sentence}

--- a/code/learning/human-languages/telugu/book/chapters/ch09-sorry.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch09-sorry.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:a59621bd41d42067
+% canonical-source-hash: fnv1a64:012d9dd03b6465c1
 % canonical-lessons: TE-C09-kshaminchandi
 
 \chapter{Sorry}
@@ -8,7 +8,7 @@
 This chapter is generated from the canonical micro-lessons used by Language Ladder.
 Each section stays independently resumable and preserves the authored prerequisite order.
 
-\section[\te{క్షమించండి}]{\te{క్షమించండి} (kṣamin̄caṇḍi) — please forgive / sorry}
+\section[\te{క్షమించండి}]{\te{క్షమించండి} — sorry}
 
 \label{lesson:TE-C09-kshaminchandi}
 

--- a/code/learning/human-languages/telugu/book/chapters/ch12-family.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch12-family.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:21fe8857abf3df9c
+% canonical-source-hash: fnv1a64:54fc86cc71a291ff
 % canonical-lessons: TE-C12-kutumbam
 
 \chapter{Family}
@@ -15,7 +15,7 @@ Each section stays independently resumable and preserves the authored prerequisi
 
 
 \begin{quote}
-\textbf{Warm-up.} {[}PAUSE 2s{]} Telugu shares the Dravidian family's age-first sibling system — but its words for "father" and "younger sister" go their own way.
+\textbf{Warm-up.} {[}PAUSE 2s{]} Telugu also sorts siblings by relative age. Its words for "father" and "younger sister," though, go their own way.
 \end{quote}
 
 \subsection*{You'll want to know: Parents — one matches, one is Telugu's own}

--- a/code/learning/human-languages/telugu/book/chapters/ch13-head-and-hand.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch13-head-and-hand.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:83368e6f6cac4154
+% canonical-source-hash: fnv1a64:1debf26c0657eade
 % canonical-lessons: TE-C13-sharira-bhagalu
 
 \chapter{Head and Hand}
@@ -8,7 +8,7 @@
 This chapter is generated from the canonical micro-lessons used by Language Ladder.
 Each section stays independently resumable and preserves the authored prerequisite order.
 
-\section[\te{తల} \te{చెయ్యి}]{\te{తల}, \te{చెయ్యి} — head shared outright, hand shared in disguise}
+\section[\te{తల} \te{చెయ్యి}]{\te{తల}, \te{చెయ్యి} — head and hand}
 
 \label{lesson:TE-C13-sharira-bhagalu}
 

--- a/code/learning/human-languages/telugu/book/chapters/ch15-water-and-rice.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch15-water-and-rice.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:a75d12dfcd736972
+% canonical-source-hash: fnv1a64:54bde29911714c6e
 % canonical-lessons: TE-C15-neellu-biyyam
 
 \chapter{Water and Rice}
@@ -8,7 +8,7 @@
 This chapter is generated from the canonical micro-lessons used by Language Ladder.
 Each section stays independently resumable and preserves the authored prerequisite order.
 
-\section[\te{నీళ్ళు} \te{బియ్యం} \te{అన్నం}]{\te{నీళ్ళు}, \te{బియ్యం}, \te{అన్నం} — water matching its cousins, rice going its own way}
+\section[\te{నీళ్ళు} \te{బియ్యం} \te{అన్నం}]{\te{నీళ్ళు}, \te{బియ్యం}, \te{అన్నం} — water and rice}
 
 \label{lesson:TE-C15-neellu-biyyam}
 

--- a/code/learning/human-languages/telugu/book/chapters/ch16-months.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch16-months.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:8f0932ccb64f8552
+% canonical-source-hash: fnv1a64:a9b000a2c411482d
 % canonical-lessons: TE-C16-nelalu
 
 \chapter{The Traditional Months}
@@ -19,7 +19,14 @@ Each section stays independently resumable and preserves the authored prerequisi
 \end{quote}
 
 \subsection*{You'll want to know: The twelve months}
-\textbf{\te{చైత్రం}, \te{వైశాఖం}, \te{జ్యేష్ఠం}, \te{ఆషాఢం}, \te{శ్రావణం}, \te{భాద్రపదం}, \te{ఆశ్వయుజం}, \te{కార్తీకం}, \te{మార్గశిరం}, \te{పుష్యం}, \te{మాఘం}, \te{ఫాల్గుణం}} (\emph{Caitraṁ, Vaiśākhaṁ, Jyēṣṭhaṁ, Āṣāḍhaṁ, Śrāvaṇaṁ, Bhādrapadaṁ, Āśvayujaṁ, Kārtīkaṁ, Mārgaśiraṁ, Puṣyaṁ, Māghaṁ, Phālguṇaṁ}).
+The year runs in three four-month groups:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\te{చైత్రం}, \te{వైశాఖం}, \te{జ్యేష్ఠం}, \te{ఆషాఢం}} — \emph{Caitraṁ, Vaiśākhaṁ, Jyēṣṭhaṁ, Āṣāḍhaṁ}.
+  \item \textbf{\te{శ్రావణం}, \te{భాద్రపదం}, \te{ఆశ్వయుజం}, \te{కార్తీకం}} — \emph{Śrāvaṇaṁ, Bhādrapadaṁ, Āśvayujaṁ, Kārtīkaṁ}.
+  \item \textbf{\te{మార్గశిరం}, \te{పుష్యం}, \te{మాఘం}, \te{ఫాల్గుణం}} — \emph{Mārgaśiraṁ, Puṣyaṁ, Māghaṁ, Phālguṇaṁ}.
+\end{itemize}
 
 \begin{cousinweb}
 This closes out a genuine, clean split across the four Dravidian languages: \textbf{Tamil} and \textbf{Malayalam} each built their \textbf{own} solar calendar (nakshatra-named and zodiac-named, respectively) — while \textbf{Kannada} and \textbf{Telugu} instead share the \textbf{same pan-Indian Sanskritic lunisolar calendar} as Hindi's Vikram Samvat. Telugu's New Year, \textbf{Ugadi}, falls on the very same day as Kannada's — \emph{Chaitra Śuddha Pādyami}, the first day of Chaitra's bright fortnight.

--- a/code/learning/human-languages/telugu/book/chapters/ch20-numbers-and-weather.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch20-numbers-and-weather.tex
@@ -2,7 +2,7 @@
 % canonical-source-hash: fnv1a64:a7a00722b8910236
 % canonical-lessons: TE-C20-padakondu-iravai, TE-C20-vatavaranam
 
-\chapter{Numbers Eleven to Twenty and Weather}
+\chapter{Numbers 11–20 and Weather}
 \label{ch:te-numbers-and-weather}
 
 This chapter is generated from the canonical micro-lessons used by Language Ladder.

--- a/code/learning/human-languages/telugu/book/preamble.tex
+++ b/code/learning/human-languages/telugu/book/preamble.tex
@@ -35,17 +35,53 @@
 \setmainlanguage{english}
 \setotherlanguage{arabic}
 
-\newfontfamily\telugufont[Path=../../_fonts/, Script=Telugu]{NotoSansTelugu-Static.ttf}
+\newfontfamily\telugufont[
+  Path=../../_fonts/,
+  Script=Telugu,
+  BoldFont=NotoSansTelugu-Static.ttf,
+  ItalicFont=NotoSansTelugu-Static.ttf,
+  BoldItalicFont=NotoSansTelugu-Static.ttf
+]{NotoSansTelugu-Static.ttf}
 \newcommand{\te}[1]{{\telugufont #1}}
-\newfontfamily\tamilfont[Path=../../_fonts/, Script=Tamil]{NotoSansTamil-Static.ttf}
+\newfontfamily\tamilfont[
+  Path=../../_fonts/,
+  Script=Tamil,
+  BoldFont=NotoSansTamil-Static.ttf,
+  ItalicFont=NotoSansTamil-Static.ttf,
+  BoldItalicFont=NotoSansTamil-Static.ttf
+]{NotoSansTamil-Static.ttf}
 \newcommand{\ta}[1]{{\tamilfont #1}}
-\newfontfamily\kannadafont[Path=../../_fonts/, Script=Kannada]{NotoSansKannada-Static.ttf}
+\newfontfamily\kannadafont[
+  Path=../../_fonts/,
+  Script=Kannada,
+  BoldFont=NotoSansKannada-Static.ttf,
+  ItalicFont=NotoSansKannada-Static.ttf,
+  BoldItalicFont=NotoSansKannada-Static.ttf
+]{NotoSansKannada-Static.ttf}
 \newcommand{\ka}[1]{{\kannadafont #1}}
-\newfontfamily\malayalamfont[Path=../../_fonts/, Script=Malayalam]{NotoSansMalayalam-Static.ttf}
+\newfontfamily\malayalamfont[
+  Path=../../_fonts/,
+  Script=Malayalam,
+  BoldFont=NotoSansMalayalam-Static.ttf,
+  ItalicFont=NotoSansMalayalam-Static.ttf,
+  BoldItalicFont=NotoSansMalayalam-Static.ttf
+]{NotoSansMalayalam-Static.ttf}
 \newcommand{\ml}[1]{{\malayalamfont #1}}
-\newfontfamily\devanagarifont[Path=../../_fonts/, Script=Devanagari]{NotoSansDevanagari-Static.ttf}
+\newfontfamily\devanagarifont[
+  Path=../../_fonts/,
+  Script=Devanagari,
+  BoldFont=NotoSansDevanagari-Static.ttf,
+  ItalicFont=NotoSansDevanagari-Static.ttf,
+  BoldItalicFont=NotoSansDevanagari-Static.ttf
+]{NotoSansDevanagari-Static.ttf}
 \newcommand{\dv}[1]{{\devanagarifont #1}}
-\newfontfamily\arabicfont[Path=../../_fonts/, Script=Arabic]{NotoNaskhArabic-Static.ttf}
+\newfontfamily\arabicfont[
+  Path=../../_fonts/,
+  Script=Arabic,
+  BoldFont=NotoNaskhArabic-Static.ttf,
+  ItalicFont=NotoNaskhArabic-Static.ttf,
+  BoldItalicFont=NotoNaskhArabic-Static.ttf
+]{NotoNaskhArabic-Static.ttf}
 \newcommand{\ar}[1]{\textarabic{#1}}
 
 \hypersetup{
@@ -54,6 +90,24 @@
   pdfsubject={Etymology-driven Telugu curriculum},
   pdfkeywords={Telugu, Dravidian, language learning, etymology}
 }
+\pdfstringdefDisableCommands{%
+  \def\te#1{#1}% Keep script text while dropping font-only presentation.
+  \def\ta#1{#1}%
+  \def\ka#1{#1}%
+  \def\ml#1{#1}%
+  \def\dv#1{#1}%
+  \def\ar#1{#1}%
+  \def\telugufont{}%
+  \def\tamilfont{}%
+  \def\kannadafont{}%
+  \def\malayalamfont{}%
+  \def\devanagarifont{}%
+  \def\arabicfont{}%
+}
+
+% Micro-lessons intentionally end at natural pause points instead of stretching
+% their callout boxes to force every page to the same depth.
+\raggedbottom
 
 \newtcolorbox{cousinweb}{
   breakable, skin=enhanced, colback=yellow!8, colframe=yellow!45!black,

--- a/code/learning/human-languages/telugu/lessons/TE-C06-dative-subject.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C06-dative-subject.md
@@ -34,7 +34,7 @@ reviews_of: [TE-C06-dative-ku, TE-C05-nenu-telugu-maatlaadataanu, TE-C04-vellu]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C06-DATIVE-KU-01, TE-GRAMMAR-C06-DATIVE-KU-02] -->
 
-[PAUSE 2s] Chapter 5 gave you **నేను తెలుగు మాట్లాడతాను** — "**I** speak Telugu."
+[PAUSE 2s] Chapter 5 taught you how to say "**I** speak Telugu."
 Now say "I **know** Telugu." Telugu won't let you use *nēnu* — and the verb it
 uses instead will surprise you.
 

--- a/code/learning/human-languages/telugu/lessons/TE-C09-kshaminchandi.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C09-kshaminchandi.md
@@ -28,7 +28,7 @@ variety: standard-colloquial
 reviews_of: [TE-C08-dayachesi]
 ---
 
-# క్షమించండి (kṣamin̄caṇḍi) — please forgive / sorry
+# క్షమించండి — sorry
 
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C08-DAYACHESI-01, TE-ETYMON-C08-DAYACHESI-02, TE-PRAGMATICS-C08-DAYACHESI-03, TE-SCRIPT-C08-DAYACHESI-04] -->

--- a/code/learning/human-languages/telugu/lessons/TE-C12-kutumbam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C12-kutumbam.md
@@ -33,8 +33,8 @@ reviews_of: [TE-C11-rangulu]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C11-RANGULU-01, TE-ETYMON-C11-RANGULU-02] -->
 
-[PAUSE 2s] Telugu shares the Dravidian family's age-first sibling system —
-but its words for "father" and "younger sister" go their own way.
+[PAUSE 2s] Telugu also sorts siblings by relative age. Its words for "father"
+and "younger sister," though, go their own way.
 
 ## You'll want to know: Parents — one matches, one is Telugu's own
 <!-- hl-knowledge: introduces=[TE-LEX-C12-KUTUMBAM-01]; assesses=[] -->

--- a/code/learning/human-languages/telugu/lessons/TE-C13-sharira-bhagalu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C13-sharira-bhagalu.md
@@ -28,7 +28,7 @@ variety: standard-colloquial
 reviews_of: [TE-C12-kutumbam]
 ---
 
-# తల, చెయ్యి — head shared outright, hand shared in disguise
+# తల, చెయ్యి — head and hand
 
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C12-KUTUMBAM-01, TE-ETYMON-C12-KUTUMBAM-02] -->

--- a/code/learning/human-languages/telugu/lessons/TE-C15-neellu-biyyam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C15-neellu-biyyam.md
@@ -28,7 +28,7 @@ variety: standard-colloquial
 reviews_of: [TE-C14-rutuvulu]
 ---
 
-# నీళ్ళు, బియ్యం, అన్నం — water matching its cousins, rice going its own way
+# నీళ్ళు, బియ్యం, అన్నం — water and rice
 
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[TE-LEX-C14-RUTUVULU-01, TE-PRAGMATICS-C14-RUTUVULU-02] -->

--- a/code/learning/human-languages/telugu/lessons/TE-C16-nelalu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C16-nelalu.md
@@ -40,10 +40,14 @@ building its own.
 ## You'll want to know: The twelve months
 <!-- hl-knowledge: introduces=[TE-LEX-C16-NELALU-01]; assesses=[] -->
 
-**చైత్రం, వైశాఖం, జ్యేష్ఠం, ఆషాఢం, శ్రావణం, భాద్రపదం, ఆశ్వయుజం, కార్తీకం,
-మార్గశిరం, పుష్యం, మాఘం, ఫాల్గుణం** (*Caitraṁ, Vaiśākhaṁ, Jyēṣṭhaṁ,
-Āṣāḍhaṁ, Śrāvaṇaṁ, Bhādrapadaṁ, Āśvayujaṁ, Kārtīkaṁ, Mārgaśiraṁ, Puṣyaṁ,
-Māghaṁ, Phālguṇaṁ*).
+The year runs in three four-month groups:
+
+- **చైత్రం, వైశాఖం, జ్యేష్ఠం, ఆషాఢం** — *Caitraṁ, Vaiśākhaṁ, Jyēṣṭhaṁ,
+  Āṣāḍhaṁ*.
+- **శ్రావణం, భాద్రపదం, ఆశ్వయుజం, కార్తీకం** — *Śrāvaṇaṁ, Bhādrapadaṁ,
+  Āśvayujaṁ, Kārtīkaṁ*.
+- **మార్గశిరం, పుష్యం, మాఘం, ఫాల్గుణం** — *Mārgaśiraṁ, Puṣyaṁ, Māghaṁ,
+  Phālguṇaṁ*.
 
 ## The word, taken apart - The whole Dravidian family, in one honest picture
 <!-- hl-knowledge: introduces=[TE-ETYMON-C16-NELALU-02]; assesses=[] -->


### PR DESCRIPTION
## Summary
- make the complete 95-page Telugu book warning-free across layout, duplicate labels, bookmarks, and static font shapes
- preserve all Telugu and cross-script teaching content while reflowing the handful of long headings, table rows, and month lists
- keep canonical lessons, generated chapters, hashes, and Language Ladder synchronized
- record the clean baseline and advance the shared backlog to Kannada Chapters 6-31

## Validation
- forced Telugu XeLaTeX: 95 pages; zero missing glyphs, box warnings, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings
- visual QA: all 95 pages inspected; the visual-only Section 4.4 header collision was found and fixed
- PDF structure: 33 top-level bookmarks, 93 total outline entries, correct metadata, zero generator metadata leaks
- human-language-data: 84 tests passed; TypeScript build and generated-book drift check passed
- Language Ladder: 359 tests passed; production build passed
- corpus: 1,066 lessons, zero duration violations, zero unknown prerequisites, Telugu book coverage 100 percent
- unified publication: all 20 books compiled; 20 non-empty PDFs and 20 catalog entries verified

## Known debt
- HL-B24 is next: publish Kannada Chapters 6-31 from canonical lessons
- the existing Vite large-chunk advisory and queued development-only PostCSS audit item are unchanged