### PR TITLE
feat(human-languages): publish canonical Kannada chapters

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -93,9 +93,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B20 | Complete (#9765) | Publish German Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | Ten schema-v2 lessons now generate seven chapters whose source hashes are independently verified against the Language Ladder corpus. |
 | HL-B21 | Complete (#9779) | Remove German's LaTeX layout and Unicode bookmark warnings. | The forced 104-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
 | HL-B22 | Complete (#9803) | Publish Telugu Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | Thirty schema-v2 lessons now generate twenty-six chapters whose source hashes are independently verified against the Language Ladder corpus. |
-| HL-B23 | Complete in this PR | Remove Telugu's LaTeX layout, duplicate-label, bookmark, and font warnings. | The forced 95-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings. |
-| HL-B24 | Next | Publish Kannada Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Kannada PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
-| HL-B25 | Queued | Remove Kannada's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports four overfull boxes, five underfull boxes, four duplicate practice labels, 30 Hyperref warnings, and undefined bold/italic Kannada font shapes; the clean-build signal is zero of each. |
+| HL-B23 | Complete (#9815) | Remove Telugu's LaTeX layout, duplicate-label, bookmark, and font warnings. | The forced 95-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings. |
+| HL-B24 | Complete in this PR | Publish Kannada Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | Thirty schema-v2 lessons now generate twenty-six chapters whose source hashes are independently verified against the Language Ladder corpus. |
+| HL-B25 | Next | Remove Kannada's LaTeX layout, duplicate-label, bookmark, and font warnings. | The expanded 96-page build has zero missing glyphs but reports nine overfull boxes, ten underfull boxes, four duplicate practice labels, 106 Hyperref warnings, and nine font warnings; the clean-build signal is zero of each. |
 | HL-B26 | Queued | Publish Malayalam Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Malayalam PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
 | HL-B27 | Queued | Remove Malayalam's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports seven overfull boxes, eight underfull boxes, four duplicate practice labels, 28 Hyperref warnings, and undefined bold/italic Malayalam font shapes; the clean-build signal is zero of each. |
 | HL-B28 | Queued | Publish Arabic Chapters 3–27 and its writing companions from canonical lessons rather than hand-copying another twenty-five book chapters. | The Arabic PDF stops after Chapter 2 while canonical app content continues through Chapter 27 and sixteen dependency-ordered writing lessons; schema-v2 migration plus generation should close that drift safely. |
@@ -110,7 +110,7 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B37 | Queued | Remove Spanish's remaining legacy LaTeX layout, bookmark, and font warnings. | After Chapters 4–6 generation, a forced build has no missing glyphs or duplicate labels but reports 50 overfull boxes, 14 underfull boxes, 14 Hyperref warnings, and one undefined small-caps shape; the clean-build signal is zero of each. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-M02 | Queued | Extend Telugu's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson needs a scheduled place, and the map must explicitly split or justify Chapter 20's numbers-and-weather topic collision. |
-| HL-M03 | Queued | Extend Kannada's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the new stacking support step, needs a scheduled place. |
+| HL-M03 | Queued | Extend Kannada's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5; every canonical lesson needs a scheduled place, and Chapter 20's unrelated numbers/weather pairing must be split or explicitly justified. |
 | HL-M04 | Queued | Extend Malayalam's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the four new support steps, needs a scheduled place. |
 | HL-M05 | Queued | Reconcile Arabic's roadmap and authoritative session map with canonical Chapters 1–27 and the sixteen-step writing sequence. | The roadmap details only Chapters 1–4 and still calls Chapter 5+ planned; the session map stops at Chapter 2 even though prerequisite-ordered canonical lessons continue through Chapter 27. |
 | HL-M06 | Queued | Reconcile Hindi's roadmap and authoritative session map with canonical Chapters 1–33 and the eleven-step writing sequence. | The roadmap details only Chapters 1–6 and still calls Chapter 6 planned; the session map stops at Chapter 5 even though prerequisite-ordered canonical lessons continue through Chapter 33. |
@@ -754,6 +754,36 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   or font warnings. All pages were rendered and inspected; metadata, 33
   top-level bookmarks, 93 total outline entries, and generator-leak checks pass.
 - HL-B24 is next: publish Kannada Chapters 6–31 from canonical lessons.
+
+## Findings from HL-B24
+
+- All thirty canonical Kannada lessons after Chapter 5 now use schema v2 with
+  explicit spine nodes, prerequisite-safe sequences, honest sub-five-minute
+  duration budgets, typed knowledge boundaries, skills, modes, strands,
+  register, and variety metadata. The first thirty lessons remain schema v1,
+  so the track is intentionally mixed while migration proceeds incrementally.
+- Twenty-six generated chapters carry deterministic hashes and lesson ids that
+  Language Ladder independently reproduces from the canonical AST. Kannada
+  book coverage is now 100%, and the app and downloadable book share the same
+  source through Chapter 31.
+- A reusable Kannada comparison-font set renders Kannada, Tamil, Telugu,
+  Malayalam, Devanagari, and Arabic-script examples without hand-authored
+  LaTeX. The expanded book has zero missing glyphs, including PIE subscript and
+  accented transliteration characters used by the etymology lessons.
+- Chapter 20 currently combines numbers 11–20 with an unrelated weather lesson.
+  HL-M03 records the need for the authoritative roadmap and session map to split
+  that progression or explain the grouping explicitly.
+- A forced XeLaTeX build produces 96 pages with 33 top-level and 93 total
+  outline entries, correct title and author metadata, and no leaked generator
+  directives. Every rendered page was inspected; no clipping, collision, or
+  accidental blank page was found.
+- The expanded warning baseline is nine overfull boxes, three underfull
+  horizontal boxes, seven underfull vertical boxes, four duplicate practice
+  labels, 106 Hyperref warnings, and nine font warnings. HL-B25 is next and
+  records cleanup against the complete 96-page artifact.
+- The unified publication gate builds all twenty books successfully, while the
+  data package passes 84 tests and Language Ladder passes 385 tests plus its
+  production build.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -8,6 +8,14 @@
       { "unicodeScript": "Malayalam", "scriptCommand": "ml" },
       { "unicodeScript": "Devanagari", "scriptCommand": "dv" },
       { "unicodeScript": "Arabic", "scriptCommand": "ar" }
+    ],
+    "kannada-comparisons": [
+      { "unicodeScript": "Kannada", "scriptCommand": "kn" },
+      { "unicodeScript": "Tamil", "scriptCommand": "ta" },
+      { "unicodeScript": "Telugu", "scriptCommand": "te" },
+      { "unicodeScript": "Malayalam", "scriptCommand": "ml" },
+      { "unicodeScript": "Devanagari", "scriptCommand": "dv" },
+      { "unicodeScript": "Arabic", "scriptCommand": "ar" }
     ]
   },
   "targets": [
@@ -584,6 +592,214 @@
       "label": "ch:te-good-afternoon",
       "output": "telugu/book/chapters/ch31-good-afternoon.tex",
       "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 6,
+      "title": "Case Endings and Dative Subjects",
+      "label": "ch:ka-dative-case",
+      "output": "kannada/book/chapters/ch06-dative-case.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 7,
+      "title": "Numbers One to Ten",
+      "label": "ch:ka-numbers-one-to-ten",
+      "output": "kannada/book/chapters/ch07-numbers-1-10.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 8,
+      "title": "Please",
+      "label": "ch:ka-please",
+      "output": "kannada/book/chapters/ch08-please.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 9,
+      "title": "Sorry",
+      "label": "ch:ka-sorry",
+      "output": "kannada/book/chapters/ch09-sorry.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 10,
+      "title": "Days of the Week",
+      "label": "ch:ka-days-of-the-week",
+      "output": "kannada/book/chapters/ch10-days.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 11,
+      "title": "Four Core Colours",
+      "label": "ch:ka-core-colours",
+      "output": "kannada/book/chapters/ch11-colours.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 12,
+      "title": "Family",
+      "label": "ch:ka-family",
+      "output": "kannada/book/chapters/ch12-family.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 13,
+      "title": "Head and Hand",
+      "label": "ch:ka-head-and-hand",
+      "output": "kannada/book/chapters/ch13-head-and-hand.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 14,
+      "title": "Seasons",
+      "label": "ch:ka-seasons",
+      "output": "kannada/book/chapters/ch14-seasons.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 15,
+      "title": "Water and Rice",
+      "label": "ch:ka-water-and-rice",
+      "output": "kannada/book/chapters/ch15-water-and-rice.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 16,
+      "title": "The Traditional Months",
+      "label": "ch:ka-traditional-months",
+      "output": "kannada/book/chapters/ch16-months.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 17,
+      "title": "Noon and Midnight",
+      "label": "ch:ka-noon-and-midnight",
+      "output": "kannada/book/chapters/ch17-noon-and-midnight.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 18,
+      "title": "Telling Time",
+      "label": "ch:ka-telling-time",
+      "output": "kannada/book/chapters/ch18-telling-time.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 19,
+      "title": "Asking Someone's Age",
+      "label": "ch:ka-asking-age",
+      "output": "kannada/book/chapters/ch19-age.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 20,
+      "title": "Numbers 11–20 and Weather",
+      "label": "ch:ka-numbers-and-weather",
+      "output": "kannada/book/chapters/ch20-numbers-and-weather.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 21,
+      "title": "Dog and Cat",
+      "label": "ch:ka-dog-and-cat",
+      "output": "kannada/book/chapters/ch21-dog-and-cat.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 22,
+      "title": "Green and Yellow",
+      "label": "ch:ka-green-and-yellow",
+      "output": "kannada/book/chapters/ch22-green-and-yellow.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 23,
+      "title": "Day",
+      "label": "ch:ka-day",
+      "output": "kannada/book/chapters/ch23-day.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 24,
+      "title": "Night",
+      "label": "ch:ka-night",
+      "output": "kannada/book/chapters/ch24-night.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 25,
+      "title": "Good Night",
+      "label": "ch:ka-good-night",
+      "output": "kannada/book/chapters/ch25-good-night.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 26,
+      "title": "Morning",
+      "label": "ch:ka-morning",
+      "output": "kannada/book/chapters/ch26-morning.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 27,
+      "title": "Evening",
+      "label": "ch:ka-evening",
+      "output": "kannada/book/chapters/ch27-evening.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 28,
+      "title": "Afternoon",
+      "label": "ch:ka-afternoon",
+      "output": "kannada/book/chapters/ch28-afternoon.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 29,
+      "title": "Good Morning",
+      "label": "ch:ka-good-morning",
+      "output": "kannada/book/chapters/ch29-good-morning.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 30,
+      "title": "Good Evening",
+      "label": "ch:ka-good-evening",
+      "output": "kannada/book/chapters/ch30-good-evening.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "kannada",
+      "chapter": 31,
+      "title": "Good Afternoon",
+      "label": "ch:ka-good-afternoon",
+      "output": "kannada/book/chapters/ch31-good-afternoon.tex",
+      "scriptSet": "kannada-comparisons"
     },
     {
       "language": "bengali",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -330,6 +330,244 @@
       "tex": "italian/book/chapters/ch17-head-and-hand.tex"
     },
     {
+      "language": "kannada",
+      "chapter": 6,
+      "sourceHash": "fnv1a64:50403c9e67a9e065",
+      "lessonIds": [
+        "KA-C06-dative-ge",
+        "KA-C06-dative-stacking",
+        "KA-C06-dative-subject"
+      ],
+      "tex": "kannada/book/chapters/ch06-dative-case.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 7,
+      "sourceHash": "fnv1a64:d4a6f697bdb7fb98",
+      "lessonIds": [
+        "KA-C07-numbers-1-5",
+        "KA-C07-numbers-6-10"
+      ],
+      "tex": "kannada/book/chapters/ch07-numbers-1-10.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 8,
+      "sourceHash": "fnv1a64:0dd42921ebc1ff57",
+      "lessonIds": [
+        "KA-C08-dayavittu"
+      ],
+      "tex": "kannada/book/chapters/ch08-please.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 9,
+      "sourceHash": "fnv1a64:72851113a8be5055",
+      "lessonIds": [
+        "KA-C09-kshamisi"
+      ],
+      "tex": "kannada/book/chapters/ch09-sorry.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 10,
+      "sourceHash": "fnv1a64:ed7b58b40b1355d8",
+      "lessonIds": [
+        "KA-C10-vaara"
+      ],
+      "tex": "kannada/book/chapters/ch10-days.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 11,
+      "sourceHash": "fnv1a64:a577aa338975f386",
+      "lessonIds": [
+        "KA-C11-bannagalu"
+      ],
+      "tex": "kannada/book/chapters/ch11-colours.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 12,
+      "sourceHash": "fnv1a64:1cfe2ba34766cd85",
+      "lessonIds": [
+        "KA-C12-kutumba"
+      ],
+      "tex": "kannada/book/chapters/ch12-family.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 13,
+      "sourceHash": "fnv1a64:0878d10a7187db28",
+      "lessonIds": [
+        "KA-C13-dehada-bhagagalu"
+      ],
+      "tex": "kannada/book/chapters/ch13-head-and-hand.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 14,
+      "sourceHash": "fnv1a64:e6a8916497172741",
+      "lessonIds": [
+        "KA-C14-kaalagalu"
+      ],
+      "tex": "kannada/book/chapters/ch14-seasons.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 15,
+      "sourceHash": "fnv1a64:d190fb570c076825",
+      "lessonIds": [
+        "KA-C15-niiru-akki"
+      ],
+      "tex": "kannada/book/chapters/ch15-water-and-rice.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 16,
+      "sourceHash": "fnv1a64:3f5e4fc9f72d0eb7",
+      "lessonIds": [
+        "KA-C16-tingalugalu"
+      ],
+      "tex": "kannada/book/chapters/ch16-months.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 17,
+      "sourceHash": "fnv1a64:223e56c5ec67ed1a",
+      "lessonIds": [
+        "KA-C17-madhyaahna-madhyaraatri"
+      ],
+      "tex": "kannada/book/chapters/ch17-noon-and-midnight.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 18,
+      "sourceHash": "fnv1a64:41f497a34f5e25af",
+      "lessonIds": [
+        "KA-C18-gante"
+      ],
+      "tex": "kannada/book/chapters/ch18-telling-time.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 19,
+      "sourceHash": "fnv1a64:d6aaad7ff154ff8f",
+      "lessonIds": [
+        "KA-C19-vayassu"
+      ],
+      "tex": "kannada/book/chapters/ch19-age.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 20,
+      "sourceHash": "fnv1a64:ef0879e7a5fd9007",
+      "lessonIds": [
+        "KA-C20-hannondu-ippattu",
+        "KA-C20-havamana"
+      ],
+      "tex": "kannada/book/chapters/ch20-numbers-and-weather.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 21,
+      "sourceHash": "fnv1a64:03d7d39d4493a575",
+      "lessonIds": [
+        "KA-C21-naayi-bekku"
+      ],
+      "tex": "kannada/book/chapters/ch21-dog-and-cat.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 22,
+      "sourceHash": "fnv1a64:f63f1cfc23b0cb25",
+      "lessonIds": [
+        "KA-C22-hasiru-haladi"
+      ],
+      "tex": "kannada/book/chapters/ch22-green-and-yellow.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 23,
+      "sourceHash": "fnv1a64:422a48e530cebe57",
+      "lessonIds": [
+        "KA-C23-dina"
+      ],
+      "tex": "kannada/book/chapters/ch23-day.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 24,
+      "sourceHash": "fnv1a64:34c5748dc853de1e",
+      "lessonIds": [
+        "KA-C24-ratri"
+      ],
+      "tex": "kannada/book/chapters/ch24-night.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 25,
+      "sourceHash": "fnv1a64:d84a11ad7e7cac19",
+      "lessonIds": [
+        "KA-C25-shubha-ratri"
+      ],
+      "tex": "kannada/book/chapters/ch25-good-night.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 26,
+      "sourceHash": "fnv1a64:6c517d5cdb2f5b6a",
+      "lessonIds": [
+        "KA-C26-belagge"
+      ],
+      "tex": "kannada/book/chapters/ch26-morning.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 27,
+      "sourceHash": "fnv1a64:5b610fd79895225e",
+      "lessonIds": [
+        "KA-C27-sanje"
+      ],
+      "tex": "kannada/book/chapters/ch27-evening.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 28,
+      "sourceHash": "fnv1a64:6133ff939c0603ea",
+      "lessonIds": [
+        "KA-C28-aparahna"
+      ],
+      "tex": "kannada/book/chapters/ch28-afternoon.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 29,
+      "sourceHash": "fnv1a64:65f0071b2ae9fb22",
+      "lessonIds": [
+        "KA-C29-shubhodaya"
+      ],
+      "tex": "kannada/book/chapters/ch29-good-morning.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 30,
+      "sourceHash": "fnv1a64:aebe084d534a27d6",
+      "lessonIds": [
+        "KA-C30-shubha-sanje"
+      ],
+      "tex": "kannada/book/chapters/ch30-good-evening.tex"
+    },
+    {
+      "language": "kannada",
+      "chapter": 31,
+      "sourceHash": "fnv1a64:3c1a2104befa120f",
+      "lessonIds": [
+        "KA-C31-shubha-madhyahna"
+      ],
+      "tex": "kannada/book/chapters/ch31-good-afternoon.tex"
+    },
+    {
       "language": "marathi",
       "chapter": 6,
       "sourceHash": "fnv1a64:d0addd66aaedf900",

--- a/code/learning/human-languages/kannada/CHANGELOG.md
+++ b/code/learning/human-languages/kannada/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Canonical Chapters 6–31 in the book (2026-08-03)
+
+- Migrated all thirty Kannada lessons after Chapter 5 to the strict schema-v2
+  curriculum contract: canonical spine nodes, unique prerequisite-safe
+  sequence, explicit sub-five-minute budgets, typed block boundaries, and
+  closed knowledge introductions and assessments.
+- Generated twenty-six LaTeX chapters from those canonical lessons instead of
+  copying app content into a separate book source. The committed source-hash
+  manifest is independently checked against Language Ladder for Chapters 6–31.
+- Added a reusable Kannada comparison-font set for Kannada, Tamil, Telugu,
+  Malayalam, Devanagari, and Arabic-script examples. The 96-page PDF has zero
+  missing glyphs and preserves the full 33-entry top-level chapter outline.
+- Rendered and inspected all 96 pages, including the dense case, number,
+  calendar, PIE-etymology, and register sections. No clipping, collision,
+  accidental blank page, or leaked schema metadata was found.
+- The expanded artifact's cleanup baseline is nine overfull boxes, three
+  underfull horizontal boxes, seven underfull vertical boxes, four duplicate
+  practice labels, 106 Hyperref warnings, and nine font warnings. `HL-B25`
+  tracks that publication-hygiene pass separately.
+- The single all-books publication gate still compiles all twenty downloadable
+  volumes successfully.
+
 ## Sub-five-minute lesson remediation (2026-08-02)
 
 - All thirty-seven Kannada duration violations are resolved. Thirty-six lessons

--- a/code/learning/human-languages/kannada/README.md
+++ b/code/learning/human-languages/kannada/README.md
@@ -44,6 +44,22 @@ book.
 - **Chapter 5 — First Verbs** ([`lessons/KA-C05-*`](./lessons/)): mātanāḍu, **nānu
   kannaḍa mātanāḍuttēne**, iru, kelasa māḍu, practice. Stem + tense + person; no
   1st-person gender. In the book.
+- **Chapters 6–9 — Case, counting, and courtesy**
+  ([`lessons/KA-C0{6,7,8,9}-*`](./lessons/)): the dative **-ಗೆ**, visible suffix
+  stacking, **ನನಗೆ ಕನ್ನಡ ಗೊತ್ತು**, numbers one through ten, **ದಯವಿಟ್ಟು**, and
+  **ಕ್ಷಮಿಸಿ**. In the book from canonical schema-v2 lessons.
+- **Chapters 10–22 — Calendar and everyday domains**
+  ([`lessons/KA-C{10..22}-*`](./lessons/)): days, colours, family, body, seasons,
+  food, months, clock time, age, numbers 11–20, weather, and animals. In the
+  book from canonical schema-v2 lessons.
+- **Chapters 23–31 — Dayparts and greetings**
+  ([`lessons/KA-C{23..31}-*`](./lessons/)): day, night, morning, evening,
+  afternoon, and their register-aware greetings. In the book from canonical
+  schema-v2 lessons.
+
+All thirty later lessons remain below five effective minutes. Their twenty-six
+generated chapters carry the same source hashes Language Ladder recomputes from
+the browser-loaded lesson AST, so app and book cannot drift silently.
 
 ## Book / fonts
 

--- a/code/learning/human-languages/kannada/book/book.tex
+++ b/code/learning/human-languages/kannada/book/book.tex
@@ -75,4 +75,31 @@ rule. Released under CC~BY-SA~4.0.
 
 \input{chapters/ch05-first-verbs}
 
+\input{chapters/ch06-dative-case}
+\input{chapters/ch07-numbers-1-10}
+\input{chapters/ch08-please}
+\input{chapters/ch09-sorry}
+\input{chapters/ch10-days}
+\input{chapters/ch11-colours}
+\input{chapters/ch12-family}
+\input{chapters/ch13-head-and-hand}
+\input{chapters/ch14-seasons}
+\input{chapters/ch15-water-and-rice}
+\input{chapters/ch16-months}
+\input{chapters/ch17-noon-and-midnight}
+\input{chapters/ch18-telling-time}
+\input{chapters/ch19-age}
+\input{chapters/ch20-numbers-and-weather}
+\input{chapters/ch21-dog-and-cat}
+\input{chapters/ch22-green-and-yellow}
+\input{chapters/ch23-day}
+\input{chapters/ch24-night}
+\input{chapters/ch25-good-night}
+\input{chapters/ch26-morning}
+\input{chapters/ch27-evening}
+\input{chapters/ch28-afternoon}
+\input{chapters/ch29-good-morning}
+\input{chapters/ch30-good-evening}
+\input{chapters/ch31-good-afternoon}
+
 \end{document}

--- a/code/learning/human-languages/kannada/book/chapters/ch06-dative-case.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch06-dative-case.tex
@@ -1,0 +1,187 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:50403c9e67a9e065
+% canonical-lessons: KA-C06-dative-ge, KA-C06-dative-stacking, KA-C06-dative-subject
+
+\chapter{Case Endings and Dative Subjects}
+\label{ch:ka-dative-case}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[-ge]{-\kn{ಗೆ} (-ge) — "to, for"}
+
+\label{lesson:KA-C06-dative-ge}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Your first \textbf{case ending}. English puts "to" in \textbf{front}, as a separate word. Kannada sticks it on the \textbf{back} — the biggest structural fact about the language, in one suffix.
+\end{quote}
+
+\subsection*{You'll want to know: Adding it on}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{word} & \textbf{+ -ge} & \textbf{meaning} \\
+\midrule
+\kn{ಹೆಸರು} \emph{hesaru} — name & \kn{ಹೆಸರ}\textbf{\kn{ಿಗೆ}} \emph{hesar\textbf{ige}} & to/for the name \\
+\kn{ಕೆಲಸ} \emph{kelasa} — work & \kn{ಕೆಲಸ}\textbf{\kn{ಕ್ಕೆ}} \emph{kelasa\textbf{kke}} & for work \\
+\bottomrule
+\end{tabularx}
+
+Two shapes, one suffix: \textbf{-ige} after some stems, \textbf{-kke} after others. Kannada adjusts it to fit the word in front — but you can still see exactly where the noun stops and the ending starts.
+
+And with "I", which reshapes first:
+
+\begin{quote}
+\textbf{\kn{ನಾನು}} \emph{nānu} ("I") $\to$ \textbf{\kn{ನನಗೆ}} \emph{nanage} ("to me")
+\end{quote}
+
+\begin{cousinweb}
+All four descend from one Proto-Dravidian dative, \emph{\textbf{-k(k)u}}. Look at what became of its \emph{k}:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{dative} \\
+\midrule
+Tamil & \emph{-ukku} \\
+Telugu & \emph{-ku} / \emph{-ki} \\
+Malayalam & \emph{-ikku} / \emph{-inu} \\
+\textbf{Kannada} & \emph{\textbf{-ge}} / \emph{-ige} \\
+\bottomrule
+\end{tabularx}
+
+Kannada is the one that \textbf{voiced} it — \emph{k} $\to$ \emph{g} between vowels — and carried that change into the dative, where its sisters kept the hard consonant. Note the other Kannada form, \emph{\textbf{-kke}}: a \textbf{doubled} consonant resists voicing, so the geminate preserved the original \emph{k}. The two Kannada shapes are the same suffix caught on either side of a sound change.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "\emph{hesaru} … \emph{hesarige}"{]}
+  \item {[}YOU SAY: "\emph{nānu} … \emph{nanage}" — "I" … "to me"{]}
+  \item {[}YOU SAY: "\emph{kelasakke}" — "for work," from Ch. 5's \kn{ಕೆಲಸ}{]}
+  \item {[}YOU SAY: the family — "\emph{-ukku · -ku · -\textbf{ge}} · -ikku"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \textbf{-\kn{ಗೆ}} mean? ("\textbf{To}" or "\textbf{for}.") Where does it go? (\textbf{On the end} of the noun.) What is "to me"? (\textbf{\kn{ನನಗೆ}} \emph{nanage}.) Why does Kannada have \emph{g} where its sisters have \emph{k}? (Kannada \textbf{voiced} the \emph{k} between vowels; doubled \emph{-kke} resisted and kept the old hard form.)
+\end{tcolorbox}
+\section[-ge]{-\kn{ಗೆ} — one suffix, one job}
+
+\label{lesson:KA-C06-dative-stacking}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You can now attach \textbf{-\kn{ಗೆ}} and make \textbf{\kn{ನನಗೆ}} “to me.” Look at what that visible seam tells you about how Kannada builds longer words.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: Stacking versus fusion}]
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{Kannada \textbf{-ge}} & \textbf{a Latin ending like \textbf{-īs}} \\
+\midrule
+pins down the case? & \textbf{yes} — dative, always & \textbf{no} — dative \textbf{or} ablative \\
+carries number? & \textbf{no} — a separate suffix does & yes — plural, baked in \\
+carries declension class? & \textbf{no} & yes — first or second \\
+can you see the seam? & \textbf{yes}: \emph{hesar} + \emph{ige} & no — one fused lump \\
+\bottomrule
+\end{tabularx}
+
+Kannada \textbf{stacks} suffixes. Each suffix carries one meaning and sits in a fixed order, so the learner can see where the noun ends and the case marker begins. That is what \textbf{agglutinative} means here: longer words are assembled from pieces whose jobs remain visible.
+
+Latin \textbf{fuses} several jobs into one ending. \emph{-īs} carries case, plural number, and declension class at once—and it does not even settle whether the case is dative or ablative. Kannada \textbf{-\kn{ಗೆ}} carries one unambiguous job: “to/for.”
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: \emph{hesar} + \emph{ige} — a visible noun-plus-case seam{]}
+  \item {[}YOU SAY: Kannada \emph{-ge} — one job, dative{]}
+  \item {[}YOU SAY: Latin \emph{-īs} — case, plural, and declension fused{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Why is Kannada called agglutinative? (\textbf{It stacks visible pieces, each with one job.}) How many jobs can Latin \emph{-īs} fuse? (\textbf{Case, number, and declension class—and its case can still be dative or ablative.})
+\end{tcolorbox}
+\section[nanage kannaḍa gottu]{\kn{ನನಗೆ} \kn{ಕನ್ನಡ} \kn{ಗೊತ್ತು} — "I know Kannada"}
+
+\label{lesson:KA-C06-dative-subject}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Chapter 5 gave you \textbf{\kn{ನಾನು} \kn{ಕನ್ನಡ} \kn{ಮಾತನಾಡುತ್ತೇನೆ}} — "\textbf{I} speak Kannada." Now say "I \textbf{know} Kannada." Kannada will not let you use \emph{nānu}.
+\end{quote}
+
+\subsection*{You'll want to know: The sentence}
+\begin{quote}
+\textbf{\kn{ನನಗೆ} \kn{ಕನ್ನಡ} \kn{ಗೊತ್ತು}.} \emph{nanage kannaḍa gottu.} literally: "\textbf{to-me} Kannada {[}is{]} \textbf{known}."
+\end{quote}
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{piece} & \textbf{} \\
+\midrule
+\textbf{\kn{ನನಗೆ}} \emph{nanage} & "to me" — the dative from the last lesson \\
+\textbf{\kn{ಕನ್ನಡ}} \emph{kannaḍa} & Kannada (Ch. 5) \\
+\textbf{\kn{ಗೊತ್ತು}} \emph{gottu} & "known" \\
+\bottomrule
+\end{tabularx}
+
+Two things to notice. \textbf{You are not the subject} — \emph{nānu} is gone, moved into the dative, leaving \emph{kannaḍa} as the unmarked word the sentence is about. And \emph{gottu} isn't really a verb doing an action; it's closer to "\textbf{{[}is{]} known}." So nothing in this sentence is \emph{doing} anything at all.
+
+\begin{grammarlens}[title={Grammar Lens: Why: things that happen \emph{to} you}]
+Kannada separates what you \textbf{do} from what \textbf{happens to} you. Speaking is an action, so Ch. 5 used \emph{nānu}. But knowing, liking, wanting, being hungry — these \textbf{arrive}. Kannada marks that by putting the person in the \textbf{dative}.
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{English frames it as} & \textbf{Kannada frames it as} \\
+\midrule
+I \textbf{know} Kannada & Kannada is known \textbf{to me} \\
+I \textbf{like} it & it is pleasing \textbf{to me} \\
+I \textbf{am} cold & cold is \textbf{to me} \\
+\bottomrule
+\end{tabularx}
+
+English keeps one fossil of the same idea: "\textbf{methinks}" — where \emph{me} is a dative, "it seems \textbf{to me}." Kannada made it a rule.
+\end{grammarlens}
+
+\begin{grammarlens}[title={Grammar Lens: All four sisters do it}]
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{"I know {[}the language{]}"} & \textbf{the dative} \\
+\midrule
+Kannada & \emph{nanage kannaḍa gottu} & \textbf{-ge} \\
+Tamil & \emph{enakku tamiḻ teriyum} & \textbf{-ukku} \\
+Telugu & \emph{nāku telugu vaccu} & \textbf{-ku} \\
+Malayalam & \emph{enikku malayāḷam aṟiyām} & \textbf{-ikku} \\
+\bottomrule
+\end{tabularx}
+
+One construction, four languages, four suffixes that are visibly the \textbf{same suffix} — Kannada's \emph{g} being the softened \emph{k} of the others. The Dravidian family showing its bones, exactly as \emph{blanc/bianco/branco} did for Romance.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "\emph{nanage kannaḍa gottu}"{]}
+  \item {[}YOU SAY: the contrast — "\emph{nānu kannaḍa mātanāḍuttēne}" (I speak) … "\emph{nanage kannaḍa gottu}" (known to me){]}
+  \item {[}YOU SAY: the literal — "to-me Kannada known"{]}
+  \item {[}YOU SAY: the four cousins — "\emph{-ge · -ukku · -ku · -ikku}"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \textbf{\kn{ನನಗೆ} \kn{ಕನ್ನಡ} \kn{ಗೊತ್ತು}} literally say? ("\textbf{To-me} Kannada \textbf{known}.") What has English got that Kannada hasn't? (A nominative "\textbf{I}" — \emph{nānu} is replaced by the dative \emph{nanage}.) Is \emph{gottu} an action verb? (\textbf{No} — it's "{[}is{]} known"; nothing is doing anything.) Why the dative? (Knowing \textbf{happens to} you.) Which English word keeps the same idea? (\textbf{Methinks}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch07-numbers-1-10.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch07-numbers-1-10.tex
@@ -1,0 +1,137 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:d4a6f697bdb7fb98
+% canonical-lessons: KA-C07-numbers-1-5, KA-C07-numbers-6-10
+
+\chapter{Numbers One to Ten}
+\label{ch:ka-numbers-one-to-ten}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ಒಂದು} \kn{ಎರಡು} \kn{ಮೂರು} \kn{ನಾಲ್ಕು} \kn{ಐದು}]{\kn{ಒಂದು}, \kn{ಎರಡು}, \kn{ಮೂರು}, \kn{ನಾಲ್ಕು}, \kn{ಐದು} — one to five}
+
+\label{lesson:KA-C07-numbers-1-5}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} If you walked here through Tamil, you already know these numbers — Kannada just says them with its own accent.
+\end{quote}
+
+\subsection*{You'll want to know: The five}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{numeral} & \textbf{word} & \textbf{said} \\
+\midrule
+1 & \textbf{\kn{೧}} & \textbf{\kn{ಒಂದು}} & \emph{ondu} \\
+2 & \textbf{\kn{೨}} & \textbf{\kn{ಎರಡು}} & \emph{eraḍu} \\
+3 & \textbf{\kn{೩}} & \textbf{\kn{ಮೂರು}} & \emph{mūru} \\
+4 & \textbf{\kn{೪}} & \textbf{\kn{ನಾಲ್ಕು}} & \emph{nālku} \\
+5 & \textbf{\kn{೫}} & \textbf{\kn{ಐದು}} & \emph{aidu} \\
+\bottomrule
+\end{tabularx}
+
+The single symbols \textbf{\kn{೧} \kn{೨} \kn{೩} \kn{೪} \kn{೫}} are Kannada's own digits — you'll meet them on bus numbers and prices, distinct from the words above.
+
+\begin{cousinweb}
+These are \textbf{native Dravidian} numbers, not Sanskrit borrowings — the same word-stock Tamil kept. Line them up against Tamil and they are plainly the same word wearing a Kannada coat:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{Tamil} & \textbf{Kannada} \\
+\midrule
+2 & \emph{iraṇṭu} & \textbf{eraḍu} \\
+3 & \emph{mūṉṟu} & \textbf{mūru} \\
+4 & \emph{nāṉku} & \textbf{nālku} \\
+5 & \emph{aintu} & \textbf{aidu} \\
+\bottomrule
+\end{tabularx}
+
+\textbf{One} is the family's odd number: Tamil \emph{oṉṟu} and Kannada \emph{ondu} are cousins (from an old \emph{oṉ-}), but Telugu will break rank with \emph{okaṭi} when you get there. So learn \emph{ondu} now, but expect Telugu's "one" to surprise you.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: A Kannada habit to notice}]
+The \textbf{anusvara} — the small circle \textbf{\kn{ಂ}} in \emph{\kn{ಒಂದು}} (\emph{on-du}) — is a nasal that takes its colour from the letter after it: an \emph{n} before \emph{d} in \emph{ondu}, an \emph{m} before \emph{b} later in \emph{ombattu} (nine). One mark, whatever nasal the next consonant needs. You'll see it constantly.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "ondu, eraḍu, mūru, nālku, aidu"{]}
+  \item {[}YOU SAY: the Tamil$\to$Kannada shift — "iraṇṭu $\to$ eraḍu", same number, new coat{]}
+  \item {[}YOU SAY: read the digits — \kn{೧} \kn{೨} \kn{೩} \kn{೪} \kn{೫}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Count to five in Kannada. (\emph{Ondu, eraḍu, mūru, nālku, aidu}.) Are these borrowed from Sanskrit? (\textbf{No} — native Dravidian, shared with Tamil.) Which number will Telugu form differently? (\textbf{One} — \emph{okaṭi}, vs Kannada \emph{ondu}.) What does the \textbf{\kn{ಂ}} anusvara do in \emph{ondu}? (Stands for the nasal the next consonant needs — here \emph{n} before \emph{d}.) Next: six to ten.
+\end{tcolorbox}
+\section[\kn{ಆರು} \kn{ಏಳು} \kn{ಎಂಟು} \kn{ಒಂಬತ್ತು} \kn{ಹತ್ತು}]{\kn{ಆರು}, \kn{ಏಳು}, \kn{ಎಂಟು}, \kn{ಒಂಬತ್ತು}, \kn{ಹತ್ತು} — six to ten}
+
+\label{lesson:KA-C07-numbers-6-10}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Five more — and the last one shows the single sound-change that most makes Kannada \emph{sound} like Kannada.
+\end{quote}
+
+\subsection*{You'll want to know: The five}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{numeral} & \textbf{word} & \textbf{said} \\
+\midrule
+6 & \textbf{\kn{೬}} & \textbf{\kn{ಆರು}} & \emph{āru} \\
+7 & \textbf{\kn{೭}} & \textbf{\kn{ಏಳು}} & \emph{ēḷu} \\
+8 & \textbf{\kn{೮}} & \textbf{\kn{ಎಂಟು}} & \emph{eṇṭu} \\
+9 & \textbf{\kn{೯}} & \textbf{\kn{ಒಂಬತ್ತು}} & \emph{ombattu} \\
+10 & \textbf{\kn{೧೦}} & \textbf{\kn{ಹತ್ತು}} & \emph{hattu} \\
+\bottomrule
+\end{tabularx}
+
+(Ten needs two digits — \textbf{\kn{೧೦}}, a one and a zero — just like \emph{10}.)
+
+\begin{cousinweb}
+Put ten beside Tamil:
+
+\begin{quote}
+Tamil \textbf{pattu} $\to$ Kannada \textbf{hattu}.
+\end{quote}
+
+Kannada systematically softened an old word-initial \textbf{p‑} into \textbf{h‑}. It isn't a one-off: it runs right through the language —
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{Tamil} & \textbf{Kannada} \\
+\midrule
+ten & \emph{pattu} & \textbf{hattu} \\
+milk & \emph{pāl} & \textbf{hālu} \\
+tooth & \emph{pal} & \textbf{hallu} \\
+\bottomrule
+\end{tabularx}
+
+Once you know the rule, a Kannada \emph{h‑} word often hands you its Tamil cousin for free: hide the \emph{h‑}, restore a \emph{p‑}.
+\end{cousinweb}
+
+\begin{cousinweb}
+Six and seven stay close cousins (Tamil \emph{āṟu} / Kannada \emph{āru}; Tamil \emph{ēḻu} / Kannada \emph{ēḷu} — note Kannada hardened Tamil's rare \textbf{ḻ} into an ordinary retroflex \textbf{ḷ}). \textbf{Eight and nine} wander more: Kannada \emph{eṇṭu} and \emph{ombattu} are still relatives of Tamil \emph{eṭṭu} and \emph{oṉpatu}, but \textbf{Telugu} leaves the family entirely there (\emph{enimidi}, \emph{tommidi}) — so treat 8–9 as the loose cells.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "āru, ēḷu, eṇṭu, ombattu, hattu"{]}
+  \item {[}YOU SAY: the shift — "pattu $\to$ hattu", "pāl $\to$ hālu": hide the h, find the p{]}
+  \item {[}YOU SAY: read the digits — \kn{೬} \kn{೭} \kn{೮} \kn{೯} \kn{೧೦}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Count six to ten in Kannada. (\emph{Āru, ēḷu, eṇṭu, ombattu, hattu}.) What regular shift turns Tamil \emph{pattu} into Kannada \emph{hattu}? (Word-initial \textbf{p‑ $\to$ h‑} — also \emph{pāl $\to$ hālu}.) What happened to Tamil's rare \textbf{ḻ} in Kannada \emph{ēḷu}? (It hardened into an ordinary retroflex \textbf{ḷ}.) Which numbers should you trust least as family cousins? (\textbf{Eight and nine} — Telugu especially wanders.)
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch08-please.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch08-please.tex
@@ -1,0 +1,67 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:0dd42921ebc1ff57
+% canonical-lessons: KA-C08-dayavittu
+
+\chapter{Please}
+\label{ch:ka-please}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ದಯವಿಟ್ಟು}]{\kn{ದಯವಿಟ್ಟು} (dayaviṭṭu) — please (having placed compassion)}
+
+\label{lesson:KA-C08-dayavittu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Kannada's everyday "please" is, once you open it up, a small act of generosity: "having \textbf{placed} compassion" between us.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\kn{ದಯವಿಟ್ಟು}} = \textbf{please}, literally "\textbf{having placed compassion / kindness}." Two pieces:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\kn{ದಯ}} (\emph{daya}) = \textbf{compassion, kindness, grace} — from Sanskrit \textbf{daya}.
+  \item \textbf{\kn{ಇಟ್ಟು}} (\emph{iṭṭu}) = "\textbf{having placed / set down}," from the verb \textbf{\kn{ಇಡು}} (\emph{iḍu}) "to place, to put."
+\end{itemize}
+
+So \emph{dayaviṭṭu} means, at heart, \emph{setting kindness down (before you)} — asking the listener to act from compassion.
+
+That is exactly how \textbf{Tamil} builds it (\emph{tayavu seytu}, "\textbf{do} the kindness"), and the same instinct as \textbf{Arabic} \emph{min faḍlik} ("from your \textbf{grace}") and \textbf{Hindi} \emph{kṛpayā} (from \emph{kṛpā}, "\textbf{compassion}"). A wide arc of Asia says \emph{please} by naming the kindness it hopes for.
+\end{cousinweb}
+
+\begin{cousinweb}
+\textbf{daya} + a light verb, four times over:
+
+\begin{itemize}
+\raggedright
+  \item Kannada \textbf{\kn{ದಯವಿಟ್ಟು}} \emph{daya\textbf{viṭṭu}} — compassion \textbf{+ having placed}
+  \item Tamil \textbf{\ta{தயவுசெய்து}} \emph{tayavu \textbf{sey}tu} — kindness \textbf{+ do}
+  \item Telugu \textbf{\te{దయచేసి}} \emph{daya\textbf{cēsi}} — compassion \textbf{+ having done}
+  \item Malayalam \textbf{\ml{ദയവായി}} \emph{daya\textbf{vāyi}} — compassion \textbf{+ as / having become}
+\end{itemize}
+\end{cousinweb}
+
+\begin{culture}
+The honest note: a standalone please-word is a little \textbf{formal / emphatic}. Everyday Kannada politeness leans on the \textbf{respectful command} — the verb ending \textbf{‑\kn{ಿ}} (\emph{-i}): \textbf{\kn{ಕುಳಿತುಕೊಳ್ಳಿ}} (\emph{kuḷitukoḷḷi}) "please sit,"  \textbf{\kn{ಹೇಳಿ}} (\emph{hēḷi}) "please tell me." That ending already means "please" do this. Add \textbf{\kn{ದಯವಿಟ್ಟು}} in front when you want to underline the courtesy.
+\end{culture}
+
+\begin{sounds}
+Look at \textbf{\kn{ಟ್ಟು}} — a \textbf{doubled} \emph{ṭ}. The first \textbf{\kn{ಟ್}} is \emph{ṭa} silenced by the \textbf{virama} (its vowel cut), and it tucks \textbf{under} the next letter as an \emph{ottu} (a subscript form) before \textbf{\kn{ಟು}} \emph{ṭu}. Kannada writes a double consonant by stacking, not repeating side by side — a neat contrast with how the Roman alphabet just writes "tt."
+\end{sounds}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "daya" — compassion — then "iṭṭu," having placed{]}
+  \item {[}YOU SAY: the whole word — "dayaviṭṭu" = please{]}
+  \item {[}YOU SAY: the everyday way — the verb ending: "kuḷitukoḷḷi" = please sit{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What is the Kannada word for please? (\textbf{\kn{ದಯವಿಟ್ಟು}} \emph{dayaviṭṭu}.) What do its pieces mean? ("\textbf{Compassion}" \emph{daya} + "\textbf{having placed}" \emph{iṭṭu}.) Which cousins ask the same way? (\textbf{Tamil, Telugu, Malayalam} with \emph{daya} — plus \textbf{Arabic} \emph{faḍl}, \textbf{Hindi} \emph{kṛpā}.) What carries "please" in ordinary speech? (\textbf{The respectful verb ending ‑\kn{ಿ}} \emph{-i}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch09-sorry.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch09-sorry.tex
@@ -1,0 +1,60 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:72851113a8be5055
+% canonical-lessons: KA-C09-kshamisi
+
+\chapter{Sorry}
+\label{ch:ka-sorry}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ಕ್ಷಮಿಸಿ}]{\kn{ಕ್ಷಮಿಸಿ} (kṣamisi) — forgive me / sorry}
+
+\label{lesson:KA-C09-kshamisi}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You already know \textbf{\kn{ದಯವಿಟ್ಟು}}, "please." Kannada's "sorry" reuses a trick you'll see everywhere in this language: taking a Sanskrit noun and turning it into a working Kannada verb.
+\end{quote}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{\kn{ಕ್ಷಮಾ}} (\emph{kṣamā}) = "\textbf{patience, forbearance, forgiveness}" — a Sanskrit noun, unchanged.
+  \item \textbf{‑\kn{ಇಸು}} (\emph{‑isu}) = a \textbf{verb-making suffix}: bolt it onto a Sanskrit noun and you get a brand-new Kannada verb. \emph{kṣamā} + \emph{‑isu} $\to$ \textbf{\kn{ಕ್ಷಮಿಸು}} (\emph{kṣamisu}), "\textbf{to forgive}." (The same move builds \kn{ಪ್ರಾರಂಭಿಸು} \emph{prārambhisu}, "to begin," from Sanskrit \emph{prārambha}.)
+  \item \textbf{‑\kn{ಿ}} (\emph{‑i}) = the plain \textbf{imperative} ending — the very one you met on \emph{kuḷitukoḷḷi} ("please sit") in the please lesson.
+\end{itemize}
+
+So \textbf{\kn{ಕ್ಷಮಿಸಿ}} is simply "\textbf{forgive!}" — \emph{kṣamisu} wearing its imperative ending.
+\end{cousinweb}
+
+\begin{cousinweb}
+Three of the four Dravidian cousins build "sorry" from the very same Sanskrit noun, each with its own verb-making suffix and its own imperative shape:
+
+\begin{itemize}
+\raggedright
+  \item Kannada \textbf{\kn{ಕ್ಷಮಿಸಿ}} \emph{kṣami\textbf{si}} — Sanskrit \emph{kṣamā} + \textbf{‑isu} (verb) + \textbf{‑i} (imperative)
+  \item Telugu \textbf{\te{క్షమించండి}} \emph{kṣamin̄\textbf{caṇḍi}} — Sanskrit \emph{kṣamā} + \textbf{‑in̄cu} (verb) + \textbf{‑aṇḍi} (imperative)
+  \item Malayalam \textbf{\ml{ക്ഷമിക്കണം}} \emph{kṣami\textbf{kkaṇaṁ}} — Sanskrit \emph{kṣama} + \textbf{‑ikkuka} (verb) + \textbf{‑aṇaṁ} (necessitative)
+  \item Tamil \textbf{\ta{மன்னிக்கவும்}} \emph{maṉṉi\textbf{kkavum}} — its \textbf{own} native root \emph{maṉṉi}, not Sanskrit at all
+\end{itemize}
+\end{cousinweb}
+
+\begin{culture}
+\textbf{\kn{ಕ್ಷಮಿಸಿ}} is a genuine, everyday way to say "sorry" — not overly formal — but in casual conversation you'll also hear the softer \textbf{\kn{ಕ್ಷಮಿಸಿ} \kn{ಬಿಡಿ}} (\emph{kṣamisi biḍi}, roughly "just forgive {[}it{]}") or simply the borrowed English "\textbf{sorry}," which is extremely common in spoken Kannada.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "kṣamā" — the Sanskrit noun, patience/forgiveness{]}
+  \item {[}YOU SAY: the verb — "kṣamisu," to forgive — then "kṣamisi," forgive!{]}
+  \item {[}YOU SAY: contrast — Tamil's maṉṉikkavum uses its own root instead{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What is \textbf{\kn{ಕ್ಷಮಿಸಿ}} built from? (\textbf{Sanskrit kṣamā} "forgiveness" + the verb-making suffix \textbf{‑isu} + the imperative \textbf{‑i}.) Which cousin languages do the same trick, and which one doesn't? (\textbf{Telugu and Malayalam} also verb-ify \emph{kṣamā}; \textbf{Tamil} uses its own native root \emph{maṉṉi} instead.) What do people often say casually instead? (\textbf{Kṣamisi biḍi}, or simply borrowed English "\textbf{sorry}.")
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch10-days.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch10-days.tex
@@ -1,0 +1,51 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:ed7b58b40b1355d8
+% canonical-lessons: KA-C10-vaara
+
+\chapter{Days of the Week}
+\label{ch:ka-days-of-the-week}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ಸೋಮವಾರ} \kn{ಮಂಗಳವಾರ} \kn{ಬುಧವಾರ} \kn{ಗುರುವಾರ} \kn{ಶುಕ್ರವಾರ} \kn{ಶನಿವಾರ} \kn{ಭಾನುವಾರ}]{\kn{ಸೋಮವಾರ} to \kn{ಭಾನುವಾರ} — Kannada's fully Sanskritic week}
+
+\label{lesson:KA-C10-vaara}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Unlike Tamil and Malayalam, Kannada's week is built entirely from Sanskrit — the same recipe as Hindi's. But even here, one day picks a \textbf{different} Sanskrit word than Hindi does.
+\end{quote}
+
+\subsection*{You'll want to know: The pattern: {[}deity{]} + \kn{ವಾರ}, "day"}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Kannada} & \textbf{deity/planet} & \textbf{day} \\
+\midrule
+\textbf{\kn{ಸೋಮವಾರ}} (\emph{Somavāra}) & \textbf{Moon} (Soma) & Monday \\
+\textbf{\kn{ಮಂಗಳವಾರ}} (\emph{Maṅgaḷavāra}) & \textbf{Mars} (Maṅgala) & Tuesday \\
+\textbf{\kn{ಬುಧವಾರ}} (\emph{Budhavāra}) & \textbf{Mercury} (Budha) & Wednesday \\
+\textbf{\kn{ಗುರುವಾರ}} (\emph{Guruvāra}) & \textbf{Jupiter} (Guru/Bṛhaspati) & Thursday \\
+\textbf{\kn{ಶುಕ್ರವಾರ}} (\emph{Śukravāra}) & \textbf{Venus} (Śukra) & Friday \\
+\textbf{\kn{ಶನಿವಾರ}} (\emph{Śanivāra}) & \textbf{Saturn} (Śani) & Saturday \\
+\textbf{\kn{ಭಾನುವಾರ}} (\emph{Bhānuvāra}) & the \textbf{Sun} (Bhānu, "light, splendor") & Sunday \\
+\bottomrule
+\end{tabularx}
+
+Five of these are identical in shape to Hindi's — same deity, same \textbf{‑vāra/ ‑vār} ending. \textbf{Sunday} is the interesting exception: where Hindi says \textbf{\dv{रविवार}} (\emph{Ravivār}, from \emph{Ravi}, "sun"), Kannada says \textbf{\kn{ಭಾನುವಾರ}} (\emph{Bhānuvāra}), built on a \textbf{different} Sanskrit word for the sun — \textbf{Bhānu}, "light, splendor," rather than \emph{Ravi}. Sanskrit has \textbf{many} names for the sun, and different languages downstream picked different ones for their week.
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "Somavāra, Maṅgaḷavāra, Budhavāra, Guruvāra, Śukravāra, Śanivāra" — Monday through Saturday{]}
+  \item {[}YOU SAY: the different one — "Bhānuvāra," Sunday{]}
+  \item {[}YOU SAY: the contrast — Hindi says Ravivāra (Ravi), Kannada says Bhānuvāra (Bhānu) — two different Sanskrit sun-names{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What ending does every Kannada weekday share, and where's it from? (\textbf{‑\kn{ವಾರ}} \emph{-vāra}, Sanskrit "day.") Which day differs from Hindi's version, and how? (\textbf{Sunday} — Kannada's \emph{Bhānuvāra} ("light") uses a different Sanskrit sun-name than Hindi's \emph{Ravivār} ("Ravi").)
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch11-colours.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch11-colours.tex
@@ -1,0 +1,44 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:a577aa338975f386
+% canonical-lessons: KA-C11-bannagalu
+
+\chapter{Four Core Colours}
+\label{ch:ka-core-colours}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ಕಪ್ಪು} \kn{ಬಿಳಿ} \kn{ಕೆಂಪು} \kn{ನೀಲಿ}]{\kn{ಕಪ್ಪು}, \kn{ಬಿಳಿ}, \kn{ಕೆಂಪು}, \kn{ನೀಲಿ} — native colors, after a fully Sanskrit week}
+
+\label{lesson:KA-C11-bannagalu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Kannada's week ran entirely on Sanskrit deity-names. Its colors tell a different story — here, native Dravidian vocabulary is back in charge, except for one familiar exception.
+\end{quote}
+
+\subsection*{You'll want to know: Three native colors}
+\begin{itemize}
+\raggedright
+  \item \textbf{\kn{ಕಪ್ಪು}} (\emph{kappu}) = "\textbf{black}" — native Dravidian.
+  \item \textbf{\kn{ಬಿಳಿ}} (\emph{biḷi}) = "\textbf{white}" — native Dravidian.
+  \item \textbf{\kn{ಕೆಂಪು}} (\emph{kempu}) = "\textbf{red}" — native Dravidian.
+\end{itemize}
+
+\subsection*{You'll want to know: The familiar borrowed blue}
+\textbf{\kn{ನೀಲಿ}} (\emph{nīli}) = "\textbf{blue}" — from the \textbf{same Sanskrit} \kn{ನೀಲ} (\emph{nīla}) that Tamil, Malayalam, and Hindi all reach for. Even Kannada, whose week went fully Sanskritic, still keeps its everyday black/white/red \textbf{native} — it's specifically \textbf{blue} that pulls in the Sanskrit word, across all four Dravidian languages and Hindi alike.
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "kappu, biḷi, kempu" — black, white, red{]}
+  \item {[}YOU SAY: "nīli" — blue, the shared Sanskrit word{]}
+  \item {[}YOU SAY: the contrast — Kannada's week is Sanskritic, but its colors (except blue) are native{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Are Kannada's black/white/red native or Sanskrit? (\textbf{Native Dravidian} — kappu, biḷi, kempu.) Which color is the shared Sanskrit loan across Kannada, Tamil, Malayalam, and Hindi? (\textbf{Blue} — \kn{ನೀಲಿ} \emph{nīli} / \ta{நீலம்} \emph{nīlam} / \ml{നീല} \emph{nīla} / \dv{नीला} \emph{nīlā}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch12-family.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch12-family.tex
@@ -1,0 +1,57 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:1cfe2ba34766cd85
+% canonical-lessons: KA-C12-kutumba
+
+\chapter{Family}
+\label{ch:ka-family}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ಅಪ್ಪ} \kn{ಅಮ್ಮ} \kn{ಅಣ್ಣ} \kn{ತಮ್ಮ} \kn{ಅಕ್ಕ} \kn{ತಂಗಿ}]{\kn{ಅಪ್ಪ}, \kn{ಅಮ್ಮ}, and four sibling words — the same system as Tamil}
+
+\label{lesson:KA-C12-kutumba}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Kannada asks the same question Tamil does about any sibling: \textbf{older, or younger?} — and the words for answering it are almost identical.
+\end{quote}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{\kn{ಅಪ್ಪ}} (\emph{appa}) = "\textbf{father}" — matches Tamil \emph{appā} closely.
+  \item \textbf{\kn{ಅಮ್ಮ}} (\emph{amma}) = "\textbf{mother}" — matches Tamil \emph{ammā} closely.
+\end{itemize}
+\end{cousinweb}
+
+\begin{cousinweb}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Kannada} & \textbf{meaning} & \textbf{compare Tamil} \\
+\midrule
+\textbf{\kn{ಅಣ್ಣ}} (\emph{aṇṇa}) & \textbf{older} brother & \emph{aṇṇaṉ} — near match \\
+\textbf{\kn{ತಮ್ಮ}} (\emph{tamma}) & \textbf{younger} brother & \emph{tambi} — near match \\
+\textbf{\kn{ಅಕ್ಕ}} (\emph{akka}) & \textbf{older} sister & \emph{akkā} — near match \\
+\textbf{\kn{ತಂಗಿ}} (\emph{tangi}) & \textbf{younger} sister & \emph{tangai} — near match \\
+\bottomrule
+\end{tabularx}
+
+Just like Tamil, Kannada has \textbf{no single word} that simply means "brother" or "sister" — you name the sibling's \textbf{relative age} every time, not just their gender. This age-first system runs across the whole Dravidian family, not just one language.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "appa, amma" — father, mother{]}
+  \item {[}YOU SAY: "aṇṇa, tamma" — older/younger brother{]}
+  \item {[}YOU SAY: "akka, tangi" — older/younger sister{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} How many Kannada sibling words are there, and what do they split on? (\textbf{Four} — \kn{ಅಣ್ಣ}/\kn{ತಮ್ಮ}, \kn{ಅಕ್ಕ}/\kn{ತಂಗಿ} — split by \textbf{relative age}, not just gender.) How closely do Kannada's words match Tamil's? (\textbf{Very closely} — nearly the same forms across the whole set.)
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch13-head-and-hand.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch13-head-and-hand.tex
@@ -1,0 +1,40 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:0878d10a7187db28
+% canonical-lessons: KA-C13-dehada-bhagagalu
+
+\chapter{Head and Hand}
+\label{ch:ka-head-and-hand}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ತಲೆ} \kn{ಕೈ}]{\kn{ತಲೆ}, \kn{ಕೈ} — head and hand, the shared Dravidian core}
+
+\label{lesson:KA-C13-dehada-bhagagalu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Three languages, nearly one word each — Kannada's basic body parts line up with Tamil and Malayalam almost perfectly.
+\end{quote}
+
+\subsection*{You'll want to know: The words}
+\begin{itemize}
+\raggedright
+  \item \textbf{\kn{ತಲೆ}} (\emph{tale}) = "\textbf{head}" — native Dravidian, matching Tamil \emph{talai} and Malayalam \emph{thala}.
+  \item \textbf{\kn{ಕೈ}} (\emph{kai}) = "\textbf{hand}" — native Dravidian, matching Tamil and Malayalam's \emph{kai} almost exactly.
+\end{itemize}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "tale" — head{]}
+  \item {[}YOU SAY: "kai" — hand{]}
+  \item {[}YOU SAY: the match — nearly identical across Tamil, Malayalam, Kannada{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What are Kannada's words for head and hand? (\textbf{\kn{ತಲೆ} tale, \kn{ಕೈ} kai}.) How closely do they match Tamil and Malayalam? (\textbf{Very closely} — all three share essentially the same native Dravidian words.)
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch14-seasons.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch14-seasons.tex
@@ -1,0 +1,53 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:e6a8916497172741
+% canonical-lessons: KA-C14-kaalagalu
+
+\chapter{Seasons}
+\label{ch:ka-seasons}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ವಸಂತ} \kn{ಋತು} \kn{ಬೇಸಿಗೆ} \kn{ಮಳೆಗಾಲ} \kn{ಚಳಿಗಾಲ}]{\kn{ವಸಂತ} \kn{ಋತು}, \kn{ಬೇಸಿಗೆ}, \kn{ಮಳೆಗಾಲ}, \kn{ಚಳಿಗಾಲ} — native words, plus a double Sanskrit loan}
+
+\label{lesson:KA-C14-kaalagalu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Kannada's summer, rain, and cold words are native, just like Tamil's — but its word for "spring" borrows \textbf{twice} from Sanskrit, not once.
+\end{quote}
+
+\subsection*{You'll want to know: The words}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Kannada} & \textbf{meaning} & \textbf{source} \\
+\midrule
+\textbf{\kn{ವಸಂತ} \kn{ಋತು}} (\emph{vasanta ṛtu}) & "spring" & \textbf{both} \emph{vasanta} AND \textbf{\kn{ಋತು}} \emph{ṛtu} ("season") are Sanskrit \\
+\textbf{\kn{ಬೇಸಿಗೆ}} (\emph{bēsige}) & "summer" & native Dravidian \\
+\textbf{\kn{ಮಳೆಗಾಲ}} (\emph{maḷegāla}) & "rainy season" & \textbf{\kn{ಮಳೆ}} \emph{maḷe}, native Dravidian ("rain") + \textbf{\kn{ಕಾಲ}} \emph{kāla} ("time," itself a Sanskrit loan) \\
+\textbf{\kn{ಚಳಿಗಾಲ}} (\emph{caḷigāla}) & "winter/cold season" & \textbf{\kn{ಚಳಿ}} \emph{caḷi}, native Dravidian ("cold") + \emph{kāla} \\
+\bottomrule
+\end{tabularx}
+
+\begin{culture}
+Where Tamil and Malayalam just say \emph{kaalam} ("time/season," itself ultimately Sanskrit-derived too, but assimilated long ago as ordinary vocabulary), Kannada's word for spring, \textbf{\kn{ವಸಂತ} \kn{ಋತು}}, keeps \textbf{both} halves visibly Sanskrit — \emph{vasanta} the season-name, \emph{ṛtu} the very word for "season." Summer, rain, and cold, by contrast, are built on native Dravidian roots (\emph{bēsige}, \emph{maḷe}, \emph{caḷi}).
+
+And as with Tamil and Malayalam: it's \textbf{\kn{ಮಳೆಗಾಲ}} (\emph{maḷegāla}, the rains) that shapes Karnataka's agricultural year the most, not a clean four-way Western split.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "bēsige" — summer, native{]}
+  \item {[}YOU SAY: "maḷegāla" — the rains{]}
+  \item {[}YOU SAY: "caḷigāla" — the cold season, native{]}
+  \item {[}YOU SAY: the double loan — "vasanta ṛtu" — both halves Sanskrit{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What's unusual about \kn{ವಸಂತ} \kn{ಋತು} compared to Tamil/Malayalam's spring-word? (\textbf{Both halves are Sanskrit} — \emph{vasanta} and \emph{ṛtu}, "season" itself — where Tamil/Malayalam just add the long-assimilated \emph{kaalam}.) Which season actually shapes Karnataka's year most? (\textbf{\kn{ಮಳೆಗಾಲ}}, the rains.)
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch15-water-and-rice.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch15-water-and-rice.tex
@@ -1,0 +1,45 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:d190fb570c076825
+% canonical-lessons: KA-C15-niiru-akki
+
+\chapter{Water and Rice}
+\label{ch:ka-water-and-rice}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ನೀರು} \kn{ಅಕ್ಕಿ} \kn{ಅನ್ನ}]{\kn{ನೀರು}, \kn{ಅಕ್ಕಿ}, \kn{ಅನ್ನ} — water matching Tamil, and rice, raw and cooked}
+
+\label{lesson:KA-C15-niiru-akki}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Kannada's water-word sides with Tamil, not with Malayalam's surprising break from the pack.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\kn{ನೀರು}} (\emph{nīru}) = "\textbf{water}" — matching Tamil's \textbf{\ta{நீர்}} (\emph{nīr}, the root inside \emph{taṇṇīr}) closely. Kannada didn't make Malayalam's switch to the \emph{veḷ-} "bright/white" root.
+\end{cousinweb}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{\kn{ಅಕ್ಕಿ}} (\emph{akki}) = "\textbf{rice}" (raw grain).
+  \item \textbf{\kn{ಅನ್ನ}} (\emph{anna}) = "\textbf{cooked rice}" (the meal) — likely Sanskrit- influenced, the same general idea as Tamil's \emph{sātam}.
+\end{itemize}
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "nīru" — water, matching Tamil{]}
+  \item {[}YOU SAY: "akki" — raw rice{]}
+  \item {[}YOU SAY: "anna" — cooked rice{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Does Kannada's water-word match Tamil's or Malayalam's? (\textbf{Tamil's} — \emph{nīru}/\emph{nīr}, not Malayalam's \emph{veḷḷam}.) What's the raw/cooked rice pair? (\textbf{\kn{ಅಕ್ಕಿ}} \emph{akki} raw, \textbf{\kn{ಅನ್ನ}} \emph{anna} cooked.)
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch16-months.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch16-months.tex
@@ -1,0 +1,40 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:3f5e4fc9f72d0eb7
+% canonical-lessons: KA-C16-tingalugalu
+
+\chapter{The Traditional Months}
+\label{ch:ka-traditional-months}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ಚೈತ್ರ} \kn{ವೈಶಾಖ} \kn{ಜ್ಯೇಷ್ಠ} \kn{ಆಷಾಢ} \kn{ಶ್ರಾವಣ} \kn{ಭಾದ್ರಪದ} \kn{ಆಶ್ವಯುಜ} \kn{ಕಾರ್ತೀಕ} \kn{ಮಾರ್ಗಶಿರ} \kn{ಪುಷ್ಯ} \kn{ಮಾಘ} \kn{ಫಾಲ್ಗುಣ}]{\kn{ಚೈತ್ರ} to \kn{ಫಾಲ್ಗುಣ} — the calendar Kannada shares with Hindi, not with Tamil}
+
+\label{lesson:KA-C16-tingalugalu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Tamil and Malayalam each built their own solar calendar. Kannada takes a different path entirely — the same path as Hindi.
+\end{quote}
+
+\subsection*{You'll want to know: The twelve months}
+\textbf{\kn{ಚೈತ್ರ}, \kn{ವೈಶಾಖ}, \kn{ಜ್ಯೇಷ್ಠ}, \kn{ಆಷಾಢ}, \kn{ಶ್ರಾವಣ}, \kn{ಭಾದ್ರಪದ}, \kn{ಆಶ್ವಯುಜ}, \kn{ಕಾರ್ತೀಕ}, \kn{ಮಾರ್ಗಶಿರ}, \kn{ಪುಷ್ಯ}, \kn{ಮಾಘ}, \kn{ಫಾಲ್ಗುಣ}} (\emph{Caitra, Vaiśākha, Jyēṣṭha, Āṣāḍha, Śrāvaṇa, Bhādrapada, Āśvayuja, Kārtīka, Mārgaśira, Puṣya, Māgha, Phālguṇa}).
+
+\begin{culture}
+This is the \textbf{same pan-Indian Sanskritic lunisolar calendar} you already met as Hindi's \textbf{Vikram Samvat} — the same twelve month names, tied to the same \textbf{six-ṛtu} seasonal cycle. Karnataka's own New Year, \textbf{Ugadi}, falls on \emph{Chaitra Śukla Pratipada} — the first day of the bright fortnight of Chaitra — exactly the reasoning behind Hindu New Year celebrations across much of India. Unlike Tamil's or Malayalam's genuinely home-grown solar calendars, Kannada didn't build its own separate system here — it shares this one with Hindi, Telugu, and much of the rest of the subcontinent.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the twelve — "Caitra, Vaiśākha, Jyēṣṭha, Āṣāḍha, Śrāvaṇa, Bhādrapada, Āśvayuja, Kārtīka, Mārgaśira, Puṣya, Māgha, Phālguṇa"{]}
+  \item {[}YOU SAY: "Ugadi — Chaitra Śukla Pratipada"{]}
+  \item {[}YOU SAY: the honest point — shared with Hindi, unlike Tamil/Malayalam's own calendars{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Does Kannada use its own solar calendar, like Tamil and Malayalam? (\textbf{No} — it uses the \textbf{same pan-Indian lunisolar calendar} as Hindi's Vikram Samvat.) What is Kannada's New Year called, and when does it fall? (\textbf{Ugadi}, on \emph{Chaitra Śukla Pratipada}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch17-noon-and-midnight.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch17-noon-and-midnight.tex
@@ -1,0 +1,45 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:223e56c5ec67ed1a
+% canonical-lessons: KA-C17-madhyaahna-madhyaraatri
+
+\chapter{Noon and Midnight}
+\label{ch:ka-noon-and-midnight}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ಮಧ್ಯಾಹ್ನ} \kn{ಮಧ್ಯರಾತ್ರಿ}]{\kn{ಮಧ್ಯಾಹ್ನ}, \kn{ಮಧ್ಯರಾತ್ರಿ} — one Sanskrit root, two everyday Kannada words}
+
+\label{lesson:KA-C17-madhyaahna-madhyaraatri}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You've just seen Hindi's \emph{dopahar} (an old timekeeping unit) and \emph{aadhi raat} (plain "half night"). Kannada takes a completely different path — straight to Sanskrit, and straight down the middle.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\kn{ಮಧ್ಯಾಹ್ನ}} (\emph{madhyāhna}) = "\textbf{noon, midday}" — a Sanskrit \emph{tatsama} (borrowed whole, unchanged) compound: \textbf{\kn{ಮಧ್ಯ}} (\emph{madhya}, "\textbf{middle}") + \textbf{\kn{ಅಹ್ನ}} (\emph{ahna}, "\textbf{day}"). This is the everyday, ordinary Kannada word for noon — not a formal or bookish alternative the way it can feel in some of its sister languages.
+\end{cousinweb}
+
+\begin{cousinweb}
+\textbf{\kn{ಮಧ್ಯರಾತ್ರಿ}} (\emph{madhyarātri}) = "\textbf{midnight}" — the exact same \textbf{\kn{ಮಧ್ಯ}} (\emph{madhya}, "middle") root, this time compounded with \textbf{\kn{ರಾತ್ರಿ}} (\emph{rātri}, "\textbf{night}"). Same logic, same "middle" word, just paired with "night" instead of "day."
+\end{cousinweb}
+
+\begin{culture}
+Both words are unmistakably \textbf{Sanskrit tatsama} compounds — Kannada borrowed them whole rather than building native Dravidian equivalents. That's worth contrasting directly with Hindi, a language actually \emph{descended} from Sanskrit: Hindi has these exact same words too (\emph{madhyāhna}, \emph{madhyarātri}), but treats them as the more \textbf{formal, literary} register — its everyday words are the homegrown \emph{dopahar} ("two pahars") and \emph{aadhi raat} ("half night") instead. Kannada, by contrast, took the Sanskrit-formal compound and made it the \textbf{plain, everyday} word — there's no separate native-Dravidian doublet in common use here the way there is for some other concepts.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "madhyāhna" — noon, "middle of the day"{]}
+  \item {[}YOU SAY: "madhyarātri" — midnight, "middle of the night"{]}
+  \item {[}YOU SAY: the shared piece — "madhya," middle, in both words{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What Sanskrit root do \textbf{\kn{ಮಧ್ಯಾಹ್ನ}} and \textbf{\kn{ಮಧ್ಯರಾತ್ರಿ}} share, and what does it mean? (\textbf{\kn{ಮಧ್ಯ}}, \emph{madhya}, "middle.") Are these native Dravidian words or Sanskrit borrowings? (\textbf{Sanskrit tatsama} borrowings, taken whole.) Does Hindi treat its version of these words as everyday or formal? (\textbf{Formal/literary} — Hindi's everyday words are \emph{dopahar} and \emph{aadhi raat} instead.)
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch18-telling-time.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch18-telling-time.tex
@@ -1,0 +1,49 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:41f497a34f5e25af
+% canonical-lessons: KA-C18-gante
+
+\chapter{Telling Time}
+\label{ch:ka-telling-time}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ಗಂಟೆ}]{\kn{ಗಂಟೆ} — the same "bell" word as Hindi, borrowed through Prakrit}
+
+\label{lesson:KA-C18-gante}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You've already met Hindi's \emph{ghanṭā} — "hour," literally "bell." Kannada has the exact same word, arriving by the exact same logic.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\kn{ಗಂಟೆ}} (\emph{gaṇṭe}) = "\textbf{hour}" — and, just like Hindi, it means "\textbf{bell, gong}" just as commonly. It's related to the same Sanskrit \textbf{\dv{घण्टा}} (\emph{ghaṇṭā}, "bell"). The semantic shift is identical to Hindi's: temples, towns, and clock towers announced the hour by striking a bell, so the bell-word became the hour-word.
+\end{cousinweb}
+
+\begin{culture}
+This is a genuinely different picture from what you'll see in Tamil. Kannada's \emph{gaṇṭe}, like Hindi's \emph{ghanṭā}, is a \textbf{Sanskrit-derived} "bell $\to$ hour" word. Tamil, by contrast, most likely uses a \textbf{native Dravidian} word for exactly the same "bell $\to$ hour" idea — a different root entirely, arrived at independently (though even specialists don't call this fully settled). So the \emph{pattern} (bell-word becomes hour-word) repeats across languages, but the \emph{word itself} splits along the same Sanskrit/native line you've seen before in this course (compare \emph{madhyāhna} vs. Tamil's \emph{naḷ}-based words for noon).
+\end{culture}
+
+\begin{grammarlens}[title={Grammar Lens: telling the time}]
+\begin{quote}
+\textbf{\kn{ಒಂದು} \kn{ಗಂಟೆ}.} — "One o'clock." (\emph{ondu gaṇṭe}, "one hour/bell") \textbf{\kn{ಎರಡು} \kn{ಗಂಟೆ}.} — "Two o'clock." (\emph{eraḍu gaṇṭe}, "two hour/bell")
+\end{quote}
+
+Kannada simply pairs the cardinal number with \emph{gaṇṭe} — no ordinal/cardinal split like Arabic's, no singular/plural verb switch like Hindi's \emph{bajnā}.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "gaṇṭe" — hour, also "bell"{]}
+  \item {[}YOU SAY: "ondu gaṇṭe" — one o'clock{]}
+  \item {[}YOU SAY: "eraḍu gaṇṭe" — two o'clock{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \textbf{\kn{ಗಂಟೆ}} mean besides "hour," and what Sanskrit word is it related to? (\textbf{"Bell, gong"} — related to Sanskrit \emph{ghaṇṭā}.) Is this the same root Hindi uses for "hour"? (\textbf{Yes} — Hindi's \emph{ghanṭā} is the same Sanskrit word.) Does Tamil use this same Sanskrit root for "hour"? (\textbf{Most likely not} — it uses a native Dravidian word instead, arrived at independently.)
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch19-age.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch19-age.tex
@@ -1,0 +1,53 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:d6aaad7ff154ff8f
+% canonical-lessons: KA-C19-vayassu
+
+\chapter{Asking Someone's Age}
+\label{ch:ka-asking-age}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ನಿನ್ನ} \kn{ವಯಸ್ಸು} \kn{ಎಷ್ಟು}?]{\kn{ನಿನ್ನ} \kn{ವಯಸ್ಸು} \kn{ಎಷ್ಟು}? — "your age, how much?"}
+
+\label{lesson:KA-C19-vayassu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Here's a genuinely nice callback: the Sanskrit word behind Kannada's "age" is a distant cousin of a Latin word you already know.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\kn{ವಯಸ್ಸು}} (\emph{vayassu}) = "\textbf{age}" — from Sanskrit \textbf{\dv{वयस्}} (\emph{vayas}, "age, youth, vigor, strength"), which traces back to \textbf{Proto-Indo-European} \emph{\textbf{wéyh\textsubscript{1}os}. That PIE root is the \textbf{same} one behind Latin \textbf{vīs}, "force, strength, vigor" — so Sanskrit's word for "age" and Latin's word for "force" are genuine, distant cousins, both carrying the older sense of "vigor, life-force" before splitting toward different specific meanings.}
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: a simple possessive, no verb}]
+\begin{quote}
+\textbf{\kn{ನಿನ್ನ} \kn{ವಯಸ್ಸು} \kn{ಎಷ್ಟು}?} — "How old are you?" — literally "\textbf{your age}
+\end{quote}
+
+how-much\textbf{?" (\emph{ninna vayassu eṣṭu?})}
+
+\begin{quote}
+\textbf{\kn{ನನ್ನ} \kn{ವಯಸ್ಸು} \kn{ಇಪ್ಪತ್ತು}.} — "I am twenty years old." — literally "\textbf{my age}
+\end{quote}
+
+{[}is{]} \textbf{twenty}." (\emph{nanna vayassu ippattu.})
+
+Just like Arabic's \emph{ʿumr}, this is a \textbf{verbless} construction in the present tense — Kannada simply states "your age" and "how much," with no "is" needed. But notice the shape is simpler than Arabic's: no possessive suffix fused onto the noun, just the ordinary possessive word \textbf{\kn{ನಿನ್ನ}} (\emph{ninna}, "your") sitting in front of \textbf{\kn{ವಯಸ್ಸು}}.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "vayassu" — age{]}
+  \item {[}YOU SAY: "ninna vayassu eṣṭu?" — how old are you?{]}
+  \item {[}YOU SAY: "nanna vayassu ippattu" — I am twenty, "my age {[}is{]} twenty"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What Sanskrit word is \textbf{\kn{ವಯಸ್ಸು}} from, and what Latin word is its PIE cousin? (\textbf{\dv{वयस्}}, \emph{vayas}, "age/vigor" — cousin of Latin \textbf{vīs}, "force," both from PIE \emph{wéyh\textsubscript{1}os.) Does Kannada use a verb to state age? (\textbf{No} — "your age how-much," no verb needed.) How do you say "I am twenty"? (}Nanna vayassu ippattu\emph{ — "my age {[}is{]} twenty.")}
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch20-numbers-and-weather.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch20-numbers-and-weather.tex
@@ -1,0 +1,83 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:ef0879e7a5fd9007
+% canonical-lessons: KA-C20-hannondu-ippattu, KA-C20-havamana
+
+\chapter{Numbers 11–20 and Weather}
+\label{ch:ka-numbers-and-weather}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ಹನ್ನೊಂದು} — \kn{ಇಪ್ಪತ್ತು}]{\kn{ಹನ್ನೊಂದು}, \kn{ಇಪ್ಪತ್ತು} — a real "two-tens" compound, just not one you can see today}
+
+\label{lesson:KA-C20-hannondu-ippattu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You've now seen four different language families each build "twenty" as its own special, opaque word — Sanskrit's \emph{vimshati}, Latin's \emph{viginti}, Arabic's \emph{ʿishrūn}. Kannada's twenty genuinely started life as "two tens" too — but be careful: the modern surface no longer shows it plainly.
+\end{quote}
+
+\begin{cousinweb}
+Kannada's teens are built on \textbf{\kn{ಹತ್ತು}} (\emph{hattu}, "\textbf{ten}") plus each digit — \textbf{\kn{ಹನ್ನೊಂದು}} (\emph{hannondu}, 11), \textbf{\kn{ಹನ್ನೆರಡು}} (\emph{hanneraḍu}, 12), and onward through \textbf{\kn{ಹತ್ತೊಂಬತ್ತು}} (\emph{hattombattu}, 19). Each teen is a compound built the same way English builds "four-\textbf{teen}" — just placed the same digit-plus-ten pattern in front instead of behind.
+\end{cousinweb}
+
+\begin{cousinweb}
+\textbf{\kn{ಇಪ್ಪತ್ತು}} (\emph{ippattu}, "\textbf{twenty}") traces back to Proto-Dravidian \textbf{*ir-} ("\textbf{two}") + \textbf{*paHtu} ("\textbf{ten}") — a genuine compositional origin, "two-tens." But be honest about what's actually visible today: the \textbf{*ir-} piece is an old \emph{bound} root, not the same as modern Kannada's everyday word for "two," \textbf{\kn{ಎರಡು}} (\emph{eraḍu}) — a separate, longer descendant of the same ancient family. And the "ten" piece surfaces here as \textbf{-pp-} (geminated after the \emph{r}), not as modern \textbf{\kn{ಹತ್ತು}} (\emph{hattu})'s \textbf{h-} — because Kannada's historical \emph{p $\to$ h} shift only fired at the \textbf{start} of a word, and this "ten" sits in the \textbf{middle} of the compound, so it never lenited. So \emph{ippattu} really did start as "two-tens" — you just can't spot modern \emph{eraḍu} or modern \emph{hattu} inside it anymore the way you might expect. Compare this to Sanskrit's \textbf{\dv{विंशति}} (\emph{vimshati}), Latin's \textbf{vīgintī}, and Arabic's \textbf{\ar{عشرون}} (\emph{ʿishrūn}): those have \textbf{no} compositional "two-ten" origin at all, not even a buried one — a genuinely different kind of history from Kannada's.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "hannondu, hanneraḍu" — 11, 12{]}
+  \item {[}YOU SAY: "hattu" — ten (today's word), "eraḍu" — two (today's word){]}
+  \item {[}YOU SAY: "ippattu" — twenty, "two-tens" underneath, from the OLD \emph{ir-/ }paHtu roots, not directly from hattu/eraḍu{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} How are Kannada's teens built? (\textbf{\kn{ಹತ್ತು}} (ten) + a digit, compounded.) Does \textbf{\kn{ಇಪ್ಪತ್ತು}} (twenty) have a compositional "two-tens" origin? (\textbf{Yes} — Proto-Dravidian \emph{*ir-} "two" + \emph{*paHtu} "ten.") Can you still spot modern \emph{eraḍu} or modern \emph{hattu} inside it today? (\textbf{No} — the old bound "two" root and the un-lenited middle-of-word "ten" root look different from their modern standalone descendants.) Do Sanskrit's \emph{vimshati} or Latin's \emph{vīgintī} have any compositional origin like this at all? (\textbf{No} — neither has a buried "two-ten" history the way Kannada's does.)
+\end{tcolorbox}
+\section[\kn{ಹವಾಮಾನ}]{\kn{ಹವಾಮಾನ} — a genuine two-language hybrid word}
+
+\label{lesson:KA-C20-havamana}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Kannada's word for "weather" isn't purely Sanskrit or purely native — it's a compound with a piece from each of two different borrowed sources.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\kn{ಹವಾಮಾನ}} (\emph{havāmāna}) = "\textbf{weather}" — built from two pieces:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\kn{ಹವಾ}} (\emph{hava}, "\textbf{air}") — itself a loanword, from \textbf{Persian} \textbf{\ar{هوا}} (\emph{havā}), which traces back to \textbf{Arabic} \textbf{\ar{هَوَاء}} (\emph{hawāʾ}, "air"). This is the exact same root behind Hindi's own \textbf{\dv{हवा}} (\emph{havā}, "air, wind").
+  \item \textbf{\kn{ಮಾನ}} (\emph{māna}, "\textbf{measure}") — from \textbf{Sanskrit} \textbf{\dv{मान}} (\emph{māna}), "measure, standard" (the same word behind \emph{pramāṇa}, "proof, measure of truth").
+\end{itemize}
+
+So \emph{havāmāna} literally means "\textbf{air-measure}" — and it's genuinely a two-source hybrid, not a single borrowed compound: one piece Perso-Arabic, one piece Sanskrit, fused into one Kannada word.
+\end{cousinweb}
+
+\subsection*{You'll want to know: \kn{ಮಳೆ} \kn{ಬರುತ್ತಿದೆ} — "rain is coming"}
+\begin{quote}
+\textbf{\kn{ಮಳೆ} \kn{ಬರುತ್ತಿದೆ}.} — "It's raining." — literally "\textbf{rain is coming}."
+\end{quote}
+
+(\emph{maḷe baruttide.})
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "havāmāna" — weather, literally "air-measure"{]}
+  \item {[}YOU SAY: "hava" — air, a Persian/Arabic loan{]}
+  \item {[}YOU SAY: "maḷe baruttide" — it's raining, "rain is coming"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What are the two pieces of \textbf{\kn{ಹವಾಮಾನ}}, and where does each come from? (\textbf{\kn{ಹವಾ}}, "air," a \textbf{Persian/Arabic} loan; \textbf{\kn{ಮಾನ}}, "measure," native \textbf{Sanskrit}.) What does \emph{havāmāna} literally mean? ("\textbf{Air-measure}.") What other Indian language shares the exact same word for "air"? (\textbf{Hindi} — \emph{havā}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch21-dog-and-cat.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch21-dog-and-cat.tex
@@ -1,0 +1,40 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:03d7d39d4493a575
+% canonical-lessons: KA-C21-naayi-bekku
+
+\chapter{Dog and Cat}
+\label{ch:ka-dog-and-cat}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ನಾಯಿ}, \kn{ಬೆಕ್ಕು}]{\kn{ನಾಯಿ}, \kn{ಬೆಕ್ಕು} — solid ground, and a genuine split}
+
+\label{lesson:KA-C21-naayi-bekku}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} After a whole arc of mystery dog-words — Spanish's \emph{perro}, English's \emph{dog}, Hindi's \emph{kuttā} — here's the opposite: a dog-word with absolutely no mystery attached.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\kn{ನಾಯಿ}} (\emph{nāyi}, "\textbf{dog}") is a genuine, native \textbf{Proto-Dravidian} root — no debate, no substrate mystery, nothing like the \emph{perro}/\emph{dog}/\emph{kuttā} pattern you've now seen across three unrelated language families. It's the same root shared right across the Dravidian family.
+\end{cousinweb}
+
+\begin{cousinweb}
+\textbf{\kn{ಬೆಕ್ಕು}} (\emph{bekku}, "\textbf{cat}") is where things get honestly more complicated. It's cognate with a \textbf{different} ancient Dravidian root — the same one behind Tamil and Malayalam's word for "\textbf{wildcat}" or "\textbf{civet cat}" — not the same root as Tamil's \textbf{everyday} word for cat. So unlike "dog," where Dravidian largely agrees on one shared root, "cat" genuinely \textbf{splits}: different Dravidian languages settled on different ancient roots for their everyday word.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "nāyi" — dog, solid native Dravidian, no mystery{]}
+  \item {[}YOU SAY: "bekku" — cat, a different Dravidian root than Tamil's everyday word{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Is \textbf{\kn{ನಾಯಿ}} a mystery word, like Spanish's \emph{perro} or Hindi's \emph{kuttā}? (\textbf{No} — a solid, native Proto-Dravidian root.) Does \textbf{\kn{ಬೆಕ್ಕು}} come from the same root as Tamil's everyday cat-word? (\textbf{No} — a genuinely different ancient Dravidian root, related instead to the word for "wildcat.")
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch22-green-and-yellow.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch22-green-and-yellow.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:f63f1cfc23b0cb25
+% canonical-lessons: KA-C22-hasiru-haladi
+
+\chapter{Green and Yellow}
+\label{ch:ka-green-and-yellow}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ಹಸಿರು}, \kn{ಹಳದಿ}]{\kn{ಹಸಿರು}, \kn{ಹಳದಿ} — a real Dravidian family, and a borrowed cousin of gelb}
+
+\label{lesson:KA-C22-hasiru-haladi}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Kannada's green word belongs to a real Dravidian family you'll meet again soon. Its yellow word isn't native at all — and it turns out to be hiding the very same ancient root this whole arc keeps circling back to.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\kn{ಹಸಿರು}} (\textbf{hasiru}, "\textbf{green}") comes from \textbf{Old Kannada} \textbf{\kn{ಪಸಿರ್}} (\textbf{pasir}), from \textbf{Proto-Dravidian} \emph{\textbf{*pac-}}, "\textbf{green}" — the \textbf{exact same root} behind \textbf{Tamil}'s \textbf{\ta{பச்சை}} (\emph{paccai}) and \textbf{Telugu}'s \textbf{\te{పచ్చ}} (\emph{pacca}). Kannada even keeps a doublet of its own, \textbf{\kn{ಪಚ್ಚೆ}} (\emph{pacce}), sitting right alongside \emph{hasiru}. So unlike Kannada's \textbf{blue} (\kn{ನೀಲಿ}, borrowed from Sanskrit), green here is the real, deep, native Dravidian word — and this particular root will keep resurfacing as Telugu, Malayalam, and Tamil's own green words come up later in this same arc.
+\end{cousinweb}
+
+\begin{cousinweb}
+\textbf{\kn{ಹಳದಿ}} (\textbf{haḷadi}, "\textbf{yellow}") is \textbf{not} Kannada's native turmeric word — that's \textbf{\kn{ಅರಿಶಿನ}} (\emph{ariśina}). Instead, \emph{haḷadi} appears to be shaped by Sanskrit/Hindi \textbf{\dv{हरिद्रा}/\dv{हल्दी}} (\textbf{haridrā}/\emph{haldi}, "\textbf{turmeric}"), the same word that gives "turmeric" across a huge swath of Indo-Aryan languages (Hindi/Urdu/Punjabi \emph{haldi}, Bengali \emph{holud}, Odia \emph{haladi}) — and in some of these, like Bengali and Odia, that turmeric-word doubles as the everyday word for the color \textbf{yellow} itself, exactly as \emph{haḷadi} does in Kannada (Hindi keeps the two separate: \emph{haldi} stays "turmeric," while "yellow" is the unrelated word \emph{pīlā}). Here's the part that closes a loop running through this whole arc: \textbf{haridrā} itself traces back to \textbf{\dv{हरि}} (\textbf{hari}, "\textbf{yellow, tawny}"), from \textbf{Proto-Indo- European} \emph{\textbf{*ǵ\textsuperscript{h}elh₃-}} — the \textbf{same ancient root} already behind Hindi's own \textbf{\dv{हरा}} (\emph{harā}, "green") and German's \textbf{gelb} ("yellow"). So Kannada picked up its yellow word from a completely different language family, Indo-Aryan rather than Dravidian — and that borrowed word still lands on the exact same PIE root this arc has been tracing all along.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "\kn{ಹಸಿರು}" — green, a real Dravidian cousin of Tamil paccai and Telugu pacca{]}
+  \item {[}YOU SAY: "\kn{ಹಳದಿ}" — yellow, borrowed, and secretly a cousin of gelb{]}
+  \item {[}YOU SAY: the contrast — hasiru is native Dravidian; haladi is a Sanskrit/ Hindi loan built on the turmeric word{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What Proto-Dravidian root gives \textbf{\kn{ಹಸಿರು}} (\emph{hasiru}), and which two other Dravidian languages share it? (\emph{\textbf{*pac-}}, "green" — shared with \textbf{Tamil}'s \emph{paccai} and \textbf{Telugu}'s \emph{pacca}.) Is \textbf{\kn{ಹಳದಿ}} (\emph{haḷadi}) Kannada's native word for turmeric? (\textbf{No} — that's \emph{ariśina}; \emph{haḷadi} is a Sanskrit/Hindi loan.) What ancient PIE root connects \textbf{haḷadi}, through Sanskrit \textbf{hari}, to Hindi's \textbf{harā} and German's \textbf{gelb}? (\emph{\textbf{*ǵ\textsuperscript{h}elh₃-}}, "to shine.")
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch23-day.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch23-day.tex
@@ -1,0 +1,45 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:422a48e530cebe57
+% canonical-lessons: KA-C23-dina
+
+\chapter{Day}
+\label{ch:ka-day}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ದಿನ}]{\kn{ದಿನ} (dina) — "day," Sanskrit kept whole}
+
+\label{lesson:KA-C23-dina}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You've already met Sanskrit's "middle" compounds for noon and midnight. Here's the plain word for "day" itself — and a genuinely interesting twist on how borrowing works.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\kn{ದಿನ}} (\textbf{dina}) — "\textbf{day}" — is a Sanskrit \textbf{tatsama} word: borrowed \textbf{whole}, unchanged, the same way \emph{madhyāhna}/\emph{madhyarātri} were (Chapter 17). It's Kannada's ordinary, everyday word for "a day."
+\end{cousinweb}
+
+\begin{cousinweb}
+Here's the honest twist: Kannada's \emph{dina} and Hindi's \textbf{\dv{दिन}} (\emph{din}) trace to the \textbf{exact same} Sanskrit word, \textbf{\dv{दिन}} (\emph{dina}) — but they got there by \textbf{different routes}. Hindi's \emph{din} is a \textbf{tadbhava} form: Sanskrit \emph{dina} wore down naturally over centuries, through Prakrit, losing its final vowel along the way. Kannada's \emph{dina}, by contrast, is a direct \textbf{tatsama} borrowing — taken straight from Sanskrit, unworn, keeping the full shape. So Kannada's \emph{dina} and Hindi's \emph{din} look almost identical, but one is an unbroken \textbf{inheritance} (eroded), the other a \textbf{later borrowing} (kept whole) — genuinely different histories landing on nearly the same modern word.
+\end{cousinweb}
+
+\begin{cousinweb}
+Kannada does have a genuine \textbf{native Dravidian} word here too: \textbf{\kn{ಹಗಲು}} (\emph{hagalu}) — but be careful, it means specifically "\textbf{daytime}" (the daylight hours, as opposed to night), not "\textbf{a day}" as a calendar unit. It's not a synonym for \emph{dina}; it's a different sense of "day" entirely.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "dina" — "day," Sanskrit tatsama, kept whole{]}
+  \item {[}YOU SAY: the twist — dina and Hindi's din, same Sanskrit source, but borrowing vs. natural erosion{]}
+  \item {[}YOU SAY: hagalu — native Dravidian, "daytime," a different sense than dina{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Is Kannada's \textbf{\kn{ದಿನ}} a tatsama borrowing or a tadbhava inheritance? (\textbf{Tatsama} — borrowed whole from Sanskrit.) How does this differ from Hindi's \textbf{\dv{दिन}} (\emph{din}), even though both trace to the same Sanskrit word? (\textbf{Din is tadbhava} — naturally eroded through Prakrit — while Kannada's \emph{dina} was borrowed later, unworn.) What does \textbf{\kn{ಹಗಲು}} (\emph{hagalu}) mean, and is it a synonym for \emph{dina}? (\textbf{"Daytime"} — a different sense, not "a day" as a calendar unit.)
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch24-night.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch24-night.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:34c5748dc853de1e
+% canonical-lessons: KA-C24-ratri
+
+\chapter{Night}
+\label{ch:ka-night}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ರಾತ್ರಿ}]{\kn{ರಾತ್ರಿ} (rātri) — "night," and its native cousin, pushed aside}
+
+\label{lesson:KA-C24-ratri}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Last lesson's \emph{dina} had a living native partner, \emph{hagalu}. This word's native partner tells a different, more honest story — one of being pushed out, not living alongside.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\kn{ರಾತ್ರಿ}} (\textbf{rātri}) — "\textbf{night}" — is the same Sanskrit \textbf{tatsama} word already hiding inside \textbf{\kn{ಮಧ್ಯರಾತ್ರಿ}} (\emph{madhyarātri}, "midnight," Chapter 17), now standing on its own as Kannada's ordinary, everyday word for "night."
+\end{cousinweb}
+
+\begin{cousinweb}
+Kannada \textbf{does} have a genuine \textbf{native Dravidian} word for night: \textbf{\kn{ಇರುಳು}} (\textbf{iruḷu}), from \textbf{Proto-Dravidian} \emph{\textbf{*cirVḷ}} — a real pan-Dravidian cognate, matching \textbf{Tamil}'s \textbf{\ta{இருள்}} (\emph{iruḷ}), \textbf{Malayalam}'s \textbf{\ml{ഇരുൾ}} (\emph{iruḷ}), and \textbf{Telugu}'s \textbf{\te{ఇరులు}} (\emph{irulu}). But here's the honest difference from last lesson's \emph{hagalu}: while \emph{hagalu} is still a \textbf{living, everyday} word (just for a different sense, "daytime"), \emph{iruḷu} has been genuinely \textbf{pushed aside} by the Sanskrit loan — it now survives mainly in \textbf{older poetry}, carrying extra metaphorical weight ("darkness," even "ignorance"), rather than in everyday speech. \emph{Rātri} simply \textbf{won} the job of "night" in modern Kannada.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "rātri" — "night," already met inside madhyarātri{]}
+  \item {[}YOU SAY: "iruḷu" — the real native word, now mostly archaic/poetic{]}
+  \item {[}YOU SAY: the honest contrast — hagalu still lives (different sense); iruḷu was pushed aside (same sense, lost the job){]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Where have you already met \textbf{\kn{ರಾತ್ರಿ}} before this lesson? (\textbf{\kn{ಮಧ್ಯರಾತ್ರಿ}}, \emph{madhyarātri}, "midnight.") What genuine native Dravidian word for "night" does Kannada have, and what's its status today? (\textbf{\kn{ಇರುಳು}}, \emph{iruḷu} — largely \textbf{archaic}, surviving mainly in older poetry.) How is \emph{iruḷu}'s story different from \emph{hagalu}'s, from last lesson? (\textbf{Hagalu still lives}, for a different sense {[}"daytime"{]}; \textbf{iruḷu was pushed aside} entirely by the Sanskrit loan, for the same sense {[}"night"{]}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch25-good-night.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch25-good-night.tex
@@ -1,0 +1,45 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:d84a11ad7e7cac19
+% canonical-lessons: KA-C25-shubha-ratri
+
+\chapter{Good Night}
+\label{ch:ka-good-night}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ಶುಭ} \kn{ರಾತ್ರಿ}]{\kn{ಶುಭ} \kn{ರಾತ್ರಿ} (śubha rātri) — "good night," auspicious to the end}
+
+\label{lesson:KA-C25-shubha-ratri}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You already have \emph{rātri}. Pair it with one more Sanskrit word, and you have Kannada's everyday "good night" — the same phrase, word for word, as Hindi's.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\kn{ಶುಭ} \kn{ರಾತ್ರಿ}} (\textbf{śubha rātri}) — "\textbf{good night}" — literally "\textbf{auspicious night}." Both pieces are Sanskrit \textbf{tatsama}: \textbf{\kn{ರಾತ್ರಿ}} (\emph{rātri}, "night," already met last lesson) plus \textbf{\kn{ಶುಭ}} (\emph{śubha}, "\textbf{auspicious, good}").
+\end{cousinweb}
+
+\begin{cousinweb}
+\textbf{\kn{ಶುಭ}} (\textbf{śubha}) comes from the Sanskrit verbal root \textbf{śubh}, whose core sense is "\textbf{to be beautiful, splendid}" — traceable to a well-sourced \textbf{Proto-Indo-European} root, \emph{\textbf{*ḱewb\textsuperscript{h}-}} ("to be beautiful"). A further, more speculative connection to a root meaning "to shine" has also been proposed — but either way, the underlying idea is a familiar one: \textbf{auspiciousness imagined as a kind of radiance or beauty}.
+\end{cousinweb}
+
+\begin{cousinweb}
+Here's the honest cross-language note: \textbf{\kn{ಶುಭ} \kn{ರಾತ್ರಿ}} and Hindi's own \textbf{\dv{शुभ} \dv{रात्रि}} are, word for word, the \textbf{exact same phrase} — a Dravidian language and an Indo-Aryan language landing on an identical "good night." The most likely explanation is \textbf{shared Sanskrit vocabulary}, not one language directly copying the phrase from the other — but be honest about the limits of that claim: "good night" as a farewell greeting is itself a \textbf{modern} convention across Indian languages, not an ancient one, so some degree of cross-language reinforcement (Hindi's wide reach as a pan-Indian media language, for instance) can't be ruled out either. Unlike Hindi, where \emph{rātri} is the formal member of a live doublet against everyday \emph{raat}, Kannada's \emph{rātri} is simply the ordinary word (Chapter 24) — so this phrase draws on shared \textbf{Sanskrit vocabulary}, not a shared "formal-versus-everyday" register split the way it does in Hindi.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "śubha rātri" — "good night," literally "auspicious night"{]}
+  \item {[}YOU SAY: śubha's own root — śubh, "to be beautiful" $\to$ "auspicious"{]}
+  \item {[}YOU SAY: the honest cross-language note — identical to Hindi's shubh rātri, most likely via shared Sanskrit vocabulary, though direct reinforcement can't be fully ruled out{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \textbf{\kn{ಶುಭ} \kn{ರಾತ್ರಿ}} literally mean? ("\textbf{Auspicious night}.") What does \textbf{\kn{ಶುಭ}} literally trace back to? (A root meaning "\textbf{to be beautiful, splendid}.") Is Kannada's \emph{śubha rātri} definitely borrowed directly from Hindi? (\textbf{Most likely not} — shared Sanskrit vocabulary is the more parsimonious explanation, though since "good night" as a farewell is itself a modern convention, some cross-language reinforcement can't be fully ruled out.)
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch26-morning.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch26-morning.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:6c517d5cdb2f5b6a
+% canonical-lessons: KA-C26-belagge
+
+\chapter{Morning}
+\label{ch:ka-morning}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ಬೆಳಗ್ಗೆ}]{\kn{ಬೆಳಗ್ಗೆ} (beḷagge) — the one time-word that's genuinely Kannada's own}
+
+\label{lesson:KA-C26-belagge}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Every everyday time-word you've met in Kannada so far — day, night, noon, midnight — has been Sanskrit, borrowed whole. This one breaks that pattern completely.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\kn{ಬೆಳಗ್ಗೆ}} (\textbf{beḷagge}) — "\textbf{morning}" — is \textbf{native Dravidian}, built on \textbf{\kn{ಬೆಳಗು}} (\emph{beḷagu}, "\textbf{to shine, to become bright, to dawn}") and the related noun \textbf{\kn{ಬೆಳಕು}} (\emph{beḷaku}, "\textbf{light}"). Morning is, quite literally, "the shining," "the dawning" — a transparent, homegrown metaphor, no borrowed vocabulary anywhere in it.
+\end{cousinweb}
+
+\begin{culture}
+Here's what makes this lesson different from every other Kannada time-word lesson so far: \textbf{\kn{ದಿನ}} (\emph{dina}, "day"), \textbf{\kn{ರಾತ್ರಿ}} (\emph{ratri}, "night"), and \textbf{\kn{ಮಧ್ಯಾಹ್ನ}} (\emph{madhyāhna}, "noon") are all genuine \textbf{Sanskrit tatsama} borrowings, taken whole, doing the plain everyday job in Kannada. \textbf{\kn{ಬೆಳಗ್ಗೆ}} breaks that streak — it's the one everyday time-word in this set that's actually \textbf{Kannada's own}, not a loan from anywhere. If you'd only met \emph{dina}, \emph{ratri}, and \emph{madhyāhna}, you might start to assume every Kannada time-word is Sanskrit underneath. This one is the honest counter-example — though, matching the pattern already seen with \emph{hagalu} and \emph{iruḷu} (Chapters 23–24), a native compound for "noon" does technically exist too: \textbf{\kn{ನಡುಹಗಲು}} (\emph{naḍuhagalu}, "middle-of-daytime," built from \emph{naḍu}, "middle," the same everyday word already met, plus \emph{hagalu}). It just lost the everyday job to \emph{madhyāhna}, the same way \emph{hagalu} and \emph{iruḷu} were pushed into narrower, or archaic, roles by their own Sanskrit competitors.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "beḷagge" — "morning," native Dravidian{]}
+  \item {[}YOU SAY: the root — beḷagu, "to shine, to dawn," and beḷaku, "light"{]}
+  \item {[}YOU SAY: the contrast — dina, ratri, madhyāhna are all Sanskrit; beḷagge is genuinely Kannada's own{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What native root does \kn{ಬೆಳಗ್ಗೆ} come from, and what does it mean? (\textbf{\kn{ಬೆಳಗು}/\kn{ಬೆಳಕು}} — "to shine/dawn" and "light.") Is \kn{ಬೆಳಗ್ಗೆ} a Sanskrit tatsama, like dina, ratri, and madhyāhna? (\textbf{No} — genuinely native Dravidian, the odd one out among Kannada's everyday time-words.)
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch27-evening.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch27-evening.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:5b610fd79895225e
+% canonical-lessons: KA-C27-sanje
+
+\chapter{Evening}
+\label{ch:ka-evening}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ಸಂಜೆ}]{\kn{ಸಂಜೆ} (sañje) — a Sanskrit word that arrived already worn down}
+
+\label{lesson:KA-C27-sanje}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} \kn{ದಿನ}, \kn{ರಾತ್ರಿ}, and \kn{ಮಧ್ಯಾಹ್ನ} all arrived in Kannada whole, unworn, straight from Sanskrit. This word took a very different route — and it lands somewhere genuinely surprising.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\kn{ಸಂಜೆ}} (\textbf{sañje}) — "\textbf{evening}" — traces to \textbf{Sanskrit} \textbf{\kn{ಸಂಧ್ಯಾ}} (\emph{saṃdhyā}, "\textbf{twilight}," literally "the junction of day and night") — but it didn't arrive in Kannada as a fresh, whole tatsama the way \emph{dina}, \emph{ratri}, and \emph{madhyāhna} did. Instead, it came by way of \textbf{Maharashtri Prakrit} \textbf{\kn{ಸಂಝಾ}} (\emph{sañjhā}) — Sanskrit's word, already worn down by centuries of everyday Middle Indo-Aryan speech, \emph{then} borrowed into Kannada in that already-eroded shape.
+\end{cousinweb}
+
+\begin{cousinweb}
+Here's the genuinely surprising part: Hindi's own evening word, \textbf{\dv{साँझ}} (\emph{sāñjh}), comes from the \textbf{exact same} Sanskrit \textbf{\kn{ಸಂಧ್ಯಾ}} — but by a \textbf{different} route. Hindi \emph{inherited} it, generation to generation, through \textbf{Śauraseni Prakrit} (a different, sister Middle Indo-Aryan dialect than the Maharashtri Prakrit Kannada borrowed from). Two separate erosion paths — one an unbroken inheritance within the Indo-Aryan family, one a loan crossing into a completely different language family — and they land on nearly \textbf{identical-sounding} modern words, \emph{sañje} and \emph{sāñjh}, purely because they share the same Sanskrit starting point.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "sañje" — "evening," from Sanskrit sandhyā via Maharashtri Prakrit{]}
+  \item {[}YOU SAY: the contrast with dina/ratri/madhyāhna — those arrived whole; sañje arrived already worn down{]}
+  \item {[}YOU SAY: the striking convergence — Hindi's \dv{साँझ}, same Sanskrit root, different Prakrit path, nearly the same sound today{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Does \kn{ಸಂಜೆ} arrive in Kannada as a fresh, whole Sanskrit tatsama, like \emph{dina} and \emph{ratri} did? (\textbf{No} — it arrived already worn down, via Maharashtri Prakrit \kn{ಸಂಝಾ}.) What Hindi word shares \kn{ಸಂಜೆ}'s exact Sanskrit root, and by what different path did it get there? (\textbf{\dv{साँझ}} (sāñjh) — inherited via a different sister Prakrit, Śauraseni, rather than borrowed via Maharashtri.)
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch28-afternoon.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch28-afternoon.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:6133ff939c0603ea
+% canonical-lessons: KA-C28-aparahna
+
+\chapter{Afternoon}
+\label{ch:ka-afternoon}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ಅಪರಾಹ್ನ}]{\kn{ಅಪರಾಹ್ನ} (aparāhna) — the same "-ahna" pattern, a different first piece}
+
+\label{lesson:KA-C28-aparahna}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You already know \kn{ಮಧ್ಯಾಹ್ನ}, "noon" — "middle" plus "day." This lesson's word for "afternoon" uses the exact same building pattern, just with a different first piece.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\kn{ಅಪರಾಹ್ನ}} (\textbf{aparāhna}) — "\textbf{afternoon}" — is a genuine \textbf{Sanskrit tatsama}: \textbf{\kn{ಅಪರ}} (\emph{apara}, "\textbf{latter, further}") + the same \textbf{-\kn{ಅಹ್ನ}} (\emph{-ahna}, "\textbf{day}") suffix already hiding inside \textbf{\kn{ಮಧ್ಯಾಹ್ನ}} (\emph{madhyāhna}, "noon," Chapter 17). Same clean two-piece structure, same "day" ending — just swap \emph{madhya} ("middle") for \emph{apara} ("latter, further along") and you move from "noon" to "afternoon." This distinction comes from a genuine, classical \textbf{five-part Sanskrit division of the day} — \emph{prāta} (early morning), \emph{saṅgava}, \emph{madhyāhna} (noon), \emph{aparāhna} (afternoon), \emph{sāyāhna} (evening) — with \emph{aparāhna} landing specifically as the fourth part, after noon and before evening.
+\end{cousinweb}
+
+\begin{culture}
+Here's where this lesson needs real care: some sources describe \textbf{\kn{ಮಧ್ಯಾಹ್ನ}} itself being stretched loosely in casual modern speech to cover the whole afternoon too — which would echo Hindi's own \dv{दोपहर}, already found in this course to have genuinely widened from "precisely noon" to "the whole afternoon." But the evidence for Kannada is \textbf{much thinner} than what backed the Hindi finding — general dictionary listings rather than clear, independently-confirmed usage sources. Treat this as a plausible, hedged parallel, not a settled fact the way \dv{दोपहर}'s widening was. \textbf{\kn{ಅಪರಾಹ್ನ}} remains the more precisely, formally correct word for "afternoon" specifically.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "aparāhna" — "afternoon," apara + ahna{]}
+  \item {[}YOU SAY: the shared piece with madhyāhna — both end in "-ahna," "day"{]}
+  \item {[}YOU SAY: the honest hedge — madhyāhna MAY also loosely cover "afternoon" in casual speech, but this is far less certain than Hindi's dopahar-widening story{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What suffix does \kn{ಅಪರಾಹ್ನ} share with \kn{ಮಧ್ಯಾಹ್ನ}, and what does it mean? (\textbf{-\kn{ಅಹ್ನ}}, \emph{-ahna}, "day.") What's the difference in their first pieces? (\textbf{\kn{ಅಪರ}}, \emph{apara}, "latter/further" vs. \textbf{\kn{ಮಧ್ಯ}}, \emph{madhya}, "middle.") Is the claim that \kn{ಮಧ್ಯಾಹ್ನ} also covers "afternoon" in casual speech as well-supported as Hindi's \dv{दोपहर}-widening finding? (\textbf{No} — much more thinly sourced; treat it as a hedged possibility, not a settled fact.)
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch29-good-morning.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch29-good-morning.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:65f0071b2ae9fb22
+% canonical-lessons: KA-C29-shubhodaya
+
+\chapter{Good Morning}
+\label{ch:ka-good-morning}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ಶುಭೋದಯ}]{\kn{ಶುಭೋದಯ} (śubhōdaya) — "good morning," a third root for morning}
+
+\label{lesson:KA-C29-shubhodaya}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You already have \kn{ಬೆಳಗ್ಗೆ}, the everyday word for "morning." This greeting reaches for a completely different word for the same idea — and, honestly, this lesson's twist is about how uncertain its own "everyday" status turns out to be, once you look closely.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\kn{ಶುಭೋದಯ}} (\textbf{śubhōdaya}) — "\textbf{good morning}" — is built from \textbf{\kn{ಶುಭ}} (\emph{śubha}, "\textbf{good, auspicious}") plus \textbf{\kn{ಉದಯ}} (\emph{udaya}, "\textbf{rising, sunrise}," from Sanskrit \textbf{ud-} "up" + \textbf{i} "to go" — the same root behind \textbf{\kn{ಸೂರ್ಯೋದಯ}}, \emph{sūryōdaya}, "sunrise" itself). This is a \textbf{completely different word} from \textbf{\kn{ಬೆಳಗ್ಗೆ}} (\emph{beḷagge}, Chapter 26's native "morning") — Kannada now has (at least) two unrelated roots circling the idea of morning: one native ("the shining"), one Sanskrit ("the rising").
+\end{cousinweb}
+
+\begin{culture}
+Here's where this lesson needs real care. Some sources describe \textbf{\kn{ಶುಭೋದಯ}} as the most common everyday way to say "good morning" in Kannada — but these are largely the same genre of generic phrasebook site whose claims about Hindi's \dv{सुप्रभात} turned out, on closer inspection, to be overstated. A more careful source instead describes \kn{ಶುಭೋದಯ} as reserved mainly for \textbf{formal or written} contexts — speeches, greeting cards, WhatsApp images — calling it "not as frequently used in daily conversations" as \textbf{\kn{ನಮಸ್ಕಾರ}}/\textbf{\kn{ನಮಸ್ತೆ}}, and at least one native-speaker account suggests casual spoken Kannada often reaches for \textbf{English} "good morning" instead of \kn{ಶುಭೋದಯ} entirely. Taken together, this looks like the \textbf{same} formal/written skew already found for Hindi's \dv{सुप्रभात}, not the genuine cross-language contrast a first pass at the sources might suggest. A native alternate, \textbf{\kn{ಶುಭ} \kn{ಮುಂಜಾನೆ}} (\emph{śubha muñjāne}, using \emph{muñjāne}, "the early morning, before sunrise"), also exists as a real, attested greeting construction — but its own register isn't independently confirmed here either.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "śubhōdaya" — "good morning," śubha + udaya{]}
+  \item {[}YOU SAY: the root contrast — beḷagge is native "shining"; udaya is Sanskrit "rising"{]}
+  \item {[}YOU SAY: the honest note — sources conflict, but the more careful ones point to the same formal/written skew already found for Hindi{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Does \kn{ಶುಭೋದಯ} share a root with \kn{ಬೆಳಗ್ಗೆ}? (\textbf{No} — \kn{ಉದಯ}, "rising," is a completely different Sanskrit root from native \kn{ಬೆಳಗ್ಗೆ}'s "shining.") Is \kn{ಶುಭೋದಯ} genuinely common in everyday casual Kannada speech? (\textbf{Unclear, and possibly not} — sources conflict; the more careful ones describe it skewing formal/written, with \kn{ನಮಸ್ಕಾರ}/\kn{ನಮಸ್ತೆ} covering casual mornings instead, and one native-speaker account suggests English "good morning" often gets used in casual speech instead of \kn{ಶುಭೋದಯ} entirely.)
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch30-good-evening.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch30-good-evening.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:aebe084d534a27d6
+% canonical-lessons: KA-C30-shubha-sanje
+
+\chapter{Good Evening}
+\label{ch:ka-good-evening}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ಶುಭ} \kn{ಸಂಜೆ}]{\kn{ಶುಭ} \kn{ಸಂಜೆ} (śubha sañje) — formal, and correctly citing where \kn{ಸಂಜೆ} comes from}
+
+\label{lesson:KA-C30-shubha-sanje}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You already have \kn{ಸಂಜೆ}, "evening" — and you already know it's a Sanskrit word that arrived in Kannada already worn down, via Prakrit. Keep that fact straight here, since it's an easy one to second-guess.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\kn{ಶುಭ} \kn{ಸಂಜೆ}} (\textbf{śubha sañje}) — "\textbf{good evening}" — pairs \textbf{\kn{ಶುಭ}} ("good, auspicious") with \textbf{\kn{ಸಂಜೆ}}, the exact word from Chapter 27: Sanskrit \textbf{\kn{ಸಂಧ್ಯಾ}} (\emph{saṃdhyā}), borrowed into Kannada via \textbf{Maharashtri Prakrit} \kn{ಸಂಝಾ} (\emph{sañjhā}). You might run across a plausible-sounding claim elsewhere that \kn{ಸಂಜೆ} is "native Dravidian" — it isn't, and you already have the real answer from Chapter 27. Don't let a claim that merely \emph{sounds} plausible override something you've already verified.
+\end{cousinweb}
+
+\begin{culture}
+Here's where this lesson needs to be careful about its own sourcing, not just the etymology's. General impressions lean toward \textbf{\kn{ಶುಭ} \kn{ಸಂಜೆ}} skewing \textbf{formal}, with the all-purpose \textbf{\kn{ನಮಸ್ಕಾರ}} — or, among younger urban speakers, borrowed English "\textbf{hello}" — more likely to cover ordinary casual conversation. But the evidence for this specific register claim is genuinely \textbf{thin}: it's the same kind of impression that, for both Hindi's \dv{सुप्रभात} and Kannada's own \kn{ಶುಭೋದಯ}, needed real digging to confirm or correct, and here that deeper digging hasn't turned up anything more solid than a general leaning. Treat this as an open \textbf{question}, echoing the same one already raised for those two greetings, not a third confirmed data point — this lesson doesn't have strong enough sourcing to settle it either way.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "śubha sañje" — "good evening," a genuinely Sanskrit-rooted pairing{]}
+  \item {[}YOU SAY: the correction — \kn{ಸಂಜೆ} is Sanskrit-via-Prakrit, NOT native Dravidian, whatever a plausible-sounding claim elsewhere might say{]}
+  \item {[}YOU SAY: \kn{ನಮಸ್ಕಾರ} — the likely all-purpose everyday alternative, though this greeting's own register remains an open question{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Is \kn{ಸಂಜೆ} native Dravidian? (\textbf{No} — Sanskrit \kn{ಸಂಧ್ಯಾ} via Maharashtri Prakrit, already established in Chapter 27; be skeptical of any claim otherwise.) Is it settled that \kn{ಶುಭ} \kn{ಸಂಜೆ} is formal/rare in casual speech, the way \dv{सुप्रभात} and \kn{ಶುಭೋದಯ} turned out to be? (\textbf{Not settled} — the impression leans that way, with \kn{ನಮಸ್ಕಾರ} likely covering casual use, but the sourcing here is too thin to call it confirmed.)
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch31-good-afternoon.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch31-good-afternoon.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:3c1a2104befa120f
+% canonical-lessons: KA-C31-shubha-madhyahna
+
+\chapter{Good Afternoon}
+\label{ch:ka-good-afternoon}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\kn{ಶುಭ} \kn{ಮಧ್ಯಾಹ್ನ}]{\kn{ಶುಭ} \kn{ಮಧ್ಯಾಹ್ನ} (śubha madhyāhna) — the "noon" word doing the afternoon's job}
+
+\label{lesson:KA-C31-shubha-madhyahna}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Two lessons ago you met a careful hedge: does \kn{ಮಧ್ಯಾಹ್ನ}, "noon," also loosely cover "afternoon"? This greeting hands you a real data point.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\kn{ಶುಭ} \kn{ಮಧ್ಯಾಹ್ನ}} (\textbf{śubha madhyāhna}) — "\textbf{good afternoon}" — is the standard greeting for this concept. Notice which noun it actually reuses: \textbf{\kn{ಮಧ್ಯಾಹ್ನ}} (\emph{madhyāhna}, "noon," Chapter 17) — \textbf{not} \textbf{\kn{ಅಪರಾಹ್ನ}} (\emph{aparāhna}, the word Chapter 28 established as the more precisely "afternoon"-specific term). This is exactly the kind of concrete usage evidence that bears on Chapter 28's own hedge: if the standard \textbf{greeting} for "good afternoon" reaches for \emph{madhyāhna} rather than \emph{aparāhna}, that's a real (if still not fully conclusive) sign that \emph{madhyāhna}'s job has genuinely stretched to cover the afternoon in everyday use, not just at noon itself.
+\end{cousinweb}
+
+\begin{culture}
+Here's the useful discipline this lesson followed: checking a claim against an actual, directly fetched source page, not just trusting a search-engine's own summary of one. That check turned up \textbf{two} claims of very different strength. \textbf{\kn{ನಮಸ್ಕಾರ}}'s status as a genuinely \textbf{universal} greeting — suited to any time of day, any occasion — is independently confirmed across multiple fetched sources; that one's solid. The claim that \textbf{\kn{ಶುಭ} \kn{ಮಧ್ಯಾಹ್ನ}} leans \textbf{formal or semi-formal} — workplaces, official meetings — traces back to just \textbf{one} source. It's a real, directly-verified data point, worth taking seriously — but it isn't cross-corroborated the way the \kn{ನಮಸ್ಕಾರ} claim is, so treat it as a single well-checked impression, not a settled fact.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "śubha madhyāhna" — "good afternoon," reusing the "noon" word, not "aparāhna"{]}
+  \item {[}YOU SAY: why that matters — real evidence for madhyāhna's meaning stretching to cover "afternoon"{]}
+  \item {[}YOU SAY: \kn{ನಮಸ್ಕಾರ} — the confirmed universal, any-time-of-day greeting, cross-checked across multiple sources{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Does \kn{ಶುಭ} \kn{ಮಧ್ಯಾಹ್ನ} use \kn{ಮಧ್ಯಾಹ್ನ} ("noon") or \kn{ಅಪರಾಹ್ನ} (the more precise "afternoon" word)? (\textbf{\kn{ಮಧ್ಯಾಹ್ನ}} — real evidence for its meaning stretching to cover "afternoon" too.) Is the "formal/workplace" register claim for \kn{ಶುಭ} \kn{ಮಧ್ಯಾಹ್ನ} as solidly confirmed as \kn{ನಮಸ್ಕಾರ}'s universal status? (\textbf{No} — the workplace claim rests on a single directly-verified source, not cross-corroborated the way \kn{ನಮಸ್ಕಾರ}'s is.) What's the confirmed universal, any-time-of-day alternative? (\textbf{\kn{ನಮಸ್ಕಾರ}}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/preamble.tex
+++ b/code/learning/human-languages/kannada/book/preamble.tex
@@ -19,23 +19,37 @@
 \newunicodechar{ṟ}{\b{r}}
 \newunicodechar{ṁ}{\.{m}}
 \newunicodechar{ḻ}{\b{l}}
+\newunicodechar{ḱ}{\'{k}}
+\newunicodechar{₃}{\textsubscript{3}}
 
 \usepackage[table]{xcolor}
 \usepackage{tcolorbox}
 \tcbuselibrary{skins,breakable}
 \usepackage{booktabs}
 \usepackage{longtable}
+\usepackage{tabularx}
 \usepackage{array}
 \usepackage[hidelinks]{hyperref}
 \usepackage{titlesec}
 
 \usepackage{polyglossia}
 \setmainlanguage{english}
+\setotherlanguage{arabic}
 
 % Vendored Kannada font (../../_fonts/ from <lang>/book/); Script=Kannada drives
 % the shaping. \kn{...} = an inline Kannada snippet within English text.
 \newfontfamily\kannadafont[Path=../../_fonts/, Script=Kannada]{NotoSansKannada-Static.ttf}
 \newcommand{\kn}[1]{{\kannadafont #1}}
+\newfontfamily\tamilfont[Path=../../_fonts/, Script=Tamil]{NotoSansTamil-Static.ttf}
+\newcommand{\ta}[1]{{\tamilfont #1}}
+\newfontfamily\telugufont[Path=../../_fonts/, Script=Telugu]{NotoSansTelugu-Static.ttf}
+\newcommand{\te}[1]{{\telugufont #1}}
+\newfontfamily\malayalamfont[Path=../../_fonts/, Script=Malayalam]{NotoSansMalayalam-Static.ttf}
+\newcommand{\ml}[1]{{\malayalamfont #1}}
+\newfontfamily\devanagarifont[Path=../../_fonts/, Script=Devanagari]{NotoSansDevanagari-Static.ttf}
+\newcommand{\dv}[1]{{\devanagarifont #1}}
+\newfontfamily\arabicfont[Path=../../_fonts/, Script=Arabic]{NotoNaskhArabic-Static.ttf}
+\newcommand{\ar}[1]{\textarabic{#1}}
 
 \hypersetup{
   pdftitle={Kannada, Step by Step, Root by Root},
@@ -54,10 +68,10 @@
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
   fonttitle=\bfseries, title={Why it's said this way}
 }
-\newtcolorbox{grammarlens}{
+\newtcolorbox{grammarlens}[1][]{
   breakable, skin=enhanced, colback=blue!5, colframe=blue!35!black,
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
-  fonttitle=\bfseries, title={Grammar Lens}
+  fonttitle=\bfseries, title={Grammar Lens}, #1
 }
 \newtcolorbox{sounds}{
   breakable, skin=enhanced, colback=green!6, colframe=green!30!black,

--- a/code/learning/human-languages/kannada/lessons/KA-C06-dative-ge.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C06-dative-ge.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C06-dative-ge
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 310
 chapter: 6
 type: word
 headword: -ಗೆ
@@ -10,19 +13,33 @@ prerequisites: [KA-C05-practice, KA-C03-naanu, KA-C02-hesaru]
 sounds: [voiced-g]
 roots: [dravidian-dative-ku]
 etymology_hook: "-ge is Kannada's form of shared Dravidian *-k(k)u: k voiced to g between vowels while doubled -kke kept the hard consonant"
-est_minutes: 4
 reviews_of: [KA-C03-naanu, KA-C02-hesaru, KA-C05-practice]
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [KA-LEX-C06-DATIVE-GE-01, KA-ETYMON-C06-DATIVE-GE-02]
+practises:
+  knowledge: [KA-LEX-C06-DATIVE-GE-01, KA-ETYMON-C06-DATIVE-GE-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # -ಗೆ (-ge) — "to, for"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Your first **case ending**. English puts "to" in **front**, as a
 separate word. Kannada sticks it on the **back** — the biggest structural fact
 about the language, in one suffix.
 
-## Adding it on
+## You'll want to know: Adding it on
+<!-- hl-knowledge: introduces=[KA-LEX-C06-DATIVE-GE-01]; assesses=[] -->
 
 | word | + -ge | meaning |
 |---|---|---|
@@ -37,7 +54,8 @@ And with "I", which reshapes first:
 
 > **ನಾನು** *nānu* ("I") → **ನನಗೆ** *nanage* ("to me")
 
-## The g that was once a k
+## The word, taken apart: The g that was once a k
+<!-- hl-knowledge: introduces=[KA-ETYMON-C06-DATIVE-GE-02]; assesses=[] -->
 
 All four descend from one Proto-Dravidian dative, ***-k(k)u***. Look at what
 became of its *k*:
@@ -56,6 +74,7 @@ geminate preserved the original *k*. The two Kannada shapes are the same suffix
 caught on either side of a sound change.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C06-DATIVE-GE-01, KA-ETYMON-C06-DATIVE-GE-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "*hesaru* … *hesarige*"]
@@ -64,6 +83,7 @@ caught on either side of a sound change.
 - [YOU SAY: the family — "*-ukku · -ku · -**ge*** · -ikku"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C06-DATIVE-GE-01, KA-ETYMON-C06-DATIVE-GE-02] -->
 
 [PAUSE 3s] What does **-ಗೆ** mean? ("**To**" or "**for**.") Where does it go?
 (**On the end** of the noun.) What is "to me"? (**ನನಗೆ** *nanage*.) Why does

--- a/code/learning/human-languages/kannada/lessons/KA-C06-dative-stacking.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C06-dative-stacking.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C06-dative-stacking
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 320
 chapter: 6
 type: grammar
 headword: -ಗೆ — stacking
@@ -10,18 +13,32 @@ prerequisites: [KA-C06-dative-ge]
 sounds: []
 roots: [dravidian-dative-ku]
 etymology_hook: "Kannada -ge carries one unambiguous case meaning at a visible seam; Latin -īs fuses case, number, and declension and can name two cases"
-est_minutes: 4
 reviews_of: [KA-C06-dative-ge, KA-C05-practice]
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [KA-LEX-C06-DATIVE-GE-01, KA-ETYMON-C06-DATIVE-GE-02]
+introduces:
+  knowledge: [KA-GRAMMAR-C06-DATIVE-STACKING-01]
+practises:
+  knowledge: [KA-LEX-C06-DATIVE-GE-01, KA-ETYMON-C06-DATIVE-GE-02, KA-GRAMMAR-C06-DATIVE-STACKING-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # -ಗೆ — one suffix, one job
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C06-DATIVE-GE-01, KA-ETYMON-C06-DATIVE-GE-02] -->
 
 [PAUSE 2s] You can now attach **-ಗೆ** and make **ನನಗೆ** “to me.” Look at what
 that visible seam tells you about how Kannada builds longer words.
 
-## Stacking versus fusion
+## Grammar Lens: Stacking versus fusion
+<!-- hl-knowledge: introduces=[KA-GRAMMAR-C06-DATIVE-STACKING-01]; assesses=[] -->
 
 | | Kannada **-ge** | a Latin ending like **-īs** |
 |---|---|---|
@@ -40,6 +57,7 @@ and declension class at once—and it does not even settle whether the case is
 dative or ablative. Kannada **-ಗೆ** carries one unambiguous job: “to/for.”
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C06-DATIVE-GE-01, KA-ETYMON-C06-DATIVE-GE-02, KA-GRAMMAR-C06-DATIVE-STACKING-01] -->
 
 [PAUSE 1s]
 - [YOU SAY: *hesar* + *ige* — a visible noun-plus-case seam]
@@ -47,6 +65,7 @@ dative or ablative. Kannada **-ಗೆ** carries one unambiguous job: “to/for.�
 - [YOU SAY: Latin *-īs* — case, plural, and declension fused]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C06-DATIVE-GE-01, KA-ETYMON-C06-DATIVE-GE-02, KA-GRAMMAR-C06-DATIVE-STACKING-01] -->
 
 [PAUSE 3s] Why is Kannada called agglutinative? (**It stacks visible pieces,
 each with one job.**) How many jobs can Latin *-īs* fuse? (**Case, number, and

--- a/code/learning/human-languages/kannada/lessons/KA-C06-dative-subject.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C06-dative-subject.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C06-dative-subject
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 330
 chapter: 6
 type: phrase
 headword: ನನಗೆ ಕನ್ನಡ ಗೊತ್ತು
@@ -10,18 +13,32 @@ prerequisites: [KA-C06-dative-stacking, KA-C05-naanu-kannada-maatanaaduttene]
 sounds: [gemination-tt]
 roots: [dravidian-dative-ku]
 etymology_hook: "Dravidian puts the EXPERIENCER in the dative — knowing, liking, wanting all happen TO you rather than being done BY you — so 'I know Kannada' has no nominative 'I', the person sitting in the dative instead (a 'dative subject'); gottu is not even a verb but a noun-like word meaning 'known', which is why nothing in the sentence is 'doing' anything"
-est_minutes: 4
 reviews_of: [KA-C06-dative-stacking, KA-C06-dative-ge, KA-C05-naanu-kannada-maatanaaduttene, KA-C03-naanu]
+duration:
+  max_seconds: 285
+requires:
+  knowledge: [KA-GRAMMAR-C06-DATIVE-STACKING-01]
+introduces:
+  knowledge: [KA-LEX-C06-DATIVE-SUBJECT-01, KA-GRAMMAR-C06-DATIVE-SUBJECT-02, KA-GRAMMAR-C06-DATIVE-SUBJECT-03]
+practises:
+  knowledge: [KA-GRAMMAR-C06-DATIVE-STACKING-01, KA-LEX-C06-DATIVE-SUBJECT-01, KA-GRAMMAR-C06-DATIVE-SUBJECT-02, KA-GRAMMAR-C06-DATIVE-SUBJECT-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # ನನಗೆ ಕನ್ನಡ ಗೊತ್ತು — "I know Kannada"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-GRAMMAR-C06-DATIVE-STACKING-01] -->
 
 [PAUSE 2s] Chapter 5 gave you **ನಾನು ಕನ್ನಡ ಮಾತನಾಡುತ್ತೇನೆ** — "**I** speak Kannada."
 Now say "I **know** Kannada." Kannada will not let you use *nānu*.
 
-## The sentence
+## You'll want to know: The sentence
+<!-- hl-knowledge: introduces=[KA-LEX-C06-DATIVE-SUBJECT-01]; assesses=[] -->
 
 > **ನನಗೆ ಕನ್ನಡ ಗೊತ್ತು.**
 > *nanage kannaḍa gottu.*
@@ -38,7 +55,8 @@ dative, leaving *kannaḍa* as the unmarked word the sentence is about. And *got
 isn't really a verb doing an action; it's closer to "**[is] known**." So nothing
 in this sentence is *doing* anything at all.
 
-## Why: things that happen *to* you
+## Grammar Lens: Why: things that happen *to* you
+<!-- hl-knowledge: introduces=[KA-GRAMMAR-C06-DATIVE-SUBJECT-02]; assesses=[] -->
 
 Kannada separates what you **do** from what **happens to** you. Speaking is an
 action, so Ch. 5 used *nānu*. But knowing, liking, wanting, being hungry — these
@@ -53,7 +71,8 @@ action, so Ch. 5 used *nānu*. But knowing, liking, wanting, being hungry — th
 English keeps one fossil of the same idea: "**methinks**" — where *me* is a
 dative, "it seems **to me**." Kannada made it a rule.
 
-## All four sisters do it
+## Grammar Lens: All four sisters do it
+<!-- hl-knowledge: introduces=[KA-GRAMMAR-C06-DATIVE-SUBJECT-03]; assesses=[] -->
 
 | language | "I know [the language]" | the dative |
 |---|---|---|
@@ -67,6 +86,7 @@ suffix** — Kannada's *g* being the softened *k* of the others. The Dravidian
 family showing its bones, exactly as *blanc/bianco/branco* did for Romance.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-GRAMMAR-C06-DATIVE-STACKING-01, KA-LEX-C06-DATIVE-SUBJECT-01, KA-GRAMMAR-C06-DATIVE-SUBJECT-02, KA-GRAMMAR-C06-DATIVE-SUBJECT-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "*nanage kannaḍa gottu*"]
@@ -75,6 +95,7 @@ family showing its bones, exactly as *blanc/bianco/branco* did for Romance.
 - [YOU SAY: the four cousins — "*-ge · -ukku · -ku · -ikku*"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-GRAMMAR-C06-DATIVE-STACKING-01, KA-LEX-C06-DATIVE-SUBJECT-01, KA-GRAMMAR-C06-DATIVE-SUBJECT-02, KA-GRAMMAR-C06-DATIVE-SUBJECT-03] -->
 
 [PAUSE 3s] What does **ನನಗೆ ಕನ್ನಡ ಗೊತ್ತು** literally say? ("**To-me** Kannada
 **known**.") What has English got that Kannada hasn't? (A nominative "**I**" —

--- a/code/learning/human-languages/kannada/lessons/KA-C07-numbers-1-5.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C07-numbers-1-5.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C07-numbers-1-5
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 340
 chapter: 7
 type: word
 headword: ಒಂದು ಎರಡು ಮೂರು ನಾಲ್ಕು ಐದು
@@ -9,18 +12,32 @@ prerequisites: [KA-C01-namaskara]
 sounds: [kannada-inherent-a, anusvara, retroflex-series]
 roots: [proto-dravidian-numbers]
 etymology_hook: "Kannada shares Tamil's native Dravidian numbers — 2–5 the same word in a Kannada coat (iraṇṭu ↔ eraḍu)"
-est_minutes: 4
 reviews_of: [KA-C01-namaskara]
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [KA-LEX-C07-NUMBERS-1-5-01, KA-ETYMON-C07-NUMBERS-1-5-02, KA-GRAMMAR-C07-NUMBERS-1-5-03]
+practises:
+  knowledge: [KA-LEX-C07-NUMBERS-1-5-01, KA-ETYMON-C07-NUMBERS-1-5-02, KA-GRAMMAR-C07-NUMBERS-1-5-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # ಒಂದು, ಎರಡು, ಮೂರು, ನಾಲ್ಕು, ಐದು — one to five
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] If you walked here through Tamil, you already know these numbers —
 Kannada just says them with its own accent.
 
-## The five
+## You'll want to know: The five
+<!-- hl-knowledge: introduces=[KA-LEX-C07-NUMBERS-1-5-01]; assesses=[] -->
 
 | | numeral | word | said |
 |---|---|---|---|
@@ -33,7 +50,8 @@ Kannada just says them with its own accent.
 The single symbols **೧ ೨ ೩ ೪ ೫** are Kannada's own digits — you'll meet them on
 bus numbers and prices, distinct from the words above.
 
-## The family stays together
+## The word, taken apart: The family stays together
+<!-- hl-knowledge: introduces=[KA-ETYMON-C07-NUMBERS-1-5-02]; assesses=[] -->
 
 These are **native Dravidian** numbers, not Sanskrit borrowings — the same
 word-stock Tamil kept. Line them up against Tamil and they are plainly the same
@@ -50,7 +68,8 @@ word wearing a Kannada coat:
 (from an old *oṉ-*), but Telugu will break rank with *okaṭi* when you get there.
 So learn *ondu* now, but expect Telugu's "one" to surprise you.
 
-## A Kannada habit to notice
+## Grammar Lens: A Kannada habit to notice
+<!-- hl-knowledge: introduces=[KA-GRAMMAR-C07-NUMBERS-1-5-03]; assesses=[] -->
 
 The **anusvara** — the small circle **ಂ** in *ಒಂದು* (*on-du*) — is a nasal
 that takes its colour from the letter after it: an *n* before *d* in *ondu*, an
@@ -58,6 +77,7 @@ that takes its colour from the letter after it: an *n* before *d* in *ondu*, an
 consonant needs. You'll see it constantly.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C07-NUMBERS-1-5-01, KA-ETYMON-C07-NUMBERS-1-5-02, KA-GRAMMAR-C07-NUMBERS-1-5-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "ondu, eraḍu, mūru, nālku, aidu"]
@@ -65,6 +85,7 @@ consonant needs. You'll see it constantly.
 - [YOU SAY: read the digits — ೧ ೨ ೩ ೪ ೫]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C07-NUMBERS-1-5-01, KA-ETYMON-C07-NUMBERS-1-5-02, KA-GRAMMAR-C07-NUMBERS-1-5-03] -->
 
 [PAUSE 3s] Count to five in Kannada. (*Ondu, eraḍu, mūru, nālku, aidu*.) Are
 these borrowed from Sanskrit? (**No** — native Dravidian, shared with Tamil.)

--- a/code/learning/human-languages/kannada/lessons/KA-C07-numbers-6-10.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C07-numbers-6-10.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C07-numbers-6-10
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 350
 chapter: 7
 type: word
 headword: ಆರು ಏಳು ಎಂಟು ಒಂಬತ್ತು ಹತ್ತು
@@ -9,18 +12,32 @@ prerequisites: [KA-C07-numbers-1-5]
 sounds: [kannada-inherent-a, anusvara, retroflex-la]
 roots: [proto-dravidian-numbers]
 etymology_hook: "ten shows Kannada's signature p→h shift — Tamil pattu becomes hattu, as pāl (milk) becomes hālu"
-est_minutes: 4
 reviews_of: [KA-C07-numbers-1-5]
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [KA-LEX-C07-NUMBERS-1-5-01, KA-ETYMON-C07-NUMBERS-1-5-02, KA-GRAMMAR-C07-NUMBERS-1-5-03]
+introduces:
+  knowledge: [KA-LEX-C07-NUMBERS-6-10-01, KA-ETYMON-C07-NUMBERS-6-10-02, KA-ETYMON-C07-NUMBERS-6-10-03]
+practises:
+  knowledge: [KA-LEX-C07-NUMBERS-1-5-01, KA-ETYMON-C07-NUMBERS-1-5-02, KA-GRAMMAR-C07-NUMBERS-1-5-03, KA-LEX-C07-NUMBERS-6-10-01, KA-ETYMON-C07-NUMBERS-6-10-02, KA-ETYMON-C07-NUMBERS-6-10-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # ಆರು, ಏಳು, ಎಂಟು, ಒಂಬತ್ತು, ಹತ್ತು — six to ten
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C07-NUMBERS-1-5-01, KA-ETYMON-C07-NUMBERS-1-5-02, KA-GRAMMAR-C07-NUMBERS-1-5-03] -->
 
 [PAUSE 2s] Five more — and the last one shows the single sound-change that most
 makes Kannada *sound* like Kannada.
 
-## The five
+## You'll want to know: The five
+<!-- hl-knowledge: introduces=[KA-LEX-C07-NUMBERS-6-10-01]; assesses=[] -->
 
 | | numeral | word | said |
 |---|---|---|---|
@@ -32,7 +49,8 @@ makes Kannada *sound* like Kannada.
 
 (Ten needs two digits — **೧೦**, a one and a zero — just like *10*.)
 
-## Ten reveals the p → h shift
+## The word, taken apart: Ten reveals the p → h shift
+<!-- hl-knowledge: introduces=[KA-ETYMON-C07-NUMBERS-6-10-02]; assesses=[] -->
 
 Put ten beside Tamil:
 
@@ -50,7 +68,8 @@ a one-off: it runs right through the language —
 Once you know the rule, a Kannada *h‑* word often hands you its Tamil cousin for
 free: hide the *h‑*, restore a *p‑*.
 
-## Where the family parts
+## The word, taken apart: Where the family parts
+<!-- hl-knowledge: introduces=[KA-ETYMON-C07-NUMBERS-6-10-03]; assesses=[] -->
 
 Six and seven stay close cousins (Tamil *āṟu* / Kannada *āru*; Tamil *ēḻu* /
 Kannada *ēḷu* — note Kannada hardened Tamil's rare **ḻ** into an ordinary
@@ -59,6 +78,7 @@ are still relatives of Tamil *eṭṭu* and *oṉpatu*, but **Telugu** leaves th
 family entirely there (*enimidi*, *tommidi*) — so treat 8–9 as the loose cells.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C07-NUMBERS-1-5-01, KA-ETYMON-C07-NUMBERS-1-5-02, KA-GRAMMAR-C07-NUMBERS-1-5-03, KA-LEX-C07-NUMBERS-6-10-01, KA-ETYMON-C07-NUMBERS-6-10-02, KA-ETYMON-C07-NUMBERS-6-10-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "āru, ēḷu, eṇṭu, ombattu, hattu"]
@@ -66,6 +86,7 @@ family entirely there (*enimidi*, *tommidi*) — so treat 8–9 as the loose cel
 - [YOU SAY: read the digits — ೬ ೭ ೮ ೯ ೧೦]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C07-NUMBERS-1-5-01, KA-ETYMON-C07-NUMBERS-1-5-02, KA-GRAMMAR-C07-NUMBERS-1-5-03, KA-LEX-C07-NUMBERS-6-10-01, KA-ETYMON-C07-NUMBERS-6-10-02, KA-ETYMON-C07-NUMBERS-6-10-03] -->
 
 [PAUSE 3s] Count six to ten in Kannada. (*Āru, ēḷu, eṇṭu, ombattu, hattu*.) What
 regular shift turns Tamil *pattu* into Kannada *hattu*? (Word-initial **p‑ → h‑**

--- a/code/learning/human-languages/kannada/lessons/KA-C08-dayavittu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C08-dayavittu.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C08-dayavittu
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 360
 chapter: 8
 type: word
 headword: ದಯವಿಟ್ಟು
@@ -9,18 +12,32 @@ prerequisites: [KA-C01-dhanyavada]
 sounds: [kannada-vowel-sign-i, kannada-virama-ottu, kannada-geminate-tta]
 roots: [daya-compassion]
 etymology_hook: "ದಯವಿಟ್ಟು = 'having placed compassion' — Kannada asks please with daya, like Tamil, Arabic faḍl and Hindi kṛpā"
-est_minutes: 4
 reviews_of: [KA-C01-dhanyavada]
+duration:
+  max_seconds: 270
+requires:
+  knowledge: []
+introduces:
+  knowledge: [KA-ETYMON-C08-DAYAVITTU-01, KA-ETYMON-C08-DAYAVITTU-02, KA-PRAGMATICS-C08-DAYAVITTU-03, KA-SCRIPT-C08-DAYAVITTU-04]
+practises:
+  knowledge: [KA-ETYMON-C08-DAYAVITTU-01, KA-ETYMON-C08-DAYAVITTU-02, KA-PRAGMATICS-C08-DAYAVITTU-03, KA-SCRIPT-C08-DAYAVITTU-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: polite
+variety: standard-colloquial
 ---
 
 # ದಯವಿಟ್ಟು (dayaviṭṭu) — please (having placed compassion)
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Kannada's everyday "please" is, once you open it up, a small act of
 generosity: "having **placed** compassion" between us.
 
-## The word
+## The word, taken apart: The word
+<!-- hl-knowledge: introduces=[KA-ETYMON-C08-DAYAVITTU-01]; assesses=[] -->
 
 **ದಯವಿಟ್ಟು** = **please**, literally "**having placed compassion / kindness**." Two
 pieces:
@@ -37,7 +54,8 @@ and the same instinct as **Arabic** *min faḍlik* ("from your **grace**") and
 **Hindi** *kṛpayā* (from *kṛpā*, "**compassion**"). A wide arc of Asia says
 *please* by naming the kindness it hopes for.
 
-## The Dravidian family, side by side
+## The word, taken apart: The Dravidian family, side by side
+<!-- hl-knowledge: introduces=[KA-ETYMON-C08-DAYAVITTU-02]; assesses=[] -->
 
 **daya** + a light verb, four times over:
 
@@ -46,7 +64,8 @@ and the same instinct as **Arabic** *min faḍlik* ("from your **grace**") and
 - Telugu **దయచేసి** *daya**cēsi*** — compassion **+ having done**
 - Malayalam **ദയവായി** *daya**vāyi*** — compassion **+ as / having become**
 
-## Be honest about how it's used
+## Why it's said this way: about how it's used
+<!-- hl-knowledge: introduces=[KA-PRAGMATICS-C08-DAYAVITTU-03]; assesses=[] -->
 
 The honest note: a standalone please-word is a little **formal / emphatic**.
 Everyday Kannada politeness leans on the **respectful command** — the verb ending
@@ -54,7 +73,8 @@ Everyday Kannada politeness leans on the **respectful command** — the verb end
 "please tell me." That ending already means "please" do this. Add **ದಯವಿಟ್ಟು** in
 front when you want to underline the courtesy.
 
-## Sound & structure point
+## Sounds you'll need: Sound and structure
+<!-- hl-knowledge: introduces=[KA-SCRIPT-C08-DAYAVITTU-04]; assesses=[] -->
 
 Look at **ಟ್ಟು** — a **doubled** *ṭ*. The first **ಟ್** is *ṭa* silenced by the
 **virama** (its vowel cut), and it tucks **under** the next letter as an *ottu*
@@ -63,6 +83,7 @@ stacking, not repeating side by side — a neat contrast with how the Roman
 alphabet just writes "tt."
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C08-DAYAVITTU-01, KA-ETYMON-C08-DAYAVITTU-02, KA-PRAGMATICS-C08-DAYAVITTU-03, KA-SCRIPT-C08-DAYAVITTU-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "daya" — compassion — then "iṭṭu," having placed]
@@ -70,6 +91,7 @@ alphabet just writes "tt."
 - [YOU SAY: the everyday way — the verb ending: "kuḷitukoḷḷi" = please sit]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C08-DAYAVITTU-01, KA-ETYMON-C08-DAYAVITTU-02, KA-PRAGMATICS-C08-DAYAVITTU-03, KA-SCRIPT-C08-DAYAVITTU-04] -->
 
 [PAUSE 3s] What is the Kannada word for please? (**ದಯವಿಟ್ಟು** *dayaviṭṭu*.) What
 do its pieces mean? ("**Compassion**" *daya* + "**having placed**" *iṭṭu*.) Which

--- a/code/learning/human-languages/kannada/lessons/KA-C09-kshamisi.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C09-kshamisi.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C09-kshamisi
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 370
 chapter: 9
 type: word
 headword: ಕ್ಷಮಿಸಿ
@@ -9,19 +12,33 @@ prerequisites: [KA-C08-dayavittu]
 sounds: [kannada-conjunct-kssa, kannada-vowel-sign-i]
 roots: [kshama-sanskrit]
 etymology_hook: "ಕ್ಷಮಿಸಿ kṣamisi ← Sanskrit kṣamā 'patience/forgiveness' + Kannada verb-making -isu — the same trick Kannada uses to borrow Sanskrit nouns as verbs"
-est_minutes: 4
 reviews_of: [KA-C08-dayavittu]
+duration:
+  max_seconds: 245
+requires:
+  knowledge: [KA-ETYMON-C08-DAYAVITTU-01, KA-ETYMON-C08-DAYAVITTU-02, KA-PRAGMATICS-C08-DAYAVITTU-03, KA-SCRIPT-C08-DAYAVITTU-04]
+introduces:
+  knowledge: [KA-ETYMON-C09-KSHAMISI-01, KA-ETYMON-C09-KSHAMISI-02, KA-PRAGMATICS-C09-KSHAMISI-03]
+practises:
+  knowledge: [KA-ETYMON-C08-DAYAVITTU-01, KA-ETYMON-C08-DAYAVITTU-02, KA-PRAGMATICS-C08-DAYAVITTU-03, KA-SCRIPT-C08-DAYAVITTU-04, KA-ETYMON-C09-KSHAMISI-01, KA-ETYMON-C09-KSHAMISI-02, KA-PRAGMATICS-C09-KSHAMISI-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: polite-repair
+variety: standard-colloquial
 ---
 
 # ಕ್ಷಮಿಸಿ (kṣamisi) — forgive me / sorry
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C08-DAYAVITTU-01, KA-ETYMON-C08-DAYAVITTU-02, KA-PRAGMATICS-C08-DAYAVITTU-03, KA-SCRIPT-C08-DAYAVITTU-04] -->
 
 [PAUSE 2s] You already know **ದಯವಿಟ್ಟು**, "please." Kannada's "sorry" reuses
 a trick you'll see everywhere in this language: taking a Sanskrit noun and
 turning it into a working Kannada verb.
 
 ## The word, taken apart
+<!-- hl-knowledge: introduces=[KA-ETYMON-C09-KSHAMISI-01]; assesses=[] -->
 
 - **ಕ್ಷಮಾ** (*kṣamā*) = "**patience, forbearance, forgiveness**" — a Sanskrit
   noun, unchanged.
@@ -35,7 +52,8 @@ turning it into a working Kannada verb.
 So **ಕ್ಷಮಿಸಿ** is simply "**forgive!**" — *kṣamisu* wearing its imperative
 ending.
 
-## The Dravidian family, side by side
+## The word, taken apart: The Dravidian family, side by side
+<!-- hl-knowledge: introduces=[KA-ETYMON-C09-KSHAMISI-02]; assesses=[] -->
 
 Three of the four Dravidian cousins build "sorry" from the very same Sanskrit
 noun, each with its own verb-making suffix and its own imperative shape:
@@ -49,7 +67,8 @@ noun, each with its own verb-making suffix and its own imperative shape:
 - Tamil **மன்னிக்கவும்** *maṉṉi**kkavum*** — its **own** native root *maṉṉi*,
   not Sanskrit at all
 
-## Be honest about how it's used
+## Why it's said this way: about how it's used
+<!-- hl-knowledge: introduces=[KA-PRAGMATICS-C09-KSHAMISI-03]; assesses=[] -->
 
 **ಕ್ಷಮಿಸಿ** is a genuine, everyday way to say "sorry" — not overly formal —
 but in casual conversation you'll also hear the softer **ಕ್ಷಮಿಸಿ ಬಿಡಿ**
@@ -57,6 +76,7 @@ but in casual conversation you'll also hear the softer **ಕ್ಷಮಿಸಿ �
 "**sorry**," which is extremely common in spoken Kannada.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C08-DAYAVITTU-01, KA-ETYMON-C08-DAYAVITTU-02, KA-PRAGMATICS-C08-DAYAVITTU-03, KA-SCRIPT-C08-DAYAVITTU-04, KA-ETYMON-C09-KSHAMISI-01, KA-ETYMON-C09-KSHAMISI-02, KA-PRAGMATICS-C09-KSHAMISI-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "kṣamā" — the Sanskrit noun, patience/forgiveness]
@@ -64,6 +84,7 @@ but in casual conversation you'll also hear the softer **ಕ್ಷಮಿಸಿ �
 - [YOU SAY: contrast — Tamil's maṉṉikkavum uses its own root instead]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C08-DAYAVITTU-01, KA-ETYMON-C08-DAYAVITTU-02, KA-PRAGMATICS-C08-DAYAVITTU-03, KA-SCRIPT-C08-DAYAVITTU-04, KA-ETYMON-C09-KSHAMISI-01, KA-ETYMON-C09-KSHAMISI-02, KA-PRAGMATICS-C09-KSHAMISI-03] -->
 
 [PAUSE 3s] What is **ಕ್ಷಮಿಸಿ** built from? (**Sanskrit kṣamā** "forgiveness"
 + the verb-making suffix **‑isu** + the imperative **‑i**.) Which cousin

--- a/code/learning/human-languages/kannada/lessons/KA-C10-vaara.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C10-vaara.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C10-vaara
+spine_node: SPINE-TIME-OF-DAY
+sequence: 380
 chapter: 10
 type: word
 headword: ಸೋಮವಾರ ಮಂಗಳವಾರ ಬುಧವಾರ ಗುರುವಾರ ಶುಕ್ರವಾರ ಶನಿವಾರ ಭಾನುವಾರ
@@ -9,19 +12,33 @@ prerequisites: [KA-C09-kshamisi]
 sounds: [kannada-anusvara, kannada-conjunct-kra]
 roots: [sanskrit-planet-words]
 etymology_hook: "Kannada's week is fully Sanskritic like Hindi's — Somavāra, Maṅgaḷavāra… — but Sunday is Bhānuvāra ('day of light'), a different Sanskrit sun-name than Hindi's Ravivāra"
-est_minutes: 4
 reviews_of: [KA-C09-kshamisi]
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [KA-ETYMON-C09-KSHAMISI-01, KA-ETYMON-C09-KSHAMISI-02, KA-PRAGMATICS-C09-KSHAMISI-03]
+introduces:
+  knowledge: [KA-LEX-C10-VAARA-01]
+practises:
+  knowledge: [KA-ETYMON-C09-KSHAMISI-01, KA-ETYMON-C09-KSHAMISI-02, KA-PRAGMATICS-C09-KSHAMISI-03, KA-LEX-C10-VAARA-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # ಸೋಮವಾರ to ಭಾನುವಾರ — Kannada's fully Sanskritic week
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C09-KSHAMISI-01, KA-ETYMON-C09-KSHAMISI-02, KA-PRAGMATICS-C09-KSHAMISI-03] -->
 
 [PAUSE 2s] Unlike Tamil and Malayalam, Kannada's week is built entirely from
 Sanskrit — the same recipe as Hindi's. But even here, one day picks a
 **different** Sanskrit word than Hindi does.
 
-## The pattern: [deity] + ವಾರ, "day"
+## You'll want to know: The pattern: [deity] + ವಾರ, "day"
+<!-- hl-knowledge: introduces=[KA-LEX-C10-VAARA-01]; assesses=[] -->
 
 | Kannada | deity/planet | day |
 |---|---|---|
@@ -42,6 +59,7 @@ sun, and different languages downstream picked different ones for their
 week.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C09-KSHAMISI-01, KA-ETYMON-C09-KSHAMISI-02, KA-PRAGMATICS-C09-KSHAMISI-03, KA-LEX-C10-VAARA-01] -->
 
 [PAUSE 1s]
 - [YOU SAY: "Somavāra, Maṅgaḷavāra, Budhavāra, Guruvāra, Śukravāra,
@@ -51,6 +69,7 @@ week.
   (Bhānu) — two different Sanskrit sun-names]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C09-KSHAMISI-01, KA-ETYMON-C09-KSHAMISI-02, KA-PRAGMATICS-C09-KSHAMISI-03, KA-LEX-C10-VAARA-01] -->
 
 [PAUSE 3s] What ending does every Kannada weekday share, and where's it
 from? (**‑ವಾರ** *-vāra*, Sanskrit "day.") Which day differs from Hindi's

--- a/code/learning/human-languages/kannada/lessons/KA-C11-bannagalu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C11-bannagalu.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C11-bannagalu
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 390
 chapter: 11
 type: word
 headword: ಕಪ್ಪು ಬಿಳಿ ಕೆಂಪು ನೀಲಿ
@@ -9,25 +12,40 @@ prerequisites: [KA-C10-vaara]
 sounds: [kannada-anusvara, kannada-virama-geminate]
 roots: [dravidian-native-colors, sanskrit-nila]
 etymology_hook: "ಕಪ್ಪು/ಬಿಳಿ/ಕೆಂಪು (black/white/red) are native Dravidian, unlike Kannada's fully-Sanskritic day-names — but ನೀಲಿ (blue) is Sanskrit, same root as Tamil/Hindi/Malayalam"
-est_minutes: 4
 reviews_of: [KA-C10-vaara]
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [KA-LEX-C10-VAARA-01]
+introduces:
+  knowledge: [KA-LEX-C11-BANNAGALU-01, KA-LEX-C11-BANNAGALU-02]
+practises:
+  knowledge: [KA-LEX-C10-VAARA-01, KA-LEX-C11-BANNAGALU-01, KA-LEX-C11-BANNAGALU-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # ಕಪ್ಪು, ಬಿಳಿ, ಕೆಂಪು, ನೀಲಿ — native colors, after a fully Sanskrit week
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C10-VAARA-01] -->
 
 [PAUSE 2s] Kannada's week ran entirely on Sanskrit deity-names. Its colors
 tell a different story — here, native Dravidian vocabulary is back in
 charge, except for one familiar exception.
 
-## Three native colors
+## You'll want to know: Three native colors
+<!-- hl-knowledge: introduces=[KA-LEX-C11-BANNAGALU-01]; assesses=[] -->
 
 - **ಕಪ್ಪು** (*kappu*) = "**black**" — native Dravidian.
 - **ಬಿಳಿ** (*biḷi*) = "**white**" — native Dravidian.
 - **ಕೆಂಪು** (*kempu*) = "**red**" — native Dravidian.
 
-## The familiar borrowed blue
+## You'll want to know: The familiar borrowed blue
+<!-- hl-knowledge: introduces=[KA-LEX-C11-BANNAGALU-02]; assesses=[] -->
 
 **ನೀಲಿ** (*nīli*) = "**blue**" — from the **same Sanskrit** ನೀಲ (*nīla*)
 that Tamil, Malayalam, and Hindi all reach for. Even Kannada, whose week
@@ -36,6 +54,7 @@ it's specifically **blue** that pulls in the Sanskrit word, across all four
 Dravidian languages and Hindi alike.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C10-VAARA-01, KA-LEX-C11-BANNAGALU-01, KA-LEX-C11-BANNAGALU-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "kappu, biḷi, kempu" — black, white, red]
@@ -44,6 +63,7 @@ Dravidian languages and Hindi alike.
   (except blue) are native]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C10-VAARA-01, KA-LEX-C11-BANNAGALU-01, KA-LEX-C11-BANNAGALU-02] -->
 
 [PAUSE 3s] Are Kannada's black/white/red native or Sanskrit? (**Native
 Dravidian** — kappu, biḷi, kempu.) Which color is the shared Sanskrit loan

--- a/code/learning/human-languages/kannada/lessons/KA-C12-kutumba.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C12-kutumba.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C12-kutumba
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 400
 chapter: 12
 type: word
 headword: ಅಪ್ಪ ಅಮ್ಮ ಅಣ್ಣ ತಮ್ಮ ಅಕ್ಕ ತಂಗಿ
@@ -9,24 +12,39 @@ prerequisites: [KA-C11-bannagalu]
 sounds: [kannada-retroflex-nna, kannada-anusvara]
 roots: [dravidian-appa-amma, dravidian-age-graded-siblings]
 etymology_hook: "ಅಪ್ಪ appa/ಅಮ್ಮ amma and the four sibling words (ಅಣ್ಣ/ತಮ್ಮ, ಅಕ್ಕ/ತಂಗಿ) match Tamil's set almost word-for-word — Kannada splits siblings by age too"
-est_minutes: 4
 reviews_of: [KA-C11-bannagalu]
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [KA-LEX-C11-BANNAGALU-01, KA-LEX-C11-BANNAGALU-02]
+introduces:
+  knowledge: [KA-ETYMON-C12-KUTUMBA-01, KA-ETYMON-C12-KUTUMBA-02]
+practises:
+  knowledge: [KA-LEX-C11-BANNAGALU-01, KA-LEX-C11-BANNAGALU-02, KA-ETYMON-C12-KUTUMBA-01, KA-ETYMON-C12-KUTUMBA-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # ಅಪ್ಪ, ಅಮ್ಮ, and four sibling words — the same system as Tamil
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C11-BANNAGALU-01, KA-LEX-C11-BANNAGALU-02] -->
 
 [PAUSE 2s] Kannada asks the same question Tamil does about any sibling:
 **older, or younger?** — and the words for answering it are almost
 identical.
 
-## Parents — native, and matching Tamil
+## The word, taken apart: Parents — native, and matching Tamil
+<!-- hl-knowledge: introduces=[KA-ETYMON-C12-KUTUMBA-01]; assesses=[] -->
 
 - **ಅಪ್ಪ** (*appa*) = "**father**" — matches Tamil *appā* closely.
 - **ಅಮ್ಮ** (*amma*) = "**mother**" — matches Tamil *ammā* closely.
 
-## Four sibling words, age before gender
+## The word, taken apart: Four sibling words, age before gender
+<!-- hl-knowledge: introduces=[KA-ETYMON-C12-KUTUMBA-02]; assesses=[] -->
 
 | Kannada | meaning | compare Tamil |
 |---|---|---|
@@ -41,6 +59,7 @@ their gender. This age-first system runs across the whole Dravidian family,
 not just one language.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C11-BANNAGALU-01, KA-LEX-C11-BANNAGALU-02, KA-ETYMON-C12-KUTUMBA-01, KA-ETYMON-C12-KUTUMBA-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "appa, amma" — father, mother]
@@ -48,6 +67,7 @@ not just one language.
 - [YOU SAY: "akka, tangi" — older/younger sister]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C11-BANNAGALU-01, KA-LEX-C11-BANNAGALU-02, KA-ETYMON-C12-KUTUMBA-01, KA-ETYMON-C12-KUTUMBA-02] -->
 
 [PAUSE 3s] How many Kannada sibling words are there, and what do they split
 on? (**Four** — ಅಣ್ಣ/ತಮ್ಮ, ಅಕ್ಕ/ತಂಗಿ — split by **relative age**, not just

--- a/code/learning/human-languages/kannada/lessons/KA-C13-dehada-bhagagalu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C13-dehada-bhagagalu.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C13-dehada-bhagagalu
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 410
 chapter: 13
 type: word
 headword: ತಲೆ ಕೈ
@@ -9,18 +12,32 @@ prerequisites: [KA-C12-kutumba]
 sounds: [kannada-vowel-sign-ai]
 roots: [dravidian-tale-kai]
 etymology_hook: "ತಲೆ tale (head) and ಕೈ kai (hand) are native Dravidian, matching Tamil talai/kai and Malayalam thala/kai closely — a shared core across three of the four languages"
-est_minutes: 4
 reviews_of: [KA-C12-kutumba]
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [KA-ETYMON-C12-KUTUMBA-01, KA-ETYMON-C12-KUTUMBA-02]
+introduces:
+  knowledge: [KA-LEX-C13-DEHADA-BHAGAGALU-01]
+practises:
+  knowledge: [KA-ETYMON-C12-KUTUMBA-01, KA-ETYMON-C12-KUTUMBA-02, KA-LEX-C13-DEHADA-BHAGAGALU-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # ತಲೆ, ಕೈ — head and hand, the shared Dravidian core
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C12-KUTUMBA-01, KA-ETYMON-C12-KUTUMBA-02] -->
 
 [PAUSE 2s] Three languages, nearly one word each — Kannada's basic body
 parts line up with Tamil and Malayalam almost perfectly.
 
-## The words
+## You'll want to know: The words
+<!-- hl-knowledge: introduces=[KA-LEX-C13-DEHADA-BHAGAGALU-01]; assesses=[] -->
 
 - **ತಲೆ** (*tale*) = "**head**" — native Dravidian, matching Tamil *talai*
   and Malayalam *thala*.
@@ -28,6 +45,7 @@ parts line up with Tamil and Malayalam almost perfectly.
   Malayalam's *kai* almost exactly.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C12-KUTUMBA-01, KA-ETYMON-C12-KUTUMBA-02, KA-LEX-C13-DEHADA-BHAGAGALU-01] -->
 
 [PAUSE 1s]
 - [YOU SAY: "tale" — head]
@@ -35,6 +53,7 @@ parts line up with Tamil and Malayalam almost perfectly.
 - [YOU SAY: the match — nearly identical across Tamil, Malayalam, Kannada]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C12-KUTUMBA-01, KA-ETYMON-C12-KUTUMBA-02, KA-LEX-C13-DEHADA-BHAGAGALU-01] -->
 
 [PAUSE 3s] What are Kannada's words for head and hand? (**ತಲೆ tale, ಕೈ
 kai**.) How closely do they match Tamil and Malayalam? (**Very closely** —

--- a/code/learning/human-languages/kannada/lessons/KA-C14-kaalagalu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C14-kaalagalu.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C14-kaalagalu
+spine_node: SPINE-TIME-OF-DAY
+sequence: 420
 chapter: 14
 type: word
 headword: ವಸಂತ ಋತು ಬೇಸಿಗೆ ಮಳೆಗಾಲ ಚಳಿಗಾಲ
@@ -9,19 +12,33 @@ prerequisites: [KA-C13-dehada-bhagagalu]
 sounds: [kannada-vocalic-r, kannada-anusvara]
 roots: [dravidian-besige-male-chali, sanskrit-vasanta]
 etymology_hook: "ಬೇಸಿಗೆ besige (summer) and ಮಳೆ male (rain) are native Dravidian; ವಸಂತ ಋತು vasanta rutu (spring) uses the same Sanskrit vasanta AND the Sanskrit word rutu itself, 'season' — a double Sanskrit loan where Tamil/Malayalam just say kaalam"
-est_minutes: 4
 reviews_of: [KA-C13-dehada-bhagagalu]
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [KA-LEX-C13-DEHADA-BHAGAGALU-01]
+introduces:
+  knowledge: [KA-LEX-C14-KAALAGALU-01, KA-PRAGMATICS-C14-KAALAGALU-02]
+practises:
+  knowledge: [KA-LEX-C13-DEHADA-BHAGAGALU-01, KA-LEX-C14-KAALAGALU-01, KA-PRAGMATICS-C14-KAALAGALU-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # ವಸಂತ ಋತು, ಬೇಸಿಗೆ, ಮಳೆಗಾಲ, ಚಳಿಗಾಲ — native words, plus a double Sanskrit loan
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C13-DEHADA-BHAGAGALU-01] -->
 
 [PAUSE 2s] Kannada's summer, rain, and cold words are native, just like
 Tamil's — but its word for "spring" borrows **twice** from Sanskrit, not
 once.
 
-## The words
+## You'll want to know: The words
+<!-- hl-knowledge: introduces=[KA-LEX-C14-KAALAGALU-01]; assesses=[] -->
 
 | Kannada | meaning | source |
 |---|---|---|
@@ -30,7 +47,8 @@ once.
 | **ಮಳೆಗಾಲ** (*maḷegāla*) | "rainy season" | **ಮಳೆ** *maḷe*, native Dravidian ("rain") + **ಕಾಲ** *kāla* ("time," itself a Sanskrit loan) |
 | **ಚಳಿಗಾಲ** (*caḷigāla*) | "winter/cold season" | **ಚಳಿ** *caḷi*, native Dravidian ("cold") + *kāla* |
 
-## Be honest about the double loan — and the real season
+## Why it's said this way: about the double loan — and the real season
+<!-- hl-knowledge: introduces=[KA-PRAGMATICS-C14-KAALAGALU-02]; assesses=[] -->
 
 Where Tamil and Malayalam just say *kaalam* ("time/season," itself
 ultimately Sanskrit-derived too, but assimilated long ago as ordinary
@@ -44,6 +62,7 @@ that shapes Karnataka's agricultural year the most, not a clean four-way
 Western split.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C13-DEHADA-BHAGAGALU-01, KA-LEX-C14-KAALAGALU-01, KA-PRAGMATICS-C14-KAALAGALU-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "bēsige" — summer, native]
@@ -52,6 +71,7 @@ Western split.
 - [YOU SAY: the double loan — "vasanta ṛtu" — both halves Sanskrit]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C13-DEHADA-BHAGAGALU-01, KA-LEX-C14-KAALAGALU-01, KA-PRAGMATICS-C14-KAALAGALU-02] -->
 
 [PAUSE 3s] What's unusual about ವಸಂತ ಋತು compared to Tamil/Malayalam's
 spring-word? (**Both halves are Sanskrit** — *vasanta* and *ṛtu*, "season"

--- a/code/learning/human-languages/kannada/lessons/KA-C15-niiru-akki.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C15-niiru-akki.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C15-niiru-akki
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 430
 chapter: 15
 type: word
 headword: ನೀರು ಅಕ್ಕಿ ಅನ್ನ
@@ -9,30 +12,46 @@ prerequisites: [KA-C14-kaalagalu]
 sounds: [kannada-vowel-sign-ii, kannada-geminate-kka]
 roots: [niiru-water-dravidian, akki-rice-dravidian]
 etymology_hook: "ನೀರು niiru (water) matches Tamil's nir/thanneer closely — unlike Malayalam's genuinely different vellam; ಅಕ್ಕಿ akki (rice) and ಅನ್ನ anna (cooked rice) complete the same raw/cooked distinction found across the family"
-est_minutes: 4
 reviews_of: [KA-C14-kaalagalu]
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [KA-LEX-C14-KAALAGALU-01, KA-PRAGMATICS-C14-KAALAGALU-02]
+introduces:
+  knowledge: [KA-ETYMON-C15-NIIRU-AKKI-01, KA-ETYMON-C15-NIIRU-AKKI-02]
+practises:
+  knowledge: [KA-LEX-C14-KAALAGALU-01, KA-PRAGMATICS-C14-KAALAGALU-02, KA-ETYMON-C15-NIIRU-AKKI-01, KA-ETYMON-C15-NIIRU-AKKI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # ನೀರು, ಅಕ್ಕಿ, ಅನ್ನ — water matching Tamil, and rice, raw and cooked
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C14-KAALAGALU-01, KA-PRAGMATICS-C14-KAALAGALU-02] -->
 
 [PAUSE 2s] Kannada's water-word sides with Tamil, not with Malayalam's
 surprising break from the pack.
 
-## ನೀರು — matching Tamil
+## The word, taken apart: ನೀರು — matching Tamil
+<!-- hl-knowledge: introduces=[KA-ETYMON-C15-NIIRU-AKKI-01]; assesses=[] -->
 
 **ನೀರು** (*nīru*) = "**water**" — matching Tamil's **நீர்** (*nīr*, the
 root inside *taṇṇīr*) closely. Kannada didn't make Malayalam's switch to
 the *veḷ-* "bright/white" root.
 
-## ಅಕ್ಕಿ, ಅನ್ನ — rice, raw and cooked
+## The word, taken apart: ಅಕ್ಕಿ, ಅನ್ನ — rice, raw and cooked
+<!-- hl-knowledge: introduces=[KA-ETYMON-C15-NIIRU-AKKI-02]; assesses=[] -->
 
 - **ಅಕ್ಕಿ** (*akki*) = "**rice**" (raw grain).
 - **ಅನ್ನ** (*anna*) = "**cooked rice**" (the meal) — likely Sanskrit-
   influenced, the same general idea as Tamil's *sātam*.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C14-KAALAGALU-01, KA-PRAGMATICS-C14-KAALAGALU-02, KA-ETYMON-C15-NIIRU-AKKI-01, KA-ETYMON-C15-NIIRU-AKKI-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "nīru" — water, matching Tamil]
@@ -40,6 +59,7 @@ the *veḷ-* "bright/white" root.
 - [YOU SAY: "anna" — cooked rice]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C14-KAALAGALU-01, KA-PRAGMATICS-C14-KAALAGALU-02, KA-ETYMON-C15-NIIRU-AKKI-01, KA-ETYMON-C15-NIIRU-AKKI-02] -->
 
 [PAUSE 3s] Does Kannada's water-word match Tamil's or Malayalam's? (**Tamil's**
 — *nīru*/*nīr*, not Malayalam's *veḷḷam*.) What's the raw/cooked rice pair?

--- a/code/learning/human-languages/kannada/lessons/KA-C16-tingalugalu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C16-tingalugalu.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C16-tingalugalu
+spine_node: SPINE-TIME-OF-DAY
+sequence: 440
 chapter: 16
 type: word
 headword: ಚೈತ್ರ ವೈಶಾಖ ಜ್ಯೇಷ್ಠ ಆಷಾಢ ಶ್ರಾವಣ ಭಾದ್ರಪದ ಆಶ್ವಯುಜ ಕಾರ್ತೀಕ ಮಾರ್ಗಶಿರ ಪುಷ್ಯ ಮಾಘ ಫಾಲ್ಗುಣ
@@ -9,25 +12,40 @@ prerequisites: [KA-C15-niiru-akki]
 sounds: [kannada-conjunct-shtha, kannada-anusvara]
 roots: [sanskrit-lunisolar-chaitra-system]
 etymology_hook: "Unlike Tamil and Malayalam, which built their OWN solar calendars, Kannada uses the same pan-Indian Sanskritic lunisolar calendar as Hindi's Vikram Samvat — Ugadi falls on Chaitra Shukla Pratipada, the SAME calendar Telugu uses too"
-est_minutes: 4
 reviews_of: [KA-C15-niiru-akki]
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [KA-ETYMON-C15-NIIRU-AKKI-01, KA-ETYMON-C15-NIIRU-AKKI-02]
+introduces:
+  knowledge: [KA-LEX-C16-TINGALUGALU-01, KA-PRAGMATICS-C16-TINGALUGALU-02]
+practises:
+  knowledge: [KA-ETYMON-C15-NIIRU-AKKI-01, KA-ETYMON-C15-NIIRU-AKKI-02, KA-LEX-C16-TINGALUGALU-01, KA-PRAGMATICS-C16-TINGALUGALU-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # ಚೈತ್ರ to ಫಾಲ್ಗುಣ — the calendar Kannada shares with Hindi, not with Tamil
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C15-NIIRU-AKKI-01, KA-ETYMON-C15-NIIRU-AKKI-02] -->
 
 [PAUSE 2s] Tamil and Malayalam each built their own solar calendar. Kannada
 takes a different path entirely — the same path as Hindi.
 
-## The twelve months
+## You'll want to know: The twelve months
+<!-- hl-knowledge: introduces=[KA-LEX-C16-TINGALUGALU-01]; assesses=[] -->
 
 **ಚೈತ್ರ, ವೈಶಾಖ, ಜ್ಯೇಷ್ಠ, ಆಷಾಢ, ಶ್ರಾವಣ, ಭಾದ್ರಪದ, ಆಶ್ವಯುಜ, ಕಾರ್ತೀಕ,
 ಮಾರ್ಗಶಿರ, ಪುಷ್ಯ, ಮಾಘ, ಫಾಲ್ಗುಣ** (*Caitra, Vaiśākha, Jyēṣṭha, Āṣāḍha,
 Śrāvaṇa, Bhādrapada, Āśvayuja, Kārtīka, Mārgaśira, Puṣya, Māgha,
 Phālguṇa*).
 
-## Be honest: this is Hindi's calendar too, not a Dravidian one
+## Why it's said this way: this is Hindi's calendar too, not a Dravidian one
+<!-- hl-knowledge: introduces=[KA-PRAGMATICS-C16-TINGALUGALU-02]; assesses=[] -->
 
 This is the **same pan-Indian Sanskritic lunisolar calendar** you already
 met as Hindi's **Vikram Samvat** — the same twelve month names, tied to the
@@ -39,6 +57,7 @@ calendars, Kannada didn't build its own separate system here — it shares
 this one with Hindi, Telugu, and much of the rest of the subcontinent.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C15-NIIRU-AKKI-01, KA-ETYMON-C15-NIIRU-AKKI-02, KA-LEX-C16-TINGALUGALU-01, KA-PRAGMATICS-C16-TINGALUGALU-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: the twelve — "Caitra, Vaiśākha, Jyēṣṭha, Āṣāḍha, Śrāvaṇa,
@@ -48,6 +67,7 @@ this one with Hindi, Telugu, and much of the rest of the subcontinent.
   own calendars]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C15-NIIRU-AKKI-01, KA-ETYMON-C15-NIIRU-AKKI-02, KA-LEX-C16-TINGALUGALU-01, KA-PRAGMATICS-C16-TINGALUGALU-02] -->
 
 [PAUSE 3s] Does Kannada use its own solar calendar, like Tamil and
 Malayalam? (**No** — it uses the **same pan-Indian lunisolar calendar** as

--- a/code/learning/human-languages/kannada/lessons/KA-C17-madhyaahna-madhyaraatri.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C17-madhyaahna-madhyaraatri.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C17-madhyaahna-madhyaraatri
+spine_node: SPINE-TIME-OF-DAY
+sequence: 450
 chapter: 17
 type: word
 headword: ಮಧ್ಯಾಹ್ನ ಮಧ್ಯರಾತ್ರಿ
@@ -9,19 +12,33 @@ prerequisites: [KA-C16-tingalugalu]
 sounds: [kannada-conjunct-dhya, kannada-vowel-sign-aa]
 roots: [sanskrit-madhya-middle]
 etymology_hook: "ಮಧ್ಯಾಹ್ನ (madhyāhna, noon) and ಮಧ್ಯರಾತ್ರಿ (madhyarātri, midnight) are both direct Sanskrit tatsama compounds on madhya, 'middle' — Kannada's everyday words for these times are the SAME Sanskrit-formal register that Hindi keeps as a bookish alternate to its own colloquial dopahar / aadhi raat"
-est_minutes: 4
 reviews_of: [KA-C16-tingalugalu]
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [KA-LEX-C16-TINGALUGALU-01, KA-PRAGMATICS-C16-TINGALUGALU-02]
+introduces:
+  knowledge: [KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03]
+practises:
+  knowledge: [KA-LEX-C16-TINGALUGALU-01, KA-PRAGMATICS-C16-TINGALUGALU-02, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # ಮಧ್ಯಾಹ್ನ, ಮಧ್ಯರಾತ್ರಿ — one Sanskrit root, two everyday Kannada words
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C16-TINGALUGALU-01, KA-PRAGMATICS-C16-TINGALUGALU-02] -->
 
 [PAUSE 2s] You've just seen Hindi's *dopahar* (an old timekeeping unit) and
 *aadhi raat* (plain "half night"). Kannada takes a completely different
 path — straight to Sanskrit, and straight down the middle.
 
-## ಮಧ್ಯಾಹ್ನ — "middle of the day"
+## The word, taken apart: ಮಧ್ಯಾಹ್ನ — "middle of the day"
+<!-- hl-knowledge: introduces=[KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01]; assesses=[] -->
 
 **ಮಧ್ಯಾಹ್ನ** (*madhyāhna*) = "**noon, midday**" — a Sanskrit *tatsama*
 (borrowed whole, unchanged) compound: **ಮಧ್ಯ** (*madhya*, "**middle**") +
@@ -29,14 +46,16 @@ path — straight to Sanskrit, and straight down the middle.
 noon — not a formal or bookish alternative the way it can feel in some of
 its sister languages.
 
-## ಮಧ್ಯರಾತ್ರಿ — "middle of the night"
+## The word, taken apart: ಮಧ್ಯರಾತ್ರಿ — "middle of the night"
+<!-- hl-knowledge: introduces=[KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02]; assesses=[] -->
 
 **ಮಧ್ಯರಾತ್ರಿ** (*madhyarātri*) = "**midnight**" — the exact same **ಮಧ್ಯ**
 (*madhya*, "middle") root, this time compounded with **ರಾತ್ರಿ** (*rātri*,
 "**night**"). Same logic, same "middle" word, just paired with "night"
 instead of "day."
 
-## Be honest: this is Sanskrit's "middle," used as Kannada's default
+## Why it's said this way: this is Sanskrit's "middle," used as Kannada's default
+<!-- hl-knowledge: introduces=[KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03]; assesses=[] -->
 
 Both words are unmistakably **Sanskrit tatsama** compounds — Kannada
 borrowed them whole rather than building native Dravidian equivalents.
@@ -50,6 +69,7 @@ everyday** word — there's no separate native-Dravidian doublet in common
 use here the way there is for some other concepts.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C16-TINGALUGALU-01, KA-PRAGMATICS-C16-TINGALUGALU-02, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "madhyāhna" — noon, "middle of the day"]
@@ -57,6 +77,7 @@ use here the way there is for some other concepts.
 - [YOU SAY: the shared piece — "madhya," middle, in both words]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C16-TINGALUGALU-01, KA-PRAGMATICS-C16-TINGALUGALU-02, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03] -->
 
 [PAUSE 3s] What Sanskrit root do **ಮಧ್ಯಾಹ್ನ** and **ಮಧ್ಯರಾತ್ರಿ** share, and
 what does it mean? (**ಮಧ್ಯ**, *madhya*, "middle.") Are these native Dravidian

--- a/code/learning/human-languages/kannada/lessons/KA-C18-gante.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C18-gante.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C18-gante
+spine_node: SPINE-TIME-OF-DAY
+sequence: 460
 chapter: 18
 type: word
 headword: ಗಂಟೆ
@@ -9,25 +12,40 @@ prerequisites: [KA-C17-madhyaahna-madhyaraatri]
 sounds: [kannada-anusvara, kannada-vowel-sign-e]
 roots: [sanskrit-ghanta-bell]
 etymology_hook: "ಗಂಟೆ (gaṇṭe, 'hour') is related to Sanskrit घण्टा (ghaṇṭā, 'bell') — the SAME word and the SAME bell-strikes-the-hour logic as Hindi's ghanṭā, unlike Tamil's most-likely-native maṇi"
-est_minutes: 4
 reviews_of: [KA-C17-madhyaahna-madhyaraatri]
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03]
+introduces:
+  knowledge: [KA-ETYMON-C18-GANTE-01, KA-PRAGMATICS-C18-GANTE-02, KA-GRAMMAR-C18-GANTE-03]
+practises:
+  knowledge: [KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C18-GANTE-01, KA-PRAGMATICS-C18-GANTE-02, KA-GRAMMAR-C18-GANTE-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # ಗಂಟೆ — the same "bell" word as Hindi, borrowed through Prakrit
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03] -->
 
 [PAUSE 2s] You've already met Hindi's *ghanṭā* — "hour," literally "bell." Kannada
 has the exact same word, arriving by the exact same logic.
 
-## ಗಂಟೆ — bell AND hour, again
+## The word, taken apart: ಗಂಟೆ — bell AND hour, again
+<!-- hl-knowledge: introduces=[KA-ETYMON-C18-GANTE-01]; assesses=[] -->
 
 **ಗಂಟೆ** (*gaṇṭe*) = "**hour**" — and, just like Hindi, it means "**bell, gong**"
 just as commonly. It's related to the same Sanskrit **घण्टा** (*ghaṇṭā*, "bell").
 The semantic shift is identical to Hindi's: temples, towns, and clock towers
 announced the hour by striking a bell, so the bell-word became the hour-word.
 
-## Be honest: this is Kannada matching Hindi, not matching Tamil
+## Why it's said this way: this is Kannada matching Hindi, not matching Tamil
+<!-- hl-knowledge: introduces=[KA-PRAGMATICS-C18-GANTE-02]; assesses=[] -->
 
 This is a genuinely different picture from what you'll see in Tamil. Kannada's
 *gaṇṭe*, like Hindi's *ghanṭā*, is a **Sanskrit-derived** "bell → hour" word.
@@ -39,6 +57,7 @@ splits along the same Sanskrit/native line you've seen before in this course
 (compare *madhyāhna* vs. Tamil's *naḷ*-based words for noon).
 
 ## Grammar Lens: telling the time
+<!-- hl-knowledge: introduces=[KA-GRAMMAR-C18-GANTE-03]; assesses=[] -->
 
 > **ಒಂದು ಗಂಟೆ.** — "One o'clock." (*ondu gaṇṭe*, "one hour/bell")
 > **ಎರಡು ಗಂಟೆ.** — "Two o'clock." (*eraḍu gaṇṭe*, "two hour/bell")
@@ -47,6 +66,7 @@ Kannada simply pairs the cardinal number with *gaṇṭe* — no ordinal/cardina
 like Arabic's, no singular/plural verb switch like Hindi's *bajnā*.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C18-GANTE-01, KA-PRAGMATICS-C18-GANTE-02, KA-GRAMMAR-C18-GANTE-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "gaṇṭe" — hour, also "bell"]
@@ -54,6 +74,7 @@ like Arabic's, no singular/plural verb switch like Hindi's *bajnā*.
 - [YOU SAY: "eraḍu gaṇṭe" — two o'clock]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C18-GANTE-01, KA-PRAGMATICS-C18-GANTE-02, KA-GRAMMAR-C18-GANTE-03] -->
 
 [PAUSE 3s] What does **ಗಂಟೆ** mean besides "hour," and what Sanskrit word is it
 related to? (**"Bell, gong"** — related to Sanskrit *ghaṇṭā*.) Is this the same

--- a/code/learning/human-languages/kannada/lessons/KA-C19-vayassu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C19-vayassu.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C19-vayassu
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 470
 chapter: 19
 type: phrase
 headword: ನಿನ್ನ ವಯಸ್ಸು ಎಷ್ಟು?
@@ -9,18 +12,32 @@ prerequisites: [KA-C18-gante]
 sounds: [kannada-anusvara, kannada-conjunct-ssu]
 roots: [sanskrit-vayas-vigor-age]
 etymology_hook: "ವಯಸ್ಸು (vayassu, 'age') is from Sanskrit वयस् (vayas, 'age, youth, vigor'), from PIE *wéyh₁os — the SAME PIE root as Latin's vīs ('force'), the very word you met in Latin's age lesson's own vocabulary family; Kannada asks age with a simple possessive, 'your age how-much,' no verb at all"
-est_minutes: 4
 reviews_of: [KA-C18-gante]
+duration:
+  max_seconds: 250
+requires:
+  knowledge: [KA-ETYMON-C18-GANTE-01, KA-PRAGMATICS-C18-GANTE-02, KA-GRAMMAR-C18-GANTE-03]
+introduces:
+  knowledge: [KA-ETYMON-C19-VAYASSU-01, KA-GRAMMAR-C19-VAYASSU-02]
+practises:
+  knowledge: [KA-ETYMON-C18-GANTE-01, KA-PRAGMATICS-C18-GANTE-02, KA-GRAMMAR-C18-GANTE-03, KA-ETYMON-C19-VAYASSU-01, KA-GRAMMAR-C19-VAYASSU-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # ನಿನ್ನ ವಯಸ್ಸು ಎಷ್ಟು? — "your age, how much?"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C18-GANTE-01, KA-PRAGMATICS-C18-GANTE-02, KA-GRAMMAR-C18-GANTE-03] -->
 
 [PAUSE 2s] Here's a genuinely nice callback: the Sanskrit word behind Kannada's
 "age" is a distant cousin of a Latin word you already know.
 
-## ವಯಸ್ಸು — a Sanskrit word, and a PIE cousin of Latin vīs
+## The word, taken apart: ವಯಸ್ಸು — a Sanskrit word, and a PIE cousin of Latin vīs
+<!-- hl-knowledge: introduces=[KA-ETYMON-C19-VAYASSU-01]; assesses=[] -->
 
 **ವಯಸ್ಸು** (*vayassu*) = "**age**" — from Sanskrit **वयस्** (*vayas*, "age,
 youth, vigor, strength"), which traces back to **Proto-Indo-European**
@@ -30,6 +47,7 @@ genuine, distant cousins, both carrying the older sense of "vigor, life-force"
 before splitting toward different specific meanings.
 
 ## Grammar Lens: a simple possessive, no verb
+<!-- hl-knowledge: introduces=[KA-GRAMMAR-C19-VAYASSU-02]; assesses=[] -->
 
 > **ನಿನ್ನ ವಯಸ್ಸು ಎಷ್ಟು?** — "How old are you?" — literally "**your age
   how-much**?" (*ninna vayassu eṣṭu?*)
@@ -43,6 +61,7 @@ the noun, just the ordinary possessive word **ನಿನ್ನ** (*ninna*, "your"
 in front of **ವಯಸ್ಸು**.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C18-GANTE-01, KA-PRAGMATICS-C18-GANTE-02, KA-GRAMMAR-C18-GANTE-03, KA-ETYMON-C19-VAYASSU-01, KA-GRAMMAR-C19-VAYASSU-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "vayassu" — age]
@@ -50,6 +69,7 @@ in front of **ವಯಸ್ಸು**.
 - [YOU SAY: "nanna vayassu ippattu" — I am twenty, "my age [is] twenty"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C18-GANTE-01, KA-PRAGMATICS-C18-GANTE-02, KA-GRAMMAR-C18-GANTE-03, KA-ETYMON-C19-VAYASSU-01, KA-GRAMMAR-C19-VAYASSU-02] -->
 
 [PAUSE 3s] What Sanskrit word is **ವಯಸ್ಸು** from, and what Latin word is its PIE
 cousin? (**वयस्**, *vayas*, "age/vigor" — cousin of Latin **vīs**, "force," both

--- a/code/learning/human-languages/kannada/lessons/KA-C20-hannondu-ippattu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C20-hannondu-ippattu.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C20-hannondu-ippattu
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 480
 chapter: 20
 type: word
 headword: ಹನ್ನೊಂದು — ಇಪ್ಪತ್ತು
@@ -9,13 +12,26 @@ prerequisites: [KA-C19-vayassu]
 sounds: [kannada-anusvara-o, kannada-geminate-pp]
 roots: [dravidian-hattu-ten, dravidian-ir-two-bound]
 etymology_hook: "ಹನ್ನೊಂದು-ಹತ್ತೊಂಬತ್ತು (11-19) are compounds echoing ಹತ್ತು (hattu, 'ten') + a digit — ಇಪ್ಪತ್ತು (ippattu, 'twenty') traces to Proto-Dravidian *ir- ('two') + *paHtu ('ten'), a real compositional origin, but Kannada's own sound changes (gemination, and a p→h shift that only fires word-initially) mean neither modern eraḍu nor modern hattu is directly visible inside it today — unlike Sanskrit/Latin/Arabic, which have no compositional origin for 'twenty' AT ALL"
-est_minutes: 4
 reviews_of: [KA-C19-vayassu]
+duration:
+  max_seconds: 295
+requires:
+  knowledge: [KA-ETYMON-C19-VAYASSU-01, KA-GRAMMAR-C19-VAYASSU-02]
+introduces:
+  knowledge: [KA-ETYMON-C20-HANNONDU-IPPATTU-01, KA-ETYMON-C20-HANNONDU-IPPATTU-02]
+practises:
+  knowledge: [KA-ETYMON-C19-VAYASSU-01, KA-GRAMMAR-C19-VAYASSU-02, KA-ETYMON-C20-HANNONDU-IPPATTU-01, KA-ETYMON-C20-HANNONDU-IPPATTU-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # ಹನ್ನೊಂದು, ಇಪ್ಪತ್ತು — a real "two-tens" compound, just not one you can see today
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C19-VAYASSU-01, KA-GRAMMAR-C19-VAYASSU-02] -->
 
 [PAUSE 2s] You've now seen four different language families each build
 "twenty" as its own special, opaque word — Sanskrit's *vimshati*, Latin's
@@ -23,7 +39,8 @@ reviews_of: [KA-C19-vayassu]
 "two tens" too — but be careful: the modern surface no longer shows it
 plainly.
 
-## ಹನ್ನೊಂದು–ಹತ್ತೊಂಬತ್ತು — "ten" + digit
+## The word, taken apart: ಹನ್ನೊಂದು–ಹತ್ತೊಂಬತ್ತು — "ten" + digit
+<!-- hl-knowledge: introduces=[KA-ETYMON-C20-HANNONDU-IPPATTU-01]; assesses=[] -->
 
 Kannada's teens are built on **ಹತ್ತು** (*hattu*, "**ten**") plus each digit —
 **ಹನ್ನೊಂದು** (*hannondu*, 11), **ಹನ್ನೆರಡು** (*hanneraḍu*, 12), and onward
@@ -31,7 +48,8 @@ through **ಹತ್ತೊಂಬತ್ತು** (*hattombattu*, 19). Each teen is 
 built the same way English builds "four-**teen**" — just placed the same
 digit-plus-ten pattern in front instead of behind.
 
-## ಇಪ್ಪತ್ತು — "two-tens" underneath, but not on the surface anymore
+## The word, taken apart: ಇಪ್ಪತ್ತು — "two-tens" underneath, but not on the surface anymore
+<!-- hl-knowledge: introduces=[KA-ETYMON-C20-HANNONDU-IPPATTU-02]; assesses=[] -->
 
 **ಇಪ್ಪತ್ತು** (*ippattu*, "**twenty**") traces back to Proto-Dravidian
 **\*ir-** ("**two**") + **\*paHtu** ("**ten**") — a genuine compositional
@@ -50,6 +68,7 @@ all, not even a buried one — a genuinely different kind of history from
 Kannada's.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C19-VAYASSU-01, KA-GRAMMAR-C19-VAYASSU-02, KA-ETYMON-C20-HANNONDU-IPPATTU-01, KA-ETYMON-C20-HANNONDU-IPPATTU-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "hannondu, hanneraḍu" — 11, 12]
@@ -58,6 +77,7 @@ Kannada's.
   *paHtu roots, not directly from hattu/eraḍu]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C19-VAYASSU-01, KA-GRAMMAR-C19-VAYASSU-02, KA-ETYMON-C20-HANNONDU-IPPATTU-01, KA-ETYMON-C20-HANNONDU-IPPATTU-02] -->
 
 [PAUSE 3s] How are Kannada's teens built? (**ಹತ್ತು** (ten) + a digit,
 compounded.) Does **ಇಪ್ಪತ್ತು** (twenty) have a compositional "two-tens"

--- a/code/learning/human-languages/kannada/lessons/KA-C20-havamana.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C20-havamana.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C20-havamana
+spine_node: SPINE-TIME-OF-DAY
+sequence: 490
 chapter: 20
 type: phrase
 headword: ಹವಾಮಾನ
@@ -9,19 +12,33 @@ prerequisites: [KA-C18-gante]
 sounds: [kannada-vowel-sign-aa, kannada-compound-word]
 roots: [persian-hava-air, sanskrit-maana-measure]
 etymology_hook: "ಹವಾಮಾನ (havāmāna, 'weather') is a genuine hybrid compound: ಹವಾ (hava, 'air') is itself a Persian/Arabic loan (havā ← Arabic hawāʾ, the SAME root behind Hindi's hawa), fused with ಮಾನ (māna, 'measure,' native Sanskrit) — literally 'air-measure'"
-est_minutes: 4
 reviews_of: [KA-C18-gante]
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [KA-ETYMON-C18-GANTE-01, KA-PRAGMATICS-C18-GANTE-02, KA-GRAMMAR-C18-GANTE-03]
+introduces:
+  knowledge: [KA-ETYMON-C20-HAVAMANA-01, KA-LEX-C20-HAVAMANA-02]
+practises:
+  knowledge: [KA-ETYMON-C18-GANTE-01, KA-PRAGMATICS-C18-GANTE-02, KA-GRAMMAR-C18-GANTE-03, KA-ETYMON-C20-HAVAMANA-01, KA-LEX-C20-HAVAMANA-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # ಹವಾಮಾನ — a genuine two-language hybrid word
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C18-GANTE-01, KA-PRAGMATICS-C18-GANTE-02, KA-GRAMMAR-C18-GANTE-03] -->
 
 [PAUSE 2s] Kannada's word for "weather" isn't purely Sanskrit or purely
 native — it's a compound with a piece from each of two different borrowed
 sources.
 
-## ಹವಾಮಾನ — "air-measure," a hybrid compound
+## The word, taken apart: ಹವಾಮಾನ — "air-measure," a hybrid compound
+<!-- hl-knowledge: introduces=[KA-ETYMON-C20-HAVAMANA-01]; assesses=[] -->
 
 **ಹವಾಮಾನ** (*havāmāna*) = "**weather**" — built from two pieces:
 
@@ -36,12 +53,14 @@ So *havāmāna* literally means "**air-measure**" — and it's genuinely a
 two-source hybrid, not a single borrowed compound: one piece Perso-Arabic, one
 piece Sanskrit, fused into one Kannada word.
 
-## ಮಳೆ ಬರುತ್ತಿದೆ — "rain is coming"
+## You'll want to know: ಮಳೆ ಬರುತ್ತಿದೆ — "rain is coming"
+<!-- hl-knowledge: introduces=[KA-LEX-C20-HAVAMANA-02]; assesses=[] -->
 
 > **ಮಳೆ ಬರುತ್ತಿದೆ.** — "It's raining." — literally "**rain is coming**."
   (*maḷe baruttide.*)
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C18-GANTE-01, KA-PRAGMATICS-C18-GANTE-02, KA-GRAMMAR-C18-GANTE-03, KA-ETYMON-C20-HAVAMANA-01, KA-LEX-C20-HAVAMANA-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "havāmāna" — weather, literally "air-measure"]
@@ -49,6 +68,7 @@ piece Sanskrit, fused into one Kannada word.
 - [YOU SAY: "maḷe baruttide" — it's raining, "rain is coming"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C18-GANTE-01, KA-PRAGMATICS-C18-GANTE-02, KA-GRAMMAR-C18-GANTE-03, KA-ETYMON-C20-HAVAMANA-01, KA-LEX-C20-HAVAMANA-02] -->
 
 [PAUSE 3s] What are the two pieces of **ಹವಾಮಾನ**, and where does each come
 from? (**ಹವಾ**, "air," a **Persian/Arabic** loan; **ಮಾನ**, "measure," native

--- a/code/learning/human-languages/kannada/lessons/KA-C21-naayi-bekku.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C21-naayi-bekku.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C21-naayi-bekku
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 500
 chapter: 21
 type: word
 headword: ನಾಯಿ, ಬೆಕ್ಕು
@@ -9,26 +12,41 @@ prerequisites: [KA-C20-hannondu-ippattu]
 sounds: [kannada-vowel-sign-e, kannada-geminate-kk]
 roots: [dravidian-naay-dog, dravidian-veruku-wildcat]
 etymology_hook: "ನಾಯಿ (nāyi, 'dog') is a solid, native Proto-Dravidian root — no mystery, unlike every dog-word you've met elsewhere in this arc; ಬೆಕ್ಕು (bekku, 'cat') is cognate with a DIFFERENT ancient Dravidian root, the same one behind Tamil/Malayalam's word for wildcat/civet cat — Kannada's everyday cat-word and Tamil's everyday cat-word (pūnai) come from two genuinely separate Dravidian roots"
-est_minutes: 4
 reviews_of: [KA-C20-hannondu-ippattu]
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [KA-ETYMON-C20-HANNONDU-IPPATTU-01, KA-ETYMON-C20-HANNONDU-IPPATTU-02]
+introduces:
+  knowledge: [KA-ETYMON-C21-NAAYI-BEKKU-01, KA-ETYMON-C21-NAAYI-BEKKU-02]
+practises:
+  knowledge: [KA-ETYMON-C20-HANNONDU-IPPATTU-01, KA-ETYMON-C20-HANNONDU-IPPATTU-02, KA-ETYMON-C21-NAAYI-BEKKU-01, KA-ETYMON-C21-NAAYI-BEKKU-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # ನಾಯಿ, ಬೆಕ್ಕು — solid ground, and a genuine split
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C20-HANNONDU-IPPATTU-01, KA-ETYMON-C20-HANNONDU-IPPATTU-02] -->
 
 [PAUSE 2s] After a whole arc of mystery dog-words — Spanish's *perro*,
 English's *dog*, Hindi's *kuttā* — here's the opposite: a dog-word with
 absolutely no mystery attached.
 
-## ನಾಯಿ — solid ground at last
+## The word, taken apart: ನಾಯಿ — solid ground at last
+<!-- hl-knowledge: introduces=[KA-ETYMON-C21-NAAYI-BEKKU-01]; assesses=[] -->
 
 **ನಾಯಿ** (*nāyi*, "**dog**") is a genuine, native **Proto-Dravidian** root —
 no debate, no substrate mystery, nothing like the *perro*/*dog*/*kuttā*
 pattern you've now seen across three unrelated language families. It's the
 same root shared right across the Dravidian family.
 
-## ಬೆಕ್ಕು — a genuinely different root than Tamil's
+## The word, taken apart: ಬೆಕ್ಕು — a genuinely different root than Tamil's
+<!-- hl-knowledge: introduces=[KA-ETYMON-C21-NAAYI-BEKKU-02]; assesses=[] -->
 
 **ಬೆಕ್ಕು** (*bekku*, "**cat**") is where things get honestly more
 complicated. It's cognate with a **different** ancient Dravidian root — the
@@ -39,6 +57,7 @@ cat**" — not the same root as Tamil's **everyday** word for cat. So unlike
 for their everyday word.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C20-HANNONDU-IPPATTU-01, KA-ETYMON-C20-HANNONDU-IPPATTU-02, KA-ETYMON-C21-NAAYI-BEKKU-01, KA-ETYMON-C21-NAAYI-BEKKU-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "nāyi" — dog, solid native Dravidian, no mystery]
@@ -46,6 +65,7 @@ for their everyday word.
   word]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C20-HANNONDU-IPPATTU-01, KA-ETYMON-C20-HANNONDU-IPPATTU-02, KA-ETYMON-C21-NAAYI-BEKKU-01, KA-ETYMON-C21-NAAYI-BEKKU-02] -->
 
 [PAUSE 3s] Is **ನಾಯಿ** a mystery word, like Spanish's *perro* or Hindi's
 *kuttā*? (**No** — a solid, native Proto-Dravidian root.) Does **ಬೆಕ್ಕು**

--- a/code/learning/human-languages/kannada/lessons/KA-C22-hasiru-haladi.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C22-hasiru-haladi.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C22-hasiru-haladi
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 510
 chapter: 22
 type: word
 headword: ಹಸಿರು, ಹಳದಿ
@@ -9,19 +12,33 @@ prerequisites: [KA-C11-bannagalu, KA-C21-naayi-bekku]
 sounds: [kannada-retroflex-lla, kannada-virama-geminate]
 roots: [proto-dravidian-pac-green, sanskrit-haridra-turmeric]
 etymology_hook: "ಹಸಿರು (hasiru, 'green') ← Old Kannada ಪಸಿರ್ (pasir) ← Proto-Dravidian *pac-, 'green' — the SAME root as Tamil's பச்சை (paccai) and Telugu's పచ్చ (pacca); ಹಳದಿ (haḷadi, 'yellow') appears to be a Sanskrit/Hindi loan built on हरिद्रा (haridrā, 'turmeric'), which traces to हरि (hari, 'yellow, tawny') from Proto-Indo-European *ǵʰelh₃- — the same ancient root already behind Hindi's harā (green) and German's gelb (yellow); note that Hindi itself keeps 'turmeric' (haldi) and 'yellow' (pīlā) as two separate, unrelated words, unlike Kannada/Bengali/Odia which reuse the turmeric-word for the color"
-est_minutes: 4
 reviews_of: [KA-C21-naayi-bekku]
+duration:
+  max_seconds: 299
+requires:
+  knowledge: [KA-LEX-C11-BANNAGALU-01, KA-LEX-C11-BANNAGALU-02, KA-ETYMON-C21-NAAYI-BEKKU-01, KA-ETYMON-C21-NAAYI-BEKKU-02]
+introduces:
+  knowledge: [KA-ETYMON-C22-HASIRU-HALADI-01, KA-ETYMON-C22-HASIRU-HALADI-02]
+practises:
+  knowledge: [KA-LEX-C11-BANNAGALU-01, KA-LEX-C11-BANNAGALU-02, KA-ETYMON-C21-NAAYI-BEKKU-01, KA-ETYMON-C21-NAAYI-BEKKU-02, KA-ETYMON-C22-HASIRU-HALADI-01, KA-ETYMON-C22-HASIRU-HALADI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # ಹಸಿರು, ಹಳದಿ — a real Dravidian family, and a borrowed cousin of gelb
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C11-BANNAGALU-01, KA-LEX-C11-BANNAGALU-02, KA-ETYMON-C21-NAAYI-BEKKU-01, KA-ETYMON-C21-NAAYI-BEKKU-02] -->
 
 [PAUSE 2s] Kannada's green word belongs to a real Dravidian family you'll
 meet again soon. Its yellow word isn't native at all — and it turns out to
 be hiding the very same ancient root this whole arc keeps circling back to.
 
-## ಹಸಿರು — a genuine pan-Dravidian word
+## The word, taken apart: ಹಸಿರು — a genuine pan-Dravidian word
+<!-- hl-knowledge: introduces=[KA-ETYMON-C22-HASIRU-HALADI-01]; assesses=[] -->
 
 **ಹಸಿರು** (**hasiru**, "**green**") comes from **Old Kannada** **ಪಸಿರ್**
 (**pasir**), from **Proto-Dravidian** ***\*pac-***, "**green**" — the
@@ -32,7 +49,8 @@ be hiding the very same ancient root this whole arc keeps circling back to.
 Dravidian word — and this particular root will keep resurfacing as Telugu,
 Malayalam, and Tamil's own green words come up later in this same arc.
 
-## ಹಳದಿ — a turmeric-word loan, and a secret cousin of gelb
+## The word, taken apart: ಹಳದಿ — a turmeric-word loan, and a secret cousin of gelb
+<!-- hl-knowledge: introduces=[KA-ETYMON-C22-HASIRU-HALADI-02]; assesses=[] -->
 
 **ಹಳದಿ** (**haḷadi**, "**yellow**") is **not** Kannada's native turmeric
 word — that's **ಅರಿಶಿನ** (*ariśina*). Instead, *haḷadi* appears to be shaped
@@ -52,6 +70,7 @@ family, Indo-Aryan rather than Dravidian — and that borrowed word still
 lands on the exact same PIE root this arc has been tracing all along.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C11-BANNAGALU-01, KA-LEX-C11-BANNAGALU-02, KA-ETYMON-C21-NAAYI-BEKKU-01, KA-ETYMON-C21-NAAYI-BEKKU-02, KA-ETYMON-C22-HASIRU-HALADI-01, KA-ETYMON-C22-HASIRU-HALADI-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "ಹಸಿರು" — green, a real Dravidian cousin of Tamil paccai and
@@ -61,6 +80,7 @@ lands on the exact same PIE root this arc has been tracing all along.
   Hindi loan built on the turmeric word]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C11-BANNAGALU-01, KA-LEX-C11-BANNAGALU-02, KA-ETYMON-C21-NAAYI-BEKKU-01, KA-ETYMON-C21-NAAYI-BEKKU-02, KA-ETYMON-C22-HASIRU-HALADI-01, KA-ETYMON-C22-HASIRU-HALADI-02] -->
 
 [PAUSE 3s] What Proto-Dravidian root gives **ಹಸಿರು** (*hasiru*), and which
 two other Dravidian languages share it? (***\*pac-***, "green" — shared with

--- a/code/learning/human-languages/kannada/lessons/KA-C23-dina.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C23-dina.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C23-dina
+spine_node: SPINE-TIME-OF-DAY
+sequence: 520
 chapter: 23
 type: word
 headword: ದಿನ
@@ -9,25 +12,40 @@ prerequisites: [KA-C17-madhyaahna-madhyaraatri]
 sounds: [kannada-vowel-sign-i, kannada-na]
 roots: [sanskrit-dina, dravidian-hagalu-daytime]
 etymology_hook: "ದಿನ (dina, 'day') is a Sanskrit tatsama word, borrowed whole and unworn — the SAME Sanskrit दिन already behind Hindi's own दिन (din), but Hindi's din is a tadbhava form, eroded by centuries of ordinary sound change (Sanskrit dina → Prakrit → din), while Kannada's dina keeps the full, unshortened Sanskrit shape; Kannada also has a genuine native Dravidian word, ಹಗಲು (hagalu), but it specifically means 'daytime' (as opposed to night), not 'a day' as a calendar unit"
-est_minutes: 4
 reviews_of: [KA-C17-madhyaahna-madhyaraatri]
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03]
+introduces:
+  knowledge: [KA-ETYMON-C23-DINA-01, KA-ETYMON-C23-DINA-02, KA-ETYMON-C23-DINA-03]
+practises:
+  knowledge: [KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C23-DINA-01, KA-ETYMON-C23-DINA-02, KA-ETYMON-C23-DINA-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # ದಿನ (dina) — "day," Sanskrit kept whole
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03] -->
 
 [PAUSE 2s] You've already met Sanskrit's "middle" compounds for noon and
 midnight. Here's the plain word for "day" itself — and a genuinely
 interesting twist on how borrowing works.
 
-## ದಿನ — "day"
+## The word, taken apart: ದಿನ — "day"
+<!-- hl-knowledge: introduces=[KA-ETYMON-C23-DINA-01]; assesses=[] -->
 
 **ದಿನ** (**dina**) — "**day**" — is a Sanskrit **tatsama** word: borrowed
 **whole**, unchanged, the same way *madhyāhna*/*madhyarātri* were
 (Chapter 17). It's Kannada's ordinary, everyday word for "a day."
 
-## The same word as Hindi's din — but a different kind of relative
+## The word, taken apart: The same word as Hindi's din — but a different kind of relative
+<!-- hl-knowledge: introduces=[KA-ETYMON-C23-DINA-02]; assesses=[] -->
 
 Here's the honest twist: Kannada's *dina* and Hindi's **दिन** (*din*) trace
 to the **exact same** Sanskrit word, **दिन** (*dina*) — but they got there
@@ -40,7 +58,8 @@ but one is an unbroken **inheritance** (eroded), the other a **later
 borrowing** (kept whole) — genuinely different histories landing on nearly
 the same modern word.
 
-## A real native word — but for a different sense
+## The word, taken apart: A real native word — but for a different sense
+<!-- hl-knowledge: introduces=[KA-ETYMON-C23-DINA-03]; assesses=[] -->
 
 Kannada does have a genuine **native Dravidian** word here too: **ಹಗಲು**
 (*hagalu*) — but be careful, it means specifically "**daytime**" (the
@@ -48,6 +67,7 @@ daylight hours, as opposed to night), not "**a day**" as a calendar unit.
 It's not a synonym for *dina*; it's a different sense of "day" entirely.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C23-DINA-01, KA-ETYMON-C23-DINA-02, KA-ETYMON-C23-DINA-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "dina" — "day," Sanskrit tatsama, kept whole]
@@ -57,6 +77,7 @@ It's not a synonym for *dina*; it's a different sense of "day" entirely.
   dina]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C23-DINA-01, KA-ETYMON-C23-DINA-02, KA-ETYMON-C23-DINA-03] -->
 
 [PAUSE 3s] Is Kannada's **ದಿನ** a tatsama borrowing or a tadbhava
 inheritance? (**Tatsama** — borrowed whole from Sanskrit.) How does this

--- a/code/learning/human-languages/kannada/lessons/KA-C24-ratri.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C24-ratri.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C24-ratri
+spine_node: SPINE-TIME-OF-DAY
+sequence: 530
 chapter: 24
 type: word
 headword: ರಾತ್ರಿ
@@ -9,26 +12,41 @@ prerequisites: [KA-C17-madhyaahna-madhyaraatri, KA-C23-dina]
 sounds: [kannada-conjunct-tra, kannada-vowel-sign-i]
 roots: [sanskrit-ratri, proto-dravidian-cirvl]
 etymology_hook: "ರಾತ್ರಿ (rātri, 'night') is a Sanskrit tatsama word, the same one already hiding inside ಮಧ್ಯರಾತ್ರಿ (madhyarātri, 'midnight'), now standing alone as Kannada's everyday word for 'night'; Kannada DOES have a genuine native Dravidian word, ಇರುಳು (iruḷu) ← Proto-Dravidian *cirVḷ, cognate with Tamil இருள், Malayalam ഇരുൾ, and Telugu ఇరులు — but unlike ಹಗಲು (hagalu, still a living word for 'daytime'), iruḷu has been pushed into archaism, surviving mainly in older poetry"
-est_minutes: 4
 reviews_of: [KA-C17-madhyaahna-madhyaraatri, KA-C23-dina]
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C23-DINA-01, KA-ETYMON-C23-DINA-02, KA-ETYMON-C23-DINA-03]
+introduces:
+  knowledge: [KA-ETYMON-C24-RATRI-01, KA-ETYMON-C24-RATRI-02]
+practises:
+  knowledge: [KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C23-DINA-01, KA-ETYMON-C23-DINA-02, KA-ETYMON-C23-DINA-03, KA-ETYMON-C24-RATRI-01, KA-ETYMON-C24-RATRI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # ರಾತ್ರಿ (rātri) — "night," and its native cousin, pushed aside
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C23-DINA-01, KA-ETYMON-C23-DINA-02, KA-ETYMON-C23-DINA-03] -->
 
 [PAUSE 2s] Last lesson's *dina* had a living native partner, *hagalu*.
 This word's native partner tells a different, more honest story — one of
 being pushed out, not living alongside.
 
-## ರಾತ್ರಿ — "night"
+## The word, taken apart: ರಾತ್ರಿ — "night"
+<!-- hl-knowledge: introduces=[KA-ETYMON-C24-RATRI-01]; assesses=[] -->
 
 **ರಾತ್ರಿ** (**rātri**) — "**night**" — is the same Sanskrit **tatsama**
 word already hiding inside **ಮಧ್ಯರಾತ್ರಿ** (*madhyarātri*, "midnight,"
 Chapter 17), now standing on its own as Kannada's ordinary, everyday word
 for "night."
 
-## ಇರುಳು — a real native word, pushed into archaism
+## The word, taken apart: ಇರುಳು — a real native word, pushed into archaism
+<!-- hl-knowledge: introduces=[KA-ETYMON-C24-RATRI-02]; assesses=[] -->
 
 Kannada **does** have a genuine **native Dravidian** word for night:
 **ಇರುಳು** (**iruḷu**), from **Proto-Dravidian** ***\*cirVḷ*** — a real
@@ -43,6 +61,7 @@ everyday speech. *Rātri* simply **won** the job of "night" in modern
 Kannada.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C23-DINA-01, KA-ETYMON-C23-DINA-02, KA-ETYMON-C23-DINA-03, KA-ETYMON-C24-RATRI-01, KA-ETYMON-C24-RATRI-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "rātri" — "night," already met inside madhyarātri]
@@ -51,6 +70,7 @@ Kannada.
   iruḷu was pushed aside (same sense, lost the job)]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C23-DINA-01, KA-ETYMON-C23-DINA-02, KA-ETYMON-C23-DINA-03, KA-ETYMON-C24-RATRI-01, KA-ETYMON-C24-RATRI-02] -->
 
 [PAUSE 3s] Where have you already met **ರಾತ್ರಿ** before this lesson?
 (**ಮಧ್ಯರಾತ್ರಿ**, *madhyarātri*, "midnight.") What genuine native Dravidian

--- a/code/learning/human-languages/kannada/lessons/KA-C25-shubha-ratri.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C25-shubha-ratri.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C25-shubha-ratri
+spine_node: SPINE-TIME-OF-DAY
+sequence: 540
 chapter: 25
 type: phrase
 headword: ಶುಭ ರಾತ್ರಿ
@@ -9,26 +12,41 @@ prerequisites: [KA-C24-ratri]
 sounds: [kannada-sha, kannada-bha]
 roots: [sanskrit-shubha-beautiful, sanskrit-ratri]
 etymology_hook: "ಶುಭ ರಾತ್ರಿ (śubha rātri), 'good night,' literally 'auspicious night' — both pieces are Sanskrit tatsama: ರಾತ್ರಿ (rātri, already met last lesson) plus ಶುಭ (śubha, 'auspicious, good'), from Sanskrit root śubh, 'to be beautiful, splendid,' from a well-sourced PIE root *ḱewbʰ-; the exact same phrase, शुभ रात्रि, is also common in Hindi — most likely shared Sanskrit vocabulary rather than one language directly borrowing the whole phrase from the other, though 'good night' as a farewell is itself a modern convention across Indian languages, so some cross-language reinforcement can't be ruled out"
-est_minutes: 4
 reviews_of: [KA-C24-ratri]
+duration:
+  max_seconds: 285
+requires:
+  knowledge: [KA-ETYMON-C24-RATRI-01, KA-ETYMON-C24-RATRI-02]
+introduces:
+  knowledge: [KA-ETYMON-C25-SHUBHA-RATRI-01, KA-ETYMON-C25-SHUBHA-RATRI-02, KA-ETYMON-C25-SHUBHA-RATRI-03]
+practises:
+  knowledge: [KA-ETYMON-C24-RATRI-01, KA-ETYMON-C24-RATRI-02, KA-ETYMON-C25-SHUBHA-RATRI-01, KA-ETYMON-C25-SHUBHA-RATRI-02, KA-ETYMON-C25-SHUBHA-RATRI-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral-parting
+variety: standard-colloquial
 ---
 
 # ಶುಭ ರಾತ್ರಿ (śubha rātri) — "good night," auspicious to the end
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C24-RATRI-01, KA-ETYMON-C24-RATRI-02] -->
 
 [PAUSE 2s] You already have *rātri*. Pair it with one more Sanskrit word,
 and you have Kannada's everyday "good night" — the same phrase, word for
 word, as Hindi's.
 
-## ಶುಭ ರಾತ್ರಿ — "auspicious night"
+## The word, taken apart: ಶುಭ ರಾತ್ರಿ — "auspicious night"
+<!-- hl-knowledge: introduces=[KA-ETYMON-C25-SHUBHA-RATRI-01]; assesses=[] -->
 
 **ಶುಭ ರಾತ್ರಿ** (**śubha rātri**) — "**good night**" — literally
 "**auspicious night**." Both pieces are Sanskrit **tatsama**: **ರಾತ್ರಿ**
 (*rātri*, "night," already met last lesson) plus **ಶುಭ** (*śubha*,
 "**auspicious, good**").
 
-## ಶುಭ — from a root meaning "to be beautiful"
+## The word, taken apart: ಶುಭ — from a root meaning "to be beautiful"
+<!-- hl-knowledge: introduces=[KA-ETYMON-C25-SHUBHA-RATRI-02]; assesses=[] -->
 
 **ಶುಭ** (**śubha**) comes from the Sanskrit verbal root **śubh**, whose
 core sense is "**to be beautiful, splendid**" — traceable to a
@@ -37,7 +55,8 @@ beautiful"). A further, more speculative connection to a root meaning "to
 shine" has also been proposed — but either way, the underlying idea is a
 familiar one: **auspiciousness imagined as a kind of radiance or beauty**.
 
-## A phrase shared across two different language families
+## The word, taken apart: A phrase shared across two different language families
+<!-- hl-knowledge: introduces=[KA-ETYMON-C25-SHUBHA-RATRI-03]; assesses=[] -->
 
 Here's the honest cross-language note: **ಶುಭ ರಾತ್ರಿ** and Hindi's own
 **शुभ रात्रि** are, word for word, the **exact same phrase** — a Dravidian
@@ -54,6 +73,7 @@ this phrase draws on shared **Sanskrit vocabulary**, not a shared
 "formal-versus-everyday" register split the way it does in Hindi.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C24-RATRI-01, KA-ETYMON-C24-RATRI-02, KA-ETYMON-C25-SHUBHA-RATRI-01, KA-ETYMON-C25-SHUBHA-RATRI-02, KA-ETYMON-C25-SHUBHA-RATRI-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "śubha rātri" — "good night," literally "auspicious night"]
@@ -63,6 +83,7 @@ this phrase draws on shared **Sanskrit vocabulary**, not a shared
   reinforcement can't be fully ruled out]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C24-RATRI-01, KA-ETYMON-C24-RATRI-02, KA-ETYMON-C25-SHUBHA-RATRI-01, KA-ETYMON-C25-SHUBHA-RATRI-02, KA-ETYMON-C25-SHUBHA-RATRI-03] -->
 
 [PAUSE 3s] What does **ಶುಭ ರಾತ್ರಿ** literally mean? ("**Auspicious
 night**.") What does **ಶುಭ** literally trace back to? (A root meaning "**to

--- a/code/learning/human-languages/kannada/lessons/KA-C26-belagge.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C26-belagge.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C26-belagge
+spine_node: SPINE-TIME-OF-DAY
+sequence: 550
 chapter: 26
 type: word
 headword: ಬೆಳಗ್ಗೆ
@@ -9,19 +12,33 @@ prerequisites: [KA-C17-madhyaahna-madhyaraatri, KA-C23-dina, KA-C24-ratri]
 sounds: [kannada-conjunct-gge, kannada-vowel-sign-e]
 roots: [proto-dravidian-belaku-light]
 etymology_hook: "ಬೆಳಗ್ಗೆ (beḷagge, 'morning') is native Dravidian, from ಬೆಳಗು (beḷagu, 'to shine, to become bright, to dawn') and ಬೆಳಕು (beḷaku, 'light') — unlike EVERY other everyday time-word already met in Kannada's arc, ದಿನ/dina ('day'), ರಾತ್ರಿ/ratri ('night'), and ಮಧ್ಯಾಹ್ನ/madhyāhna ('noon') — all genuine Sanskrit tatsama borrowings — ಬೆಳಗ್ಗೆ is the odd one out, Kannada's own word, no Sanskrit involved"
-est_minutes: 4
 reviews_of: [KA-C17-madhyaahna-madhyaraatri, KA-C23-dina, KA-C24-ratri]
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C23-DINA-01, KA-ETYMON-C23-DINA-02, KA-ETYMON-C23-DINA-03, KA-ETYMON-C24-RATRI-01, KA-ETYMON-C24-RATRI-02]
+introduces:
+  knowledge: [KA-ETYMON-C26-BELAGGE-01, KA-PRAGMATICS-C26-BELAGGE-02]
+practises:
+  knowledge: [KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C23-DINA-01, KA-ETYMON-C23-DINA-02, KA-ETYMON-C23-DINA-03, KA-ETYMON-C24-RATRI-01, KA-ETYMON-C24-RATRI-02, KA-ETYMON-C26-BELAGGE-01, KA-PRAGMATICS-C26-BELAGGE-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # ಬೆಳಗ್ಗೆ (beḷagge) — the one time-word that's genuinely Kannada's own
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C23-DINA-01, KA-ETYMON-C23-DINA-02, KA-ETYMON-C23-DINA-03, KA-ETYMON-C24-RATRI-01, KA-ETYMON-C24-RATRI-02] -->
 
 [PAUSE 2s] Every everyday time-word you've met in Kannada so far —
 day, night, noon, midnight — has been Sanskrit, borrowed whole. This one
 breaks that pattern completely.
 
-## ಬೆಳಗ್ಗೆ — light, dawning, genuinely native
+## The word, taken apart: ಬೆಳಗ್ಗೆ — light, dawning, genuinely native
+<!-- hl-knowledge: introduces=[KA-ETYMON-C26-BELAGGE-01]; assesses=[] -->
 
 **ಬೆಳಗ್ಗೆ** (**beḷagge**) — "**morning**" — is **native Dravidian**,
 built on **ಬೆಳಗು** (*beḷagu*, "**to shine, to become bright, to
@@ -29,7 +46,8 @@ dawn**") and the related noun **ಬೆಳಕು** (*beḷaku*, "**light**"). Mor
 is, quite literally, "the shining," "the dawning" — a transparent,
 homegrown metaphor, no borrowed vocabulary anywhere in it.
 
-## Be honest: the one word in this whole family that isn't Sanskrit
+## Why it's said this way: the one word in this whole family that isn't Sanskrit
+<!-- hl-knowledge: introduces=[KA-PRAGMATICS-C26-BELAGGE-02]; assesses=[] -->
 
 Here's what makes this lesson different from every other Kannada
 time-word lesson so far: **ದಿನ** (*dina*, "day"), **ರಾತ್ರಿ** (*ratri*,
@@ -48,6 +66,7 @@ already met, plus *hagalu*). It just lost the everyday job to
 narrower, or archaic, roles by their own Sanskrit competitors.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C23-DINA-01, KA-ETYMON-C23-DINA-02, KA-ETYMON-C23-DINA-03, KA-ETYMON-C24-RATRI-01, KA-ETYMON-C24-RATRI-02, KA-ETYMON-C26-BELAGGE-01, KA-PRAGMATICS-C26-BELAGGE-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "beḷagge" — "morning," native Dravidian]
@@ -56,6 +75,7 @@ narrower, or archaic, roles by their own Sanskrit competitors.
   beḷagge is genuinely Kannada's own]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C23-DINA-01, KA-ETYMON-C23-DINA-02, KA-ETYMON-C23-DINA-03, KA-ETYMON-C24-RATRI-01, KA-ETYMON-C24-RATRI-02, KA-ETYMON-C26-BELAGGE-01, KA-PRAGMATICS-C26-BELAGGE-02] -->
 
 [PAUSE 3s] What native root does ಬೆಳಗ್ಗೆ come from, and what does it
 mean? (**ಬೆಳಗು/ಬೆಳಕು** — "to shine/dawn" and "light.") Is ಬೆಳಗ್ಗೆ a

--- a/code/learning/human-languages/kannada/lessons/KA-C27-sanje.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C27-sanje.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C27-sanje
+spine_node: SPINE-TIME-OF-DAY
+sequence: 560
 chapter: 27
 type: word
 headword: ಸಂಜೆ
@@ -9,19 +12,33 @@ prerequisites: [KA-C24-ratri, KA-C26-belagge]
 sounds: [kannada-anusvara, kannada-ja]
 roots: [sanskrit-sandhya-junction]
 etymology_hook: "ಸಂಜೆ (sañje, 'evening') is borrowed — from Maharashtri Prakrit ಸಂಝಾ (sañjhā), itself from Sanskrit ಸಂಧ್ಯಾ (saṃdhyā, 'twilight, junction of day and night'); unlike dina/ratri/madhyāhna (fresh Sanskrit TATSAMA, taken whole and unworn), ಸಂಜೆ arrived already eroded, in its Prakrit-worn shape; Hindi's साँझ (sāñjh) descends from the SAME Sanskrit word, but via a DIFFERENT, sister Middle Indo-Aryan dialect, Śauraseni Prakrit — two independent erosion paths off one Sanskrit root, converging on near-identical modern forms across two different language families"
-est_minutes: 4
 reviews_of: [KA-C24-ratri, KA-C26-belagge]
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [KA-ETYMON-C24-RATRI-01, KA-ETYMON-C24-RATRI-02, KA-ETYMON-C26-BELAGGE-01, KA-PRAGMATICS-C26-BELAGGE-02]
+introduces:
+  knowledge: [KA-ETYMON-C27-SANJE-01, KA-ETYMON-C27-SANJE-02]
+practises:
+  knowledge: [KA-ETYMON-C24-RATRI-01, KA-ETYMON-C24-RATRI-02, KA-ETYMON-C26-BELAGGE-01, KA-PRAGMATICS-C26-BELAGGE-02, KA-ETYMON-C27-SANJE-01, KA-ETYMON-C27-SANJE-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # ಸಂಜೆ (sañje) — a Sanskrit word that arrived already worn down
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C24-RATRI-01, KA-ETYMON-C24-RATRI-02, KA-ETYMON-C26-BELAGGE-01, KA-PRAGMATICS-C26-BELAGGE-02] -->
 
 [PAUSE 2s] ದಿನ, ರಾತ್ರಿ, and ಮಧ್ಯಾಹ್ನ all arrived in Kannada whole,
 unworn, straight from Sanskrit. This word took a very different route —
 and it lands somewhere genuinely surprising.
 
-## ಸಂಜೆ — a Sanskrit word, but already eroded on arrival
+## The word, taken apart: ಸಂಜೆ — a Sanskrit word, but already eroded on arrival
+<!-- hl-knowledge: introduces=[KA-ETYMON-C27-SANJE-01]; assesses=[] -->
 
 **ಸಂಜೆ** (**sañje**) — "**evening**" — traces to **Sanskrit** **ಸಂಧ್ಯಾ**
 (*saṃdhyā*, "**twilight**," literally "the junction of day and night")
@@ -31,7 +48,8 @@ and it lands somewhere genuinely surprising.
 worn down by centuries of everyday Middle Indo-Aryan speech, *then*
 borrowed into Kannada in that already-eroded shape.
 
-## A striking convergence: the same Sanskrit word, two independent paths
+## The word, taken apart: A striking convergence: the same Sanskrit word, two independent paths
+<!-- hl-knowledge: introduces=[KA-ETYMON-C27-SANJE-02]; assesses=[] -->
 
 Here's the genuinely surprising part: Hindi's own evening word,
 **साँझ** (*sāñjh*), comes from the **exact same** Sanskrit **ಸಂಧ್ಯಾ** —
@@ -45,6 +63,7 @@ words, *sañje* and *sāñjh*, purely because they share the same Sanskrit
 starting point.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C24-RATRI-01, KA-ETYMON-C24-RATRI-02, KA-ETYMON-C26-BELAGGE-01, KA-PRAGMATICS-C26-BELAGGE-02, KA-ETYMON-C27-SANJE-01, KA-ETYMON-C27-SANJE-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "sañje" — "evening," from Sanskrit sandhyā via Maharashtri
@@ -55,6 +74,7 @@ starting point.
   root, different Prakrit path, nearly the same sound today]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C24-RATRI-01, KA-ETYMON-C24-RATRI-02, KA-ETYMON-C26-BELAGGE-01, KA-PRAGMATICS-C26-BELAGGE-02, KA-ETYMON-C27-SANJE-01, KA-ETYMON-C27-SANJE-02] -->
 
 [PAUSE 3s] Does ಸಂಜೆ arrive in Kannada as a fresh, whole Sanskrit
 tatsama, like *dina* and *ratri* did? (**No** — it arrived already worn

--- a/code/learning/human-languages/kannada/lessons/KA-C28-aparahna.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C28-aparahna.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C28-aparahna
+spine_node: SPINE-TIME-OF-DAY
+sequence: 570
 chapter: 28
 type: word
 headword: ಅಪರಾಹ್ನ
@@ -9,19 +12,33 @@ prerequisites: [KA-C17-madhyaahna-madhyaraatri]
 sounds: [kannada-conjunct-hna, kannada-vowel-sign-aa]
 roots: [sanskrit-apara-latter, sanskrit-ahna-day]
 etymology_hook: "ಅಪರಾಹ್ನ (aparāhna, 'afternoon') is a genuine Sanskrit tatsama, distinct from ಮಧ್ಯಾಹ್ನ (madhyāhna, 'noon,' already met in Chapter 17) — both share the SAME '-ahna' suffix ('day,' related to ahan), differing only in the first piece: ಅಪರ (apara, 'latter, further') vs ಮಧ್ಯ (madhya, 'middle') — the classical five-part Sanskrit day division (prāta/saṅgava/madhyāhna/aparāhna/sāyāhna) kept this distinction sharp; in practice, though, some sources describe ಮಧ್ಯಾಹ್ನ ALSO being stretched loosely to cover the whole afternoon in casual modern speech — a MUCH more thinly sourced echo of Hindi's clearer दोपहर-widening story, worth flagging honestly rather than asserting as settled"
-est_minutes: 4
 reviews_of: [KA-C17-madhyaahna-madhyaraatri]
+duration:
+  max_seconds: 270
+requires:
+  knowledge: [KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03]
+introduces:
+  knowledge: [KA-ETYMON-C28-APARAHNA-01, KA-PRAGMATICS-C28-APARAHNA-02]
+practises:
+  knowledge: [KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C28-APARAHNA-01, KA-PRAGMATICS-C28-APARAHNA-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 ---
 
 # ಅಪರಾಹ್ನ (aparāhna) — the same "-ahna" pattern, a different first piece
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03] -->
 
 [PAUSE 2s] You already know ಮಧ್ಯಾಹ್ನ, "noon" — "middle" plus "day." This
 lesson's word for "afternoon" uses the exact same building pattern, just
 with a different first piece.
 
-## ಅಪರಾಹ್ನ — "the latter part of the day"
+## The word, taken apart: ಅಪರಾಹ್ನ — "the latter part of the day"
+<!-- hl-knowledge: introduces=[KA-ETYMON-C28-APARAHNA-01]; assesses=[] -->
 
 **ಅಪರಾಹ್ನ** (**aparāhna**) — "**afternoon**" — is a genuine **Sanskrit
 tatsama**: **ಅಪರ** (*apara*, "**latter, further**") + the same **-ಅಹ್ನ**
@@ -34,7 +51,8 @@ day** — *prāta* (early morning), *saṅgava*, *madhyāhna* (noon),
 *aparāhna* (afternoon), *sāyāhna* (evening) — with *aparāhna* landing
 specifically as the fourth part, after noon and before evening.
 
-## Be honest: a much thinner echo of Hindi's दोपहर story
+## Why it's said this way: a much thinner echo of Hindi's दोपहर story
+<!-- hl-knowledge: introduces=[KA-PRAGMATICS-C28-APARAHNA-02]; assesses=[] -->
 
 Here's where this lesson needs real care: some sources describe
 **ಮಧ್ಯಾಹ್ನ** itself being stretched loosely in casual modern speech to
@@ -48,6 +66,7 @@ this as a plausible, hedged parallel, not a settled fact the way
 correct word for "afternoon" specifically.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C28-APARAHNA-01, KA-PRAGMATICS-C28-APARAHNA-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "aparāhna" — "afternoon," apara + ahna]
@@ -57,6 +76,7 @@ correct word for "afternoon" specifically.
   Hindi's dopahar-widening story]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C28-APARAHNA-01, KA-PRAGMATICS-C28-APARAHNA-02] -->
 
 [PAUSE 3s] What suffix does ಅಪರಾಹ್ನ share with ಮಧ್ಯಾಹ್ನ, and what does
 it mean? (**-ಅಹ್ನ**, *-ahna*, "day.") What's the difference in their

--- a/code/learning/human-languages/kannada/lessons/KA-C29-shubhodaya.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C29-shubhodaya.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C29-shubhodaya
+spine_node: SPINE-TIME-OF-DAY
+sequence: 580
 chapter: 29
 type: phrase
 headword: ಶುಭೋದಯ
@@ -9,20 +12,34 @@ prerequisites: [KA-C26-belagge]
 sounds: [kannada-vowel-sign-oo, kannada-bha]
 roots: [su-good, udaya-sanskrit-rise]
 etymology_hook: "ಶುಭೋದಯ (śubhōdaya, 'good morning') = ಶುಭ (śubha, 'good, auspicious') + ಉದಯ (udaya, 'rising, sunrise,' ← Sanskrit ud- 'up' + i 'to go' — the same root behind sūryodaya, 'sunrise') — a COMPLETELY DIFFERENT root from ಬೆಳಗ್ಗೆ (beḷagge, KA-C26's native word for 'morning'); be honest about register: sources genuinely CONFLICT here — some describe ಶುಭೋದಯ as common in everyday speech, but a more careful source describes it as reserved for formal or written contexts (speeches, greeting cards, WhatsApp images) and 'not as frequently used in daily conversations' as ನಮಸ್ಕಾರ/ನಮಸ್ತೆ, with at least one native-speaker account suggesting casual spoken Kannada often reaches for English 'good morning' instead — the SAME formal/written skew pattern already found for Hindi's सुप्रभात, not a genuine cross-language contrast"
-est_minutes: 4
 reviews_of: [KA-C26-belagge]
+duration:
+  max_seconds: 299
+requires:
+  knowledge: [KA-ETYMON-C26-BELAGGE-01, KA-PRAGMATICS-C26-BELAGGE-02]
+introduces:
+  knowledge: [KA-ETYMON-C29-SHUBHODAYA-01, KA-PRAGMATICS-C29-SHUBHODAYA-02]
+practises:
+  knowledge: [KA-ETYMON-C26-BELAGGE-01, KA-PRAGMATICS-C26-BELAGGE-02, KA-ETYMON-C29-SHUBHODAYA-01, KA-PRAGMATICS-C29-SHUBHODAYA-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: formal-traditional
+variety: standard-colloquial
 ---
 
 # ಶುಭೋದಯ (śubhōdaya) — "good morning," a third root for morning
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C26-BELAGGE-01, KA-PRAGMATICS-C26-BELAGGE-02] -->
 
 [PAUSE 2s] You already have ಬೆಳಗ್ಗೆ, the everyday word for "morning."
 This greeting reaches for a completely different word for the same idea
 — and, honestly, this lesson's twist is about how uncertain its own
 "everyday" status turns out to be, once you look closely.
 
-## ಶುಭೋದಯ — ಶುಭ + ಉದಯ, a third morning-root
+## The word, taken apart: ಶುಭೋದಯ — ಶುಭ + ಉದಯ, a third morning-root
+<!-- hl-knowledge: introduces=[KA-ETYMON-C29-SHUBHODAYA-01]; assesses=[] -->
 
 **ಶುಭೋದಯ** (**śubhōdaya**) — "**good morning**" — is built from **ಶುಭ**
 (*śubha*, "**good, auspicious**") plus **ಉದಯ** (*udaya*, "**rising,
@@ -33,7 +50,8 @@ native "morning") — Kannada now has (at least) two unrelated roots
 circling the idea of morning: one native ("the shining"), one Sanskrit
 ("the rising").
 
-## Be honest: sources conflict, and the careful ones point to Hindi's own story
+## Why it's said this way: sources conflict, and the careful ones point to Hindi's own story
+<!-- hl-knowledge: introduces=[KA-PRAGMATICS-C29-SHUBHODAYA-02]; assesses=[] -->
 
 Here's where this lesson needs real care. Some sources describe
 **ಶುಭೋದಯ** as the most common everyday way to say "good morning" in
@@ -53,6 +71,7 @@ also exists as a real, attested greeting construction — but its own
 register isn't independently confirmed here either.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C26-BELAGGE-01, KA-PRAGMATICS-C26-BELAGGE-02, KA-ETYMON-C29-SHUBHODAYA-01, KA-PRAGMATICS-C29-SHUBHODAYA-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "śubhōdaya" — "good morning," śubha + udaya]
@@ -62,6 +81,7 @@ register isn't independently confirmed here either.
   ones point to the same formal/written skew already found for Hindi]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C26-BELAGGE-01, KA-PRAGMATICS-C26-BELAGGE-02, KA-ETYMON-C29-SHUBHODAYA-01, KA-PRAGMATICS-C29-SHUBHODAYA-02] -->
 
 [PAUSE 3s] Does ಶುಭೋದಯ share a root with ಬೆಳಗ್ಗೆ? (**No** — ಉದಯ,
 "rising," is a completely different Sanskrit root from native ಬೆಳಗ್ಗೆ's

--- a/code/learning/human-languages/kannada/lessons/KA-C30-shubha-sanje.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C30-shubha-sanje.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C30-shubha-sanje
+spine_node: SPINE-TIME-OF-DAY
+sequence: 590
 chapter: 30
 type: phrase
 headword: ಶುಭ ಸಂಜೆ
@@ -10,18 +13,32 @@ sounds: [kannada-sha, kannada-anusvara]
 roots: [su-good, sanskrit-sandhya-junction]
 reviews_of: [KA-C27-sanje, KA-C29-shubhodaya]
 etymology_hook: "ಶುಭ ಸಂಜೆ (śubha sañje, 'good evening') pairs śubha with ಸಂಜೆ (sañje, 'evening,' already met in Chapter 27 as a Sanskrit tatsama borrowed via Maharashtri Prakrit — NOT native Dravidian, despite a plausible-sounding claim you might encounter elsewhere that it's a native word); register evidence here is genuinely thin — a general, leans-formal impression (with ನಮಸ್ಕಾರ or, among younger urban speakers, English 'hello,' likely covering casual use) rather than a specific, well-sourced usage-context claim; this echoes, cautiously, the same formal-skew QUESTION already raised (not settled) for Hindi's सुप्रभात and Kannada's own ಶುಭೋದಯ, without overstating either lesson's own hedged conclusion into flat fact"
-est_minutes: 4
+duration:
+  max_seconds: 280
+requires:
+  knowledge: [KA-ETYMON-C27-SANJE-01, KA-ETYMON-C27-SANJE-02, KA-ETYMON-C29-SHUBHODAYA-01, KA-PRAGMATICS-C29-SHUBHODAYA-02]
+introduces:
+  knowledge: [KA-ETYMON-C30-SHUBHA-SANJE-01, KA-PRAGMATICS-C30-SHUBHA-SANJE-02]
+practises:
+  knowledge: [KA-ETYMON-C27-SANJE-01, KA-ETYMON-C27-SANJE-02, KA-ETYMON-C29-SHUBHODAYA-01, KA-PRAGMATICS-C29-SHUBHODAYA-02, KA-ETYMON-C30-SHUBHA-SANJE-01, KA-PRAGMATICS-C30-SHUBHA-SANJE-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: formal-and-neutral
+variety: standard-colloquial
 ---
 
 # ಶುಭ ಸಂಜೆ (śubha sañje) — formal, and correctly citing where ಸಂಜೆ comes from
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C27-SANJE-01, KA-ETYMON-C27-SANJE-02, KA-ETYMON-C29-SHUBHODAYA-01, KA-PRAGMATICS-C29-SHUBHODAYA-02] -->
 
 [PAUSE 2s] You already have ಸಂಜೆ, "evening" — and you already know it's
 a Sanskrit word that arrived in Kannada already worn down, via Prakrit.
 Keep that fact straight here, since it's an easy one to second-guess.
 
-## ಶುಭ ಸಂಜೆ — built correctly on Chapter 27's word
+## The word, taken apart: ಶುಭ ಸಂಜೆ — built correctly on Chapter 27's word
+<!-- hl-knowledge: introduces=[KA-ETYMON-C30-SHUBHA-SANJE-01]; assesses=[] -->
 
 **ಶುಭ ಸಂಜೆ** (**śubha sañje**) — "**good evening**" — pairs **ಶುಭ**
 ("good, auspicious") with **ಸಂಜೆ**, the exact word from Chapter 27:
@@ -31,7 +48,8 @@ claim elsewhere that ಸಂಜೆ is "native Dravidian" — it isn't, and you
 already have the real answer from Chapter 27. Don't let a claim that
 merely *sounds* plausible override something you've already verified.
 
-## Be honest: a genuinely thin evidence base, not a settled pattern
+## Why it's said this way: a genuinely thin evidence base, not a settled pattern
+<!-- hl-knowledge: introduces=[KA-PRAGMATICS-C30-SHUBHA-SANJE-02]; assesses=[] -->
 
 Here's where this lesson needs to be careful about its own sourcing, not
 just the etymology's. General impressions lean toward **ಶುಭ ಸಂಜೆ**
@@ -47,6 +65,7 @@ greetings, not a third confirmed data point — this lesson doesn't have
 strong enough sourcing to settle it either way.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C27-SANJE-01, KA-ETYMON-C27-SANJE-02, KA-ETYMON-C29-SHUBHODAYA-01, KA-PRAGMATICS-C29-SHUBHODAYA-02, KA-ETYMON-C30-SHUBHA-SANJE-01, KA-PRAGMATICS-C30-SHUBHA-SANJE-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "śubha sañje" — "good evening," a genuinely Sanskrit-rooted
@@ -57,6 +76,7 @@ strong enough sourcing to settle it either way.
   though this greeting's own register remains an open question]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C27-SANJE-01, KA-ETYMON-C27-SANJE-02, KA-ETYMON-C29-SHUBHODAYA-01, KA-PRAGMATICS-C29-SHUBHODAYA-02, KA-ETYMON-C30-SHUBHA-SANJE-01, KA-PRAGMATICS-C30-SHUBHA-SANJE-02] -->
 
 [PAUSE 3s] Is ಸಂಜೆ native Dravidian? (**No** — Sanskrit ಸಂಧ್ಯಾ via
 Maharashtri Prakrit, already established in Chapter 27; be skeptical of

--- a/code/learning/human-languages/kannada/lessons/KA-C31-shubha-madhyahna.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C31-shubha-madhyahna.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: KA-C31-shubha-madhyahna
+spine_node: SPINE-TIME-OF-DAY
+sequence: 600
 chapter: 31
 type: phrase
 headword: ಶುಭ ಮಧ್ಯಾಹ್ನ
@@ -9,19 +12,33 @@ prerequisites: [KA-C17-madhyaahna-madhyaraatri, KA-C28-aparahna, KA-C30-shubha-s
 sounds: [kannada-conjunct-dhya, kannada-vowel-sign-aa]
 roots: [su-good, sanskrit-madhya-middle]
 etymology_hook: "ಶುಭ ಮಧ್ಯಾಹ್ನ (śubha madhyāhna, 'good afternoon') is the standard afternoon greeting — but notice which noun it reuses: ಮಧ್ಯಾಹ್ನ (madhyāhna, 'noon,' KA-C17), NOT ಅಪರಾಹ್ನ (aparāhna, the more precisely-'afternoon' word from KA-C28) — a real-world data point for KA-C28's own hedge about whether madhyāhna has loosely widened to cover the afternoon too; be careful with the register claim here: one source, fetched directly rather than trusted from a search summary, describes ಶುಭ ಮಧ್ಯಾಹ್ನ as leaning FORMAL or semi-formal, workplaces and official meetings — but this wasn't cross-corroborated by a second source the way ನಮಸ್ಕಾರ's genuinely universal, any-time-of-day status was (confirmed independently across multiple fetched sources), so treat the workplace/formal framing as a single data point, not a settled fact"
-est_minutes: 4
 reviews_of: [KA-C17-madhyaahna-madhyaraatri, KA-C28-aparahna, KA-C30-shubha-sanje]
+duration:
+  max_seconds: 295
+requires:
+  knowledge: [KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C28-APARAHNA-01, KA-PRAGMATICS-C28-APARAHNA-02, KA-ETYMON-C30-SHUBHA-SANJE-01, KA-PRAGMATICS-C30-SHUBHA-SANJE-02]
+introduces:
+  knowledge: [KA-ETYMON-C31-SHUBHA-MADHYAHNA-01, KA-PRAGMATICS-C31-SHUBHA-MADHYAHNA-02]
+practises:
+  knowledge: [KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C28-APARAHNA-01, KA-PRAGMATICS-C28-APARAHNA-02, KA-ETYMON-C30-SHUBHA-SANJE-01, KA-PRAGMATICS-C30-SHUBHA-SANJE-02, KA-ETYMON-C31-SHUBHA-MADHYAHNA-01, KA-PRAGMATICS-C31-SHUBHA-MADHYAHNA-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: formal-workplace
+variety: standard-colloquial
 ---
 
 # ಶುಭ ಮಧ್ಯಾಹ್ನ (śubha madhyāhna) — the "noon" word doing the afternoon's job
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C28-APARAHNA-01, KA-PRAGMATICS-C28-APARAHNA-02, KA-ETYMON-C30-SHUBHA-SANJE-01, KA-PRAGMATICS-C30-SHUBHA-SANJE-02] -->
 
 [PAUSE 2s] Two lessons ago you met a careful hedge: does ಮಧ್ಯಾಹ್ನ,
 "noon," also loosely cover "afternoon"? This greeting hands you a real
 data point.
 
-## ಶುಭ ಮಧ್ಯಾಹ್ನ — reusing the "noon" word, not the "afternoon" one
+## The word, taken apart: ಶುಭ ಮಧ್ಯಾಹ್ನ — reusing the "noon" word, not the "afternoon" one
+<!-- hl-knowledge: introduces=[KA-ETYMON-C31-SHUBHA-MADHYAHNA-01]; assesses=[] -->
 
 **ಶುಭ ಮಧ್ಯಾಹ್ನ** (**śubha madhyāhna**) — "**good afternoon**" — is the
 standard greeting for this concept. Notice which noun it actually
@@ -34,7 +51,8 @@ rather than *aparāhna*, that's a real (if still not fully conclusive)
 sign that *madhyāhna*'s job has genuinely stretched to cover the
 afternoon in everyday use, not just at noon itself.
 
-## Be honest: one verified claim, one still just a single data point
+## Why it's said this way: one verified claim, one still just a single data point
+<!-- hl-knowledge: introduces=[KA-PRAGMATICS-C31-SHUBHA-MADHYAHNA-02]; assesses=[] -->
 
 Here's the useful discipline this lesson followed: checking a claim
 against an actual, directly fetched source page, not just trusting a
@@ -49,6 +67,7 @@ it isn't cross-corroborated the way the ನಮಸ್ಕಾರ claim is, so treat
 a single well-checked impression, not a settled fact.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C28-APARAHNA-01, KA-PRAGMATICS-C28-APARAHNA-02, KA-ETYMON-C30-SHUBHA-SANJE-01, KA-PRAGMATICS-C30-SHUBHA-SANJE-02, KA-ETYMON-C31-SHUBHA-MADHYAHNA-01, KA-PRAGMATICS-C31-SHUBHA-MADHYAHNA-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "śubha madhyāhna" — "good afternoon," reusing the "noon"
@@ -59,6 +78,7 @@ a single well-checked impression, not a settled fact.
   cross-checked across multiple sources]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C28-APARAHNA-01, KA-PRAGMATICS-C28-APARAHNA-02, KA-ETYMON-C30-SHUBHA-SANJE-01, KA-PRAGMATICS-C30-SHUBHA-SANJE-02, KA-ETYMON-C31-SHUBHA-MADHYAHNA-01, KA-PRAGMATICS-C31-SHUBHA-MADHYAHNA-02] -->
 
 [PAUSE 3s] Does ಶುಭ ಮಧ್ಯಾಹ್ನ use ಮಧ್ಯಾಹ್ನ ("noon") or ಅಪರಾಹ್ನ (the more
 precise "afternoon" word)? (**ಮಧ್ಯಾಹ್ನ** — real evidence for its

--- a/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
@@ -152,6 +152,41 @@ describe("generated book source hashes", () => {
     expect(bookHashStatus(lessons, "telugu", chapter)).toBe("synced");
   });
 
+  it.each([
+    [6, 3],
+    [7, 2],
+    [8, 1],
+    [9, 1],
+    [10, 1],
+    [11, 1],
+    [12, 1],
+    [13, 1],
+    [14, 1],
+    [15, 1],
+    [16, 1],
+    [17, 1],
+    [18, 1],
+    [19, 1],
+    [20, 2],
+    [21, 1],
+    [22, 1],
+    [23, 1],
+    [24, 1],
+    [25, 1],
+    [26, 1],
+    [27, 1],
+    [28, 1],
+    [29, 1],
+    [30, 1],
+    [31, 1],
+  ])("matches the browser-loaded Kannada Chapter %i AST across %i lessons", (chapter, count) => {
+    const lessons = loadLessons();
+    const expected = expectedBookHash("kannada", chapter);
+    expect(expected?.lessonIds).toHaveLength(count);
+    expect(actualChapterHash(lessons, "kannada", chapter)).toBe(expected?.sourceHash);
+    expect(bookHashStatus(lessons, "kannada", chapter)).toBe("synced");
+  });
+
   it("reports a generated chapter stale when one canonical lesson changes", () => {
     const lessons = loadLessons();
     const changed = lessons.map((lesson) =>


### PR DESCRIPTION
## Summary

- migrate all 30 Kannada lessons in Chapters 6–31 to the strict schema-v2 shared curriculum contract
- generate 26 Kannada LaTeX chapters from the same canonical AST used by Language Ladder
- add multi-script Kannada book rendering, source-hash parity checks, and backlog/publication documentation

## Validation

- `human-language-data`: 84/84 tests; generated-book staleness check passes
- `language-ladder`: 385/385 tests; production build passes
- focused post-rebase app/book-hash suite: 110/110 checks
- Kannada XeLaTeX: 96 pages, zero missing glyphs; all pages visually inspected
- PDF metadata/outline: 33 top-level and 93 total entries; no schema metadata leaks
- unified publication gate: all 20 books compile successfully in one job-equivalent local pass

## Follow-up

HL-B25 records the measured Kannada warning-cleanup tranche. HL-M03 records the roadmap/session-map work and the Chapter 20 numbers/weather grouping.