### PR TITLE
fix(semantic-ir-to-rust): Array#[]= (bracket-index write) unimplemented

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.39.2 — fix: `Array#[]=` (bracket-index write) was unimplemented
+
+Part of "Python/JS/Go/Rust backends: implement `[]`/`[]=` bracket-index
+runtime dispatch" — `arr[i] = v` lowers through the same
+`__method__("[]=", recv, i, v)` envelope every Collections method uses
+(PR #9686), not the SIR-native `SeqSet` statement. `Array#[]` (read) and
+`Hash#[]`/`Hash#[]=` already worked on this backend; only `Array#[]=`'s
+name was missing from `array_method`'s catalog, so a bracket-index write
+on an Array reached the `unknown_method` `NoMethodError` floor at
+runtime.
+
+Fixed by delegating to the pre-existing `seq_set` primitive — the SAME
+one the native `SeqSet` statement already lowers to — so the two paths
+share one strictness rule (`0 <= i < len`, panics outside; no
+auto-grow, matching the Go/C/Rust `SeqSet` reference) rather than
+risking two independently-maintained implementations drifting apart.
+`"[]="` also added to the `Value::Seq` arm of the `respond_to?`
+membership check.
+
+Python, JavaScript, TypeScript, and Go still have NO `[]`/`[]=` runtime
+dispatch entries at all (a larger gap than Rust's single missing name) —
+tracked as separate follow-ups per backend.
+
+`semantic-ir-to-rust` 0.39.1 -> 0.39.2.
+
 ## 0.39.1 — `is_rust_keyword` missing `crate`/`extern`/`self`/`Self`/`super` (task #116 audit)
 
 Follow-up to task #110/#112 (`semantic-ir-to-javascript`/`-typescript`'s

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.39.1"
+version = "0.39.2"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -1669,7 +1669,7 @@ pub const RUNTIME: &str = r##"mod __sir {
             Value::Exception(_) => name == "message",
             Value::Seq(_) => matches!(
                 name,
-                "length" | "size" | "first" | "last" | "[]" | "reverse" | "sort" | "join"
+                "length" | "size" | "first" | "last" | "[]" | "[]=" | "reverse" | "sort" | "join"
                     | "include?" | "push" | "append" | "pop" | "fetch" | "each" | "map"
                     | "collect" | "select" | "filter" | "reject" | "find" | "detect" | "any?"
                     | "all?" | "none?" | "reduce" | "inject" | "sort_by" | "min_by" | "max_by"
@@ -1800,6 +1800,19 @@ pub const RUNTIME: &str = r##"mod __sir {
                 recv
             }
             "pop" => items_rc.borrow_mut().pop().unwrap_or(Value::Nil),
+            // `Array#[]=` — the OO-surface indexed write (`arr[i] = v`, as
+            // opposed to the SIR-native `SeqSet` statement). Delegates to the
+            // SAME `seq_set` primitive `SeqSet` lowers to, so the two paths
+            // share one strictness rule (`0 <= i < len`, panics outside —
+            // matching the Go/C/Rust `SeqSet` reference, no auto-grow).
+            // Bracket-index write lowers through `__method__` (this dispatch),
+            // matching how `[]`'s lenient read above is the OO-surface
+            // counterpart to `SeqIndex`.
+            "[]=" => {
+                let idx = pos.first().cloned().unwrap_or(Value::Nil);
+                let val = pos.get(1).cloned().unwrap_or(Value::Nil);
+                seq_set(&recv, &idx, val)
+            }
             // `Array#fetch(i)` is the STRICT indexed read: unlike `arr[i]`
             // (which returns `nil` out of bounds), a `fetch` past the end
             // (or a negative index past the front) raises `IndexError` in

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_bracket_index_write.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_bracket_index_write.rs
@@ -1,0 +1,211 @@
+//! End-to-end proof for `Array#[]=` (the OO-surface bracket-index write,
+//! `arr[i] = v`) on the Rust backend — the gap in "Python/JS/Go/Rust
+//! backends: implement `[]`/`[]=` bracket-index runtime dispatch".
+//!
+//! `arr[i] = v` lowers through the SAME `__method__("[]=", recv, i, v)`
+//! envelope every Collections method uses (PR #9686), NOT the SIR-native
+//! `SeqSet` statement — those are two separate paths that happen to need the
+//! same semantics. Before this fix, `array_method`'s `"[]="` name was simply
+//! absent, so any bracket-index write reached the `unknown_method` floor
+//! (`NoMethodError`) at runtime — `Array#[]` (read) and `Hash#[]`/`Hash#[]=`
+//! already worked; only `Array#[]=` was missing.
+//!
+//! The fix delegates to the pre-existing `seq_set` primitive (the same one
+//! `SeqSet` already lowers to), so the two paths share one strictness rule:
+//! `0 <= i < len`, panics outside — no auto-grow, matching the Go/C/Rust
+//! `SeqSet` reference.
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span, Stmt,
+};
+use semantic_ir_to_rust::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn seq(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+
+/// `recv.meth(args…)` — the `__method__` dispatch envelope.
+fn method(recv: Expr, name: &str, mut args: Vec<Expr>) -> Expr {
+    let mut all = vec![recv, Expr::StrLit { value: name.into(), span: s() }];
+    all.append(&mut args);
+    Expr::BuiltinCall { name: "__method__".into(), args: all, effects: EffectSet::PURE, span: s() }
+}
+
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "print".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE,
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+fn demo_module(name: &str, main_stmts: Vec<Stmt>) -> Module {
+    Module {
+        // A distinct name per test -- these run as parallel threads in the
+        // same process (cargo test's default), so a shared name collides on
+        // the same temp file path and one test's compile/run clobbers
+        // another's (the exact hazard `compile_and_run_c` hit; see that
+        // crate's CHANGELOG).
+        name: name.into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Sequences,
+            Feature::Strings,
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts: main_stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn compile_and_run(module: &Module) -> Option<std::process::Output> {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return None;
+    }
+    let artifact = compile(module).expect("module should compile to Rust source");
+
+    let dir = std::env::temp_dir();
+    let nonce = format!("{}_{}", std::process::id(), module.name);
+    let src_path = dir.join(format!("sir_bracket_write_{nonce}.rs"));
+    let bin_path = dir.join(format!("sir_bracket_write_{nonce}{}", if cfg!(windows) { ".exe" } else { "" }));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd.arg(&src_path).arg("-o").arg(&bin_path).output().expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker") && (stderr.contains("not found") || stderr.contains("No such file")) {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return None;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+    Some(run_out)
+}
+
+#[test]
+fn array_bracket_write_is_visible_on_a_later_read() {
+    let m = demo_module("bracket_write_visible_on_read", vec![
+        Stmt::LetBinding {
+            name: "a".into(),
+            sir_type: None,
+            value: seq(vec![ilit(10), ilit(20), ilit(30)]),
+            span: s(),
+        },
+        Stmt::ExprStmt {
+            expr: method(
+                Expr::VarRef { name: "a".into(), scope: semantic_ir::Scope::Local, span: s() },
+                "[]=",
+                vec![ilit(1), ilit(99)],
+            ),
+            span: s(),
+        },
+        print_stmt(method(
+            Expr::VarRef { name: "a".into(), scope: semantic_ir::Scope::Local, span: s() },
+            "[]",
+            vec![ilit(1)],
+        )),
+    ]);
+    if let Some(out) = compile_and_run(&m) {
+        assert!(out.status.success(), "compiled binary exited non-zero:\n{}", String::from_utf8_lossy(&out.stderr));
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "99\n");
+    }
+}
+
+#[test]
+fn array_bracket_write_returns_the_assigned_value() {
+    // Ruby: `arr[i] = v` evaluates to `v` (the RHS), not the receiver.
+    let m = demo_module("bracket_write_returns_rhs", vec![
+        Stmt::LetBinding {
+            name: "a".into(),
+            sir_type: None,
+            value: seq(vec![ilit(1), ilit(2)]),
+            span: s(),
+        },
+        print_stmt(method(
+            Expr::VarRef { name: "a".into(), scope: semantic_ir::Scope::Local, span: s() },
+            "[]=",
+            vec![ilit(0), ilit(42)],
+        )),
+    ]);
+    if let Some(out) = compile_and_run(&m) {
+        assert!(out.status.success(), "compiled binary exited non-zero:\n{}", String::from_utf8_lossy(&out.stderr));
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "42\n");
+    }
+}
+
+#[test]
+fn array_bracket_write_out_of_range_panics_not_silently_no_ops() {
+    // Matches SeqSet's existing strictness (0 <= i < len, no auto-grow) --
+    // this test proves the OO-surface path shares that trap rather than
+    // silently doing nothing or corrupting memory.
+    let m = demo_module("bracket_write_out_of_range", vec![
+        Stmt::LetBinding {
+            name: "a".into(),
+            sir_type: None,
+            value: seq(vec![ilit(1)]),
+            span: s(),
+        },
+        Stmt::ExprStmt {
+            expr: method(
+                Expr::VarRef { name: "a".into(), scope: semantic_ir::Scope::Local, span: s() },
+                "[]=",
+                vec![ilit(5), ilit(1)],
+            ),
+            span: s(),
+        },
+    ]);
+    if let Some(out) = compile_and_run(&m) {
+        assert!(!out.status.success(), "expected a panic (non-zero exit) on out-of-range []=");
+    }
+}


### PR DESCRIPTION
## Summary
- Part of "Python/JS/Go/Rust backends: implement `[]`/`[]=` bracket-index runtime dispatch" — `arr[i] = v` lowers through the same `__method__("[]=", recv, i, v)` envelope every Collections method uses (PR #9686), not the SIR-native `SeqSet` statement
- `Array#[]` (read) and `Hash#[]`/`Hash#[]=` already worked on this backend; only `Array#[]=`'s name was missing from `array_method`'s catalog, so a bracket-index write on an Array hit the `unknown_method` `NoMethodError` floor at runtime
- Fixed by delegating to the pre-existing `seq_set` primitive — the same one the native `SeqSet` statement already lowers to — so the two paths share one strictness rule (`0 <= i < len`, panics outside; no auto-grow, matching the Go/C/Rust `SeqSet` reference) instead of risking two implementations drifting apart
- `"[]="` also added to the `Value::Seq` arm of the `respond_to?` membership check
- Python, JavaScript, TypeScript, and Go still have no `[]`/`[]=` dispatch at all (a larger gap than Rust's single missing name) — tracked as separate follow-ups per backend

## Test plan
- [x] New `compile_and_run_bracket_index_write.rs`: write visible on later read, write returns the assigned value (not the receiver), out-of-range write panics (not a silent no-op)
- [x] Full `semantic-ir-to-rust` test suite green
- [x] `sir-conformance` full corpus green (no regressions)
- [x] `cargo clippy -p semantic-ir-to-rust --all-targets` clean
- [x] Security review passed (no findings)
- [x] CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)