### PR TITLE
Persist Chief daemon credentials safely

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -1019,4 +1019,5 @@ members = [
   "markdown-docx",
   "task-core",
   "task-wasm",
+  "chief-of-staff-daemon-credential",
 ]

--- a/code/packages/rust/chief-of-staff-daemon-credential/BUILD
+++ b/code/packages/rust/chief-of-staff-daemon-credential/BUILD
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+cargo test -p chief-of-staff-daemon-credential -- --nocapture
+cargo clippy -p chief-of-staff-daemon-credential --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-daemon-credential --no-deps

--- a/code/packages/rust/chief-of-staff-daemon-credential/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-credential/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-08-03
+
+### Added
+
+- Added create-or-load persistence that never overwrites an existing credential.
+- Added canonical bounded reads and zeroizing returned secret storage.
+- Added descriptor-relative Unix no-follow traversal, owner/mode validation, and
+  mode-`000` to mode-`0600` publication after durable writes.
+- Added Windows ancestor locking, reparse-point rejection, and explicit protected
+  current-user-only DACL creation and validation.
+- Added creator-race, invalid-content, unsafe-object, permission, and stable-error
+  coverage.

--- a/code/packages/rust/chief-of-staff-daemon-credential/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-daemon-credential/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "chief-of-staff-daemon-credential"
+version = "0.1.0"
+edition = "2021"
+description = "Race-resistant owner-only local credential persistence for the D18 Chief daemon"
+license = "MIT"
+
+[dependencies]
+chief-of-staff-daemon-policy = { path = "../chief-of-staff-daemon-policy" }
+coding_adventures_zeroize = { path = "../zeroize" }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.52", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_SystemServices",
+    "Win32_System_Threading",
+] }

--- a/code/packages/rust/chief-of-staff-daemon-credential/README.md
+++ b/code/packages/rust/chief-of-staff-daemon-credential/README.md
@@ -1,0 +1,31 @@
+# chief-of-staff-daemon-credential
+
+Race-resistant owner-only local credential persistence for the D18 Chief daemon.
+
+`load_or_create_credential` accepts one bounded absolute path whose parent already
+exists. It loads a canonical 64-byte lowercase-hex credential or claims the absent
+file name without ever truncating or replacing an existing object. Returned secret
+text is wiped on drop.
+
+The Unix implementation walks from `/` with directory file descriptors and
+`openat(O_NOFOLLOW)`. New content is written and synchronized at mode `000`, then
+published as `0600`; existing files must be regular, owned by the effective user,
+and grant no group/world access.
+
+The Windows implementation holds every ancestor directory without delete sharing,
+rejects reparse points, and supplies an explicit protected security descriptor to
+`CreateFileW(CREATE_NEW)`. The descriptor contains exactly one allow ACE for the
+current token user. Existing files must have the same owner and protected one-ACE
+DACL; inherited directory permissions are never trusted.
+
+## Dependencies
+
+- chief-of-staff-daemon-policy
+- coding-adventures-zeroize
+
+## Development
+
+```bash
+# Run tests
+bash BUILD
+```

--- a/code/packages/rust/chief-of-staff-daemon-credential/required_capabilities.json
+++ b/code/packages/rust/chief-of-staff-daemon-credential/required_capabilities.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/chief-of-staff-daemon-credential",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "configured operator credential path",
+      "justification": "Loads one bounded credential only after rejecting links, non-regular files, foreign ownership, and broad access controls."
+    },
+    {
+      "category": "fs",
+      "action": "create",
+      "target": "configured operator credential path",
+      "justification": "Claims an absent credential name without overwrite and creates it with owner-only platform security metadata."
+    },
+    {
+      "category": "fs",
+      "action": "write",
+      "target": "configured operator credential path",
+      "justification": "Writes and synchronizes one freshly generated canonical credential before making it readable."
+    },
+    {
+      "category": "ffi",
+      "action": "call",
+      "target": "libc openat/fstat/fchmod and Windows file/token/security APIs",
+      "justification": "Uses handle-relative no-follow file operations and native ownership/access-control inspection unavailable through portable Rust filesystem APIs."
+    },
+    {
+      "category": "time",
+      "action": "sleep",
+      "target": "1ms bounded credential publication retry",
+      "justification": "Lets concurrent creators wait up to 250ms for the winning process to finish durable owner-only publication."
+    }
+  ],
+  "justification": "OS trust-boundary adapter that durably creates or loads exactly one local bearer credential without following links, inheriting broad access, or overwriting existing content."
+}

--- a/code/packages/rust/chief-of-staff-daemon-credential/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-credential/src/lib.rs
@@ -1,0 +1,289 @@
+//! Race-resistant owner-only local credential persistence for the D18 Chief daemon.
+
+#![deny(missing_docs)]
+
+use chief_of_staff_daemon_policy::{
+    generate_local_credential, LocalAuthError, LocalBearerAuthorizer,
+};
+use coding_adventures_zeroize::Zeroizing;
+use core::fmt::{self, Display, Formatter};
+use std::path::Path;
+
+#[cfg(unix)]
+mod unix;
+#[cfg(windows)]
+mod windows;
+
+const ENCODED_CREDENTIAL_BYTES: usize = 64;
+const MAX_PATH_BYTES: usize = 4096;
+
+/// Stable, payload-blind credential-file failure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CredentialFileError {
+    /// The supplied path was not a bounded absolute path with a regular final name.
+    InvalidPath,
+    /// The parent directory chain could not be opened without following links.
+    ParentUnavailable,
+    /// The credential file could not be opened, read, written, or synchronized.
+    AccessFailed,
+    /// The path resolved to a link, reparse point, directory, or other non-regular object.
+    UnsafeFileType,
+    /// The existing file is not owned by the current effective user.
+    InsecureOwner,
+    /// The existing file grants access beyond its owner.
+    InsecurePermissions,
+    /// The existing file was not exactly one canonical 64-byte lowercase-hex credential.
+    InvalidCredential,
+    /// The operating-system random source could not generate a fresh credential.
+    RandomnessUnavailable,
+}
+
+impl Display for CredentialFileError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidPath => "chief credential: invalid path",
+            Self::ParentUnavailable => "chief credential: parent unavailable",
+            Self::AccessFailed => "chief credential: access failed",
+            Self::UnsafeFileType => "chief credential: unsafe file type",
+            Self::InsecureOwner => "chief credential: insecure owner",
+            Self::InsecurePermissions => "chief credential: insecure permissions",
+            Self::InvalidCredential => "chief credential: invalid credential",
+            Self::RandomnessUnavailable => "chief credential: randomness unavailable",
+        })
+    }
+}
+
+impl std::error::Error for CredentialFileError {}
+
+/// Load one existing owner-only credential, or atomically claim an absent file name and create it.
+///
+/// The path must be absolute and its parent directory must already exist. The adapter never
+/// overwrites an existing file. It rejects links and non-regular objects, validates existing
+/// ownership and access controls before reading, caps the read at 65 bytes, and returns secret
+/// material in a zeroizing allocation.
+pub fn load_or_create_credential(path: &Path) -> Result<Zeroizing<String>, CredentialFileError> {
+    #[cfg(unix)]
+    {
+        unix::load_or_create(path)
+    }
+    #[cfg(windows)]
+    {
+        windows::load_or_create(path)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = path;
+        Err(CredentialFileError::AccessFailed)
+    }
+}
+
+fn fresh_credential() -> Result<Zeroizing<String>, CredentialFileError> {
+    generate_local_credential().map_err(|error| match error {
+        LocalAuthError::RandomnessUnavailable => CredentialFileError::RandomnessUnavailable,
+        LocalAuthError::InvalidCredentialEncoding | LocalAuthError::AuthenticationFailed => {
+            CredentialFileError::InvalidCredential
+        }
+    })
+}
+
+fn validate_credential(bytes: &[u8]) -> Result<Zeroizing<String>, CredentialFileError> {
+    if bytes.len() != ENCODED_CREDENTIAL_BYTES {
+        return Err(CredentialFileError::InvalidCredential);
+    }
+    let text = std::str::from_utf8(bytes).map_err(|_| CredentialFileError::InvalidCredential)?;
+    LocalBearerAuthorizer::new(text).map_err(|_| CredentialFileError::InvalidCredential)?;
+    Ok(Zeroizing::new(text.to_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new(label: &str) -> Self {
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let temporary_root = fs::canonicalize(std::env::temp_dir()).unwrap();
+            let path = temporary_root.join(format!(
+                "chief-credential-{label}-{}-{nonce}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).unwrap();
+            Self(path)
+        }
+
+        fn credential(&self) -> PathBuf {
+            self.0.join("operator.credential")
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn creates_once_then_loads_the_identical_canonical_credential() {
+        let directory = TestDirectory::new("round-trip");
+        let path = directory.credential();
+        let first = load_or_create_credential(&path).unwrap();
+        let second = load_or_create_credential(&path).unwrap();
+        assert_eq!(&*first, &*second);
+        assert_eq!(fs::read(&path).unwrap(), first.as_bytes());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[test]
+    fn concurrent_creators_converge_without_overwrite() {
+        let directory = TestDirectory::new("race");
+        let path = Arc::new(directory.credential());
+        let barrier = Arc::new(Barrier::new(8));
+        let workers: Vec<_> = (0..8)
+            .map(|_| {
+                let path = Arc::clone(&path);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    load_or_create_credential(&path).unwrap().to_string()
+                })
+            })
+            .collect();
+        let credentials: Vec<_> = workers
+            .into_iter()
+            .map(|worker| worker.join().unwrap())
+            .collect();
+        assert!(credentials
+            .iter()
+            .all(|credential| credential == &credentials[0]));
+    }
+
+    #[test]
+    fn invalid_existing_content_is_preserved_and_rejected() {
+        let directory = TestDirectory::new("invalid");
+        let path = directory.credential();
+        load_or_create_credential(&path).unwrap();
+        fs::write(&path, b"not-a-credential").unwrap();
+        assert!(matches!(
+            load_or_create_credential(&path),
+            Err(CredentialFileError::InvalidCredential)
+        ));
+        assert_eq!(fs::read(path).unwrap(), b"not-a-credential");
+    }
+
+    #[test]
+    fn missing_parent_and_relative_paths_fail_closed() {
+        let directory = TestDirectory::new("paths");
+        assert!(matches!(
+            load_or_create_credential(Path::new("relative.credential")),
+            Err(CredentialFileError::InvalidPath)
+        ));
+        assert!(matches!(
+            load_or_create_credential(&directory.0.join("missing/credential")),
+            Err(CredentialFileError::ParentUnavailable)
+        ));
+    }
+
+    #[test]
+    fn errors_are_stable_and_payload_blind() {
+        let expected = [
+            (
+                CredentialFileError::InvalidPath,
+                "chief credential: invalid path",
+            ),
+            (
+                CredentialFileError::ParentUnavailable,
+                "chief credential: parent unavailable",
+            ),
+            (
+                CredentialFileError::AccessFailed,
+                "chief credential: access failed",
+            ),
+            (
+                CredentialFileError::UnsafeFileType,
+                "chief credential: unsafe file type",
+            ),
+            (
+                CredentialFileError::InsecureOwner,
+                "chief credential: insecure owner",
+            ),
+            (
+                CredentialFileError::InsecurePermissions,
+                "chief credential: insecure permissions",
+            ),
+            (
+                CredentialFileError::InvalidCredential,
+                "chief credential: invalid credential",
+            ),
+            (
+                CredentialFileError::RandomnessUnavailable,
+                "chief credential: randomness unavailable",
+            ),
+        ];
+        for (error, message) in expected {
+            assert_eq!(error.to_string(), message);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlinks_directories_and_broad_permissions() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let directory = TestDirectory::new("unsafe");
+        let target = directory.0.join("target");
+        fs::write(
+            &target,
+            b"0000000000000000000000000000000000000000000000000000000000000000",
+        )
+        .unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o600)).unwrap();
+
+        let link = directory.credential();
+        symlink(&target, &link).unwrap();
+        assert!(matches!(
+            load_or_create_credential(&link),
+            Err(CredentialFileError::UnsafeFileType)
+        ));
+        fs::remove_file(&link).unwrap();
+
+        fs::create_dir(&link).unwrap();
+        assert!(matches!(
+            load_or_create_credential(&link),
+            Err(CredentialFileError::UnsafeFileType)
+        ));
+        fs::remove_dir(&link).unwrap();
+
+        fs::copy(&target, &link).unwrap();
+        fs::set_permissions(&link, fs::Permissions::from_mode(0o640)).unwrap();
+        assert!(matches!(
+            load_or_create_credential(&link),
+            Err(CredentialFileError::InsecurePermissions)
+        ));
+
+        let real_parent = directory.0.join("real-parent");
+        let linked_parent = directory.0.join("linked-parent");
+        fs::create_dir(&real_parent).unwrap();
+        symlink(&real_parent, &linked_parent).unwrap();
+        assert!(matches!(
+            load_or_create_credential(&linked_parent.join("credential")),
+            Err(CredentialFileError::ParentUnavailable)
+        ));
+    }
+}

--- a/code/packages/rust/chief-of-staff-daemon-credential/src/unix.rs
+++ b/code/packages/rust/chief-of-staff-daemon-credential/src/unix.rs
@@ -1,0 +1,207 @@
+use super::{
+    fresh_credential, validate_credential, CredentialFileError, ENCODED_CREDENTIAL_BYTES,
+    MAX_PATH_BYTES,
+};
+use coding_adventures_zeroize::Zeroizing;
+use std::ffi::{CString, OsStr};
+use std::fs::File;
+use std::io::{Read, Write};
+use std::mem::MaybeUninit;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Component, Path};
+use std::time::Duration;
+
+const PUBLICATION_RETRIES: usize = 250;
+
+enum OpenFailure {
+    Missing,
+    Busy,
+    Public(CredentialFileError),
+}
+
+enum CreateFailure {
+    Exists,
+    Public(CredentialFileError),
+}
+
+pub(super) fn load_or_create(path: &Path) -> Result<Zeroizing<String>, CredentialFileError> {
+    let (parent, name) = open_parent(path)?;
+    match open_existing(&parent, &name) {
+        Ok(file) => load(file),
+        Err(OpenFailure::Public(error)) => Err(error),
+        Err(OpenFailure::Busy) => Err(CredentialFileError::AccessFailed),
+        Err(OpenFailure::Missing) => {
+            let credential = fresh_credential()?;
+            match create_new(&parent, &name) {
+                Ok(mut file) => {
+                    verify_created_file(&file)?;
+                    file.write_all(credential.as_bytes())
+                        .and_then(|()| file.sync_all())
+                        .map_err(|_| CredentialFileError::AccessFailed)?;
+                    if unsafe { libc::fchmod(file.as_raw_fd(), 0o600) } != 0 {
+                        return Err(CredentialFileError::AccessFailed);
+                    }
+                    file.sync_all()
+                        .map_err(|_| CredentialFileError::AccessFailed)?;
+                    if unsafe { libc::fsync(parent.as_raw_fd()) } != 0 {
+                        return Err(CredentialFileError::AccessFailed);
+                    }
+                    Ok(credential)
+                }
+                Err(CreateFailure::Exists) => open_existing(&parent, &name)
+                    .map_err(|failure| match failure {
+                        OpenFailure::Missing
+                        | OpenFailure::Busy
+                        | OpenFailure::Public(CredentialFileError::AccessFailed) => {
+                            CredentialFileError::AccessFailed
+                        }
+                        OpenFailure::Public(error) => error,
+                    })
+                    .and_then(load),
+                Err(CreateFailure::Public(error)) => Err(error),
+            }
+        }
+    }
+}
+
+fn open_parent(path: &Path) -> Result<(OwnedFd, CString), CredentialFileError> {
+    if !path.is_absolute() || path.as_os_str().as_bytes().len() > MAX_PATH_BYTES {
+        return Err(CredentialFileError::InvalidPath);
+    }
+    let components: Vec<_> = path.components().collect();
+    if components.len() < 2 || components[0] != Component::RootDir {
+        return Err(CredentialFileError::InvalidPath);
+    }
+    let name = match components.last() {
+        Some(Component::Normal(name)) => c_string(name)?,
+        _ => return Err(CredentialFileError::InvalidPath),
+    };
+    let root = unsafe {
+        libc::open(
+            c"/".as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    let mut directory = owned_fd(root).map_err(|_| CredentialFileError::ParentUnavailable)?;
+    for component in &components[1..components.len() - 1] {
+        let Component::Normal(part) = component else {
+            return Err(CredentialFileError::InvalidPath);
+        };
+        let part = c_string(part)?;
+        let next = unsafe {
+            libc::openat(
+                directory.as_raw_fd(),
+                part.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            )
+        };
+        directory = owned_fd(next).map_err(|_| CredentialFileError::ParentUnavailable)?;
+    }
+    Ok((directory, name))
+}
+
+fn c_string(value: &OsStr) -> Result<CString, CredentialFileError> {
+    CString::new(value.as_bytes()).map_err(|_| CredentialFileError::InvalidPath)
+}
+
+fn owned_fd(raw: libc::c_int) -> Result<OwnedFd, ()> {
+    if raw < 0 {
+        Err(())
+    } else {
+        Ok(unsafe { OwnedFd::from_raw_fd(raw) })
+    }
+}
+
+fn open_existing(parent: &OwnedFd, name: &CString) -> Result<File, OpenFailure> {
+    for _ in 0..PUBLICATION_RETRIES {
+        match open_existing_once(parent, name) {
+            Err(OpenFailure::Busy) => std::thread::sleep(Duration::from_millis(1)),
+            result => return result,
+        }
+    }
+    Err(OpenFailure::Public(CredentialFileError::AccessFailed))
+}
+
+fn open_existing_once(parent: &OwnedFd, name: &CString) -> Result<File, OpenFailure> {
+    let raw = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if raw < 0 {
+        return match std::io::Error::last_os_error().raw_os_error() {
+            Some(libc::ENOENT) => Err(OpenFailure::Missing),
+            Some(libc::EACCES) => Err(OpenFailure::Busy),
+            Some(libc::ELOOP) => Err(OpenFailure::Public(CredentialFileError::UnsafeFileType)),
+            _ => Err(OpenFailure::Public(CredentialFileError::AccessFailed)),
+        };
+    }
+    Ok(File::from(unsafe { OwnedFd::from_raw_fd(raw) }))
+}
+
+fn create_new(parent: &OwnedFd, name: &CString) -> Result<File, CreateFailure> {
+    let raw = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_RDWR | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            0o000,
+        )
+    };
+    if raw < 0 {
+        return match std::io::Error::last_os_error().raw_os_error() {
+            Some(libc::EEXIST) => Err(CreateFailure::Exists),
+            Some(libc::ELOOP) => Err(CreateFailure::Public(CredentialFileError::UnsafeFileType)),
+            _ => Err(CreateFailure::Public(CredentialFileError::AccessFailed)),
+        };
+    }
+    Ok(File::from(unsafe { OwnedFd::from_raw_fd(raw) }))
+}
+
+fn load(file: File) -> Result<Zeroizing<String>, CredentialFileError> {
+    verify_file(&file)?;
+    let mut bytes = Zeroizing::new(Vec::with_capacity(ENCODED_CREDENTIAL_BYTES + 1));
+    file.take((ENCODED_CREDENTIAL_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|_| CredentialFileError::AccessFailed)?;
+    validate_credential(&bytes)
+}
+
+fn verify_file(file: &File) -> Result<(), CredentialFileError> {
+    let stat = file_stat(file)?;
+    verify_identity(&stat)?;
+    if stat.st_mode & 0o077 != 0 || stat.st_mode & 0o400 == 0 {
+        return Err(CredentialFileError::InsecurePermissions);
+    }
+    Ok(())
+}
+
+fn verify_created_file(file: &File) -> Result<(), CredentialFileError> {
+    let stat = file_stat(file)?;
+    verify_identity(&stat)?;
+    if stat.st_mode & 0o777 != 0 {
+        return Err(CredentialFileError::InsecurePermissions);
+    }
+    Ok(())
+}
+
+fn file_stat(file: &File) -> Result<libc::stat, CredentialFileError> {
+    let mut stat = MaybeUninit::<libc::stat>::uninit();
+    if unsafe { libc::fstat(file.as_raw_fd(), stat.as_mut_ptr()) } != 0 {
+        return Err(CredentialFileError::AccessFailed);
+    }
+    Ok(unsafe { stat.assume_init() })
+}
+
+fn verify_identity(stat: &libc::stat) -> Result<(), CredentialFileError> {
+    if stat.st_mode & libc::S_IFMT != libc::S_IFREG {
+        return Err(CredentialFileError::UnsafeFileType);
+    }
+    if stat.st_uid != unsafe { libc::geteuid() } {
+        return Err(CredentialFileError::InsecureOwner);
+    }
+    Ok(())
+}

--- a/code/packages/rust/chief-of-staff-daemon-credential/src/windows.rs
+++ b/code/packages/rust/chief-of-staff-daemon-credential/src/windows.rs
@@ -1,0 +1,435 @@
+use super::{
+    fresh_credential, validate_credential, CredentialFileError, ENCODED_CREDENTIAL_BYTES,
+    MAX_PATH_BYTES,
+};
+use coding_adventures_zeroize::Zeroizing;
+use std::ffi::c_void;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::mem::{size_of, MaybeUninit};
+use std::os::windows::ffi::OsStrExt;
+use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
+use std::path::{Component, Path};
+use std::ptr::{addr_of, null, null_mut};
+use std::time::Duration;
+use windows_sys::Win32::Foundation::{
+    GetLastError, BOOL, ERROR_ALREADY_EXISTS, ERROR_FILE_EXISTS, ERROR_FILE_NOT_FOUND,
+    ERROR_PATH_NOT_FOUND, ERROR_SHARING_VIOLATION, HANDLE, INVALID_HANDLE_VALUE, PSID,
+};
+use windows_sys::Win32::Security::{
+    AclSizeInformation, AddAccessAllowedAce, EqualSid, GetAce, GetAclInformation,
+    GetKernelObjectSecurity, GetLengthSid, GetSecurityDescriptorControl, GetSecurityDescriptorDacl,
+    GetSecurityDescriptorOwner, GetTokenInformation, InitializeAcl, InitializeSecurityDescriptor,
+    SetSecurityDescriptorControl, SetSecurityDescriptorDacl, SetSecurityDescriptorOwner, TokenUser,
+    ACCESS_ALLOWED_ACE, ACL, ACL_REVISION, ACL_SIZE_INFORMATION, DACL_SECURITY_INFORMATION,
+    OWNER_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES, SECURITY_DESCRIPTOR,
+    SE_DACL_PROTECTED, TOKEN_QUERY, TOKEN_USER,
+};
+use windows_sys::Win32::Storage::FileSystem::{
+    CreateFileW, FileAttributeTagInfo, GetFileInformationByHandleEx, CREATE_NEW,
+    FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT, FILE_ATTRIBUTE_TAG_INFO,
+    FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_GENERIC_READ,
+    FILE_GENERIC_WRITE, FILE_READ_ATTRIBUTES, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+};
+use windows_sys::Win32::System::SystemServices::{
+    ACCESS_ALLOWED_ACE_TYPE, SECURITY_DESCRIPTOR_REVISION,
+};
+use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+const OWNER_ACCESS: u32 = FILE_GENERIC_READ | FILE_GENERIC_WRITE;
+const MAX_SECURITY_DESCRIPTOR_BYTES: u32 = 64 * 1024;
+const PUBLICATION_RETRIES: usize = 250;
+const MINIMUM_SID_BYTES: usize = 8;
+
+enum OpenFailure {
+    Missing,
+    Busy,
+    Public(CredentialFileError),
+}
+
+enum CreateFailure {
+    Exists,
+    Public(CredentialFileError),
+}
+
+pub(super) fn load_or_create(path: &Path) -> Result<Zeroizing<String>, CredentialFileError> {
+    validate_path(path)?;
+    let _parent_locks = lock_parents(path)?;
+    match open_existing(path) {
+        Ok(file) => load(file),
+        Err(OpenFailure::Public(error)) => Err(error),
+        Err(OpenFailure::Busy) => Err(CredentialFileError::AccessFailed),
+        Err(OpenFailure::Missing) => {
+            let credential = fresh_credential()?;
+            match create_new(path) {
+                Ok(mut file) => {
+                    verify_file(&file)?;
+                    file.write_all(credential.as_bytes())
+                        .and_then(|()| file.sync_all())
+                        .map_err(|_| CredentialFileError::AccessFailed)?;
+                    Ok(credential)
+                }
+                Err(CreateFailure::Exists) => open_existing(path)
+                    .map_err(|failure| match failure {
+                        OpenFailure::Missing
+                        | OpenFailure::Busy
+                        | OpenFailure::Public(CredentialFileError::AccessFailed) => {
+                            CredentialFileError::AccessFailed
+                        }
+                        OpenFailure::Public(error) => error,
+                    })
+                    .and_then(load),
+                Err(CreateFailure::Public(error)) => Err(error),
+            }
+        }
+    }
+}
+
+fn validate_path(path: &Path) -> Result<(), CredentialFileError> {
+    let encoded_units = path.as_os_str().encode_wide().count();
+    if !path.is_absolute()
+        || encoded_units == 0
+        || encoded_units > MAX_PATH_BYTES
+        || path
+            .components()
+            .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
+        || !matches!(path.components().next_back(), Some(Component::Normal(_)))
+    {
+        return Err(CredentialFileError::InvalidPath);
+    }
+    if path.as_os_str().encode_wide().any(|unit| unit == 0) {
+        return Err(CredentialFileError::InvalidPath);
+    }
+    Ok(())
+}
+
+fn lock_parents(path: &Path) -> Result<Vec<OwnedHandle>, CredentialFileError> {
+    let parent = path.parent().ok_or(CredentialFileError::InvalidPath)?;
+    let mut ancestors: Vec<_> = parent
+        .ancestors()
+        .filter(|ancestor| !ancestor.as_os_str().is_empty())
+        .collect();
+    ancestors.reverse();
+    ancestors
+        .into_iter()
+        .map(open_directory)
+        .collect::<Result<Vec<_>, _>>()
+}
+
+fn open_directory(path: &Path) -> Result<OwnedHandle, CredentialFileError> {
+    let wide = wide_path(path)?;
+    let raw = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            FILE_READ_ATTRIBUTES,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            null(),
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+            0,
+        )
+    };
+    let handle = owned_handle(raw).map_err(|_| CredentialFileError::ParentUnavailable)?;
+    let attributes = file_attributes(raw).map_err(|_| CredentialFileError::ParentUnavailable)?;
+    if attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY == 0
+        || attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != 0
+    {
+        return Err(CredentialFileError::ParentUnavailable);
+    }
+    Ok(handle)
+}
+
+fn open_existing(path: &Path) -> Result<File, OpenFailure> {
+    for _ in 0..PUBLICATION_RETRIES {
+        match open_existing_once(path) {
+            Err(OpenFailure::Busy) => std::thread::sleep(Duration::from_millis(1)),
+            result => return result,
+        }
+    }
+    Err(OpenFailure::Public(CredentialFileError::AccessFailed))
+}
+
+fn open_existing_once(path: &Path) -> Result<File, OpenFailure> {
+    let wide = wide_path(path).map_err(OpenFailure::Public)?;
+    let raw = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            FILE_GENERIC_READ,
+            0,
+            null(),
+            OPEN_EXISTING,
+            FILE_FLAG_OPEN_REPARSE_POINT,
+            0,
+        )
+    };
+    if raw == INVALID_HANDLE_VALUE {
+        return match unsafe { GetLastError() } {
+            ERROR_FILE_NOT_FOUND | ERROR_PATH_NOT_FOUND => Err(OpenFailure::Missing),
+            ERROR_SHARING_VIOLATION => Err(OpenFailure::Busy),
+            _ => Err(OpenFailure::Public(CredentialFileError::AccessFailed)),
+        };
+    }
+    Ok(File::from(unsafe {
+        OwnedHandle::from_raw_handle(raw as *mut c_void)
+    }))
+}
+
+fn create_new(path: &Path) -> Result<File, CreateFailure> {
+    let wide = wide_path(path).map_err(CreateFailure::Public)?;
+    let mut security = OwnerSecurity::new().map_err(CreateFailure::Public)?;
+    let attributes = security.attributes();
+    let raw = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            OWNER_ACCESS,
+            0,
+            &attributes,
+            CREATE_NEW,
+            FILE_FLAG_OPEN_REPARSE_POINT,
+            0,
+        )
+    };
+    if raw == INVALID_HANDLE_VALUE {
+        return match unsafe { GetLastError() } {
+            ERROR_ALREADY_EXISTS | ERROR_FILE_EXISTS => Err(CreateFailure::Exists),
+            _ => Err(CreateFailure::Public(CredentialFileError::AccessFailed)),
+        };
+    }
+    Ok(File::from(unsafe {
+        OwnedHandle::from_raw_handle(raw as *mut c_void)
+    }))
+}
+
+fn wide_path(path: &Path) -> Result<Vec<u16>, CredentialFileError> {
+    let mut wide: Vec<_> = path.as_os_str().encode_wide().collect();
+    if wide.is_empty() || wide.len() > MAX_PATH_BYTES || wide.contains(&0) {
+        return Err(CredentialFileError::InvalidPath);
+    }
+    wide.push(0);
+    Ok(wide)
+}
+
+fn owned_handle(raw: HANDLE) -> Result<OwnedHandle, ()> {
+    if raw == INVALID_HANDLE_VALUE {
+        Err(())
+    } else {
+        Ok(unsafe { OwnedHandle::from_raw_handle(raw as *mut c_void) })
+    }
+}
+
+fn load(file: File) -> Result<Zeroizing<String>, CredentialFileError> {
+    verify_file(&file)?;
+    let mut bytes = Zeroizing::new(Vec::with_capacity(ENCODED_CREDENTIAL_BYTES + 1));
+    file.take((ENCODED_CREDENTIAL_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|_| CredentialFileError::AccessFailed)?;
+    validate_credential(&bytes)
+}
+
+fn verify_file(file: &File) -> Result<(), CredentialFileError> {
+    let raw = file.as_raw_handle() as HANDLE;
+    let attributes = file_attributes(raw)?;
+    if attributes.FileAttributes & (FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT) != 0 {
+        return Err(CredentialFileError::UnsafeFileType);
+    }
+    verify_owner_acl(raw)
+}
+
+fn file_attributes(raw: HANDLE) -> Result<FILE_ATTRIBUTE_TAG_INFO, CredentialFileError> {
+    let mut information = MaybeUninit::<FILE_ATTRIBUTE_TAG_INFO>::zeroed();
+    if unsafe {
+        GetFileInformationByHandleEx(
+            raw,
+            FileAttributeTagInfo,
+            information.as_mut_ptr().cast(),
+            size_of::<FILE_ATTRIBUTE_TAG_INFO>() as u32,
+        )
+    } == 0
+    {
+        return Err(CredentialFileError::AccessFailed);
+    }
+    Ok(unsafe { information.assume_init() })
+}
+
+struct CurrentUserSid {
+    _storage: Vec<usize>,
+    sid: PSID,
+}
+
+impl CurrentUserSid {
+    fn query() -> Result<Self, CredentialFileError> {
+        let mut raw_token = 0;
+        if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut raw_token) } == 0 {
+            return Err(CredentialFileError::AccessFailed);
+        }
+        let _token = owned_handle(raw_token).map_err(|_| CredentialFileError::AccessFailed)?;
+        let mut needed = 0;
+        unsafe {
+            GetTokenInformation(raw_token, TokenUser, null_mut(), 0, &mut needed);
+        }
+        if needed == 0 || needed > MAX_SECURITY_DESCRIPTOR_BYTES {
+            return Err(CredentialFileError::AccessFailed);
+        }
+        let mut storage = vec![0usize; bytes_to_words(needed)];
+        if unsafe {
+            GetTokenInformation(
+                raw_token,
+                TokenUser,
+                storage.as_mut_ptr().cast(),
+                needed,
+                &mut needed,
+            )
+        } == 0
+        {
+            return Err(CredentialFileError::AccessFailed);
+        }
+        let token_user = storage.as_ptr().cast::<TOKEN_USER>();
+        let sid = unsafe { (*token_user).User.Sid };
+        if sid.is_null() || unsafe { GetLengthSid(sid) } == 0 {
+            return Err(CredentialFileError::AccessFailed);
+        }
+        Ok(Self {
+            _storage: storage,
+            sid,
+        })
+    }
+}
+
+struct OwnerSecurity {
+    _owner: CurrentUserSid,
+    _acl_storage: Vec<u32>,
+    descriptor: SECURITY_DESCRIPTOR,
+}
+
+impl OwnerSecurity {
+    fn new() -> Result<Self, CredentialFileError> {
+        let owner = CurrentUserSid::query()?;
+        let sid_bytes = unsafe { GetLengthSid(owner.sid) } as usize;
+        let acl_bytes =
+            size_of::<ACL>() + size_of::<ACCESS_ALLOWED_ACE>() - size_of::<u32>() + sid_bytes;
+        let mut acl_storage = vec![0u32; acl_bytes.div_ceil(size_of::<u32>())];
+        let acl = acl_storage.as_mut_ptr().cast::<ACL>();
+        if unsafe { InitializeAcl(acl, acl_bytes as u32, ACL_REVISION) } == 0
+            || unsafe { AddAccessAllowedAce(acl, ACL_REVISION, OWNER_ACCESS, owner.sid) } == 0
+        {
+            return Err(CredentialFileError::AccessFailed);
+        }
+        let mut descriptor = unsafe { MaybeUninit::<SECURITY_DESCRIPTOR>::zeroed().assume_init() };
+        let descriptor_ptr: PSECURITY_DESCRIPTOR =
+            (&mut descriptor as *mut SECURITY_DESCRIPTOR).cast();
+        if unsafe { InitializeSecurityDescriptor(descriptor_ptr, SECURITY_DESCRIPTOR_REVISION) }
+            == 0
+            || unsafe { SetSecurityDescriptorOwner(descriptor_ptr, owner.sid, 0) } == 0
+            || unsafe { SetSecurityDescriptorDacl(descriptor_ptr, 1, acl, 0) } == 0
+            || unsafe {
+                SetSecurityDescriptorControl(descriptor_ptr, SE_DACL_PROTECTED, SE_DACL_PROTECTED)
+            } == 0
+        {
+            return Err(CredentialFileError::AccessFailed);
+        }
+        Ok(Self {
+            _owner: owner,
+            _acl_storage: acl_storage,
+            descriptor,
+        })
+    }
+
+    fn attributes(&mut self) -> SECURITY_ATTRIBUTES {
+        SECURITY_ATTRIBUTES {
+            nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
+            lpSecurityDescriptor: (&mut self.descriptor as *mut SECURITY_DESCRIPTOR).cast(),
+            bInheritHandle: 0,
+        }
+    }
+}
+
+fn verify_owner_acl(raw: HANDLE) -> Result<(), CredentialFileError> {
+    let current = CurrentUserSid::query()?;
+    let information = OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION;
+    let mut needed = 0;
+    unsafe {
+        GetKernelObjectSecurity(raw, information, null_mut(), 0, &mut needed);
+    }
+    if needed == 0 || needed > MAX_SECURITY_DESCRIPTOR_BYTES {
+        return Err(CredentialFileError::AccessFailed);
+    }
+    let mut storage = vec![0usize; bytes_to_words(needed)];
+    let descriptor: PSECURITY_DESCRIPTOR = storage.as_mut_ptr().cast();
+    if unsafe { GetKernelObjectSecurity(raw, information, descriptor, needed, &mut needed) } == 0 {
+        return Err(CredentialFileError::AccessFailed);
+    }
+
+    let mut owner = null_mut();
+    let mut owner_defaulted: BOOL = 0;
+    if unsafe { GetSecurityDescriptorOwner(descriptor, &mut owner, &mut owner_defaulted) } == 0 {
+        return Err(CredentialFileError::AccessFailed);
+    }
+    if owner.is_null() || unsafe { EqualSid(owner, current.sid) } == 0 {
+        return Err(CredentialFileError::InsecureOwner);
+    }
+
+    let mut control = 0;
+    let mut revision = 0;
+    if unsafe { GetSecurityDescriptorControl(descriptor, &mut control, &mut revision) } == 0 {
+        return Err(CredentialFileError::AccessFailed);
+    }
+    if control & SE_DACL_PROTECTED == 0 {
+        return Err(CredentialFileError::InsecurePermissions);
+    }
+
+    let mut present: BOOL = 0;
+    let mut dacl: *mut ACL = null_mut();
+    let mut defaulted: BOOL = 0;
+    if unsafe { GetSecurityDescriptorDacl(descriptor, &mut present, &mut dacl, &mut defaulted) }
+        == 0
+    {
+        return Err(CredentialFileError::AccessFailed);
+    }
+    if present == 0 || dacl.is_null() {
+        return Err(CredentialFileError::InsecurePermissions);
+    }
+
+    let mut acl_information = MaybeUninit::<ACL_SIZE_INFORMATION>::zeroed();
+    if unsafe {
+        GetAclInformation(
+            dacl,
+            acl_information.as_mut_ptr().cast(),
+            size_of::<ACL_SIZE_INFORMATION>() as u32,
+            AclSizeInformation,
+        )
+    } == 0
+    {
+        return Err(CredentialFileError::AccessFailed);
+    }
+    if unsafe { acl_information.assume_init() }.AceCount != 1 {
+        return Err(CredentialFileError::InsecurePermissions);
+    }
+
+    let mut ace_pointer: *mut c_void = null_mut();
+    if unsafe { GetAce(dacl, 0, &mut ace_pointer) } == 0 || ace_pointer.is_null() {
+        return Err(CredentialFileError::AccessFailed);
+    }
+    let ace = ace_pointer.cast::<ACCESS_ALLOWED_ACE>();
+    let ace = unsafe { &*ace };
+    let sid_offset = size_of::<ACCESS_ALLOWED_ACE>() - size_of::<u32>();
+    if usize::from(ace.Header.AceSize) < sid_offset + MINIMUM_SID_BYTES {
+        return Err(CredentialFileError::InsecurePermissions);
+    }
+    let sid = addr_of!(ace.SidStart).cast_mut().cast();
+    let sid_bytes = unsafe { GetLengthSid(sid) } as usize;
+    let minimum_size = sid_offset + sid_bytes;
+    if u32::from(ace.Header.AceType) != ACCESS_ALLOWED_ACE_TYPE
+        || ace.Header.AceFlags != 0
+        || sid_bytes < MINIMUM_SID_BYTES
+        || usize::from(ace.Header.AceSize) < minimum_size
+        || ace.Mask != OWNER_ACCESS
+        || unsafe { EqualSid(sid, current.sid) } == 0
+    {
+        return Err(CredentialFileError::InsecurePermissions);
+    }
+    Ok(())
+}
+
+fn bytes_to_words(bytes: u32) -> usize {
+    (bytes as usize).div_ceil(size_of::<usize>())
+}

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -2021,6 +2021,19 @@ biometric_timeout = 30           # seconds
 hardware_key_timeout = 60        # seconds
 ```
 
+The operator credential path is a fail-closed local trust boundary. Composition
+MUST load an existing canonical 64-byte lowercase-hex credential or claim an absent
+file name without truncating or replacing any existing object. Reads are bounded,
+links and non-regular files are rejected, and returned secret storage is wiped on
+drop. On Unix, every path component is opened relative to a trusted directory handle
+without following links; new bytes are durably written at mode `000` before the file
+is published as owner-readable/writable mode `0600`. Existing files must be owned by
+the effective user and grant no group/world access. On Windows, ancestor directory
+handles prevent replacement during validation, reparse points are rejected, and
+creation supplies a protected DACL with exactly one allow ACE for the current token
+user. Existing Windows credentials must retain that owner and protected one-ACE DACL;
+inherited directory permissions are not sufficient.
+
 **Host restart policies:**
 
 | Policy       | Behavior                                          |


### PR DESCRIPTION
## Summary

- add a reusable owner-only credential create/load adapter for D18 daemon composition
- prevent link or reparse traversal, overwrites, partial-publication races, and broad permissions on Unix and Windows
- document the exact credential trust boundary and required OS capabilities

## Security model

Unix uses descriptor-relative no-follow opens, exclusive mode-000 publication, durable writes, and a final 0600 mode. Windows locks ancestor directories, rejects reparse points, and creates and verifies an explicit protected current-user-only DACL. Existing content is bounded and canonical, and returned secrets zeroize on drop.

## Validation

- package BUILD gate: 6 focused tests, strict Clippy, and rustdoc
- Windows cross-target check and strict all-target Clippy
- affected-package planner: 55 built, 1184 skipped
- focused Tarpaulin: 113/130 host-coverable lines (86.9%)
- manual security review, including bounded SID parsing and parent-directory durability

This is the next bounded implementation slice for #128. Windows CI is expected to exercise the native ACL and reparse-point tests.