### PR TITLE
fix(semantic-ir-to-c): Foo.new never invoked initialize

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.36.3 — fix: `Foo.new` never invoked `initialize`
+
+Filed as a follow-up in 0.36.1 and fixed here. `__new__` used to lower
+straight to `_sir_new_instance(cls)` — a bare allocation — and the
+emitter's own scan REJECTED any `__new__` with more than the class-name
+arg ("`__new__` with constructor arguments or a non-constant class name"),
+so `Foo.new(args)` either compiled to an object whose constructor never
+ran (every `@ivar` an `initialize` would have set stayed nil) or, once
+constructor args were involved, failed to compile at all. This matched
+NONE of the other five backends: Go's `_sir_call_new`, Rust's equivalent,
+and Ruby's `sir_new` have always allocated THEN explicitly invoked the
+registered `initialize` (if any) with the constructor args — a comment on
+`semantic-ir-to-ruby`'s own `__new__` arm already described this as
+mirroring "the Go/C/Rust runtimes", which was aspirational for C until
+now. The `counter_state` program in `sir-conformance`'s corpus (`class
+Counter; def initialize; @n = 0; end; ...`) was previously SKIPPED on the
+C backend for exactly this reason (a declared v0 gap, not a faithfulness
+bug) — it now runs and agrees with every other backend.
+
+Fixed with a new `_sir_call_new(cls, argc, ...)` runtime helper: allocate
+via the existing `_sir_new_instance`, resolve `initialize` up the
+ancestry with the existing `_sir_resolve_method` (the same walk
+`_sir_call_method` uses, so an inherited `initialize` runs correctly),
+bind `self` to the new object and invoke it with the constructor args if
+found, restore `self`, and always return the object — even with no
+`initialize` registered (Ruby's default no-op `Object#initialize`). The
+emitter's scan now only requires `__new__`'s first arg to be a `StrLit`
+class name; any further args are ordinary constructor arguments emitted
+like any other call args, no longer specially rejected.
+
+`semantic-ir-to-c` 0.36.2 -> 0.36.3.
+
 ## 0.36.2 — fix: `<<` builtin name collided between C's bitwise shift and Ruby's operator
 
 `variadic_helper`'s `"<<" => "_sir_shift_left"` entry (added when Ruby's

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.36.2"
+version = "0.36.3"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -1506,13 +1506,21 @@ fn emit_builtin_simple(out: &mut String, name: &str, args: &[Expr], indent: usiz
         }
         return;
     }
-    // OOP slice 1: `Foo.new` → `_sir_new_instance("Foo")`.  `args[0]` is the class
-    // name (a `StrLit`), emitted as a QUOTED C string literal (no injection); the
-    // scan guarantees exactly one `StrLit` arg (constructor args need `initialize`,
-    // a later slice), so this arm never reaches the compound path.
+    // `Foo.new(args…)` → `_sir_call_new("Foo", argc, args…)`.  `args[0]` is the
+    // class name (a `StrLit`), emitted as a QUOTED C string literal (no
+    // injection); the remaining args are the constructor arguments, passed
+    // through to the registered `initialize` (if any) — matching the Go/Rust/
+    // Ruby backends, which have always run `initialize` here (see this crate's
+    // CHANGELOG for the fix that brought C in line with them).
     if name == "__new__" {
         if let Some(Expr::StrLit { value, .. }) = args.first() {
-            let _ = write!(out, "_sir_new_instance({})", quote_c_string(value));
+            let ctor_args = &args[1..];
+            let _ = write!(out, "_sir_call_new({}, {}", quote_c_string(value), ctor_args.len());
+            for a in ctor_args {
+                out.push_str(", ");
+                emit_expr(out, a, indent);
+            }
+            out.push(')');
         } else {
             let _ = write!(out, "_sir_unknown_builtin({})", quote_c_string(name));
         }
@@ -2169,15 +2177,13 @@ fn scan_expr_for_builtin(e: &Expr) -> Option<(String, Span)> {
             if !is_supported_builtin(name) {
                 return Some((name.clone(), span.clone()));
             }
-            // OOP slice 1: `__new__` must be `[StrLit(class)]` — exactly one
-            // constant class name, no constructor arguments (those need
-            // `initialize`, a later slice).  Anything else is rejected cleanly so
-            // the emitter's single-`StrLit` assumption holds.
-            if name == "__new__"
-                && !matches!(args.as_slice(), [Expr::StrLit { .. }])
-            {
+            // `__new__` must start with `StrLit(class)` — a constant class name;
+            // any further args are constructor arguments forwarded to
+            // `initialize` and emitted like ordinary call args, so they need no
+            // shape constraint of their own.
+            if name == "__new__" && !matches!(args.first(), Some(Expr::StrLit { .. })) {
                 return Some((
-                    "__new__ with constructor arguments or a non-constant class name".to_string(),
+                    "__new__ with a non-constant class name".to_string(),
                     span.clone(),
                 ));
             }

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -1311,6 +1311,39 @@ SirValue _sir_call_method(SirValue recv, const char *method, int argc, ...) {
     return r;
 }
 
+/* `Foo.new(args…)` — allocate a `cls` instance and run its `initialize`.
+ *
+ * Allocates via `_sir_new_instance`, then — if `initialize` resolves on `cls`
+ * or an ancestor (`_sir_resolve_method`, the same ancestry walk `_sir_call_
+ * method` uses) — binds `self` to the new object and invokes it with `args`,
+ * so constructor-body `@ivar` assignments land on the new object (mirroring
+ * the Go/Rust/Ruby backends, which have always run `initialize` here).  Self
+ * is restored afterward, same save/restore as `_sir_call_method`.  The object
+ * is always returned, even with no `initialize` registered — a plain
+ * allocation, matching Ruby's default no-op `Object#initialize`. */
+SirValue _sir_call_new(const char *cls, int argc, ...) {
+    va_list ap;
+    SirValue *args, obj, fn;
+    obj = _sir_new_instance(cls);
+    fn = _sir_resolve_method(cls, "initialize");
+    if (fn.tag == SIR_CLOSURE) {
+        va_start(ap, argc);
+        args = _sir_va_collect(argc, ap);
+        va_end(ap);
+        {
+            SirValue saved_self = _sir_current_self;
+            const char *saved_class = _sir_current_class;
+            _sir_current_self = obj;
+            _sir_current_class = obj.as.inst->sir_class;
+            fn.as.clo->fn(fn.as.clo->caps, args, argc);
+            _sir_current_self = saved_self;
+            _sir_current_class = saved_class;
+        }
+        if (args) free(args);
+    }
+    return obj;
+}
+
 /* OOP slice 4: `super` from within `defining_class`'s method `method`.  Resolve
  * `method` starting at the SUPERCLASS of `defining_class` (so it does not
  * re-enter the same override) and apply it to the CURRENT `self` — `super` runs

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_classes.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_classes.rs
@@ -169,14 +169,6 @@ fn rejects(stmts: Vec<Stmt>, feats: &[Feature]) -> bool {
 
 #[test]
 fn deferred_oop_shapes_are_rejected_cleanly() {
-    // `__new__` with a constructor argument (needs `initialize`, a later slice).
-    assert!(
-        rejects(
-            vec![puts(bc("__new__", vec![strlit("Foo"), ilit(1)]))],
-            &[Feature::Classes, Feature::Constants, Feature::Strings]
-        ),
-        "__new__ with ctor args must be rejected"
-    );
     // A MALFORMED `__def_method__` (no closure) — a well-formed one is now
     // supported (slice 2), but a missing closure must reject, not mis-emit.
     assert!(

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_initialize.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_initialize.rs
@@ -1,0 +1,122 @@
+//! Execution proof that `Foo.new` runs the class's `initialize` on the C
+//! backend — lower REAL Ruby source, emit C, compile with a real cc, run,
+//! assert stdout. Skips gracefully when no `cc` is present.
+//!
+//! Before this fix, `__new__` only allocated (`_sir_new_instance`) and never
+//! invoked `initialize`, so every `@ivar` a constructor set was silently
+//! nil — masked in earlier tests by `_sir_plus_v`'s nil-defaults-to-0
+//! arithmetic coincidentally making `Counter`-style examples still print the
+//! "right" answer for `@n = 0`-style starts. `_sir_call_new` (the fix) mirrors
+//! the Go/Rust/Ruby backends: allocate, resolve `initialize` up the ancestry,
+//! invoke it with the constructor args if found, return the object either way.
+
+use std::process::Command;
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    ["cc", "clang", "gcc"]
+        .iter()
+        .find(|c| {
+            Command::new(c)
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        })
+        .map(|s| s.to_string())
+}
+
+fn run_ruby(src: &str) -> Option<String> {
+    let cc = find_cc()?;
+    let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
+    let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
+    let dir = std::env::temp_dir();
+    // Hash the full source (not just its length) so two equal-length sources
+    // running as parallel threads in the same process (cargo test's default)
+    // don't collide on the same temp file — see compile_and_run_class_methods.rs.
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    src.hash(&mut hasher);
+    let stem = format!("sirc_init_{}_{}", std::process::id(), hasher.finish());
+    let cpath = dir.join(format!("{stem}.c"));
+    let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::write(&cpath, &art.source).expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .arg("-lm") // Linux needs -lm to link floor/ceil/fabs (macOS libSystem folds it in)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        art.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "program exited non-zero");
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn initialize_with_no_args_sets_an_ivar() {
+    match run_ruby(
+        "class Counter\n  def initialize\n    @n = 0\n  end\n  def inc\n    @n = @n + 1\n  end\n  \
+         def value\n    @n\n  end\nend\n\
+         c = Counter.new\nc.inc\nc.inc\nputs c.value\n",
+    ) {
+        Some(out) => assert_eq!(out, "2\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn initialize_receives_constructor_arguments() {
+    // Before the fix, `Point.new(3, 4)` compiled (constructor args were
+    // accepted at the SIR level) but silently dropped them -- `@x`/`@y`
+    // stayed nil. Now `initialize`'s params bind the `.new` args.
+    match run_ruby(
+        "class Point\n  def initialize(x, y)\n    @x = x\n    @y = y\n  end\n  \
+         def sum\n    @x + @y\n  end\nend\n\
+         p = Point.new(3, 4)\nputs p.sum\n",
+    ) {
+        Some(out) => assert_eq!(out, "7\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn class_with_no_initialize_still_constructs() {
+    // No `initialize` registered for `Empty` -- `_sir_call_new` must still
+    // return a plain allocation (Ruby's default no-op `Object#initialize`),
+    // not raise or leave the object unusable.
+    match run_ruby(
+        "class Empty\n  def tag\n    1\n  end\nend\n\
+         e = Empty.new\nputs e.tag\n",
+    ) {
+        Some(out) => assert_eq!(out, "1\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn initialize_is_inherited_by_a_subclass_with_none_of_its_own() {
+    // `Sub` defines no `initialize` of its own, so `Sub.new` must resolve
+    // `Animal#initialize` up the ancestry (the same `_sir_resolve_method` walk
+    // `_sir_call_method` already uses for ordinary dispatch) and run it on the
+    // new `Sub` instance.
+    match run_ruby(
+        "class Animal\n  def initialize(name)\n    @name = name\n  end\n  \
+         def label\n    @name\n  end\nend\n\
+         class Dog < Animal\nend\n\
+         d = Dog.new(\"Rex\")\nputs d.label\n",
+    ) {
+        Some(out) => assert_eq!(out, "Rex\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}

--- a/code/specs/SIR24-semantic-ir-to-c.md
+++ b/code/specs/SIR24-semantic-ir-to-c.md
@@ -397,7 +397,12 @@ lockstep:
    `Modules` (a module's methods register like a class's; `include`/`extend`
    record `(class, module)` mixins that `_sir_resolve_method` /
    `_sir_resolve_class_method` consult) landed in 0.21.0 — the FINAL OOP slice,
-   giving full 6-backend OOP parity.
+   giving full 6-backend OOP parity, EXCEPT that `Foo.new` did not actually run
+   `initialize` until 0.36.3 (`_sir_call_new`: allocate, resolve `initialize`
+   up the ancestry, invoke it with the constructor args, return the object) —
+   `__new__` had silently rejected constructor arguments since 0.13.0, so
+   every other backend's `.new` ran the constructor and C's did not. True
+   parity landed in 0.36.3.
 7. **Optional / later** — `Bignum`; SIR21 sized-integer native lowering
    (`int64_t`/`uint32_t` from `IntSpec`); `Range` / regex / backtick shims.
 


### PR DESCRIPTION
## Summary
- `Foo.new`'s C backend allocated an instance but never invoked its `initialize` — the emitter's own scan actively rejected any constructor argument, and even zero-arg `initialize` calls never ran, silently leaving every `@ivar` an `initialize` would set as `nil`
- Every other backend (Go/Rust/Ruby) has always allocated then explicitly run the registered `initialize` with constructor args; C was the outlier, previously discovered and filed as a follow-up while implementing bracket-index write (#9827)
- New `_sir_call_new(cls, argc, ...)` runtime helper mirrors Go's `_sir_call_new`: allocate via `_sir_new_instance`, resolve `initialize` up the ancestry via the existing `_sir_resolve_method`, invoke with `self` bound to the new object if found, restore `self`, always return the object
- `sir-conformance`'s `counter_state` corpus program was previously *skipped* on the C backend for this exact gap (a declared v0 limitation, not a faithfulness bug) — it now runs and agrees with all five other backends

## Test plan
- [x] New `compile_and_run_initialize.rs`: no-arg `initialize` setting an ivar, constructor-arg-binding `initialize`, no-`initialize` class still constructs, inherited `initialize` runs for a subclass with none of its own
- [x] Updated `compile_and_run_classes.rs`: removed the now-stale "ctor args must be rejected" assertion
- [x] Full `semantic-ir-to-c` test suite green (emit + all execution-proof suites)
- [x] `sir-conformance` full corpus green — `counter_state` flips from skipped to passing on C, agrees with Go/Rust/Ruby/Python/JS
- [x] `cargo clippy -p semantic-ir-to-c --all-targets` clean
- [x] Security review passed (no findings)
- [x] Spec (`SIR24-semantic-ir-to-c.md`) updated to correct the "full 6-backend OOP parity" claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)