### PR TITLE
Fix parallel xargs output races

### DIFF
--- a/code/programs/go/unix-tools/xargs_test.go
+++ b/code/programs/go/unix-tools/xargs_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 
 	clibuilder "github.com/adhithyan15/coding-adventures/code/packages/go/cli-builder"
@@ -154,10 +155,13 @@ type xargsExecRecord struct {
 }
 
 func makeMockXargsExec(records *[]xargsExecRecord) xargsExecFunc {
+	var mu sync.Mutex
 	return func(name string, args []string, stdout, stderr io.Writer) int {
 		argsCopy := make([]string, len(args))
 		copy(argsCopy, args)
+		mu.Lock()
 		*records = append(*records, xargsExecRecord{name, argsCopy})
+		mu.Unlock()
 		// Simulate echo: write args to stdout.
 		fmt.Fprintln(stdout, strings.Join(args, " "))
 		return 0
@@ -322,4 +326,3 @@ func TestXargsInvalidSpec(t *testing.T) {
 		t.Errorf("exit code = %d, want 1", rc)
 	}
 }
-

--- a/code/programs/go/unix-tools/xargs_tool.go
+++ b/code/programs/go/unix-tools/xargs_tool.go
@@ -61,13 +61,13 @@ import (
 // =========================================================================
 
 type XargsOptions struct {
-	NullDelimiter  bool   // -0: items separated by NUL
-	Delimiter      string // -d: custom delimiter
-	MaxArgs        int    // -n: max args per command invocation
-	ReplaceStr     string // -I: replacement string
-	Verbose        bool   // -t: print command before executing
-	NoRunIfEmpty   bool   // -r: don't run if input is empty
-	MaxProcs       int    // -P: max parallel processes
+	NullDelimiter bool   // -0: items separated by NUL
+	Delimiter     string // -d: custom delimiter
+	MaxArgs       int    // -n: max args per command invocation
+	ReplaceStr    string // -I: replacement string
+	Verbose       bool   // -t: print command before executing
+	NoRunIfEmpty  bool   // -r: don't run if input is empty
+	MaxProcs      int    // -P: max parallel processes
 }
 
 // =========================================================================
@@ -161,6 +161,17 @@ func xargsBatchItems(items []string, maxArgs int) [][]string {
 
 type xargsExecFunc func(name string, args []string, stdout, stderr io.Writer) int
 
+type xargsLockedWriter struct {
+	mu     *sync.Mutex
+	writer io.Writer
+}
+
+func (w xargsLockedWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.writer.Write(p)
+}
+
 // xargsRealExec executes a real system command.
 func xargsRealExec(name string, args []string, stdout, stderr io.Writer) int {
 	cmd := exec.Command(name, args...)
@@ -224,8 +235,11 @@ func xargsExecute(cmdParts []string, items []string, opts XargsOptions,
 	if opts.MaxProcs > 1 {
 		// Parallel execution.
 		var mu sync.Mutex
+		var outputMu sync.Mutex
 		var wg sync.WaitGroup
 		sem := make(chan struct{}, opts.MaxProcs)
+		parallelStdout := xargsLockedWriter{mu: &outputMu, writer: stdout}
+		parallelStderr := xargsLockedWriter{mu: &outputMu, writer: stderr}
 
 		for _, batch := range batches {
 			wg.Add(1)
@@ -236,11 +250,9 @@ func xargsExecute(cmdParts []string, items []string, opts XargsOptions,
 
 				args := append(append([]string{}, initialArgs...), b...)
 				if opts.Verbose {
-					mu.Lock()
-					fmt.Fprintf(stderr, "%s %s\n", cmdName, strings.Join(args, " "))
-					mu.Unlock()
+					fmt.Fprintf(parallelStderr, "%s %s\n", cmdName, strings.Join(args, " "))
 				}
-				rc := execFn(cmdName, args, stdout, stderr)
+				rc := execFn(cmdName, args, parallelStdout, parallelStderr)
 				if rc != 0 {
 					mu.Lock()
 					exitCode = rc


### PR DESCRIPTION
## Summary
- serialize writes from parallel Go xargs workers without serializing command execution
- make the injected executor test recorder safe for concurrent workers
- repair the newest-main CodeQL crash in `TestXargsParallelExecution` from run 30853333213

## Validation
- `go test ./...`
- `go test -race ./...`
- `go test -race -run TestXargsParallelExecution -count=100 .`
- `go test -run TestXargsParallelExecution -count=1000 .`
- `go vet ./...`
- `git diff --check`