### PR TITLE
fix(spice): lower diode energy gap

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower diode model-card `EG` energy gap.
 - Validate and lower diode model-card `XTI` temperature exponent.
 - Validate and lower diode model-card `FC` depletion coefficient.
 - Validate and lower diode model-card `M` / `MJ` grading coefficient.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1278,6 +1278,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             M=model.params.get("M", model.params.get("MJ", 0.5)),
             Fc=model.params.get("FC", 0.5),
             Xti=model.params.get("XTI", 3.0),
+            Eg=model.params.get("EG", 1.11),
             Rs=model.params.get("RS", 0.0),
         )
     if prefix == "Q":
@@ -1989,6 +1990,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             temperature_exponent
         ):
             raise NetlistParseError("diode XTI must be finite")
+        energy_gap = params.get("EG")
+        if energy_gap is not None and (
+            not math.isfinite(energy_gap) or energy_gap <= 0.0
+        ):
+            raise NetlistParseError("diode EG must be finite and positive")
     if kind in {"NPN", "PNP"}:
         saturation_current = params.get("IS")
         if saturation_current is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -999,6 +999,23 @@ def test_rejects_non_finite_diode_temperature_exponent() -> None:
         parse_netlist(".model clamp D(XTI=1e999)")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0.5", 0.5), ("1.2", 1.2)])
+def test_lowers_positive_diode_energy_gap(value: str, expected: float) -> None:
+    parsed = parse_netlist(f".model clamp D(EG={value})\nD1 in out clamp")
+
+    diode = parsed.circuit.elements[0]
+    assert isinstance(diode, Diode)
+    assert diode.Eg == expected
+
+
+@pytest.mark.parametrize("value", ["0", "-0.1", "1e999"])
+def test_rejects_invalid_diode_energy_gap(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="diode EG must be finite and positive"
+    ):
+        parse_netlist(f".model clamp D(EG={value})")
+
+
 def test_parse_diode_junction_capacitance_alias() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower diode model-card `EG` energy gap.
 - Validate and lower diode model-card `XTI` temperature exponent.
 - Validate and lower diode model-card `FC` depletion coefficient.
 - Validate and lower diode model-card `M` / `MJ` grading coefficient.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1249,6 +1249,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("diode XTI must be finite");
   }
+  const diodeEnergyGap = params.get("EG");
+  if (
+    kind === "D" &&
+    diodeEnergyGap !== undefined &&
+    (!Number.isFinite(diodeEnergyGap) || diodeEnergyGap <= 0.0)
+  ) {
+    throw new NetlistParseError("diode EG must be finite and positive");
+  }
   const bjtForwardBeta =
     params.get("BF") ??
     params.get("BETA") ??
@@ -1839,6 +1847,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       gradingCoefficient: model.params.get("M") ?? model.params.get("MJ") ?? 0.5,
       forwardBiasDepletionCoefficient: model.params.get("FC") ?? 0.5,
       saturationCurrentTemperatureExponent: model.params.get("XTI") ?? 3.0,
+      energyGapElectronVolts: model.params.get("EG") ?? 1.11,
       seriesResistance: model.params.get("RS") ?? 0.0,
     };
   }

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1044,6 +1044,24 @@ D1 in out clamp
     );
   });
 
+  it.each([
+    ["0.5", 0.5],
+    ["1.2", 1.2],
+  ])("lowers positive diode EG energy gap %s", (value, expected) => {
+    const parsed = parseNetlist(`.model clamp D(EG=${value})\nD1 in out clamp`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "diode",
+      energyGapElectronVolts: expected,
+    });
+  });
+
+  it.each(["0", "-0.1", "1e999"])("rejects invalid diode EG %s", (value) => {
+    expect(() => parseNetlist(`.model clamp D(EG=${value})`)).toThrow(
+      "diode EG must be finite and positive",
+    );
+  });
+
   it("parses BJT models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NPN(IS=1e-14 BF=120 VT=25m CJE=2p CJC=3p TF=4n TR=5n)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4426,15 +4426,20 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine diode depletion-coefficient field.
 
 421. Python and TypeScript Berkeley SPICE diode temperature-exponent parity.
-   - Status: completed in this diode temperature-exponent parity slice.
+   - Status: completed in PR 9824.
    - Both parser facades validate finite `XTI` values and lower them into the
      shared engine diode saturation-current temperature-exponent field.
+
+422. Python and TypeScript Berkeley SPICE diode energy-gap parity.
+   - Status: completed in this diode energy-gap parity slice.
+   - Both parser facades validate positive finite `EG` values and lower them
+     into the shared engine diode energy-gap field.
 
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE model-card validation parity.
-   - Continue the audited diode model-card lowering surfaces with `EG`, `KF`,
-     and `AF` validation and lowering parity.
+   - Continue the audited diode model-card lowering surfaces with `KF` and `AF`
+     validation and lowering parity.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary
- validate positive finite diode model-card `EG` values in Python and TypeScript
- lower valid values into the existing engine energy-gap field
- add cross-language parity coverage and advance the SPICE completion backlog

## Verification
- Python `spice-netlist-parser`: `bash BUILD` (342 tests), Ruff clean
- TypeScript `spice-engine`: `bash BUILD` (448 tests)
- TypeScript `spice-netlist-parser`: `bash BUILD` (331 tests)
- TypeScript parser coverage: 86.31% lines