### PR TITLE
Add JFET saturation current parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `IS` gate saturation current.
 - Validate and lower JFET model-card `FC` depletion coefficient.
 - Validate and lower JFET model-card `PB` / `VJ` junction potential.
 - Validate and lower JFET model-card `AF` flicker-noise exponent.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1339,6 +1339,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Af=model.params.get("AF", 1.0),
             Pb=model.params.get("PB", model.params.get("VJ", 1.0)),
             Fc=model.params.get("FC", 0.5),
+            Is=model.params.get("IS", 1.0e-14),
         )
     if prefix == "M":
         _require_min_fields(fields, 6, "MOSFET")
@@ -2099,6 +2100,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or depletion_coefficient >= 1.0
         ):
             raise NetlistParseError("JFET FC must be finite and in [0, 1)")
+        saturation_current = params.get("IS")
+        if saturation_current is not None and (
+            not math.isfinite(saturation_current) or saturation_current <= 0.0
+        ):
+            raise NetlistParseError("JFET IS must be finite and positive")
     if kind in {"NMOS", "PMOS"}:
         if "LEVEL" in params:
             level = params["LEVEL"]

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1467,6 +1467,25 @@ def test_rejects_invalid_jfet_forward_bias_depletion_coefficient(value: str) -> 
         parse_netlist(f".model fast NJF(FC={value})")
 
 
+def test_parse_jfet_gate_saturation_current() -> None:
+    parsed = parse_netlist(
+        """
+.model fast NJF(IS=2p)
+J1 drain gate source fast
+"""
+    )
+
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert isclose(jfet.Is, 2.0e-12)
+
+
+@pytest.mark.parametrize("value", ["0", "-1p", "1e999"])
+def test_rejects_invalid_jfet_gate_saturation_current(value: str) -> None:
+    with pytest.raises(NetlistParseError, match="JFET IS must be finite and positive"):
+        parse_netlist(f".model fast NJF(IS={value})")
+
+
 def test_parse_pjf_model_aliases_beta() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `IS` gate saturation current.
 - Validate and lower JFET model-card `FC` depletion coefficient.
 - Validate and lower JFET model-card `PB` / `VJ` junction potential.
 - Validate and lower JFET model-card `AF` flicker-noise exponent.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1379,6 +1379,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("JFET FC must be finite and in [0, 1)");
   }
+  const jfetSaturationCurrent = params.get("IS");
+  if (
+    (kind === "NJF" || kind === "PJF") &&
+    jfetSaturationCurrent !== undefined &&
+    (!Number.isFinite(jfetSaturationCurrent) || jfetSaturationCurrent <= 0.0)
+  ) {
+    throw new NetlistParseError("JFET IS must be finite and positive");
+  }
   const level = params.get("LEVEL");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1970,6 +1978,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("AF") ?? 1.0,
       model.params.get("PB") ?? model.params.get("VJ") ?? 1.0,
       model.params.get("FC") ?? 0.5,
+      model.params.get("IS") ?? 1.0e-14,
     );
   }
   if (prefix === "M") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1506,6 +1506,24 @@ J1 drain gate source fast
     },
   );
 
+  it("parses the JFET gate saturation current", () => {
+    const parsed = parseNetlist(`
+.model fast NJF(IS=2p)
+J1 drain gate source fast
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      gateSaturationCurrent: 2.0e-12,
+    });
+  });
+
+  it.each(["0", "-1p", "1e999"])("rejects invalid JFET gate saturation current %s", (value) => {
+    expect(() => parseNetlist(`.model fast NJF(IS=${value})`)).toThrow(
+      "JFET IS must be finite and positive",
+    );
+  });
+
   it("parses PJF model beta aliases", () => {
     const parsed = parseNetlist(`
 .model pslow PJF(B=750u)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4462,15 +4462,20 @@ the Rust, Python, and TypeScript surfaces together.
      junction-potential field.
 
 428. Python and TypeScript Berkeley SPICE JFET depletion-coefficient parity.
-   - Status: completed in this JFET depletion-coefficient parity slice.
+   - Status: completed in PR 9842.
    - Both parser facades validate finite `FC` values in `[0, 1)` and lower
      them into the shared engine JFET forward-bias depletion field.
+
+429. Python and TypeScript Berkeley SPICE JFET gate-current parity.
+   - Status: completed in this JFET gate-current parity slice.
+   - Both parser facades validate positive finite `IS` values and lower them
+     into the shared engine JFET gate saturation-current field.
 
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE model-card validation parity.
-   - Continue the audited JFET model-card gaps, beginning with `IS`, then `XTI`,
-     `EG`, `B`, `NLEV`, `GDSNOI`, `RD`, `RS`,
+   - Continue the audited JFET model-card gaps, beginning with `XTI`, then `EG`,
+     `B`, `NLEV`, `GDSNOI`, `RD`, `RS`,
      `TCV`, `VTOTC`, `TNOM` / `T_NOM`, `BEX`, and `BETATCE`.
    - Continue the audited BJT model-card gaps after the smaller JFET fields;
      prioritize direct engine fields before adding new model surfaces.


### PR DESCRIPTION
## Summary
- validate positive finite JFET `IS` model-card values in Python and TypeScript
- lower `IS` into the existing engine gate saturation-current field
- advance the audited parser-to-engine backlog to JFET temperature exponent

## Verification
- `code/packages/python/spice-netlist-parser/BUILD`
- Python parser Ruff checks
- `code/packages/typescript/spice-engine/BUILD`
- `code/packages/typescript/spice-netlist-parser/BUILD`
- TypeScript parser coverage suite (86.58% lines)