### PR TITLE
Make the 31-chapter Tamil book warning-free

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -103,9 +103,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B29 | Complete (#9861) | Remove Arabic's LaTeX layout, duplicate-label, bookmark, font, and header-only-verso warnings. | The forced 104-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; intentionally empty versos are truly empty. |
 | HL-B30 | Complete (#9868) | Publish Hindi Chapters 6–33 and its writing companions from canonical lessons rather than hand-copying another twenty-eight book chapters. | Fifty-one lessons now use schema v2; forty later lessons generate twenty-eight chapters whose source hashes are independently verified against Language Ladder, while eleven prerequisite-ordered writing companions remain inside the gentle hand-authored opening chapters. |
 | HL-B31 | Complete (#9871) | Remove Hindi's LaTeX layout, duplicate-label, bookmark, font, and header-only-verso warnings. | The forced 114-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; intentionally blank chapter versos are truly empty. |
-| HL-B32 | Complete in this PR | Publish Tamil Chapters 6–31 and its writing companions from canonical lessons rather than hand-copying another twenty-six book chapters. | Fifty-one lessons now use schema v2; forty-three later lessons generate twenty-six chapters whose source hashes are independently verified against Language Ladder, while eight prerequisite-ordered writing companions remain inside the gentle hand-authored opening chapter. |
-| HL-B33 | Next | Remove Tamil's LaTeX layout, duplicate-label, bookmark, font, and header-only-verso warnings. | The expanded forced 117-page build has zero missing glyphs but reports 30 overfull lines, five underfull lines, eleven underfull pages, four duplicate practice labels, 146 Hyperref warnings, and 19 font warnings; the clean-build signal is zero of each and intentionally blank versos are truly empty. |
-| HL-B34 | Queued | Publish Latin Chapters 2–36 from canonical lessons rather than hand-copying another thirty-five book chapters. | The Latin PDF contains only Chapter 1 while canonical app content continues through Chapter 36; schema-v2 migration plus generation should close that drift safely. |
+| HL-B32 | Complete (#9875) | Publish Tamil Chapters 6–31 and its writing companions from canonical lessons rather than hand-copying another twenty-six book chapters. | Fifty-one lessons now use schema v2; forty-three later lessons generate twenty-six chapters whose source hashes are independently verified against Language Ladder, while eight prerequisite-ordered writing companions remain inside the gentle hand-authored opening chapter. |
+| HL-B33 | Complete in this PR | Remove Tamil's LaTeX layout, duplicate-label, bookmark, font, and header-only-verso warnings. | The forced 117-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; intentionally blank chapter versos are truly empty. |
+| HL-B34 | Next | Publish Latin Chapters 2–36 from canonical lessons rather than hand-copying another thirty-five book chapters. | The Latin PDF contains only Chapter 1 while canonical app content continues through Chapter 36; schema-v2 migration plus generation should close that drift safely. |
 | HL-B35 | Queued | Remove Latin's remaining LaTeX layout and font warnings. | A forced build succeeds with no missing glyphs, overfull boxes, duplicate labels, or Hyperref warnings, but reports one underfull box and a small-caps font-shape substitution; the clean-build signal is zero of each. |
 | HL-B36 | Queued | Publish Spanish Chapters 19–33 from canonical lessons rather than hand-copying another fifteen book chapters. | The Spanish PDF stops after Chapter 18 while canonical app content continues through Chapter 33; schema-v2 migration plus generation should raise book coverage from 55% to 100%. |
 | HL-B37 | Queued | Remove Spanish's remaining legacy LaTeX layout, bookmark, and font warnings. | After Chapters 4–6 generation, a forced build has no missing glyphs or duplicate labels but reports 50 overfull boxes, 14 underfull boxes, 14 Hyperref warnings, and one undefined small-caps shape; the clean-build signal is zero of each. |
@@ -993,6 +993,26 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   verso cleanup instead of mixing publication hygiene into canonical content.
 - The roadmap and authoritative session map still stop before the complete
   Chapter 31 corpus. HL-M07 continues to own that progression-metadata work.
+
+## Findings from HL-B33
+
+- Explicit static-font shape mappings remove all nineteen Tamil and comparison-
+  script substitutions without introducing a system-font dependency.
+- PDF-safe definitions preserve Tamil text in the outline while eliminating
+  all 146 Hyperref warnings. Five unique practice labels remove the four
+  duplicate destinations.
+- Flexible page bottoms and a true-empty `\cleardoublepage` keep the open-right
+  print layout while removing all eleven underfull-page warnings and every
+  header-only verso.
+- Shorter canonical headings, a two-column weekday comparison, and a scannable
+  recall checklist remove the remaining line warnings in both book and app
+  content. Regeneration keeps their lesson ids and source hashes independently
+  verifiable instead of creating book-only copies.
+- The forced XeLaTeX build remains 117 pages with correct title/author metadata,
+  106 outline entries, zero schema leaks, and zero missing glyphs, overfull or
+  underfull boxes, duplicate labels, Hyperref warnings, LaTeX warnings, or font
+  warnings. All rendered pages were inspected again.
+- HL-B34 is next: publish Latin Chapters 2–36 from the canonical app corpus.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -1672,7 +1672,7 @@
     {
       "language": "tamil",
       "chapter": 10,
-      "sourceHash": "fnv1a64:1e54c48f58723696",
+      "sourceHash": "fnv1a64:2538dae6127ff3d7",
       "lessonIds": [
         "TA-C10-vaara-kizhamai"
       ],
@@ -1690,7 +1690,7 @@
     {
       "language": "tamil",
       "chapter": 12,
-      "sourceHash": "fnv1a64:c60c5953173c6f66",
+      "sourceHash": "fnv1a64:37498296b121ed1e",
       "lessonIds": [
         "TA-C12-kudumbam"
       ],
@@ -1765,7 +1765,7 @@
     {
       "language": "tamil",
       "chapter": 20,
-      "sourceHash": "fnv1a64:974d434fad0acba2",
+      "sourceHash": "fnv1a64:fa1b550899c021f3",
       "lessonIds": [
         "TA-C20-pathinondru-irupathu",
         "TA-C20-vaanilai"
@@ -1851,7 +1851,7 @@
     {
       "language": "tamil",
       "chapter": 29,
-      "sourceHash": "fnv1a64:98b7381596bab2bd",
+      "sourceHash": "fnv1a64:6c788bc0104707ff",
       "lessonIds": [
         "TA-C29-kaalai-vanakkam"
       ],
@@ -1860,7 +1860,7 @@
     {
       "language": "tamil",
       "chapter": 30,
-      "sourceHash": "fnv1a64:f4dbb1b65e6b99db",
+      "sourceHash": "fnv1a64:f5c2a578b5b6df4d",
       "lessonIds": [
         "TA-C30-maalai-vanakkam"
       ],

--- a/code/learning/human-languages/tamil/CHANGELOG.md
+++ b/code/learning/human-languages/tamil/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Warning-free 31-chapter edition
+
+- The forced 117-page XeLaTeX build now reports zero missing glyphs,
+  overfull or underfull boxes, duplicate labels, Hyperref warnings, LaTeX
+  warnings, or font warnings.
+- Every Tamil and comparison-script font maps bold and italic teaching
+  contexts to the vendored static files, while PDF-safe script commands keep
+  the full Tamil text in bookmarks without font-command warnings.
+- Unique practice labels remove duplicate destinations, short running heads
+  keep navigation readable, and open-right chapter versos remain print-friendly
+  while rendering truly empty.
+- Five canonical micro-lessons use shorter headings, a clearer two-column
+  weekday table, and a scannable wrap-up checklist. The generated chapters and
+  independently verified source hashes therefore stay synchronized with
+  Language Ladder instead of receiving book-only patches.
+
 ## Canonical Chapters 6–31 publication
 
 - Fifty-one lessons now use schema v2 with explicit shared-spine placement,

--- a/code/learning/human-languages/tamil/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch01-greetings.tex
@@ -52,7 +52,7 @@ the word. It serves as both \textbf{hello and goodbye}, any time, to almost
 anyone, respectful without being stiff.
 \end{culture}
 
-\section{\ta{நன்றி} \emph{(naṉṟi)} --- ``thank you,'' literally ``goodness''}
+\section[\ta{நன்றி}]{\ta{நன்றி} \emph{(naṉṟi)} --- ``thank you''}
 \label{lesson:nandri}
 
 \begin{sounds}
@@ -166,7 +166,7 @@ predictable from the letter alone --- you pick it up by ear, word by word.
 \end{grammarlens}
 
 \section{Recap, and how Tamil says goodbye}
-\label{lesson:practice}
+\label{lesson:ta-greetings-practice}
 
 \begin{center}
 \begin{tabular}{@{}lll@{}}

--- a/code/learning/human-languages/tamil/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch02-introductions.tex
@@ -81,7 +81,7 @@ where English needs \emph{is}, Hindi needs \emph{hai}, and Arabic (you'll see)
 also drops it. Tamil says only ``my name Arun.''
 \end{grammarlens}
 
-\section{\ta{நீ} / \ta{நீங்கள்} \emph{(n\=\i\ / n\=\i\d{n}gaḷ)} --- ``you,'' familiar and respectful}
+\section[\ta{நீ} / \ta{நீங்கள்}]{\ta{நீ} / \ta{நீங்கள்} \emph{(n\=\i\ / n\=\i\d{n}gaḷ)} --- ``you,'' familiar and respectful}
 \label{lesson:nii-niingal}
 
 \begin{sounds}
@@ -148,7 +148,7 @@ casual speech Tamils often just smile, or say the English ``nice to meet you.'')
 \end{cousinweb}
 
 \section{The whole exchange}
-\label{lesson:practice}
+\label{lesson:ta-introductions-practice}
 
 \begin{center}
 \begin{tabular}{@{}lll@{}}

--- a/code/learning/human-languages/tamil/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch03-responding.tex
@@ -100,7 +100,7 @@ plain ``no.'' Hold \emph{iru} / \emph{illai} together --- ``is'' and ``is-not.''
 \end{grammarlens}
 
 \section{The whole exchange}
-\label{lesson:practice}
+\label{lesson:ta-responding-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/tamil/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch04-farewells.tex
@@ -76,7 +76,7 @@ let's see [each other].'' Note the retroflex \ta{ள்} (\emph{\d{l}}), tongue-
 curled up and back --- a sound English lacks.
 \end{cousinweb}
 
-\section{\ta{மீண்டும் சந்திப்போம்} \emph{(m\=\i\d{n}\d{t}um sandipp\=om)} --- ``we'll meet again''}
+\section[\ta{மீண்டும் சந்திப்போம்}]{\ta{மீண்டும் சந்திப்போம்} \emph{(m\=\i\d{n}\d{t}um sandipp\=om)} --- ``we'll meet again''}
 \label{lesson:mindum-sandippom}
 
 \begin{cousinweb}
@@ -90,7 +90,7 @@ a Sanskrit borrowing --- the recurring thread of this track.
 \end{cousinweb}
 
 \section{The farewells}
-\label{lesson:practice}
+\label{lesson:ta-farewells-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/tamil/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch05-first-verbs.tex
@@ -92,7 +92,7 @@ on. Millennia side by side, Tamil and Hindi quietly traded habits like this.
 \end{grammarlens}
 
 \section{Sentences about yourself}
-\label{lesson:practice}
+\label{lesson:ta-first-verbs-practice}
 
 \begin{center}
 \begin{tabular}{@{}ll@{}}

--- a/code/learning/human-languages/tamil/book/chapters/ch10-days.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch10-days.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:1e54c48f58723696
+% canonical-source-hash: fnv1a64:2538dae6127ff3d7
 % canonical-lessons: TA-C10-vaara-kizhamai
 
 \chapter{Days of the Week}
@@ -8,7 +8,7 @@
 This chapter is generated from the canonical micro-lessons used by Language Ladder.
 Each section stays independently resumable and preserves the authored prerequisite order.
 
-\section[\ta{திங்கள்} \ta{செவ்வாய்} \ta{புதன்} \ta{வியாழன்} \ta{வெள்ளி} \ta{சனி} \ta{ஞாயிறு}]{\ta{திங்கள்} to \ta{ஞாயிறு} — the week, home-grown and borrowed together}
+\section[\ta{திங்கள்}–\ta{ஞாயிறு}]{\ta{திங்கள்}–\ta{ஞாயிறு} — a home-grown and borrowed week}
 
 \label{lesson:TA-C10-vaara-kizhamai}
 
@@ -22,17 +22,17 @@ Each section stays independently resumable and preserves the authored prerequisi
 Every Tamil weekday ends in \textbf{\ta{கிழமை}} (\emph{kizhamai}), "\textbf{day}" — a native Dravidian word, not the Sanskrit \textbf{\ta{வாரம்}} (\emph{vāram}) that Hindi, Kannada, and Telugu build on (though Tamil also keeps a more formal, Sanskritic \emph{-vāram} set alongside this everyday one):
 
 \noindent
-\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
-\textbf{Tamil} & \textbf{planet-word} & \textbf{meaning of the planet-word} & \textbf{source} \\
+\textbf{Tamil weekday} & \textbf{planet-word, meaning, and source} \\
 \midrule
-\textbf{\ta{திங்கள்கிழமை}} & \emph{thiṅgaḷ} & "\textbf{Moon}" & Tamil's \textbf{own} word for moon \\
-\textbf{\ta{செவ்வாய்க்கிழமை}} & \emph{cevvāy} & traditionally read as "\textbf{the red one}" & likely Tamil's \textbf{own} descriptive name for Mars \\
-\textbf{\ta{புதன்கிழமை}} & \emph{pudhaṉ} & \textbf{Mercury} & borrowed from Sanskrit \textbf{Budha} \\
-\textbf{\ta{வியாழக்கிழமை}} & \emph{viyāzhaṉ} & \textbf{Jupiter} & likely from Sanskrit, via a name for \textbf{Bṛhaspati} \\
-\textbf{\ta{வெள்ளிக்கிழமை}} & \emph{veḷḷi} & traditionally read as "\textbf{silver}" & likely Tamil's \textbf{own} descriptive name for Venus \\
-\textbf{\ta{சனிக்கிழமை}} & \emph{saṉi} & \textbf{Saturn} & borrowed from Sanskrit \textbf{Śani} \\
-\textbf{\ta{ஞாயிற்றுக்கிழமை}} & \emph{ñāyiṟu} & "\textbf{Sun}" & Tamil's \textbf{own} word for sun \\
+\textbf{\ta{திங்கள்கிழமை}} & \emph{thiṅgaḷ}, "\textbf{Moon}" — Tamil's \textbf{own} word \\
+\textbf{\ta{செவ்வாய்க்கிழமை}} & \emph{cevvāy}, traditionally "\textbf{the red one}" — likely Tamil's \textbf{own} descriptive name \\
+\textbf{\ta{புதன்கிழமை}} & \emph{pudhaṉ}, \textbf{Mercury} — borrowed from Sanskrit \textbf{Budha} \\
+\textbf{\ta{வியாழக்கிழமை}} & \emph{viyāzhaṉ}, \textbf{Jupiter} — likely from Sanskrit, via a name for \textbf{Bṛhaspati} \\
+\textbf{\ta{வெள்ளிக்கிழமை}} & \emph{veḷḷi}, traditionally "\textbf{silver}" — likely Tamil's \textbf{own} descriptive name \\
+\textbf{\ta{சனிக்கிழமை}} & \emph{saṉi}, \textbf{Saturn} — borrowed from Sanskrit \textbf{Śani} \\
+\textbf{\ta{ஞாயிற்றுக்கிழமை}} & \emph{ñāyiṟu}, "\textbf{Sun}" — Tamil's \textbf{own} word \\
 \bottomrule
 \end{tabularx}
 \end{grammarlens}

--- a/code/learning/human-languages/tamil/book/chapters/ch12-family.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch12-family.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:c60c5953173c6f66
+% canonical-source-hash: fnv1a64:37498296b121ed1e
 % canonical-lessons: TA-C12-kudumbam
 
 \chapter{Family}
@@ -8,14 +8,14 @@
 This chapter is generated from the canonical micro-lessons used by Language Ladder.
 Each section stays independently resumable and preserves the authored prerequisite order.
 
-\section[\ta{அப்பா} \ta{அம்மா} \ta{அண்ணன்} \ta{தம்பி} \ta{அக்கா} \ta{தங்கை}]{\ta{அப்பா}, \ta{அம்மா}, and four ways to say "brother/sister"}
+\section[\ta{அப்பா} \ta{அம்மா} \ta{அண்ணன்} \ta{தம்பி} \ta{அக்கா} \ta{தங்கை}]{\ta{அப்பா}, \ta{அம்மா}, and four sibling words}
 
 \label{lesson:TA-C12-kudumbam}
 
 
 
 \begin{quote}
-\textbf{Warm-up.} {[}PAUSE 2s{]} You've learned Spanish's \emph{hermano/hermana} and French's \emph{frère/sœur} — one word each for "brother" and "sister." Tamil asks a question those languages never do: \textbf{is this sibling older or younger than you?}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You've learned Spanish \emph{hermano} and \emph{hermana}, plus French \emph{frère} and \emph{sœur} — one word each for "brother" and "sister." Tamil asks a question those languages never do: \textbf{is this sibling older or younger than you?}
 \end{quote}
 
 \begin{cousinweb}

--- a/code/learning/human-languages/tamil/book/chapters/ch20-numbers-and-weather.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch20-numbers-and-weather.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:974d434fad0acba2
+% canonical-source-hash: fnv1a64:fa1b550899c021f3
 % canonical-lessons: TA-C20-pathinondru-irupathu, TA-C20-vaanilai
 
 \chapter{Numbers Eleven to Twenty and Weather}
@@ -8,7 +8,7 @@
 This chapter is generated from the canonical micro-lessons used by Language Ladder.
 Each section stays independently resumable and preserves the authored prerequisite order.
 
-\section[\ta{பதினொன்று} — \ta{இருபது}]{\ta{பதினொன்று}, \ta{இருபது} — Dravidian's shared, transparent twenty}
+\section[\ta{பதினொன்று} — \ta{இருபது}]{\ta{பதினொன்று}–\ta{இருபது} — shared Dravidian patterns}
 
 \label{lesson:TA-C20-pathinondru-irupathu}
 

--- a/code/learning/human-languages/tamil/book/chapters/ch29-good-morning.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch29-good-morning.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:98b7381596bab2bd
+% canonical-source-hash: fnv1a64:6c788bc0104707ff
 % canonical-lessons: TA-C29-kaalai-vanakkam
 
 \chapter{Good Morning}
@@ -8,7 +8,7 @@
 This chapter is generated from the canonical micro-lessons used by Language Ladder.
 Each section stays independently resumable and preserves the authored prerequisite order.
 
-\section[\ta{காலை} \ta{வணக்கம்}]{\ta{காலை} \ta{வணக்கம்} (kālai vaṇakkam) — "morning greetings," built from two words you already know}
+\section[\ta{காலை} \ta{வணக்கம்}]{\ta{காலை} \ta{வணக்கம்} — "morning greetings"}
 
 \label{lesson:TA-C29-kaalai-vanakkam}
 
@@ -36,5 +36,12 @@ Here's the honest structural surprise: Hindi, Kannada, Telugu, and Malayalam eac
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
-{[}PAUSE 3s{]} What two already-known words does \ta{காலை} \ta{வணக்கம்} build from? (\ta{காலை}, "morning" + \ta{வணக்கம்}, "reverence/hello.") Does Tamil's morning greeting follow the śubha-equivalent + time-word pattern used by Hindi/Kannada/Telugu/Malayalam? (\textbf{No} — it's simply \ta{வணக்கம்}, Tamil's own general greeting, specified with \ta{காலை} in front.) Is the "suprabhatham as a casual alternative" claim confirmed? (\textbf{No} — it appears on neither of the two sources actually fetched; deliberately not asserted here.)
+{[}PAUSE 3s{]}
+
+\begin{itemize}
+\raggedright
+  \item What two known words build \ta{காலை} \ta{வணக்கம்}? (\textbf{\ta{காலை}}, "morning" + \textbf{\ta{வணக்கம்}}, "reverence/hello.")
+  \item Does it follow the śubha-equivalent + time-word pattern used by Hindi, Kannada, Telugu, and Malayalam? (\textbf{No} — \ta{காலை} simply specifies Tamil's own general greeting, \ta{வணக்கம்}.)
+  \item Is "suprabhatham" confirmed as a casual alternative? (\textbf{No} — neither fetched source supports that claim, so this lesson does not assert it.)
+\end{itemize}
 \end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch30-good-evening.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch30-good-evening.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:f4dbb1b65e6b99db
+% canonical-source-hash: fnv1a64:f5c2a578b5b6df4d
 % canonical-lessons: TA-C30-maalai-vanakkam
 
 \chapter{Good Evening}
@@ -8,7 +8,7 @@
 This chapter is generated from the canonical micro-lessons used by Language Ladder.
 Each section stays independently resumable and preserves the authored prerequisite order.
 
-\section[\ta{மாலை} \ta{வணக்கம்}]{\ta{மாலை} \ta{வணக்கம்} (mālai vaṇakkam) — "evening greetings," the same pattern, re-verified}
+\section[\ta{மாலை} \ta{வணக்கம்}]{\ta{மாலை} \ta{வணக்கம்} — "evening greetings"}
 
 \label{lesson:TA-C30-maalai-vanakkam}
 

--- a/code/learning/human-languages/tamil/book/preamble.tex
+++ b/code/learning/human-languages/tamil/book/preamble.tex
@@ -25,6 +25,7 @@
 \usepackage{longtable}
 \usepackage{tabularx}
 \usepackage{array}
+\setlength{\tabcolsep}{5pt}
 \usepackage[hidelinks]{hyperref}
 \usepackage{titlesec}
 
@@ -33,21 +34,95 @@
 \setotherlanguage{tamil}
 \setotherlanguage{arabic}
 
-% Vendored Tamil font (../../_fonts/ from <lang>/book/).
-\newfontfamily\tamilfont[Path=../../_fonts/, Script=Tamil]{NotoSansTamil-Static.ttf}
+% Vendored static script fonts. Explicitly map every requested shape to the
+% same complete glyph file so bold or italic teaching context cannot fall back
+% to a system font or emit a substitution warning.
+\newfontfamily\tamilfont[
+  Path=../../_fonts/,
+  Script=Tamil,
+  BoldFont=NotoSansTamil-Static.ttf,
+  ItalicFont=NotoSansTamil-Static.ttf,
+  BoldItalicFont=NotoSansTamil-Static.ttf
+]{NotoSansTamil-Static.ttf}
 
 % Inline Tamil snippet within English text.
 \newcommand{\ta}[1]{\texttamil{#1}}
-\newfontfamily\telugufont[Path=../../_fonts/, Script=Telugu]{NotoSansTelugu-Static.ttf}
+\newfontfamily\telugufont[
+  Path=../../_fonts/,
+  Script=Telugu,
+  BoldFont=NotoSansTelugu-Static.ttf,
+  ItalicFont=NotoSansTelugu-Static.ttf,
+  BoldItalicFont=NotoSansTelugu-Static.ttf
+]{NotoSansTelugu-Static.ttf}
 \newcommand{\te}[1]{{\telugufont #1}}
-\newfontfamily\kannadafont[Path=../../_fonts/, Script=Kannada]{NotoSansKannada-Static.ttf}
+\newfontfamily\kannadafont[
+  Path=../../_fonts/,
+  Script=Kannada,
+  BoldFont=NotoSansKannada-Static.ttf,
+  ItalicFont=NotoSansKannada-Static.ttf,
+  BoldItalicFont=NotoSansKannada-Static.ttf
+]{NotoSansKannada-Static.ttf}
 \newcommand{\ka}[1]{{\kannadafont #1}}
-\newfontfamily\malayalamfont[Path=../../_fonts/, Script=Malayalam]{NotoSansMalayalam-Static.ttf}
+\newfontfamily\malayalamfont[
+  Path=../../_fonts/,
+  Script=Malayalam,
+  BoldFont=NotoSansMalayalam-Static.ttf,
+  ItalicFont=NotoSansMalayalam-Static.ttf,
+  BoldItalicFont=NotoSansMalayalam-Static.ttf
+]{NotoSansMalayalam-Static.ttf}
 \newcommand{\ml}[1]{{\malayalamfont #1}}
-\newfontfamily\devanagarifont[Path=../../_fonts/, Script=Devanagari]{NotoSansDevanagari-Static.ttf}
+\newfontfamily\devanagarifont[
+  Path=../../_fonts/,
+  Script=Devanagari,
+  BoldFont=NotoSansDevanagari-Static.ttf,
+  ItalicFont=NotoSansDevanagari-Static.ttf,
+  BoldItalicFont=NotoSansDevanagari-Static.ttf
+]{NotoSansDevanagari-Static.ttf}
 \newcommand{\dv}[1]{{\devanagarifont #1}}
-\newfontfamily\arabicfont[Path=../../_fonts/, Script=Arabic]{NotoNaskhArabic-Static.ttf}
+\newfontfamily\arabicfont[
+  Path=../../_fonts/,
+  Script=Arabic,
+  BoldFont=NotoNaskhArabic-Static.ttf,
+  ItalicFont=NotoNaskhArabic-Static.ttf,
+  BoldItalicFont=NotoNaskhArabic-Static.ttf
+]{NotoNaskhArabic-Static.ttf}
 \newcommand{\ar}[1]{\textarabic{#1}}
+\pdfstringdefDisableCommands{%
+  \def\ta#1{#1}% Keep script text while dropping font-only presentation.
+  \def\te#1{#1}%
+  \def\ka#1{#1}%
+  \def\ml#1{#1}%
+  \def\dv#1{#1}%
+  \def\ar#1{#1}%
+  \def\tamilfont{}%
+  \def\telugufont{}%
+  \def\kannadafont{}%
+  \def\malayalamfont{}%
+  \def\devanagarifont{}%
+  \def\arabicfont{}%
+}
+
+% Micro-lessons intentionally end at natural pause points instead of stretching
+% their callout boxes to force every page to the same depth. The small reserve
+% also lets prose choose a cleaner line break before it exceeds the measure.
+\raggedbottom
+\emergencystretch=2em
+\hbadness=2000
+
+% Polyglossia's bidi support can leave running heads on the blank verso that
+% book.cls inserts before an open-right chapter. Keep the print-friendly verso,
+% but make it truly empty.
+\makeatletter
+\renewcommand{\cleardoublepage}{%
+  \clearpage
+  \if@twoside
+    \ifodd\c@page\else
+      \hbox{}\thispagestyle{empty}\newpage
+      \if@twocolumn\hbox{}\newpage\fi
+    \fi
+  \fi
+}
+\makeatother
 
 \hypersetup{
   pdftitle={Tamil, Step by Step, Root by Root},

--- a/code/learning/human-languages/tamil/lessons/TA-C10-vaara-kizhamai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C10-vaara-kizhamai.md
@@ -5,7 +5,7 @@ spine_node: SPINE-TIME-OF-DAY
 sequence: 300
 chapter: 10
 type: word
-headword: திங்கள் செவ்வாய் புதன் வியாழன் வெள்ளி சனி ஞாயிறு
+headword: திங்கள்–ஞாயிறு
 gloss: the seven weekdays — a mix of Tamil's OWN planet-words and Sanskrit borrowings
 concept_tag: TA-DAYS-WEEK
 prerequisites: [TA-C09-sorry-register]
@@ -28,7 +28,7 @@ variety: standard-colloquial
 reviews_of: [TA-C09-sorry-register, TA-C09-mannikkavum]
 ---
 
-# திங்கள் to ஞாயிறு — the week, home-grown and borrowed together
+# திங்கள்–ஞாயிறு — a home-grown and borrowed week
 
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[TA-PRAGMATICS-SORRY-REGISTER-01] -->
@@ -46,15 +46,15 @@ Dravidian word, not the Sanskrit **வாரம்** (*vāram*) that Hindi, Kann
 Telugu build on (though Tamil also keeps a more formal, Sanskritic
 *-vāram* set alongside this everyday one):
 
-| Tamil | planet-word | meaning of the planet-word | source |
-|---|---|---|---|
-| **திங்கள்கிழமை** | *thiṅgaḷ* | "**Moon**" | Tamil's **own** word for moon |
-| **செவ்வாய்க்கிழமை** | *cevvāy* | traditionally read as "**the red one**" | likely Tamil's **own** descriptive name for Mars |
-| **புதன்கிழமை** | *pudhaṉ* | **Mercury** | borrowed from Sanskrit **Budha** |
-| **வியாழக்கிழமை** | *viyāzhaṉ* | **Jupiter** | likely from Sanskrit, via a name for **Bṛhaspati** |
-| **வெள்ளிக்கிழமை** | *veḷḷi* | traditionally read as "**silver**" | likely Tamil's **own** descriptive name for Venus |
-| **சனிக்கிழமை** | *saṉi* | **Saturn** | borrowed from Sanskrit **Śani** |
-| **ஞாயிற்றுக்கிழமை** | *ñāyiṟu* | "**Sun**" | Tamil's **own** word for sun |
+| Tamil weekday | planet-word, meaning, and source |
+|---|---|
+| **திங்கள்கிழமை** | *thiṅgaḷ*, "**Moon**" — Tamil's **own** word |
+| **செவ்வாய்க்கிழமை** | *cevvāy*, traditionally "**the red one**" — likely Tamil's **own** descriptive name |
+| **புதன்கிழமை** | *pudhaṉ*, **Mercury** — borrowed from Sanskrit **Budha** |
+| **வியாழக்கிழமை** | *viyāzhaṉ*, **Jupiter** — likely from Sanskrit, via a name for **Bṛhaspati** |
+| **வெள்ளிக்கிழமை** | *veḷḷi*, traditionally "**silver**" — likely Tamil's **own** descriptive name |
+| **சனிக்கிழமை** | *saṉi*, **Saturn** — borrowed from Sanskrit **Śani** |
+| **ஞாயிற்றுக்கிழமை** | *ñāyiṟu*, "**Sun**" — Tamil's **own** word |
 
 ## Why it's said this way: Be honest about the mix
 <!-- hl-knowledge: introduces=[TA-PRAGMATICS-VAARA-KIZHAMAI-02]; assesses=[] -->

--- a/code/learning/human-languages/tamil/lessons/TA-C12-kudumbam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C12-kudumbam.md
@@ -28,13 +28,13 @@ variety: standard-colloquial
 reviews_of: [TA-C11-nirangal]
 ---
 
-# அப்பா, அம்மா, and four ways to say "brother/sister"
+# அப்பா, அம்மா, and four sibling words
 
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-NIRANGAL-01] -->
 
-[PAUSE 2s] You've learned Spanish's *hermano/hermana* and French's
-*frère/sœur* — one word each for "brother" and "sister." Tamil asks a
+[PAUSE 2s] You've learned Spanish *hermano* and *hermana*, plus French
+*frère* and *sœur* — one word each for "brother" and "sister." Tamil asks a
 question those languages never do: **is this sibling older or younger than
 you?**
 

--- a/code/learning/human-languages/tamil/lessons/TA-C20-pathinondru-irupathu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C20-pathinondru-irupathu.md
@@ -28,7 +28,7 @@ variety: standard-colloquial
 reviews_of: [TA-C19-age-register-grammar, TA-C19-vayathu]
 ---
 
-# பதினொன்று, இருபது — Dravidian's shared, transparent twenty
+# பதினொன்று–இருபது — shared Dravidian patterns
 
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[TA-GRAMMAR-AGE-REGISTER-GRAMMAR-01] -->

--- a/code/learning/human-languages/tamil/lessons/TA-C29-kaalai-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C29-kaalai-vanakkam.md
@@ -28,7 +28,7 @@ variety: standard-colloquial
 reviews_of: [TA-C26-kaalai, TA-C01-vanakkam-family-register, TA-C01-vanakkam]
 ---
 
-# காலை வணக்கம் (kālai vaṇakkam) — "morning greetings," built from two words you already know
+# காலை வணக்கம் — "morning greetings"
 
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-KAALAI-01] -->
@@ -79,11 +79,11 @@ deliberately **not** asserted here.
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-KAALAI-01, TA-LEX-KAALAI-VANAKKAM-01, TA-PRAGMATICS-KAALAI-VANAKKAM-02] -->
 
-[PAUSE 3s] What two already-known words does காலை வணக்கம் build
-from? (காலை, "morning" + வணக்கம், "reverence/hello.") Does
-Tamil's morning greeting follow the śubha-equivalent + time-word
-pattern used by Hindi/Kannada/Telugu/Malayalam? (**No** — it's simply
-வணக்கம், Tamil's own general greeting, specified with காலை in
-front.) Is the "suprabhatham as a casual alternative" claim confirmed?
-(**No** — it appears on neither of the two sources actually fetched;
-deliberately not asserted here.)
+[PAUSE 3s]
+- What two known words build காலை வணக்கம்? (**காலை**, "morning" +
+  **வணக்கம்**, "reverence/hello.")
+- Does it follow the śubha-equivalent + time-word pattern used by Hindi,
+  Kannada, Telugu, and Malayalam? (**No** — காலை simply specifies Tamil's
+  own general greeting, வணக்கம்.)
+- Is "suprabhatham" confirmed as a casual alternative? (**No** — neither
+  fetched source supports that claim, so this lesson does not assert it.)

--- a/code/learning/human-languages/tamil/lessons/TA-C30-maalai-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C30-maalai-vanakkam.md
@@ -28,7 +28,7 @@ variety: standard-colloquial
 reviews_of: [TA-C27-maalai, TA-C29-kaalai-vanakkam]
 ---
 
-# மாலை வணக்கம் (mālai vaṇakkam) — "evening greetings," the same pattern, re-verified
+# மாலை வணக்கம் — "evening greetings"
 
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-MAALAI-01, TA-LEX-KAALAI-VANAKKAM-01] -->


### PR DESCRIPTION
## Summary
- make every Tamil and comparison-script font shape deterministic with vendored static fonts and PDF-safe bookmark commands
- remove duplicate practice destinations, layout warnings, and header-only open-right versos
- keep book/app content aligned by shortening five canonical headings, simplifying the weekday table, and regenerating verified chapter hashes

## Validation
- `human-language-data`: build, generated-book check, 84 tests, curriculum report
- `language-ladder`: production build and 464 tests
- forced XeLaTeX build: 117 pages; zero missing glyphs, overfull or underfull boxes, duplicate labels, Hyperref warnings, LaTeX warnings, or font warnings
- PDF: correct title/author, 106 outline entries, 18 intentional empty pages, zero schema leaks
- all 117 rendered pages visually inspected
- `git diff --check`

## Follow-up
HL-B34 is next: publish Latin Chapters 2–36 from the canonical app corpus.