### PR TITLE
feat(semantic-ir-to-rust): << (Ruby's shift operator) as a top-level builtin

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.39.3 — `<<` (Ruby's shift operator) as a top-level builtin
+
+Part of "Python/JS/Rust/Ruby backends: implement shift-operator runtime
+dispatch". `ruby-to-semantic-ir` lowers `<<` to a top-level
+`BuiltinCall("<<", [lhs, rhs, ...])` — a separate protocol from the
+`__method__("<<", recv, arg)` Collections dispatch. The operator form
+reached `call_builtin_by_name`'s floor and panicked `unknown builtin:
+<<` — every Ruby program using `<<` as an operator (`a << 1`, `arr << x`,
+`"a" << "b"`) failed at runtime.
+
+New `shift_left`, polymorphic like the existing `plus`: Array pushes each
+RHS operand in place (chains left-to-right, since the frontend lowers a
+`<<` chain to one variadic call); Integer bitwise-shifts via
+`shift_left_i64`, PORTED from the C/Go backends' helper of the same name
+for identical overflow/negative-amount/saturation semantics; String
+concatenates to a new string, raising the SAME rescuable `TypeError`
+`plus` raises for a non-string operand.
+
+Simpler than the C/Go ports needed: Rust's `i64::unsigned_abs()` already
+handles `i64::MIN` correctly (no manual wraparound trick needed), and
+`f as i64` has been a SATURATING, NaN-safe conversion by language
+guarantee since Rust 1.45 (no manual float-to-int saturation helper
+needed either) — only the shift-count-must-be-checked-before-native-`<<`
+guard (Rust panics/masks on an out-of-range shift count, same hazard as
+Go) needed porting.
+
+Ruby backend (`semantic-ir-to-ruby`) already had `<<` support from
+earlier work; Python and JS/TS backends still lack the top-level
+operator, tracked as separate follow-ups.
+
+`semantic-ir-to-rust` 0.39.2 -> 0.39.3.
+
 ## 0.39.2 — fix: `Array#[]=` (bracket-index write) was unimplemented
 
 Part of "Python/JS/Go/Rust backends: implement `[]`/`[]=` bracket-index

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.39.2"
+version = "0.39.3"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -315,6 +315,125 @@ pub const RUNTIME: &str = r##"mod __sir {
         }
     }
 
+    // ── polymorphic `<<` (Ruby's shift operator) ────────────────────
+    //
+    // `<<` -- Ruby's shift operator, polymorphic like `plus`:
+    //   Array   -- push each RHS operand IN PLACE, returns the (mutated)
+    //              receiver. Chains left-to-right: `a << 1 << 2` pushes
+    //              both (the frontend lowers a `<<` chain to ONE variadic
+    //              call, the same convention `plus` already folds over).
+    //   Integer -- bitwise shift; see `shift_left_i64` below, PORTED from
+    //              the C/Go backends' helper of the same name for
+    //              identical overflow/negative-amount semantics (no
+    //              bignum growth -- saturates at i64::MAX/i64::MIN rather
+    //              than wrapping).
+    //   String  -- concatenates and returns a NEW string, raising the
+    //              SAME rescuable `TypeError` `plus` raises for a
+    //              non-string operand (Ruby raises `TypeError` for `<<`
+    //              on an incompatible operand too, so this is not a new
+    //              divergence from `plus`).
+    pub fn shift_left(args: Vec<Value>) -> Value {
+        match args.first() {
+            Some(Value::Seq(items)) => {
+                for a in &args[1..] {
+                    items.borrow_mut().push(a.clone());
+                }
+                Value::Seq(Rc::clone(items))
+            }
+            Some(Value::Str(_)) => {
+                let mut out = String::new();
+                for a in &args {
+                    match a {
+                        Value::Str(s) => out.push_str(s),
+                        other => raise(
+                            "TypeError",
+                            Value::Str(Rc::from(
+                                format!(
+                                    "no implicit conversion of {} into String",
+                                    ruby_class_name(other)
+                                )
+                                .as_str(),
+                            )),
+                        ),
+                    }
+                }
+                Value::Str(Rc::from(out.as_str()))
+            }
+            _ => {
+                let mut acc = args.first().map(as_i64).unwrap_or(0);
+                for a in &args[1..] {
+                    acc = shift_left_i64(acc, shift_amount_arg(a));
+                }
+                Value::Int(acc)
+            }
+        }
+    }
+
+    // Extracts a shift-amount argument as a plain i64 -- an Integer passes
+    // through, a Float truncates toward zero via Rust's `as i64` cast
+    // (SATURATING and NaN-safe by language guarantee since Rust 1.45 --
+    // "if the source value is `NaN`... the result is 0; otherwise the
+    // result is clamped to the range of the target type", so no manual
+    // overflow guard is needed here unlike the C/Go backends' equivalent
+    // helper); anything else contributes a 0 shift.
+    fn shift_amount_arg(v: &Value) -> i64 {
+        match v {
+            Value::Int(n) => *n,
+            Value::Float(f) => *f as i64,
+            _ => 0,
+        }
+    }
+
+    // Bitwise-shifts `n` by `amount`, matching real Ruby's rules (ported
+    // from the C/Go backends' `shift_left_i64` -- see those for the full
+    // rationale):
+    //   - `amount == 0` or `n == 0`: identity.
+    //   - `amount < 0`: REVERSES direction -- a right shift by
+    //     `amount.unsigned_abs()` (`5 << -1 == 5 >> 1 == 2`).
+    //   - `amount > 0`: LEFT shift, SATURATES at i64::MAX/i64::MIN rather
+    //     than wrapping once the true mathematical result would not fit.
+    //   - A shift amount whose magnitude is >= 64 drains every bit:
+    //     saturates to 0/-1 (right) or i64::MAX/i64::MIN (left, `n != 0`).
+    // Rust's native `<<`/`>>` panic (in a debug build) or silently mask
+    // the shift amount mod 64 (in a release build) for a count >= the bit
+    // width, so every shift below is manually guarded to a checked,
+    // in-range amount before it ever reaches a native `<<`/`>>`.
+    fn shift_left_i64(n: i64, amount: i64) -> i64 {
+        if amount == 0 || n == 0 {
+            return n;
+        }
+        if amount < 0 {
+            let k = amount.unsigned_abs();
+            if k >= 64 {
+                return if n < 0 { -1 } else { 0 };
+            }
+            return n >> k;
+        }
+        let k = amount as u64;
+        let neg = n < 0;
+        if k >= 64 {
+            return if neg { i64::MIN } else { i64::MAX };
+        }
+        let mag = n.unsigned_abs();
+        if (mag >> (64 - k)) != 0 {
+            return if neg { i64::MIN } else { i64::MAX };
+        }
+        let shifted = mag << k;
+        let limit = if neg { i64::MAX as u64 + 1 } else { i64::MAX as u64 };
+        if shifted > limit {
+            return if neg { i64::MIN } else { i64::MAX };
+        }
+        if neg {
+            if shifted == limit {
+                i64::MIN
+            } else {
+                -(shifted as i64)
+            }
+        } else {
+            shifted as i64
+        }
+    }
+
     pub fn minus(args: Vec<Value>) -> Value {
         if args.is_empty() {
             return Value::Int(0);
@@ -1189,6 +1308,7 @@ pub const RUNTIME: &str = r##"mod __sir {
     pub fn call_builtin_by_name(name: &str, args: Vec<Value>) -> Value {
         match name {
             "+" => plus(args),
+            "<<" => shift_left(args),
             "-" => minus(args),
             "*" => times(args),
             "/" => divide(args),

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -359,8 +359,9 @@ pub const RUNTIME: &str = r##"mod __sir {
                 }
                 Value::Str(Rc::from(out.as_str()))
             }
-            _ => {
-                let mut acc = args.first().map(as_i64).unwrap_or(0);
+            None => Value::Int(0),
+            Some(first) => {
+                let mut acc = as_i64(first);
                 for a in &args[1..] {
                     acc = shift_left_i64(acc, shift_amount_arg(a));
                 }

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_shift_operator.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_shift_operator.rs
@@ -145,6 +145,18 @@ fn compile_and_run(module: &Module) -> Option<String> {
 }
 
 #[test]
+fn empty_args_does_not_panic() {
+    // A hand-built `BuiltinCall("<<", [])` (no receiver at all) must not
+    // panic on an empty-slice index -- caught by security review: the
+    // integer fallback arm indexed `args[1..]` before checking `args` was
+    // non-empty.
+    let m = demo_module("shift_empty", vec![print_stmt(shift(vec![]))]);
+    if let Some(out) = compile_and_run(&m) {
+        assert_eq!(out, "0\n");
+    }
+}
+
+#[test]
 fn integer_shift_left() {
     let m = demo_module("shift_int", vec![print_stmt(shift(vec![ilit(5), ilit(2)]))]);
     if let Some(out) = compile_and_run(&m) {

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_shift_operator.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_shift_operator.rs
@@ -1,0 +1,203 @@
+//! End-to-end proof for the `<<` builtin (Ruby's shift operator) as a
+//! top-level `BuiltinCall("<<", [lhs, rhs, ...])` on the Rust backend — part
+//! of "Python/JS/Rust/Ruby backends: implement shift-operator runtime
+//! dispatch".
+//!
+//! `ruby-to-semantic-ir` lowers `<<` to this envelope (distinct from the
+//! `__method__("<<", recv, arg)` Collections-dispatch protocol). Before this
+//! fix, the top-level operator reached `call_builtin_by_name`'s floor and
+//! panicked `unknown builtin: <<` — every Ruby program using `<<` as an
+//! operator failed at runtime on Rust.
+//!
+//! This test hand-builds SIR modules exercising each receiver type, emits
+//! Rust, compiles with `rustc`, runs the binary, and asserts stdout:
+//!
+//!   * `5 << 2`       → `20`   (Integer left shift)
+//!   * `5 << -1`      → `2`    (negative amount reverses direction)
+//!   * `1 << 63`      → saturates to `i64::MAX` (no bignum growth)
+//!   * `[1, 2] << 3`  → `[1, 2, 3]` (Array push, mutates receiver)
+//!   * `"ab" << "cd"` → `abcd` (String concat, new string)
+//!
+//! Gates on `rustc`; logs a skip when absent.
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Scope, Span,
+    Stmt,
+};
+use semantic_ir_to_rust::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn seq(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+
+fn shift(args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: "<<".into(), args, effects: EffectSet::PURE, span: s() }
+}
+
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "print".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE,
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+fn demo_module(name: &str, main_stmts: Vec<Stmt>) -> Module {
+    Module {
+        // A distinct name per test -- these run as parallel threads in the
+        // same process (cargo test's default), so a shared name collides on
+        // the same temp file path.
+        name: name.into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Sequences,
+            Feature::Strings,
+            Feature::Closures,
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts: main_stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn compile_and_run(module: &Module) -> Option<String> {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return None;
+    }
+    let artifact = compile(module).expect("module should compile to Rust source");
+
+    let dir = std::env::temp_dir();
+    let nonce = format!("{}_{}", std::process::id(), module.name);
+    let src_path = dir.join(format!("sir_shift_{nonce}.rs"));
+    let bin_path = dir.join(format!("sir_shift_{nonce}{}", if cfg!(windows) { ".exe" } else { "" }));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd.arg(&src_path).arg("-o").arg(&bin_path).output().expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker") && (stderr.contains("not found") || stderr.contains("No such file")) {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return None;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+    assert!(
+        run_out.status.success(),
+        "compiled binary exited non-zero:\n{}",
+        String::from_utf8_lossy(&run_out.stderr)
+    );
+    Some(String::from_utf8_lossy(&run_out.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn integer_shift_left() {
+    let m = demo_module("shift_int", vec![print_stmt(shift(vec![ilit(5), ilit(2)]))]);
+    if let Some(out) = compile_and_run(&m) {
+        assert_eq!(out, "20\n");
+    }
+}
+
+#[test]
+fn negative_amount_reverses_direction() {
+    let m = demo_module("shift_neg", vec![print_stmt(shift(vec![ilit(5), ilit(-1)]))]);
+    if let Some(out) = compile_and_run(&m) {
+        assert_eq!(out, "2\n");
+    }
+}
+
+#[test]
+fn overflow_saturates_instead_of_wrapping() {
+    let m = demo_module("shift_overflow", vec![print_stmt(shift(vec![ilit(1), ilit(63)]))]);
+    if let Some(out) = compile_and_run(&m) {
+        assert_eq!(out, "9223372036854775807\n");
+    }
+}
+
+#[test]
+fn array_receiver_pushes_in_place() {
+    let m = demo_module(
+        "shift_array",
+        vec![
+            Stmt::LetBinding {
+                name: "a".into(),
+                sir_type: None,
+                value: seq(vec![ilit(1), ilit(2)]),
+                span: s(),
+            },
+            Stmt::ExprStmt {
+                expr: shift(vec![
+                    Expr::VarRef { name: "a".into(), scope: Scope::Local, span: s() },
+                    ilit(3),
+                ]),
+                span: s(),
+            },
+            print_stmt(Expr::VarRef { name: "a".into(), scope: Scope::Local, span: s() }),
+        ],
+    );
+    if let Some(out) = compile_and_run(&m) {
+        assert_eq!(out, "[1, 2, 3]\n");
+    }
+}
+
+#[test]
+fn string_receiver_concatenates_to_a_new_string() {
+    let m = demo_module("shift_string", vec![print_stmt(shift(vec![slit("ab"), slit("cd")]))]);
+    if let Some(out) = compile_and_run(&m) {
+        assert_eq!(out, "abcd\n");
+    }
+}


### PR DESCRIPTION
## Summary
- Part of "Python/JS/Rust/Ruby backends: implement shift-operator runtime dispatch" — `ruby-to-semantic-ir` lowers `<<` to a top-level `BuiltinCall("<<", [lhs, rhs, ...])`, a separate protocol from the `__method__("<<", recv, arg)` Collections dispatch
- The operator form reached `call_builtin_by_name`'s floor and panicked `unknown builtin: <<` — every Ruby program using `<<` as an operator (`a << 1`, `arr << x`, `"a" << "b"`) failed at runtime
- New `shift_left`, polymorphic like the existing `plus`: Array pushes each RHS operand in place, Integer bitwise-shifts via `shift_left_i64` (ported from the C/Go backends' helper of the same name for identical overflow/negative-amount/saturation semantics), String concatenates raising the same rescuable `TypeError` `plus` already raises for a non-string operand
- Simpler than the C/Go ports: Rust's `i64::unsigned_abs()` already handles `i64::MIN` correctly, and `f as i64` has been a saturating, NaN-safe conversion by language guarantee since Rust 1.45 — only the shift-count-must-be-checked-before-native-`<<` guard needed porting
- Ruby backend already had `<<` support; Python and JS/TS backends still lack it, tracked as separate follow-ups

**Security review caught and fixed one issue during development**: the integer arm's wildcard match indexed `args[1..]` before checking `args` was non-empty, so a hand-built zero-arg `BuiltinCall("<<", [])` would panic on an out-of-bounds slice index. Fixed to match the sibling `minus`'s existing `args.is_empty()` guard convention, with a regression test. Re-review passed clean.

## Test plan
- [x] New `compile_and_run_shift_operator.rs`: empty args (no panic), Integer left shift, negative amount reverses direction, overflow saturates (not wraps), Array push in place, String concat to a new string — each compiled and run with a real `rustc`
- [x] Full `semantic-ir-to-rust` test suite green
- [x] `sir-conformance` full corpus green (no regressions)
- [x] `cargo clippy -p semantic-ir-to-rust --all-targets` clean
- [x] Security review: 1 LOW finding (empty-args panic), fixed, re-reviewed clean
- [x] CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)