### PR TITLE
feat(semantic-ir-to-c): string interpolation ("a#{x}b")

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.36.4 — string interpolation (`"a#{x}b"`)
+
+Filed as its own backlog item ("C backend: support string interpolation").
+The Ruby frontend already lowers `"a#{x}b"` to `Expr::StrConcat { parts }`
+for every backend (Python/TypeScript already had real emit arms; Go/JS/Rust
+reject it with a deferred-node message); the C backend rejected
+`Feature::StringInterpolation` outright — no emitter arm existed at all.
+
+New runtime helper `_sir_display_str(SirValue) -> char*` (plus
+`_sir_display_seq`/`_sir_display_map`/`_sir_display_pair`/
+`_sir_display_float`) renders a value Ruby's `to_s` way into a fresh
+string — a STRING-RETURNING PARALLEL to the existing `puts`/`print`
+`FILE*`-writing `_sir_fmt` family, not a refactor of it, so that
+already-tested path is completely untouched (the two are kept in
+lockstep by inspection: same tag list, same per-tag text, same recursion
+structure and depth cap, so `#{arr}` and `puts arr` always agree).
+
+`Expr::StrConcat`'s emitter arm folds each part through
+`_sir_display_str` and pairwise through `_sir_cat` (which takes exactly
+two operands) into one `_sir_str(...)` — `emit_str_concat` for the
+simple-operand case (inline, mirroring `SeqLit`'s simple path) and
+`emit_str_concat_names` for the compound-operand case (over
+`hoist_operands`-hoisted temps, mirroring `SeqLit`'s hoisted path).
+`Feature::StringInterpolation` added to `ACCEPTED_FEATURES`.
+
+`semantic-ir-to-c` 0.36.3 -> 0.36.4.
+
 ## 0.36.2 — fix: `<<` builtin name collided between C's bitwise shift and Ruby's operator
 
 `variadic_helper`'s `"<<" => "_sir_shift_left"` entry (added when Ruby's

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.36.2"
+version = "0.36.4"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -940,6 +940,21 @@ fn emit_assign(out: &mut String, dst: &str, e: &Expr, indent: usize) {
                 let _ = writeln!(out, "{pad}{dst} = _sir_convert({dst}, {bits}, {signed});");
             }
         }
+        // SIR18 string interpolation with a compound part: hoist parts into
+        // temps (preserving left-to-right evaluation order, matching every
+        // other compound-operand form here), then fold them via
+        // `emit_str_concat_names`.
+        Expr::StrConcat { parts, .. } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let ops: Vec<&Expr> = parts.iter().collect();
+            let names = hoist_operands(out, &ops, inner);
+            let _ = write!(out, "{ipad}{dst} = ");
+            emit_str_concat_names(out, &names);
+            out.push_str(";\n");
+            let _ = writeln!(out, "{pad}}}");
+        }
         // SIR16 sequences with a compound operand: hoist operands into temps
         // (preserving left-to-right order), then build/read the sequence.
         Expr::SeqLit { items, .. } => {
@@ -1303,6 +1318,10 @@ fn is_simple(e: &Expr) -> bool {
             .iter()
             .all(|e| is_simple(&e.key) && is_simple(&e.value)),
         Expr::MapGet { map, key, .. } => is_simple(map) && is_simple(key),
+        // SIR18 string interpolation: a `_sir_str(_sir_cat(...))` fold is
+        // simple iff every part is (they render inline as fold operands);
+        // otherwise `emit_assign` hoists them, mirroring `SeqLit`.
+        Expr::StrConcat { parts, .. } => parts.iter().all(is_simple),
         // SIR16+ nodes / Intrinsic are not accepted in v0 → unreachable after
         // the capability check.  Treat as non-simple defensively.
         _ => false,
@@ -1407,8 +1426,66 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             emit_expr(out, key, indent);
             out.push(')');
         }
+        // SIR18 string interpolation (simple-operand form; a compound part is
+        // hoisted by `emit_assign` via `emit_str_concat_names`).
+        Expr::StrConcat { parts, .. } => emit_str_concat(out, parts, indent),
         other => unreachable!("emit_expr on compound/unsupported node: {other:?}"),
     }
+}
+
+/// SIR18 string interpolation (`"a#{x}b"` -> `Expr::StrConcat { parts }`).
+/// Each part renders through `_sir_display_str` (Ruby's `to_s`-style
+/// display, a string-returning parallel to the `puts`/`print` FILE*-writing
+/// `_sir_fmt` — see the runtime) and the results fold pairwise through
+/// `_sir_cat` (which takes exactly two operands) into one `_sir_str(...)`.
+/// An empty `parts` (`""` with no literal segments — the frontend does not
+/// emit this today, but nothing prevents a hand-built module from it) folds
+/// to the empty string rather than reaching the loop with nothing to fold.
+fn emit_str_concat(out: &mut String, parts: &[Expr], indent: usize) {
+    out.push_str("_sir_str(");
+    if parts.is_empty() {
+        out.push_str("\"\"");
+    } else {
+        for _ in 1..parts.len() {
+            out.push_str("_sir_cat(");
+        }
+        for (i, p) in parts.iter().enumerate() {
+            out.push_str("_sir_display_str(");
+            emit_expr(out, p, indent);
+            out.push(')');
+            if i > 0 {
+                out.push(')');
+            }
+            if i + 1 < parts.len() {
+                out.push_str(", ");
+            }
+        }
+    }
+    out.push(')');
+}
+
+/// Same fold as [`emit_str_concat`], but over already-hoisted temp names —
+/// `emit_assign`'s compound-operand path (mirroring how `SeqLit`/`MapLit`
+/// hoist their own compound operands via `hoist_operands`).
+fn emit_str_concat_names(out: &mut String, names: &[String]) {
+    out.push_str("_sir_str(");
+    if names.is_empty() {
+        out.push_str("\"\"");
+    } else {
+        for _ in 1..names.len() {
+            out.push_str("_sir_cat(");
+        }
+        for (i, n) in names.iter().enumerate() {
+            let _ = write!(out, "_sir_display_str({n})");
+            if i > 0 {
+                out.push(')');
+            }
+            if i + 1 < names.len() {
+                out.push_str(", ");
+            }
+        }
+    }
+    out.push(')');
 }
 
 /// SIR26 integer conversion → the portable `_sir_convert(v, bits, signed)`

--- a/code/packages/rust/semantic-ir-to-c/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/lib.rs
@@ -191,6 +191,13 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // CLASS-method resolution.  Names are quoted C string literals (no injection).
     // This completes the C backend's OOP surface (full 6-backend OOP parity).
     Feature::Modules,
+    // `Feature::StringInterpolation` — `"a#{x}b"` lowers to `Expr::StrConcat
+    // { parts }` (the frontend already does this for every backend). Each
+    // part renders through the new `_sir_display_str` runtime helper (a
+    // string-returning parallel to the existing `puts`/`print` FILE*-writing
+    // `_sir_fmt`, not a refactor of it — so that already-tested path is
+    // untouched) and the results are concatenated with `_sir_cat`.
+    Feature::StringInterpolation,
 ];
 
 impl Backend for CBackend {

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -966,6 +966,111 @@ void _sir_fmt(FILE *out, SirValue v) {
     _sir_fmt_depth--;
 }
 
+/* ---- SIR18 string interpolation: value display AS A STRING -- */
+
+/* `"a#{x}b"` needs each part's Ruby `to_s`-style display rendered into a
+ * fresh string to concatenate, not written to a `FILE*` — so this is a
+ * SEPARATE function from `_sir_fmt` above, not a refactor of it: `_sir_fmt`
+ * backs the already-tested `puts`/`print` path, and duplicating its per-tag
+ * rendering here (into `_sir_cat`-built strings instead of `fputs` calls)
+ * keeps that path completely untouched. The two are kept in lockstep by
+ * inspection — same tag list, same per-tag text, same recursion structure —
+ * so `#{arr}` and `puts arr` always agree. */
+char *_sir_display_str(SirValue v);
+
+char *_sir_display_seq(SirValue v) {
+    char *acc = _sir_dup("[");
+    int64_t i;
+    for (i = 0; i < v.as.seq->len; i++) {
+        if (i) acc = _sir_cat(acc, ", ");
+        acc = _sir_cat(acc, _sir_display_str(v.as.seq->items[i]));
+    }
+    return _sir_cat(acc, "]");
+}
+
+char *_sir_display_map(SirValue v) {
+    char *acc = _sir_dup("{");
+    int64_t i;
+    for (i = 0; i < v.as.map->len; i++) {
+        if (i) acc = _sir_cat(acc, ", ");
+        acc = _sir_cat(acc, _sir_display_str(v.as.map->entries[i].key));
+        acc = _sir_cat(acc, ": ");
+        acc = _sir_cat(acc, _sir_display_str(v.as.map->entries[i].val));
+    }
+    return _sir_cat(acc, "}");
+}
+
+char *_sir_display_float(double f) {
+    char buf[64];
+    if (f != f)                    return _sir_dup("NaN");
+    if (f == f * 0.5 && f != 0.0)  return _sir_dup(f < 0 ? "-Infinity" : "Infinity");
+    snprintf(buf, sizeof(buf), "%.17g", f);
+    if (!strchr(buf, '.') && !strchr(buf, 'e') && !strchr(buf, 'E') &&
+        !strchr(buf, 'n') && !strchr(buf, 'N')) {
+        size_t L = strlen(buf);
+        if (L + 2 < sizeof(buf)) { buf[L] = '.'; buf[L + 1] = '0'; buf[L + 2] = '\0'; }
+    }
+    return _sir_dup(buf);
+}
+
+char *_sir_display_pair(SirValue v) {
+    SirValue cur = v;
+    char *acc = _sir_dup("(");
+    int first = 1;
+    for (;;) {
+        if (cur.tag == SIR_PAIR) {
+            if (!first) acc = _sir_cat(acc, " ");
+            first = 0;
+            acc = _sir_cat(acc, _sir_display_str(cur.as.pair->car));
+            cur = cur.as.pair->cdr;
+        } else if (cur.tag == SIR_NIL) {
+            break;
+        } else {
+            acc = _sir_cat(acc, " . ");
+            acc = _sir_cat(acc, _sir_display_str(cur));
+            break;
+        }
+    }
+    return _sir_cat(acc, ")");
+}
+
+/* Bounded exactly like `_sir_fmt_depth`/`SIR_MAX_FMT_DEPTH` above — a
+ * self-referential sequence/map (constructible via `SeqSet`/`MapSet`) would
+ * otherwise recurse forever. */
+#define SIR_MAX_DISPLAY_DEPTH 500
+static int _sir_display_depth = 0;
+
+char *_sir_display_str(SirValue v) {
+    char buf[32];
+    char *result;
+    if (_sir_display_depth > SIR_MAX_DISPLAY_DEPTH) return _sir_dup("[...]");
+    _sir_display_depth++;
+    switch (v.tag) {
+        case SIR_NIL:   result = _sir_dup(SIR_DISPLAY_RUBY ? "" : "nil"); break;
+        case SIR_BOOL:  result = _sir_dup(v.as.b ? (SIR_DISPLAY_RUBY ? "true" : "#t")
+                                                  : (SIR_DISPLAY_RUBY ? "false" : "#f")); break;
+        case SIR_INT:   snprintf(buf, sizeof(buf), "%lld", (long long)v.as.i); result = _sir_dup(buf); break;
+        case SIR_FLOAT: result = _sir_display_float(v.as.f); break;
+        case SIR_STR:   result = _sir_dup(v.as.s); break;
+        case SIR_SYM:   result = _sir_dup(v.as.s); break;
+        case SIR_PAIR:  result = _sir_display_pair(v); break;
+        case SIR_SEQ:   result = _sir_display_seq(v); break;
+        case SIR_MAP:   result = _sir_display_map(v); break;
+        case SIR_CLOSURE: result = _sir_dup("#<closure>"); break;
+        case SIR_ERROR:
+            result = (v.as.err->msg.tag == SIR_NIL)
+                ? _sir_dup(v.as.err->sir_class)
+                : _sir_display_str(v.as.err->msg);
+            break;
+        case SIR_INSTANCE:
+            result = _sir_cat(_sir_cat("#<", v.as.inst->sir_class), ">");
+            break;
+        default: result = _sir_dup("");
+    }
+    _sir_display_depth--;
+    return result;
+}
+
 /* ---- SIR17 exceptions (setjmp/longjmp handler stack) -------- */
 
 /* Construct an exception value.  `class` is interned; `msg` is a `SIR_STR` (or

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_string_interpolation.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_string_interpolation.rs
@@ -1,0 +1,124 @@
+//! Execution proof for SIR18 string interpolation (`"a#{x}b"`) on the C
+//! backend — lower REAL Ruby source, emit C, compile with a real cc, run,
+//! assert stdout. Skips gracefully when no `cc` is present.
+//!
+//! The Ruby frontend already lowers `"a#{x}b"` to `Expr::StrConcat { parts }`
+//! for every backend (Python/TypeScript already emit it); the C backend
+//! rejected `Feature::StringInterpolation` outright until this PR. Each part
+//! renders through a new `_sir_display_str` runtime helper (Ruby's `to_s`
+//! style — a string-returning parallel to the `puts`/`print` FILE*-writing
+//! `_sir_fmt`) and the parts concatenate with `_sir_cat`.
+
+use std::process::Command;
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    ["cc", "clang", "gcc"]
+        .iter()
+        .find(|c| {
+            Command::new(c)
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        })
+        .map(|s| s.to_string())
+}
+
+fn run_ruby(src: &str) -> Option<String> {
+    let cc = find_cc()?;
+    let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
+    let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
+    let dir = std::env::temp_dir();
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    src.hash(&mut hasher);
+    let stem = format!("sirc_interp_{}_{}", std::process::id(), hasher.finish());
+    let cpath = dir.join(format!("{stem}.c"));
+    let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::write(&cpath, &art.source).expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .arg("-lm")
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        art.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "program exited non-zero");
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn interpolates_a_local_variable() {
+    match run_ruby("x = 5\nputs \"value is #{x}\"\n") {
+        Some(out) => assert_eq!(out, "value is 5\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn interpolates_an_expression() {
+    match run_ruby("x = 5\nputs \"next is #{x + 1}\"\n") {
+        Some(out) => assert_eq!(out, "next is 6\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn interpolates_multiple_segments_in_order() {
+    match run_ruby("a = 1\nb = 2\nputs \"#{a} + #{b} = #{a + b}\"\n") {
+        Some(out) => assert_eq!(out, "1 + 2 = 3\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn interpolates_a_string_value_without_extra_quoting() {
+    match run_ruby("name = \"world\"\nputs \"hello #{name}\"\n") {
+        Some(out) => assert_eq!(out, "hello world\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn interpolates_an_array_value() {
+    match run_ruby("a = [1, 2, 3]\nputs \"list: #{a}\"\n") {
+        Some(out) => assert_eq!(out, "list: [1, 2, 3]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn interpolates_a_nil_value() {
+    // Matches this backend's existing `puts nil` -> "nil" convention (see
+    // e.g. compile_and_run_index_bracket.rs) -- `_sir_display_str` and
+    // `_sir_fmt` render SIR_NIL identically.
+    match run_ruby("x = nil\nputs \"got [#{x}]\"\n") {
+        Some(out) => assert_eq!(out, "got [nil]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn interpolation_inside_a_method_body_uses_a_parameter() {
+    // A compound part (a method call through __method__) reaches the hoisted
+    // emit_assign path, not just the simple emit_expr path.
+    match run_ruby(
+        "class Greeter\n  def hello(name)\n    \"hi #{name}!\"\n  end\nend\n\
+         puts Greeter.new.hello(\"Ada\")\n",
+    ) {
+        Some(out) => assert_eq!(out, "hi Ada!\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}

--- a/code/specs/SIR24-semantic-ir-to-c.md
+++ b/code/specs/SIR24-semantic-ir-to-c.md
@@ -400,6 +400,14 @@ lockstep:
    giving full 6-backend OOP parity.
 7. **Optional / later** — `Bignum`; SIR21 sized-integer native lowering
    (`int64_t`/`uint32_t` from `IntSpec`); `Range` / regex / backtick shims.
+8. **SIR18 string interpolation** (`"a#{x}b"` → `Expr::StrConcat { parts }`) —
+   a new `_sir_display_str` runtime helper (Ruby's `to_s`-style display into a
+   fresh string; a string-returning PARALLEL to the pre-existing
+   `puts`/`print` `_sir_fmt` family, not a refactor of it) plus an emitter arm
+   that folds each part through it and pairwise through `_sir_cat` into one
+   `_sir_str(...)` — landed in 0.36.4. `Feature::StringInterpolation` had been
+   the C backend's only remaining unaccepted `Strings`-adjacent feature; every
+   other backend but Go/JS/Rust already had a real emit arm for it.
 
 ## Out of scope (v0)
 


### PR DESCRIPTION
## Summary
- The Ruby frontend already lowers `"a#{x}b"` to `Expr::StrConcat { parts }` for every backend (Python/TypeScript already have real emit arms); the C backend rejected `Feature::StringInterpolation` outright, with no emitter arm at all — filed as its own backlog item while working the SIR Collections batch
- New runtime helper `_sir_display_str(SirValue) -> char*` (plus `_sir_display_seq`/`_sir_display_map`/`_sir_display_pair`/`_sir_display_float`) renders a value Ruby's `to_s` way into a fresh string — a string-returning **parallel** to the existing `puts`/`print` `FILE*`-writing `_sir_fmt` family, not a refactor of it, so that already-tested path stays completely untouched
- `Expr::StrConcat`'s emitter arm folds each part through `_sir_display_str` and pairwise through `_sir_cat` (which takes exactly two operands) into one `_sir_str(...)` — `emit_str_concat` for the simple-operand case (mirroring `SeqLit`'s inline path) and `emit_str_concat_names` for the compound-operand case (mirroring `SeqLit`'s hoisted-temp path)
- `Feature::StringInterpolation` added to `ACCEPTED_FEATURES`

## Test plan
- [x] New `compile_and_run_string_interpolation.rs`: local variable, expression, multiple segments in order, string value (no extra quoting), array value, nil value, and interpolation inside a method body (exercising the compound/hoisted emit path)
- [x] Full `semantic-ir-to-c` test suite green
- [x] `sir-conformance` full corpus green (no regressions)
- [x] `cargo clippy -p semantic-ir-to-c --all-targets` clean
- [x] Security review passed (no findings)
- [x] Spec (`SIR24-semantic-ir-to-c.md`) and CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)