### PR TITLE
Add JFET NLEV parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `NLEV` noise equation level.
 - Validate and lower JFET model-card `EG` energy gap.
 - Validate and lower JFET model-card `XTI` temperature exponent.
 - Validate and lower JFET model-card `IS` gate saturation current.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1342,6 +1342,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Is=model.params.get("IS", 1.0e-14),
             Xti=model.params.get("XTI", 3.0),
             Eg=model.params.get("EG", 1.11),
+            Nlev=model.params.get("NLEV", 1.0),
         )
     if prefix == "M":
         _require_min_fields(fields, 6, "MOSFET")
@@ -2117,6 +2118,15 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(energy_gap) or energy_gap <= 0.0
         ):
             raise NetlistParseError("JFET EG must be finite and positive")
+        noise_level = params.get("NLEV")
+        if noise_level is not None and (
+            not math.isfinite(noise_level)
+            or noise_level < 1.0
+            or noise_level != math.floor(noise_level)
+        ):
+            raise NetlistParseError(
+                "JFET NLEV must be a finite integer greater than or equal to 1"
+            )
     if kind in {"NMOS", "PMOS"}:
         if "LEVEL" in params:
             level = params["LEVEL"]

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1524,6 +1524,29 @@ def test_rejects_invalid_jfet_energy_gap(value: str) -> None:
         parse_netlist(f".model fast NJF(EG={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("1", 1.0), ("3", 3.0)])
+def test_parse_jfet_noise_equation_level(value: str, expected: float) -> None:
+    parsed = parse_netlist(
+        f"""
+.model fast NJF(NLEV={value})
+J1 drain gate source fast
+"""
+    )
+
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert jfet.Nlev == expected
+
+
+@pytest.mark.parametrize("value", ["0", "1.5", "1e999"])
+def test_rejects_invalid_jfet_noise_equation_level(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="JFET NLEV must be a finite integer greater than or equal to 1",
+    ):
+        parse_netlist(f".model fast NJF(NLEV={value})")
+
+
 def test_parse_pjf_model_aliases_beta() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `NLEV` noise equation level.
 - Validate and lower JFET model-card `EG` energy gap.
 - Validate and lower JFET model-card `XTI` temperature exponent.
 - Validate and lower JFET model-card `IS` gate saturation current.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1403,6 +1403,18 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("JFET EG must be finite and positive");
   }
+  const jfetNoiseLevel = params.get("NLEV");
+  if (
+    (kind === "NJF" || kind === "PJF") &&
+    jfetNoiseLevel !== undefined &&
+    (!Number.isFinite(jfetNoiseLevel) ||
+      jfetNoiseLevel < 1.0 ||
+      !Number.isInteger(jfetNoiseLevel))
+  ) {
+    throw new NetlistParseError(
+      "JFET NLEV must be a finite integer greater than or equal to 1",
+    );
+  }
   const level = params.get("LEVEL");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1997,6 +2009,8 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("IS") ?? 1.0e-14,
       model.params.get("XTI") ?? 3.0,
       model.params.get("EG") ?? 1.11,
+      1.0,
+      model.params.get("NLEV") ?? 1.0,
     );
   }
   if (prefix === "M") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1563,6 +1563,27 @@ J1 drain gate source fast
     );
   });
 
+  it.each([
+    ["1", 1.0],
+    ["3", 3.0],
+  ])("parses JFET noise equation level %s", (value, expected) => {
+    const parsed = parseNetlist(`
+.model fast NJF(NLEV=${value})
+J1 drain gate source fast
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      noiseEquationLevel: expected,
+    });
+  });
+
+  it.each(["0", "1.5", "1e999"])("rejects invalid JFET noise equation level %s", (value) => {
+    expect(() => parseNetlist(`.model fast NJF(NLEV=${value})`)).toThrow(
+      "JFET NLEV must be a finite integer greater than or equal to 1",
+    );
+  });
+
   it("parses PJF model beta aliases", () => {
     const parsed = parseNetlist(`
 .model pslow PJF(B=750u)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4477,15 +4477,23 @@ the Rust, Python, and TypeScript surfaces together.
      shared engine JFET gate-current temperature-exponent field.
 
 431. Python and TypeScript Berkeley SPICE JFET energy-gap parity.
-   - Status: completed in this JFET energy-gap parity slice.
+   - Status: completed in PR 9851.
    - Both parser facades validate positive finite `EG` values and lower them
      into the shared engine JFET bandgap-voltage field.
+
+432. Python and TypeScript Berkeley SPICE JFET noise-level parity.
+   - Status: implemented in this JFET noise-level parity slice.
+   - Both parser facades validate `NLEV` as a finite integer greater than or
+     equal to 1 and lower it into the shared engine noise-equation-level field.
 
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE model-card validation parity.
-   - Continue the audited JFET model-card gaps, beginning with `B`, then `NLEV`,
-     `GDSNOI`, `RD`, `RS`,
+   - Resolve the JFET `B` policy before lowering it: all three parser facades
+     currently use `B` as a legacy beta alias, while the engine model uses `B`
+     for Parker-Skellern doping-tail shaping. Do not assign one card value to
+     both fields silently.
+   - Continue the unambiguous audited JFET gaps with `GDSNOI`, `RD`, `RS`,
      `TCV`, `VTOTC`, `TNOM` / `T_NOM`, `BEX`, and `BETATCE`.
    - Continue the audited BJT model-card gaps after the smaller JFET fields;
      prioritize direct engine fields before adding new model surfaces.


### PR DESCRIPTION
## Summary
- validate JFET `NLEV` as a finite integer greater than or equal to 1 in Python and TypeScript
- lower `NLEV` into the shared engine noise-equation-level field
- document the existing `B` beta-alias versus doping-tail semantic collision for explicit follow-up

## Verification
- Python `spice-netlist-parser`: `bash BUILD && .venv/bin/ruff check .` (386 passed)
- TypeScript `spice-netlist-parser`: `bash BUILD` (371 passed)
- TypeScript `spice-netlist-parser`: `npx vitest run --coverage` (86.69% lines)
- TypeScript `spice-engine`: `bash BUILD` (448 passed)