### PR TITLE
Add JFET flicker-noise coefficient parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `KF` flicker-noise coefficient.
 - Validate and lower diode model-card `AF` flicker-noise exponent.
 - Validate and lower diode model-card `KF` flicker-noise coefficient.
 - Validate and lower diode model-card `EG` energy gap.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1335,6 +1335,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             lambda_=model.params.get("LAMBDA", 0.0),
             Cgs=model.params.get("CGS", model.params.get("CGS0", 0.0)),
             Cgd=model.params.get("CGD", model.params.get("CGD0", 0.0)),
+            Kf=model.params.get("KF", 0.0),
         )
     if prefix == "M":
         _require_min_fields(fields, 6, "MOSFET")
@@ -2071,6 +2072,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or gate_drain_capacitance < 0.0
         ):
             raise NetlistParseError("JFET CGD must be finite and non-negative")
+        flicker_noise_coefficient = params.get("KF")
+        if flicker_noise_coefficient is not None and (
+            not math.isfinite(flicker_noise_coefficient)
+            or flicker_noise_coefficient < 0.0
+        ):
+            raise NetlistParseError("JFET KF must be finite and non-negative")
     if kind in {"NMOS", "PMOS"}:
         if "LEVEL" in params:
             level = params["LEVEL"]

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1367,6 +1367,27 @@ def test_rejects_invalid_jfet_gate_drain_capacitance(value: str) -> None:
         parse_netlist(f".model fast NJF(CGD={value})")
 
 
+def test_parse_jfet_flicker_noise_coefficient() -> None:
+    parsed = parse_netlist(
+        """
+.model fast NJF(KF=2e-18)
+J1 drain gate source fast
+"""
+    )
+
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert isclose(jfet.Kf, 2.0e-18)
+
+
+@pytest.mark.parametrize("value", ["-1e-18", "1e999"])
+def test_rejects_invalid_jfet_flicker_noise_coefficient(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="JFET KF must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NJF(KF={value})")
+
+
 def test_parse_pjf_model_aliases_beta() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `KF` flicker-noise coefficient.
 - Validate and lower diode model-card `AF` flicker-noise exponent.
 - Validate and lower diode model-card `KF` flicker-noise coefficient.
 - Validate and lower diode model-card `EG` energy gap.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1345,6 +1345,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("JFET CGD must be finite and non-negative");
   }
+  const jfetFlickerNoiseCoefficient = params.get("KF");
+  if (
+    (kind === "NJF" || kind === "PJF") &&
+    jfetFlickerNoiseCoefficient !== undefined &&
+    (!Number.isFinite(jfetFlickerNoiseCoefficient) || jfetFlickerNoiseCoefficient < 0.0)
+  ) {
+    throw new NetlistParseError("JFET KF must be finite and non-negative");
+  }
   const level = params.get("LEVEL");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1932,6 +1940,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("LAMBDA") ?? 0.0,
       model.params.get("CGS") ?? model.params.get("CGS0") ?? 0.0,
       model.params.get("CGD") ?? model.params.get("CGD0") ?? 0.0,
+      model.params.get("KF") ?? 0.0,
     );
   }
   if (prefix === "M") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1408,6 +1408,27 @@ J1 drain gate source fast
     },
   );
 
+  it("parses the JFET flicker-noise coefficient", () => {
+    const parsed = parseNetlist(`
+.model fast NJF(KF=2e-18)
+J1 drain gate source fast
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      flickerNoiseCoefficient: 2.0e-18,
+    });
+  });
+
+  it.each(["-1e-18", "1e999"])(
+    "rejects invalid JFET flicker-noise coefficient %s",
+    (value) => {
+      expect(() => parseNetlist(`.model fast NJF(KF=${value})`)).toThrow(
+        "JFET KF must be finite and non-negative",
+      );
+    },
+  );
+
   it("parses PJF model beta aliases", () => {
     const parsed = parseNetlist(`
 .model pslow PJF(B=750u)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4441,15 +4441,24 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine diode flicker-noise coefficient field.
 
 424. Python and TypeScript Berkeley SPICE diode flicker-noise exponent parity.
-   - Status: completed in this diode flicker-noise exponent parity slice.
+   - Status: completed in PR 9831.
    - Both parser facades validate finite non-negative `AF` values and lower
      them into the shared engine diode flicker-noise exponent field.
+
+425. Python and TypeScript Berkeley SPICE JFET flicker-noise coefficient parity.
+   - Status: completed in this JFET flicker-noise coefficient parity slice.
+   - Both parser facades validate finite non-negative `KF` values and lower
+     them into the shared engine JFET flicker-noise coefficient field.
 
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE model-card validation parity.
-   - Perform a fresh parser-to-engine model-card completion audit across diode,
-     BJT, JFET, and MOS surfaces and prioritize the next smallest live gap.
+   - Continue the audited JFET model-card gaps, beginning with `AF`, then
+     `PB` / `VJ`, `FC`, `IS`, `XTI`, `EG`, `B`, `NLEV`, `GDSNOI`, `RD`, `RS`,
+     `TCV`, `VTOTC`, `TNOM` / `T_NOM`, `BEX`, and `BETATCE`.
+   - Continue the audited BJT model-card gaps after the smaller JFET fields;
+     prioritize direct engine fields before adding new model surfaces.
+   - Re-audit MOS lowering after those direct JFET and BJT omissions close.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary
- validate finite non-negative JFET `KF` model-card values in Python and TypeScript
- lower `KF` into the existing engine flicker-noise coefficient field
- record the fresh model-card audit and prioritize the remaining JFET/BJT gaps

## Verification
- `code/packages/python/spice-netlist-parser/BUILD`
- Python parser Ruff checks
- `code/packages/typescript/spice-engine/BUILD`
- `code/packages/typescript/spice-netlist-parser/BUILD`
- TypeScript parser coverage suite (86.42% lines)