### PR TITLE
fix(build-tool): make Rust resolution field-aware

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,11 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": {
+    "number": 9832,
+    "url": "https://github.com/adhithyan15/coding-adventures/pull/9832",
+    "branch": "codex/build-tool-haskell-rust-field-aware-manifest-resolution"
+  },
   "last_inventory": {
     "revision": "88772e0dc3fce6f7303ea381076e6eeaa3c30b1c",
     "schema_version": 3,
@@ -415,11 +419,11 @@
     {
       "id": "build-tool-haskell-post-python-field-aware-manifest-resolution",
       "title": "Make Haskell Rust manifest resolution field-aware",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-haskell-non-cabal-field-aware-manifest-resolution"],
       "branch": "codex/build-tool-haskell-rust-field-aware-manifest-resolution",
-      "pr_number": null,
-      "notes": "Narrowed from the post-Python umbrella after guarded PR #9817 auto-merged exact head 2444811586 as b608f29c45 on 2026-08-03. The post-merge collision-checked inventory initially held 1,247 identities and 4,400 slots, 173 high-consensus packages with 272 missing slots, 797 singletons with 11,158 missing slots, 602 Rust singletons, and zero collisions or unknown buckets. The selection audit identified Rust as the largest clean dependency-shaped repair: its then-current 945-package snapshot had 3,201 Haskell edges versus 2,353 canonical Go edges, 848 false edges, and zero missing edges. TypeScript has larger two-sided drift (147 false and 948 missing), while Ruby has 123 false and zero missing; resolving Rust first removes the most false-cycle risk without mixing alias discovery and missing-edge work. The implementation now reads only inline path entries in Cargo's top-level dependencies table and ignores every non-authoritative table. Full-graph validation exposed two valid renamed-package edges that the Go oracle itself omitted, so the shared contract and both engines now honor Cargo package overrides before alias lookup. After conflict-free rebases through merged parity PR #9829 at 88772e0d, both engines discover 948 packages and match exactly at 2,373 edges with zero differences; the Haskell front door completes the lane with zero failures. The refreshed collision-checked inventory has 1,249 identities and 4,403 slots, 173 high-consensus packages with 271 missing slots, 799 singletons with 11,186 missing slots, 604 Rust singletons, and zero collisions or unknown buckets. Haskell ZIP fills an existing identity. The new chief-of-staff-daemon-credential and chief-of-staff-daemon singletons own concrete native authority and have newly logged excluded native-authority reviews. PR #9829 changes existing SPICE packages only, leaves inventory unchanged, and does not displace this selected repair."
+      "pr_number": 9832,
+      "notes": "Narrowed from the post-Python umbrella after guarded PR #9817 auto-merged exact head 2444811586 as b608f29c45 on 2026-08-03. The post-merge collision-checked inventory initially held 1,247 identities and 4,400 slots, 173 high-consensus packages with 272 missing slots, 797 singletons with 11,158 missing slots, 602 Rust singletons, and zero collisions or unknown buckets. The selection audit identified Rust as the largest clean dependency-shaped repair: its then-current 945-package snapshot had 3,201 Haskell edges versus 2,353 canonical Go edges, 848 false edges, and zero missing edges. TypeScript has larger two-sided drift (147 false and 948 missing), while Ruby has 123 false and zero missing; resolving Rust first removes the most false-cycle risk without mixing alias discovery and missing-edge work. The implementation now reads only inline path entries in Cargo's top-level dependencies table and ignores every non-authoritative table. Full-graph validation exposed two valid renamed-package edges that the Go oracle itself omitted, so the shared contract and both engines now honor Cargo package overrides before alias lookup. After conflict-free rebases through merged parity PR #9829 at 88772e0d, both engines discover 948 packages and match exactly at 2,373 edges with zero differences; the Haskell front door completes the lane with zero failures. The refreshed collision-checked inventory has 1,249 identities and 4,403 slots, 173 high-consensus packages with 271 missing slots, 799 singletons with 11,186 missing slots, 604 Rust singletons, and zero collisions or unknown buckets. Haskell ZIP fills an existing identity. The new chief-of-staff-daemon-credential and chief-of-staff-daemon singletons own concrete native authority and have newly logged excluded native-authority reviews. PR #9829 changes existing SPICE packages only, leaves inventory unchanged, and does not displace this selected repair. Ready-for-review PR #9832 is open with the complete validation summary."
     },
     {
       "id": "build-tool-haskell-post-rust-field-aware-manifest-resolution",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,22 +11,18 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": {
-    "number": 9817,
-    "url": "https://github.com/adhithyan15/coding-adventures/pull/9817",
-    "branch": "codex/build-tool-haskell-python-field-aware-manifest-resolution"
-  },
+  "active_pr": null,
   "last_inventory": {
-    "revision": "9441f4c74344f5e3fcba0b58e838af81fd512f63",
+    "revision": "88772e0dc3fce6f7303ea381076e6eeaa3c30b1c",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1247,
-    "implementation_package_slots": 4400,
+    "implementation_identities": 1249,
+    "implementation_package_slots": 4403,
     "high_consensus_packages": 173,
-    "high_consensus_missing_slots": 272,
-    "singleton_packages": 797,
-    "singleton_missing_slots": 11158,
-    "rust_singletons": 602,
+    "high_consensus_missing_slots": 271,
+    "singleton_packages": 799,
+    "singleton_missing_slots": 11186,
+    "rust_singletons": 604,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -410,7 +406,7 @@
     {
       "id": "build-tool-haskell-non-cabal-field-aware-manifest-resolution",
       "title": "Make Haskell Python manifest resolution field-aware and name-normalized",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-haskell-remaining-field-aware-manifest-resolution"],
       "branch": "codex/build-tool-haskell-python-field-aware-manifest-resolution",
       "pr_number": 9817,
@@ -418,12 +414,21 @@
     },
     {
       "id": "build-tool-haskell-post-python-field-aware-manifest-resolution",
-      "title": "Make the remaining post-Python Haskell build-tool manifest readers field-aware",
-      "status": "pending",
+      "title": "Make Haskell Rust manifest resolution field-aware",
+      "status": "in-progress",
       "depends_on": ["build-tool-haskell-non-cabal-field-aware-manifest-resolution"],
+      "branch": "codex/build-tool-haskell-rust-field-aware-manifest-resolution",
+      "pr_number": null,
+      "notes": "Narrowed from the post-Python umbrella after guarded PR #9817 auto-merged exact head 2444811586 as b608f29c45 on 2026-08-03. The post-merge collision-checked inventory initially held 1,247 identities and 4,400 slots, 173 high-consensus packages with 272 missing slots, 797 singletons with 11,158 missing slots, 602 Rust singletons, and zero collisions or unknown buckets. The selection audit identified Rust as the largest clean dependency-shaped repair: its then-current 945-package snapshot had 3,201 Haskell edges versus 2,353 canonical Go edges, 848 false edges, and zero missing edges. TypeScript has larger two-sided drift (147 false and 948 missing), while Ruby has 123 false and zero missing; resolving Rust first removes the most false-cycle risk without mixing alias discovery and missing-edge work. The implementation now reads only inline path entries in Cargo's top-level dependencies table and ignores every non-authoritative table. Full-graph validation exposed two valid renamed-package edges that the Go oracle itself omitted, so the shared contract and both engines now honor Cargo package overrides before alias lookup. After conflict-free rebases through merged parity PR #9829 at 88772e0d, both engines discover 948 packages and match exactly at 2,373 edges with zero differences; the Haskell front door completes the lane with zero failures. The refreshed collision-checked inventory has 1,249 identities and 4,403 slots, 173 high-consensus packages with 271 missing slots, 799 singletons with 11,186 missing slots, 604 Rust singletons, and zero collisions or unknown buckets. Haskell ZIP fills an existing identity. The new chief-of-staff-daemon-credential and chief-of-staff-daemon singletons own concrete native authority and have newly logged excluded native-authority reviews. PR #9829 changes existing SPICE packages only, leaves inventory unchanged, and does not displace this selected repair."
+    },
+    {
+      "id": "build-tool-haskell-post-rust-field-aware-manifest-resolution",
+      "title": "Make the remaining post-Rust Haskell build-tool manifest readers field-aware",
+      "status": "pending",
+      "depends_on": ["build-tool-haskell-post-python-field-aware-manifest-resolution"],
       "branch": null,
       "pr_number": null,
-      "notes": "Narrowed from the non-Cabal umbrella after the leverage audit selected the exact 488-package Python lane. The generic reader remains reachable for Ruby, Go, TypeScript, Dart, Rust/Wasm, Elixir, Perl, Swift, Java/Kotlin, and .NET. After the Python field and distribution-name rules are fixed, compare each remaining real lane with the Go oracle, add language-neutral field-boundary fixtures, and split implementation into dependency-shaped ecosystem slices rather than recreating a broad multi-language PR."
+      "notes": "Materialized after the post-Python leverage audit selected Rust. Remaining exact graph drift is TypeScript 147 false/948 missing, Ruby 123/0, Perl 95/2, Swift 65/0, C# 47/178, F# 39/178, Go 26/0, Kotlin 9/13, Elixir 8/0, Java 4/24, Dart 0/67, and the non-denominator Wasm execution target 12/1. Re-run the complete oracle audit after Rust lands, then split the highest-leverage coherent ecosystem without combining unrelated manifest grammars."
     },
     {
       "id": "build-tool-elixir-engine-rockspec-utf8-conformance",
@@ -1523,7 +1528,7 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "Share a Python/Rust/TypeScript corpus for MOS W/L/NRD/NRS/AD/AS/PD/PS and TOX/U0/UO/KP/VT0/VTO/VTH validation, including aliases, case, duplicates, NaN/Infinity, and stable diagnostics. Discovered across merged PRs #9427, #9429, #9432, #9436, #9437, #9439, #9443, #9448, #9450, #9453, #9459, #9464, #9469, and #9473."
+      "notes": "Share a Python/Rust/TypeScript corpus for MOS W/L/NRD/NRS/AD/AS/PD/PS and TOX/U0/UO/KP/VT0/VTO/VTH validation, including aliases, case, duplicates, NaN/Infinity, and stable diagnostics. Discovered across merged PRs #9427, #9429, #9432, #9436, #9437, #9439, #9443, #9448, #9450, #9453, #9459, #9464, #9469, and #9473. Merged PR #9829 adds finite non-negative diode KF validation and Python/TypeScript lowering coverage, but it is a narrow partial advance rather than completion of this shared multi-lane corpus."
     },
     {
       "id": "smart-home-switch-entity-command-contract",
@@ -1752,6 +1757,24 @@
       "branch": null,
       "pr_number": null,
       "notes": "Discovered in the collision-clean 5c85a498 inventory after chief-of-staff-daemon-keyring landed as a Rust-only production key loader. The crate opens operator-configured filesystem paths, rejects link/device/race substitutions through native file-handle inspection, and supplies trusted keys to the concrete Chief host, so the package is not an all-language portable target. Review the minimum truthful fs:read and platform file-identity evidence; keep bounded 32-byte Ed25519 key decoding, subgroup validation, trust-tier mapping, and redacted stable diagnostics in shared portable fixtures where reusable; and record the residual file-loading adapter as a native-runtime exception. This review is excluded from autonomous delivery selection by parity policy."
+    },
+    {
+      "id": "chief-daemon-credential-native-authority-review",
+      "title": "Review the Chief daemon credential persistence native-authority exception",
+      "status": "pending",
+      "depends_on": ["chief-daemon-runtime-native-authority-review"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-clean 7acde69a inventory after chief-of-staff-daemon-credential landed as a Rust-only owner-only bearer-credential persistence adapter. The crate owns concrete filesystem read/create/write, native Unix and Windows file/security FFI, durable publication, ownership and ACL validation, bounded sleep/retry, secret generation, and zeroization, so the production adapter is not an all-language portable target. Review the minimum truthful native authority and platform evidence; keep bounded canonical credential decoding, stable redacted errors, and injected persistence-state semantics in portable fixtures where safe and reusable. This review is excluded from autonomous delivery selection by parity policy and does not displace the active Haskell Rust resolver repair."
+    },
+    {
+      "id": "chief-daemon-executable-native-authority-review",
+      "title": "Review the Chief daemon composition-root native-authority exception",
+      "status": "pending",
+      "depends_on": ["chief-daemon-runtime-native-authority-review", "chief-daemon-keyring-native-authority-review", "chief-daemon-credential-native-authority-review", "chief-process-supervisor-native-authority-review"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-clean bbb0276a inventory after chief-of-staff-daemon landed as the Rust-only concrete D18 composition root. It reads environment and configuration, opens trusted files, creates and writes durable credential/state paths, listens on loopback, executes and signals child processes, handles shutdown signals, and owns monotonic scheduling and bounded waits. Review the composed authority and platform evidence after its component native reviews; keep only dependency-injected orchestration ordering in portable contracts, and do not manufacture all-language privileged daemon executables. This review is excluded from autonomous delivery selection by parity policy and does not displace the active Haskell Rust resolver repair."
     },
     {
       "id": "smart-home-synology-surveillance-native-authority-review",

--- a/code/programs/go/build-tool/CHANGELOG.md
+++ b/code/programs/go/build-tool/CHANGELOG.md
@@ -32,6 +32,9 @@ All notable changes to the Go build tool will be documented in this file.
 
 ### Fixed
 
+- Rust dependency resolution now honors Cargo inline-table `package` renames
+  for path dependencies while retaining the top-level `[dependencies]` field
+  boundary.
 - Lua `.rockspec` metadata is now decoded as strict UTF-8 before dependency
   parsing. Invalid bytes fail closed with `METADATA_INVALID_UTF8`, package and
   repository-relative manifest identity, and CLI exit code 2 without leaking

--- a/code/programs/go/build-tool/README.md
+++ b/code/programs/go/build-tool/README.md
@@ -78,6 +78,12 @@ bytes stop resolution with `METADATA_INVALID_UTF8`, identify the package and
 repository-relative manifest, and return CLI exit code 2 without exposing the
 checkout path or silently replacing input.
 
+Cargo dependency resolution reads inline path dependencies from the top-level
+`[dependencies]` table. When a dependency uses a local source alias together
+with `package = "published-name"`, the published package name drives internal
+lookup. Package metadata, features, dev/build/target tables, and registry-only
+dependencies remain outside this graph contract.
+
 ## Canonical discovery identities
 
 Discovery uses only the exact bucket immediately below a `packages` or

--- a/code/programs/go/build-tool/internal/resolver/resolver.go
+++ b/code/programs/go/build-tool/internal/resolver/resolver.go
@@ -405,9 +405,9 @@ func parseDartDeps(pkg discovery.Package, knownNames map[string]string) []string
 //	[dependencies]
 //	logic-gates = { path = "../logic-gates" }
 //
-// We look for lines in the [dependencies] section that contain `path =` and
-// extract the crate name (the key before the `=`). We then look up that name
-// in the known names mapping.
+// We look for inline-table entries in the [dependencies] section with a
+// quoted `path` field and extract the crate name (the key before the first
+// `=`). We then look up that name in the known names mapping.
 func parseRustDeps(pkg discovery.Package, knownNames map[string]string) []string {
 	cargoToml := filepath.Join(pkg.Path, "Cargo.toml")
 	data, err := os.ReadFile(cargoToml)
@@ -434,13 +434,19 @@ func parseRustDeps(pkg discovery.Package, knownNames map[string]string) []string
 		}
 
 		// Look for lines like: logic-gates = { path = "../logic-gates" }
-		if strings.Contains(trimmed, "path") && strings.Contains(trimmed, "=") {
+		if strings.Contains(trimmed, "=") {
 			// Extract the crate name (everything before the first '=')
 			parts := strings.SplitN(trimmed, "=", 2)
 			if len(parts) < 2 {
 				continue
 			}
+			if cargoInlineStringValue(parts[1], "path") == "" {
+				continue
+			}
 			crateName := strings.TrimSpace(strings.ToLower(parts[0]))
+			if packageName := cargoInlineStringValue(parts[1], "package"); packageName != "" {
+				crateName = strings.ToLower(packageName)
+			}
 			if pkgName, ok := knownNames[crateName]; ok {
 				internalDeps = append(internalDeps, pkgName)
 			}
@@ -448,6 +454,53 @@ func parseRustDeps(pkg discovery.Package, knownNames map[string]string) []string
 	}
 
 	return internalDeps
+}
+
+// cargoInlineStringValue returns a quoted string field from a Cargo inline
+// table. Commas inside quoted strings stay within their field, so a package
+// rename cannot be confused with neighboring version or path metadata.
+func cargoInlineStringValue(value, target string) string {
+	for _, field := range splitCargoInlineFields(value) {
+		field = strings.TrimLeft(strings.TrimSpace(field), "{")
+		parts := strings.SplitN(field, "=", 2)
+		if len(parts) != 2 || strings.TrimSpace(strings.ToLower(parts[0])) != target {
+			continue
+		}
+		quoted := strings.TrimSpace(strings.TrimRight(strings.TrimSpace(parts[1]), "}"))
+		if len(quoted) >= 2 && ((quoted[0] == '"' && quoted[len(quoted)-1] == '"') ||
+			(quoted[0] == '\'' && quoted[len(quoted)-1] == '\'')) {
+			return quoted[1 : len(quoted)-1]
+		}
+	}
+	return ""
+}
+
+func splitCargoInlineFields(value string) []string {
+	fields := make([]string, 0, 3)
+	start := 0
+	var quote byte
+	for index := 0; index < len(value); index++ {
+		character := value[index]
+		if quote != 0 {
+			if quote == '"' && character == '\\' {
+				index++
+				continue
+			}
+			if character == quote {
+				quote = 0
+			}
+			continue
+		}
+		if character == '"' || character == '\'' {
+			quote = character
+			continue
+		}
+		if character == ',' {
+			fields = append(fields, value[start:index])
+			start = index + 1
+		}
+	}
+	return append(fields, value[start:])
 }
 
 func dependencyScope(language string) string {

--- a/code/programs/go/build-tool/internal/resolver/resolver_test.go
+++ b/code/programs/go/build-tool/internal/resolver/resolver_test.go
@@ -978,12 +978,26 @@ func TestParseRustDeps(t *testing.T) {
 name = "arithmetic"
 version = "0.1.0"
 edition = "2021"
+description = "Mentions gamma without depending on it"
+
+[features]
+gamma = ["gamma"]
 
 [dependencies]
-logic-gates = { path = "../logic-gates" }
+logic_alias = { package = "logic-gates", path = "../logic-gates" }
+gamma = { version = "0.1.0", features = ["path"] }
+serde = "1"
+
+[dev-dependencies]
+gamma = { path = "../gamma" }
 `,
 		"logic-gates/Cargo.toml": `[package]
 name = "logic-gates"
+version = "0.1.0"
+edition = "2021"
+`,
+		"gamma/Cargo.toml": `[package]
+name = "gamma"
 version = "0.1.0"
 edition = "2021"
 `,
@@ -992,6 +1006,7 @@ edition = "2021"
 	packages := []discovery.Package{
 		{Name: "rust/arithmetic", Path: filepath.Join(root, "arithmetic"), Language: "rust"},
 		{Name: "rust/logic-gates", Path: filepath.Join(root, "logic-gates"), Language: "rust"},
+		{Name: "rust/gamma", Path: filepath.Join(root, "gamma"), Language: "rust"},
 	}
 
 	known := BuildKnownNames(packages)

--- a/code/programs/haskell/build-tool/CHANGELOG.md
+++ b/code/programs/haskell/build-tool/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this package will be documented in this file.
   fields plus misleading package names in metadata, options, and comments.
 - Haskell consumption of the shared Python dependency diamond plus a PEP 621
   field-boundary and distribution-name normalization fixture.
+- Shared Rust field-boundary coverage for top-level Cargo path dependencies,
+  package renames, and representative non-authoritative tables.
 
 ### Changed
 
@@ -38,6 +40,8 @@ All notable changes to this package will be documented in this file.
   stanzas, ignoring comments and every non-authoritative manifest field.
 - Resolve Python edges only from PEP 621 `[project].dependencies`, with PEP 503
   case and separator normalization before internal-package lookup.
+- Resolve Rust edges only from inline path dependencies in Cargo's top-level
+  `[dependencies]` table, honoring `package` renames before alias lookup.
 
 ## [0.1.0] - 2026-04-05
 

--- a/code/programs/haskell/build-tool/README.md
+++ b/code/programs/haskell/build-tool/README.md
@@ -48,6 +48,14 @@ PEP 503 naming. Shared fixtures cover the canonical diamond, field boundaries,
 version and environment markers, and mixed-separator aliases. The complete
 488-package Python lane matches the Go oracle at 1,118 edges.
 
+Rust dependency resolution reads only inline, path-based entries in the
+top-level Cargo `[dependencies]` table. Package metadata, features, workspace
+fields, dev/build/target dependency tables, comments, and registry-only
+dependencies cannot invent graph edges. Renamed dependencies use the inline
+`package = "..."` value rather than the local source alias. The shared
+field-boundary fixture and complete 948-package lane match the canonical Go
+resolver exactly at 2,373 edges.
+
 Package hashing reads included files as raw bytes. Repository-relative paths
 are normalized to `/`, encoded explicitly as UTF-8, and combined with those
 bytes using the existing boundary framing before `git hash-object` receives

--- a/code/programs/haskell/build-tool/src/BuildTool.hs
+++ b/code/programs/haskell/build-tool/src/BuildTool.hs
@@ -23,7 +23,7 @@ import Data.Char (isAlpha, isAlphaNum, ord, toLower)
 import Data.List (intercalate, isPrefixOf, nub, sort, sortOn)
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
-import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
+import Data.Maybe (fromMaybe, listToMaybe, mapMaybe, maybeToList)
 import qualified Data.Set as Set
 import Data.Set (Set)
 import qualified Data.Text as Text
@@ -779,6 +779,7 @@ readManifestTokens pkg
     | packageLanguage pkg == "lua" = readLuaDependencyTokens pkg
     | packageLanguage pkg == "haskell" = readCabalDependencyTokens pkg
     | packageLanguage pkg == "python" = readPythonDependencyTokens pkg
+    | packageLanguage pkg == "rust" = readRustDependencyTokens pkg
     | otherwise = readGenericManifestTokens pkg
 
 readCabalDependencyTokens :: Package -> IO [String]
@@ -930,6 +931,100 @@ hasUnquotedCharacter target = go Nothing
     go (Just quote) (character : rest)
         | character == quote = go Nothing rest
         | otherwise = go (Just quote) rest
+
+readRustDependencyTokens :: Package -> IO [String]
+readRustDependencyTokens pkg = do
+    let cargoPath = packagePath pkg </> "Cargo.toml"
+    exists <- doesFileExist cargoPath
+    if not exists
+        then pure []
+        else do
+            contents <- readFileStrict cargoPath
+            pure (rustDependencyTokens contents)
+
+rustDependencyTokens :: String -> [String]
+rustDependencyTokens = nub . collect False . lines
+  where
+    collect _ [] = []
+    collect inDependencies (rawLine : rest) =
+        let stripped = trim (stripTomlComment rawLine)
+         in case tomlSectionName stripped of
+                Just sectionName -> collect (sectionName == "dependencies") rest
+                Nothing ->
+                    if inDependencies
+                        then maybeToList (rustDependencyToken stripped) ++ collect True rest
+                        else collect False rest
+
+rustDependencyToken :: String -> Maybe String
+rustDependencyToken stripped =
+    let (dependencyKey, assignment) = break (== '=') stripped
+        dependencyValue = drop 1 assignment
+        normalizedKey = map toLower (trim dependencyKey)
+        resolvedKey =
+            map toLower
+                (fromMaybe normalizedKey (cargoInlineStringValue "package" dependencyValue))
+     in if null assignment
+            || null normalizedKey
+            || not (hasCargoPathAssignment dependencyValue)
+            then Nothing
+            else Just resolvedKey
+
+cargoInlineStringValue :: String -> String -> Maybe String
+cargoInlineStringValue fieldName value =
+    listToMaybe
+        [ quotedValue
+        | field <- splitCargoInlineFields value
+        , let withoutOpeningBrace = dropWhile (`elem` [' ', '\t', '{']) field
+        , let (key, assignment) = break (== '=') withoutOpeningBrace
+        , map toLower (trim key) == fieldName
+        , not (null assignment)
+        , quotedValue <- take 1 (extractQuotedValues (drop 1 assignment))
+        ]
+
+splitCargoInlineFields :: String -> [String]
+splitCargoInlineFields = go Nothing []
+  where
+    go _ current [] = [reverse current]
+    go Nothing current (',' : rest) = reverse current : go Nothing [] rest
+    go Nothing current (character : rest)
+        | character `elem` ['"', '\''] = go (Just character) (character : current) rest
+        | otherwise = go Nothing (character : current) rest
+    go (Just quote) current ('\\' : escaped : rest)
+        | quote == '"' = go (Just quote) (escaped : '\\' : current) rest
+    go (Just quote) current (character : rest)
+        | character == quote = go Nothing (character : current) rest
+        | otherwise = go (Just quote) (character : current) rest
+
+hasCargoPathAssignment :: String -> Bool
+hasCargoPathAssignment = scan Nothing . map toLower . hideTomlStringContents
+  where
+    scan _ [] = False
+    scan previous remaining@(character : rest)
+        | isCargoPathFieldStart previous remaining = True
+        | otherwise = scan (Just character) rest
+
+    isCargoPathFieldStart previous remaining =
+        "path" `isPrefixOf` remaining
+            && maybe True (not . isCargoKeyCharacter) previous
+            && case dropWhile (`elem` [' ', '\t']) (drop 4 remaining) of
+                '=' : _ -> True
+                _ -> False
+
+isCargoKeyCharacter :: Char -> Bool
+isCargoKeyCharacter character = isAlphaNum character || character `elem` ['_', '-']
+
+hideTomlStringContents :: String -> String
+hideTomlStringContents = go Nothing
+  where
+    go _ [] = []
+    go Nothing (character : rest)
+        | character `elem` ['"', '\''] = ' ' : go (Just character) rest
+        | otherwise = character : go Nothing rest
+    go (Just quote) ('\\' : _escaped : rest)
+        | quote == '"' = ' ' : ' ' : go (Just quote) rest
+    go (Just quote) (character : rest)
+        | character == quote = ' ' : go Nothing rest
+        | otherwise = ' ' : go (Just quote) rest
 
 readGenericManifestTokens :: Package -> IO [String]
 readGenericManifestTokens pkg = do

--- a/code/programs/haskell/build-tool/test/ResolutionUtf8Spec.hs
+++ b/code/programs/haskell/build-tool/test/ResolutionUtf8Spec.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module ResolutionUtf8Spec (resolutionCabalSpec, resolutionPythonSpec, resolutionUtf8Spec) where
+module ResolutionUtf8Spec (resolutionCabalSpec, resolutionPythonSpec, resolutionRustSpec, resolutionUtf8Spec) where
 
 import Control.Exception (bracket, try)
 import Control.Monad (forM_)
@@ -194,6 +194,26 @@ resolutionPythonSpec = describe "Python resolution conformance" $ do
                     Right
                         [ ["python/beta-helper", "python/delta", "python/gamma"]
                         , ["python/alpha"]
+                        ]
+
+resolutionRustSpec :: Spec
+resolutionRustSpec = describe "Rust resolution conformance" $ do
+    it "reads only inline path dependencies in the top-level dependencies table" $
+        withFixture "resolution-rust-field-aware.json" $ \root fixture -> do
+            graph <- resolveFixtureFor "rust" root
+            graphEdges graph `shouldBe` fixtureExpectedEdges fixture
+            DG.nodes graph
+                `shouldBe`
+                    [ "rust/alpha"
+                    , "rust/beta-helper"
+                    , "rust/delta"
+                    , "rust/gamma"
+                    ]
+            DG.independentGroups graph
+                `shouldBe`
+                    Right
+                        [ ["rust/beta-helper", "rust/delta", "rust/gamma"]
+                        , ["rust/alpha"]
                         ]
 
 assertMetadataError :: FilePath -> MetadataEncodingError -> Expectation

--- a/code/programs/haskell/build-tool/test/Spec.hs
+++ b/code/programs/haskell/build-tool/test/Spec.hs
@@ -2,7 +2,7 @@ import Test.Hspec
 
 import BuildToolSpec (buildToolSpec)
 import HashingSpec (hashingSpec)
-import ResolutionUtf8Spec (resolutionCabalSpec, resolutionPythonSpec, resolutionUtf8Spec)
+import ResolutionUtf8Spec (resolutionCabalSpec, resolutionPythonSpec, resolutionRustSpec, resolutionUtf8Spec)
 
 main :: IO ()
 main = hspec spec
@@ -14,3 +14,4 @@ spec = do
     resolutionUtf8Spec
     resolutionCabalSpec
     resolutionPythonSpec
+    resolutionRustSpec

--- a/code/scripts/tests/test_build_tool_conformance_runner.py
+++ b/code/scripts/tests/test_build_tool_conformance_runner.py
@@ -131,7 +131,7 @@ class CorpusTests(unittest.TestCase):
         summary = runner.validate_corpus(FIXTURE_ROOT)
 
         self.assertEqual(summary["schema_version"], 1)
-        self.assertEqual(summary["case_count"], 43)
+        self.assertEqual(summary["case_count"], 44)
         self.assertEqual(summary["implementation_count"], 16)
         self.assertEqual(summary["established_languages"], 15)
         self.assertEqual(summary["execution_case_count"], 0)
@@ -851,7 +851,7 @@ class CommandLineTests(unittest.TestCase):
 
         self.assertEqual(exit_code, 0)
         summary = json.loads(stdout.getvalue())
-        self.assertEqual(summary["case_count"], 43)
+        self.assertEqual(summary["case_count"], 44)
 
     def test_validate_result_reports_match_and_rejects_execution_override(self) -> None:
         case_path = CASES_ROOT / "graph-diamond.json"

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -314,6 +314,16 @@ normalization: each run of hyphens, underscores, or periods becomes one hyphen
 before internal-package lookup. Extras, version specifiers, and environment
 markers do not form part of the normalized distribution name.
 
+For Rust `Cargo.toml` manifests, dependency candidates come only from inline
+entries in the top-level `[dependencies]` table whose value contains a `path`
+assignment. The dependency key before the first `=` is matched against known
+Cargo package names unless the inline table provides a quoted `package`
+override, in which case that published package name is authoritative. Resolvers
+ignore `[package]`, `[lib]`, features, workspace
+metadata, dev dependencies, build dependencies, target-specific dependency
+tables, non-path registry dependencies, comments, and every other field or
+table. Reaching any new TOML table ends the authoritative dependency table.
+
 ### 3. Graph and scheduling
 
 Required cases cover isolated nodes, chains, diamonds, multiple components,

--- a/code/specs/fixtures/build-tool-v1/cases/resolution-rust-field-aware.json
+++ b/code/specs/fixtures/build-tool-v1/cases/resolution-rust-field-aware.json
@@ -1,0 +1,87 @@
+{
+  "schema_version": 1,
+  "id": "resolution/rust-field-aware",
+  "domain": "resolution",
+  "summary": "Rust resolution reads only inline path dependencies in the top-level Cargo dependencies table.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "resolution"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/rust/alpha/BUILD",
+        "content_utf8": "echo build alpha\n"
+      },
+      {
+        "path": "code/packages/rust/alpha/Cargo.toml",
+        "content_utf8": "[package]\nname = \"alpha\"\nversion = \"0.1.0\"\ndescription = \"Mentions gamma without depending on it.\"\n\n[features]\ngamma = [\"coding-adventures-gamma\"]\n\n[dependencies]\nbeta_alias = { package = \"beta-helper\", path = \"../beta-helper\" }\ndelta = { version = \"0.1.0\", path = \"../delta\" } # gamma stays a comment\ngamma = { version = \"0.1.0\", features = [\"path\"] }\nserde = \"1\"\n\n[dev-dependencies]\ngamma = { path = \"../gamma\" }\n\n[build-dependencies]\ngamma = { path = \"../gamma\" }\n\n[target.'cfg(unix)'.dependencies]\ngamma = { path = \"../gamma\" }\n"
+      },
+      {
+        "path": "code/packages/rust/beta-helper/BUILD",
+        "content_utf8": "echo build beta-helper\n"
+      },
+      {
+        "path": "code/packages/rust/beta-helper/Cargo.toml",
+        "content_utf8": "[package]\nname = \"beta-helper\"\nversion = \"0.1.0\"\n"
+      },
+      {
+        "path": "code/packages/rust/delta/BUILD",
+        "content_utf8": "echo build delta\n"
+      },
+      {
+        "path": "code/packages/rust/delta/Cargo.toml",
+        "content_utf8": "[package]\nname = \"delta\"\nversion = \"0.1.0\"\n"
+      },
+      {
+        "path": "code/packages/rust/gamma/BUILD",
+        "content_utf8": "echo build gamma\n"
+      },
+      {
+        "path": "code/packages/rust/gamma/Cargo.toml",
+        "content_utf8": "[package]\nname = \"gamma\"\nversion = \"0.1.0\"\n"
+      }
+    ]
+  },
+  "input": {
+    "operation": "resolution",
+    "options": {
+      "code_root": "code",
+      "language": "rust"
+    },
+    "arguments": [],
+    "environment": {},
+    "changed_paths": []
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "resolution/rust-field-aware",
+    "domain": "resolution",
+    "outcome": "ok",
+    "result": {
+      "edges": [
+        [
+          "rust/beta-helper",
+          "rust/alpha"
+        ],
+        [
+          "rust/delta",
+          "rust/alpha"
+        ]
+      ]
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 5000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 256,
+    "cpu_time_ms": 5000
+  }
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,19 +106,19 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-working inventory was regenerated on August 3, 2026 from `9441f4c7` after
-rebasing the Haskell Python-resolution slice. The inventory contains 1,247 normalized
-implementation identities across 4,400 established-lane package slots and
+working inventory was regenerated on August 3, 2026 from `88772e0d` after
+rebasing the Haskell Rust-resolution slice. The inventory contains 1,249 normalized
+implementation identities across 4,403 established-lane package slots and
 found zero canonical collisions or unknown language buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 173 | 272 |
+| Present in 10-15 languages | 173 | 271 |
 | Present in 5-9 languages | 120 | 905 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 795 | 11,130 |
+| Present in one language | 799 | 11,186 |
 
-The loop must not start by attempting 11,130 singleton ports. It should finish
+The loop must not start by attempting 11,186 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 The seventeen newest mixed Rust identities are `smart-home-camera-media`,
 `smart-home-onvif-integration`, `smart-home-shelly-integration`,
@@ -326,25 +326,32 @@ program edges and identities, and matches the Go oracle exactly. That repair
 exposed the same generic-token debt in the real 205-package Haskell lane. PR
 #9806 completed the dependency-shaped Cabal slice: it replaced 43 false edges
 from non-authoritative manifest text with `build-depends` parsing and now
-matches all 486 canonical edges. The post-merge leverage audit selects Python
-next because it is the largest affected lane: 488 real packages collapse into
-an all-node cycle, with 1,492 Haskell edges versus 1,118 canonical edges, 383
-false edges, and nine missing PEP 503-normalized edges. A dependent backlog
-owner carries the remaining post-Python readers. The post-rebase `9441f4c7`
-collision-checked inventory has 1,247
-identities and 4,400 implementation slots across 15 established lanes, with
-173 high-consensus packages and 272 missing slots, 797 singleton packages and
-11,158 missing slots, 602 Rust singletons, and zero collisions or unknown
-buckets. The Python slice now reads only PEP 621
-`[project].dependencies` and applies PEP 503 distribution-name normalization.
-Its full 488-package lane completes without failures, and the repaired
-1,118-edge graph matches the Go oracle exactly: zero Haskell-only edges and
-zero Go-only edges. The two unrelated Python `BUILD_windows` prerequisite gaps
+matches all 486 canonical edges. The next leverage audit selected Python
+because its 488 real packages collapsed into an all-node cycle, with 1,492
+Haskell edges versus 1,118 canonical edges, 383 false edges, and nine missing
+PEP 503-normalized edges. PR #9817 completed that slice by reading only PEP 621
+`[project].dependencies` and applying PEP 503 distribution-name normalization;
+the real lane now completes without failures and its 1,118-edge graph matches
+the Go oracle exactly. The new post-merge audit selects Rust because it is the
+largest remaining clean repair: 945 packages, 3,201 Haskell edges versus 2,353
+canonical edges, 848 false edges, and zero missing edges. A dependent backlog
+owner carries the remaining post-Rust readers. The repair reads only inline
+path entries from Cargo's top-level `[dependencies]` table. Full-graph
+validation also exposed valid renamed dependencies missing from the Go oracle,
+so the shared contract and both engines now honor Cargo `package` overrides.
+On the rebased tree, both engines discover 948 packages and match exactly at
+2,373 edges; the Haskell front door completes the lane with zero failures. The
+`88772e0d` collision-checked inventory has 1,249
+identities and 4,403 implementation slots across 15 established lanes, with
+173 high-consensus packages and 271 missing slots, 799 singleton packages and
+11,186 missing slots, 604 Rust singletons, and zero collisions or unknown
+buckets. The two unrelated Python `BUILD_windows` prerequisite gaps
 exposed by the full validator remain owned by
 `build-file-standalone-integrity`. Java/Kotlin/F# ZIP and Java/Kotlin ZStd fill
 existing identities; ZStd
-is complete across all 15 lanes and ZIP now spans 12. The new Chief daemon
-keyring and Synology Surveillance singleton packages own concrete filesystem or
+is complete across all 15 lanes and ZIP now spans 13. The Chief daemon keyring,
+new Chief daemon credential persistence adapter, Chief daemon composition root,
+and Synology Surveillance singleton packages own concrete filesystem or
 credentialed network authority and have excluded native-authority review
 owners. The previously discovered singleton,
 `smart-home-blue-iris-integration`, is a concrete TCP/TLS and credentialed NVR

--- a/lessons.md
+++ b/lessons.md
@@ -2063,6 +2063,17 @@ Three independent, compounding bugs were found by comparing against the real RFC
 
 Fixed in `java/zstd`: `code/packages/java/zstd/src/main/java/com/codingadventures/zstd/Zstd.java` (`buildDecodeTable`, `buildEncodeTable`, `encodeSequencesSection`, `decompressBlock`, new `fseInitState` method). Verified against the real `zstd` CLI across an 82-case fuzz corpus (varying periodic patterns, semi-random run-length data, pure random data, and prose at multiple repeat counts) in both directions, plus the two dedicated JUnit interop tests (`tc9CliInterop`, `rtCliInteropHighSequenceCount`).
 
+## Adjudicate oracle differences against the manifest contract
+
+A full Haskell-versus-Go Rust graph comparison initially showed two Haskell-only
+edges. Deleting them to match the reference engine would have hidden valid Cargo
+dependencies: each entry used a local source alias plus an authoritative
+`package = "..."` published-name override. A reference engine is evidence, not
+the specification. When parity comparison finds an extra edge, inspect the real
+manifest and shared behavior contract before classifying it as false. If the
+oracle is incomplete, add a language-neutral fixture and repair every affected
+engine in the same dependency-shaped slice.
+
 ## Adding shared build-tool fixtures must update the pinned corpus-summary tests
 
 Adding three valid conformance cases changed `validate-corpus` from 38 to 41,


### PR DESCRIPTION
## Summary
- replace Haskell's generic whole-manifest Rust token scan with top-level Cargo `[dependencies]` parsing for inline path dependencies
- honor Cargo `package = ...` renames in both Haskell and the canonical Go resolver, and reject misleading `path` text in unrelated fields/tables
- add a language-neutral Rust field-boundary fixture, update corpus pins/docs/changelogs, and record the refreshed parity inventory/backlog

## Parity evidence
- final base: `88772e0d`; collision-checked inventory: 1,249 identities / 4,403 established-lane slots / 0 collisions / 0 unknown buckets
- complete Rust lane: both engines discover 948 packages and produce exactly 2,373 edges; Haskell-only 0, Go-only 0
- complete Rust front doors: Go `948 would-build`; Haskell `built=0, skipped=948, failed=0`
- newly landed `chief-of-staff-daemon-credential` and `chief-of-staff-daemon` were classified as excluded native-authority reviews rather than portable parity targets

## Validation
- `cabal test all --test-show-details=direct` — 20 build-tool + 3 directed-graph + 4 graph examples pass
- `cabal test spec --ghc-options=-Werror --test-show-details=direct` — 20 examples pass
- `cabal check` — clean
- `cabal haddock all` — builds; pre-existing missing-documentation/link warnings only
- HPC — 44% top-level definitions (96/218), 54% alternatives (152/278), 58% expressions (1,867/3,204)
- `go test ./...`, `go vet ./...`, `go build -trimpath ./...` — pass
- `python -m unittest discover -s code/scripts/tests -p test_build_tool_conformance_runner.py` — 40 tests pass
- `python code/scripts/build_tool_conformance.py validate-corpus` — 44 cases / 100 files valid
- full Go and Haskell Rust plans/front doors — 948 packages, 2,373 exact edges, zero failures
- `python code/scripts/package_parity_report.py --root . --format json --fail-on-collisions` — clean
- `git diff --check`, `gofmt -d`, state/dependency validation, changed-diff credential scan, and direct dangerous-API review — clean

## Advisory checks
- no dependencies or authority surface added; `cabal outdated` reports only existing `containers` 0.8 and `time` 1.16.0.1 beyond current bounds
- HLint, Fourmolu, OSV Scanner, and gosec are not installed locally