### PR TITLE
Add Level 2 defineAgent runtime

### DIFF
--- a/code/packages/typescript/chief-of-staff-sdk/CHANGELOG.md
+++ b/code/packages/typescript/chief-of-staff-sdk/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.0] - 2026-08-03
+
+### Added
+
+- Level 2 `defineAgent` registration for one-file TypeScript agents.
+- Injected `SimpleAgentRuntime` with receive, handler, publish, acknowledge
+  ordering and fail-closed UTF-8/output validation.
+
 ## [0.1.0] - 2026-08-03
 
 ### Added

--- a/code/packages/typescript/chief-of-staff-sdk/README.md
+++ b/code/packages/typescript/chief-of-staff-sdk/README.md
@@ -5,7 +5,24 @@ Chief of Staff host. Agent code never needs filesystem, network, process,
 clock, or random-number permissions. It sends typed requests to a host over an
 injected transport, and the host enforces the sealed manifest.
 
-This first Level 3 slice implements direct encrypted-channel access:
+The SDK supports Level 2 one-file handlers and Level 3 direct encrypted-channel
+access. A Level 2 agent contains only its handler:
+
+```typescript
+import { defineAgent } from "@coding-adventures/chief-of-staff-sdk";
+
+defineAgent(async (message) => {
+  const { city } = JSON.parse(message.plaintext);
+  return `The weather in ${city} is sunny.`;
+});
+```
+
+The trusted wrapper binds that definition to a `SimpleAgentRuntime`. Each
+`runOnce()` performs receive, strict UTF-8 decoding, handler execution,
+publication, and acknowledgement in that order. Handler and publication
+failures leave the input unacknowledged for host-driven retry.
+
+Level 3 agents can operate channels directly:
 
 ```typescript
 import {
@@ -46,3 +63,5 @@ wire and `bigint` in agent code, avoiding JavaScript's 53-bit integer limit.
   content types, payloads, and protocol lines are rejected.
 - Host errors retain their numeric code and structured data without exposing
   unchecked response objects as SDK values.
+- Level 2 input must be strict UTF-8, handler output must be non-empty text,
+  and publication must succeed before acknowledgement.

--- a/code/packages/typescript/chief-of-staff-sdk/package-lock.json
+++ b/code/packages/typescript/chief-of-staff-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/chief-of-staff-sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/chief-of-staff-sdk",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.0",

--- a/code/packages/typescript/chief-of-staff-sdk/package.json
+++ b/code/packages/typescript/chief-of-staff-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/chief-of-staff-sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Capability-safe TypeScript SDK for Chief of Staff agents",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/chief-of-staff-sdk/src/index.ts
+++ b/code/packages/typescript/chief-of-staff-sdk/src/index.ts
@@ -154,6 +154,131 @@ export interface Message {
   readonly payload: Uint8Array;
 }
 
+/** UTF-8 message presented to a one-file Level 2 agent handler. */
+export interface AgentMessage extends Message {
+  /** Verified payload decoded as strict UTF-8 text. */
+  readonly plaintext: string;
+}
+
+/** The complete author-facing contract for a Level 2 one-file agent. */
+export type AgentHandler = (message: AgentMessage) => Promise<string>;
+
+/** Static channel wiring supplied by the trusted agent wrapper. */
+export interface SimpleAgentRuntimeConfig {
+  /** Channel from which the agent receives its next input. */
+  readonly inputChannelId: string;
+  /** Different one-way channel to which the agent publishes responses. */
+  readonly outputChannelId: string;
+}
+
+/** Result of polling at most one Level 2 input message. */
+export type SimpleAgentRunOutcome =
+  | { readonly status: "idle" }
+  | {
+      readonly status: "processed";
+      /** Input identity acknowledged after successful publication. */
+      readonly inputMessageId: string;
+      /** Output identity returned by the host. */
+      readonly outputMessageId: string;
+      /** Exact handler text encoded and published by the runtime. */
+      readonly response: string;
+    };
+
+/** MIME type used for Level 2 handler responses. */
+export const SIMPLE_AGENT_RESPONSE_CONTENT_TYPE = "text/plain; charset=utf-8";
+
+/**
+ * Injected receive/handler/publish/ack runtime for one-file Level 2 agents.
+ *
+ * A handler or publication failure leaves the input unacknowledged so the
+ * host can redeliver it after recovery. The runtime performs no ambient I/O.
+ */
+export class SimpleAgentRuntime {
+  private readonly inputChannelId: string;
+  private readonly outputChannelId: string;
+
+  constructor(
+    private readonly channels: ChannelClient,
+    config: SimpleAgentRuntimeConfig,
+    private readonly handler: AgentHandler,
+  ) {
+    validateIdentifier(config.inputChannelId, "inputChannelId");
+    validateIdentifier(config.outputChannelId, "outputChannelId");
+    if (config.inputChannelId === config.outputChannelId) {
+      throw new ChiefSdkError(
+        "Level 2 input and output channels must be different",
+      );
+    }
+    validateHandler(handler);
+    this.inputChannelId = config.inputChannelId;
+    this.outputChannelId = config.outputChannelId;
+  }
+
+  /** Poll and process at most one input message. */
+  async runOnce(): Promise<SimpleAgentRunOutcome> {
+    const input = await this.channels.read(this.inputChannelId);
+    if (input === null) {
+      return { status: "idle" };
+    }
+
+    let plaintext: string;
+    try {
+      plaintext = new TextDecoder("utf-8", { fatal: true }).decode(
+        input.payload,
+      );
+    } catch {
+      throw new ChiefSdkError("Level 2 input payload is not UTF-8 text");
+    }
+    const message: AgentMessage = { ...input, plaintext };
+    const response = await this.handler(message);
+    if (typeof response !== "string" || response.trim().length === 0) {
+      throw new ChiefSdkError(
+        "Level 2 agent handler must return non-empty text",
+      );
+    }
+
+    const outputMessageId = await this.channels.write(
+      this.outputChannelId,
+      new TextEncoder().encode(response),
+      SIMPLE_AGENT_RESPONSE_CONTENT_TYPE,
+    );
+    await this.channels.ack(this.inputChannelId, input.id);
+    return {
+      status: "processed",
+      inputMessageId: input.id,
+      outputMessageId,
+      response,
+    };
+  }
+}
+
+let definedAgentHandler: AgentHandler | undefined;
+
+/** Register the single handler exported by a Level 2 agent module. */
+export function defineAgent(handler: AgentHandler): void {
+  validateHandler(handler);
+  if (definedAgentHandler !== undefined) {
+    throw new ChiefSdkError("a Level 2 agent handler is already defined");
+  }
+  definedAgentHandler = handler;
+}
+
+/** Clear the registered Level 2 handler during wrapper shutdown or tests. */
+export function clearDefinedAgent(): void {
+  definedAgentHandler = undefined;
+}
+
+/** Bind the currently defined handler to trusted channel wiring. */
+export function createDefinedAgentRuntime(
+  channels: ChannelClient,
+  config: SimpleAgentRuntimeConfig,
+): SimpleAgentRuntime {
+  if (definedAgentHandler === undefined) {
+    throw new ChiefSdkError("no Level 2 agent handler has been defined");
+  }
+  return new SimpleAgentRuntime(channels, config, definedAgentHandler);
+}
+
 /** Typed Level 3 channel client over one host transport. */
 export class ChannelClient {
   constructor(private readonly transport: HostTransport) {}
@@ -302,6 +427,12 @@ function validateIdentifier(
   field: string,
 ): asserts value is string {
   validateNonEmptyString(value, field, MAX_IDENTIFIER_BYTES);
+}
+
+function validateHandler(value: unknown): asserts value is AgentHandler {
+  if (typeof value !== "function") {
+    throw new ChiefSdkError("Level 2 agent handler must be a function");
+  }
 }
 
 function validateNonEmptyString(

--- a/code/packages/typescript/chief-of-staff-sdk/tests/sdk.test.ts
+++ b/code/packages/typescript/chief-of-staff-sdk/tests/sdk.test.ts
@@ -1,14 +1,19 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  SIMPLE_AGENT_RESPONSE_CONTENT_TYPE,
   ChannelClient,
   ChiefSdkError,
   HostRpcError,
   JsonRpcLineTransport,
+  SimpleAgentRuntime,
   channel_ack,
   channel_read,
   channel_write,
+  clearDefinedAgent,
   clearHostTransport,
   configureHostTransport,
+  createDefinedAgentRuntime,
+  defineAgent,
   type HostTransport,
   type JsonLineDuplex,
 } from "../src/index.js";
@@ -46,11 +51,16 @@ class ScriptedTransport implements HostTransport {
     params: Readonly<Record<string, unknown>>,
   ): Promise<unknown> {
     this.calls.push({ method, params });
-    return this.results.shift();
+    const result = this.results.shift();
+    if (result instanceof Error) throw result;
+    return result;
   }
 }
 
-beforeEach(() => clearHostTransport());
+beforeEach(() => {
+  clearHostTransport();
+  clearDefinedAgent();
+});
 
 describe("JsonRpcLineTransport", () => {
   it("writes strict requests and returns matching results", async () => {
@@ -286,5 +296,180 @@ describe("module-level channel API", () => {
       "channel.write",
       "channel.ack",
     ]);
+  });
+});
+
+describe("Level 2 defineAgent runtime", () => {
+  const incoming = {
+    message_id: "0198-input",
+    sequence: "7",
+    timestamp_ns: "9007199254740993",
+    content_type: "application/json",
+    payload_b64: "eyJjaXR5IjoiU2VhdHRsZSJ9",
+  };
+
+  it("runs a defined one-file handler before publishing and acknowledging", async () => {
+    const handler = vi.fn(async (message) => {
+      const body = JSON.parse(message.plaintext) as { city: string };
+      expect(message.sequence).toBe(7n);
+      expect(message.contentType).toBe("application/json");
+      return `The weather in ${body.city} is sunny.`;
+    });
+    defineAgent(handler);
+    const transport = new ScriptedTransport(
+      incoming,
+      { message_id: "0198-output" },
+      null,
+    );
+    const runtime = createDefinedAgentRuntime(new ChannelClient(transport), {
+      inputChannelId: "weather-requests",
+      outputChannelId: "weather-reports",
+    });
+
+    await expect(runtime.runOnce()).resolves.toEqual({
+      status: "processed",
+      inputMessageId: "0198-input",
+      outputMessageId: "0198-output",
+      response: "The weather in Seattle is sunny.",
+    });
+    expect(handler).toHaveBeenCalledOnce();
+    expect(transport.calls.map((call) => call.method)).toEqual([
+      "channel.read",
+      "channel.write",
+      "channel.ack",
+    ]);
+    expect(transport.calls[1]!.params).toEqual({
+      channel_id: "weather-reports",
+      payload_b64: "VGhlIHdlYXRoZXIgaW4gU2VhdHRsZSBpcyBzdW5ueS4=",
+      content_type: SIMPLE_AGENT_RESPONSE_CONTENT_TYPE,
+    });
+  });
+
+  it("returns idle without invoking the handler or output channel", async () => {
+    const handler = vi.fn(async () => "unused");
+    const runtime = new SimpleAgentRuntime(
+      new ChannelClient(new ScriptedTransport(null)),
+      { inputChannelId: "in", outputChannelId: "out" },
+      handler,
+    );
+
+    await expect(runtime.runOnce()).resolves.toEqual({ status: "idle" });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("leaves input unacknowledged when handler or publication fails", async () => {
+    const handlerFailure = new ScriptedTransport(incoming);
+    const throwingRuntime = new SimpleAgentRuntime(
+      new ChannelClient(handlerFailure),
+      { inputChannelId: "in", outputChannelId: "out" },
+      async () => {
+        throw new Error("handler failed");
+      },
+    );
+    await expect(throwingRuntime.runOnce()).rejects.toThrow("handler failed");
+    expect(handlerFailure.calls.map((call) => call.method)).toEqual([
+      "channel.read",
+    ]);
+
+    const publishFailure = new ScriptedTransport(
+      incoming,
+      new HostRpcError(-32001, "CapabilityDenied"),
+    );
+    const publishingRuntime = new SimpleAgentRuntime(
+      new ChannelClient(publishFailure),
+      { inputChannelId: "in", outputChannelId: "out" },
+      async () => "response",
+    );
+    await expect(publishingRuntime.runOnce()).rejects.toThrow(
+      "CapabilityDenied",
+    );
+    expect(publishFailure.calls.map((call) => call.method)).toEqual([
+      "channel.read",
+      "channel.write",
+    ]);
+  });
+
+  it("rejects non-UTF-8 input and empty or non-string handler output", async () => {
+    const nonUtf8 = { ...incoming, payload_b64: "/w==" };
+    const invalidInputRuntime = new SimpleAgentRuntime(
+      new ChannelClient(new ScriptedTransport(nonUtf8)),
+      { inputChannelId: "in", outputChannelId: "out" },
+      async () => "unused",
+    );
+    await expect(invalidInputRuntime.runOnce()).rejects.toThrow("UTF-8");
+
+    for (const response of ["   ", 42] as unknown[]) {
+      const transport = new ScriptedTransport(incoming);
+      const runtime = new SimpleAgentRuntime(
+        new ChannelClient(transport),
+        { inputChannelId: "in", outputChannelId: "out" },
+        async () => response as string,
+      );
+      await expect(runtime.runOnce()).rejects.toThrow("non-empty text");
+      expect(transport.calls.map((call) => call.method)).toEqual([
+        "channel.read",
+      ]);
+    }
+  });
+
+  it("preserves an acknowledgement failure after publication", async () => {
+    const transport = new ScriptedTransport(
+      incoming,
+      { message_id: "output" },
+      new HostRpcError(-32603, "ack failed"),
+    );
+    const runtime = new SimpleAgentRuntime(
+      new ChannelClient(transport),
+      { inputChannelId: "in", outputChannelId: "out" },
+      async () => "response",
+    );
+
+    await expect(runtime.runOnce()).rejects.toThrow("ack failed");
+    expect(transport.calls.map((call) => call.method)).toEqual([
+      "channel.read",
+      "channel.write",
+      "channel.ack",
+    ]);
+  });
+
+  it("validates registration and static one-way channel wiring", () => {
+    expect(() =>
+      createDefinedAgentRuntime(new ChannelClient(new ScriptedTransport()), {
+        inputChannelId: "in",
+        outputChannelId: "out",
+      }),
+    ).toThrow("no Level 2");
+    expect(() => defineAgent(null as unknown as () => Promise<string>)).toThrow(
+      "function",
+    );
+    expect(
+      () =>
+        new SimpleAgentRuntime(
+          new ChannelClient(new ScriptedTransport()),
+          { inputChannelId: "same", outputChannelId: "same" },
+          async () => "response",
+        ),
+    ).toThrow("different");
+    expect(
+      () =>
+        new SimpleAgentRuntime(
+          new ChannelClient(new ScriptedTransport()),
+          { inputChannelId: "", outputChannelId: "out" },
+          async () => "response",
+        ),
+    ).toThrow("inputChannelId");
+  });
+
+  it("allows exactly one handler definition per wrapper process", async () => {
+    defineAgent(async () => "first");
+    const first = createDefinedAgentRuntime(
+      new ChannelClient(
+        new ScriptedTransport(incoming, { message_id: "one" }, null),
+      ),
+      { inputChannelId: "in", outputChannelId: "out" },
+    );
+
+    await expect(first.runOnce()).resolves.toMatchObject({ response: "first" });
+    expect(() => defineAgent(async () => "second")).toThrow("already defined");
   });
 });


### PR DESCRIPTION
## Summary

- add the `defineAgent(handler)` contract for one-file TypeScript agents
- add an injected `SimpleAgentRuntime` with receive → strict UTF-8 handler → publish → acknowledge ordering
- fail closed on invalid wiring, malformed text, empty output, handler failures, and channel failures without granting ambient OS authority

## Validation

- `npm run build`
- `npm run test:coverage` (31 tests; 95.83% lines, 100% functions)
- repository build planner: 1 changed / 1 affected package
- repository affected-package build gate: 1 built / 722 skipped

Part of #139.
Part of #128.