### PR TITLE
fix(spice): lower diode flicker-noise exponent

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower diode model-card `AF` flicker-noise exponent.
 - Validate and lower diode model-card `KF` flicker-noise coefficient.
 - Validate and lower diode model-card `EG` energy gap.
 - Validate and lower diode model-card `XTI` temperature exponent.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1281,6 +1281,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Eg=model.params.get("EG", 1.11),
             Rs=model.params.get("RS", 0.0),
             Kf=model.params.get("KF", 0.0),
+            Af=model.params.get("AF", 1.0),
         )
     if prefix == "Q":
         _require_fields(fields, 5, "BJT")
@@ -2002,6 +2003,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or flicker_noise_coefficient < 0.0
         ):
             raise NetlistParseError("diode KF must be finite and non-negative")
+        flicker_noise_exponent = params.get("AF")
+        if flicker_noise_exponent is not None and (
+            not math.isfinite(flicker_noise_exponent)
+            or flicker_noise_exponent < 0.0
+        ):
+            raise NetlistParseError("diode AF must be finite and non-negative")
     if kind in {"NPN", "PNP"}:
         saturation_current = params.get("IS")
         if saturation_current is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1035,6 +1035,25 @@ def test_rejects_invalid_diode_flicker_noise_coefficient(value: str) -> None:
         parse_netlist(f".model clamp D(KF={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("1.5", 1.5)])
+def test_lowers_valid_diode_flicker_noise_exponent(
+    value: str, expected: float
+) -> None:
+    parsed = parse_netlist(f".model clamp D(AF={value})\nD1 in out clamp")
+
+    diode = parsed.circuit.elements[0]
+    assert isinstance(diode, Diode)
+    assert diode.Af == expected
+
+
+@pytest.mark.parametrize("value", ["-0.1", "1e999"])
+def test_rejects_invalid_diode_flicker_noise_exponent(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="diode AF must be finite and non-negative"
+    ):
+        parse_netlist(f".model clamp D(AF={value})")
+
+
 def test_parse_diode_junction_capacitance_alias() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower diode model-card `AF` flicker-noise exponent.
 - Validate and lower diode model-card `KF` flicker-noise coefficient.
 - Validate and lower diode model-card `EG` energy gap.
 - Validate and lower diode model-card `XTI` temperature exponent.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1265,6 +1265,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("diode KF must be finite and non-negative");
   }
+  const diodeFlickerNoiseExponent = params.get("AF");
+  if (
+    kind === "D" &&
+    diodeFlickerNoiseExponent !== undefined &&
+    (!Number.isFinite(diodeFlickerNoiseExponent) || diodeFlickerNoiseExponent < 0.0)
+  ) {
+    throw new NetlistParseError("diode AF must be finite and non-negative");
+  }
   const bjtForwardBeta =
     params.get("BF") ??
     params.get("BETA") ??
@@ -1858,6 +1866,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       energyGapElectronVolts: model.params.get("EG") ?? 1.11,
       seriesResistance: model.params.get("RS") ?? 0.0,
       flickerNoiseCoefficient: model.params.get("KF") ?? 0.0,
+      flickerNoiseExponent: model.params.get("AF") ?? 1.0,
     };
   }
   if (prefix === "Q") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1080,6 +1080,24 @@ D1 in out clamp
     );
   });
 
+  it.each([
+    ["0", 0.0],
+    ["1.5", 1.5],
+  ])("lowers valid diode AF flicker-noise exponent %s", (value, expected) => {
+    const parsed = parseNetlist(`.model clamp D(AF=${value})\nD1 in out clamp`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "diode",
+      flickerNoiseExponent: expected,
+    });
+  });
+
+  it.each(["-0.1", "1e999"])("rejects invalid diode AF %s", (value) => {
+    expect(() => parseNetlist(`.model clamp D(AF=${value})`)).toThrow(
+      "diode AF must be finite and non-negative",
+    );
+  });
+
   it("parses BJT models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NPN(IS=1e-14 BF=120 VT=25m CJE=2p CJC=3p TF=4n TR=5n)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4436,16 +4436,20 @@ the Rust, Python, and TypeScript surfaces together.
      into the shared engine diode energy-gap field.
 
 423. Python and TypeScript Berkeley SPICE diode flicker-noise coefficient parity.
-   - Status: completed in this diode flicker-noise coefficient parity slice.
+   - Status: completed in PR 9829.
    - Both parser facades validate finite non-negative `KF` values and lower
      them into the shared engine diode flicker-noise coefficient field.
+
+424. Python and TypeScript Berkeley SPICE diode flicker-noise exponent parity.
+   - Status: completed in this diode flicker-noise exponent parity slice.
+   - Both parser facades validate finite non-negative `AF` values and lower
+     them into the shared engine diode flicker-noise exponent field.
 
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE model-card validation parity.
-   - Complete the audited diode model-card lowering surfaces with `AF`
-     validation and lowering parity, then perform a fresh parser-to-engine
-     model-card audit.
+   - Perform a fresh parser-to-engine model-card completion audit across diode,
+     BJT, JFET, and MOS surfaces and prioritize the next smallest live gap.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary
- validate finite, non-negative diode model-card `AF` values in Python and TypeScript
- lower valid values into the existing engine flicker-noise exponent field
- add cross-language parity coverage and advance the SPICE plan to a fresh model-card audit

## Verification
- Python `spice-netlist-parser`: `bash BUILD` (350 tests), Ruff clean
- TypeScript `spice-engine`: `bash BUILD` (448 tests)
- TypeScript `spice-netlist-parser`: `bash BUILD` (339 tests)
- TypeScript parser coverage: 86.38% lines