### PR TITLE
fix(spice): lower diode junction potential

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower diode model-card `VJ` / `PB` junction potential.
 - Validate and lower finite, non-negative diode model-card `RS` series resistance.
 - Validate positive finite diode model-card `IBV` breakdown current.
 - Validate positive finite diode model-card `BV` breakdown voltage.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1274,6 +1274,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
                 "CJO", model.params.get("CJ", model.params.get("CJ0", 0.0))
             ),
             Tt=model.params.get("TT", 0.0),
+            Vj=model.params.get("VJ", model.params.get("PB", 1.0)),
             Rs=model.params.get("RS", 0.0),
         )
     if prefix == "Q":
@@ -1963,6 +1964,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(series_resistance) or series_resistance < 0.0
         ):
             raise NetlistParseError("diode RS must be finite and non-negative")
+        junction_potential = params.get("VJ", params.get("PB"))
+        if junction_potential is not None and (
+            not math.isfinite(junction_potential) or junction_potential <= 0.0
+        ):
+            raise NetlistParseError("diode VJ must be finite and positive")
     if kind in {"NPN", "PNP"}:
         saturation_current = params.get("IS")
         if saturation_current is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -910,6 +910,32 @@ def test_rejects_invalid_diode_series_resistance(value: str) -> None:
         parse_netlist(f".model clamp D(RS={value})")
 
 
+@pytest.mark.parametrize("parameter", ["VJ", "PB"])
+def test_lowers_diode_junction_potential_alias(parameter: str) -> None:
+    parsed = parse_netlist(f".model clamp D({parameter}=0.8)\nD1 in out clamp")
+
+    diode = parsed.circuit.elements[0]
+    assert isinstance(diode, Diode)
+    assert diode.Vj == 0.8
+
+
+def test_diode_junction_potential_prefers_canonical_name() -> None:
+    parsed = parse_netlist(".model clamp D(PB=0.8 VJ=0.7)\nD1 in out clamp")
+
+    diode = parsed.circuit.elements[0]
+    assert isinstance(diode, Diode)
+    assert diode.Vj == 0.7
+
+
+@pytest.mark.parametrize("parameter", ["VJ", "PB"])
+@pytest.mark.parametrize("value", ["0", "-0.1", "1e999"])
+def test_rejects_invalid_diode_junction_potential(
+    parameter: str, value: str
+) -> None:
+    with pytest.raises(NetlistParseError, match="diode VJ must be finite and positive"):
+        parse_netlist(f".model clamp D({parameter}={value})")
+
+
 def test_parse_diode_junction_capacitance_alias() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower diode model-card `VJ` / `PB` junction potential.
 - Validate and lower finite, non-negative diode model-card `RS` series resistance.
 - Validate positive finite diode model-card `IBV` breakdown current.
 - Validate positive finite diode model-card `BV` breakdown voltage.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1215,6 +1215,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("diode RS must be finite and non-negative");
   }
+  const diodeJunctionPotential = params.get("VJ") ?? params.get("PB");
+  if (
+    kind === "D" &&
+    diodeJunctionPotential !== undefined &&
+    (!Number.isFinite(diodeJunctionPotential) || diodeJunctionPotential <= 0.0)
+  ) {
+    throw new NetlistParseError("diode VJ must be finite and positive");
+  }
   const bjtForwardBeta =
     params.get("BF") ??
     params.get("BETA") ??
@@ -1801,6 +1809,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
         model.params.get("CJO") ?? model.params.get("CJ") ?? model.params.get("CJ0") ?? 0.0,
         model.params.get("TT") ?? 0.0,
       ),
+      junctionPotential: model.params.get("VJ") ?? model.params.get("PB") ?? 1.0,
       seriesResistance: model.params.get("RS") ?? 0.0,
     };
   }

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -945,6 +945,37 @@ D1 in out clamp
     );
   });
 
+  it.each(["VJ", "PB"])("lowers diode %s junction potential alias", (parameter) => {
+    const parsed = parseNetlist(`.model clamp D(${parameter}=0.8)\nD1 in out clamp`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "diode",
+      junctionPotential: 0.8,
+    });
+  });
+
+  it("prefers canonical diode VJ over PB", () => {
+    const parsed = parseNetlist(`.model clamp D(PB=0.8 VJ=0.7)\nD1 in out clamp`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "diode",
+      junctionPotential: 0.7,
+    });
+  });
+
+  it.each([
+    ["VJ", "0"],
+    ["VJ", "-0.1"],
+    ["VJ", "1e999"],
+    ["PB", "0"],
+    ["PB", "-0.1"],
+    ["PB", "1e999"],
+  ])("rejects invalid diode %s junction potential %s", (parameter, value) => {
+    expect(() => parseNetlist(`.model clamp D(${parameter}=${value})`)).toThrow(
+      "diode VJ must be finite and positive",
+    );
+  });
+
   it("parses BJT models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NPN(IS=1e-14 BF=120 VT=25m CJE=2p CJC=3p TF=4n TR=5n)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4404,16 +4404,22 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine diode breakdown-current field.
 
 417. Python and TypeScript Berkeley SPICE diode series-resistance parity.
-   - Status: completed in this diode series-resistance parity slice.
+   - Status: completed in PR 9813.
    - Both parser facades validate finite non-negative `RS` values and lower
      them into the shared engine diode series-resistance field.
+
+418. Python and TypeScript Berkeley SPICE diode junction-potential parity.
+   - Status: completed in this diode junction-potential parity slice.
+   - Both parser facades validate positive finite `VJ` / `PB` values and lower
+     them into the shared engine diode junction-potential field with canonical
+     `VJ` precedence.
 
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE model-card validation parity.
-   - Continue the audited diode model-card lowering surfaces with junction
-     potential `VJ`, grading coefficient `M`, and depletion coefficient `FC`,
-     followed by `XTI`, `EG`, `KF`, and `AF` validation and lowering parity.
+   - Continue the audited diode model-card lowering surfaces with grading
+     coefficient `M` / `MJ` and depletion coefficient `FC`, followed by `XTI`,
+     `EG`, `KF`, and `AF` validation and lowering parity.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary
- validate positive finite diode model-card `VJ` and `PB` values in Python and TypeScript
- lower both spellings into the existing engine junction-potential field with canonical `VJ` precedence
- add cross-language parity coverage and advance the SPICE completion backlog

## Verification
- Python `spice-netlist-parser`: `bash BUILD` (322 tests), Ruff clean
- TypeScript `spice-engine`: `bash BUILD` (448 tests)
- TypeScript `spice-netlist-parser`: `bash BUILD` (311 tests)
- TypeScript parser coverage: 86.14% lines