### PR TITLE
Add JFET junction potential parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `PB` / `VJ` junction potential.
 - Validate and lower JFET model-card `AF` flicker-noise exponent.
 - Validate and lower JFET model-card `KF` flicker-noise coefficient.
 - Validate and lower diode model-card `AF` flicker-noise exponent.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1337,6 +1337,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Cgd=model.params.get("CGD", model.params.get("CGD0", 0.0)),
             Kf=model.params.get("KF", 0.0),
             Af=model.params.get("AF", 1.0),
+            Pb=model.params.get("PB", model.params.get("VJ", 1.0)),
         )
     if prefix == "M":
         _require_min_fields(fields, 6, "MOSFET")
@@ -2085,6 +2086,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or flicker_noise_exponent < 0.0
         ):
             raise NetlistParseError("JFET AF must be finite and non-negative")
+        junction_potential = params.get("PB", params.get("VJ"))
+        if junction_potential is not None and (
+            not math.isfinite(junction_potential) or junction_potential <= 0.0
+        ):
+            raise NetlistParseError("JFET PB must be finite and positive")
     if kind in {"NMOS", "PMOS"}:
         if "LEVEL" in params:
             level = params["LEVEL"]

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1409,6 +1409,42 @@ def test_rejects_invalid_jfet_flicker_noise_exponent(value: str) -> None:
         parse_netlist(f".model fast NJF(AF={value})")
 
 
+@pytest.mark.parametrize("parameter", ["PB", "VJ"])
+def test_parse_jfet_junction_potential_aliases(parameter: str) -> None:
+    parsed = parse_netlist(
+        f"""
+.model fast NJF({parameter}=0.8)
+J1 drain gate source fast
+"""
+    )
+
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert isclose(jfet.Pb, 0.8)
+
+
+def test_jfet_junction_potential_prefers_canonical_name() -> None:
+    parsed = parse_netlist(
+        """
+.model fast NJF(PB=0.9 VJ=0.8)
+J1 drain gate source fast
+"""
+    )
+
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert isclose(jfet.Pb, 0.9)
+
+
+@pytest.mark.parametrize("parameter", ["PB", "VJ"])
+@pytest.mark.parametrize("value", ["0", "-0.1", "1e999"])
+def test_rejects_invalid_jfet_junction_potential(
+    parameter: str, value: str
+) -> None:
+    with pytest.raises(NetlistParseError, match="JFET PB must be finite and positive"):
+        parse_netlist(f".model fast NJF({parameter}={value})")
+
+
 def test_parse_pjf_model_aliases_beta() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `PB` / `VJ` junction potential.
 - Validate and lower JFET model-card `AF` flicker-noise exponent.
 - Validate and lower JFET model-card `KF` flicker-noise coefficient.
 - Validate and lower diode model-card `AF` flicker-noise exponent.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1361,6 +1361,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("JFET AF must be finite and non-negative");
   }
+  const jfetJunctionPotential = params.get("PB") ?? params.get("VJ");
+  if (
+    (kind === "NJF" || kind === "PJF") &&
+    jfetJunctionPotential !== undefined &&
+    (!Number.isFinite(jfetJunctionPotential) || jfetJunctionPotential <= 0.0)
+  ) {
+    throw new NetlistParseError("JFET PB must be finite and positive");
+  }
   const level = params.get("LEVEL");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1950,6 +1958,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("CGD") ?? model.params.get("CGD0") ?? 0.0,
       model.params.get("KF") ?? 0.0,
       model.params.get("AF") ?? 1.0,
+      model.params.get("PB") ?? model.params.get("VJ") ?? 1.0,
     );
   }
   if (prefix === "M") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1450,6 +1450,38 @@ J1 drain gate source fast
     },
   );
 
+  it.each(["PB", "VJ"])("parses the JFET %s junction-potential alias", (parameter) => {
+    const parsed = parseNetlist(`
+.model fast NJF(${parameter}=0.8)
+J1 drain gate source fast
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      junctionPotential: 0.8,
+    });
+  });
+
+  it("prefers canonical JFET PB over the VJ alias", () => {
+    const parsed = parseNetlist(`
+.model fast NJF(PB=0.9 VJ=0.8)
+J1 drain gate source fast
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      junctionPotential: 0.9,
+    });
+  });
+
+  it.each(["PB", "VJ"])("rejects invalid JFET %s junction potential", (parameter) => {
+    for (const value of ["0", "-0.1", "1e999"]) {
+      expect(() => parseNetlist(`.model fast NJF(${parameter}=${value})`)).toThrow(
+        "JFET PB must be finite and positive",
+      );
+    }
+  });
+
   it("parses PJF model beta aliases", () => {
     const parsed = parseNetlist(`
 .model pslow PJF(B=750u)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4451,15 +4451,21 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine JFET flicker-noise coefficient field.
 
 426. Python and TypeScript Berkeley SPICE JFET flicker-noise exponent parity.
-   - Status: completed in this JFET flicker-noise exponent parity slice.
+   - Status: completed in PR 9837.
    - Both parser facades validate finite non-negative `AF` values and lower
      them into the shared engine JFET flicker-noise exponent field.
+
+427. Python and TypeScript Berkeley SPICE JFET junction-potential parity.
+   - Status: completed in this JFET junction-potential parity slice.
+   - Both parser facades validate positive finite `PB` / `VJ` values, prefer
+     canonical `PB`, and lower the result into the shared engine JFET
+     junction-potential field.
 
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE model-card validation parity.
-   - Continue the audited JFET model-card gaps, beginning with `PB` / `VJ`,
-     then `FC`, `IS`, `XTI`, `EG`, `B`, `NLEV`, `GDSNOI`, `RD`, `RS`,
+   - Continue the audited JFET model-card gaps, beginning with `FC`, then `IS`,
+     `XTI`, `EG`, `B`, `NLEV`, `GDSNOI`, `RD`, `RS`,
      `TCV`, `VTOTC`, `TNOM` / `T_NOM`, `BEX`, and `BETATCE`.
    - Continue the audited BJT model-card gaps after the smaller JFET fields;
      prioritize direct engine fields before adding new model surfaces.


### PR DESCRIPTION
## Summary
- validate positive finite JFET `PB` and `VJ` model-card values in Python and TypeScript
- prefer canonical `PB` and lower the result into the existing engine junction-potential field
- advance the audited parser-to-engine backlog to JFET depletion coefficient

## Verification
- `code/packages/python/spice-netlist-parser/BUILD`
- Python parser Ruff checks
- `code/packages/typescript/spice-engine/BUILD`
- `code/packages/typescript/spice-netlist-parser/BUILD`
- TypeScript parser coverage suite (86.5% lines)