### PR TITLE
Add JFET GDSNOI parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `GDSNOI` channel-noise coefficient.
 - Validate and lower JFET model-card `NLEV` noise equation level.
 - Validate and lower JFET model-card `EG` energy gap.
 - Validate and lower JFET model-card `XTI` temperature exponent.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1343,6 +1343,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Xti=model.params.get("XTI", 3.0),
             Eg=model.params.get("EG", 1.11),
             Nlev=model.params.get("NLEV", 1.0),
+            Gdsnoi=model.params.get("GDSNOI", 1.0),
         )
     if prefix == "M":
         _require_min_fields(fields, 6, "MOSFET")
@@ -2127,6 +2128,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             raise NetlistParseError(
                 "JFET NLEV must be a finite integer greater than or equal to 1"
             )
+        channel_noise_coefficient = params.get("GDSNOI")
+        if channel_noise_coefficient is not None and (
+            not math.isfinite(channel_noise_coefficient)
+            or channel_noise_coefficient < 0.0
+        ):
+            raise NetlistParseError("JFET GDSNOI must be finite and non-negative")
     if kind in {"NMOS", "PMOS"}:
         if "LEVEL" in params:
             level = params["LEVEL"]

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1547,6 +1547,28 @@ def test_rejects_invalid_jfet_noise_equation_level(value: str) -> None:
         parse_netlist(f".model fast NJF(NLEV={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("1.5", 1.5)])
+def test_parse_jfet_channel_noise_coefficient(value: str, expected: float) -> None:
+    parsed = parse_netlist(
+        f"""
+.model fast NJF(GDSNOI={value})
+J1 drain gate source fast
+"""
+    )
+
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert jfet.Gdsnoi == expected
+
+
+@pytest.mark.parametrize("value", ["-0.1", "1e999"])
+def test_rejects_invalid_jfet_channel_noise_coefficient(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="JFET GDSNOI must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NJF(GDSNOI={value})")
+
+
 def test_parse_pjf_model_aliases_beta() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `GDSNOI` channel-noise coefficient.
 - Validate and lower JFET model-card `NLEV` noise equation level.
 - Validate and lower JFET model-card `EG` energy gap.
 - Validate and lower JFET model-card `XTI` temperature exponent.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1415,6 +1415,15 @@ function parseModelCard(fields: readonly string[]): ModelCard {
       "JFET NLEV must be a finite integer greater than or equal to 1",
     );
   }
+  const jfetChannelNoiseCoefficient = params.get("GDSNOI");
+  if (
+    (kind === "NJF" || kind === "PJF") &&
+    jfetChannelNoiseCoefficient !== undefined &&
+    (!Number.isFinite(jfetChannelNoiseCoefficient) ||
+      jfetChannelNoiseCoefficient < 0.0)
+  ) {
+    throw new NetlistParseError("JFET GDSNOI must be finite and non-negative");
+  }
   const level = params.get("LEVEL");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -2011,6 +2020,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("EG") ?? 1.11,
       1.0,
       model.params.get("NLEV") ?? 1.0,
+      model.params.get("GDSNOI") ?? 1.0,
     );
   }
   if (prefix === "M") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1584,6 +1584,30 @@ J1 drain gate source fast
     );
   });
 
+  it.each([
+    ["0", 0.0],
+    ["1.5", 1.5],
+  ])("parses JFET channel noise coefficient %s", (value, expected) => {
+    const parsed = parseNetlist(`
+.model fast NJF(GDSNOI=${value})
+J1 drain gate source fast
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      channelNoiseCoefficient: expected,
+    });
+  });
+
+  it.each(["-0.1", "1e999"])(
+    "rejects invalid JFET channel noise coefficient %s",
+    (value) => {
+      expect(() => parseNetlist(`.model fast NJF(GDSNOI=${value})`)).toThrow(
+        "JFET GDSNOI must be finite and non-negative",
+      );
+    },
+  );
+
   it("parses PJF model beta aliases", () => {
     const parsed = parseNetlist(`
 .model pslow PJF(B=750u)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4482,9 +4482,14 @@ the Rust, Python, and TypeScript surfaces together.
      into the shared engine JFET bandgap-voltage field.
 
 432. Python and TypeScript Berkeley SPICE JFET noise-level parity.
-   - Status: implemented in this JFET noise-level parity slice.
+   - Status: completed in PR 9853.
    - Both parser facades validate `NLEV` as a finite integer greater than or
      equal to 1 and lower it into the shared engine noise-equation-level field.
+
+433. Python and TypeScript Berkeley SPICE JFET channel-noise parity.
+   - Status: implemented in this JFET channel-noise parity slice.
+   - Both parser facades validate finite, non-negative `GDSNOI` values and
+     lower them into the shared engine channel-noise-coefficient field.
 
 ## Backlog
 
@@ -4493,7 +4498,7 @@ the Rust, Python, and TypeScript surfaces together.
      currently use `B` as a legacy beta alias, while the engine model uses `B`
      for Parker-Skellern doping-tail shaping. Do not assign one card value to
      both fields silently.
-   - Continue the unambiguous audited JFET gaps with `GDSNOI`, `RD`, `RS`,
+   - Continue the unambiguous audited JFET gaps with `RD`, `RS`,
      `TCV`, `VTOTC`, `TNOM` / `T_NOM`, `BEX`, and `BETATCE`.
    - Continue the audited BJT model-card gaps after the smaller JFET fields;
      prioritize direct engine fields before adding new model surfaces.


### PR DESCRIPTION
## Summary
- validate JFET `GDSNOI` as finite and non-negative in Python and TypeScript
- lower `GDSNOI` into the shared engine channel-noise coefficient
- advance the SPICE implementation plan while preserving the explicit `B` alias-policy gap

## Verification
- Python `spice-netlist-parser`: `bash BUILD && .venv/bin/ruff check .` (390 passed)
- TypeScript `spice-netlist-parser`: `bash BUILD` (375 passed)
- TypeScript `spice-netlist-parser`: `npx vitest run --coverage` (86.73% lines)
- TypeScript `spice-engine`: `bash BUILD` (448 passed)