### PR TITLE
fix(c-to-sir,sir-c,sir-ruby): << SIR builtin name collided between C bitwise shift and Ruby operator

### DIFF
--- a/code/packages/rust/c-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/c-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+### Fixed — `<<` lowered to a SIR builtin name that collided with Ruby's `<<`
+
+`ruby-to-semantic-ir` gained a polymorphic `<<` operator (Array push /
+String concat / saturating-Integer-shift), lowered to the SAME bare
+`BuiltinCall("<<", ...)` name this crate already used for C's raw bitwise
+left shift. `semantic-ir-to-c`'s emit-time dispatch had to pick ONE
+meaning for that shared name and picked Ruby's — so a C program's `<<`
+silently got Ruby's saturating semantics instead of a raw bit-shift.
+Caught by `three_way_conformance`'s "uint64 logical right shift of a
+high-bit value" case: `uint64_t x = 1; uint64_t y = x << 63;` needs the
+true bit pattern `0x8000000000000000`, which isn't representable without
+saturating, so it silently clamped to `INT64_MAX` and the subsequent
+`y >> 32` read back the wrong high word (`2147483647` instead of the
+correct `2147483648`).
+
+Fixed by lowering C's `<<` to a distinct `c<<` builtin name instead
+(mirroring the existing `>>`/`u>>` signed/unsigned split, which never had
+this collision — Ruby doesn't implement `>>` at all). `semantic-ir-to-c`
+and `semantic-ir-to-ruby` both updated to recognize `c<<` alongside `<<`;
+see their own CHANGELOGs.
+
+`>>`/`u>>` were never affected (Ruby has no `>>` operator), so this only
+touches `<<`.
+
 ### Fixed (CI — Linux link failure)
 
 - Three C-compiling test helpers (`tests/three_way_conformance.rs`'s two,

--- a/code/packages/rust/c-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/c-to-semantic-ir/src/lib.rs
@@ -469,7 +469,12 @@ mod tests {
         // expression narrows only where C says: at the u8 assignment.
         let m = lower("int main(void) { uint8_t x = 1 << 3; return 0; }");
         let text = semantic_ir::print_module(&m);
-        assert!(text.contains("(builtin-call <<"), "no shift:\n{text}");
+        // `c<<`, not `<<` -- the C frontend's own bitwise left shift lowers
+        // to a DISTINCT builtin name from Ruby's polymorphic `<<` operator
+        // (Array push/String concat/saturating-Integer-shift), which shares
+        // the bare `"<<"` name at the SIR level. See the shift-lowering
+        // code's own comment for the collision this rename fixes.
+        assert!(text.contains("(builtin-call c<<"), "no shift:\n{text}");
         // shift performed at i32, then the declaration narrows to u8.
         assert!(
             text.contains("(convert (int i32 ub)"),

--- a/code/packages/rust/c-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/c-to-semantic-ir/src/lower.rs
@@ -1836,7 +1836,31 @@ impl Lowerer {
             // a `uint64_t` whose top bit is set is a *negative* int64 and a
             // native `>>` would sign-extend it.  Route unsigned `>>` to a
             // distinct `u>>` builtin the backends render as a logical shift.
-            let name = if op == ">>" && !lp.signed { "u>>" } else { op };
+            //
+            // Bug fix — `<<` routes to a DISTINCT `c<<` builtin, not the bare
+            // `"<<"` name: the Ruby frontend (`ruby-to-semantic-ir`) ALSO
+            // emits `BuiltinCall("<<", ...)`, but for Ruby's own polymorphic
+            // `<<` (Array push / String concat / SATURATING Integer shift —
+            // no bignum growth, unlike C's raw two's-complement bit pattern).
+            // Both frontends sharing the bare name `"<<"` meant the C
+            // backend's `_sir_builtin_method_v`-adjacent dispatch tables had
+            // to pick ONE meaning for it — it silently picked Ruby's
+            // saturating semantics for EVERY `<<`, including C-sourced ones,
+            // so `uint64_t x = 1; uint64_t y = x << 63;` (a value whose true
+            // bit pattern needs `INT64_MAX + 1`, unrepresentable without
+            // saturating) got silently clamped to `INT64_MAX` instead of the
+            // correct `0x8000000000000000` bit pattern — caught by
+            // `three_way_conformance`'s "uint64 logical right shift of a
+            // high-bit value" case. `>>`/`u>>` never had this collision
+            // (Ruby doesn't implement `>>` at all), so only `<<` needs the
+            // rename.
+            let name = if op == "<<" {
+                "c<<"
+            } else if !lp.signed {
+                "u>>"
+            } else {
+                op
+            };
             return Ok((convert(builtin(name, vec![le, re]), lp), CType::Int(lp)));
         }
 

--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.36.2 — fix: `<<` builtin name collided between C's bitwise shift and Ruby's operator
+
+`variadic_helper`'s `"<<" => "_sir_shift_left"` entry (added when Ruby's
+polymorphic `<<` operator landed in 0.36.0) is checked BEFORE
+`fixed_helper`'s `"<<" => ("_sir_shl", 2)` entry (C's raw bitwise left
+shift, pre-existing from `c-to-semantic-ir`'s own milestone-6 shift
+lowering) — so `fixed_helper`'s entry was silently DEAD CODE for the name
+`"<<"`. Every C program's `<<` was actually getting Ruby's
+saturate-instead-of-grow-a-bignum Integer-shift semantics, not a raw bit
+shift. Caught by `c-to-semantic-ir`'s `three_way_conformance` test: a
+uint64 value needing the bit pattern `0x8000000000000000` (one past
+`INT64_MAX`, unrepresentable without saturating) got silently clamped,
+corrupting a later logical-right-shift read.
+
+Fixed at the source: `c-to-semantic-ir` now lowers its OWN `<<` to a
+distinct `c<<` builtin name (mirroring the pre-existing `>>`/`u>>`
+signed/unsigned split), so `fixed_helper`'s `"<<"` key is renamed to
+`"c<<"` here too — `variadic_helper`'s `"<<"` entry is UNCHANGED and
+still correctly means Ruby's operator. The rarely-reached
+`_sir_builtin_dispatch` closure-lookup table (`Scope::Builtin` VarRef,
+e.g. a hypothetical `arr.reduce(:<<)`) gained the same split: `"<<"` now
+calls `_sir_shift_left_v` (Ruby semantics, matching `variadic_helper`)
+and a new `"c<<"` entry calls `_sir_shl` (C semantics) — previously it
+only had the C mapping under the bare name, which would have been wrong
+for a Ruby-sourced `<<` closure reference.
+
+`semantic-ir-to-c` 0.36.1 -> 0.36.2.
+
 ## 0.36.1 — execution proof for dotted/chained bracket-index writes
 
 No runtime code changed: `_sir_builtin_method_v`'s existing `"[]="` arm

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.36.1"
+version = "0.36.2"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -2366,7 +2366,13 @@ fn fixed_helper(name: &str) -> Option<(&'static str, usize)> {
         "|" => ("_sir_bor", 2),
         "^" => ("_sir_bxor", 2),
         "~" => ("_sir_bnot", 1),
-        "<<" => ("_sir_shl", 2),
+        // `c<<` -- the C frontend's OWN bitwise left shift, DISTINCT from
+        // Ruby's `<<` (Array push/String concat/saturating-Integer-shift),
+        // which shares the SAME bare `"<<"` name at the SIR level and is
+        // handled by `variadic_helper` above (checked BEFORE this table, so
+        // an unrenamed `"<<"` here would be dead code shadowed by Ruby's
+        // entry -- exactly the bug this rename fixes; see the CHANGELOG).
+        "c<<" => ("_sir_shl", 2),
         ">>" => ("_sir_shr", 2),
         "u>>" => ("_sir_lshr", 2),
         // Milestone 6 truncating division / remainder (signed + unsigned).

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -3696,7 +3696,18 @@ SirValue _sir_builtin_dispatch(SirValue *caps, SirValue *args, int argc) {
     if (strcmp(name, "|") == 0)        return _sir_bor(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
     if (strcmp(name, "^") == 0)        return _sir_bxor(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
     if (strcmp(name, "~") == 0)        return _sir_bnot(_sir_arg(args, argc, 0));
-    if (strcmp(name, "<<") == 0)       return _sir_shl(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
+    /* `"<<"` here is Ruby's polymorphic shift operator (Array push/String
+       concat/saturating-Integer-shift) -- matching `variadic_helper`'s
+       `"<<" => "_sir_shift_left"` mapping in emit.rs, for a builtin
+       referenced BY NAME (`Scope::Builtin`, e.g. a hypothetical
+       `arr.reduce(:<<)`) rather than emitted inline. `"c<<"` is the C
+       frontend's OWN raw bitwise left shift -- kept as a DISTINCT name so
+       the two never collide (the bug this split fixes: both frontends
+       used to share the bare `"<<"` name, so the C-emit-time dispatch had
+       to pick ONE meaning and silently applied Ruby's saturating semantics
+       to C-sourced shifts too -- see this crate's CHANGELOG). */
+    if (strcmp(name, "<<") == 0)       return _sir_shift_left_v(args, argc);
+    if (strcmp(name, "c<<") == 0)      return _sir_shl(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
     if (strcmp(name, ">>") == 0)       return _sir_shr(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
     if (strcmp(name, "u>>") == 0)      return _sir_lshr(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
     if (strcmp(name, "tdiv") == 0)     return _sir_itdiv(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));

--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.20.1 — accept `c<<`, the C frontend's own bitwise left shift
+
+`c-to-semantic-ir` and `ruby-to-semantic-ir` both used to lower their
+`<<` to the SAME bare `BuiltinCall("<<", ...)` name — one meaning C's raw
+bitwise left shift, the other Ruby's polymorphic `<<` (Array push/String
+concat/saturating-Integer-shift). `semantic-ir-to-c` had to pick ONE
+meaning for the shared name and got it wrong for C-sourced programs (see
+its own 0.36.2 CHANGELOG entry). `c-to-semantic-ir` now emits a distinct
+`c<<` for its own shift; this backend accepts it in `SUPPORTED_BUILTINS`
+and renders it identically to `<<` (Ruby's native `<<` operator already
+computes the mathematically correct arbitrary-precision left shift for
+any Integer operand, so no new runtime behavior is needed — just
+recognizing the renamed builtin so the structural scan doesn't reject a
+C-sourced program using it).
+
+`semantic-ir-to-ruby` 0.20.0 -> 0.20.1.
+
 ## 0.20.0 — fix: `puts` on an Array bracket-displayed instead of unpacking
 
 The same bug independently discovered and fixed in `semantic-ir-to-c`

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.20.0"
+version = "0.20.1"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -39,6 +39,15 @@ const SUPPORTED_BUILTINS: &[&str] = &[
     "^",
     "~",
     "<<",
+    // `c<<` -- the C frontend's OWN `<<` (bitwise left shift), a distinct SIR
+    // name from Ruby's own polymorphic `<<` operator (Array push/String
+    // concat/saturating-Integer-shift, both share the bare `"<<"` name at
+    // the SIR level; see `semantic-ir-to-c`'s CHANGELOG for the collision
+    // this rename fixes). Ruby's native `<<` already does the mathematically
+    // correct arbitrary-precision left shift for ANY Integer operand, so
+    // `c<<` renders identically to `<<` here -- no new runtime behavior
+    // needed, just accepting the renamed builtin.
+    "c<<",
     ">>",
     "u>>",
     // Truncating division / remainder (SIR27 milestone 6) — distinct from the
@@ -1456,7 +1465,7 @@ fn emit_builtin(name: &str, args: &[Expr]) -> String {
         "|" => format!("({} | {})", arg(&a, 0), arg(&a, 1)),
         "^" => format!("({} ^ {})", arg(&a, 0), arg(&a, 1)),
         "~" => format!("(~{})", arg(&a, 0)),
-        "<<" => format!("({} << {})", arg(&a, 0), arg(&a, 1)),
+        "<<" | "c<<" => format!("({} << {})", arg(&a, 0), arg(&a, 1)),
         // Both `>>` and the unsigned `u>>` render the same: a Ruby unsigned
         // value is a masked non-negative Integer, so `>>` is already logical
         // there (the distinction only matters for the C backend's signed int64).


### PR DESCRIPTION
## Summary
- Discovered while babysitting an unrelated PR (#9821): `c-to-semantic-ir`'s `three_way_conformance` test failed with a wrong shift result — confirmed reproducible on a completely clean `origin/main`, unrelated to that PR.
- Root cause: this session's earlier `<<` operator PR (#9811, Ruby's polymorphic `<<`) lowered to `BuiltinCall("<<", ...)` — the SAME bare name `c-to-semantic-ir` already used for C's raw bitwise left shift. `semantic-ir-to-c`'s emit-time dispatch had to pick ONE meaning for the shared name and picked Ruby's, so every C-sourced `<<` silently got Ruby's saturate-instead-of-overflow semantics instead of a raw bit shift — a uint64 value needing the bit pattern `0x8000000000000000` (unrepresentable without saturating) got silently clamped to `INT64_MAX`, corrupting a later logical-right-shift read (`2147483647` instead of the correct `2147483648`).
- Fixed by renaming C's own `<<` to a distinct `c<<` builtin name (mirroring the pre-existing `>>`/`u>>` signed/unsigned split, which never collided since Ruby doesn't implement `>>`). Updated `semantic-ir-to-c`'s `fixed_helper` and `_sir_builtin_dispatch`, and `semantic-ir-to-ruby`'s `SUPPORTED_BUILTINS`/emit table to recognize `c<<` alongside `<<`. `variadic_helper`'s `"<<" => "_sir_shift_left"` (Ruby's operator) is unchanged.

## Test plan
- [x] The originally-failing `c-to-semantic-ir::three_way_byte_identical_over_corpus` now passes
- [x] Updated one unit test asserting the emitted SIR text for C's `<<` (now expects `c<<`, not `<<`)
- [x] Full regression suites green: `c-to-semantic-ir` (57+2 tests), `semantic-ir-to-c` (all tests, including the existing Ruby `<<` execution-proof suite — unaffected), `semantic-ir-to-ruby` (123 tests), `sir-conformance`
- [x] `cargo clippy --all-targets` clean across all touched crates
- [x] Security review passed (verified the pre-existing `_sir_arg` bounds-check pattern isn't newly exposed by the rename; the two additional issues the review agent raised were false positives from a stale checkout on its end, directly disproven against my actual worktree — `_sir_shift_left_v` is defined and 11 tests exercise it successfully, and `variadic_helper`'s `<<` entry is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)