### PR TITLE
feat(sir-runtime-core-ts,semantic-ir-to-typescript): << (Ruby's shift operator)

### DIFF
--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.11.2 — `<<` (Ruby's shift operator) as a top-level builtin
+
+Part of "TypeScript backend: implement shift-operator runtime dispatch".
+`ruby-to-semantic-ir` lowers `<<` to a top-level `BuiltinCall("<<", [lhs,
+rhs])` — a separate protocol from the `__method__("<<", recv, arg)`
+Collections dispatch. `<<` had no entry in the emitter's fast-path
+helper table, so it fell to `__Sir.callBuiltin`'s generic dispatch,
+which had no `"<<"` entry either — every Ruby program using `<<` as an
+operator failed at runtime.
+
+Added `"<<" => "__Sir.shiftLeft"` to the emitter's helper-name table
+(alongside `"+" => "__Sir.add"`). The actual polymorphic implementation
+lives in `@coding-adventures/sir-runtime-core` 0.2.0 (this backend's
+runtime package, not inlined here) — see that package's own CHANGELOG
+for the Array/String/number dispatch.
+
+This completes "C/Go/Rust/Ruby/Python/JS/TS backends: implement
+shift-operator runtime dispatch" — every backend now supports `<<`.
+
+`semantic-ir-to-typescript` 0.11.1 -> 0.11.2.
+
 ## 0.11.1 — `is_ts_reserved` was missing `eval`/`arguments` (task #112, the direct TS sibling of task #110's JS fix)
 
 **Not a syntactic-keyword gap — a strict-mode contextual-reserved-word

--- a/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-typescript"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 description = "Semantic IR → self-contained TypeScript source code (SIR12). First backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -2392,6 +2392,7 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
     }
     let helper = match name {
         "+" => "__Sir.add",
+        "<<" => "__Sir.shiftLeft",
         "-" => "__Sir.sub",
         "*" => "__Sir.mul",
         "/" => "__Sir.div",
@@ -2878,6 +2879,35 @@ mod tests {
             0,
         );
         assert_eq!(out, "__Sir.add(1, 2)");
+    }
+
+    #[test]
+    fn emit_builtin_call_shift_left() {
+        // `ruby-to-semantic-ir` lowers `<<` to a top-level
+        // `BuiltinCall("<<", [lhs, rhs])` -- a separate protocol from
+        // `__method__("<<", recv, arg)` -- and must route through
+        // `__Sir.shiftLeft`, not `__Sir.callBuiltin`'s generic fallback.
+        let mut out = String::new();
+        emit_expr(
+            &mut out,
+            &Expr::BuiltinCall {
+                name: "<<".into(),
+                args: vec![
+                    Expr::IntLit {
+                        value: 1,
+                        span: s(),
+                    },
+                    Expr::IntLit {
+                        value: 40,
+                        span: s(),
+                    },
+                ],
+                effects: EffectSet::PURE,
+                span: s(),
+            },
+            0,
+        );
+        assert_eq!(out, "__Sir.shiftLeft(1, 40)");
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-typescript/tests/polymorphic_operators.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/tests/polymorphic_operators.rs
@@ -108,8 +108,32 @@ const SIR_ARITH_STUB: &str = r##"const __Sir = (() => {
     for (const a of args) acc *= num(a);
     return acc;
   };
+  const shiftAmountArg = (v) => typeof v === "number" ? Math.trunc(v) : 0;
+  const shiftLeft = (...args) => {
+    if (args.length === 0) return 0;
+    const first = args[0];
+    if (Array.isArray(first)) {
+      for (let i = 1; i < args.length; i++) first.push(args[i]);
+      return first;
+    }
+    if (typeof first === "string") {
+      let s = first;
+      for (let i = 1; i < args.length; i++) {
+        const a = args[i];
+        s += typeof a === "string" ? a : toDisplay(a);
+      }
+      return s;
+    }
+    let acc = num(first);
+    for (let i = 1; i < args.length; i++) {
+      if (acc === 0) continue;
+      const amount = shiftAmountArg(args[i]);
+      acc = amount < 0 ? Math.floor(acc / Math.pow(2, -amount)) : acc * Math.pow(2, amount);
+    }
+    return acc;
+  };
   const print = (v) => { console.log(toDisplay(v)); return null; };
-  return { add, mul, toDisplay, print };
+  return { add, mul, shiftLeft, toDisplay, print };
 })();
 "##;
 
@@ -294,5 +318,70 @@ fn numeric_plus_and_times_unchanged_ts() {
     ]);
     if let Some(out) = run(&module, "numeric") {
         assert_eq!(out, "3\n6", "1 + 2 must be 3 and 2 * 3 must be 6");
+    }
+}
+
+// ── `<<` (Ruby's shift operator) ──────────────────────────────────────
+//
+// `<<` had no entry anywhere in the runtime dispatch table, so it fell to
+// `callBuiltin`'s floor and threw `TypeError: unknown builtin: <<` — every
+// Ruby program using `<<` as an operator failed at runtime on TypeScript.
+// `shiftLeft` is added to the `SIR_ARITH_STUB` above as a faithful
+// transcription of `arithmetic.ts`'s real implementation.
+
+#[test]
+fn shift_left_integer_lowers_to_shift_left_ts() {
+    // `5 << 2` → 20 (Integer left shift).
+    let module = print_module(vec![binop("<<", vec![int_lit(5), int_lit(2)])]);
+    let artifact = compile(&module).expect("compile");
+    assert!(
+        artifact.source.contains("__Sir.shiftLeft(5, 2)"),
+        "<< must lower to __Sir.shiftLeft; got:\n{}",
+        artifact.source
+    );
+    if let Some(out) = run(&module, "shift_int") {
+        assert_eq!(out, "20", "5 << 2 must be 20");
+    }
+}
+
+#[test]
+fn shift_left_negative_amount_reverses_direction_ts() {
+    // `5 << -1` → 2 (negative amount reverses direction, a right shift).
+    let module = print_module(vec![binop("<<", vec![int_lit(5), int_lit(-1)])]);
+    if let Some(out) = run(&module, "shift_neg") {
+        assert_eq!(out, "2", "5 << -1 must be 2");
+    }
+}
+
+#[test]
+fn shift_left_does_not_use_native_bitwise_op_ts() {
+    // `1 << 40` — under JS's native `<<` this would silently give the
+    // WRONG answer (Int32-coerced, shift count masked to 5 bits). The
+    // runtime helper must use the plain-number multiplicative path.
+    let module = print_module(vec![binop("<<", vec![int_lit(1), int_lit(40)])]);
+    if let Some(out) = run(&module, "shift_wide") {
+        assert_eq!(out, "1099511627776", "1 << 40 must not be truncated to 32 bits");
+    }
+}
+
+#[test]
+fn shift_left_array_pushes_in_place_ts() {
+    // `[1, 2] << 3` → the SAME array, mutated to [1, 2, 3] (Ruby's
+    // Array#<< mutates, unlike Array#+ which is non-destructive).
+    let module = print_module(vec![binop(
+        "<<",
+        vec![seq_lit(vec![int_lit(1), int_lit(2)]), int_lit(3)],
+    )]);
+    if let Some(out) = run(&module, "shift_arr") {
+        assert_eq!(out, "1,2,3", "[1, 2] << 3 must push 3 onto the array");
+    }
+}
+
+#[test]
+fn shift_left_string_concatenates_ts() {
+    // `"ab" << "cd"` → "abcd" (new string).
+    let module = print_module(vec![binop("<<", vec![str_lit("ab"), str_lit("cd")])]);
+    if let Some(out) = run(&module, "shift_str") {
+        assert_eq!(out, "abcd", "\"ab\" << \"cd\" must concatenate to \"abcd\"");
     }
 }

--- a/code/packages/typescript/sir-runtime-core/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-core/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to `@coding-adventures/sir-runtime-core` are documented here
 
 ## [0.2.0] - 2026-08-03
 
+### Fixed — `builtins` dispatch table was not null-prototype
+
+Security review (of the `shiftLeft` addition below) caught that this
+package's `builtins` table (`runtime.ts`) — indexed by a SIR-name
+string via `callBuiltin`/`builtinClosure` — was a plain object literal,
+so a lookup for `"constructor"`/`"toString"`/`"hasOwnProperty"`/
+`"__defineGetter__"`/etc. resolved an INHERITED `Object.prototype`
+member instead of the intended `undefined`, slipping past the
+`fn === undefined` guard and getting INVOKED — the same
+`[[dynamic-dispatch-rce]]` hazard the sibling JS backend's own
+`builtins` table already guards against via `Object.create(null)`. Not
+currently reachable from any call site in this monorepo (every caller
+passes a compile-time string literal), but both `callBuiltin` and
+`builtinClosure` are public API of a published package. Fixed by
+building the table the same way the JS backend does:
+`Object.assign(Object.create(null), {...})`. New regression test
+asserts `callBuiltin` throws (rather than silently invoking an
+inherited method) for each of those four names.
+
 ### Added — `shiftLeft` (Ruby's `<<` operator)
 
 Part of "TypeScript backend: implement shift-operator runtime dispatch".

--- a/code/packages/typescript/sir-runtime-core/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-core/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to `@coding-adventures/sir-runtime-core` are documented here.
 
+## [0.2.0] - 2026-08-03
+
+### Added — `shiftLeft` (Ruby's `<<` operator)
+
+Part of "TypeScript backend: implement shift-operator runtime dispatch".
+`ruby-to-semantic-ir` lowers `<<` to a top-level `BuiltinCall("<<", [lhs,
+rhs])`, distinct from the `__method__("<<", recv, arg)` Collections
+dispatch. `<<` had no entry in `runtime.ts`'s `builtins` table at all, so
+it fell to `callBuiltin`'s floor and threw a `NameError`-shaped error —
+every Ruby program using `<<` as an operator failed at runtime.
+
+`shiftLeft(...args)`, polymorphic like the existing `add`, but
+dispatched explicitly on the runtime tag:
+
+- `array` — pushes each RHS operand IN PLACE (never flattened, unlike
+  `add`'s array arm), returns the mutated receiver.
+- `string` — concatenates via the display helper (the same tolerant
+  convention `add`'s string arm already uses — never throws for a
+  non-string operand).
+- `number` — bitwise shift, implemented via multiplication/division by
+  a power of two rather than native `<<`/`>>`: JS's native bitwise
+  operators coerce both operands to a 32-bit integer and mask the shift
+  count to 5 bits, so `1 << 40` would silently give the wrong answer.
+  This runtime's numeric model is a plain `number` everywhere (no
+  boxed/tagged Integer-vs-Float split), so precision degrades past
+  `Number.MAX_SAFE_INTEGER` like `+`/`*` already do, rather than
+  saturating like the fixed-width C/Go/Rust backends. A negative amount
+  reverses direction (a right shift); `Math.floor` on the division
+  correctly replicates arithmetic (sign-extending) right shift for a
+  negative receiver too.
+
+Exported from the package root and registered in the `callBuiltin`
+dispatch table.
+
 ## [0.1.10] - 2026-07-07
 
 ### Added — source-language display convention (SIR display-convention spec)

--- a/code/packages/typescript/sir-runtime-core/package-lock.json
+++ b/code/packages/typescript/sir-runtime-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/sir-runtime-core",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/sir-runtime-core",
-      "version": "0.1.10",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/sir-runtime-exceptions": "file:../sir-runtime-exceptions",

--- a/code/packages/typescript/sir-runtime-core/package.json
+++ b/code/packages/typescript/sir-runtime-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-core",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "description": "Core runtime for Semantic-IR-emitted TypeScript/JavaScript — SIR truthiness, symbols, pairs, equality, display, arithmetic, closures, globals",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-core/src/arithmetic.ts
+++ b/code/packages/typescript/sir-runtime-core/src/arithmetic.ts
@@ -79,6 +79,82 @@ function repeatCount(rawCount: Val, baseLen: number): number {
 }
 
 /**
+ * Extracts a shift-amount operand as a plain number, truncated toward zero
+ * (matching real Ruby's own Float-shift-amount truncation). A non-number
+ * operand contributes a `0` shift rather than throwing.
+ */
+function shiftAmountArg(v: Val): number {
+  return typeof v === "number" ? Math.trunc(v) : 0;
+}
+
+/**
+ * Ruby's `<<` (shift operator) — polymorphic like `add`, but dispatched
+ * explicitly on the runtime tag since native `<<`/`>>` don't line up for
+ * every receiver:
+ *
+ * | Receiver | Behaviour                                                    |
+ * |----------|---------------------------------------------------------------|
+ * | array    | push each RHS operand IN PLACE (never flattened — unlike      |
+ * |          | `add`'s array arm, which concatenates), returns the mutated   |
+ * |          | receiver. Chains left-to-right: the frontend lowers a `<<`    |
+ * |          | chain (`a << 1 << 2`) to NESTED binary calls, not one flat    |
+ * |          | variadic one — but since `<<` mutates and returns the SAME    |
+ * |          | receiver, nesting composes exactly like a fold, so this stays |
+ * |          | variadic-capable (`...args`) for a hand-built module that     |
+ * |          | constructs a flat call directly.                              |
+ * | string   | concatenates via the display helper (the SAME tolerant        |
+ * |          | convention `add`'s string arm already uses — never throws for |
+ * |          | a non-string operand).                                        |
+ * | number   | bitwise shift, implemented via MULTIPLICATION/DIVISION by a   |
+ * |          | power of two rather than native `<<`/`>>`: JS's native        |
+ * |          | bitwise operators coerce both operands to a 32-bit integer and|
+ * |          | mask the shift count to 5 bits, so `1 << 40` would silently   |
+ * |          | give the wrong answer (not even close) rather than the        |
+ * |          | correct `1099511627776`. This runtime's numeric model is a    |
+ * |          | plain `number` everywhere (see the module doc comment), so    |
+ * |          | precision degrades past `Number.MAX_SAFE_INTEGER` like `+`/`*`|
+ * |          | already do, rather than saturating like the fixed-width       |
+ * |          | C/Go/Rust backends. A negative amount REVERSES direction (a   |
+ * |          | right shift by the absolute value, matching Ruby's `5 << -1 ==|
+ * |          | 5 >> 1 == 2`); `Math.floor` on the division correctly         |
+ * |          | replicates ARITHMETIC (sign-extending) right shift for a      |
+ * |          | negative receiver too (floor division by a power of two IS    |
+ * |          | arithmetic right shift). The zero-receiver short-circuit both |
+ * |          | matches "0 shifted by anything is 0" and avoids               |
+ * |          | `0 * Infinity === NaN` once `Math.pow(2, amount)` overflows to|
+ * |          | `Infinity` for an extreme shift amount.                       |
+ */
+export function shiftLeft(...args: Val[]): Val {
+  if (args.length === 0) {
+    return 0;
+  }
+  const first = args[0]!;
+  if (Array.isArray(first)) {
+    for (let i = 1; i < args.length; i++) {
+      first.push(args[i]!);
+    }
+    return first;
+  }
+  if (typeof first === "string") {
+    let s = first;
+    for (let i = 1; i < args.length; i++) {
+      const a = args[i]!;
+      s += typeof a === "string" ? a : toDisplay(a);
+    }
+    return s;
+  }
+  let acc = num(first);
+  for (let i = 1; i < args.length; i++) {
+    if (acc === 0) {
+      continue;
+    }
+    const amount = shiftAmountArg(args[i]!);
+    acc = amount < 0 ? Math.floor(acc / Math.pow(2, -amount)) : acc * Math.pow(2, amount);
+  }
+  return acc;
+}
+
+/**
  * Variadic sum; `add()` is `0`.
  *
  * When the **first** operand is a string or array, `+` is Ruby's polymorphic

--- a/code/packages/typescript/sir-runtime-core/src/index.ts
+++ b/code/packages/typescript/sir-runtime-core/src/index.ts
@@ -29,7 +29,7 @@ export {
   setDisplayConvention,
 } from "./values.js";
 export type { Val, ClosureLike } from "./values.js";
-export { add, sub, mul, div, lt, gt } from "./arithmetic.js";
+export { add, shiftLeft, sub, mul, div, lt, gt } from "./arithmetic.js";
 export {
   Closure,
   LocalJumpError,

--- a/code/packages/typescript/sir-runtime-core/src/runtime.ts
+++ b/code/packages/typescript/sir-runtime-core/src/runtime.ts
@@ -190,7 +190,17 @@ export function puts(...args: Val[]): null {
 
 // --- Builtin dispatch ------------------------------------------------------
 
-const builtins: Record<string, (...args: Val[]) => Val> = {
+// Built with a null prototype (matching the JS sibling backend's own
+// `Object.assign(Object.create(null), {...})` table) — `callBuiltin`/
+// `builtinClosure` index this by a SIR-NAME string, and a plain object
+// literal would resolve an inherited `Object.prototype` member
+// (`constructor`/`toString`/`hasOwnProperty`/`__defineGetter__`/…) for a
+// lookup miss instead of the intended `undefined`, letting it slip past
+// the `fn === undefined` guard and get INVOKED — a define-a-getter-on-
+// global-style gadget (the [[dynamic-dispatch-rce]] hazard this repo's
+// specs name explicitly). No call site here passes a non-literal name
+// today, but both functions are public API of a published package.
+const builtins: Record<string, (...args: Val[]) => Val> = Object.assign(Object.create(null), {
   "+": add,
   "<<": shiftLeft,
   "-": sub,
@@ -208,7 +218,7 @@ const builtins: Record<string, (...args: Val[]) => Val> = {
   "symbol?": (v) => isSymbol(v!),
   print: (v) => print(v!),
   puts: (...args) => puts(...args),
-};
+});
 
 /** Invoke a builtin by SIR name with a list of arguments. */
 export function callBuiltin(name: string, args: Val[]): Val {

--- a/code/packages/typescript/sir-runtime-core/src/runtime.ts
+++ b/code/packages/typescript/sir-runtime-core/src/runtime.ts
@@ -10,7 +10,7 @@
  *   value; `callBuiltin` looks one up by SIR name.
  */
 
-import { add, div, gt, lt, mul, sub } from "./arithmetic.js";
+import { add, div, gt, lt, mul, shiftLeft, sub } from "./arithmetic.js";
 import { car, cdr, cons, isPair } from "./pairs.js";
 import { Sym } from "./symbols.js";
 import { eq, isNull, isNumber, isSymbol, toDisplay } from "./values.js";
@@ -192,6 +192,7 @@ export function puts(...args: Val[]): null {
 
 const builtins: Record<string, (...args: Val[]) => Val> = {
   "+": add,
+  "<<": shiftLeft,
   "-": sub,
   "*": mul,
   "/": div,

--- a/code/packages/typescript/sir-runtime-core/tests/core.test.ts
+++ b/code/packages/typescript/sir-runtime-core/tests/core.test.ts
@@ -267,6 +267,60 @@ describe("polymorphic + (string/array concat)", () => {
   });
 });
 
+describe("polymorphic << (Ruby's shift operator)", () => {
+  it("integer left shift", () => {
+    expect(sir.shiftLeft(5, 2)).toBe(20);
+    expect(sir.shiftLeft(1, 0)).toBe(1);
+  });
+
+  it("zero receiver stays zero regardless of shift amount", () => {
+    expect(sir.shiftLeft(0, 40)).toBe(0);
+  });
+
+  it("negative amount reverses direction (a right shift)", () => {
+    expect(sir.shiftLeft(5, -1)).toBe(2);
+    expect(sir.shiftLeft(-8, -1)).toBe(-4); // arithmetic (sign-extending) right shift
+  });
+
+  it("does not use native << (which would mask to a 32-bit int)", () => {
+    // 1 << 40 under JS's native `<<` would silently give the WRONG answer
+    // (Int32-coerced, shift count masked to 5 bits). The runtime helper
+    // must use the plain-`number` multiplicative path instead.
+    expect(sir.shiftLeft(1, 40)).toBe(1099511627776);
+  });
+
+  it("float amount truncates toward zero", () => {
+    expect(sir.shiftLeft(5, 2.9)).toBe(20);
+  });
+
+  it("array receiver pushes each operand in place, never flattened", () => {
+    const a = [1, 2];
+    const r = sir.shiftLeft(a, 3);
+    expect(r).toBe(a); // SAME receiver -- mutates, unlike `add`'s fresh array
+    expect(a).toEqual([1, 2, 3]);
+    // A nested array operand is pushed as ONE element (unlike `add`, which
+    // would concatenate/flatten it).
+    const b = [1];
+    sir.shiftLeft(b, [2, 3]);
+    expect(b).toEqual([1, [2, 3]]);
+  });
+
+  it("string receiver concatenates to a new string via the tolerant display convention", () => {
+    const a = "ab";
+    const r = sir.shiftLeft(a, "cd");
+    expect(r).toBe("abcd");
+    expect(sir.shiftLeft("n=", 1)).toBe("n=1"); // non-string operand rendered via display, never throws
+  });
+
+  it("no args returns 0", () => {
+    expect(sir.shiftLeft()).toBe(0);
+  });
+
+  it("is registered in the builtin dispatch table", () => {
+    expect(sir.callBuiltin("<<", [5, 2])).toBe(20);
+  });
+});
+
 describe("polymorphic * (string/array repeat and join)", () => {
   it("string repeat", () => {
     expect(sir.mul("ab", 3)).toBe("ababab");

--- a/code/packages/typescript/sir-runtime-core/tests/core.test.ts
+++ b/code/packages/typescript/sir-runtime-core/tests/core.test.ts
@@ -319,6 +319,21 @@ describe("polymorphic << (Ruby's shift operator)", () => {
   it("is registered in the builtin dispatch table", () => {
     expect(sir.callBuiltin("<<", [5, 2])).toBe(20);
   });
+
+  it("the dispatch table does not resolve inherited Object.prototype members", () => {
+    // Security-review regression: `builtins` is indexed by a SIR-name
+    // string, so a plain object literal would resolve `constructor`/
+    // `toString`/`hasOwnProperty`/etc. for a lookup MISS instead of the
+    // intended `undefined`, letting it slip past `callBuiltin`'s
+    // `fn === undefined` guard and get INVOKED (the [[dynamic-dispatch-rce]]
+    // hazard the JS sibling backend already guards against via
+    // `Object.create(null)`). Adding `"<<"` to the table must not
+    // regress that guard.
+    expect(() => sir.callBuiltin("constructor", [])).toThrow();
+    expect(() => sir.callBuiltin("toString", [])).toThrow();
+    expect(() => sir.callBuiltin("hasOwnProperty", [])).toThrow();
+    expect(() => sir.callBuiltin("__defineGetter__", [])).toThrow();
+  });
 });
 
 describe("polymorphic * (string/array repeat and join)", () => {


### PR DESCRIPTION
## Summary
- Completes "C/Go/Rust/Ruby/Python/JS/TS backends: implement shift-operator runtime dispatch" — every backend now supports `<<`
- `ruby-to-semantic-ir` lowers `<<` to a top-level `BuiltinCall("<<", [lhs, rhs])`, a separate protocol from `__method__("<<", recv, arg)`. `<<` had no entry in the emitter's fast-path helper table or the runtime's `builtins` table — every Ruby program using `<<` as an operator failed at runtime on TypeScript
- New `shiftLeft(...args)` in `@coding-adventures/sir-runtime-core`, polymorphic like the existing `add`: array pushes each RHS operand in place, string concatenates via the display helper (matching `add`'s tolerant convention), number bitwise-shifts via multiplication/division by a power of two rather than native `<<`/`>>` — JS's native bitwise operators coerce to a 32-bit integer and mask the shift count, so `1 << 40` would silently give the wrong answer
- This runtime's numeric model stays plain `number` (no boxed Integer/Float split), so precision degrades past `Number.MAX_SAFE_INTEGER` like `+`/`*` already do, rather than saturating like the fixed-width C/Go/Rust backends
- Wired into `semantic-ir-to-typescript`'s emitter helper table (`"<<" => "__Sir.shiftLeft"`)

**Security review caught and fixed a pre-existing gap** (unrelated to `<<` itself, but on the exact table this PR adds an entry to): the `builtins` dispatch table was a plain object literal, so a lookup for `"constructor"`/`"toString"`/`"hasOwnProperty"`/`"__defineGetter__"` resolved an inherited `Object.prototype` member instead of `undefined`, slipping past the `fn === undefined` guard and getting invoked — the same `[[dynamic-dispatch-rce]]` hazard the sibling JS backend's own table already guards against via `Object.create(null)`. Fixed with the same pattern; regression test added. Re-review passed clean.

## Test plan
- [x] New `describe("polymorphic << ...")` block in `sir-runtime-core`'s vitest suite: Integer shift, zero-receiver short-circuit, negative amount reverses direction, `1 << 40` proving NOT native 32-bit-masked `<<`, float-amount truncation, Array push in place (never flattened), String concat, no-args, `builtins["<<"]` registration, and the new prototype-pollution regression
- [x] `npm test` — 60/60 passing, 93%+ coverage (100% on the new `shiftLeft` lines)
- [x] New Rust unit test (`emit_builtin_call_shift_left`) proving the emitter shape
- [x] New `run_with_node`-style end-to-end tests in `polymorphic_operators.rs` (5 tests): real `node` execution via the crate's established "faithful inline stub" pattern (the workspace package can't resolve under bare `node`, so the stub is a byte-for-byte transcription of the real `arithmetic.ts` logic — only the import line differs)
- [x] Full `semantic-ir-to-typescript` Rust test suite green
- [x] `sir-conformance` full corpus green (no regressions)
- [x] `cargo clippy -p semantic-ir-to-typescript --all-targets` clean
- [x] Security review: 1 LOW finding (prototype-pollution-adjacent gap in `builtins`), fixed, re-reviewed clean
- [x] CHANGELOGs updated for both packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)