### PR TITLE
feat(ruby): bracket-index write with a dotted/chained receiver

### DIFF
--- a/code/grammars/ruby/ruby.grammar
+++ b/code/grammars/ruby/ruby.grammar
@@ -477,12 +477,34 @@ ensure_clause   = "ensure" { !"end" statement } ;
 # `[` where an assignment operator was expected. Placed BEFORE `assignment`
 # so the bracket form wins — `assignment` itself fails to match cleanly on
 # `NAME [` anyway (no assignment operator follows a bare `NAME` there), so
-# this ordering doesn't shadow anything. v0 scope: a single bracket on a
-# bare NAME receiver (`a[i] = v`, `h[k] = v`) — a dotted/chained receiver
-# (`obj.data[i] = v`) or nested brackets on the LHS (`a[i][j] = v`) are NOT
-# covered by this rule (falls through to a clean parse-error, not a silent
-# misparse); can be widened later if needed.
-index_assignment = NAME index_suffix EQUALS expression ;
+# this ordering doesn't shadow anything.
+#
+# Widened to a dotted/chained receiver (`obj.data[i] = v`) and nested
+# brackets (`a[i][j] = v`) — originally v0-scoped to a bare-NAME, single-
+# bracket receiver only. The widened LHS reuses `dot_call`/`scope_resolution`/
+# `index_suffix`, the SAME three postfix element kinds `factor`'s own
+# repetition already admits for READS, so the receiver chain covers exactly
+# what a read expression like `obj.data[i]` already parses as.
+#
+# The tricky part: telling apart "brackets that belong to the RECEIVER"
+# from "the FINAL bracket that's actually being assigned into." For
+# `a[i][j] = v`, `[i]` is a receiver postfix (read `a[i]` first, THEN write
+# index `j` into it) while `[j]` is the write target — but a plain greedy
+# `{ dot_call | scope_resolution | index_suffix }` repetition (this parser
+# has no backtracking once a repetition commits) would swallow BOTH
+# brackets, leaving nothing for a REQUIRED trailing `index_suffix` to match
+# and failing the whole rule. Fixed with a positive lookahead
+# (`index_write_receiver_postfix &index_write_receiver_postfix`): each
+# repetition iteration only commits to consuming a postfix element if
+# ANOTHER one is confirmed to follow (checked without consuming) — so for
+# `a[i][j]`, `[i]` is consumed (an ELSE follows: `[j]`) but `[j]` is NOT
+# (nothing postfix-shaped follows — next is `=`), correctly leaving `[j]`
+# for the mandatory trailing `index_suffix`. For the original single-
+# bracket case (`a[i] = v`), the lookahead fails on the very first
+# iteration (nothing follows `[i]` either), so the repetition contributes
+# zero elements and behavior is unchanged from before this widening.
+index_write_receiver_postfix = dot_call | scope_resolution | index_suffix ;
+index_assignment = NAME { index_write_receiver_postfix &index_write_receiver_postfix } index_suffix EQUALS expression ;
 assignment   = NAME ( EQUALS | "+=" | "-=" | "*=" | "/=" | "%=" | "**=" | "<<=" | ">>=" | "&=" | "|=" | "^=" | "||=" | "&&=" ) expression ;
 # Phase 7e — Ruby 3.0 rightward (single-line) assignment `expr => var`.
 #

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.8.1] - 2026-08-03
+
+### Widened — bracket-index WRITE (`recv[expr] = value`) to a dotted/chained receiver
+
+`index_assignment` was v0-scoped to a bare-`NAME`, single-bracket receiver
+only (`a[i] = v`, `h[k] = v`) — a dotted receiver (`obj.data[i] = v`) or
+nested brackets (`a[i][j] = v`) fell through to a clean parse error.
+Widened via a new `index_write_receiver_postfix = dot_call |
+scope_resolution | index_suffix` rule, reused in a repetition:
+`index_assignment = NAME { index_write_receiver_postfix
+&index_write_receiver_postfix } index_suffix EQUALS expression`.
+
+The interesting part: telling apart brackets that belong to the RECEIVER
+from the FINAL bracket that's the actual write target. For `a[i][j] = v`,
+a plain greedy `{ dot_call | scope_resolution | index_suffix }`
+repetition (this parser has no backtracking once a repetition commits)
+would swallow BOTH brackets, leaving nothing for the required trailing
+`index_suffix` and failing the whole rule. Fixed with a POSITIVE
+LOOKAHEAD: each repetition iteration only commits to consuming a postfix
+element if ANOTHER one is confirmed to follow (checked without
+consuming) — so `[i]` in `a[i][j]` is consumed (`[j]` follows) but `[j]`
+is not (nothing follows — next is `=`), correctly leaving it for the
+mandatory trailing `index_suffix`. Verified with a standalone probe
+grammar before touching `ruby.grammar` (no prior usage of a
+lookahead-over-a-grouped-alternation existed anywhere in this repo's
+~130 grammar files, so this was unverified territory for the shared
+`parser` engine). The original single-bracket case parses identically to
+before (the lookahead fails on the very first iteration, contributing
+zero repetition elements).
+
+New tests: `test_bracket_index_write_with_chained_brackets`,
+`test_bracket_index_write_with_dotted_receiver`,
+`test_bracket_index_write_single_bracket_still_has_no_receiver_postfix`
+(the backward-compatibility regression check).
+
+`coding-adventures-ruby-parser` 0.8.0 -> 0.8.1.
+
 ## [0.8.0] - 2026-08-03
 
 ### Added — `<<` as a binary operator

--- a/code/packages/rust/ruby-parser/Cargo.toml
+++ b/code/packages/rust/ruby-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-ruby-parser"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 description = "Ruby parser — parses Ruby source code into an AST using the grammar-driven parser and the ruby.grammar file"
 

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -700,14 +700,27 @@ pub fn parser_grammar() -> ParserGrammar {
             line_number: 453,
         },
         GrammarRule {
+            name: r#"index_write_receiver_postfix"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"dot_call"#.to_string() },
+                GrammarElement::RuleReference { name: r#"scope_resolution"#.to_string() },
+                GrammarElement::RuleReference { name: r#"index_suffix"#.to_string() },
+            ] },
+            line_number: 506,
+        },
+        GrammarRule {
             name: r#"index_assignment"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::RuleReference { name: r#"index_write_receiver_postfix"#.to_string() },
+                        GrammarElement::PositiveLookahead { element: Box::new(GrammarElement::RuleReference { name: r#"index_write_receiver_postfix"#.to_string() }) },
+                    ] }) },
                 GrammarElement::RuleReference { name: r#"index_suffix"#.to_string() },
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 485,
+            line_number: 507,
         },
         GrammarRule {
             name: r#"assignment"#.to_string(),
@@ -731,7 +744,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 486,
+            line_number: 508,
         },
         GrammarRule {
             name: r#"rightward_assignment"#.to_string(),
@@ -740,7 +753,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"=>"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 505,
+            line_number: 527,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -763,7 +776,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 522,
+            line_number: 544,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -786,7 +799,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"block"#.to_string() }) },
             ] },
-            line_number: 523,
+            line_number: 545,
         },
         GrammarRule {
             name: r#"scope_resolution"#.to_string(),
@@ -797,7 +810,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
                     ] }) },
             ] },
-            line_number: 531,
+            line_number: 553,
         },
         GrammarRule {
             name: r#"call_arg"#.to_string(),
@@ -816,7 +829,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 586,
+            line_number: 608,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -842,17 +855,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 634,
+            line_number: 656,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 637,
+            line_number: 659,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 744,
+            line_number: 766,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -865,7 +878,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 745,
+            line_number: 767,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -888,7 +901,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 746,
+            line_number: 768,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -902,7 +915,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 747,
+            line_number: 769,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -916,7 +929,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 748,
+            line_number: 770,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -927,7 +940,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 755,
+            line_number: 777,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -945,7 +958,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"shift"#.to_string() },
                     ] }) },
             ] },
-            line_number: 771,
+            line_number: 793,
         },
         GrammarRule {
             name: r#"shift"#.to_string(),
@@ -956,7 +969,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 772,
+            line_number: 794,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -970,7 +983,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 773,
+            line_number: 795,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -984,7 +997,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 774,
+            line_number: 796,
         },
         GrammarRule {
             name: r#"super_expr"#.to_string(),
@@ -992,7 +1005,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"super"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"super_args"#.to_string() }) },
             ] },
-            line_number: 843,
+            line_number: 865,
         },
         GrammarRule {
             name: r#"index_suffix"#.to_string(),
@@ -1001,7 +1014,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 855,
+            line_number: 877,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -1042,7 +1055,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"index_suffix"#.to_string() },
                     ] }) },
             ] },
-            line_number: 856,
+            line_number: 878,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -1055,7 +1068,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 875,
+            line_number: 897,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -1063,7 +1076,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 876,
+            line_number: 898,
         },
         GrammarRule {
             name: r#"defined_expression"#.to_string(),
@@ -1071,7 +1084,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"defined?"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 887,
+            line_number: 909,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -1083,7 +1096,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 894,
+            line_number: 916,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -1098,7 +1111,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 895,
+            line_number: 917,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -1113,7 +1126,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 896,
+            line_number: 918,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -1133,7 +1146,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 897,
+            line_number: 919,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -5290,6 +5290,66 @@ mod tests {
         }
     }
 
+    // -------------------------------------------------------------------
+    // Widened `index_assignment` to a dotted/chained receiver
+    // (`obj.data[i] = v`, `a[i][j] = v`) -- originally v0-scoped to a
+    // bare-NAME, single-bracket receiver only (see the grammar's
+    // `index_write_receiver_postfix` rule for the lookahead trick that
+    // tells the RECEIVER's postfixes apart from the FINAL write-target
+    // bracket, needed since this parser has no backtracking once a
+    // repetition commits).
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn test_bracket_index_write_with_chained_brackets() {
+        // `a[0][1] = 3` -- the FIRST `[0]` belongs to the receiver chain
+        // (wrapped in `index_write_receiver_postfix`), the SECOND `[1]` is
+        // the write target (the rule's own trailing, mandatory
+        // `index_suffix`).
+        let ast = parse_ruby("a[0][1] = 3\n");
+        assert_program_root(&ast);
+        assert_eq!(count_statements(&ast), 1);
+        let ia = find_descendant(&ast, "index_assignment")
+            .expect("expected index_assignment subnode");
+        assert!(
+            tree_contains_rule(ia, "index_write_receiver_postfix"),
+            "the first bracket should be a receiver postfix, not the write target"
+        );
+    }
+
+    #[test]
+    fn test_bracket_index_write_with_dotted_receiver() {
+        // `obj.data[0] = 3` -- `.data` is a receiver postfix (a `dot_call`
+        // wrapped in `index_write_receiver_postfix`), `[0]` is the write
+        // target.
+        let ast = parse_ruby("obj.data[0] = 3\n");
+        assert_program_root(&ast);
+        assert_eq!(count_statements(&ast), 1);
+        let ia = find_descendant(&ast, "index_assignment")
+            .expect("expected index_assignment subnode");
+        let postfix = find_descendant(ia, "index_write_receiver_postfix")
+            .expect("expected a receiver postfix");
+        assert!(
+            tree_contains_rule(postfix, "dot_call"),
+            "the receiver postfix should wrap a dot_call"
+        );
+    }
+
+    #[test]
+    fn test_bracket_index_write_single_bracket_still_has_no_receiver_postfix() {
+        // Regression: the ORIGINAL v0-scoped shape (no receiver postfixes
+        // at all) must still parse the same way after widening the
+        // grammar to admit the (now-optional) postfix chain.
+        let ast = parse_ruby("a[0] = 9\n");
+        assert_program_root(&ast);
+        let ia = find_descendant(&ast, "index_assignment")
+            .expect("expected index_assignment subnode");
+        assert!(
+            !tree_contains_rule(ia, "index_write_receiver_postfix"),
+            "a single-bracket write has no receiver postfixes"
+        );
+    }
+
     #[test]
     fn test_bracket_index_write_is_not_confused_with_plain_assignment() {
         // A plain assignment (`x = 1`) must NOT be mis-routed through the new

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## 0.9.1 — lower a dotted/chained bracket-index write receiver
+
+`ruby-parser` 0.8.1 widens `index_assignment`'s grammar to admit a
+receiver postfix chain (`index_write_receiver_postfix` — `dot_call` /
+`scope_resolution` / `index_suffix`) before the mandatory write-target
+`index_suffix`. This release adds the matching lowering: for each
+`index_write_receiver_postfix` child, unwrap its single
+`dot_call`/`scope_resolution`/`index_suffix` grandchild and fold it into
+the running `receiver` expression via the SAME `fold_one_dot_call`/
+`fold_one_scope_resolution`/`fold_one_index_suffix` helpers
+`apply_dot_chain` already uses for READ postfix chains — so
+`obj.data[0] = v` folds `.data` identically to how a plain `obj.data`
+read would, then dispatches `[]=` on THAT (rather than the bare `obj`
+receiver), and `a[0][1] = v` folds the first `[0]` as a receiver-side
+READ (`__method__("[]", a, 0)`) before dispatching `[]=` on its result.
+
+New tests: `chained_bracket_index_write_uses_the_inner_bracket_as_receiver`,
+`dotted_bracket_index_write_folds_the_dot_call_as_receiver`,
+`chained_and_dotted_bracket_index_write_pass_sir_validator`.
+
+`ruby-to-semantic-ir` 0.9.0 -> 0.9.1.
+
 ## 0.9.0 — lower `<<` (Ruby's shift operator)
 
 `ruby-parser` 0.8.0 adds the `shift` grammar rule for `<<` (see that

--- a/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruby-to-semantic-ir"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "Ruby AST → narrow-waist Semantic IR. Phase 5 of the Ruby parser project — first frontend for the ruby-parser → SIR pipeline."
 

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -9597,4 +9597,80 @@ b = "y"
         let result = semantic_ir::validate(&m);
         assert!(result.is_ok(), "validator rejected bracket-index program: {:?}", result);
     }
+
+    // -------------------------------------------------------------------
+    // Widened `index_assignment` to a dotted/chained receiver -- see the
+    // grammar's `index_write_receiver_postfix` rule (in `ruby.grammar`)
+    // for the lookahead trick that separates the RECEIVER's postfixes
+    // from the FINAL write-target bracket.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn chained_bracket_index_write_uses_the_inner_bracket_as_receiver() {
+        // `a[0][1] = 3` -- the OUTER `__method__("[]=", ...)`'s receiver
+        // must be a NESTED `__method__("[]", a, 0)` (a READ of `a[0]`),
+        // not the bare `a` VarRef directly -- proving the first bracket
+        // was folded as a receiver postfix, not swallowed into the write.
+        let m = lower("a[0][1] = 3\n");
+        let main = main_body(&m);
+        let stmt = main.stmts.first().expect("expected one statement");
+        match stmt {
+            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. } => {
+                assert_eq!(name, "__method__");
+                assert!(matches!(&args[1], Expr::StrLit { value, .. } if value == "[]="));
+                assert!(matches!(&args[2], Expr::IntLit { value: 1, .. }), "write index is 1");
+                assert!(matches!(&args[3], Expr::IntLit { value: 3, .. }), "RHS value is 3");
+                match &args[0] {
+                    Expr::BuiltinCall { name: inner_name, args: inner_args, .. } => {
+                        assert_eq!(inner_name, "__method__");
+                        assert!(matches!(&inner_args[1], Expr::StrLit { value, .. } if value == "[]"));
+                        assert!(matches!(&inner_args[0], Expr::VarRef { name, .. } if name == "a"));
+                        assert!(matches!(&inner_args[2], Expr::IntLit { value: 0, .. }), "receiver index is 0");
+                    }
+                    other => panic!("expected a nested __method__(\"[]\", a, 0) receiver, got {:?}", other),
+                }
+            }
+            other => panic!("expected __method__ BuiltinCall statement for `a[0][1] = 3`, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn dotted_bracket_index_write_folds_the_dot_call_as_receiver() {
+        // `obj.data[0] = 3` -- the write's receiver must be a `__method__`
+        // dispatch to `"data"` (a plain 0-arg method call), NOT the bare
+        // `obj` VarRef -- proving `.data` was folded via the SAME
+        // `fold_one_dot_call` helper `apply_dot_chain` uses for reads.
+        let m = lower("obj.data[0] = 3\n");
+        let main = main_body(&m);
+        let stmt = main.stmts.first().expect("expected one statement");
+        match stmt {
+            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. } => {
+                assert_eq!(name, "__method__");
+                assert!(matches!(&args[1], Expr::StrLit { value, .. } if value == "[]="));
+                match &args[0] {
+                    Expr::BuiltinCall { name: inner_name, args: inner_args, .. } => {
+                        assert_eq!(inner_name, "__method__");
+                        assert!(matches!(&inner_args[0], Expr::VarRef { name, .. } if name == "obj"));
+                        assert!(matches!(&inner_args[1], Expr::StrLit { value, .. } if value == "data"));
+                        assert_eq!(inner_args.len(), 2, "0-arg method call: [recv, \"data\"]");
+                    }
+                    other => panic!("expected a nested __method__(obj, \"data\") receiver, got {:?}", other),
+                }
+            }
+            other => panic!("expected __method__ BuiltinCall statement for `obj.data[0] = 3`, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn chained_and_dotted_bracket_index_write_pass_sir_validator() {
+        let m = lower(
+            "a = [[1, 2], [3, 4]]\na[0][1] = 9\nclass Box\n  def data\n    [1, 2]\n  end\nend\nb = Box.new\nb.data[0] = 3\nputs a[0][1]\n",
+        );
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected chained/dotted bracket-index write program: {:?}",
+            result
+        );
+    }
 }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -9658,18 +9658,62 @@ impl Lowerer {
 
     /// Lower an `index_assignment` statement (`recv[expr] = value`).
     /// Grammar shape:
-    ///     index_assignment = NAME index_suffix EQUALS expression ;
+    ///     index_write_receiver_postfix = dot_call | scope_resolution | index_suffix ;
+    ///     index_assignment = NAME { index_write_receiver_postfix &index_write_receiver_postfix } index_suffix EQUALS expression ;
     ///
     /// `recv[k] = v` is sugar for `recv.[]=(k, v)` — lowered to the SAME
     /// `__method__` envelope `fold_one_index_suffix` uses for reads (see
     /// its own doc comment for why this reuses method dispatch instead of
-    /// a compile-time Array-vs-Hash guess). v0 scope: a bare `NAME`
-    /// receiver only (`a[i] = v`, `h[k] = v`) — a dotted/chained receiver
-    /// (`obj.data[i] = v`) isn't covered (the grammar rule itself doesn't
-    /// admit one, so that shape falls through to a clean parse error
-    /// rather than a silent misparse).
+    /// a compile-time Array-vs-Hash guess).
+    ///
+    /// Originally v0-scoped to a bare `NAME` receiver only; widened to a
+    /// dotted/chained receiver (`obj.data[i] = v`, `a[i][j] = v`) via the
+    /// grammar's `index_write_receiver_postfix` repetition (see that
+    /// rule's own doc comment for how the lookahead tells the RECEIVER's
+    /// postfixes apart from the FINAL write-target bracket). Each
+    /// `index_write_receiver_postfix` child here wraps exactly one
+    /// `dot_call`/`scope_resolution`/`index_suffix` grandchild — unwrapped
+    /// and folded via the SAME `fold_one_dot_call`/`fold_one_scope_
+    /// resolution`/`fold_one_index_suffix` helpers `apply_dot_chain` uses
+    /// for READ postfix chains, so a receiver like `obj.data` here lowers
+    /// identically to how `obj.data` would lower as a plain read
+    /// expression, just consumed as an intermediate `receiver` rather
+    /// than the statement's final value.
     fn lower_index_assignment(&mut self, node: &GrammarASTNode) -> Result<Stmt, RubyLowerError> {
         let (name, name_span) = self.expect_first_name_token(node)?;
+        let scope = if self.current_params.contains(&name) {
+            Scope::Param
+        } else {
+            Scope::Local
+        };
+        let mut receiver = Expr::VarRef {
+            name,
+            scope,
+            span: name_span,
+        };
+        for child in &node.children {
+            let ASTNodeOrToken::Node(sub) = child else { continue };
+            if sub.rule_name != "index_write_receiver_postfix" {
+                continue;
+            }
+            let inner = self.first_node_child(sub).ok_or_else(|| RubyLowerError {
+                message: "index_write_receiver_postfix had no inner postfix".to_string(),
+                line: sub.start_line.unwrap_or(0),
+                column: sub.start_column.unwrap_or(0),
+            })?;
+            receiver = match inner.rule_name.as_str() {
+                "dot_call" => self.fold_one_dot_call(receiver, inner)?,
+                "scope_resolution" => self.fold_one_scope_resolution(receiver, inner)?,
+                "index_suffix" => self.fold_one_index_suffix(receiver, inner)?,
+                other => {
+                    return Err(RubyLowerError {
+                        message: format!("unexpected index_write_receiver_postfix shape `{other}`"),
+                        line: inner.start_line.unwrap_or(0),
+                        column: inner.start_column.unwrap_or(0),
+                    });
+                }
+            };
+        }
         let index_suffix_node =
             self.find_node_child(node, "index_suffix")
                 .ok_or_else(|| RubyLowerError {
@@ -9694,16 +9738,6 @@ impl Lowerer {
             })?;
         let value = self.lower_expression(value_node)?;
         let span = self.span_of(node);
-        let scope = if self.current_params.contains(&name) {
-            Scope::Param
-        } else {
-            Scope::Local
-        };
-        let receiver = Expr::VarRef {
-            name,
-            scope,
-            span: name_span,
-        };
         self.features_used.insert(Feature::Strings);
         Ok(Stmt::ExprStmt {
             expr: Expr::BuiltinCall {

--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.36.1 — execution proof for dotted/chained bracket-index writes
+
+No runtime code changed: `_sir_builtin_method_v`'s existing `"[]="` arm
+already dispatches on the receiver's ACTUAL runtime tag (Array vs Hash vs
+whatever an arbitrary receiver EXPRESSION evaluates to), so it already
+handled `obj.data[0] = v` and `a[0][1] = v` correctly the moment
+`ruby-to-semantic-ir` 0.9.1 started emitting the right nested `__method__`
+calls for those receiver shapes — no C-side change needed. This release
+just adds the execution proof: `chained_bracket_write_on_a_nested_array`,
+`dotted_receiver_write_through_an_oop_method_call`,
+`dotted_receiver_write_through_a_hash_value_persists`, and a regression
+check (`single_bracket_write_on_a_bare_name_receiver_is_unaffected`) that
+the original v0-scoped shape still runs identically.
+
+Along the way, discovered (and filed as its own follow-up, NOT fixed
+here) that `ClassName.new` never invokes `initialize` in this backend —
+`_sir_new_instance` only allocates a bare instance; already documented
+in-code as a deferred "later slice" (`emit.rs`), just not previously
+tracked as an explicit backlog item. Worked around in this PR's own
+OOP-dot-call test by using a method that returns a literal rather than an
+ivar, so the test proves the RECEIVER-CHAIN dispatch is correct
+independent of that separate gap.
+
 ## 0.36.0 — `<<`, Ruby's shift operator
 
 `ruby-to-semantic-ir` 0.9.0 lowers `<<` to a top-level `BuiltinCall("<<",

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.36.0"
+version = "0.36.1"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_index_bracket.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_index_bracket.rs
@@ -11,6 +11,11 @@
 //! are the non-string-key Hash writes (`h[2] = ...`, `h[:sym] = ...`) — the
 //! rejected heuristic design (string-literal key -> Map, else -> Seq) would
 //! have mis-routed these to the Array path and crashed.
+//!
+//! Bracket-index WRITE was originally v0-scoped to a bare-NAME, single-
+//! bracket receiver only; later widened to a dotted/chained receiver
+//! (`obj.data[i] = v`, `a[i][j] = v`) — see the tests near the end of this
+//! file for that follow-up's coverage.
 
 use std::process::Command;
 
@@ -148,6 +153,65 @@ fn hash_write_updates_an_existing_key_in_place() {
 fn chained_array_read() {
     match run_ruby("a = [[1, 2], [3, 4]]\nputs a[1][0]\n") {
         Some(out) => assert_eq!(out, "3\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+// -----------------------------------------------------------------------
+// Bug fix: bracket-index WRITE with a dotted/chained receiver
+// (`obj.data[i] = v`, `a[i][j] = v`) -- originally v0-scoped to a bare-NAME,
+// single-bracket receiver only (`a[i] = v`). The grammar's
+// `index_write_receiver_postfix` repetition (see its own doc comment in
+// `ruby.grammar` for the lookahead trick that tells the RECEIVER's
+// postfixes apart from the FINAL write-target bracket) widens this to the
+// same dot/scope/bracket postfix chain `factor` already admits for reads.
+// Every value below is independently confirmed against a live `ruby -e`
+// interpreter.
+// -----------------------------------------------------------------------
+
+#[test]
+fn chained_bracket_write_on_a_nested_array() {
+    match run_ruby("a = [[1, 2], [3, 4]]\na[0][1] = 99\nputs a[0][1]\nputs a[0][0]\nputs a[1][0]\n") {
+        Some(out) => assert_eq!(out, "99\n1\n3\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn dotted_receiver_write_through_an_oop_method_call() {
+    match run_ruby(
+        "class Box\n  def data\n    [1, 2]\n  end\nend\nb = Box.new\nb.data[0] = 42\nputs b.data[0]\n",
+    ) {
+        // `data` returns a FRESH `[1, 2]` literal every call (no ivar
+        // persistence), so the write lands in one temporary array and the
+        // second `b.data[0]` call reads a brand-new one -- `1`, not `42`.
+        // Real Ruby behaves identically for this exact program (confirmed);
+        // this is a semantically-honest execution proof, not a runtime
+        // quirk. What matters here is that the write DISPATCHES correctly
+        // (no NoMethodError/crash) on an OOP-method-call receiver chain.
+        Some(out) => assert_eq!(out, "1\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn dotted_receiver_write_through_a_hash_value_persists() {
+    // Unlike the OOP-method case above, a Hash VALUE is a genuinely shared
+    // object (real Ruby: mutating `h["a"]` in place is visible on every
+    // subsequent `h["a"]` read) -- so this write DOES persist.
+    match run_ruby("h = {\"a\" => [1, 2]}\nh[\"a\"][0] = 42\nputs h[\"a\"][0]\nputs h[\"a\"][1]\n") {
+        Some(out) => assert_eq!(out, "42\n2\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn single_bracket_write_on_a_bare_name_receiver_is_unaffected() {
+    // Regression check: the ORIGINAL v0-scoped shape (no receiver
+    // postfixes at all) must still parse/lower/run identically after
+    // widening the grammar to admit the (now-optional) postfix chain.
+    match run_ruby("a = [1, 2, 3]\na[1] = 20\nputs a[0]\nputs a[1]\nputs a[2]\n") {
+        Some(out) => assert_eq!(out, "1\n20\n3\n"),
         None => eprintln!("skip: no cc"),
     }
 }

--- a/code/specs/sir-collection-methods.md
+++ b/code/specs/sir-collection-methods.md
@@ -205,6 +205,7 @@ repo's standard workflow):
 | — | Bug fix: `puts` on an Array bracket-displayed instead of unpacking (C AND Ruby backends) | ✅ merged | #9772 |
 | — | Follow-up: `round(ndigits)`, the multi-digit form deferred by slice 9 | ✅ merged | — |
 | — | Follow-up: String char-set methods (`count`/`delete`/`squeeze`) + padding methods (`ljust`/`rjust`/`center`), deferred by slice 8 | ✅ merged | — |
+| — | Follow-up: bracket-index write with a dotted/chained receiver (`obj.data[i] = v`, `a[i][j] = v`), deferred by the bracket-index bug fix (#9686) | ✅ merged | — |
 
 **Slice 8's char-set/padding deferral is now closed**: `count(charset, ...)`,
 `delete(charset, ...)`, `squeeze(charset=nil)`, and `ljust`/`rjust`/


### PR DESCRIPTION
## Summary
- Widens `index_assignment` (`recv[expr] = value`) past its original v0 scope of a bare-NAME, single-bracket receiver only, to admit a dotted receiver (`obj.data[i] = v`) and nested brackets (`a[i][j] = v`) — the same `dot_call`/`scope_resolution`/`index_suffix` postfix chain `factor` already admits for reads.
- Grammar: new `index_write_receiver_postfix` rule reused in a repetition guarded by a positive lookahead on itself (`index_write_receiver_postfix &index_write_receiver_postfix`), which tells apart brackets belonging to the receiver from the FINAL write-target bracket — this parser has no backtracking once a repetition commits, so a plain greedy repetition would otherwise swallow every bracket including the last one. Verified the lookahead-over-a-grouped-alternation technique with a standalone probe grammar first, since no prior usage of it existed anywhere in this repo's ~130 grammar files.
- Lowering: folds each receiver postfix via the SAME `fold_one_dot_call`/`fold_one_scope_resolution`/`fold_one_index_suffix` helpers `apply_dot_chain` already uses for read postfix chains.
- No C backend changes needed — the existing `[]=` dispatch already handles arbitrary receiver expressions by their actual runtime tag; `semantic-ir-to-c` only gained new execution-proof tests.
- Discovered along the way (filed as its own follow-up, not fixed here): `ClassName.new` never invokes `initialize` in the C backend.

## Test plan
- [x] New `ruby-parser` tests: chained-bracket and dotted-receiver parse shapes, plus a regression check that the original single-bracket shape has no receiver postfixes
- [x] New `ruby-to-semantic-ir` tests: verify the lowered `__method__` nesting for both chained-bracket and dotted-receiver writes, plus SIR-validator pass
- [x] New `semantic-ir-to-c` execution-proof tests: chained-bracket write on a nested array, dotted receiver through an OOP method call, dotted receiver through a Hash value (persists, matching real Ruby's shared-object semantics), and a single-bracket regression check — every expected value confirmed against a live `ruby -e` interpreter
- [x] Full regression suites green: `coding-adventures-ruby-parser` (302 tests), `ruby-to-semantic-ir` (441 tests), `semantic-ir-to-c`
- [x] `cargo clippy --all-targets` clean across all three touched crates
- [x] Security review passed (traced the lookahead's parse complexity, confirmed no panic risk in the new lowering code, confirmed the receiver expression is moved not duplicated — no double-execution risk for a side-effecting receiver chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)