### PR TITLE
Add JFET temperature exponent parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `XTI` temperature exponent.
 - Validate and lower JFET model-card `IS` gate saturation current.
 - Validate and lower JFET model-card `FC` depletion coefficient.
 - Validate and lower JFET model-card `PB` / `VJ` junction potential.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1340,6 +1340,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Pb=model.params.get("PB", model.params.get("VJ", 1.0)),
             Fc=model.params.get("FC", 0.5),
             Is=model.params.get("IS", 1.0e-14),
+            Xti=model.params.get("XTI", 3.0),
         )
     if prefix == "M":
         _require_min_fields(fields, 6, "MOSFET")
@@ -2105,6 +2106,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(saturation_current) or saturation_current <= 0.0
         ):
             raise NetlistParseError("JFET IS must be finite and positive")
+        temperature_exponent = params.get("XTI")
+        if temperature_exponent is not None and not math.isfinite(
+            temperature_exponent
+        ):
+            raise NetlistParseError("JFET XTI must be finite")
     if kind in {"NMOS", "PMOS"}:
         if "LEVEL" in params:
             level = params["LEVEL"]

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1486,6 +1486,25 @@ def test_rejects_invalid_jfet_gate_saturation_current(value: str) -> None:
         parse_netlist(f".model fast NJF(IS={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("2.5", 2.5)])
+def test_parse_jfet_temperature_exponent(value: str, expected: float) -> None:
+    parsed = parse_netlist(
+        f"""
+.model fast NJF(XTI={value})
+J1 drain gate source fast
+"""
+    )
+
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert isclose(jfet.Xti, expected)
+
+
+def test_rejects_non_finite_jfet_temperature_exponent() -> None:
+    with pytest.raises(NetlistParseError, match="JFET XTI must be finite"):
+        parse_netlist(".model fast NJF(XTI=1e999)")
+
+
 def test_parse_pjf_model_aliases_beta() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `XTI` temperature exponent.
 - Validate and lower JFET model-card `IS` gate saturation current.
 - Validate and lower JFET model-card `FC` depletion coefficient.
 - Validate and lower JFET model-card `PB` / `VJ` junction potential.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1387,6 +1387,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("JFET IS must be finite and positive");
   }
+  const jfetTemperatureExponent = params.get("XTI");
+  if (
+    (kind === "NJF" || kind === "PJF") &&
+    jfetTemperatureExponent !== undefined &&
+    !Number.isFinite(jfetTemperatureExponent)
+  ) {
+    throw new NetlistParseError("JFET XTI must be finite");
+  }
   const level = params.get("LEVEL");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1979,6 +1987,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("PB") ?? model.params.get("VJ") ?? 1.0,
       model.params.get("FC") ?? 0.5,
       model.params.get("IS") ?? 1.0e-14,
+      model.params.get("XTI") ?? 3.0,
     );
   }
   if (prefix === "M") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1524,6 +1524,27 @@ J1 drain gate source fast
     );
   });
 
+  it.each([
+    ["0", 0.0],
+    ["2.5", 2.5],
+  ])("parses JFET temperature exponent %s", (value, expected) => {
+    const parsed = parseNetlist(`
+.model fast NJF(XTI=${value})
+J1 drain gate source fast
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      gateSaturationCurrentTemperatureExponent: expected,
+    });
+  });
+
+  it("rejects a non-finite JFET temperature exponent", () => {
+    expect(() => parseNetlist(".model fast NJF(XTI=1e999)")).toThrow(
+      "JFET XTI must be finite",
+    );
+  });
+
   it("parses PJF model beta aliases", () => {
     const parsed = parseNetlist(`
 .model pslow PJF(B=750u)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4467,15 +4467,20 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine JFET forward-bias depletion field.
 
 429. Python and TypeScript Berkeley SPICE JFET gate-current parity.
-   - Status: completed in this JFET gate-current parity slice.
+   - Status: completed in PR 9843.
    - Both parser facades validate positive finite `IS` values and lower them
      into the shared engine JFET gate saturation-current field.
+
+430. Python and TypeScript Berkeley SPICE JFET temperature-exponent parity.
+   - Status: completed in this JFET temperature-exponent parity slice.
+   - Both parser facades validate finite `XTI` values and lower them into the
+     shared engine JFET gate-current temperature-exponent field.
 
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE model-card validation parity.
-   - Continue the audited JFET model-card gaps, beginning with `XTI`, then `EG`,
-     `B`, `NLEV`, `GDSNOI`, `RD`, `RS`,
+   - Continue the audited JFET model-card gaps, beginning with `EG`, then `B`,
+     `NLEV`, `GDSNOI`, `RD`, `RS`,
      `TCV`, `VTOTC`, `TNOM` / `T_NOM`, `BEX`, and `BETATCE`.
    - Continue the audited BJT model-card gaps after the smaller JFET fields;
      prioritize direct engine fields before adding new model surfaces.


### PR DESCRIPTION
## Summary
- validate finite JFET `XTI` model-card values in Python and TypeScript
- lower `XTI` into the existing engine gate-current temperature-exponent field
- advance the audited parser-to-engine backlog to JFET energy gap

## Verification
- `code/packages/python/spice-netlist-parser/BUILD`
- Python parser Ruff checks
- `code/packages/typescript/spice-engine/BUILD`
- `code/packages/typescript/spice-netlist-parser/BUILD`
- TypeScript parser coverage suite (86.62% lines)