### PR TITLE
feat(learning): track neural implementation coverage

### DIFF
--- a/.github/workflows/deploy-ml-learning.yml
+++ b/.github/workflows/deploy-ml-learning.yml
@@ -38,10 +38,12 @@ on:
       - "code/specs/fixtures/reference-validation-v1/**"
       - "code/specs/fixtures/cross-language-consumers-v1/**"
       - "code/specs/fixtures/neural-learning-rust-cabi-v1/**"
+      - "code/specs/fixtures/neural-learning-implementation-coverage-v1/**"
       - "code/scripts/validate_*_labs.py"
       - "code/scripts/validate_reference_fixture_catalog.py"
       - "code/scripts/validate_cross_language_fixture_consumers.py"
       - "code/scripts/validate_neural_learning_rust_cabi.py"
+      - "code/scripts/validate_neural_learning_implementation_coverage.py"
       - "code/programs/go/neural-fixture-consumer/**"
       - "code/programs/ruby/neural-fixture-consumer/**"
       - "code/programs/rust/neural-fixture-consumer/**"
@@ -100,6 +102,9 @@ jobs:
 
       - name: Validate neural-learning Rust C ABI
         run: python3 code/scripts/validate_neural_learning_rust_cabi.py
+
+      - name: Validate native and Rust-core implementation coverage
+        run: python3 code/scripts/validate_neural_learning_implementation_coverage.py
 
   build-and-deploy:
     needs: validate-language-consumers

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1285 | 1282 | 99 | 61 | 8 | 1117 |
+| 1287 | 1283 | 99 | 62 | 8 | 1118 |
 
 ## Method
 
@@ -27,7 +27,7 @@ mention provides a complete lesson.
 | P0 | 86 | 26 | 6 | 55 |
 | P1 | 9 | 21 | 0 | 90 |
 | P2 | 1 | 3 | 1 | 152 |
-| P3 | 3 | 11 | 1 | 820 |
+| P3 | 3 | 12 | 1 | 821 |
 
 ## P0 Backlog
 
@@ -925,6 +925,7 @@ mention provides a complete lesson.
 | `cfb-writer` | 1 | missing |
 | `chief-of-staff-channel-endpoints` | 1 | missing |
 | `chief-of-staff-channel-store` | 1 | missing |
+| `chief-of-staff-cli` | 1 | missing |
 | `chief-of-staff-cli-core` | 1 | missing |
 | `chief-of-staff-daemon` | 1 | missing |
 | `chief-of-staff-daemon-api` | 1 | missing |
@@ -1207,6 +1208,7 @@ mention provides a complete lesson.
 | `smart-home-dashboard-core` | 1 | missing |
 | `smart-home-discovery` | 1 | missing |
 | `smart-home-discovery-service` | 1 | missing |
+| `smart-home-enphase-envoy-integration` | 1 | missing |
 | `smart-home-event-streams` | 1 | missing |
 | `smart-home-frigate-integration` | 1 | missing |
 | `smart-home-fronius-local-integration` | 1 | missing |
@@ -1252,7 +1254,6 @@ mention provides a complete lesson.
 | `tetrad-type-checker` | 1 | missing |
 | `text-core` | 1 | index-only |
 | `text-interfaces` | 1 | missing |
-| `text-native` | 1 | missing |
 | `text-native-coretext` | 1 | missing |
 | `thread-mle` | 1 | missing |
 | `transport-platform` | 1 | missing |

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -52,13 +52,14 @@ larger network:
 32. [Reference Fixtures: Make Every Expected Answer Earn Your Trust](./reference-fixtures-by-hand.md)
 33. [One Fixture, Three Languages](./one-fixture-three-languages.md)
 34. [A Rust C ABI, by Hand](./rust-c-abi-by-hand.md)
-35. [Matrix Math](../matrix-math.md)
-36. [Loss Functions](../loss-functions.md)
-37. [Gradient Descent](../gradient-descent.md)
-38. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-39. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-40. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-41. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+35. [Native and Rust-core Coverage, by Hand](./native-and-rust-core-coverage-by-hand.md)
+36. [Matrix Math](../matrix-math.md)
+37. [Loss Functions](../loss-functions.md)
+38. [Gradient Descent](../gradient-descent.md)
+39. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+40. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+41. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+42. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -68,7 +69,7 @@ networks.
 ## Interactive Lab
 
 The TypeScript [ML Learning Visualizer](../../programs/typescript/ml-learning-visualizer/README.md)
-has twenty-one complementary views:
+has twenty-three complementary views:
 
 - **Training microscope:** pause one update and reveal multiplication, bias,
   activation, loss, chain-rule gradients, and parameter movement one phase at a
@@ -173,6 +174,12 @@ has twenty-one complementary views:
   Ruby, and Rust expose native source, exact commands, and one closed receipt
   contract; the browser recomputes the paper trace without claiming to run the
   external programs.
+- **Rust C ABI lab:** keep caller-owned buffers, versioned functions, closed
+  statuses, and validate-before-write behavior visible across the foreign-
+  function boundary.
+- **Implementation coverage lab:** keep the same 1.35 answer fixed while
+  separating three native arithmetic owners from one Python-to-Rust binding
+  and linking every count to executable evidence.
 
 ## Language-Neutral Corpus
 
@@ -331,6 +338,11 @@ hand calculation, and five failure probes. Its validator dynamically loads the
 compiled Rust shared library and checks that rejected calls leave outputs
 unchanged.
 
+NN36 adds `code/specs/fixtures/neural-learning-implementation-coverage-v1`,
+which classifies the NN34 Go, Ruby, and Rust lanes as native and the NN35
+Python `ctypes` lane as a Rust-core binding. Its validator reruns both
+executable gates before reporting `3 native + 1 binding = 4 verified lanes`.
+
 Validate the bootstrap corpus with:
 
 ```text
@@ -367,6 +379,7 @@ python code/scripts/validate_precision_residency_labs.py
 python code/scripts/validate_reference_fixture_catalog.py
 python code/scripts/validate_cross_language_fixture_consumers.py
 python code/scripts/validate_neural_learning_rust_cabi.py
+python code/scripts/validate_neural_learning_implementation_coverage.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -62,11 +62,11 @@ trace, and tests.
   - [x] Backward and optimizer graph lowering.
   - [x] CPU, Rust core, and accelerated-backend parity.
   - [x] Precision, quantization, and buffer-residency experiments.
-- [ ] Cross-language consumers
+- [x] Cross-language consumers
   - [x] Validate every fixture with the reference implementation.
   - [x] Add thin consumers in representative language families.
   - [x] Define a stable Rust C ABI for high-performance execution.
-  - [ ] Track native implementation versus Rust-core binding coverage.
+  - [x] Track native implementation versus Rust-core binding coverage.
 
 ## Loop Rules
 

--- a/code/learning/machine-learning/curriculum.md
+++ b/code/learning/machine-learning/curriculum.md
@@ -135,6 +135,13 @@ versioned header, language-neutral ABI catalog, direct Rust tests, and a Python
 the comparison baseline; the next tranche can add binding-backed lanes and
 track which language concepts use native code or the Rust core.
 
+NN36 closes that comparison with an executable ownership inventory. Go, Ruby,
+and Rust remain three native lanes; Python `ctypes` is one Rust-core binding.
+The language-neutral catalog preserves the 1.35 paper oracle, records who owns
+each calculation, and reruns both underlying gates before counting `3 + 1 = 4`
+verified lanes. Future coverage grows only when a real native implementation or
+Rust-core binding earns the same fixture result.
+
 ## Corpus Rule
 
 Every new curriculum unit should contribute all of the following:

--- a/code/learning/machine-learning/native-and-rust-core-coverage-by-hand.md
+++ b/code/learning/machine-learning/native-and-rust-core-coverage-by-hand.md
@@ -1,0 +1,126 @@
+# Native and Rust-core coverage, by hand
+
+The word **coverage** can hide an important engineering choice. Two languages
+may both produce the right answer while getting there in very different ways.
+One may calculate the answer itself. Another may ask a shared Rust library to
+calculate it.
+
+NN36 keeps those paths separate.
+
+## First, keep the mathematics fixed
+
+Every lane receives the same tiny neuron:
+
+```text
+inputs  = [2, -1]
+weights = [0.5, -0.25]
+bias    = 0.1
+```
+
+Multiply matching positions:
+
+```text
+contribution 1 =  2 *  0.5  = 1.0
+contribution 2 = -1 * -0.25 = 0.25
+```
+
+Add both contributions and the bias:
+
+```text
+prediction = 1.0 + 0.25 + 0.1 = 1.35
+```
+
+That answer does not reveal who performed the arithmetic. Coverage metadata
+answers the separate ownership question.
+
+## What does native mean?
+
+A **native implementation** owns the calculation inside its own language
+lane. The Go program parses the fixture and multiplies in Go. Ruby does the
+same in Ruby. The Rust command-line program does it in Rust.
+
+NN36 has three such lanes:
+
+```text
+Go native   = 1 lane
+Ruby native = 1 lane
+Rust native = 1 lane
+---------------------
+native total = 3 lanes
+```
+
+The word native describes ownership here, not operating-system machine code.
+Ruby is interpreted, but its lane still owns the two multiplications and the
+sum instead of delegating them to the shared Rust core.
+
+## What does Rust-core binding mean?
+
+A **binding** is a small adapter that lets one language call an interface
+owned by another implementation. The Python lane allocates input and output
+buffers with `ctypes`, calls the versioned NN35 C ABI, and reads the result.
+Rust performs the weighted sum.
+
+That gives one binding lane:
+
+```text
+Python caller --ctypes--> C ABI v1 --calls--> Rust arithmetic
+
+Rust-core binding total = 1 lane
+```
+
+Python still owns its objects and buffers. Rust owns the neural arithmetic.
+The label records exactly that split.
+
+## Count the two categories
+
+Now the coverage arithmetic is small enough to audit on paper:
+
+```text
+native implementations = 3
+Rust-core bindings      = 1
+total verified lanes    = 3 + 1 = 4
+
+native share            = 3 / 4
+binding share           = 1 / 4
+```
+
+These fractions describe the four current implementation paths. A larger
+number is not automatically better. Four copied bugs would still be four
+lanes. One carefully tested shared core may be the safer design for some
+products.
+
+## Registered is not the same as verified
+
+The browser can read the catalog, check its closed shape, and recompute 1.35.
+It cannot run Go, Ruby, Python, or a native shared library.
+
+The executable coverage gate does the stronger work:
+
+```bash
+python code/scripts/validate_neural_learning_implementation_coverage.py
+```
+
+It runs the three native consumers, distrusts and checks their receipts, builds
+the Rust shared library, crosses the C ABI through Python, and only then reports
+`3 native + 1 binding = 4 verified lanes`.
+
+## Explore the ownership map
+
+Open **Implementation Coverage** in the ML Learning Visualizer. Select a lane
+and follow four facts:
+
+1. which language starts the call;
+2. whether the lane is native or a Rust-core binding;
+3. which language owns the arithmetic;
+4. which executable validator earns the coverage claim.
+
+The prediction stays at 1.35 while ownership changes. That is the central idea:
+portable mathematics and implementation architecture are related, but they are
+not the same fact.
+
+## Growing the matrix honestly
+
+A future language can add a native lane, a Rust-core binding, both, or neither.
+Each new checkmark needs a runnable path against the same language-neutral
+fixture. Planned support remains missing until that gate exists. This keeps the
+coverage table useful as an engineering inventory instead of a wish list.

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -4,7 +4,7 @@ Interactive machine learning lab for building intuition around small models.
 
 ## What It Shows
 
-The app has twenty-two workbenches that move from one arithmetic update to small
+The app has twenty-three workbenches that move from one arithmetic update to small
 spatial and hidden-layer networks.
 
 ### Training-step microscope
@@ -292,6 +292,15 @@ failure probes to see the returned status and whether output memory may change.
 The browser recomputes the committed ABI catalog; the Python validator builds
 and dynamically loads the real shared library.
 
+### Implementation coverage
+
+The Implementation Coverage workbench keeps the NN03 `1.35` answer fixed while
+it separates three native arithmetic owners from one Python `ctypes` caller
+that delegates the calculation to Rust. Select a lane to inspect its
+classification, owner, interface, evidence file, and executable validator. The
+browser checks registrations; the NN36 validator reruns both native and binding
+gates before counting four verified lanes.
+
 ## Lab Families
 
 - Basics: clean linear relationships such as Celsius to Fahrenheit.
@@ -455,6 +464,12 @@ C declarations, version number, status table, ownership rules, paper trace,
 and closed-output failure probes. Run `python
 code/scripts/validate_neural_learning_rust_cabi.py` to build and call the actual
 shared library.
+
+NN36 under `code/specs/fixtures/neural-learning-implementation-coverage-v1`
+classifies the NN34 lanes as native and the NN35 Python `ctypes` call as a
+Rust-core binding. Run `python
+code/scripts/validate_neural_learning_implementation_coverage.py` to execute
+both gates before accepting the `3 native + 1 binding` inventory.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/src/App.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/App.tsx
@@ -11,6 +11,7 @@ import { ForwardLoweringWorkbench } from "./ForwardLoweringWorkbench.js";
 import { GradientAccumulationWorkbench } from "./GradientAccumulationWorkbench.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
 import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
+import { ImplementationCoverageWorkbench } from "./ImplementationCoverageWorkbench.js";
 import { LAB_CATEGORIES, LABS, type LabDefinition } from "./labs.js";
 import { LinearNetworkDiagram } from "./NetworkDiagram.js";
 import { OptimizationWorkbench } from "./OptimizationWorkbench.js";
@@ -187,7 +188,7 @@ function groupColor(group: string | undefined, groups: string[]): string {
 
 export function App() {
   const [workbench, setWorkbench] = useState<
-    "microscope" | "optimization" | "linear" | "hidden" | "convolution" | "image-cnn" | "residual" | "recurrent" | "attention" | "representation" | "structured" | "deep" | "tensor" | "autograd" | "gradient-buffer" | "forward-lowering" | "training-lowering" | "backend-parity" | "precision-residency" | "reference-validation" | "language-consumers" | "rust-c-abi"
+    "microscope" | "optimization" | "linear" | "hidden" | "convolution" | "image-cnn" | "residual" | "recurrent" | "attention" | "representation" | "structured" | "deep" | "tensor" | "autograd" | "gradient-buffer" | "forward-lowering" | "training-lowering" | "backend-parity" | "precision-residency" | "reference-validation" | "language-consumers" | "rust-c-abi" | "implementation-coverage"
   >("microscope");
   const [selectedLabId, setSelectedLabId] = useState(LABS[0]!.id);
   const selectedLab = LABS.find((lab) => lab.id === selectedLabId) ?? LABS[0]!;
@@ -330,6 +331,8 @@ export function App() {
                 ? "One fixture can cross language boundaries"
               : workbench === "rust-c-abi"
                 ? "One stable seam can cross runtime boundaries"
+              : workbench === "implementation-coverage"
+                ? "Coverage should reveal who owns the arithmetic"
               : workbench === "linear"
                 ? "100-lab foundation"
                 : "Hidden-layer playground"}
@@ -492,6 +495,13 @@ export function App() {
             >
               Rust C ABI
             </button>
+            <button
+              className={workbench === "implementation-coverage" ? "mode-button mode-button--active" : "mode-button"}
+              type="button"
+              onClick={() => setWorkbench("implementation-coverage")}
+            >
+              Implementation Coverage
+            </button>
           </div>
           <div className="formula">
             {workbench === "microscope" ? (
@@ -534,6 +544,8 @@ export function App() {
               <>one fixture {"->"} <strong>registered CLI contracts</strong> {"->"} expected receipts</>
             ) : workbench === "rust-c-abi" ? (
               <>caller buffers {"->"} <strong>stable Rust C ABI</strong> {"->"} status + outputs</>
+            ) : workbench === "implementation-coverage" ? (
+              <>same fixture {"->"} <strong>native or Rust-core owner</strong> {"->"} verified lane count</>
             ) : workbench === "linear" ? (
               <>y = <strong>{formatNumber(model.weight)}</strong>x + <strong>{formatNumber(model.bias)}</strong></>
             ) : (
@@ -583,6 +595,8 @@ export function App() {
         <CrossLanguageConsumerWorkbench />
       ) : workbench === "rust-c-abi" ? (
         <RustCAbiWorkbench />
+      ) : workbench === "implementation-coverage" ? (
+        <ImplementationCoverageWorkbench />
       ) : workbench === "hidden" ? <HiddenLayerWorkbench /> : (
       <main className="workspace workspace--lab">
         <nav className="lab-rail" aria-label="ML lab examples">

--- a/code/programs/typescript/ml-learning-visualizer/src/ImplementationCoverageWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/ImplementationCoverageWorkbench.tsx
@@ -1,0 +1,100 @@
+import { useMemo, useState } from "react";
+import {
+  implementationCoverageCatalog,
+  traceImplementationCoverage,
+  type CoverageLaneId,
+} from "./implementation-coverage.js";
+
+function number(value: number): string {
+  return Number.isInteger(value) ? value.toFixed(1) : value.toString();
+}
+
+export function ImplementationCoverageWorkbench() {
+  const [laneId, setLaneId] = useState<CoverageLaneId>("go-native");
+  const trace = useMemo(() => traceImplementationCoverage(laneId), [laneId]);
+  const hand = trace.catalog.handCheck;
+
+  return (
+    <main className="workspace workspace--language-consumers workspace--implementation-coverage">
+      <section className="consumer-stage">
+        <header className="consumer-intro">
+          <div>
+            <p className="eyebrow">NN36 - count ownership, not just languages</p>
+            <h2>Implementation coverage</h2>
+            <p>{trace.catalog.question}</p>
+          </div>
+          <span className="consumer-chip">3 native + 1 binding</span>
+        </header>
+
+        <section className="consumer-paper" aria-label="Implementation coverage hand calculation">
+          <div className="panel-heading">
+            <div><p className="eyebrow">1 - hold the answer still</p><h2>Every lane must still earn 1.35</h2></div>
+            <span className="consumer-result consumer-result--pass">4 verified lanes</span>
+          </div>
+          <div className="consumer-products">
+            <div><small>contribution 1</small><code>{number(hand.inputs[0])} * {number(hand.weights[0])}</code><strong>= {number(hand.contributions[0])}</strong></div>
+            <div><small>contribution 2</small><code>{number(hand.inputs[1])} * {number(hand.weights[1])}</code><strong>= {number(hand.contributions[1])}</strong></div>
+            <div><small>prediction</small><code>1.0 + 0.25 + 0.1</code><strong>= {number(hand.prediction)}</strong></div>
+            <div><small>coverage</small><code>3 native + 1 binding</code><strong>= 4 lanes</strong></div>
+          </div>
+        </section>
+
+        <section className="consumer-lanes" aria-label="Native and Rust-core coverage lanes">
+          <div className="panel-heading">
+            <div><p className="eyebrow">2 - inspect ownership</p><h2>Select an implementation path</h2></div>
+            <span className="consumer-chip">owner: {trace.lane.arithmeticOwner}</span>
+          </div>
+          <div className="consumer-lane-grid implementation-coverage-lanes">
+            {implementationCoverageCatalog.lanes.map((lane) => (
+              <button
+                aria-label={`Inspect ${lane.language} ${lane.implementation} coverage lane`}
+                aria-pressed={lane.id === laneId}
+                key={lane.id}
+                onClick={() => setLaneId(lane.id)}
+                type="button"
+              >
+                <small>{lane.implementation.replaceAll("-", " ")}</small>
+                <strong>{lane.language}</strong>
+                <span>{lane.arithmeticOwner} owns arithmetic</span>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className="consumer-selected" aria-label="Selected implementation coverage contract">
+          <div className="panel-heading">
+            <div><p className="eyebrow">3 - follow the call</p><h2>{trace.lane.interface}</h2></div>
+            <span className="consumer-chip">{trace.lane.id}</span>
+          </div>
+          <dl>
+            <div><dt>classification</dt><dd><code>{trace.lane.implementation}</code></dd></div>
+            <div><dt>arithmetic owner</dt><dd><code>{trace.lane.arithmeticOwner}</code></dd></div>
+            <div><dt>execution evidence</dt><dd><code>{trace.lane.evidence}</code></dd></div>
+            <div><dt>validator</dt><dd><code>{trace.lane.validator}</code></dd></div>
+          </dl>
+        </section>
+
+        <section className="consumer-protocol" aria-label="Implementation coverage rules">
+          <div className="panel-heading">
+            <div><p className="eyebrow">4 - count only earned evidence</p><h2>Coverage is an inventory</h2></div>
+          </div>
+          <ol>
+            {trace.catalog.rules.map((rule, index) => (
+              <li key={rule}><span>{index + 1}</span><p>{rule}</p></li>
+            ))}
+          </ol>
+        </section>
+      </section>
+
+      <aside className="consumer-controls">
+        <p className="eyebrow">One fixture, two ownership models</p>
+        <h2>{trace.nativeFraction} native; {trace.bindingFraction} binding</h2>
+        <code className="consumer-command">{trace.catalog.contracts.coverage_validator}</code>
+        <section><p className="eyebrow">Native</p><p>Go, Ruby, and Rust each parse the NN03 fixture and perform their own two products and sum.</p></section>
+        <section><p className="eyebrow">Rust-core binding</p><p>Python allocates buffers with `ctypes`, crosses the versioned C ABI, and lets Rust perform the arithmetic.</p></section>
+        <section><p className="eyebrow">Executable evidence</p><p>The coverage validator reruns both underlying gates before it prints the four-lane total.</p></section>
+        <section><p className="eyebrow">Browser evidence</p><p>This view validates registered metadata and recomputes the paper trace. It does not execute Go, Ruby, Python, or the native library.</p></section>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/implementation-coverage.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/implementation-coverage.ts
@@ -1,0 +1,214 @@
+import catalogDocument from "../../../../specs/fixtures/neural-learning-implementation-coverage-v1/catalog.json";
+import sourceFixtureDocument from "../../../../specs/fixtures/neural-learning-v1/labs/00-weighted-neuron.json";
+
+const IMPLEMENTATIONS = ["native", "rust-core-binding"] as const;
+const CANONICAL_CONTRACTS = {
+  native_catalog: "code/specs/fixtures/cross-language-consumers-v1/catalog.json",
+  rust_c_abi_catalog: "code/specs/fixtures/neural-learning-rust-cabi-v1/catalog.json",
+  native_validator: "code/scripts/validate_cross_language_fixture_consumers.py",
+  binding_validator: "code/scripts/validate_neural_learning_rust_cabi.py",
+  coverage_validator: "code/scripts/validate_neural_learning_implementation_coverage.py",
+} as const;
+const CANONICAL_LANES = [
+  {
+    id: "go-native",
+    language: "Go",
+    implementation: "native",
+    arithmetic_owner: "Go",
+    interface: "fixture JSON to Go arithmetic",
+    evidence: "code/programs/go/neural-fixture-consumer/main.go",
+    validator: CANONICAL_CONTRACTS.native_validator,
+  },
+  {
+    id: "ruby-native",
+    language: "Ruby",
+    implementation: "native",
+    arithmetic_owner: "Ruby",
+    interface: "fixture JSON to Ruby arithmetic",
+    evidence: "code/programs/ruby/neural-fixture-consumer/main.rb",
+    validator: CANONICAL_CONTRACTS.native_validator,
+  },
+  {
+    id: "rust-native",
+    language: "Rust",
+    implementation: "native",
+    arithmetic_owner: "Rust",
+    interface: "fixture JSON to Rust arithmetic",
+    evidence: "code/programs/rust/neural-fixture-consumer/src/main.rs",
+    validator: CANONICAL_CONTRACTS.native_validator,
+  },
+  {
+    id: "python-ctypes-rust-core",
+    language: "Python",
+    implementation: "rust-core-binding",
+    arithmetic_owner: "Rust",
+    interface: "Python ctypes to versioned C ABI",
+    evidence: "code/scripts/validate_neural_learning_rust_cabi.py",
+    validator: CANONICAL_CONTRACTS.binding_validator,
+  },
+] as const;
+const CANONICAL_RULES = [
+  "native means the language lane owns the weighted-neuron arithmetic",
+  "rust-core-binding means the caller crosses the stable C ABI and Rust owns the arithmetic",
+  "a registered lane counts as verified only after its executable validator passes",
+  "coverage counts implementation paths, not code quality, speed, or curriculum mastery",
+] as const;
+
+export type ImplementationKind = typeof IMPLEMENTATIONS[number];
+export type CoverageLaneId = typeof CANONICAL_LANES[number]["id"];
+
+export interface CoverageLane {
+  readonly id: CoverageLaneId;
+  readonly language: string;
+  readonly implementation: ImplementationKind;
+  readonly arithmeticOwner: string;
+  readonly interface: string;
+  readonly evidence: string;
+  readonly validator: string;
+}
+
+export interface ImplementationCoverageCatalog {
+  readonly title: string;
+  readonly question: string;
+  readonly sourceFixture: string;
+  readonly contracts: typeof CANONICAL_CONTRACTS;
+  readonly handCheck: {
+    readonly inputs: readonly [number, number];
+    readonly weights: readonly [number, number];
+    readonly contributions: readonly [number, number];
+    readonly bias: number;
+    readonly prediction: number;
+    readonly nativeImplementations: 3;
+    readonly rustCoreBindings: 1;
+    readonly totalVerifiedLanes: 4;
+  };
+  readonly lanes: readonly CoverageLane[];
+  readonly rules: readonly string[];
+}
+
+export interface ImplementationCoverageTrace {
+  readonly catalog: ImplementationCoverageCatalog;
+  readonly lane: CoverageLane;
+  readonly nativeLaneIds: readonly CoverageLaneId[];
+  readonly bindingLaneIds: readonly CoverageLaneId[];
+  readonly nativeFraction: "3 / 4";
+  readonly bindingFraction: "1 / 4";
+}
+
+function closedObject(value: unknown, keys: readonly string[], context: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error(`${context}: expected object`);
+  const result = value as Record<string, unknown>;
+  const actual = Object.keys(result).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) throw new Error(`${context}: unexpected keys`);
+  return result;
+}
+
+function nonemptyText(value: unknown, context: string): string {
+  if (typeof value !== "string" || value.trim().length === 0 || value.length > 512 || /[\u0000-\u001f]/.test(value)) throw new Error(`${context}: invalid text`);
+  return value;
+}
+
+function pair(value: unknown, context: string): [number, number] {
+  if (!Array.isArray(value) || value.length !== 2 || value.some((entry) => typeof entry !== "number" || !Number.isFinite(entry))) throw new Error(`${context}: expected two finite numbers`);
+  return [value[0] as number, value[1] as number];
+}
+
+function singleton(value: unknown, context: string): number {
+  if (!Array.isArray(value) || value.length !== 1 || typeof value[0] !== "number" || !Number.isFinite(value[0])) throw new Error(`${context}: expected one finite number`);
+  return value[0];
+}
+
+function parseSourceFixtureHand(value: unknown) {
+  const fixture = closedObject(value, ["schema_version", "id", "title", "stage", "question", "concepts", "model", "dataset", "training", "expected"], "source fixture");
+  if (fixture.schema_version !== 1 || fixture.id !== "weighted-neuron-forward" || fixture.stage !== "forward" || fixture.training !== null) throw new Error("source fixture: wrong identity");
+  const model = closedObject(fixture.model, ["kind", "input_count", "layers"], "source fixture model");
+  if (model.kind !== "single-neuron" || model.input_count !== 2 || !Array.isArray(model.layers) || model.layers.length !== 1) throw new Error("source fixture: wrong model");
+  const layer = closedObject(model.layers[0], ["name", "weights", "biases", "activation"], "source fixture layer");
+  if (layer.name !== "output" || layer.activation !== "identity" || !Array.isArray(layer.weights) || layer.weights.length !== 2) throw new Error("source fixture: wrong layer");
+  const weights: [number, number] = [
+    singleton(layer.weights[0], "source fixture weights[0]"),
+    singleton(layer.weights[1], "source fixture weights[1]"),
+  ];
+  const bias = singleton(layer.biases, "source fixture biases");
+  const dataset = closedObject(fixture.dataset, ["input_labels", "target_labels", "rows"], "source fixture dataset");
+  if (!Array.isArray(dataset.rows) || dataset.rows.length !== 1) throw new Error("source fixture: wrong rows");
+  const row = closedObject(dataset.rows[0], ["label", "input", "target"], "source fixture row");
+  const inputs = pair(row.input, "source fixture input");
+  const expected = closedObject(fixture.expected, ["absolute_tolerance", "forward", "first_step"], "source fixture expected");
+  if (!Array.isArray(expected.forward) || expected.forward.length !== 1 || expected.first_step !== null) throw new Error("source fixture: wrong expectation");
+  const forward = closedObject(expected.forward[0], ["row", "prediction"], "source fixture forward");
+  const prediction = singleton(forward.prediction, "source fixture prediction");
+  if (row.label !== "worked example" || forward.row !== row.label || inputs[0] !== 2 || inputs[1] !== -1 || weights[0] !== 0.5 || weights[1] !== -0.25 || bias !== 0.1 || prediction !== 1.35) throw new Error("source fixture: wrong canonical hand example");
+  return { inputs, weights, bias, prediction };
+}
+
+const sourceFixtureHand = parseSourceFixtureHand(sourceFixtureDocument);
+
+export function parseImplementationCoverageCatalog(value: unknown): ImplementationCoverageCatalog {
+  const catalog = closedObject(value, ["schema_version", "id", "title", "question", "source_fixture", "contracts", "hand_check", "lanes", "rules"], "catalog");
+  if (catalog.schema_version !== 1 || catalog.id !== "weighted-neuron-implementation-coverage" || catalog.source_fixture !== "code/specs/fixtures/neural-learning-v1/labs/00-weighted-neuron.json") throw new Error("catalog: wrong identity");
+  const contracts = closedObject(catalog.contracts, Object.keys(CANONICAL_CONTRACTS), "contracts");
+  if (JSON.stringify(contracts) !== JSON.stringify(CANONICAL_CONTRACTS)) throw new Error("contracts: wrong values");
+
+  const hand = closedObject(catalog.hand_check, ["inputs", "weights", "contributions", "bias", "prediction", "native_implementations", "rust_core_bindings", "total_verified_lanes"], "hand_check");
+  const inputs = pair(hand.inputs, "hand_check.inputs");
+  const weights = pair(hand.weights, "hand_check.weights");
+  const contributions = pair(hand.contributions, "hand_check.contributions");
+  const bias = hand.bias;
+  const prediction = hand.prediction;
+  if (typeof bias !== "number" || !Number.isFinite(bias) || typeof prediction !== "number" || !Number.isFinite(prediction)) throw new Error("hand_check: expected finite arithmetic");
+  const recomputed = [inputs[0] * weights[0], inputs[1] * weights[1]] as const;
+  if (contributions[0] !== recomputed[0] || contributions[1] !== recomputed[1] || prediction !== recomputed[0] + recomputed[1] + bias) throw new Error("hand_check: dishonest arithmetic");
+  if (inputs[0] !== sourceFixtureHand.inputs[0] || inputs[1] !== sourceFixtureHand.inputs[1] || weights[0] !== sourceFixtureHand.weights[0] || weights[1] !== sourceFixtureHand.weights[1] || bias !== sourceFixtureHand.bias || prediction !== sourceFixtureHand.prediction) throw new Error("hand_check: catalog disagrees with NN03 source fixture");
+  if (hand.native_implementations !== 3 || hand.rust_core_bindings !== 1 || hand.total_verified_lanes !== 4) throw new Error("hand_check: dishonest coverage count");
+
+  if (!Array.isArray(catalog.lanes) || JSON.stringify(catalog.lanes) !== JSON.stringify(CANONICAL_LANES)) throw new Error("lanes: wrong values");
+  const lanes = catalog.lanes.map((raw, index) => {
+    const lane = closedObject(raw, ["id", "language", "implementation", "arithmetic_owner", "interface", "evidence", "validator"], `lanes[${index}]`);
+    return {
+      id: lane.id as CoverageLaneId,
+      language: nonemptyText(lane.language, `lanes[${index}].language`),
+      implementation: lane.implementation as ImplementationKind,
+      arithmeticOwner: nonemptyText(lane.arithmetic_owner, `lanes[${index}].arithmetic_owner`),
+      interface: nonemptyText(lane.interface, `lanes[${index}].interface`),
+      evidence: nonemptyText(lane.evidence, `lanes[${index}].evidence`),
+      validator: nonemptyText(lane.validator, `lanes[${index}].validator`),
+    };
+  });
+  if (!Array.isArray(catalog.rules) || JSON.stringify(catalog.rules) !== JSON.stringify(CANONICAL_RULES)) throw new Error("rules: wrong values");
+
+  return {
+    title: nonemptyText(catalog.title, "catalog.title"),
+    question: nonemptyText(catalog.question, "catalog.question"),
+    sourceFixture: catalog.source_fixture as string,
+    contracts: CANONICAL_CONTRACTS,
+    handCheck: {
+      inputs,
+      weights,
+      contributions,
+      bias,
+      prediction,
+      nativeImplementations: 3,
+      rustCoreBindings: 1,
+      totalVerifiedLanes: 4,
+    },
+    lanes,
+    rules: [...CANONICAL_RULES],
+  };
+}
+
+export const implementationCoverageCatalog = parseImplementationCoverageCatalog(catalogDocument);
+
+export function traceImplementationCoverage(laneId: CoverageLaneId = "go-native"): ImplementationCoverageTrace {
+  const lane = implementationCoverageCatalog.lanes.find((item) => item.id === laneId);
+  if (lane === undefined) throw new Error(`unknown coverage lane: ${laneId}`);
+  return {
+    catalog: implementationCoverageCatalog,
+    lane,
+    nativeLaneIds: implementationCoverageCatalog.lanes.filter((item) => item.implementation === "native").map((item) => item.id),
+    bindingLaneIds: implementationCoverageCatalog.lanes.filter((item) => item.implementation === "rust-core-binding").map((item) => item.id),
+    nativeFraction: "3 / 4",
+    bindingFraction: "1 / 4",
+  };
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -792,6 +792,10 @@ button.distribution-card[aria-pressed="true"] {
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
+.implementation-coverage-lanes {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
 .consumer-receipt {
   display: flex;
   flex-wrap: wrap;
@@ -895,6 +899,10 @@ button.distribution-card[aria-pressed="true"] {
 
   .consumer-products,
   .consumer-protocol ol {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .implementation-coverage-lanes {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -66,6 +66,12 @@ import { traceHopfieldRecall } from "./hopfield-memory.js";
 import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
 import { InitializationWorkbench } from "./InitializationWorkbench.js";
 import { initializerScale, traceInitializationDistributions } from "./initialization-distribution-lab.js";
+import { ImplementationCoverageWorkbench } from "./ImplementationCoverageWorkbench.js";
+import {
+  implementationCoverageCatalog,
+  parseImplementationCoverageCatalog,
+  traceImplementationCoverage,
+} from "./implementation-coverage.js";
 import { MessagePassingWorkbench } from "./MessagePassingWorkbench.js";
 import { traceTinyMessagePassing } from "./message-passing-lab.js";
 import { OptimizationWorkbench } from "./OptimizationWorkbench.js";
@@ -87,6 +93,7 @@ import precisionResidencyDocument from "../../../../specs/fixtures/precision-res
 import referenceCatalogDocument from "../../../../specs/fixtures/reference-validation-v1/catalog.json";
 import consumerCatalogDocument from "../../../../specs/fixtures/cross-language-consumers-v1/catalog.json";
 import cAbiCatalogDocument from "../../../../specs/fixtures/neural-learning-rust-cabi-v1/catalog.json";
+import implementationCoverageCatalogDocument from "../../../../specs/fixtures/neural-learning-implementation-coverage-v1/catalog.json";
 import { RecurrentWorkbench } from "./RecurrentWorkbench.js";
 import { RepresentationWorkbench } from "./RepresentationWorkbench.js";
 import { ResidualWorkbench } from "./ResidualWorkbench.js";
@@ -2726,5 +2733,49 @@ describe("neural-learning Rust C ABI", () => {
     expect(screen.getByLabelText("Selected C ABI trace").textContent)
       .toMatch(/NEURAL_LEARNING_NON_FINITE.*status 5.*byte-for-byte unchanged/s);
     expect(screen.getByText(/Python validator dynamically loads the compiled native library/)).toBeTruthy();
+  });
+});
+
+describe("neural-learning implementation coverage", () => {
+  it("distinguishes three native owners from one Rust-core binding", () => {
+    const binding = traceImplementationCoverage("python-ctypes-rust-core");
+
+    expect(implementationCoverageCatalog.handCheck.contributions).toEqual([1, 0.25]);
+    expect(implementationCoverageCatalog.handCheck.prediction).toBe(1.35);
+    expect(binding.nativeLaneIds).toEqual(["go-native", "ruby-native", "rust-native"]);
+    expect(binding.bindingLaneIds).toEqual(["python-ctypes-rust-core"]);
+    expect(binding.lane.arithmeticOwner).toBe("Rust");
+    expect(binding.nativeFraction).toBe("3 / 4");
+  });
+
+  it("fails closed on reclassified lanes and dishonest counts", () => {
+    expect(() => parseImplementationCoverageCatalog({})).toThrow(/unexpected keys/);
+
+    const reclassified = JSON.parse(JSON.stringify(implementationCoverageCatalogDocument));
+    reclassified.lanes[0].implementation = "rust-core-binding";
+    expect(() => parseImplementationCoverageCatalog(reclassified)).toThrow(/wrong values/);
+
+    const dishonest = JSON.parse(JSON.stringify(implementationCoverageCatalogDocument));
+    dishonest.hand_check.rust_core_bindings = 2;
+    expect(() => parseImplementationCoverageCatalog(dishonest)).toThrow(/dishonest coverage count/);
+
+    const crossWired = JSON.parse(JSON.stringify(implementationCoverageCatalogDocument));
+    crossWired.hand_check.inputs[0] = 3;
+    crossWired.hand_check.contributions[0] = 1.5;
+    crossWired.hand_check.prediction = 1.85;
+    expect(() => parseImplementationCoverageCatalog(crossWired)).toThrow(/disagrees with NN03/);
+  });
+
+  it("shows the ownership boundary without claiming browser execution", () => {
+    render(React.createElement(ImplementationCoverageWorkbench));
+    expect(screen.getByRole("heading", { name: "Implementation coverage" })).toBeTruthy();
+    expect(screen.getAllByText("3 native + 1 binding")).toHaveLength(2);
+    expect(screen.getByLabelText("Implementation coverage hand calculation").textContent)
+      .toMatch(/2\.0 \* 0\.5.*1\.0.*-1\.0 \* -0\.25.*0\.25.*3 native \+ 1 binding.*4 lanes/s);
+
+    fireEvent.click(screen.getByRole("button", { name: "Inspect Python rust-core-binding coverage lane" }));
+    expect(screen.getByLabelText("Selected implementation coverage contract").textContent)
+      .toMatch(/Python ctypes to versioned C ABI.*rust-core-binding.*Rust.*validate_neural_learning_rust_cabi\.py/s);
+    expect(screen.getByText(/does not execute Go, Ruby, Python, or the native library/)).toBeTruthy();
   });
 });

--- a/code/scripts/tests/test_neural_learning_implementation_coverage.py
+++ b/code/scripts/tests/test_neural_learning_implementation_coverage.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import importlib
+import json
+import shutil
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "code" / "scripts"))
+
+validator = importlib.import_module("validate_neural_learning_implementation_coverage")
+DEFAULT_FIXTURE_ROOT = validator.DEFAULT_FIXTURE_ROOT
+ImplementationCoverageError = validator.ImplementationCoverageError
+execute_coverage = validator.execute_coverage
+load_json = validator.load_json
+validate_catalog_document = validator.validate_catalog_document
+validate_fixture_root = validator.validate_fixture_root
+
+
+def catalog_document() -> dict[str, object]:
+    return load_json(DEFAULT_FIXTURE_ROOT / "catalog.json")
+
+
+def test_catalog_matches_language_neutral_schema() -> None:
+    schema = load_json(DEFAULT_FIXTURE_ROOT / "schema.json")
+    errors = sorted(
+        Draft202012Validator(schema).iter_errors(catalog_document()),
+        key=lambda error: list(error.path),
+    )
+
+    assert errors == []
+
+
+def test_hand_check_recomputes_arithmetic_and_coverage_counts() -> None:
+    hand = validate_fixture_root()["hand_check"]
+
+    contributions = [
+        hand["inputs"][index] * hand["weights"][index] for index in range(2)
+    ]
+    assert contributions == [1.0, 0.25]
+    assert sum(contributions, hand["bias"]) == 1.35
+    assert hand["native_implementations"] + hand["rust_core_bindings"] == 4
+
+
+def test_executes_three_native_lanes_and_one_real_rust_core_binding() -> None:
+    receipt = execute_coverage(validate_fixture_root())
+
+    assert receipt.native_lane_ids == ("go-native", "ruby-native", "rust-native")
+    assert receipt.binding_lane_ids == ("python-ctypes-rust-core",)
+    assert receipt.prediction == 1.35
+    assert receipt.total_verified_lanes == 4
+
+
+def test_catalog_rejects_unknown_fields() -> None:
+    document = catalog_document()
+    document["surprise"] = True
+
+    with pytest.raises(ImplementationCoverageError, match="unexpected shape"):
+        validate_catalog_document(document)
+
+
+def test_catalog_rejects_dishonest_coverage_count() -> None:
+    document = deepcopy(catalog_document())
+    document["hand_check"]["rust_core_bindings"] = 2
+
+    with pytest.raises(ImplementationCoverageError, match="coverage count"):
+        validate_catalog_document(document)
+
+
+def test_catalog_rejects_booleans_in_integer_fields() -> None:
+    boolean_version = deepcopy(catalog_document())
+    boolean_version["schema_version"] = True
+
+    with pytest.raises(ImplementationCoverageError, match="identity"):
+        validate_catalog_document(boolean_version)
+
+    boolean_count = deepcopy(catalog_document())
+    boolean_count["hand_check"]["rust_core_bindings"] = True
+
+    with pytest.raises(ImplementationCoverageError, match="coverage count"):
+        validate_catalog_document(boolean_count)
+
+
+def test_catalog_rejects_reclassified_lane() -> None:
+    document = deepcopy(catalog_document())
+    document["lanes"][0]["implementation"] = "rust-core-binding"
+
+    with pytest.raises(ImplementationCoverageError, match="not canonical"):
+        validate_catalog_document(document)
+
+
+def test_fixture_root_rejects_extra_files(tmp_path: Path) -> None:
+    for name in (
+        "catalog.json",
+        "schema.json",
+        "README.md",
+        "CHANGELOG.md",
+        "extra.txt",
+    ):
+        (tmp_path / name).write_text("{}", encoding="utf-8")
+
+    with pytest.raises(ImplementationCoverageError, match="file roster"):
+        validate_fixture_root(tmp_path)
+
+
+def test_fixture_root_rejects_schema_body_drift(tmp_path: Path) -> None:
+    root = tmp_path / "fixture"
+    shutil.copytree(DEFAULT_FIXTURE_ROOT, root)
+    schema_path = root / "schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    schema["title"] = "drifted"
+    schema_path.write_text(json.dumps(schema), encoding="utf-8")
+
+    with pytest.raises(ImplementationCoverageError, match="schema body"):
+        validate_fixture_root(root)

--- a/code/scripts/validate_neural_learning_implementation_coverage.py
+++ b/code/scripts/validate_neural_learning_implementation_coverage.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Validate NN36 native-versus-Rust-core coverage with real execution evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from validate_cross_language_fixture_consumers import (
+    ConsumerValidationError,
+    execute_consumers,
+)
+from validate_cross_language_fixture_consumers import (
+    validate_fixture_root as validate_native_fixture_root,
+)
+from validate_neural_learning_rust_cabi import (
+    CAbiValidationError,
+    execute_abi,
+)
+from validate_neural_learning_rust_cabi import (
+    validate_fixture_root as validate_cabi_fixture_root,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT
+    / "code"
+    / "specs"
+    / "fixtures"
+    / "neural-learning-implementation-coverage-v1"
+)
+EXPECTED_FILES = {"catalog.json", "schema.json", "README.md", "CHANGELOG.md"}
+MAXIMUM_FILE_BYTES = 1_000_000
+EXPECTED_SCHEMA_SHA256 = (
+    "5b366838673ddcd0fad66dcf0560e97b79ce9f777b3fd1b4744dda44a984e86b"
+)
+EXPECTED_CONTRACTS = {
+    "native_catalog": "code/specs/fixtures/cross-language-consumers-v1/catalog.json",
+    "rust_c_abi_catalog": "code/specs/fixtures/neural-learning-rust-cabi-v1/catalog.json",
+    "native_validator": "code/scripts/validate_cross_language_fixture_consumers.py",
+    "binding_validator": "code/scripts/validate_neural_learning_rust_cabi.py",
+    "coverage_validator": "code/scripts/validate_neural_learning_implementation_coverage.py",
+}
+EXPECTED_LANES = (
+    {
+        "id": "go-native",
+        "language": "Go",
+        "implementation": "native",
+        "arithmetic_owner": "Go",
+        "interface": "fixture JSON to Go arithmetic",
+        "evidence": "code/programs/go/neural-fixture-consumer/main.go",
+        "validator": EXPECTED_CONTRACTS["native_validator"],
+    },
+    {
+        "id": "ruby-native",
+        "language": "Ruby",
+        "implementation": "native",
+        "arithmetic_owner": "Ruby",
+        "interface": "fixture JSON to Ruby arithmetic",
+        "evidence": "code/programs/ruby/neural-fixture-consumer/main.rb",
+        "validator": EXPECTED_CONTRACTS["native_validator"],
+    },
+    {
+        "id": "rust-native",
+        "language": "Rust",
+        "implementation": "native",
+        "arithmetic_owner": "Rust",
+        "interface": "fixture JSON to Rust arithmetic",
+        "evidence": "code/programs/rust/neural-fixture-consumer/src/main.rs",
+        "validator": EXPECTED_CONTRACTS["native_validator"],
+    },
+    {
+        "id": "python-ctypes-rust-core",
+        "language": "Python",
+        "implementation": "rust-core-binding",
+        "arithmetic_owner": "Rust",
+        "interface": "Python ctypes to versioned C ABI",
+        "evidence": "code/scripts/validate_neural_learning_rust_cabi.py",
+        "validator": EXPECTED_CONTRACTS["binding_validator"],
+    },
+)
+EXPECTED_RULES = (
+    "native means the language lane owns the weighted-neuron arithmetic",
+    "rust-core-binding means the caller crosses the stable C ABI and Rust owns the arithmetic",
+    "a registered lane counts as verified only after its executable validator passes",
+    "coverage counts implementation paths, not code quality, speed, or curriculum mastery",
+)
+
+
+class ImplementationCoverageError(ValueError):
+    """Raised when NN36 metadata or execution evidence is inconsistent."""
+
+
+@dataclass(frozen=True)
+class CoverageReceipt:
+    """Counts derived only after all registered implementation paths execute."""
+
+    native_lane_ids: tuple[str, ...]
+    binding_lane_ids: tuple[str, ...]
+    prediction: float
+    total_verified_lanes: int
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ImplementationCoverageError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        size = path.stat().st_size
+        if size <= 0 or size > MAXIMUM_FILE_BYTES:
+            raise ImplementationCoverageError(f"{path}: invalid file size")
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=lambda token: (_ for _ in ()).throw(
+                ImplementationCoverageError(f"non-finite JSON number: {token}")
+            ),
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ImplementationCoverageError(f"{path}: {error}") from error
+    if not isinstance(value, dict):
+        raise ImplementationCoverageError(f"{path}: top-level value must be an object")
+    return value
+
+
+def _object(value: Any, keys: set[str], context: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != keys:
+        raise ImplementationCoverageError(f"{context}: unexpected shape")
+    return value
+
+
+def _repo_file(value: Any, expected: str, context: str) -> Path:
+    if value != expected or not isinstance(value, str) or "\\" in value:
+        raise ImplementationCoverageError(f"{context}: path is not canonical")
+    relative = PurePosixPath(value)
+    if relative.is_absolute() or "." in relative.parts or ".." in relative.parts:
+        raise ImplementationCoverageError(f"{context}: path is not normalized")
+    resolved = (REPO_ROOT / Path(*relative.parts)).resolve()
+    try:
+        resolved.relative_to(REPO_ROOT.resolve())
+    except ValueError as error:
+        raise ImplementationCoverageError(
+            f"{context}: path escapes the repository"
+        ) from error
+    if not resolved.is_file():
+        raise ImplementationCoverageError(f"{context}: file does not exist")
+    return resolved
+
+
+def _finite_number(value: Any, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ImplementationCoverageError(f"{context}: expected a number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ImplementationCoverageError(f"{context}: expected a finite number")
+    return result
+
+
+def validate_catalog_document(document: Any) -> dict[str, Any]:
+    catalog = _object(
+        document,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "source_fixture",
+            "contracts",
+            "hand_check",
+            "lanes",
+            "rules",
+        },
+        "catalog",
+    )
+    if (
+        type(catalog["schema_version"]) is not int
+        or catalog["schema_version"] != 1
+        or catalog["id"] != "weighted-neuron-implementation-coverage"
+    ):
+        raise ImplementationCoverageError("catalog identity is not canonical")
+    for key in ("title", "question"):
+        value = catalog[key]
+        if not isinstance(value, str) or not value.strip() or len(value) > 300:
+            raise ImplementationCoverageError(f"catalog.{key}: invalid text")
+    source_fixture = _repo_file(
+        catalog["source_fixture"],
+        "code/specs/fixtures/neural-learning-v1/labs/00-weighted-neuron.json",
+        "source_fixture",
+    )
+
+    contracts = _object(catalog["contracts"], set(EXPECTED_CONTRACTS), "contracts")
+    if contracts != EXPECTED_CONTRACTS:
+        raise ImplementationCoverageError("contract paths are not canonical")
+    contract_paths = {
+        key: _repo_file(value, EXPECTED_CONTRACTS[key], f"contracts.{key}")
+        for key, value in contracts.items()
+    }
+
+    hand = _object(
+        catalog["hand_check"],
+        {
+            "inputs",
+            "weights",
+            "contributions",
+            "bias",
+            "prediction",
+            "native_implementations",
+            "rust_core_bindings",
+            "total_verified_lanes",
+        },
+        "hand_check",
+    )
+    if hand["inputs"] != [2.0, -1.0] or hand["weights"] != [0.5, -0.25]:
+        raise ImplementationCoverageError("hand-check operands are not canonical")
+    contributions = [
+        _finite_number(hand["inputs"][index], f"hand_check.inputs[{index}]")
+        * _finite_number(hand["weights"][index], f"hand_check.weights[{index}]")
+        for index in range(2)
+    ]
+    prediction = sum(contributions, _finite_number(hand["bias"], "hand_check.bias"))
+    if hand["contributions"] != contributions or hand["prediction"] != prediction:
+        raise ImplementationCoverageError("hand-check arithmetic is dishonest")
+    expected_counts = {
+        "native_implementations": 3,
+        "rust_core_bindings": 1,
+        "total_verified_lanes": 4,
+    }
+    if any(
+        type(hand[key]) is not int or hand[key] != expected
+        for key, expected in expected_counts.items()
+    ) or (
+        hand["native_implementations"] + hand["rust_core_bindings"]
+        != hand["total_verified_lanes"]
+    ):
+        raise ImplementationCoverageError("hand-check coverage count is dishonest")
+
+    if catalog["lanes"] != list(EXPECTED_LANES):
+        raise ImplementationCoverageError("coverage lanes are not canonical")
+    for index, lane in enumerate(catalog["lanes"]):
+        _object(
+            lane,
+            {
+                "id",
+                "language",
+                "implementation",
+                "arithmetic_owner",
+                "interface",
+                "evidence",
+                "validator",
+            },
+            f"lanes[{index}]",
+        )
+        _repo_file(
+            lane["evidence"],
+            EXPECTED_LANES[index]["evidence"],
+            f"lanes[{index}].evidence",
+        )
+        _repo_file(
+            lane["validator"],
+            EXPECTED_LANES[index]["validator"],
+            f"lanes[{index}].validator",
+        )
+    if catalog["rules"] != list(EXPECTED_RULES):
+        raise ImplementationCoverageError("coverage rules are not canonical")
+
+    source = load_json(source_fixture)
+    if source.get("id") != "weighted-neuron-forward":
+        raise ImplementationCoverageError("source fixture identity is not canonical")
+
+    native_catalog = validate_native_fixture_root()
+    if [lane["id"] for lane in native_catalog["lanes"]] != [
+        lane["id"] for lane in EXPECTED_LANES[:3]
+    ]:
+        raise ImplementationCoverageError("NN34 native lanes drifted")
+    cabi_catalog = validate_cabi_fixture_root()
+    if cabi_catalog["abi"]["version_number"] != 0x0001_0000:
+        raise ImplementationCoverageError("NN35 ABI version drifted")
+
+    return {
+        **catalog,
+        "source_fixture": source_fixture,
+        "contract_paths": contract_paths,
+        "native_catalog": native_catalog,
+        "cabi_catalog": cabi_catalog,
+    }
+
+
+def validate_fixture_root(root: Path = DEFAULT_FIXTURE_ROOT) -> dict[str, Any]:
+    try:
+        files = {
+            path.relative_to(root).as_posix()
+            for path in root.rglob("*")
+            if path.is_file()
+        }
+    except OSError as error:
+        raise ImplementationCoverageError(
+            f"cannot enumerate fixture root: {error}"
+        ) from error
+    if files != EXPECTED_FILES:
+        raise ImplementationCoverageError("fixture file roster is not canonical")
+    schema_path = root / "schema.json"
+    try:
+        schema_digest = hashlib.sha256(schema_path.read_bytes()).hexdigest()
+    except OSError as error:
+        raise ImplementationCoverageError(f"cannot read schema: {error}") from error
+    if schema_digest != EXPECTED_SCHEMA_SHA256:
+        raise ImplementationCoverageError("schema body is not canonical")
+    schema = load_json(schema_path)
+    if (
+        schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema"
+        or schema.get("$id")
+        != "https://coding-adventures.dev/schemas/neural-learning-implementation-coverage-v1.json"
+    ):
+        raise ImplementationCoverageError("schema identity is not canonical")
+    return validate_catalog_document(load_json(root / "catalog.json"))
+
+
+def execute_coverage(catalog: dict[str, Any]) -> CoverageReceipt:
+    native_results = execute_consumers(catalog["native_catalog"])
+    native_lane_ids = tuple(result.lane_id for result in native_results)
+    expected_native_ids = tuple(lane["id"] for lane in EXPECTED_LANES[:3])
+    if native_lane_ids != expected_native_ids:
+        raise ImplementationCoverageError("native execution evidence is incomplete")
+
+    binding_receipt = execute_abi(catalog["cabi_catalog"])
+    if (
+        binding_receipt.version != 0x0001_0000
+        or binding_receipt.status != 0
+        or binding_receipt.contributions != (1.0, 0.25)
+        or binding_receipt.prediction != catalog["hand_check"]["prediction"]
+    ):
+        raise ImplementationCoverageError("Rust-core binding evidence is dishonest")
+
+    binding_lane_ids = (EXPECTED_LANES[3]["id"],)
+    total = len(native_lane_ids) + len(binding_lane_ids)
+    if total != catalog["hand_check"]["total_verified_lanes"]:
+        raise ImplementationCoverageError("executed coverage count is dishonest")
+    return CoverageReceipt(
+        native_lane_ids=native_lane_ids,
+        binding_lane_ids=binding_lane_ids,
+        prediction=binding_receipt.prediction,
+        total_verified_lanes=total,
+    )
+
+
+def main() -> int:
+    try:
+        catalog = validate_fixture_root()
+        receipt = execute_coverage(catalog)
+    except (
+        ImplementationCoverageError,
+        ConsumerValidationError,
+        CAbiValidationError,
+    ) as error:
+        raise SystemExit(
+            f"neural-learning implementation coverage invalid: {error}"
+        ) from error
+    print(
+        "NN36 implementation coverage passed: "
+        f"{len(receipt.native_lane_ids)} native + "
+        f"{len(receipt.binding_lane_ids)} Rust-core binding = "
+        f"{receipt.total_verified_lanes} verified lanes; "
+        f"prediction {receipt.prediction:g}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/specs/NN36-neural-learning-implementation-coverage-lab.md
+++ b/code/specs/NN36-neural-learning-implementation-coverage-lab.md
@@ -1,0 +1,75 @@
+# NN36: Native and Rust-core implementation coverage
+
+## Status
+
+Implemented.
+
+## Purpose
+
+NN36 records who owns the arithmetic behind each verified language lane. It
+keeps the three NN34 native implementations visible beside the first NN35
+Rust-core binding instead of flattening both designs into one ambiguous
+"language supported" claim.
+
+## Contract
+
+`code/specs/fixtures/neural-learning-implementation-coverage-v1/` contains:
+
+- `catalog.json`: the source fixture, upstream contracts, four coverage lanes,
+  hand calculation, and classification rules;
+- `schema.json`: the closed Draft 2020-12 interchange shape;
+- `README.md` and `CHANGELOG.md`: execution and evolution notes.
+
+Every lane still answers the NN03 weighted-neuron fixture:
+
+```text
+2 * 0.5 + (-1) * (-0.25) + 0.1 = 1.35
+```
+
+## Coverage matrix
+
+| Lane | Language | Classification | Arithmetic owner | Boundary |
+| --- | --- | --- | --- | --- |
+| `go-native` | Go | native | Go | fixture JSON |
+| `ruby-native` | Ruby | native | Ruby | fixture JSON |
+| `rust-native` | Rust | native | Rust | fixture JSON |
+| `python-ctypes-rust-core` | Python | Rust-core binding | Rust | `ctypes` to C ABI v1 |
+
+The hand-sized coverage count is therefore:
+
+```text
+native implementations = 3
+Rust-core bindings      = 1
+total verified lanes    = 3 + 1 = 4
+```
+
+This is an inventory. It is not a code-quality score, performance comparison,
+or claim that four separate neural-network curricula are complete.
+
+## Executable gate
+
+Run the complete coverage contract from the repository root:
+
+```bash
+python code/scripts/validate_neural_learning_implementation_coverage.py
+```
+
+The validator fails closed on path, lane, ownership, count, or schema drift.
+It then runs all three NN34 native consumers and the real NN35 dynamic-library
+call. The four-lane result is printed only after both underlying gates pass.
+
+## Interactive trace
+
+The **Implementation Coverage** workbench preserves the paper arithmetic while
+the learner switches among lanes. For each lane it exposes the classification,
+arithmetic owner, interface, source evidence, and executable validator.
+
+The browser validates registered metadata and recomputes the hand example. It
+does not claim to execute Go, Ruby, Python, or the native shared library.
+
+## Extension rule
+
+Add a lane only with a real executable gate. A future native consumer must own
+the arithmetic named by its classification. A future binding must cross the
+stable Rust ABI and prove the Rust result. Missing work should remain absent or
+explicitly missing rather than being inferred from a language name.

--- a/code/specs/fixtures/neural-learning-implementation-coverage-v1/CHANGELOG.md
+++ b/code/specs/fixtures/neural-learning-implementation-coverage-v1/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## v1
+
+- Track the NN34 Go, Ruby, and Rust implementations as native lanes.
+- Track the NN35 Python `ctypes` call as one Rust-core binding lane.
+- Reuse the NN03 hand calculation and require both executable gates to pass.
+- Distinguish implementation-path counts from quality, speed, and mastery.

--- a/code/specs/fixtures/neural-learning-implementation-coverage-v1/README.md
+++ b/code/specs/fixtures/neural-learning-implementation-coverage-v1/README.md
@@ -1,0 +1,19 @@
+# Neural-learning implementation coverage v1 fixture
+
+This catalog tracks who owns the arithmetic for the first portable neural
+fixture. Go, Ruby, and Rust each compute the NN03 neuron natively. Python uses
+`ctypes` to cross the NN35 C ABI, so the shared Rust core owns that lane's
+arithmetic.
+
+Run the closed coverage gate from the repository root:
+
+```bash
+python code/scripts/validate_neural_learning_implementation_coverage.py
+```
+
+The validator checks the catalog, cross-checks the NN34 and NN35 contracts,
+executes all three native consumers, and calls the compiled Rust shared library
+through Python. A lane is counted only when its real execution gate passes.
+
+The `3 native + 1 binding = 4 verified lanes` calculation is an inventory, not
+a quality score, benchmark, or claim of curriculum mastery.

--- a/code/specs/fixtures/neural-learning-implementation-coverage-v1/catalog.json
+++ b/code/specs/fixtures/neural-learning-implementation-coverage-v1/catalog.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": 1,
+  "id": "weighted-neuron-implementation-coverage",
+  "title": "Native and Rust-core implementation coverage",
+  "question": "Which language lanes own the weighted-neuron arithmetic, and which lane delegates it to the shared Rust core?",
+  "source_fixture": "code/specs/fixtures/neural-learning-v1/labs/00-weighted-neuron.json",
+  "contracts": {
+    "native_catalog": "code/specs/fixtures/cross-language-consumers-v1/catalog.json",
+    "rust_c_abi_catalog": "code/specs/fixtures/neural-learning-rust-cabi-v1/catalog.json",
+    "native_validator": "code/scripts/validate_cross_language_fixture_consumers.py",
+    "binding_validator": "code/scripts/validate_neural_learning_rust_cabi.py",
+    "coverage_validator": "code/scripts/validate_neural_learning_implementation_coverage.py"
+  },
+  "hand_check": {
+    "inputs": [2.0, -1.0],
+    "weights": [0.5, -0.25],
+    "contributions": [1.0, 0.25],
+    "bias": 0.1,
+    "prediction": 1.35,
+    "native_implementations": 3,
+    "rust_core_bindings": 1,
+    "total_verified_lanes": 4
+  },
+  "lanes": [
+    {
+      "id": "go-native",
+      "language": "Go",
+      "implementation": "native",
+      "arithmetic_owner": "Go",
+      "interface": "fixture JSON to Go arithmetic",
+      "evidence": "code/programs/go/neural-fixture-consumer/main.go",
+      "validator": "code/scripts/validate_cross_language_fixture_consumers.py"
+    },
+    {
+      "id": "ruby-native",
+      "language": "Ruby",
+      "implementation": "native",
+      "arithmetic_owner": "Ruby",
+      "interface": "fixture JSON to Ruby arithmetic",
+      "evidence": "code/programs/ruby/neural-fixture-consumer/main.rb",
+      "validator": "code/scripts/validate_cross_language_fixture_consumers.py"
+    },
+    {
+      "id": "rust-native",
+      "language": "Rust",
+      "implementation": "native",
+      "arithmetic_owner": "Rust",
+      "interface": "fixture JSON to Rust arithmetic",
+      "evidence": "code/programs/rust/neural-fixture-consumer/src/main.rs",
+      "validator": "code/scripts/validate_cross_language_fixture_consumers.py"
+    },
+    {
+      "id": "python-ctypes-rust-core",
+      "language": "Python",
+      "implementation": "rust-core-binding",
+      "arithmetic_owner": "Rust",
+      "interface": "Python ctypes to versioned C ABI",
+      "evidence": "code/scripts/validate_neural_learning_rust_cabi.py",
+      "validator": "code/scripts/validate_neural_learning_rust_cabi.py"
+    }
+  ],
+  "rules": [
+    "native means the language lane owns the weighted-neuron arithmetic",
+    "rust-core-binding means the caller crosses the stable C ABI and Rust owns the arithmetic",
+    "a registered lane counts as verified only after its executable validator passes",
+    "coverage counts implementation paths, not code quality, speed, or curriculum mastery"
+  ]
+}

--- a/code/specs/fixtures/neural-learning-implementation-coverage-v1/schema.json
+++ b/code/specs/fixtures/neural-learning-implementation-coverage-v1/schema.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/neural-learning-implementation-coverage-v1.json",
+  "title": "Neural-learning implementation coverage v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "id", "title", "question", "source_fixture", "contracts", "hand_check", "lanes", "rules"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "id": { "const": "weighted-neuron-implementation-coverage" },
+    "title": { "type": "string", "minLength": 1 },
+    "question": { "type": "string", "minLength": 1 },
+    "source_fixture": { "const": "code/specs/fixtures/neural-learning-v1/labs/00-weighted-neuron.json" },
+    "contracts": {
+      "const": {
+        "native_catalog": "code/specs/fixtures/cross-language-consumers-v1/catalog.json",
+        "rust_c_abi_catalog": "code/specs/fixtures/neural-learning-rust-cabi-v1/catalog.json",
+        "native_validator": "code/scripts/validate_cross_language_fixture_consumers.py",
+        "binding_validator": "code/scripts/validate_neural_learning_rust_cabi.py",
+        "coverage_validator": "code/scripts/validate_neural_learning_implementation_coverage.py"
+      }
+    },
+    "hand_check": {
+      "const": {
+        "inputs": [2.0, -1.0],
+        "weights": [0.5, -0.25],
+        "contributions": [1.0, 0.25],
+        "bias": 0.1,
+        "prediction": 1.35,
+        "native_implementations": 3,
+        "rust_core_bindings": 1,
+        "total_verified_lanes": 4
+      }
+    },
+    "lanes": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 4,
+      "prefixItems": [
+        {
+          "const": {
+            "id": "go-native",
+            "language": "Go",
+            "implementation": "native",
+            "arithmetic_owner": "Go",
+            "interface": "fixture JSON to Go arithmetic",
+            "evidence": "code/programs/go/neural-fixture-consumer/main.go",
+            "validator": "code/scripts/validate_cross_language_fixture_consumers.py"
+          }
+        },
+        {
+          "const": {
+            "id": "ruby-native",
+            "language": "Ruby",
+            "implementation": "native",
+            "arithmetic_owner": "Ruby",
+            "interface": "fixture JSON to Ruby arithmetic",
+            "evidence": "code/programs/ruby/neural-fixture-consumer/main.rb",
+            "validator": "code/scripts/validate_cross_language_fixture_consumers.py"
+          }
+        },
+        {
+          "const": {
+            "id": "rust-native",
+            "language": "Rust",
+            "implementation": "native",
+            "arithmetic_owner": "Rust",
+            "interface": "fixture JSON to Rust arithmetic",
+            "evidence": "code/programs/rust/neural-fixture-consumer/src/main.rs",
+            "validator": "code/scripts/validate_cross_language_fixture_consumers.py"
+          }
+        },
+        {
+          "const": {
+            "id": "python-ctypes-rust-core",
+            "language": "Python",
+            "implementation": "rust-core-binding",
+            "arithmetic_owner": "Rust",
+            "interface": "Python ctypes to versioned C ABI",
+            "evidence": "code/scripts/validate_neural_learning_rust_cabi.py",
+            "validator": "code/scripts/validate_neural_learning_rust_cabi.py"
+          }
+        }
+      ],
+      "items": false
+    },
+    "rules": {
+      "const": [
+        "native means the language lane owns the weighted-neuron arithmetic",
+        "rust-core-binding means the caller crosses the stable C ABI and Rust owns the arithmetic",
+        "a registered lane counts as verified only after its executable validator passes",
+        "coverage counts implementation paths, not code quality, speed, or curriculum mastery"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add the NN36 native-versus-Rust-core coverage lesson, closed fixture, and executable validator
- classify three NN34 native lanes and one Python ctypes Rust-core binding against the same NN03 oracle
- add an interactive ownership workbench, tests, CI wiring, roadmap completion, and regenerated learning inventory

## Validation
- NN36 direct validator: 3 native + 1 Rust-core binding = 4 verified lanes; prediction 1.35
- 39 focused Python tests passed across NN34-NN36 and coverage reporting
- 180 visualizer tests passed
- production Vite build passed
- responsive browser QA passed at 1440x900 and 390x844 with no overflow
- local Markdown links, workflow YAML, JSON parsing, Ruff, and git diff --check passed
- independent security review approved after boolean/schema/source-binding hardening