### PR TITLE
fix(spice): lower diode temperature exponent

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower diode model-card `XTI` temperature exponent.
 - Validate and lower diode model-card `FC` depletion coefficient.
 - Validate and lower diode model-card `M` / `MJ` grading coefficient.
 - Validate and lower diode model-card `VJ` / `PB` junction potential.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1277,6 +1277,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Vj=model.params.get("VJ", model.params.get("PB", 1.0)),
             M=model.params.get("M", model.params.get("MJ", 0.5)),
             Fc=model.params.get("FC", 0.5),
+            Xti=model.params.get("XTI", 3.0),
             Rs=model.params.get("RS", 0.0),
         )
     if prefix == "Q":
@@ -1983,6 +1984,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or depletion_coefficient >= 1.0
         ):
             raise NetlistParseError("diode FC must be finite and in [0, 1)")
+        temperature_exponent = params.get("XTI")
+        if temperature_exponent is not None and not math.isfinite(
+            temperature_exponent
+        ):
+            raise NetlistParseError("diode XTI must be finite")
     if kind in {"NPN", "PNP"}:
         saturation_current = params.get("IS")
         if saturation_current is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -983,6 +983,22 @@ def test_rejects_invalid_diode_depletion_coefficient(value: str) -> None:
         parse_netlist(f".model clamp D(FC={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("-1", -1.0), ("4", 4.0)])
+def test_lowers_finite_diode_temperature_exponent(
+    value: str, expected: float
+) -> None:
+    parsed = parse_netlist(f".model clamp D(XTI={value})\nD1 in out clamp")
+
+    diode = parsed.circuit.elements[0]
+    assert isinstance(diode, Diode)
+    assert diode.Xti == expected
+
+
+def test_rejects_non_finite_diode_temperature_exponent() -> None:
+    with pytest.raises(NetlistParseError, match="diode XTI must be finite"):
+        parse_netlist(".model clamp D(XTI=1e999)")
+
+
 def test_parse_diode_junction_capacitance_alias() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower diode model-card `XTI` temperature exponent.
 - Validate and lower diode model-card `FC` depletion coefficient.
 - Validate and lower diode model-card `M` / `MJ` grading coefficient.
 - Validate and lower diode model-card `VJ` / `PB` junction potential.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1241,6 +1241,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("diode FC must be finite and in [0, 1)");
   }
+  const diodeTemperatureExponent = params.get("XTI");
+  if (
+    kind === "D" &&
+    diodeTemperatureExponent !== undefined &&
+    !Number.isFinite(diodeTemperatureExponent)
+  ) {
+    throw new NetlistParseError("diode XTI must be finite");
+  }
   const bjtForwardBeta =
     params.get("BF") ??
     params.get("BETA") ??
@@ -1830,6 +1838,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       junctionPotential: model.params.get("VJ") ?? model.params.get("PB") ?? 1.0,
       gradingCoefficient: model.params.get("M") ?? model.params.get("MJ") ?? 0.5,
       forwardBiasDepletionCoefficient: model.params.get("FC") ?? 0.5,
+      saturationCurrentTemperatureExponent: model.params.get("XTI") ?? 3.0,
       seriesResistance: model.params.get("RS") ?? 0.0,
     };
   }

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1026,6 +1026,24 @@ D1 in out clamp
     },
   );
 
+  it.each([
+    ["-1", -1.0],
+    ["4", 4.0],
+  ])("lowers finite diode XTI temperature exponent %s", (value, expected) => {
+    const parsed = parseNetlist(`.model clamp D(XTI=${value})\nD1 in out clamp`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "diode",
+      saturationCurrentTemperatureExponent: expected,
+    });
+  });
+
+  it("rejects non-finite diode XTI temperature exponent", () => {
+    expect(() => parseNetlist(`.model clamp D(XTI=1e999)`)).toThrow(
+      "diode XTI must be finite",
+    );
+  });
+
   it("parses BJT models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NPN(IS=1e-14 BF=120 VT=25m CJE=2p CJC=3p TF=4n TR=5n)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4421,15 +4421,20 @@ the Rust, Python, and TypeScript surfaces together.
      canonical `M` precedence.
 
 420. Python and TypeScript Berkeley SPICE diode depletion-coefficient parity.
-   - Status: completed in this diode depletion-coefficient parity slice.
+   - Status: completed in PR 9822.
    - Both parser facades validate finite `FC` values in `[0, 1)` and lower
      them into the shared engine diode depletion-coefficient field.
+
+421. Python and TypeScript Berkeley SPICE diode temperature-exponent parity.
+   - Status: completed in this diode temperature-exponent parity slice.
+   - Both parser facades validate finite `XTI` values and lower them into the
+     shared engine diode saturation-current temperature-exponent field.
 
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE model-card validation parity.
-   - Continue the audited diode model-card lowering surfaces with `XTI`, `EG`,
-     `KF`, and `AF` validation and lowering parity.
+   - Continue the audited diode model-card lowering surfaces with `EG`, `KF`,
+     and `AF` validation and lowering parity.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary
- validate finite diode model-card `XTI` values in Python and TypeScript
- lower valid values, including negative exponents, into the existing engine temperature-exponent field
- add cross-language parity coverage and advance the SPICE completion backlog

## Verification
- Python `spice-netlist-parser`: `bash BUILD` (337 tests), Ruff clean
- TypeScript `spice-engine`: `bash BUILD` (448 tests)
- TypeScript `spice-netlist-parser`: `bash BUILD` (326 tests)
- TypeScript parser coverage: 86.27% lines