### PR TITLE
feat(learning): add stable neural Rust C ABI

### DIFF
--- a/.github/workflows/deploy-ml-learning.yml
+++ b/.github/workflows/deploy-ml-learning.yml
@@ -37,12 +37,15 @@ on:
       - "code/specs/fixtures/precision-residency-v1/**"
       - "code/specs/fixtures/reference-validation-v1/**"
       - "code/specs/fixtures/cross-language-consumers-v1/**"
+      - "code/specs/fixtures/neural-learning-rust-cabi-v1/**"
       - "code/scripts/validate_*_labs.py"
       - "code/scripts/validate_reference_fixture_catalog.py"
       - "code/scripts/validate_cross_language_fixture_consumers.py"
+      - "code/scripts/validate_neural_learning_rust_cabi.py"
       - "code/programs/go/neural-fixture-consumer/**"
       - "code/programs/ruby/neural-fixture-consumer/**"
       - "code/programs/rust/neural-fixture-consumer/**"
+      - "code/packages/rust/neural-learning-capi/**"
       - "code/packages/typescript/cli-builder/**"
       - "code/packages/typescript/directed-graph/**"
       - "code/packages/typescript/state-machine/**"
@@ -94,6 +97,9 @@ jobs:
 
       - name: Validate cross-language neural fixture consumers
         run: python3 code/scripts/validate_cross_language_fixture_consumers.py
+
+      - name: Validate neural-learning Rust C ABI
+        run: python3 code/scripts/validate_neural_learning_rust_cabi.py
 
   build-and-deploy:
     needs: validate-language-consumers

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1256 | 1278 | 98 | 61 | 8 | 1089 |
+| 1285 | 1282 | 99 | 61 | 8 | 1117 |
 
 ## Method
 
@@ -24,10 +24,10 @@ mention provides a complete lesson.
 
 | Priority | Dedicated | Related | Index only | Missing |
 | --- | ---: | ---: | ---: | ---: |
-| P0 | 86 | 25 | 6 | 55 |
-| P1 | 9 | 22 | 0 | 90 |
+| P0 | 86 | 26 | 6 | 55 |
+| P1 | 9 | 21 | 0 | 90 |
 | P2 | 1 | 3 | 1 | 152 |
-| P3 | 2 | 11 | 1 | 792 |
+| P3 | 3 | 11 | 1 | 820 |
 
 ## P0 Backlog
 
@@ -492,8 +492,10 @@ mention provides a complete lesson.
 | `forme-doc-page-shell` | 1 | missing |
 | `forme-style-to-terminal` | 1 | missing |
 | `smart-home-shelly-integration` | 1 | missing |
+| `venture-browser-cairo` | 1 | missing |
 | `venture-browser-core` | 1 | missing |
 | `venture-browser-macos` | 1 | missing |
+| `venture-browser-qt` | 1 | missing |
 | `mosaic-pkg-card-browser` | 0 | missing |
 | `mosaic-pkg-note-editor` | 0 | missing |
 | `mosaic-pkg-note-type-editor` | 0 | missing |
@@ -826,6 +828,7 @@ mention provides a complete lesson.
 | --- | ---: | --- |
 | `board-vm-protocol` | 1 | missing |
 | `board-vm-tcp` | 1 | missing |
+| `chief-of-staff-host-control-protocol` | 1 | missing |
 | `dns-message` | 1 | missing |
 | `embeddable-http-server` | 1 | missing |
 | `embeddable-tcp-server` | 1 | missing |
@@ -839,6 +842,7 @@ mention provides a complete lesson.
 | `lang-refinement-protocol` | 1 | missing |
 | `smart-home-local-http` | 1 | missing |
 | `smart-home-platform-http` | 1 | missing |
+| `smart-home-unifi-network-integration` | 1 | missing |
 | `tcp-reactor` | 1 | missing |
 | `tcp-runtime` | 1 | missing |
 | `tls-platform` | 1 | missing |
@@ -919,7 +923,24 @@ mention provides a complete lesson.
 | `capability-os-sandbox` | 1 | missing |
 | `cfb` | 1 | missing |
 | `cfb-writer` | 1 | missing |
+| `chief-of-staff-channel-endpoints` | 1 | missing |
+| `chief-of-staff-channel-store` | 1 | missing |
+| `chief-of-staff-cli-core` | 1 | missing |
+| `chief-of-staff-daemon` | 1 | missing |
+| `chief-of-staff-daemon-api` | 1 | missing |
+| `chief-of-staff-daemon-config` | 1 | missing |
+| `chief-of-staff-daemon-credential` | 1 | missing |
+| `chief-of-staff-daemon-installer` | 1 | missing |
+| `chief-of-staff-daemon-keyring` | 1 | missing |
+| `chief-of-staff-daemon-policy` | 1 | missing |
+| `chief-of-staff-daemon-runtime` | 1 | missing |
+| `chief-of-staff-daemon-service-files` | 1 | missing |
 | `chief-of-staff-host-runtime` | 1 | missing |
+| `chief-of-staff-orchestrator-core` | 1 | missing |
+| `chief-of-staff-process-supervisor` | 1 | missing |
+| `chief-of-staff-secure-host-channel` | 1 | missing |
+| `chief-of-staff-service-reconciler` | 1 | missing |
+| `chief-of-staff-service-registry` | 1 | missing |
 | `chief-of-staff-smart-home-tools` | 1 | missing |
 | `chief-of-staff-tool-api` | 1 | missing |
 | `chief-of-staff-tool-audit-store` | 1 | missing |
@@ -1144,6 +1165,7 @@ mention provides a complete lesson.
 | `ppt-writer` | 1 | missing |
 | `pptx-writer` | 1 | missing |
 | `presentationml` | 1 | missing |
+| `process-shutdown` | 1 | missing |
 | `prolog-core` | 1 | missing |
 | `protobuf` | 1 | missing |
 | `python-bridge` | 1 | missing |
@@ -1177,6 +1199,8 @@ mention provides a complete lesson.
 | `skill-store` | 1 | missing |
 | `smart-home-airgradient-local-integration` | 1 | missing |
 | `smart-home-automation-runtime` | 1 | missing |
+| `smart-home-axis-vapix-integration` | 1 | missing |
+| `smart-home-blue-iris-integration` | 1 | missing |
 | `smart-home-camera-media` | 1 | missing |
 | `smart-home-capability-cage` | 1 | missing |
 | `smart-home-core` | 1 | missing |
@@ -1184,6 +1208,7 @@ mention provides a complete lesson.
 | `smart-home-discovery` | 1 | missing |
 | `smart-home-discovery-service` | 1 | missing |
 | `smart-home-event-streams` | 1 | missing |
+| `smart-home-frigate-integration` | 1 | missing |
 | `smart-home-fronius-local-integration` | 1 | missing |
 | `smart-home-govee-lan-integration` | 1 | missing |
 | `smart-home-heos-cli-integration` | 1 | missing |
@@ -1207,6 +1232,7 @@ mention provides a complete lesson.
 | `smart-home-runtime` | 1 | missing |
 | `smart-home-runtime-store` | 1 | missing |
 | `smart-home-sonos-upnp-integration` | 1 | missing |
+| `smart-home-synology-surveillance-integration` | 1 | missing |
 | `smart-home-tasmota-local-integration` | 1 | missing |
 | `smart-home-testkit` | 1 | missing |
 | `smart-home-wemo-upnp-integration` | 1 | missing |
@@ -1279,6 +1305,8 @@ mention provides a complete lesson.
 | `wave-physics` | 1 | missing |
 | `weather-agent-e2e` | 1 | missing |
 | `web-core` | 1 | missing |
+| `websocket-core` | 1 | missing |
+| `websocket-runtime` | 1 | missing |
 | `win32-event-loop` | 1 | missing |
 | `wolfram-repl` | 1 | missing |
 | `wolfram-runtime` | 1 | missing |

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -51,13 +51,14 @@ larger network:
 31. [Precision, Quantization, and Buffer Residency, by Hand](./precision-quantization-and-residency-by-hand.md)
 32. [Reference Fixtures: Make Every Expected Answer Earn Your Trust](./reference-fixtures-by-hand.md)
 33. [One Fixture, Three Languages](./one-fixture-three-languages.md)
-34. [Matrix Math](../matrix-math.md)
-35. [Loss Functions](../loss-functions.md)
-36. [Gradient Descent](../gradient-descent.md)
-37. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-38. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-39. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-40. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+34. [A Rust C ABI, by Hand](./rust-c-abi-by-hand.md)
+35. [Matrix Math](../matrix-math.md)
+36. [Loss Functions](../loss-functions.md)
+37. [Gradient Descent](../gradient-descent.md)
+38. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+39. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+40. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+41. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -324,6 +325,12 @@ fixture. Each program recomputes the arithmetic and emits the same bounded JSON
 receipt; the orchestrator rejects command drift, extra output, and dishonest
 results before comparing all three lanes.
 
+NN35 adds `code/specs/fixtures/neural-learning-rust-cabi-v1`, which pins the
+versioned public header, closed status table, caller-owned buffer rules, NN03
+hand calculation, and five failure probes. Its validator dynamically loads the
+compiled Rust shared library and checks that rejected calls leave outputs
+unchanged.
+
 Validate the bootstrap corpus with:
 
 ```text
@@ -359,6 +366,7 @@ python code/scripts/validate_backend_parity_labs.py
 python code/scripts/validate_precision_residency_labs.py
 python code/scripts/validate_reference_fixture_catalog.py
 python code/scripts/validate_cross_language_fixture_consumers.py
+python code/scripts/validate_neural_learning_rust_cabi.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a
@@ -432,6 +440,9 @@ covering all 30 fixture families and 33 lab documents.
 The first NN34 lab computes `2 * 0.5 + (-1) * (-0.25) + 0.1 = 1.35`, then makes
 Go, Ruby, and Rust earn parity by independently reading that same fixture and
 emitting one schema-checked receipt.
+The first NN35 lab moves that exact arithmetic behind a versioned C function,
+returns `[1.0, 0.25]` and `1.35` through caller-owned buffers, and proves five
+failure statuses write no partial answer.
 
 ## How to Study a Model
 

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -65,7 +65,7 @@ trace, and tests.
 - [ ] Cross-language consumers
   - [x] Validate every fixture with the reference implementation.
   - [x] Add thin consumers in representative language families.
-  - [ ] Define a stable Rust C ABI for high-performance execution.
+  - [x] Define a stable Rust C ABI for high-performance execution.
   - [ ] Track native implementation versus Rust-core binding coverage.
 
 ## Loop Rules

--- a/code/learning/machine-learning/curriculum.md
+++ b/code/learning/machine-learning/curriculum.md
@@ -127,6 +127,14 @@ registered commands distinct from evidence that an external process ran. The
 next cross-language tranche can therefore define a stable Rust C ABI without
 confusing a native reference baseline with a core binding.
 
+NN35 defines that stable boundary. One allocation-free C function accepts
+caller-owned binary64 buffers, exposes both weighted contributions and the
+prediction, and returns a closed status without partial output writes. A
+versioned header, language-neutral ABI catalog, direct Rust tests, and a Python
+`ctypes` call all pin the same `0x00010000` contract. Native NN34 lanes remain
+the comparison baseline; the next tranche can add binding-backed lanes and
+track which language concepts use native code or the Rust core.
+
 ## Corpus Rule
 
 Every new curriculum unit should contribute all of the following:

--- a/code/learning/machine-learning/rust-c-abi-by-hand.md
+++ b/code/learning/machine-learning/rust-c-abi-by-hand.md
@@ -1,0 +1,147 @@
+# A Rust C ABI, by hand
+
+<!-- learning-concepts: neural-learning-capi -->
+
+The NN34 programs agree on an answer, but each program still performs its own
+arithmetic. What if many languages should share one fast Rust implementation?
+
+They need a doorway. A **foreign-function interface**, usually shortened to
+**FFI**, is a doorway through which one language calls code built by another.
+The doorway used here is a **C ABI**. ABI means *application binary interface*:
+the exact low-level agreement about function names, argument shapes, return
+values, and memory ownership.
+
+“C” describes the agreement, not the caller. Python, Ruby, Go, Swift, C#, and
+many other runtimes know how to call a C-shaped function.
+
+## Keep the model small enough for paper
+
+The Rust core starts with the same NN03 neuron:
+
+```text
+inputs  = [2, -1]
+weights = [0.5, -0.25]
+bias    = 0.1
+```
+
+Multiply corresponding values:
+
+```text
+contribution 0 =  2 *  0.5  = 1.0
+contribution 1 = -1 * -0.25 = 0.25
+```
+
+Then add the bias:
+
+```text
+prediction = 1.0 + 0.25 + 0.1 = 1.35
+```
+
+The identity activation changes nothing, so `1.35` is the final answer. The C
+function returns both contributions as well as the prediction. That makes the
+native call as auditable as the paper calculation.
+
+## Read the function from left to right
+
+The complete declaration is long, but each piece has one job:
+
+```c
+uint32_t neural_learning_weighted_sum_f64_v1(
+    const double *inputs,
+    const double *weights,
+    uint64_t input_count,
+    double bias,
+    double *contributions_out,
+    uint64_t contributions_capacity,
+    double *prediction_out);
+```
+
+- `const double *inputs` points to numbers the core may read but not change.
+- `const double *weights` does the same for weights.
+- `uint64_t input_count` says how many input-weight pairs are readable.
+- `double bias` passes one binary64 value directly.
+- `double *contributions_out` points to caller-owned writable slots.
+- `uint64_t contributions_capacity` proves how many output slots exist.
+- `double *prediction_out` points to one caller-owned writable slot.
+- the returned `uint32_t` is a closed status code, not the prediction.
+
+The `_v1` suffix makes evolution visible. A future incompatible function can
+use `_v2` without silently changing what an already-compiled caller means.
+
+## Why the caller owns every buffer
+
+Rust and a foreign runtime may use different allocators. If Rust allocated a
+vector and Ruby or C tried to free it, the mismatch could corrupt memory.
+
+NN35 avoids the allocator handshake entirely:
+
+1. the caller allocates inputs and outputs;
+2. Rust borrows those buffers only for the call;
+3. Rust returns a status;
+4. the caller eventually frees its own memory in its own normal way.
+
+No Rust `Vec`, `String`, reference, enum layout, or panic crosses the boundary.
+
+## Failure must not leave half an answer
+
+Suppose the caller provides room for only one contribution even though there
+are two inputs. The function returns status `3`,
+`NEURAL_LEARNING_BUFFER_TOO_SMALL`.
+
+More importantly, it writes neither output. The caller can initialize output
+memory to visible sentinels:
+
+```text
+contributions_out before = [91, 92]
+prediction_out before    = 93
+```
+
+After the rejected call:
+
+```text
+status                    = 3
+contributions_out after  = [91, 92]
+prediction_out after     = 93
+```
+
+The core follows the same validate-then-write rule for null pointers, zero
+inputs, non-finite arithmetic, and overlapping mutable buffers. A foreign
+caller never has to guess whether some prefix of an answer is trustworthy.
+
+## Version numbers are data too
+
+`neural_learning_abi_version()` returns `0x00010000`:
+
+```text
+high 16 bits = major version = 1
+low  16 bits = minor version = 0
+```
+
+A binding can check that number before its first compute call. Function names,
+the public header, the status messages, and the language-neutral NN35 catalog
+all pin the same contract.
+
+## Explore success and failure
+
+Open the **Rust C ABI** view in the ML Learning Visualizer. Select the paper
+example or one of five failure probes. The trace shows which check wins, which
+status returns, and whether output memory may change.
+
+The browser validates the committed catalog and recomputes its arithmetic. It
+does not load the native library. Direct ABI evidence comes from:
+
+```bash
+python code/scripts/validate_neural_learning_rust_cabi.py
+```
+
+That validator builds the shared library, loads it through Python's C FFI, and
+calls the exported symbols. A Rust-only unit test is useful, but it is not a
+substitute for crossing the actual ABI.
+
+## What comes next
+
+NN35 defines the shared Rust doorway without replacing the native NN34 lanes.
+The next tranche can add binding-backed consumers and record, language by
+language, whether a concept is implemented natively, delegated to the Rust
+core, or still missing. Both paths must continue to earn the same fixture
+receipt and tolerance result.

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -341,6 +341,7 @@ members = [
     "matrix",
     "multi-directed-graph",
     "neural-network",
+    "neural-learning-capi",
     "neural-graph-vm",
     "ml-framework-core",
     "ml-framework-keras",

--- a/code/packages/rust/neural-learning-capi/BUILD
+++ b/code/packages/rust/neural-learning-capi/BUILD
@@ -1,0 +1,1 @@
+cargo test -p neural-learning-capi -- --nocapture

--- a/code/packages/rust/neural-learning-capi/BUILD_windows
+++ b/code/packages/rust/neural-learning-capi/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p neural-learning-capi -- --nocapture

--- a/code/packages/rust/neural-learning-capi/CHANGELOG.md
+++ b/code/packages/rust/neural-learning-capi/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Define the versioned, allocation-free weighted-neuron C ABI.
+- Add closed status codes, static status messages, and panic containment.
+- Publish a portable C header and direct ABI tests.

--- a/code/packages/rust/neural-learning-capi/Cargo.toml
+++ b/code/packages/rust/neural-learning-capi/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "neural-learning-capi"
+version = "0.1.0"
+edition = "2021"
+description = "Stable allocation-free C ABI for the neural-learning weighted-neuron core"
+license = "MIT"
+
+[lib]
+crate-type = ["cdylib", "staticlib", "rlib"]

--- a/code/packages/rust/neural-learning-capi/README.md
+++ b/code/packages/rust/neural-learning-capi/README.md
@@ -1,0 +1,36 @@
+# neural-learning-capi
+
+This crate exposes the first neural-learning Rust core through a stable C ABI.
+It computes one identity-activated weighted neuron while preserving the NN03
+paper trace: every weighted contribution and the final prediction are returned
+to the caller.
+
+The ABI is deliberately small:
+
+- fixed-width integer lengths and status codes;
+- caller-owned input and output buffers;
+- no Rust allocation crosses the boundary;
+- no Rust type or layout appears in the header;
+- every exported operation catches panics before they can unwind into C;
+- a version query and versioned function name make evolution explicit.
+
+The public declarations are in `include/neural_learning.h`. On success,
+`neural_learning_weighted_sum_f64_v1` returns `NEURAL_LEARNING_OK`, writes
+exactly `input_count` contributions, and writes one prediction. On failure it
+returns a closed status code and does not write either output.
+
+Callers must provide live, aligned buffers for the declared lengths. Input
+buffers may overlap each other because they are read-only. Output buffers must
+not overlap the inputs or each other. The function rejects detectable overlap,
+null pointers, zero or excessive lengths, short output buffers, misalignment,
+and non-finite arithmetic.
+
+From `code/packages/rust`:
+
+```bash
+cargo test -p neural-learning-capi
+cargo build -p neural-learning-capi --release
+```
+
+The build produces a shared library, static library, and Rust library so both
+foreign consumers and direct Rust tests exercise the same implementation.

--- a/code/packages/rust/neural-learning-capi/include/neural_learning.h
+++ b/code/packages/rust/neural-learning-capi/include/neural_learning.h
@@ -1,0 +1,37 @@
+#ifndef CODING_ADVENTURES_NEURAL_LEARNING_H
+#define CODING_ADVENTURES_NEURAL_LEARNING_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#define NEURAL_LEARNING_ABI_VERSION_V1 UINT32_C(0x00010000)
+#define NEURAL_LEARNING_OK UINT32_C(0)
+#define NEURAL_LEARNING_NULL_POINTER UINT32_C(1)
+#define NEURAL_LEARNING_EMPTY_INPUT UINT32_C(2)
+#define NEURAL_LEARNING_BUFFER_TOO_SMALL UINT32_C(3)
+#define NEURAL_LEARNING_VALUE_TOO_LARGE UINT32_C(4)
+#define NEURAL_LEARNING_NON_FINITE UINT32_C(5)
+#define NEURAL_LEARNING_PANIC UINT32_C(6)
+#define NEURAL_LEARNING_OVERLAPPING_BUFFER UINT32_C(7)
+#define NEURAL_LEARNING_MISALIGNED_POINTER UINT32_C(8)
+
+uint32_t neural_learning_abi_version(void);
+
+const char *neural_learning_status_message_v1(uint32_t status);
+
+uint32_t neural_learning_weighted_sum_f64_v1(
+    const double *inputs,
+    const double *weights,
+    uint64_t input_count,
+    double bias,
+    double *contributions_out,
+    uint64_t contributions_capacity,
+    double *prediction_out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/code/packages/rust/neural-learning-capi/src/lib.rs
+++ b/code/packages/rust/neural-learning-capi/src/lib.rs
@@ -1,0 +1,311 @@
+//! Stable C ABI for the first neural-learning Rust execution core.
+//!
+//! The exported operation is intentionally the same two-input weighted neuron
+//! learners can calculate on paper, but it accepts any non-empty bounded input
+//! length. The C boundary uses only fixed-width integers, IEEE-754 doubles,
+//! pointers, and status codes. No Rust-owned allocation crosses the boundary.
+
+#![deny(unsafe_op_in_unsafe_fn)]
+
+use std::ffi::c_char;
+use std::mem::{align_of, size_of};
+use std::panic::{self, AssertUnwindSafe};
+
+pub const ABI_VERSION_V1: u32 = 0x0001_0000;
+const MAX_INPUT_COUNT: u64 = 1 << 20;
+
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Status {
+    Ok = 0,
+    NullPointer = 1,
+    EmptyInput = 2,
+    BufferTooSmall = 3,
+    ValueTooLarge = 4,
+    NonFinite = 5,
+    Panic = 6,
+    OverlappingBuffer = 7,
+    MisalignedPointer = 8,
+}
+
+#[no_mangle]
+pub extern "C" fn neural_learning_abi_version() -> u32 {
+    ABI_VERSION_V1
+}
+
+#[no_mangle]
+pub extern "C" fn neural_learning_status_message_v1(status: u32) -> *const c_char {
+    let message: &'static [u8] = match status {
+        0 => b"ok\0",
+        1 => b"null pointer\0",
+        2 => b"input count must be positive\0",
+        3 => b"contribution buffer is too small\0",
+        4 => b"input count is too large\0",
+        5 => b"all inputs and arithmetic results must be finite\0",
+        6 => b"Rust panic was contained\0",
+        7 => b"mutable output buffers must not overlap other buffers\0",
+        8 => b"pointer is not aligned for a double\0",
+        _ => b"unknown status\0",
+    };
+    message.as_ptr().cast()
+}
+
+fn aligned<T>(pointer: *const T) -> bool {
+    (pointer as usize).is_multiple_of(align_of::<T>())
+}
+
+fn byte_range<T>(pointer: *const T, count: usize) -> Option<(usize, usize)> {
+    let start = pointer as usize;
+    let bytes = count.checked_mul(size_of::<T>())?;
+    start.checked_add(bytes).map(|end| (start, end))
+}
+
+fn overlaps(left: (usize, usize), right: (usize, usize)) -> bool {
+    left.0 < right.1 && right.0 < left.1
+}
+
+fn contain_panic(operation: impl FnOnce() -> Status) -> u32 {
+    match panic::catch_unwind(AssertUnwindSafe(operation)) {
+        Ok(status) => status as u32,
+        Err(_) => Status::Panic as u32,
+    }
+}
+
+unsafe fn weighted_sum(
+    inputs: *const f64,
+    weights: *const f64,
+    input_count: u64,
+    bias: f64,
+    contributions_out: *mut f64,
+    contributions_capacity: u64,
+    prediction_out: *mut f64,
+) -> Status {
+    if inputs.is_null()
+        || weights.is_null()
+        || contributions_out.is_null()
+        || prediction_out.is_null()
+    {
+        return Status::NullPointer;
+    }
+    if input_count == 0 {
+        return Status::EmptyInput;
+    }
+    if input_count > MAX_INPUT_COUNT {
+        return Status::ValueTooLarge;
+    }
+    if contributions_capacity < input_count {
+        return Status::BufferTooSmall;
+    }
+    if !aligned(inputs)
+        || !aligned(weights)
+        || !aligned(contributions_out.cast_const())
+        || !aligned(prediction_out.cast_const())
+    {
+        return Status::MisalignedPointer;
+    }
+
+    let count = match usize::try_from(input_count) {
+        Ok(count) => count,
+        Err(_) => return Status::ValueTooLarge,
+    };
+    let inputs_range = match byte_range(inputs, count) {
+        Some(range) => range,
+        None => return Status::ValueTooLarge,
+    };
+    let weights_range = match byte_range(weights, count) {
+        Some(range) => range,
+        None => return Status::ValueTooLarge,
+    };
+    let contributions_range = match byte_range(contributions_out.cast_const(), count) {
+        Some(range) => range,
+        None => return Status::ValueTooLarge,
+    };
+    let prediction_range = match byte_range(prediction_out.cast_const(), 1) {
+        Some(range) => range,
+        None => return Status::ValueTooLarge,
+    };
+    if overlaps(contributions_range, inputs_range)
+        || overlaps(contributions_range, weights_range)
+        || overlaps(prediction_range, inputs_range)
+        || overlaps(prediction_range, weights_range)
+        || overlaps(prediction_range, contributions_range)
+    {
+        return Status::OverlappingBuffer;
+    }
+    if !bias.is_finite() {
+        return Status::NonFinite;
+    }
+
+    let mut prediction = bias;
+    for index in 0..count {
+        // SAFETY: the caller contract requires readable buffers for `count`
+        // aligned doubles; range arithmetic above rules out address overflow.
+        let input = unsafe { inputs.add(index).read() };
+        // SAFETY: same contract and checks as the input read above.
+        let weight = unsafe { weights.add(index).read() };
+        let contribution = input * weight;
+        prediction += contribution;
+        if !input.is_finite()
+            || !weight.is_finite()
+            || !contribution.is_finite()
+            || !prediction.is_finite()
+        {
+            return Status::NonFinite;
+        }
+    }
+
+    for index in 0..count {
+        // SAFETY: the first pass validated all reads and arithmetic. The caller
+        // provides a writable, non-overlapping output buffer of this length.
+        let contribution = unsafe { inputs.add(index).read() * weights.add(index).read() };
+        unsafe { contributions_out.add(index).write(contribution) };
+    }
+    // SAFETY: `prediction_out` is a checked, non-overlapping one-double slot.
+    unsafe { prediction_out.write(prediction) };
+    Status::Ok
+}
+
+/// Compute an identity-activated weighted neuron and expose its paper trace.
+///
+/// # Safety
+///
+/// Each non-null pointer must address live, aligned storage for its declared
+/// length. Inputs must be readable and outputs writable for the duration of
+/// the call. Mutable outputs must not overlap inputs or one another.
+#[no_mangle]
+pub unsafe extern "C" fn neural_learning_weighted_sum_f64_v1(
+    inputs: *const f64,
+    weights: *const f64,
+    input_count: u64,
+    bias: f64,
+    contributions_out: *mut f64,
+    contributions_capacity: u64,
+    prediction_out: *mut f64,
+) -> u32 {
+    contain_panic(|| unsafe {
+        weighted_sum(
+            inputs,
+            weights,
+            input_count,
+            bias,
+            contributions_out,
+            contributions_capacity,
+            prediction_out,
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CStr;
+    use std::ptr;
+
+    #[test]
+    fn reports_version_and_static_status_messages() {
+        assert_eq!(neural_learning_abi_version(), ABI_VERSION_V1);
+        let message = unsafe { CStr::from_ptr(neural_learning_status_message_v1(0)) };
+        assert_eq!(message.to_str().unwrap(), "ok");
+    }
+
+    #[test]
+    fn contains_panics_without_touching_caller_outputs() {
+        let contributions = [91.0, 92.0];
+        let prediction = 93.0;
+        let status = contain_panic(|| panic!("forced panic at the ABI boundary"));
+        assert_eq!(status, Status::Panic as u32);
+        assert_eq!(contributions, [91.0, 92.0]);
+        assert_eq!(prediction, 93.0);
+    }
+
+    #[test]
+    fn matches_the_hand_calculation() {
+        let inputs = [2.0, -1.0];
+        let weights = [0.5, -0.25];
+        let mut contributions = [0.0; 2];
+        let mut prediction = 0.0;
+        let status = unsafe {
+            neural_learning_weighted_sum_f64_v1(
+                inputs.as_ptr(),
+                weights.as_ptr(),
+                2,
+                0.1,
+                contributions.as_mut_ptr(),
+                2,
+                &mut prediction,
+            )
+        };
+        assert_eq!(status, Status::Ok as u32);
+        assert_eq!(contributions, [1.0, 0.25]);
+        assert_eq!(prediction, 1.35);
+    }
+
+    #[test]
+    fn rejects_bad_arguments_without_writing_outputs() {
+        let inputs = [2.0, -1.0];
+        let weights = [0.5, -0.25];
+        let mut contributions = [91.0, 92.0];
+        let mut prediction = 93.0;
+        let short = unsafe {
+            neural_learning_weighted_sum_f64_v1(
+                inputs.as_ptr(),
+                weights.as_ptr(),
+                2,
+                0.1,
+                contributions.as_mut_ptr(),
+                1,
+                &mut prediction,
+            )
+        };
+        assert_eq!(short, Status::BufferTooSmall as u32);
+        assert_eq!(contributions, [91.0, 92.0]);
+        assert_eq!(prediction, 93.0);
+
+        let null = unsafe {
+            neural_learning_weighted_sum_f64_v1(
+                ptr::null(),
+                weights.as_ptr(),
+                2,
+                0.1,
+                contributions.as_mut_ptr(),
+                2,
+                &mut prediction,
+            )
+        };
+        assert_eq!(null, Status::NullPointer as u32);
+    }
+
+    #[test]
+    fn rejects_non_finite_and_overlapping_buffers() {
+        let inputs = [f64::INFINITY, -1.0];
+        let weights = [0.5, -0.25];
+        let mut contributions = [0.0; 2];
+        let mut prediction = 0.0;
+        let non_finite = unsafe {
+            neural_learning_weighted_sum_f64_v1(
+                inputs.as_ptr(),
+                weights.as_ptr(),
+                2,
+                0.1,
+                contributions.as_mut_ptr(),
+                2,
+                &mut prediction,
+            )
+        };
+        assert_eq!(non_finite, Status::NonFinite as u32);
+
+        let mut aliased = [2.0, -1.0];
+        let overlap = unsafe {
+            neural_learning_weighted_sum_f64_v1(
+                aliased.as_ptr(),
+                weights.as_ptr(),
+                2,
+                0.1,
+                aliased.as_mut_ptr(),
+                2,
+                &mut prediction,
+            )
+        };
+        assert_eq!(overlap, Status::OverlappingBuffer as u32);
+    }
+}

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -4,7 +4,7 @@ Interactive machine learning lab for building intuition around small models.
 
 ## What It Shows
 
-The app has twenty-one workbenches that move from one arithmetic update to small
+The app has twenty-two workbenches that move from one arithmetic update to small
 spatial and hidden-layer networks.
 
 ### Training-step microscope
@@ -284,6 +284,14 @@ and one closed receipt protocol. The browser recomputes every contribution and
 the `1.35` prediction, but labels external execution as registered until the
 Python orchestrator runs the real programs.
 
+### Rust C ABI
+
+The Rust C ABI workbench keeps the NN03 paper arithmetic visible while one
+versioned function receives caller-owned buffers. Select success or five
+failure probes to see the returned status and whether output memory may change.
+The browser recomputes the committed ABI catalog; the Python validator builds
+and dynamically loads the real shared library.
+
 ## Lab Families
 
 - Basics: clean linear relationships such as Celsius to Fahrenheit.
@@ -441,6 +449,12 @@ NN34 under `code/specs/fixtures/cross-language-consumers-v1` points three native
 language-family consumers at the same NN03 source fixture. Run `python
 code/scripts/validate_cross_language_fixture_consumers.py` to execute their
 fixed commands and compare their bounded JSON receipts.
+
+NN35 under `code/specs/fixtures/neural-learning-rust-cabi-v1` pins the public
+C declarations, version number, status table, ownership rules, paper trace,
+and closed-output failure probes. Run `python
+code/scripts/validate_neural_learning_rust_cabi.py` to build and call the actual
+shared library.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/src/App.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/App.tsx
@@ -19,6 +19,7 @@ import { ReferenceValidationWorkbench } from "./ReferenceValidationWorkbench.js"
 import { RecurrentWorkbench } from "./RecurrentWorkbench.js";
 import { RepresentationWorkbench } from "./RepresentationWorkbench.js";
 import { ResidualWorkbench } from "./ResidualWorkbench.js";
+import { RustCAbiWorkbench } from "./RustCAbiWorkbench.js";
 import { StructuredWorkbench } from "./StructuredWorkbench.js";
 import { TensorBroadcastingWorkbench } from "./TensorBroadcastingWorkbench.js";
 import { TrainingStepMicroscope } from "./TrainingStepMicroscope.js";
@@ -186,7 +187,7 @@ function groupColor(group: string | undefined, groups: string[]): string {
 
 export function App() {
   const [workbench, setWorkbench] = useState<
-    "microscope" | "optimization" | "linear" | "hidden" | "convolution" | "image-cnn" | "residual" | "recurrent" | "attention" | "representation" | "structured" | "deep" | "tensor" | "autograd" | "gradient-buffer" | "forward-lowering" | "training-lowering" | "backend-parity" | "precision-residency" | "reference-validation" | "language-consumers"
+    "microscope" | "optimization" | "linear" | "hidden" | "convolution" | "image-cnn" | "residual" | "recurrent" | "attention" | "representation" | "structured" | "deep" | "tensor" | "autograd" | "gradient-buffer" | "forward-lowering" | "training-lowering" | "backend-parity" | "precision-residency" | "reference-validation" | "language-consumers" | "rust-c-abi"
   >("microscope");
   const [selectedLabId, setSelectedLabId] = useState(LABS[0]!.id);
   const selectedLab = LABS.find((lab) => lab.id === selectedLabId) ?? LABS[0]!;
@@ -327,6 +328,8 @@ export function App() {
                 ? "Every stored answer needs an independent witness"
               : workbench === "language-consumers"
                 ? "One fixture can cross language boundaries"
+              : workbench === "rust-c-abi"
+                ? "One stable seam can cross runtime boundaries"
               : workbench === "linear"
                 ? "100-lab foundation"
                 : "Hidden-layer playground"}
@@ -482,6 +485,13 @@ export function App() {
             >
               Language Consumers
             </button>
+            <button
+              className={workbench === "rust-c-abi" ? "mode-button mode-button--active" : "mode-button"}
+              type="button"
+              onClick={() => setWorkbench("rust-c-abi")}
+            >
+              Rust C ABI
+            </button>
           </div>
           <div className="formula">
             {workbench === "microscope" ? (
@@ -522,6 +532,8 @@ export function App() {
               <>catalog {"->"} <strong>inspect registrations</strong> {"->"} CLI evidence</>
             ) : workbench === "language-consumers" ? (
               <>one fixture {"->"} <strong>registered CLI contracts</strong> {"->"} expected receipts</>
+            ) : workbench === "rust-c-abi" ? (
+              <>caller buffers {"->"} <strong>stable Rust C ABI</strong> {"->"} status + outputs</>
             ) : workbench === "linear" ? (
               <>y = <strong>{formatNumber(model.weight)}</strong>x + <strong>{formatNumber(model.bias)}</strong></>
             ) : (
@@ -569,6 +581,8 @@ export function App() {
         <ReferenceValidationWorkbench />
       ) : workbench === "language-consumers" ? (
         <CrossLanguageConsumerWorkbench />
+      ) : workbench === "rust-c-abi" ? (
+        <RustCAbiWorkbench />
       ) : workbench === "hidden" ? <HiddenLayerWorkbench /> : (
       <main className="workspace workspace--lab">
         <nav className="lab-rail" aria-label="ML lab examples">

--- a/code/programs/typescript/ml-learning-visualizer/src/RustCAbiWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/RustCAbiWorkbench.tsx
@@ -1,0 +1,100 @@
+import { useMemo, useState } from "react";
+import { cAbiCatalog, traceCAbi, type CAbiProbeId } from "./rust-c-abi.js";
+
+const PROBES: readonly CAbiProbeId[] = ["success", "null-input", "empty-input", "short-output", "non-finite", "overlapping-output"];
+
+function label(probe: CAbiProbeId): string {
+  return probe === "success" ? "paper example" : probe.replaceAll("-", " ");
+}
+export function RustCAbiWorkbench() {
+  const [probeId, setProbeId] = useState<CAbiProbeId>("success");
+  const trace = useMemo(() => traceCAbi(probeId), [probeId]);
+
+  return (
+    <main className="workspace workspace--language-consumers workspace--rust-c-abi">
+      <section className="consumer-stage">
+        <header className="consumer-intro">
+          <div>
+            <p className="eyebrow">NN35 - stable foreign-function boundary</p>
+            <h2>Rust C ABI</h2>
+            <p>{trace.catalog.question}</p>
+          </div>
+          <span className="consumer-chip">ABI {trace.catalog.versionHex}</span>
+        </header>
+
+        <section className="consumer-paper" aria-label="Rust C ABI hand calculation">
+          <div className="panel-heading">
+            <div><p className="eyebrow">1 - keep the arithmetic visible</p><h2>The same trace crosses the boundary</h2></div>
+            <span className="consumer-result consumer-result--pass">status 0</span>
+          </div>
+          <div className="consumer-products">
+            <div><small>contribution 1</small><code>2.0 * 0.5</code><strong>= 1.0</strong></div>
+            <div><small>contribution 2</small><code>-1.0 * -0.25</code><strong>= 0.25</strong></div>
+            <div><small>bias</small><code>1.0 + 0.25 + 0.1</code><strong>= 1.35</strong></div>
+            <div><small>identity</small><code>identity(1.35)</code><strong>= 1.35</strong></div>
+          </div>
+        </section>
+
+        <section className="consumer-selected" aria-label="Versioned C function contract">
+          <div className="panel-heading">
+            <div><p className="eyebrow">2 - freeze the seam</p><h2>One versioned compute function</h2></div>
+          </div>
+          <code className="consumer-command">{trace.catalog.functions[2]}</code>
+          <div className="consumer-receipt">
+            <span>caller owns <code>inputs</code></span>
+            <span>caller owns <code>weights</code></span>
+            <span>caller owns <code>contributions_out</code></span>
+            <span>caller owns <code>prediction_out</code></span>
+          </div>
+        </section>
+
+        <section className="consumer-lanes" aria-label="C ABI success and failure probes">
+          <div className="panel-heading">
+            <div><p className="eyebrow">3 - probe the boundary</p><h2>Select a deterministic call</h2></div>
+            <span className={trace.status.code === 0 ? "consumer-result consumer-result--pass" : "consumer-result consumer-result--fail"}>
+              status {trace.status.code}
+            </span>
+          </div>
+          <div className="consumer-lane-grid rust-c-abi-probes">
+            {PROBES.map((probe) => (
+              <button
+                aria-label={`Inspect ${label(probe)} C ABI probe`}
+                aria-pressed={probe === probeId}
+                key={probe}
+                onClick={() => setProbeId(probe)}
+                type="button"
+              >
+                <small>{probe === "success" ? "writes after validation" : "fails before writes"}</small>
+                <strong>{label(probe)}</strong>
+                <span>{probe === "success" ? "NEURAL_LEARNING_OK" : cAbiCatalog.statuses[cAbiCatalog.probes.find((item) => item.id === probe)?.expectedStatus ?? 0]?.symbol}</span>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className="consumer-protocol" aria-label="Selected C ABI trace">
+          <div className="panel-heading">
+            <div><p className="eyebrow">4 - inspect the result</p><h2>{trace.status.symbol}</h2></div>
+            <code>{trace.status.message}</code>
+          </div>
+          <ol>
+            <li><span>1</span><p>{trace.boundaryCheck}</p></li>
+            <li><span>2</span><p>return status <strong>{trace.status.code}</strong></p></li>
+            <li><span>3</span><p>contribution outputs {trace.outputsWritten ? "become [1.0, 0.25]" : "stay byte-for-byte unchanged"}</p></li>
+            <li><span>4</span><p>prediction output {trace.outputsWritten ? "becomes 1.35" : "stays byte-for-byte unchanged"}</p></li>
+          </ol>
+        </section>
+      </section>
+
+      <aside className="consumer-controls">
+        <p className="eyebrow">Stable means boring on purpose</p>
+        <h2>No Rust layout leaks out</h2>
+        <code className="consumer-command">{trace.catalog.header}</code>
+        <section><p className="eyebrow">Fixed vocabulary</p><p>Only C pointers, IEEE-754 doubles, `uint64_t` lengths, and `uint32_t` statuses cross the seam.</p></section>
+        <section><p className="eyebrow">Closed writes</p><p>The core validates the complete call and arithmetic before touching caller-owned output memory.</p></section>
+        <section><p className="eyebrow">No allocator handshake</p><p>The caller allocates and frees every buffer, so Rust and foreign runtimes never mix allocators.</p></section>
+        <section><p className="eyebrow">Browser evidence</p><p>This workbench recomputes the committed catalog. The Python validator dynamically loads the compiled native library.</p></section>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/rust-c-abi.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/rust-c-abi.ts
@@ -1,0 +1,187 @@
+import catalogDocument from "../../../../specs/fixtures/neural-learning-rust-cabi-v1/catalog.json";
+import sourceFixtureDocument from "../../../../specs/fixtures/neural-learning-v1/labs/00-weighted-neuron.json";
+
+const PROBE_IDS = ["success", "null-input", "empty-input", "short-output", "non-finite", "overlapping-output"] as const;
+const CANONICAL_FUNCTIONS = [
+  "uint32_t neural_learning_abi_version(void)",
+  "const char *neural_learning_status_message_v1(uint32_t status)",
+  "uint32_t neural_learning_weighted_sum_f64_v1(const double *inputs, const double *weights, uint64_t input_count, double bias, double *contributions_out, uint64_t contributions_capacity, double *prediction_out)",
+] as const;
+const CANONICAL_RULES = [
+  "all lengths and status values use fixed-width unsigned integers",
+  "callers own every input and output buffer",
+  "no Rust allocation or Rust type crosses the boundary",
+  "mutable outputs do not overlap inputs or one another",
+  "a Rust panic is caught and becomes status 6",
+] as const;
+const CANONICAL_STATUSES = [
+  ["NEURAL_LEARNING_OK", "ok"],
+  ["NEURAL_LEARNING_NULL_POINTER", "null pointer"],
+  ["NEURAL_LEARNING_EMPTY_INPUT", "input count must be positive"],
+  ["NEURAL_LEARNING_BUFFER_TOO_SMALL", "contribution buffer is too small"],
+  ["NEURAL_LEARNING_VALUE_TOO_LARGE", "input count is too large"],
+  ["NEURAL_LEARNING_NON_FINITE", "all inputs and arithmetic results must be finite"],
+  ["NEURAL_LEARNING_PANIC", "Rust panic was contained"],
+  ["NEURAL_LEARNING_OVERLAPPING_BUFFER", "mutable output buffers must not overlap other buffers"],
+  ["NEURAL_LEARNING_MISALIGNED_POINTER", "pointer is not aligned for a double"],
+] as const;
+
+export type CAbiProbeId = typeof PROBE_IDS[number];
+
+export interface CAbiStatus {
+  readonly code: number;
+  readonly symbol: string;
+  readonly message: string;
+}
+
+export interface CAbiProbe {
+  readonly id: Exclude<CAbiProbeId, "success">;
+  readonly expectedStatus: number;
+  readonly outputsUnchanged: true;
+}
+
+export interface CAbiCatalog {
+  readonly title: string;
+  readonly question: string;
+  readonly versionNumber: 65536;
+  readonly versionHex: "0x00010000";
+  readonly header: "code/packages/rust/neural-learning-capi/include/neural_learning.h";
+  readonly crate: "code/packages/rust/neural-learning-capi/Cargo.toml";
+  readonly functions: readonly string[];
+  readonly rules: readonly string[];
+  readonly statuses: readonly CAbiStatus[];
+  readonly inputs: readonly [number, number];
+  readonly weights: readonly [number, number];
+  readonly bias: number;
+  readonly expectedContributions: readonly [number, number];
+  readonly expectedPrediction: number;
+  readonly probes: readonly CAbiProbe[];
+}
+
+export interface CAbiTrace {
+  readonly catalog: CAbiCatalog;
+  readonly probeId: CAbiProbeId;
+  readonly contributions: readonly [number, number];
+  readonly prediction: number;
+  readonly status: CAbiStatus;
+  readonly outputsWritten: boolean;
+  readonly boundaryCheck: string;
+}
+
+function closedObject(value: unknown, keys: readonly string[], context: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error(`${context}: expected object`);
+  const result = value as Record<string, unknown>;
+  const actual = Object.keys(result).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) throw new Error(`${context}: unexpected keys`);
+  return result;
+}
+
+function finiteVector(value: unknown, context: string): [number, number] {
+  if (!Array.isArray(value) || value.length !== 2 || value.some((entry) => typeof entry !== "number" || !Number.isFinite(entry))) throw new Error(`${context}: expected two finite numbers`);
+  return [value[0] as number, value[1] as number];
+}
+
+function text(value: unknown, context: string): string {
+  if (typeof value !== "string" || value.trim().length === 0 || value.length > 512 || /[\u0000-\u001f]/.test(value)) throw new Error(`${context}: invalid text`);
+  return value;
+}
+
+export function parseCAbiCatalog(value: unknown): CAbiCatalog {
+  const catalog = closedObject(value, ["schema_version", "id", "title", "question", "source_fixture", "abi", "statuses", "hand_check", "failure_probes"], "catalog");
+  if (catalog.schema_version !== 1 || catalog.id !== "weighted-neuron-rust-c-abi" || catalog.source_fixture !== "code/specs/fixtures/neural-learning-v1/labs/00-weighted-neuron.json") throw new Error("catalog: wrong identity");
+  const abi = closedObject(catalog.abi, ["version_number", "version_hex", "header", "crate", "library_base_name", "functions", "rules"], "abi");
+  if (abi.version_number !== 65536 || abi.version_hex !== "0x00010000" || abi.header !== "code/packages/rust/neural-learning-capi/include/neural_learning.h" || abi.crate !== "code/packages/rust/neural-learning-capi/Cargo.toml" || abi.library_base_name !== "neural_learning_capi") throw new Error("abi: wrong identity");
+  if (!Array.isArray(abi.functions) || JSON.stringify(abi.functions) !== JSON.stringify(CANONICAL_FUNCTIONS)) throw new Error("abi: wrong functions");
+  if (!Array.isArray(abi.rules) || JSON.stringify(abi.rules) !== JSON.stringify(CANONICAL_RULES)) throw new Error("abi: wrong rules");
+  const functions = abi.functions.map((entry, index) => text(entry, `functions[${index}]`));
+  const rules = abi.rules.map((entry, index) => text(entry, `rules[${index}]`));
+
+  if (!Array.isArray(catalog.statuses) || catalog.statuses.length !== 9) throw new Error("statuses: expected nine entries");
+  const statuses = catalog.statuses.map((value, index) => {
+    const status = closedObject(value, ["code", "symbol", "message"], `statuses[${index}]`);
+    const canonical = CANONICAL_STATUSES[index];
+    if (status.code !== index || !canonical || status.symbol !== canonical[0] || status.message !== canonical[1]) throw new Error(`statuses[${index}]: wrong identity`);
+    return { code: index, symbol: canonical[0], message: canonical[1] };
+  });
+
+  const hand = closedObject(catalog.hand_check, ["inputs", "weights", "bias", "contributions_capacity", "expected_status", "expected_contributions", "expected_prediction", "absolute_tolerance"], "hand_check");
+  const inputs = finiteVector(hand.inputs, "hand_check.inputs");
+  const weights = finiteVector(hand.weights, "hand_check.weights");
+  const expectedContributions = finiteVector(hand.expected_contributions, "hand_check.expected_contributions");
+  if (typeof hand.bias !== "number" || !Number.isFinite(hand.bias) || typeof hand.expected_prediction !== "number" || !Number.isFinite(hand.expected_prediction) || hand.contributions_capacity !== 2 || hand.expected_status !== 0 || typeof hand.absolute_tolerance !== "number" || hand.absolute_tolerance <= 0) throw new Error("hand_check: wrong contract");
+  const contributions = [inputs[0] * weights[0], inputs[1] * weights[1]] as const;
+  const prediction = contributions[0] + contributions[1] + hand.bias;
+  if (inputs[0] !== 2 || inputs[1] !== -1 || weights[0] !== 0.5 || weights[1] !== -0.25 || expectedContributions[0] !== contributions[0] || expectedContributions[1] !== contributions[1] || hand.expected_prediction !== prediction) throw new Error("hand_check: dishonest arithmetic");
+
+  if (!Array.isArray(catalog.failure_probes) || catalog.failure_probes.length !== 5) throw new Error("failure_probes: expected five entries");
+  const probes = catalog.failure_probes.map((value, index) => {
+    const probe = closedObject(value, ["id", "expected_status", "outputs_unchanged"], `failure_probes[${index}]`);
+    const expectedId = PROBE_IDS[index + 1];
+    if (probe.id !== expectedId || probe.expected_status !== [1, 2, 3, 5, 7][index] || probe.outputs_unchanged !== true) throw new Error(`failure_probes[${index}]: wrong probe`);
+    return { id: expectedId as CAbiProbe["id"], expectedStatus: probe.expected_status as number, outputsUnchanged: true as const };
+  });
+  return {
+    title: text(catalog.title, "catalog.title"),
+    question: text(catalog.question, "catalog.question"),
+    versionNumber: 65536,
+    versionHex: "0x00010000",
+    header: abi.header,
+    crate: abi.crate,
+    functions,
+    rules,
+    statuses,
+    inputs,
+    weights,
+    bias: hand.bias,
+    expectedContributions,
+    expectedPrediction: hand.expected_prediction,
+    probes,
+  };
+}
+
+export const cAbiCatalog = parseCAbiCatalog(catalogDocument);
+
+function validateSourceFixture(value: unknown, catalog: CAbiCatalog): void {
+  const fixture = closedObject(value, ["schema_version", "id", "title", "stage", "question", "concepts", "model", "dataset", "training", "expected"], "source fixture");
+  if (fixture.schema_version !== 1 || fixture.id !== "weighted-neuron-forward" || fixture.stage !== "forward" || fixture.training !== null) throw new Error("source fixture: wrong identity");
+  const model = closedObject(fixture.model, ["kind", "input_count", "layers"], "source model");
+  if (model.kind !== "single-neuron" || model.input_count !== 2 || !Array.isArray(model.layers) || model.layers.length !== 1) throw new Error("source fixture: wrong model");
+  const layer = closedObject(model.layers[0], ["name", "weights", "biases", "activation"], "source layer");
+  if (layer.name !== "output" || layer.activation !== "identity" || JSON.stringify(layer.weights) !== JSON.stringify([[0.5], [-0.25]]) || JSON.stringify(layer.biases) !== JSON.stringify([0.1])) throw new Error("source fixture: wrong layer");
+  const dataset = closedObject(fixture.dataset, ["input_labels", "target_labels", "rows"], "source dataset");
+  if (!Array.isArray(dataset.rows) || dataset.rows.length !== 1) throw new Error("source fixture: wrong rows");
+  const row = closedObject(dataset.rows[0], ["label", "input", "target"], "source row");
+  const expected = closedObject(fixture.expected, ["absolute_tolerance", "forward", "first_step"], "source expected");
+  if (!Array.isArray(expected.forward) || expected.forward.length !== 1 || expected.first_step !== null) throw new Error("source fixture: wrong expectation");
+  const forward = closedObject(expected.forward[0], ["row", "prediction"], "source forward");
+  if (row.label !== "worked example" || forward.row !== row.label || JSON.stringify(row.input) !== JSON.stringify(catalog.inputs) || JSON.stringify(forward.prediction) !== JSON.stringify([catalog.expectedPrediction]) || expected.absolute_tolerance !== 0.000001) throw new Error("source fixture: catalog disagreement");
+}
+
+validateSourceFixture(sourceFixtureDocument, cAbiCatalog);
+
+const BOUNDARY_CHECKS: Readonly<Record<CAbiProbeId, string>> = {
+  success: "validate buffers, calculate twice, then write outputs",
+  "null-input": "reject a required null input pointer",
+  "empty-input": "reject an input_count of zero",
+  "short-output": "reject capacity smaller than input_count",
+  "non-finite": "reject infinity before any output write",
+  "overlapping-output": "reject mutable output overlapping an input buffer",
+};
+
+export function traceCAbi(probeId: CAbiProbeId = "success"): CAbiTrace {
+  if (!PROBE_IDS.includes(probeId)) throw new Error(`unknown C ABI probe: ${probeId}`);
+  const probe = probeId === "success" ? undefined : cAbiCatalog.probes.find((candidate) => candidate.id === probeId);
+  const statusCode = probe?.expectedStatus ?? 0;
+  const status = cAbiCatalog.statuses[statusCode];
+  if (!status) throw new Error(`missing C ABI status ${statusCode}`);
+  return {
+    catalog: cAbiCatalog,
+    probeId,
+    contributions: cAbiCatalog.expectedContributions,
+    prediction: cAbiCatalog.expectedPrediction,
+    status,
+    outputsWritten: probeId === "success",
+    boundaryCheck: BOUNDARY_CHECKS[probeId],
+  };
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -783,6 +783,15 @@ button.distribution-card[aria-pressed="true"] {
   overflow-wrap: anywhere;
 }
 
+.workspace--rust-c-abi .consumer-selected > .consumer-command {
+  display: block;
+  margin-top: 11px;
+}
+
+.rust-c-abi-probes {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
 .consumer-receipt {
   display: flex;
   flex-wrap: wrap;

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -86,9 +86,12 @@ import {
 import precisionResidencyDocument from "../../../../specs/fixtures/precision-residency-v1/labs/00-tiny-affine.json";
 import referenceCatalogDocument from "../../../../specs/fixtures/reference-validation-v1/catalog.json";
 import consumerCatalogDocument from "../../../../specs/fixtures/cross-language-consumers-v1/catalog.json";
+import cAbiCatalogDocument from "../../../../specs/fixtures/neural-learning-rust-cabi-v1/catalog.json";
 import { RecurrentWorkbench } from "./RecurrentWorkbench.js";
 import { RepresentationWorkbench } from "./RepresentationWorkbench.js";
 import { ResidualWorkbench } from "./ResidualWorkbench.js";
+import { RustCAbiWorkbench } from "./RustCAbiWorkbench.js";
+import { cAbiCatalog, parseCAbiCatalog, traceCAbi } from "./rust-c-abi.js";
 import { TrainingStepMicroscope } from "./TrainingStepMicroscope.js";
 import { TrainingStabilizersWorkbench } from "./TrainingStabilizersWorkbench.js";
 import { traceTrainingStabilizers } from "./training-stabilizers-lab.js";
@@ -2685,5 +2688,43 @@ describe("cross-language fixture consumers", () => {
     expect(screen.getByLabelText("Selected consumer contract").textContent)
       .toMatch(/Expected receipt from the Rust CLI.*rust-native.*Cargo\.toml.*maximum error.*0/s);
     expect(screen.getByText(/registered commands, not external runtime execution/)).toBeTruthy();
+  });
+});
+
+describe("neural-learning Rust C ABI", () => {
+  it("recomputes the paper trace and maps every deterministic failure status", () => {
+    const success = traceCAbi();
+
+    expect(cAbiCatalog.versionNumber).toBe(0x0001_0000);
+    expect(success.contributions).toEqual([1, 0.25]);
+    expect(success.prediction).toBe(1.35);
+    expect(success.status.symbol).toBe("NEURAL_LEARNING_OK");
+    expect(cAbiCatalog.probes.map((probe) => probe.expectedStatus)).toEqual([1, 2, 3, 5, 7]);
+    expect(traceCAbi("non-finite").outputsWritten).toBe(false);
+  });
+
+  it("fails closed on changed statuses and dishonest arithmetic", () => {
+    expect(() => parseCAbiCatalog({})).toThrow(/unexpected keys/);
+
+    const changedStatus = JSON.parse(JSON.stringify(cAbiCatalogDocument));
+    changedStatus.statuses[1].code = 8;
+    expect(() => parseCAbiCatalog(changedStatus)).toThrow(/wrong identity/);
+
+    const dishonest = JSON.parse(JSON.stringify(cAbiCatalogDocument));
+    dishonest.hand_check.expected_prediction = 99;
+    expect(() => parseCAbiCatalog(dishonest)).toThrow(/dishonest arithmetic/);
+  });
+
+  it("shows success writes and failure output preservation without claiming native browser execution", () => {
+    render(React.createElement(RustCAbiWorkbench));
+    expect(screen.getByRole("heading", { name: "Rust C ABI" })).toBeTruthy();
+    expect(screen.getByText("ABI 0x00010000")).toBeTruthy();
+    expect(screen.getByLabelText("Rust C ABI hand calculation").textContent)
+      .toMatch(/2\.0 \* 0\.5.*= 1\.0.*-1\.0 \* -0\.25.*= 0\.25.*1\.35/s);
+
+    fireEvent.click(screen.getByRole("button", { name: "Inspect non finite C ABI probe" }));
+    expect(screen.getByLabelText("Selected C ABI trace").textContent)
+      .toMatch(/NEURAL_LEARNING_NON_FINITE.*status 5.*byte-for-byte unchanged/s);
+    expect(screen.getByText(/Python validator dynamically loads the compiled native library/)).toBeTruthy();
   });
 });

--- a/code/scripts/tests/test_neural_learning_rust_cabi.py
+++ b/code/scripts/tests/test_neural_learning_rust_cabi.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "code" / "scripts"))
+
+validator = importlib.import_module("validate_neural_learning_rust_cabi")
+CAbiValidationError = validator.CAbiValidationError
+DEFAULT_FIXTURE_ROOT = validator.DEFAULT_FIXTURE_ROOT
+execute_abi = validator.execute_abi
+load_json = validator.load_json
+validate_catalog_document = validator.validate_catalog_document
+validate_fixture_root = validator.validate_fixture_root
+
+
+def catalog_document() -> dict[str, object]:
+    return load_json(DEFAULT_FIXTURE_ROOT / "catalog.json")
+
+
+def test_catalog_matches_language_neutral_schema() -> None:
+    schema = load_json(DEFAULT_FIXTURE_ROOT / "schema.json")
+    errors = sorted(
+        Draft202012Validator(schema).iter_errors(catalog_document()),
+        key=lambda error: list(error.path),
+    )
+
+    assert errors == []
+
+
+def test_catalog_recomputes_the_nn03_hand_trace() -> None:
+    hand = validate_fixture_root()["hand_check"]
+
+    contributions = [
+        hand["inputs"][index] * hand["weights"][index] for index in range(2)
+    ]
+    assert contributions == [1.0, 0.25]
+    assert sum(contributions, hand["bias"]) == 1.35
+
+
+def test_compiled_dynamic_library_matches_success_and_failure_probes() -> None:
+    receipt = execute_abi(validate_fixture_root())
+
+    assert receipt.version == 0x0001_0000
+    assert receipt.status == 0
+    assert receipt.contributions == (1.0, 0.25)
+    assert receipt.prediction == 1.35
+    assert receipt.failure_statuses == (1, 2, 3, 5, 7)
+
+
+def test_catalog_rejects_unknown_fields() -> None:
+    document = catalog_document()
+    document["surprise"] = True
+
+    with pytest.raises(CAbiValidationError, match="unexpected shape"):
+        validate_catalog_document(document)
+
+
+def test_catalog_rejects_dishonest_arithmetic() -> None:
+    document = deepcopy(catalog_document())
+    document["hand_check"]["expected_contributions"][1] = -0.25
+
+    with pytest.raises(CAbiValidationError, match="arithmetic is dishonest"):
+        validate_catalog_document(document)
+
+
+def test_catalog_rejects_status_reordering() -> None:
+    document = deepcopy(catalog_document())
+    document["statuses"][1], document["statuses"][2] = (
+        document["statuses"][2],
+        document["statuses"][1],
+    )
+
+    with pytest.raises(CAbiValidationError, match="status table"):
+        validate_catalog_document(document)
+
+
+def test_fixture_root_rejects_extra_files(tmp_path: Path) -> None:
+    for name in ("catalog.json", "schema.json", "README.md", "CHANGELOG.md", "extra.txt"):
+        (tmp_path / name).write_text("{}", encoding="utf-8")
+
+    with pytest.raises(CAbiValidationError, match="file roster"):
+        validate_fixture_root(tmp_path)

--- a/code/scripts/validate_neural_learning_rust_cabi.py
+++ b/code/scripts/validate_neural_learning_rust_cabi.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""Validate the NN35 catalog and execute the compiled Rust C ABI."""
+
+from __future__ import annotations
+
+import ctypes
+import json
+import math
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT / "code" / "specs" / "fixtures" / "neural-learning-rust-cabi-v1"
+)
+RUST_WORKSPACE = REPO_ROOT / "code" / "packages" / "rust"
+EXPECTED_FILES = {"catalog.json", "schema.json", "README.md", "CHANGELOG.md"}
+MAXIMUM_FILE_BYTES = 1_000_000
+ABI_VERSION = 0x0001_0000
+MAXIMUM_BUILD_LOG_BYTES = 32_768
+STATUS_MESSAGES = (
+    "ok",
+    "null pointer",
+    "input count must be positive",
+    "contribution buffer is too small",
+    "input count is too large",
+    "all inputs and arithmetic results must be finite",
+    "Rust panic was contained",
+    "mutable output buffers must not overlap other buffers",
+    "pointer is not aligned for a double",
+)
+STATUS_SYMBOLS = (
+    "NEURAL_LEARNING_OK",
+    "NEURAL_LEARNING_NULL_POINTER",
+    "NEURAL_LEARNING_EMPTY_INPUT",
+    "NEURAL_LEARNING_BUFFER_TOO_SMALL",
+    "NEURAL_LEARNING_VALUE_TOO_LARGE",
+    "NEURAL_LEARNING_NON_FINITE",
+    "NEURAL_LEARNING_PANIC",
+    "NEURAL_LEARNING_OVERLAPPING_BUFFER",
+    "NEURAL_LEARNING_MISALIGNED_POINTER",
+)
+ABI_FUNCTIONS = (
+    "uint32_t neural_learning_abi_version(void)",
+    "const char *neural_learning_status_message_v1(uint32_t status)",
+    "uint32_t neural_learning_weighted_sum_f64_v1(const double *inputs, const double *weights, uint64_t input_count, double bias, double *contributions_out, uint64_t contributions_capacity, double *prediction_out)",
+)
+ABI_RULES = (
+    "all lengths and status values use fixed-width unsigned integers",
+    "callers own every input and output buffer",
+    "no Rust allocation or Rust type crosses the boundary",
+    "mutable outputs do not overlap inputs or one another",
+    "a Rust panic is caught and becomes status 6",
+)
+FAILURE_PROBES = (
+    ("null-input", 1),
+    ("empty-input", 2),
+    ("short-output", 3),
+    ("non-finite", 5),
+    ("overlapping-output", 7),
+)
+
+
+class CAbiValidationError(ValueError):
+    """Raised when the NN35 document or compiled ABI breaks its contract."""
+
+
+@dataclass(frozen=True)
+class AbiReceipt:
+    """Closed execution evidence from the real dynamic library."""
+
+    version: int
+    status: int
+    contributions: tuple[float, float]
+    prediction: float
+    failure_statuses: tuple[int, ...]
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise CAbiValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        size = path.stat().st_size
+        if size <= 0 or size > MAXIMUM_FILE_BYTES:
+            raise CAbiValidationError(f"{path}: invalid file size")
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=lambda token: (_ for _ in ()).throw(
+                CAbiValidationError(f"non-finite JSON number: {token}")
+            ),
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise CAbiValidationError(f"{path}: {error}") from error
+    if not isinstance(value, dict):
+        raise CAbiValidationError(f"{path}: top-level value must be an object")
+    return value
+
+
+def _object(value: Any, keys: set[str], context: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != keys:
+        raise CAbiValidationError(f"{context}: unexpected shape")
+    return value
+
+
+def _repo_file(value: Any, expected: str, context: str) -> Path:
+    if value != expected or not isinstance(value, str) or "\\" in value:
+        raise CAbiValidationError(f"{context}: path is not canonical")
+    relative = PurePosixPath(value)
+    if relative.is_absolute() or "." in relative.parts or ".." in relative.parts:
+        raise CAbiValidationError(f"{context}: path is not normalized")
+    resolved = (REPO_ROOT / Path(*relative.parts)).resolve()
+    try:
+        resolved.relative_to(REPO_ROOT.resolve())
+    except ValueError as error:
+        raise CAbiValidationError(f"{context}: path escapes the repository") from error
+    if not resolved.is_file():
+        raise CAbiValidationError(f"{context}: file does not exist")
+    return resolved
+
+
+def _finite_number(value: Any, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise CAbiValidationError(f"{context}: expected a number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise CAbiValidationError(f"{context}: expected a finite number")
+    return result
+
+
+def validate_catalog_document(document: Any) -> dict[str, Any]:
+    catalog = _object(
+        document,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "source_fixture",
+            "abi",
+            "statuses",
+            "hand_check",
+            "failure_probes",
+        },
+        "catalog",
+    )
+    if catalog["schema_version"] != 1 or catalog["id"] != "weighted-neuron-rust-c-abi":
+        raise CAbiValidationError("catalog identity is not canonical")
+    for key in ("title", "question"):
+        value = catalog[key]
+        if not isinstance(value, str) or not value.strip() or len(value) > 300:
+            raise CAbiValidationError(f"catalog.{key}: invalid text")
+    source_fixture = _repo_file(
+        catalog["source_fixture"],
+        "code/specs/fixtures/neural-learning-v1/labs/00-weighted-neuron.json",
+        "source_fixture",
+    )
+
+    abi = _object(
+        catalog["abi"],
+        {
+            "version_number",
+            "version_hex",
+            "header",
+            "crate",
+            "library_base_name",
+            "functions",
+            "rules",
+        },
+        "abi",
+    )
+    if abi["version_number"] != ABI_VERSION or abi["version_hex"] != "0x00010000":
+        raise CAbiValidationError("abi version is not canonical")
+    header = _repo_file(
+        abi["header"],
+        "code/packages/rust/neural-learning-capi/include/neural_learning.h",
+        "abi.header",
+    )
+    crate = _repo_file(
+        abi["crate"],
+        "code/packages/rust/neural-learning-capi/Cargo.toml",
+        "abi.crate",
+    )
+    if abi["library_base_name"] != "neural_learning_capi":
+        raise CAbiValidationError("library name is not canonical")
+    if abi["functions"] != list(ABI_FUNCTIONS):
+        raise CAbiValidationError("abi function declarations are not canonical")
+    header_text = header.read_text(encoding="utf-8")
+    normalized_header = "".join(header_text.split())
+    for function in ABI_FUNCTIONS:
+        if f"{''.join(function.split())};" not in normalized_header:
+            raise CAbiValidationError(f"public header declaration drifted: {function}")
+    if abi["rules"] != list(ABI_RULES):
+        raise CAbiValidationError("abi ownership rules are not canonical")
+    expected_macros = {
+        "NEURAL_LEARNING_ABI_VERSION_V1": "0x00010000",
+        **{symbol: str(code) for code, symbol in enumerate(STATUS_SYMBOLS)},
+    }
+    for symbol, value in expected_macros.items():
+        if f"#define {symbol} UINT32_C({value})" not in header_text:
+            raise CAbiValidationError(f"public header macro drifted: {symbol}")
+
+    statuses = catalog["statuses"]
+    if not isinstance(statuses, list) or len(statuses) != len(STATUS_MESSAGES):
+        raise CAbiValidationError("status table is incomplete")
+    for code, (entry, message, symbol) in enumerate(
+        zip(statuses, STATUS_MESSAGES, STATUS_SYMBOLS, strict=True)
+    ):
+        status = _object(entry, {"code", "symbol", "message"}, f"statuses[{code}]")
+        if (
+            status["code"] != code
+            or status["message"] != message
+            or status["symbol"] != symbol
+        ):
+            raise CAbiValidationError("status table is not canonical")
+
+    hand = _object(
+        catalog["hand_check"],
+        {
+            "inputs",
+            "weights",
+            "bias",
+            "contributions_capacity",
+            "expected_status",
+            "expected_contributions",
+            "expected_prediction",
+            "absolute_tolerance",
+        },
+        "hand_check",
+    )
+    if hand["inputs"] != [2.0, -1.0] or hand["weights"] != [0.5, -0.25]:
+        raise CAbiValidationError("hand-check operands are not canonical")
+    contributions = [
+        _finite_number(hand["inputs"][index], f"inputs[{index}]")
+        * _finite_number(hand["weights"][index], f"weights[{index}]")
+        for index in range(2)
+    ]
+    prediction = sum(contributions, _finite_number(hand["bias"], "bias"))
+    tolerance = _finite_number(hand["absolute_tolerance"], "absolute_tolerance")
+    if (
+        hand["contributions_capacity"] != 2
+        or hand["expected_status"] != 0
+        or hand["expected_contributions"] != contributions
+        or hand["expected_prediction"] != prediction
+        or tolerance <= 0
+    ):
+        raise CAbiValidationError("hand-check arithmetic is dishonest")
+
+    source = _object(
+        load_json(source_fixture),
+        {
+            "schema_version",
+            "id",
+            "title",
+            "stage",
+            "question",
+            "concepts",
+            "model",
+            "dataset",
+            "training",
+            "expected",
+        },
+        "source fixture",
+    )
+    if source["schema_version"] != 1 or source["id"] != "weighted-neuron-forward" or source["stage"] != "forward" or source["training"] is not None:
+        raise CAbiValidationError("source fixture identity is not canonical")
+    model = _object(source["model"], {"kind", "input_count", "layers"}, "source model")
+    if model["kind"] != "single-neuron" or model["input_count"] != 2 or not isinstance(model["layers"], list) or len(model["layers"]) != 1:
+        raise CAbiValidationError("source fixture model is not canonical")
+    layer = _object(model["layers"][0], {"name", "weights", "biases", "activation"}, "source layer")
+    if layer["name"] != "output" or layer["activation"] != "identity" or layer["weights"] != [[0.5], [-0.25]] or layer["biases"] != [0.1]:
+        raise CAbiValidationError("source fixture layer disagrees with the ABI hand check")
+    dataset = _object(source["dataset"], {"input_labels", "target_labels", "rows"}, "source dataset")
+    if not isinstance(dataset["rows"], list) or len(dataset["rows"]) != 1:
+        raise CAbiValidationError("source fixture dataset is not canonical")
+    row = _object(dataset["rows"][0], {"label", "input", "target"}, "source row")
+    expected = _object(source["expected"], {"absolute_tolerance", "forward", "first_step"}, "source expected")
+    if not isinstance(expected["forward"], list) or len(expected["forward"]) != 1:
+        raise CAbiValidationError("source fixture expectation is not canonical")
+    forward = _object(expected["forward"][0], {"row", "prediction"}, "source forward")
+    if (
+        row["label"] != "worked example"
+        or row["input"] != hand["inputs"]
+        or forward["row"] != row["label"]
+        or forward["prediction"] != [hand["expected_prediction"]]
+        or expected["absolute_tolerance"] != hand["absolute_tolerance"]
+        or expected["first_step"] is not None
+    ):
+        raise CAbiValidationError("source fixture disagrees with the ABI hand check")
+
+    probes = catalog["failure_probes"]
+    if not isinstance(probes, list) or len(probes) != len(FAILURE_PROBES):
+        raise CAbiValidationError("failure probes are incomplete")
+    for index, (probe, expected) in enumerate(zip(probes, FAILURE_PROBES, strict=True)):
+        item = _object(probe, {"id", "expected_status", "outputs_unchanged"}, f"failure_probes[{index}]")
+        if (item["id"], item["expected_status"]) != expected or item["outputs_unchanged"] is not True:
+            raise CAbiValidationError("failure probe is not canonical")
+
+    return {
+        **catalog,
+        "source_fixture": source_fixture,
+        "header": header,
+        "crate": crate,
+    }
+
+
+def validate_fixture_root(root: Path = DEFAULT_FIXTURE_ROOT) -> dict[str, Any]:
+    try:
+        files = {path.relative_to(root).as_posix() for path in root.rglob("*") if path.is_file()}
+    except OSError as error:
+        raise CAbiValidationError(f"cannot enumerate fixture root: {error}") from error
+    if files != EXPECTED_FILES:
+        raise CAbiValidationError("fixture file roster is not canonical")
+    schema = load_json(root / "schema.json")
+    if (
+        schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema"
+        or schema.get("$id")
+        != "https://coding-adventures.dev/schemas/neural-learning-rust-cabi-v1.json"
+    ):
+        raise CAbiValidationError("schema identity is not canonical")
+    return validate_catalog_document(load_json(root / "catalog.json"))
+
+
+def _library_path() -> Path:
+    if os.name == "nt":
+        name = "neural_learning_capi.dll"
+    elif sys.platform == "darwin":
+        name = "libneural_learning_capi.dylib"
+    else:
+        name = "libneural_learning_capi.so"
+    return RUST_WORKSPACE / "target" / "debug" / name
+
+
+def build_library() -> Path:
+    command = ["cargo", "build", "-p", "neural-learning-capi"]
+    creation_flags = 0
+    start_new_session = os.name != "nt"
+    if os.name == "nt":
+        creation_flags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    try:
+        with tempfile.TemporaryFile() as build_log:
+            process = subprocess.Popen(
+                command,
+                cwd=RUST_WORKSPACE,
+                stdin=subprocess.DEVNULL,
+                stdout=build_log,
+                stderr=subprocess.STDOUT,
+                creationflags=creation_flags,
+                start_new_session=start_new_session,
+            )
+            try:
+                return_code = process.wait(timeout=120)
+            except subprocess.TimeoutExpired as error:
+                if os.name == "nt":
+                    try:
+                        terminated = subprocess.run(
+                            ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                            stdin=subprocess.DEVNULL,
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL,
+                            timeout=10,
+                            check=False,
+                        )
+                    except (OSError, subprocess.SubprocessError):
+                        terminated = None
+                    if terminated is None or terminated.returncode != 0:
+                        process.kill()
+                else:
+                    try:
+                        os.killpg(process.pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                process.wait(timeout=10)
+                build_log.flush()
+                build_log.seek(0, os.SEEK_END)
+                size = build_log.tell()
+                build_log.seek(max(0, size - MAXIMUM_BUILD_LOG_BYTES))
+                tail = build_log.read().decode("utf-8", errors="replace").strip()
+                detail = f"\nCargo output tail:\n{tail}" if tail else ""
+                raise CAbiValidationError(
+                    f"Rust C ABI build timed out after 120 seconds{detail}"
+                ) from error
+            build_log.flush()
+            build_log.seek(0, os.SEEK_END)
+            size = build_log.tell()
+            build_log.seek(max(0, size - MAXIMUM_BUILD_LOG_BYTES))
+            build_tail = build_log.read().decode("utf-8", errors="replace").strip()
+    except (OSError, subprocess.SubprocessError) as error:
+        raise CAbiValidationError(f"Rust C ABI build could not complete: {error}") from error
+    if return_code != 0:
+        detail = f"\nCargo output tail:\n{build_tail}" if build_tail else ""
+        raise CAbiValidationError(
+            f"Rust C ABI build failed with exit {return_code}{detail}"
+        )
+    library = _library_path()
+    if not library.is_file():
+        raise CAbiValidationError("Rust C ABI build did not produce the expected library")
+    return library
+
+
+def _load_library(path: Path) -> ctypes.CDLL:
+    try:
+        library = ctypes.CDLL(str(path))
+    except OSError as error:
+        raise CAbiValidationError(f"cannot load Rust C ABI library: {error}") from error
+    double_pointer = ctypes.POINTER(ctypes.c_double)
+    library.neural_learning_abi_version.argtypes = []
+    library.neural_learning_abi_version.restype = ctypes.c_uint32
+    library.neural_learning_status_message_v1.argtypes = [ctypes.c_uint32]
+    library.neural_learning_status_message_v1.restype = ctypes.c_char_p
+    library.neural_learning_weighted_sum_f64_v1.argtypes = [
+        double_pointer,
+        double_pointer,
+        ctypes.c_uint64,
+        ctypes.c_double,
+        double_pointer,
+        ctypes.c_uint64,
+        double_pointer,
+    ]
+    library.neural_learning_weighted_sum_f64_v1.restype = ctypes.c_uint32
+    return library
+
+
+def execute_abi(catalog: dict[str, Any], library_path: Path | None = None) -> AbiReceipt:
+    library = _load_library(library_path or build_library())
+    version = int(library.neural_learning_abi_version())
+    if version != ABI_VERSION:
+        raise CAbiValidationError(f"library reported unexpected ABI version {version}")
+    for code, expected in enumerate(STATUS_MESSAGES):
+        raw = library.neural_learning_status_message_v1(code)
+        if raw is None or raw.decode("utf-8", errors="strict") != expected:
+            raise CAbiValidationError(f"library status message {code} is dishonest")
+
+    hand = catalog["hand_check"]
+    vector_type = ctypes.c_double * 2
+    inputs = vector_type(*hand["inputs"])
+    weights = vector_type(*hand["weights"])
+    contributions = vector_type(91.0, 92.0)
+    prediction = ctypes.c_double(93.0)
+    status = int(
+        library.neural_learning_weighted_sum_f64_v1(
+            inputs,
+            weights,
+            2,
+            hand["bias"],
+            contributions,
+            2,
+            ctypes.byref(prediction),
+        )
+    )
+    if status != 0 or list(contributions) != hand["expected_contributions"] or prediction.value != hand["expected_prediction"]:
+        raise CAbiValidationError("compiled library disagrees with the hand calculation")
+
+    failure_statuses: list[int] = []
+    for probe_id, expected_status in FAILURE_PROBES:
+        probe_inputs = vector_type(2.0, -1.0)
+        probe_weights = vector_type(0.5, -0.25)
+        probe_contributions = vector_type(91.0, 92.0)
+        probe_prediction = ctypes.c_double(93.0)
+        call_inputs = probe_inputs
+        count = 2
+        capacity = 2
+        if probe_id == "null-input":
+            call_inputs = ctypes.POINTER(ctypes.c_double)()
+        elif probe_id == "empty-input":
+            count = 0
+        elif probe_id == "short-output":
+            capacity = 1
+        elif probe_id == "non-finite":
+            probe_inputs[0] = math.inf
+        elif probe_id == "overlapping-output":
+            probe_contributions = probe_inputs
+        contribution_sentinel = list(probe_contributions)
+        probe_status = int(
+            library.neural_learning_weighted_sum_f64_v1(
+                call_inputs,
+                probe_weights,
+                count,
+                0.1,
+                probe_contributions,
+                capacity,
+                ctypes.byref(probe_prediction),
+            )
+        )
+        if probe_status != expected_status or list(probe_contributions) != contribution_sentinel or probe_prediction.value != 93.0:
+            raise CAbiValidationError(f"failure probe {probe_id} broke its closed-output contract")
+        failure_statuses.append(probe_status)
+
+    return AbiReceipt(
+        version=version,
+        status=status,
+        contributions=(contributions[0], contributions[1]),
+        prediction=prediction.value,
+        failure_statuses=tuple(failure_statuses),
+    )
+
+
+def main() -> int:
+    try:
+        catalog = validate_fixture_root()
+        receipt = execute_abi(catalog)
+    except CAbiValidationError as error:
+        raise SystemExit(f"neural-learning Rust C ABI invalid: {error}") from error
+    print(
+        "neural-learning Rust C ABI v1 passed: "
+        f"status {receipt.status}, contributions {list(receipt.contributions)}, "
+        f"prediction {receipt.prediction:g}, failure statuses {list(receipt.failure_statuses)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/specs/NN35-neural-learning-rust-c-abi-lab.md
+++ b/code/specs/NN35-neural-learning-rust-c-abi-lab.md
@@ -1,0 +1,58 @@
+# NN35: Stable Rust C ABI
+
+## Status
+
+Implemented.
+
+## Purpose
+
+NN35 moves the NN03 weighted-neuron arithmetic behind a stable foreign-function
+boundary. A C, Go, Ruby, Python, Swift, or other FFI-capable caller can reuse
+the Rust execution core without depending on Rust layout or ownership rules.
+
+## Contract
+
+`code/specs/fixtures/neural-learning-rust-cabi-v1/` pins the ABI version,
+function declarations, status table, ownership rules, hand calculation, and
+failure probes. The public header is
+`code/packages/rust/neural-learning-capi/include/neural_learning.h`.
+
+The compute function accepts caller-owned binary64 input and weight buffers,
+one bias, a caller-owned contribution buffer, and a caller-owned prediction
+slot. Success writes the visible paper trace. Failure returns a closed status
+code without writing either output.
+
+## Stability rules
+
+- Exported names are versioned when their signatures or semantics may evolve.
+- Lengths and statuses use fixed-width integers.
+- No Rust type, reference, string, vector, allocator, or unwinding crosses C.
+- The version query returns `0x00010000`, meaning ABI major 1, minor 0.
+- Panics are caught and mapped to status 6.
+- Callers supply live, aligned buffers; mutable buffers may not overlap.
+
+## Direct evidence
+
+From the repository root:
+
+```bash
+python code/scripts/validate_neural_learning_rust_cabi.py
+cargo test --manifest-path code/packages/rust/Cargo.toml -p neural-learning-capi
+```
+
+The validator compiles and dynamically loads the actual shared library. It
+does not accept a Rust-only proxy as evidence for the exported calling
+convention.
+
+## Interactive trace
+
+The Rust C ABI workbench reads the same catalog. Learners can select success or
+one failure probe and inspect which boundary check runs, which status returns,
+and whether caller-owned output bytes are allowed to change. The browser
+recomputes catalog claims but does not claim to load native code.
+
+## Cross-language direction
+
+NN35 defines the core boundary only. The next tranche can add binding-backed
+consumer lanes and track them beside the NN34 native baselines. Both lane types
+must continue to read the same fixture and emit the same mathematical receipt.

--- a/code/specs/fixtures/neural-learning-rust-cabi-v1/CHANGELOG.md
+++ b/code/specs/fixtures/neural-learning-rust-cabi-v1/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## v1
+
+- Pin the allocation-free weighted-neuron function and ABI version query.
+- Pin nine status values and their static messages.
+- Reuse the NN03 `2 * 0.5 + (-1) * (-0.25) + 0.1 = 1.35` example.
+- Add five deterministic failure probes with unchanged-output guarantees.

--- a/code/specs/fixtures/neural-learning-rust-cabi-v1/README.md
+++ b/code/specs/fixtures/neural-learning-rust-cabi-v1/README.md
@@ -1,0 +1,18 @@
+# Neural-learning Rust C ABI v1 fixture
+
+This deterministic catalog describes the first stable C boundary for the
+neural-learning roadmap. It pins the exported C signatures, version number,
+closed status table, ownership rules, NN03 hand calculation, and representative
+failure probes.
+
+Validate the document and execute the compiled Rust library from the repository
+root:
+
+```bash
+python code/scripts/validate_neural_learning_rust_cabi.py
+```
+
+The validator builds the local `neural-learning-capi` crate without a shell,
+loads only that known artifact, checks the exported ABI version and status
+messages, executes the paper example, and verifies that rejected calls leave
+caller-owned outputs unchanged.

--- a/code/specs/fixtures/neural-learning-rust-cabi-v1/catalog.json
+++ b/code/specs/fixtures/neural-learning-rust-cabi-v1/catalog.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": 1,
+  "id": "weighted-neuron-rust-c-abi",
+  "title": "A versioned C boundary for the weighted-neuron paper trace",
+  "question": "Can a foreign runtime call one stable Rust function and recover the same two contributions and prediction as the NN03 fixture?",
+  "source_fixture": "code/specs/fixtures/neural-learning-v1/labs/00-weighted-neuron.json",
+  "abi": {
+    "version_number": 65536,
+    "version_hex": "0x00010000",
+    "header": "code/packages/rust/neural-learning-capi/include/neural_learning.h",
+    "crate": "code/packages/rust/neural-learning-capi/Cargo.toml",
+    "library_base_name": "neural_learning_capi",
+    "functions": [
+      "uint32_t neural_learning_abi_version(void)",
+      "const char *neural_learning_status_message_v1(uint32_t status)",
+      "uint32_t neural_learning_weighted_sum_f64_v1(const double *inputs, const double *weights, uint64_t input_count, double bias, double *contributions_out, uint64_t contributions_capacity, double *prediction_out)"
+    ],
+    "rules": [
+      "all lengths and status values use fixed-width unsigned integers",
+      "callers own every input and output buffer",
+      "no Rust allocation or Rust type crosses the boundary",
+      "mutable outputs do not overlap inputs or one another",
+      "a Rust panic is caught and becomes status 6"
+    ]
+  },
+  "statuses": [
+    { "code": 0, "symbol": "NEURAL_LEARNING_OK", "message": "ok" },
+    { "code": 1, "symbol": "NEURAL_LEARNING_NULL_POINTER", "message": "null pointer" },
+    { "code": 2, "symbol": "NEURAL_LEARNING_EMPTY_INPUT", "message": "input count must be positive" },
+    { "code": 3, "symbol": "NEURAL_LEARNING_BUFFER_TOO_SMALL", "message": "contribution buffer is too small" },
+    { "code": 4, "symbol": "NEURAL_LEARNING_VALUE_TOO_LARGE", "message": "input count is too large" },
+    { "code": 5, "symbol": "NEURAL_LEARNING_NON_FINITE", "message": "all inputs and arithmetic results must be finite" },
+    { "code": 6, "symbol": "NEURAL_LEARNING_PANIC", "message": "Rust panic was contained" },
+    { "code": 7, "symbol": "NEURAL_LEARNING_OVERLAPPING_BUFFER", "message": "mutable output buffers must not overlap other buffers" },
+    { "code": 8, "symbol": "NEURAL_LEARNING_MISALIGNED_POINTER", "message": "pointer is not aligned for a double" }
+  ],
+  "hand_check": {
+    "inputs": [2.0, -1.0],
+    "weights": [0.5, -0.25],
+    "bias": 0.1,
+    "contributions_capacity": 2,
+    "expected_status": 0,
+    "expected_contributions": [1.0, 0.25],
+    "expected_prediction": 1.35,
+    "absolute_tolerance": 0.000001
+  },
+  "failure_probes": [
+    { "id": "null-input", "expected_status": 1, "outputs_unchanged": true },
+    { "id": "empty-input", "expected_status": 2, "outputs_unchanged": true },
+    { "id": "short-output", "expected_status": 3, "outputs_unchanged": true },
+    { "id": "non-finite", "expected_status": 5, "outputs_unchanged": true },
+    { "id": "overlapping-output", "expected_status": 7, "outputs_unchanged": true }
+  ]
+}

--- a/code/specs/fixtures/neural-learning-rust-cabi-v1/schema.json
+++ b/code/specs/fixtures/neural-learning-rust-cabi-v1/schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/neural-learning-rust-cabi-v1.json",
+  "title": "Neural-learning Rust C ABI v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "id", "title", "question", "source_fixture", "abi", "statuses", "hand_check", "failure_probes"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "id": { "const": "weighted-neuron-rust-c-abi" },
+    "title": { "type": "string", "minLength": 1 },
+    "question": { "type": "string", "minLength": 1 },
+    "source_fixture": { "const": "code/specs/fixtures/neural-learning-v1/labs/00-weighted-neuron.json" },
+    "abi": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version_number", "version_hex", "header", "crate", "library_base_name", "functions", "rules"],
+      "properties": {
+        "version_number": { "const": 65536 },
+        "version_hex": { "const": "0x00010000" },
+        "header": { "const": "code/packages/rust/neural-learning-capi/include/neural_learning.h" },
+        "crate": { "const": "code/packages/rust/neural-learning-capi/Cargo.toml" },
+        "library_base_name": { "const": "neural_learning_capi" },
+        "functions": {
+          "const": [
+            "uint32_t neural_learning_abi_version(void)",
+            "const char *neural_learning_status_message_v1(uint32_t status)",
+            "uint32_t neural_learning_weighted_sum_f64_v1(const double *inputs, const double *weights, uint64_t input_count, double bias, double *contributions_out, uint64_t contributions_capacity, double *prediction_out)"
+          ]
+        },
+        "rules": {
+          "type": "array",
+          "minItems": 5,
+          "maxItems": 5,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "statuses": {
+      "const": [
+        { "code": 0, "symbol": "NEURAL_LEARNING_OK", "message": "ok" },
+        { "code": 1, "symbol": "NEURAL_LEARNING_NULL_POINTER", "message": "null pointer" },
+        { "code": 2, "symbol": "NEURAL_LEARNING_EMPTY_INPUT", "message": "input count must be positive" },
+        { "code": 3, "symbol": "NEURAL_LEARNING_BUFFER_TOO_SMALL", "message": "contribution buffer is too small" },
+        { "code": 4, "symbol": "NEURAL_LEARNING_VALUE_TOO_LARGE", "message": "input count is too large" },
+        { "code": 5, "symbol": "NEURAL_LEARNING_NON_FINITE", "message": "all inputs and arithmetic results must be finite" },
+        { "code": 6, "symbol": "NEURAL_LEARNING_PANIC", "message": "Rust panic was contained" },
+        { "code": 7, "symbol": "NEURAL_LEARNING_OVERLAPPING_BUFFER", "message": "mutable output buffers must not overlap other buffers" },
+        { "code": 8, "symbol": "NEURAL_LEARNING_MISALIGNED_POINTER", "message": "pointer is not aligned for a double" }
+      ]
+    },
+    "hand_check": {
+      "const": {
+        "inputs": [2.0, -1.0],
+        "weights": [0.5, -0.25],
+        "bias": 0.1,
+        "contributions_capacity": 2,
+        "expected_status": 0,
+        "expected_contributions": [1.0, 0.25],
+        "expected_prediction": 1.35,
+        "absolute_tolerance": 0.000001
+      }
+    },
+    "failure_probes": {
+      "const": [
+        { "id": "null-input", "expected_status": 1, "outputs_unchanged": true },
+        { "id": "empty-input", "expected_status": 2, "outputs_unchanged": true },
+        { "id": "short-output", "expected_status": 3, "outputs_unchanged": true },
+        { "id": "non-finite", "expected_status": 5, "outputs_unchanged": true },
+        { "id": "overlapping-output", "expected_status": 7, "outputs_unchanged": true }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- define NN35's stable, allocation-free Rust C ABI and public header for the weighted-neuron execution core
- add the paper lesson, deterministic fixture, compiled-library validator, and exact cross-language contract checks
- add the interactive Rust C ABI workbench, CI wiring, coverage refresh, and roadmap/curriculum updates

## Validation
- `python code/scripts/validate_neural_learning_rust_cabi.py`
- 29 focused Python tests and Ruff
- Rust fmt, 5 tests, Clippy with warnings denied, and release build
- Clang and GCC C11 header checks
- 177 Vitest tests and Vite production build
- responsive browser QA at 1440x900 and 390x844, including the non-finite unchanged-output trace and horizontal-overflow checks
- changed Markdown link validation and `git diff --check`
- independent security review: pass, no remaining findings