### PR TITLE
Add verified agent package discovery

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -1029,6 +1029,7 @@ members = [
   "chief-of-staff-daemon-installer",
   "chief-of-staff-cli",
   "chief-of-staff-agent-manifest",
+  "chief-of-staff-agent-discovery",
   "chief-of-staff-skill-parser",
   "chief-of-staff-skill-runtime",
   "chief-of-staff-agent-stdio-protocol",

--- a/code/packages/rust/chief-of-staff-agent-discovery/BUILD
+++ b/code/packages/rust/chief-of-staff-agent-discovery/BUILD
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+cargo test -p chief-of-staff-agent-discovery -- --nocapture
+cargo clippy -p chief-of-staff-agent-discovery --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-agent-discovery --no-deps

--- a/code/packages/rust/chief-of-staff-agent-discovery/BUILD_windows
+++ b/code/packages/rust/chief-of-staff-agent-discovery/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p chief-of-staff-agent-discovery && cargo clippy -p chief-of-staff-agent-discovery --all-targets -- -D warnings

--- a/code/packages/rust/chief-of-staff-agent-discovery/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-agent-discovery/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0 - 2026-08-03
+
+- Add explicit package inspection and stable `.agent` directory scans.
+- Derive registration candidates from authenticated manifests with tier checks.

--- a/code/packages/rust/chief-of-staff-agent-discovery/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-agent-discovery/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "chief-of-staff-agent-discovery"
+version = "0.1.0"
+edition = "2021"
+description = "Verified package discovery and registration candidates for D18 agents"
+license = "MIT"
+
+[dependencies]
+chief-of-staff-agent-manifest = { path = "../chief-of-staff-agent-manifest" }
+chief-of-staff-host-runtime = { path = "../chief-of-staff-host-runtime" }
+chief-of-staff-service-registry = { path = "../chief-of-staff-service-registry" }
+chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
+
+[dev-dependencies]
+coding_adventures_ed25519 = { path = "../ed25519" }

--- a/code/packages/rust/chief-of-staff-agent-discovery/README.md
+++ b/code/packages/rust/chief-of-staff-agent-discovery/README.md
@@ -1,0 +1,7 @@
+# chief-of-staff-agent-discovery
+
+Verified discovery for sealed D18 `.agent` packages. It supports explicit
+inspection and stable, non-recursive directory scans. Every candidate is
+signature-verified before the exact authenticated manifest bytes are parsed.
+The result is an inert `HostRegistration`; callers must explicitly submit it to
+the authenticated control plane. Discovery never registers or starts agents.

--- a/code/packages/rust/chief-of-staff-agent-discovery/required_capabilities.json
+++ b/code/packages/rust/chief-of-staff-agent-discovery/required_capabilities.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/chief-of-staff-agent-discovery",
+  "capabilities": [
+    {"category": "fs", "action": "list", "target": "configured-agent-packages-directory", "justification": "Lists immediate candidates in the configured agents directory."},
+    {"category": "fs", "action": "read", "target": "configured-agent-package-files", "justification": "Reads sealed files for signature and manifest verification."}
+  ],
+  "justification": "Discovers configured sealed packages and returns inert registration candidates without process, network, clock, random, or registry access."
+}

--- a/code/packages/rust/chief-of-staff-agent-discovery/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-agent-discovery/src/lib.rs
@@ -1,0 +1,376 @@
+//! Verified package discovery and registration candidates for D18 agents.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use chief_of_staff_agent_manifest::{parse_manifest, AgentManifest, ManifestError};
+use chief_of_staff_host_runtime::{
+    verify_agent_package, PackageKeyring, PackageVerificationError, VerifiedAgentPackage,
+};
+use chief_of_staff_service_registry::{
+    HostName, HostRegistration, PackagePath, RegistryError, RestartPolicy,
+};
+use chief_of_staff_tool_api::PrivilegeTier;
+use core::fmt::{self, Display, Formatter};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// One authenticated package plus the inert registration it declares.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DiscoveredAgent {
+    package: VerifiedAgentPackage,
+    manifest: AgentManifest,
+    registration: HostRegistration,
+}
+
+impl DiscoveredAgent {
+    /// Borrow the cryptographically verified sealed package.
+    pub fn package(&self) -> &VerifiedAgentPackage {
+        &self.package
+    }
+    /// Borrow the parsed, authenticated schema-v1 manifest.
+    pub fn manifest(&self) -> &AgentManifest {
+        &self.manifest
+    }
+    /// Borrow the immutable candidate for explicit service registration.
+    pub fn registration(&self) -> &HostRegistration {
+        &self.registration
+    }
+    /// Consume this result and return its registration candidate.
+    pub fn into_registration(self) -> HostRegistration {
+        self.registration
+    }
+}
+
+/// Fail-closed package discovery error.
+#[derive(Debug)]
+pub enum DiscoveryError {
+    /// The scan root is not a real, non-symlink directory.
+    InvalidPackagesDirectory(PathBuf),
+    /// Filesystem access failed.
+    Io {
+        /// Path being accessed.
+        path: PathBuf,
+        /// Underlying filesystem error.
+        source: std::io::Error,
+    },
+    /// Package signature or sealed layout verification failed.
+    Package {
+        /// Candidate package path.
+        path: PathBuf,
+        /// Verification failure.
+        source: PackageVerificationError,
+    },
+    /// Authenticated manifest bytes are not UTF-8.
+    NonUtf8Manifest(PathBuf),
+    /// The authenticated manifest is invalid or incompatible.
+    Manifest {
+        /// Candidate package path.
+        path: PathBuf,
+        /// Strict manifest error.
+        source: ManifestError,
+    },
+    /// The manifest tier exceeds the signing key ceiling.
+    TierExceeded {
+        /// Stable manifest agent identity.
+        agent: String,
+        /// Manifest-requested tier number.
+        requested: u8,
+        /// Maximum tier authorized by the signing key.
+        maximum: PrivilegeTier,
+    },
+    /// The canonical package path is not portable UTF-8.
+    NonUtf8Path(PathBuf),
+    /// A registry identity or path rejected the manifest data.
+    Registry {
+        /// Canonical candidate package path.
+        path: PathBuf,
+        /// Registry value validation failure.
+        source: RegistryError,
+    },
+    /// Two candidates declare the same agent identity.
+    DuplicateAgent(String),
+}
+
+impl Display for DiscoveryError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidPackagesDirectory(p) => {
+                write!(f, "invalid agent packages directory: {}", p.display())
+            }
+            Self::Io { path, source } => write!(
+                f,
+                "agent discovery I/O failed at '{}': {source}",
+                path.display()
+            ),
+            Self::Package { path, source } => write!(
+                f,
+                "agent package verification failed at '{}': {source}",
+                path.display()
+            ),
+            Self::NonUtf8Manifest(p) => {
+                write!(f, "authenticated manifest is not UTF-8: {}", p.display())
+            }
+            Self::Manifest { path, source } => write!(
+                f,
+                "authenticated manifest is invalid at '{}': {source}",
+                path.display()
+            ),
+            Self::TierExceeded {
+                agent,
+                requested,
+                maximum,
+            } => write!(
+                f,
+                "agent '{agent}' requests tier {requested} above signing-key ceiling {maximum}"
+            ),
+            Self::NonUtf8Path(p) => write!(f, "agent package path is not UTF-8: {}", p.display()),
+            Self::Registry { path, source } => write!(
+                f,
+                "agent registration is invalid at '{}': {source}",
+                path.display()
+            ),
+            Self::DuplicateAgent(agent) => {
+                write!(f, "duplicate discovered agent identity: {agent}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for DiscoveryError {}
+
+/// Verify and inspect one operator-selected package without registering it.
+pub fn inspect_agent_package(
+    path: &Path,
+    keyring: &PackageKeyring,
+) -> Result<DiscoveredAgent, DiscoveryError> {
+    let package =
+        verify_agent_package(path, keyring).map_err(|source| DiscoveryError::Package {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    let source = std::str::from_utf8(package.manifest_bytes())
+        .map_err(|_| DiscoveryError::NonUtf8Manifest(path.to_path_buf()))?;
+    let manifest = parse_manifest(source).map_err(|source| DiscoveryError::Manifest {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if manifest.privilege_tier > tier_number(package.maximum_tier()) {
+        return Err(DiscoveryError::TierExceeded {
+            agent: manifest.agent.clone(),
+            requested: manifest.privilege_tier,
+            maximum: package.maximum_tier(),
+        });
+    }
+    let canonical = fs::canonicalize(path).map_err(|source| DiscoveryError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let portable = canonical
+        .to_str()
+        .ok_or_else(|| DiscoveryError::NonUtf8Path(canonical.clone()))?;
+    let host_name =
+        HostName::new(manifest.agent.clone()).map_err(|source| DiscoveryError::Registry {
+            path: canonical.clone(),
+            source,
+        })?;
+    let package_path = PackagePath::new(portable).map_err(|source| DiscoveryError::Registry {
+        path: canonical.clone(),
+        source,
+    })?;
+    let registration = HostRegistration::new(
+        host_name,
+        package_path,
+        package.digest(),
+        restart_policy(&manifest.restart_policy),
+    );
+    Ok(DiscoveredAgent {
+        package,
+        manifest,
+        registration,
+    })
+}
+
+/// Scan immediate `.agent` children and return one complete stable snapshot.
+///
+/// Non-package siblings are ignored. One invalid or duplicate candidate fails
+/// the entire scan so callers cannot accidentally act on a partial catalog.
+pub fn discover_agent_packages(
+    directory: &Path,
+    keyring: &PackageKeyring,
+) -> Result<Vec<DiscoveredAgent>, DiscoveryError> {
+    let metadata = fs::symlink_metadata(directory).map_err(|source| DiscoveryError::Io {
+        path: directory.to_path_buf(),
+        source,
+    })?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err(DiscoveryError::InvalidPackagesDirectory(
+            directory.to_path_buf(),
+        ));
+    }
+    let entries = fs::read_dir(directory).map_err(|source| DiscoveryError::Io {
+        path: directory.to_path_buf(),
+        source,
+    })?;
+    let mut candidates = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|source| DiscoveryError::Io {
+            path: directory.to_path_buf(),
+            source,
+        })?;
+        if entry
+            .file_name()
+            .to_str()
+            .is_some_and(|name| name.ends_with(".agent"))
+        {
+            candidates.push(entry.path());
+        }
+    }
+    candidates.sort();
+    let mut identities = BTreeSet::new();
+    let mut agents = Vec::with_capacity(candidates.len());
+    for path in candidates {
+        let agent = inspect_agent_package(&path, keyring)?;
+        if !identities.insert(agent.manifest.agent.clone()) {
+            return Err(DiscoveryError::DuplicateAgent(agent.manifest.agent));
+        }
+        agents.push(agent);
+    }
+    agents.sort_by(|a, b| a.manifest.agent.cmp(&b.manifest.agent));
+    Ok(agents)
+}
+
+fn tier_number(tier: PrivilegeTier) -> u8 {
+    match tier {
+        PrivilegeTier::Tier0 => 0,
+        PrivilegeTier::Tier1 => 1,
+        PrivilegeTier::Tier2 => 2,
+        PrivilegeTier::Tier3 => 3,
+    }
+}
+
+fn restart_policy(value: &str) -> RestartPolicy {
+    match value {
+        "always" => RestartPolicy::Always,
+        "never" => RestartPolicy::Never,
+        _ => RestartPolicy::OnFailure,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chief_of_staff_host_runtime::{
+        hash_package_contents, DenoLaunchPlan, PackageKeyType, TrustedPackageKey,
+    };
+    use coding_adventures_ed25519::{generate_keypair, sign};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_FIXTURE: AtomicU64 = AtomicU64::new(0);
+
+    struct Fixture {
+        root: PathBuf,
+        keyring: PackageKeyring,
+        secret: [u8; 64],
+    }
+    impl Fixture {
+        fn new(max: PrivilegeTier) -> Self {
+            let root = std::env::temp_dir().join(format!(
+                "chief-discovery-{}-{}",
+                std::process::id(),
+                NEXT_FIXTURE.fetch_add(1, Ordering::Relaxed)
+            ));
+            fs::create_dir_all(&root).unwrap();
+            let (public, secret) = generate_keypair(&[51; 32]);
+            let mut keyring = PackageKeyring::new();
+            keyring
+                .trust(
+                    TrustedPackageKey::new("test", PackageKeyType::Production, public, max)
+                        .unwrap(),
+                )
+                .unwrap();
+            Self {
+                root,
+                keyring,
+                secret,
+            }
+        }
+        fn package(&self, dir: &str, agent: &str, tier: u8) -> PathBuf {
+            let path = self.root.join(dir);
+            fs::create_dir_all(path.join("code")).unwrap();
+            fs::write(path.join("code/agent_runtime.ts"), "console.log('ok');\n").unwrap();
+            fs::write(path.join("launch.sh"), DenoLaunchPlan::launch_script()).unwrap();
+            fs::write(path.join("PUBKEY_ID"), "test\n").unwrap();
+            fs::write(path.join("manifest.json"), manifest(agent, tier)).unwrap();
+            let digest = hash_package_contents(&path).unwrap().0;
+            fs::write(path.join("SIGNATURE"), sign(&digest, &self.secret)).unwrap();
+            path
+        }
+    }
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+    fn manifest(agent: &str, tier: u8) -> String {
+        format!(
+            r#"{{"version":1,"agent":"{agent}","description":"Verified package discovery test agent.","privilege_tier":{tier},"channels":{{"reads":["agent-input"],"writes":["agent-output"]}},"capabilities":[],"restart_policy":"always","justification":"Uses only declared encrypted channels."}}"#
+        )
+    }
+
+    #[test]
+    fn explicit_candidate_uses_authenticated_identity() {
+        let f = Fixture::new(PrivilegeTier::Tier2);
+        let path = f.package("weather.agent", "weather-agent", 2);
+        let found = inspect_agent_package(&path, &f.keyring).unwrap();
+        assert_eq!(found.registration().host_name().as_str(), "weather-agent");
+        assert_eq!(
+            found.registration().package_hash(),
+            &found.package().digest()
+        );
+        assert!(Path::new(found.registration().package_path().as_str()).is_absolute());
+    }
+    #[test]
+    fn scan_is_sorted_and_ignores_siblings() {
+        let f = Fixture::new(PrivilegeTier::Tier3);
+        f.package("z.agent", "zulu-agent", 0);
+        f.package("a.agent", "alpha-agent", 0);
+        fs::write(f.root.join("README"), "ignore").unwrap();
+        let names = discover_agent_packages(&f.root, &f.keyring)
+            .unwrap()
+            .into_iter()
+            .map(|a| a.manifest.agent)
+            .collect::<Vec<_>>();
+        assert_eq!(names, ["alpha-agent", "zulu-agent"]);
+    }
+    #[test]
+    fn scan_fails_on_one_invalid_candidate() {
+        let f = Fixture::new(PrivilegeTier::Tier3);
+        f.package("ok.agent", "valid-agent", 0);
+        fs::create_dir(f.root.join("bad.agent")).unwrap();
+        assert!(matches!(
+            discover_agent_packages(&f.root, &f.keyring),
+            Err(DiscoveryError::Package { .. })
+        ));
+    }
+    #[test]
+    fn signing_key_tier_is_enforced() {
+        let f = Fixture::new(PrivilegeTier::Tier1);
+        let path = f.package("high.agent", "high-agent", 2);
+        assert!(matches!(
+            inspect_agent_package(&path, &f.keyring),
+            Err(DiscoveryError::TierExceeded { requested: 2, .. })
+        ));
+    }
+    #[test]
+    fn duplicate_identities_fail_the_snapshot() {
+        let f = Fixture::new(PrivilegeTier::Tier3);
+        f.package("one.agent", "same-agent", 0);
+        f.package("two.agent", "same-agent", 0);
+        assert!(matches!(
+            discover_agent_packages(&f.root, &f.keyring),
+            Err(DiscoveryError::DuplicateAgent(_))
+        ));
+    }
+}

--- a/code/packages/rust/chief-of-staff-host-runtime/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host-runtime/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Retain authenticated manifest bytes for race-free package discovery.
 - Expose read-only trusted public-key lookup for daemon composition and audits.
 - Add a canonical deny-all Deno launch plan shared by package generation,
   verification, and process activation.

--- a/code/packages/rust/chief-of-staff-host-runtime/README.md
+++ b/code/packages/rust/chief-of-staff-host-runtime/README.md
@@ -29,6 +29,8 @@ before SHA-256, preventing concatenation ambiguity. `SIGNATURE` is 64 raw
 Ed25519 bytes over that digest, while `PUBKEY_ID` selects a reviewed key from the
 orchestrator keyring. Production, developer, and third-party keys carry explicit
 privilege ceilings; developer keys are structurally capped at Tier 1.
+The verified result retains the exact authenticated manifest bytes so discovery
+does not re-read policy through a verify/read race.
 
 `spawn_deno_verified` closes the next launch boundary. It re-verifies the sealed
 package immediately before creating processes, requires the signed

--- a/code/packages/rust/chief-of-staff-host-runtime/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host-runtime/src/lib.rs
@@ -5,8 +5,8 @@
 mod package;
 
 pub use package::{
-    verify_agent_package, DenoLaunchPlan, PackageKeyType, PackageKeyring, PackageVerificationError,
-    TrustedPackageKey, VerifiedAgentPackage,
+    hash_package_contents, verify_agent_package, DenoLaunchPlan, PackageKeyType, PackageKeyring,
+    PackageVerificationError, TrustedPackageKey, VerifiedAgentPackage,
 };
 
 use chief_of_staff_tool_api::{
@@ -1663,6 +1663,7 @@ for line in sys.stdin:
         let package = VerifiedAgentPackage {
             path: std::env::temp_dir(),
             digest: [0; 32],
+            manifest_bytes: Vec::new(),
             key_id: "dev-1".to_string(),
             key_type: PackageKeyType::Developer,
             maximum_tier: PrivilegeTier::Tier1,
@@ -1733,6 +1734,7 @@ for line in sys.stdin:
         let package = VerifiedAgentPackage {
             path: std::env::temp_dir(),
             digest: [0; 32],
+            manifest_bytes: Vec::new(),
             key_id: "dev-1".to_string(),
             key_type: PackageKeyType::Developer,
             maximum_tier: PrivilegeTier::Tier1,

--- a/code/packages/rust/chief-of-staff-host-runtime/src/package.rs
+++ b/code/packages/rust/chief-of-staff-host-runtime/src/package.rs
@@ -122,6 +122,7 @@ impl PackageKeyring {
 pub struct VerifiedAgentPackage {
     pub(crate) path: PathBuf,
     pub(crate) digest: [u8; 32],
+    pub(crate) manifest_bytes: Vec<u8>,
     pub(crate) key_id: String,
     pub(crate) key_type: PackageKeyType,
     pub(crate) maximum_tier: PrivilegeTier,
@@ -134,6 +135,11 @@ impl VerifiedAgentPackage {
 
     pub fn digest(&self) -> [u8; 32] {
         self.digest
+    }
+
+    /// Borrow the exact `manifest.json` bytes covered by the verified digest.
+    pub fn manifest_bytes(&self) -> &[u8] {
+        &self.manifest_bytes
     }
 
     pub fn key_id(&self) -> &str {
@@ -170,7 +176,8 @@ pub fn verify_agent_package(
     let signature: [u8; 64] = signature_bytes
         .try_into()
         .map_err(|_| PackageVerificationError::InvalidSignatureLength)?;
-    let (digest, files) = hash_package_contents(package_path)?;
+    let entries = package_contents(package_path)?;
+    let (digest, files) = hash_contents(&entries);
     for required in ["manifest.json", "launch.sh"] {
         if !files.contains(required) {
             return Err(PackageVerificationError::MissingRequiredFile(required));
@@ -182,9 +189,9 @@ pub fn verify_agent_package(
     if !files.contains(DENO_ENTRYPOINT) {
         return Err(PackageVerificationError::MissingDenoEntrypoint);
     }
-    let launch_script =
-        fs::read_to_string(package_path.join("launch.sh")).map_err(PackageVerificationError::Io)?;
-    if launch_script != DenoLaunchPlan::launch_script() {
+    let launch_script = file_bytes(&entries, "launch.sh")
+        .expect("required launch script must be present in collected package files");
+    if launch_script != DenoLaunchPlan::launch_script().as_bytes() {
         return Err(PackageVerificationError::UntrustedLaunchScript);
     }
     if !coding_adventures_ed25519::verify(&digest, &signature, &key.public_key) {
@@ -193,6 +200,9 @@ pub fn verify_agent_package(
     Ok(VerifiedAgentPackage {
         path: package_path.to_path_buf(),
         digest,
+        manifest_bytes: file_bytes(&entries, "manifest.json")
+            .expect("required manifest must be present in collected package files")
+            .to_vec(),
         key_id,
         key_type: key.key_type,
         maximum_tier: key.maximum_tier,
@@ -202,9 +212,20 @@ pub fn verify_agent_package(
 pub fn hash_package_contents(
     package_path: &Path,
 ) -> Result<([u8; 32], BTreeSet<String>), PackageVerificationError> {
+    let entries = package_contents(package_path)?;
+    Ok(hash_contents(&entries))
+}
+
+fn package_contents(
+    package_path: &Path,
+) -> Result<Vec<(String, Vec<u8>)>, PackageVerificationError> {
     let mut entries = Vec::new();
     collect_files(package_path, package_path, &mut entries)?;
     entries.sort_by(|left, right| left.0.cmp(&right.0));
+    Ok(entries)
+}
+
+fn hash_contents(entries: &[(String, Vec<u8>)]) -> ([u8; 32], BTreeSet<String>) {
     let mut hasher = Sha256Hasher::new();
     hasher.update(HASH_DOMAIN);
     let mut paths = BTreeSet::new();
@@ -213,9 +234,16 @@ pub fn hash_package_contents(
         hasher.update(&(path.len() as u64).to_be_bytes());
         hasher.update(path.as_bytes());
         hasher.update(&(bytes.len() as u64).to_be_bytes());
-        hasher.update(&bytes);
+        hasher.update(bytes);
     }
-    Ok((hasher.digest(), paths))
+    (hasher.digest(), paths)
+}
+
+fn file_bytes<'a>(entries: &'a [(String, Vec<u8>)], path: &str) -> Option<&'a [u8]> {
+    entries
+        .iter()
+        .find(|(candidate, _)| candidate == path)
+        .map(|(_, bytes)| bytes.as_slice())
 }
 
 fn collect_files(
@@ -367,6 +395,7 @@ mod tests {
         let verified = verify_agent_package(&path, &keyring).unwrap();
         assert_eq!(verified.key_id(), "prod-1");
         assert_eq!(verified.key_type(), PackageKeyType::Production);
+        assert_eq!(verified.manifest_bytes(), b"{\"runtime\":\"typescript\"}");
         fs::write(path.join("code/agent.ts"), b"console.log('tampered');\n").unwrap();
         assert!(matches!(
             verify_agent_package(&path, &keyring),

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -170,6 +170,9 @@ capabilities remain manifest declarations but do not widen Deno OS permissions.
 The shared manifest codec accepts version 1 only and rejects malformed JSON,
 duplicate or unknown fields, and invalid nested capability declarations before
 a package can participate in discovery or registration.
+Discovery supports explicit inspection and stable immediate-child `.agent`
+scans. It parses only authenticated manifest bytes, enforces signing-key tier
+ceilings, and returns inert candidates for explicit control-plane registration.
 
 The Level 1 runtime injects a provider-neutral LLM client plus authorized input
 and output channel endpoints. For each verified UTF-8 message it sends the full


### PR DESCRIPTION
## Summary

- add explicit inspection and stable directory scanning for sealed `.agent` packages
- parse only the exact manifest bytes covered by the verified package digest
- enforce signing-key privilege ceilings and fail closed on invalid or duplicate candidates
- derive inert `HostRegistration` values while keeping durable registration explicit
- retain authenticated manifest bytes in `VerifiedAgentPackage` to eliminate the verify/read race

Part of #128 and #139.

## Validation

- 25 focused discovery/host-runtime tests
- strict Clippy and warnings-as-errors rustdoc
- dependency-aware build-tool gate: 93 affected packages built, 1140 skipped
- focused gates rerun after rebasing onto current `origin/main`
