### PR TITLE
fix(spice): lower diode flicker-noise coefficient

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower diode model-card `KF` flicker-noise coefficient.
 - Validate and lower diode model-card `EG` energy gap.
 - Validate and lower diode model-card `XTI` temperature exponent.
 - Validate and lower diode model-card `FC` depletion coefficient.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1280,6 +1280,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Xti=model.params.get("XTI", 3.0),
             Eg=model.params.get("EG", 1.11),
             Rs=model.params.get("RS", 0.0),
+            Kf=model.params.get("KF", 0.0),
         )
     if prefix == "Q":
         _require_fields(fields, 5, "BJT")
@@ -1995,6 +1996,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(energy_gap) or energy_gap <= 0.0
         ):
             raise NetlistParseError("diode EG must be finite and positive")
+        flicker_noise_coefficient = params.get("KF")
+        if flicker_noise_coefficient is not None and (
+            not math.isfinite(flicker_noise_coefficient)
+            or flicker_noise_coefficient < 0.0
+        ):
+            raise NetlistParseError("diode KF must be finite and non-negative")
     if kind in {"NPN", "PNP"}:
         saturation_current = params.get("IS")
         if saturation_current is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1016,6 +1016,25 @@ def test_rejects_invalid_diode_energy_gap(value: str) -> None:
         parse_netlist(f".model clamp D(EG={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("2e-18", 2e-18)])
+def test_lowers_valid_diode_flicker_noise_coefficient(
+    value: str, expected: float
+) -> None:
+    parsed = parse_netlist(f".model clamp D(KF={value})\nD1 in out clamp")
+
+    diode = parsed.circuit.elements[0]
+    assert isinstance(diode, Diode)
+    assert diode.Kf == expected
+
+
+@pytest.mark.parametrize("value", ["-1e-18", "1e999"])
+def test_rejects_invalid_diode_flicker_noise_coefficient(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="diode KF must be finite and non-negative"
+    ):
+        parse_netlist(f".model clamp D(KF={value})")
+
+
 def test_parse_diode_junction_capacitance_alias() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower diode model-card `KF` flicker-noise coefficient.
 - Validate and lower diode model-card `EG` energy gap.
 - Validate and lower diode model-card `XTI` temperature exponent.
 - Validate and lower diode model-card `FC` depletion coefficient.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1257,6 +1257,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("diode EG must be finite and positive");
   }
+  const diodeFlickerNoiseCoefficient = params.get("KF");
+  if (
+    kind === "D" &&
+    diodeFlickerNoiseCoefficient !== undefined &&
+    (!Number.isFinite(diodeFlickerNoiseCoefficient) || diodeFlickerNoiseCoefficient < 0.0)
+  ) {
+    throw new NetlistParseError("diode KF must be finite and non-negative");
+  }
   const bjtForwardBeta =
     params.get("BF") ??
     params.get("BETA") ??
@@ -1849,6 +1857,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       saturationCurrentTemperatureExponent: model.params.get("XTI") ?? 3.0,
       energyGapElectronVolts: model.params.get("EG") ?? 1.11,
       seriesResistance: model.params.get("RS") ?? 0.0,
+      flickerNoiseCoefficient: model.params.get("KF") ?? 0.0,
     };
   }
   if (prefix === "Q") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1062,6 +1062,24 @@ D1 in out clamp
     );
   });
 
+  it.each([
+    ["0", 0.0],
+    ["2e-18", 2.0e-18],
+  ])("lowers valid diode KF flicker-noise coefficient %s", (value, expected) => {
+    const parsed = parseNetlist(`.model clamp D(KF=${value})\nD1 in out clamp`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "diode",
+      flickerNoiseCoefficient: expected,
+    });
+  });
+
+  it.each(["-1e-18", "1e999"])("rejects invalid diode KF %s", (value) => {
+    expect(() => parseNetlist(`.model clamp D(KF=${value})`)).toThrow(
+      "diode KF must be finite and non-negative",
+    );
+  });
+
   it("parses BJT models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NPN(IS=1e-14 BF=120 VT=25m CJE=2p CJC=3p TF=4n TR=5n)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4431,15 +4431,21 @@ the Rust, Python, and TypeScript surfaces together.
      shared engine diode saturation-current temperature-exponent field.
 
 422. Python and TypeScript Berkeley SPICE diode energy-gap parity.
-   - Status: completed in this diode energy-gap parity slice.
+   - Status: completed in PR 9826.
    - Both parser facades validate positive finite `EG` values and lower them
      into the shared engine diode energy-gap field.
+
+423. Python and TypeScript Berkeley SPICE diode flicker-noise coefficient parity.
+   - Status: completed in this diode flicker-noise coefficient parity slice.
+   - Both parser facades validate finite non-negative `KF` values and lower
+     them into the shared engine diode flicker-noise coefficient field.
 
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE model-card validation parity.
-   - Continue the audited diode model-card lowering surfaces with `KF` and `AF`
-     validation and lowering parity.
+   - Complete the audited diode model-card lowering surfaces with `AF`
+     validation and lowering parity, then perform a fresh parser-to-engine
+     model-card audit.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary
- validate finite, non-negative diode model-card `KF` values in Python and TypeScript
- lower valid values into the existing engine flicker-noise coefficient field
- add cross-language parity coverage and advance the SPICE completion backlog

## Verification
- Python `spice-netlist-parser`: `bash BUILD` (346 tests), Ruff clean
- TypeScript `spice-engine`: `bash BUILD` (448 tests)
- TypeScript `spice-netlist-parser`: `bash BUILD` (335 tests)
- TypeScript parser coverage: 86.35% lines