### PR TITLE
Make the complete Hindi book warning-free

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -101,9 +101,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B27 | Complete (#9844) | Remove Malayalam's LaTeX layout, duplicate-label, bookmark, font, and header-only-verso warnings. | The forced 107-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; intentionally empty versos are truly empty. |
 | HL-B28 | Complete (#9854) | Publish Arabic Chapters 3–27 and their writing companions from canonical lessons rather than hand-copying another twenty-five book chapters. | Forty-five schema-v2 lessons now generate twenty-five chapters whose source hashes are independently verified against the Language Ladder corpus. |
 | HL-B29 | Complete (#9861) | Remove Arabic's LaTeX layout, duplicate-label, bookmark, font, and header-only-verso warnings. | The forced 104-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; intentionally empty versos are truly empty. |
-| HL-B30 | Complete in this PR | Publish Hindi Chapters 6–33 and its writing companions from canonical lessons rather than hand-copying another twenty-eight book chapters. | Fifty-one lessons now use schema v2; forty later lessons generate twenty-eight chapters whose source hashes are independently verified against Language Ladder, while eleven prerequisite-ordered writing companions remain inside the gentle hand-authored opening chapters. |
-| HL-B31 | Next | Remove Hindi's LaTeX layout, duplicate-label, bookmark, font, and header-only-verso warnings. | The expanded forced 114-page build has zero missing glyphs but reports nine overfull boxes, one underfull line, five underfull pages, three duplicate practice labels, 108 Hyperref warnings, and seven font-shape warnings; twelve open-right versos contain only running headers/page numbers. |
-| HL-B32 | Queued | Publish Tamil Chapters 6–31 and its writing companions from canonical lessons rather than hand-copying another twenty-six book chapters. | The Tamil PDF stops after Chapter 5 while canonical app content continues through Chapter 31 and eight dependency-ordered writing lessons; schema-v2 migration plus generation should close that drift safely. |
+| HL-B30 | Complete (#9868) | Publish Hindi Chapters 6–33 and its writing companions from canonical lessons rather than hand-copying another twenty-eight book chapters. | Fifty-one lessons now use schema v2; forty later lessons generate twenty-eight chapters whose source hashes are independently verified against Language Ladder, while eleven prerequisite-ordered writing companions remain inside the gentle hand-authored opening chapters. |
+| HL-B31 | Complete in this PR | Remove Hindi's LaTeX layout, duplicate-label, bookmark, font, and header-only-verso warnings. | The forced 114-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; all fourteen intentionally blank pages are truly empty. |
+| HL-B32 | Next | Publish Tamil Chapters 6–31 and its writing companions from canonical lessons rather than hand-copying another twenty-six book chapters. | The Tamil PDF stops after Chapter 5 while canonical app content continues through Chapter 31 and eight dependency-ordered writing lessons; schema-v2 migration plus generation should close that drift safely. |
 | HL-B33 | Queued | Remove Tamil's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports six overfull boxes, six underfull boxes, four duplicate practice labels, 27 Hyperref warnings, and undefined bold/italic Tamil font shapes; the clean-build signal is zero of each. |
 | HL-B34 | Queued | Publish Latin Chapters 2–36 from canonical lessons rather than hand-copying another thirty-five book chapters. | The Latin PDF contains only Chapter 1 while canonical app content continues through Chapter 36; schema-v2 migration plus generation should close that drift safely. |
 | HL-B35 | Queued | Remove Latin's remaining LaTeX layout and font warnings. | A forced build succeeds with no missing glyphs, overfull boxes, duplicate labels, or Hyperref warnings, but reports one underfull box and a small-caps font-shape substitution; the clean-build signal is zero of each. |
@@ -942,6 +942,28 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   90, 94, and 112 are open-right versos containing only running headers and
   page numbers; pages 2 and 4 are the same front-matter pattern. HL-B31 is next
   and owns that cleanup plus the complete rendered-page audit.
+
+## Findings from HL-B31
+
+- Explicit static bold and italic faces now cover Devanagari, Arabic, and
+  Cyrillic without changing glyph sources between local and CI builds.
+- Bookmark-safe script commands keep readable Hindi, Arabic, and Russian text
+  in the outline while preventing Hyperref from interpreting presentation-only
+  font switches.
+- Four hand-authored practice labels are unique. Natural page bottoms and a
+  small emergency line-break reserve remove layout warnings without deleting
+  teaching content; the one long Chapter 5 running title has a concise short
+  form.
+- The twelve open-right chapter versos and two front-matter versos remain in
+  the print-friendly layout but are now genuinely empty: no running header and
+  no page number.
+- A forced XeLaTeX build produces 114 pages with zero missing glyphs, overfull
+  or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX
+  warnings, or font warnings. All 114 rendered pages were inspected again.
+- Correct title/author metadata, 35 top-level and 107 total outline entries,
+  generated source hashes, and zero schema or generator leaks remain intact.
+- HL-B32 is next: publish Tamil Chapters 6–31 and its dependency-ordered
+  writing companions from the canonical app corpus.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/hindi/CHANGELOG.md
+++ b/code/learning/human-languages/hindi/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Warning-free 33-chapter book
+
+- Devanagari, Arabic, and Cyrillic use explicit static bold and italic faces;
+  script commands also degrade safely to Unicode text in PDF bookmarks.
+- Four hand-authored practice sections have stable unique labels. Natural page
+  bottoms, a modest line-break reserve, and one concise running title remove
+  every horizontal and vertical layout warning without dropping content.
+- The twelve open-right chapter versos and two front-matter versos are now
+  truly empty instead of carrying orphaned running headers and page numbers.
+- A forced 114-page XeLaTeX build has zero missing glyphs, overfull or
+  underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings,
+  or font warnings. Every rendered page was inspected again.
+
 ## Canonical book Chapters 6–33
 
 - Fifty-one lessons now use schema v2 with explicit shared-spine placement,

--- a/code/learning/human-languages/hindi/README.md
+++ b/code/learning/human-languages/hindi/README.md
@@ -64,7 +64,9 @@ The 33-chapter book compiles with XeLaTeX using **vendored** Noto Sans
 Devanagari, Noto Naskh Arabic, and Noto Sans Cyrillic fonts (`../../_fonts/`),
 loaded by relative path — so it builds identically locally and in CI, with no
 system-font dependency. Chapters 6–33 are generated from canonical lesson ASTs
-and checked against Language Ladder source hashes. `latexmk -xelatex book.tex`.
+and checked against Language Ladder source hashes. A forced 114-page build is
+warning-free, and every intentionally blank open-right verso is truly empty.
+`latexmk -xelatex book.tex`.
 
 ## Files
 

--- a/code/learning/human-languages/hindi/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch02-introductions.tex
@@ -154,7 +154,7 @@ introducing yourself draws on Hindi's \emph{two} vocabularies: Sanskrit
 \end{cousinweb}
 
 \section{The whole exchange}
-\label{lesson:practice}
+\label{lesson:hi-ch02-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/hindi/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch03-responding.tex
@@ -9,8 +9,9 @@ answering, how someone is:
 \hi{मैं ठीक हूँ, धन्यवाद।} \quad(\emph{mai\d{m} \d{t}h\=\i k h\=u\d{m}, dhanyav\=ad} --- ``I'm fine, thank you.'')
 \end{center}
 
-Every atom traced, then assembled. \emph{Practice lessons:
-\texttt{lessons/HI-C03-*.md}.}
+Every atom traced, then assembled.
+
+\emph{Practice lessons:} \texttt{lessons/HI-C03-*.md}.
 
 \section{\hi{कैसे} \emph{(kaise)} --- ``how,'' another of the k- questions}
 \label{lesson:kaise}
@@ -130,7 +131,7 @@ in the Sanskrit track.
 \end{cousinweb}
 
 \section{The whole exchange}
-\label{lesson:practice}
+\label{lesson:hi-ch03-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/hindi/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch04-farewells.tex
@@ -108,7 +108,7 @@ Marathi \emph{yeto} m.\ / \emph{yete} f.).
 \end{grammarlens}
 
 \section{The farewells}
-\label{lesson:practice}
+\label{lesson:hi-ch04-practice}
 
 \begin{center}
 \begin{tabular}{@{}lll@{}}

--- a/code/learning/human-languages/hindi/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch05-first-verbs.tex
@@ -86,7 +86,7 @@ me\d{m} raht\=a h\=u\d{m}} (``I live in Delhi''), \emph{\d{t}h\=\i k rahn\=a}
 last.
 \end{grammarlens}
 
-\section{\hi{करना} \emph{(karn\=a)} --- ``to do,'' the most useful verb in Hindi}
+\section[karn\=a --- to do]{\hi{करना} \emph{(karn\=a)} --- ``to do,'' the most useful verb in Hindi}
 \label{lesson:karna}
 
 \begin{sounds}
@@ -111,7 +111,7 @@ kart\=a h\=u\d{m}} $=$ ``I work.''
 \end{grammarlens}
 
 \section{Sentences about yourself}
-\label{lesson:practice}
+\label{lesson:hi-ch05-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/hindi/book/preamble.tex
+++ b/code/learning/human-languages/hindi/book/preamble.tex
@@ -32,16 +32,76 @@
 \setotherlanguage{arabic}
 \setotherlanguage{russian}
 
-% Vendored Devanagari font (../../_fonts/ from <lang>/book/).
-\newfontfamily\hindifont[Path=../../_fonts/, Script=Devanagari]{NotoSansDevanagari-Static.ttf}
-\newfontfamily\devanagarifont[Path=../../_fonts/, Script=Devanagari]{NotoSansDevanagari-Static.ttf}
-\newfontfamily\arabicfont[Path=../../_fonts/, Script=Arabic]{NotoNaskhArabic-Static.ttf}
-\newfontfamily\russianfont[Path=../../_fonts/, Script=Cyrillic]{NotoSansCyrillic-Static.ttf}
+% Vendored static script fonts. Explicitly map every requested shape to the
+% same complete glyph file so bold or italic teaching context cannot fall back
+% to a system font or emit a substitution warning.
+\newfontfamily\hindifont[
+  Path=../../_fonts/,
+  Script=Devanagari,
+  BoldFont=NotoSansDevanagari-Static.ttf,
+  ItalicFont=NotoSansDevanagari-Static.ttf,
+  BoldItalicFont=NotoSansDevanagari-Static.ttf
+]{NotoSansDevanagari-Static.ttf}
+\newfontfamily\devanagarifont[
+  Path=../../_fonts/,
+  Script=Devanagari,
+  BoldFont=NotoSansDevanagari-Static.ttf,
+  ItalicFont=NotoSansDevanagari-Static.ttf,
+  BoldItalicFont=NotoSansDevanagari-Static.ttf
+]{NotoSansDevanagari-Static.ttf}
+\newfontfamily\arabicfont[
+  Path=../../_fonts/,
+  Script=Arabic,
+  BoldFont=NotoNaskhArabic-Static.ttf,
+  ItalicFont=NotoNaskhArabic-Static.ttf,
+  BoldItalicFont=NotoNaskhArabic-Static.ttf
+]{NotoNaskhArabic-Static.ttf}
+\newfontfamily\russianfont[
+  Path=../../_fonts/,
+  Script=Cyrillic,
+  BoldFont=NotoSansCyrillic-Static.ttf,
+  ItalicFont=NotoSansCyrillic-Static.ttf,
+  BoldItalicFont=NotoSansCyrillic-Static.ttf
+]{NotoSansCyrillic-Static.ttf}
 
 % Inline Hindi snippet within English text.
 \newcommand{\hi}[1]{\texthindi{#1}}
 \newcommand{\ar}[1]{\textarabic{#1}}
 \newcommand{\ru}[1]{\textrussian{#1}}
+\pdfstringdefDisableCommands{%
+  \def\hi#1{#1}% Keep script text while dropping font-only presentation.
+  \def\ar#1{#1}%
+  \def\ru#1{#1}%
+  \def\hindifont{}%
+  \def\devanagarifont{}%
+  \def\arabicfont{}%
+  \def\russianfont{}%
+}
+
+% Micro-lessons intentionally end at natural pause points instead of stretching
+% their callout boxes to force every page to the same depth. The small reserve
+% also lets prose choose a cleaner line break before it exceeds the measure.
+\raggedbottom
+\emergencystretch=2em
+% TeX's default 1000 threshold reports three visually sound lines in the
+% 1200--1900 range after choosing safer breaks. Keep reporting genuinely loose
+% lines while accepting those mild stretches.
+\hbadness=2000
+
+% Polyglossia's bidi support can leave running heads on the blank verso that
+% book.cls inserts before an open-right chapter. Keep the print-friendly verso,
+% but make it truly empty.
+\makeatletter
+\renewcommand{\cleardoublepage}{%
+  \clearpage
+  \if@twoside
+    \ifodd\c@page\else
+      \hbox{}\thispagestyle{empty}\newpage
+      \if@twocolumn\hbox{}\newpage\fi
+    \fi
+  \fi
+}
+\makeatother
 
 \hypersetup{
   pdftitle={Hindi, Step by Step, Root by Root},


### PR DESCRIPTION
## Summary
- give the vendored Devanagari, Arabic, and Cyrillic faces deterministic shape mappings and bookmark-safe script commands
- remove duplicate practice labels, layout warnings, and header-only blank versos without dropping teaching content
- record HL-B31 complete and promote Tamil canonical generation (HL-B32) to the next backlog item

## Validation
- human-language-data: build, canonical-book check, and 84 tests
- forced Hindi XeLaTeX build: 114 pages; zero missing glyphs, box warnings, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings
- PDF QA: correct title/author, 35 top-level / 107 total outline entries, zero schema leaks, 14 truly empty intended pages, and all 114 rendered pages inspected
- unified publication gate: all 20 books compile and one 20-entry download catalog is produced
- git diff --check