### PR TITLE
fix(spice): lower diode grading coefficient

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower diode model-card `M` / `MJ` grading coefficient.
 - Validate and lower diode model-card `VJ` / `PB` junction potential.
 - Validate and lower finite, non-negative diode model-card `RS` series resistance.
 - Validate positive finite diode model-card `IBV` breakdown current.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1275,6 +1275,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             ),
             Tt=model.params.get("TT", 0.0),
             Vj=model.params.get("VJ", model.params.get("PB", 1.0)),
+            M=model.params.get("M", model.params.get("MJ", 0.5)),
             Rs=model.params.get("RS", 0.0),
         )
     if prefix == "Q":
@@ -1969,6 +1970,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(junction_potential) or junction_potential <= 0.0
         ):
             raise NetlistParseError("diode VJ must be finite and positive")
+        grading_coefficient = params.get("M", params.get("MJ"))
+        if grading_coefficient is not None and (
+            not math.isfinite(grading_coefficient) or grading_coefficient < 0.0
+        ):
+            raise NetlistParseError("diode M must be finite and non-negative")
     if kind in {"NPN", "PNP"}:
         saturation_current = params.get("IS")
         if saturation_current is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -936,6 +936,34 @@ def test_rejects_invalid_diode_junction_potential(
         parse_netlist(f".model clamp D({parameter}={value})")
 
 
+@pytest.mark.parametrize("parameter", ["M", "MJ"])
+def test_lowers_diode_grading_coefficient_alias(parameter: str) -> None:
+    parsed = parse_netlist(f".model clamp D({parameter}=0.4)\nD1 in out clamp")
+
+    diode = parsed.circuit.elements[0]
+    assert isinstance(diode, Diode)
+    assert diode.M == 0.4
+
+
+def test_diode_grading_coefficient_prefers_canonical_name() -> None:
+    parsed = parse_netlist(".model clamp D(MJ=0.4 M=0.3)\nD1 in out clamp")
+
+    diode = parsed.circuit.elements[0]
+    assert isinstance(diode, Diode)
+    assert diode.M == 0.3
+
+
+@pytest.mark.parametrize("parameter", ["M", "MJ"])
+@pytest.mark.parametrize("value", ["-0.1", "1e999"])
+def test_rejects_invalid_diode_grading_coefficient(
+    parameter: str, value: str
+) -> None:
+    with pytest.raises(
+        NetlistParseError, match="diode M must be finite and non-negative"
+    ):
+        parse_netlist(f".model clamp D({parameter}={value})")
+
+
 def test_parse_diode_junction_capacitance_alias() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower diode model-card `M` / `MJ` grading coefficient.
 - Validate and lower diode model-card `VJ` / `PB` junction potential.
 - Validate and lower finite, non-negative diode model-card `RS` series resistance.
 - Validate positive finite diode model-card `IBV` breakdown current.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1223,6 +1223,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("diode VJ must be finite and positive");
   }
+  const diodeGradingCoefficient = params.get("M") ?? params.get("MJ");
+  if (
+    kind === "D" &&
+    diodeGradingCoefficient !== undefined &&
+    (!Number.isFinite(diodeGradingCoefficient) || diodeGradingCoefficient < 0.0)
+  ) {
+    throw new NetlistParseError("diode M must be finite and non-negative");
+  }
   const bjtForwardBeta =
     params.get("BF") ??
     params.get("BETA") ??
@@ -1810,6 +1818,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
         model.params.get("TT") ?? 0.0,
       ),
       junctionPotential: model.params.get("VJ") ?? model.params.get("PB") ?? 1.0,
+      gradingCoefficient: model.params.get("M") ?? model.params.get("MJ") ?? 0.5,
       seriesResistance: model.params.get("RS") ?? 0.0,
     };
   }

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -976,6 +976,35 @@ D1 in out clamp
     );
   });
 
+  it.each(["M", "MJ"])("lowers diode %s grading coefficient alias", (parameter) => {
+    const parsed = parseNetlist(`.model clamp D(${parameter}=0.4)\nD1 in out clamp`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "diode",
+      gradingCoefficient: 0.4,
+    });
+  });
+
+  it("prefers canonical diode M over MJ", () => {
+    const parsed = parseNetlist(`.model clamp D(MJ=0.4 M=0.3)\nD1 in out clamp`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "diode",
+      gradingCoefficient: 0.3,
+    });
+  });
+
+  it.each([
+    ["M", "-0.1"],
+    ["M", "1e999"],
+    ["MJ", "-0.1"],
+    ["MJ", "1e999"],
+  ])("rejects invalid diode %s grading coefficient %s", (parameter, value) => {
+    expect(() => parseNetlist(`.model clamp D(${parameter}=${value})`)).toThrow(
+      "diode M must be finite and non-negative",
+    );
+  });
+
   it("parses BJT models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NPN(IS=1e-14 BF=120 VT=25m CJE=2p CJC=3p TF=4n TR=5n)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4409,17 +4409,23 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine diode series-resistance field.
 
 418. Python and TypeScript Berkeley SPICE diode junction-potential parity.
-   - Status: completed in this diode junction-potential parity slice.
+   - Status: completed in PR 9816.
    - Both parser facades validate positive finite `VJ` / `PB` values and lower
      them into the shared engine diode junction-potential field with canonical
      `VJ` precedence.
 
+419. Python and TypeScript Berkeley SPICE diode grading-coefficient parity.
+   - Status: completed in this diode grading-coefficient parity slice.
+   - Both parser facades validate finite non-negative `M` / `MJ` values and
+     lower them into the shared engine diode grading-coefficient field with
+     canonical `M` precedence.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE model-card validation parity.
-   - Continue the audited diode model-card lowering surfaces with grading
-     coefficient `M` / `MJ` and depletion coefficient `FC`, followed by `XTI`,
-     `EG`, `KF`, and `AF` validation and lowering parity.
+   - Continue the audited diode model-card lowering surfaces with depletion
+     coefficient `FC`, followed by `XTI`, `EG`, `KF`, and `AF` validation and
+     lowering parity.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary
- validate finite, non-negative diode model-card `M` and `MJ` values in Python and TypeScript
- lower both spellings into the existing engine grading-coefficient field with canonical `M` precedence
- add cross-language parity coverage and advance the SPICE completion backlog

## Verification
- Python `spice-netlist-parser`: `bash BUILD` (329 tests), Ruff clean
- TypeScript `spice-engine`: `bash BUILD` (448 tests)
- TypeScript `spice-netlist-parser`: `bash BUILD` (318 tests)
- TypeScript parser coverage: 86.19% lines