### PR TITLE
Add reusable Axis HTTP Digest authentication

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -730,6 +730,7 @@ members = [
     "nib-jvm-compiler",
     "bitset-c",
     "http-core",
+    "http-digest-auth",
     "ieee802154-core",
     "ieee802154-security",
     "http1",

--- a/code/packages/rust/http-digest-auth/BUILD
+++ b/code/packages/rust/http-digest-auth/BUILD
@@ -1,0 +1,1 @@
+cargo test -p http-digest-auth

--- a/code/packages/rust/http-digest-auth/CHANGELOG.md
+++ b/code/packages/rust/http-digest-auth/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Add bounded Digest challenge parsing for RFC 7616 MD5 and SHA-256 families.
+- Add zeroizing `qop=auth` and legacy authorization construction.
+- Cover the published MD5 and SHA-256 request-digest examples.

--- a/code/packages/rust/http-digest-auth/Cargo.toml
+++ b/code/packages/rust/http-digest-auth/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "http-digest-auth"
+version = "0.1.0"
+edition = "2021"
+description = "Bounded RFC 7616 HTTP Digest challenge parsing and authorization"
+license = "MIT"
+
+[dependencies]
+coding_adventures_md5 = { path = "../md5" }
+coding_adventures_sha256 = { path = "../sha256" }
+coding_adventures_zeroize = { path = "../zeroize" }

--- a/code/packages/rust/http-digest-auth/README.md
+++ b/code/packages/rust/http-digest-auth/README.md
@@ -1,0 +1,18 @@
+# http-digest-auth
+
+Bounded RFC 7616 HTTP Digest authentication primitives for production HTTP
+transports.
+
+The package parses one `WWW-Authenticate: Digest ...` challenge and builds a
+zeroizing `Authorization` value for `qop=auth` or the legacy no-`qop` form. It
+supports MD5, MD5-sess, SHA-256, and SHA-256-sess. Callers own network I/O,
+credential leasing, nonce-count state, retry limits, and CSPRNG-backed client
+nonce generation.
+
+The parser rejects oversized challenges, duplicate or malformed directives,
+unsupported quality-of-protection modes, unsupported algorithms, header
+injection, and `userhash=true`. Passwords and derived response material are
+held only in zeroizing buffers and the returned authorization value does not
+implement `Debug` or `Display`.
+
+Protocol reference: [RFC 7616](https://www.rfc-editor.org/rfc/rfc7616)

--- a/code/packages/rust/http-digest-auth/src/lib.rs
+++ b/code/packages/rust/http-digest-auth/src/lib.rs
@@ -1,0 +1,494 @@
+//! Bounded RFC 7616 HTTP Digest authentication primitives.
+
+#![forbid(unsafe_code)]
+
+use coding_adventures_md5::hex_string as md5_hex;
+use coding_adventures_sha256::sha256_hex;
+use coding_adventures_zeroize::Zeroizing;
+use std::collections::BTreeMap;
+use std::fmt;
+
+pub const VERSION: &str = "0.1.0";
+pub const MAX_CHALLENGE_BYTES: usize = 8 * 1024;
+pub const MAX_DIRECTIVES: usize = 32;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DigestAlgorithm {
+    Md5,
+    Md5Sess,
+    Sha256,
+    Sha256Sess,
+}
+
+impl DigestAlgorithm {
+    fn parse(value: Option<&str>) -> Result<Self, DigestAuthError> {
+        match value.unwrap_or("MD5").to_ascii_lowercase().as_str() {
+            "md5" => Ok(Self::Md5),
+            "md5-sess" => Ok(Self::Md5Sess),
+            "sha-256" => Ok(Self::Sha256),
+            "sha-256-sess" => Ok(Self::Sha256Sess),
+            other => Err(DigestAuthError::UnsupportedAlgorithm(other.to_string())),
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Md5 => "MD5",
+            Self::Md5Sess => "MD5-sess",
+            Self::Sha256 => "SHA-256",
+            Self::Sha256Sess => "SHA-256-sess",
+        }
+    }
+
+    fn session(self) -> bool {
+        matches!(self, Self::Md5Sess | Self::Sha256Sess)
+    }
+
+    fn hash(self, bytes: &[u8]) -> Zeroizing<String> {
+        Zeroizing::new(match self {
+            Self::Md5 | Self::Md5Sess => md5_hex(bytes),
+            Self::Sha256 | Self::Sha256Sess => sha256_hex(bytes),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DigestQop {
+    Auth,
+    Legacy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DigestChallenge {
+    realm: String,
+    nonce: String,
+    opaque: Option<String>,
+    algorithm: DigestAlgorithm,
+    qop: DigestQop,
+    stale: bool,
+}
+
+impl DigestChallenge {
+    pub fn parse(header_value: &str) -> Result<Self, DigestAuthError> {
+        if header_value.len() > MAX_CHALLENGE_BYTES {
+            return Err(DigestAuthError::ChallengeTooLarge {
+                limit: MAX_CHALLENGE_BYTES,
+            });
+        }
+        reject_unsafe("challenge", header_value)?;
+        let (scheme, directives) = header_value.trim().split_once(char::is_whitespace).ok_or(
+            DigestAuthError::MalformedChallenge("missing Digest directives"),
+        )?;
+        if !scheme.eq_ignore_ascii_case("Digest") {
+            return Err(DigestAuthError::WrongScheme);
+        }
+        let directives = parse_directives(directives)?;
+        let realm = required(&directives, "realm")?.to_string();
+        let nonce = required(&directives, "nonce")?.to_string();
+        let algorithm = DigestAlgorithm::parse(directives.get("algorithm").map(String::as_str))?;
+        let qop = match directives.get("qop") {
+            Some(value)
+                if value
+                    .split(',')
+                    .any(|item| item.trim().eq_ignore_ascii_case("auth")) =>
+            {
+                DigestQop::Auth
+            }
+            Some(_) => return Err(DigestAuthError::UnsupportedQop),
+            None => DigestQop::Legacy,
+        };
+        if directives
+            .get("charset")
+            .is_some_and(|value| !value.eq_ignore_ascii_case("UTF-8"))
+        {
+            return Err(DigestAuthError::UnsupportedCharset);
+        }
+        if directives
+            .get("userhash")
+            .is_some_and(|value| value.eq_ignore_ascii_case("true"))
+        {
+            return Err(DigestAuthError::UnsupportedUserhash);
+        }
+        let stale = match directives.get("stale") {
+            None => false,
+            Some(value) if value.eq_ignore_ascii_case("false") => false,
+            Some(value) if value.eq_ignore_ascii_case("true") => true,
+            Some(_) => return Err(DigestAuthError::MalformedChallenge("invalid stale value")),
+        };
+        Ok(Self {
+            realm,
+            nonce,
+            opaque: directives.get("opaque").cloned(),
+            algorithm,
+            qop,
+            stale,
+        })
+    }
+
+    pub fn algorithm(&self) -> DigestAlgorithm {
+        self.algorithm
+    }
+
+    pub fn qop(&self) -> DigestQop {
+        self.qop
+    }
+
+    pub fn stale(&self) -> bool {
+        self.stale
+    }
+
+    pub fn authorization(
+        &self,
+        username: &str,
+        password: &str,
+        method: &str,
+        uri: &str,
+        client_nonce: &str,
+        nonce_count: u32,
+    ) -> Result<Zeroizing<String>, DigestAuthError> {
+        reject_unsafe("username", username)?;
+        reject_unsafe("password", password)?;
+        reject_unsafe("method", method)?;
+        reject_unsafe("uri", uri)?;
+        reject_unsafe("client nonce", client_nonce)?;
+        if username.is_empty()
+            || username.contains(':')
+            || method.is_empty()
+            || !method.bytes().all(is_token)
+            || !uri.starts_with('/')
+            || uri.bytes().any(|byte| !byte.is_ascii_graphic())
+        {
+            return Err(DigestAuthError::InvalidInput(
+                "username must be non-empty without colons, method must be an HTTP token, and uri must be ASCII origin-form",
+            ));
+        }
+        if client_nonce.is_empty() || client_nonce.bytes().any(|byte| !byte.is_ascii_graphic()) {
+            return Err(DigestAuthError::InvalidInput(
+                "client nonce must contain visible ASCII",
+            ));
+        }
+        if self.qop == DigestQop::Auth && nonce_count == 0 {
+            return Err(DigestAuthError::InvalidInput(
+                "nonce count must be positive for qop=auth",
+            ));
+        }
+
+        let a1 = Zeroizing::new(format!("{username}:{}:{password}", self.realm));
+        let base_ha1 = self.algorithm.hash(a1.as_bytes());
+        let ha1 = if self.algorithm.session() {
+            let session = Zeroizing::new(format!(
+                "{}:{}:{client_nonce}",
+                base_ha1.as_str(),
+                self.nonce
+            ));
+            self.algorithm.hash(session.as_bytes())
+        } else {
+            base_ha1
+        };
+        let a2 = Zeroizing::new(format!("{method}:{uri}"));
+        let ha2 = self.algorithm.hash(a2.as_bytes());
+        let nc = format!("{nonce_count:08x}");
+        let response_input = match self.qop {
+            DigestQop::Auth => Zeroizing::new(format!(
+                "{}:{}:{nc}:{client_nonce}:auth:{}",
+                ha1.as_str(),
+                self.nonce,
+                ha2.as_str()
+            )),
+            DigestQop::Legacy => {
+                Zeroizing::new(format!("{}:{}:{}", ha1.as_str(), self.nonce, ha2.as_str()))
+            }
+        };
+        let response = self.algorithm.hash(response_input.as_bytes());
+
+        let quoted_username = Zeroizing::new(quote(username));
+        let mut header = format!(
+            "Digest username=\"{}\", realm=\"{}\", nonce=\"{}\", uri=\"{}\", algorithm={}, response=\"{}\"",
+            quoted_username.as_str(),
+            quote(&self.realm),
+            quote(&self.nonce),
+            quote(uri),
+            self.algorithm.label(),
+            response.as_str(),
+        );
+        if let Some(opaque) = &self.opaque {
+            header.push_str(&format!(", opaque=\"{}\"", quote(opaque)));
+        }
+        if self.qop == DigestQop::Auth {
+            header.push_str(&format!(
+                ", qop=auth, nc={nc}, cnonce=\"{}\"",
+                quote(client_nonce)
+            ));
+        }
+        Ok(Zeroizing::new(header))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DigestAuthError {
+    WrongScheme,
+    ChallengeTooLarge { limit: usize },
+    MalformedChallenge(&'static str),
+    MissingDirective(&'static str),
+    DuplicateDirective(String),
+    TooManyDirectives { limit: usize },
+    UnsupportedAlgorithm(String),
+    UnsupportedQop,
+    UnsupportedCharset,
+    UnsupportedUserhash,
+    UnsafeText(&'static str),
+    InvalidInput(&'static str),
+}
+
+impl fmt::Display for DigestAuthError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::WrongScheme => formatter.write_str("authentication challenge is not Digest"),
+            Self::ChallengeTooLarge { limit } => {
+                write!(formatter, "Digest challenge exceeds {limit} bytes")
+            }
+            Self::MalformedChallenge(message) => {
+                write!(formatter, "malformed Digest challenge: {message}")
+            }
+            Self::MissingDirective(name) => write!(formatter, "Digest challenge is missing {name}"),
+            Self::DuplicateDirective(name) => write!(formatter, "Digest challenge repeats {name}"),
+            Self::TooManyDirectives { limit } => {
+                write!(formatter, "Digest challenge exceeds {limit} directives")
+            }
+            Self::UnsupportedAlgorithm(name) => {
+                write!(formatter, "unsupported Digest algorithm {name}")
+            }
+            Self::UnsupportedQop => formatter.write_str("Digest challenge does not offer qop=auth"),
+            Self::UnsupportedCharset => {
+                formatter.write_str("Digest challenge uses an unsupported charset")
+            }
+            Self::UnsupportedUserhash => {
+                formatter.write_str("Digest userhash=true is not supported")
+            }
+            Self::UnsafeText(field) => write!(formatter, "{field} contains unsafe HTTP text"),
+            Self::InvalidInput(message) => write!(formatter, "invalid Digest input: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for DigestAuthError {}
+
+fn parse_directives(input: &str) -> Result<BTreeMap<String, String>, DigestAuthError> {
+    let bytes = input.as_bytes();
+    let mut cursor = 0usize;
+    let mut directives = BTreeMap::new();
+    while cursor < bytes.len() {
+        while cursor < bytes.len() && (bytes[cursor].is_ascii_whitespace() || bytes[cursor] == b',')
+        {
+            cursor += 1;
+        }
+        if cursor == bytes.len() {
+            break;
+        }
+        let name_start = cursor;
+        while cursor < bytes.len() && is_token(bytes[cursor]) {
+            cursor += 1;
+        }
+        if cursor == name_start {
+            return Err(DigestAuthError::MalformedChallenge(
+                "invalid directive name",
+            ));
+        }
+        let name = input[name_start..cursor].to_ascii_lowercase();
+        while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+        if bytes.get(cursor) != Some(&b'=') {
+            return Err(DigestAuthError::MalformedChallenge(
+                "directive is missing equals",
+            ));
+        }
+        cursor += 1;
+        while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+        let value = if bytes.get(cursor) == Some(&b'\"') {
+            cursor += 1;
+            let mut value = String::new();
+            let mut closed = false;
+            while cursor < bytes.len() {
+                match bytes[cursor] {
+                    b'\\' => {
+                        cursor += 1;
+                        let escaped =
+                            *bytes
+                                .get(cursor)
+                                .ok_or(DigestAuthError::MalformedChallenge(
+                                    "truncated quoted escape",
+                                ))?;
+                        value.push(char::from(escaped));
+                        cursor += 1;
+                    }
+                    b'\"' => {
+                        cursor += 1;
+                        closed = true;
+                        break;
+                    }
+                    byte if byte.is_ascii() && !byte.is_ascii_control() => {
+                        value.push(char::from(byte));
+                        cursor += 1;
+                    }
+                    _ => return Err(DigestAuthError::MalformedChallenge("invalid quoted value")),
+                }
+            }
+            if !closed {
+                return Err(DigestAuthError::MalformedChallenge(
+                    "unterminated quoted value",
+                ));
+            }
+            value
+        } else {
+            let value_start = cursor;
+            while cursor < bytes.len() && bytes[cursor] != b',' {
+                cursor += 1;
+            }
+            input[value_start..cursor].trim().to_string()
+        };
+        if value.is_empty() {
+            return Err(DigestAuthError::MalformedChallenge("empty directive value"));
+        }
+        while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+        if cursor < bytes.len() && bytes[cursor] != b',' {
+            return Err(DigestAuthError::MalformedChallenge(
+                "missing directive separator",
+            ));
+        }
+        if directives.insert(name.clone(), value).is_some() {
+            return Err(DigestAuthError::DuplicateDirective(name));
+        }
+        if directives.len() > MAX_DIRECTIVES {
+            return Err(DigestAuthError::TooManyDirectives {
+                limit: MAX_DIRECTIVES,
+            });
+        }
+    }
+    Ok(directives)
+}
+
+fn required<'a>(
+    directives: &'a BTreeMap<String, String>,
+    name: &'static str,
+) -> Result<&'a str, DigestAuthError> {
+    directives
+        .get(name)
+        .map(String::as_str)
+        .ok_or(DigestAuthError::MissingDirective(name))
+}
+
+fn reject_unsafe(field: &'static str, value: &str) -> Result<(), DigestAuthError> {
+    if value.contains(['\r', '\n', '\0']) {
+        Err(DigestAuthError::UnsafeText(field))
+    } else {
+        Ok(())
+    }
+}
+
+fn is_token(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || b"!#$%&'*+-.^_`|~".contains(&byte)
+}
+
+fn quote(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('\"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn published_md5_example_matches() {
+        let challenge = DigestChallenge::parse(
+            r#"Digest realm="testrealm@host.com", qop="auth,auth-int", nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", opaque="5ccc069c403ebaf9f0171e9517f40e41""#,
+        )
+        .unwrap();
+        let header = challenge
+            .authorization(
+                "Mufasa",
+                "Circle Of Life",
+                "GET",
+                "/dir/index.html",
+                "0a4f113b",
+                1,
+            )
+            .unwrap();
+        assert!(header.contains("response=\"6629fae49393a05397450978507c4ef1\""));
+        assert!(header.contains("qop=auth, nc=00000001, cnonce=\"0a4f113b\""));
+    }
+
+    #[test]
+    fn published_sha256_example_matches() {
+        let challenge = DigestChallenge::parse(
+            r#"Digest realm="http-auth@example.org", qop="auth, auth-int", algorithm=SHA-256, nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v", opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS""#,
+        )
+        .unwrap();
+        let header = challenge
+            .authorization(
+                "Mufasa",
+                "Circle of Life",
+                "GET",
+                "/dir/index.html",
+                "f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ",
+                1,
+            )
+            .unwrap();
+        assert!(header.contains(
+            "response=\"753927fa0e85d155564e2e272a28d1802ca10daf4496794697cf8db5856cb6c1\""
+        ));
+        assert_eq!(challenge.algorithm(), DigestAlgorithm::Sha256);
+    }
+
+    #[test]
+    fn parses_session_and_legacy_variants() {
+        let challenge = DigestChallenge::parse(
+            r#"Digest realm="camera", nonce="n\"once", algorithm=MD5-sess, stale=true"#,
+        )
+        .unwrap();
+        assert_eq!(challenge.algorithm(), DigestAlgorithm::Md5Sess);
+        assert_eq!(challenge.qop(), DigestQop::Legacy);
+        assert!(challenge.stale());
+        let header = challenge
+            .authorization("root", "secret", "GET", "/status", "client", 0)
+            .unwrap();
+        assert!(!header.contains("qop="));
+        assert!(header.contains("nonce=\"n\\\"once\""));
+    }
+
+    #[test]
+    fn rejects_ambiguous_or_unsafe_challenges() {
+        assert!(matches!(
+            DigestChallenge::parse(r#"Digest realm="a", realm="b", nonce="n""#),
+            Err(DigestAuthError::DuplicateDirective(name)) if name == "realm"
+        ));
+        assert!(matches!(
+            DigestChallenge::parse(r#"Digest realm="a", nonce="n", qop="auth-int""#),
+            Err(DigestAuthError::UnsupportedQop)
+        ));
+        assert!(matches!(
+            DigestChallenge::parse("Digest realm=\"a\r\nb\", nonce=\"n\""),
+            Err(DigestAuthError::UnsafeText("challenge"))
+        ));
+        assert!(matches!(
+            DigestChallenge::parse(r#"Basic realm="a""#),
+            Err(DigestAuthError::WrongScheme)
+        ));
+    }
+
+    #[test]
+    fn authorization_rejects_injection_and_zero_nonce_count() {
+        let challenge =
+            DigestChallenge::parse(r#"Digest realm="camera", nonce="nonce", qop="auth""#).unwrap();
+        assert!(challenge
+            .authorization("root", "secret", "GET\r\nInjected", "/", "c", 1)
+            .is_err());
+        assert!(challenge
+            .authorization("root", "secret", "GET", "/", "c", 0)
+            .is_err());
+    }
+}

--- a/code/packages/rust/smart-home-axis-vapix-integration/CHANGELOG.md
+++ b/code/packages/rust/smart-home-axis-vapix-integration/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.3.0
+
+- Probe Axis endpoints without credentials and select advertised Basic or
+  Digest authentication instead of sending Basic preemptively.
+- Add SHA-256/MD5 Digest challenge handling with CSPRNG client nonces,
+  nonce-count reuse, and one bounded retry for refreshed or stale challenges.
+- Keep all credentials and generated authorization values transport-private and
+  zeroizing while preserving certificate-verifying production HTTPS.
+
 ## 0.2.0
 
 - Add capability-probed Axis position and preset inspection.

--- a/code/packages/rust/smart-home-axis-vapix-integration/Cargo.toml
+++ b/code/packages/rust/smart-home-axis-vapix-integration/Cargo.toml
@@ -1,14 +1,16 @@
 [package]
 name = "smart-home-axis-vapix-integration"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Authenticated Axis VAPIX discovery, inspection, and bounded PTZ control"
 license = "MIT"
 
 [dependencies]
 base64 = "0.22"
+coding_adventures_csprng = { path = "../csprng" }
 coding_adventures_zeroize = { path = "../zeroize" }
 http-core = { path = "../http-core" }
+http-digest-auth = { path = "../http-digest-auth" }
 http1 = { path = "../http1" }
 serde_json = "1"
 smart-home-core = { path = "../smart-home-core" }

--- a/code/packages/rust/smart-home-axis-vapix-integration/README.md
+++ b/code/packages/rust/smart-home-axis-vapix-integration/README.md
@@ -9,8 +9,13 @@ The package:
   advertisements through the shared mDNS runtime;
 - requires credential-free HTTPS origins for production, with plain HTTP
   permitted only for loopback transport tests;
-- represents credentials as a `VaultRef` in request plans and materializes the
-  Basic authorization value only inside the bounded transport;
+- represents credentials as a `VaultRef` in request plans, probes without an
+  authorization header, and selects a supported Basic or Digest challenge;
+- prefers SHA-256 Digest over MD5 when a device advertises multiple supported
+  challenges, uses CSPRNG-backed client nonces, maintains an in-memory nonce
+  count, and retries once when the device returns a fresh or stale challenge;
+- materializes Basic and Digest authorization values only inside the bounded
+  transport, with credentials and derived response values in zeroizing memory;
 - calls the authenticated Basic Device Information and API Discovery JSON CGIs;
 - probes the documented PTZ command inventory, current position, server presets,
   native speed control, and `CtlQueueing` mode before advertising `camera.ptz`;
@@ -26,7 +31,7 @@ The package:
 - preserves confirmed position from inspection instead of inventing optimistic
   orientation after movement.
 
-The first production slice intentionally targets VAPIX camera 1. Event
+The production path intentionally targets VAPIX camera 1. Event
 streaming, snapshots, media transfer, multi-channel enumeration, and advanced
 zoom/guard-tour control remain separate slices with additional host or
 capability prerequisites.

--- a/code/packages/rust/smart-home-axis-vapix-integration/src/lib.rs
+++ b/code/packages/rust/smart-home-axis-vapix-integration/src/lib.rs
@@ -3,9 +3,11 @@
 #![forbid(unsafe_code)]
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use coding_adventures_csprng::random_array;
 use coding_adventures_zeroize::Zeroizing;
 use http1::{parse_response_head, Http1ParseError};
-use http_core::{find_header, BodyKind};
+use http_core::{find_header, BodyKind, Header};
+use http_digest_auth::{DigestAuthError, DigestChallenge};
 use serde_json::{json, Map as JsonMap, Value as JsonValue};
 use smart_home_core::{
     AgentId, Bridge, BridgeId, BridgeTransport, Capability, CapabilityId, CapabilityMode,
@@ -31,7 +33,7 @@ use std::time::Duration;
 use tls_platform::{default_connector, TlsConfig, TlsConnector};
 use url_parser::{Url, UrlError};
 
-pub const VERSION: &str = "0.2.0";
+pub const VERSION: &str = "0.3.0";
 pub const INTEGRATION_ID: &str = "axis_vapix";
 pub const PROTOCOL_ID: &str = "axis_vapix";
 pub const VIDEO_MDNS_SERVICE_TYPE: &str = "_axis-video._tcp.local";
@@ -58,6 +60,7 @@ pub enum AxisError {
     Tls(String),
     Http(String),
     HttpStatus(u16),
+    Authentication(String),
     ResponseTooLarge {
         limit: usize,
     },
@@ -92,6 +95,9 @@ impl fmt::Display for AxisError {
             Self::Tls(message) => write!(formatter, "Axis TLS failed: {message}"),
             Self::Http(message) => write!(formatter, "invalid Axis HTTP response: {message}"),
             Self::HttpStatus(status) => write!(formatter, "Axis endpoint returned HTTP {status}"),
+            Self::Authentication(message) => {
+                write!(formatter, "Axis authentication failed: {message}")
+            }
             Self::ResponseTooLarge { limit } => {
                 write!(formatter, "Axis response exceeds {limit} bytes")
             }
@@ -148,6 +154,12 @@ impl From<serde_json::Error> for AxisError {
 impl From<RuntimeError> for AxisError {
     fn from(error: RuntimeError) -> Self {
         Self::Runtime(error)
+    }
+}
+
+impl From<DigestAuthError> for AxisError {
+    fn from(error: DigestAuthError) -> Self {
+        Self::Authentication(error.to_string())
     }
 }
 
@@ -453,6 +465,16 @@ pub struct AxisLanTransport {
     connector: Box<dyn TlsConnector>,
     tls_config: TlsConfig,
     maximum_response_bytes: usize,
+    auth_state: Option<AxisAuthState>,
+}
+
+#[derive(Clone)]
+enum AxisAuthState {
+    Basic,
+    Digest {
+        challenge: DigestChallenge,
+        nonce_count: u32,
+    },
 }
 
 impl Default for AxisLanTransport {
@@ -467,6 +489,7 @@ impl AxisLanTransport {
             connector,
             tls_config,
             maximum_response_bytes: DEFAULT_MAX_RESPONSE_BYTES,
+            auth_state: None,
         }
     }
 
@@ -474,16 +497,58 @@ impl AxisLanTransport {
         self.maximum_response_bytes = maximum.max(1);
         self
     }
-}
 
-impl AxisTransport for AxisLanTransport {
-    fn execute(
+    fn authorization_header(
         &mut self,
+        url: &Url,
         plan: &LocalHttpRequestPlan,
         credentials: &AxisCredentials,
+    ) -> Result<Zeroizing<String>, AxisError> {
+        match self.auth_state.as_mut().ok_or_else(|| {
+            AxisError::Authentication("device did not select an authentication scheme".to_string())
+        })? {
+            AxisAuthState::Basic => {
+                let raw = Zeroizing::new(format!(
+                    "{}:{}",
+                    credentials.username.as_str(),
+                    credentials.password.as_str()
+                ));
+                let encoded = Zeroizing::new(BASE64.encode(raw.as_bytes()));
+                Ok(Zeroizing::new(format!("Basic {}", encoded.as_str())))
+            }
+            AxisAuthState::Digest {
+                challenge,
+                nonce_count,
+            } => {
+                *nonce_count = nonce_count.checked_add(1).ok_or_else(|| {
+                    AxisError::Authentication("Digest nonce count exhausted".to_string())
+                })?;
+                let random = Zeroizing::new(
+                    random_array::<16>()
+                        .map_err(|error| AxisError::Authentication(error.to_string()))?,
+                );
+                let client_nonce = Zeroizing::new(hex_bytes(random.as_slice()));
+                challenge
+                    .authorization(
+                        credentials.username.as_str(),
+                        credentials.password.as_str(),
+                        plan.method.as_str(),
+                        &request_target(url)?,
+                        client_nonce.as_str(),
+                        *nonce_count,
+                    )
+                    .map_err(AxisError::from)
+            }
+        }
+    }
+
+    fn exchange(
+        &mut self,
+        url: &Url,
+        plan: &LocalHttpRequestPlan,
         session_cookie: Option<&str>,
-    ) -> Result<AxisHttpResponse, AxisError> {
-        let url = Url::parse(&plan.url)?;
+        authorization: Option<&str>,
+    ) -> Result<AxisWireResponse, AxisError> {
         let host = url
             .host
             .as_deref()
@@ -491,17 +556,12 @@ impl AxisTransport for AxisLanTransport {
         let port = url
             .effective_port()
             .ok_or(AxisError::MissingField("request URL port"))?;
-        if url.scheme == "http" && !is_loopback_host(host) {
-            return Err(AxisError::Validation(
-                "Basic credentials may use HTTP only on loopback tests".to_string(),
-            ));
-        }
         let timeout = Duration::from_millis(plan.timeout_ms.max(1));
         let request = Zeroizing::new(encode_http_request(
-            &url,
+            url,
             plan,
-            credentials,
             session_cookie,
+            authorization,
         )?);
         let response = match url.scheme.as_str() {
             "http" => {
@@ -531,7 +591,42 @@ impl AxisTransport for AxisLanTransport {
                 )))
             }
         };
-        decode_http_response(&response, self.maximum_response_bytes)
+        decode_wire_response(&response, self.maximum_response_bytes)
+    }
+}
+
+impl AxisTransport for AxisLanTransport {
+    fn execute(
+        &mut self,
+        plan: &LocalHttpRequestPlan,
+        credentials: &AxisCredentials,
+        session_cookie: Option<&str>,
+    ) -> Result<AxisHttpResponse, AxisError> {
+        let url = Url::parse(&plan.url)?;
+        let host = url
+            .host
+            .as_deref()
+            .ok_or(AxisError::MissingField("request URL host"))?;
+        let _ = url
+            .effective_port()
+            .ok_or(AxisError::MissingField("request URL port"))?;
+        if url.scheme == "http" && !is_loopback_host(host) {
+            return Err(AxisError::Validation(
+                "Axis credentials may use HTTP only on loopback tests".to_string(),
+            ));
+        }
+        let mut response = if self.auth_state.is_some() {
+            let authorization = self.authorization_header(&url, plan, credentials)?;
+            self.exchange(&url, plan, session_cookie, Some(authorization.as_str()))?
+        } else {
+            self.exchange(&url, plan, session_cookie, None)?
+        };
+        if response.status == 401 {
+            self.auth_state = Some(select_auth_state(&response.headers)?);
+            let authorization = self.authorization_header(&url, plan, credentials)?;
+            response = self.exchange(&url, plan, session_cookie, Some(authorization.as_str()))?;
+        }
+        response.into_success()
     }
 }
 
@@ -1389,11 +1484,80 @@ fn has_unsafe_http_text(value: &str) -> bool {
     value.contains(['\r', '\n', '\0'])
 }
 
+fn request_target(url: &Url) -> Result<String, AxisError> {
+    let target = if url.path.is_empty() {
+        "/".to_string()
+    } else if let Some(query) = &url.query {
+        format!("{}?{query}", url.path)
+    } else {
+        url.path.clone()
+    };
+    if has_unsafe_http_text(&target) {
+        Err(AxisError::Validation(
+            "request target contains unsafe HTTP text".to_string(),
+        ))
+    } else {
+        Ok(target)
+    }
+}
+
+fn hex_bytes(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn select_auth_state(headers: &[Header]) -> Result<AxisAuthState, AxisError> {
+    let challenges = headers
+        .iter()
+        .filter(|header| header.name.eq_ignore_ascii_case("WWW-Authenticate"))
+        .map(|header| header.value.trim())
+        .collect::<Vec<_>>();
+    let mut digest_error = None;
+    let mut digest = Vec::new();
+    for value in &challenges {
+        if value
+            .split_ascii_whitespace()
+            .next()
+            .is_some_and(|scheme| scheme.eq_ignore_ascii_case("Digest"))
+        {
+            match DigestChallenge::parse(value) {
+                Ok(challenge) => digest.push(challenge),
+                Err(error) => digest_error = Some(error),
+            }
+        }
+    }
+    if let Some(challenge) = digest.into_iter().max_by_key(|challenge| {
+        use http_digest_auth::DigestAlgorithm;
+        match challenge.algorithm() {
+            DigestAlgorithm::Sha256 | DigestAlgorithm::Sha256Sess => 2,
+            DigestAlgorithm::Md5 | DigestAlgorithm::Md5Sess => 1,
+        }
+    }) {
+        return Ok(AxisAuthState::Digest {
+            challenge,
+            nonce_count: 0,
+        });
+    }
+    if challenges.iter().any(|value| {
+        value
+            .split_ascii_whitespace()
+            .next()
+            .is_some_and(|scheme| scheme.eq_ignore_ascii_case("Basic"))
+    }) {
+        return Ok(AxisAuthState::Basic);
+    }
+    if let Some(error) = digest_error {
+        return Err(AxisError::from(error));
+    }
+    Err(AxisError::Authentication(
+        "401 response did not offer supported Basic or Digest authentication".to_string(),
+    ))
+}
+
 fn encode_http_request(
     url: &Url,
     plan: &LocalHttpRequestPlan,
-    credentials: &AxisCredentials,
     session_cookie: Option<&str>,
+    authorization: Option<&str>,
 ) -> Result<Vec<u8>, AxisError> {
     let host = url
         .host
@@ -1402,13 +1566,7 @@ fn encode_http_request(
     let port = url
         .effective_port()
         .ok_or(AxisError::MissingField("request URL port"))?;
-    let target = if url.path.is_empty() {
-        "/".to_string()
-    } else if let Some(query) = &url.query {
-        format!("{}?{query}", url.path)
-    } else {
-        url.path.clone()
-    };
+    let target = request_target(url)?;
     if has_unsafe_http_text(&target) || has_unsafe_http_text(host) {
         return Err(AxisError::Validation(
             "request target contains unsafe HTTP text".to_string(),
@@ -1417,6 +1575,11 @@ fn encode_http_request(
     if session_cookie.is_some_and(has_unsafe_http_text) {
         return Err(AxisError::Validation(
             "session cookie contains unsafe HTTP text".to_string(),
+        ));
+    }
+    if authorization.is_some_and(has_unsafe_http_text) {
+        return Err(AxisError::Validation(
+            "authorization contains unsafe HTTP text".to_string(),
         ));
     }
     let default_port = if url.scheme == "https" { 443 } else { 80 };
@@ -1439,15 +1602,9 @@ fn encode_http_request(
         }
         seen.insert(header.name.to_ascii_lowercase());
         if header.name.eq_ignore_ascii_case("Authorization") {
-            let raw = Zeroizing::new(format!(
-                "{}:{}",
-                credentials.username.as_str(),
-                credentials.password.as_str()
-            ));
-            let encoded = Zeroizing::new(BASE64.encode(raw.as_bytes()));
-            request.extend_from_slice(
-                format!("Authorization: Basic {}\r\n", encoded.as_str()).as_bytes(),
-            );
+            if let Some(value) = authorization {
+                request.extend_from_slice(format!("Authorization: {value}\r\n").as_bytes());
+            }
         } else if header.name.eq_ignore_ascii_case("Cookie") {
             return Err(AxisError::Validation(
                 "session cookies must not be stored in Axis request plans".to_string(),
@@ -1458,7 +1615,7 @@ fn encode_http_request(
     }
     if !seen.contains("authorization") {
         return Err(AxisError::Validation(
-            "Axis request plan is missing Vault-backed Basic authorization".to_string(),
+            "Axis request plan is missing a Vault-backed authorization placeholder".to_string(),
         ));
     }
     if let Some(cookie) = session_cookie {
@@ -1528,12 +1685,33 @@ fn read_bounded(reader: &mut dyn Read, maximum: usize) -> Result<Vec<u8>, AxisEr
     Ok(bytes)
 }
 
+struct AxisWireResponse {
+    status: u16,
+    headers: Vec<Header>,
+    body: Vec<u8>,
+    session_cookie: Option<Zeroizing<String>>,
+}
+
+impl AxisWireResponse {
+    fn into_success(self) -> Result<AxisHttpResponse, AxisError> {
+        if !(200..300).contains(&self.status) {
+            return Err(AxisError::HttpStatus(self.status));
+        }
+        Ok(AxisHttpResponse {
+            body: self.body,
+            session_cookie: self.session_cookie,
+        })
+    }
+}
+
+#[cfg(test)]
 fn decode_http_response(bytes: &[u8], maximum: usize) -> Result<AxisHttpResponse, AxisError> {
+    decode_wire_response(bytes, maximum)?.into_success()
+}
+
+fn decode_wire_response(bytes: &[u8], maximum: usize) -> Result<AxisWireResponse, AxisError> {
     let parsed = parse_response_head(bytes)
         .map_err(|error: Http1ParseError| AxisError::Http(error.to_string()))?;
-    if !(200..300).contains(&parsed.head.status) {
-        return Err(AxisError::HttpStatus(parsed.head.status));
-    }
     let input = &bytes[parsed.body_offset..];
     let body = match parsed.body_kind {
         BodyKind::None => Vec::new(),
@@ -1566,7 +1744,9 @@ fn decode_http_response(bytes: &[u8], maximum: usize) -> Result<AxisHttpResponse
             }
         })
         .transpose()?;
-    Ok(AxisHttpResponse {
+    Ok(AxisWireResponse {
+        status: parsed.head.status,
+        headers: parsed.head.headers,
         body,
         session_cookie,
     })
@@ -1629,6 +1809,27 @@ mod tests {
 
     fn queue_response(body: &str) -> Vec<u8> {
         format!("HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nSet-Cookie: ptz=lease-token; Path=/\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len()).into_bytes()
+    }
+
+    fn auth_challenge(value: &str) -> Vec<u8> {
+        format!(
+            "HTTP/1.1 401 Unauthorized\r\nWWW-Authenticate: {value}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        )
+        .into_bytes()
+    }
+
+    fn request_header<'a>(request: &'a str, name: &str) -> Option<&'a str> {
+        request.lines().find_map(|line| {
+            let (candidate, value) = line.split_once(':')?;
+            candidate.eq_ignore_ascii_case(name).then_some(value.trim())
+        })
+    }
+
+    fn quoted_directive<'a>(header: &'a str, name: &str) -> Option<&'a str> {
+        let marker = format!("{name}=\"");
+        let start = header.find(&marker)? + marker.len();
+        let end = header[start..].find('\"')? + start;
+        Some(&header[start..end])
     }
 
     fn start_server(
@@ -1781,10 +1982,38 @@ mod tests {
     }
 
     #[test]
+    fn challenge_selection_prefers_supported_sha256_digest() {
+        let headers = vec![
+            Header {
+                name: "WWW-Authenticate".to_string(),
+                value: r#"Basic realm="AXIS""#.to_string(),
+            },
+            Header {
+                name: "WWW-Authenticate".to_string(),
+                value: r#"Digest realm="AXIS", nonce="md5", algorithm=MD5, qop="auth""#.to_string(),
+            },
+            Header {
+                name: "WWW-Authenticate".to_string(),
+                value: r#"Digest realm="AXIS", nonce="sha", algorithm=SHA-256, qop="auth""#
+                    .to_string(),
+            },
+        ];
+        let state = select_auth_state(&headers).unwrap();
+        assert!(matches!(
+            state,
+            AxisAuthState::Digest { challenge, nonce_count: 0 }
+                if challenge.algorithm() == http_digest_auth::DigestAlgorithm::Sha256
+        ));
+    }
+
+    #[test]
     fn waiting_queue_request_is_dropped_before_control_is_rejected() {
         let waiting = r#"<a name="2"></a><a name="8"></a><a name="30"></a>"#;
-        let (port, requests, handle) =
-            start_server(vec![queue_response(waiting), text_response("")]);
+        let (port, requests, handle) = start_server(vec![
+            auth_challenge(r#"Basic realm="AXIS""#),
+            queue_response(waiting),
+            text_response(""),
+        ]);
         let mut client =
             AxisClient::new(config(port), credentials(), AxisLanTransport::default()).unwrap();
         assert!(matches!(
@@ -1793,15 +2022,22 @@ mod tests {
         ));
         handle.join().unwrap();
         let requests = requests.lock().unwrap();
-        assert_eq!(requests.len(), 2);
-        assert!(requests[1].contains("control=drop&camera=1"));
-        assert!(requests[1].contains("Cookie: ptz=lease-token"));
+        assert_eq!(requests.len(), 3);
+        assert!(request_header(&requests[0], "Authorization").is_none());
+        assert!(requests[2].contains("control=drop&camera=1"));
+        assert!(requests[2].contains("Cookie: ptz=lease-token"));
     }
 
     #[test]
     fn real_http_inspection_installs_confirmed_axis_camera() {
-        let (port, requests, handle) =
-            start_server(vec![response(DEVICE_INFO), response(API_LIST)]);
+        let digest_value = r#"Digest realm="AXIS", nonce="server-nonce", algorithm=SHA-256, qop="auth", opaque="axis-opaque""#;
+        let stale_digest_value = r#"Digest realm="AXIS", nonce="fresh-nonce", algorithm=SHA-256, qop="auth", opaque="axis-opaque", stale=true"#;
+        let (port, requests, handle) = start_server(vec![
+            auth_challenge(digest_value),
+            response(DEVICE_INFO),
+            auth_challenge(stale_digest_value),
+            response(API_LIST),
+        ]);
         let client =
             AxisClient::new(config(port), credentials(), AxisLanTransport::default()).unwrap();
         let mut integration = AxisRuntimeIntegration::new(client);
@@ -1833,19 +2069,47 @@ mod tests {
         );
 
         let requests = requests.lock().unwrap();
-        assert_eq!(requests.len(), 2);
+        assert_eq!(requests.len(), 4);
         assert!(requests[0].contains(&format!("POST {BASIC_DEVICE_INFO_PATH} HTTP/1.1")));
-        assert!(requests[1].contains(&format!("POST {API_DISCOVERY_PATH} HTTP/1.1")));
-        assert!(requests
-            .iter()
-            .all(|request| request.contains("Authorization: Basic cm9vdDpzZWNyZXQ=")));
+        assert!(request_header(&requests[0], "Authorization").is_none());
+        assert!(requests[1].contains(&format!("POST {BASIC_DEVICE_INFO_PATH} HTTP/1.1")));
+        assert!(requests[2].contains(&format!("POST {API_DISCOVERY_PATH} HTTP/1.1")));
+        assert!(requests[3].contains(&format!("POST {API_DISCOVERY_PATH} HTTP/1.1")));
+        let challenge = DigestChallenge::parse(digest_value).unwrap();
+        for (request, uri, nonce_count) in [
+            (&requests[1], BASIC_DEVICE_INFO_PATH, 1),
+            (&requests[2], API_DISCOVERY_PATH, 2),
+        ] {
+            let authorization = request_header(request, "Authorization").unwrap();
+            let client_nonce = quoted_directive(authorization, "cnonce").unwrap();
+            let expected = challenge
+                .authorization("root", "secret", "POST", uri, client_nonce, nonce_count)
+                .unwrap();
+            assert_eq!(authorization, expected.as_str());
+        }
+        let stale_challenge = DigestChallenge::parse(stale_digest_value).unwrap();
+        let authorization = request_header(&requests[3], "Authorization").unwrap();
+        let client_nonce = quoted_directive(authorization, "cnonce").unwrap();
+        let expected = stale_challenge
+            .authorization(
+                "root",
+                "secret",
+                "POST",
+                API_DISCOVERY_PATH,
+                client_nonce,
+                1,
+            )
+            .unwrap();
+        assert_eq!(authorization, expected.as_str());
         assert!(requests.iter().all(|request| !request.contains("vault://")));
+        assert!(requests.iter().all(|request| !request.contains("secret")));
     }
 
     #[test]
     fn real_http_ptz_probe_queue_recall_and_bounded_move_are_exact() {
         let queue_granted = r#"<a name="1"></a><a name="0"></a><a name="30"></a>"#;
         let (port, requests, handle) = start_server(vec![
+            auth_challenge(r#"Basic realm="AXIS""#),
             response(DEVICE_INFO),
             response(PTZ_API_LIST),
             text_response("continuouspantiltmove=-100..100,-100..100\ngotoserverpresetno=integer\nspeed=integer\nquery=position\n"),
@@ -1956,18 +2220,20 @@ mod tests {
             .as_deref()
             .is_some_and(|message| message.contains("bounded PTZ left")));
         let requests = requests.lock().unwrap();
-        assert_eq!(requests.len(), 13);
-        assert!(requests[2].starts_with(&format!("GET {PTZ_CONTROL_PATH}?info=1&camera=1 ")));
-        assert!(requests[5].contains("group=PTZ.Various.V1.CtlQueueing"));
-        assert!(requests[6].contains("control=request&camera=1"));
-        assert!(requests[7].contains("gotoserverpresetno=3&speed=50&camera=1"));
-        assert!(requests[7].contains("Cookie: ptz=lease-token"));
-        assert!(requests[8].contains("control=drop&camera=1"));
-        assert!(requests[10].contains("continuouspantiltmove=-25,0&camera=1"));
-        assert!(requests[11].contains("continuouspantiltmove=0,0&camera=1"));
-        assert!(requests[12].contains("control=drop&camera=1"));
+        assert_eq!(requests.len(), 14);
+        assert!(request_header(&requests[0], "Authorization").is_none());
+        assert!(requests[3].starts_with(&format!("GET {PTZ_CONTROL_PATH}?info=1&camera=1 ")));
+        assert!(requests[6].contains("group=PTZ.Various.V1.CtlQueueing"));
+        assert!(requests[7].contains("control=request&camera=1"));
+        assert!(requests[8].contains("gotoserverpresetno=3&speed=50&camera=1"));
+        assert!(requests[8].contains("Cookie: ptz=lease-token"));
+        assert!(requests[9].contains("control=drop&camera=1"));
+        assert!(requests[11].contains("continuouspantiltmove=-25,0&camera=1"));
+        assert!(requests[12].contains("continuouspantiltmove=0,0&camera=1"));
+        assert!(requests[13].contains("control=drop&camera=1"));
         assert!(requests
             .iter()
+            .skip(1)
             .all(|request| request.contains("Authorization: Basic cm9vdDpzZWNyZXQ=")));
         assert!(requests.iter().all(|request| !request.contains("vault://")));
     }
@@ -2025,9 +2291,10 @@ mod tests {
 
     #[test]
     fn client_rejects_vapix_errors() {
-        let (port, _requests, handle) = start_server(vec![response(
-            r#"{"apiVersion":"1.0","error":{"code":1000,"message":"bad input"}}"#,
-        )]);
+        let (port, _requests, handle) = start_server(vec![
+            auth_challenge(r#"Basic realm="AXIS""#),
+            response(r#"{"apiVersion":"1.0","error":{"code":1000,"message":"bad input"}}"#),
+        ]);
         let mut client =
             AxisClient::new(config(port), credentials(), AxisLanTransport::default()).unwrap();
         assert!(matches!(

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Record challenge-selected Basic/Digest authentication for the Axis VAPIX
+  production transport.
 - Promote Enphase Envoy to a first-party authenticated local IQ Gateway meter
   telemetry runtime with Vault-backed bearer-token and TLS trust-root boundaries.
 - Promote UniFi Network to a first-party local API-key runtime for bounded

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -45221,7 +45221,7 @@ pub fn first_party_catalog() -> Vec<IntegrationCatalogEntry> {
         base_entry(
             "axis_vapix",
             "Axis VAPIX",
-            "Authenticated local Axis camera and NVR discovery, inspection, and bounded PTZ control.",
+            "Challenge-authenticated local Axis camera and NVR discovery, inspection, and bounded PTZ control.",
             IntegrationCategory::CameraMedia,
             ConnectivityClass::LocalPolling,
             ImplementationStatus::FirstPartyRuntime,
@@ -45243,7 +45243,7 @@ pub fn first_party_catalog() -> Vec<IntegrationCatalogEntry> {
             PrimitiveFamily::Supervision,
         ])
         .with_notes(&[
-            "Production inspection requires HTTPS Basic authentication; plain HTTP is accepted only for loopback transport tests.",
+            "Production inspection requires certificate-verifying HTTPS and selects advertised Basic or Digest authentication; plain HTTP is accepted only for loopback transport tests.",
             "Camera 1 PTZ is capability-probed, human-approved, queue-aware, and bounded with an explicit native stop.",
             "Event streaming, snapshots, media transfer, multi-channel PTZ, and advanced PTZ functions remain separate capability-specific work.",
         ]),
@@ -81180,6 +81180,10 @@ mod tests {
         assert!(axis
             .required_primitives
             .contains(&PrimitiveFamily::VaultLease));
+        assert!(axis
+            .notes
+            .iter()
+            .any(|note| note.contains("Basic or Digest")));
         assert!(!axis
             .required_primitives
             .contains(&PrimitiveFamily::CameraMedia));

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1085,6 +1085,28 @@ documented API 2.0 contract:
   exact path-prefixed login, version, and monitor requests plus transport-private
   credential and JWT handling.
 
+## Current Axis HTTP Digest Authentication Slice
+
+This slice closes the reusable HTTP Digest prerequisite and wires it into the
+existing Axis VAPIX production transport:
+
+- `http-digest-auth` parses bounded RFC 7616 challenges and builds zeroizing
+  MD5, MD5-sess, SHA-256, and SHA-256-sess authorization values for `qop=auth`
+  or the legacy no-`qop` form.
+- Duplicate, oversized, malformed, unsupported-algorithm, `auth-int`-only,
+  unsupported-charset, `userhash=true`, and header-injection inputs fail closed.
+- The Axis transport now follows the documented unauthenticated-request then
+  `401 WWW-Authenticate` flow, prefers supported SHA-256 Digest over MD5 and
+  Basic, and keeps the selected challenge and nonce count only in transport
+  memory.
+- Digest client nonces come from the OS CSPRNG. Credentials, A1 material,
+  derived responses, Basic values, Digest values, and encoded request bytes are
+  zeroized and never enter request plans, debug output, or normalized state.
+- Authentication is retried at most once per request. A real loopback exchange
+  proves the exact unauthenticated probe, authenticated retry, preemptive nonce
+  count, and `stale=true` nonce refresh while production TLS remains
+  certificate-verifying.
+
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
@@ -1164,36 +1186,34 @@ and then by prerequisite readiness:
    controls only when each operation has a specific native capability probe,
    bounded semantics, and readable verification where the device exposes it.
 29. Add Axis event streaming only after the existing WebSocket protocol core has
-   a concrete authenticated host, digest or short-lived session-token lifecycle,
-   and subscription supervision.
+   a concrete authenticated host using the completed Digest primitive or a
+   short-lived session token, plus subscription supervision.
 30. Add Axis snapshots and media transfer only through the camera-media lease and
    a concrete media executor.
-31. Add reusable HTTP Digest authentication before supporting Axis devices that
-   cannot expose the preferred HTTPS Basic-auth path.
-32. Enumerate Axis video sources/channels before extending PTZ beyond the current
+31. Enumerate Axis video sources/channels before extending PTZ beyond the current
    capability-probed VAPIX camera 1 boundary.
-33. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
+32. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
    only when each operation has a specific capability probe and readable state.
-34. Add Reolink snapshot, recording search/download, and playback operations only
+33. Add Reolink snapshot, recording search/download, and playback operations only
    through the existing camera-media lease and a concrete media executor.
-35. Add Reolink current-position, zoom, guard-point, or patrol controls only when
+34. Add Reolink current-position, zoom, guard-point, or patrol controls only when
    each operation has a capability-specific probe and the firmware exposes the
    native state needed to avoid invented orientation claims.
-36. Add Reolink push events only after a concrete webhook or event-stream host
+35. Add Reolink push events only after a concrete webhook or event-stream host
    and subscription lifecycle exist.
-37. Add authenticated KLAP/Tapo devices and other broader-device families only
+36. Add authenticated KLAP/Tapo devices and other broader-device families only
    after their authentication and session prerequisites are concrete.
-38. Add ONVIF PullPoint events once a concrete event host and subscription
+37. Add ONVIF PullPoint events once a concrete event host and subscription
    lifecycle exist.
-39. Add RTSP media transfer and recording once concrete media transfer and
+38. Add RTSP media transfer and recording once concrete media transfer and
    recorder host primitives exist.
-40. Add a production Matter commissioning, secure-session, and network host only
+39. Add a production Matter commissioning, secure-session, and network host only
    after certificate, fabric, Interaction Model encoding, subscription, and
    transport prerequisites exist.
-41. Add a Thread border-router host only after an actual host transport exists.
-42. Add a production Zigbee coordinator, join, and security host only after
+40. Add a Thread border-router host only after an actual host transport exists.
+41. Add a production Zigbee coordinator, join, and security host only after
    concrete coordinator transport and security primitives exist.
-43. Add production Z-Wave inclusion and S2 only after concrete host transport
+42. Add production Z-Wave inclusion and S2 only after concrete host transport
    and security primitives exist.
 
 ## End-To-End Definition


### PR DESCRIPTION
## Summary
- add a bounded reusable RFC 7616 Digest challenge and authorization package with MD5/SHA-256 session variants, qop=auth, legacy mode, and zeroizing derived values
- update the Axis VAPIX transport to probe unauthenticated, prefer advertised SHA-256 Digest, reuse nonce counts, refresh stale challenges once, and retain Basic fallback
- add exact loopback protocol coverage and update the Smart Home catalog and completion inventory

## Validation
- `sh http-digest-auth/BUILD` (5 passed)
- `sh smart-home-axis-vapix-integration/BUILD` (11 passed)
- `sh smart-home-integration-catalog/BUILD` (334 passed)
- `cargo clippy -p http-digest-auth -p smart-home-axis-vapix-integration -p smart-home-integration-catalog --all-targets -- -D warnings`
- focused `rustfmt --check` and `git diff --check`

## Boundaries
- production Axis HTTPS certificate verification remains unchanged
- authentication retries are bounded to one retry after a 401 challenge
- event streaming still requires a concrete authenticated event host and supervised subscriptions