### PR TITLE
fix(human-languages): clean Malayalam book warnings

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -97,9 +97,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B23 | Complete (#9815) | Remove Telugu's LaTeX layout, duplicate-label, bookmark, and font warnings. | The forced 95-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings. |
 | HL-B24 | Complete (#9823) | Publish Kannada Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | Thirty schema-v2 lessons now generate twenty-six chapters whose source hashes are independently verified against the Language Ladder corpus. |
 | HL-B25 | Complete (#9828) | Remove Kannada's LaTeX layout, duplicate-label, bookmark, and font warnings. | The forced 96-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings. |
-| HL-B26 | Complete in this PR | Publish Malayalam Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | Thirty-three schema-v2 lessons now generate twenty-six chapters whose source hashes are independently verified against the Language Ladder corpus. |
-| HL-B27 | Next | Remove Malayalam's LaTeX layout, duplicate-label, bookmark, font, and header-only-verso warnings. | The expanded 107-page build has zero missing glyphs but reports 17 overfull boxes, four underfull horizontal boxes, ten underfull vertical boxes, four duplicate practice labels, 108 Hyperref warnings, and seven font warnings; the clean-build signal is zero of each and intentionally empty versos have no running header. |
-| HL-B28 | Queued | Publish Arabic Chapters 3–27 and its writing companions from canonical lessons rather than hand-copying another twenty-five book chapters. | The Arabic PDF stops after Chapter 2 while canonical app content continues through Chapter 27 and sixteen dependency-ordered writing lessons; schema-v2 migration plus generation should close that drift safely. |
+| HL-B26 | Complete (#9838) | Publish Malayalam Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | Thirty-three schema-v2 lessons now generate twenty-six chapters whose source hashes are independently verified against the Language Ladder corpus. |
+| HL-B27 | Complete in this PR | Remove Malayalam's LaTeX layout, duplicate-label, bookmark, font, and header-only-verso warnings. | The forced 107-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; intentionally empty versos are truly empty. |
+| HL-B28 | Next | Publish Arabic Chapters 3–27 and its writing companions from canonical lessons rather than hand-copying another twenty-five book chapters. | The Arabic PDF stops after Chapter 2 while canonical app content continues through Chapter 27 and sixteen dependency-ordered writing lessons; schema-v2 migration plus generation should close that drift safely. |
 | HL-B29 | Queued | Remove Arabic's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports one overfull box, four underfull boxes, one duplicate practice label, 14 Hyperref warnings, and undefined bold/italic Arabic font shapes; the clean-build signal is zero of each. |
 | HL-B30 | Queued | Publish Hindi Chapters 6–33 and its writing companions from canonical lessons rather than hand-copying another twenty-eight book chapters. | The Hindi PDF stops after Chapter 5 while canonical app content continues through Chapter 33 and eleven dependency-ordered writing lessons; schema-v2 migration plus generation should close that drift safely. |
 | HL-B31 | Queued | Remove Hindi's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports two overfull boxes, five underfull boxes, three duplicate practice labels, 29 Hyperref warnings, undefined bold/italic Devanagari font shapes, and a visibly colliding final-page running header; the clean-build signal is zero of each. |
@@ -839,8 +839,28 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - The unified publication gate builds and catalogs all twenty books in one job
   (270.4 seconds locally), while the data package passes 84 tests and Language
   Ladder passes 411 tests plus its production build.
-- HL-B27 is next: make the complete Malayalam artifact warning-free before
-  starting Arabic's larger canonical-book migration in HL-B28.
+- HL-B27 follows by making the complete Malayalam artifact warning-free before
+  Arabic's larger canonical-book migration in HL-B28.
+
+## Findings from HL-B27
+
+- Explicit static bold and italic faces now cover Malayalam and all five
+  comparison scripts, while bookmark-safe Unicode commands preserve readable
+  outlines without asking Hyperref to interpret font switches.
+- The five handwritten recap labels are unique. Concise running titles and
+  narrow copy-flow edits in Chapters 1–3, 12, 20, and 22 remove every remaining
+  horizontal overflow without dropping or weakening teaching content.
+- Intentionally short micro-lessons use natural page bottoms, and open-right
+  chapter breaks now insert genuinely empty versos with no running header or
+  page number.
+- A forced XeLaTeX build produces 107 pages with zero missing glyphs, overfull
+  or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX
+  warnings, or font warnings. All 107 rendered pages were inspected again.
+- The correct title and author metadata, 33 top-level and 97 total outline
+  entries, generated source hashes, and zero schema or generator leaks remain
+  intact.
+- HL-B28 is next: publish Arabic Chapters 3–27 and the dependency-ordered
+  writing companions from the canonical app corpus.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -626,7 +626,7 @@
     {
       "language": "malayalam",
       "chapter": 12,
-      "sourceHash": "fnv1a64:2217e46400958a60",
+      "sourceHash": "fnv1a64:e42ba8156c6e3d9a",
       "lessonIds": [
         "ML-C12-kudumbam"
       ],
@@ -699,7 +699,7 @@
     {
       "language": "malayalam",
       "chapter": 20,
-      "sourceHash": "fnv1a64:ff43af581284ce6c",
+      "sourceHash": "fnv1a64:f974ebaac51f7c0e",
       "lessonIds": [
         "ML-C20-pathinonnu-irupathu",
         "ML-C20-kalavastha"
@@ -718,7 +718,7 @@
     {
       "language": "malayalam",
       "chapter": 22,
-      "sourceHash": "fnv1a64:d73a4752e9a4a0c2",
+      "sourceHash": "fnv1a64:ec9b97d7e41fedb0",
       "lessonIds": [
         "ML-C22-paccha-manja"
       ],

--- a/code/learning/human-languages/malayalam/CHANGELOG.md
+++ b/code/learning/human-languages/malayalam/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Warning-free complete book (2026-08-03)
+
+- Added explicit static bold and italic faces for Malayalam and every
+  comparison script, plus bookmark-safe Unicode commands, eliminating all
+  font-shape and Hyperref warnings without dropping multilingual examples.
+- Made the five handwritten recap labels unique and shortened only the running
+  titles that exceeded the text block. Small sentence-level copy-flow repairs
+  in the generated family, number, and colour chapters remove the remaining
+  horizontal overflows while preserving the canonical teaching sequence.
+- Added natural page bottoms for deliberately short micro-lessons and made
+  open-right chapter versos truly empty, without a running header or page
+  number.
+- The forced 107-page build now has zero missing glyphs, overfull or underfull
+  boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font
+  warnings. All 107 pages were rendered and visually inspected.
+- The 33 top-level and 97 total outline entries, title and author metadata,
+  generated source hashes, and zero schema or generator leaks remain intact.
+
 ## Canonical Chapters 6–31 in the book (2026-08-03)
 
 - Migrated all thirty-three Malayalam lessons after Chapter 5 to the strict

--- a/code/learning/human-languages/malayalam/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/malayalam/book/chapters/ch01-greetings.tex
@@ -155,7 +155,7 @@ Hindi & \emph{nahīṁ} & Indo-European (unrelated) \\
 \end{center}
 \end{cognates}
 
-\section{\ml{ശരി} \emph{(śari)} --- ``okay,'' the whole-family word once more}
+\section[Śari --- ``okay'']{\ml{ശരി} \emph{(śari)} --- ``okay,'' the whole-family word once more}
 \label{lesson:sari}
 
 \begin{sounds}
@@ -181,7 +181,7 @@ learn the four side by side.
 \end{grammarlens}
 
 \section{Recap, and how Malayalam says goodbye}
-\label{lesson:practice}
+\label{lesson:ml-c01-practice}
 
 \begin{center}
 \begin{tabular}{@{}llll@{}}

--- a/code/learning/human-languages/malayalam/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/malayalam/book/chapters/ch02-introductions.tex
@@ -73,7 +73,7 @@ verbless sentence. Malayalam is subject--object--\emph{verb}, and the copula
 Malayalis sometimes drop \emph{\=aṇŭ}, but the full, correct form keeps it.)
 \end{grammarlens}
 
-\section{\ml{നീ} / \ml{നിങ്ങൾ} \emph{(n\=\i\ / niṅṅaḷ)} --- ``you,'' familiar and respectful}
+\section[Familiar and respectful ``you'']{\ml{നീ} / \ml{നിങ്ങൾ} \emph{(n\=\i\ / niṅṅaḷ)} --- ``you,'' familiar and respectful}
 \label{lesson:nii-ningal}
 
 \begin{sounds}
@@ -135,10 +135,10 @@ Telugu use. So even Malayalam, the great keeper of native words (recall
 \end{cousinweb}
 
 \section{The whole exchange}
-\label{lesson:practice}
+\label{lesson:ml-c02-practice}
 
 \begin{center}
-\begin{tabular}{@{}lll@{}}
+\begin{tabularx}{\textwidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}Xl@{}}
 \toprule
 Malayalam & & English \\
 \midrule
@@ -147,7 +147,7 @@ Malayalam & & English \\
 \ml{എന്റെ പേര് അരുൺ ആണ്.} & \emph{enṟe p\=eru Arun \=aṇŭ} & My name is Arun. \\
 \ml{സന്തോഷം.} & \emph{sant\=oṣam} & Pleased to meet you. \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 Every atom traced: \emph{p\=eru} (Dravidian *p\=er, \emph{not} \emph{name}),

--- a/code/learning/human-languages/malayalam/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/malayalam/book/chapters/ch03-responding.tex
@@ -28,7 +28,7 @@ Dravidian question-root heading Tamil's \emph{eppa\d{t}i} --- the most native
 layer of a language otherwise rich in Sanskrit.
 \end{cousinweb}
 
-\section{\ml{സുഖമാണോ?} \emph{(sukham\=a\d{n}\=o)} --- ``how are you?''}
+\section[Sukhamāṇō? --- ``how are you?'']{\ml{സുഖമാണോ?} --- ``are you well?''}
 \label{lesson:sukhamaano}
 
 \ml{സുഖം} (\emph{sukha\d{m}}, ``well-being'') $+$ \ml{ആണ്} (\emph{\=a\d{n}\u{u}},
@@ -104,7 +104,7 @@ without the question \emph{-\=o}.
 \end{grammarlens}
 
 \section{The whole exchange}
-\label{lesson:practice}
+\label{lesson:ml-c03-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/malayalam/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/malayalam/book/chapters/ch04-farewells.tex
@@ -88,7 +88,7 @@ verb.
 \end{cousinweb}
 
 \section{The farewells}
-\label{lesson:practice}
+\label{lesson:ml-c04-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/malayalam/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/malayalam/book/chapters/ch05-first-verbs.tex
@@ -91,7 +91,7 @@ languages, two from an unrelated family, one shared trick.
 \end{grammarlens}
 
 \section{Sentences about yourself}
-\label{lesson:practice}
+\label{lesson:ml-c05-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/malayalam/book/chapters/ch12-family.tex
+++ b/code/learning/human-languages/malayalam/book/chapters/ch12-family.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:2217e46400958a60
+% canonical-source-hash: fnv1a64:e42ba8156c6e3d9a
 % canonical-lessons: ML-C12-kudumbam
 
 \chapter{Family}
@@ -52,5 +52,5 @@ Notice these don't closely match Tamil/Kannada/Telugu's \emph{aṇṇaṉ/anna},
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
-{[}PAUSE 3s{]} Do Malayalam's sibling words closely match Tamil's? (\textbf{No} — Malayalam built its own distinct set (cēṭṭan/aniyan/cēcci/aniyatti), unlike how closely Kannada and Telugu track Tamil.) Does Malayalam still split siblings by age? (\textbf{Yes} — four words, older vs. younger, the same structural pattern across the whole Dravidian family.)
+{[}PAUSE 3s{]} Do Malayalam's sibling words closely match Tamil's? (\textbf{No} — Malayalam built its own distinct set (cēṭṭan, aniyan, cēcci, and aniyatti), unlike how closely Kannada and Telugu track Tamil.) Does Malayalam still split siblings by age? (\textbf{Yes} — four words, older vs. younger, the same structural pattern across the whole Dravidian family.)
 \end{tcolorbox}

--- a/code/learning/human-languages/malayalam/book/chapters/ch20-numbers-and-weather.tex
+++ b/code/learning/human-languages/malayalam/book/chapters/ch20-numbers-and-weather.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:ff43af581284ce6c
+% canonical-source-hash: fnv1a64:f974ebaac51f7c0e
 % canonical-lessons: ML-C20-pathinonnu-irupathu, ML-C20-kalavastha
 
 \chapter{Numbers 11–20 and Weather}
@@ -19,7 +19,7 @@ Each section stays independently resumable and preserves the authored prerequisi
 \end{quote}
 
 \subsection*{You'll want to know}
-Malayalam's teens echo \textbf{\ml{പത്ത്}} (\emph{pathu}, "\textbf{ten}") plus each digit — \textbf{\ml{പതിനൊന്ന്}} (\emph{pathinonnu}, 11), \textbf{\ml{പന്ത്രണ്ട്}} (\emph{panthraṇṭŭ}, 12), and onward through \textbf{\ml{പത്തൊമ്പത്}} (\emph{pathompathu}, 19) — the same digit-plus-ten-echo compounding as its Dravidian cousins.
+Malayalam's teens echo \textbf{\ml{പത്ത്}} (\emph{pathu}, "\textbf{ten}") plus each digit. \textbf{\ml{പതിനൊന്ന്}} (\emph{pathinonnu}) is 11, \textbf{\ml{പന്ത്രണ്ട്}} (\emph{panthraṇṭŭ}) is 12, and the pattern continues through \textbf{\ml{പത്തൊമ്പത്}} (\emph{pathompathu}, 19) — the same digit-plus-ten-echo compounding as its Dravidian cousins.
 
 \begin{cousinweb}
 \textbf{\ml{ഇരുപത്}} (\emph{irupathu}, "\textbf{twenty}") = \textbf{\ml{ഇരു}} (\emph{iru}, an older word for "\textbf{two}") + \textbf{\ml{പത്ത്}} (\emph{pathu}, "\textbf{ten}") — still fully visible as "\textbf{two-tens}" today. This matches \textbf{Tamil's own} \emph{irupathu} almost letter-for-letter, both languages having kept this compound transparent — unlike Telugu's \emph{iravai}, which most likely continues the same underlying pattern but has worn down past the point of visibly splitting apart.

--- a/code/learning/human-languages/malayalam/book/chapters/ch22-green-and-yellow.tex
+++ b/code/learning/human-languages/malayalam/book/chapters/ch22-green-and-yellow.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:d73a4752e9a4a0c2
+% canonical-source-hash: fnv1a64:ec9b97d7e41fedb0
 % canonical-lessons: ML-C22-paccha-manja
 
 \chapter{Green and Yellow}
@@ -22,7 +22,7 @@ Each section stays independently resumable and preserves the authored prerequisi
 \textbf{\ml{പച്ച}} (\textbf{paccha}, "\textbf{green}") comes from \textbf{Proto-Dravidian} \emph{\textbf{*pac-}} — matching \textbf{Tamil}'s \textbf{\ta{பச்சை}} (\emph{paccai}) almost exactly, and the same root already seen in Kannada's \emph{hasiru} and Telugu's \emph{pacca}. No surprises here; this is the familiar family from the last two lessons.
 
 \begin{culture}
-\textbf{\ml{മഞ്ഞ}} (\textbf{mañña}, "\textbf{yellow}") is a \textbf{doublet} of \textbf{\ml{മഞ്ഞൾ}} (\textbf{maññaḷ}, "\textbf{turmeric}") — but this is a \textbf{completely different} Dravidian root from \emph{pac-}, matching \textbf{Tamil}'s own turmeric/yellow pair, \textbf{\ta{மஞ்சள்}} (\emph{mañcaḷ}), closely. So here's the honest shape of this arc so far: Kannada split green and yellow into two unrelated families (native vs. Sanskrit loan); Telugu kept them as doublets of the \textbf{same} native root; and Malayalam keeps them as \textbf{two separate} native Dravidian roots, each one independently matching its Tamil counterpart. No single pattern holds across all three languages — the honest answer is that each solved "green vs. yellow" its own way.
+\textbf{\ml{മഞ്ഞ}} (\emph{mañña}, "yellow") and \textbf{\ml{മഞ്ഞൾ}} (\emph{maññaḷ}, "turmeric") are a native \textbf{doublet pair}. This is a \textbf{completely different} Dravidian root from \emph{pac-}, matching \textbf{Tamil}'s own turmeric/yellow pair, \textbf{\ta{மஞ்சள்}} (\emph{mañcaḷ}), closely. So here's the honest shape of this arc so far: Kannada split green and yellow into two unrelated families (native vs. Sanskrit loan); Telugu kept them as doublets of the \textbf{same} native root; and Malayalam keeps them as \textbf{two separate} native Dravidian roots, each one independently matching its Tamil counterpart. No single pattern holds across all three languages — the honest answer is that each solved "green vs. yellow" its own way.
 \end{culture}
 
 \subsection*{Guided Practice}

--- a/code/learning/human-languages/malayalam/book/preamble.tex
+++ b/code/learning/human-languages/malayalam/book/preamble.tex
@@ -36,17 +36,53 @@
 \setmainlanguage{english}
 \setotherlanguage{arabic}
 
-\newfontfamily\malayalamfont[Path=../../_fonts/, Script=Malayalam]{NotoSansMalayalam-Static.ttf}
+\newfontfamily\malayalamfont[
+  Path=../../_fonts/,
+  Script=Malayalam,
+  BoldFont=NotoSansMalayalam-Static.ttf,
+  ItalicFont=NotoSansMalayalam-Static.ttf,
+  BoldItalicFont=NotoSansMalayalam-Static.ttf
+]{NotoSansMalayalam-Static.ttf}
 \newcommand{\ml}[1]{{\malayalamfont #1}}
-\newfontfamily\tamilfont[Path=../../_fonts/, Script=Tamil]{NotoSansTamil-Static.ttf}
+\newfontfamily\tamilfont[
+  Path=../../_fonts/,
+  Script=Tamil,
+  BoldFont=NotoSansTamil-Static.ttf,
+  ItalicFont=NotoSansTamil-Static.ttf,
+  BoldItalicFont=NotoSansTamil-Static.ttf
+]{NotoSansTamil-Static.ttf}
 \newcommand{\ta}[1]{{\tamilfont #1}}
-\newfontfamily\telugufont[Path=../../_fonts/, Script=Telugu]{NotoSansTelugu-Static.ttf}
+\newfontfamily\telugufont[
+  Path=../../_fonts/,
+  Script=Telugu,
+  BoldFont=NotoSansTelugu-Static.ttf,
+  ItalicFont=NotoSansTelugu-Static.ttf,
+  BoldItalicFont=NotoSansTelugu-Static.ttf
+]{NotoSansTelugu-Static.ttf}
 \newcommand{\te}[1]{{\telugufont #1}}
-\newfontfamily\kannadafont[Path=../../_fonts/, Script=Kannada]{NotoSansKannada-Static.ttf}
+\newfontfamily\kannadafont[
+  Path=../../_fonts/,
+  Script=Kannada,
+  BoldFont=NotoSansKannada-Static.ttf,
+  ItalicFont=NotoSansKannada-Static.ttf,
+  BoldItalicFont=NotoSansKannada-Static.ttf
+]{NotoSansKannada-Static.ttf}
 \newcommand{\ka}[1]{{\kannadafont #1}}
-\newfontfamily\devanagarifont[Path=../../_fonts/, Script=Devanagari]{NotoSansDevanagari-Static.ttf}
+\newfontfamily\devanagarifont[
+  Path=../../_fonts/,
+  Script=Devanagari,
+  BoldFont=NotoSansDevanagari-Static.ttf,
+  ItalicFont=NotoSansDevanagari-Static.ttf,
+  BoldItalicFont=NotoSansDevanagari-Static.ttf
+]{NotoSansDevanagari-Static.ttf}
 \newcommand{\dv}[1]{{\devanagarifont #1}}
-\newfontfamily\arabicfont[Path=../../_fonts/, Script=Arabic]{NotoNaskhArabic-Static.ttf}
+\newfontfamily\arabicfont[
+  Path=../../_fonts/,
+  Script=Arabic,
+  BoldFont=NotoNaskhArabic-Static.ttf,
+  ItalicFont=NotoNaskhArabic-Static.ttf,
+  BoldItalicFont=NotoNaskhArabic-Static.ttf
+]{NotoNaskhArabic-Static.ttf}
 \newcommand{\ar}[1]{\textarabic{#1}}
 
 \hypersetup{
@@ -55,6 +91,40 @@
   pdfsubject={Etymology-driven Malayalam curriculum},
   pdfkeywords={Malayalam, Dravidian, language learning, etymology}
 }
+\pdfstringdefDisableCommands{%
+  \def\ml#1{#1}% Keep script text while dropping font-only presentation.
+  \def\ta#1{#1}%
+  \def\te#1{#1}%
+  \def\ka#1{#1}%
+  \def\dv#1{#1}%
+  \def\ar#1{#1}%
+  \def\malayalamfont{}%
+  \def\tamilfont{}%
+  \def\telugufont{}%
+  \def\kannadafont{}%
+  \def\devanagarifont{}%
+  \def\arabicfont{}%
+}
+
+% Micro-lessons intentionally end at natural pause points instead of stretching
+% their callout boxes to force every page to the same depth.
+\raggedbottom
+\emergencystretch=2em
+
+% Polyglossia's bidi support can leave running heads on the blank verso that
+% book.cls inserts before an open-right chapter. Keep the print-friendly verso,
+% but make it truly empty.
+\makeatletter
+\renewcommand{\cleardoublepage}{%
+  \clearpage
+  \if@twoside
+    \ifodd\c@page\else
+      \hbox{}\thispagestyle{empty}\newpage
+      \if@twocolumn\hbox{}\newpage\fi
+    \fi
+  \fi
+}
+\makeatother
 
 \newtcolorbox{cousinweb}{
   breakable, skin=enhanced, colback=yellow!8, colframe=yellow!45!black,
@@ -66,10 +136,10 @@
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
   fonttitle=\bfseries, title={Why it's said this way}
 }
-\newtcolorbox{grammarlens}{
+\newtcolorbox{grammarlens}[1][]{
   breakable, skin=enhanced, colback=blue!5, colframe=blue!35!black,
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
-  fonttitle=\bfseries, title={Grammar Lens}
+  fonttitle=\bfseries, title={Grammar Lens}, #1
 }
 \newtcolorbox{sounds}{
   breakable, skin=enhanced, colback=green!6, colframe=green!30!black,

--- a/code/learning/human-languages/malayalam/lessons/ML-C12-kudumbam.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C12-kudumbam.md
@@ -76,7 +76,7 @@ languages, even where the specific words diverge.
 <!-- hl-knowledge: introduces=[]; assesses=[ML-CONCEPT-C12-KUDUMBAM-01, ML-CONCEPT-C12-KUDUMBAM-02] -->
 
 [PAUSE 3s] Do Malayalam's sibling words closely match Tamil's? (**No** —
-Malayalam built its own distinct set (cēṭṭan/aniyan/cēcci/aniyatti), unlike
+Malayalam built its own distinct set (cēṭṭan, aniyan, cēcci, and aniyatti), unlike
 how closely Kannada and Telugu track Tamil.) Does Malayalam still split
 siblings by age? (**Yes** — four words, older vs. younger, the same
 structural pattern across the whole Dravidian family.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C20-pathinonnu-irupathu.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C20-pathinonnu-irupathu.md
@@ -40,10 +40,10 @@ identically to its closest cousin, Tamil.
 ## You'll want to know
 <!-- hl-knowledge: introduces=[ML-CONCEPT-C20-PATHINONNU-IRUPATHU-01]; assesses=[] -->
 
-Malayalam's teens echo **പത്ത്** (*pathu*, "**ten**") plus each digit —
-**പതിനൊന്ന്** (*pathinonnu*, 11), **പന്ത്രണ്ട്** (*panthraṇṭŭ*, 12), and
-onward through **പത്തൊമ്പത്** (*pathompathu*, 19) — the same
-digit-plus-ten-echo compounding as its Dravidian cousins.
+Malayalam's teens echo **പത്ത്** (*pathu*, "**ten**") plus each digit.
+**പതിനൊന്ന്** (*pathinonnu*) is 11, **പന്ത്രണ്ട്** (*panthraṇṭŭ*) is 12,
+and the pattern continues through **പത്തൊമ്പത്** (*pathompathu*, 19) — the
+same digit-plus-ten-echo compounding as its Dravidian cousins.
 
 ## The word, taken apart
 <!-- hl-knowledge: introduces=[ML-CONCEPT-C20-PATHINONNU-IRUPATHU-02]; assesses=[] -->

--- a/code/learning/human-languages/malayalam/lessons/ML-C22-paccha-manja.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C22-paccha-manja.md
@@ -49,9 +49,9 @@ here; this is the familiar family from the last two lessons.
 ## Why it's said this way
 <!-- hl-knowledge: introduces=[ML-CONCEPT-C22-PACCHA-MANJA-02]; assesses=[] -->
 
-**മഞ്ഞ** (**mañña**, "**yellow**") is a **doublet** of **മഞ്ഞൾ**
-(**maññaḷ**, "**turmeric**") — but this is a **completely different**
-Dravidian root from *pac-*, matching **Tamil**'s own turmeric/yellow pair,
+**മഞ്ഞ** (*mañña*, "yellow") and **മഞ്ഞൾ** (*maññaḷ*, "turmeric") are a
+native **doublet pair**. This is a **completely different** Dravidian root
+from *pac-*, matching **Tamil**'s own turmeric/yellow pair,
 **மஞ்சள்** (*mañcaḷ*), closely. So here's the honest
 shape of this arc so far: Kannada split green and yellow into two unrelated
 families (native vs. Sanskrit loan); Telugu kept them as doublets of the


### PR DESCRIPTION
## Summary
- give Malayalam and every comparison script explicit static font faces plus bookmark-safe Unicode fallbacks
- remove duplicate practice labels, layout overflow, stretched micro-lessons, and header-only blank versos
- keep canonical lesson copy, generated LaTeX, source hashes, the app corpus, and the downloadable book synchronized

## Validation
- `latexmk -xelatex -interaction=nonstopmode -halt-on-error -g book.tex` (107 pages; zero missing glyphs, overfull/underfull boxes, Hyperref warnings, LaTeX warnings, or font warnings)
- visually inspected all 107 rendered pages; 33 top-level / 97 total outline entries and zero generator/schema leaks
- human-language-data: 84 tests; build, generate, and check gates pass
- Language Ladder: 411 tests and production build pass
- unified publication job: 20 PDFs / 20 catalog entries; bundled Malayalam PDF exactly matches the forced build