### PR TITLE
feat(semantic-ir-to-javascript): << (Ruby's shift operator) as a top-level builtin

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 0.51.7 — `<<` (Ruby's shift operator) as a top-level builtin
+
+Part of "JS/TS backend: implement shift-operator runtime dispatch".
+`ruby-to-semantic-ir` lowers `<<` to a top-level `BuiltinCall("<<", [lhs,
+rhs])` — a separate protocol from the `__method__("<<", recv, arg)`
+Collections dispatch (Array#push already used on this backend). `<<` had
+no entry in the `builtins` table at all, so it fell to `callBuiltin`'s
+floor and threw `TypeError: unknown builtin: <<` — every Ruby program
+using `<<` as an operator failed at runtime.
+
+New `shiftLeft(...args)`, polymorphic like the existing `plus`:
+
+- Array — pushes each RHS operand IN PLACE (never flattened, unlike
+  `plus`'s Array arm), returns the mutated receiver.
+- String — concatenates via `format` (the same tolerant convention
+  `plus`'s String arm already uses — never raises for a non-string
+  operand).
+- numeric — bitwise shift, implemented via multiplication/division by a
+  power of two rather than native `<<`/`>>`: JS's native bitwise
+  operators coerce both operands to Int32 and mask the shift count to 5
+  bits, so `1 << 40` would silently give the wrong answer, not even
+  close. This backend's numeric model stays plain `number` (no
+  arbitrary-precision integer type — a deliberate, already-tested
+  divergence from the TypeScript sibling package), so precision degrades
+  past `Number.MAX_SAFE_INTEGER` like `+`/`*` already do, rather than
+  saturating like the fixed-width C/Go/Rust backends. A negative amount
+  reverses direction (a right shift); `Math.floor` on the division
+  correctly replicates arithmetic (sign-extending) right shift for a
+  negative receiver too.
+
+Added to both the emitter's 2-arg polymorphic-operator fast path
+(`__Sir.shiftLeft`, alongside `+`/`*`/`-`/`/`/`%`) and the runtime
+`builtins` table (for a first-class `:<<` symbol reference / a hand-built
+module's non-2-arg call).
+
+Only the TypeScript sibling backend (`semantic-ir-to-typescript`, a fully
+separate crate) remains for this task.
+
+`semantic-ir-to-javascript` 0.51.6 -> 0.51.7.
+
 ## 0.51.6 — Axiom's three reserved SIR23 heads gain a real JS evaluator (MA13/Wave 7 close-out)
 
 **Wires `__axiom_declare`/`__axiom_coerce`/`__axiom_has`** — the three

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.51.6"
+version = "0.51.7"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -1716,6 +1716,16 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
     if args.len() == 2 {
         let poly = match name {
             "+" => Some("__Sir.plus"),
+            // `<<` (Ruby's shift operator) is ALSO polymorphic — native JS
+            // `<<` is wrong for every receiver type (Int32-coercing bitwise
+            // op for numbers, string concat via `+` only, no Array-push
+            // meaning at all) — so it routes through `__Sir.shiftLeft` the
+            // same way. The frontend always emits this as a 2-arg call (a
+            // `<<` chain lowers to NESTED binary calls, not one flat
+            // variadic one), so this fast path covers every frontend-
+            // sourced use; `__Sir.shiftLeft` itself stays variadic-capable
+            // for a hand-built module.
+            "<<" => Some("__Sir.shiftLeft"),
             "*" => Some("__Sir.times"),
             // `/` routes through the runtime `divide` helper, which ADDS
             // the Ruby zero-divisor check (native JS `/` yields `Infinity`,

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -610,6 +610,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     // variadic `(+ 1 2 3)`, gets the same string/array/numeric dispatch
     // as the inlined 2-arg form.
     "+": (...a) => plus(...a),
+    "<<": (...a) => shiftLeft(...a),
     "-": (...a) => a.length === 1 ? neg(a[0]) : numFold(a.slice(1), a[0], (x, y) => x - y),
     "*": (...a) => times(...a),
     "/": (...a) => a.length === 1
@@ -806,6 +807,66 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
   // `+` — left-associative fold so the variadic contract survives.  The
   // arm is chosen by the FIRST operand; `plus()` with no args is `0`,
   // mirroring the numeric identity.
+  // `<<` — Ruby's shift operator, polymorphic like `plus`:
+  //   Array   — push each RHS operand IN PLACE (`.push`, never flattened —
+  //             unlike `plus`'s Array arm, which concatenates, `<<` pushes
+  //             a nested-array operand as ONE element), returns the
+  //             (mutated) receiver. The frontend lowers a `<<` chain
+  //             (`a << 1 << 2`) to NESTED binary calls
+  //             (`shiftLeft(shiftLeft(a, 1), 2)`), not one flat variadic
+  //             call — but since `<<` mutates and returns the SAME
+  //             receiver, nesting composes exactly like a fold, so this
+  //             function stays variadic-capable (`...args`) for a
+  //             hand-built module that constructs a flat call directly.
+  //   String  — concatenates via `format` (the SAME tolerant convention
+  //             `plus`'s String arm already uses on this backend — never
+  //             raises for a non-string operand, unlike the C/Rust/Python
+  //             backends' stricter TypeError).
+  //   numeric — bitwise shift, implemented via MULTIPLICATION/DIVISION by
+  //             a power of two rather than native `<<`/`>>`: JS's native
+  //             bitwise operators coerce both operands to Int32 and mask
+  //             the shift count to 5 bits, so `1 << 40` would silently
+  //             give the WRONG answer (not even close) rather than the
+  //             correct `1099511627776`. This backend's numeric model is
+  //             plain `number` everywhere (see `numFold`) — deliberately
+  //             NOT the arbitrary-precision integer primitive (a
+  //             divergence from the TypeScript sibling package; see
+  //             `symbolic_uses_plain_numbers_not_bigint`) — so, like
+  //             `+`/`*`, precision silently degrades past
+  //             `Number.MAX_SAFE_INTEGER` (2^53) rather than saturating
+  //             like the fixed-width C/Go/Rust backends. A negative
+  //             amount REVERSES direction (a right shift by the absolute
+  //             value, matching Ruby's `5 << -1 == 5 >> 1 == 2`);
+  //             `Math.floor` on the division correctly replicates
+  //             ARITHMETIC (sign-extending) right shift for a negative
+  //             receiver too (floor division by a power of two IS
+  //             arithmetic right shift). The `acc === 0` short-circuit
+  //             both matches "0 shifted by anything is 0" and avoids
+  //             `0 * Infinity === NaN` once `Math.pow(2, amount)`
+  //             overflows to `Infinity` for an extreme shift amount.
+  function shiftAmountArg(v) {
+    return isNum(v) ? Math.trunc(numOf(v)) : 0;
+  }
+  function shiftLeft(...args) {
+    if (args.length === 0) { return 0; }
+    const first = args[0];
+    if (Array.isArray(first)) {
+      for (const a of args.slice(1)) { first.push(a); }
+      return first;
+    }
+    if (typeof first === "string") {
+      let acc = first;
+      for (const a of args.slice(1)) { acc += format(a); }
+      return acc;
+    }
+    let acc = numOf(first);
+    for (const a of args.slice(1)) {
+      if (acc === 0) { continue; }
+      const amount = shiftAmountArg(a);
+      acc = amount < 0 ? Math.floor(acc / Math.pow(2, -amount)) : acc * Math.pow(2, amount);
+    }
+    return acc;
+  }
   function plus(...args) {
     if (args.length === 0) { return 0; }
     const first = args[0];
@@ -6437,7 +6498,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
   return {
     Sym, Pair, Closure,
     intern, applyClosure, truthy, matlabTruthy, format, print, puts,
-    plus, times, divide,
+    plus, times, divide, shiftLeft,
     // Tagged floats (Ruby Integer vs Float). Exported so the emitter can
     // mint a boxed float at a `FloatLit` and route `-`/`%`/`neg` through
     // the re-tagging helpers. `mkFloat` is the sole factory.

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -319,6 +319,60 @@ console.log(o.join("|"));
 }
 
 #[test]
+fn shift_left_polymorphic_dispatch() {
+    // `<<` — Ruby's shift operator, part of "JS/TS backend: implement
+    // shift-operator runtime dispatch". Before this fix `<<` had no entry
+    // in the `builtins` table at all, so ANY use of `<<` as an operator
+    // threw `TypeError: unknown builtin: <<`. Exercises every receiver
+    // arm directly against `__Sir.shiftLeft`/`__Sir.builtins["<<"]`.
+    let snippet = r#"
+const F = __Sir; const o = [];
+o.push(String(F.shiftLeft(5, 2)));                       // 20 (Integer left shift)
+o.push(String(F.shiftLeft(5, -1)));                       // 2  (negative amount reverses direction)
+o.push(String(F.shiftLeft(-8, -1)));                      // -4 (arithmetic right shift on a negative receiver)
+o.push(String(F.shiftLeft(0, 40)));                       // 0  (0 shifted by anything is 0)
+o.push(String(F.shiftLeft(1, 40)));                       // 1099511627776 -- proves NOT the native
+                                                            // Int32-masked `<<` (which would give the wrong answer)
+const a = [1, 2];
+const pushed = F.shiftLeft(a, 3);
+o.push(String(pushed === a));                             // true (mutates and returns the SAME receiver)
+o.push(JSON.stringify(a));                                // [1,2,3]
+o.push(F.shiftLeft("ab", "cd"));                           // abcd (new string)
+o.push(String(F.shiftLeft(5, 2.9)));                       // 20 (float amount truncates toward zero)
+o.push(String(F.builtins["<<"](5, 2)));                    // 20 (registered in the builtins table too)
+console.log(o.join("|"));
+"#;
+    if let Some(stdout) = run_runtime_snippet(snippet, "shiftleft") {
+        assert_eq!(
+            stdout,
+            "20|2|-4|0|1099511627776|true|[1,2,3]|abcd|20|20",
+        );
+    }
+}
+
+#[test]
+fn shift_left_operator_emits_through_the_polymorphic_fast_path() {
+    // Proves the EMITTER routes a real `BuiltinCall("<<", [lhs, rhs])` (the
+    // shape `ruby-to-semantic-ir` produces) through `__Sir.shiftLeft`, not
+    // native JS `<<` (which would be silently wrong for `1 << 40`) and not
+    // the generic `callBuiltin` indirection.
+    let module = module_with_main(
+        vec![print(bc("<<", vec![int(1), int(40)]))],
+        Expr::NilLit { span: sp() },
+        &[],
+    );
+    let artifact = compile(&module).expect("compile to javascript");
+    assert!(
+        artifact.source.contains("__Sir.shiftLeft(1, 40)"),
+        "expected the 2-arg fast path to route through __Sir.shiftLeft; got:\n{}",
+        artifact.source
+    );
+    if let Some(stdout) = run_module(&module, "shiftop") {
+        assert_eq!(stdout, "1099511627776");
+    }
+}
+
+#[test]
 fn numof_unwraps_scalar_ndarray_for_comparison_and_negation() {
     // Regression test for the while-loop-accumulator bug found by
     // `matlab-to-semantic-ir`'s oracle test (`tests/oracle.rs`, previously


### PR DESCRIPTION
## Summary
- Part of "JS/TS backend: implement shift-operator runtime dispatch" — `ruby-to-semantic-ir` lowers `<<` to a top-level `BuiltinCall("<<", [lhs, rhs])`, a separate protocol from the `__method__("<<", recv, arg)` Collections dispatch (Array#push already used on this backend)
- `<<` had no entry in the `builtins` table at all, so it fell to `callBuiltin`'s floor and threw `TypeError: unknown builtin: <<` — every Ruby program using `<<` as an operator failed at runtime
- New `shiftLeft(...args)`, polymorphic like the existing `plus`: Array pushes each RHS operand in place (never flattened), String concatenates via `format` (matching `plus`'s tolerant, never-raises convention), numeric bitwise-shifts via **multiplication/division by a power of two rather than native `<<`/`>>`** — JS's native bitwise operators coerce to Int32 and mask the shift count to 5 bits, so `1 << 40` would silently give the wrong answer with a naive native implementation
- This backend's numeric model deliberately stays plain `number` (no arbitrary-precision integer type — a divergence from the TypeScript sibling package, already covered by an existing test), so precision degrades past `Number.MAX_SAFE_INTEGER` the same way `+`/`*` already do, rather than saturating like the fixed-width C/Go/Rust backends
- Added to both the emitter's 2-arg polymorphic-operator fast path (`__Sir.shiftLeft`, alongside `+`/`*`/`-`/`/`/`%`) and the runtime `builtins` table
- Only the TypeScript sibling backend (a fully separate crate) remains for this task; C/Go/Rust/Ruby/Python already have `<<`

## Test plan
- [x] New `shift_left_polymorphic_dispatch`: Integer shift, negative amount reverses direction, arithmetic right shift on a negative receiver, zero-receiver short-circuit, `1 << 40` proving NOT the native Int32-masked op, Array push in place (mutates + returns same receiver), String concat, float-amount truncation, `builtins["<<"]` registration — all run through a real `node`
- [x] New `shift_left_operator_emits_through_the_polymorphic_fast_path`: proves a real `BuiltinCall("<<", [1, 40])` emits `__Sir.shiftLeft(1, 40)` and, run under `node`, prints the correct `1099511627776`
- [x] Full `semantic-ir-to-javascript` test suite green (147 unit tests + 96 `run_with_node` execution-proof tests, all through a real Node.js interpreter)
- [x] `sir-conformance` full corpus green (no regressions)
- [x] `cargo clippy -p semantic-ir-to-javascript --all-targets` clean
- [x] Security review passed (no findings; explicitly verified the new `builtins["<<"]` entry doesn't undermine the `Object.create(null)` prototype-pollution mitigation)
- [x] CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)