### PR TITLE
fix(human-languages): clean Arabic book warnings

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -99,9 +99,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B25 | Complete (#9828) | Remove Kannada's LaTeX layout, duplicate-label, bookmark, and font warnings. | The forced 96-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings. |
 | HL-B26 | Complete (#9838) | Publish Malayalam Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | Thirty-three schema-v2 lessons now generate twenty-six chapters whose source hashes are independently verified against the Language Ladder corpus. |
 | HL-B27 | Complete (#9844) | Remove Malayalam's LaTeX layout, duplicate-label, bookmark, font, and header-only-verso warnings. | The forced 107-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; intentionally empty versos are truly empty. |
-| HL-B28 | Complete in this PR | Publish Arabic Chapters 3–27 and their writing companions from canonical lessons rather than hand-copying another twenty-five book chapters. | Forty-five schema-v2 lessons now generate twenty-five chapters whose source hashes are independently verified against the Language Ladder corpus. |
-| HL-B29 | Next | Remove Arabic's LaTeX layout, duplicate-label, bookmark, font, and header-only-verso warnings. | The expanded 104-page build has zero missing glyphs but reports five overfull boxes, ten underfull vertical boxes, one duplicate practice label, 77 Hyperref warnings, two LaTeX warnings, and six font warnings; the clean-build signal is zero of each and intentionally empty versos have no running header. |
-| HL-B30 | Queued | Publish Hindi Chapters 6–33 and its writing companions from canonical lessons rather than hand-copying another twenty-eight book chapters. | The Hindi PDF stops after Chapter 5 while canonical app content continues through Chapter 33 and eleven dependency-ordered writing lessons; schema-v2 migration plus generation should close that drift safely. |
+| HL-B28 | Complete (#9854) | Publish Arabic Chapters 3–27 and their writing companions from canonical lessons rather than hand-copying another twenty-five book chapters. | Forty-five schema-v2 lessons now generate twenty-five chapters whose source hashes are independently verified against the Language Ladder corpus. |
+| HL-B29 | Complete in this PR | Remove Arabic's LaTeX layout, duplicate-label, bookmark, font, and header-only-verso warnings. | The forced 104-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; intentionally empty versos are truly empty. |
+| HL-B30 | Next | Publish Hindi Chapters 6–33 and its writing companions from canonical lessons rather than hand-copying another twenty-eight book chapters. | The Hindi PDF stops after Chapter 5 while canonical app content continues through Chapter 33 and eleven dependency-ordered writing lessons; schema-v2 migration plus generation should close that drift safely. |
 | HL-B31 | Queued | Remove Hindi's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports two overfull boxes, five underfull boxes, three duplicate practice labels, 29 Hyperref warnings, undefined bold/italic Devanagari font shapes, and a visibly colliding final-page running header; the clean-build signal is zero of each. |
 | HL-B32 | Queued | Publish Tamil Chapters 6–31 and its writing companions from canonical lessons rather than hand-copying another twenty-six book chapters. | The Tamil PDF stops after Chapter 5 while canonical app content continues through Chapter 31 and eight dependency-ordered writing lessons; schema-v2 migration plus generation should close that drift safely. |
 | HL-B33 | Queued | Remove Tamil's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports six overfull boxes, six underfull boxes, four duplicate practice labels, 27 Hyperref warnings, and undefined bold/italic Tamil font shapes; the clean-build signal is zero of each. |
@@ -890,8 +890,28 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - The corpus report remains at zero duration violations and zero unknown
   prerequisites across 1,066 lessons. It now reports 104 lesson chapters without
   book chapters, 25 fewer than before this migration.
-- HL-B29 is next: make the complete Arabic artifact warning-free before
-  starting Hindi's larger canonical-book migration in HL-B30.
+- HL-B29 follows by making the complete Arabic artifact warning-free before
+  Hindi's larger canonical-book migration in HL-B30.
+
+## Findings from HL-B29
+
+- Explicit static bold and italic faces now cover Arabic and Hebrew, while
+  bookmark-safe Unicode commands preserve readable outlines without asking
+  Hyperref to interpret font switches.
+- The two handwritten recap labels are unique. A small emergency line-break
+  reserve removes all five horizontal overflows without dropping or weakening
+  teaching content.
+- Intentionally short micro-lessons use natural page bottoms, and open-right
+  chapter breaks now insert genuinely empty versos with no running header or
+  page number.
+- A forced XeLaTeX build produces 104 pages with zero missing glyphs, overfull
+  or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX
+  warnings, or font warnings. All 104 rendered pages were inspected again.
+- The correct title and author metadata, 29 top-level and 90 total outline
+  entries, generated source hashes, and zero schema or generator leaks remain
+  intact.
+- HL-B30 is next: publish Hindi Chapters 6–33 and the dependency-ordered
+  writing companions from the canonical app corpus.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/arabic/CHANGELOG.md
+++ b/code/learning/human-languages/arabic/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Warning-free complete book (2026-08-03)
+
+- Added explicit static bold and italic faces for Arabic and Hebrew, plus
+  bookmark-safe Unicode commands, eliminating all font-shape and Hyperref
+  warnings without dropping multilingual examples.
+- Made the two handwritten recap labels unique and added a small emergency
+  line-break reserve, removing every horizontal overflow while preserving the
+  canonical teaching sequence.
+- Added natural page bottoms for deliberately short micro-lessons and made
+  open-right chapter versos truly empty, without a running header or page
+  number.
+- The forced 104-page build now has zero missing glyphs, overfull or underfull
+  boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font
+  warnings. All 104 pages were rendered and visually inspected.
+- The 29 top-level and 90 total outline entries, title and author metadata,
+  generated source hashes, and zero schema or generator leaks remain intact.
+
 ## Canonical Chapters 3–27 in the book (2026-08-03)
 
 - Migrated all forty-five Arabic lessons in Chapters 3–27, including six

--- a/code/learning/human-languages/arabic/README.md
+++ b/code/learning/human-languages/arabic/README.md
@@ -67,6 +67,11 @@ Sans Hebrew fonts (`../../_fonts/`), loaded by relative path — so Arabic scrip
 and Semitic comparisons build identically locally and in CI, with no system-font
 dependency. `latexmk -xelatex book.tex`.
 
+The complete 104-page artifact builds with zero missing glyphs, layout,
+duplicate-destination, bookmark, LaTeX, or font-shape warnings. Open-right blank
+versos are intentionally retained for print and contain no running header or
+page number.
+
 ## Files
 
 - [`lessons/`](./lessons/) · [`pronunciation-reference.md`](./pronunciation-reference.md)

--- a/code/learning/human-languages/arabic/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/arabic/book/chapters/ch01-greetings.tex
@@ -189,7 +189,7 @@ nothing.''
 \end{cousinweb}
 
 \section{The day of greetings}
-\label{lesson:practice}
+\label{lesson:ar-c01-practice}
 
 \begin{center}
 \begin{tabular}{@{}lll@{}}

--- a/code/learning/human-languages/arabic/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/arabic/book/chapters/ch02-introductions.tex
@@ -133,7 +133,7 @@ option is \ar{فرصة سعيدة} (\emph{fur\d{s}a sa`\=\i da}, ``a happy occas
 \end{cousinweb}
 
 \section{The whole exchange}
-\label{lesson:practice}
+\label{lesson:ar-c02-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/arabic/book/preamble.tex
+++ b/code/learning/human-languages/arabic/book/preamble.tex
@@ -34,9 +34,23 @@
 \setmainlanguage{english}
 \setotherlanguage{arabic}
 
-% Vendored Arabic font (static instance; ../../_fonts/ from <lang>/book/).
-\newfontfamily\arabicfont[Path=../../_fonts/, Script=Arabic]{NotoNaskhArabic-Static.ttf}
-\newfontfamily\hebrewfont[Path=../../_fonts/, Script=Hebrew]{NotoSansHebrew-Static.ttf}
+% Vendored static script fonts. Explicitly map every requested shape to the
+% same complete glyph file so bold or italic teaching context cannot fall back
+% to a system font or emit a substitution warning.
+\newfontfamily\arabicfont[
+  Path=../../_fonts/,
+  Script=Arabic,
+  BoldFont=NotoNaskhArabic-Static.ttf,
+  ItalicFont=NotoNaskhArabic-Static.ttf,
+  BoldItalicFont=NotoNaskhArabic-Static.ttf
+]{NotoNaskhArabic-Static.ttf}
+\newfontfamily\hebrewfont[
+  Path=../../_fonts/,
+  Script=Hebrew,
+  BoldFont=NotoSansHebrew-Static.ttf,
+  ItalicFont=NotoSansHebrew-Static.ttf,
+  BoldItalicFont=NotoSansHebrew-Static.ttf
+]{NotoSansHebrew-Static.ttf}
 
 \hypersetup{
   pdftitle={Arabic, Step by Step, Root by Root},
@@ -48,6 +62,33 @@
 % Convenience: inline Arabic snippet (RTL, Arabic font) within English text.
 \newcommand{\ar}[1]{\textarabic{#1}}
 \newcommand{\he}[1]{{\hebrewfont #1}}
+\pdfstringdefDisableCommands{%
+  \def\ar#1{#1}% Keep script text while dropping font-only presentation.
+  \def\he#1{#1}%
+  \def\arabicfont{}%
+  \def\hebrewfont{}%
+}
+
+% Micro-lessons intentionally end at natural pause points instead of stretching
+% their callout boxes to force every page to the same depth. The small reserve
+% also lets prose choose a cleaner line break before it exceeds the measure.
+\raggedbottom
+\emergencystretch=2em
+
+% Polyglossia's bidi support can leave running heads on the blank verso that
+% book.cls inserts before an open-right chapter. Keep the print-friendly verso,
+% but make it truly empty.
+\makeatletter
+\renewcommand{\cleardoublepage}{%
+  \clearpage
+  \if@twoside
+    \ifodd\c@page\else
+      \hbox{}\thispagestyle{empty}\newpage
+      \if@twocolumn\hbox{}\newpage\fi
+    \fi
+  \fi
+}
+\makeatother
 
 % Cousin/Root box: the root family + connections.
 \newtcolorbox{cousinweb}{


### PR DESCRIPTION
## Summary
- declare deterministic bold and italic shapes for vendored Arabic and Hebrew fonts
- keep script text in PDF bookmarks while removing font-only commands from Hyperref strings
- make handwritten recap labels unique and let short micro-lessons end naturally
- preserve open-right print layout with genuinely blank versos
- advance the human-languages backlog to Hindi's canonical-book migration

## Validation
- forced Arabic XeLaTeX build: 104 pages; zero missing glyphs, overfull/underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings
- PDF structure: correct title/author; 29 top-level / 90 total outline entries; zero schema/generator leaks; all 104 pages visually inspected
- human-language data: 84/84 tests; generation check; 0 duration violations; 0 unknown prerequisites
- Language Ladder: 436/436 tests; production build
- unified publication: 20 PDFs and 20 catalog entries; bundled Arabic PDF byte-identical to the validated book
- git diff --check