### PR TITLE
Add Level 4 agent stdio host

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -1031,4 +1031,5 @@ members = [
   "chief-of-staff-skill-parser",
   "chief-of-staff-skill-runtime",
   "chief-of-staff-agent-stdio-protocol",
+  "chief-of-staff-agent-stdio-host",
 ]

--- a/code/packages/rust/chief-of-staff-agent-stdio-host/BUILD
+++ b/code/packages/rust/chief-of-staff-agent-stdio-host/BUILD
@@ -1,0 +1,1 @@
+cargo test -p chief-of-staff-agent-stdio-host -- --nocapture && cargo clippy -p chief-of-staff-agent-stdio-host --all-targets -- -D warnings && RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-agent-stdio-host --no-deps

--- a/code/packages/rust/chief-of-staff-agent-stdio-host/BUILD_windows
+++ b/code/packages/rust/chief-of-staff-agent-stdio-host/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p chief-of-staff-agent-stdio-host -- --nocapture && cargo clippy -p chief-of-staff-agent-stdio-host --all-targets -- -D warnings

--- a/code/packages/rust/chief-of-staff-agent-stdio-host/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-agent-stdio-host/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-08-03
+
+- Add a shell-free, long-lived subprocess session for the Level 4 JSON-lines protocol.
+- Add receive, response, publish, and acknowledge orchestration over injected channel endpoints.
+- Kill and reap the owned child after protocol, framing, or process-I/O failure.

--- a/code/packages/rust/chief-of-staff-agent-stdio-host/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-agent-stdio-host/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "chief-of-staff-agent-stdio-host"
+version = "0.1.0"
+edition = "2021"
+description = "Level 4 subprocess host over Chief channels and JSON lines"
+license = "MIT"
+
+[dependencies]
+chief-of-staff-agent-stdio-protocol = { path = "../chief-of-staff-agent-stdio-protocol" }
+chief-of-staff-channel-crypto = { path = "../chief-of-staff-channel-crypto" }
+chief-of-staff-channel-endpoints = { path = "../chief-of-staff-channel-endpoints" }
+
+[[bin]]
+name = "chief-agent-stdio-test-child"
+path = "src/bin/chief_agent_stdio_test_child.rs"
+test = false

--- a/code/packages/rust/chief-of-staff-agent-stdio-host/README.md
+++ b/code/packages/rust/chief-of-staff-agent-stdio-host/README.md
@@ -1,0 +1,24 @@
+# chief-of-staff-agent-stdio-host
+
+Host-side runtime for D18 Level 4 agents written in any language. It launches
+an already-authorized executable without a shell, keeps one ordered request in
+flight over piped stdin/stdout, and uses the versioned
+`chief-agent-stdio-v1` codec.
+
+`LevelFourHost::run_once` deliberately performs:
+
+1. receive one verified channel message;
+2. obtain one correlated subprocess response;
+3. publish the response to the output channel;
+4. acknowledge the input message.
+
+Protocol, process, and publication failures therefore leave the input cursor
+unchanged. The concrete session kills and reaps its owned child after an I/O or
+protocol failure and when dropped. Package verification, sandbox selection,
+restart policy, and timeout supervision remain responsibilities of the caller.
+
+## Validation
+
+```sh
+sh chief-of-staff-agent-stdio-host/BUILD
+```

--- a/code/packages/rust/chief-of-staff-agent-stdio-host/required_capabilities.json
+++ b/code/packages/rust/chief-of-staff-agent-stdio-host/required_capabilities.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/chief-of-staff-agent-stdio-host",
+  "capabilities": [
+    {
+      "category": "proc",
+      "action": "exec",
+      "target": "*",
+      "justification": "Launches the exact already-authorized Level 4 agent executable without invoking a shell."
+    },
+    {
+      "category": "proc",
+      "action": "signal",
+      "target": "*",
+      "justification": "Kills and reaps only the child process owned by the session after protocol or pipe failure."
+    }
+  ],
+  "justification": "Concrete process adapter that transports bounded Level 4 records over owned child pipes; package trust, sandbox policy, restart policy, and timeouts are injected or enforced by its caller."
+}

--- a/code/packages/rust/chief-of-staff-agent-stdio-host/src/bin/chief_agent_stdio_test_child.rs
+++ b/code/packages/rust/chief-of-staff-agent-stdio-host/src/bin/chief_agent_stdio_test_child.rs
@@ -1,0 +1,43 @@
+use std::io::{self, BufRead, Write};
+
+const PROTOCOL: &str = "chief-agent-stdio-v1";
+
+fn main() {
+    let mode = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "success".to_string());
+    let stdin = io::stdin();
+    let mut stdout = io::stdout().lock();
+    for line in stdin.lock().lines() {
+        let line = line.expect("read test host input");
+        if mode == "eof" {
+            return;
+        }
+        if mode == "exit" {
+            std::process::exit(42);
+        }
+        if mode == "malformed" {
+            writeln!(stdout, "not-json").expect("write malformed response");
+            stdout.flush().expect("flush malformed response");
+            continue;
+        }
+        let message_id = extract_field(&line, "message_id").expect("message_id field");
+        let response_id = if mode == "mismatch" {
+            "01980000-0000-7000-8000-000000000099"
+        } else {
+            message_id
+        };
+        writeln!(
+            stdout,
+            "{{\"protocol\":\"{PROTOCOL}\",\"kind\":\"response\",\"input_message_id\":\"{response_id}\",\"content_type\":\"text/plain; charset=utf-8\",\"payload_b64\":\"d29ybGQ=\"}}"
+        )
+        .expect("write response");
+        stdout.flush().expect("flush response");
+    }
+}
+
+fn extract_field<'a>(line: &'a str, field: &str) -> Option<&'a str> {
+    let marker = format!("\"{field}\":\"");
+    let value = line.split_once(&marker)?.1;
+    value.split_once('"').map(|(value, _)| value)
+}

--- a/code/packages/rust/chief-of-staff-agent-stdio-host/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-agent-stdio-host/src/lib.rs
@@ -1,0 +1,424 @@
+//! Subprocess host for D18 Level 4 any-language agents.
+//!
+//! The runtime composes the pure JSON-lines codec with injected channel
+//! endpoints. Package verification, sandbox policy, restart policy, and
+//! timeout supervision remain outside this package.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use chief_of_staff_agent_stdio_protocol::{
+    decode_response_line, encode_input_line, AgentInput, AgentResponse, ProtocolError,
+    MAX_LINE_BYTES,
+};
+use chief_of_staff_channel_crypto::Sequence;
+use chief_of_staff_channel_endpoints::{
+    ChannelEndpointError, MessageId, Originator, PublishedMessage, Receiver,
+};
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+use std::io::{BufRead, BufReader, BufWriter, Read, Write};
+use std::process::{Child, ChildStdin, ChildStdout, Command, ExitStatus, Stdio};
+
+/// Shell-free executable and arguments for one Level 4 agent session.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AgentCommand {
+    program: String,
+    args: Vec<String>,
+}
+
+impl AgentCommand {
+    /// Validate an exact program path/name and argument vector.
+    pub fn new<I, S>(program: impl Into<String>, args: I) -> Result<Self, AgentStdioError>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let command = Self {
+            program: program.into(),
+            args: args.into_iter().map(Into::into).collect(),
+        };
+        if command.program.is_empty() || command.program.contains('\0') {
+            return Err(AgentStdioError::InvalidCommand(
+                "program must be non-empty and contain no NUL",
+            ));
+        }
+        if command.args.iter().any(|argument| argument.contains('\0')) {
+            return Err(AgentStdioError::InvalidCommand(
+                "arguments must contain no NUL",
+            ));
+        }
+        Ok(command)
+    }
+
+    /// Borrow the exact executable path or name.
+    pub fn program(&self) -> &str {
+        &self.program
+    }
+
+    /// Borrow the exact argument vector.
+    pub fn args(&self) -> &[String] {
+        &self.args
+    }
+}
+
+/// Error from process launch, JSON-lines transport, or protocol validation.
+#[derive(Debug)]
+pub enum AgentStdioError {
+    /// An executable or argument violated the shell-free command contract.
+    InvalidCommand(&'static str),
+    /// A caller attempted to reuse an invalidated process session.
+    SessionClosed,
+    /// The operating system rejected process launch.
+    Spawn(std::io::Error),
+    /// A child pipe was unexpectedly unavailable.
+    MissingPipe(&'static str),
+    /// Writing or flushing the child stdin pipe failed.
+    Write(std::io::Error),
+    /// Reading the child stdout pipe failed.
+    Read(std::io::Error),
+    /// The child closed stdout before returning a complete response line.
+    UnexpectedEof(Option<ExitStatus>),
+    /// The child had already exited before the next request.
+    ProcessExited(ExitStatus),
+    /// A response exceeded the bounded line size.
+    LineTooLong,
+    /// A response line was not UTF-8.
+    NonUtf8,
+    /// The shared Level 4 codec rejected input encoding or agent output.
+    Protocol(ProtocolError),
+}
+
+impl Display for AgentStdioError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidCommand(message) => write!(formatter, "invalid agent command: {message}"),
+            Self::SessionClosed => formatter.write_str("agent process session is closed"),
+            Self::Spawn(error) => write!(formatter, "agent process launch failed: {error}"),
+            Self::MissingPipe(pipe) => write!(formatter, "agent process omitted its {pipe} pipe"),
+            Self::Write(error) => write!(formatter, "agent stdin write failed: {error}"),
+            Self::Read(error) => write!(formatter, "agent stdout read failed: {error}"),
+            Self::UnexpectedEof(Some(status)) => {
+                write!(
+                    formatter,
+                    "agent stdout closed before a response ({status})"
+                )
+            }
+            Self::UnexpectedEof(None) => {
+                formatter.write_str("agent stdout closed before a response")
+            }
+            Self::ProcessExited(status) => {
+                write!(
+                    formatter,
+                    "agent process exited before the next request ({status})"
+                )
+            }
+            Self::LineTooLong => formatter.write_str("agent response line exceeds protocol limit"),
+            Self::NonUtf8 => formatter.write_str("agent response line is not UTF-8"),
+            Self::Protocol(error) => write!(formatter, "agent protocol failed: {error}"),
+        }
+    }
+}
+
+impl Error for AgentStdioError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Spawn(error) | Self::Write(error) | Self::Read(error) => Some(error),
+            Self::Protocol(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl From<ProtocolError> for AgentStdioError {
+    fn from(error: ProtocolError) -> Self {
+        Self::Protocol(error)
+    }
+}
+
+/// Response provider used by the channel orchestration layer.
+pub trait AgentResponder {
+    /// Produce exactly one response for the current verified input.
+    fn respond(&mut self, input: &AgentInput) -> Result<AgentResponse, AgentStdioError>;
+}
+
+/// One owned long-lived child process speaking `chief-agent-stdio-v1`.
+pub struct StdioAgentSession {
+    child: Child,
+    writer: Option<BufWriter<ChildStdin>>,
+    reader: Option<BufReader<ChildStdout>>,
+    closed: bool,
+}
+
+impl StdioAgentSession {
+    /// Launch one already-authorized executable with piped stdin/stdout.
+    ///
+    /// No shell is invoked. The child inherits stderr so the caller's runtime
+    /// can route uncaught failures into its normal logging path.
+    pub fn spawn(command: &AgentCommand) -> Result<Self, AgentStdioError> {
+        let mut child = Command::new(command.program())
+            .args(command.args())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .map_err(AgentStdioError::Spawn)?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or(AgentStdioError::MissingPipe("stdin"));
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or(AgentStdioError::MissingPipe("stdout"));
+        match (stdin, stdout) {
+            (Ok(stdin), Ok(stdout)) => Ok(Self {
+                child,
+                writer: Some(BufWriter::new(stdin)),
+                reader: Some(BufReader::new(stdout)),
+                closed: false,
+            }),
+            (stdin, stdout) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                Err(stdin
+                    .err()
+                    .or_else(|| stdout.err())
+                    .expect("one pipe failed"))
+            }
+        }
+    }
+
+    /// Return the operating-system child identifier while the session owns it.
+    pub fn child_id(&self) -> u32 {
+        self.child.id()
+    }
+
+    /// Kill and reap the owned child. Repeating shutdown is harmless.
+    pub fn shutdown(&mut self) {
+        if self.closed {
+            return;
+        }
+        self.writer.take();
+        self.reader.take();
+        match self.child.try_wait() {
+            Ok(Some(_)) => {}
+            Ok(None) | Err(_) => {
+                let _ = self.child.kill();
+                let _ = self.child.wait();
+            }
+        }
+        self.closed = true;
+    }
+
+    fn fail<T>(&mut self, error: AgentStdioError) -> Result<T, AgentStdioError> {
+        self.shutdown();
+        Err(error)
+    }
+
+    fn preflight(&mut self) -> Result<(), AgentStdioError> {
+        if self.closed {
+            return Err(AgentStdioError::SessionClosed);
+        }
+        match self.child.try_wait() {
+            Ok(Some(status)) => self.fail(AgentStdioError::ProcessExited(status)),
+            Ok(None) => Ok(()),
+            Err(error) => self.fail(AgentStdioError::Read(error)),
+        }
+    }
+}
+
+impl AgentResponder for StdioAgentSession {
+    fn respond(&mut self, input: &AgentInput) -> Result<AgentResponse, AgentStdioError> {
+        self.preflight()?;
+        let line = encode_input_line(input)?;
+        let write_result = match self.writer.as_mut() {
+            Some(writer) => writer
+                .write_all(line.as_bytes())
+                .and_then(|_| writer.flush()),
+            None => return self.fail(AgentStdioError::MissingPipe("stdin")),
+        };
+        if let Err(error) = write_result {
+            return self.fail(AgentStdioError::Write(error));
+        }
+
+        let mut response_bytes = Vec::new();
+        let read_result = match self.reader.as_mut() {
+            Some(reader) => reader
+                .take((MAX_LINE_BYTES + 1) as u64)
+                .read_until(b'\n', &mut response_bytes),
+            None => return self.fail(AgentStdioError::MissingPipe("stdout")),
+        };
+        let bytes_read = match read_result {
+            Ok(bytes_read) => bytes_read,
+            Err(error) => return self.fail(AgentStdioError::Read(error)),
+        };
+        if bytes_read == 0 {
+            let status = self.child.try_wait().ok().flatten();
+            return self.fail(AgentStdioError::UnexpectedEof(status));
+        }
+        if response_bytes.len() > MAX_LINE_BYTES {
+            return self.fail(AgentStdioError::LineTooLong);
+        }
+        let response_line = match std::str::from_utf8(&response_bytes) {
+            Ok(line) => line,
+            Err(_) => return self.fail(AgentStdioError::NonUtf8),
+        };
+        match decode_response_line(response_line, input.message_id()) {
+            Ok(response) => Ok(response),
+            Err(error) => self.fail(AgentStdioError::Protocol(error)),
+        }
+    }
+}
+
+impl Drop for StdioAgentSession {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+/// Result of polling one Level 4 input message.
+#[derive(Clone, Debug)]
+pub enum LevelFourRunOutcome {
+    /// No verified channel message was waiting.
+    Idle,
+    /// One response was published and its input was acknowledged.
+    Processed {
+        /// Input message completed by the subprocess.
+        input_message_id: MessageId,
+        /// Sequence returned by the monotonic acknowledgement.
+        acknowledged_through: Sequence,
+        /// Receipt for the published subprocess response.
+        output: PublishedMessage,
+    },
+}
+
+/// Failure from a subprocess response or injected channel endpoint.
+#[derive(Debug)]
+pub enum LevelFourHostError {
+    /// The subprocess session or protocol failed.
+    Agent(AgentStdioError),
+    /// A receive, publish, or acknowledge operation failed.
+    Channel(ChannelEndpointError),
+}
+
+impl Display for LevelFourHostError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Agent(error) => write!(formatter, "Level 4 agent failed: {error}"),
+            Self::Channel(error) => write!(formatter, "Level 4 channel failed: {error}"),
+        }
+    }
+}
+
+impl Error for LevelFourHostError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Agent(error) => Some(error),
+            Self::Channel(error) => Some(error),
+        }
+    }
+}
+
+impl From<AgentStdioError> for LevelFourHostError {
+    fn from(error: AgentStdioError) -> Self {
+        Self::Agent(error)
+    }
+}
+
+impl From<ChannelEndpointError> for LevelFourHostError {
+    fn from(error: ChannelEndpointError) -> Self {
+        Self::Channel(error)
+    }
+}
+
+/// Level 4 process adapter bound to one response provider.
+pub struct LevelFourHost<'a> {
+    responder: &'a mut dyn AgentResponder,
+}
+
+impl<'a> LevelFourHost<'a> {
+    /// Bind one responder after package verification and sandbox selection.
+    pub fn new(responder: &'a mut dyn AgentResponder) -> Self {
+        Self { responder }
+    }
+
+    /// Poll and process at most one verified channel message.
+    ///
+    /// Ordering is receive, subprocess response, publish, acknowledge. Any
+    /// error before the last step therefore leaves the durable input cursor
+    /// unchanged for replay.
+    pub fn run_once(
+        &mut self,
+        receiver: &mut dyn Receiver,
+        originator: &dyn Originator,
+    ) -> Result<LevelFourRunOutcome, LevelFourHostError> {
+        let Some(message) = receiver.receive(1)?.into_iter().next() else {
+            return Ok(LevelFourRunOutcome::Idle);
+        };
+        let message_id = format_uuid(message.message_id.as_bytes());
+        let input = AgentInput::new(
+            message_id.clone(),
+            format_uuid(&receiver.channel_id().0),
+            message.sequence.0,
+            message.timestamp_ns,
+            message.content_type,
+            message.payload,
+        )
+        .map_err(AgentStdioError::Protocol)?;
+        let response = self.responder.respond(&input)?;
+        if response.input_message_id() != message_id {
+            return Err(AgentStdioError::Protocol(ProtocolError::CorrelationMismatch).into());
+        }
+        let output = originator.publish(response.payload(), response.content_type())?;
+        let acknowledged_through = receiver.acknowledge(message.message_id)?;
+        Ok(LevelFourRunOutcome::Processed {
+            input_message_id: message.message_id,
+            acknowledged_through,
+            output,
+        })
+    }
+}
+
+fn format_uuid(bytes: &[u8; 16]) -> String {
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        bytes[0],
+        bytes[1],
+        bytes[2],
+        bytes[3],
+        bytes[4],
+        bytes[5],
+        bytes[6],
+        bytes[7],
+        bytes[8],
+        bytes[9],
+        bytes[10],
+        bytes[11],
+        bytes[12],
+        bytes[13],
+        bytes[14],
+        bytes[15]
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_and_uuid_format_are_stable() {
+        let command = AgentCommand::new("python", ["agent.py", "--once"]).unwrap();
+        assert_eq!(command.program(), "python");
+        assert_eq!(command.args(), ["agent.py", "--once"]);
+        assert!(AgentCommand::new("", std::iter::empty::<String>()).is_err());
+        assert!(AgentCommand::new("python", ["bad\0arg"]).is_err());
+        assert_eq!(
+            format_uuid(&[
+                0x01, 0x98, 0xab, 0xcd, 0xef, 0x01, 0x72, 0x34, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23,
+                0x45, 0x67,
+            ]),
+            "0198abcd-ef01-7234-89ab-cdef01234567"
+        );
+    }
+}

--- a/code/packages/rust/chief-of-staff-agent-stdio-host/tests/fixtures/echo_agent.py
+++ b/code/packages/rust/chief-of-staff-agent-stdio-host/tests/fixtures/echo_agent.py
@@ -1,0 +1,16 @@
+import base64
+import json
+import sys
+
+
+for line in sys.stdin:
+    message = json.loads(line)
+    response = {
+        "protocol": "chief-agent-stdio-v1",
+        "kind": "response",
+        "input_message_id": message["message_id"],
+        "content_type": "text/plain; charset=utf-8",
+        "payload_b64": base64.b64encode(b"python-world").decode("ascii"),
+    }
+    sys.stdout.write(json.dumps(response, separators=(",", ":")) + "\n")
+    sys.stdout.flush()

--- a/code/packages/rust/chief-of-staff-agent-stdio-host/tests/stdio_host.rs
+++ b/code/packages/rust/chief-of-staff-agent-stdio-host/tests/stdio_host.rs
@@ -1,0 +1,315 @@
+use chief_of_staff_agent_stdio_host::{
+    AgentCommand, AgentResponder, AgentStdioError, LevelFourHost, LevelFourHostError,
+    LevelFourRunOutcome, StdioAgentSession,
+};
+use chief_of_staff_agent_stdio_protocol::{AgentInput, AgentResponse};
+use chief_of_staff_channel_crypto::{ChannelId, Sequence};
+use chief_of_staff_channel_endpoints::{
+    AgentId, ChannelEndpointError, MessageId, Originator, PublishedMessage, ReceivedMessage,
+    Receiver,
+};
+use std::cell::{Cell, RefCell};
+use std::process::Command;
+
+fn message_id(byte: u8) -> MessageId {
+    let mut bytes = [byte; 16];
+    bytes[6] = 0x70;
+    bytes[8] = 0x80;
+    MessageId::from_uuid_v7(bytes).unwrap()
+}
+
+fn channel_id(byte: u8) -> ChannelId {
+    let mut bytes = [byte; 16];
+    bytes[6] = 0x70;
+    bytes[8] = 0x80;
+    ChannelId(bytes)
+}
+
+struct FakeReceiver {
+    id: AgentId,
+    messages: Vec<ReceivedMessage>,
+    acknowledgements: Vec<MessageId>,
+    fail_acknowledge: bool,
+}
+
+impl FakeReceiver {
+    fn with_message() -> Self {
+        Self {
+            id: AgentId::new(b"level-four-agent".to_vec()).unwrap(),
+            messages: vec![ReceivedMessage {
+                message_id: message_id(7),
+                sequence: Sequence(4),
+                timestamp_ns: 9_007_199_254_740_993,
+                content_type: "application/octet-stream".to_string(),
+                payload: b"hello".to_vec(),
+            }],
+            acknowledgements: Vec::new(),
+            fail_acknowledge: false,
+        }
+    }
+}
+
+impl Receiver for FakeReceiver {
+    fn id(&self) -> &AgentId {
+        &self.id
+    }
+
+    fn channel_id(&self) -> ChannelId {
+        channel_id(3)
+    }
+
+    fn public_key(&self) -> [u8; 32] {
+        [2; 32]
+    }
+
+    fn receive(&mut self, _limit: usize) -> Result<Vec<ReceivedMessage>, ChannelEndpointError> {
+        Ok(std::mem::take(&mut self.messages))
+    }
+
+    fn acknowledge(&mut self, message_id: MessageId) -> Result<Sequence, ChannelEndpointError> {
+        if self.fail_acknowledge {
+            return Err(ChannelEndpointError::ChannelDestroyed);
+        }
+        self.acknowledgements.push(message_id);
+        Ok(Sequence(5))
+    }
+}
+
+struct FakeOriginator {
+    id: AgentId,
+    publications: RefCell<Vec<(Vec<u8>, String)>>,
+    fail: Cell<bool>,
+}
+
+impl FakeOriginator {
+    fn new() -> Self {
+        Self {
+            id: AgentId::new(b"level-four-output".to_vec()).unwrap(),
+            publications: RefCell::new(Vec::new()),
+            fail: Cell::new(false),
+        }
+    }
+}
+
+impl Originator for FakeOriginator {
+    fn id(&self) -> &AgentId {
+        &self.id
+    }
+
+    fn channel_id(&self) -> ChannelId {
+        channel_id(4)
+    }
+
+    fn public_key(&self) -> [u8; 32] {
+        [4; 32]
+    }
+
+    fn publish(
+        &self,
+        payload: &[u8],
+        content_type: &str,
+    ) -> Result<PublishedMessage, ChannelEndpointError> {
+        if self.fail.get() {
+            return Err(ChannelEndpointError::ChannelDestroyed);
+        }
+        self.publications
+            .borrow_mut()
+            .push((payload.to_vec(), content_type.to_string()));
+        Ok(PublishedMessage {
+            message_id: message_id(9),
+            sequence: Sequence(8),
+            timestamp_ns: 11,
+        })
+    }
+}
+
+fn child(mode: &str) -> StdioAgentSession {
+    let command =
+        AgentCommand::new(env!("CARGO_BIN_EXE_chief-agent-stdio-test-child"), [mode]).unwrap();
+    StdioAgentSession::spawn(&command).unwrap()
+}
+
+fn python_program() -> &'static str {
+    ["python3", "python"]
+        .into_iter()
+        .find(|program| {
+            Command::new(program)
+                .arg("--version")
+                .output()
+                .is_ok_and(|output| output.status.success())
+        })
+        .expect("the repository build image must provide Python")
+}
+
+#[test]
+fn real_subprocess_flows_then_publishes_and_acknowledges() {
+    let mut session = child("success");
+    let mut receiver = FakeReceiver::with_message();
+    let originator = FakeOriginator::new();
+    let outcome = LevelFourHost::new(&mut session)
+        .run_once(&mut receiver, &originator)
+        .unwrap();
+
+    assert!(matches!(
+        outcome,
+        LevelFourRunOutcome::Processed {
+            input_message_id,
+            acknowledged_through: Sequence(5),
+            ..
+        } if input_message_id == message_id(7)
+    ));
+    assert_eq!(
+        originator.publications.borrow().as_slice(),
+        &[(b"world".to_vec(), "text/plain; charset=utf-8".to_string())]
+    );
+    assert_eq!(receiver.acknowledgements, [message_id(7)]);
+}
+
+#[test]
+fn one_long_lived_session_handles_multiple_ordered_messages() {
+    let mut session = child("success");
+    let first = AgentInput::new(
+        "01980000-0000-7000-8000-000000000001",
+        "01980000-0000-7000-8000-000000000010",
+        1,
+        2,
+        "text/plain",
+        b"first".to_vec(),
+    )
+    .unwrap();
+    let second = AgentInput::new(
+        "01980000-0000-7000-8000-000000000002",
+        "01980000-0000-7000-8000-000000000010",
+        2,
+        3,
+        "text/plain",
+        b"second".to_vec(),
+    )
+    .unwrap();
+    assert_eq!(session.respond(&first).unwrap().payload(), b"world");
+    assert_eq!(session.respond(&second).unwrap().payload(), b"world");
+}
+
+#[test]
+fn sdk_free_python_agent_uses_the_normative_json_lines_contract() {
+    let script = format!(
+        "{}/tests/fixtures/echo_agent.py",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let command = AgentCommand::new(python_program(), [script]).unwrap();
+    let mut session = StdioAgentSession::spawn(&command).unwrap();
+    let input = AgentInput::new(
+        "01980000-0000-7000-8000-000000000001",
+        "01980000-0000-7000-8000-000000000010",
+        u64::MAX,
+        9_007_199_254_740_993,
+        "application/octet-stream",
+        [0, 255, 128, 65],
+    )
+    .unwrap();
+    let response = session.respond(&input).unwrap();
+    assert_eq!(response.input_message_id(), input.message_id());
+    assert_eq!(response.content_type(), "text/plain; charset=utf-8");
+    assert_eq!(response.payload(), b"python-world");
+}
+
+#[test]
+fn malformed_mismatched_and_early_exit_children_fail_closed() {
+    for (mode, expected) in [
+        ("malformed", "protocol"),
+        ("mismatch", "correlation"),
+        ("eof", "before a response"),
+        ("exit", "before a response"),
+    ] {
+        let mut session = child(mode);
+        let input = AgentInput::new(
+            "01980000-0000-7000-8000-000000000001",
+            "01980000-0000-7000-8000-000000000010",
+            1,
+            2,
+            "text/plain",
+            b"input".to_vec(),
+        )
+        .unwrap();
+        let error = session.respond(&input).unwrap_err();
+        assert!(error.to_string().contains(expected), "{mode}: {error}");
+        assert!(
+            session.respond(&input).is_err(),
+            "{mode} session stayed open"
+        );
+    }
+}
+
+struct FixedResponder {
+    response: AgentResponse,
+}
+
+impl AgentResponder for FixedResponder {
+    fn respond(&mut self, _input: &AgentInput) -> Result<AgentResponse, AgentStdioError> {
+        Ok(self.response.clone())
+    }
+}
+
+#[test]
+fn idle_and_pre_ack_failures_leave_cursor_unchanged() {
+    let mut idle_receiver = FakeReceiver::with_message();
+    idle_receiver.messages.clear();
+    let originator = FakeOriginator::new();
+    let mut responder = FixedResponder {
+        response: AgentResponse::new("unused", "text/plain", b"unused".to_vec()).unwrap(),
+    };
+    assert!(matches!(
+        LevelFourHost::new(&mut responder)
+            .run_once(&mut idle_receiver, &originator)
+            .unwrap(),
+        LevelFourRunOutcome::Idle
+    ));
+
+    let mut receiver = FakeReceiver::with_message();
+    let mut mismatched = FixedResponder {
+        response: AgentResponse::new("different", "text/plain", b"no".to_vec()).unwrap(),
+    };
+    assert!(matches!(
+        LevelFourHost::new(&mut mismatched).run_once(&mut receiver, &originator),
+        Err(LevelFourHostError::Agent(AgentStdioError::Protocol(_)))
+    ));
+    assert!(receiver.acknowledgements.is_empty());
+    assert!(originator.publications.borrow().is_empty());
+
+    let mut receiver = FakeReceiver::with_message();
+    let mut response = FixedResponder {
+        response: AgentResponse::new(
+            "07070707-0707-7007-8007-070707070707",
+            "text/plain",
+            b"no".to_vec(),
+        )
+        .unwrap(),
+    };
+    originator.fail.set(true);
+    assert!(matches!(
+        LevelFourHost::new(&mut response).run_once(&mut receiver, &originator),
+        Err(LevelFourHostError::Channel(_))
+    ));
+    assert!(receiver.acknowledgements.is_empty());
+}
+
+#[test]
+fn acknowledgement_failure_occurs_after_publication() {
+    let mut receiver = FakeReceiver::with_message();
+    receiver.fail_acknowledge = true;
+    let originator = FakeOriginator::new();
+    let mut response = FixedResponder {
+        response: AgentResponse::new(
+            "07070707-0707-7007-8007-070707070707",
+            "text/plain",
+            b"published".to_vec(),
+        )
+        .unwrap(),
+    };
+    assert!(matches!(
+        LevelFourHost::new(&mut response).run_once(&mut receiver, &originator),
+        Err(LevelFourHostError::Channel(_))
+    ));
+    assert_eq!(originator.publications.borrow().len(), 1);
+    assert!(receiver.acknowledgements.is_empty());
+}

--- a/code/packages/rust/chief-of-staff-agent-stdio-protocol/README.md
+++ b/code/packages/rust/chief-of-staff-agent-stdio-protocol/README.md
@@ -7,7 +7,8 @@ It needs no Chief of Staff SDK.
 The host writes one `message` object per line. The agent writes one correlated
 `response` object per line. The codec owns validation and framing but does not
 open pipes, spawn a process, read a clock, or acknowledge a channel message.
-Those effects remain in the future subprocess host adapter.
+Those effects are composed by the sibling `chief-of-staff-agent-stdio-host`
+package.
 
 ```json
 {"protocol":"chief-agent-stdio-v1","kind":"message","message_id":"019...","channel_id":"019...","sequence":"7","timestamp_ns":"42","content_type":"text/plain","payload_b64":"aGVsbG8="}

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -205,6 +205,15 @@ and correlation mismatches fail before output publication or input
 acknowledgement. Nonzero process exit and EOF before a valid response likewise
 leave the input cursor unchanged for recovery.
 
+The host keeps one ordered subprocess session per Level 4 agent and permits
+only one input to be in flight on that session. It receives one verified
+channel message, obtains and validates the correlated subprocess response,
+publishes the output, and only then acknowledges the input. Protocol or pipe
+failure invalidates the session; the host kills and reaps its owned child so a
+supervisor can restart from the unchanged channel cursor. Package verification,
+sandbox selection, restart policy, and timeout enforcement remain outside the
+wire codec and process adapter.
+
 ---
 
 ## Key Concepts


### PR DESCRIPTION
## Summary

- add a shell-free, long-lived subprocess session for the `chief-agent-stdio-v1` JSON-lines contract
- compose verified channel receive, correlated agent response, output publication, and input acknowledgement in recovery-safe order
- invalidate, kill, and reap the owned child after framing, protocol, or pipe failures
- cover a real SDK-free Python agent plus malformed, mismatched, EOF, nonzero-exit, multi-message, and channel-failure behavior

## Why

#9864 established the Level 4 wire contract. This slice makes that contract executable while keeping package verification, sandbox selection, restart policy, and timeout supervision at their existing caller-owned boundaries.

## Validation

- `cargo test -p chief-of-staff-agent-stdio-host -- --nocapture` (7 passed: 1 unit, 6 integration)
- `cargo clippy -p chief-of-staff-agent-stdio-host --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p chief-of-staff-agent-stdio-host --no-deps`
- affected build planner: 28 built, 1,203 skipped
- `cargo fmt --package chief-of-staff-agent-stdio-host -- --check`
- `git diff --check`

Part of #139.
Part of #128.
