### PR TITLE
fix(spice): lower diode depletion coefficient

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower diode model-card `FC` depletion coefficient.
 - Validate and lower diode model-card `M` / `MJ` grading coefficient.
 - Validate and lower diode model-card `VJ` / `PB` junction potential.
 - Validate and lower finite, non-negative diode model-card `RS` series resistance.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1276,6 +1276,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Tt=model.params.get("TT", 0.0),
             Vj=model.params.get("VJ", model.params.get("PB", 1.0)),
             M=model.params.get("M", model.params.get("MJ", 0.5)),
+            Fc=model.params.get("FC", 0.5),
             Rs=model.params.get("RS", 0.0),
         )
     if prefix == "Q":
@@ -1975,6 +1976,13 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(grading_coefficient) or grading_coefficient < 0.0
         ):
             raise NetlistParseError("diode M must be finite and non-negative")
+        depletion_coefficient = params.get("FC")
+        if depletion_coefficient is not None and (
+            not math.isfinite(depletion_coefficient)
+            or depletion_coefficient < 0.0
+            or depletion_coefficient >= 1.0
+        ):
+            raise NetlistParseError("diode FC must be finite and in [0, 1)")
     if kind in {"NPN", "PNP"}:
         saturation_current = params.get("IS")
         if saturation_current is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -964,6 +964,25 @@ def test_rejects_invalid_diode_grading_coefficient(
         parse_netlist(f".model clamp D({parameter}={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("0.6", 0.6)])
+def test_lowers_valid_diode_depletion_coefficient(
+    value: str, expected: float
+) -> None:
+    parsed = parse_netlist(f".model clamp D(FC={value})\nD1 in out clamp")
+
+    diode = parsed.circuit.elements[0]
+    assert isinstance(diode, Diode)
+    assert diode.Fc == expected
+
+
+@pytest.mark.parametrize("value", ["-0.1", "1", "1e999"])
+def test_rejects_invalid_diode_depletion_coefficient(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match=r"diode FC must be finite and in \[0, 1\)"
+    ):
+        parse_netlist(f".model clamp D(FC={value})")
+
+
 def test_parse_diode_junction_capacitance_alias() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower diode model-card `FC` depletion coefficient.
 - Validate and lower diode model-card `M` / `MJ` grading coefficient.
 - Validate and lower diode model-card `VJ` / `PB` junction potential.
 - Validate and lower finite, non-negative diode model-card `RS` series resistance.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1231,6 +1231,16 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("diode M must be finite and non-negative");
   }
+  const diodeDepletionCoefficient = params.get("FC");
+  if (
+    kind === "D" &&
+    diodeDepletionCoefficient !== undefined &&
+    (!Number.isFinite(diodeDepletionCoefficient) ||
+      diodeDepletionCoefficient < 0.0 ||
+      diodeDepletionCoefficient >= 1.0)
+  ) {
+    throw new NetlistParseError("diode FC must be finite and in [0, 1)");
+  }
   const bjtForwardBeta =
     params.get("BF") ??
     params.get("BETA") ??
@@ -1819,6 +1829,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       ),
       junctionPotential: model.params.get("VJ") ?? model.params.get("PB") ?? 1.0,
       gradingCoefficient: model.params.get("M") ?? model.params.get("MJ") ?? 0.5,
+      forwardBiasDepletionCoefficient: model.params.get("FC") ?? 0.5,
       seriesResistance: model.params.get("RS") ?? 0.0,
     };
   }

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1005,6 +1005,27 @@ D1 in out clamp
     );
   });
 
+  it.each([
+    ["0", 0.0],
+    ["0.6", 0.6],
+  ])("lowers valid diode FC depletion coefficient %s", (value, expected) => {
+    const parsed = parseNetlist(`.model clamp D(FC=${value})\nD1 in out clamp`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "diode",
+      forwardBiasDepletionCoefficient: expected,
+    });
+  });
+
+  it.each(["-0.1", "1", "1e999"])(
+    "rejects invalid diode FC depletion coefficient %s",
+    (value) => {
+      expect(() => parseNetlist(`.model clamp D(FC=${value})`)).toThrow(
+        "diode FC must be finite and in [0, 1)",
+      );
+    },
+  );
+
   it("parses BJT models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NPN(IS=1e-14 BF=120 VT=25m CJE=2p CJC=3p TF=4n TR=5n)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4415,17 +4415,21 @@ the Rust, Python, and TypeScript surfaces together.
      `VJ` precedence.
 
 419. Python and TypeScript Berkeley SPICE diode grading-coefficient parity.
-   - Status: completed in this diode grading-coefficient parity slice.
+   - Status: completed in PR 9820.
    - Both parser facades validate finite non-negative `M` / `MJ` values and
      lower them into the shared engine diode grading-coefficient field with
      canonical `M` precedence.
 
+420. Python and TypeScript Berkeley SPICE diode depletion-coefficient parity.
+   - Status: completed in this diode depletion-coefficient parity slice.
+   - Both parser facades validate finite `FC` values in `[0, 1)` and lower
+     them into the shared engine diode depletion-coefficient field.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE model-card validation parity.
-   - Continue the audited diode model-card lowering surfaces with depletion
-     coefficient `FC`, followed by `XTI`, `EG`, `KF`, and `AF` validation and
-     lowering parity.
+   - Continue the audited diode model-card lowering surfaces with `XTI`, `EG`,
+     `KF`, and `AF` validation and lowering parity.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary
- validate finite diode model-card `FC` values in `[0, 1)` in Python and TypeScript
- lower valid values into the existing engine forward-bias depletion-coefficient field
- add boundary-focused parity coverage and advance the SPICE completion backlog

## Verification
- Python `spice-netlist-parser`: `bash BUILD` (334 tests), Ruff clean
- TypeScript `spice-engine`: `bash BUILD` (448 tests)
- TypeScript `spice-netlist-parser`: `bash BUILD` (323 tests)
- TypeScript parser coverage: 86.23% lines