### PR TITLE
Add JFET flicker-noise exponent parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `AF` flicker-noise exponent.
 - Validate and lower JFET model-card `KF` flicker-noise coefficient.
 - Validate and lower diode model-card `AF` flicker-noise exponent.
 - Validate and lower diode model-card `KF` flicker-noise coefficient.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1336,6 +1336,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Cgs=model.params.get("CGS", model.params.get("CGS0", 0.0)),
             Cgd=model.params.get("CGD", model.params.get("CGD0", 0.0)),
             Kf=model.params.get("KF", 0.0),
+            Af=model.params.get("AF", 1.0),
         )
     if prefix == "M":
         _require_min_fields(fields, 6, "MOSFET")
@@ -2078,6 +2079,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or flicker_noise_coefficient < 0.0
         ):
             raise NetlistParseError("JFET KF must be finite and non-negative")
+        flicker_noise_exponent = params.get("AF")
+        if flicker_noise_exponent is not None and (
+            not math.isfinite(flicker_noise_exponent)
+            or flicker_noise_exponent < 0.0
+        ):
+            raise NetlistParseError("JFET AF must be finite and non-negative")
     if kind in {"NMOS", "PMOS"}:
         if "LEVEL" in params:
             level = params["LEVEL"]

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1388,6 +1388,27 @@ def test_rejects_invalid_jfet_flicker_noise_coefficient(value: str) -> None:
         parse_netlist(f".model fast NJF(KF={value})")
 
 
+def test_parse_jfet_flicker_noise_exponent() -> None:
+    parsed = parse_netlist(
+        """
+.model fast NJF(AF=1.4)
+J1 drain gate source fast
+"""
+    )
+
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert isclose(jfet.Af, 1.4)
+
+
+@pytest.mark.parametrize("value", ["-0.1", "1e999"])
+def test_rejects_invalid_jfet_flicker_noise_exponent(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="JFET AF must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NJF(AF={value})")
+
+
 def test_parse_pjf_model_aliases_beta() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `AF` flicker-noise exponent.
 - Validate and lower JFET model-card `KF` flicker-noise coefficient.
 - Validate and lower diode model-card `AF` flicker-noise exponent.
 - Validate and lower diode model-card `KF` flicker-noise coefficient.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1353,6 +1353,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("JFET KF must be finite and non-negative");
   }
+  const jfetFlickerNoiseExponent = params.get("AF");
+  if (
+    (kind === "NJF" || kind === "PJF") &&
+    jfetFlickerNoiseExponent !== undefined &&
+    (!Number.isFinite(jfetFlickerNoiseExponent) || jfetFlickerNoiseExponent < 0.0)
+  ) {
+    throw new NetlistParseError("JFET AF must be finite and non-negative");
+  }
   const level = params.get("LEVEL");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1941,6 +1949,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("CGS") ?? model.params.get("CGS0") ?? 0.0,
       model.params.get("CGD") ?? model.params.get("CGD0") ?? 0.0,
       model.params.get("KF") ?? 0.0,
+      model.params.get("AF") ?? 1.0,
     );
   }
   if (prefix === "M") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1429,6 +1429,27 @@ J1 drain gate source fast
     },
   );
 
+  it("parses the JFET flicker-noise exponent", () => {
+    const parsed = parseNetlist(`
+.model fast NJF(AF=1.4)
+J1 drain gate source fast
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      flickerNoiseExponent: 1.4,
+    });
+  });
+
+  it.each(["-0.1", "1e999"])(
+    "rejects invalid JFET flicker-noise exponent %s",
+    (value) => {
+      expect(() => parseNetlist(`.model fast NJF(AF=${value})`)).toThrow(
+        "JFET AF must be finite and non-negative",
+      );
+    },
+  );
+
   it("parses PJF model beta aliases", () => {
     const parsed = parseNetlist(`
 .model pslow PJF(B=750u)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4446,15 +4446,20 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine diode flicker-noise exponent field.
 
 425. Python and TypeScript Berkeley SPICE JFET flicker-noise coefficient parity.
-   - Status: completed in this JFET flicker-noise coefficient parity slice.
+   - Status: completed in PR 9835.
    - Both parser facades validate finite non-negative `KF` values and lower
      them into the shared engine JFET flicker-noise coefficient field.
+
+426. Python and TypeScript Berkeley SPICE JFET flicker-noise exponent parity.
+   - Status: completed in this JFET flicker-noise exponent parity slice.
+   - Both parser facades validate finite non-negative `AF` values and lower
+     them into the shared engine JFET flicker-noise exponent field.
 
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE model-card validation parity.
-   - Continue the audited JFET model-card gaps, beginning with `AF`, then
-     `PB` / `VJ`, `FC`, `IS`, `XTI`, `EG`, `B`, `NLEV`, `GDSNOI`, `RD`, `RS`,
+   - Continue the audited JFET model-card gaps, beginning with `PB` / `VJ`,
+     then `FC`, `IS`, `XTI`, `EG`, `B`, `NLEV`, `GDSNOI`, `RD`, `RS`,
      `TCV`, `VTOTC`, `TNOM` / `T_NOM`, `BEX`, and `BETATCE`.
    - Continue the audited BJT model-card gaps after the smaller JFET fields;
      prioritize direct engine fields before adding new model surfaces.


### PR DESCRIPTION
## Summary
- validate finite non-negative JFET `AF` model-card values in Python and TypeScript
- lower `AF` into the existing engine flicker-noise exponent field
- advance the audited parser-to-engine backlog to JFET junction potential

## Verification
- `code/packages/python/spice-netlist-parser/BUILD`
- Python parser Ruff checks
- `code/packages/typescript/spice-engine/BUILD`
- `code/packages/typescript/spice-netlist-parser/BUILD`
- TypeScript parser coverage suite (86.46% lines)