### PR TITLE
Publish Tamil through Chapter 31 from canonical lessons

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -102,9 +102,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B28 | Complete (#9854) | Publish Arabic Chapters 3–27 and their writing companions from canonical lessons rather than hand-copying another twenty-five book chapters. | Forty-five schema-v2 lessons now generate twenty-five chapters whose source hashes are independently verified against the Language Ladder corpus. |
 | HL-B29 | Complete (#9861) | Remove Arabic's LaTeX layout, duplicate-label, bookmark, font, and header-only-verso warnings. | The forced 104-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; intentionally empty versos are truly empty. |
 | HL-B30 | Complete (#9868) | Publish Hindi Chapters 6–33 and its writing companions from canonical lessons rather than hand-copying another twenty-eight book chapters. | Fifty-one lessons now use schema v2; forty later lessons generate twenty-eight chapters whose source hashes are independently verified against Language Ladder, while eleven prerequisite-ordered writing companions remain inside the gentle hand-authored opening chapters. |
-| HL-B31 | Complete in this PR | Remove Hindi's LaTeX layout, duplicate-label, bookmark, font, and header-only-verso warnings. | The forced 114-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; all fourteen intentionally blank pages are truly empty. |
-| HL-B32 | Next | Publish Tamil Chapters 6–31 and its writing companions from canonical lessons rather than hand-copying another twenty-six book chapters. | The Tamil PDF stops after Chapter 5 while canonical app content continues through Chapter 31 and eight dependency-ordered writing lessons; schema-v2 migration plus generation should close that drift safely. |
-| HL-B33 | Queued | Remove Tamil's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports six overfull boxes, six underfull boxes, four duplicate practice labels, 27 Hyperref warnings, and undefined bold/italic Tamil font shapes; the clean-build signal is zero of each. |
+| HL-B31 | Complete (#9871) | Remove Hindi's LaTeX layout, duplicate-label, bookmark, font, and header-only-verso warnings. | The forced 114-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; intentionally blank chapter versos are truly empty. |
+| HL-B32 | Complete in this PR | Publish Tamil Chapters 6–31 and its writing companions from canonical lessons rather than hand-copying another twenty-six book chapters. | Fifty-one lessons now use schema v2; forty-three later lessons generate twenty-six chapters whose source hashes are independently verified against Language Ladder, while eight prerequisite-ordered writing companions remain inside the gentle hand-authored opening chapter. |
+| HL-B33 | Next | Remove Tamil's LaTeX layout, duplicate-label, bookmark, font, and header-only-verso warnings. | The expanded forced 117-page build has zero missing glyphs but reports 30 overfull lines, five underfull lines, eleven underfull pages, four duplicate practice labels, 146 Hyperref warnings, and 19 font warnings; the clean-build signal is zero of each and intentionally blank versos are truly empty. |
 | HL-B34 | Queued | Publish Latin Chapters 2–36 from canonical lessons rather than hand-copying another thirty-five book chapters. | The Latin PDF contains only Chapter 1 while canonical app content continues through Chapter 36; schema-v2 migration plus generation should close that drift safely. |
 | HL-B35 | Queued | Remove Latin's remaining LaTeX layout and font warnings. | A forced build succeeds with no missing glyphs, overfull boxes, duplicate labels, or Hyperref warnings, but reports one underfull box and a small-caps font-shape substitution; the clean-build signal is zero of each. |
 | HL-B36 | Queued | Publish Spanish Chapters 19–33 from canonical lessons rather than hand-copying another fifteen book chapters. | The Spanish PDF stops after Chapter 18 while canonical app content continues through Chapter 33; schema-v2 migration plus generation should raise book coverage from 55% to 100%. |
@@ -962,8 +962,37 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   warnings, or font warnings. All 114 rendered pages were inspected again.
 - Correct title/author metadata, 35 top-level and 107 total outline entries,
   generated source hashes, and zero schema or generator leaks remain intact.
+- TeX Live places two additional chapter transitions on blank even pages that
+  MiKTeX does not need. The production artifact therefore has sixteen blank
+  pages versus fourteen locally; both layouts remain 114 pages and preserve
+  all content, and the two platform-specific versos were visually confirmed
+  empty.
 - HL-B32 is next: publish Tamil Chapters 6–31 and its dependency-ordered
   writing companions from the canonical app corpus.
+
+## Findings from HL-B32
+
+- Fifty-one Tamil lessons now use the strict schema-v2 contract: eight inline
+  writing steps followed by forty-three content micro-lessons through Chapter
+  31. Sequences 100–600 are unique and prerequisite-safe, and every typed body
+  block declares the knowledge it introduces or assesses.
+- The complete Tamil slice remains below five minutes. Effective durations
+  range up to 299 seconds; the retroflex writing step and dative-subject lesson
+  remain the intentionally watched boundary cases rather than losing their
+  script, grammar, or etymology depth.
+- Twenty-six generated chapters replace twenty-six potential hand-maintained
+  copies. The committed source manifest lets Language Ladder independently
+  reproduce every lesson id and canonical hash used by the PDF; repository-wide
+  lesson chapters without a book chapter fall from 76 to 50.
+- A forced XeLaTeX build expands the book from 29 to 117 pages with zero
+  missing glyphs, correct title/author metadata, 33 top-level and 106 total
+  outline entries, and zero schema or generator leaks.
+- The expanded book exposes 30 overfull lines, five underfull lines, eleven
+  underfull pages, four duplicate practice labels, 146 Hyperref warnings, and
+  19 font warnings. HL-B33 is next and owns the full rendered-page and blank-
+  verso cleanup instead of mixing publication hygiene into canonical content.
+- The roadmap and authoritative session map still stop before the complete
+  Chapter 31 corpus. HL-M07 continues to own that progression-metadata work.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -71,7 +71,7 @@ edition is authored.
 | [Punjabi](./punjabi/README.md) | Indo-Aryan / Gurmukhi (vendored font) | Chapters 1-6 authored (lessons + book, script inline) |
 | [Bengali](./bengali/README.md) | Indo-Aryan / Bengali (vendored font) | Chapters 1–6 authored (lessons + book; Chapter 6 canonical/generated) |
 | [Gujarati](./gujarati/README.md) | Indo-Aryan / Gujarati (vendored font) | Chapters 1-6 authored (lessons + book, script inline) |
-| [Tamil](./tamil/README.md) | Dravidian / Tamil (vendored font) | Chapters 1-2 authored (lessons + book) |
+| [Tamil](./tamil/README.md) | Dravidian / Tamil (vendored font) | Chapters 1–31 authored; Chapters 6–31 canonical/generated for app + book; 8 inline writing steps |
 | [Kannada](./kannada/README.md) | Dravidian / Kannada (vendored font) | Chapters 1-2 authored (lessons + book) |
 | [Telugu](./telugu/README.md) | Dravidian / Telugu (vendored font) | Chapters 1-2 authored (lessons + book) |
 | [Malayalam](./malayalam/README.md) | Dravidian / Malayalam (vendored font) | Chapters 1–31 authored; Chapters 6–31 canonical/generated for app + book |

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -25,6 +25,14 @@
       { "unicodeScript": "Devanagari", "scriptCommand": "dv" },
       { "unicodeScript": "Arabic", "scriptCommand": "ar" }
     ],
+    "tamil-comparisons": [
+      { "unicodeScript": "Tamil", "scriptCommand": "ta" },
+      { "unicodeScript": "Telugu", "scriptCommand": "te" },
+      { "unicodeScript": "Kannada", "scriptCommand": "ka" },
+      { "unicodeScript": "Malayalam", "scriptCommand": "ml" },
+      { "unicodeScript": "Devanagari", "scriptCommand": "dv" },
+      { "unicodeScript": "Arabic", "scriptCommand": "ar" }
+    ],
     "arabic-main": [
       { "unicodeScript": "Arabic", "scriptCommand": "ar" },
       { "unicodeScript": "Hebrew", "scriptCommand": "he" }
@@ -1449,6 +1457,214 @@
       "label": "ch:hi-good-afternoon",
       "output": "hindi/book/chapters/ch33-good-afternoon.tex",
       "scriptSet": "hindi-main"
+    },
+    {
+      "language": "tamil",
+      "chapter": 6,
+      "title": "Dative Case and Dative Subjects",
+      "label": "ch:ta-dative-case",
+      "output": "tamil/book/chapters/ch06-dative-case.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 7,
+      "title": "Numbers One to Ten",
+      "label": "ch:ta-numbers-one-to-ten",
+      "output": "tamil/book/chapters/ch07-numbers-1-10.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 8,
+      "title": "Please",
+      "label": "ch:ta-please",
+      "output": "tamil/book/chapters/ch08-please.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 9,
+      "title": "Sorry",
+      "label": "ch:ta-sorry",
+      "output": "tamil/book/chapters/ch09-sorry.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 10,
+      "title": "Days of the Week",
+      "label": "ch:ta-days-of-the-week",
+      "output": "tamil/book/chapters/ch10-days.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 11,
+      "title": "Colours",
+      "label": "ch:ta-colours",
+      "output": "tamil/book/chapters/ch11-colours.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 12,
+      "title": "Family",
+      "label": "ch:ta-family",
+      "output": "tamil/book/chapters/ch12-family.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 13,
+      "title": "Body Parts",
+      "label": "ch:ta-body-parts",
+      "output": "tamil/book/chapters/ch13-body-parts.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 14,
+      "title": "Seasons",
+      "label": "ch:ta-seasons",
+      "output": "tamil/book/chapters/ch14-seasons.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 15,
+      "title": "Water and Rice",
+      "label": "ch:ta-water-and-rice",
+      "output": "tamil/book/chapters/ch15-water-and-rice.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 16,
+      "title": "Tamil Months",
+      "label": "ch:ta-tamil-months",
+      "output": "tamil/book/chapters/ch16-months.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 17,
+      "title": "Noon and Midnight",
+      "label": "ch:ta-noon-and-midnight",
+      "output": "tamil/book/chapters/ch17-noon-and-midnight.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 18,
+      "title": "Telling Time",
+      "label": "ch:ta-telling-time",
+      "output": "tamil/book/chapters/ch18-telling-time.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 19,
+      "title": "Asking Someone's Age",
+      "label": "ch:ta-asking-age",
+      "output": "tamil/book/chapters/ch19-age.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 20,
+      "title": "Numbers Eleven to Twenty and Weather",
+      "label": "ch:ta-numbers-and-weather",
+      "output": "tamil/book/chapters/ch20-numbers-and-weather.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 21,
+      "title": "Dog and Cat",
+      "label": "ch:ta-dog-and-cat",
+      "output": "tamil/book/chapters/ch21-dog-and-cat.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 22,
+      "title": "Green and Yellow",
+      "label": "ch:ta-green-and-yellow",
+      "output": "tamil/book/chapters/ch22-green-and-yellow.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 23,
+      "title": "Day",
+      "label": "ch:ta-day",
+      "output": "tamil/book/chapters/ch23-day.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 24,
+      "title": "Night",
+      "label": "ch:ta-night",
+      "output": "tamil/book/chapters/ch24-night.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 25,
+      "title": "Good Night",
+      "label": "ch:ta-good-night",
+      "output": "tamil/book/chapters/ch25-good-night.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 26,
+      "title": "Morning",
+      "label": "ch:ta-morning",
+      "output": "tamil/book/chapters/ch26-morning.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 27,
+      "title": "Evening",
+      "label": "ch:ta-evening",
+      "output": "tamil/book/chapters/ch27-evening.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 28,
+      "title": "Afternoon",
+      "label": "ch:ta-afternoon",
+      "output": "tamil/book/chapters/ch28-afternoon.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 29,
+      "title": "Good Morning",
+      "label": "ch:ta-good-morning",
+      "output": "tamil/book/chapters/ch29-good-morning.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 30,
+      "title": "Good Evening",
+      "label": "ch:ta-good-evening",
+      "output": "tamil/book/chapters/ch30-good-evening.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 31,
+      "title": "Good Afternoon",
+      "label": "ch:ta-good-afternoon",
+      "output": "tamil/book/chapters/ch31-good-afternoon.tex",
+      "scriptSet": "tamil-comparisons"
     },
     {
       "language": "bengali",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -1626,6 +1626,257 @@
       "tex": "spanish/book/chapters/ch06-first-verbs.tex"
     },
     {
+      "language": "tamil",
+      "chapter": 6,
+      "sourceHash": "fnv1a64:f39b57f3b08140c4",
+      "lessonIds": [
+        "TA-C06-dative-ukku",
+        "TA-C06-dative-stacking",
+        "TA-C06-dative-subject",
+        "TA-C06-dative-subject-family"
+      ],
+      "tex": "tamil/book/chapters/ch06-dative-case.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 7,
+      "sourceHash": "fnv1a64:1c193954d5aaadb3",
+      "lessonIds": [
+        "TA-C07-numbers-1-5",
+        "TA-C07-numbers-1-5-family",
+        "TA-C07-numbers-6-10",
+        "TA-C07-numbers-6-10-family"
+      ],
+      "tex": "tamil/book/chapters/ch07-numbers-1-10.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 8,
+      "sourceHash": "fnv1a64:f6321c5249da200d",
+      "lessonIds": [
+        "TA-C08-tayavuseytu",
+        "TA-C08-please-register"
+      ],
+      "tex": "tamil/book/chapters/ch08-please.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 9,
+      "sourceHash": "fnv1a64:ceed6b208e6e60b0",
+      "lessonIds": [
+        "TA-C09-mannikkavum",
+        "TA-C09-sorry-register"
+      ],
+      "tex": "tamil/book/chapters/ch09-sorry.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 10,
+      "sourceHash": "fnv1a64:1e54c48f58723696",
+      "lessonIds": [
+        "TA-C10-vaara-kizhamai"
+      ],
+      "tex": "tamil/book/chapters/ch10-days.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 11,
+      "sourceHash": "fnv1a64:bbcb6ccf4fd05171",
+      "lessonIds": [
+        "TA-C11-nirangal"
+      ],
+      "tex": "tamil/book/chapters/ch11-colours.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 12,
+      "sourceHash": "fnv1a64:c60c5953173c6f66",
+      "lessonIds": [
+        "TA-C12-kudumbam"
+      ],
+      "tex": "tamil/book/chapters/ch12-family.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 13,
+      "sourceHash": "fnv1a64:1dbbb29d47b23eee",
+      "lessonIds": [
+        "TA-C13-udal-uruppugal"
+      ],
+      "tex": "tamil/book/chapters/ch13-body-parts.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 14,
+      "sourceHash": "fnv1a64:89ffa688255fddbc",
+      "lessonIds": [
+        "TA-C14-kaalangal"
+      ],
+      "tex": "tamil/book/chapters/ch14-seasons.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 15,
+      "sourceHash": "fnv1a64:5ab3afd6c620e3aa",
+      "lessonIds": [
+        "TA-C15-thanneer-arisi"
+      ],
+      "tex": "tamil/book/chapters/ch15-water-and-rice.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 16,
+      "sourceHash": "fnv1a64:4adcb4d90d11981d",
+      "lessonIds": [
+        "TA-C16-thamizh-maadangal"
+      ],
+      "tex": "tamil/book/chapters/ch16-months.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 17,
+      "sourceHash": "fnv1a64:06273003bfe95d72",
+      "lessonIds": [
+        "TA-C17-nanpakal-nalliravu",
+        "TA-C17-transparent-middle-synonyms"
+      ],
+      "tex": "tamil/book/chapters/ch17-noon-and-midnight.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 18,
+      "sourceHash": "fnv1a64:b273f5380b760010",
+      "lessonIds": [
+        "TA-C18-mani",
+        "TA-C18-mani-homophone-time"
+      ],
+      "tex": "tamil/book/chapters/ch18-telling-time.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 19,
+      "sourceHash": "fnv1a64:44a46feca59b14fa",
+      "lessonIds": [
+        "TA-C19-vayathu",
+        "TA-C19-age-register-grammar"
+      ],
+      "tex": "tamil/book/chapters/ch19-age.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 20,
+      "sourceHash": "fnv1a64:974d434fad0acba2",
+      "lessonIds": [
+        "TA-C20-pathinondru-irupathu",
+        "TA-C20-vaanilai"
+      ],
+      "tex": "tamil/book/chapters/ch20-numbers-and-weather.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 21,
+      "sourceHash": "fnv1a64:99b608014f6d04e5",
+      "lessonIds": [
+        "TA-C21-naay-poonai"
+      ],
+      "tex": "tamil/book/chapters/ch21-dog-and-cat.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 22,
+      "sourceHash": "fnv1a64:3c34a0b9cf9e6a96",
+      "lessonIds": [
+        "TA-C22-paccai-manjal"
+      ],
+      "tex": "tamil/book/chapters/ch22-green-and-yellow.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 23,
+      "sourceHash": "fnv1a64:cbbbe0dcc581dbf8",
+      "lessonIds": [
+        "TA-C23-naal",
+        "TA-C23-day-family-register"
+      ],
+      "tex": "tamil/book/chapters/ch23-day.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 24,
+      "sourceHash": "fnv1a64:5eac37ebcb9ae8cc",
+      "lessonIds": [
+        "TA-C24-iravu",
+        "TA-C24-night-register-darkness"
+      ],
+      "tex": "tamil/book/chapters/ch24-night.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 25,
+      "sourceHash": "fnv1a64:d95cb3daafa21b66",
+      "lessonIds": [
+        "TA-C25-iniya-iravu",
+        "TA-C25-goodnight-alternatives"
+      ],
+      "tex": "tamil/book/chapters/ch25-good-night.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 26,
+      "sourceHash": "fnv1a64:cbad1f7eb1bb2816",
+      "lessonIds": [
+        "TA-C26-kaalai"
+      ],
+      "tex": "tamil/book/chapters/ch26-morning.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 27,
+      "sourceHash": "fnv1a64:771849e1943269f5",
+      "lessonIds": [
+        "TA-C27-maalai"
+      ],
+      "tex": "tamil/book/chapters/ch27-evening.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 28,
+      "sourceHash": "fnv1a64:925a2b9b870e5d0f",
+      "lessonIds": [
+        "TA-C28-pirpakal",
+        "TA-C28-afternoon-boundary"
+      ],
+      "tex": "tamil/book/chapters/ch28-afternoon.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 29,
+      "sourceHash": "fnv1a64:98b7381596bab2bd",
+      "lessonIds": [
+        "TA-C29-kaalai-vanakkam"
+      ],
+      "tex": "tamil/book/chapters/ch29-good-morning.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 30,
+      "sourceHash": "fnv1a64:f4dbb1b65e6b99db",
+      "lessonIds": [
+        "TA-C30-maalai-vanakkam"
+      ],
+      "tex": "tamil/book/chapters/ch30-good-evening.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 31,
+      "sourceHash": "fnv1a64:f8ee12008eeeb646",
+      "lessonIds": [
+        "TA-C31-matiya-vanakkam",
+        "TA-C31-afternoon-greeting-root"
+      ],
+      "tex": "tamil/book/chapters/ch31-good-afternoon.tex"
+    },
+    {
       "language": "telugu",
       "chapter": 6,
       "sourceHash": "fnv1a64:a0d2c6d28e4fa358",

--- a/code/learning/human-languages/tamil/CHANGELOG.md
+++ b/code/learning/human-languages/tamil/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Canonical Chapters 6–31 publication
+
+- Fifty-one lessons now use schema v2 with explicit shared-spine placement,
+  prerequisite-safe sequences, typed knowledge boundaries, sub-five-minute
+  budgets, skills, modes, strands, register, and variety.
+- Eight dependency-ordered writing companions keep Tamil script inside the
+  first spoken chapter; forty-three later lessons generate twenty-six chapters
+  that extend the downloadable book through Chapter 31.
+- A reusable multi-script generator set selects the appropriate vendored font
+  for Tamil, Telugu, Kannada, Malayalam, Devanagari, and Arabic comparisons.
+- Canonical lesson ids and source hashes are independently reproduced by
+  Language Ladder, keeping book and app content synchronized. The 117-page
+  forced XeLaTeX build has zero missing glyphs and intact PDF metadata.
+- The expanded book's remaining layout, duplicate-label, bookmark, font, and
+  blank-verso cleanup is recorded in `HL-B33`; roadmap/session-map
+  reconciliation remains in `HL-M07`.
+
 ## Sub-five-minute lesson remediation — 42 violations to zero
 
 - Corrects twenty-two declared budgets whose lesson bodies already compute

--- a/code/learning/human-languages/tamil/README.md
+++ b/code/learning/human-languages/tamil/README.md
@@ -44,12 +44,24 @@ shown, LaTeX book.
 - **Chapter 5 — First Verbs** ([`lessons/TA-C05-*`](./lessons/)): pēsu, **nāṉ
   tamiḻ pēsugiṟēṉ**, vāḻ, vēlai sey, practice. Stem + tense + person; no gender
   in the 1st person. In the book.
+- **Chapters 6–31 — Cases, numbers, courtesy, calendar, family, body, food,
+  time, weather, animals, colours, and greetings**
+  ([`lessons/TA-C{06..31}-*`](./lessons/)): forty-three prerequisite-ordered
+  micro-lessons continue the same inline script, grammar, and etymology method.
+  All are schema v2, stay below five minutes, and generate twenty-six book
+  chapters from the exact canonical sources consumed by Language Ladder.
+- **Writing W01–W04** ([`lessons/TA-W*`](./lessons/)): eight gentle steps teach
+  curves, the abugida, retroflexion, the three Tamil n letters, the puḷḷi, vowel
+  signs, and whole-word writing for **வணக்கம்** and **நன்றி**. They are
+  dependency-ordered schema-v2 companions embedded inside Chapter 1 rather than
+  a gated alphabet course.
 
 ## Book / fonts
 
-The book compiles with XeLaTeX using the **vendored** Noto Sans Tamil font
-(`../../_fonts/`), loaded by relative path — so it builds identically locally
-and in CI, no system-font dependency. `latexmk -xelatex book.tex`.
+The 31-chapter book compiles with XeLaTeX using **vendored** Noto fonts
+(`../../_fonts/`) for Tamil and every comparison script, with no system-font
+dependency. Chapters 6–31 are generated from canonical lesson ASTs and checked
+against Language Ladder source hashes. `latexmk -xelatex book.tex`.
 
 ## Files
 
@@ -57,5 +69,7 @@ and in CI, no system-font dependency. `latexmk -xelatex book.tex`.
   · [`roadmap.md`](./roadmap.md) · [`session-map.md`](./session-map.md)
   · [`book/`](./book/)
 
-Lessons are slug-named (e.g. `TA-C01-vanakkam`); order lives in the book and
-`session-map.md`.
+Lessons are slug-named (e.g. `TA-C01-vanakkam`); canonical prerequisite and
+sequence metadata governs app/book order. The older roadmap and session map do
+not yet enumerate the complete Chapter 31 sequence; that explicit debt is
+tracked as `HL-M07` in the shared backlog.

--- a/code/learning/human-languages/tamil/book/book.tex
+++ b/code/learning/human-languages/tamil/book/book.tex
@@ -74,4 +74,31 @@ rule. Released under CC~BY-SA~4.0.
 
 \input{chapters/ch05-first-verbs}
 
+\input{chapters/ch06-dative-case}
+\input{chapters/ch07-numbers-1-10}
+\input{chapters/ch08-please}
+\input{chapters/ch09-sorry}
+\input{chapters/ch10-days}
+\input{chapters/ch11-colours}
+\input{chapters/ch12-family}
+\input{chapters/ch13-body-parts}
+\input{chapters/ch14-seasons}
+\input{chapters/ch15-water-and-rice}
+\input{chapters/ch16-months}
+\input{chapters/ch17-noon-and-midnight}
+\input{chapters/ch18-telling-time}
+\input{chapters/ch19-age}
+\input{chapters/ch20-numbers-and-weather}
+\input{chapters/ch21-dog-and-cat}
+\input{chapters/ch22-green-and-yellow}
+\input{chapters/ch23-day}
+\input{chapters/ch24-night}
+\input{chapters/ch25-good-night}
+\input{chapters/ch26-morning}
+\input{chapters/ch27-evening}
+\input{chapters/ch28-afternoon}
+\input{chapters/ch29-good-morning}
+\input{chapters/ch30-good-evening}
+\input{chapters/ch31-good-afternoon}
+
 \end{document}

--- a/code/learning/human-languages/tamil/book/chapters/ch06-dative-case.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch06-dative-case.tex
@@ -1,0 +1,203 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:f39b57f3b08140c4
+% canonical-lessons: TA-C06-dative-ukku, TA-C06-dative-stacking, TA-C06-dative-subject, TA-C06-dative-subject-family
+
+\chapter{Dative Case and Dative Subjects}
+\label{ch:ta-dative-case}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[-ukku]{-\ta{உக்கு} (-ukku) — "to, for"}
+
+\label{lesson:TA-C06-dative-ukku}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Your first \textbf{case ending}. English says "\textbf{to} me" with a separate word in front. Tamil says it with a piece \textbf{stuck on the back} — and that small difference is the biggest structural fact about the language.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: Adding it on}]
+Take a noun you know and add \textbf{-\ta{உக்கு}}:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{word} & \textbf{+ the dative} & \textbf{meaning} \\
+\midrule
+\ta{பெயர்} \emph{peyar} — name & \textbf{\ta{பெயருக்கு}} \emph{peyar\textbf{ukku}} & to/for the name \\
+\ta{வேலை} \emph{vēlai} — work & \ta{வேலை}\textbf{\ta{க்கு}} \emph{vēlai\textbf{kku}} & for work \\
+\bottomrule
+\end{tabularx}
+
+The suffix has two shapes — \textbf{-\ta{உக்கு}} \emph{-ukku} and \textbf{-\ta{க்கு}} \emph{-kku} — chosen by the sound the noun ends in. One case, two forms; the seam still shows.
+
+And with "I" — this one is irregular and worth memorising, because you'll use it constantly:
+
+\begin{quote}
+\textbf{\ta{நான்}} \emph{nāṉ} ("I") $\to$ \textbf{\ta{எனக்கு}} \emph{enakku} ("to me")
+\end{quote}
+
+The pronoun changes its body (\emph{nāṉ} $\to$ \emph{en-}) before the suffix lands. Nouns don't — they just take the ending.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "\emph{peyar} … \emph{peyarukku}"{]}
+  \item {[}YOU SAY: "\emph{nāṉ} … \emph{enakku}" — "I" … "to me"{]}
+  \item {[}YOU SAY: "\emph{vēlaikku}" — "for work," from Ch. 5's \ta{வேலை}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \textbf{-\ta{உக்கு}} mean? ("\textbf{To}" or "\textbf{for}.") Where does it go? (\textbf{On the end} of the noun — Tamil adds, it doesn't put a word in front.) What is "to me"? (\textbf{\ta{எனக்கு}} \emph{enakku} — the pronoun's body changes to \emph{en-} first.) Why does the suffix show up as \emph{-ukku} and \emph{-kku}? (\textbf{One case, two shapes}, chosen by the noun's ending.) Next: compare that visible one-purpose suffix with a fused Latin ending.
+\end{tcolorbox}
+\section[peyar + ukku]{-\ta{உக்கு} — one carriage in a suffix train}
+
+\label{lesson:TA-C06-dative-stacking}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You can point to \emph{peyar} and \emph{-ukku} separately. That visible seam is the structural lesson.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: Stacking versus fusion}]
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{Tamil \textbf{-ukku}} & \textbf{Latin \textbf{-īs}} \\
+\midrule
+fixes the case? & \textbf{dative}, always & dative \textbf{or} ablative \\
+carries number? & no; another suffix can & plural is baked in \\
+carries declension? & no & first/second class is baked in \\
+visible seam? & \textbf{peyar + ukku} & one fused ending \\
+\bottomrule
+\end{tabularx}
+
+Tamil \textbf{stacks}. Each suffix contributes one meaning in a fixed order, like a train carriage. Latin \textbf{fuses} case, number, and class into an indivisible ending, and \emph{-īs} does not even identify one case by itself.
+
+This is \textbf{agglutinative} structure: long words remain buildable because their pieces stay legible. The comparison is not about simplicity; it is about where the grammatical information lives.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SEGMENT: \emph{peyar + ukku}{]}
+  \item {[}YOU SAY: "one suffix, one meaning, visible seam"{]}
+  \item {[}YOU CONTRAST: Tamil stacks · Latin fuses{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \emph{-ukku} contribute? (\textbf{Dative to/for}, one meaning.) What does Latin \emph{-īs} fuse? (\textbf{Case, plural number, and declension class}.) Which system leaves the seam visible? (\textbf{Tamil's agglutinative stack}.)
+\end{tcolorbox}
+\section[enakkut tamiḻ teriyum]{\ta{எனக்குத்} \ta{தமிழ்} \ta{தெரியும்} — "I know Tamil"}
+
+\label{lesson:TA-C06-dative-subject}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} In Chapter 5 you said \textbf{\ta{நான்} \ta{தமிழ்} \ta{பேசுகிறேன்}} — "\textbf{I} speak Tamil," with \emph{nāṉ} as the subject. Now say "I \textbf{know} Tamil." Tamil will not let you use \emph{nāṉ}.
+\end{quote}
+
+\subsection*{You'll want to know: The sentence}
+\begin{quote}
+\textbf{\ta{எனக்குத்} \ta{தமிழ்} \ta{தெரியும்}.} \emph{enakku tamiḻ teriyum.} literally: "\textbf{to-me} Tamil is-known."
+\end{quote}
+
+Word by word:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{piece} & \textbf{} \\
+\midrule
+\textbf{\ta{எனக்கு}}(\textbf{\ta{த்}}) \emph{enakku(t)} & "to me" — the dative from the last lesson \\
+\textbf{\ta{தமிழ்}} \emph{tamiḻ} & Tamil (Ch. 5) \\
+\textbf{\ta{தெரியும்}} \emph{teriyum} & "is known / is apparent" \\
+\bottomrule
+\end{tabularx}
+
+That extra \textbf{\ta{த்}} on \emph{enakku} is \textbf{sandhi} — a joining consonant Tamil inserts between certain words to smooth the seam. It belongs to neither word on its own; it exists only because they are next to each other. Nothing to learn yet, but worth noticing, because you will see it constantly.
+
+\textbf{You are not the subject.} \emph{Nāṉ} is gone — the person has been moved into the dative. What's left in the plain, unmarked form is \emph{tamiḻ}: the sentence is now about \textbf{the language}, and you are merely the one it is known \textbf{to}.
+
+(Grammarians call \emph{enakku} the \textbf{dative subject}, because it behaves like the subject even though it isn't in the subject case. The odd feeling of the sentence is exactly that split.)
+
+\begin{grammarlens}[title={Grammar Lens: Why: things that happen \emph{to} you}]
+Tamil sorts verbs by whether you \textbf{do} something or something \textbf{happens to} you. Speaking is something you do — so Ch. 5 used \emph{nāṉ}. But knowing, liking, wanting, being hungry, being cold: these arrive at you. Tamil marks that by putting the person in the \textbf{dative}.
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{English frames it as} & \textbf{Tamil frames it as} \\
+\midrule
+I \textbf{know} Tamil & Tamil is known \textbf{to me} \\
+I \textbf{like} it & it is pleasing \textbf{to me} \\
+I \textbf{am} cold & cold is \textbf{to me} \\
+\bottomrule
+\end{tabularx}
+
+English does this occasionally and archaically — "\textbf{methinks}" is exactly it (\emph{me} is dative: "it seems \textbf{to me}"). Tamil made it a rule.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "\emph{enakku tamiḻ teriyum}"{]}
+  \item {[}YOU SAY: the contrast — "\emph{nāṉ tamiḻ pēsugiṟēṉ}" (I speak) … "\emph{enakku tamiḻ teriyum}" (known to me){]}
+  \item {[}YOU SAY: the literal — "to-me Tamil is-known"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \textbf{\ta{எனக்குத்} \ta{தமிழ்} \ta{தெரியும்}} literally say? ("\textbf{To-me} Tamil \textbf{is-known}.") Which word has English got that Tamil hasn't? (A nominative "\textbf{I}" — \emph{nāṉ} is replaced by the dative \emph{enakku}.) Why does Tamil use the dative here? (Because knowing \textbf{happens to} you; you don't \textbf{do} it.) Which English word preserves the same idea? (\textbf{Methinks} — "it seems \textbf{to me}".) Next: watch all four Dravidian sisters use the same experiencer shape.
+\end{tcolorbox}
+\section[\ta{எனக்கு} / \te{నాకు} / \ka{ನನಗೆ} / \ml{എനിക്ക്}]{-ukku, -ku, -ge, -ikku — the family shows its bones}
+
+\label{lesson:TA-C06-dative-subject-family}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Tamil says knowing happens \textbf{to} you. Its three closest sisters make the same grammatical choice.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: Four sentences, one construction}]
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{"I know {[}the language{]}"} & \textbf{dative} \\
+\midrule
+Tamil & \emph{enakku tamiḻ teriyum} & \textbf{-ukku} \\
+Telugu & \emph{nāku telugu vaccu} & \textbf{-ku} \\
+Kannada & \emph{nanage kannaḍa gottu} & \textbf{-ge} \\
+Malayalam & \emph{enikku malayāḷam aṟiyām} & \textbf{-ikku} \\
+\bottomrule
+\end{tabularx}
+
+The verbs differ, but the experiencer sits in a dative whose forms visibly belong together: \emph{-ukku / -ku / -ge / -ikku}. This is family evidence, just as \emph{blanc/bianco/branco} exposes Romance kinship.
+
+The comparison also makes cross-language practice useful: once you recognize "to me," you can search for the known or apparent thing rather than forcing an English subject onto the sentence.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "-ukku · -ku · -ge · -ikku"{]}
+  \item {[}YOU POINT: the experiencer in each sentence{]}
+  \item {[}YOU PARAPHRASE: "the language is known to me"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Do the four sisters agree on dative experiencers? (\textbf{Yes}.) Which four suffix shapes reveal the relationship? (\emph{\textbf{-ukku, -ku, -ge, -ikku}}.) What stays plain in the sentence? (The thing \textbf{known or experienced}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch07-numbers-1-10.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch07-numbers-1-10.tex
@@ -1,0 +1,183 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:1c193954d5aaadb3
+% canonical-lessons: TA-C07-numbers-1-5, TA-C07-numbers-1-5-family, TA-C07-numbers-6-10, TA-C07-numbers-6-10-family
+
+\chapter{Numbers One to Ten}
+\label{ch:ta-numbers-one-to-ten}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{ஒன்று} \ta{இரண்டு} \ta{மூன்று} \ta{நான்கு} \ta{ஐந்து}]{\ta{ஒன்று}, \ta{இரண்டு}, \ta{மூன்று}, \ta{நான்கு}, \ta{ஐந்து} — one to five}
+
+\label{lesson:TA-C07-numbers-1-5}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Five words — and the same point \emph{vaṇakkam} made, told again in numbers: Tamil counts with \textbf{its own} words, not borrowed ones.
+\end{quote}
+
+\subsection*{You'll want to know: The five}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{numeral} & \textbf{word} & \textbf{said} \\
+\midrule
+1 & \textbf{\ta{௧}} & \textbf{\ta{ஒன்று}} & \emph{oṉṟu} \\
+2 & \textbf{\ta{௨}} & \textbf{\ta{இரண்டு}} & \emph{iraṇṭu} \\
+3 & \textbf{\ta{௩}} & \textbf{\ta{மூன்று}} & \emph{mūṉṟu} \\
+4 & \textbf{\ta{௪}} & \textbf{\ta{நான்கு}} & \emph{nāṉku} \\
+5 & \textbf{\ta{௫}} & \textbf{\ta{ஐந்து}} & \emph{aintu} \\
+\bottomrule
+\end{tabularx}
+
+Two writing systems sit side by side here: the \textbf{word} (spelled out in letters) and the \textbf{numeral} (a single symbol — \ta{௧} \ta{௨} \ta{௩} \ta{௪} \ta{௫}, Tamil's own digits, as distinct from 1 2 3 4 5 as they are from Roman I II III). You'll meet the digits again whenever a price or a page number is written in Tamil.
+
+If you're doing the writing track, you can already read pieces of these: \textbf{\ta{ந}} and \textbf{\ta{ன}} (the \emph{n}-family), \textbf{\ta{ற}} the hard \emph{r} inside \emph{mūṉṟu}, and the \textbf{puḷḷi} dot that stacks \emph{\ta{ன்ற}} into the single cluster you hear in \textbf{\ta{ஒன்று}} and \textbf{\ta{மூன்று}}.
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "oṉṟu, iraṇṭu, mūṉṟu, nāṉku, aintu"{]}
+  \item {[}YOU SAY: read the digits aloud — \ta{௧} \ta{௨} \ta{௩} \ta{௪} \ta{௫}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Count to five in Tamil. (\emph{Oṉṟu, iraṇṭu, mūṉṟu, nāṉku, aintu}.) Are Tamil's numbers borrowed from Sanskrit, like Hindi's? (\textbf{No} — they're native Dravidian.) Which two writing systems sit side by side? (Spelled-out \textbf{words} and Tamil's own \textbf{numerals}.) Next: compare these native forms across the family.
+\end{tcolorbox}
+\section[\ta{இரண்டு} \ta{மூன்று} \ta{நான்கு} \ta{ஐந்து}]{Two to five — one family in four regional coats}
+
+\label{lesson:TA-C07-numbers-1-5-family}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Hindi's number forms are Sanskrit worn smooth. Tamil's are native Dravidian, so their sister-language shapes reveal the family directly.
+\end{quote}
+
+\begin{cousinweb}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{Tamil} & \textbf{Kannada} & \textbf{Telugu} & \textbf{Malayalam} \\
+\midrule
+2 & \emph{iraṇṭu} & \emph{eraḍu} & \emph{reṇḍu} & \emph{raṇṭu} \\
+3 & \emph{mūṉṟu} & \emph{mūru} & \emph{mūḍu} & \emph{mūnnu} \\
+4 & \emph{nāṉku} & \emph{nālku} & \emph{nālugu} & \emph{nālu} \\
+5 & \emph{aintu} & \emph{aidu} & \emph{aidu} & \emph{añcu} \\
+\bottomrule
+\end{tabularx}
+
+Each row is one word in four regional coats. That shared skeleton is why one Dravidian language gives you a running start on another.
+
+\textbf{One} is less tidy: Tamil \emph{oṉṟu}, Kannada \emph{ondu}, and Malayalam \emph{onnu} share old \emph{oṉ-}, while Telugu uses the separate formation \emph{okaṭi}. The family agrees more neatly on 2–5 than on 1.
+\end{cousinweb}
+
+\begin{sounds}
+In \emph{oṉṟu} and \emph{mūṉṟu}, \textbf{\ta{ன்ற}} is alveolar \emph{n} running into hard \emph{ṟ}, almost one knock: \emph{on-ru, muun-ru}. Puḷḷi on \textbf{\ta{ன்}} removes its vowel before the cluster.
+\end{sounds}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "iraṇṭu · eraḍu · reṇḍu · raṇṭu"{]}
+  \item {[}YOU SAY: \emph{oṉṟu} and \emph{mūṉṟu}, holding \textbf{\ta{ன்ற}} together{]}
+  \item {[}YOU IDENTIFY: Telugu \emph{okaṭi} as the different "one"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Are these forms borrowed? (\textbf{No}, native Dravidian.) Which numbers stay tidiest across the family? (\textbf{Two through five}.) Which language forms "one" differently? (\textbf{Telugu}, \emph{okaṭi}.)
+\end{tcolorbox}
+\section[\ta{ஆறு} \ta{ஏழு} \ta{எட்டு} \ta{ஒன்பது} \ta{பத்து}]{\ta{ஆறு}, \ta{ஏழு}, \ta{எட்டு}, \ta{ஒன்பது}, \ta{பத்து} — six to ten}
+
+\label{lesson:TA-C07-numbers-6-10}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Five more — and one of them is written with the single letter Tamil is most proud of.
+\end{quote}
+
+\subsection*{You'll want to know: The five}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{numeral} & \textbf{word} & \textbf{said} \\
+\midrule
+6 & \textbf{\ta{௬}} & \textbf{\ta{ஆறு}} & \emph{āṟu} \\
+7 & \textbf{\ta{௭}} & \textbf{\ta{ஏழு}} & \emph{ēḻu} \\
+8 & \textbf{\ta{௮}} & \textbf{\ta{எட்டு}} & \emph{eṭṭu} \\
+9 & \textbf{\ta{௯}} & \textbf{\ta{ஒன்பது}} & \emph{oṉpatu} \\
+10 & \textbf{\ta{௰}} & \textbf{\ta{பத்து}} & \emph{pattu} \\
+\bottomrule
+\end{tabularx}
+
+\subsection*{You'll want to know: Seven carries the letter that names the language}
+Look at \textbf{\ta{ஏழு}} (\emph{ēḻu}, seven). Its middle letter is \textbf{\ta{ழ}} — the retroflex approximant, the sound English can only clumsily spell \emph{zh}. It is the rarest and most characteristic sound in Tamil, and it sits inside the language's \textbf{own name}: \emph{Tamiḻ} (\ta{தமிழ்}) ends in this very letter. So \emph{seven} is a free daily rehearsal of the sound that says who the language is. Curl the tongue back, don't touch, and voice it: \emph{ē-ḻu}.
+
+(You met its cousin \emph{\ta{ற}} — the hard \emph{ṟ} — back in \emph{\ta{ஆறு}} / \emph{āṟu}, six. Tamil keeps these apart carefully: \textbf{\ta{ஆறு}} \emph{āṟu} and \textbf{\ta{ஏழு}} \emph{ēḻu} end in two different sounds English would both call "r/zh".)
+
+\begin{grammarlens}[title={Grammar Lens: Nine is built from words you already have}]
+\textbf{\ta{ஒன்பது}} (\emph{oṉpatu}, nine) is not a fresh word to memorise — it is two you already know, joined:
+
+\begin{quote}
+\textbf{\ta{ஒன்}} (\emph{oṉ-}, "one," from last lesson) + \textbf{\ta{பது}} (\emph{patu}, "ten") $\to$ \textbf{\ta{ஒன்பது}} = "one‑to‑ten" — one short of ten.
+\end{quote}
+
+And ten itself is \textbf{\ta{பத்து}} (\emph{pattu}). Say \emph{oṉpatu} then \emph{pattu} and you can hear nine leaning on ten. That is a common Dravidian habit — nine described as one-away-from-ten rather than named outright.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "āṟu, ēḻu, eṭṭu, oṉpatu, pattu"{]}
+  \item {[}YOU SAY: seven, feeling the \ta{ழ} — "ē‑ḻu", the sound in \emph{Tamiḻ}{]}
+  \item {[}YOU SAY: nine taken apart — "oṉ + patu $\to$ oṉpatu", one short of ten{]}
+  \item {[}YOU SAY: read the digits — \ta{௬} \ta{௭} \ta{௮} \ta{௯} \ta{௰}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Count six to ten in Tamil. (\emph{Āṟu, ēḻu, eṭṭu, oṉpatu, pattu}.) Which number is written with \textbf{\ta{ழ}}, and where else does that letter appear? (\textbf{Seven}, \emph{ēḻu} — the same letter that ends \emph{Tamiḻ}.) How is \textbf{nine} built? (\emph{Oṉ} "one" + \emph{patu} "ten" $\to$ \emph{oṉpatu}, one short of ten.) Next: follow these forms across the family and hear Kannada \emph{p} soften to \emph{h}.
+\end{tcolorbox}
+\section[\ta{ஆறு} \ta{ஏழு} \ta{பத்து}]{Six to ten — family resemblances and one Kannada shift}
+
+\label{lesson:TA-C07-numbers-6-10-family}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The Tamil forms are learned. Now use their sister shapes as evidence for inheritance and regular sound change.
+\end{quote}
+
+\begin{cousinweb}
+Six and seven remain close: Tamil \emph{āṟu}, Kannada \emph{āru}, Malayalam \emph{āṟu}; Tamil \emph{ēḻu}, Kannada \emph{ēḷu}, Malayalam \emph{ēḻu}. Tamil and Malayalam also keep eight and nine nearly identical: \emph{eṭṭu} and \emph{oṉpatu/onpatu}.
+
+Telugu wanders on eight and nine with \emph{enimidi} and \emph{tommidi}, so those forms are less reliable as family-wide recognition anchors.
+\end{cousinweb}
+
+\begin{cousinweb}
+Tamil and Malayalam say \textbf{pattu}, while Kannada says \textbf{hattu}. The initial \emph{p $\to$ h} is a regular Kannada shift, not a random replacement. Compare Tamil \emph{pāl}, "milk," with Kannada \emph{hālu}.
+
+A correspondence lets differences prove relationship: repeated \emph{p/h} pairs are stronger evidence than one accidental resemblance.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: Tamil \emph{pattu} · Kannada \emph{hattu}{]}
+  \item {[}YOU SAY: Tamil \emph{pāl} · Kannada \emph{hālu}{]}
+  \item {[}YOU IDENTIFY: \emph{ēḻu / ēḷu / ēḻu} as one inherited seven{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What happens to Tamil \emph{pattu} in Kannada? (\emph{P} regularly softens to \emph{\textbf{h}}: \emph{hattu}.) Which second pair confirms the pattern? (\emph{Pāl / hālu}, "milk.") Which language diverges most on eight and nine? (\textbf{Telugu}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch08-please.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch08-please.tex
@@ -1,0 +1,97 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:f6321c5249da200d
+% canonical-lessons: TA-C08-tayavuseytu, TA-C08-please-register
+
+\chapter{Please}
+\label{ch:ta-please}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{தயவுசெய்து}]{\ta{தயவுசெய்து} (tayavu seytu) — please (do the kindness)}
+
+\label{lesson:TA-C08-tayavuseytu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Across a whole band of Asia, the word for \emph{please} is really the word \textbf{compassion}, dressed as a small request. Tamil says it most literally of all: "\textbf{do} the kindness."
+\end{quote}
+
+\subsection*{You'll want to know: The phrase}
+\textbf{\ta{தயவுசெய்து}} = \textbf{please}, literally "\textbf{do the kindness / grace}." It is two pieces snapped together:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\ta{தயவு}} (\emph{tayavu}) = \textbf{kindness, compassion, grace} — from Sanskrit \textbf{daya} "compassion."
+  \item \textbf{\ta{செய்து}} (\emph{seytu}) = "\textbf{having done}," from the verb \textbf{\ta{செய்}} (\emph{sey}) "to do."
+\end{itemize}
+
+So \emph{tayavu seytu} is an invitation: \emph{do me the kindness (of…)}. You place it in front of a request the way English puts "please" in front of one.
+
+This is the same instinct as \textbf{Arabic} \emph{min faḍlik} ("from your \textbf{grace}") and \textbf{Hindi} \emph{kṛpayā} (from \emph{kṛpā}, "\textbf{compassion}"). Naming the kindness you hope for is one of the great strategies of politeness — different from French's "if it \textbf{pleases} you," and from Latin/German's "I \textbf{ask}."
+
+\begin{cousinweb}
+All four Dravidian cousins build \emph{please} the very same way — \textbf{daya} plus a light verb "do / place / become":
+
+\begin{itemize}
+\raggedright
+  \item Tamil \textbf{\ta{தயவுசெய்து}} \emph{tayavu \textbf{sey}tu} — kindness \textbf{+ do}
+  \item Kannada \textbf{\ka{ದಯವಿಟ್ಟು}} \emph{daya\textbf{viṭṭu}} — compassion \textbf{+ having placed}
+  \item Telugu \textbf{\te{దయచేసి}} \emph{daya\textbf{cēsi}} — compassion \textbf{+ having done}
+  \item Malayalam \textbf{\ml{ദയവായി}} \emph{daya\textbf{vāyi}} — compassion \textbf{+ as / having become}
+\end{itemize}
+
+One idea, four scripts. Learn one and you can almost read the others.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "tayavu" — the kindness — then "seytu," having done{]}
+  \item {[}YOU SAY: the whole phrase — "tayavu seytu" = please, do the kindness{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What is the Tamil phrase for please? (\textbf{\ta{தயவுசெய்து}} \emph{tayavu seytu}.) What do its two pieces mean? ("\textbf{Kindness}" \emph{tayavu} + "\textbf{having done}" \emph{seytu} — \emph{do the kindness}.) Which languages ask the same way? (\textbf{Kannada, Telugu, Malayalam} with \emph{daya}, and further off \textbf{Arabic} \emph{faḍl} and \textbf{Hindi} \emph{kṛpā}.) Next: decide when the standalone phrase is natural and when the verb carries the courtesy.
+\end{tcolorbox}
+\section[\ta{தயவுசெய்து} / -\ta{உங்கள்}]{\ta{தயவுசெய்து} or -\ta{உங்கள்}? — politeness in phrase or verb}
+
+\label{lesson:TA-C08-please-register}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Tamil has a phrase meaning "do the kindness," but everyday courtesy often sits somewhere English speakers do not expect: inside the verb.
+\end{quote}
+
+\begin{culture}
+A standalone \textbf{\ta{தயவுசெய்து}} is more emphatic and formal than English "please." Ordinary polite commands use respectful \textbf{-\ta{உங்கள்}} (\emph{-uṅgaḷ}):
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\ta{உட்காருங்கள்}} \emph{uṭkāruṅgaḷ} — please sit
+  \item \textbf{\ta{சொல்லுங்கள்}} \emph{solluṅgaḷ} — please tell me
+\end{itemize}
+
+Use \emph{tayavu seytu} to mark "please, do me the kindness" warmly or formally. Let the verb ending carry routine courtesy.
+\end{culture}
+
+\subsection*{Script you'll notice: Read the join in \ta{செய்து}}
+\textbf{\ta{செ}} is \emph{ca} with the \textbf{\ta{ெ}} sign for \emph{e}. \textbf{\ta{ய்}} is \emph{ya} shut off by puḷḷi, a bare \emph{y}, before \textbf{\ta{து}} \emph{tu}. The same dot that built numbers now makes the consonant seam in \emph{seytu} visible.
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU CHOOSE: emphatic request $\to$ \textbf{\ta{தயவுசெய்து}}{]}
+  \item {[}YOU CHOOSE: ordinary "please sit" $\to$ \textbf{\ta{உட்காருங்கள்}}{]}
+  \item {[}YOU SEGMENT: \ta{செ} + \ta{ய்} + \ta{து} $\to$ \ta{செய்து}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What carries everyday "please"? (The respectful verb ending \emph{\textbf{-uṅgaḷ}}.) When is \emph{tayavu seytu} especially useful? (A \textbf{markedly polite or emphatic} request.) What silences \emph{y} in \textbf{\ta{ய்}}? (The \textbf{puḷḷi}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch09-sorry.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch09-sorry.tex
@@ -1,0 +1,96 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:ceed6b208e6e60b0
+% canonical-lessons: TA-C09-mannikkavum, TA-C09-sorry-register
+
+\chapter{Sorry}
+\label{ch:ta-sorry}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{மன்னிக்கவும்}]{\ta{மன்னிக்கவும்} (maṉṉikkavum) — please forgive}
+
+\label{lesson:TA-C09-mannikkavum}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You already know \textbf{\ta{தயவுசெய்து}}, "please." Tamil's "sorry" gives you something its Dravidian cousins don't: a forgiveness-word that's Tamil through and through, not borrowed from Sanskrit.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\ta{மன்னிக்கவும்}} is built from three pieces:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\ta{மன்னி}} (\emph{maṉṉi}) = "\textbf{to forgive, excuse, pardon}" — and unlike the words you'll meet in Kannada, Telugu, and Malayalam, this is Tamil's \textbf{own} native verb, not borrowed from Sanskrit \textbf{kṣamā}.
+  \item \textbf{‑\ta{க்க}} (\emph{‑kka}) = an infinitive-forming ending.
+  \item \textbf{‑\ta{உம்}} (\emph{‑um}) = a formal, written-register particle used to make a soft, general request or permission — the same particle you'd see on a sign asking visitors to \emph{\ta{வரவும்}} ("please come" / "you may come").
+\end{itemize}
+
+So \textbf{\ta{மன்னிக்கவும்}} reads as something like "\textbf{may {[}one{]} forgive}" — a polite, slightly formal way of asking for forgiveness, more at home in writing or a considered apology than tossed off in passing.
+\end{cousinweb}
+
+\begin{cousinweb}
+Where Kannada, Telugu, and Malayalam all reach for the Sanskrit noun \textbf{kṣamā} ("patience, forgiveness") and turn it into a verb, \textbf{Tamil uses its own root}:
+
+\begin{itemize}
+\raggedright
+  \item Tamil \textbf{\ta{மன்னிக்கவும்}} \emph{maṉṉi\textbf{kkavum}} — from Tamil \textbf{\ta{மன்னி}} \emph{maṉṉi}
+  \item Kannada \textbf{\ka{ಕ್ಷಮಿಸಿ}} \emph{kṣami\textbf{si}} — from Sanskrit \textbf{kṣamā}
+  \item Telugu \textbf{\te{క్షమించండి}} \emph{kṣamin̄\textbf{caṇḍi}} — from Sanskrit \textbf{kṣamā}
+  \item Malayalam \textbf{\ml{ക്ഷമിക്കണം}} \emph{kṣami\textbf{kkaṇam}} — from Sanskrit \textbf{kṣamā}
+\end{itemize}
+
+Where "please" showed the whole family sharing one Sanskrit-derived idea (\emph{daya}), "sorry" shows the opposite: Tamil kept its own word while its cousins borrowed the same Sanskrit one.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "maṉṉi" — forgive — the Tamil root, not from Sanskrit{]}
+  \item {[}YOU SAY: the whole word — "maṉṉikkavum" = please forgive{]}
+  \item {[}YOU SAY: contrast — Kannada, Telugu, Malayalam all use kṣamā instead{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \textbf{\ta{மன்னிக்கவும்}} mean, and what is it built from? (\textbf{"Please forgive"} — \emph{maṉṉi} "to forgive" + \emph{‑kkavum}, a formal request ending.) What's different about Tamil's forgiveness-word compared to Kannada, Telugu, and Malayalam? (\textbf{It's Tamil's own native root} — the other three borrow Sanskrit \emph{kṣamā} instead.) Next: place the word in its real register and read the doubled alveolar n.
+\end{tcolorbox}
+\section[\ta{மன்னிக்கவும்} / sorry]{\ta{மன்னிக்கவும்} — formal forgiveness and a doubled n}
+
+\label{lesson:TA-C09-sorry-register}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The root is native Tamil. Its everyday conversational fit is less simple than a one-to-one dictionary entry suggests.
+\end{quote}
+
+\begin{culture}
+\textbf{\ta{மன்னிக்கவும்}} leans formal: a "please forgive" on a notice or in a considered apology. Spoken Tamil may use shorter regional forms or borrow English "sorry." Colloquial variation is real, so treat formal/written as a reliable center, not a claim that one casual form covers every region.
+\end{culture}
+
+\subsection*{Script you'll notice: Read \ta{ன்னி}}
+In \textbf{\ta{ன்னி}}, alveolar \textbf{\ta{ன}} is first silenced by puḷḷi and then repeated before the vowel. The spelling holds the consonant across the syllable boundary:
+
+\begin{quote}
+\textbf{\ta{ன்} + \ta{னி} $\to$ \ta{ன்னி}} — \emph{ṉ-ṉi}
+\end{quote}
+
+This is the same gemination-by-repetition principle used elsewhere in Tamil; the sound is doubled without inventing a new ligature.
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "maṉ-ṉi-kkavum," holding both doubled consonants{]}
+  \item {[}YOU CHOOSE: considered/formal apology $\to$ \textbf{\ta{மன்னிக்கவும்}}{]}
+  \item {[}YOU QUALIFY: casual alternatives vary by region{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What is the reliable register center of \emph{maṉṉikkavum}? (\textbf{Formal/written or considered apology}.) Must every region use it casually? (\textbf{No}.) How does \textbf{\ta{ன்னி}} show a doubled \emph{ṉ}? (Puḷḷi stops the first \textbf{\ta{ன்}}, then full \textbf{\ta{னி}} follows.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch10-days.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch10-days.tex
@@ -1,0 +1,56 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:1e54c48f58723696
+% canonical-lessons: TA-C10-vaara-kizhamai
+
+\chapter{Days of the Week}
+\label{ch:ta-days-of-the-week}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{திங்கள்} \ta{செவ்வாய்} \ta{புதன்} \ta{வியாழன்} \ta{வெள்ளி} \ta{சனி} \ta{ஞாயிறு}]{\ta{திங்கள்} to \ta{ஞாயிறு} — the week, home-grown and borrowed together}
+
+\label{lesson:TA-C10-vaara-kizhamai}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You've seen Hindi's week built entirely from Sanskrit deity-names plus \textbf{\dv{वार}} (\emph{vār}). Tamil's week tells a richer story: it uses its \textbf{own} word for "day," and \textbf{some} of its planet-names are Tamil's own too — while others are borrowed, just like Hindi's.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: The pattern: {[}planet{]} + \ta{கிழமை}, "day"}]
+Every Tamil weekday ends in \textbf{\ta{கிழமை}} (\emph{kizhamai}), "\textbf{day}" — a native Dravidian word, not the Sanskrit \textbf{\ta{வாரம்}} (\emph{vāram}) that Hindi, Kannada, and Telugu build on (though Tamil also keeps a more formal, Sanskritic \emph{-vāram} set alongside this everyday one):
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Tamil} & \textbf{planet-word} & \textbf{meaning of the planet-word} & \textbf{source} \\
+\midrule
+\textbf{\ta{திங்கள்கிழமை}} & \emph{thiṅgaḷ} & "\textbf{Moon}" & Tamil's \textbf{own} word for moon \\
+\textbf{\ta{செவ்வாய்க்கிழமை}} & \emph{cevvāy} & traditionally read as "\textbf{the red one}" & likely Tamil's \textbf{own} descriptive name for Mars \\
+\textbf{\ta{புதன்கிழமை}} & \emph{pudhaṉ} & \textbf{Mercury} & borrowed from Sanskrit \textbf{Budha} \\
+\textbf{\ta{வியாழக்கிழமை}} & \emph{viyāzhaṉ} & \textbf{Jupiter} & likely from Sanskrit, via a name for \textbf{Bṛhaspati} \\
+\textbf{\ta{வெள்ளிக்கிழமை}} & \emph{veḷḷi} & traditionally read as "\textbf{silver}" & likely Tamil's \textbf{own} descriptive name for Venus \\
+\textbf{\ta{சனிக்கிழமை}} & \emph{saṉi} & \textbf{Saturn} & borrowed from Sanskrit \textbf{Śani} \\
+\textbf{\ta{ஞாயிற்றுக்கிழமை}} & \emph{ñāyiṟu} & "\textbf{Sun}" & Tamil's \textbf{own} word for sun \\
+\bottomrule
+\end{tabularx}
+\end{grammarlens}
+
+\begin{culture}
+Notice the pattern: \textbf{Moon, Mars, Venus, and Sun} all carry Tamil's own descriptive or native words, while \textbf{Mercury, Jupiter, and Saturn} carry Sanskrit ones. This isn't Tamil "failing" to have its own full week — it's a genuine \textbf{blend}, native Dravidian vocabulary standing right alongside Sanskrit loans, in the same list. (Note for the Tamil-speaking reviewer: this lesson spells Monday \textbf{\ta{திங்கள்கிழமை}}, the common form — the more traditional sandhi-shifted spelling \textbf{\ta{திங்கட்கிழமை}} may be preferred and should be swapped in on review if so. The \emph{cevvāy} "red one" and \emph{viyāzhaṉ} Jupiter-name derivations in particular are worth treating as the traditional, commonly-given account rather than settled certainty — exact planet-name histories this old are not always fully nailed down.)
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "thiṅgaḷ" — moon, Tamil's own word — then "kizhamai," day{]}
+  \item {[}YOU SAY: the borrowed ones — "pudhaṉ, viyāzhaṉ, saṉi" — Mercury, Jupiter, Saturn from Sanskrit{]}
+  \item {[}YOU SAY: the native ones — "thiṅgaḷ, cevvāy, veḷḷi, ñāyiṟu" — moon, Mars, Venus, sun{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does every Tamil weekday end in, and where does that word come from? (\textbf{\ta{கிழமை}} \emph{kizhamai}, "day" — Tamil's \textbf{own} word, not Sanskrit \emph{vāra}.) Which four planet-names are Tamil's own, and which three are Sanskrit borrowings? (\textbf{Moon, Mars, Venus, Sun are native}; \textbf{Mercury, Jupiter, Saturn are Sanskrit} — \emph{Budha, Bṛhaspati, Śani}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch11-colours.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch11-colours.tex
@@ -1,0 +1,52 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:bbcb6ccf4fd05171
+% canonical-lessons: TA-C11-nirangal
+
+\chapter{Colours}
+\label{ch:ta-colours}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{கருப்பு} \ta{வெள்ளை} \ta{சிவப்பு} \ta{நீலம்}]{\ta{கருப்பு}, \ta{வெள்ளை}, \ta{சிவப்பு}, \ta{நீலம்} — three of Tamil's own, one borrowed}
+
+\label{lesson:TA-C11-nirangal}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You've already seen Tamil mix native and Sanskrit words in its day-names. Colors tell a \textbf{cleaner} version of the same story: three colors are Tamil's own, and the fourth is the one color that keeps showing up borrowed, in language after language.
+\end{quote}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{\ta{கருப்பு}} (\emph{karuppu}) = "\textbf{black}" — native Tamil/Dravidian.
+  \item \textbf{\ta{வெள்ளை}} (\emph{veḷḷai}) = "\textbf{white}" — native Tamil/Dravidian, and built on the very same \textbf{\ta{வெள்}} (\emph{veḷ-}, "bright, silvery") root you already met in \textbf{\ta{வெள்ளி}} (\emph{veḷḷi}), "Venus/silver," from the days-of-the-week lesson.
+  \item \textbf{\ta{சிவப்பு}} (\emph{sivappu}) = "\textbf{red}" — native Tamil/Dravidian.
+\end{itemize}
+\end{cousinweb}
+
+\begin{cousinweb}
+\textbf{\ta{நீலம்}} (\emph{nīlam}) = "\textbf{blue}" — from \textbf{Sanskrit} \ta{நீல} (\emph{nīla}), "dark blue," the very same root behind Hindi's \textbf{\dv{नीला}} (\emph{nīlā}). This \emph{nīla} is also the name of the indigo plant and its dye — part of why blue dye is so historically linked to India — but be careful: the English word \textbf{indigo} itself is a \emph{separate}, Greek-derived word (describing where the dye was imported \emph{from}, not descended from \emph{nīla} by sound change; see the Hindi color lesson for that careful distinction).
+\end{cousinweb}
+
+\begin{culture}
+This isn't random. You may remember from Latin's color lesson that \textbf{"blue"} is, across many of the world's languages, one of the \textbf{last} basic colors to settle into its own fixed word — often arriving late, or borrowed, compared to black, white, and red. Tamil's colors look like exactly this pattern in miniature: three old, native words, and one — blue — reaching outside the language for a Sanskrit loan.
+
+(Note for the Tamil-speaking reviewer: please confirm \emph{karuppu, veḷḷai, sivappu, nīlam} are the forms you'd teach first — regional/colloquial Tamil may prefer different everyday variants, and this lesson would benefit from your check the way the day-names lesson did.)
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the three native ones — "karuppu, veḷḷai, sivappu" — black, white, red{]}
+  \item {[}YOU SAY: the borrowed one — "nīlam" — blue, from Sanskrit{]}
+  \item {[}YOU SAY: the echo — "veḷḷai" and "veḷḷi" share the same veḷ- root{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which three Tamil colors are native, and which one is borrowed? (\textbf{Karuppu, veḷḷai, sivappu} (black/white/red) are native; \textbf{nīlam} (blue) is a \textbf{Sanskrit} loan.) What root does \emph{veḷḷai} share with a word you already know? (\textbf{Veḷ-} "bright/silvery" — the same root as \emph{veḷḷi}, "Venus/silver.") Why might blue be the one borrowed color? (\textbf{Blue is often one of the last basic colors} to settle into a fixed word across many languages — the same pattern Latin's \emph{caeruleus} showed.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch12-family.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch12-family.tex
@@ -1,0 +1,60 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:c60c5953173c6f66
+% canonical-lessons: TA-C12-kudumbam
+
+\chapter{Family}
+\label{ch:ta-family}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{அப்பா} \ta{அம்மா} \ta{அண்ணன்} \ta{தம்பி} \ta{அக்கா} \ta{தங்கை}]{\ta{அப்பா}, \ta{அம்மா}, and four ways to say "brother/sister"}
+
+\label{lesson:TA-C12-kudumbam}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You've learned Spanish's \emph{hermano/hermana} and French's \emph{frère/sœur} — one word each for "brother" and "sister." Tamil asks a question those languages never do: \textbf{is this sibling older or younger than you?}
+\end{quote}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{\ta{அப்பா}} (\emph{appā}) = "\textbf{father}"
+  \item \textbf{\ta{அம்மா}} (\emph{ammā}) = "\textbf{mother}"
+\end{itemize}
+
+Both are native Dravidian words, of the same simple, worldwide "baby-talk" shape (a repeated consonant plus a vowel) found across unrelated language families everywhere — not borrowed from Sanskrit, not a coincidence with any one language in particular, just how small children's mouths tend to form their first words for parents.
+\end{cousinweb}
+
+\subsection*{You'll want to know: Siblings — split by age, not just gender}
+Here's the real lesson: Tamil doesn't have one word for "brother" and one for "sister." It has \textbf{four}:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Tamil} & \textbf{meaning} \\
+\midrule
+\textbf{\ta{அண்ணன்}} (\emph{aṇṇaṉ}) & \textbf{older} brother \\
+\textbf{\ta{தம்பி}} (\emph{tambi}) & \textbf{younger} brother \\
+\textbf{\ta{அக்கா}} (\emph{akkā}) & \textbf{older} sister \\
+\textbf{\ta{தங்கை}} (\emph{tangai}) & \textbf{younger} sister \\
+\bottomrule
+\end{tabularx}
+
+There is no single Tamil word that just means "brother" the way Spanish \emph{hermano} does — you're expected to know, and say, \textbf{whether they're older or younger than you} every time you refer to a sibling. This isn't a small detail: it reflects how central \textbf{relative age and seniority} are in South Asian family structure and address — the same instinct that makes "older sibling" versus "younger sibling" a live, spoken distinction, not just something you \emph{could} mention if you wanted to.
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "appā, ammā" — father, mother{]}
+  \item {[}YOU SAY: the four siblings — "aṇṇaṉ, tambi" (older/younger brother), "akkā, tangai" (older/younger sister){]}
+  \item {[}YOU SAY: the key question — "older, or younger?" — before you can even say "brother" or "sister" in Tamil{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} How many Tamil words mean "brother" or "sister," and why? (\textbf{Four} — \ta{அண்ணன்}/\ta{தம்பி} for older/younger brother, \ta{அக்கா}/\ta{தங்கை} for older/younger sister — Tamil requires knowing the sibling's \textbf{age relative to you}.) Are \ta{அப்பா} and \ta{அம்மா} borrowed from Sanskrit? (\textbf{No} — native Dravidian baby-talk-type words, of a shape found across unrelated languages worldwide.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch13-body-parts.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch13-body-parts.tex
@@ -1,0 +1,42 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:1dbbb29d47b23eee
+% canonical-lessons: TA-C13-udal-uruppugal
+
+\chapter{Body Parts}
+\label{ch:ta-body-parts}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{தலை} \ta{கை}]{\ta{தலை}, \ta{கை} — head and hand, both Tamil's own}
+
+\label{lesson:TA-C13-udal-uruppugal}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You've seen Hindi's \emph{sir} and \emph{hāth} trace all the way back to Sanskrit. Tamil's words for the same two body parts tell a simpler story: \textbf{both are native.}
+\end{quote}
+
+\subsection*{You'll want to know: The words}
+\begin{itemize}
+\raggedright
+  \item \textbf{\ta{தலை}} (\emph{talai}) = "\textbf{head}" — native Dravidian.
+  \item \textbf{\ta{கை}} (\emph{kai}) = "\textbf{hand}" — native Dravidian.
+\end{itemize}
+
+Neither is borrowed from Sanskrit, unlike Hindi's \emph{sir} (< Sanskrit \emph{śiras}) or \emph{hāth} (< Sanskrit \emph{hasta}). Tamil simply kept its own words for two of the most basic parts of the body.
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "talai" — head{]}
+  \item {[}YOU SAY: "kai" — hand{]}
+  \item {[}YOU SAY: the contrast — Hindi borrowed these from Sanskrit; Tamil didn't{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What are Tamil's words for head and hand? (\textbf{\ta{தலை}} \emph{talai}, \textbf{\ta{கை}} \emph{kai}.) Are either of these Sanskrit loans? (\textbf{No} — both native Dravidian, unlike Hindi's Sanskrit-descended \emph{sir} and \emph{hāth}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch14-seasons.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch14-seasons.tex
@@ -1,0 +1,55 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:89ffa688255fddbc
+% canonical-lessons: TA-C14-kaalangal
+
+\chapter{Seasons}
+\label{ch:ta-seasons}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{வசந்த} \ta{காலம்} \ta{கோடைக்} \ta{காலம்} \ta{மழைக்} \ta{காலம்} \ta{குளிர்} \ta{காலம்}]{\ta{வசந்த} \ta{காலம்}, \ta{கோடை}, \ta{மழை}, \ta{குளிர்} — the four words, and the real season underneath}
+
+\label{lesson:TA-C14-kaalangal}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Tamil has words that line up with Spanish's four seasons — but, just like the Hindi lesson on \dv{ऋतु}, forcing them into a clean four-way split hides what actually matters on the ground.
+\end{quote}
+
+\subsection*{You'll want to know: The four words}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Tamil} & \textbf{meaning} & \textbf{source} \\
+\midrule
+\textbf{\ta{வசந்த} \ta{காலம்}} (\emph{vasantha kaalam}) & "spring" & \emph{vasantham} is a \textbf{Sanskrit} loan \\
+\textbf{\ta{கோடைக்} \ta{காலம்}} (\emph{kodai kaalam}) & "summer" & \textbf{\ta{கோடை}} \emph{kodai} is \textbf{native} Tamil for "heat" \\
+\textbf{\ta{மழைக்} \ta{காலம்}} (\emph{mazhai kaalam}) & "rainy season" & \textbf{\ta{மழை}} \emph{mazhai}, native Tamil for "rain" \\
+\textbf{\ta{குளிர்} \ta{காலம்}} (\emph{kulir kaalam}) & "winter/cold season" & \textbf{\ta{குளிர்}} \emph{kulir}, native Tamil for "cold" \\
+\bottomrule
+\end{tabularx}
+
+Every one of these is built the same way: a word for the \textbf{feel} of the season (heat, rain, cold — or the borrowed \emph{vasantham}) plus \textbf{\ta{காலம்}} (\emph{kaalam}), "\textbf{time/season}." Be honest about \emph{kaalam} itself, too: it's ultimately from Sanskrit \textbf{\dv{काल}} (\emph{kāla}, "time") — but it was assimilated into Tamil so long ago and so thoroughly that it functions as completely ordinary vocabulary today, quite unlike a fresh, still-foreign-feeling loan like \emph{vasantham}.
+
+\begin{culture}
+Just as Hindi's traditional calendar makes the monsoon (\emph{varṣā}) its own central season rather than a footnote, Tamil Nadu's actual climate is shaped far more by \textbf{\ta{மழைக்காலம்}} (\emph{mazhai kaalam}, "the rains") than by any crisp four-way Western split. There's no dramatic autumn leaf-fall in a tropical climate, and "spring" as a distinct, keenly-felt season is a much weaker idea here than in temperate Europe. The four words above are real and used — but the rains, not a European four-season year, are what actually organizes agricultural and everyday life across much of Tamil Nadu.
+
+(Note for the Tamil-speaking reviewer: please check whether these are the words and register you'd teach first, and whether there's more to say about how Tamil Nadu's own seasonal year is actually divided in practice.)
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "kodai" — heat/summer, native — then "kaalam," time/season{]}
+  \item {[}YOU SAY: "mazhai kaalam" — the rains, the real central season{]}
+  \item {[}YOU SAY: "kulir kaalam" — the cold season{]}
+  \item {[}YOU SAY: the one loanword — "vasantha kaalam," spring, from Sanskrit{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which of the four season-words is a Sanskrit loan, and which are native Tamil? (\textbf{\ta{வசந்தம்}} \emph{vasantham} is Sanskrit; \textbf{\ta{கோடை}, \ta{மழை}, \ta{குளிர்}} are all native.) What season actually shapes life in Tamil Nadu the most, and why doesn't the four-season frame capture that? (\textbf{\ta{மழைக்காலம்}}, the \textbf{rains} — Tamil Nadu's tropical climate doesn't have a sharp four-way split the way temperate Europe does.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch15-water-and-rice.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch15-water-and-rice.tex
@@ -1,0 +1,49 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:5ab3afd6c620e3aa
+% canonical-lessons: TA-C15-thanneer-arisi
+
+\chapter{Water and Rice}
+\label{ch:ta-water-and-rice}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{தண்ணீர்} \ta{அரிசி} \ta{சாதம்}]{\ta{தண்ணீர்}, \ta{அரிசி}, \ta{சாதம்} — water, and rice, the real staple}
+
+\label{lesson:TA-C15-thanneer-arisi}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Every language so far in this arc taught "bread" as the staple food. Here, that would be \textbf{dishonest} — bread isn't the everyday staple in Tamil food culture. \textbf{Rice} is, and it comes with one of the most famous (if contested) etymological journeys of any food-word.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{தண்ணீர்} — water, literally "cool water"}
+\textbf{\ta{தண்ணீர்}} (\emph{taṇṇīr}) = "\textbf{water}" — built from \textbf{\ta{தண்}} (\emph{taṇ}, "\textbf{cool}") + \textbf{\ta{நீர்}} (\emph{nīr}, "\textbf{water}"). Everyday Tamil doesn't just say "water" — it says, quite literally, "\textbf{cool water}."
+
+\subsection*{You'll want to know: \ta{அரிசி} and \ta{சாதம்} — rice, raw and cooked}
+Tamil, like most of South India, distinguishes the \textbf{uncooked grain} from the \textbf{cooked dish} with two separate words, not one:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\ta{அரிசி}} (\emph{arisi}) = "\textbf{rice}" (the raw, husked grain) — native Dravidian.
+  \item \textbf{\ta{சாதம்}} (\emph{sātam}) = "\textbf{cooked rice}" (the meal itself, what's actually eaten) — likely Sanskrit-influenced. Tamil also keeps a native word for the same idea, \textbf{\ta{சோறு}} (\emph{cōṟu}) — the two sit side by side as everyday near-synonyms.
+\end{itemize}
+
+\begin{culture}
+Here's the exciting part, held with appropriate care: many etymologists connect \textbf{\ta{அரிசி}} (\emph{arisi}) to the \textbf{English word "rice" itself} — the proposed chain runs Dravidian \emph{arisi} $\to$ \textbf{Greek} \emph{óryza} $\to$ Latin \emph{oryza} $\to$ Old French \emph{ris} $\to$ English \textbf{rice}. If true, English speakers have been saying a Dravidian word for centuries without knowing it. But be honest: standard etymological dictionaries mark Greek \emph{óryza}'s origin as \textbf{genuinely uncertain} — a Dravidian source is one widely cited hypothesis among others (an Indo-Aryan \emph{vrīhi}-related source is also proposed), not a settled, universally agreed fact.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "taṇ" — cool — then "nīr," water — then "taṇṇīr," cool water{]}
+  \item {[}YOU SAY: "arisi" — raw rice — then "sātam," cooked rice{]}
+  \item {[}YOU SAY: the famous (contested) link — "arisi" $\to$ possibly English "rice"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \textbf{\ta{தண்ணீர்}} literally mean? (\textbf{"Cool water"} — \emph{taṇ} "cool" + \emph{nīr} "water.") What two words does Tamil use for rice, and why two? (\textbf{\ta{அரிசி}} \emph{arisi}, raw grain; \textbf{\ta{சாதம்}} \emph{sātam}, cooked rice — the raw grain and the cooked meal get separate words.) Is it certain that English "rice" comes from Tamil \emph{arisi}? (\textbf{Not certain} — it's a widely cited hypothesis via Greek \emph{óryza}, but that Greek word's origin is genuinely disputed among etymologists.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch16-months.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch16-months.tex
@@ -1,0 +1,42 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:4adcb4d90d11981d
+% canonical-lessons: TA-C16-thamizh-maadangal
+
+\chapter{Tamil Months}
+\label{ch:ta-tamil-months}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{சித்திரை} \ta{வைகாசி} \ta{ஆனி} \ta{ஆடி} \ta{ஆவணி} \ta{புரட்டாசி} \ta{ஐப்பசி} \ta{கார்த்திகை} \ta{மார்கழி} \ta{தை} \ta{மாசி} \ta{பங்குனி}]{\ta{சித்திரை} to \ta{பங்குனி} — Tamil's own solar calendar}
+
+\label{lesson:TA-C16-thamizh-maadangal}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} By now you've seen Arabic and Hindi each juggle two calendars. Tamil adds a \textbf{third distinct system} to the mix — one still actively used for Tamil New Year and Pongal, not a historical curiosity.
+\end{quote}
+
+\subsection*{You'll want to know: The twelve Tamil months}
+\textbf{\ta{சித்திரை}, \ta{வைகாசி}, \ta{ஆனி}, \ta{ஆடி}, \ta{ஆவணி}, \ta{புரட்டாசி}, \ta{ஐப்பசி}, \ta{கார்த்திகை}, \ta{மார்கழி}, \ta{தை}, \ta{மாசி}, \ta{பங்குனி}} (\emph{Chithirai, Vaikāsi, Āṉi, Āḍi, Āvaṇi, Puraṭṭāsi, Aippasi, Kārthigai, Mārgazhi, Thai, Māsi, Panguṉi}).
+
+This is the \textbf{Tamil solar calendar} — a real, independent civil calendar, distinct from both the Gregorian calendar and the Hindu lunisolar (Vikram Samvat–style) calendar. Its months are traditionally tied to \textbf{nakshatras} (the 27 lunar-mansion star groups): each month is named for the nakshatra the \textbf{moon} sits near on the \textbf{full-moon (pournami) day} that falls within that month — the moon's position, not the sun's, and tied to that month's full moon specifically, not simply the month's start.
+
+\begin{culture}
+You've now met three genuinely separate calendar traditions across this course: the Gregorian solar calendar (borrowed names, everyday civil use in most of the world), the pan-Indian Hindu lunisolar calendar (Chaitra, Vaishākh... tied to the six \emph{ṛtu}), and now Tamil's \textbf{own} solar calendar, following neither. \textbf{\ta{சித்திரை} 1} (the 1st of Chithirai) is \textbf{Tamil New Year}; \textbf{\ta{தை} 1} (the 1st of Thai) is \textbf{Pongal}, one of Tamil Nadu's most important harvest festivals. These dates are fixed by the Tamil solar calendar, and only shift slightly against the Gregorian calendar (rather than drifting widely, the way lunar/lunisolar festival dates do) because it's solar too — just a different solar calendar, starting its year at a different point and naming its months differently.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the twelve — "Chithirai, Vaikāsi, Āṉi, Āḍi, Āvaṇi, Puraṭṭāsi, Aippasi, Kārthigai, Mārgazhi, Thai, Māsi, Panguṉi"{]}
+  \item {[}YOU SAY: "Chithirai 1" — Tamil New Year{]}
+  \item {[}YOU SAY: "Thai 1" — Pongal{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What kind of calendar is the Tamil month system — solar, lunar, or lunisolar? (\textbf{Solar} — a genuinely separate calendar from both Gregorian and Hindu lunisolar.) What are the twelve months traditionally named for? (\textbf{Nakshatras}, lunar-mansion star groups.) What two important occasions are dated by this calendar? (\textbf{Tamil New Year} (Chithirai 1) and \textbf{Pongal} (Thai 1).)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch17-noon-and-midnight.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch17-noon-and-midnight.tex
@@ -1,0 +1,74 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:06273003bfe95d72
+% canonical-lessons: TA-C17-nanpakal-nalliravu, TA-C17-transparent-middle-synonyms
+
+\chapter{Noon and Midnight}
+\label{ch:ta-noon-and-midnight}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{நண்பகல்} \ta{நள்ளிரவு}]{\ta{நண்பகல்}, \ta{நள்ளிரவு} — one old "middle" root, two survival stories}
+
+\label{lesson:TA-C17-nanpakal-nalliravu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You've just watched Kannada and Telugu each reach for Sanskrit's \emph{madhya} to name noon. Tamil doesn't reach for Sanskrit at all here — it reaches into its own, much older layer of vocabulary instead.
+\end{quote}
+
+\begin{cousinweb}
+Both of today's words trace back to the same root: \textbf{\ta{நள்}} (\emph{naḷ}), a \textbf{Proto-Dravidian} word for "\textbf{middle, centre}" — a genuine synonym of the everyday \textbf{\ta{நடு}} (\emph{naṭu}, "middle") you already know, just from an older layer of the vocabulary. \ta{நள்} didn't disappear from Tamil; it survives today mainly in \textbf{literary/poetic} compounds — \textbf{\ta{நள்ளிருள்}} (\emph{naḷḷiruḷ}, "thick darkness") and \textbf{\ta{நள்ளென்} \ta{கங்குல்}} (\emph{naḷḷeṉ kaṅkul}, "deep night") — rather than in everyday colloquial speech.
+\end{cousinweb}
+
+\begin{cousinweb}
+\textbf{\ta{நள்ளிரவு}} (\emph{naḷḷiravu}) = "\textbf{midnight}" = \textbf{\ta{நள்}} (\emph{naḷ}, "middle") + \textbf{\ta{இரவு}} (\emph{iravu}, "\textbf{night}," a word every Tamil speaker still uses on its own) — \ta{நள்} shows up here exactly as you'd expect. \textbf{\ta{நண்பகல்}} (\emph{naṇpakal}) = "\textbf{noon, midday}" traces to the \textbf{same} \ta{நள்} root, fused with \textbf{\ta{பகல்}} (\emph{pakal}, "\textbf{daytime}") — but here it surfaces as \textbf{\ta{நண்}-} rather than \ta{நள்}-, a sandhi-driven surface change before the following \ta{ப}. Same root, two different faces, depending on what it's fused to.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "naḷ" — an old word for "middle" — then "naḷḷiravu," midnight{]}
+  \item {[}YOU SAY: "naṇpakal" — noon, the same naḷ root, resurfacing as naṇ-{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What old Proto-Dravidian root do \ta{நண்பகல்} and \ta{நள்ளிரவு} both trace back to, and what does it mean? (\textbf{\ta{நள்}} \emph{naḷ}, "middle" — surviving mainly in literary compounds like \emph{naḷḷiruḷ}, "thick darkness.") Why does it surface as \textbf{naṇ-} in \emph{naṇpakal}? (A sandhi change before following \textbf{p}.) Does Tamil reach for Sanskrit here? (\textbf{No}.) Next: meet the transparent \emph{naṭu} synonyms Tamil kept beside these older compounds.
+\end{tcolorbox}
+\section[\ta{நடுப்பகல்}, \ta{நடு} \ta{இரவு}]{\ta{நடுப்பகல்} and \ta{நடு} \ta{இரவு} — the transparent twins}
+
+\label{lesson:TA-C17-transparent-middle-synonyms}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} \emph{Naṇpakal} and \emph{naḷḷiravu} preserve an older middle-root in fused forms. Tamil also kept versions whose pieces remain obvious today.
+\end{quote}
+
+\subsection*{You'll want to know: The living synonyms}
+\begin{itemize}
+\raggedright
+  \item \textbf{\ta{நடுப்பகல்}} (\emph{naṭuppakal}) — "middle-daytime," a dictionary synonym of \emph{naṇpakal}
+  \item \textbf{\ta{நடு} \ta{இரவு}} (\emph{naṭu iravu}) — "middle night," the transparent synonym of \emph{naḷḷiravu}
+\end{itemize}
+
+Both use \textbf{\ta{நடு}} (\emph{naṭu}, "middle"), the everyday word still heard in \emph{naṭuvē}, "in the middle."
+
+Latin daughter languages often inherit one fate for an old compound: eroded or transparent. Tamil kept \textbf{both fates inside one language}—old fused forms and fresh transparent synonyms side by side.
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "naṇpakal · naṭuppakal" — two noon forms{]}
+  \item {[}YOU SAY: "naḷḷiravu · naṭu iravu" — two midnight forms{]}
+  \item {[}YOU POINT: \emph{naṭu} as the visible everyday "middle"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which everyday word builds the transparent forms? (\textbf{\ta{நடு}}, \emph{naṭu}, "middle.") What did Tamil keep simultaneously? (\textbf{Older fused compounds and transparent synonyms}.) Are any pieces Sanskrit loans? (\textbf{No}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch18-telling-time.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch18-telling-time.tex
@@ -1,0 +1,78 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:b273f5380b760010
+% canonical-lessons: TA-C18-mani, TA-C18-mani-homophone-time
+
+\chapter{Telling Time}
+\label{ch:ta-telling-time}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{மணி}]{\ta{மணி} — Tamil's native "bell," and a real homophone trap}
+
+\label{lesson:TA-C18-mani}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You've just watched Kannada and Telugu both borrow Sanskrit's "bell" word for "hour," matching Hindi exactly. Tamil goes its own way again here — with a genuinely tricky twist along the way.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\ta{மணி}} (\emph{maṇi}) = "\textbf{hour, o'clock}" — and it also means "\textbf{bell, gong}," the same double duty you've now seen several times. Wiktionary's Tamil entry gives this \emph{maṇi} its \textbf{own etymology}, separate from a Sanskrit-loan entry of the same spelling — most likely a \textbf{native Dravidian} word, not the Sanskrit \textbf{\dv{घण्टा}} (\emph{ghaṇṭā}) behind Kannada's \emph{gaṇṭe}, Telugu's \emph{ganṭa}, and Hindi's \emph{ghanṭā}. On this account, Tamil underwent the \textbf{same} "a bell announces the hour, so the bell-word becomes the hour-word" shift on its own, from a different starting point — though even the comparative Dravidian dictionary (DEDR) flags a possible Sanskrit connection for this whole word-family as unresolved, so hold "native" as the best current account rather than a settled fact.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "maṇi" — hour, also "bell" — native, NOT from Sanskrit ghaṇṭā{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Is Tamil's \textbf{\ta{மணி}} ("hour") from the same Sanskrit root as Kannada/Telugu/Hindi's hour-words? (\textbf{Most likely no} — it's treated as a native Dravidian "bell" word that independently reached "hour" the same way, though even DEDR flags this as not fully settled.) What semantic path links the meanings? (A \textbf{bell announces the hour}.) Next: distinguish the likely Sanskrit gem homophone and tell the time.
+\end{tcolorbox}
+\section[\ta{மணி} / \ta{மணி}]{\ta{மணி} — hour or jewel? Context decides}
+
+\label{lesson:TA-C18-mani-homophone-time}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The likely native bell/hour word shares its spelling and sound with a clear Sanskrit loan meaning something entirely different.
+\end{quote}
+
+\begin{cousinweb}
+Tamil dictionaries list a second \textbf{\ta{மணி}} from Sanskrit \textbf{\dv{मणि}} (\emph{maṇi}), "gem, jewel." On that analysis, bell/hour and gem are \textbf{homophones}: one likely native, one borrowed, identical on the page. Context separates clock time from a jewel or personal name.
+
+Malayalam dictionaries analyze their cognate differently, treating bell/hour and gem as one Sanskrit-derived word. Closely related languages do not always settle the same etymological question in the same way.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: Tell the time}]
+\begin{quote}
+\textbf{\ta{ஒரு} \ta{மணி}.} — one o'clock, literally "one hour/bell"
+\end{quote}
+
+>
+
+\begin{quote}
+\textbf{\ta{இரண்டு} \ta{மணி}.} — two o'clock
+\end{quote}
+
+The number comes first; \emph{maṇi} supplies the clock unit.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "oru maṇi" — one o'clock{]}
+  \item {[}YOU SAY: "iraṇṭu maṇi" — two o'clock{]}
+  \item {[}YOU CHOOSE BY CONTEXT: clock $\to$ hour · jewelry/name $\to$ gem{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What is the homophone trap? (A likely separate Sanskrit-borrowed \textbf{\ta{மணி}} means \textbf{gem}.) Does Malayalam analyze the same forms identically? (\textbf{No}.) How do you say two o'clock? (\textbf{\ta{இரண்டு} \ta{மணி}}, \emph{iraṇṭu maṇi}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch19-age.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch19-age.tex
@@ -1,0 +1,82 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:44a46feca59b14fa
+% canonical-lessons: TA-C19-vayathu, TA-C19-age-register-grammar
+
+\chapter{Asking Someone's Age}
+\label{ch:ta-asking-age}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{உனக்கு} \ta{எத்தனை} \ta{வயது} \ta{ஆகிறது}?]{\ta{உனக்கு} \ta{எத்தனை} \ta{வயது} \ta{ஆகிறது}? — Tamil actually has BOTH shapes}
+
+\label{lesson:TA-C19-vayathu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Same Sanskrit word one more time — but be careful here: Tamil isn't locked into just one of the two grammatical shapes you've now seen. It has both, in different registers.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{வயது} — the same Sanskrit "vigor/age" word, a fourth time}
+\textbf{\ta{வயது}} (\emph{vayathu}) = "\textbf{age}" — the same Sanskrit \textbf{\dv{वयस्}} (\emph{vayas}, "age, vigor," PIE cousin of Latin \textbf{vīs}) you've now met four times across Kannada, Telugu, Malayalam, and Tamil. All four Dravidian languages borrowed this exact Sanskrit word for "age" — none of them built a native alternative for this particular concept, unlike some others you've seen in this course.
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "vayathu" — age{]}
+  \item {[}YOU CONNECT: Sanskrit \emph{vayas} · Tamil \emph{vayathu} · Latin \emph{vīs}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Is Tamil's \textbf{\ta{வயது}} the same Sanskrit word borrowed by all four Dravidian languages here? (\textbf{Yes} — none built a native alternative for this concept.) What did \emph{vayas} originally include besides age? (\textbf{Vigor}.) Next: choose between Tamil's casual possessive and formal dative-plus-become shapes.
+\end{tcolorbox}
+\section[\ta{உன்} \ta{வயசு} \ta{என்ன}? / \ta{உனக்கு} \ta{எத்தனை} \ta{வயது} \ta{ஆகிறது}?]{Your age what? / To you how many years becomes?}
+
+\label{lesson:TA-C19-age-register-grammar}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Tamil did not choose one age construction. Register selects between two shapes already visible elsewhere in the family.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: Casual possessive}]
+\begin{quote}
+\textbf{\ta{உன்} \ta{வயசு} \ta{என்ன}?} — "your age what?"
+\end{quote}
+
+Casual speech uses a plain possessive with no dative and no verb, like Kannada and Telugu.
+\end{grammarlens}
+
+\begin{grammarlens}[title={Grammar Lens: Formal dative plus "become"}]
+\begin{quote}
+\textbf{\ta{உனக்கு} \ta{எத்தனை} \ta{வயது} \ta{ஆகிறது}?} — "to you how many years is becoming?"
+\end{quote}
+
+>
+
+\begin{quote}
+\textbf{\ta{எனக்கு} \ta{இருபது} \ta{வயது} \ta{ஆகிறது}.} — "to me twenty years is becoming."
+\end{quote}
+
+Formal/written Tamil uses the dative experiencer plus \textbf{\ta{ஆகிறது}} (\emph{aakirathu}, "is becoming," from \emph{aaku}). Malayalam uses a similar dative shape but chooses "exists" instead.
+
+Do not compress these into "Tamil's one grammar." Both live in the language; setting and register choose between them.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "un vayasu enna?" — casual{]}
+  \item {[}YOU SAY: "unakku ettanai vayathu aakirathu?" — formal{]}
+  \item {[}YOU ANSWER: "enakku irupathu vayathu aakirathu"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which shape is casual? (\textbf{Possessive}: "your age what?") Which is formal? (\textbf{Dative + aakirathu}, "become.") Does Malayalam use the same verb? (\textbf{No} — it uses "exists.")
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch20-numbers-and-weather.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch20-numbers-and-weather.tex
@@ -1,0 +1,84 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:974d434fad0acba2
+% canonical-lessons: TA-C20-pathinondru-irupathu, TA-C20-vaanilai
+
+\chapter{Numbers Eleven to Twenty and Weather}
+\label{ch:ta-numbers-and-weather}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{பதினொன்று} — \ta{இருபது}]{\ta{பதினொன்று}, \ta{இருபது} — Dravidian's shared, transparent twenty}
+
+\label{lesson:TA-C20-pathinondru-irupathu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Here's how this arc closes: four completely different approaches to "twenty" across Sanskrit, Latin, Arabic — and then all four Dravidian languages quietly agreeing on the exact same compositional idea.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{பதினொன்று}–\ta{பத்தொன்பது} — "ten" + digit}
+Tamil's teens echo \textbf{\ta{பத்து}} (\emph{pathu}, "\textbf{ten}") plus each digit — \textbf{\ta{பதினொன்று}} (\emph{patiṉoṉḏṟu}, 11), \textbf{\ta{பன்னிரண்டு}} (\emph{paṉṉiraṇḍu}, 12), and onward through \textbf{\ta{பத்தொன்பது}} (\emph{pattoṉbatu}, 19) — the same digit-plus- ten-echo compounding you've now seen across Kannada, Telugu, and Malayalam.
+
+\subsection*{You'll want to know: \ta{இருபது} — transparently "two-tens"}
+\textbf{\ta{இருபது}} (\emph{irupathu}, "\textbf{twenty}") = \textbf{\ta{இரு}} (\emph{iru}, an older word for "\textbf{two}," alongside the everyday \textbf{\ta{இரண்டு}} \emph{iraṇḍu}) + \textbf{\ta{பத்து}} (\emph{pathu}, "\textbf{ten}") — fully transparent as "\textbf{two-tens}," matching \textbf{Malayalam's} own \emph{irupathu} almost letter-for-letter.
+
+\begin{culture}
+This closes the numbers arc with a genuinely clean pattern. Every Dravidian language in this course builds "twenty" the \textbf{same} compositional way — some (Tamil, Malayalam) keeping it fully transparent on the surface today, some (Kannada) with the same compositional origin but no longer visibly matching the modern standalone words for "two" and "ten," some (Telugu) worn down further but most likely from the same root. Compare that to the other three families you've met: Sanskrit's \textbf{\dv{विंशति}} (\emph{vimshati}), Latin's \textbf{vīgintī}, and Arabic's \textbf{\ar{عشرون}} (\emph{ʿishrūn}) are each their \textbf{own} special, non-compositional word for twenty — none built transparently from "two" and "ten" the way every single Dravidian language in this course does.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "patiṉoṉḏṟu, paṉṉiraṇḍu" — 11, 12{]}
+  \item {[}YOU SAY: "iru" — an older word for two, "pathu" — ten{]}
+  \item {[}YOU SAY: "irupathu" — twenty, "two-tens," transparent{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What two pieces build \textbf{\ta{இருபது}} (twenty)? (\textbf{\ta{இரு}} "two" + \textbf{\ta{பத்து}} "ten" — "\textbf{two-tens}.") Do all four Dravidian languages in this course build "twenty" the same compositional way? (\textbf{Yes} — Tamil and Malayalam keep it fully transparent today; Kannada shares the same compositional origin but its modern "two"/"ten" words no longer visibly match; Telugu's is worn down further but most likely the same root.) Do Sanskrit, Latin, or Arabic build their word for twenty this way? (\textbf{No} — each has its own special, non-compositional standalone word instead.)
+\end{tcolorbox}
+\section[\ta{வானிலை}]{\ta{வானிலை} — "the standing of the sky," most likely all native}
+
+\label{lesson:TA-C20-vaanilai}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You've now seen a Persian+Sanskrit hybrid (Kannada), a pure Sanskrit compound (Telugu), and a Sanskrit compound echoing "time" (Malayalam). Tamil most likely breaks the pattern one more time — with a word built entirely from native pieces.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{வானிலை} — vaanam + nilai}
+\textbf{\ta{வானிலை}} (\emph{vāṉilai}) = "\textbf{weather}" — built from:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\ta{வானம்}} (\emph{vāṉam}, "\textbf{sky}") — most likely a \textbf{native Dravidian} word, with confirmed cognates in \textbf{Kannada} \textbf{\ka{ಬಾನು}} (\emph{bānu}, "sky") and \textbf{Telugu} \textbf{\te{వాన}} (\emph{vāna}, "rain," from the same sky/rain-cloud root) — distinct from the Sanskrit sky word \emph{ākāśa} that those same two languages use elsewhere.
+  \item \textbf{\ta{நிலை}} (\emph{nilai}, "\textbf{state, standing, condition}") — from \textbf{\ta{நில்}} (\emph{nil}, "\textbf{to stand}"), one of Tamil's most basic native verb roots.
+\end{itemize}
+
+So \emph{vāṉilai} literally means "\textbf{the standing of the sky}" or "\textbf{the sky's state}" — and unlike its three Dravidian cousins, neither piece here is a Sanskrit or Persian/Arabic loan. (Treat "native" as the best current account rather than a fully settled fact, the same hedge you've seen elsewhere in this course — but both pieces are independently well-attested as old, native Dravidian vocabulary.)
+
+\subsection*{You'll want to know: \ta{மழை} \ta{பெய்கிறது} — "rain is falling"}
+\begin{quote}
+\textbf{\ta{மழை} \ta{பெய்கிறது}.} — "It's raining." — literally "\textbf{rain is falling}."
+\end{quote}
+
+(\emph{mazhai peykiRathu} — from \textbf{\ta{பெய்}} \emph{pey}, "to fall/pour," specifically used for rain.)
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "vāṉilai" — weather, "the standing of the sky"{]}
+  \item {[}YOU SAY: "vāṉam" — sky, "nilai" — state, from "nil," to stand{]}
+  \item {[}YOU SAY: "mazhai peykiRathu" — it's raining, "rain is falling"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What are the two pieces of \textbf{\ta{வானிலை}}, and what does the whole word literally mean? (\textbf{\ta{வானம்}}, "sky," + \textbf{\ta{நிலை}}, "state/standing" — "\textbf{the standing of the sky}.") Is either piece a Sanskrit or Persian/Arabic loan, unlike Kannada, Telugu, or Malayalam's weather words? (\textbf{Most likely not} — both pieces are native Dravidian.) What Tamil word does Malayalam's \emph{mazha} match for "rain"? (\textbf{\ta{மழை}}, \emph{mazhai}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch21-dog-and-cat.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch21-dog-and-cat.tex
@@ -1,0 +1,40 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:99b608014f6d04e5
+% canonical-lessons: TA-C21-naay-poonai
+
+\chapter{Dog and Cat}
+\label{ch:ta-dog-and-cat}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{நாய்}, \ta{பூனை}]{\ta{நாய்}, \ta{பூனை} — solid ground to close the arc, and an honest three-way split}
+
+\label{lesson:TA-C21-naay-poonai}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} This whole ANIMALS arc kept finding mystery dog-words — Spanish's \emph{perro}, English's \emph{dog}, Hindi's \emph{kuttā}, each one an unsolved puzzle displacing an older, expected word. Tamil's dog-word closes the arc on the complete opposite footing: total, undisputed solid ground.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{நாய்} — no mystery, anywhere}
+\textbf{\ta{நாய்}} (\emph{nāy}, "\textbf{dog}") is a solid, native \textbf{Proto-Dravidian} root — the exact same one behind Kannada's \textbf{\ka{ನಾಯಿ}} (\emph{nāyi}) and Malayalam's \textbf{\ml{നായ}} (\emph{nāya}). There is no debate about its origin, no substrate mystery, nothing like the \emph{perro}/\emph{dog}/\emph{kuttā} pattern that ran through Spanish, English, and Hindi. Three unrelated language families each lost their expected word for "dog" to an unexplained newcomer — and right here, in the Dravidian family, the expected word simply \textbf{survived}, plainly and solidly, across (at least) three of its languages.
+
+\begin{cousinweb}
+\textbf{\ta{பூனை}} (\emph{pūnai}, "\textbf{cat}") is Tamil's own everyday word, matching Malayalam's \textbf{\ml{പൂച്ച}} (\emph{pūcha}) closely — but be honest that "cat" splits Dravidian in a way "dog" doesn't. Kannada's everyday word, \textbf{\ka{ಬೆಕ್ಕು}} (\emph{bekku}), comes from a \textbf{different} ancient root (related to the word for "wildcat"); Telugu's, \textbf{\te{పిల్లి}} (\emph{pilli}), comes from yet \textbf{another} separate Proto-Dravidian root, most likely the very source behind Sanskrit's \emph{biḍāla} and Hindi's \emph{billī}. Tamil itself even keeps \textbf{rarer, alternate} cat-words — \textbf{\ta{பில்லி}} and \textbf{\ta{வெருகு}} — cognate with Telugu's and Kannada's everyday choices respectively, showing that all three roots were once available across the family; each language just settled on a different one as its everyday word.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "nāy" — dog, solid native Dravidian, no mystery anywhere{]}
+  \item {[}YOU SAY: "pūnai" — cat, Tamil's everyday word, matching Malayalam{]}
+  \item {[}YOU SAY: the honest split — Kannada's bekku and Telugu's pilli come from two other, separate ancient roots{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Is \textbf{\ta{நாய்}} a mystery word, like Spanish's \emph{perro}, English's \emph{dog}, or Hindi's \emph{kuttā}? (\textbf{No} — a solid, undisputed native Dravidian root, shared with Kannada and Malayalam.) Does \textbf{\ta{பூனை}} share a root with Kannada's \emph{bekku} or Telugu's \emph{pilli}? (\textbf{No} — all three are genuinely separate ancient Dravidian roots; Tamil even keeps rarer alternate cat-words, \emph{pilli} and \emph{veruku}, echoing both of them.) Which Dravidian cat-word is most likely the source of Sanskrit's \emph{biḍāla} and Hindi's \emph{billī}? (\textbf{Telugu's pilli}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch22-green-and-yellow.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch22-green-and-yellow.tex
@@ -1,0 +1,46 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:3c34a0b9cf9e6a96
+% canonical-lessons: TA-C22-paccai-manjal
+
+\chapter{Green and Yellow}
+\label{ch:ta-green-and-yellow}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{பச்சை}, \ta{மஞ்சள்}]{\ta{பச்சை}, \ta{மஞ்சள்} — closing the Dravidian arc, holding both patterns at once}
+
+\label{lesson:TA-C22-paccai-manjal}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You've now seen three different Dravidian answers to "how do green and yellow relate": Kannada split them apart, Telugu fused them into one root, Malayalam kept them as two separate native words. Tamil, it turns out, quietly contains a trace of \textbf{both} of the last two patterns.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{பச்சை} — the familiar pan-Dravidian green}
+\textbf{\ta{பச்சை}} (\textbf{paccai}, "\textbf{green}") $\leftarrow$ \textbf{Proto-Dravidian} \emph{\textbf{*pac-}} — the same root you've now met four times: Kannada's \emph{hasiru}, Telugu's \emph{pacca}, Malayalam's \emph{paccha}, and now Tamil's own \emph{paccai}.
+
+\begin{cousinweb}
+\textbf{\ta{மஞ்சள்}} (\textbf{mañcaḷ}, "\textbf{yellow, turmeric}") is Tamil's actual, everyday word for yellow — and it comes from a \textbf{completely separate} native Dravidian root, matching Malayalam's \textbf{\ml{മഞ്ഞ}/\ml{മഞ്ഞൾ}} (\emph{mañña}/\emph{maññaḷ}) closely. Like Malayalam's pair, this root has no Sanskrit involvement — it sits alongside \emph{paccai}, not descended from it.
+\end{cousinweb}
+
+\begin{cousinweb}
+The \textbf{Tamil Lexicon} also records \textbf{\ta{பசுப்பு}} (\textbf{pacuppu}, "\textbf{greenish yellow}") — a genuine \textbf{doublet} of \emph{paccai} itself, from the same \emph{\textbf{*pac-}} root, matching Telugu's \emph{pasupu} closely. Unlike Telugu, though, this doublet is \textbf{not} Tamil's everyday word for yellow — that job belongs to \emph{mañcaḷ}; \emph{pacuppu} survives mainly as a dictionary-recorded shade word. So Tamil, uniquely in this arc, holds a trace of \textbf{both} patterns at once: a \emph{pac-} doublet sitting quietly in the dictionary (Telugu's pattern), next to a separate, dominant root doing the everyday work (Malayalam's pattern).
+
+(Note for the Tamil-speaking reviewer: \emph{pacuppu}'s everyday currency is the part I'm least certain of — please confirm whether it's a word you'd recognize as "greenish yellow," or whether it reads as archaic/purely literary in the Tamil you'd teach first.)
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "\ta{பச்சை}" — green, the pan-Dravidian \emph{pac- word{]}}
+  \item {[}YOU SAY: "\ta{மஞ்சள்}" — yellow, Tamil's real everyday word, a separate root{]}
+  \item {[}YOU SAY: "\ta{பசுப்பு}" — a rarer doublet of paccai, echoing Telugu's pattern{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What is Tamil's everyday word for yellow, and is it related to \textbf{paccai}? (\textbf{\ta{மஞ்சள்}}, \emph{mañcaḷ} — \textbf{no}, a completely separate native root, matching Malayalam's \emph{mañña/maññaḷ}.) What rarer Tamil word IS a doublet of \emph{paccai}, from the same \emph{pac-} root? (\textbf{\ta{பசுப்பு}}, \emph{pacuppu}, "greenish yellow" — echoing Telugu's \emph{pacca/pasupu} pattern.) Does any one pattern hold across all the Dravidian languages in this arc? (\textbf{No} — Kannada splits native/loan, Telugu fuses one root, Malayalam keeps two separate roots, and Tamil turns out to hold traces of both Telugu's and Malayalam's patterns at once.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch23-day.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch23-day.tex
@@ -1,0 +1,75 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:cbbbe0dcc581dbf8
+% canonical-lessons: TA-C23-naal, TA-C23-day-family-register
+
+\chapter{Day}
+\label{ch:ta-day}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{நாள்}]{\ta{நாள்} (nāḷ) — "day," the one this arc's Dravidian languages didn't lose}
+
+\label{lesson:TA-C23-naal}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You've now seen three Dravidian languages reach for a loanword — Sanskrit, twice, and Persian once — to name their everyday word for "day." Tamil doesn't. This lesson is about the one that didn't.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\ta{நாள்}} (\textbf{nāḷ}) — "\textbf{day}" — is native \textbf{Dravidian}, from \textbf{Proto-Dravidian} \emph{\textbf{*nāḷ}}. You've already met it, hiding inside \textbf{\ta{நாளை}} (\emph{nāḷai}, "tomorrow," Chapter 4). But here's the honest headline of this lesson: \ta{நாள்} isn't a survivor clinging to one narrow sense the way some native words elsewhere in this arc have been — it is simply Tamil's \textbf{plain, everyday, unmarked} word for counting a day, as ordinary as \textbf{\ta{மூன்று} \ta{நாள்}} (\emph{mūnṟu nāḷ}, "\textbf{three days}").
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "nāḷ" — "day," native Dravidian, already met inside "tomorrow"{]}
+  \item {[}YOU SAY: "mūnṟu nāḷ" — three days{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Where did you already meet \textbf{\ta{நாள்}} before this lesson? (Inside \textbf{\ta{நாளை}}, \emph{nāḷai}, "tomorrow," Chapter 4.) Is Tamil's everyday day-word a loanword? (\textbf{No} — \textbf{\ta{நாள்}} is native Dravidian.) Is it marginal or literary? (\textbf{No} — it is the plain everyday counting word.) Next: compare the other sisters' borrowed day-words and Tamil's formal \emph{tiṉam}.
+\end{tcolorbox}
+\section[\ta{நாள்} / \ta{தினம்}]{\ta{நாள்} and \ta{தினம்} — everyday native, formal borrowed}
+
+\label{lesson:TA-C23-day-family-register}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} \emph{Nāḷ} is plainly native and everyday. Put that lexical choice beside the other Dravidian tracks.
+\end{quote}
+
+\subsection*{You'll want to know: Four everyday day-words}
+\begin{itemize}
+\raggedright
+  \item Kannada \textbf{dina} — Sanskrit tatsama
+  \item Telugu \textbf{rōju} — Persian loan
+  \item Malayalam \textbf{divasam} — Sanskrit tatsama
+  \item Tamil \textbf{nāḷ} — native Dravidian
+\end{itemize}
+
+Tamil is the only one here whose unmarked everyday counting word remains native.
+
+\subsection*{You'll want to know: Tamil still has \ta{தினம்}}
+\textbf{\ta{தினம்}} (\emph{tiṉam}) is the same Sanskrit \emph{dina} as Kannada/Malayalam, ultimately from PIE \emph{\textbf{dyew-}}, "shine," also behind Latin \emph{diēs}. Tamil assigns it formal and compound work: \textbf{\ta{சுதந்திர} \ta{தினம்}}, "Independence Day," and \textbf{\ta{தினசரி}}, "daily." Casual counting remains \emph{nāḷ}.
+
+The language did not reject the loan; it gave native and borrowed forms different jobs.
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "mūnṟu nāḷ" — three days{]}
+  \item {[}YOU SAY: "sutantira tiṉam" — Independence Day{]}
+  \item {[}YOU CLASSIFY: everyday native · formal/compound Sanskrit{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which track alone keeps a native everyday day-word? (\textbf{Tamil}.) Where does \emph{tiṉam} appear? (\textbf{Formal compounds}.) Is it unrelated to Kannada \emph{dina}? (\textbf{No} — it is the same Sanskrit tatsama.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch24-night.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch24-night.tex
@@ -1,0 +1,71 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:5eac37ebcb9ae8cc
+% canonical-lessons: TA-C24-iravu, TA-C24-night-register-darkness
+
+\chapter{Night}
+\label{ch:ta-night}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{இரவு}]{\ta{இரவு} (iravu) — "night," and a register question worth a native speaker's ear}
+
+\label{lesson:TA-C24-iravu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Last lesson, Tamil's native day-word had no real competition. This lesson's honest twist, hedged carefully, is that "night" may not tell the same story — and this is exactly the kind of claim worth checking against your own ear, not just a dictionary's.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{இரவு} — already standing on its own, inside "midnight"}
+\textbf{\ta{இரவு}} (\textbf{iravu}) — "\textbf{night}" — is native \textbf{Dravidian}, from \textbf{Proto-Dravidian} \emph{\textbf{*cira}} ("darkness"). You've technically already met it standing fully on its own: Chapter 17, while explaining \textbf{\ta{நள்ளிரவு}} (\emph{naḷḷiravu}, "midnight," \ta{நள்} + \ta{இரவு}), noted directly that \ta{இரவு} itself is a word every Tamil speaker still uses on its own. This lesson gives it its own full chapter.
+
+\begin{cousinweb}
+Tamil also keeps \textbf{\ta{ராத்திரி}} (\textbf{rāttiri}), a Sanskrit \textbf{tatsama} from \textbf{\dv{रात्रि}} (\emph{rātri}) — the same word already met, as a tatsama, in Kannada's \emph{ratri} and Telugu's \emph{ratri} (though those two lessons didn't draw out its PIE ancestry). It traces to \textbf{Proto-Indo-European} \emph{\textbf{*h\textsubscript{1}reh\textsubscript{1}-}} ("\textbf{to rest}"), a \textbf{completely different} root from Latin \emph{nox}'s \emph{\textbf{*nók\textsuperscript{w}ts}} — the same specific comparison already drawn for Hindi's \emph{raat} and Malayalam's \emph{rāthri} earlier in this arc, now a third confirmation, same false-cognate pattern, same honest non-relationship to \emph{nox}.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "iravu" — "night," native, already met inside naḷḷiravu{]}
+  \item {[}YOU SAY: "rāttiri" — Sanskrit loan, same PIE \emph{h\textsubscript{1}reh\textsubscript{1}- already drawn for Hindi and Malayalam, NOT related to Latin nox{]}}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Where did you already meet \textbf{\ta{இரவு}} before this lesson? (Inside \textbf{\ta{நள்ளிரவு}}, \emph{naḷḷiravu}, "midnight," Chapter 17.) Does \textbf{\ta{ராத்திரி}}'s PIE root match Latin \emph{nox}'s? (\textbf{No} — \emph{\textbf{*h\textsubscript{1}reh\textsubscript{1}-}} "to rest," the same false-cognate pattern already drawn for Hindi and Malayalam earlier in this arc.) Next: treat the proposed register split as a hypothesis and keep "darkness" separate from "night."
+\end{tcolorbox}
+\section[\ta{இரவு} / \ta{ராத்திரி} / \ta{இருள்}]{Night words — a register hypothesis and a semantic boundary}
+
+\label{lesson:TA-C24-night-register-darkness}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} \emph{Iravu} is native and \emph{rāttiri} borrowed. That alone does not tell you which one conversational Tamil prefers.
+\end{quote}
+
+\begin{culture}
+At least one dictionary says \textbf{\ta{ராத்திரி}} is more common colloquially, implying native \textbf{\ta{இரவு}} may lean literary/written. If accurate, this reverses the day story, where native \emph{nāḷ} is uncontested everyday speech.
+
+But the evidence is limited and dictionary-level. Treat this as a prompt for a native speaker's ear, not settled fact. Register judgments require real usage, region, and setting—not a purity assumption about native versus borrowed words.
+\end{culture}
+
+\subsection*{You'll want to know: Darkness is a different word}
+\textbf{\ta{இருள்}} (\emph{iruḷ}) means \textbf{darkness}, from Proto-Dravidian \emph{\textbf{cirVḷ}} and cognate with Kannada, Telugu, and Malayalam forms. It is not \emph{iravu} "night as a time period" and comes from a different reconstructed root despite the similar sound.
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU QUALIFY: "one source says \emph{rāttiri} is more colloquial"{]}
+  \item {[}YOU ASK: compare that claim with native regional usage{]}
+  \item {[}YOU CONTRAST: \emph{iravu} night · \emph{iruḷ} darkness{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Is the \emph{rāttiri} register claim settled? (\textbf{No} — limited sourcing, worth checking against native usage.) Is \textbf{\ta{இருள்}} interchangeable with \textbf{\ta{இரவு}}? (\textbf{No} — darkness versus a time period, from different roots.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch25-good-night.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch25-good-night.tex
@@ -1,0 +1,76 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:d95cb3daafa21b66
+% canonical-lessons: TA-C25-iniya-iravu, TA-C25-goodnight-alternatives
+
+\chapter{Good Night}
+\label{ch:ta-good-night}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{இனிய} \ta{இரவு}]{\ta{இனிய} \ta{இரவு} (iṉiya iravu) — "good night," and Tamil breaking the pattern one more time}
+
+\label{lesson:TA-C25-iniya-iravu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Four languages in this arc all reached for the same Sanskrit phrase to say "good night." This lesson closes the arc with the one that didn't — and it's a pattern you've actually seen from Tamil before, all the way back in Chapter 1.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\ta{இனிய} \ta{இரவு}} (\textbf{iṉiya iravu}) — "\textbf{good night}" — literally "\textbf{sweet, pleasant night}." \textbf{\ta{இனிய}} (\emph{iṉiya}, "sweet, pleasant, dear") is native \textbf{Dravidian}, from \textbf{Proto-Dravidian} \emph{\textbf{*in-}} ("sweet") — the same root behind \textbf{\ta{இனிப்பு}} (\emph{iṉippu}, "sweet, dessert"). Paired with \textbf{\ta{இரவு}} (\emph{iravu}, "night," already met last lesson), the whole phrase is built from Tamil's own word-stock, start to finish.
+\end{cousinweb}
+
+\begin{culture}
+Every other language in this arc's GREETING-GOODNIGHT lesson reached for the \textbf{same} Sanskrit phrase: Hindi's \textbf{\dv{शुभ} \dv{रात्रि}}, Kannada's \textbf{\ka{ಶುಭ} \ka{ರಾತ್ರಿ}}, Telugu's \textbf{\te{శుభ} \te{రాత్రి}}, Malayalam's \textbf{\ml{ശുഭ} \ml{രാത്രി}} — all four built from the identical tatsama pair, \textbf{śubh} ("to be beautiful") + \textbf{rātri} ("night"). Tamil's standard phrase reaches for \textbf{none} of that — no śubha-descended "good night" turned up as a commonly used Tamil form in the phrasebook sources checked for this lesson. Instead, Tamil built its own phrase from its own vocabulary.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "iṉiya iravu" — "good night," literally "sweet night," fully native{]}
+  \item {[}YOU SAY: the pattern it breaks — every other language this arc shares one Sanskrit śubh(a) rātri phrase; Tamil doesn't{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \textbf{\ta{இனிய} \ta{இரவு}} literally mean, and what root does \textbf{\ta{இனிய}} come from? ("\textbf{Sweet/pleasant night}" — Proto-Dravidian \emph{\textbf{in-}}, "sweet.") Does Tamil's "good night" share the same Sanskrit śubha rātri phrase as Hindi, Kannada, Telugu, and Malayalam? (\textbf{No} — no such form turned up in the sources checked for this lesson; Tamil's standard phrase is fully native, breaking the pattern shared by all four other languages.) Next: connect that choice back to Chapter 1 and build two native alternatives.
+\end{tcolorbox}
+\section[\ta{நல்ல} \ta{இரவு} / \ta{இரவு} \ta{வணக்கம்}]{\ta{நல்ல} \ta{இரவு} and \ta{இரவு} \ta{வணக்கம்} — old roots recombined}
+
+\label{lesson:TA-C25-goodnight-alternatives}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Tamil's native "sweet night" repeats the lexical choice that opened the course: build greetings from its own roots rather than the shared Sanskrit formula.
+\end{quote}
+
+\subsection*{You'll want to know: The Chapter 1 echo}
+\textbf{\ta{வணக்கம்}} comes from native \emph{vaṇaṅku}, "bow," while neighboring greetings use Sanskrit \emph{namas-}. At the other end of the day, \textbf{\ta{இனிய} \ta{இரவு}} is native while the same neighbors share Sanskrit \emph{śubha rātri}.
+
+Tamil also keeps two transparent alternatives:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\ta{நல்ல} \ta{இரவு}} — "good night," using \emph{nalla}, from the \textbf{nal-} "good" root already inside \emph{nalam} and \emph{naṉṟi}
+  \item \textbf{\ta{இரவு} \ta{வணக்கம்}} — "night greetings," especially for close friends/family, recombining two fully known words
+\end{itemize}
+
+The learner does not memorize isolated formulas; known roots generate options.
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "nalla iravu" — good night{]}
+  \item {[}YOU SAY: "iravu vaṇakkam" — night greetings{]}
+  \item {[}YOU TRACE: \emph{nal-} $\to$ \emph{nalam / naṉṟi / nalla}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which root builds \textbf{\ta{நல்ல}}? (\textbf{Nal-}, good.) What two known words make \textbf{\ta{இரவு} \ta{வணக்கம்}}? (\textbf{Night + greetings}.) What lexical pattern connects Chapter 1 and this chapter? (\textbf{Tamil keeps native greeting roots where neighbors share Sanskrit formulas}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch26-morning.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch26-morning.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:cbad1f7eb1bb2816
+% canonical-lessons: TA-C26-kaalai
+
+\chapter{Morning}
+\label{ch:ta-morning}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{காலை}]{\ta{காலை} (kālai) — "morning," an honestly uncertain etymology}
+
+\label{lesson:TA-C26-kaalai}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Every other language in this arc had a confidently-sourced story for its "morning" word — Sanskrit, or clearly native. Tamil's own word for morning is different: even Wiktionary itself isn't sure where it comes from.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\ta{காலை}} (\textbf{kālai}) — "\textbf{morning}" — has an etymology that Wiktionary itself only hedges at: "\textbf{possibly} from Sanskrit \textbf{\dv{काल्य}} (\emph{kālya})." That's a real hedge from the source itself, not one this lesson is adding for caution's sake. Complicating things further: the related word \textbf{\ta{கால்}} (\emph{kāl}) carries \textbf{six} entirely distinct etymologies in Tamil — "leg/foot," "irrigation channel," "forest," "wind," a Sanskrit-derived "time" sense, and a conjunction meaning "if, when" — and \textbf{\ta{காலை}} may be an accusative-type form built on the "time" sense specifically, or may not be. Be honest: this is genuinely \textbf{less settled} than Kannada's confidently-native morning word or Telugu's confidently-Sanskrit one. Don't manufacture certainty the primary source itself doesn't have.
+\end{cousinweb}
+
+\begin{cousinweb}
+Wiktionary does confirm one solid fact: \textbf{\ta{பகல்}} (already met, Chapter 17, "\textbf{daytime}") is listed as \ta{காலை}'s \textbf{coordinate term} — the two words sit side by side in the same semantic field, whatever \ta{காலை}'s deeper root turns out to be. And \textbf{\ta{அதிகாலை}} ("\textbf{early dawn}") is confirmed, per the Tamil Lexicon, as a fully transparent compound: \textbf{ati-} ("excessive, very") + \textbf{\ta{காலை}}, glossed simply as "early dawn" by the Tamil Lexicon.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "kālai" — "morning," an honestly uncertain etymology{]}
+  \item {[}YOU SAY: the hedge itself — Wiktionary says "possibly" Sanskrit kālya, not a confident claim{]}
+  \item {[}YOU SAY: "atikaalai" — "early dawn," a transparent ati- + kālai compound{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Is \ta{காலை}'s etymology as confidently sourced as Kannada's or Telugu's morning words? (\textbf{No} — Wiktionary itself only says "possibly" Sanskrit kālya; genuinely uncertain, not settled.) What coordinate term does Wiktionary list alongside \ta{காலை}? (\textbf{\ta{பகல்}}, "daytime," already met in Chapter 17.) What does \ta{அதிகாலை} literally build on? (\textbf{ati-} ("very") + \textbf{\ta{காலை}} — a transparent compound for "early dawn.")
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch27-evening.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch27-evening.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:771849e1943269f5
+% canonical-lessons: TA-C27-maalai
+
+\chapter{Evening}
+\label{ch:ta-evening}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{மாலை}]{\ta{மாலை} (mālai) — "evening," and a garland that only looks like the same word}
+
+\label{lesson:TA-C27-maalai}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Last lesson's morning word had an uncertain origin. This evening word is different — confidently native — but it comes with its own honest twist: it looks exactly like a completely unrelated word.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\ta{மாலை}} (\textbf{mālai}) — "\textbf{evening}" — happens to be spelled identically to another, completely \textbf{unrelated} Tamil word: \textbf{\ta{மாலை}} meaning "\textbf{garland, wreath, necklace}." Wiktionary treats these as \textbf{two separate etymologies}, not one word with two senses. The garland sense traces to Old Tamil and is compared to Sanskrit \textbf{\dv{माला}} (\emph{mālā}) — with a genuinely interesting note: it's "\textbf{probably borrowed FROM Dravidian languages}" \textbf{into} Sanskrit, not the other way around. A rare reverse-direction loan, worth noticing against this whole project's usual Sanskrit-into-Dravidian pattern.
+\end{cousinweb}
+
+\begin{cousinweb}
+The \textbf{evening} sense of \textbf{\ta{மாலை}} is a \textbf{separate} Old Tamil word entirely, compared instead to \textbf{\ta{மால்}} (\emph{māl}) — which Wiktionary traces to \textbf{Proto-Dravidian} \emph{\textbf{*mā/*māl}}, with senses including "\textbf{\ta{கருமை}}" ("\textbf{blackness, darkness}"), plus archaic senses of "illusion, confusion" and, as a proper noun, the Hindu deity \textbf{Vishnu}. Be honest about the exact mechanism here: Wiktionary's own etymology for "evening" only says "\textbf{compare māl}" — it does \textbf{not} explicitly state that "evening" derives specifically from the \textbf{darkness} sense rather than some other sense of this multi-meaning root. The connection (evening = the time it grows dark) is natural and plausible, but not nailed down with full certainty by the source itself. What IS certain: this is confidently \textbf{native} Dravidian vocabulary, a genuine contrast with TA-C26's uncertain \ta{காலை}.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "mālai" — "evening," confidently native Dravidian vocabulary{]}
+  \item {[}YOU SAY: the homonym twist — a completely separate word, mālai, means "garland," probably borrowed INTO Sanskrit from Dravidian{]}
+  \item {[}YOU SAY: the honest hedge — "evening" plausibly connects to māl's "darkness" sense, but Wiktionary doesn't spell out that exact link{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Are evening-mālai and garland-mālai the same word with two meanings? (\textbf{No} — Wiktionary treats them as two entirely separate etymologies; a genuine homonym, not one word stretched.) Which direction did the garland sense's Sanskrit connection likely travel? (\textbf{Dravidian into Sanskrit} — a reverse-direction loan, per Wiktionary's own "probably borrowed from Dravidian languages" note.) Is it fully certain that "evening" derives from māl's "darkness" sense specifically? (\textbf{No} — plausible and natural, but Wiktionary only says "compare māl," without spelling out that exact mechanism.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch28-afternoon.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch28-afternoon.tex
@@ -1,0 +1,67 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:925a2b9b870e5d0f
+% canonical-lessons: TA-C28-pirpakal, TA-C28-afternoon-boundary
+
+\chapter{Afternoon}
+\label{ch:ta-afternoon}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{பிற்பகல்}]{\ta{பிற்பகல்} (piṟpakal) — "afternoon," a similar sandhi trick to \ta{நண்பகல்}}
+
+\label{lesson:TA-C28-pirpakal}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You already met a sandhi-driven surface change in Chapter 17 — \ta{நள்} resurfacing as \ta{நண்}. This lesson's afternoon word does a similar kind of trick, with a different word — though be honest that the two changes aren't identical.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{பிற்பகல்} — \ta{பின்} (after) + \ta{பகல்} (daytime), a similar sandhi story}
+\textbf{\ta{பிற்பகல்}} (\textbf{piṟpakal}) — "\textbf{afternoon}" — is a transparent compound: \textbf{\ta{பின்}} (\emph{piṉ}, "\textbf{after}") plus \textbf{\ta{பகல்}} (\emph{pakal}, "\textbf{daytime}," already met inside \ta{நண்பகல்}, TA-C17 — though be aware the \ta{பிற்பகல்} Wiktionary page itself glosses \ta{பகல்} as "noon" in its own etymology line, a small inconsistency across Wiktionary's own entries, not something this lesson introduces). Here's the familiar pattern: \ta{பின்} doesn't stay \ta{பின்} in this compound — it surfaces as \textbf{\ta{பிற்}-} before the following \ta{ப} — a \textbf{similar} kind of consonant sandhi to the one already taught in Chapter 17, where \textbf{\ta{நள்}} became \textbf{\ta{நண்}} before its own following \ta{ப}. Be honest, though: Wiktionary's own etymology for \ta{பிற்பகல்} doesn't discuss this mechanism at all, and the two changes move in different phonetic directions (nasal$\to$stop here, lateral$\to$nasal there) — this is the lesson's own observation, not a sourced equivalence. Wiktionary labels this word \textbf{formal register}.
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "piṟpakal" — "afternoon," piṉ ("after") + pakal ("daytime"){]}
+  \item {[}YOU SAY: the sandhi echo — piṉ surfaces as piṟ-, a similar kind of change to TA-C17's naḷ$\to$naṇ, though not phonetically identical{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \ta{பிற்பகல்} literally build from, and what sandhi change happens to the first piece? (\textbf{\ta{பின்}} "after" + \ta{பகல்} "daytime" — \ta{பின்} surfaces as \ta{பிற்}-, a similar kind of sandhi to TA-C17's naḷ$\to$naṇ, though the two changes move in different phonetic directions, not identical mechanisms.) What register does the fetched page label? (\textbf{Formal}.) Next: inspect the real noon/afternoon boundary blur and the separate \emph{matiyam} root.
+\end{tcolorbox}
+\section[\ta{நடுப்பகல்} / \ta{மதியம்}]{Noon or afternoon? — let the sources keep their blur}
+
+\label{lesson:TA-C28-afternoon-boundary}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} \emph{Piṟpakal} transparently says after-daytime. Dictionaries still do not draw a perfectly hard semantic boundary around its synonyms.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{நடுப்பகல்} overlaps}
+Wiktionary's \emph{piṟpakal} page lists \textbf{\ta{நடுப்பகல்}} as an afternoon synonym, while the earlier noon lesson documents the same word as a synonym of \textbf{\ta{நண்பகல்}}, "noon." This is genuine noon/afternoon boundary blur, not an inconsistency to erase. Time-period categories can widen differently across speakers and sources.
+
+\begin{cousinweb}
+\textbf{\ta{மதியம்}} (\emph{matiyam}) is a Sanskrit tatsama from \emph{madhya}, "middle," the same root used by Kannada and Telugu. The fetched entry gives it \textbf{noon}, a synonym of \emph{naṇpakal}, not a dedicated afternoon meaning.
+
+An initial search summary claimed \emph{matiyam} once meant "moon," but that claim is absent from the actual fetched page. It is therefore \textbf{not asserted}. Source inspection outranks a search snippet.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: \emph{naṭuppakal} can overlap noon and afternoon{]}
+  \item {[}YOU SAY: \emph{matiyam} — Sanskrit \emph{madhya}, "middle," listed as noon{]}
+  \item {[}YOU LABEL: the moon claim unsupported{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Does the source draw a hard noon/afternoon line? (\textbf{No}.) What is \emph{matiyam}'s sourced root and sense? (Sanskrit \emph{\textbf{madhya}}, "middle," and \textbf{noon}.) Is "originally moon" confirmed? (\textbf{No}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch29-good-morning.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch29-good-morning.tex
@@ -1,0 +1,40 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:98b7381596bab2bd
+% canonical-lessons: TA-C29-kaalai-vanakkam
+
+\chapter{Good Morning}
+\label{ch:ta-good-morning}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{காலை} \ta{வணக்கம்}]{\ta{காலை} \ta{வணக்கம்} (kālai vaṇakkam) — "morning greetings," built from two words you already know}
+
+\label{lesson:TA-C29-kaalai-vanakkam}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Every other language in this arc built its "good morning" on a word meaning "good" or "auspicious." Tamil does something completely different: it just puts its everyday greeting word after its word for "morning."
+\end{quote}
+
+\subsection*{You'll want to know: \ta{காலை} \ta{வணக்கம்} — literally, "morning greetings"}
+\textbf{\ta{காலை} \ta{வணக்கம்}} (\textbf{kālai vaṇakkam}) — "\textbf{good morning}" — is confirmed, by two independently-fetched sources, as Tamil's standard greeting for this time of day, used "\textbf{from sunrise until around 11 AM}." It's built from two words you already have: \textbf{\ta{காலை}} (already met, Chapter 26, "\textbf{morning}") plus \textbf{\ta{வணக்கம்}} (already met, Chapter 1, "\textbf{reverence, homage}" — Tamil's everyday word for "hello"). Literally: "\textbf{morning salutations}."
+
+\begin{culture}
+Here's the honest structural surprise: Hindi, Kannada, Telugu, and Malayalam each build their morning greeting on a \textbf{śubha}-equivalent word ("good, auspicious") plus a time-word. Tamil does something genuinely \textbf{different} — there's no "good/auspicious" word here at all. It's simply \textbf{\ta{வணக்கம்}}, Tamil's own general greeting, specified with \textbf{\ta{காலை}} in front of it to mean "morning" greetings specifically. Also be honest about a claim that didn't hold up: an initial search summary suggested a Sanskrit-borrowed word, "suprabhatham," serves as a casual alternative — but that claim appears on \textbf{neither} of the two pages actually fetched, so it's deliberately \textbf{not} asserted here.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "kālai vaṇakkam" — "good morning," literally "morning greetings"{]}
+  \item {[}YOU SAY: the honest structural surprise — no śubha-equivalent word here at all, unlike every other language in this arc{]}
+  \item {[}YOU SAY: the two pieces you already know — kālai (Chapter 26) + vaṇakkam (Chapter 1){]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What two already-known words does \ta{காலை} \ta{வணக்கம்} build from? (\ta{காலை}, "morning" + \ta{வணக்கம்}, "reverence/hello.") Does Tamil's morning greeting follow the śubha-equivalent + time-word pattern used by Hindi/Kannada/Telugu/Malayalam? (\textbf{No} — it's simply \ta{வணக்கம்}, Tamil's own general greeting, specified with \ta{காலை} in front.) Is the "suprabhatham as a casual alternative" claim confirmed? (\textbf{No} — it appears on neither of the two sources actually fetched; deliberately not asserted here.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch30-good-evening.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch30-good-evening.tex
@@ -1,0 +1,40 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:f4dbb1b65e6b99db
+% canonical-lessons: TA-C30-maalai-vanakkam
+
+\chapter{Good Evening}
+\label{ch:ta-good-evening}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{மாலை} \ta{வணக்கம்}]{\ta{மாலை} \ta{வணக்கம்} (mālai vaṇakkam) — "evening greetings," the same pattern, re-verified}
+
+\label{lesson:TA-C30-maalai-vanakkam}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Last chapter's morning greeting followed its own pattern. This lesson checks whether the evening greeting follows the same one — rather than assuming it automatically does.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{மாலை} \ta{வணக்கம்} — the same compositional pattern, independently confirmed}
+\textbf{\ta{மாலை} \ta{வணக்கம்}} (\textbf{mālai vaṇakkam}) — "\textbf{good evening}" — is confirmed, by two independently-fetched sources, as a real, standard Tamil evening greeting, used roughly from \textbf{afternoon through nightfall} (the two sources give slightly different exact windows — "after noon through evening" versus "late afternoon until nightfall" — a small, unsurprising looseness, matching the noon/afternoon boundary-blur already seen in TA-C28). It's built exactly the same way as TA-C29's morning greeting: \textbf{\ta{மாலை}} (already met, Chapter 27, "\textbf{evening}") plus \textbf{\ta{வணக்கம்}} (already met, Chapter 1, Tamil's general greeting). Literally: "\textbf{evening salutations}."
+
+\begin{culture}
+Here's the honest methodological point: just because TA-C29's morning greeting followed the "time-word + vaṇakkam" pattern doesn't mean this evening greeting was assumed to follow it automatically. This arc has repeatedly found that greeting formation doesn't reliably generalize, even within the very same language — Malayalam's own morning greeting broke from the śubha+time-word pattern its afternoon and evening greetings both share, so "the pattern probably repeats" was never a safe assumption on its own. So this greeting was independently verified via direct fetch before confirming the pattern really does repeat here — and it does, cleanly: no śubha-equivalent word appears in Tamil's evening greeting either, same as the morning one.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "mālai vaṇakkam" — "good evening," literally "evening greetings"{]}
+  \item {[}YOU SAY: the two pieces you already know — mālai (Chapter 27) + vaṇakkam (Chapter 1){]}
+  \item {[}YOU SAY: the honest methodological point — this pattern was re-verified, not assumed to carry over automatically{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What two already-known words does \ta{மாலை} \ta{வணக்கம்} build from? (\ta{மாலை}, "evening" + \ta{வணக்கம்}, "greetings.") Was it assumed that the evening greeting would follow the same pattern as the morning one, or was it independently checked? (\textbf{Independently checked} — via direct fetch, not assumed, since this arc has learned that greeting patterns don't reliably generalize.) Does \ta{மாலை} \ta{வணக்கம்} use a śubha-equivalent word, like Hindi/Kannada/Telugu/Malayalam's evening greetings do? (\textbf{No} — same as Tamil's morning greeting, no śubha-equivalent word appears here either.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch31-good-afternoon.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch31-good-afternoon.tex
@@ -1,0 +1,77 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:f8ee12008eeeb646
+% canonical-lessons: TA-C31-matiya-vanakkam, TA-C31-afternoon-greeting-root
+
+\chapter{Good Afternoon}
+\label{ch:ta-good-afternoon}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[\ta{மதிய} \ta{வணக்கம்}]{\ta{மதிய} \ta{வணக்கம்} (matiya vaṇakkam) — a sourced afternoon greeting}
+
+\label{lesson:TA-C31-matiya-vanakkam}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You already know that Tamil's noon and afternoon boundaries can blur. Now learn one afternoon greeting without pretending that all speakers or teaching sources divide the day in exactly the same way.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{\ta{மதிய} \ta{வணக்கம்}} (\textbf{matiya vaṇakkam}) — "\textbf{good afternoon}" — is confirmed, by two independently-fetched sources, as Tamil's afternoon greeting, used roughly "\textbf{noon to around 4 PM}." A third source, already used for the morning and evening greetings, doesn't list a distinct afternoon greeting at all — it only covers "before noon" and "after noon through evening," implicitly treating those two as bookending the whole day. This is an honest extension of TA-C28's own noon/afternoon boundary-blur into the greeting layer, not a new problem to worry about.
+
+Use \textbf{\ta{மதிய} \ta{வணக்கம்}} when that afternoon slot fits the people and setting around you. Treat "noon to 4" as a useful learning window, not as a universal clock rule.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "matiya vaṇakkam" — "good afternoon," confirmed real, used roughly noon to 4 PM{]}
+  \item {[}YOU SAY: the honest qualification — one source does not teach a separate afternoon greeting at all{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What is one sourced Tamil greeting for "good afternoon"? (\textbf{\ta{மதிய} \ta{வணக்கம்}, matiya vaṇakkam}.) Do all three fetched sources agree on a distinct "afternoon" greeting slot? (\textbf{No} — two confirm \ta{மதிய} \ta{வணக்கம்} directly; a third doesn't list a separate afternoon greeting at all, treating morning and evening as bookending the day.) What clock window is a useful guide rather than a universal rule? (\textbf{Roughly noon to 4 PM}.)
+\end{tcolorbox}
+\section[\ta{மதிய}]{\ta{மதிய} — the greeting takes a different root}
+
+\label{lesson:TA-C31-afternoon-greeting-root}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You can now say \textbf{\ta{மதிய} \ta{வணக்கம்}}. This final step explains why its first word is not the ordinary afternoon word \textbf{\ta{பிற்பகல்}}.
+\end{quote}
+
+\begin{cousinweb}
+The greeting begins with \textbf{\ta{மதிய}} (\textbf{matiya}). It is the adjectival form of \textbf{\ta{மதியம்}} (\textbf{matiyam}), "noon." That noun entered Tamil from Sanskrit \textbf{madhya}, "middle": noon is the middle of the day.
+
+The adjective \textbf{\ta{மதிய}} can be glossed "of or pertaining to afternoon." That lets Tamil build \textbf{\ta{மதிய} \ta{வணக்கம்}} even though the dedicated word you learned for "afternoon" was \textbf{\ta{பிற்பகல்}}, the native compound from \textbf{piṉ} (after) + \textbf{pakal} (daytime).
+
+Keep the two paths separate:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\ta{பிற்பகல்}}: after + daytime $\to$ afternoon
+  \item \textbf{\ta{மதிய} \ta{வணக்கம்}}: middle/noon adjective + greeting $\to$ good afternoon
+\end{itemize}
+
+The time word and the greeting do not have to share a root. That is one more reason not to manufacture a greeting by translating its pieces from another language.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: matiyam — "noon," ultimately from Sanskrit madhya, "middle"{]}
+  \item {[}YOU SAY: pirpakal — "afternoon," built from "after" + "daytime"{]}
+  \item {[}YOU SAY: matiya vaṇakkam — the afternoon greeting, built on matiya{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Does \textbf{\ta{மதிய} \ta{வணக்கம்}} begin with \textbf{\ta{பிற்பகல்}}? (\textbf{No.}) What noun is \textbf{\ta{மதிய}} related to? (\textbf{\ta{மதியம்}, "noon."}) What older root lies behind it? (\textbf{Sanskrit madhya, "middle."}) Why should you learn the whole greeting rather than construct it from the time word? (\textbf{Tamil uses a different root in the greeting.})
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/preamble.tex
+++ b/code/learning/human-languages/tamil/book/preamble.tex
@@ -16,12 +16,14 @@
 \newunicodechar{ṟ}{\b{r}}
 \newunicodechar{ḻ}{\b{l}}
 \newunicodechar{ṁ}{\.{m}}
+\newunicodechar{ḱ}{\'{k}}
 
 \usepackage[table]{xcolor}
 \usepackage{tcolorbox}
 \tcbuselibrary{skins,breakable}
 \usepackage{booktabs}
 \usepackage{longtable}
+\usepackage{tabularx}
 \usepackage{array}
 \usepackage[hidelinks]{hyperref}
 \usepackage{titlesec}
@@ -29,12 +31,23 @@
 \usepackage{polyglossia}
 \setmainlanguage{english}
 \setotherlanguage{tamil}
+\setotherlanguage{arabic}
 
 % Vendored Tamil font (../../_fonts/ from <lang>/book/).
 \newfontfamily\tamilfont[Path=../../_fonts/, Script=Tamil]{NotoSansTamil-Static.ttf}
 
 % Inline Tamil snippet within English text.
 \newcommand{\ta}[1]{\texttamil{#1}}
+\newfontfamily\telugufont[Path=../../_fonts/, Script=Telugu]{NotoSansTelugu-Static.ttf}
+\newcommand{\te}[1]{{\telugufont #1}}
+\newfontfamily\kannadafont[Path=../../_fonts/, Script=Kannada]{NotoSansKannada-Static.ttf}
+\newcommand{\ka}[1]{{\kannadafont #1}}
+\newfontfamily\malayalamfont[Path=../../_fonts/, Script=Malayalam]{NotoSansMalayalam-Static.ttf}
+\newcommand{\ml}[1]{{\malayalamfont #1}}
+\newfontfamily\devanagarifont[Path=../../_fonts/, Script=Devanagari]{NotoSansDevanagari-Static.ttf}
+\newcommand{\dv}[1]{{\devanagarifont #1}}
+\newfontfamily\arabicfont[Path=../../_fonts/, Script=Arabic]{NotoNaskhArabic-Static.ttf}
+\newcommand{\ar}[1]{\textarabic{#1}}
 
 \hypersetup{
   pdftitle={Tamil, Step by Step, Root by Root},
@@ -53,10 +66,10 @@
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
   fonttitle=\bfseries, title={Why it's said this way}
 }
-\newtcolorbox{grammarlens}{
+\newtcolorbox{grammarlens}[1][]{
   breakable, skin=enhanced, colback=blue!5, colframe=blue!35!black,
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
-  fonttitle=\bfseries, title={Grammar Lens}
+  fonttitle=\bfseries, title={Grammar Lens}, #1
 }
 \newtcolorbox{sounds}{
   breakable, skin=enhanced, colback=green!6, colframe=green!30!black,

--- a/code/learning/human-languages/tamil/lessons/TA-C06-dative-stacking.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C06-dative-stacking.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C06-dative-stacking
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 190
 chapter: 6
 type: grammar
 headword: பெயர் + உக்கு
@@ -8,18 +11,32 @@ romanization: "peyar + ukku"
 prerequisites: [TA-C06-dative-ukku]
 sounds: [gemination-kk]
 roots: [dravidian-agglutination, latin-fusion]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-GRAMMAR-DATIVE-UKKU-01]
+introduces:
+  knowledge: [TA-GRAMMAR-DATIVE-STACKING-01]
+practises:
+  knowledge: [TA-GRAMMAR-DATIVE-UKKU-01, TA-GRAMMAR-DATIVE-STACKING-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C06-dative-ukku]
 ---
 
 # -உக்கு — one carriage in a suffix train
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-GRAMMAR-DATIVE-UKKU-01] -->
 
 [PAUSE 2s] You can point to *peyar* and *-ukku* separately. That visible seam is
 the structural lesson.
 
-## Stacking versus fusion
+## Grammar Lens: Stacking versus fusion
+<!-- hl-knowledge: introduces=[TA-GRAMMAR-DATIVE-STACKING-01]; assesses=[] -->
 
 | | Tamil **-ukku** | Latin **-īs** |
 |---|---|---|
@@ -37,6 +54,7 @@ pieces stay legible. The comparison is not about simplicity; it is about where
 the grammatical information lives.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-GRAMMAR-DATIVE-UKKU-01, TA-GRAMMAR-DATIVE-STACKING-01] -->
 
 [PAUSE 1s]
 - [YOU SEGMENT: *peyar + ukku*]
@@ -44,6 +62,7 @@ the grammatical information lives.
 - [YOU CONTRAST: Tamil stacks · Latin fuses]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-GRAMMAR-DATIVE-UKKU-01, TA-GRAMMAR-DATIVE-STACKING-01] -->
 
 [PAUSE 3s] What does *-ukku* contribute? (**Dative to/for**, one meaning.) What
 does Latin *-īs* fuse? (**Case, plural number, and declension class**.) Which

--- a/code/learning/human-languages/tamil/lessons/TA-C06-dative-subject-family.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C06-dative-subject-family.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C06-dative-subject-family
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 210
 chapter: 6
 type: grammar
 headword: எனக்கு / నాకు / ನನಗೆ / എനിക്ക്
@@ -7,18 +10,32 @@ gloss: all four Dravidian sisters put the experiencer in visibly related dative 
 prerequisites: [TA-C06-dative-subject]
 sounds: [dravidian-dative-cognates]
 roots: [dravidian-dative-ku]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-LEX-DATIVE-SUBJECT-01]
+introduces:
+  knowledge: [TA-GRAMMAR-DATIVE-SUBJECT-FAMILY-01]
+practises:
+  knowledge: [TA-LEX-DATIVE-SUBJECT-01, TA-GRAMMAR-DATIVE-SUBJECT-FAMILY-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C06-dative-subject, TA-C06-dative-stacking]
 ---
 
 # -ukku, -ku, -ge, -ikku — the family shows its bones
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-DATIVE-SUBJECT-01] -->
 
 [PAUSE 2s] Tamil says knowing happens **to** you. Its three closest sisters make
 the same grammatical choice.
 
-## Four sentences, one construction
+## Grammar Lens: Four sentences, one construction
+<!-- hl-knowledge: introduces=[TA-GRAMMAR-DATIVE-SUBJECT-FAMILY-01]; assesses=[] -->
 
 | language | "I know [the language]" | dative |
 |---|---|---|
@@ -36,6 +53,7 @@ The comparison also makes cross-language practice useful: once you recognize
 English subject onto the sentence.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-DATIVE-SUBJECT-01, TA-GRAMMAR-DATIVE-SUBJECT-FAMILY-01] -->
 
 [PAUSE 1s]
 - [YOU SAY: "-ukku · -ku · -ge · -ikku"]
@@ -43,6 +61,7 @@ English subject onto the sentence.
 - [YOU PARAPHRASE: "the language is known to me"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-DATIVE-SUBJECT-01, TA-GRAMMAR-DATIVE-SUBJECT-FAMILY-01] -->
 
 [PAUSE 3s] Do the four sisters agree on dative experiencers? (**Yes**.) Which
 four suffix shapes reveal the relationship? (***-ukku, -ku, -ge, -ikku***.)

--- a/code/learning/human-languages/tamil/lessons/TA-C06-dative-subject.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C06-dative-subject.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C06-dative-subject
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 200
 chapter: 6
 type: phrase
 headword: எனக்குத் தமிழ் தெரியும்
@@ -10,19 +13,33 @@ prerequisites: [TA-C06-dative-stacking, TA-C05-naan-tamizh-pesugiren]
 sounds: [gemination-kk]
 roots: [dravidian-dative-ku]
 etymology_hook: "Dravidian puts the EXPERIENCER in the dative: knowing, liking, wanting and being cold all happen TO you rather than being done BY you — so 'I know Tamil' has no nominative 'I' at all, the person sitting in the dative instead (a 'dative subject'), and the same construction runs through Telugu, Kannada and Malayalam"
-est_minutes: 4
+duration:
+  max_seconds: 297
+requires:
+  knowledge: [TA-GRAMMAR-DATIVE-STACKING-01]
+introduces:
+  knowledge: [TA-LEX-DATIVE-SUBJECT-01, TA-GRAMMAR-DATIVE-SUBJECT-02]
+practises:
+  knowledge: [TA-GRAMMAR-DATIVE-STACKING-01, TA-LEX-DATIVE-SUBJECT-01, TA-GRAMMAR-DATIVE-SUBJECT-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C06-dative-stacking, TA-C06-dative-ukku, TA-C05-naan-tamizh-pesugiren, TA-C03-naan]
 ---
 
 # எனக்குத் தமிழ் தெரியும் — "I know Tamil"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-GRAMMAR-DATIVE-STACKING-01] -->
 
 [PAUSE 2s] In Chapter 5 you said **நான் தமிழ் பேசுகிறேன்** — "**I** speak Tamil,"
 with *nāṉ* as the subject. Now say "I **know** Tamil." Tamil will not let you use
 *nāṉ*.
 
-## The sentence
+## You'll want to know: The sentence
+<!-- hl-knowledge: introduces=[TA-LEX-DATIVE-SUBJECT-01]; assesses=[] -->
 
 > **எனக்குத் தமிழ் தெரியும்.**
 > *enakku tamiḻ teriyum.*
@@ -49,7 +66,8 @@ about **the language**, and you are merely the one it is known **to**.
 subject even though it isn't in the subject case. The odd feeling of the sentence
 is exactly that split.)
 
-## Why: things that happen *to* you
+## Grammar Lens: Why: things that happen *to* you
+<!-- hl-knowledge: introduces=[TA-GRAMMAR-DATIVE-SUBJECT-02]; assesses=[] -->
 
 Tamil sorts verbs by whether you **do** something or something **happens to** you.
 Speaking is something you do — so Ch. 5 used *nāṉ*. But knowing, liking, wanting,
@@ -66,6 +84,7 @@ English does this occasionally and archaically — "**methinks**" is exactly it
 (*me* is dative: "it seems **to me**"). Tamil made it a rule.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-GRAMMAR-DATIVE-STACKING-01, TA-LEX-DATIVE-SUBJECT-01, TA-GRAMMAR-DATIVE-SUBJECT-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "*enakku tamiḻ teriyum*"]
@@ -73,6 +92,7 @@ English does this occasionally and archaically — "**methinks**" is exactly it
 - [YOU SAY: the literal — "to-me Tamil is-known"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-GRAMMAR-DATIVE-STACKING-01, TA-LEX-DATIVE-SUBJECT-01, TA-GRAMMAR-DATIVE-SUBJECT-02] -->
 
 [PAUSE 3s] What does **எனக்குத் தமிழ் தெரியும்** literally say? ("**To-me** Tamil
 **is-known**.") Which word has English got that Tamil hasn't? (A nominative

--- a/code/learning/human-languages/tamil/lessons/TA-C06-dative-ukku.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C06-dative-ukku.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C06-dative-ukku
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 180
 chapter: 6
 type: word
 headword: -உக்கு
@@ -10,19 +13,33 @@ prerequisites: [TA-C05-practice, TA-C03-naan, TA-C02-peyar]
 sounds: [gemination-kk]
 roots: [dravidian-dative-ku]
 etymology_hook: "Dravidian marks case by ADDING a suffix that means one thing and stays visible at the seam — the opposite of Latin, where a fused ending like -īs carries case AND number AND declension at once, and doesn't even settle which case (dative or ablative); -ukku is the shared Dravidian dative, cousin of Telugu -ku, Kannada -ge, Malayalam -ikku"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [TA-GRAMMAR-DATIVE-UKKU-01]
+practises:
+  knowledge: [TA-GRAMMAR-DATIVE-UKKU-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C03-naan, TA-C02-peyar, TA-C05-practice]
 ---
 
 # -உக்கு (-ukku) — "to, for"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Your first **case ending**. English says "**to** me" with a separate
 word in front. Tamil says it with a piece **stuck on the back** — and that small
 difference is the biggest structural fact about the language.
 
-## Adding it on
+## Grammar Lens: Adding it on
+<!-- hl-knowledge: introduces=[TA-GRAMMAR-DATIVE-UKKU-01]; assesses=[] -->
 
 Take a noun you know and add **-உக்கு**:
 
@@ -43,6 +60,7 @@ The pronoun changes its body (*nāṉ* → *en-*) before the suffix lands. Nouns
 — they just take the ending.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-GRAMMAR-DATIVE-UKKU-01] -->
 
 [PAUSE 1s]
 - [YOU SAY: "*peyar* … *peyarukku*"]
@@ -50,6 +68,7 @@ The pronoun changes its body (*nāṉ* → *en-*) before the suffix lands. Nouns
 - [YOU SAY: "*vēlaikku*" — "for work," from Ch. 5's வேலை]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-GRAMMAR-DATIVE-UKKU-01] -->
 
 [PAUSE 3s] What does **-உக்கு** mean? ("**To**" or "**for**.") Where does it go?
 (**On the end** of the noun — Tamil adds, it doesn't put a word in front.) What is

--- a/code/learning/human-languages/tamil/lessons/TA-C07-numbers-1-5-family.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C07-numbers-1-5-family.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C07-numbers-1-5-family
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 230
 chapter: 7
 type: etymology
 headword: இரண்டு மூன்று நான்கு ஐந்து
@@ -7,18 +10,32 @@ gloss: two through five remain visible cousins across the Dravidian family while
 prerequisites: [TA-C07-numbers-1-5]
 sounds: [alveolar-n-r-cluster]
 roots: [proto-dravidian-numbers]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-LEX-NUMBERS-1-5-01]
+introduces:
+  knowledge: [TA-ETYMON-NUMBERS-1-5-FAMILY-01, TA-SOUND-NUMBERS-1-5-FAMILY-02]
+practises:
+  knowledge: [TA-LEX-NUMBERS-1-5-01, TA-ETYMON-NUMBERS-1-5-FAMILY-01, TA-SOUND-NUMBERS-1-5-FAMILY-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C07-numbers-1-5, TA-C01-vanakkam-family-register]
 ---
 
 # Two to five — one family in four regional coats
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-NUMBERS-1-5-01] -->
 
 [PAUSE 2s] Hindi's number forms are Sanskrit worn smooth. Tamil's are native
 Dravidian, so their sister-language shapes reveal the family directly.
 
-## The cousin table
+## The word, taken apart - The cousin table
+<!-- hl-knowledge: introduces=[TA-ETYMON-NUMBERS-1-5-FAMILY-01]; assesses=[] -->
 
 | | Tamil | Kannada | Telugu | Malayalam |
 |---|---|---|---|---|
@@ -34,12 +51,14 @@ Dravidian language gives you a running start on another.
 old *oṉ-*, while Telugu uses the separate formation *okaṭi*. The family agrees
 more neatly on 2–5 than on 1.
 
-## Hear the Tamil cluster
+## Sounds you'll need: Hear the Tamil cluster
+<!-- hl-knowledge: introduces=[TA-SOUND-NUMBERS-1-5-FAMILY-02]; assesses=[] -->
 
 In *oṉṟu* and *mūṉṟu*, **ன்ற** is alveolar *n* running into hard *ṟ*, almost one
 knock: *on-ru, muun-ru*. Puḷḷi on **ன்** removes its vowel before the cluster.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-NUMBERS-1-5-01, TA-ETYMON-NUMBERS-1-5-FAMILY-01, TA-SOUND-NUMBERS-1-5-FAMILY-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "iraṇṭu · eraḍu · reṇḍu · raṇṭu"]
@@ -47,6 +66,7 @@ knock: *on-ru, muun-ru*. Puḷḷi on **ன்** removes its vowel before the cl
 - [YOU IDENTIFY: Telugu *okaṭi* as the different "one"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-NUMBERS-1-5-01, TA-ETYMON-NUMBERS-1-5-FAMILY-01, TA-SOUND-NUMBERS-1-5-FAMILY-02] -->
 
 [PAUSE 3s] Are these forms borrowed? (**No**, native Dravidian.) Which numbers
 stay tidiest across the family? (**Two through five**.) Which language forms

--- a/code/learning/human-languages/tamil/lessons/TA-C07-numbers-1-5.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C07-numbers-1-5.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C07-numbers-1-5
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 220
 chapter: 7
 type: word
 headword: ஒன்று இரண்டு மூன்று நான்கு ஐந்து
@@ -9,18 +12,32 @@ prerequisites: [TA-C01-vanakkam]
 sounds: [tamil-inherent-a, pulli-virama, alveolar-rra, retroflex-nn]
 roots: [proto-dravidian-numbers]
 etymology_hook: "Tamil's numbers are native Dravidian, not borrowed — and 2–5 stay visibly cousin across Tamil, Kannada, Telugu, Malayalam"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [TA-LEX-NUMBERS-1-5-01]
+practises:
+  knowledge: [TA-LEX-NUMBERS-1-5-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C01-vanakkam]
 ---
 
 # ஒன்று, இரண்டு, மூன்று, நான்கு, ஐந்து — one to five
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Five words — and the same point *vaṇakkam* made, told again in
 numbers: Tamil counts with **its own** words, not borrowed ones.
 
-## The five
+## You'll want to know: The five
+<!-- hl-knowledge: introduces=[TA-LEX-NUMBERS-1-5-01]; assesses=[] -->
 
 | | numeral | word | said |
 |---|---|---|---|
@@ -41,12 +58,14 @@ dot that stacks *ன்ற* into the single cluster you hear in **ஒன்ற�
 **மூன்று**.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-NUMBERS-1-5-01] -->
 
 [PAUSE 1s]
 - [YOU SAY: "oṉṟu, iraṇṭu, mūṉṟu, nāṉku, aintu"]
 - [YOU SAY: read the digits aloud — ௧ ௨ ௩ ௪ ௫]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-NUMBERS-1-5-01] -->
 
 [PAUSE 3s] Count to five in Tamil. (*Oṉṟu, iraṇṭu, mūṉṟu, nāṉku, aintu*.) Are
 Tamil's numbers borrowed from Sanskrit, like Hindi's? (**No** — they're native

--- a/code/learning/human-languages/tamil/lessons/TA-C07-numbers-6-10-family.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C07-numbers-6-10-family.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C07-numbers-6-10-family
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 250
 chapter: 7
 type: etymology
 headword: ஆறு ஏழு பத்து
@@ -7,18 +10,32 @@ gloss: six, seven, and ten stay family cousins while Kannada regularly softens p
 prerequisites: [TA-C07-numbers-6-10]
 sounds: [kannada-p-to-h, tamil-retroflex-liquid]
 roots: [proto-dravidian-numbers]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-LEX-NUMBERS-6-10-01]
+introduces:
+  knowledge: [TA-ETYMON-NUMBERS-6-10-FAMILY-01, TA-ETYMON-NUMBERS-6-10-FAMILY-02]
+practises:
+  knowledge: [TA-LEX-NUMBERS-6-10-01, TA-ETYMON-NUMBERS-6-10-FAMILY-01, TA-ETYMON-NUMBERS-6-10-FAMILY-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C07-numbers-6-10, TA-C07-numbers-1-5-family]
 ---
 
 # Six to ten — family resemblances and one Kannada shift
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-NUMBERS-6-10-01] -->
 
 [PAUSE 2s] The Tamil forms are learned. Now use their sister shapes as evidence
 for inheritance and regular sound change.
 
-## The stable cousins
+## The word, taken apart - The stable cousins
+<!-- hl-knowledge: introduces=[TA-ETYMON-NUMBERS-6-10-FAMILY-01]; assesses=[] -->
 
 Six and seven remain close: Tamil *āṟu*, Kannada *āru*, Malayalam *āṟu*;
 Tamil *ēḻu*, Kannada *ēḷu*, Malayalam *ēḻu*. Tamil and Malayalam also keep
@@ -27,7 +44,8 @@ eight and nine nearly identical: *eṭṭu* and *oṉpatu/onpatu*.
 Telugu wanders on eight and nine with *enimidi* and *tommidi*, so those forms
 are less reliable as family-wide recognition anchors.
 
-## pattu → hattu
+## The word, taken apart - pattu → hattu
+<!-- hl-knowledge: introduces=[TA-ETYMON-NUMBERS-6-10-FAMILY-02]; assesses=[] -->
 
 Tamil and Malayalam say **pattu**, while Kannada says **hattu**. The initial
 *p → h* is a regular Kannada shift, not a random replacement. Compare Tamil
@@ -37,6 +55,7 @@ A correspondence lets differences prove relationship: repeated *p/h* pairs
 are stronger evidence than one accidental resemblance.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-NUMBERS-6-10-01, TA-ETYMON-NUMBERS-6-10-FAMILY-01, TA-ETYMON-NUMBERS-6-10-FAMILY-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: Tamil *pattu* · Kannada *hattu*]
@@ -44,6 +63,7 @@ are stronger evidence than one accidental resemblance.
 - [YOU IDENTIFY: *ēḻu / ēḷu / ēḻu* as one inherited seven]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-NUMBERS-6-10-01, TA-ETYMON-NUMBERS-6-10-FAMILY-01, TA-ETYMON-NUMBERS-6-10-FAMILY-02] -->
 
 [PAUSE 3s] What happens to Tamil *pattu* in Kannada? (*P* regularly softens to
 ***h***: *hattu*.) Which second pair confirms the pattern? (*Pāl / hālu*,

--- a/code/learning/human-languages/tamil/lessons/TA-C07-numbers-6-10.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C07-numbers-6-10.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C07-numbers-6-10
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 240
 chapter: 7
 type: word
 headword: ஆறு ஏழு எட்டு ஒன்பது பத்து
@@ -9,18 +12,32 @@ prerequisites: [TA-C07-numbers-1-5-family]
 sounds: [tamil-inherent-a, pulli-virama, tamil-zha-llla]
 roots: [proto-dravidian-numbers]
 etymology_hook: "seven ஏழு ēḻu carries ழ — the letter and sound in the name Tamiḻ itself; and nine is oṉ (one) + patu (ten)"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-ETYMON-NUMBERS-1-5-FAMILY-01]
+introduces:
+  knowledge: [TA-LEX-NUMBERS-6-10-01, TA-LEX-NUMBERS-6-10-02, TA-GRAMMAR-NUMBERS-6-10-03]
+practises:
+  knowledge: [TA-ETYMON-NUMBERS-1-5-FAMILY-01, TA-LEX-NUMBERS-6-10-01, TA-LEX-NUMBERS-6-10-02, TA-GRAMMAR-NUMBERS-6-10-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C07-numbers-1-5-family, TA-C07-numbers-1-5, TA-C01-vanakkam]
 ---
 
 # ஆறு, ஏழு, எட்டு, ஒன்பது, பத்து — six to ten
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-NUMBERS-1-5-FAMILY-01] -->
 
 [PAUSE 2s] Five more — and one of them is written with the single letter Tamil
 is most proud of.
 
-## The five
+## You'll want to know: The five
+<!-- hl-knowledge: introduces=[TA-LEX-NUMBERS-6-10-01]; assesses=[] -->
 
 | | numeral | word | said |
 |---|---|---|---|
@@ -30,7 +47,8 @@ is most proud of.
 | 9 | **௯** | **ஒன்பது** | *oṉpatu* |
 | 10 | **௰** | **பத்து** | *pattu* |
 
-## Seven carries the letter that names the language
+## You'll want to know: Seven carries the letter that names the language
+<!-- hl-knowledge: introduces=[TA-LEX-NUMBERS-6-10-02]; assesses=[] -->
 
 Look at **ஏழு** (*ēḻu*, seven). Its middle letter is **ழ** — the retroflex
 approximant, the sound English can only clumsily spell *zh*. It is the rarest
@@ -43,7 +61,8 @@ touch, and voice it: *ē-ḻu*.
 these apart carefully: **ஆறு** *āṟu* and **ஏழு** *ēḻu* end in two different
 sounds English would both call "r/zh".)
 
-## Nine is built from words you already have
+## Grammar Lens: Nine is built from words you already have
+<!-- hl-knowledge: introduces=[TA-GRAMMAR-NUMBERS-6-10-03]; assesses=[] -->
 
 **ஒன்பது** (*oṉpatu*, nine) is not a fresh word to memorise — it is two you
 already know, joined:
@@ -56,6 +75,7 @@ nine leaning on ten. That is a common Dravidian habit — nine described as
 one-away-from-ten rather than named outright.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-NUMBERS-1-5-FAMILY-01, TA-LEX-NUMBERS-6-10-01, TA-LEX-NUMBERS-6-10-02, TA-GRAMMAR-NUMBERS-6-10-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "āṟu, ēḻu, eṭṭu, oṉpatu, pattu"]
@@ -64,6 +84,7 @@ one-away-from-ten rather than named outright.
 - [YOU SAY: read the digits — ௬ ௭ ௮ ௯ ௰]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-NUMBERS-1-5-FAMILY-01, TA-LEX-NUMBERS-6-10-01, TA-LEX-NUMBERS-6-10-02, TA-GRAMMAR-NUMBERS-6-10-03] -->
 
 [PAUSE 3s] Count six to ten in Tamil. (*Āṟu, ēḻu, eṭṭu, oṉpatu, pattu*.) Which
 number is written with **ழ**, and where else does that letter appear? (**Seven**,

--- a/code/learning/human-languages/tamil/lessons/TA-C08-please-register.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C08-please-register.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C08-please-register
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 270
 chapter: 8
 type: grammar
 headword: தயவுசெய்து / -உங்கள்
@@ -7,18 +10,32 @@ gloss: standalone please is emphatic while everyday courtesy often lives in the 
 prerequisites: [TA-C08-tayavuseytu]
 sounds: [tamil-vowel-sign-e, pulli-virama]
 roots: [tamil-respectful-imperative]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-LEX-TAYAVUSEYTU-01]
+introduces:
+  knowledge: [TA-PRAGMATICS-PLEASE-REGISTER-01, TA-SCRIPT-PLEASE-REGISTER-02]
+practises:
+  knowledge: [TA-LEX-TAYAVUSEYTU-01, TA-PRAGMATICS-PLEASE-REGISTER-01, TA-SCRIPT-PLEASE-REGISTER-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C08-tayavuseytu]
 ---
 
 # தயவுசெய்து or -உங்கள்? — politeness in phrase or verb
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TAYAVUSEYTU-01] -->
 
 [PAUSE 2s] Tamil has a phrase meaning "do the kindness," but everyday courtesy
 often sits somewhere English speakers do not expect: inside the verb.
 
-## Choose by emphasis
+## Why it's said this way: Choose by emphasis
+<!-- hl-knowledge: introduces=[TA-PRAGMATICS-PLEASE-REGISTER-01]; assesses=[] -->
 
 A standalone **தயவுசெய்து** is more emphatic and formal than English "please."
 Ordinary polite commands use respectful **-உங்கள்** (*-uṅgaḷ*):
@@ -29,13 +46,15 @@ Ordinary polite commands use respectful **-உங்கள்** (*-uṅgaḷ*):
 Use *tayavu seytu* to mark "please, do me the kindness" warmly or formally. Let
 the verb ending carry routine courtesy.
 
-## Read the join in செய்து
+## Script you'll notice: Read the join in செய்து
+<!-- hl-knowledge: introduces=[TA-SCRIPT-PLEASE-REGISTER-02]; assesses=[] -->
 
 **செ** is *ca* with the **ெ** sign for *e*. **ய்** is *ya* shut off by puḷḷi,
 a bare *y*, before **து** *tu*. The same dot that built numbers now makes the
 consonant seam in *seytu* visible.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TAYAVUSEYTU-01, TA-PRAGMATICS-PLEASE-REGISTER-01, TA-SCRIPT-PLEASE-REGISTER-02] -->
 
 [PAUSE 1s]
 - [YOU CHOOSE: emphatic request → **தயவுசெய்து**]
@@ -43,6 +62,7 @@ consonant seam in *seytu* visible.
 - [YOU SEGMENT: செ + ய் + து → செய்து]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TAYAVUSEYTU-01, TA-PRAGMATICS-PLEASE-REGISTER-01, TA-SCRIPT-PLEASE-REGISTER-02] -->
 
 [PAUSE 3s] What carries everyday "please"? (The respectful verb ending
 ***-uṅgaḷ***.) When is *tayavu seytu* especially useful? (A **markedly polite or

--- a/code/learning/human-languages/tamil/lessons/TA-C08-tayavuseytu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C08-tayavuseytu.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C08-tayavuseytu
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 260
 chapter: 8
 type: phrase
 headword: தயவுசெய்து
@@ -9,19 +12,33 @@ prerequisites: [TA-C01-aam]
 sounds: [tamil-vowel-sign-u, pulli-virama, tamil-vowel-sign-e]
 roots: [daya-compassion]
 etymology_hook: "தயவுசெய்து = 'do the kindness' — Tamil asks please by naming daya 'compassion', like Arabic faḍl and Hindi kṛpā"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [TA-LEX-TAYAVUSEYTU-01, TA-ETYMON-TAYAVUSEYTU-02]
+practises:
+  knowledge: [TA-LEX-TAYAVUSEYTU-01, TA-ETYMON-TAYAVUSEYTU-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C01-aam]
 ---
 
 # தயவுசெய்து (tayavu seytu) — please (do the kindness)
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Across a whole band of Asia, the word for *please* is really the word
 **compassion**, dressed as a small request. Tamil says it most literally of all:
 "**do** the kindness."
 
-## The phrase
+## You'll want to know: The phrase
+<!-- hl-knowledge: introduces=[TA-LEX-TAYAVUSEYTU-01]; assesses=[] -->
 
 **தயவுசெய்து** = **please**, literally "**do the kindness / grace**." It is two
 pieces snapped together:
@@ -38,7 +55,8 @@ This is the same instinct as **Arabic** *min faḍlik* ("from your **grace**") a
 for is one of the great strategies of politeness — different from French's "if
 it **pleases** you," and from Latin/German's "I **ask**."
 
-## The Dravidian family, side by side
+## The word, taken apart - The Dravidian family, side by side
+<!-- hl-knowledge: introduces=[TA-ETYMON-TAYAVUSEYTU-02]; assesses=[] -->
 
 All four Dravidian cousins build *please* the very same way — **daya** plus a
 light verb "do / place / become":
@@ -51,12 +69,14 @@ light verb "do / place / become":
 One idea, four scripts. Learn one and you can almost read the others.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TAYAVUSEYTU-01, TA-ETYMON-TAYAVUSEYTU-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "tayavu" — the kindness — then "seytu," having done]
 - [YOU SAY: the whole phrase — "tayavu seytu" = please, do the kindness]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TAYAVUSEYTU-01, TA-ETYMON-TAYAVUSEYTU-02] -->
 
 [PAUSE 3s] What is the Tamil phrase for please? (**தயவுசெய்து** *tayavu seytu*.)
 What do its two pieces mean? ("**Kindness**" *tayavu* + "**having done**" *seytu*

--- a/code/learning/human-languages/tamil/lessons/TA-C09-mannikkavum.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C09-mannikkavum.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C09-mannikkavum
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 280
 chapter: 9
 type: phrase
 headword: மன்னிக்கவும்
@@ -9,19 +12,33 @@ prerequisites: [TA-C08-please-register]
 sounds: [tamil-double-nnna, pulli-virama]
 roots: [manni-tamil]
 etymology_hook: "மன்னிக்கவும் maṉṉikkavum is built on மன்னி maṉṉi 'to forgive' — Tamil's OWN native word, unlike its Dravidian cousins' Sanskrit kṣamā"
-est_minutes: 4
+duration:
+  max_seconds: 245
+requires:
+  knowledge: [TA-PRAGMATICS-PLEASE-REGISTER-01]
+introduces:
+  knowledge: [TA-ETYMON-MANNIKKAVUM-01, TA-ETYMON-MANNIKKAVUM-02]
+practises:
+  knowledge: [TA-PRAGMATICS-PLEASE-REGISTER-01, TA-ETYMON-MANNIKKAVUM-01, TA-ETYMON-MANNIKKAVUM-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C08-please-register, TA-C08-tayavuseytu]
 ---
 
 # மன்னிக்கவும் (maṉṉikkavum) — please forgive
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-PRAGMATICS-PLEASE-REGISTER-01] -->
 
 [PAUSE 2s] You already know **தயவுசெய்து**, "please." Tamil's "sorry" gives
 you something its Dravidian cousins don't: a forgiveness-word that's Tamil
 through and through, not borrowed from Sanskrit.
 
-## The word, taken apart
+## The word, taken apart - Roots and family
+<!-- hl-knowledge: introduces=[TA-ETYMON-MANNIKKAVUM-01]; assesses=[] -->
 
 **மன்னிக்கவும்** is built from three pieces:
 
@@ -37,7 +54,8 @@ So **மன்னிக்கவும்** reads as something like "**may [one]
 a polite, slightly formal way of asking for forgiveness, more at home in
 writing or a considered apology than tossed off in passing.
 
-## The Dravidian family, side by side — and Tamil's own path
+## The word, taken apart - The Dravidian family, side by side — and Tamil's own path
+<!-- hl-knowledge: introduces=[TA-ETYMON-MANNIKKAVUM-02]; assesses=[] -->
 
 Where Kannada, Telugu, and Malayalam all reach for the Sanskrit noun **kṣamā**
 ("patience, forgiveness") and turn it into a verb, **Tamil uses its own root**:
@@ -52,6 +70,7 @@ Where "please" showed the whole family sharing one Sanskrit-derived idea
 cousins borrowed the same Sanskrit one.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-PRAGMATICS-PLEASE-REGISTER-01, TA-ETYMON-MANNIKKAVUM-01, TA-ETYMON-MANNIKKAVUM-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "maṉṉi" — forgive — the Tamil root, not from Sanskrit]
@@ -59,6 +78,7 @@ cousins borrowed the same Sanskrit one.
 - [YOU SAY: contrast — Kannada, Telugu, Malayalam all use kṣamā instead]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-PRAGMATICS-PLEASE-REGISTER-01, TA-ETYMON-MANNIKKAVUM-01, TA-ETYMON-MANNIKKAVUM-02] -->
 
 [PAUSE 3s] What does **மன்னிக்கவும்** mean, and what is it built from?
 (**"Please forgive"** — *maṉṉi* "to forgive" + *‑kkavum*, a formal request

--- a/code/learning/human-languages/tamil/lessons/TA-C09-sorry-register.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C09-sorry-register.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C09-sorry-register
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 290
 chapter: 9
 type: grammar
 headword: மன்னிக்கவும் / sorry
@@ -7,25 +10,40 @@ gloss: the native forgiveness request leans formal while colloquial apologies va
 prerequisites: [TA-C09-mannikkavum]
 sounds: [tamil-double-alveolar-n, pulli-virama]
 roots: [manni-tamil]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-ETYMON-MANNIKKAVUM-01]
+introduces:
+  knowledge: [TA-PRAGMATICS-SORRY-REGISTER-01, TA-SCRIPT-SORRY-REGISTER-02]
+practises:
+  knowledge: [TA-ETYMON-MANNIKKAVUM-01, TA-PRAGMATICS-SORRY-REGISTER-01, TA-SCRIPT-SORRY-REGISTER-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C09-mannikkavum, TA-C08-please-register]
 ---
 
 # மன்னிக்கவும் — formal forgiveness and a doubled n
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-MANNIKKAVUM-01] -->
 
 [PAUSE 2s] The root is native Tamil. Its everyday conversational fit is less
 simple than a one-to-one dictionary entry suggests.
 
-## Register first
+## Why it's said this way: Register first
+<!-- hl-knowledge: introduces=[TA-PRAGMATICS-SORRY-REGISTER-01]; assesses=[] -->
 
 **மன்னிக்கவும்** leans formal: a "please forgive" on a notice or in a considered
 apology. Spoken Tamil may use shorter regional forms or borrow English "sorry."
 Colloquial variation is real, so treat formal/written as a reliable center, not
 a claim that one casual form covers every region.
 
-## Read ன்னி
+## Script you'll notice: Read ன்னி
+<!-- hl-knowledge: introduces=[TA-SCRIPT-SORRY-REGISTER-02]; assesses=[] -->
 
 In **ன்னி**, alveolar **ன** is first silenced by puḷḷi and then repeated before
 the vowel. The spelling holds the consonant across the syllable boundary:
@@ -36,6 +54,7 @@ This is the same gemination-by-repetition principle used elsewhere in Tamil;
 the sound is doubled without inventing a new ligature.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-MANNIKKAVUM-01, TA-PRAGMATICS-SORRY-REGISTER-01, TA-SCRIPT-SORRY-REGISTER-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "maṉ-ṉi-kkavum," holding both doubled consonants]
@@ -43,6 +62,7 @@ the sound is doubled without inventing a new ligature.
 - [YOU QUALIFY: casual alternatives vary by region]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-MANNIKKAVUM-01, TA-PRAGMATICS-SORRY-REGISTER-01, TA-SCRIPT-SORRY-REGISTER-02] -->
 
 [PAUSE 3s] What is the reliable register center of *maṉṉikkavum*?
 (**Formal/written or considered apology**.) Must every region use it casually?

--- a/code/learning/human-languages/tamil/lessons/TA-C10-vaara-kizhamai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C10-vaara-kizhamai.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C10-vaara-kizhamai
+spine_node: SPINE-TIME-OF-DAY
+sequence: 300
 chapter: 10
 type: word
 headword: திங்கள் செவ்வாய் புதன் வியாழன் வெள்ளி சனி ஞாயிறு
@@ -9,20 +12,34 @@ prerequisites: [TA-C09-sorry-register]
 sounds: [tamil-alveolar-rra, pulli-virama, tamil-nya]
 roots: [dravidian-native-planet-words, sanskrit-planet-words]
 etymology_hook: "Tamil names its week with கிழமை kizhamai 'day' — a native Dravidian word, not Sanskrit vāra — and four of its seven planet-names (moon, Mars, Venus, sun) are Tamil's own, not borrowed"
-est_minutes: 4
+duration:
+  max_seconds: 277
+requires:
+  knowledge: [TA-PRAGMATICS-SORRY-REGISTER-01]
+introduces:
+  knowledge: [TA-GRAMMAR-VAARA-KIZHAMAI-01, TA-PRAGMATICS-VAARA-KIZHAMAI-02]
+practises:
+  knowledge: [TA-PRAGMATICS-SORRY-REGISTER-01, TA-GRAMMAR-VAARA-KIZHAMAI-01, TA-PRAGMATICS-VAARA-KIZHAMAI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C09-sorry-register, TA-C09-mannikkavum]
 ---
 
 # திங்கள் to ஞாயிறு — the week, home-grown and borrowed together
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-PRAGMATICS-SORRY-REGISTER-01] -->
 
 [PAUSE 2s] You've seen Hindi's week built entirely from Sanskrit deity-names
 plus **वार** (*vār*). Tamil's week tells a richer story: it uses its **own**
 word for "day," and **some** of its planet-names are Tamil's own too — while
 others are borrowed, just like Hindi's.
 
-## The pattern: [planet] + கிழமை, "day"
+## Grammar Lens: The pattern: [planet] + கிழமை, "day"
+<!-- hl-knowledge: introduces=[TA-GRAMMAR-VAARA-KIZHAMAI-01]; assesses=[] -->
 
 Every Tamil weekday ends in **கிழமை** (*kizhamai*), "**day**" — a native
 Dravidian word, not the Sanskrit **வாரம்** (*vāram*) that Hindi, Kannada, and
@@ -39,7 +56,8 @@ Telugu build on (though Tamil also keeps a more formal, Sanskritic
 | **சனிக்கிழமை** | *saṉi* | **Saturn** | borrowed from Sanskrit **Śani** |
 | **ஞாயிற்றுக்கிழமை** | *ñāyiṟu* | "**Sun**" | Tamil's **own** word for sun |
 
-## Be honest about the mix
+## Why it's said this way: Be honest about the mix
+<!-- hl-knowledge: introduces=[TA-PRAGMATICS-VAARA-KIZHAMAI-02]; assesses=[] -->
 
 Notice the pattern: **Moon, Mars, Venus, and Sun** all carry Tamil's own
 descriptive or native words, while **Mercury, Jupiter, and Saturn** carry
@@ -54,6 +72,7 @@ commonly-given account rather than settled certainty — exact planet-name
 histories this old are not always fully nailed down.)
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-PRAGMATICS-SORRY-REGISTER-01, TA-GRAMMAR-VAARA-KIZHAMAI-01, TA-PRAGMATICS-VAARA-KIZHAMAI-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "thiṅgaḷ" — moon, Tamil's own word — then "kizhamai," day]
@@ -63,6 +82,7 @@ histories this old are not always fully nailed down.)
   Venus, sun]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-PRAGMATICS-SORRY-REGISTER-01, TA-GRAMMAR-VAARA-KIZHAMAI-01, TA-PRAGMATICS-VAARA-KIZHAMAI-02] -->
 
 [PAUSE 3s] What does every Tamil weekday end in, and where does that word
 come from? (**கிழமை** *kizhamai*, "day" — Tamil's **own** word, not Sanskrit

--- a/code/learning/human-languages/tamil/lessons/TA-C11-nirangal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C11-nirangal.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C11-nirangal
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 310
 chapter: 11
 type: word
 headword: கருப்பு வெள்ளை சிவப்பு நீலம்
@@ -9,20 +12,34 @@ prerequisites: [TA-C10-vaara-kizhamai]
 sounds: [tamil-double-lla, pulli-virama]
 roots: [dravidian-native-colors, sanskrit-nila]
 etymology_hook: "கருப்பு, வெள்ளை, சிவப்பு (black/white/red) are Tamil's OWN native words; நீலம் (blue) is a Sanskrit loan — the same 'blue arrives late' pattern Latin's caeruleus showed"
-est_minutes: 4
+duration:
+  max_seconds: 288
+requires:
+  knowledge: [TA-GRAMMAR-VAARA-KIZHAMAI-01]
+introduces:
+  knowledge: [TA-ETYMON-NIRANGAL-01, TA-ETYMON-NIRANGAL-02, TA-PRAGMATICS-NIRANGAL-03]
+practises:
+  knowledge: [TA-GRAMMAR-VAARA-KIZHAMAI-01, TA-ETYMON-NIRANGAL-01, TA-ETYMON-NIRANGAL-02, TA-PRAGMATICS-NIRANGAL-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C10-vaara-kizhamai]
 ---
 
 # கருப்பு, வெள்ளை, சிவப்பு, நீலம் — three of Tamil's own, one borrowed
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-GRAMMAR-VAARA-KIZHAMAI-01] -->
 
 [PAUSE 2s] You've already seen Tamil mix native and Sanskrit words in its
 day-names. Colors tell a **cleaner** version of the same story: three colors
 are Tamil's own, and the fourth is the one color that keeps showing up
 borrowed, in language after language.
 
-## Three native colors
+## The word, taken apart - Three native colors
+<!-- hl-knowledge: introduces=[TA-ETYMON-NIRANGAL-01]; assesses=[] -->
 
 - **கருப்பு** (*karuppu*) = "**black**" — native Tamil/Dravidian.
 - **வெள்ளை** (*veḷḷai*) = "**white**" — native Tamil/Dravidian, and built on
@@ -30,7 +47,8 @@ borrowed, in language after language.
   **வெள்ளி** (*veḷḷi*), "Venus/silver," from the days-of-the-week lesson.
 - **சிவப்பு** (*sivappu*) = "**red**" — native Tamil/Dravidian.
 
-## One borrowed color
+## The word, taken apart - One borrowed color
+<!-- hl-knowledge: introduces=[TA-ETYMON-NIRANGAL-02]; assesses=[] -->
 
 **நீலம்** (*nīlam*) = "**blue**" — from **Sanskrit** நீல (*nīla*), "dark
 blue," the very same root behind Hindi's **नीला** (*nīlā*). This *nīla* is
@@ -40,7 +58,8 @@ itself is a *separate*, Greek-derived word (describing where the dye was
 imported *from*, not descended from *nīla* by sound change; see the Hindi
 color lesson for that careful distinction).
 
-## Be honest about why blue is the odd one out
+## Why it's said this way: Be honest about why blue is the odd one out
+<!-- hl-knowledge: introduces=[TA-PRAGMATICS-NIRANGAL-03]; assesses=[] -->
 
 This isn't random. You may remember from Latin's color lesson that **"blue"**
 is, across many of the world's languages, one of the **last** basic colors
@@ -55,6 +74,7 @@ may prefer different everyday variants, and this lesson would benefit from
 your check the way the day-names lesson did.)
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-GRAMMAR-VAARA-KIZHAMAI-01, TA-ETYMON-NIRANGAL-01, TA-ETYMON-NIRANGAL-02, TA-PRAGMATICS-NIRANGAL-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: the three native ones — "karuppu, veḷḷai, sivappu" — black,
@@ -63,6 +83,7 @@ your check the way the day-names lesson did.)
 - [YOU SAY: the echo — "veḷḷai" and "veḷḷi" share the same veḷ- root]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-GRAMMAR-VAARA-KIZHAMAI-01, TA-ETYMON-NIRANGAL-01, TA-ETYMON-NIRANGAL-02, TA-PRAGMATICS-NIRANGAL-03] -->
 
 [PAUSE 3s] Which three Tamil colors are native, and which one is borrowed?
 (**Karuppu, veḷḷai, sivappu** (black/white/red) are native; **nīlam** (blue)

--- a/code/learning/human-languages/tamil/lessons/TA-C12-kudumbam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C12-kudumbam.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C12-kudumbam
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 320
 chapter: 12
 type: word
 headword: அப்பா அம்மா அண்ணன் தம்பி அக்கா தங்கை
@@ -9,20 +12,34 @@ prerequisites: [TA-C11-nirangal]
 sounds: [tamil-double-nna-retroflex, pulli-virama]
 roots: [dravidian-appa-amma, dravidian-age-graded-siblings]
 etymology_hook: "அப்பா appā/அம்மா ammā (native, baby-talk-type words found worldwide) are just the start — Tamil has FOUR sibling words, split by the sibling's AGE relative to you, not just their gender"
-est_minutes: 4
+duration:
+  max_seconds: 252
+requires:
+  knowledge: [TA-ETYMON-NIRANGAL-01]
+introduces:
+  knowledge: [TA-ETYMON-KUDUMBAM-01, TA-LEX-KUDUMBAM-02]
+practises:
+  knowledge: [TA-ETYMON-NIRANGAL-01, TA-ETYMON-KUDUMBAM-01, TA-LEX-KUDUMBAM-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C11-nirangal]
 ---
 
 # அப்பா, அம்மா, and four ways to say "brother/sister"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-NIRANGAL-01] -->
 
 [PAUSE 2s] You've learned Spanish's *hermano/hermana* and French's
 *frère/sœur* — one word each for "brother" and "sister." Tamil asks a
 question those languages never do: **is this sibling older or younger than
 you?**
 
-## Parents — simple and native
+## The word, taken apart - Parents — simple and native
+<!-- hl-knowledge: introduces=[TA-ETYMON-KUDUMBAM-01]; assesses=[] -->
 
 - **அப்பா** (*appā*) = "**father**"
 - **அம்மா** (*ammā*) = "**mother**"
@@ -33,7 +50,8 @@ families everywhere — not borrowed from Sanskrit, not a coincidence with any
 one language in particular, just how small children's mouths tend to form
 their first words for parents.
 
-## Siblings — split by age, not just gender
+## You'll want to know: Siblings — split by age, not just gender
+<!-- hl-knowledge: introduces=[TA-LEX-KUDUMBAM-02]; assesses=[] -->
 
 Here's the real lesson: Tamil doesn't have one word for "brother" and one
 for "sister." It has **four**:
@@ -54,6 +72,7 @@ sibling" versus "younger sibling" a live, spoken distinction, not just
 something you *could* mention if you wanted to.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-NIRANGAL-01, TA-ETYMON-KUDUMBAM-01, TA-LEX-KUDUMBAM-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "appā, ammā" — father, mother]
@@ -63,6 +82,7 @@ something you *could* mention if you wanted to.
   say "brother" or "sister" in Tamil]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-NIRANGAL-01, TA-ETYMON-KUDUMBAM-01, TA-LEX-KUDUMBAM-02] -->
 
 [PAUSE 3s] How many Tamil words mean "brother" or "sister," and why?
 (**Four** — அண்ணன்/தம்பி for older/younger brother, அக்கா/தங்கை for

--- a/code/learning/human-languages/tamil/lessons/TA-C13-udal-uruppugal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C13-udal-uruppugal.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C13-udal-uruppugal
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 330
 chapter: 13
 type: word
 headword: தலை கை
@@ -9,19 +12,33 @@ prerequisites: [TA-C12-kudumbam]
 sounds: [tamil-vowel-sign-ai]
 roots: [dravidian-talai-kai]
 etymology_hook: "தலை talai (head) and கை kai (hand) are Tamil's OWN native words — unlike Hindi's sir/hāth, which both descend from Sanskrit"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-ETYMON-KUDUMBAM-01]
+introduces:
+  knowledge: [TA-LEX-UDAL-URUPPUGAL-01]
+practises:
+  knowledge: [TA-ETYMON-KUDUMBAM-01, TA-LEX-UDAL-URUPPUGAL-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C12-kudumbam]
 ---
 
 # தலை, கை — head and hand, both Tamil's own
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-KUDUMBAM-01] -->
 
 [PAUSE 2s] You've seen Hindi's *sir* and *hāth* trace all the way back to
 Sanskrit. Tamil's words for the same two body parts tell a simpler story:
 **both are native.**
 
-## The words
+## You'll want to know: The words
+<!-- hl-knowledge: introduces=[TA-LEX-UDAL-URUPPUGAL-01]; assesses=[] -->
 
 - **தலை** (*talai*) = "**head**" — native Dravidian.
 - **கை** (*kai*) = "**hand**" — native Dravidian.
@@ -31,6 +48,7 @@ or *hāth* (< Sanskrit *hasta*). Tamil simply kept its own words for two of
 the most basic parts of the body.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-KUDUMBAM-01, TA-LEX-UDAL-URUPPUGAL-01] -->
 
 [PAUSE 1s]
 - [YOU SAY: "talai" — head]
@@ -38,6 +56,7 @@ the most basic parts of the body.
 - [YOU SAY: the contrast — Hindi borrowed these from Sanskrit; Tamil didn't]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-KUDUMBAM-01, TA-LEX-UDAL-URUPPUGAL-01] -->
 
 [PAUSE 3s] What are Tamil's words for head and hand? (**தலை** *talai*,
 **கை** *kai*.) Are either of these Sanskrit loans? (**No** — both native

--- a/code/learning/human-languages/tamil/lessons/TA-C14-kaalangal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C14-kaalangal.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C14-kaalangal
+spine_node: SPINE-TIME-OF-DAY
+sequence: 340
 chapter: 14
 type: word
 headword: வசந்த காலம் கோடைக் காலம் மழைக் காலம் குளிர் காலம்
@@ -9,19 +12,33 @@ prerequisites: [TA-C13-udal-uruppugal]
 sounds: [tamil-vowel-sign-ai, tamil-retroflex-lla]
 roots: [dravidian-kodai-mazhai-kulir, sanskrit-vasantha]
 etymology_hook: "கோடை kodai (summer heat) and குளிர் kulir (cold) are native Tamil words; வசந்தம் vasantham (spring) is a Sanskrit loan — but the season that actually shapes life in Tamil Nadu is மழைக்காலம், the RAINS, not any of the four Western ones"
-est_minutes: 4
+duration:
+  max_seconds: 284
+requires:
+  knowledge: [TA-LEX-UDAL-URUPPUGAL-01]
+introduces:
+  knowledge: [TA-LEX-KAALANGAL-01, TA-PRAGMATICS-KAALANGAL-02]
+practises:
+  knowledge: [TA-LEX-UDAL-URUPPUGAL-01, TA-LEX-KAALANGAL-01, TA-PRAGMATICS-KAALANGAL-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C13-udal-uruppugal]
 ---
 
 # வசந்த காலம், கோடை, மழை, குளிர் — the four words, and the real season underneath
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-UDAL-URUPPUGAL-01] -->
 
 [PAUSE 2s] Tamil has words that line up with Spanish's four seasons — but,
 just like the Hindi lesson on ऋतु, forcing them into a clean four-way split
 hides what actually matters on the ground.
 
-## The four words
+## You'll want to know: The four words
+<!-- hl-knowledge: introduces=[TA-LEX-KAALANGAL-01]; assesses=[] -->
 
 | Tamil | meaning | source |
 |---|---|---|
@@ -38,7 +55,8 @@ into Tamil so long ago and so thoroughly that it functions as completely
 ordinary vocabulary today, quite unlike a fresh, still-foreign-feeling loan
 like *vasantham*.
 
-## Be honest: the rains are the real season here
+## Why it's said this way: Be honest: the rains are the real season here
+<!-- hl-knowledge: introduces=[TA-PRAGMATICS-KAALANGAL-02]; assesses=[] -->
 
 Just as Hindi's traditional calendar makes the monsoon (*varṣā*) its own
 central season rather than a footnote, Tamil Nadu's actual climate is
@@ -55,6 +73,7 @@ words and register you'd teach first, and whether there's more to say about
 how Tamil Nadu's own seasonal year is actually divided in practice.)
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-UDAL-URUPPUGAL-01, TA-LEX-KAALANGAL-01, TA-PRAGMATICS-KAALANGAL-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "kodai" — heat/summer, native — then "kaalam," time/season]
@@ -63,6 +82,7 @@ how Tamil Nadu's own seasonal year is actually divided in practice.)
 - [YOU SAY: the one loanword — "vasantha kaalam," spring, from Sanskrit]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-UDAL-URUPPUGAL-01, TA-LEX-KAALANGAL-01, TA-PRAGMATICS-KAALANGAL-02] -->
 
 [PAUSE 3s] Which of the four season-words is a Sanskrit loan, and which are
 native Tamil? (**வசந்தம்** *vasantham* is Sanskrit; **கோடை, மழை, குளிர்**

--- a/code/learning/human-languages/tamil/lessons/TA-C15-thanneer-arisi.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C15-thanneer-arisi.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C15-thanneer-arisi
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 350
 chapter: 15
 type: word
 headword: தண்ணீர் அரிசி சாதம்
@@ -9,26 +12,41 @@ prerequisites: [TA-C14-kaalangal]
 sounds: [tamil-retroflex-nna-double, tamil-vowel-sign-ii]
 roots: [thann-cool-nir-water, arisi-rice-dravidian]
 etymology_hook: "அரிசி arisi (uncooked rice) may be the ULTIMATE source of the English word 'rice' itself, via Greek oryza — a widely cited hypothesis, though etymologists don't all agree on the exact chain"
-est_minutes: 4
+duration:
+  max_seconds: 254
+requires:
+  knowledge: [TA-LEX-KAALANGAL-01]
+introduces:
+  knowledge: [TA-LEX-THANNEER-ARISI-01, TA-LEX-THANNEER-ARISI-02, TA-PRAGMATICS-THANNEER-ARISI-03]
+practises:
+  knowledge: [TA-LEX-KAALANGAL-01, TA-LEX-THANNEER-ARISI-01, TA-LEX-THANNEER-ARISI-02, TA-PRAGMATICS-THANNEER-ARISI-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C14-kaalangal]
 ---
 
 # தண்ணீர், அரிசி, சாதம் — water, and rice, the real staple
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-KAALANGAL-01] -->
 
 [PAUSE 2s] Every language so far in this arc taught "bread" as the staple
 food. Here, that would be **dishonest** — bread isn't the everyday
 staple in Tamil food culture. **Rice** is, and it comes with one of the
 most famous (if contested) etymological journeys of any food-word.
 
-## தண்ணீர் — water, literally "cool water"
+## You'll want to know: தண்ணீர் — water, literally "cool water"
+<!-- hl-knowledge: introduces=[TA-LEX-THANNEER-ARISI-01]; assesses=[] -->
 
 **தண்ணீர்** (*taṇṇīr*) = "**water**" — built from **தண்** (*taṇ*, "**cool**")
 + **நீர்** (*nīr*, "**water**"). Everyday Tamil doesn't just say "water" —
 it says, quite literally, "**cool water**."
 
-## அரிசி and சாதம் — rice, raw and cooked
+## You'll want to know: அரிசி and சாதம் — rice, raw and cooked
+<!-- hl-knowledge: introduces=[TA-LEX-THANNEER-ARISI-02]; assesses=[] -->
 
 Tamil, like most of South India, distinguishes the **uncooked grain** from
 the **cooked dish** with two separate words, not one:
@@ -40,7 +58,8 @@ the **cooked dish** with two separate words, not one:
   the same idea, **சோறு** (*cōṟu*) — the two sit side by side as everyday
   near-synonyms.
 
-## Be honest about a famous (contested) word-journey
+## Why it's said this way: Be honest about a famous (contested) word-journey
+<!-- hl-knowledge: introduces=[TA-PRAGMATICS-THANNEER-ARISI-03]; assesses=[] -->
 
 Here's the exciting part, held with appropriate care: many etymologists
 connect **அரிசி** (*arisi*) to the **English word "rice" itself** — the
@@ -53,6 +72,7 @@ among others (an Indo-Aryan *vrīhi*-related source is also proposed), not a
 settled, universally agreed fact.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-KAALANGAL-01, TA-LEX-THANNEER-ARISI-01, TA-LEX-THANNEER-ARISI-02, TA-PRAGMATICS-THANNEER-ARISI-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "taṇ" — cool — then "nīr," water — then "taṇṇīr," cool water]
@@ -60,6 +80,7 @@ settled, universally agreed fact.
 - [YOU SAY: the famous (contested) link — "arisi" → possibly English "rice"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-KAALANGAL-01, TA-LEX-THANNEER-ARISI-01, TA-LEX-THANNEER-ARISI-02, TA-PRAGMATICS-THANNEER-ARISI-03] -->
 
 [PAUSE 3s] What does **தண்ணீர்** literally mean? (**"Cool water"** — *taṇ*
 "cool" + *nīr* "water.") What two words does Tamil use for rice, and why

--- a/code/learning/human-languages/tamil/lessons/TA-C16-thamizh-maadangal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C16-thamizh-maadangal.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C16-thamizh-maadangal
+spine_node: SPINE-TIME-OF-DAY
+sequence: 360
 chapter: 16
 type: word
 headword: சித்திரை வைகாசி ஆனி ஆடி ஆவணி புரட்டாசி ஐப்பசி கார்த்திகை மார்கழி தை மாசி பங்குனி
@@ -9,19 +12,33 @@ prerequisites: [TA-C15-thanneer-arisi]
 sounds: [tamil-vowel-sign-ai, tamil-retroflex-lla]
 roots: [tamil-solar-calendar-nakshatra]
 etymology_hook: "The Tamil solar calendar's twelve months are named for nakshatras (lunar-mansion star groups) the MOON sits near on the full-moon day within that month — a THIRD calendar system, alongside the Gregorian and the pan-Indian Hindu lunisolar calendar, still governing Tamil New Year and Pongal today"
-est_minutes: 4
+duration:
+  max_seconds: 267
+requires:
+  knowledge: [TA-LEX-THANNEER-ARISI-01]
+introduces:
+  knowledge: [TA-LEX-THAMIZH-MAADANGAL-01, TA-PRAGMATICS-THAMIZH-MAADANGAL-02]
+practises:
+  knowledge: [TA-LEX-THANNEER-ARISI-01, TA-LEX-THAMIZH-MAADANGAL-01, TA-PRAGMATICS-THAMIZH-MAADANGAL-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C15-thanneer-arisi]
 ---
 
 # சித்திரை to பங்குனி — Tamil's own solar calendar
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-THANNEER-ARISI-01] -->
 
 [PAUSE 2s] By now you've seen Arabic and Hindi each juggle two calendars.
 Tamil adds a **third distinct system** to the mix — one still actively
 used for Tamil New Year and Pongal, not a historical curiosity.
 
-## The twelve Tamil months
+## You'll want to know: The twelve Tamil months
+<!-- hl-knowledge: introduces=[TA-LEX-THAMIZH-MAADANGAL-01]; assesses=[] -->
 
 **சித்திரை, வைகாசி, ஆனி, ஆடி, ஆவணி, புரட்டாசி, ஐப்பசி, கார்த்திகை,
 மார்கழி, தை, மாசி, பங்குனி** (*Chithirai, Vaikāsi, Āṉi, Āḍi, Āvaṇi,
@@ -35,7 +52,8 @@ the **moon** sits near on the **full-moon (pournami) day** that falls
 within that month — the moon's position, not the sun's, and tied to that
 month's full moon specifically, not simply the month's start.
 
-## Be honest: this is a THIRD calendar, not a variant of the others
+## Why it's said this way: Be honest: this is a THIRD calendar, not a variant of the others
+<!-- hl-knowledge: introduces=[TA-PRAGMATICS-THAMIZH-MAADANGAL-02]; assesses=[] -->
 
 You've now met three genuinely separate calendar traditions across this
 course: the Gregorian solar calendar (borrowed names, everyday civil use
@@ -50,6 +68,7 @@ dates do) because it's solar too — just a different solar calendar,
 starting its year at a different point and naming its months differently.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-THANNEER-ARISI-01, TA-LEX-THAMIZH-MAADANGAL-01, TA-PRAGMATICS-THAMIZH-MAADANGAL-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: the twelve — "Chithirai, Vaikāsi, Āṉi, Āḍi, Āvaṇi, Puraṭṭāsi,
@@ -58,6 +77,7 @@ starting its year at a different point and naming its months differently.
 - [YOU SAY: "Thai 1" — Pongal]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-THANNEER-ARISI-01, TA-LEX-THAMIZH-MAADANGAL-01, TA-PRAGMATICS-THAMIZH-MAADANGAL-02] -->
 
 [PAUSE 3s] What kind of calendar is the Tamil month system — solar,
 lunar, or lunisolar? (**Solar** — a genuinely separate calendar from both

--- a/code/learning/human-languages/tamil/lessons/TA-C17-nanpakal-nalliravu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C17-nanpakal-nalliravu.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C17-nanpakal-nalliravu
+spine_node: SPINE-TIME-OF-DAY
+sequence: 370
 chapter: 17
 type: word
 headword: நண்பகல் நள்ளிரவு
@@ -9,19 +12,33 @@ prerequisites: [TA-C16-thamizh-maadangal]
 sounds: [tamil-retroflex-lla, tamil-vowel-sign-u]
 roots: [tamil-nal-middle-proto-dravidian, tamil-naTu-middle]
 etymology_hook: "நண்பகல் (naṇpakal, noon) and நள்ளிரவு (naḷḷiravu, midnight) both trace to நள் (naḷ, 'middle'), a documented Proto-Dravidian root that survives today mainly in literary compounds like நள்ளிருள் ('thick darkness') — but Tamil ALSO keeps fully transparent synonyms, நடுப்பகல்/நடு இரவு, built directly on நடு (naṭu), the everyday colloquial word for 'middle'"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-LEX-THAMIZH-MAADANGAL-01]
+introduces:
+  knowledge: [TA-ETYMON-NANPAKAL-NALLIRAVU-01, TA-ETYMON-NANPAKAL-NALLIRAVU-02]
+practises:
+  knowledge: [TA-LEX-THAMIZH-MAADANGAL-01, TA-ETYMON-NANPAKAL-NALLIRAVU-01, TA-ETYMON-NANPAKAL-NALLIRAVU-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C16-thamizh-maadangal]
 ---
 
 # நண்பகல், நள்ளிரவு — one old "middle" root, two survival stories
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-THAMIZH-MAADANGAL-01] -->
 
 [PAUSE 2s] You've just watched Kannada and Telugu each reach for Sanskrit's
 *madhya* to name noon. Tamil doesn't reach for Sanskrit at all here — it
 reaches into its own, much older layer of vocabulary instead.
 
-## நள் — an old, documented Dravidian word for "middle"
+## The word, taken apart - நள் — an old, documented Dravidian word for "middle"
+<!-- hl-knowledge: introduces=[TA-ETYMON-NANPAKAL-NALLIRAVU-01]; assesses=[] -->
 
 Both of today's words trace back to the same root: **நள்** (*naḷ*), a
 **Proto-Dravidian** word for "**middle, centre**" — a genuine synonym of
@@ -31,7 +48,8 @@ today mainly in **literary/poetic** compounds — **நள்ளிருள்*
 "thick darkness") and **நள்ளென் கங்குல்** (*naḷḷeṉ kaṅkul*, "deep
 night") — rather than in everyday colloquial speech.
 
-## நண்பகல் and நள்ளிரவு — the same root, two different surfaces
+## The word, taken apart - நண்பகல் and நள்ளிரவு — the same root, two different surfaces
+<!-- hl-knowledge: introduces=[TA-ETYMON-NANPAKAL-NALLIRAVU-02]; assesses=[] -->
 
 **நள்ளிரவு** (*naḷḷiravu*) = "**midnight**" = **நள்** (*naḷ*, "middle") +
 **இரவு** (*iravu*, "**night**," a word every Tamil speaker still uses on
@@ -43,12 +61,14 @@ following ப. Same root, two different faces, depending on what it's fused
 to.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-THAMIZH-MAADANGAL-01, TA-ETYMON-NANPAKAL-NALLIRAVU-01, TA-ETYMON-NANPAKAL-NALLIRAVU-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "naḷ" — an old word for "middle" — then "naḷḷiravu," midnight]
 - [YOU SAY: "naṇpakal" — noon, the same naḷ root, resurfacing as naṇ-]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-THAMIZH-MAADANGAL-01, TA-ETYMON-NANPAKAL-NALLIRAVU-01, TA-ETYMON-NANPAKAL-NALLIRAVU-02] -->
 
 [PAUSE 3s] What old Proto-Dravidian root do நண்பகல் and நள்ளிரவு both trace
 back to, and what does it mean? (**நள்** *naḷ*, "middle" — surviving mainly

--- a/code/learning/human-languages/tamil/lessons/TA-C17-transparent-middle-synonyms.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C17-transparent-middle-synonyms.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C17-transparent-middle-synonyms
+spine_node: SPINE-TIME-OF-DAY
+sequence: 380
 chapter: 17
 type: etymology
 headword: நடுப்பகல், நடு இரவு
@@ -7,18 +10,32 @@ gloss: Tamil kept transparent middle-day and middle-night synonyms beside the ol
 prerequisites: [TA-C17-nanpakal-nalliravu]
 sounds: [tamil-gemination]
 roots: [tamil-naTu-middle, tamil-nal-middle-proto-dravidian]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-ETYMON-NANPAKAL-NALLIRAVU-01]
+introduces:
+  knowledge: [TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01]
+practises:
+  knowledge: [TA-ETYMON-NANPAKAL-NALLIRAVU-01, TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C17-nanpakal-nalliravu]
 ---
 
 # நடுப்பகல் and நடு இரவு — the transparent twins
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-NANPAKAL-NALLIRAVU-01] -->
 
 [PAUSE 2s] *Naṇpakal* and *naḷḷiravu* preserve an older middle-root in fused
 forms. Tamil also kept versions whose pieces remain obvious today.
 
-## The living synonyms
+## You'll want to know: The living synonyms
+<!-- hl-knowledge: introduces=[TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01]; assesses=[] -->
 
 - **நடுப்பகல்** (*naṭuppakal*) — "middle-daytime," a dictionary synonym of
   *naṇpakal*
@@ -33,6 +50,7 @@ transparent. Tamil kept **both fates inside one language**—old fused forms and
 fresh transparent synonyms side by side.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-NANPAKAL-NALLIRAVU-01, TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01] -->
 
 [PAUSE 1s]
 - [YOU SAY: "naṇpakal · naṭuppakal" — two noon forms]
@@ -40,6 +58,7 @@ fresh transparent synonyms side by side.
 - [YOU POINT: *naṭu* as the visible everyday "middle"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-NANPAKAL-NALLIRAVU-01, TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01] -->
 
 [PAUSE 3s] Which everyday word builds the transparent forms? (**நடு**, *naṭu*,
 "middle.") What did Tamil keep simultaneously? (**Older fused compounds and

--- a/code/learning/human-languages/tamil/lessons/TA-C18-mani-homophone-time.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C18-mani-homophone-time.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C18-mani-homophone-time
+spine_node: SPINE-TIME-OF-DAY
+sequence: 400
 chapter: 18
 type: etymology
 headword: மணி / மணி
@@ -7,18 +10,32 @@ gloss: the hour-word and Sanskrit gem-word are likely homophones, then maṇi te
 prerequisites: [TA-C18-mani]
 sounds: [tamil-retroflex-nna, tamil-vowel-sign-i]
 roots: [tamil-mani-bell, sanskrit-mani-gem]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-ETYMON-MANI-01]
+introduces:
+  knowledge: [TA-ETYMON-MANI-HOMOPHONE-TIME-01, TA-GRAMMAR-MANI-HOMOPHONE-TIME-02]
+practises:
+  knowledge: [TA-ETYMON-MANI-01, TA-ETYMON-MANI-HOMOPHONE-TIME-01, TA-GRAMMAR-MANI-HOMOPHONE-TIME-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C18-mani, TA-C07-numbers-1-5]
 ---
 
 # மணி — hour or jewel? Context decides
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-MANI-01] -->
 
 [PAUSE 2s] The likely native bell/hour word shares its spelling and sound with
 a clear Sanskrit loan meaning something entirely different.
 
-## The homophone trap
+## The word, taken apart - The homophone trap
+<!-- hl-knowledge: introduces=[TA-ETYMON-MANI-HOMOPHONE-TIME-01]; assesses=[] -->
 
 Tamil dictionaries list a second **மணி** from Sanskrit **मणि** (*maṇi*), "gem,
 jewel." On that analysis, bell/hour and gem are **homophones**: one likely
@@ -29,7 +46,8 @@ Malayalam dictionaries analyze their cognate differently, treating bell/hour
 and gem as one Sanskrit-derived word. Closely related languages do not always
 settle the same etymological question in the same way.
 
-## Tell the time
+## Grammar Lens: Tell the time
+<!-- hl-knowledge: introduces=[TA-GRAMMAR-MANI-HOMOPHONE-TIME-02]; assesses=[] -->
 
 > **ஒரு மணி.** — one o'clock, literally "one hour/bell"
 >
@@ -38,6 +56,7 @@ settle the same etymological question in the same way.
 The number comes first; *maṇi* supplies the clock unit.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-MANI-01, TA-ETYMON-MANI-HOMOPHONE-TIME-01, TA-GRAMMAR-MANI-HOMOPHONE-TIME-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "oru maṇi" — one o'clock]
@@ -45,6 +64,7 @@ The number comes first; *maṇi* supplies the clock unit.
 - [YOU CHOOSE BY CONTEXT: clock → hour · jewelry/name → gem]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-MANI-01, TA-ETYMON-MANI-HOMOPHONE-TIME-01, TA-GRAMMAR-MANI-HOMOPHONE-TIME-02] -->
 
 [PAUSE 3s] What is the homophone trap? (A likely separate Sanskrit-borrowed
 **மணி** means **gem**.) Does Malayalam analyze the same forms identically?

--- a/code/learning/human-languages/tamil/lessons/TA-C18-mani.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C18-mani.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C18-mani
+spine_node: SPINE-TIME-OF-DAY
+sequence: 390
 chapter: 18
 type: word
 headword: மணி
@@ -9,19 +12,33 @@ prerequisites: [TA-C17-transparent-middle-synonyms]
 sounds: [tamil-retroflex-nna, tamil-vowel-sign-i]
 roots: [tamil-mani-bell]
 etymology_hook: "மணி (maṇi, 'hour') — Tamil's own dictionaries (Wiktionary) split this into a native Dravidian 'bell, gong' word (→'hour', via the same bell-strikes-the-hour logic as Sanskrit's ghaṇṭā) and a wholly separate Sanskrit loan meaning 'gem' — though even the comparative Dravidian dictionary (DEDR) flags a possible Sanskrit connection for the whole family as unresolved, so treat 'native' as the best current account, not a closed case"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01]
+introduces:
+  knowledge: [TA-ETYMON-MANI-01]
+practises:
+  knowledge: [TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01, TA-ETYMON-MANI-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C17-transparent-middle-synonyms, TA-C17-nanpakal-nalliravu]
 ---
 
 # மணி — Tamil's native "bell," and a real homophone trap
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01] -->
 
 [PAUSE 2s] You've just watched Kannada and Telugu both borrow Sanskrit's "bell"
 word for "hour," matching Hindi exactly. Tamil goes its own way again here — with
 a genuinely tricky twist along the way.
 
-## மணி — native "bell," independently landing on "hour"
+## The word, taken apart - மணி — native "bell," independently landing on "hour"
+<!-- hl-knowledge: introduces=[TA-ETYMON-MANI-01]; assesses=[] -->
 
 **மணி** (*maṇi*) = "**hour, o'clock**" — and it also means "**bell, gong**," the
 same double duty you've now seen several times. Wiktionary's Tamil entry gives
@@ -35,11 +52,13 @@ possible Sanskrit connection for this whole word-family as unresolved, so hold
 "native" as the best current account rather than a settled fact.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01, TA-ETYMON-MANI-01] -->
 
 [PAUSE 1s]
 - [YOU SAY: "maṇi" — hour, also "bell" — native, NOT from Sanskrit ghaṇṭā]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01, TA-ETYMON-MANI-01] -->
 
 [PAUSE 3s] Is Tamil's **மணி** ("hour") from the same Sanskrit root as
 Kannada/Telugu/Hindi's hour-words? (**Most likely no** — it's treated as a native

--- a/code/learning/human-languages/tamil/lessons/TA-C19-age-register-grammar.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C19-age-register-grammar.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C19-age-register-grammar
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 420
 chapter: 19
 type: grammar
 headword: உன் வயசு என்ன? / உனக்கு எத்தனை வயது ஆகிறது?
@@ -7,25 +10,40 @@ gloss: casual Tamil uses a possessive age question while formal Tamil uses dativ
 prerequisites: [TA-C19-vayathu]
 sounds: [tamil-dative-ukku, tamil-verb-aakiradhu]
 roots: [tamil-aaku-become]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-LEX-VAYATHU-01]
+introduces:
+  knowledge: [TA-GRAMMAR-AGE-REGISTER-GRAMMAR-01, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-02]
+practises:
+  knowledge: [TA-LEX-VAYATHU-01, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-01, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C19-vayathu, TA-C06-dative-subject-family]
 ---
 
 # Your age what? / To you how many years becomes?
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-VAYATHU-01] -->
 
 [PAUSE 2s] Tamil did not choose one age construction. Register selects between
 two shapes already visible elsewhere in the family.
 
-## Casual possessive
+## Grammar Lens: Casual possessive
+<!-- hl-knowledge: introduces=[TA-GRAMMAR-AGE-REGISTER-GRAMMAR-01]; assesses=[] -->
 
 > **உன் வயசு என்ன?** — "your age what?"
 
 Casual speech uses a plain possessive with no dative and no verb, like Kannada
 and Telugu.
 
-## Formal dative plus "become"
+## Grammar Lens: Formal dative plus "become"
+<!-- hl-knowledge: introduces=[TA-GRAMMAR-AGE-REGISTER-GRAMMAR-02]; assesses=[] -->
 
 > **உனக்கு எத்தனை வயது ஆகிறது?** — "to you how many years is becoming?"
 >
@@ -39,6 +57,7 @@ Do not compress these into "Tamil's one grammar." Both live in the language;
 setting and register choose between them.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-VAYATHU-01, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-01, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "un vayasu enna?" — casual]
@@ -46,6 +65,7 @@ setting and register choose between them.
 - [YOU ANSWER: "enakku irupathu vayathu aakirathu"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-VAYATHU-01, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-01, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-02] -->
 
 [PAUSE 3s] Which shape is casual? (**Possessive**: "your age what?") Which is
 formal? (**Dative + aakirathu**, "become.") Does Malayalam use the same verb?

--- a/code/learning/human-languages/tamil/lessons/TA-C19-vayathu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C19-vayathu.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C19-vayathu
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 410
 chapter: 19
 type: phrase
 headword: உனக்கு எத்தனை வயது ஆகிறது?
@@ -9,19 +12,33 @@ prerequisites: [TA-C18-mani-homophone-time]
 sounds: [tamil-dative-ukku, tamil-verb-aakiradhu]
 roots: [sanskrit-vayas-vigor-age]
 etymology_hook: "வயது (vayathu, 'age') is the same Sanskrit वयस् (vayas, 'vigor, age,' PIE cousin of Latin vīs) as its Kannada/Telugu/Malayalam cousins — Tamil actually has BOTH shapes seen so far: a plain possessive in casual speech ('un vayasu enna?', matching Kannada/Telugu), and this more formal dative-subject + ஆகிறது (aakirathu, 'is becoming') construction, matching Malayalam's shape"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-ETYMON-MANI-HOMOPHONE-TIME-01]
+introduces:
+  knowledge: [TA-LEX-VAYATHU-01]
+practises:
+  knowledge: [TA-ETYMON-MANI-HOMOPHONE-TIME-01, TA-LEX-VAYATHU-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C18-mani-homophone-time, TA-C18-mani]
 ---
 
 # உனக்கு எத்தனை வயது ஆகிறது? — Tamil actually has BOTH shapes
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-MANI-HOMOPHONE-TIME-01] -->
 
 [PAUSE 2s] Same Sanskrit word one more time — but be careful here: Tamil isn't
 locked into just one of the two grammatical shapes you've now seen. It has
 both, in different registers.
 
-## வயது — the same Sanskrit "vigor/age" word, a fourth time
+## You'll want to know: வயது — the same Sanskrit "vigor/age" word, a fourth time
+<!-- hl-knowledge: introduces=[TA-LEX-VAYATHU-01]; assesses=[] -->
 
 **வயது** (*vayathu*) = "**age**" — the same Sanskrit **वयस्** (*vayas*, "age,
 vigor," PIE cousin of Latin **vīs**) you've now met four times across Kannada,
@@ -30,12 +47,14 @@ Sanskrit word for "age" — none of them built a native alternative for this
 particular concept, unlike some others you've seen in this course.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-MANI-HOMOPHONE-TIME-01, TA-LEX-VAYATHU-01] -->
 
 [PAUSE 1s]
 - [YOU SAY: "vayathu" — age]
 - [YOU CONNECT: Sanskrit *vayas* · Tamil *vayathu* · Latin *vīs*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-MANI-HOMOPHONE-TIME-01, TA-LEX-VAYATHU-01] -->
 
 [PAUSE 3s] Is Tamil's **வயது** the same Sanskrit word borrowed by all four
 Dravidian languages here? (**Yes** — none built a native alternative for this

--- a/code/learning/human-languages/tamil/lessons/TA-C20-pathinondru-irupathu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C20-pathinondru-irupathu.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C20-pathinondru-irupathu
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 430
 chapter: 20
 type: word
 headword: பதினொன்று — இருபது
@@ -9,33 +12,49 @@ prerequisites: [TA-C19-age-register-grammar]
 sounds: [tamil-vowel-sign-o, tamil-rra-letter]
 roots: [dravidian-pathu-ten, dravidian-iru-two]
 etymology_hook: "பதினொன்று-பத்தொன்பது (11-19) echo பத்து (pathu, 'ten') + a digit — இருபது (irupathu, 'twenty') is transparently 'two-tens', இரு (iru, an older word for 'two') + பத்து (pathu, 'ten'), matching Malayalam's own irupathu almost exactly — closing the arc: all four Dravidian languages build twenty compositionally, where Sanskrit/Latin/Arabic each have their own opaque, non-compositional special word"
-est_minutes: 4
+duration:
+  max_seconds: 248
+requires:
+  knowledge: [TA-GRAMMAR-AGE-REGISTER-GRAMMAR-01]
+introduces:
+  knowledge: [TA-LEX-PATHINONDRU-IRUPATHU-01, TA-LEX-PATHINONDRU-IRUPATHU-02, TA-PRAGMATICS-PATHINONDRU-IRUPATHU-03]
+practises:
+  knowledge: [TA-GRAMMAR-AGE-REGISTER-GRAMMAR-01, TA-LEX-PATHINONDRU-IRUPATHU-01, TA-LEX-PATHINONDRU-IRUPATHU-02, TA-PRAGMATICS-PATHINONDRU-IRUPATHU-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C19-age-register-grammar, TA-C19-vayathu]
 ---
 
 # பதினொன்று, இருபது — Dravidian's shared, transparent twenty
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-GRAMMAR-AGE-REGISTER-GRAMMAR-01] -->
 
 [PAUSE 2s] Here's how this arc closes: four completely different
 approaches to "twenty" across Sanskrit, Latin, Arabic — and then all four
 Dravidian languages quietly agreeing on the exact same compositional idea.
 
-## பதினொன்று–பத்தொன்பது — "ten" + digit
+## You'll want to know: பதினொன்று–பத்தொன்பது — "ten" + digit
+<!-- hl-knowledge: introduces=[TA-LEX-PATHINONDRU-IRUPATHU-01]; assesses=[] -->
 
 Tamil's teens echo **பத்து** (*pathu*, "**ten**") plus each digit —
 **பதினொன்று** (*patiṉoṉḏṟu*, 11), **பன்னிரண்டு** (*paṉṉiraṇḍu*, 12), and
 onward through **பத்தொன்பது** (*pattoṉbatu*, 19) — the same digit-plus-
 ten-echo compounding you've now seen across Kannada, Telugu, and Malayalam.
 
-## இருபது — transparently "two-tens"
+## You'll want to know: இருபது — transparently "two-tens"
+<!-- hl-knowledge: introduces=[TA-LEX-PATHINONDRU-IRUPATHU-02]; assesses=[] -->
 
 **இருபது** (*irupathu*, "**twenty**") = **இரு** (*iru*, an older word for
 "**two**," alongside the everyday **இரண்டு** *iraṇḍu*) + **பத்து** (*pathu*,
 "**ten**") — fully transparent as "**two-tens**," matching **Malayalam's**
 own *irupathu* almost letter-for-letter.
 
-## Be honest: one shared Dravidian idea, four different other-family answers
+## Why it's said this way: Be honest: one shared Dravidian idea, four different other-family answers
+<!-- hl-knowledge: introduces=[TA-PRAGMATICS-PATHINONDRU-IRUPATHU-03]; assesses=[] -->
 
 This closes the numbers arc with a genuinely clean pattern. Every Dravidian
 language in this course builds "twenty" the **same** compositional way —
@@ -50,6 +69,7 @@ for twenty — none built transparently from "two" and "ten" the way every
 single Dravidian language in this course does.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-GRAMMAR-AGE-REGISTER-GRAMMAR-01, TA-LEX-PATHINONDRU-IRUPATHU-01, TA-LEX-PATHINONDRU-IRUPATHU-02, TA-PRAGMATICS-PATHINONDRU-IRUPATHU-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "patiṉoṉḏṟu, paṉṉiraṇḍu" — 11, 12]
@@ -57,6 +77,7 @@ single Dravidian language in this course does.
 - [YOU SAY: "irupathu" — twenty, "two-tens," transparent]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-GRAMMAR-AGE-REGISTER-GRAMMAR-01, TA-LEX-PATHINONDRU-IRUPATHU-01, TA-LEX-PATHINONDRU-IRUPATHU-02, TA-PRAGMATICS-PATHINONDRU-IRUPATHU-03] -->
 
 [PAUSE 3s] What two pieces build **இருபது** (twenty)? (**இரு** "two" +
 **பத்து** "ten" — "**two-tens**.") Do all four Dravidian languages in this

--- a/code/learning/human-languages/tamil/lessons/TA-C20-vaanilai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C20-vaanilai.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C20-vaanilai
+spine_node: SPINE-TIME-OF-DAY
+sequence: 440
 chapter: 20
 type: word
 headword: வானிலை
@@ -9,20 +12,34 @@ prerequisites: [TA-C18-mani-homophone-time]
 sounds: [tamil-vowel-sign-ai, tamil-compound-word]
 roots: [dravidian-vaanam-sky, dravidian-nilai-state]
 etymology_hook: "வானிலை (vāṉilai, 'weather') most likely breaks from Kannada/Telugu/Malayalam's Sanskrit compounds entirely — வானம் (vāṉam, 'sky,' likely native Dravidian, with confirmed cognates in Kannada ಬಾನು/bānu and Telugu వాన/vāna, distinct from the Sanskrit sky word ākāśa) + நிலை (nilai, 'state, standing,' from நில் nil, 'to stand,' a core native Dravidian verb) — literally 'the state/standing of the sky'"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-ETYMON-MANI-HOMOPHONE-TIME-01]
+introduces:
+  knowledge: [TA-LEX-VAANILAI-01, TA-LEX-VAANILAI-02]
+practises:
+  knowledge: [TA-ETYMON-MANI-HOMOPHONE-TIME-01, TA-LEX-VAANILAI-01, TA-LEX-VAANILAI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C18-mani-homophone-time, TA-C18-mani]
 ---
 
 # வானிலை — "the standing of the sky," most likely all native
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-MANI-HOMOPHONE-TIME-01] -->
 
 [PAUSE 2s] You've now seen a Persian+Sanskrit hybrid (Kannada), a pure
 Sanskrit compound (Telugu), and a Sanskrit compound echoing "time" (Malayalam).
 Tamil most likely breaks the pattern one more time — with a word built
 entirely from native pieces.
 
-## வானிலை — vaanam + nilai
+## You'll want to know: வானிலை — vaanam + nilai
+<!-- hl-knowledge: introduces=[TA-LEX-VAANILAI-01]; assesses=[] -->
 
 **வானிலை** (*vāṉilai*) = "**weather**" — built from:
 
@@ -41,13 +58,15 @@ rather than a fully settled fact, the same hedge you've seen elsewhere in this
 course — but both pieces are independently well-attested as old, native
 Dravidian vocabulary.)
 
-## மழை பெய்கிறது — "rain is falling"
+## You'll want to know: மழை பெய்கிறது — "rain is falling"
+<!-- hl-knowledge: introduces=[TA-LEX-VAANILAI-02]; assesses=[] -->
 
 > **மழை பெய்கிறது.** — "It's raining." — literally "**rain is falling**."
   (*mazhai peykiRathu* — from **பெய்** *pey*, "to fall/pour," specifically used
   for rain.)
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-MANI-HOMOPHONE-TIME-01, TA-LEX-VAANILAI-01, TA-LEX-VAANILAI-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "vāṉilai" — weather, "the standing of the sky"]
@@ -55,6 +74,7 @@ Dravidian vocabulary.)
 - [YOU SAY: "mazhai peykiRathu" — it's raining, "rain is falling"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-MANI-HOMOPHONE-TIME-01, TA-LEX-VAANILAI-01, TA-LEX-VAANILAI-02] -->
 
 [PAUSE 3s] What are the two pieces of **வானிலை**, and what does the whole word
 literally mean? (**வானம்**, "sky," + **நிலை**, "state/standing" — "**the

--- a/code/learning/human-languages/tamil/lessons/TA-C21-naay-poonai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C21-naay-poonai.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C21-naay-poonai
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 450
 chapter: 21
 type: word
 headword: நாய், பூனை
@@ -9,20 +12,34 @@ prerequisites: [TA-C20-pathinondru-irupathu]
 sounds: [tamil-vowel-sign-ai, tamil-final-y]
 roots: [dravidian-naay-dog, dravidian-punai-cat]
 etymology_hook: "நாய் (nāy, 'dog') is a solid, undisputed native Proto-Dravidian root — the SAME root behind Kannada's naayi and Malayalam's naaya — closing this whole arc's dog-word theme on solid ground, the honest opposite of Spanish's perro, English's dog, and Hindi's kuttā, all genuine unsolved mysteries; பூனை (pūnai, 'cat') is Tamil's everyday word, matching Malayalam closely but genuinely different from Kannada's bekku and Telugu's pilli — Tamil itself even keeps rarer alternate cat-words (பில்லி, வெருகு) echoing those other roots"
-est_minutes: 4
+duration:
+  max_seconds: 263
+requires:
+  knowledge: [TA-LEX-PATHINONDRU-IRUPATHU-01]
+introduces:
+  knowledge: [TA-LEX-NAAY-POONAI-01, TA-ETYMON-NAAY-POONAI-02]
+practises:
+  knowledge: [TA-LEX-PATHINONDRU-IRUPATHU-01, TA-LEX-NAAY-POONAI-01, TA-ETYMON-NAAY-POONAI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C20-pathinondru-irupathu]
 ---
 
 # நாய், பூனை — solid ground to close the arc, and an honest three-way split
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-PATHINONDRU-IRUPATHU-01] -->
 
 [PAUSE 2s] This whole ANIMALS arc kept finding mystery dog-words — Spanish's
 *perro*, English's *dog*, Hindi's *kuttā*, each one an unsolved puzzle
 displacing an older, expected word. Tamil's dog-word closes the arc on the
 complete opposite footing: total, undisputed solid ground.
 
-## நாய் — no mystery, anywhere
+## You'll want to know: நாய் — no mystery, anywhere
+<!-- hl-knowledge: introduces=[TA-LEX-NAAY-POONAI-01]; assesses=[] -->
 
 **நாய்** (*nāy*, "**dog**") is a solid, native **Proto-Dravidian** root —
 the exact same one behind Kannada's **ನಾಯಿ** (*nāyi*) and Malayalam's
@@ -33,7 +50,8 @@ expected word for "dog" to an unexplained newcomer — and right here, in the
 Dravidian family, the expected word simply **survived**, plainly and
 solidly, across (at least) three of its languages.
 
-## பூனை — Tamil's word, and an honest three-way Dravidian split
+## The word, taken apart - பூனை — Tamil's word, and an honest three-way Dravidian split
+<!-- hl-knowledge: introduces=[TA-ETYMON-NAAY-POONAI-02]; assesses=[] -->
 
 **பூனை** (*pūnai*, "**cat**") is Tamil's own everyday word, matching
 Malayalam's **പൂച്ച** (*pūcha*) closely — but be honest that "cat"
@@ -48,6 +66,7 @@ three roots were once available across the family; each language just
 settled on a different one as its everyday word.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-PATHINONDRU-IRUPATHU-01, TA-LEX-NAAY-POONAI-01, TA-ETYMON-NAAY-POONAI-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "nāy" — dog, solid native Dravidian, no mystery anywhere]
@@ -56,6 +75,7 @@ settled on a different one as its everyday word.
   two other, separate ancient roots]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-PATHINONDRU-IRUPATHU-01, TA-LEX-NAAY-POONAI-01, TA-ETYMON-NAAY-POONAI-02] -->
 
 [PAUSE 3s] Is **நாய்** a mystery word, like Spanish's *perro*, English's
 *dog*, or Hindi's *kuttā*? (**No** — a solid, undisputed native Dravidian

--- a/code/learning/human-languages/tamil/lessons/TA-C22-paccai-manjal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C22-paccai-manjal.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C22-paccai-manjal
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 460
 chapter: 22
 type: word
 headword: பச்சை, மஞ்சள்
@@ -9,26 +12,41 @@ prerequisites: [TA-C11-nirangal, TA-C21-naay-poonai]
 sounds: [tamil-double-lla, pulli-virama]
 roots: [proto-dravidian-pac-green, dravidian-mancal-turmeric]
 etymology_hook: "பச்சை (paccai, 'green') ← Proto-Dravidian *pac-, the same root as Kannada's hasiru, Telugu's pacca, and Malayalam's paccha; மஞ்சள் (mañcaḷ, 'yellow, turmeric') is a SEPARATE native Dravidian root, matching Malayalam's മഞ്ഞ/മഞ്ഞൾ (mañña/maññaḷ) closely — modern comparative Dravidian linguistics treats it as inherited (cognates in Kannada, Kodava, Tulu), though one older Tamil dictionary source floats a Sanskrit derivation via मञ्जिष्ठा (mañjiṣṭha, a red-dye plant name) that the semantic mismatch makes unlikely; the Tamil Lexicon additionally records பசுப்பு (pacuppu, 'greenish yellow'), a genuine doublet of paccai from the *pac- root — a rarer word, but one that means Tamil quietly holds BOTH of this arc's Dravidian patterns (Telugu's one-root-doublet AND Malayalam's two-separate-roots) inside itself"
-est_minutes: 4
+duration:
+  max_seconds: 283
+requires:
+  knowledge: [TA-ETYMON-NIRANGAL-01, TA-LEX-NAAY-POONAI-01]
+introduces:
+  knowledge: [TA-LEX-PACCAI-MANJAL-01, TA-ETYMON-PACCAI-MANJAL-02, TA-ETYMON-PACCAI-MANJAL-03]
+practises:
+  knowledge: [TA-ETYMON-NIRANGAL-01, TA-LEX-NAAY-POONAI-01, TA-LEX-PACCAI-MANJAL-01, TA-ETYMON-PACCAI-MANJAL-02, TA-ETYMON-PACCAI-MANJAL-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C21-naay-poonai]
 ---
 
 # பச்சை, மஞ்சள் — closing the Dravidian arc, holding both patterns at once
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-NIRANGAL-01, TA-LEX-NAAY-POONAI-01] -->
 
 [PAUSE 2s] You've now seen three different Dravidian answers to "how do
 green and yellow relate": Kannada split them apart, Telugu fused them into
 one root, Malayalam kept them as two separate native words. Tamil, it turns
 out, quietly contains a trace of **both** of the last two patterns.
 
-## பச்சை — the familiar pan-Dravidian green
+## You'll want to know: பச்சை — the familiar pan-Dravidian green
+<!-- hl-knowledge: introduces=[TA-LEX-PACCAI-MANJAL-01]; assesses=[] -->
 
 **பச்சை** (**paccai**, "**green**") ← **Proto-Dravidian** ***\*pac-*** — the
 same root you've now met four times: Kannada's *hasiru*, Telugu's *pacca*,
 Malayalam's *paccha*, and now Tamil's own *paccai*.
 
-## மஞ்சள் — Tamil's real, everyday yellow, a separate native root
+## The word, taken apart - மஞ்சள் — Tamil's real, everyday yellow, a separate native root
+<!-- hl-knowledge: introduces=[TA-ETYMON-PACCAI-MANJAL-02]; assesses=[] -->
 
 **மஞ்சள்** (**mañcaḷ**, "**yellow, turmeric**") is Tamil's actual, everyday
 word for yellow — and it comes from a **completely separate** native
@@ -36,7 +54,8 @@ Dravidian root, matching Malayalam's **മഞ്ഞ/മഞ്ഞൾ** (*mañña*
 closely. Like Malayalam's pair, this root has no Sanskrit involvement — it
 sits alongside *paccai*, not descended from it.
 
-## பசுப்பு — a rarer doublet, echoing Telugu in miniature
+## The word, taken apart - பசுப்பு — a rarer doublet, echoing Telugu in miniature
+<!-- hl-knowledge: introduces=[TA-ETYMON-PACCAI-MANJAL-03]; assesses=[] -->
 
 The **Tamil Lexicon** also records **பசுப்பு** (**pacuppu**, "**greenish
 yellow**") — a genuine **doublet** of *paccai* itself, from the same
@@ -53,6 +72,7 @@ recognize as "greenish yellow," or whether it reads as archaic/purely
 literary in the Tamil you'd teach first.)
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-NIRANGAL-01, TA-LEX-NAAY-POONAI-01, TA-LEX-PACCAI-MANJAL-01, TA-ETYMON-PACCAI-MANJAL-02, TA-ETYMON-PACCAI-MANJAL-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "பச்சை" — green, the pan-Dravidian *pac- word]
@@ -60,6 +80,7 @@ literary in the Tamil you'd teach first.)
 - [YOU SAY: "பசுப்பு" — a rarer doublet of paccai, echoing Telugu's pattern]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-NIRANGAL-01, TA-LEX-NAAY-POONAI-01, TA-LEX-PACCAI-MANJAL-01, TA-ETYMON-PACCAI-MANJAL-02, TA-ETYMON-PACCAI-MANJAL-03] -->
 
 [PAUSE 3s] What is Tamil's everyday word for yellow, and is it related to
 **paccai**? (**மஞ்சள்**, *mañcaḷ* — **no**, a completely separate native

--- a/code/learning/human-languages/tamil/lessons/TA-C23-day-family-register.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C23-day-family-register.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C23-day-family-register
+spine_node: SPINE-TIME-OF-DAY
+sequence: 480
 chapter: 23
 type: etymology
 headword: நாள் / தினம்
@@ -7,18 +10,32 @@ gloss: Tamil alone keeps a native everyday day-word while Sanskrit tiṉam occup
 prerequisites: [TA-C23-naal]
 sounds: [tamil-retroflex-lla]
 roots: [proto-dravidian-naal-day, sanskrit-dina]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-ETYMON-NAAL-01]
+introduces:
+  knowledge: [TA-LEX-DAY-FAMILY-REGISTER-01, TA-LEX-DAY-FAMILY-REGISTER-02]
+practises:
+  knowledge: [TA-ETYMON-NAAL-01, TA-LEX-DAY-FAMILY-REGISTER-01, TA-LEX-DAY-FAMILY-REGISTER-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C23-naal]
 ---
 
 # நாள் and தினம் — everyday native, formal borrowed
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-NAAL-01] -->
 
 [PAUSE 2s] *Nāḷ* is plainly native and everyday. Put that lexical choice beside
 the other Dravidian tracks.
 
-## Four everyday day-words
+## You'll want to know: Four everyday day-words
+<!-- hl-knowledge: introduces=[TA-LEX-DAY-FAMILY-REGISTER-01]; assesses=[] -->
 
 - Kannada **dina** — Sanskrit tatsama
 - Telugu **rōju** — Persian loan
@@ -28,7 +45,8 @@ the other Dravidian tracks.
 Tamil is the only one here whose unmarked everyday counting word remains
 native.
 
-## Tamil still has தினம்
+## You'll want to know: Tamil still has தினம்
+<!-- hl-knowledge: introduces=[TA-LEX-DAY-FAMILY-REGISTER-02]; assesses=[] -->
 
 **தினம்** (*tiṉam*) is the same Sanskrit *dina* as Kannada/Malayalam, ultimately
 from PIE ***dyew-***, "shine," also behind Latin *diēs*. Tamil assigns it
@@ -39,6 +57,7 @@ The language did not reject the loan; it gave native and borrowed forms
 different jobs.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-NAAL-01, TA-LEX-DAY-FAMILY-REGISTER-01, TA-LEX-DAY-FAMILY-REGISTER-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "mūnṟu nāḷ" — three days]
@@ -46,6 +65,7 @@ different jobs.
 - [YOU CLASSIFY: everyday native · formal/compound Sanskrit]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-NAAL-01, TA-LEX-DAY-FAMILY-REGISTER-01, TA-LEX-DAY-FAMILY-REGISTER-02] -->
 
 [PAUSE 3s] Which track alone keeps a native everyday day-word? (**Tamil**.)
 Where does *tiṉam* appear? (**Formal compounds**.) Is it unrelated to Kannada

--- a/code/learning/human-languages/tamil/lessons/TA-C23-naal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C23-naal.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C23-naal
+spine_node: SPINE-TIME-OF-DAY
+sequence: 470
 chapter: 23
 type: word
 headword: நாள்
@@ -9,19 +12,33 @@ prerequisites: [TA-C04-naalai, TA-C17-transparent-middle-synonyms]
 sounds: [tamil-retroflex-lla, tamil-vowel-sign-aa]
 roots: [proto-dravidian-naal-day, sanskrit-dina]
 etymology_hook: "நாள் (nāḷ, 'day') is native Dravidian, from Proto-Dravidian *nāḷ, already met inside நாளை (nāḷai, 'tomorrow,' Chapter 4) — and it is genuinely Tamil's plain, everyday, unmarked word for counting a day (as in மூன்று நாள், mūnṟu nāḷ, 'three days'); this makes Tamil the odd one out among this arc's Dravidian languages so far — Kannada's ದಿನ/dina and Malayalam's ദിവസം/divasam are both Sanskrit tatsama words doing the everyday job, and Telugu's రోజు/rōju is a Persian loanword doing it — Tamil is the only one where a NATIVE word holds that plain, everyday spot, uncontested; Tamil ALSO has தினம் (tiṉam), the exact same Sanskrit tatsama as Kannada's dina/Malayalam's dinam (← Sanskrit दिन/dina ← PIE *dyew-, 'to shine'), but here it functions mainly in formal/adverbial and compound use — சுதந்திர தினம் (sutantira tiṉam, 'Independence Day') and தினசரி (tiṉacari, 'daily') — not as the plain everyday noun"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01]
+introduces:
+  knowledge: [TA-ETYMON-NAAL-01]
+practises:
+  knowledge: [TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01, TA-ETYMON-NAAL-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C04-naalai, TA-C17-transparent-middle-synonyms, TA-C17-nanpakal-nalliravu]
 ---
 
 # நாள் (nāḷ) — "day," the one this arc's Dravidian languages didn't lose
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01] -->
 
 [PAUSE 2s] You've now seen three Dravidian languages reach for a
 loanword — Sanskrit, twice, and Persian once — to name their everyday
 word for "day." Tamil doesn't. This lesson is about the one that didn't.
 
-## நாள் — genuinely native, genuinely everyday
+## The word, taken apart - நாள் — genuinely native, genuinely everyday
+<!-- hl-knowledge: introduces=[TA-ETYMON-NAAL-01]; assesses=[] -->
 
 **நாள்** (**nāḷ**) — "**day**" — is native **Dravidian**, from
 **Proto-Dravidian** ***\*nāḷ***. You've already met it, hiding inside
@@ -32,12 +49,14 @@ some native words elsewhere in this arc have been — it is simply Tamil's
 **மூன்று நாள்** (*mūnṟu nāḷ*, "**three days**").
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01, TA-ETYMON-NAAL-01] -->
 
 [PAUSE 1s]
 - [YOU SAY: "nāḷ" — "day," native Dravidian, already met inside "tomorrow"]
 - [YOU SAY: "mūnṟu nāḷ" — three days]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01, TA-ETYMON-NAAL-01] -->
 
 [PAUSE 3s] Where did you already meet **நாள்** before this lesson? (Inside
 **நாளை**, *nāḷai*, "tomorrow," Chapter 4.) Is Tamil's everyday day-word a

--- a/code/learning/human-languages/tamil/lessons/TA-C24-iravu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C24-iravu.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C24-iravu
+spine_node: SPINE-TIME-OF-DAY
+sequence: 490
 chapter: 24
 type: word
 headword: இரவு
@@ -9,20 +12,34 @@ prerequisites: [TA-C17-transparent-middle-synonyms, TA-C23-day-family-register]
 sounds: [tamil-vowel-sign-u, tamil-retroflex-lla]
 roots: [proto-dravidian-cira-darkness, sanskrit-ratri, proto-dravidian-cirvl]
 etymology_hook: "இரவு (iravu, 'night') is native Dravidian, from Proto-Dravidian *cira ('darkness') — already used standalone inside நள்ளிரவு (naḷḷiravu, 'midnight,' Chapter 17: 'இரவு, a word every Tamil speaker still uses on its own'); Tamil also has ராத்திரி (rāttiri), a Sanskrit tatsama from रात्रि (rātri) ← PIE *h₁reh₁- ('to rest') — the SAME PIE root already confirmed, specifically, for Hindi's raat and Malayalam's rāthri in this arc (Kannada's and Telugu's rātri lessons note the Sanskrit tatsama status but don't independently make this same PIE-root/nox comparison), a completely different root from Latin nox's *nókʷts; be honest about register here, and flag it clearly for a native speaker's own read: at least one Tamil dictionary source states plainly that 'colloquially, ராத்திரி is more common,' implying இரவு leans more literary/formal — if accurate, this runs the OPPOSITE direction from நாள்'s story last lesson, where the native word was the uncontested everyday choice and no loanword competed; this claim rests on limited dictionary-level sourcing, not deep confirmation, and register judgments about Sanskrit-loan versus native-Tamil vocabulary are exactly the kind of thing a native speaker's own ear should settle, not a scraped source"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01, TA-LEX-DAY-FAMILY-REGISTER-01]
+introduces:
+  knowledge: [TA-LEX-IRAVU-01, TA-ETYMON-IRAVU-02]
+practises:
+  knowledge: [TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01, TA-LEX-DAY-FAMILY-REGISTER-01, TA-LEX-IRAVU-01, TA-ETYMON-IRAVU-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C17-transparent-middle-synonyms, TA-C23-day-family-register, TA-C23-naal]
 ---
 
 # இரவு (iravu) — "night," and a register question worth a native speaker's ear
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01, TA-LEX-DAY-FAMILY-REGISTER-01] -->
 
 [PAUSE 2s] Last lesson, Tamil's native day-word had no real competition.
 This lesson's honest twist, hedged carefully, is that "night" may not tell
 the same story — and this is exactly the kind of claim worth checking
 against your own ear, not just a dictionary's.
 
-## இரவு — already standing on its own, inside "midnight"
+## You'll want to know: இரவு — already standing on its own, inside "midnight"
+<!-- hl-knowledge: introduces=[TA-LEX-IRAVU-01]; assesses=[] -->
 
 **இரவு** (**iravu**) — "**night**" — is native **Dravidian**, from
 **Proto-Dravidian** ***\*cira*** ("darkness"). You've technically already
@@ -31,7 +48,8 @@ met it standing fully on its own: Chapter 17, while explaining
 இரவு itself is a word every Tamil speaker still uses on its own. This
 lesson gives it its own full chapter.
 
-## ராத்திரி — the same PIE root, and the same false-cognate story already drawn twice
+## The word, taken apart - ராத்திரி — the same PIE root, and the same false-cognate story already drawn twice
+<!-- hl-knowledge: introduces=[TA-ETYMON-IRAVU-02]; assesses=[] -->
 
 Tamil also keeps **ராத்திரி** (**rāttiri**), a Sanskrit **tatsama** from
 **रात्रि** (*rātri*) — the same word already met, as a tatsama, in
@@ -44,6 +62,7 @@ third confirmation, same false-cognate pattern, same honest
 non-relationship to *nox*.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01, TA-LEX-DAY-FAMILY-REGISTER-01, TA-LEX-IRAVU-01, TA-ETYMON-IRAVU-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "iravu" — "night," native, already met inside naḷḷiravu]
@@ -51,6 +70,7 @@ non-relationship to *nox*.
   Hindi and Malayalam, NOT related to Latin nox]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01, TA-LEX-DAY-FAMILY-REGISTER-01, TA-LEX-IRAVU-01, TA-ETYMON-IRAVU-02] -->
 
 [PAUSE 3s] Where did you already meet **இரவு** before this lesson? (Inside
 **நள்ளிரவு**, *naḷḷiravu*, "midnight," Chapter 17.) Does **ராத்திரி**'s PIE

--- a/code/learning/human-languages/tamil/lessons/TA-C24-night-register-darkness.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C24-night-register-darkness.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C24-night-register-darkness
+spine_node: SPINE-TIME-OF-DAY
+sequence: 500
 chapter: 24
 type: grammar
 headword: இரவு / ராத்திரி / இருள்
@@ -7,18 +10,32 @@ gloss: one source prefers rāttiri colloquially, a claim to test against native 
 prerequisites: [TA-C24-iravu]
 sounds: [tamil-retroflex-lla]
 roots: [proto-dravidian-cira-darkness, proto-dravidian-cirvl, sanskrit-ratri]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-LEX-IRAVU-01]
+introduces:
+  knowledge: [TA-PRAGMATICS-NIGHT-REGISTER-DARKNESS-01, TA-LEX-NIGHT-REGISTER-DARKNESS-02]
+practises:
+  knowledge: [TA-LEX-IRAVU-01, TA-PRAGMATICS-NIGHT-REGISTER-DARKNESS-01, TA-LEX-NIGHT-REGISTER-DARKNESS-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C24-iravu, TA-C23-day-family-register]
 ---
 
 # Night words — a register hypothesis and a semantic boundary
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-IRAVU-01] -->
 
 [PAUSE 2s] *Iravu* is native and *rāttiri* borrowed. That alone does not tell
 you which one conversational Tamil prefers.
 
-## Hedge the register claim
+## Why it's said this way: Hedge the register claim
+<!-- hl-knowledge: introduces=[TA-PRAGMATICS-NIGHT-REGISTER-DARKNESS-01]; assesses=[] -->
 
 At least one dictionary says **ராத்திரி** is more common colloquially, implying
 native **இரவு** may lean literary/written. If accurate, this reverses the day
@@ -28,7 +45,8 @@ But the evidence is limited and dictionary-level. Treat this as a prompt for a
 native speaker's ear, not settled fact. Register judgments require real usage,
 region, and setting—not a purity assumption about native versus borrowed words.
 
-## Darkness is a different word
+## You'll want to know: Darkness is a different word
+<!-- hl-knowledge: introduces=[TA-LEX-NIGHT-REGISTER-DARKNESS-02]; assesses=[] -->
 
 **இருள்** (*iruḷ*) means **darkness**, from Proto-Dravidian ***cirVḷ*** and
 cognate with Kannada, Telugu, and Malayalam forms. It is not *iravu* "night as a
@@ -36,6 +54,7 @@ time period" and comes from a different reconstructed root despite the similar
 sound.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-IRAVU-01, TA-PRAGMATICS-NIGHT-REGISTER-DARKNESS-01, TA-LEX-NIGHT-REGISTER-DARKNESS-02] -->
 
 [PAUSE 1s]
 - [YOU QUALIFY: "one source says *rāttiri* is more colloquial"]
@@ -43,6 +62,7 @@ sound.
 - [YOU CONTRAST: *iravu* night · *iruḷ* darkness]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-IRAVU-01, TA-PRAGMATICS-NIGHT-REGISTER-DARKNESS-01, TA-LEX-NIGHT-REGISTER-DARKNESS-02] -->
 
 [PAUSE 3s] Is the *rāttiri* register claim settled? (**No** — limited sourcing,
 worth checking against native usage.) Is **இருள்** interchangeable with **இரவு**?

--- a/code/learning/human-languages/tamil/lessons/TA-C25-goodnight-alternatives.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C25-goodnight-alternatives.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C25-goodnight-alternatives
+spine_node: SPINE-TIME-OF-DAY
+sequence: 520
 chapter: 25
 type: etymology
 headword: நல்ல இரவு / இரவு வணக்கம்
@@ -7,19 +10,33 @@ gloss: Tamil repeats its native greeting loyalty with good-night alternatives bu
 prerequisites: [TA-C25-iniya-iravu]
 sounds: [tamil-geminate-lla]
 roots: [tamil-nal-good, vaṇaṅku]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-ETYMON-INIYA-IRAVU-01]
+introduces:
+  knowledge: [TA-LEX-GOODNIGHT-ALTERNATIVES-01]
+practises:
+  knowledge: [TA-ETYMON-INIYA-IRAVU-01, TA-LEX-GOODNIGHT-ALTERNATIVES-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C25-iniya-iravu, TA-C01-vanakkam-family-register, TA-C01-nandri]
 ---
 
 # நல்ல இரவு and இரவு வணக்கம் — old roots recombined
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-INIYA-IRAVU-01] -->
 
 [PAUSE 2s] Tamil's native "sweet night" repeats the lexical choice that opened
 the course: build greetings from its own roots rather than the shared Sanskrit
 formula.
 
-## The Chapter 1 echo
+## You'll want to know: The Chapter 1 echo
+<!-- hl-knowledge: introduces=[TA-LEX-GOODNIGHT-ALTERNATIVES-01]; assesses=[] -->
 
 **வணக்கம்** comes from native *vaṇaṅku*, "bow," while neighboring greetings use
 Sanskrit *namas-*. At the other end of the day, **இனிய இரவு** is native while
@@ -35,6 +52,7 @@ Tamil also keeps two transparent alternatives:
 The learner does not memorize isolated formulas; known roots generate options.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-INIYA-IRAVU-01, TA-LEX-GOODNIGHT-ALTERNATIVES-01] -->
 
 [PAUSE 1s]
 - [YOU SAY: "nalla iravu" — good night]
@@ -42,6 +60,7 @@ The learner does not memorize isolated formulas; known roots generate options.
 - [YOU TRACE: *nal-* → *nalam / naṉṟi / nalla*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-INIYA-IRAVU-01, TA-LEX-GOODNIGHT-ALTERNATIVES-01] -->
 
 [PAUSE 3s] Which root builds **நல்ல**? (**Nal-**, good.) What two known words
 make **இரவு வணக்கம்**? (**Night + greetings**.) What lexical pattern connects

--- a/code/learning/human-languages/tamil/lessons/TA-C25-iniya-iravu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C25-iniya-iravu.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C25-iniya-iravu
+spine_node: SPINE-TIME-OF-DAY
+sequence: 510
 chapter: 25
 type: phrase
 headword: இனிய இரவு
@@ -9,20 +12,34 @@ prerequisites: [TA-C24-night-register-darkness]
 sounds: [tamil-nnna, tamil-vowel-sign-i]
 roots: [proto-dravidian-in-sweet, tamil-nal-good, vaṇaṅku]
 etymology_hook: "இனிய இரவு (iṉiya iravu), 'good night,' literally 'sweet/pleasant night' — இனிய (iṉiya, 'sweet, pleasant, dear') is native Dravidian, from Proto-Dravidian *in- ('sweet'), the same root behind இனிப்பு (iṉippu, 'sweet, dessert'); paired with இரவு (iravu, 'night,' already met last lesson). Unlike Hindi's, Kannada's, Telugu's, and Malayalam's shared śubh(a) rātri/rāthri phrase — all four built on the same Sanskrit tatsama pair (śubh 'to be beautiful' + rātri 'night') — Tamil's standard 'good night' phrase reaches for NO Sanskrit at all; the phrasebook sources checked did not surface a Tamil śubha-rāttiri equivalent as a commonly used form. Tamil also keeps நல்ல இரவு (nalla iravu, 'good night,' literally using நல்ல/nalla, 'good,' the same nal- root already met in நலம்/nalam and நன்றி/naṉṟi), and — for close friends and family — இரவு வணக்கம் (iravu vaṇakkam, 'night greetings'), built ENTIRELY from two words already taught in this course: இரவு ('night,' last lesson) and வணக்கம் ('greetings,' Chapter 1's very first word, from வணங்கு/vaṇaṅku, 'to bow')"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-PRAGMATICS-NIGHT-REGISTER-DARKNESS-01]
+introduces:
+  knowledge: [TA-ETYMON-INIYA-IRAVU-01, TA-PRAGMATICS-INIYA-IRAVU-02]
+practises:
+  knowledge: [TA-PRAGMATICS-NIGHT-REGISTER-DARKNESS-01, TA-ETYMON-INIYA-IRAVU-01, TA-PRAGMATICS-INIYA-IRAVU-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C24-night-register-darkness, TA-C24-iravu]
 ---
 
 # இனிய இரவு (iṉiya iravu) — "good night," and Tamil breaking the pattern one more time
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-PRAGMATICS-NIGHT-REGISTER-DARKNESS-01] -->
 
 [PAUSE 2s] Four languages in this arc all reached for the same Sanskrit
 phrase to say "good night." This lesson closes the arc with the one that
 didn't — and it's a pattern you've actually seen from Tamil before, all
 the way back in Chapter 1.
 
-## இனிய இரவு — "sweet night," fully native
+## The word, taken apart - இனிய இரவு — "sweet night," fully native
+<!-- hl-knowledge: introduces=[TA-ETYMON-INIYA-IRAVU-01]; assesses=[] -->
 
 **இனிய இரவு** (**iṉiya iravu**) — "**good night**" — literally "**sweet,
 pleasant night**." **இனிய** (*iṉiya*, "sweet, pleasant, dear") is native
@@ -31,7 +48,8 @@ root behind **இனிப்பு** (*iṉippu*, "sweet, dessert"). Paired wit
 **இரவு** (*iravu*, "night," already met last lesson), the whole phrase is
 built from Tamil's own word-stock, start to finish.
 
-## The pattern this breaks
+## Why it's said this way: The pattern this breaks
+<!-- hl-knowledge: introduces=[TA-PRAGMATICS-INIYA-IRAVU-02]; assesses=[] -->
 
 Every other language in this arc's GREETING-GOODNIGHT lesson reached for
 the **same** Sanskrit phrase: Hindi's **शुभ रात्रि**, Kannada's **ಶುಭ
@@ -43,6 +61,7 @@ Tamil form in the phrasebook sources checked for this lesson. Instead,
 Tamil built its own phrase from its own vocabulary.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-PRAGMATICS-NIGHT-REGISTER-DARKNESS-01, TA-ETYMON-INIYA-IRAVU-01, TA-PRAGMATICS-INIYA-IRAVU-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "iṉiya iravu" — "good night," literally "sweet night," fully native]
@@ -50,6 +69,7 @@ Tamil built its own phrase from its own vocabulary.
   one Sanskrit śubh(a) rātri phrase; Tamil doesn't]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-PRAGMATICS-NIGHT-REGISTER-DARKNESS-01, TA-ETYMON-INIYA-IRAVU-01, TA-PRAGMATICS-INIYA-IRAVU-02] -->
 
 [PAUSE 3s] What does **இனிய இரவு** literally mean, and what root does
 **இனிய** come from? ("**Sweet/pleasant night**" — Proto-Dravidian ***in-***,

--- a/code/learning/human-languages/tamil/lessons/TA-C26-kaalai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C26-kaalai.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C26-kaalai
+spine_node: SPINE-TIME-OF-DAY
+sequence: 530
 chapter: 26
 type: word
 headword: காலை
@@ -9,20 +12,34 @@ prerequisites: [TA-C17-transparent-middle-synonyms, TA-C24-night-register-darkne
 sounds: [tamil-vowel-sign-ai, tamil-long-aa]
 roots: [uncertain-etymology, sanskrit-kalya-time-possible]
 etymology_hook: "காலை (kālai, 'morning') has a genuinely UNCERTAIN etymology — Wiktionary itself hedges with 'possibly from Sanskrit काल्य (kālya),' not a confident claim, and separately notes கால் (kāl) has SIX distinct etymologies, one of which ('time,' from Sanskrit काल/kāla) may or may not be what காலை derives from as an accusative-type form; be honest that this is genuinely less settled than Kannada's ಬೆಳಗ್ಗೆ (confidently native) or Telugu's ఉదయం (confidently Sanskrit tatsama) — don't manufacture false confidence where the primary source itself hedges; Wiktionary lists பகல் (already met, TA-C17, 'daytime') as a coordinate term; அதிகாலை ('early dawn') is a transparent compound of ati- ('excessive, very') + kālai, per the Tamil Lexicon (DDSA, University of Madras)"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01, TA-PRAGMATICS-NIGHT-REGISTER-DARKNESS-01]
+introduces:
+  knowledge: [TA-ETYMON-KAALAI-01, TA-ETYMON-KAALAI-02]
+practises:
+  knowledge: [TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01, TA-PRAGMATICS-NIGHT-REGISTER-DARKNESS-01, TA-ETYMON-KAALAI-01, TA-ETYMON-KAALAI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C17-transparent-middle-synonyms, TA-C24-night-register-darkness, TA-C17-nanpakal-nalliravu, TA-C24-iravu]
 ---
 
 # காலை (kālai) — "morning," an honestly uncertain etymology
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01, TA-PRAGMATICS-NIGHT-REGISTER-DARKNESS-01] -->
 
 [PAUSE 2s] Every other language in this arc had a confidently-sourced
 story for its "morning" word — Sanskrit, or clearly native. Tamil's
 own word for morning is different: even Wiktionary itself isn't sure
 where it comes from.
 
-## காலை — genuinely uncertain, and worth saying so plainly
+## The word, taken apart - காலை — genuinely uncertain, and worth saying so plainly
+<!-- hl-knowledge: introduces=[TA-ETYMON-KAALAI-01]; assesses=[] -->
 
 **காலை** (**kālai**) — "**morning**" — has an etymology that
 Wiktionary itself only hedges at: "**possibly** from Sanskrit
@@ -37,7 +54,8 @@ is genuinely **less settled** than Kannada's confidently-native
 morning word or Telugu's confidently-Sanskrit one. Don't manufacture
 certainty the primary source itself doesn't have.
 
-## What IS confirmed: a coordinate term and a transparent compound
+## The word, taken apart - What IS confirmed: a coordinate term and a transparent compound
+<!-- hl-knowledge: introduces=[TA-ETYMON-KAALAI-02]; assesses=[] -->
 
 Wiktionary does confirm one solid fact: **பகல்** (already met,
 Chapter 17, "**daytime**") is listed as காலை's **coordinate term**
@@ -48,6 +66,7 @@ compound: **ati-** ("excessive, very") + **காலை**, glossed simply
 as "early dawn" by the Tamil Lexicon.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01, TA-PRAGMATICS-NIGHT-REGISTER-DARKNESS-01, TA-ETYMON-KAALAI-01, TA-ETYMON-KAALAI-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "kālai" — "morning," an honestly uncertain etymology]
@@ -57,6 +76,7 @@ as "early dawn" by the Tamil Lexicon.
   compound]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01, TA-PRAGMATICS-NIGHT-REGISTER-DARKNESS-01, TA-ETYMON-KAALAI-01, TA-ETYMON-KAALAI-02] -->
 
 [PAUSE 3s] Is காலை's etymology as confidently sourced as Kannada's
 or Telugu's morning words? (**No** — Wiktionary itself only says

--- a/code/learning/human-languages/tamil/lessons/TA-C27-maalai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C27-maalai.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C27-maalai
+spine_node: SPINE-TIME-OF-DAY
+sequence: 540
 chapter: 27
 type: word
 headword: மாலை
@@ -9,20 +12,34 @@ prerequisites: [TA-C26-kaalai]
 sounds: [tamil-vowel-sign-aa, tamil-vowel-sign-ai]
 roots: [proto-dravidian-maal, proto-dravidian-maal-darkness-possible]
 etymology_hook: "மாலை (mālai, 'evening') is a genuine HOMONYM, not one word with two meanings: Wiktionary lists it under TWO entirely separate etymologies. Etymology 1 is 'மாலை' meaning 'garland, wreath, necklace' — traced to Old Tamil, and compared to Sanskrit माला (mālā) with the note 'probably borrowed FROM Dravidian languages' (a reverse-direction loan, Dravidian-into-Sanskrit, a genuine contrast with this project's usual Sanskrit-into-Dravidian pattern). Etymology 2 is the completely separate 'மாலை' meaning 'evening' — also from Old Tamil, but compared instead to மால் (māl), which Wiktionary traces to Proto-Dravidian *mā/*māl and glosses with several senses including 'கருமை' ('blackness, darkness'), plus 'illusion/confusion' and, as a proper noun, the Hindu deity Vishnu; be honest that Wiktionary's etymology for the 'evening' sense only says 'compare māl,' not an explicit 'evening derives specifically from the darkness sense' claim — a natural, plausible connection (evening = growing dark), but not spelled out with full certainty by the source itself; still, this is confidently NATIVE Dravidian vocabulary, a genuine contrast with TA-C26's uncertain காலை"
-est_minutes: 4
+duration:
+  max_seconds: 273
+requires:
+  knowledge: [TA-ETYMON-KAALAI-01]
+introduces:
+  knowledge: [TA-ETYMON-MAALAI-01, TA-ETYMON-MAALAI-02]
+practises:
+  knowledge: [TA-ETYMON-KAALAI-01, TA-ETYMON-MAALAI-01, TA-ETYMON-MAALAI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C26-kaalai]
 ---
 
 # மாலை (mālai) — "evening," and a garland that only looks like the same word
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-KAALAI-01] -->
 
 [PAUSE 2s] Last lesson's morning word had an uncertain origin. This
 evening word is different — confidently native — but it comes with
 its own honest twist: it looks exactly like a completely unrelated
 word.
 
-## மாலை — a genuine homonym, not one word wearing two meanings
+## The word, taken apart - மாலை — a genuine homonym, not one word wearing two meanings
+<!-- hl-knowledge: introduces=[TA-ETYMON-MAALAI-01]; assesses=[] -->
 
 **மாலை** (**mālai**) — "**evening**" — happens to be spelled
 identically to another, completely **unrelated** Tamil word: **மாலை**
@@ -34,7 +51,8 @@ borrowed FROM Dravidian languages**" **into** Sanskrit, not the other
 way around. A rare reverse-direction loan, worth noticing against this
 whole project's usual Sanskrit-into-Dravidian pattern.
 
-## The evening sense — confidently native, plausibly "the dark one"
+## The word, taken apart - The evening sense — confidently native, plausibly "the dark one"
+<!-- hl-knowledge: introduces=[TA-ETYMON-MAALAI-02]; assesses=[] -->
 
 The **evening** sense of **மாலை** is a **separate** Old Tamil
 word entirely, compared instead to **மால்** (*māl*) — which
@@ -51,6 +69,7 @@ itself. What IS certain: this is confidently **native** Dravidian
 vocabulary, a genuine contrast with TA-C26's uncertain காலை.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-KAALAI-01, TA-ETYMON-MAALAI-01, TA-ETYMON-MAALAI-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "mālai" — "evening," confidently native Dravidian
@@ -61,6 +80,7 @@ vocabulary, a genuine contrast with TA-C26's uncertain காலை.
   "darkness" sense, but Wiktionary doesn't spell out that exact link]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-KAALAI-01, TA-ETYMON-MAALAI-01, TA-ETYMON-MAALAI-02] -->
 
 [PAUSE 3s] Are evening-mālai and garland-mālai the same word with two
 meanings? (**No** — Wiktionary treats them as two entirely separate

--- a/code/learning/human-languages/tamil/lessons/TA-C28-afternoon-boundary.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C28-afternoon-boundary.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C28-afternoon-boundary
+spine_node: SPINE-TIME-OF-DAY
+sequence: 560
 chapter: 28
 type: etymology
 headword: நடுப்பகல் / மதியம்
@@ -7,25 +10,40 @@ gloss: dictionary synonymy blurs noon and afternoon while Sanskrit matiyam remai
 prerequisites: [TA-C28-pirpakal]
 sounds: [tamil-vowel-sign-i]
 roots: [tamil-naTu-middle, sanskrit-madhya-middle]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-LEX-PIRPAKAL-01]
+introduces:
+  knowledge: [TA-LEX-AFTERNOON-BOUNDARY-01, TA-ETYMON-AFTERNOON-BOUNDARY-02]
+practises:
+  knowledge: [TA-LEX-PIRPAKAL-01, TA-LEX-AFTERNOON-BOUNDARY-01, TA-ETYMON-AFTERNOON-BOUNDARY-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C28-pirpakal, TA-C17-transparent-middle-synonyms]
 ---
 
 # Noon or afternoon? — let the sources keep their blur
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-PIRPAKAL-01] -->
 
 [PAUSE 2s] *Piṟpakal* transparently says after-daytime. Dictionaries still do
 not draw a perfectly hard semantic boundary around its synonyms.
 
-## நடுப்பகல் overlaps
+## You'll want to know: நடுப்பகல் overlaps
+<!-- hl-knowledge: introduces=[TA-LEX-AFTERNOON-BOUNDARY-01]; assesses=[] -->
 
 Wiktionary's *piṟpakal* page lists **நடுப்பகல்** as an afternoon synonym, while
 the earlier noon lesson documents the same word as a synonym of **நண்பகல்**,
 "noon." This is genuine noon/afternoon boundary blur, not an inconsistency to
 erase. Time-period categories can widen differently across speakers and sources.
 
-## மதியம் is related but distinct
+## The word, taken apart - மதியம் is related but distinct
+<!-- hl-knowledge: introduces=[TA-ETYMON-AFTERNOON-BOUNDARY-02]; assesses=[] -->
 
 **மதியம்** (*matiyam*) is a Sanskrit tatsama from *madhya*, "middle," the same
 root used by Kannada and Telugu. The fetched entry gives it **noon**, a synonym
@@ -36,6 +54,7 @@ absent from the actual fetched page. It is therefore **not asserted**. Source
 inspection outranks a search snippet.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-PIRPAKAL-01, TA-LEX-AFTERNOON-BOUNDARY-01, TA-ETYMON-AFTERNOON-BOUNDARY-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: *naṭuppakal* can overlap noon and afternoon]
@@ -43,6 +62,7 @@ inspection outranks a search snippet.
 - [YOU LABEL: the moon claim unsupported]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-PIRPAKAL-01, TA-LEX-AFTERNOON-BOUNDARY-01, TA-ETYMON-AFTERNOON-BOUNDARY-02] -->
 
 [PAUSE 3s] Does the source draw a hard noon/afternoon line? (**No**.) What is
 *matiyam*'s sourced root and sense? (Sanskrit ***madhya***, "middle," and

--- a/code/learning/human-languages/tamil/lessons/TA-C28-pirpakal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C28-pirpakal.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C28-pirpakal
+spine_node: SPINE-TIME-OF-DAY
+sequence: 550
 chapter: 28
 type: word
 headword: பிற்பகல்
@@ -9,20 +12,34 @@ prerequisites: [TA-C17-transparent-middle-synonyms]
 sounds: [tamil-retroflex-rra, tamil-pulli-virama]
 roots: [tamil-pin-after, sanskrit-madhya-middle]
 etymology_hook: "பிற்பகல் (piṟpakal, 'afternoon') is, per Wiktionary, a transparent compound of பின் (piṉ, 'after') + பகல் (pakal, 'daytime,' already met inside நண்பகல், TA-C17) — with பின் surfacing as பிற்- before the following ப — a similar kind of consonant sandhi to the one already taught in TA-C17 for நள்→நண் before ப, though be honest that Wiktionary's own etymology for பிற்பகல் doesn't discuss the sandhi mechanism at all, and the two changes move in different phonetic directions (nasal→stop here, vs. lateral→nasal there) — this comparison is the lesson's own linguistic observation, not a Wiktionary-sourced equivalence claim; Wiktionary labels பிற்பகல் formal register. Be honest about a genuine citable tension: Wiktionary's OWN பிற்பகல் page lists நடுப்பகல் as ITS synonym too — even though TA-C17 established நடுப்பகல் as a synonym of நண்பகல் specifically (noon, not afternoon); this looks like the same kind of noon/afternoon boundary-blur already seen elsewhere in this arc (Malayalam's TIME-AFTERNOON widening), not a contradiction to paper over. Separately, மதியம் is a Sanskrit tatsama (from madhya, 'middle,' the SAME root Kannada and Telugu both reach for) meaning specifically 'noon,' Wiktionary-listed as a synonym of நண்பகல் — NOT 'afternoon' specifically, despite it being the closest Tamil gets to the madhya-based words seen elsewhere in this arc; an unverified claim (from a search summary, not the actual Wiktionary page) that matiyam 'originally meant moon' is deliberately NOT asserted here, since it doesn't appear on the fetched source at all"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01]
+introduces:
+  knowledge: [TA-LEX-PIRPAKAL-01]
+practises:
+  knowledge: [TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01, TA-LEX-PIRPAKAL-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C17-transparent-middle-synonyms, TA-C17-nanpakal-nalliravu]
 ---
 
 # பிற்பகல் (piṟpakal) — "afternoon," a similar sandhi trick to நண்பகல்
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01] -->
 
 [PAUSE 2s] You already met a sandhi-driven surface change in Chapter
 17 — நள் resurfacing as நண். This lesson's afternoon word does a
 similar kind of trick, with a different word — though be honest that
 the two changes aren't identical.
 
-## பிற்பகல் — பின் (after) + பகல் (daytime), a similar sandhi story
+## You'll want to know: பிற்பகல் — பின் (after) + பகல் (daytime), a similar sandhi story
+<!-- hl-knowledge: introduces=[TA-LEX-PIRPAKAL-01]; assesses=[] -->
 
 **பிற்பகல்** (**piṟpakal**) — "**afternoon**" — is a transparent
 compound: **பின்** (*piṉ*, "**after**") plus **பகல்** (*pakal*,
@@ -41,6 +58,7 @@ lesson's own observation, not a sourced equivalence. Wiktionary labels this word
 **formal register**.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01, TA-LEX-PIRPAKAL-01] -->
 
 [PAUSE 1s]
 - [YOU SAY: "piṟpakal" — "afternoon," piṉ ("after") + pakal
@@ -49,6 +67,7 @@ lesson's own observation, not a sourced equivalence. Wiktionary labels this word
   of change to TA-C17's naḷ→naṇ, though not phonetically identical]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TRANSPARENT-MIDDLE-SYNONYMS-01, TA-LEX-PIRPAKAL-01] -->
 
 [PAUSE 3s] What does பிற்பகல் literally build from, and what
 sandhi change happens to the first piece? (**பின்** "after" + பகல்

--- a/code/learning/human-languages/tamil/lessons/TA-C29-kaalai-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C29-kaalai-vanakkam.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C29-kaalai-vanakkam
+spine_node: SPINE-TIME-OF-DAY
+sequence: 570
 chapter: 29
 type: phrase
 headword: காலை வணக்கம்
@@ -9,20 +12,34 @@ prerequisites: [TA-C26-kaalai, TA-C01-vanakkam-family-register]
 sounds: [tamil-geminate-kka, tamil-vowel-sign-ai]
 roots: [vaṇaṅku]
 etymology_hook: "காலை வணக்கம் (kālai vaṇakkam, 'good morning'), literally 'morning greetings/salutations,' is confirmed by TWO independently-fetched sources (talkpal.ai, preply.com — practical language-learning content, not lexicographic/scholarly references like TA-C26's Wiktionary and Tamil Lexicon; worth naming that source-tier difference explicitly) as Tamil's standard greeting for this time of day — talkpal.ai glosses it directly as காலை ('morning') + வணக்கம் ('a respectful greeting, similar to hello or salutations'), and preply.com independently labels it 'formal,' 'used before noon'; both agree on timing (roughly sunrise to 11 AM). Be honest about what this ISN'T: unlike Hindi/Kannada/Telugu/Malayalam, which each build their morning greeting on a śubha-equivalent word ('good, auspicious') plus a time-word, Tamil's own greeting is entirely different in structure — it's simply its own general greeting word, வணக்கம் (already met, TA-C01, 'reverence, homage,' Tamil's everyday word for 'hello'), specified with the time-of-day word காலை (already met, TA-C26) in front of it. Also be honest about a claim that did NOT check out: an initial WebSearch summary suggested a Sanskrit-borrowed word, 'suprabhatham,' serves as a casual alternative — but this claim appears on NEITHER of the two directly-fetched pages, so it is deliberately NOT asserted here"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-ETYMON-KAALAI-01]
+introduces:
+  knowledge: [TA-LEX-KAALAI-VANAKKAM-01, TA-PRAGMATICS-KAALAI-VANAKKAM-02]
+practises:
+  knowledge: [TA-ETYMON-KAALAI-01, TA-LEX-KAALAI-VANAKKAM-01, TA-PRAGMATICS-KAALAI-VANAKKAM-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C26-kaalai, TA-C01-vanakkam-family-register, TA-C01-vanakkam]
 ---
 
 # காலை வணக்கம் (kālai vaṇakkam) — "morning greetings," built from two words you already know
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-KAALAI-01] -->
 
 [PAUSE 2s] Every other language in this arc built its "good morning"
 on a word meaning "good" or "auspicious." Tamil does something
 completely different: it just puts its everyday greeting word after
 its word for "morning."
 
-## காலை வணக்கம் — literally, "morning greetings"
+## You'll want to know: காலை வணக்கம் — literally, "morning greetings"
+<!-- hl-knowledge: introduces=[TA-LEX-KAALAI-VANAKKAM-01]; assesses=[] -->
 
 **காலை வணக்கம்** (**kālai vaṇakkam**) — "**good morning**" —
 is confirmed, by two independently-fetched sources, as Tamil's
@@ -33,7 +50,8 @@ around 11 AM**." It's built from two words you already have:
 Tamil's everyday word for "hello"). Literally: "**morning
 salutations**."
 
-## Be honest: this breaks the pattern every other language followed
+## Why it's said this way: Be honest: this breaks the pattern every other language followed
+<!-- hl-knowledge: introduces=[TA-PRAGMATICS-KAALAI-VANAKKAM-02]; assesses=[] -->
 
 Here's the honest structural surprise: Hindi, Kannada, Telugu, and
 Malayalam each build their morning greeting on a **śubha**-equivalent
@@ -48,6 +66,7 @@ appears on **neither** of the two pages actually fetched, so it's
 deliberately **not** asserted here.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-KAALAI-01, TA-LEX-KAALAI-VANAKKAM-01, TA-PRAGMATICS-KAALAI-VANAKKAM-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "kālai vaṇakkam" — "good morning," literally "morning
@@ -58,6 +77,7 @@ deliberately **not** asserted here.
   vaṇakkam (Chapter 1)]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-KAALAI-01, TA-LEX-KAALAI-VANAKKAM-01, TA-PRAGMATICS-KAALAI-VANAKKAM-02] -->
 
 [PAUSE 3s] What two already-known words does காலை வணக்கம் build
 from? (காலை, "morning" + வணக்கம், "reverence/hello.") Does

--- a/code/learning/human-languages/tamil/lessons/TA-C30-maalai-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C30-maalai-vanakkam.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C30-maalai-vanakkam
+spine_node: SPINE-TIME-OF-DAY
+sequence: 580
 chapter: 30
 type: phrase
 headword: மாலை வணக்கம்
@@ -9,19 +12,33 @@ prerequisites: [TA-C27-maalai, TA-C29-kaalai-vanakkam]
 sounds: [tamil-vowel-sign-aa, tamil-geminate-kka]
 roots: [vaṇaṅku]
 etymology_hook: "மாலை வணக்கம் (mālai vaṇakkam, 'good evening'), literally 'evening greetings/salutations,' is confirmed by TWO independently-fetched sources (talkpal.ai, preply.com — practical language-learning content, the same source tier as TA-C29's) as a real, standard Tamil evening greeting — preply.com labels it formal and gives timing 'used after noon through evening,' while talkpal.ai independently gives 'can be used from late afternoon until nightfall'; both agree on the general afternoon-into-evening window, with some looseness in exact boundaries (unsurprising, matching the boundary-blur already seen in TA-C28's noon/afternoon overlap). Structurally, this follows the EXACT SAME compositional pattern as TA-C29's kālai vaṇakkam: மாலை (already met, TA-C27, 'evening') plus வணக்கம் (already met, TA-C01, Tamil's general greeting) — this pattern was independently re-verified here, not just assumed to automatically carry over from the morning greeting, since this whole arc has repeatedly found that greeting formation doesn't reliably generalize even within a single language"
-est_minutes: 4
+duration:
+  max_seconds: 265
+requires:
+  knowledge: [TA-ETYMON-MAALAI-01, TA-LEX-KAALAI-VANAKKAM-01]
+introduces:
+  knowledge: [TA-LEX-MAALAI-VANAKKAM-01, TA-PRAGMATICS-MAALAI-VANAKKAM-02]
+practises:
+  knowledge: [TA-ETYMON-MAALAI-01, TA-LEX-KAALAI-VANAKKAM-01, TA-LEX-MAALAI-VANAKKAM-01, TA-PRAGMATICS-MAALAI-VANAKKAM-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C27-maalai, TA-C29-kaalai-vanakkam]
 ---
 
 # மாலை வணக்கம் (mālai vaṇakkam) — "evening greetings," the same pattern, re-verified
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-MAALAI-01, TA-LEX-KAALAI-VANAKKAM-01] -->
 
 [PAUSE 2s] Last chapter's morning greeting followed its own pattern.
 This lesson checks whether the evening greeting follows the same
 one — rather than assuming it automatically does.
 
-## மாலை வணக்கம் — the same compositional pattern, independently confirmed
+## You'll want to know: மாலை வணக்கம் — the same compositional pattern, independently confirmed
+<!-- hl-knowledge: introduces=[TA-LEX-MAALAI-VANAKKAM-01]; assesses=[] -->
 
 **மாலை வணக்கம்** (**mālai vaṇakkam**) — "**good evening**" — is
 confirmed, by two independently-fetched sources, as a real, standard
@@ -34,7 +51,8 @@ as TA-C29's morning greeting: **மாலை** (already met, Chapter 27,
 "**evening**") plus **வணக்கம்** (already met, Chapter 1, Tamil's
 general greeting). Literally: "**evening salutations**."
 
-## Be honest: this pattern was re-checked, not assumed
+## Why it's said this way: Be honest: this pattern was re-checked, not assumed
+<!-- hl-knowledge: introduces=[TA-PRAGMATICS-MAALAI-VANAKKAM-02]; assesses=[] -->
 
 Here's the honest methodological point: just because TA-C29's morning
 greeting followed the "time-word + vaṇakkam" pattern doesn't mean this
@@ -50,6 +68,7 @@ the pattern really does repeat here — and it does, cleanly: no
 as the morning one.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-MAALAI-01, TA-LEX-KAALAI-VANAKKAM-01, TA-LEX-MAALAI-VANAKKAM-01, TA-PRAGMATICS-MAALAI-VANAKKAM-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "mālai vaṇakkam" — "good evening," literally "evening
@@ -60,6 +79,7 @@ as the morning one.
   re-verified, not assumed to carry over automatically]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-MAALAI-01, TA-LEX-KAALAI-VANAKKAM-01, TA-LEX-MAALAI-VANAKKAM-01, TA-PRAGMATICS-MAALAI-VANAKKAM-02] -->
 
 [PAUSE 3s] What two already-known words does மாலை வணக்கம் build
 from? (மாலை, "evening" + வணக்கம், "greetings.") Was it assumed

--- a/code/learning/human-languages/tamil/lessons/TA-C31-afternoon-greeting-root.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C31-afternoon-greeting-root.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C31-afternoon-greeting-root
+spine_node: SPINE-TIME-OF-DAY
+sequence: 600
 chapter: 31
 type: etymology
 headword: மதிய
@@ -9,18 +12,32 @@ prerequisites: [TA-C31-matiya-vanakkam]
 sounds: [tamil-vowel-sign-i]
 roots: [sanskrit-madhya-middle]
 etymology_hook: "மதிய is the adjectival form of மதியம் ('noon,' from Sanskrit madhya, 'middle') and can pertain to afternoon; மதிய வணக்கம் therefore does not reuse பிற்பகல், the native compound learned for 'afternoon'"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-ETYMON-MATIYA-VANAKKAM-01]
+introduces:
+  knowledge: [TA-ETYMON-AFTERNOON-GREETING-ROOT-01]
+practises:
+  knowledge: [TA-ETYMON-MATIYA-VANAKKAM-01, TA-ETYMON-AFTERNOON-GREETING-ROOT-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C31-matiya-vanakkam, TA-C28-afternoon-boundary, TA-C28-pirpakal]
 ---
 
 # மதிய — the greeting takes a different root
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-MATIYA-VANAKKAM-01] -->
 
 [PAUSE 2s] You can now say **மதிய வணக்கம்**. This final step explains
 why its first word is not the ordinary afternoon word **பிற்பகல்**.
 
-## From "middle" to noon, then afternoon
+## The word, taken apart - From "middle" to noon, then afternoon
+<!-- hl-knowledge: introduces=[TA-ETYMON-AFTERNOON-GREETING-ROOT-01]; assesses=[] -->
 
 The greeting begins with **மதிய** (**matiya**). It is the adjectival
 form of **மதியம்** (**matiyam**), "noon." That noun entered Tamil from
@@ -41,6 +58,7 @@ more reason not to manufacture a greeting by translating its pieces
 from another language.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-MATIYA-VANAKKAM-01, TA-ETYMON-AFTERNOON-GREETING-ROOT-01] -->
 
 [PAUSE 1s]
 - [YOU SAY: matiyam — "noon," ultimately from Sanskrit madhya, "middle"]
@@ -48,6 +66,7 @@ from another language.
 - [YOU SAY: matiya vaṇakkam — the afternoon greeting, built on matiya]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-MATIYA-VANAKKAM-01, TA-ETYMON-AFTERNOON-GREETING-ROOT-01] -->
 
 [PAUSE 3s] Does **மதிய வணக்கம்** begin with **பிற்பகல்**? (**No.**)
 What noun is **மதிய** related to? (**மதியம், "noon."**) What older root

--- a/code/learning/human-languages/tamil/lessons/TA-C31-matiya-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C31-matiya-vanakkam.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-C31-matiya-vanakkam
+spine_node: SPINE-TIME-OF-DAY
+sequence: 590
 chapter: 31
 type: phrase
 headword: மதிய வணக்கம்
@@ -9,19 +12,33 @@ prerequisites: [TA-C28-afternoon-boundary, TA-C29-kaalai-vanakkam]
 sounds: [tamil-vowel-sign-i, tamil-geminate-kka]
 roots: [vaṇaṅku]
 etymology_hook: "மதிய வணக்கம் (matiya vaṇakkam, 'good afternoon') is confirmed by two independently fetched sources for roughly noon to 4 PM; a third source does not list a distinct afternoon greeting, so learn the phrase while keeping the source disagreement visible"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-LEX-AFTERNOON-BOUNDARY-01, TA-LEX-KAALAI-VANAKKAM-01]
+introduces:
+  knowledge: [TA-ETYMON-MATIYA-VANAKKAM-01]
+practises:
+  knowledge: [TA-LEX-AFTERNOON-BOUNDARY-01, TA-LEX-KAALAI-VANAKKAM-01, TA-ETYMON-MATIYA-VANAKKAM-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C28-afternoon-boundary, TA-C28-pirpakal, TA-C29-kaalai-vanakkam]
 ---
 
 # மதிய வணக்கம் (matiya vaṇakkam) — a sourced afternoon greeting
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-AFTERNOON-BOUNDARY-01, TA-LEX-KAALAI-VANAKKAM-01] -->
 
 [PAUSE 2s] You already know that Tamil's noon and afternoon boundaries
 can blur. Now learn one afternoon greeting without pretending that all
 speakers or teaching sources divide the day in exactly the same way.
 
-## மதிய வணக்கம் — confirmed, with a flexible boundary
+## The word, taken apart - மதிய வணக்கம் — confirmed, with a flexible boundary
+<!-- hl-knowledge: introduces=[TA-ETYMON-MATIYA-VANAKKAM-01]; assesses=[] -->
 
 **மதிய வணக்கம்** (**matiya vaṇakkam**) — "**good afternoon**" —
 is confirmed, by two independently-fetched sources, as Tamil's
@@ -38,6 +55,7 @@ setting around you. Treat "noon to 4" as a useful learning window, not
 as a universal clock rule.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-AFTERNOON-BOUNDARY-01, TA-LEX-KAALAI-VANAKKAM-01, TA-ETYMON-MATIYA-VANAKKAM-01] -->
 
 [PAUSE 1s]
 - [YOU SAY: "matiya vaṇakkam" — "good afternoon," confirmed real, used
@@ -46,6 +64,7 @@ as a universal clock rule.
   separate afternoon greeting at all]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-AFTERNOON-BOUNDARY-01, TA-LEX-KAALAI-VANAKKAM-01, TA-ETYMON-MATIYA-VANAKKAM-01] -->
 
 [PAUSE 3s] What is one sourced Tamil greeting for "good afternoon"?
 (**மதிய வணக்கம், matiya vaṇakkam**.) Do all three fetched sources

--- a/code/learning/human-languages/tamil/lessons/TA-W01-abugida-va-ka.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W01-abugida-va-ka.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-W01-abugida-va-ka
+spine_node: SPINE-MEET-GREET
+sequence: 110
 chapter: 1
 type: writing
 headword: "வ, க"
@@ -8,18 +11,32 @@ romanization: "va, ka"
 prerequisites: [TA-W01-curves-va-ka]
 sounds: [tamil-inherent-a, tamil-contextual-k]
 roots: [tamil-abugida]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-SCRIPT-CURVES-VA-KA-01]
+introduces:
+  knowledge: [TA-SCRIPT-ABUGIDA-VA-KA-01, TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-ABUGIDA-VA-KA-03, TA-SOUND-ABUGIDA-VA-KA-04]
+practises:
+  knowledge: [TA-SCRIPT-CURVES-VA-KA-01, TA-SCRIPT-ABUGIDA-VA-KA-01, TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-ABUGIDA-VA-KA-03, TA-SOUND-ABUGIDA-VA-KA-04]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-W01-curves-va-ka, TA-C01-vanakkam]
 ---
 
 # வ and க — the vowel inside each consonant
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-CURVES-VA-KA-01] -->
 
 [PAUSE 2s] Tamil's letters do not join and they carry many curves. Now learn the
 sound that arrives for free inside every consonant.
 
-## The vowel you get for free
+## Script you'll notice: The vowel you get for free
+<!-- hl-knowledge: introduces=[TA-SCRIPT-ABUGIDA-VA-KA-01]; assesses=[] -->
 
 Tamil is an **abugida**, like Devanagari: a consonant already contains a vowel.
 
@@ -28,18 +45,21 @@ Tamil is an **abugida**, like Devanagari: a consonant already contains a vowel.
 Every consonant carries a built-in **a** until a later mark removes or replaces
 it.
 
-## வ — "va"
+## Script you'll notice: வ — "va"
+<!-- hl-knowledge: introduces=[TA-SCRIPT-ABUGIDA-VA-KA-02]; assesses=[] -->
 
 1. **a near-closed loop on the left**
 2. **a full-height arm across the top, ending in a descender on the right**
 
-## க — "ka"
+## Script you'll notice: க — "ka"
+<!-- hl-knowledge: introduces=[TA-SCRIPT-ABUGIDA-VA-KA-03]; assesses=[] -->
 
 1. **a straight horizontal top bar**
 2. **a bowl hanging from its left end**
 3. **a short right stroke that hooks left below**
 
-## One letter, three sounds
+## Sounds you'll need: One letter, three sounds
+<!-- hl-knowledge: introduces=[TA-SOUND-ABUGIDA-VA-KA-04]; assesses=[] -->
 
 Devanagari separates क, ख, ग, घ. Tamil uses **க** across that space: *k* at the
 start of a word and when doubled (**க்க**), *g* after a nasal (**ங்க**), and a
@@ -50,6 +70,7 @@ Tamil therefore needs only 18 consonant letters where Devanagari needs 33; its
 native words do not depend on those written distinctions.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-CURVES-VA-KA-01, TA-SCRIPT-ABUGIDA-VA-KA-01, TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-ABUGIDA-VA-KA-03, TA-SOUND-ABUGIDA-VA-KA-04] -->
 
 [PAUSE 1s]
 - [YOU WRITE: வ — "left loop, top arm, descender"]
@@ -58,6 +79,7 @@ native words do not depend on those written distinctions.
 - [YOU CONTRAST: initial *k* · after a nasal *g* · between vowels soft *h*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-CURVES-VA-KA-01, TA-SCRIPT-ABUGIDA-VA-KA-01, TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-ABUGIDA-VA-KA-03, TA-SOUND-ABUGIDA-VA-KA-04] -->
 
 [PAUSE 3s] What does **க** say alone? (**Ka** — the vowel is inherent.) What
 kind of script is this? (An **abugida**.) Which sounds can க spell? (*k*, *g*,

--- a/code/learning/human-languages/tamil/lessons/TA-W01-curves-va-ka.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W01-curves-va-ka.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-W01-curves-va-ka
+spine_node: SPINE-MEET-GREET
+sequence: 100
 chapter: 1
 type: writing
 headword: "தமிழ் எழுத்து"
@@ -9,13 +12,26 @@ prerequisites: [TA-C01-vanakkam-family-register]
 sounds: [tamil-inherent-a]
 roots: [palm-leaf-stylus]
 etymology_hook: "the usual explanation for Tamil's curves is PALM LEAVES — a long straight cut runs along the leaf's fibres and can split it, so a stylus favours curves; treat it as the standard account rather than settled, since early Tamil-Brahmi was angular and the rounding came later via Vatteluttu"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [TA-SCRIPT-CURVES-VA-KA-01]
+practises:
+  knowledge: [TA-SCRIPT-CURVES-VA-KA-01]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-C01-vanakkam-family-register, TA-C01-vanakkam]
 ---
 
 # Tamil's curves — the writing surface leaves a trace
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Before the first letter, look at a line of Tamil and notice what
 isn't there:
@@ -27,7 +43,8 @@ Devanagari — no hanging head-line, and a great deal of curve. (Straight stroke
 do exist: most of these letters have a flat bar across the top.) The roundness
 has a usual explanation, and it is the best story in this chapter.
 
-## The script is the shape of its writing surface
+## Script you'll notice: The script is the shape of its writing surface
+<!-- hl-knowledge: introduces=[TA-SCRIPT-CURVES-VA-KA-01]; assesses=[] -->
 
 Tamil was written for centuries on **palm leaves**, scratched with a metal
 stylus and then rubbed with soot to make the scratches show.
@@ -48,6 +65,7 @@ leaves fingerprints on the letters.** Latin's straight strokes suit a wax tablet
 and a chisel; Tamil's curves suit a stylus and a leaf.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-CURVES-VA-KA-01] -->
 
 [PAUSE 1s]
 - [YOU TRACE: a curve crossing the imagined grain of a palm leaf]
@@ -55,6 +73,7 @@ and a chisel; Tamil's curves suit a stylus and a leaf.
 - [YOU SAY: the usual reason for the curves — "a straight line can **split the leaf**"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-CURVES-VA-KA-01] -->
 
 [PAUSE 3s] Why is Tamil round? (The **usual** explanation: it was incised on **palm
 leaves**, where a straight stroke along the grain can **split** them — though

--- a/code/learning/human-languages/tamil/lessons/TA-W02-ma-retroflex-na.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W02-ma-retroflex-na.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-W02-ma-retroflex-na
+spine_node: SPINE-MEET-GREET
+sequence: 120
 chapter: 1
 type: writing
 headword: "ம, ண"
@@ -9,19 +12,33 @@ prerequisites: [TA-W01-abugida-va-ka]
 sounds: [retroflex-n]
 roots: []
 etymology_hook: "ண is a RETROFLEX n, made with the tongue curled back to the roof of the mouth — a sound English does not have and cannot hear at first; Tamil writes it with its own letter because words genuinely differ by it, which is why the script needs three separate n-letters"
-est_minutes: 4
+duration:
+  max_seconds: 299
+requires:
+  knowledge: [TA-SCRIPT-ABUGIDA-VA-KA-01]
+introduces:
+  knowledge: [TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SOUND-MA-RETROFLEX-NA-03]
+practises:
+  knowledge: [TA-SCRIPT-ABUGIDA-VA-KA-01, TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SOUND-MA-RETROFLEX-NA-03]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-W01-abugida-va-ka, TA-W01-curves-va-ka]
 ---
 
 # ம and ண — a loop, and a curled tongue
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-ABUGIDA-VA-KA-01] -->
 
 [PAUSE 2s] Two more letters, and with them you'll have every letter of the
 course's first word. One is easy. The other is a sound you may not be able to
 hear yet.
 
-## ம — "ma"
+## Script you'll notice: ம
+<!-- hl-knowledge: introduces=[TA-SCRIPT-MA-RETROFLEX-NA-01]; assesses=[] -->
 
 1. **a straight vertical stroke on the LEFT**
 2. **a horizontal along the bottom**
@@ -31,7 +48,8 @@ Get the sides the right way round. The **upright is on the left** and the
 **curve on the right** — which is the reverse of what most people guess, and the
 reverse of the Devanagari habit of hanging a shape off a right-hand spine.
 
-## ண — "ṇa"
+## Script you'll notice: ண
+<!-- hl-knowledge: introduces=[TA-SCRIPT-MA-RETROFLEX-NA-02]; assesses=[] -->
 
 1. **a straight top bar**
 2. **a loop on the left**
@@ -40,7 +58,8 @@ reverse of the Devanagari habit of hanging a shape off a right-hand spine.
 
 The dot under the romanization — **ṇ**, not plain *n* — is doing real work.
 
-## Retroflex: the tongue curls back
+## Sounds you'll need: Retroflex
+<!-- hl-knowledge: introduces=[TA-SOUND-MA-RETROFLEX-NA-03]; assesses=[] -->
 
 Say English **n**. Your tongue touches just behind your teeth.
 
@@ -59,6 +78,7 @@ a *linguistic area*: neighbouring languages that borrowed a sound from each othe
 rather than inheriting it.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-ABUGIDA-VA-KA-01, TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SOUND-MA-RETROFLEX-NA-03] -->
 
 [PAUSE 1s]
 - [YOU WRITE: ம — "left upright, bottom, **right** arch"]
@@ -66,6 +86,7 @@ rather than inheriting it.
 - [YOU SAY: plain *n*, then curl the tongue back — **ṇ**]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-ABUGIDA-VA-KA-01, TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SOUND-MA-RETROFLEX-NA-03] -->
 
 [PAUSE 3s] Draw **ம** — which side is the upright on? (**The left**; the
 arch closes it on the right.) Draw **ண** — what makes it *not* ன? (**One extra arch**: ண has **two** arches where ன has one. Both end in the same straight vertical.) What does the dot in **ṇ** mean? (**Retroflex** — the tongue curls

--- a/code/learning/human-languages/tamil/lessons/TA-W02-three-ns.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W02-three-ns.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-W02-three-ns
+spine_node: SPINE-MEET-GREET
+sequence: 130
 chapter: 1
 type: writing
 headword: "ந, ன, ண"
@@ -8,17 +11,31 @@ romanization: "na, ṉa, ṇa"
 prerequisites: [TA-W02-ma-retroflex-na]
 sounds: [dental-n, alveolar-n, retroflex-n]
 roots: [south-asian-linguistic-area]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-SCRIPT-MA-RETROFLEX-NA-01]
+introduces:
+  knowledge: [TA-SCRIPT-THREE-NS-01]
+practises:
+  knowledge: [TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-THREE-NS-01]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-W02-ma-retroflex-na]
 ---
 
 # ந, ன, ண — three stops on one tongue-map
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-MA-RETROFLEX-NA-01] -->
 
 [PAUSE 2s] English writes one *n*. Tamil keeps three tongue positions apart.
 
-## The backward walk
+## Script you'll notice: The backward walk
+<!-- hl-knowledge: introduces=[TA-SCRIPT-THREE-NS-01]; assesses=[] -->
 
 | letter | sound | tongue |
 |---|---|---|
@@ -39,6 +56,7 @@ shared geography makes the region a **linguistic area**: neighbors can borrow a
 sound pattern without inheriting it from one ancestor.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-THREE-NS-01] -->
 
 [PAUSE 1s]
 - [YOU SAY: dental ந at the teeth]
@@ -47,6 +65,7 @@ sound pattern without inheriting it from one ancestor.
 - [YOU TRACE: one arch in ன · two arches in ண]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-THREE-NS-01] -->
 
 [PAUSE 3s] How many n-letters does Tamil have? (**Three**.) What separates them?
 (Tongue position: **dental, alveolar, retroflex**.) Which two differ by one

--- a/code/learning/human-languages/tamil/lessons/TA-W03-pulli-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W03-pulli-vanakkam.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-W03-pulli-vanakkam
+spine_node: SPINE-MEET-GREET
+sequence: 140
 chapter: 1
 type: writing
 headword: "்"
@@ -9,20 +12,34 @@ prerequisites: [TA-W02-three-ns, TA-W01-abugida-va-ka]
 sounds: [pulli, gemination-kk, final-m]
 roots: [tamil-pulli]
 etymology_hook: "the puḷḷi ் is literally 'the dot', and where Devanagari's virama makes two consonants FUSE into a conjunct, Tamil's dot simply sits there — both letters keep their full shape, which is why Tamil has ~247 characters to Devanagari's many hundreds of ligatures"
-est_minutes: 4
+duration:
+  max_seconds: 294
+requires:
+  knowledge: [TA-SCRIPT-THREE-NS-01, TA-SCRIPT-ABUGIDA-VA-KA-01]
+introduces:
+  knowledge: [TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-PULLI-VANAKKAM-02]
+practises:
+  knowledge: [TA-SCRIPT-THREE-NS-01, TA-SCRIPT-ABUGIDA-VA-KA-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-PULLI-VANAKKAM-02]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-W02-three-ns, TA-W02-ma-retroflex-na, TA-C01-vanakkam]
 ---
 
 # ் — the dot that leaves both letters visible
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-THREE-NS-01, TA-SCRIPT-ABUGIDA-VA-KA-01] -->
 
 [PAUSE 2s] Every consonant carries a built-in **a**. So how do you write a
 consonant with **no** vowel — the *k* in *vaṇakkam*, or the *m* at the end?
 
 One dot.
 
-## The puḷḷi
+## Script you'll notice: The puḷḷi
+<!-- hl-knowledge: introduces=[TA-SCRIPT-PULLI-VANAKKAM-01]; assesses=[] -->
 
 > **க** = *ka*  →  **க்** = *k*
 
@@ -37,7 +54,8 @@ draw the letters a lesson has actually broken into strokes.** The data file
 behind this track covers 11 letters so far and says so (`complete: false`) — it
 grows as the chapters need it.
 
-## What Tamil does *not* do
+## Script you'll notice: What Tamil does *not* do
+<!-- hl-knowledge: introduces=[TA-SCRIPT-PULLI-VANAKKAM-02]; assesses=[] -->
 
 If you have done the Devanagari track, this is the moment to notice a real
 divergence.
@@ -64,12 +82,14 @@ words** — **க்ஷ** *kṣa* and **ஸ்ரீ** *śrī*. They sit outside
 consonants and outside the 247.)
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-THREE-NS-01, TA-SCRIPT-ABUGIDA-VA-KA-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-PULLI-VANAKKAM-02] -->
 
 [PAUSE 1s]
 - [YOU WRITE: க் — "க, then the dot above"]
 - [YOU WRITE: க்க — two full letters, dot intact, **no fusing**]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-THREE-NS-01, TA-SCRIPT-ABUGIDA-VA-KA-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-PULLI-VANAKKAM-02] -->
 
 [PAUSE 3s] What does the **puḷḷi** do, and what does the word mean? (Removes the
 **inherent vowel**; *puḷḷi* is simply "**the dot**".) What does Devanagari do

--- a/code/learning/human-languages/tamil/lessons/TA-W03-write-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W03-write-vanakkam.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-W03-write-vanakkam
+spine_node: SPINE-MEET-GREET
+sequence: 150
 chapter: 1
 type: writing
 headword: "வணக்கம்"
@@ -8,18 +11,32 @@ romanization: "vaṇakkam"
 prerequisites: [TA-W03-pulli-vanakkam, TA-W02-ma-retroflex-na, TA-W01-abugida-va-ka]
 sounds: [pulli, gemination-kk, final-m]
 roots: [tamil-vananku]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-ABUGIDA-VA-KA-01]
+introduces:
+  knowledge: [TA-SCRIPT-WRITE-VANAKKAM-01]
+practises:
+  knowledge: [TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-ABUGIDA-VA-KA-01, TA-SCRIPT-WRITE-VANAKKAM-01]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-W03-pulli-vanakkam, TA-C01-vanakkam]
 ---
 
 # வணக்கம் — the first whole written word
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-ABUGIDA-VA-KA-01] -->
 
 [PAUSE 2s] You know the four letter bodies and the vowel-killing dot. Assemble
 them left to right.
 
-## Build the word
+## Script you'll notice: Build the word
+<!-- hl-knowledge: introduces=[TA-SCRIPT-WRITE-VANAKKAM-01]; assesses=[] -->
 
 | piece | | |
 |---|---|---|
@@ -38,6 +55,7 @@ bare *m*, so the word closes instead of trailing into *ma*.
 That is the first word of the course, written by hand.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-ABUGIDA-VA-KA-01, TA-SCRIPT-WRITE-VANAKKAM-01] -->
 
 [PAUSE 1s]
 - [YOU WRITE: க் — க with the dot]
@@ -46,6 +64,7 @@ That is the first word of the course, written by hand.
 - [YOU SAY: "vaṇa**k-k**am" — hold the middle]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-ABUGIDA-VA-KA-01, TA-SCRIPT-WRITE-VANAKKAM-01] -->
 
 [PAUSE 3s] Write **வணக்கம்**. What is special about **க்க**? (It is **doubled**
 and held.) Why does the word end in *m*, not *ma*? (Final **ம்** carries a

--- a/code/learning/human-languages/tamil/lessons/TA-W04-i-sign-write-nandri.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W04-i-sign-write-nandri.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-W04-i-sign-write-nandri
+spine_node: SPINE-MEET-GREET
+sequence: 170
 chapter: 1
 type: writing
 headword: "ி, நன்றி"
@@ -8,18 +11,32 @@ romanization: "i, naṉṟi / nandri"
 prerequisites: [TA-W04-vowel-signs-nandri, TA-W03-pulli-vanakkam]
 sounds: [matra-i, nasal-stop-voicing]
 roots: [tamil-nandri]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01]
+introduces:
+  knowledge: [TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-02, TA-SOUND-I-SIGN-WRITE-NANDRI-03]
+practises:
+  knowledge: [TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-02, TA-SOUND-I-SIGN-WRITE-NANDRI-03]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-W04-vowel-signs-nandri, TA-C01-nandri]
 ---
 
 # ி and நன்றி — replace the vowel, then hear *ndr*
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01] -->
 
 [PAUSE 2s] A consonant can keep *a* or lose it under a puḷḷi. The third option
 is to replace it with a vowel sign.
 
-## The first vowel sign
+## Script you'll notice: The first vowel sign
+<!-- hl-knowledge: introduces=[TA-SCRIPT-I-SIGN-WRITE-NANDRI-01]; assesses=[] -->
 
 > **ற** = *ṟa* → **றி** = *ṟi*
 
@@ -27,7 +44,8 @@ is to replace it with a vowel sign.
 hangs from it. Later, **ை** (*ai*) will appear before its consonant on the page
 but after it in speech, the same eye/ear trap as Devanagari ि.
 
-## Assemble நன்றி
+## Script you'll notice: Assemble நன்றி
+<!-- hl-knowledge: introduces=[TA-SCRIPT-I-SIGN-WRITE-NANDRI-02]; assesses=[] -->
 
 > **ந · ன் · றி → நன்றி**
 
@@ -37,7 +55,8 @@ but after it in speech, the same eye/ear trap as Devanagari ि.
 | **ன்** | *ṉ* — alveolar, with puḷḷi | Lessons 3–4 |
 | **றி** | *ṟi* — ற plus the i-sign | this lesson |
 
-## Why *nandri* has a d-sound
+## Sounds you'll need: Why *nandri* has a d-sound
+<!-- hl-knowledge: introduces=[TA-SOUND-I-SIGN-WRITE-NANDRI-03]; assesses=[] -->
 
 **ன் + ற** is pronounced close to **ndr**. This follows a broader Tamil rule: a
 **nasal voices the stop after it**.
@@ -53,6 +72,7 @@ spellings and the common English romanization **nandri**, whose *d* is heard but
 not separately written.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-02, TA-SOUND-I-SIGN-WRITE-NANDRI-03] -->
 
 [PAUSE 1s]
 - [YOU WRITE: றி — ற plus the hook above right]
@@ -60,6 +80,7 @@ not separately written.
 - [YOU SAY: "ன் + ற = **ndr**"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-02, TA-SOUND-I-SIGN-WRITE-NANDRI-03] -->
 
 [PAUSE 3s] What are a consonant's three vowel choices? (Keep inherent **a**,
 **remove** it with puḷḷi, or **replace** it with a vowel sign.) Where does **ி**

--- a/code/learning/human-languages/tamil/lessons/TA-W04-vowel-signs-nandri.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W04-vowel-signs-nandri.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: TA-W04-vowel-signs-nandri
+spine_node: SPINE-MEET-GREET
+sequence: 160
 chapter: 1
 type: writing
 headword: "ந, ன, ற"
@@ -9,19 +12,33 @@ prerequisites: [TA-W03-write-vanakkam]
 sounds: [dental-vs-alveolar-vs-retroflex-n, matra-i]
 roots: []
 etymology_hook: "நன்றி is spelled ந ன் றி, and ன் + ற is said 'ndr' — an instance of the general Tamil rule that a NASAL VOICES THE STOP after it (ந்த nd, ண்ட ṇḍ, ன்ற ndr); each of the three n-letters produces its own cluster, which is what the three separate letters buy you"
-est_minutes: 4
+duration:
+  max_seconds: 250
+requires:
+  knowledge: [TA-SCRIPT-WRITE-VANAKKAM-01]
+introduces:
+  knowledge: [TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-02]
+practises:
+  knowledge: [TA-SCRIPT-WRITE-VANAKKAM-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-02]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
 reviews_of: [TA-W03-write-vanakkam, TA-W03-pulli-vanakkam, TA-C01-nandri]
 ---
 
 # ந, ன, ற — the letter bodies inside நன்றி
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-WRITE-VANAKKAM-01] -->
 
 [PAUSE 2s] Lesson 2 showed you that Tamil has **three** n-letters and promised
 you'd draw the other two when a word needed them. Chapter 1's *thank you* needs
 both.
 
-## The two remaining n's
+## Script you'll notice: The two remaining n's
+<!-- hl-knowledge: introduces=[TA-SCRIPT-VOWEL-SIGNS-NANDRI-01]; assesses=[] -->
 
 **ந** — *na*, the **dental** n, tongue against the teeth:
 
@@ -46,7 +63,8 @@ contrast, and it is the cheapest way to keep them apart.
 With Lesson 2's **ண** (retroflex), that completes the set. Same consonant to an
 English ear; three letters, three tongue positions, in Tamil.
 
-## ற — "ṟa", the hard r
+## Script you'll notice: ற — "ṟa", the hard r
+<!-- hl-knowledge: introduces=[TA-SCRIPT-VOWEL-SIGNS-NANDRI-02]; assesses=[] -->
 
 1. **two arches side by side** — giving it three legs down to the baseline
 2. **the right leg keeps going below the baseline**, sweeps **left**, and drops
@@ -59,6 +77,7 @@ The dot under **ṟ** marks it as the *hard* or trilled r, distinct from Tamil's
 other r. You'll meet the contrast properly later; for now, learn the shape.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-WRITE-VANAKKAM-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-02] -->
 
 [PAUSE 1s]
 - [YOU WRITE: ந — "top bar, **two** verticals, then the curl that sweeps left"]
@@ -66,6 +85,7 @@ other r. You'll meet the contrast properly later; for now, learn the shape.
 - [YOU WRITE: ற — "two arches, then the leg that sweeps left and drops"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-WRITE-VANAKKAM-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-02] -->
 
 [PAUSE 3s] Name Tamil's three n-letters and their tongue positions. (**ந**
 dental, **ன** alveolar, **ண** retroflex.) What are a consonant's three


### PR DESCRIPTION
## Summary
- migrate 51 Tamil lessons through Chapter 31 and four inline writing units to the prerequisite-safe schema-v2 curriculum contract
- generate Chapters 6–31 from the same canonical lesson ASTs consumed by Language Ladder, with independently checked source hashes
- wire the expanded 117-page Tamil book and record the measured layout-warning cleanup as HL-B33

## Validation
- `human-language-data`: build, generated-book check, 84 tests, curriculum report
- `language-ladder`: production build and 464 tests
- forced XeLaTeX build: 117 pages, zero missing glyphs, correct title/author metadata, 106 outline entries
- all 117 locally rendered pages visually inspected
- `git diff --check`

## Follow-up
HL-B33 owns the now-expanded book's 30 overfull lines, 5 underfull lines, 11 underfull pages, 4 duplicate practice labels, 146 Hyperref warnings, 19 font warnings, and header-only versos.