### PR TITLE
Compose the Chief daemon executable

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -1020,4 +1020,5 @@ members = [
   "task-core",
   "task-wasm",
   "chief-of-staff-daemon-credential",
+  "chief-of-staff-daemon",
 ]

--- a/code/packages/rust/chief-of-staff-daemon-keyring/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-keyring/CHANGELOG.md
@@ -7,3 +7,5 @@
 - Reject non-canonical, identity, low-order, and mixed-order public keys.
 - Map production and developer declarations to their Tier 3 and Tier 1 ceilings.
 - Keep filesystem and key details out of stable operator-facing failures.
+- Keep Windows key files open without writer/delete sharing while validating
+  them, using only stable Rust metadata APIs.

--- a/code/packages/rust/chief-of-staff-daemon-keyring/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-daemon-keyring/Cargo.toml
@@ -10,3 +10,6 @@ chief-of-staff-daemon-config = { path = "../chief-of-staff-daemon-config" }
 chief-of-staff-host-runtime = { path = "../chief-of-staff-host-runtime" }
 chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
 coding_adventures_ed25519 = { path = "../ed25519" }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.52", features = ["Win32_Storage_FileSystem"] }

--- a/code/packages/rust/chief-of-staff-daemon-keyring/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-keyring/src/lib.rs
@@ -86,7 +86,7 @@ fn read_public_key(path: &Path) -> Result<[u8; ED25519_PUBLIC_KEY_BYTES], Keyrin
         return Err(KeyringLoadError::KeyFileNotRegular);
     }
 
-    let file = File::open(path).map_err(|_| KeyringLoadError::KeyFileUnavailable)?;
+    let file = open_readonly(path)?;
     let opened = file
         .metadata()
         .map_err(|_| KeyringLoadError::KeyFileUnavailable)?;
@@ -111,6 +111,21 @@ fn read_public_key(path: &Path) -> Result<[u8; ED25519_PUBLIC_KEY_BYTES], Keyrin
     Ok(public_key)
 }
 
+#[cfg(not(windows))]
+fn open_readonly(path: &Path) -> Result<File, KeyringLoadError> {
+    File::open(path).map_err(|_| KeyringLoadError::KeyFileUnavailable)
+}
+
+#[cfg(windows)]
+fn open_readonly(path: &Path) -> Result<File, KeyringLoadError> {
+    use std::os::windows::fs::OpenOptionsExt;
+    std::fs::OpenOptions::new()
+        .read(true)
+        .share_mode(windows_sys::Win32::Storage::FileSystem::FILE_SHARE_READ)
+        .open(path)
+        .map_err(|_| KeyringLoadError::KeyFileUnavailable)
+}
+
 #[cfg(unix)]
 fn same_file(left: &Metadata, right: &Metadata) -> bool {
     use std::os::unix::fs::MetadataExt;
@@ -120,8 +135,10 @@ fn same_file(left: &Metadata, right: &Metadata) -> bool {
 #[cfg(windows)]
 fn same_file(left: &Metadata, right: &Metadata) -> bool {
     use std::os::windows::fs::MetadataExt;
-    left.volume_serial_number() == right.volume_serial_number()
-        && left.file_index() == right.file_index()
+    left.file_attributes() == right.file_attributes()
+        && left.creation_time() == right.creation_time()
+        && left.last_write_time() == right.last_write_time()
+        && left.file_size() == right.file_size()
 }
 
 #[cfg(not(any(unix, windows)))]

--- a/code/packages/rust/chief-of-staff-daemon/BUILD
+++ b/code/packages/rust/chief-of-staff-daemon/BUILD
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+cargo test -p chief-of-staff-daemon -- --nocapture
+cargo clippy -p chief-of-staff-daemon --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-daemon --no-deps

--- a/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0 - 2026-08-03
+
+- Add the concrete cross-platform Chief daemon executable.
+- Compose strict configuration, owner-only local authentication, trusted package
+  keys, durable registry storage, verified host supervision, authenticated
+  WebSocket serving, periodic reconciliation, and cooperative process shutdown.
+- Bound and race-check configuration-file loading without following a final
+  symlink.

--- a/code/packages/rust/chief-of-staff-daemon/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-daemon/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "chief-of-staff-daemon"
+version = "0.1.0"
+edition = "2021"
+description = "Concrete cross-platform daemon executable for D18 Chief of Staff"
+license = "MIT"
+
+[lib]
+name = "chief_of_staff_daemon"
+path = "src/lib.rs"
+
+[[bin]]
+name = "chief-of-staff-daemon"
+path = "src/main.rs"
+
+[dependencies]
+chief-of-staff-daemon-api = { path = "../chief-of-staff-daemon-api" }
+chief-of-staff-daemon-config = { path = "../chief-of-staff-daemon-config" }
+chief-of-staff-daemon-credential = { path = "../chief-of-staff-daemon-credential" }
+chief-of-staff-daemon-keyring = { path = "../chief-of-staff-daemon-keyring" }
+chief-of-staff-daemon-policy = { path = "../chief-of-staff-daemon-policy" }
+chief-of-staff-daemon-runtime = { path = "../chief-of-staff-daemon-runtime" }
+chief-of-staff-orchestrator-core = { path = "../chief-of-staff-orchestrator-core" }
+chief-of-staff-process-supervisor = { path = "../chief-of-staff-process-supervisor" }
+chief-of-staff-service-reconciler = { path = "../chief-of-staff-service-reconciler" }
+coding_adventures_x3dh = { path = "../x3dh" }
+process-shutdown = { path = "../process-shutdown" }
+storage-core = { path = "../storage-core" }
+coding_adventures_storage_fs = { path = "../storage-fs" }
+transport-platform = { path = "../transport-platform" }
+websocket-runtime = { path = "../websocket-runtime" }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.52", features = ["Win32_Storage_FileSystem"] }
+
+[dev-dependencies]
+coding_adventures_ed25519 = { path = "../ed25519" }
+
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"

--- a/code/packages/rust/chief-of-staff-daemon/README.md
+++ b/code/packages/rust/chief-of-staff-daemon/README.md
@@ -1,0 +1,36 @@
+# chief-of-staff-daemon
+
+Concrete, dependency-free-at-runtime executable for the D18 Chief of Staff
+orchestrator. It composes the repository-owned configuration, credential,
+package trust, storage, process supervision, control API, WebSocket runtime,
+reconciliation, and shutdown packages without adding new policy.
+
+Run with the spec-default config path:
+
+```sh
+chief-of-staff-daemon
+```
+
+The process resolves `~/.chief-of-staff/config.toml` from `HOME` on Unix or
+`USERPROFILE` on Windows. One explicit absolute config path may be supplied:
+
+```sh
+chief-of-staff-daemon /absolute/path/to/config.toml
+```
+
+The configured credential parent and trusted public-key files must already
+exist. The daemon creates or initializes the configured state directory, binds
+only the loopback address accepted by `chief-of-staff-daemon-config`, performs
+one reconciliation before serving, and then reconciles at the configured health
+interval. Channel topology mutation remains denied until the Trust Checker is
+implemented.
+
+SIGINT, SIGTERM, Ctrl+C, Ctrl+Break, console close, logoff, and system shutdown
+request a cooperative listener stop. Dropping the composed process supervisor
+reaps every child still owned by this daemon instance.
+
+## Validation
+
+```sh
+sh chief-of-staff-daemon/BUILD
+```

--- a/code/packages/rust/chief-of-staff-daemon/required_capabilities.json
+++ b/code/packages/rust/chief-of-staff-daemon/required_capabilities.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/chief-of-staff-daemon",
+  "capabilities": [
+    {
+      "category": "env",
+      "action": "read",
+      "target": "HOME or USERPROFILE",
+      "justification": "Resolves the spec-default per-user configuration path and validated home-relative paths."
+    },
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "configured config, public keys, packages, credential, and state paths",
+      "justification": "Loads bounded configuration and composes the existing keyring, package verification, credential, and durable registry adapters."
+    },
+    {
+      "category": "fs",
+      "action": "create",
+      "target": "configured credential and state paths",
+      "justification": "Composes owner-only credential publication and filesystem-backed durable registry initialization."
+    },
+    {
+      "category": "fs",
+      "action": "write",
+      "target": "configured credential and state paths",
+      "justification": "Persists the local credential and durable orchestrator intent through their existing bounded adapters."
+    },
+    {
+      "category": "net",
+      "action": "listen",
+      "target": "configured loopback address",
+      "justification": "Serves the authenticated local WebSocket control API."
+    },
+    {
+      "category": "proc",
+      "action": "exec",
+      "target": "configured Chief host executable",
+      "justification": "Composes verified shell-free host process supervision."
+    },
+    {
+      "category": "proc",
+      "action": "signal",
+      "target": "self and owned host children",
+      "justification": "Receives cooperative service shutdown and reaps owned children during teardown."
+    },
+    {
+      "category": "time",
+      "action": "read",
+      "target": "monotonic process clock",
+      "justification": "Schedules reconciliation and validates host heartbeat age."
+    },
+    {
+      "category": "time",
+      "action": "sleep",
+      "target": "bounded reconciliation, shutdown, and process-control waits",
+      "justification": "Composes existing bounded scheduler, signal delivery, credential publication, and child shutdown waits."
+    }
+  ],
+  "justification": "Composition root for the local D18 Chief daemon; all privileged behavior remains inside repository-owned bounded adapters."
+}

--- a/code/packages/rust/chief-of-staff-daemon/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon/src/lib.rs
@@ -1,0 +1,573 @@
+//! Concrete composition root for the D18 Chief daemon.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use chief_of_staff_daemon_api::{BindAddress, DaemonApi, DaemonApiError};
+use chief_of_staff_daemon_config::{parse_config, ChiefConfig, ConfigError};
+use chief_of_staff_daemon_credential::{load_or_create_credential, CredentialFileError};
+use chief_of_staff_daemon_keyring::{load_package_keyring, KeyringLoadError};
+use chief_of_staff_daemon_policy::{DenyChannelWiring, LocalAuthError, LocalBearerAuthorizer};
+use chief_of_staff_daemon_runtime::{ChiefDaemonRuntime, DaemonRuntimeError, ReconcileSchedule};
+use chief_of_staff_orchestrator_core::OrchestratorCore;
+use chief_of_staff_process_supervisor::{
+    HostProgram, ProcessSupervisorConfig, ProcessSupervisorError, SystemMonotonicClock,
+    UuidV7SessionIdSource,
+};
+use chief_of_staff_service_reconciler::{ConfigError as ReconcileConfigError, ReconcileConfig};
+use coding_adventures_storage_fs::FsStorageBackend;
+use coding_adventures_x3dh::generate_identity_keypair;
+use process_shutdown::{ShutdownError, ShutdownListener};
+use std::env;
+use std::ffi::OsString;
+use std::fmt::{self, Display, Formatter};
+use std::fs::{self, File, Metadata};
+use std::io::Read;
+use std::net::SocketAddr;
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+use storage_core::{StorageBackend, StorageError};
+use transport_platform::{PlatformError, TransportPlatform};
+use websocket_runtime::WebSocketServerOptions;
+
+const MAX_CONFIG_BYTES: usize = 256 * 1024;
+const DEFAULT_CONFIG_SUFFIX: &str = ".chief-of-staff/config.toml";
+const HEARTBEAT_GRACE_INTERVALS: u64 = 3;
+
+/// Stable payload-blind startup, serving, and teardown failure.
+#[derive(Debug)]
+pub enum ChiefDaemonError {
+    /// More than one config argument was supplied or a path was unsafe.
+    InvalidInvocation,
+    /// The platform-specific home environment variable was absent or unsafe.
+    HomeUnavailable,
+    /// The config path could not be inspected, opened, or read.
+    ConfigFileUnavailable,
+    /// The config path was a symlink or was not a regular file.
+    ConfigFileNotRegular,
+    /// The config path stopped naming the opened file during validation.
+    ConfigFileChanged,
+    /// The config file exceeded the parser's documented bound.
+    ConfigFileTooLarge,
+    /// The config file was not valid UTF-8.
+    ConfigFileEncoding,
+    /// Strict typed TOML validation failed.
+    Config(ConfigError),
+    /// A configured trusted package key could not be loaded.
+    Keyring(KeyringLoadError),
+    /// The local operator credential could not be loaded or created safely.
+    Credential(CredentialFileError),
+    /// Local bearer policy construction failed.
+    Authentication(LocalAuthError),
+    /// Durable registry storage initialization failed.
+    Storage(StorageError),
+    /// Host process supervision configuration was invalid.
+    Process(ProcessSupervisorError),
+    /// Reconciliation configuration was invalid.
+    Reconciliation(ReconcileConfigError),
+    /// The host transport provider could not initialize.
+    Platform(PlatformError),
+    /// The authenticated WebSocket runtime failed.
+    Runtime(DaemonRuntimeError),
+    /// Native cooperative shutdown installation or restoration failed.
+    Shutdown(ShutdownError),
+    /// Runtime teardown did not release the sole control-plane reference.
+    ControlPlaneRetained,
+    /// The control-plane mutex could not be recovered during teardown.
+    ControlPlaneRecovery(DaemonApiError),
+    /// This target has no supported production transport provider.
+    UnsupportedPlatform,
+}
+
+impl Display for ChiefDaemonError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidInvocation => "chief daemon: invalid invocation",
+            Self::HomeUnavailable => "chief daemon: home directory unavailable",
+            Self::ConfigFileUnavailable => "chief daemon: config file unavailable",
+            Self::ConfigFileNotRegular => "chief daemon: config path is not a regular file",
+            Self::ConfigFileChanged => "chief daemon: config path changed during validation",
+            Self::ConfigFileTooLarge => "chief daemon: config file exceeds size limit",
+            Self::ConfigFileEncoding => "chief daemon: config file is not UTF-8",
+            Self::Config(_) => "chief daemon: config validation failed",
+            Self::Keyring(_) => "chief daemon: package keyring failed",
+            Self::Credential(_) => "chief daemon: operator credential failed",
+            Self::Authentication(_) => "chief daemon: local authentication policy failed",
+            Self::Storage(_) => "chief daemon: durable storage failed",
+            Self::Process(_) => "chief daemon: process supervision failed",
+            Self::Reconciliation(_) => "chief daemon: reconciliation configuration failed",
+            Self::Platform(_) => "chief daemon: transport provider failed",
+            Self::Runtime(_) => "chief daemon: runtime failed",
+            Self::Shutdown(_) => "chief daemon: shutdown listener failed",
+            Self::ControlPlaneRetained => "chief daemon: control plane remained retained",
+            Self::ControlPlaneRecovery(_) => "chief daemon: control plane recovery failed",
+            Self::UnsupportedPlatform => "chief daemon: unsupported platform",
+        })
+    }
+}
+
+impl std::error::Error for ChiefDaemonError {}
+
+/// Resolved absolute startup paths independent of process-global environment.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StartupPaths {
+    home: PathBuf,
+    config: PathBuf,
+}
+
+impl StartupPaths {
+    /// Return the validated absolute home directory.
+    pub fn home(&self) -> &Path {
+        &self.home
+    }
+
+    /// Return the validated absolute config-file path.
+    pub fn config(&self) -> &Path {
+        &self.config
+    }
+}
+
+/// Resolve zero or one config argument against an explicit home value.
+pub fn resolve_startup_paths<I>(
+    args: I,
+    home: Option<OsString>,
+) -> Result<StartupPaths, ChiefDaemonError>
+where
+    I: IntoIterator<Item = OsString>,
+{
+    let home = home
+        .map(PathBuf::from)
+        .ok_or(ChiefDaemonError::HomeUnavailable)?;
+    if !is_safe_absolute(&home) {
+        return Err(ChiefDaemonError::HomeUnavailable);
+    }
+    let mut args = args.into_iter();
+    let config = match args.next() {
+        Some(path) => PathBuf::from(path),
+        None => home.join(DEFAULT_CONFIG_SUFFIX),
+    };
+    if args.next().is_some() || !is_safe_absolute(&config) {
+        return Err(ChiefDaemonError::InvalidInvocation);
+    }
+    Ok(StartupPaths { home, config })
+}
+
+/// Load one bounded, stable, regular config file and apply the strict schema.
+pub fn load_config_file(path: &Path) -> Result<ChiefConfig, ChiefDaemonError> {
+    if !is_safe_absolute(path) {
+        return Err(ChiefDaemonError::InvalidInvocation);
+    }
+    let before = fs::symlink_metadata(path).map_err(|_| ChiefDaemonError::ConfigFileUnavailable)?;
+    if !before.file_type().is_file() {
+        return Err(ChiefDaemonError::ConfigFileNotRegular);
+    }
+    let file = open_readonly(path)?;
+    let opened = file
+        .metadata()
+        .map_err(|_| ChiefDaemonError::ConfigFileUnavailable)?;
+    let after = fs::symlink_metadata(path).map_err(|_| ChiefDaemonError::ConfigFileUnavailable)?;
+    if !opened.file_type().is_file() || !after.file_type().is_file() {
+        return Err(ChiefDaemonError::ConfigFileNotRegular);
+    }
+    if !same_file(&before, &opened) || !same_file(&after, &opened) {
+        return Err(ChiefDaemonError::ConfigFileChanged);
+    }
+    let mut bytes = Vec::with_capacity(MAX_CONFIG_BYTES + 1);
+    file.take((MAX_CONFIG_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|_| ChiefDaemonError::ConfigFileUnavailable)?;
+    if bytes.len() > MAX_CONFIG_BYTES {
+        return Err(ChiefDaemonError::ConfigFileTooLarge);
+    }
+    let source = std::str::from_utf8(&bytes).map_err(|_| ChiefDaemonError::ConfigFileEncoding)?;
+    parse_config(source).map_err(ChiefDaemonError::Config)
+}
+
+#[cfg(not(windows))]
+fn open_readonly(path: &Path) -> Result<File, ChiefDaemonError> {
+    File::open(path).map_err(|_| ChiefDaemonError::ConfigFileUnavailable)
+}
+
+#[cfg(windows)]
+fn open_readonly(path: &Path) -> Result<File, ChiefDaemonError> {
+    use std::os::windows::fs::OpenOptionsExt;
+    std::fs::OpenOptions::new()
+        .read(true)
+        .share_mode(windows_sys::Win32::Storage::FileSystem::FILE_SHARE_READ)
+        .open(path)
+        .map_err(|_| ChiefDaemonError::ConfigFileUnavailable)
+}
+
+/// Resolve process environment and run the daemon until shutdown or failure.
+pub fn run_from_env() -> Result<(), ChiefDaemonError> {
+    let home = platform_home();
+    let paths = resolve_startup_paths(env::args_os().skip(1), home)?;
+    let config = load_config_file(paths.config())?;
+    run(config, paths.home())
+}
+
+/// Compose all production adapters from a validated config and explicit home.
+pub fn run(config: ChiefConfig, home: &Path) -> Result<(), ChiefDaemonError> {
+    if !is_safe_absolute(home) {
+        return Err(ChiefDaemonError::HomeUnavailable);
+    }
+    let state_dir = config
+        .orchestrator()
+        .state_dir()
+        .resolve(home)
+        .map_err(ChiefDaemonError::Config)?;
+    let credential_path = config
+        .orchestrator()
+        .credential_path()
+        .resolve(home)
+        .map_err(ChiefDaemonError::Config)?;
+    let host_executable = config
+        .host_defaults()
+        .executable()
+        .resolve(home)
+        .map_err(ChiefDaemonError::Config)?;
+
+    let keyring =
+        Arc::new(load_package_keyring(config.keyring(), home).map_err(ChiefDaemonError::Keyring)?);
+    let credential =
+        load_or_create_credential(&credential_path).map_err(ChiefDaemonError::Credential)?;
+    let bearer =
+        LocalBearerAuthorizer::new(&credential).map_err(ChiefDaemonError::Authentication)?;
+    drop(credential);
+
+    let backend: Arc<dyn StorageBackend> = Arc::new(FsStorageBackend::new(state_dir));
+    backend.initialize().map_err(ChiefDaemonError::Storage)?;
+    let program = HostProgram::new(host_executable, std::iter::empty::<OsString>())
+        .map_err(ChiefDaemonError::Process)?;
+    let process_config = ProcessSupervisorConfig::new(
+        program,
+        config.host_defaults().bootstrap_timeout(),
+        config.host_defaults().graceful_stop_timeout(),
+    )
+    .map_err(ChiefDaemonError::Process)?;
+    let interval = config.host_defaults().health_check_interval();
+    let interval_ns = u64::try_from(interval.as_nanos()).unwrap_or(u64::MAX);
+    let reconcile_config =
+        ReconcileConfig::new(interval_ns.saturating_mul(HEARTBEAT_GRACE_INTERVALS))
+            .map_err(ChiefDaemonError::Reconciliation)?;
+    let schedule = ReconcileSchedule::new(interval).map_err(ChiefDaemonError::Runtime)?;
+    let clock = Arc::new(SystemMonotonicClock::new());
+    let core = OrchestratorCore::with_process_supervisor(
+        backend,
+        process_config,
+        keyring,
+        Arc::new(generate_identity_keypair()),
+        clock,
+        Box::new(UuidV7SessionIdSource),
+        reconcile_config,
+        DenyChannelWiring,
+    );
+    let api = Arc::new(DaemonApi::new(core, bearer));
+    let address = BindAddress::Ip(SocketAddr::new(
+        config.orchestrator().bind(),
+        config.orchestrator().port(),
+    ));
+    run_platform(address, api, schedule)
+}
+
+fn serve<P, C, A>(
+    platform: P,
+    address: BindAddress,
+    api: Arc<DaemonApi<C, A>>,
+    schedule: ReconcileSchedule,
+) -> Result<(), ChiefDaemonError>
+where
+    P: TransportPlatform,
+    C: chief_of_staff_daemon_api::ChiefControlPlane + Send + 'static,
+    A: chief_of_staff_daemon_api::SessionAuthorizer + Send + Sync + 'static,
+    A::Session: Send + 'static,
+{
+    let mut runtime = ChiefDaemonRuntime::bind(
+        platform,
+        address,
+        WebSocketServerOptions::default(),
+        Arc::clone(&api),
+        schedule,
+    )
+    .map_err(ChiefDaemonError::Runtime)?;
+    let stop = runtime.stop_handle();
+    let listener =
+        ShutdownListener::install(move |_| stop.stop()).map_err(ChiefDaemonError::Shutdown)?;
+    eprintln!("chief daemon listening on {}", runtime.local_addr());
+    let runtime_result = runtime.serve();
+    let shutdown_result = listener.uninstall();
+    drop(runtime);
+    let recovery_result = Arc::try_unwrap(api)
+        .map_err(|_| ChiefDaemonError::ControlPlaneRetained)
+        .and_then(|api| {
+            api.into_parts()
+                .map(|_| ())
+                .map_err(ChiefDaemonError::ControlPlaneRecovery)
+        });
+    runtime_result.map_err(ChiefDaemonError::Runtime)?;
+    shutdown_result.map_err(ChiefDaemonError::Shutdown)?;
+    recovery_result
+}
+
+#[cfg(target_os = "linux")]
+fn run_platform<C, A>(
+    address: BindAddress,
+    api: Arc<DaemonApi<C, A>>,
+    schedule: ReconcileSchedule,
+) -> Result<(), ChiefDaemonError>
+where
+    C: chief_of_staff_daemon_api::ChiefControlPlane + Send + 'static,
+    A: chief_of_staff_daemon_api::SessionAuthorizer + Send + Sync + 'static,
+    A::Session: Send + 'static,
+{
+    let platform = transport_platform::linux::EpollTransportPlatform::new()
+        .map_err(ChiefDaemonError::Platform)?;
+    serve(platform, address, api, schedule)
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+fn run_platform<C, A>(
+    address: BindAddress,
+    api: Arc<DaemonApi<C, A>>,
+    schedule: ReconcileSchedule,
+) -> Result<(), ChiefDaemonError>
+where
+    C: chief_of_staff_daemon_api::ChiefControlPlane + Send + 'static,
+    A: chief_of_staff_daemon_api::SessionAuthorizer + Send + Sync + 'static,
+    A::Session: Send + 'static,
+{
+    let platform = transport_platform::bsd::KqueueTransportPlatform::new()
+        .map_err(ChiefDaemonError::Platform)?;
+    serve(platform, address, api, schedule)
+}
+
+#[cfg(target_os = "windows")]
+fn run_platform<C, A>(
+    address: BindAddress,
+    api: Arc<DaemonApi<C, A>>,
+    schedule: ReconcileSchedule,
+) -> Result<(), ChiefDaemonError>
+where
+    C: chief_of_staff_daemon_api::ChiefControlPlane + Send + 'static,
+    A: chief_of_staff_daemon_api::SessionAuthorizer + Send + Sync + 'static,
+    A::Session: Send + 'static,
+{
+    let platform = transport_platform::windows::WindowsTransportPlatform::new()
+        .map_err(ChiefDaemonError::Platform)?;
+    serve(platform, address, api, schedule)
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly",
+    target_os = "windows"
+)))]
+fn run_platform<C, A>(
+    _address: BindAddress,
+    _api: Arc<DaemonApi<C, A>>,
+    _schedule: ReconcileSchedule,
+) -> Result<(), ChiefDaemonError> {
+    Err(ChiefDaemonError::UnsupportedPlatform)
+}
+
+#[cfg(unix)]
+fn platform_home() -> Option<OsString> {
+    env::var_os("HOME")
+}
+
+#[cfg(windows)]
+fn platform_home() -> Option<OsString> {
+    env::var_os("USERPROFILE")
+}
+
+#[cfg(not(any(unix, windows)))]
+fn platform_home() -> Option<OsString> {
+    None
+}
+
+fn is_safe_absolute(path: &Path) -> bool {
+    path.is_absolute()
+        && !path
+            .components()
+            .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
+}
+
+#[cfg(unix)]
+fn same_file(left: &Metadata, right: &Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    left.dev() == right.dev() && left.ino() == right.ino()
+}
+
+#[cfg(windows)]
+fn same_file(left: &Metadata, right: &Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+    left.file_attributes() == right.file_attributes()
+        && left.creation_time() == right.creation_time()
+        && left.last_write_time() == right.last_write_time()
+        && left.file_size() == right.file_size()
+}
+
+#[cfg(not(any(unix, windows)))]
+fn same_file(left: &Metadata, right: &Metadata) -> bool {
+    left.len() == right.len()
+        && left.modified().ok() == right.modified().ok()
+        && left.created().ok() == right.created().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_DIR: AtomicU64 = AtomicU64::new(0);
+
+    const VALID_CONFIG: &str = r#"
+[orchestrator]
+bind = "127.0.0.1"
+port = 7463
+packages_dir = "~/.chief-of-staff/agents/"
+state_dir = "~/.chief-of-staff/state/"
+credential_path = "~/.chief-of-staff/run/operator.credential"
+
+[keyring]
+trusted_keys = [
+  { id = "prod-001", path = "~/.chief-of-staff/keys/prod.pub", type = "production" },
+]
+
+[hosts.defaults]
+restart_policy = "on-failure"
+health_check_interval = 5000
+executable = "~/.chief-of-staff/bin/chief-of-staff-host"
+bootstrap_timeout = 10000
+graceful_stop_timeout = 5000
+
+[vault]
+storage_path = "~/.chief-of-staff/vault/"
+default_lease_ttl = 30
+container = true
+
+[privilege]
+tier_1_auto_approve_timeout = 5
+biometric_timeout = 30
+hardware_key_timeout = 60
+"#;
+
+    struct TestDir(PathBuf);
+
+    impl TestDir {
+        fn new() -> Self {
+            let path = env::temp_dir().join(format!(
+                "chief-daemon-app-{}-{}",
+                std::process::id(),
+                NEXT_DIR.fetch_add(1, Ordering::Relaxed)
+            ));
+            fs::create_dir(&path).unwrap();
+            Self(path)
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn resolves_default_and_explicit_absolute_config_paths() {
+        let directory = TestDir::new();
+        let default = resolve_startup_paths(
+            Vec::<OsString>::new(),
+            Some(directory.0.clone().into_os_string()),
+        )
+        .unwrap();
+        assert_eq!(default.home(), directory.0);
+        assert_eq!(default.config(), directory.0.join(DEFAULT_CONFIG_SUFFIX));
+
+        let explicit_path = directory.0.join("custom.toml");
+        let explicit = resolve_startup_paths(
+            vec![explicit_path.clone().into_os_string()],
+            Some(directory.0.clone().into_os_string()),
+        )
+        .unwrap();
+        assert_eq!(explicit.config(), explicit_path);
+    }
+
+    #[test]
+    fn rejects_missing_home_relative_paths_and_extra_arguments() {
+        assert_eq!(
+            resolve_startup_paths(Vec::<OsString>::new(), None)
+                .unwrap_err()
+                .to_string(),
+            "chief daemon: home directory unavailable"
+        );
+        let directory = TestDir::new();
+        assert!(matches!(
+            resolve_startup_paths(
+                vec![OsString::from("relative.toml")],
+                Some(directory.0.clone().into_os_string())
+            ),
+            Err(ChiefDaemonError::InvalidInvocation)
+        ));
+        assert!(matches!(
+            resolve_startup_paths(
+                vec![
+                    directory.0.join("one").into_os_string(),
+                    directory.0.join("two").into_os_string()
+                ],
+                Some(directory.0.clone().into_os_string())
+            ),
+            Err(ChiefDaemonError::InvalidInvocation)
+        ));
+    }
+
+    #[test]
+    fn loads_a_bounded_regular_config() {
+        let directory = TestDir::new();
+        let path = directory.0.join("config.toml");
+        fs::write(&path, VALID_CONFIG).unwrap();
+        let config = load_config_file(&path).unwrap();
+        assert_eq!(config.orchestrator().port(), 7463);
+    }
+
+    #[test]
+    fn rejects_oversized_and_non_utf8_configs() {
+        let directory = TestDir::new();
+        let oversized = directory.0.join("oversized.toml");
+        fs::write(&oversized, vec![b'x'; MAX_CONFIG_BYTES + 1]).unwrap();
+        assert!(matches!(
+            load_config_file(&oversized),
+            Err(ChiefDaemonError::ConfigFileTooLarge)
+        ));
+        let encoded = directory.0.join("encoded.toml");
+        fs::write(&encoded, [0xff]).unwrap();
+        assert!(matches!(
+            load_config_file(&encoded),
+            Err(ChiefDaemonError::ConfigFileEncoding)
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_a_final_config_symlink() {
+        use std::os::unix::fs::symlink;
+        let directory = TestDir::new();
+        let target = directory.0.join("target.toml");
+        let link = directory.0.join("config.toml");
+        fs::write(&target, VALID_CONFIG).unwrap();
+        symlink(&target, &link).unwrap();
+        assert!(matches!(
+            load_config_file(&link),
+            Err(ChiefDaemonError::ConfigFileNotRegular)
+        ));
+    }
+}

--- a/code/packages/rust/chief-of-staff-daemon/src/main.rs
+++ b/code/packages/rust/chief-of-staff-daemon/src/main.rs
@@ -1,0 +1,8 @@
+//! Process entry point for the D18 Chief daemon.
+
+fn main() {
+    if let Err(error) = chief_of_staff_daemon::run_from_env() {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+}

--- a/code/packages/rust/chief-of-staff-daemon/tests/daemon_smoke.rs
+++ b/code/packages/rust/chief-of-staff-daemon/tests/daemon_smoke.rs
@@ -1,0 +1,140 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::io::Read;
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+static NEXT_DIR: AtomicU64 = AtomicU64::new(0);
+
+struct TestDir(PathBuf);
+
+impl TestDir {
+    fn new() -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "chief-daemon-smoke-{}-{}",
+            std::process::id(),
+            NEXT_DIR.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir(&path).unwrap();
+        Self(path.canonicalize().unwrap())
+    }
+}
+
+impl Drop for TestDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn wait_until_listening(child: &mut Child, port: u16) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return;
+        }
+        if let Some(status) = child.try_wait().unwrap() {
+            let mut stderr = String::new();
+            child
+                .stderr
+                .as_mut()
+                .unwrap()
+                .read_to_string(&mut stderr)
+                .unwrap();
+            panic!("daemon exited before binding ({status}): {stderr}");
+        }
+        assert!(Instant::now() < deadline, "daemon did not bind in time");
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn wait_for_exit(child: &mut Child) -> std::process::ExitStatus {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            return status;
+        }
+        assert!(Instant::now() < deadline, "daemon did not stop in time");
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn write_config(home: &Path, port: u16) -> PathBuf {
+    fs::create_dir(home.join("run")).unwrap();
+    fs::create_dir(home.join("keys")).unwrap();
+    let public_key = coding_adventures_ed25519::generate_keypair(&[7; 32]).0;
+    fs::write(home.join("keys/production.pub"), public_key).unwrap();
+    let config = format!(
+        r#"
+[orchestrator]
+bind = "127.0.0.1"
+port = {port}
+packages_dir = "~/agents"
+state_dir = "~/state"
+credential_path = "~/run/operator.credential"
+
+[keyring]
+trusted_keys = [
+  {{ id = "prod-001", path = "~/keys/production.pub", type = "production" }},
+]
+
+[hosts.defaults]
+restart_policy = "on-failure"
+health_check_interval = 20
+executable = "~/bin/chief-of-staff-host"
+bootstrap_timeout = 1000
+graceful_stop_timeout = 1000
+
+[vault]
+storage_path = "~/vault"
+default_lease_ttl = 30
+container = true
+
+[privilege]
+tier_1_auto_approve_timeout = 5
+biometric_timeout = 30
+hardware_key_timeout = 60
+"#
+    );
+    let path = home.join("config.toml");
+    fs::write(&path, config).unwrap();
+    path
+}
+
+#[test]
+fn daemon_binds_reconciles_and_stops_on_sigterm() {
+    let directory = TestDir::new();
+    let port = TcpListener::bind(("127.0.0.1", 0))
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port();
+    let config = write_config(&directory.0, port);
+    let mut child = Command::new(env!("CARGO_BIN_EXE_chief-of-staff-daemon"))
+        .arg(config)
+        .env("HOME", &directory.0)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    wait_until_listening(&mut child, port);
+    // SAFETY: `child.id()` is the live subprocess created above, and SIGTERM is
+    // installed by that subprocess's process-shutdown listener.
+    assert_eq!(unsafe { libc::kill(child.id() as i32, libc::SIGTERM) }, 0);
+    let status = wait_for_exit(&mut child);
+    let mut stderr = String::new();
+    child
+        .stderr
+        .as_mut()
+        .unwrap()
+        .read_to_string(&mut stderr)
+        .unwrap();
+    assert!(status.success(), "daemon failed ({status}): {stderr}");
+    assert!(directory.0.join("run/operator.credential").is_file());
+    assert!(directory.0.join("state").is_dir());
+}

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -2034,6 +2034,20 @@ creation supplies a protected DACL with exactly one allow ACE for the current to
 user. Existing Windows credentials must retain that owner and protected one-ACE DACL;
 inherited directory permissions are not sufficient.
 
+The concrete `chief-of-staff-daemon` executable is the composition root for these
+contracts. With no arguments it resolves `~/.chief-of-staff/config.toml` from the
+platform user-home environment; one explicit absolute config path is also accepted.
+The config file is bounded to 256 KiB, must remain a regular non-link file throughout
+loading, and is parsed by the closed schema above. Startup then loads the package
+keyring and local credential, initializes the filesystem service registry, constructs
+the verified shell-free host supervisor, binds the authenticated WebSocket API to the
+validated loopback address, reconciles once, and schedules further reconciliation at
+`health_check_interval`. Three missed intervals are tolerated before a heartbeat is
+stale. Channel topology mutation remains fail-closed until the Trust Checker exists.
+Unix `SIGINT`/`SIGTERM` and Windows console termination events cooperatively stop the
+listener; teardown releases the control plane and reaps every child owned by that
+daemon instance.
+
 **Host restart policies:**
 
 | Policy       | Behavior                                          |


### PR DESCRIPTION
## Summary

- add the concrete `chief-of-staff-daemon` composition root and executable
- load bounded configuration, trusted package keys, owner-only credentials, storage, the process supervisor, API, scheduler, and platform shutdown signals
- keep the initial channel topology deny-all and document the exact startup/shutdown contract in D18
- make Windows key-file validation use stable APIs while denying writer/delete sharing during the read

## Security

- enforce loopback-only serving from the strict configuration schema
- zeroize the bearer credential after constructing the retained constant-time authorizer
- reject oversized, relative, linked, or non-regular configuration/key material as applicable
- emit stable payload-blind startup errors

## Validation

- `sh chief-of-staff-daemon/BUILD` (5 unit tests, subprocess smoke test, strict Clippy, rustdoc warnings denied)
- focused Tarpaulin: 127/158 lines, 80.38%
- Windows cross-target `cargo check --all-targets` and strict Clippy
- Linux cross-target `cargo check --all-targets`
- affected Rust plan: 63 built, 866 skipped
- `git diff --check`

Advances #128 and #138.