### PR TITLE
Add safe agent package reload activation

### DIFF
--- a/code/packages/rust/chief-of-staff-daemon-api/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add an independently authorized `reload_host` operation and typed client call.
+- Preserve stopped/inactive reload conflicts as stable public conflict responses.
+
 ## 0.1.0
 
 - Add a bounded, versioned JSON request/response protocol for Chief host lifecycle operations.

--- a/code/packages/rust/chief-of-staff-daemon-api/README.md
+++ b/code/packages/rust/chief-of-staff-daemon-api/README.md
@@ -15,6 +15,10 @@ constructs typed host-lifecycle requests, checks response versions and IDs, and
 retains stable remote error codes without exposing remote details through its
 diagnostic display.
 
+`reload_host` is separately authorized from registration. It can atomically
+replace package identity only after stopped durable intent and fresh inactive
+supervisor evidence; a running replacement is launched by later reconciliation.
+
 `DaemonApi::reconcile_once` is the local scheduler boundary. It runs convergence
 through the same serialized control plane as authenticated requests without
 pretending that the daemon process is a remote session.

--- a/code/packages/rust/chief-of-staff-daemon-api/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-api/src/lib.rs
@@ -38,6 +38,8 @@ const MAX_CREDENTIAL_BYTES: usize = 4096;
 pub enum Operation {
     /// Register immutable host package identity and initial intent.
     RegisterHost,
+    /// Replace package identity for a stopped, supervisor-inactive host.
+    ReloadHost,
     /// List durable host records.
     ListHosts,
     /// Change durable desired lifecycle state.
@@ -89,6 +91,13 @@ pub trait ChiefControlPlane {
         desired_state: DesiredState,
     ) -> Result<LoadedHost, ControlPlaneError>;
 
+    /// Replace package identity for a stopped, supervisor-inactive host.
+    fn reload_host(
+        &mut self,
+        registration: HostRegistration,
+        desired_state: DesiredState,
+    ) -> Result<LoadedHost, ControlPlaneError>;
+
     /// Return durable hosts in stable host-name order.
     fn list_hosts(&mut self) -> Result<Vec<LoadedHost>, ControlPlaneError>;
 
@@ -120,6 +129,14 @@ where
         desired_state: DesiredState,
     ) -> Result<LoadedHost, ControlPlaneError> {
         OrchestratorCore::register_host(self, registration, desired_state).map_err(map_core_error)
+    }
+
+    fn reload_host(
+        &mut self,
+        registration: HostRegistration,
+        desired_state: DesiredState,
+    ) -> Result<LoadedHost, ControlPlaneError> {
+        OrchestratorCore::reload_host(self, registration, desired_state).map_err(map_core_error)
     }
 
     fn list_hosts(&mut self) -> Result<Vec<LoadedHost>, ControlPlaneError> {
@@ -400,30 +417,19 @@ impl DaemonClient {
     ) -> Result<JsonValue, DaemonClientError> {
         self.call(
             "register_host",
-            object(vec![
-                (
-                    "host_name",
-                    JsonValue::String(registration.host_name().as_str().to_string()),
-                ),
-                (
-                    "package_path",
-                    JsonValue::String(registration.package_path().as_str().to_string()),
-                ),
-                (
-                    "package_hash",
-                    JsonValue::String(hex_bytes(registration.package_hash())),
-                ),
-                (
-                    "restart_policy",
-                    JsonValue::String(
-                        restart_policy_name(registration.restart_policy()).to_string(),
-                    ),
-                ),
-                (
-                    "desired_state",
-                    JsonValue::String(desired_state_name(desired_state).to_string()),
-                ),
-            ]),
+            registration_params(registration, desired_state),
+        )
+    }
+
+    /// Safely replace one stopped host's package identity and post-reload intent.
+    pub fn reload_host(
+        &mut self,
+        registration: &HostRegistration,
+        desired_state: DesiredState,
+    ) -> Result<JsonValue, DaemonClientError> {
+        self.call(
+            "reload_host",
+            registration_params(registration, desired_state),
         )
     }
 
@@ -586,6 +592,31 @@ impl std::error::Error for DaemonClientError {
     }
 }
 
+fn registration_params(registration: &HostRegistration, desired_state: DesiredState) -> JsonValue {
+    object(vec![
+        (
+            "host_name",
+            JsonValue::String(registration.host_name().as_str().to_string()),
+        ),
+        (
+            "package_path",
+            JsonValue::String(registration.package_path().as_str().to_string()),
+        ),
+        (
+            "package_hash",
+            JsonValue::String(hex_bytes(registration.package_hash())),
+        ),
+        (
+            "restart_policy",
+            JsonValue::String(restart_policy_name(registration.restart_policy()).to_string()),
+        ),
+        (
+            "desired_state",
+            JsonValue::String(desired_state_name(desired_state).to_string()),
+        ),
+    ])
+}
+
 fn decode_client_response(
     text: &str,
     expected_request_id: &str,
@@ -658,6 +689,7 @@ fn decode_remote_error(value: Option<&JsonValue>) -> Result<JsonValue, DaemonCli
 enum Method {
     Authenticate,
     RegisterHost,
+    ReloadHost,
     ListHosts,
     SetDesiredState,
     ReconcileOnce,
@@ -670,6 +702,7 @@ impl Method {
         match value {
             "authenticate" => Some(Self::Authenticate),
             "register_host" => Some(Self::RegisterHost),
+            "reload_host" => Some(Self::ReloadHost),
             "list_hosts" => Some(Self::ListHosts),
             "set_desired_state" => Some(Self::SetDesiredState),
             "reconcile_once" => Some(Self::ReconcileOnce),
@@ -683,6 +716,7 @@ impl Method {
         match self {
             Self::Authenticate => None,
             Self::RegisterHost => Some(Operation::RegisterHost),
+            Self::ReloadHost => Some(Operation::ReloadHost),
             Self::ListHosts => Some(Operation::ListHosts),
             Self::SetDesiredState => Some(Operation::SetDesiredState),
             Self::ReconcileOnce => Some(Operation::ReconcileOnce),
@@ -841,6 +875,13 @@ fn dispatch<C: ChiefControlPlane>(
             let (registration, desired_state) = parse_registration(params)?;
             control_plane
                 .register_host(registration, desired_state)
+                .map(|host| loaded_host_json(&host))
+                .map_err(PublicError::from)
+        }
+        Method::ReloadHost => {
+            let (registration, desired_state) = parse_registration(params)?;
+            control_plane
+                .reload_host(registration, desired_state)
                 .map(|host| loaded_host_json(&host))
                 .map_err(PublicError::from)
         }
@@ -1470,6 +1511,20 @@ mod tests {
         assert!(registered.contains(r#""revision":"r1""#));
         assert!(registered.contains(r#""started_at_ns":null"#));
 
+        let replacement_hash = "22".repeat(32);
+        let reloaded = api.handle_text(
+            &mut session,
+            &request(
+                "reload",
+                "reload_host",
+                &format!(
+                    r#"{{"host_name":"agent-one","package_path":"/agents/two","package_hash":"{replacement_hash}","restart_policy":"on_failure","desired_state":"stopped"}}"#
+                ),
+            ),
+        );
+        assert!(reloaded.contains(&replacement_hash));
+        assert!(reloaded.contains("/agents/two"));
+
         let listed = api.handle_text(&mut session, &request("list", "list_hosts", "{}"));
         assert!(listed.contains(r#""host_name":"agent-one""#));
 
@@ -1511,6 +1566,7 @@ mod tests {
             *operations.lock().unwrap(),
             [
                 Operation::RegisterHost,
+                Operation::ReloadHost,
                 Operation::ListHosts,
                 Operation::SetDesiredState,
                 Operation::ReconcileOnce,
@@ -1689,6 +1745,14 @@ mod tests {
             Err(ControlPlaneError::Internal)
         }
 
+        fn reload_host(
+            &mut self,
+            _registration: HostRegistration,
+            _desired_state: DesiredState,
+        ) -> Result<LoadedHost, ControlPlaneError> {
+            Err(ControlPlaneError::Internal)
+        }
+
         fn list_hosts(&mut self) -> Result<Vec<LoadedHost>, ControlPlaneError> {
             Ok(Vec::new())
         }
@@ -1809,6 +1873,20 @@ mod tests {
                 Err(ControlPlaneError::Internal)
             }
 
+            fn reload_host(
+                &mut self,
+                registration: HostRegistration,
+                desired_state: DesiredState,
+            ) -> Result<LoadedHost, ControlPlaneError> {
+                assert_eq!(registration.host_name().as_str(), "typed-host");
+                assert_eq!(registration.package_path().as_str(), "/agents/typed");
+                assert_eq!(registration.package_hash(), &[0xab; 32]);
+                assert_eq!(registration.restart_policy(), RestartPolicy::OnFailure);
+                assert_eq!(desired_state, DesiredState::Stopped);
+                self.record("reload");
+                Err(ControlPlaneError::Conflict)
+            }
+
             fn list_hosts(&mut self) -> Result<Vec<LoadedHost>, ControlPlaneError> {
                 self.record("list");
                 Ok(Vec::new())
@@ -1888,6 +1966,13 @@ mod tests {
         assert_eq!(register.remote_code(), Some("internal"));
         assert_eq!(register.remote_message(), Some("operation failed"));
         assert_eq!(register.to_string(), "chief daemon rejected the request");
+        assert_eq!(
+            client
+                .reload_host(&registration, DesiredState::Stopped)
+                .unwrap_err()
+                .remote_code(),
+            Some("conflict")
+        );
 
         assert_eq!(
             client
@@ -1916,6 +2001,7 @@ mod tests {
             [
                 "list",
                 "register",
+                "reload",
                 "set",
                 "reconcile",
                 "health",
@@ -2022,6 +2108,13 @@ mod tests {
         struct PanickingControlPlane;
         impl ChiefControlPlane for PanickingControlPlane {
             fn register_host(
+                &mut self,
+                _: HostRegistration,
+                _: DesiredState,
+            ) -> Result<LoadedHost, ControlPlaneError> {
+                unreachable!()
+            }
+            fn reload_host(
                 &mut self,
                 _: HostRegistration,
                 _: DesiredState,

--- a/code/packages/rust/chief-of-staff-daemon-runtime/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-runtime/src/lib.rs
@@ -300,6 +300,14 @@ mod tests {
             Err(ControlPlaneError::Internal)
         }
 
+        fn reload_host(
+            &mut self,
+            _registration: HostRegistration,
+            _desired_state: DesiredState,
+        ) -> Result<LoadedHost, ControlPlaneError> {
+            Err(ControlPlaneError::Internal)
+        }
+
         fn list_hosts(&mut self) -> Result<Vec<LoadedHost>, ControlPlaneError> {
             Ok(Vec::new())
         }

--- a/code/packages/rust/chief-of-staff-orchestrator-core/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-orchestrator-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add safe package reload for stopped hosts with absent or exited supervisor authority.
+- Atomically write replacement identity and post-reload desired state before reconciliation.
+
 ## 0.1.0
 
 - Add bounded register, desired-state, health, reconcile, and safe-deregister APIs.

--- a/code/packages/rust/chief-of-staff-orchestrator-core/README.md
+++ b/code/packages/rust/chief-of-staff-orchestrator-core/README.md
@@ -14,6 +14,11 @@ The core is keyless and payload-blind. Verified child processes own host-runtime
 execution and channel endpoint keys; the parent stores topology and coordinates
 lifecycle without reading agent messages or vault secrets.
 
+Package reload retains the stable host name but requires stopped durable intent
+and fresh absent or exited supervisor authority. One revision-CAS transaction
+then replaces package identity, clears stale observation, and stores whether the
+next reconciliation tick should start the replacement or leave it stopped.
+
 ## Validation
 
 ```sh

--- a/code/packages/rust/chief-of-staff-orchestrator-core/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-orchestrator-core/src/lib.rs
@@ -239,6 +239,52 @@ where
             .map_err(OrchestratorCoreError::Registry)
     }
 
+    /// Atomically activate new package identity for a stopped, inactive host.
+    ///
+    /// The stable host name is retained, cached observation is reset, and the
+    /// requested post-reload desired state is written in the same revision-CAS
+    /// transaction. A running replacement is started by the next reconciliation
+    /// tick; this operation never overlaps old and new host processes.
+    pub fn reload_host(
+        &mut self,
+        registration: HostRegistration,
+        desired_state: DesiredState,
+    ) -> Result<LoadedHost, OrchestratorCoreError<S::Error, A::Error>> {
+        let host_name = registration.host_name().clone();
+        let registry = ServiceRegistry::new(self.backend.as_ref());
+        let loaded = registry
+            .load(&host_name)
+            .map_err(OrchestratorCoreError::Registry)?
+            .ok_or_else(|| {
+                OrchestratorCoreError::Registry(RegistryError::HostNotFound(host_name.clone()))
+            })?;
+        if loaded.entry().registration() == &registration
+            && loaded.entry().desired_state() == desired_state
+        {
+            return Ok(loaded);
+        }
+        if loaded.entry().desired_state() != DesiredState::Stopped {
+            return Err(OrchestratorCoreError::HostDesiredRunning(host_name));
+        }
+        let authority = self
+            .supervisor
+            .inspect(loaded.entry().registration())
+            .map_err(|source| OrchestratorCoreError::Supervisor {
+                host_name: host_name.clone(),
+                source,
+            })?;
+        if matches!(
+            authority,
+            SupervisorObservation::Instance(ref instance)
+                if !matches!(instance.phase(), SupervisorPhase::Exited { .. })
+        ) {
+            return Err(OrchestratorCoreError::HostStillActive(host_name));
+        }
+        registry
+            .replace_stopped_registration(&loaded, registration, desired_state)
+            .map_err(OrchestratorCoreError::Registry)
+    }
+
     /// Sample time once and perform one stable-order bounded reconciliation tick.
     pub fn reconcile_once(
         &mut self,
@@ -666,6 +712,106 @@ mod tests {
             missing,
             OrchestratorCoreError::Registry(RegistryError::HostNotFound(_))
         ));
+    }
+
+    #[test]
+    fn reload_atomically_replaces_inactive_package_and_resumes_on_next_tick() {
+        let backend = Arc::new(InMemoryStorageBackend::new());
+        let supervisor = FakeSupervisor::default();
+        let state = Arc::clone(&supervisor.0);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let mut core = core(
+            Arc::clone(&backend),
+            supervisor,
+            FakeAuthorizer::allowing(events),
+            Arc::new(TestClock::new([100])),
+        );
+        core.register_host(registration("agent-host", 1), DesiredState::Stopped)
+            .expect("register stopped host");
+        let replacement = registration("agent-host", 2);
+        let reloaded = core
+            .reload_host(replacement.clone(), DesiredState::Running)
+            .expect("reload inactive host");
+        assert_eq!(reloaded.entry().registration(), &replacement);
+        assert_eq!(reloaded.entry().desired_state(), DesiredState::Running);
+        assert_eq!(
+            reloaded.entry().observation().status(),
+            &chief_of_staff_service_registry::HostStatus::Stopped
+        );
+        state
+            .lock()
+            .expect("supervisor mutex poisoned")
+            .fail_inspect = true;
+        assert_eq!(
+            core.reload_host(replacement, DesiredState::Running)
+                .expect("idempotent replay"),
+            reloaded
+        );
+        state
+            .lock()
+            .expect("supervisor mutex poisoned")
+            .fail_inspect = false;
+        assert_eq!(
+            core.reconcile_once().expect("start replacement").outcomes()[0].action(),
+            ReconcileAction::Started
+        );
+        assert_eq!(
+            state.lock().expect("supervisor mutex poisoned").starts,
+            ["agent-host"]
+        );
+    }
+
+    #[test]
+    fn reload_refuses_running_intent_or_live_supervisor_authority() {
+        let backend = Arc::new(InMemoryStorageBackend::new());
+        let supervisor = FakeSupervisor::default();
+        let state = Arc::clone(&supervisor.0);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let mut core = core(
+            Arc::clone(&backend),
+            supervisor,
+            FakeAuthorizer::allowing(events),
+            Arc::new(TestClock::new([])),
+        );
+        let old = registration("agent-host", 1);
+        core.register_host(old.clone(), DesiredState::Running)
+            .expect("register running host");
+        assert!(matches!(
+            core.reload_host(registration("agent-host", 2), DesiredState::Running),
+            Err(OrchestratorCoreError::HostDesiredRunning(_))
+        ));
+        core.set_desired_state(old.host_name(), DesiredState::Stopped)
+            .expect("request stop");
+        state
+            .lock()
+            .expect("supervisor mutex poisoned")
+            .observations
+            .insert(
+                "agent-host".to_string(),
+                SupervisorObservation::running([1; 32], 17, 100, 101, channel_id(4))
+                    .expect("valid running observation"),
+            );
+        assert!(matches!(
+            core.reload_host(registration("agent-host", 2), DesiredState::Running),
+            Err(OrchestratorCoreError::HostStillActive(_))
+        ));
+        state
+            .lock()
+            .expect("supervisor mutex poisoned")
+            .observations
+            .insert(
+                "agent-host".to_string(),
+                SupervisorObservation::exited([1; 32], Some(0), Some(100), Some(101))
+                    .expect("valid exited observation"),
+            );
+        assert_eq!(
+            core.reload_host(registration("agent-host", 2), DesiredState::Stopped)
+                .expect("reload exited host")
+                .entry()
+                .registration()
+                .package_hash(),
+            &[2; 32]
+        );
     }
 
     #[test]

--- a/code/packages/rust/chief-of-staff-service-registry/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-service-registry/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add revision-CAS package replacement for stopped host registrations.
+- Reset cached process observation when package identity changes.
+
 ## 0.1.0
 
 - Add bounded host names, portable package paths, restart policy, desired state,

--- a/code/packages/rust/chief-of-staff-service-registry/README.md
+++ b/code/packages/rust/chief-of-staff-service-registry/README.md
@@ -14,7 +14,9 @@ that reconciliation must verify after restart.
 Records use a bounded, versioned binary codec and live behind the repository's
 `StorageBackend`. Registration uses atomic create-if-absent. Every update and
 deregistration is revision-CAS guarded, preventing a stale reconciler from
-overwriting or deleting a newer observation.
+overwriting or deleting a newer observation. Package replacement is a separate
+CAS operation limited to stopped durable intent; it resets cached observation,
+and its caller must first prove the old process is absent or exited.
 
 ## Validation
 

--- a/code/packages/rust/chief-of-staff-service-registry/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-service-registry/src/lib.rs
@@ -509,6 +509,48 @@ impl<'a> ServiceRegistry<'a> {
         }
     }
 
+    /// CAS-replace package identity for a host whose durable intent is stopped.
+    ///
+    /// The replacement resets cached process observation because evidence for
+    /// the previous package cannot describe the new one. Callers remain
+    /// responsible for proving through fresh supervisor authority that the old
+    /// process is absent or exited before invoking this storage transaction.
+    pub fn replace_stopped_registration(
+        &self,
+        loaded: &LoadedHost,
+        registration: HostRegistration,
+        desired_state: DesiredState,
+    ) -> Result<LoadedHost, RegistryError> {
+        let old_name = &loaded.entry.registration.host_name;
+        if registration.host_name != *old_name {
+            return Err(RegistryError::invalid(
+                "host_name",
+                "cannot change during package replacement",
+            ));
+        }
+        if loaded.entry.registration == registration && loaded.entry.desired_state == desired_state
+        {
+            return Ok(loaded.clone());
+        }
+        if loaded.entry.desired_state != DesiredState::Stopped {
+            return Err(RegistryError::invalid(
+                "desired_state",
+                "must be stopped before package replacement",
+            ));
+        }
+        let replacement = HostEntry::registered(registration, desired_state);
+        let key = host_record_key(old_name);
+        let input = host_put(&key, encode_host_entry(&replacement))?
+            .with_if_revision(Some(loaded.revision.clone()));
+        match self.backend.put(input) {
+            Ok(record) => decode_storage_record(record, old_name),
+            Err(StorageError::Conflict { .. }) => {
+                Err(RegistryError::ConcurrentUpdate(old_name.clone()))
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+
     /// Deregister exactly the revision the caller inspected.
     pub fn deregister(&self, loaded: &LoadedHost) -> Result<(), RegistryError> {
         let name = &loaded.entry.registration.host_name;
@@ -1144,6 +1186,69 @@ mod tests {
         assert!(matches!(
             registry.update(&loaded, &replacement),
             Err(RegistryError::InvalidField { .. })
+        ));
+    }
+
+    #[test]
+    fn stopped_registration_replacement_is_cas_guarded_and_resets_observation() {
+        let backend = InMemoryStorageBackend::new();
+        let registry = ServiceRegistry::new(&backend);
+        let old = running_entry("mail-host").with_desired_state(DesiredState::Stopped);
+        let loaded = registry.register(&old).unwrap();
+        let replacement = registration("mail-host", 99);
+        let replaced = registry
+            .replace_stopped_registration(&loaded, replacement.clone(), DesiredState::Running)
+            .unwrap();
+        assert_eq!(replaced.entry().registration(), &replacement);
+        assert_eq!(replaced.entry().desired_state(), DesiredState::Running);
+        assert_eq!(replaced.entry().observation(), &HostObservation::stopped());
+        assert_eq!(
+            registry
+                .replace_stopped_registration(&replaced, replacement, DesiredState::Running,)
+                .unwrap(),
+            replaced
+        );
+        assert!(matches!(
+            registry.replace_stopped_registration(
+                &loaded,
+                registration("mail-host", 100),
+                DesiredState::Stopped,
+            ),
+            Err(RegistryError::ConcurrentUpdate(_))
+        ));
+    }
+
+    #[test]
+    fn package_replacement_requires_stopped_intent_and_stable_name() {
+        let backend = InMemoryStorageBackend::new();
+        let registry = ServiceRegistry::new(&backend);
+        let running = registry.register(&running_entry("mail-host")).unwrap();
+        assert!(matches!(
+            registry.replace_stopped_registration(
+                &running,
+                registration("mail-host", 99),
+                DesiredState::Running,
+            ),
+            Err(RegistryError::InvalidField {
+                field: "desired_state",
+                ..
+            })
+        ));
+        let stopped = running
+            .entry()
+            .clone()
+            .with_desired_state(DesiredState::Stopped);
+        let stopped = registry.update(&running, &stopped).unwrap();
+        assert!(matches!(
+            registry.replace_stopped_registration(
+                &stopped,
+                registration("other-host", 99),
+                DesiredState::Running,
+            ),
+            Err(RegistryError::InvalidField {
+                field: "host_name",
+                ..
+            })
         ));
     }
 

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -178,6 +178,12 @@ two fully verified snapshots and reports added, removed, and replaced identities
 in stable order without mutating durable registration or live process state.
 Package activation remains an explicit lifecycle operation: discovery never
 silently replaces a running agent.
+The authenticated reload operation requires stopped durable intent and fresh
+absent or exited supervisor authority. It retains the stable agent identity,
+revision-CAS replaces package identity, resets cached observation, and records
+post-reload desired state atomically. If that state is running, the next normal
+reconciliation tick launches the replacement; the orchestrator itself remains
+online throughout.
 
 The Level 1 runtime injects a provider-neutral LLM client plus authorized input
 and output channel endpoints. For each verified UTF-8 message it sends the full


### PR DESCRIPTION
## Summary

- add a revision-CAS registry transaction that replaces package identity only from stopped durable intent and resets stale observation
- require fresh absent or exited supervisor authority before the orchestrator activates a replacement
- atomically retain the stable host name and write the requested post-reload desired state
- expose `reload_host` as an independently authorized daemon operation and typed client call
- let normal reconciliation launch a running replacement without restarting the daemon

## Validation

- 54 focused tests across service registry, orchestrator core, daemon API, and daemon runtime
- strict Clippy across all four crates
- warnings-as-errors rustdoc across all four crates
- affected-package planner: 71 built and tested, 1,162 skipped

Advances #128 and #139.