### PR TITLE
Add JFET energy gap parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `EG` energy gap.
 - Validate and lower JFET model-card `XTI` temperature exponent.
 - Validate and lower JFET model-card `IS` gate saturation current.
 - Validate and lower JFET model-card `FC` depletion coefficient.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1341,6 +1341,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Fc=model.params.get("FC", 0.5),
             Is=model.params.get("IS", 1.0e-14),
             Xti=model.params.get("XTI", 3.0),
+            Eg=model.params.get("EG", 1.11),
         )
     if prefix == "M":
         _require_min_fields(fields, 6, "MOSFET")
@@ -2111,6 +2112,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             temperature_exponent
         ):
             raise NetlistParseError("JFET XTI must be finite")
+        energy_gap = params.get("EG")
+        if energy_gap is not None and (
+            not math.isfinite(energy_gap) or energy_gap <= 0.0
+        ):
+            raise NetlistParseError("JFET EG must be finite and positive")
     if kind in {"NMOS", "PMOS"}:
         if "LEVEL" in params:
             level = params["LEVEL"]

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1505,6 +1505,25 @@ def test_rejects_non_finite_jfet_temperature_exponent() -> None:
         parse_netlist(".model fast NJF(XTI=1e999)")
 
 
+def test_parse_jfet_energy_gap() -> None:
+    parsed = parse_netlist(
+        """
+.model fast NJF(EG=1.05)
+J1 drain gate source fast
+"""
+    )
+
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert isclose(jfet.Eg, 1.05)
+
+
+@pytest.mark.parametrize("value", ["0", "-0.1", "1e999"])
+def test_rejects_invalid_jfet_energy_gap(value: str) -> None:
+    with pytest.raises(NetlistParseError, match="JFET EG must be finite and positive"):
+        parse_netlist(f".model fast NJF(EG={value})")
+
+
 def test_parse_pjf_model_aliases_beta() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `EG` energy gap.
 - Validate and lower JFET model-card `XTI` temperature exponent.
 - Validate and lower JFET model-card `IS` gate saturation current.
 - Validate and lower JFET model-card `FC` depletion coefficient.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1395,6 +1395,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("JFET XTI must be finite");
   }
+  const jfetEnergyGap = params.get("EG");
+  if (
+    (kind === "NJF" || kind === "PJF") &&
+    jfetEnergyGap !== undefined &&
+    (!Number.isFinite(jfetEnergyGap) || jfetEnergyGap <= 0.0)
+  ) {
+    throw new NetlistParseError("JFET EG must be finite and positive");
+  }
   const level = params.get("LEVEL");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1988,6 +1996,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("FC") ?? 0.5,
       model.params.get("IS") ?? 1.0e-14,
       model.params.get("XTI") ?? 3.0,
+      model.params.get("EG") ?? 1.11,
     );
   }
   if (prefix === "M") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1545,6 +1545,24 @@ J1 drain gate source fast
     );
   });
 
+  it("parses the JFET energy gap", () => {
+    const parsed = parseNetlist(`
+.model fast NJF(EG=1.05)
+J1 drain gate source fast
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      bandgapVoltage: 1.05,
+    });
+  });
+
+  it.each(["0", "-0.1", "1e999"])("rejects invalid JFET energy gap %s", (value) => {
+    expect(() => parseNetlist(`.model fast NJF(EG=${value})`)).toThrow(
+      "JFET EG must be finite and positive",
+    );
+  });
+
   it("parses PJF model beta aliases", () => {
     const parsed = parseNetlist(`
 .model pslow PJF(B=750u)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4472,15 +4472,20 @@ the Rust, Python, and TypeScript surfaces together.
      into the shared engine JFET gate saturation-current field.
 
 430. Python and TypeScript Berkeley SPICE JFET temperature-exponent parity.
-   - Status: completed in this JFET temperature-exponent parity slice.
+   - Status: completed in PR 9848.
    - Both parser facades validate finite `XTI` values and lower them into the
      shared engine JFET gate-current temperature-exponent field.
+
+431. Python and TypeScript Berkeley SPICE JFET energy-gap parity.
+   - Status: completed in this JFET energy-gap parity slice.
+   - Both parser facades validate positive finite `EG` values and lower them
+     into the shared engine JFET bandgap-voltage field.
 
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE model-card validation parity.
-   - Continue the audited JFET model-card gaps, beginning with `EG`, then `B`,
-     `NLEV`, `GDSNOI`, `RD`, `RS`,
+   - Continue the audited JFET model-card gaps, beginning with `B`, then `NLEV`,
+     `GDSNOI`, `RD`, `RS`,
      `TCV`, `VTOTC`, `TNOM` / `T_NOM`, `BEX`, and `BETATCE`.
    - Continue the audited BJT model-card gaps after the smaller JFET fields;
      prioritize direct engine fields before adding new model surfaces.


### PR DESCRIPTION
## Summary
- validate positive finite JFET `EG` model-card values in Python and TypeScript
- lower `EG` into the existing engine bandgap-voltage field
- advance the audited parser-to-engine backlog to JFET doping-tail parameter

## Verification
- `code/packages/python/spice-netlist-parser/BUILD`
- Python parser Ruff checks
- `code/packages/typescript/spice-engine/BUILD`
- `code/packages/typescript/spice-netlist-parser/BUILD`
- TypeScript parser coverage suite (86.66% lines)