### PR TITLE
feat(semantic-ir-to-go): << (Ruby's shift operator) as a top-level builtin

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.37.1 — `<<` (Ruby's shift operator) as a top-level builtin
+
+Part of "Python/JS/Go/Rust/Ruby backends: implement `<<` runtime
+dispatch". `ruby-to-semantic-ir` lowers `<<` to a top-level
+`BuiltinCall("<<", [lhs, rhs, ...])` — a SEPARATE protocol from the
+`__method__("<<", recv, arg)` Collections dispatch Array#push already
+used on this backend (the pre-existing `_sir_array_responds`/`case
+"<<":` entries in the method catalog). The operator form reached
+`_sir_call_builtin_by_name`'s floor and panicked `unknown builtin: <<`
+— every Ruby program using `<<` as an operator failed at runtime on Go.
+
+New `_sir_shift_left(args []Value) Value`, polymorphic like `_sir_plus`:
+Array pushes each RHS operand in place (chains left-to-right, since the
+frontend lowers a `<<` chain to one variadic call); Integer bitwise-shifts
+via `_sir_shift_left_i64`, PORTED from the C backend's helper of the same
+name for identical overflow/negative-amount semantics (negative amount
+reverses direction; left shift saturates at MaxInt64/MinInt64 rather than
+wrapping, since this runtime has no bignum growth); String concatenates
+to a new string via the existing `_sir_as_string` (matching this
+backend's own `+` String-receiver convention, not C's looser
+silently-drop-a-non-string one).
+
+New supporting helpers `_sir_shift_amount_arg`, `_sir_f64_to_i64_saturating`
+(a non-finite/out-of-range float64->int64 conversion is
+implementation-specific in Go, same UB-avoidance discipline as C), and
+`_sir_i64_abs_u` (MinInt64-safe magnitude via uint64 wraparound).
+
+`semantic-ir-to-go` 0.37.0 -> 0.37.1.
+
 ## 0.37.0 — operator-spelling comparisons: `==`, `!=`, `<=`, `>=`
 
 The Ruby frontend lowers a comparison chain to `==`/`!=`/`<=`/`>=` builtins,

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.37.0"
+version = "0.37.1"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -1336,6 +1336,7 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
     // the emitter simple.
     let helper = match name {
         "+" => "_sir_plus",
+        "<<" => "_sir_shift_left",
         "-" => "_sir_minus",
         "*" => "_sir_times",
         "/" => "_sir_divide",

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -286,6 +286,153 @@ func _sir_as_string(v Value) string {
 	panic("no implicit conversion of " + _sir_ruby_class_name(v) + " into String")
 }
 
+// ── polymorphic `<<` (Ruby's shift operator) ───────────────────
+//
+// `<<` -- Ruby's shift operator, polymorphic like `+`:
+//   Array   -- push each RHS operand IN PLACE, returns the (mutated)
+//              receiver. Chains left-to-right: `a << 1 << 2` pushes both
+//              (the frontend lowers a `<<` chain to ONE variadic call, the
+//              same convention `_sir_plus` already folds over).
+//   Integer -- bitwise shift; see `_sir_shift_left_i64` below, PORTED from
+//              the C backend's `_sir_shift_left_i64` for identical
+//              overflow/negative-amount semantics (no bignum growth --
+//              saturates at MaxInt64/MinInt64 rather than wrapping).
+//   String  -- concatenates and returns a NEW string, via `_sir_as_string`
+//              -- matching THIS backend's own `+` String-receiver
+//              convention (a non-string RHS panics; Ruby raises TypeError
+//              for `<<` on an incompatible operand too, so this is not a
+//              new divergence from `+`).
+func _sir_shift_left(args []Value) Value {
+	if len(args) == 0 {
+		return int64(0)
+	}
+	switch first := args[0].(type) {
+	case *Seq:
+		first.Items = append(first.Items, args[1:]...)
+		return first
+	case string:
+		out := first
+		for _, a := range args[1:] {
+			out += _sir_as_string(a)
+		}
+		return out
+	}
+	acc := _sir_as_int(args[0])
+	for _, a := range args[1:] {
+		acc = _sir_shift_left_i64(acc, _sir_shift_amount_arg(a))
+	}
+	return acc
+}
+
+// Extracts a shift-amount argument as a plain int64 -- an Integer passes
+// through, a Float truncates toward zero via the saturating helper below
+// (never Go's bare `int64(f)`, which is implementation-specific for a
+// non-finite/out-of-range float); anything else contributes a 0 shift.
+func _sir_shift_amount_arg(v Value) int64 {
+	switch n := v.(type) {
+	case int64:
+		return n
+	case float64:
+		return _sir_f64_to_i64_saturating(n)
+	}
+	return 0
+}
+
+// Truncates a float64 toward zero into an int64, saturating at
+// MaxInt64/MinInt64 on overflow and mapping NaN to 0 -- Go's plain
+// `int64(f)` conversion is implementation-specific once `f` is
+// non-finite or outside the int64 range (the same UB-avoidance
+// discipline the C backend's `_sir_f64_to_i64_saturating` follows). The
+// boundary compares against 2^63 (not `math.MaxInt64`, which is one less
+// and not exactly representable as a float64 near this magnitude).
+func _sir_f64_to_i64_saturating(f float64) int64 {
+	const twoPow63 = 9223372036854775808.0
+	if math.IsNaN(f) {
+		return 0
+	}
+	if f >= twoPow63 {
+		return math.MaxInt64
+	}
+	if f < -twoPow63 {
+		return math.MinInt64
+	}
+	return int64(f)
+}
+
+// Safe magnitude of an int64 as a uint64 -- handles `math.MinInt64` (whose
+// naive negation overflows back to itself in two's complement) via a
+// uint64-wraparound trick, the same one the C backend's `_sir_i64_abs_u`
+// uses.
+func _sir_i64_abs_u(n int64) uint64 {
+	if n >= 0 {
+		return uint64(n)
+	}
+	return uint64(-(n + 1)) + 1
+}
+
+// Bitwise-shifts `n` by `amount`, matching real Ruby's rules (ported from
+// the C backend's `_sir_shift_left_i64` -- see that function's comment for
+// the full rationale):
+//   - `amount == 0` or `n == 0`: identity.
+//   - `amount < 0`: REVERSES direction -- a right shift by `|amount|`
+//     (`5 << -1 == 5 >> 1 == 2`). Go requires a non-negative, in-range
+//     shift count for `>>`/`<<` (a signed negative or >=64 count panics at
+//     runtime), so both branches are computed manually rather than handed
+//     straight to Go's shift operators.
+//   - `amount > 0`: LEFT shift, SATURATES at MaxInt64/MinInt64 rather than
+//     wrapping once the true mathematical result would not fit (no bignum
+//     growth, unlike real Ruby's `1 << 63`).
+//   - A shift amount whose magnitude is >= 64 drains every bit: saturates
+//     to 0/-1 (right) or MaxInt64/MinInt64 (left, `n != 0`).
+func _sir_shift_left_i64(n int64, amount int64) int64 {
+	if amount == 0 || n == 0 {
+		return n
+	}
+	if amount < 0 {
+		k := _sir_i64_abs_u(amount)
+		if k >= 64 {
+			if n < 0 {
+				return -1
+			}
+			return 0
+		}
+		return n >> uint(k)
+	}
+	k := uint64(amount)
+	neg := n < 0
+	if k >= 64 {
+		if neg {
+			return math.MinInt64
+		}
+		return math.MaxInt64
+	}
+	mag := _sir_i64_abs_u(n)
+	if (mag >> (64 - k)) != 0 {
+		if neg {
+			return math.MinInt64
+		}
+		return math.MaxInt64
+	}
+	shifted := mag << k
+	limit := uint64(math.MaxInt64)
+	if neg {
+		limit++
+	}
+	if shifted > limit {
+		if neg {
+			return math.MinInt64
+		}
+		return math.MaxInt64
+	}
+	if neg {
+		if shifted == limit {
+			return math.MinInt64
+		}
+		return -int64(shifted)
+	}
+	return int64(shifted)
+}
+
 func _sir_minus(args []Value) Value {
 	if len(args) == 0 {
 		return int64(0)
@@ -1207,6 +1354,8 @@ func _sir_call_builtin_by_name(name string, args []Value) Value {
 	switch name {
 	case "+":
 		return _sir_plus(args)
+	case "<<":
+		return _sir_shift_left(args)
 	case "-":
 		return _sir_minus(args)
 	case "*":

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_shift_operator.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_shift_operator.rs
@@ -1,0 +1,188 @@
+//! End-to-end proof for the `<<` builtin (Ruby's shift operator) as a
+//! top-level `BuiltinCall("<<", [lhs, rhs, ...])` on the Go backend — part of
+//! "Python/JS/Go/Rust/Ruby backends: implement `<<` runtime dispatch".
+//!
+//! `ruby-to-semantic-ir` lowers `<<` to this envelope (distinct from the
+//! `__method__("<<", recv, arg)` Collections-dispatch protocol Array#push
+//! already used on this backend). Before this fix, the top-level operator
+//! reached `_sir_call_builtin_by_name`'s floor and panicked with
+//! `unknown builtin: <<` — every Ruby program using `<<` as an operator
+//! (`a << 1`, `arr << x`, `"a" << "b"`) failed at runtime on Go.
+//!
+//! This test hand-builds SIR modules exercising each receiver type, emits
+//! Go, runs with `go run`, and asserts stdout:
+//!
+//!   * `5 << 2`                → `20`   (Integer left shift)
+//!   * `5 << -1`               → `2`    (negative amount reverses direction)
+//!   * `1 << 63`               → saturates to `math.MaxInt64` (no bignum growth)
+//!   * `[1, 2] << 3`           → `[1, 2, 3]` (Array push, mutates receiver)
+//!   * `"ab" << "cd"`          → `abcd` (String concat, new string)
+//!
+//! Gates on `go`; logs a skip when absent.
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Scope,
+    Span, Stmt,
+};
+use semantic_ir_to_go::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn seq(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+
+fn shift(args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: "<<".into(), args, effects: EffectSet::PURE, span: s() }
+}
+
+fn puts_stmt(arg: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "puts".into(),
+            args: vec![arg],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+fn demo_module(name: &str, stmts: Vec<Stmt>) -> Module {
+    Module {
+        // A distinct name per test -- these run as parallel threads in the
+        // same process (cargo test's default), so a shared name collides on
+        // the same temp file path.
+        name: name.into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Strings,
+            Feature::Sequences,
+            Feature::MutableBindings,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn run(module: &Module) -> Option<String> {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return None;
+    }
+    let artifact = compile(module).expect("module should compile to Go source");
+    let dir = std::env::temp_dir();
+    let src_path = dir.join(format!("sir_go_shift_{}_{}.go", std::process::id(), module.name));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let run_out = Command::new("go").arg("run").arg(&src_path).output().expect("invoke go run");
+    let _ = std::fs::remove_file(&src_path);
+    if !run_out.status.success() {
+        panic!(
+            "emitted Go failed to compile/run:\n--- stderr ---\n{}\n--- source ---\n{}",
+            String::from_utf8_lossy(&run_out.stderr),
+            artifact.source,
+        );
+    }
+    Some(String::from_utf8_lossy(&run_out.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn integer_shift_left() {
+    let m = demo_module("shift_int", vec![puts_stmt(shift(vec![ilit(5), ilit(2)]))]);
+    if let Some(out) = run(&m) {
+        assert_eq!(out, "20\n");
+    }
+}
+
+#[test]
+fn negative_amount_reverses_direction() {
+    let m = demo_module("shift_neg", vec![puts_stmt(shift(vec![ilit(5), ilit(-1)]))]);
+    if let Some(out) = run(&m) {
+        assert_eq!(out, "2\n");
+    }
+}
+
+#[test]
+fn overflow_saturates_instead_of_wrapping() {
+    // `1 << 63` is one past int64's positive range (no bignum growth here,
+    // unlike real Ruby) -- must saturate to MaxInt64, not silently wrap to
+    // a negative number.
+    let m = demo_module("shift_overflow", vec![puts_stmt(shift(vec![ilit(1), ilit(63)]))]);
+    if let Some(out) = run(&m) {
+        assert_eq!(out, "9223372036854775807\n");
+    }
+}
+
+#[test]
+fn array_receiver_pushes_in_place() {
+    // `puts` on an Array unpacks one element per line (real Ruby's
+    // `Kernel#puts` rule, already implemented on this backend) -- so the
+    // mutated `[1, 2, 3]` receiver prints as three lines, not a bracketed
+    // display, proving the push landed without depending on this
+    // backend's bracket-display convention.
+    let m = demo_module(
+        "shift_array",
+        vec![
+            Stmt::LetBinding {
+                name: "a".into(),
+                sir_type: None,
+                value: seq(vec![ilit(1), ilit(2)]),
+                span: s(),
+            },
+            Stmt::ExprStmt {
+                expr: shift(vec![
+                    Expr::VarRef { name: "a".into(), scope: Scope::Local, span: s() },
+                    ilit(3),
+                ]),
+                span: s(),
+            },
+            puts_stmt(Expr::VarRef { name: "a".into(), scope: Scope::Local, span: s() }),
+        ],
+    );
+    if let Some(out) = run(&m) {
+        assert_eq!(out, "1\n2\n3\n");
+    }
+}
+
+#[test]
+fn string_receiver_concatenates_to_a_new_string() {
+    let m = demo_module("shift_string", vec![puts_stmt(shift(vec![slit("ab"), slit("cd")]))]);
+    if let Some(out) = run(&m) {
+        assert_eq!(out, "abcd\n");
+    }
+}


### PR DESCRIPTION
## Summary
- Part of "Python/JS/Go/Rust/Ruby backends: implement `<<` runtime dispatch" — `ruby-to-semantic-ir` lowers `<<` to a top-level `BuiltinCall("<<", [lhs, rhs, ...])`, a separate protocol from the `__method__("<<", recv, arg)` Collections dispatch Array#push already used on this backend
- The operator form reached `_sir_call_builtin_by_name`'s floor and panicked `unknown builtin: <<` — every Ruby program using `<<` as an operator (`a << 1`, `arr << x`, `"a" << "b"`) failed at runtime on Go
- New `_sir_shift_left`, polymorphic like the existing `_sir_plus`: Array pushes each RHS operand in place (chains left-to-right, since the frontend lowers a `<<` chain to one variadic call), Integer bitwise-shifts via `_sir_shift_left_i64` (a faithful port of the C backend's helper of the same name — identical overflow/negative-amount/saturation semantics), String concatenates to a new string via the existing `_sir_as_string`
- New supporting helpers `_sir_shift_amount_arg`, `_sir_f64_to_i64_saturating` (Go's own float→int conversion is implementation-specific for out-of-range/non-finite input), and `_sir_i64_abs_u` (MinInt64-safe magnitude via uint64 wraparound)
- Ruby backend (`semantic-ir-to-ruby`) already had `<<` support from earlier work; Python, JS/TS, and Rust backends still lack the top-level operator, tracked as separate follow-ups

## Test plan
- [x] New `compile_and_run_shift_operator.rs`: Integer left shift, negative amount reverses direction, overflow saturates (not wraps), Array push in place, String concat to a new string — each compiled and run with a real `go run`
- [x] Full `semantic-ir-to-go` test suite green
- [x] `sir-conformance` full corpus green (no regressions)
- [x] `cargo clippy -p semantic-ir-to-go --all-targets` clean
- [x] Security review passed, with explicit verification that every Go native shift operator use is preceded by a guard preventing a negative or >=64 shift count (which panics in Go)
- [x] CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)