### PR TITLE
fix(human-languages): make Kannada book warning-free

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -94,9 +94,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B21 | Complete (#9779) | Remove German's LaTeX layout and Unicode bookmark warnings. | The forced 104-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
 | HL-B22 | Complete (#9803) | Publish Telugu Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | Thirty schema-v2 lessons now generate twenty-six chapters whose source hashes are independently verified against the Language Ladder corpus. |
 | HL-B23 | Complete (#9815) | Remove Telugu's LaTeX layout, duplicate-label, bookmark, and font warnings. | The forced 95-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings. |
-| HL-B24 | Complete in this PR | Publish Kannada Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | Thirty schema-v2 lessons now generate twenty-six chapters whose source hashes are independently verified against the Language Ladder corpus. |
-| HL-B25 | Next | Remove Kannada's LaTeX layout, duplicate-label, bookmark, and font warnings. | The expanded 96-page build has zero missing glyphs but reports nine overfull boxes, ten underfull boxes, four duplicate practice labels, 106 Hyperref warnings, and nine font warnings; the clean-build signal is zero of each. |
-| HL-B26 | Queued | Publish Malayalam Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Malayalam PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
+| HL-B24 | Complete (#9823) | Publish Kannada Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | Thirty schema-v2 lessons now generate twenty-six chapters whose source hashes are independently verified against the Language Ladder corpus. |
+| HL-B25 | Complete in this PR | Remove Kannada's LaTeX layout, duplicate-label, bookmark, and font warnings. | The forced 96-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings. |
+| HL-B26 | Next | Publish Malayalam Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Malayalam PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
 | HL-B27 | Queued | Remove Malayalam's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports seven overfull boxes, eight underfull boxes, four duplicate practice labels, 28 Hyperref warnings, and undefined bold/italic Malayalam font shapes; the clean-build signal is zero of each. |
 | HL-B28 | Queued | Publish Arabic Chapters 3–27 and its writing companions from canonical lessons rather than hand-copying another twenty-five book chapters. | The Arabic PDF stops after Chapter 2 while canonical app content continues through Chapter 27 and sixteen dependency-ordered writing lessons; schema-v2 migration plus generation should close that drift safely. |
 | HL-B29 | Queued | Remove Arabic's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports one overfull box, four underfull boxes, one duplicate practice label, 14 Hyperref warnings, and undefined bold/italic Arabic font shapes; the clean-build signal is zero of each. |
@@ -784,6 +784,28 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - The unified publication gate builds all twenty books successfully, while the
   data package passes 84 tests and Language Ladder passes 385 tests plus its
   production build.
+
+## Findings from HL-B25
+
+- Explicit regular, bold, italic, and bold-italic faces cover every script used
+  by Kannada comparisons without changing the vendored glyph source. Bookmark
+  fallbacks retain readable Unicode while omitting presentation-only font
+  commands.
+- The five handwritten recap labels are unique, and shorter visible or running
+  titles preserve transliteration and etymology in the lesson body without
+  overflowing page headers or PDF bookmarks.
+- Narrow canonical copy edits keep the complete teaching content while giving
+  long multilingual lines natural breakpoints. The generated chapter hashes
+  continue to be reproduced independently by the data package and Language
+  Ladder.
+- Natural page bottoms and the final line-break fixes make the forced 96-page
+  build completely clean: zero missing glyphs, overfull or underfull boxes,
+  duplicate destinations, Hyperref warnings, LaTeX warnings, and font warnings.
+- All 96 rendered pages were inspected again after cleanup. The 33 top-level
+  chapter bookmarks, 93 total outline entries, metadata, and generator-leak
+  checks remain intact, with no clipping, collision, or accidental blank page.
+- HL-B26 is next: publish Malayalam Chapters 6–31 from canonical lessons before
+  addressing that expanded book's bounded warning cleanup in HL-B27.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -332,7 +332,7 @@
     {
       "language": "kannada",
       "chapter": 6,
-      "sourceHash": "fnv1a64:50403c9e67a9e065",
+      "sourceHash": "fnv1a64:cc167694fde562f4",
       "lessonIds": [
         "KA-C06-dative-ge",
         "KA-C06-dative-stacking",
@@ -371,7 +371,7 @@
     {
       "language": "kannada",
       "chapter": 10,
-      "sourceHash": "fnv1a64:ed7b58b40b1355d8",
+      "sourceHash": "fnv1a64:33566b64ea65a0a8",
       "lessonIds": [
         "KA-C10-vaara"
       ],
@@ -407,7 +407,7 @@
     {
       "language": "kannada",
       "chapter": 14,
-      "sourceHash": "fnv1a64:e6a8916497172741",
+      "sourceHash": "fnv1a64:ec354231e214ee71",
       "lessonIds": [
         "KA-C14-kaalagalu"
       ],
@@ -443,7 +443,7 @@
     {
       "language": "kannada",
       "chapter": 18,
-      "sourceHash": "fnv1a64:41f497a34f5e25af",
+      "sourceHash": "fnv1a64:b8039d88f5603008",
       "lessonIds": [
         "KA-C18-gante"
       ],
@@ -452,7 +452,7 @@
     {
       "language": "kannada",
       "chapter": 19,
-      "sourceHash": "fnv1a64:d6aaad7ff154ff8f",
+      "sourceHash": "fnv1a64:f7c28f10b80343b3",
       "lessonIds": [
         "KA-C19-vayassu"
       ],
@@ -461,7 +461,7 @@
     {
       "language": "kannada",
       "chapter": 20,
-      "sourceHash": "fnv1a64:ef0879e7a5fd9007",
+      "sourceHash": "fnv1a64:ebc489f9095368bd",
       "lessonIds": [
         "KA-C20-hannondu-ippattu",
         "KA-C20-havamana"
@@ -561,7 +561,7 @@
     {
       "language": "kannada",
       "chapter": 31,
-      "sourceHash": "fnv1a64:3c1a2104befa120f",
+      "sourceHash": "fnv1a64:f2a6ae56d39f4220",
       "lessonIds": [
         "KA-C31-shubha-madhyahna"
       ],

--- a/code/learning/human-languages/kannada/CHANGELOG.md
+++ b/code/learning/human-languages/kannada/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Warning-free complete book (2026-08-03)
+
+- Added explicit static-font faces for every comparison script and readable
+  Unicode bookmark fallbacks, eliminating all font-shape and Hyperref warnings.
+- Made the five handwritten recap labels unique, shortened only the titles that
+  exceeded header or bookmark widths, and added natural page bottoms.
+- Adjusted a small set of canonical multilingual examples at durable line-break
+  boundaries; regenerated chapters and source hashes remain shared with
+  Language Ladder rather than diverging into book-only prose.
+- The forced 96-page XeLaTeX build now reports zero missing glyphs, overfull or
+  underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings,
+  and font warnings. All pages were inspected again with no clipping,
+  collision, accidental blank page, or leaked schema metadata.
+
 ## Canonical Chapters 6–31 in the book (2026-08-03)
 
 - Migrated all thirty Kannada lessons after Chapter 5 to the strict schema-v2

--- a/code/learning/human-languages/kannada/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch01-greetings.tex
@@ -175,7 +175,7 @@ carries you across Kannada, Telugu, and Malayalam.
 \end{grammarlens}
 
 \section{Recap, and how Kannada says goodbye}
-\label{lesson:practice}
+\label{lesson:practice-ch1}
 
 \begin{center}
 \begin{tabular}{@{}llll@{}}

--- a/code/learning/human-languages/kannada/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch02-introductions.tex
@@ -12,7 +12,7 @@ saying you're glad to meet them:
 Built the same way as the greetings --- each piece taken apart, its letters and
 its root, then assembled. \emph{Practice lessons: \texttt{lessons/KA-C02-*.md}.}
 
-\section{\kn{ಹೆಸರು} \emph{(hesaru)} --- ``name,'' and the \emph{p}$\to$\emph{h} shift}
+\section{\kn{ಹೆಸರು} \emph{(hesaru)} --- ``name,'' and the \emph{p}-to-\emph{h} shift}
 \label{lesson:hesaru}
 
 \begin{sounds}
@@ -78,7 +78,7 @@ the \textbf{zero copula} of the Dravidian family. \emph{Nanna hesaru Arun} $=$
 literally ``my name Arun.''
 \end{grammarlens}
 
-\section{\kn{ನೀನು} / \kn{ನೀವು} \emph{(n\=\i nu / n\=\i vu)} --- ``you,'' familiar and respectful}
+\section[Familiar and respectful ``you'']{\kn{ನೀನು} / \kn{ನೀವು} \emph{(n\=\i nu / n\=\i vu)} --- ``you,'' familiar and respectful}
 \label{lesson:niinu-niivu}
 
 \begin{sounds}
@@ -114,7 +114,7 @@ Kannada's question family: \emph{\=enu} (what), \emph{y\=aru} (who),
 \emph{elli} (where), \emph{y\=ake} (why).
 \end{cousinweb}
 
-\section{\kn{ನಿಮ್ಮ ಹೆಸರು ಏನು?} \emph{(nimma hesaru \=enu)} --- ``what's your name?''}
+\section[What's your name?]{\kn{ನಿಮ್ಮ ಹೆಸರು ಏನು?} --- ``what's your name?''}
 \label{lesson:nimma-hesaru-enu}
 
 \kn{ನಿಮ್ಮ} (\emph{nimma}, ``your'') is the possessive of \emph{n\=\i vu}
@@ -140,7 +140,7 @@ uses a Sanskrit word even for ``pleased.'' The same split you saw over
 \end{cousinweb}
 
 \section{The whole exchange}
-\label{lesson:practice}
+\label{lesson:practice-ch2}
 
 \begin{center}
 \begin{tabular}{@{}lll@{}}

--- a/code/learning/human-languages/kannada/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch03-responding.tex
@@ -94,8 +94,9 @@ illa} (``there's no money''). Hold \emph{iru} / \emph{illa} together --- ``is'' 
 ``is-not.''
 \end{grammarlens}
 
+\newpage
 \section{The whole exchange}
-\label{lesson:practice}
+\label{lesson:practice-ch3}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}
@@ -109,8 +110,8 @@ Kannada & English \\
 \end{tabular}
 \end{center}
 
-Every atom traced: \emph{h\=ege} (the native \=e- questions), \emph{n\=anu}
-(Proto-Dravidian, unrelated to \emph{me}), \emph{cenn\=agi} (``beautifully''), and
-the \emph{iru} / \emph{illa} pair --- ``is'' and ``is-not,'' the \emph{illa} shared
-with Tamil and Malayalam. Next chapter: the farewells --- and Kannada, like all
-its family, never says a plain ``goodbye.''
+Every atom is traced. \emph{H\=ege} belongs to the native \=e- question family;
+\emph{n\=anu} is Proto-Dravidian, unrelated to \emph{me}; and \emph{cenn\=agi}
+means ``beautifully.'' The \emph{iru} / \emph{illa} pair supplies ``is'' and
+``is-not,'' with \emph{illa} shared by Tamil and Malayalam. Next chapter: the
+farewells --- and Kannada, like all its family, never says a plain ``goodbye.''

--- a/code/learning/human-languages/kannada/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch04-farewells.tex
@@ -68,7 +68,7 @@ let's meet.'' The \emph{-\=o\d{n}a} ending is Kannada's warm ``let's \ldots'':
 \emph{h\=og\=o\d{n}a} (``let's go'').
 \end{cousinweb}
 
-\section{\kn{ಮತ್ತೆ ಸಿಗೋಣ} \emph{(matte sig\=o\d{n}a)} --- ``we'll meet again''}
+\section[We'll meet again]{\kn{ಮತ್ತೆ ಸಿಗೋಣ} --- ``we'll meet again''}
 \label{lesson:matte-sigona}
 
 \begin{cousinweb}
@@ -80,7 +80,7 @@ phrase, from home-grown stock.
 \end{cousinweb}
 
 \section{The farewells}
-\label{lesson:practice}
+\label{lesson:practice-ch4}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/kannada/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch05-first-verbs.tex
@@ -93,7 +93,7 @@ same trick.
 \end{grammarlens}
 
 \section{Sentences about yourself}
-\label{lesson:practice}
+\label{lesson:practice-ch5}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/kannada/book/chapters/ch06-dative-case.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch06-dative-case.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:50403c9e67a9e065
+% canonical-source-hash: fnv1a64:cc167694fde562f4
 % canonical-lessons: KA-C06-dative-ge, KA-C06-dative-stacking, KA-C06-dative-subject
 
 \chapter{Case Endings and Dative Subjects}
@@ -117,7 +117,7 @@ Latin \textbf{fuses} several jobs into one ending. \emph{-īs} carries case, plu
 
 
 \begin{quote}
-\textbf{Warm-up.} {[}PAUSE 2s{]} Chapter 5 gave you \textbf{\kn{ನಾನು} \kn{ಕನ್ನಡ} \kn{ಮಾತನಾಡುತ್ತೇನೆ}} — "\textbf{I} speak Kannada." Now say "I \textbf{know} Kannada." Kannada will not let you use \emph{nānu}.
+\textbf{Warm-up.} {[}PAUSE 2s{]} Chapter 5 gave you \textbf{\kn{ನಾನು} \kn{ಕನ್ನಡ}} — "\textbf{I} speak Kannada" — with the verb \textbf{\kn{ಮಾತನಾಡುತ್ತೇನೆ}}. Now say "I \textbf{know} Kannada." Kannada will not let you use \emph{nānu}.
 \end{quote}
 
 \subsection*{You'll want to know: The sentence}

--- a/code/learning/human-languages/kannada/book/chapters/ch10-days.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch10-days.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:ed7b58b40b1355d8
+% canonical-source-hash: fnv1a64:33566b64ea65a0a8
 % canonical-lessons: KA-C10-vaara
 
 \chapter{Days of the Week}
@@ -8,7 +8,7 @@
 This chapter is generated from the canonical micro-lessons used by Language Ladder.
 Each section stays independently resumable and preserves the authored prerequisite order.
 
-\section[\kn{ಸೋಮವಾರ} \kn{ಮಂಗಳವಾರ} \kn{ಬುಧವಾರ} \kn{ಗುರುವಾರ} \kn{ಶುಕ್ರವಾರ} \kn{ಶನಿವಾರ} \kn{ಭಾನುವಾರ}]{\kn{ಸೋಮವಾರ} to \kn{ಭಾನುವಾರ} — Kannada's fully Sanskritic week}
+\section[\kn{ಸೋಮವಾರ} \kn{ಮಂಗಳವಾರ} \kn{ಬುಧವಾರ} \kn{ಗುರುವಾರ} \kn{ಶುಕ್ರವಾರ} \kn{ಶನಿವಾರ} \kn{ಭಾನುವಾರ}]{\kn{ಸೋಮವಾರ} to \kn{ಭಾನುವಾರ} — the Sanskrit week}
 
 \label{lesson:KA-C10-vaara}
 

--- a/code/learning/human-languages/kannada/book/chapters/ch14-seasons.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch14-seasons.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:e6a8916497172741
+% canonical-source-hash: fnv1a64:ec354231e214ee71
 % canonical-lessons: KA-C14-kaalagalu
 
 \chapter{Seasons}
@@ -49,5 +49,5 @@ And as with Tamil and Malayalam: it's \textbf{\kn{ಮಳೆಗಾಲ}} (\emph{ma
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
-{[}PAUSE 3s{]} What's unusual about \kn{ವಸಂತ} \kn{ಋತು} compared to Tamil/Malayalam's spring-word? (\textbf{Both halves are Sanskrit} — \emph{vasanta} and \emph{ṛtu}, "season" itself — where Tamil/Malayalam just add the long-assimilated \emph{kaalam}.) Which season actually shapes Karnataka's year most? (\textbf{\kn{ಮಳೆಗಾಲ}}, the rains.)
+{[}PAUSE 3s{]} How does \kn{ವಸಂತ} \kn{ಋತು} differ from the Tamil/Malayalam spring-word? (\textbf{Both halves are Sanskrit} — \emph{vasanta} and \emph{ṛtu}, "season" itself — where Tamil/Malayalam just add the long-assimilated \emph{kaalam}.) Which season actually shapes Karnataka's year most? (\textbf{\kn{ಮಳೆಗಾಲ}}, the rains.)
 \end{tcolorbox}

--- a/code/learning/human-languages/kannada/book/chapters/ch18-telling-time.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch18-telling-time.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:41f497a34f5e25af
+% canonical-source-hash: fnv1a64:b8039d88f5603008
 % canonical-lessons: KA-C18-gante
 
 \chapter{Telling Time}
@@ -28,7 +28,11 @@ This is a genuinely different picture from what you'll see in Tamil. Kannada's \
 
 \begin{grammarlens}[title={Grammar Lens: telling the time}]
 \begin{quote}
-\textbf{\kn{ಒಂದು} \kn{ಗಂಟೆ}.} — "One o'clock." (\emph{ondu gaṇṭe}, "one hour/bell") \textbf{\kn{ಎರಡು} \kn{ಗಂಟೆ}.} — "Two o'clock." (\emph{eraḍu gaṇṭe}, "two hour/bell")
+\textbf{\kn{ಒಂದು} \kn{ಗಂಟೆ}.} — "One o'clock." (\emph{ondu gaṇṭe}, "one hour/bell")
+\end{quote}
+
+\begin{quote}
+\textbf{\kn{ಎರಡು} \kn{ಗಂಟೆ}.} — "Two o'clock." (\emph{eraḍu gaṇṭe})
 \end{quote}
 
 Kannada simply pairs the cardinal number with \emph{gaṇṭe} — no ordinal/cardinal split like Arabic's, no singular/plural verb switch like Hindi's \emph{bajnā}.

--- a/code/learning/human-languages/kannada/book/chapters/ch19-age.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch19-age.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:d6aaad7ff154ff8f
+% canonical-source-hash: fnv1a64:f7c28f10b80343b3
 % canonical-lessons: KA-C19-vayassu
 
 \chapter{Asking Someone's Age}
@@ -19,21 +19,17 @@ Each section stays independently resumable and preserves the authored prerequisi
 \end{quote}
 
 \begin{cousinweb}
-\textbf{\kn{ವಯಸ್ಸು}} (\emph{vayassu}) = "\textbf{age}" — from Sanskrit \textbf{\dv{वयस्}} (\emph{vayas}, "age, youth, vigor, strength"), which traces back to \textbf{Proto-Indo-European} \emph{\textbf{wéyh\textsubscript{1}os}. That PIE root is the \textbf{same} one behind Latin \textbf{vīs}, "force, strength, vigor" — so Sanskrit's word for "age" and Latin's word for "force" are genuine, distant cousins, both carrying the older sense of "vigor, life-force" before splitting toward different specific meanings.}
+\textbf{\kn{ವಯಸ್ಸು}} (\emph{vayassu}, "\textbf{age}") comes from Sanskrit \textbf{\dv{वयस्}} (\emph{vayas}, "age, youth, vigor, strength"), which traces back to \textbf{Proto-Indo-European} \emph{\textbf{wéyh\textsubscript{1}os}. That PIE root is the \textbf{same} one behind Latin \textbf{vīs}, "force, strength, vigor" — so Sanskrit's word for "age" and Latin's word for "force" are genuine, distant cousins, both carrying the older sense of "vigor, life-force" before splitting toward different specific meanings.}
 \end{cousinweb}
 
 \begin{grammarlens}[title={Grammar Lens: a simple possessive, no verb}]
 \begin{quote}
-\textbf{\kn{ನಿನ್ನ} \kn{ವಯಸ್ಸು} \kn{ಎಷ್ಟು}?} — "How old are you?" — literally "\textbf{your age}
+\textbf{\kn{ನಿನ್ನ} \kn{ವಯಸ್ಸು} \kn{ಎಷ್ಟು}?} — "How old are you?" — literally "\textbf{your age — how much?}" (\emph{ninna vayassu eṣṭu?})
 \end{quote}
-
-how-much\textbf{?" (\emph{ninna vayassu eṣṭu?})}
 
 \begin{quote}
-\textbf{\kn{ನನ್ನ} \kn{ವಯಸ್ಸು} \kn{ಇಪ್ಪತ್ತು}.} — "I am twenty years old." — literally "\textbf{my age}
+\textbf{\kn{ನನ್ನ} \kn{ವಯಸ್ಸು} \kn{ಇಪ್ಪತ್ತು}.} — "I am twenty years old." — literally "\textbf{my age {[}is{]} twenty}." (\emph{nanna vayassu ippattu.})
 \end{quote}
-
-{[}is{]} \textbf{twenty}." (\emph{nanna vayassu ippattu.})
 
 Just like Arabic's \emph{ʿumr}, this is a \textbf{verbless} construction in the present tense — Kannada simply states "your age" and "how much," with no "is" needed. But notice the shape is simpler than Arabic's: no possessive suffix fused onto the noun, just the ordinary possessive word \textbf{\kn{ನಿನ್ನ}} (\emph{ninna}, "your") sitting in front of \textbf{\kn{ವಯಸ್ಸು}}.
 \end{grammarlens}

--- a/code/learning/human-languages/kannada/book/chapters/ch20-numbers-and-weather.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch20-numbers-and-weather.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:ef0879e7a5fd9007
+% canonical-source-hash: fnv1a64:ebc489f9095368bd
 % canonical-lessons: KA-C20-hannondu-ippattu, KA-C20-havamana
 
 \chapter{Numbers 11–20 and Weather}
@@ -8,7 +8,7 @@
 This chapter is generated from the canonical micro-lessons used by Language Ladder.
 Each section stays independently resumable and preserves the authored prerequisite order.
 
-\section[\kn{ಹನ್ನೊಂದು} — \kn{ಇಪ್ಪತ್ತು}]{\kn{ಹನ್ನೊಂದು}, \kn{ಇಪ್ಪತ್ತು} — a real "two-tens" compound, just not one you can see today}
+\section[\kn{ಹನ್ನೊಂದು} — \kn{ಇಪ್ಪತ್ತು}]{\kn{ಹನ್ನೊಂದು} to \kn{ಇಪ್ಪತ್ತು} — numbers 11–20}
 
 \label{lesson:KA-C20-hannondu-ippattu}
 

--- a/code/learning/human-languages/kannada/book/chapters/ch31-good-afternoon.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch31-good-afternoon.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:3c1a2104befa120f
+% canonical-source-hash: fnv1a64:f2a6ae56d39f4220
 % canonical-lessons: KA-C31-shubha-madhyahna
 
 \chapter{Good Afternoon}
@@ -8,7 +8,7 @@
 This chapter is generated from the canonical micro-lessons used by Language Ladder.
 Each section stays independently resumable and preserves the authored prerequisite order.
 
-\section[\kn{ಶುಭ} \kn{ಮಧ್ಯಾಹ್ನ}]{\kn{ಶುಭ} \kn{ಮಧ್ಯಾಹ್ನ} (śubha madhyāhna) — the "noon" word doing the afternoon's job}
+\section[\kn{ಶುಭ} \kn{ಮಧ್ಯಾಹ್ನ}]{\kn{ಶುಭ} \kn{ಮಧ್ಯಾಹ್ನ} — good afternoon}
 
 \label{lesson:KA-C31-shubha-madhyahna}
 

--- a/code/learning/human-languages/kannada/book/preamble.tex
+++ b/code/learning/human-languages/kannada/book/preamble.tex
@@ -38,17 +38,53 @@
 
 % Vendored Kannada font (../../_fonts/ from <lang>/book/); Script=Kannada drives
 % the shaping. \kn{...} = an inline Kannada snippet within English text.
-\newfontfamily\kannadafont[Path=../../_fonts/, Script=Kannada]{NotoSansKannada-Static.ttf}
+\newfontfamily\kannadafont[
+  Path=../../_fonts/,
+  Script=Kannada,
+  BoldFont=NotoSansKannada-Static.ttf,
+  ItalicFont=NotoSansKannada-Static.ttf,
+  BoldItalicFont=NotoSansKannada-Static.ttf
+]{NotoSansKannada-Static.ttf}
 \newcommand{\kn}[1]{{\kannadafont #1}}
-\newfontfamily\tamilfont[Path=../../_fonts/, Script=Tamil]{NotoSansTamil-Static.ttf}
+\newfontfamily\tamilfont[
+  Path=../../_fonts/,
+  Script=Tamil,
+  BoldFont=NotoSansTamil-Static.ttf,
+  ItalicFont=NotoSansTamil-Static.ttf,
+  BoldItalicFont=NotoSansTamil-Static.ttf
+]{NotoSansTamil-Static.ttf}
 \newcommand{\ta}[1]{{\tamilfont #1}}
-\newfontfamily\telugufont[Path=../../_fonts/, Script=Telugu]{NotoSansTelugu-Static.ttf}
+\newfontfamily\telugufont[
+  Path=../../_fonts/,
+  Script=Telugu,
+  BoldFont=NotoSansTelugu-Static.ttf,
+  ItalicFont=NotoSansTelugu-Static.ttf,
+  BoldItalicFont=NotoSansTelugu-Static.ttf
+]{NotoSansTelugu-Static.ttf}
 \newcommand{\te}[1]{{\telugufont #1}}
-\newfontfamily\malayalamfont[Path=../../_fonts/, Script=Malayalam]{NotoSansMalayalam-Static.ttf}
+\newfontfamily\malayalamfont[
+  Path=../../_fonts/,
+  Script=Malayalam,
+  BoldFont=NotoSansMalayalam-Static.ttf,
+  ItalicFont=NotoSansMalayalam-Static.ttf,
+  BoldItalicFont=NotoSansMalayalam-Static.ttf
+]{NotoSansMalayalam-Static.ttf}
 \newcommand{\ml}[1]{{\malayalamfont #1}}
-\newfontfamily\devanagarifont[Path=../../_fonts/, Script=Devanagari]{NotoSansDevanagari-Static.ttf}
+\newfontfamily\devanagarifont[
+  Path=../../_fonts/,
+  Script=Devanagari,
+  BoldFont=NotoSansDevanagari-Static.ttf,
+  ItalicFont=NotoSansDevanagari-Static.ttf,
+  BoldItalicFont=NotoSansDevanagari-Static.ttf
+]{NotoSansDevanagari-Static.ttf}
 \newcommand{\dv}[1]{{\devanagarifont #1}}
-\newfontfamily\arabicfont[Path=../../_fonts/, Script=Arabic]{NotoNaskhArabic-Static.ttf}
+\newfontfamily\arabicfont[
+  Path=../../_fonts/,
+  Script=Arabic,
+  BoldFont=NotoNaskhArabic-Static.ttf,
+  ItalicFont=NotoNaskhArabic-Static.ttf,
+  BoldItalicFont=NotoNaskhArabic-Static.ttf
+]{NotoNaskhArabic-Static.ttf}
 \newcommand{\ar}[1]{\textarabic{#1}}
 
 \hypersetup{
@@ -57,6 +93,25 @@
   pdfsubject={Etymology-driven Kannada curriculum},
   pdfkeywords={Kannada, Dravidian, language learning, etymology}
 }
+\pdfstringdefDisableCommands{%
+  \def\kn#1{#1}% Keep script text while dropping font-only presentation.
+  \def\ta#1{#1}%
+  \def\te#1{#1}%
+  \def\ml#1{#1}%
+  \def\dv#1{#1}%
+  \def\ar#1{#1}%
+  \def\kannadafont{}%
+  \def\tamilfont{}%
+  \def\telugufont{}%
+  \def\malayalamfont{}%
+  \def\devanagarifont{}%
+  \def\arabicfont{}%
+}
+
+% Micro-lessons intentionally end at natural pause points instead of stretching
+% their callout boxes to force every page to the same depth.
+\raggedbottom
+\emergencystretch=2em
 
 \newtcolorbox{cousinweb}{
   breakable, skin=enhanced, colback=yellow!8, colframe=yellow!45!black,

--- a/code/learning/human-languages/kannada/lessons/KA-C06-dative-subject.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C06-dative-subject.md
@@ -34,8 +34,9 @@ variety: standard-colloquial
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[KA-GRAMMAR-C06-DATIVE-STACKING-01] -->
 
-[PAUSE 2s] Chapter 5 gave you **ನಾನು ಕನ್ನಡ ಮಾತನಾಡುತ್ತೇನೆ** — "**I** speak Kannada."
-Now say "I **know** Kannada." Kannada will not let you use *nānu*.
+[PAUSE 2s] Chapter 5 gave you **ನಾನು ಕನ್ನಡ** — "**I** speak Kannada" — with the
+verb **ಮಾತನಾಡುತ್ತೇನೆ**. Now say "I **know** Kannada." Kannada will not let you
+use *nānu*.
 
 ## You'll want to know: The sentence
 <!-- hl-knowledge: introduces=[KA-LEX-C06-DATIVE-SUBJECT-01]; assesses=[] -->

--- a/code/learning/human-languages/kannada/lessons/KA-C10-vaara.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C10-vaara.md
@@ -28,7 +28,7 @@ register: neutral
 variety: standard-colloquial
 ---
 
-# ಸೋಮವಾರ to ಭಾನುವಾರ — Kannada's fully Sanskritic week
+# ಸೋಮವಾರ to ಭಾನುವಾರ — the Sanskrit week
 
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C09-KSHAMISI-01, KA-ETYMON-C09-KSHAMISI-02, KA-PRAGMATICS-C09-KSHAMISI-03] -->

--- a/code/learning/human-languages/kannada/lessons/KA-C14-kaalagalu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C14-kaalagalu.md
@@ -73,7 +73,7 @@ Western split.
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[KA-LEX-C13-DEHADA-BHAGAGALU-01, KA-LEX-C14-KAALAGALU-01, KA-PRAGMATICS-C14-KAALAGALU-02] -->
 
-[PAUSE 3s] What's unusual about ವಸಂತ ಋತು compared to Tamil/Malayalam's
-spring-word? (**Both halves are Sanskrit** — *vasanta* and *ṛtu*, "season"
+[PAUSE 3s] How does ವಸಂತ ಋತು differ from the Tamil/Malayalam spring-word?
+(**Both halves are Sanskrit** — *vasanta* and *ṛtu*, "season"
 itself — where Tamil/Malayalam just add the long-assimilated *kaalam*.) Which season
 actually shapes Karnataka's year most? (**ಮಳೆಗಾಲ**, the rains.)

--- a/code/learning/human-languages/kannada/lessons/KA-C18-gante.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C18-gante.md
@@ -60,7 +60,8 @@ splits along the same Sanskrit/native line you've seen before in this course
 <!-- hl-knowledge: introduces=[KA-GRAMMAR-C18-GANTE-03]; assesses=[] -->
 
 > **ಒಂದು ಗಂಟೆ.** — "One o'clock." (*ondu gaṇṭe*, "one hour/bell")
-> **ಎರಡು ಗಂಟೆ.** — "Two o'clock." (*eraḍu gaṇṭe*, "two hour/bell")
+
+> **ಎರಡು ಗಂಟೆ.** — "Two o'clock." (*eraḍu gaṇṭe*)
 
 Kannada simply pairs the cardinal number with *gaṇṭe* — no ordinal/cardinal split
 like Arabic's, no singular/plural verb switch like Hindi's *bajnā*.

--- a/code/learning/human-languages/kannada/lessons/KA-C19-vayassu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C19-vayassu.md
@@ -39,7 +39,7 @@ variety: standard-colloquial
 ## The word, taken apart: ವಯಸ್ಸು — a Sanskrit word, and a PIE cousin of Latin vīs
 <!-- hl-knowledge: introduces=[KA-ETYMON-C19-VAYASSU-01]; assesses=[] -->
 
-**ವಯಸ್ಸು** (*vayassu*) = "**age**" — from Sanskrit **वयस्** (*vayas*, "age,
+**ವಯಸ್ಸು** (*vayassu*, "**age**") comes from Sanskrit **वयस्** (*vayas*, "age,
 youth, vigor, strength"), which traces back to **Proto-Indo-European**
 ***wéyh₁os**. That PIE root is the **same** one behind Latin **vīs**, "force,
 strength, vigor" — so Sanskrit's word for "age" and Latin's word for "force" are
@@ -49,10 +49,9 @@ before splitting toward different specific meanings.
 ## Grammar Lens: a simple possessive, no verb
 <!-- hl-knowledge: introduces=[KA-GRAMMAR-C19-VAYASSU-02]; assesses=[] -->
 
-> **ನಿನ್ನ ವಯಸ್ಸು ಎಷ್ಟು?** — "How old are you?" — literally "**your age
-  how-much**?" (*ninna vayassu eṣṭu?*)
-> **ನನ್ನ ವಯಸ್ಸು ಇಪ್ಪತ್ತು.** — "I am twenty years old." — literally "**my age**
-  [is] **twenty**." (*nanna vayassu ippattu.*)
+> **ನಿನ್ನ ವಯಸ್ಸು ಎಷ್ಟು?** — "How old are you?" — literally "**your age — how much?**" (*ninna vayassu eṣṭu?*)
+
+> **ನನ್ನ ವಯಸ್ಸು ಇಪ್ಪತ್ತು.** — "I am twenty years old." — literally "**my age [is] twenty**." (*nanna vayassu ippattu.*)
 
 Just like Arabic's *ʿumr*, this is a **verbless** construction in the present
 tense — Kannada simply states "your age" and "how much," with no "is" needed.

--- a/code/learning/human-languages/kannada/lessons/KA-C20-hannondu-ippattu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C20-hannondu-ippattu.md
@@ -28,7 +28,7 @@ register: neutral
 variety: standard-colloquial
 ---
 
-# ಹನ್ನೊಂದು, ಇಪ್ಪತ್ತು — a real "two-tens" compound, just not one you can see today
+# ಹನ್ನೊಂದು to ಇಪ್ಪತ್ತು — numbers 11–20
 
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C19-VAYASSU-01, KA-GRAMMAR-C19-VAYASSU-02] -->

--- a/code/learning/human-languages/kannada/lessons/KA-C31-shubha-madhyahna.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C31-shubha-madhyahna.md
@@ -28,7 +28,7 @@ register: formal-workplace
 variety: standard-colloquial
 ---
 
-# ಶುಭ ಮಧ್ಯಾಹ್ನ (śubha madhyāhna) — the "noon" word doing the afternoon's job
+# ಶುಭ ಮಧ್ಯಾಹ್ನ — good afternoon
 
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01, KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02, KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03, KA-ETYMON-C28-APARAHNA-01, KA-PRAGMATICS-C28-APARAHNA-02, KA-ETYMON-C30-SHUBHA-SANJE-01, KA-PRAGMATICS-C30-SHUBHA-SANJE-02] -->


### PR DESCRIPTION
## Summary
- make Kannada's complete 96-page book warning-free across missing glyphs, layout boxes, duplicate labels, bookmarks, LaTeX, and font shapes
- preserve book/app single-source generation while adding durable multilingual line breaks and shorter bookmark-safe titles
- record HL-B25 completion and prioritize Malayalam canonical Chapters 6-31 as HL-B26

## Validation
- `npm run build && npm run generate:books && npm run check:books && npm test -- --run` (human-language-data: 84/84)
- `npm ci && npm test -- --run && npm run build` (Language Ladder: 385/385)
- forced Kannada XeLaTeX build: 96 pages; 0 missing glyphs, overfull/underfull boxes, Hyperref, LaTeX, and font warnings
- PDF audit: correct metadata; 33 top-level/93 total outline entries; no generator metadata leaks
- rendered and inspected all 96 pages; corrected a header-only page found during visual QA; no clipping, collision, or accidental blank page
- unified local publication gate: all 20 PDFs and all 20 catalog entries in 212.8 seconds