### PR TITLE
fix(build-tool): make Haskell Python resolution field-aware

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,22 +11,18 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": {
-    "number": 9806,
-    "url": "https://github.com/adhithyan15/coding-adventures/pull/9806",
-    "branch": "codex/build-tool-haskell-remaining-field-aware-manifest-resolution"
-  },
+  "active_pr": null,
   "last_inventory": {
-    "revision": "bd73c3f160c2ccc0640577ae57ff39cc7d3149b3",
+    "revision": "9441f4c74344f5e3fcba0b58e838af81fd512f63",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1245,
-    "implementation_package_slots": 4398,
+    "implementation_identities": 1247,
+    "implementation_package_slots": 4400,
     "high_consensus_packages": 173,
     "high_consensus_missing_slots": 272,
-    "singleton_packages": 795,
-    "singleton_missing_slots": 11130,
-    "rust_singletons": 600,
+    "singleton_packages": 797,
+    "singleton_missing_slots": 11158,
+    "rust_singletons": 602,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -401,7 +397,7 @@
     {
       "id": "build-tool-haskell-remaining-field-aware-manifest-resolution",
       "title": "Make Haskell Cabal manifest resolution field-aware",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-haskell-field-aware-manifest-resolution"],
       "branch": "codex/build-tool-haskell-remaining-field-aware-manifest-resolution",
       "pr_number": 9806,
@@ -409,12 +405,21 @@
     },
     {
       "id": "build-tool-haskell-non-cabal-field-aware-manifest-resolution",
-      "title": "Make the remaining non-Cabal Haskell build-tool manifest readers field-aware",
-      "status": "pending",
+      "title": "Make Haskell Python manifest resolution field-aware and name-normalized",
+      "status": "in-progress",
       "depends_on": ["build-tool-haskell-remaining-field-aware-manifest-resolution"],
+      "branch": "codex/build-tool-haskell-python-field-aware-manifest-resolution",
+      "pr_number": null,
+      "notes": "Split from the Cabal repair after a complete real-lane oracle comparison showed that whole-manifest tokenization remains reachable across every non-Lua/non-Cabal ecosystem. Selected immediately after guarded PR #9806 merged because Python is the largest affected established lane and its exact failure is already reproduced: both engines discover 488 Python packages; the Haskell engine reports an all-node cycle, while a resolution-only Go plan succeeds. The complete graph comparison has 1,492 Haskell edges versus 1,118 canonical edges, with 383 false edges and nine missing edges. The implementation now parses only authoritative PEP 621 project dependencies, normalizes Python distribution names per PEP 503, and consumes both the existing diamond and a new language-neutral field-boundary fixture. The repaired real lane skips all 488 unchanged packages with zero failures, and its complete 1,118-edge graph matches the Go oracle exactly with zero edges unique to either engine. Final local validation covers 43 corpus cases and 92 validated files, 40 Python runner tests, 19 Haskell build-tool examples plus the seven graph examples, cabal check, Haddock generation, 41/50/54 percent Haskell definition/alternative/expression coverage, and canonical Go test/vet/build. The post-merge 4e9fc62c collision-checked inventory is unchanged at 1,245 identities and 4,398 slots, 173 high-consensus packages with 272 missing slots, 795 singletons, 600 Rust singletons, and zero collisions or unknown buckets; no new identity required classification. The canonical Go build-file validator separately reports existing missing BUILD_windows prerequisite refs in python/sir-runtime-oop and python/swi-prolog-parser; the existing build-file-standalone-integrity item owns that debt, so this resolver-semantic slice does not duplicate or widen it."
+    },
+    {
+      "id": "build-tool-haskell-post-python-field-aware-manifest-resolution",
+      "title": "Make the remaining post-Python Haskell build-tool manifest readers field-aware",
+      "status": "pending",
+      "depends_on": ["build-tool-haskell-non-cabal-field-aware-manifest-resolution"],
       "branch": null,
       "pr_number": null,
-      "notes": "Split from the Cabal repair after a complete real-lane oracle comparison showed the current selected slice has exactly 43 Haskell-only false edges, zero missing edges, and one authoritative source: Cabal build-depends fields. The generic whole-manifest reader also remains reachable for Python, Ruby, Go, TypeScript, Dart, Rust/Wasm, Elixir, Perl, Swift, Java/Kotlin, and .NET. Audit each language against the canonical Go edge oracle, add language-neutral field-boundary fixtures, and replace the generic fallback in dependency-shaped ecosystem slices without widening the exact 205-package Cabal cycle repair."
+      "notes": "Narrowed from the non-Cabal umbrella after the leverage audit selected the exact 488-package Python lane. The generic reader remains reachable for Ruby, Go, TypeScript, Dart, Rust/Wasm, Elixir, Perl, Swift, Java/Kotlin, and .NET. After the Python field and distribution-name rules are fixed, compare each remaining real lane with the Go oracle, add language-neutral field-boundary fixtures, and split implementation into dependency-shaped ecosystem slices rather than recreating a broad multi-language PR."
     },
     {
       "id": "build-tool-elixir-engine-rockspec-utf8-conformance",
@@ -1752,6 +1757,24 @@
       "branch": null,
       "pr_number": null,
       "notes": "Discovered in the collision-clean 5c85a498 inventory after smart-home-synology-surveillance-integration landed as a Rust-only production NVR adapter. The crate owns concrete TCP and platform-TLS transport, credential-referenced authenticated HTTPS sessions, Vault identity, endpoint policy, explicit logout, and SmartHomeRuntime authorization, so it is not an all-language portable target. Review truthful connect/TLS/credential/runtime authority and platform evidence; keep bounded Synology API discovery, response validation, camera-health projection, request planning, and redaction semantics in shared portable contracts where reusable; and record the residual adapter as a native-runtime exception. This review is excluded from autonomous delivery selection by parity policy."
+    },
+    {
+      "id": "process-shutdown-native-authority-review",
+      "title": "Review the process-shutdown native-authority exception",
+      "status": "pending",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-clean 7650dfef inventory after process-shutdown landed as a Rust-only cooperative signal adapter. Its declared proc:signal, native FFI, platform unsafe handlers, process-global exclusivity, and polling thread make the concrete crate a native-runtime boundary rather than an all-language portable target. Review the minimum truthful Unix and Windows authority plus platform-CI evidence, preserve signal-handler safety and restoration guarantees, and keep any reusable injected shutdown-event state machine in an authority-free portable seam. This review is excluded from autonomous delivery selection by parity policy and does not displace the active Haskell Python resolver repair."
+    },
+    {
+      "id": "smart-home-unifi-network-native-authority-review",
+      "title": "Review the UniFi Network integration native-authority exception",
+      "status": "pending",
+      "depends_on": ["rust-network-substrate-capability-truthfulness", "smart-home-lan-http-native-executor-consolidation"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-clean 7650dfef inventory after smart-home-unifi-network-integration landed as a Rust-only production adapter. The crate owns concrete TCP and platform-TLS transport, Vault-referenced API-key authentication, endpoint policy, bounded authenticated HTTPS inspection, and SmartHomeRuntime authorization, so it is not an all-language portable target. Review truthful connect/TLS/credential/runtime authority and platform evidence; keep bounded official-API response validation, stable site/device health projection, request planning, pagination, and redaction semantics in shared portable contracts where reusable; and record the residual adapter as a native-runtime exception. This review is excluded from autonomous delivery selection by parity policy and does not displace the active Haskell Python resolver repair."
     }
   ]
 }

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,11 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": {
+    "number": 9817,
+    "url": "https://github.com/adhithyan15/coding-adventures/pull/9817",
+    "branch": "codex/build-tool-haskell-python-field-aware-manifest-resolution"
+  },
   "last_inventory": {
     "revision": "9441f4c74344f5e3fcba0b58e838af81fd512f63",
     "schema_version": 3,
@@ -406,10 +410,10 @@
     {
       "id": "build-tool-haskell-non-cabal-field-aware-manifest-resolution",
       "title": "Make Haskell Python manifest resolution field-aware and name-normalized",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-haskell-remaining-field-aware-manifest-resolution"],
       "branch": "codex/build-tool-haskell-python-field-aware-manifest-resolution",
-      "pr_number": null,
+      "pr_number": 9817,
       "notes": "Split from the Cabal repair after a complete real-lane oracle comparison showed that whole-manifest tokenization remains reachable across every non-Lua/non-Cabal ecosystem. Selected immediately after guarded PR #9806 merged because Python is the largest affected established lane and its exact failure is already reproduced: both engines discover 488 Python packages; the Haskell engine reports an all-node cycle, while a resolution-only Go plan succeeds. The complete graph comparison has 1,492 Haskell edges versus 1,118 canonical edges, with 383 false edges and nine missing edges. The implementation now parses only authoritative PEP 621 project dependencies, normalizes Python distribution names per PEP 503, and consumes both the existing diamond and a new language-neutral field-boundary fixture. The repaired real lane skips all 488 unchanged packages with zero failures, and its complete 1,118-edge graph matches the Go oracle exactly with zero edges unique to either engine. Final local validation covers 43 corpus cases and 92 validated files, 40 Python runner tests, 19 Haskell build-tool examples plus the seven graph examples, cabal check, Haddock generation, 41/50/54 percent Haskell definition/alternative/expression coverage, and canonical Go test/vet/build. The post-merge 4e9fc62c collision-checked inventory is unchanged at 1,245 identities and 4,398 slots, 173 high-consensus packages with 272 missing slots, 795 singletons, 600 Rust singletons, and zero collisions or unknown buckets; no new identity required classification. The canonical Go build-file validator separately reports existing missing BUILD_windows prerequisite refs in python/sir-runtime-oop and python/swi-prolog-parser; the existing build-file-standalone-integrity item owns that debt, so this resolver-semantic slice does not duplicate or widen it."
     },
     {

--- a/code/programs/haskell/build-tool/CHANGELOG.md
+++ b/code/programs/haskell/build-tool/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to this package will be documented in this file.
   and package/program alias precedence.
 - Shared Cabal resolution coverage for inline and multiline `build-depends`
   fields plus misleading package names in metadata, options, and comments.
+- Haskell consumption of the shared Python dependency diamond plus a PEP 621
+  field-boundary and distribution-name normalization fixture.
 
 ### Changed
 
@@ -34,6 +36,8 @@ All notable changes to this package will be documented in this file.
   same-basename program aliases.
 - Resolve Haskell package edges only from Cabal `build-depends` fields across
   stanzas, ignoring comments and every non-authoritative manifest field.
+- Resolve Python edges only from PEP 621 `[project].dependencies`, with PEP 503
+  case and separator normalization before internal-package lookup.
 
 ## [0.1.0] - 2026-04-05
 

--- a/code/programs/haskell/build-tool/README.md
+++ b/code/programs/haskell/build-tool/README.md
@@ -39,6 +39,15 @@ shared `resolution-haskell-field-aware` fixture covers both inline and
 multiline dependencies plus representative non-authoritative collisions. The
 complete 205-package Haskell lane matches the Go oracle edge-for-edge.
 
+Python dependency resolution reads only the PEP 621 `[project]` table's
+`dependencies` array. Build-system requirements, optional dependency groups,
+tool tables, package metadata, and comments cannot invent graph edges. Python
+distribution names are lowercased and normalize every run of `-`, `_`, or `.`
+to one hyphen before lookup, so repository packages resolve consistently with
+PEP 503 naming. Shared fixtures cover the canonical diamond, field boundaries,
+version and environment markers, and mixed-separator aliases. The complete
+488-package Python lane matches the Go oracle at 1,118 edges.
+
 Package hashing reads included files as raw bytes. Repository-relative paths
 are normalized to `/`, encoded explicitly as UTF-8, and combined with those
 bytes using the existing boundary framing before `git hash-object` receives

--- a/code/programs/haskell/build-tool/src/BuildTool.hs
+++ b/code/programs/haskell/build-tool/src/BuildTool.hs
@@ -778,6 +778,7 @@ readManifestTokens :: Package -> IO [String]
 readManifestTokens pkg
     | packageLanguage pkg == "lua" = readLuaDependencyTokens pkg
     | packageLanguage pkg == "haskell" = readCabalDependencyTokens pkg
+    | packageLanguage pkg == "python" = readPythonDependencyTokens pkg
     | otherwise = readGenericManifestTokens pkg
 
 readCabalDependencyTokens :: Package -> IO [String]
@@ -827,6 +828,108 @@ stripCabalComment :: String -> String
 stripCabalComment [] = []
 stripCabalComment ('-' : '-' : _) = []
 stripCabalComment (character : rest) = character : stripCabalComment rest
+
+readPythonDependencyTokens :: Package -> IO [String]
+readPythonDependencyTokens pkg = do
+    let pyprojectPath = packagePath pkg </> "pyproject.toml"
+    exists <- doesFileExist pyprojectPath
+    if not exists
+        then pure []
+        else do
+            contents <- readFileStrict pyprojectPath
+            pure (pythonDependencyTokens contents)
+
+pythonDependencyTokens :: String -> [String]
+pythonDependencyTokens = nub . mapMaybe pythonDistributionToken . pythonDependencyValues
+
+pythonDependencyValues :: String -> [String]
+pythonDependencyValues = collect False False . lines
+  where
+    collect _ _ [] = []
+    collect inProject inDependencies (rawLine : rest) =
+        let uncommented = stripTomlComment rawLine
+            stripped = trim uncommented
+         in case tomlSectionName stripped of
+                Just sectionName -> collect (sectionName == "project") False rest
+                Nothing
+                    | inDependencies ->
+                        extractQuotedValues uncommented
+                            ++ collect inProject (not (hasUnquotedCharacter ']' uncommented)) rest
+                    | inProject ->
+                        case pythonDependencyArrayRemainder stripped of
+                            Nothing -> collect True False rest
+                            Just remainder ->
+                                extractQuotedValues remainder
+                                    ++ collect True (not (hasUnquotedCharacter ']' remainder)) rest
+                    | otherwise -> collect False False rest
+
+tomlSectionName :: String -> Maybe String
+tomlSectionName stripped
+    | length stripped >= 3
+        && head stripped == '['
+        && last stripped == ']'
+        && take 2 stripped /= "[[" =
+        Just (map toLower (trim (init (tail stripped))))
+    | otherwise = Nothing
+
+pythonDependencyArrayRemainder :: String -> Maybe String
+pythonDependencyArrayRemainder stripped =
+    let (field, assignment) = break (== '=') stripped
+        afterAssignment = drop 1 assignment
+        arrayRemainder = dropWhile (/= '[') afterAssignment
+     in if map toLower (trim field) == "dependencies"
+            && not (null assignment)
+            && not (null arrayRemainder)
+            then Just arrayRemainder
+            else Nothing
+
+pythonDistributionToken :: String -> Maybe String
+pythonDistributionToken value =
+    let name = takeWhile isPythonDistributionCharacter (dropWhile (`elem` [' ', '\t']) value)
+     in if null name then Nothing else Just (normalizePythonDistributionName name)
+
+isPythonDistributionCharacter :: Char -> Bool
+isPythonDistributionCharacter character =
+    isAlphaNum character || character `elem` ['-', '_', '.']
+
+normalizePythonDistributionName :: String -> String
+normalizePythonDistributionName = collapseSeparators False
+  where
+    collapseSeparators _ [] = []
+    collapseSeparators previousWasSeparator (character : rest)
+        | character `elem` ['-', '_', '.'] =
+            if previousWasSeparator
+                then collapseSeparators True rest
+                else '-' : collapseSeparators True rest
+        | otherwise = toLower character : collapseSeparators False rest
+
+stripTomlComment :: String -> String
+stripTomlComment = go Nothing
+  where
+    go _ [] = []
+    go Nothing ('#' : _) = []
+    go Nothing (character : rest)
+        | character `elem` ['"', '\''] = character : go (Just character) rest
+        | otherwise = character : go Nothing rest
+    go (Just quote) ('\\' : escaped : rest)
+        | quote == '"' = '\\' : escaped : go (Just quote) rest
+    go (Just quote) (character : rest)
+        | character == quote = character : go Nothing rest
+        | otherwise = character : go (Just quote) rest
+
+hasUnquotedCharacter :: Char -> String -> Bool
+hasUnquotedCharacter target = go Nothing
+  where
+    go _ [] = False
+    go Nothing (character : rest)
+        | character == target = True
+        | character `elem` ['"', '\''] = go (Just character) rest
+        | otherwise = go Nothing rest
+    go (Just quote) ('\\' : _escaped : rest)
+        | quote == '"' = go (Just quote) rest
+    go (Just quote) (character : rest)
+        | character == quote = go Nothing rest
+        | otherwise = go (Just quote) rest
 
 readGenericManifestTokens :: Package -> IO [String]
 readGenericManifestTokens pkg = do
@@ -900,7 +1003,10 @@ dependencyTableRemainder line =
             else Nothing
 
 quotedValues :: String -> [String]
-quotedValues = go . stripLuaComment
+quotedValues = extractQuotedValues . stripLuaComment
+
+extractQuotedValues :: String -> [String]
+extractQuotedValues = go
   where
     go [] = []
     go (character : rest)

--- a/code/programs/haskell/build-tool/test/ResolutionUtf8Spec.hs
+++ b/code/programs/haskell/build-tool/test/ResolutionUtf8Spec.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module ResolutionUtf8Spec (resolutionCabalSpec, resolutionUtf8Spec) where
+module ResolutionUtf8Spec (resolutionCabalSpec, resolutionPythonSpec, resolutionUtf8Spec) where
 
 import Control.Exception (bracket, try)
 import Control.Monad (forM_)
@@ -169,6 +169,31 @@ resolutionCabalSpec = describe "Cabal resolution conformance" $ do
                     Right
                         [ ["haskell/beta", "haskell/delta", "haskell/gamma"]
                         , ["haskell/alpha"]
+                        ]
+
+resolutionPythonSpec :: Spec
+resolutionPythonSpec = describe "Python resolution conformance" $ do
+    it "preserves the shared canonical dependency diamond" $
+        withFixture "resolution-python-diamond.json" $ \root fixture -> do
+            graph <- resolveFixtureFor "python" root
+            graphEdges graph `shouldBe` fixtureExpectedEdges fixture
+
+    it "reads only PEP 621 dependencies and normalizes distribution names" $
+        withFixture "resolution-python-field-aware.json" $ \root fixture -> do
+            graph <- resolveFixtureFor "python" root
+            graphEdges graph `shouldBe` fixtureExpectedEdges fixture
+            DG.nodes graph
+                `shouldBe`
+                    [ "python/alpha"
+                    , "python/beta-helper"
+                    , "python/delta"
+                    , "python/gamma"
+                    ]
+            DG.independentGroups graph
+                `shouldBe`
+                    Right
+                        [ ["python/beta-helper", "python/delta", "python/gamma"]
+                        , ["python/alpha"]
                         ]
 
 assertMetadataError :: FilePath -> MetadataEncodingError -> Expectation

--- a/code/programs/haskell/build-tool/test/Spec.hs
+++ b/code/programs/haskell/build-tool/test/Spec.hs
@@ -2,7 +2,7 @@ import Test.Hspec
 
 import BuildToolSpec (buildToolSpec)
 import HashingSpec (hashingSpec)
-import ResolutionUtf8Spec (resolutionCabalSpec, resolutionUtf8Spec)
+import ResolutionUtf8Spec (resolutionCabalSpec, resolutionPythonSpec, resolutionUtf8Spec)
 
 main :: IO ()
 main = hspec spec
@@ -13,3 +13,4 @@ spec = do
     hashingSpec
     resolutionUtf8Spec
     resolutionCabalSpec
+    resolutionPythonSpec

--- a/code/scripts/tests/test_build_tool_conformance_runner.py
+++ b/code/scripts/tests/test_build_tool_conformance_runner.py
@@ -131,7 +131,7 @@ class CorpusTests(unittest.TestCase):
         summary = runner.validate_corpus(FIXTURE_ROOT)
 
         self.assertEqual(summary["schema_version"], 1)
-        self.assertEqual(summary["case_count"], 42)
+        self.assertEqual(summary["case_count"], 43)
         self.assertEqual(summary["implementation_count"], 16)
         self.assertEqual(summary["established_languages"], 15)
         self.assertEqual(summary["execution_case_count"], 0)
@@ -851,7 +851,7 @@ class CommandLineTests(unittest.TestCase):
 
         self.assertEqual(exit_code, 0)
         summary = json.loads(stdout.getvalue())
-        self.assertEqual(summary["case_count"], 42)
+        self.assertEqual(summary["case_count"], 43)
 
     def test_validate_result_reports_match_and_rejects_execution_override(self) -> None:
         case_path = CASES_ROOT / "graph-diamond.json"

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -305,6 +305,15 @@ source directories, compiler options, and every other field. A new stanza may
 introduce another `build-depends:` field; reaching a sibling field or stanza
 ends the current field before scanning continues.
 
+For Python `pyproject.toml` manifests, dependency candidates come only from the
+PEP 621 `[project]` table's `dependencies = [...]` array. Resolvers ignore
+package identity and descriptive metadata, `[build-system]`,
+`[project.optional-dependencies]`, tool-specific tables, comments, and every
+other field. Distribution names are matched case-insensitively after PEP 503
+normalization: each run of hyphens, underscores, or periods becomes one hyphen
+before internal-package lookup. Extras, version specifiers, and environment
+markers do not form part of the normalized distribution name.
+
 ### 3. Graph and scheduling
 
 Required cases cover isolated nodes, chains, diamonds, multiple components,

--- a/code/specs/fixtures/build-tool-v1/cases/resolution-python-field-aware.json
+++ b/code/specs/fixtures/build-tool-v1/cases/resolution-python-field-aware.json
@@ -1,0 +1,87 @@
+{
+  "schema_version": 1,
+  "id": "resolution/python-field-aware",
+  "domain": "resolution",
+  "summary": "Python resolution reads PEP 621 project dependencies, normalizes distribution names, and ignores unrelated metadata tables.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "resolution"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/python/alpha/BUILD",
+        "content_utf8": "echo build alpha\n"
+      },
+      {
+        "path": "code/packages/python/alpha/pyproject.toml",
+        "content_utf8": "[build-system]\nrequires = [\"coding-adventures-gamma\"]\n\n[project]\nname = \"coding-adventures-alpha\"\nversion = \"0.1.0\"\ndescription = \"Mentions coding-adventures-gamma without depending on it.\"\ndependencies = [\n  \"coding_adventures_beta.helper>=0.1\",\n  \"coding-adventures-delta ; python_version >= '3.11'\", # coding-adventures-gamma stays a comment\n]\n\n[project.optional-dependencies]\ndev = [\"coding-adventures-gamma\"]\n\n[tool.demo]\ndependencies = [\"coding-adventures-gamma\"]\n"
+      },
+      {
+        "path": "code/packages/python/beta-helper/BUILD",
+        "content_utf8": "echo build beta-helper\n"
+      },
+      {
+        "path": "code/packages/python/beta-helper/pyproject.toml",
+        "content_utf8": "[project]\nname = \"coding-adventures-beta-helper\"\nversion = \"0.1.0\"\ndependencies = []\n"
+      },
+      {
+        "path": "code/packages/python/delta/BUILD",
+        "content_utf8": "echo build delta\n"
+      },
+      {
+        "path": "code/packages/python/delta/pyproject.toml",
+        "content_utf8": "[project]\nname = \"coding-adventures-delta\"\nversion = \"0.1.0\"\ndependencies = []\n"
+      },
+      {
+        "path": "code/packages/python/gamma/BUILD",
+        "content_utf8": "echo build gamma\n"
+      },
+      {
+        "path": "code/packages/python/gamma/pyproject.toml",
+        "content_utf8": "[project]\nname = \"coding-adventures-gamma\"\nversion = \"0.1.0\"\ndependencies = []\n"
+      }
+    ]
+  },
+  "input": {
+    "operation": "resolution",
+    "options": {
+      "code_root": "code",
+      "language": "python"
+    },
+    "arguments": [],
+    "environment": {},
+    "changed_paths": []
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "resolution/python-field-aware",
+    "domain": "resolution",
+    "outcome": "ok",
+    "result": {
+      "edges": [
+        [
+          "python/beta-helper",
+          "python/alpha"
+        ],
+        [
+          "python/delta",
+          "python/alpha"
+        ]
+      ]
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 5000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 256,
+    "cpu_time_ms": 5000
+  }
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,9 +106,9 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-working inventory was regenerated on August 3, 2026 from `bd73c3f1` after
-the latest Spice parser repair merged. The inventory contains 1,245 normalized
-implementation identities across 4,398 established-lane package slots and
+working inventory was regenerated on August 3, 2026 from `9441f4c7` after
+rebasing the Haskell Python-resolution slice. The inventory contains 1,247 normalized
+implementation identities across 4,400 established-lane package slots and
 found zero canonical collisions or unknown language buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
@@ -323,16 +323,26 @@ cycle failure in Haskell's whole-manifest token resolver. PR #9777 repaired the
 Lua reader: it distinguishes genuine cycles from false alias matches, parses
 only authoritative rockspec dependency fields, preserves BUILD-declared
 program edges and identities, and matches the Go oracle exactly. That repair
-exposed the same generic-token debt in the real 205-package Haskell lane. The
-selected direct child is now the dependency-shaped Cabal slice: its baseline
-has all 486 canonical edges plus 43 false edges from non-authoritative manifest
-text, and it replaces whole-file tokenization with `build-depends` parsing.
-The remaining non-Cabal readers have a separate dependent backlog owner. The
-post-rebase `bd73c3f1` collision-checked inventory has 1,245
-identities and 4,398 implementation slots across 15 established lanes, with
-173 high-consensus packages and 272 missing slots, 795 singleton packages and
-11,130 missing slots, 600 Rust singletons, and zero collisions or unknown
-buckets. Java/Kotlin/F# ZIP and Java/Kotlin ZStd fill existing identities; ZStd
+exposed the same generic-token debt in the real 205-package Haskell lane. PR
+#9806 completed the dependency-shaped Cabal slice: it replaced 43 false edges
+from non-authoritative manifest text with `build-depends` parsing and now
+matches all 486 canonical edges. The post-merge leverage audit selects Python
+next because it is the largest affected lane: 488 real packages collapse into
+an all-node cycle, with 1,492 Haskell edges versus 1,118 canonical edges, 383
+false edges, and nine missing PEP 503-normalized edges. A dependent backlog
+owner carries the remaining post-Python readers. The post-rebase `9441f4c7`
+collision-checked inventory has 1,247
+identities and 4,400 implementation slots across 15 established lanes, with
+173 high-consensus packages and 272 missing slots, 797 singleton packages and
+11,158 missing slots, 602 Rust singletons, and zero collisions or unknown
+buckets. The Python slice now reads only PEP 621
+`[project].dependencies` and applies PEP 503 distribution-name normalization.
+Its full 488-package lane completes without failures, and the repaired
+1,118-edge graph matches the Go oracle exactly: zero Haskell-only edges and
+zero Go-only edges. The two unrelated Python `BUILD_windows` prerequisite gaps
+exposed by the full validator remain owned by
+`build-file-standalone-integrity`. Java/Kotlin/F# ZIP and Java/Kotlin ZStd fill
+existing identities; ZStd
 is complete across all 15 lanes and ZIP now spans 12. The new Chief daemon
 keyring and Synology Surveillance singleton packages own concrete filesystem or
 credentialed network authority and have excluded native-authority review
@@ -343,7 +353,11 @@ of treating that host integration as an all-language portability gap. The new
 `smart-home-frigate-integration` singleton likewise owns concrete TCP/TLS,
 authenticated HTTPS, JWT cookies, Vault identity, and runtime authorization;
 it has an excluded native-authority review rather than a fabricated portable
-lane gap.
+lane gap. The new `process-shutdown` and
+`smart-home-unifi-network-integration` singletons likewise own native process
+signal/FFI authority or concrete authenticated LAN/TLS authority. Both have
+excluded native-authority review owners and do not displace the active portable
+resolver repair.
 
 This loop delivers only deterministic, authority-free package contracts and
 implementations. DNS/UDP/TCP/TLS, endpoint review, credentials and Vault,


### PR DESCRIPTION
﻿## Summary

- define the Python build-tool contract around PEP 621 `[project].dependencies` and PEP 503 distribution-name normalization
- add a language-neutral field-boundary fixture and consume it from the Haskell build-tool tests
- replace Haskell whole-manifest Python tokenization with an authoritative, quote/comment-aware dependency reader
- refresh the collision-checked parity inventory and classify the newly landed native process-shutdown and authenticated UniFi adapters under excluded review owners

The real 488-package Python lane now completes with zero failures. Haskell and the canonical Go engine each produce exactly 1,118 dependency edges, with zero edges unique to either engine.

## Validation

- `python -m unittest discover -s code/scripts/tests -p test_build_tool_conformance_runner.py` ? 40 tests pass
- `python code/scripts/build_tool_conformance.py validate-corpus` ? 43 cases / 92 files valid
- `cabal test coding-adventures-build-tool:spec --ghc-options="-Wall -Werror"` ? 19 examples pass
- `cabal test all --test-show-details=direct` ? 26 build-tool/graph examples pass
- `cabal check` ? clean
- `cabal haddock lib:coding-adventures-build-tool --haddock-all` ? builds; existing missing-doc/link warnings only
- HPC ? 41% top-level definitions, 50% alternatives, 54% expressions
- `go test ./...`, `go vet ./...`, `go build -trimpath ./...` ? pass in the canonical Go build tool
- Go resolution-only plan ? 488 packages / 1,118 edges
- Haskell real dry-run ? built=0, skipped=488, failed=0
- full edge oracle ? Haskell=1,118, Go=1,118, only-Haskell=0, only-Go=0
- collision inventory at `9441f4c7` ? 1,247 identities / 4,400 slots / zero collisions / zero unknown buckets
- state dependency/status validation, `git diff --check`, direct authority/path review, and changed-diff credential scan ? clean

## Existing advisory debt

The canonical full Go build-file validator separately reports missing `BUILD_windows` prerequisites in `python/sir-runtime-oop` and `python/swi-prolog-parser`. The existing `build-file-standalone-integrity` backlog item owns those pre-existing build metadata gaps; this resolver-semantic PR does not widen into them. `cabal outdated` reports only the existing `containers` 0.8 and `time` 1.16.0.1 upper-bound advisories. HLint, Fourmolu, and OSV Scanner are unavailable locally.
