### PR TITLE
Add JFET RD parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `RD` drain resistance.
 - Validate and lower JFET model-card `GDSNOI` channel-noise coefficient.
 - Validate and lower JFET model-card `NLEV` noise equation level.
 - Validate and lower JFET model-card `EG` energy gap.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1344,6 +1344,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Eg=model.params.get("EG", 1.11),
             Nlev=model.params.get("NLEV", 1.0),
             Gdsnoi=model.params.get("GDSNOI", 1.0),
+            Rd=model.params.get("RD", 0.0),
         )
     if prefix == "M":
         _require_min_fields(fields, 6, "MOSFET")
@@ -2134,6 +2135,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or channel_noise_coefficient < 0.0
         ):
             raise NetlistParseError("JFET GDSNOI must be finite and non-negative")
+        drain_resistance = params.get("RD")
+        if drain_resistance is not None and (
+            not math.isfinite(drain_resistance) or drain_resistance < 0.0
+        ):
+            raise NetlistParseError("JFET RD must be finite and non-negative")
     if kind in {"NMOS", "PMOS"}:
         if "LEVEL" in params:
             level = params["LEVEL"]

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1569,6 +1569,28 @@ def test_rejects_invalid_jfet_channel_noise_coefficient(value: str) -> None:
         parse_netlist(f".model fast NJF(GDSNOI={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("12.5", 12.5)])
+def test_parse_jfet_drain_resistance(value: str, expected: float) -> None:
+    parsed = parse_netlist(
+        f"""
+.model fast NJF(RD={value})
+J1 drain gate source fast
+"""
+    )
+
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert jfet.Rd == expected
+
+
+@pytest.mark.parametrize("value", ["-0.1", "1e999"])
+def test_rejects_invalid_jfet_drain_resistance(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="JFET RD must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NJF(RD={value})")
+
+
 def test_parse_pjf_model_aliases_beta() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `RD` drain resistance.
 - Validate and lower JFET model-card `GDSNOI` channel-noise coefficient.
 - Validate and lower JFET model-card `NLEV` noise equation level.
 - Validate and lower JFET model-card `EG` energy gap.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1424,6 +1424,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("JFET GDSNOI must be finite and non-negative");
   }
+  const jfetDrainResistance = params.get("RD");
+  if (
+    (kind === "NJF" || kind === "PJF") &&
+    jfetDrainResistance !== undefined &&
+    (!Number.isFinite(jfetDrainResistance) || jfetDrainResistance < 0.0)
+  ) {
+    throw new NetlistParseError("JFET RD must be finite and non-negative");
+  }
   const level = params.get("LEVEL");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -2021,6 +2029,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       1.0,
       model.params.get("NLEV") ?? 1.0,
       model.params.get("GDSNOI") ?? 1.0,
+      model.params.get("RD") ?? 0.0,
     );
   }
   if (prefix === "M") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1608,6 +1608,30 @@ J1 drain gate source fast
     },
   );
 
+  it.each([
+    ["0", 0.0],
+    ["12.5", 12.5],
+  ])("parses JFET drain resistance %s", (value, expected) => {
+    const parsed = parseNetlist(`
+.model fast NJF(RD=${value})
+J1 drain gate source fast
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      drainResistance: expected,
+    });
+  });
+
+  it.each(["-0.1", "1e999"])(
+    "rejects invalid JFET drain resistance %s",
+    (value) => {
+      expect(() => parseNetlist(`.model fast NJF(RD=${value})`)).toThrow(
+        "JFET RD must be finite and non-negative",
+      );
+    },
+  );
+
   it("parses PJF model beta aliases", () => {
     const parsed = parseNetlist(`
 .model pslow PJF(B=750u)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4487,9 +4487,14 @@ the Rust, Python, and TypeScript surfaces together.
      equal to 1 and lower it into the shared engine noise-equation-level field.
 
 433. Python and TypeScript Berkeley SPICE JFET channel-noise parity.
-   - Status: implemented in this JFET channel-noise parity slice.
+   - Status: completed in PR 9857.
    - Both parser facades validate finite, non-negative `GDSNOI` values and
      lower them into the shared engine channel-noise-coefficient field.
+
+434. Python and TypeScript Berkeley SPICE JFET drain-resistance parity.
+   - Status: implemented in this JFET drain-resistance parity slice.
+   - Both parser facades validate finite, non-negative `RD` values and lower
+     them into the shared engine intrinsic-drain-resistance field.
 
 ## Backlog
 
@@ -4498,7 +4503,7 @@ the Rust, Python, and TypeScript surfaces together.
      currently use `B` as a legacy beta alias, while the engine model uses `B`
      for Parker-Skellern doping-tail shaping. Do not assign one card value to
      both fields silently.
-   - Continue the unambiguous audited JFET gaps with `RD`, `RS`,
+   - Continue the unambiguous audited JFET gaps with `RS`,
      `TCV`, `VTOTC`, `TNOM` / `T_NOM`, `BEX`, and `BETATCE`.
    - Continue the audited BJT model-card gaps after the smaller JFET fields;
      prioritize direct engine fields before adding new model surfaces.


### PR DESCRIPTION
## Summary
- validate JFET `RD` as finite and non-negative in Python and TypeScript
- lower `RD` into the shared engine intrinsic drain-resistance field
- advance the SPICE implementation plan while preserving the explicit `B` alias-policy gap

## Verification
- Python `spice-netlist-parser`: `bash BUILD && .venv/bin/ruff check .` (394 passed)
- TypeScript `spice-netlist-parser`: `bash BUILD` (379 passed)
- TypeScript `spice-netlist-parser`: `npx vitest run --coverage` (86.77% lines)
- TypeScript `spice-engine`: `bash BUILD` (448 passed)