### PR TITLE
Add JFET forward-bias parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `FC` depletion coefficient.
 - Validate and lower JFET model-card `PB` / `VJ` junction potential.
 - Validate and lower JFET model-card `AF` flicker-noise exponent.
 - Validate and lower JFET model-card `KF` flicker-noise coefficient.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1338,6 +1338,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Kf=model.params.get("KF", 0.0),
             Af=model.params.get("AF", 1.0),
             Pb=model.params.get("PB", model.params.get("VJ", 1.0)),
+            Fc=model.params.get("FC", 0.5),
         )
     if prefix == "M":
         _require_min_fields(fields, 6, "MOSFET")
@@ -2091,6 +2092,13 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(junction_potential) or junction_potential <= 0.0
         ):
             raise NetlistParseError("JFET PB must be finite and positive")
+        depletion_coefficient = params.get("FC")
+        if depletion_coefficient is not None and (
+            not math.isfinite(depletion_coefficient)
+            or depletion_coefficient < 0.0
+            or depletion_coefficient >= 1.0
+        ):
+            raise NetlistParseError("JFET FC must be finite and in [0, 1)")
     if kind in {"NMOS", "PMOS"}:
         if "LEVEL" in params:
             level = params["LEVEL"]

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1445,6 +1445,28 @@ def test_rejects_invalid_jfet_junction_potential(
         parse_netlist(f".model fast NJF({parameter}={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("0.6", 0.6)])
+def test_parse_jfet_forward_bias_depletion_coefficient(
+    value: str, expected: float
+) -> None:
+    parsed = parse_netlist(
+        f"""
+.model fast NJF(FC={value})
+J1 drain gate source fast
+"""
+    )
+
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert isclose(jfet.Fc, expected)
+
+
+@pytest.mark.parametrize("value", ["-0.1", "1", "1e999"])
+def test_rejects_invalid_jfet_forward_bias_depletion_coefficient(value: str) -> None:
+    with pytest.raises(NetlistParseError, match=r"JFET FC must be finite and in \[0, 1\)"):
+        parse_netlist(f".model fast NJF(FC={value})")
+
+
 def test_parse_pjf_model_aliases_beta() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `FC` depletion coefficient.
 - Validate and lower JFET model-card `PB` / `VJ` junction potential.
 - Validate and lower JFET model-card `AF` flicker-noise exponent.
 - Validate and lower JFET model-card `KF` flicker-noise coefficient.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1369,6 +1369,16 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("JFET PB must be finite and positive");
   }
+  const jfetDepletionCoefficient = params.get("FC");
+  if (
+    (kind === "NJF" || kind === "PJF") &&
+    jfetDepletionCoefficient !== undefined &&
+    (!Number.isFinite(jfetDepletionCoefficient) ||
+      jfetDepletionCoefficient < 0.0 ||
+      jfetDepletionCoefficient >= 1.0)
+  ) {
+    throw new NetlistParseError("JFET FC must be finite and in [0, 1)");
+  }
   const level = params.get("LEVEL");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1959,6 +1969,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("KF") ?? 0.0,
       model.params.get("AF") ?? 1.0,
       model.params.get("PB") ?? model.params.get("VJ") ?? 1.0,
+      model.params.get("FC") ?? 0.5,
     );
   }
   if (prefix === "M") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1482,6 +1482,30 @@ J1 drain gate source fast
     }
   });
 
+  it.each([
+    ["0", 0.0],
+    ["0.6", 0.6],
+  ])("parses JFET forward-bias depletion coefficient %s", (value, expected) => {
+    const parsed = parseNetlist(`
+.model fast NJF(FC=${value})
+J1 drain gate source fast
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      forwardBiasDepletionCoefficient: expected,
+    });
+  });
+
+  it.each(["-0.1", "1", "1e999"])(
+    "rejects invalid JFET forward-bias depletion coefficient %s",
+    (value) => {
+      expect(() => parseNetlist(`.model fast NJF(FC=${value})`)).toThrow(
+        "JFET FC must be finite and in [0, 1)",
+      );
+    },
+  );
+
   it("parses PJF model beta aliases", () => {
     const parsed = parseNetlist(`
 .model pslow PJF(B=750u)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4456,16 +4456,21 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine JFET flicker-noise exponent field.
 
 427. Python and TypeScript Berkeley SPICE JFET junction-potential parity.
-   - Status: completed in this JFET junction-potential parity slice.
+   - Status: completed in PR 9839.
    - Both parser facades validate positive finite `PB` / `VJ` values, prefer
      canonical `PB`, and lower the result into the shared engine JFET
      junction-potential field.
 
+428. Python and TypeScript Berkeley SPICE JFET depletion-coefficient parity.
+   - Status: completed in this JFET depletion-coefficient parity slice.
+   - Both parser facades validate finite `FC` values in `[0, 1)` and lower
+     them into the shared engine JFET forward-bias depletion field.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE model-card validation parity.
-   - Continue the audited JFET model-card gaps, beginning with `FC`, then `IS`,
-     `XTI`, `EG`, `B`, `NLEV`, `GDSNOI`, `RD`, `RS`,
+   - Continue the audited JFET model-card gaps, beginning with `IS`, then `XTI`,
+     `EG`, `B`, `NLEV`, `GDSNOI`, `RD`, `RS`,
      `TCV`, `VTOTC`, `TNOM` / `T_NOM`, `BEX`, and `BETATCE`.
    - Continue the audited BJT model-card gaps after the smaller JFET fields;
      prioritize direct engine fields before adding new model surfaces.


### PR DESCRIPTION
## Summary
- validate finite JFET `FC` model-card values in `[0, 1)` in Python and TypeScript
- lower `FC` into the existing engine forward-bias depletion field
- advance the audited parser-to-engine backlog to JFET gate saturation current

## Verification
- `code/packages/python/spice-netlist-parser/BUILD`
- Python parser Ruff checks
- `code/packages/typescript/spice-engine/BUILD`
- `code/packages/typescript/spice-netlist-parser/BUILD`
- TypeScript parser coverage suite (86.54% lines)