### PR TITLE
Add agent message schema version contracts

### DIFF
--- a/code/packages/rust/chief-of-staff-agent-discovery/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-agent-discovery/src/lib.rs
@@ -32,7 +32,7 @@ impl DiscoveredAgent {
     pub fn package(&self) -> &VerifiedAgentPackage {
         &self.package
     }
-    /// Borrow the parsed, authenticated schema-v1 manifest.
+    /// Borrow the parsed, authenticated legacy-v1 or current-v2 manifest.
     pub fn manifest(&self) -> &AgentManifest {
         &self.manifest
     }

--- a/code/packages/rust/chief-of-staff-agent-manifest/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-agent-manifest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Add schema-v2 per-channel payload-schema version declarations while retaining
+  strict parsing and deterministic rendering for installed schema-v1 packages.
+- Add a fail-closed originator/receiver channel compatibility check.
+
 ## 0.1.0 - 2026-08-03
 
 - Define the shared typed schema-v1 agent manifest contract.

--- a/code/packages/rust/chief-of-staff-agent-manifest/README.md
+++ b/code/packages/rust/chief-of-staff-agent-manifest/README.md
@@ -4,10 +4,33 @@ Pure, fail-closed codec for the D18 `manifest.json` contract. It is the shared
 boundary between Level 1 manifest generation, signed agent packages, discovery,
 and host registration.
 
-`parse_manifest` accepts schema version 1 only. It rejects malformed JSON,
-duplicate or unknown fields, invalid nested structures, unsupported capability
-pairs, and agents that read and write the same channel. The parsed type can be
-rendered back to deterministic schema-shaped JSON with `AgentManifest::to_json`.
+`parse_manifest` accepts installed legacy schema-v1 packages and current
+schema-v2 packages. V2 maps every declared read/write channel name to a positive
+payload-schema version. Versions are scoped by channel name, so a
+writer and reader are compatible only when both declare the same version for
+that channel. `require_channel_compatibility` provides that fail-closed wiring
+check; legacy manifests remain discoverable but cannot be treated as
+schema-compatible without an explicit upgrade.
+
+```json
+{
+  "version": 2,
+  "agent": "weather-agent",
+  "description": "Produces a concise local weather forecast.",
+  "privilege_tier": 0,
+  "channels": {
+    "reads": {"weather-requests": 1},
+    "writes": {"weather-reports": 2}
+  },
+  "capabilities": [],
+  "justification": "Uses only the declared encrypted weather channels."
+}
+```
+
+The codec rejects malformed JSON, duplicate or unknown fields, invalid nested
+structures, unsupported capability pairs, incomplete schema-version maps, and
+agents that read and write the same channel. Parsed manifests render back to
+deterministic schema-shaped JSON with `AgentManifest::to_json`.
 
 This package does not scan directories, verify package signatures, register
 agents, or perform any operating-system access. Those effects belong to the

--- a/code/packages/rust/chief-of-staff-agent-manifest/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-agent-manifest/src/lib.rs
@@ -7,10 +7,12 @@ use coding_adventures_json_parser::try_parse_json;
 use coding_adventures_json_serializer::{serialize_pretty, JsonSerializerError, SerializerConfig};
 use coding_adventures_json_value::{from_ast, JsonNumber, JsonValue};
 use core::fmt::{self, Display, Formatter};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Current agent-manifest schema version understood by this package.
-pub const MANIFEST_VERSION: i64 = 1;
+pub const MANIFEST_VERSION: i64 = 2;
+/// Oldest agent-manifest schema version accepted for installed packages.
+pub const LEGACY_MANIFEST_VERSION: i64 = 1;
 /// Canonical schema URL emitted by [`AgentManifest::to_json`].
 pub const MANIFEST_SCHEMA: &str = "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/agent_manifest.schema.json";
 /// Maximum accepted UTF-8 manifest size.
@@ -65,9 +67,11 @@ pub struct VaultAccess {
     pub max_lease_ttl: u16,
 }
 
-/// Typed schema-v1 agent manifest.
+/// Typed agent manifest supporting legacy schema v1 and current schema v2.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AgentManifest {
+    /// Manifest contract version used by this document.
+    pub version: i64,
     /// Stable lowercase agent identifier.
     pub agent: String,
     /// Reviewer-facing purpose statement.
@@ -76,6 +80,11 @@ pub struct AgentManifest {
     pub privilege_tier: u8,
     /// Declared input and output channels.
     pub channels: ChannelAccess,
+    /// Positive payload-schema version for every declared channel, scoped by channel name.
+    ///
+    /// Legacy schema-v1 manifests leave this map empty. Schema-v2 channel
+    /// bindings each carry one version, represented here as a lookup map.
+    pub message_schema_versions: BTreeMap<String, u32>,
     /// Optional vault-secret declarations.
     pub vault_access: Option<VaultAccess>,
     /// Validated OS capability profile.
@@ -87,7 +96,7 @@ pub struct AgentManifest {
 }
 
 impl AgentManifest {
-    /// Validate an in-memory manifest against the schema-v1 semantic contract.
+    /// Validate an in-memory manifest against its declared semantic contract.
     pub fn validate(&self) -> Result<(), ManifestError> {
         validate_manifest(self)
     }
@@ -103,6 +112,115 @@ impl AgentManifest {
             },
         )
     }
+
+    /// Return the declared payload-schema version for one channel, if present.
+    pub fn message_schema_version(&self, channel: &str) -> Option<u32> {
+        self.message_schema_versions.get(channel).copied()
+    }
+}
+
+/// Stable reasons two manifests cannot be wired across one channel.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ChannelCompatibilityError {
+    /// The originator manifest is not internally valid.
+    InvalidOriginator(ManifestError),
+    /// The receiver manifest is not internally valid.
+    InvalidReceiver(ManifestError),
+    /// The originator does not declare write authority for the channel.
+    OriginatorDoesNotWrite(String),
+    /// The receiver does not declare read authority for the channel.
+    ReceiverDoesNotRead(String),
+    /// The originator is a legacy manifest without a schema declaration.
+    OriginatorSchemaUndeclared(String),
+    /// The receiver is a legacy manifest without a schema declaration.
+    ReceiverSchemaUndeclared(String),
+    /// Both sides declare the channel, but their payload-schema versions differ.
+    SchemaVersionMismatch {
+        /// Channel whose declarations disagree.
+        channel: String,
+        /// Version emitted by the originator.
+        originator: u32,
+        /// Version accepted by the receiver.
+        receiver: u32,
+    },
+}
+
+impl Display for ChannelCompatibilityError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidOriginator(error) => write!(formatter, "invalid originator manifest: {error}"),
+            Self::InvalidReceiver(error) => write!(formatter, "invalid receiver manifest: {error}"),
+            Self::OriginatorDoesNotWrite(channel) => {
+                write!(formatter, "originator does not write channel: {channel}")
+            }
+            Self::ReceiverDoesNotRead(channel) => {
+                write!(formatter, "receiver does not read channel: {channel}")
+            }
+            Self::OriginatorSchemaUndeclared(channel) => {
+                write!(formatter, "originator has no message schema version for channel: {channel}")
+            }
+            Self::ReceiverSchemaUndeclared(channel) => {
+                write!(formatter, "receiver has no message schema version for channel: {channel}")
+            }
+            Self::SchemaVersionMismatch {
+                channel,
+                originator,
+                receiver,
+            } => write!(
+                formatter,
+                "message schema version mismatch for channel {channel}: originator {originator}, receiver {receiver}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ChannelCompatibilityError {}
+
+/// Require exact payload-schema compatibility between one writer and reader.
+///
+/// Schema versions are scoped by channel name. Legacy schema-v1 manifests can
+/// still be discovered and inspected, but they fail closed at this wiring
+/// boundary because they do not declare what payload version they understand.
+pub fn require_channel_compatibility(
+    originator: &AgentManifest,
+    receiver: &AgentManifest,
+    channel: &str,
+) -> Result<(), ChannelCompatibilityError> {
+    originator
+        .validate()
+        .map_err(ChannelCompatibilityError::InvalidOriginator)?;
+    receiver
+        .validate()
+        .map_err(ChannelCompatibilityError::InvalidReceiver)?;
+    if !originator
+        .channels
+        .writes
+        .iter()
+        .any(|value| value == channel)
+    {
+        return Err(ChannelCompatibilityError::OriginatorDoesNotWrite(
+            channel.to_string(),
+        ));
+    }
+    if !receiver.channels.reads.iter().any(|value| value == channel) {
+        return Err(ChannelCompatibilityError::ReceiverDoesNotRead(
+            channel.to_string(),
+        ));
+    }
+    let originator_version = originator.message_schema_version(channel).ok_or_else(|| {
+        ChannelCompatibilityError::OriginatorSchemaUndeclared(channel.to_string())
+    })?;
+    let receiver_version = receiver
+        .message_schema_version(channel)
+        .ok_or_else(|| ChannelCompatibilityError::ReceiverSchemaUndeclared(channel.to_string()))?;
+    if originator_version != receiver_version {
+        return Err(ChannelCompatibilityError::SchemaVersionMismatch {
+            channel: channel.to_string(),
+            originator: originator_version,
+            receiver: receiver_version,
+        });
+    }
+    Ok(())
 }
 
 /// Stable classes of malformed or incompatible manifest input.
@@ -144,7 +262,7 @@ impl Display for ManifestError {
 
 impl std::error::Error for ManifestError {}
 
-/// Parse and validate one schema-v1 agent manifest.
+/// Parse and validate one legacy schema-v1 or current schema-v2 agent manifest.
 pub fn parse_manifest(source: &str) -> Result<AgentManifest, ManifestError> {
     if source.len() > MAX_MANIFEST_BYTES {
         return Err(ManifestError::ManifestTooLarge);
@@ -161,7 +279,7 @@ pub fn parse_manifest(source: &str) -> Result<AgentManifest, ManifestError> {
         expect_string(schema, "$schema")?;
     }
     let version = expect_integer(object.required("version")?, "version")?;
-    if version != MANIFEST_VERSION {
+    if !matches!(version, LEGACY_MANIFEST_VERSION | MANIFEST_VERSION) {
         return Err(ManifestError::UnsupportedVersion(version));
     }
     let agent = expect_string(object.required("agent")?, "agent")?;
@@ -169,7 +287,8 @@ pub fn parse_manifest(source: &str) -> Result<AgentManifest, ManifestError> {
     let privilege_tier = expect_integer(object.required("privilege_tier")?, "privilege_tier")?;
     let privilege_tier =
         u8::try_from(privilege_tier).map_err(|_| ManifestError::InvalidField("privilege_tier"))?;
-    let channels = parse_channels(object.required("channels")?)?;
+    let (channels, message_schema_versions) =
+        parse_channels(object.required("channels")?, version)?;
     let vault_access = object
         .take("vault_access")
         .map(parse_vault_access)
@@ -183,10 +302,12 @@ pub fn parse_manifest(source: &str) -> Result<AgentManifest, ManifestError> {
     let justification = expect_string(object.required("justification")?, "justification")?;
 
     let manifest = AgentManifest {
+        version,
         agent,
         description,
         privilege_tier,
         channels,
+        message_schema_versions,
         vault_access,
         capabilities,
         restart_policy,
@@ -196,12 +317,61 @@ pub fn parse_manifest(source: &str) -> Result<AgentManifest, ManifestError> {
     Ok(manifest)
 }
 
-fn parse_channels(value: JsonValue) -> Result<ChannelAccess, ManifestError> {
+fn parse_channels(
+    value: JsonValue,
+    manifest_version: i64,
+) -> Result<(ChannelAccess, BTreeMap<String, u32>), ManifestError> {
     let mut object = expect_object(value, "channels", CHANNEL_FIELDS)?;
-    Ok(ChannelAccess {
-        reads: expect_string_array(object.required("reads")?, "channels.reads")?,
-        writes: expect_string_array(object.required("writes")?, "channels.writes")?,
-    })
+    match manifest_version {
+        LEGACY_MANIFEST_VERSION => Ok((
+            ChannelAccess {
+                reads: expect_string_array(object.required("reads")?, "channels.reads")?,
+                writes: expect_string_array(object.required("writes")?, "channels.writes")?,
+            },
+            BTreeMap::new(),
+        )),
+        MANIFEST_VERSION => {
+            let reads = parse_channel_bindings(object.required("reads")?, "channels.reads")?;
+            let writes = parse_channel_bindings(object.required("writes")?, "channels.writes")?;
+            let mut versions = BTreeMap::new();
+            for (channel, version) in reads.iter().chain(&writes) {
+                versions.insert(channel.clone(), *version);
+            }
+            Ok((
+                ChannelAccess {
+                    reads: reads.into_iter().map(|(channel, _)| channel).collect(),
+                    writes: writes.into_iter().map(|(channel, _)| channel).collect(),
+                },
+                versions,
+            ))
+        }
+        _ => unreachable!("unsupported versions returned above"),
+    }
+}
+
+fn parse_channel_bindings(
+    value: JsonValue,
+    field: &'static str,
+) -> Result<Vec<(String, u32)>, ManifestError> {
+    let bindings = match value {
+        JsonValue::Object(bindings) => bindings,
+        _ => return Err(ManifestError::InvalidField(field)),
+    };
+    let mut seen = BTreeSet::new();
+    bindings
+        .into_iter()
+        .map(|(channel, value)| {
+            if !valid_identifier(&channel) || !seen.insert(channel.clone()) {
+                return Err(ManifestError::InvalidField(field));
+            }
+            let version = expect_integer(value, field)?;
+            let version = u32::try_from(version).map_err(|_| ManifestError::InvalidField(field))?;
+            if version == 0 {
+                return Err(ManifestError::InvalidField(field));
+            }
+            Ok((channel, version))
+        })
+        .collect()
 }
 
 fn parse_vault_access(value: JsonValue) -> Result<VaultAccess, ManifestError> {
@@ -241,6 +411,9 @@ fn parse_capabilities(value: JsonValue) -> Result<Vec<Capability>, ManifestError
 }
 
 fn validate_manifest(manifest: &AgentManifest) -> Result<(), ManifestError> {
+    if !matches!(manifest.version, LEGACY_MANIFEST_VERSION | MANIFEST_VERSION) {
+        return Err(ManifestError::UnsupportedVersion(manifest.version));
+    }
     if !(2..=64).contains(&manifest.agent.len()) || !valid_identifier(&manifest.agent) {
         return Err(ManifestError::InvalidField("agent"));
     }
@@ -268,6 +441,35 @@ fn validate_manifest(manifest: &AgentManifest) -> Result<(), ManifestError> {
         .any(|channel| reads.contains(channel))
     {
         return Err(ManifestError::InvalidField("channels"));
+    }
+    match manifest.version {
+        LEGACY_MANIFEST_VERSION if !manifest.message_schema_versions.is_empty() => {
+            return Err(ManifestError::InvalidField("message_schema_versions"));
+        }
+        MANIFEST_VERSION => {
+            let channel_count = manifest.channels.reads.len() + manifest.channels.writes.len();
+            let channels = manifest
+                .channels
+                .reads
+                .iter()
+                .chain(&manifest.channels.writes)
+                .collect::<BTreeSet<_>>();
+            let declarations = manifest
+                .message_schema_versions
+                .keys()
+                .collect::<BTreeSet<_>>();
+            if channels.len() != channel_count
+                || channels != declarations
+                || manifest
+                    .message_schema_versions
+                    .values()
+                    .any(|version| *version == 0)
+            {
+                return Err(ManifestError::InvalidField("message_schema_versions"));
+            }
+        }
+        LEGACY_MANIFEST_VERSION => {}
+        _ => unreachable!("unsupported versions returned above"),
     }
     if let Some(vault) = &manifest.vault_access {
         if vault.secrets.iter().any(String::is_empty) {
@@ -406,7 +608,7 @@ fn manifest_json(manifest: &AgentManifest) -> JsonValue {
         ),
         (
             "version".to_string(),
-            JsonValue::Number(JsonNumber::Integer(MANIFEST_VERSION)),
+            JsonValue::Number(JsonNumber::Integer(manifest.version)),
         ),
         (
             "agent".to_string(),
@@ -420,13 +622,7 @@ fn manifest_json(manifest: &AgentManifest) -> JsonValue {
             "privilege_tier".to_string(),
             JsonValue::Number(JsonNumber::Integer(i64::from(manifest.privilege_tier))),
         ),
-        (
-            "channels".to_string(),
-            JsonValue::Object(vec![
-                ("reads".to_string(), strings(&manifest.channels.reads)),
-                ("writes".to_string(), strings(&manifest.channels.writes)),
-            ]),
-        ),
+        ("channels".to_string(), channel_json(manifest, &strings)),
     ];
     if let Some(vault) = &manifest.vault_access {
         fields.push((
@@ -483,6 +679,34 @@ fn manifest_json(manifest: &AgentManifest) -> JsonValue {
     JsonValue::Object(fields)
 }
 
+fn channel_json(manifest: &AgentManifest, strings: &impl Fn(&[String]) -> JsonValue) -> JsonValue {
+    if manifest.version == LEGACY_MANIFEST_VERSION {
+        return JsonValue::Object(vec![
+            ("reads".to_string(), strings(&manifest.channels.reads)),
+            ("writes".to_string(), strings(&manifest.channels.writes)),
+        ]);
+    }
+    let bindings = |channels: &[String]| {
+        JsonValue::Object(
+            channels
+                .iter()
+                .map(|channel| {
+                    (
+                        channel.clone(),
+                        JsonValue::Number(JsonNumber::Integer(i64::from(
+                            manifest.message_schema_version(channel).unwrap_or(0),
+                        ))),
+                    )
+                })
+                .collect(),
+        )
+    };
+    JsonValue::Object(vec![
+        ("reads".to_string(), bindings(&manifest.channels.reads)),
+        ("writes".to_string(), bindings(&manifest.channels.writes)),
+    ])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -497,15 +721,42 @@ mod tests {
       "justification": "Uses only encrypted channels and no operating-system access."
     }"#;
 
+    const CURRENT: &str = r#"{
+      "version": 2,
+      "agent": "weather-agent",
+      "description": "Reports a concise local weather forecast.",
+      "privilege_tier": 0,
+      "channels": {
+        "reads": {"weather-requests": 1},
+        "writes": {"weather-reports": 2}
+      },
+      "capabilities": [],
+      "justification": "Uses only encrypted channels and no operating-system access."
+    }"#;
+
     #[test]
     fn parses_defaults_and_round_trips_schema_v1() {
         let manifest = parse_manifest(MINIMAL).unwrap();
+        assert_eq!(manifest.version, LEGACY_MANIFEST_VERSION);
         assert_eq!(manifest.agent, "weather-agent");
         assert_eq!(manifest.restart_policy, "on-failure");
         assert!(manifest.vault_access.is_none());
+        assert!(manifest.message_schema_versions.is_empty());
 
         let json = manifest.to_json().unwrap();
         assert!(json.starts_with(&format!("{{\n  \"$schema\": \"{MANIFEST_SCHEMA}\",")));
+        assert_eq!(parse_manifest(&json).unwrap(), manifest);
+    }
+
+    #[test]
+    fn parses_and_round_trips_current_schema_v2() {
+        let manifest = parse_manifest(CURRENT).unwrap();
+        assert_eq!(manifest.version, MANIFEST_VERSION);
+        assert_eq!(manifest.message_schema_version("weather-requests"), Some(1));
+        assert_eq!(manifest.message_schema_version("weather-reports"), Some(2));
+
+        let json = manifest.to_json().unwrap();
+        assert!(json.contains("\"weather-reports\": 2"));
         assert_eq!(parse_manifest(&json).unwrap(), manifest);
     }
 
@@ -524,14 +775,121 @@ mod tests {
     #[test]
     fn rejects_unsupported_or_malformed_versions() {
         assert_eq!(
-            parse_manifest(&MINIMAL.replace("\"version\": 1", "\"version\": 2")),
-            Err(ManifestError::UnsupportedVersion(2))
+            parse_manifest(&MINIMAL.replace("\"version\": 1", "\"version\": 3")),
+            Err(ManifestError::UnsupportedVersion(3))
         );
         assert_eq!(
             parse_manifest(&MINIMAL.replace("\"version\": 1", "\"version\": 1.0")),
             Err(ManifestError::InvalidField("version"))
         );
         assert_eq!(parse_manifest("{"), Err(ManifestError::InvalidJson));
+    }
+
+    #[test]
+    fn version_contracts_fail_closed() {
+        let v1_with_v2_binding =
+            MINIMAL.replace("[\"weather-requests\"]", "{\"weather-requests\": 1}");
+        assert_eq!(
+            parse_manifest(&v1_with_v2_binding),
+            Err(ManifestError::InvalidField("channels.reads"))
+        );
+        assert_eq!(
+            parse_manifest(&CURRENT.replace("\"weather-reports\": 2", "\"Bad_Channel\": 2")),
+            Err(ManifestError::InvalidField("channels.writes"))
+        );
+        assert_eq!(
+            parse_manifest(&CURRENT.replace("\"weather-reports\": 2", "\"weather-reports\": 0")),
+            Err(ManifestError::InvalidField("channels.writes"))
+        );
+        assert_eq!(
+            parse_manifest(&CURRENT.replace(
+                "\"weather-requests\": 1",
+                "\"weather-requests\": 1, \"weather-requests\": 2"
+            )),
+            Err(ManifestError::InvalidField("channels.reads"))
+        );
+        assert_eq!(
+            parse_manifest(
+                &CURRENT.replace("\"weather-reports\": 2", "\"weather-reports\": \"2\"")
+            ),
+            Err(ManifestError::InvalidField("channels.writes"))
+        );
+    }
+
+    #[test]
+    fn channel_compatibility_requires_matching_declared_versions() {
+        let originator = parse_manifest(CURRENT).unwrap();
+        let receiver = parse_manifest(
+            r#"{
+              "version": 2,
+              "agent": "display-agent",
+              "description": "Displays one concise local weather forecast.",
+              "privilege_tier": 0,
+              "channels": {
+                "reads": {"weather-reports": 2},
+                "writes": {}
+              },
+              "capabilities": [],
+              "justification": "Uses only the declared encrypted weather channel."
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            require_channel_compatibility(&originator, &receiver, "weather-reports"),
+            Ok(())
+        );
+        assert_eq!(
+            require_channel_compatibility(&originator, &receiver, "weather-requests"),
+            Err(ChannelCompatibilityError::OriginatorDoesNotWrite(
+                "weather-requests".to_string()
+            ))
+        );
+        let unrelated_receiver = parse_manifest(
+            r#"{
+              "version": 2,
+              "agent": "unrelated-agent",
+              "description": "Consumes no channels in this compatibility test.",
+              "privilege_tier": 0,
+              "channels": {"reads": {}, "writes": {}},
+              "capabilities": [],
+              "justification": "Uses no channels or operating-system capabilities."
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            require_channel_compatibility(&originator, &unrelated_receiver, "weather-reports"),
+            Err(ChannelCompatibilityError::ReceiverDoesNotRead(
+                "weather-reports".to_string()
+            ))
+        );
+
+        let incompatible = parse_manifest(
+            &receiver
+                .to_json()
+                .unwrap()
+                .replace("\"weather-reports\": 2", "\"weather-reports\": 1"),
+        )
+        .unwrap();
+        assert_eq!(
+            require_channel_compatibility(&originator, &incompatible, "weather-reports"),
+            Err(ChannelCompatibilityError::SchemaVersionMismatch {
+                channel: "weather-reports".to_string(),
+                originator: 2,
+                receiver: 1,
+            })
+        );
+
+        let legacy = parse_manifest(&MINIMAL.replace(
+            "\"reads\": [\"weather-requests\"], \"writes\": [\"weather-reports\"]",
+            "\"reads\": [\"weather-reports\"], \"writes\": []",
+        ))
+        .unwrap();
+        assert_eq!(
+            require_channel_compatibility(&originator, &legacy, "weather-reports"),
+            Err(ChannelCompatibilityError::ReceiverSchemaUndeclared(
+                "weather-reports".to_string()
+            ))
+        );
     }
 
     #[test]

--- a/code/packages/rust/chief-of-staff-skill-parser/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-skill-parser/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Re-export manifest types from the shared strict agent-manifest package.
+- Emit schema-v2 manifests with complete per-channel message-schema versions;
+  default zero-friction channels to version 1 and accept explicit overrides.
 
 ## 0.1.0 - 2026-08-03
 

--- a/code/packages/rust/chief-of-staff-skill-parser/README.md
+++ b/code/packages/rust/chief-of-staff-skill-parser/README.md
@@ -7,7 +7,12 @@ a typed schema-shaped manifest, and derives sorted least-privilege Deno flags.
 An H1 title, descriptive first paragraph, and `## Capabilities needed` section
 are required. The issue's zero-frontmatter form is valid; identity and safe
 defaults are inferred. Optional `---` frontmatter accepts only `agent`,
-`description`, `privilege_tier`, `reads`, `writes`, and `restart_policy`.
+`description`, `privilege_tier`, `reads`, `writes`,
+`message_schema_versions`, and `restart_policy`. The parser emits manifest v2
+and defaults every declared channel to payload schema version 1. Authors can
+override all channel versions with a complete list such as
+`message_schema_versions: [requests=1, responses=2]`; missing, extra, duplicate,
+malformed, or zero-valued entries fail closed.
 
 Capability bullets use `category:action:target`, optionally followed by
 ` | justification`. Use `- none` for an explicit empty capability profile.

--- a/code/packages/rust/chief-of-staff-skill-parser/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-skill-parser/src/lib.rs
@@ -3,7 +3,9 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
-pub use chief_of_staff_agent_manifest::{AgentManifest, Capability, ChannelAccess};
+pub use chief_of_staff_agent_manifest::{
+    AgentManifest, Capability, ChannelAccess, MANIFEST_VERSION,
+};
 use document_ast::{BlockNode, InlineNode, ListChildNode};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Display, Formatter};
@@ -46,6 +48,8 @@ pub enum SkillParseError {
     InvalidRestartPolicy,
     /// A channel identifier is invalid or is both read and written.
     InvalidChannel(String),
+    /// A per-channel message-schema version declaration is malformed or incomplete.
+    InvalidMessageSchemaVersion(String),
     /// The required capability section is absent.
     MissingCapabilitiesSection,
     /// The capability section has no list.
@@ -84,6 +88,12 @@ impl Display for SkillParseError {
             }
             Self::InvalidRestartPolicy => formatter.write_str("SKILL.md restart_policy is invalid"),
             Self::InvalidChannel(value) => write!(formatter, "invalid SKILL.md channel: {value}"),
+            Self::InvalidMessageSchemaVersion(value) => {
+                write!(
+                    formatter,
+                    "invalid SKILL.md message schema version: {value}"
+                )
+            }
             Self::MissingCapabilitiesSection => {
                 formatter.write_str("SKILL.md requires a Capabilities needed section")
             }
@@ -162,13 +172,16 @@ pub fn parse_skill(source: &str) -> Result<ParsedSkill, SkillParseError> {
         return Err(SkillParseError::InvalidRestartPolicy);
     }
     let channels = parse_channels(&metadata)?;
+    let message_schema_versions = parse_message_schema_versions(&metadata, &channels)?;
     let capabilities = parse_capabilities(&document.children, &agent)?;
     let deno_permissions = deno_permissions(&capabilities);
     let manifest = AgentManifest {
+        version: MANIFEST_VERSION,
         agent: agent.clone(),
         description,
         privilege_tier,
         channels,
+        message_schema_versions,
         vault_access: None,
         capabilities,
         restart_policy,
@@ -204,7 +217,13 @@ fn split_frontmatter(source: &str) -> Result<(BTreeMap<String, String>, String),
         }
         if !matches!(
             key,
-            "agent" | "description" | "privilege_tier" | "reads" | "writes" | "restart_policy"
+            "agent"
+                | "description"
+                | "privilege_tier"
+                | "reads"
+                | "writes"
+                | "message_schema_versions"
+                | "restart_policy"
         ) {
             return Err(SkillParseError::UnknownFrontmatterKey(key.to_string()));
         }
@@ -274,6 +293,44 @@ fn parse_channels(metadata: &BTreeMap<String, String>) -> Result<ChannelAccess, 
         return Err(SkillParseError::InvalidChannel(channel.clone()));
     }
     Ok(ChannelAccess { reads, writes })
+}
+
+fn parse_message_schema_versions(
+    metadata: &BTreeMap<String, String>,
+    channels: &ChannelAccess,
+) -> Result<BTreeMap<String, u32>, SkillParseError> {
+    let declared_channels = channels
+        .reads
+        .iter()
+        .chain(&channels.writes)
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let Some(raw) = metadata.get("message_schema_versions") else {
+        return Ok(declared_channels
+            .into_iter()
+            .map(|channel| (channel, 1))
+            .collect());
+    };
+    let mut versions = BTreeMap::new();
+    for declaration in parse_list(Some(raw))? {
+        let (channel, version) = declaration
+            .split_once('=')
+            .ok_or_else(|| SkillParseError::InvalidMessageSchemaVersion(declaration.clone()))?;
+        if !valid_identifier(channel) || !declared_channels.contains(channel) {
+            return Err(SkillParseError::InvalidMessageSchemaVersion(declaration));
+        }
+        let version = version
+            .parse::<u32>()
+            .map_err(|_| SkillParseError::InvalidMessageSchemaVersion(declaration.clone()))?;
+        if version == 0 || versions.insert(channel.to_string(), version).is_some() {
+            return Err(SkillParseError::InvalidMessageSchemaVersion(declaration));
+        }
+    }
+    if versions.keys().collect::<BTreeSet<_>>() != declared_channels.iter().collect::<BTreeSet<_>>()
+    {
+        return Err(SkillParseError::InvalidMessageSchemaVersion(raw.clone()));
+    }
+    Ok(versions)
 }
 
 fn parse_list(value: Option<&String>) -> Result<Vec<String>, SkillParseError> {
@@ -497,8 +554,10 @@ mod tests {
         let skill = parse_skill(MINIMAL).unwrap();
         assert_eq!(skill.title, "Weather Reporter");
         assert_eq!(skill.manifest.agent, "weather-reporter");
+        assert_eq!(skill.manifest.version, MANIFEST_VERSION);
         assert_eq!(skill.manifest.privilege_tier, 0);
         assert_eq!(skill.manifest.channels, ChannelAccess::default());
+        assert!(skill.manifest.message_schema_versions.is_empty());
         assert_eq!(skill.manifest.restart_policy, "on-failure");
         assert_eq!(skill.deno_permissions, ["--allow-net=api.weather.gov:443"]);
         assert!(skill.instructions.starts_with("# Weather Reporter"));
@@ -506,11 +565,19 @@ mod tests {
 
     #[test]
     fn frontmatter_overrides_metadata_and_sorts_runtime_access() {
-        let source = "---\nagent: 'forecast-agent'\ndescription: \"Produces precise forecasts for subscribed cities.\"\nprivilege_tier: 1\nreads: [weather-requests]\nwrites: [weather-reports]\nrestart_policy: always\n---\n# Forecast\n\nIgnored description because frontmatter wins.\n\n## Capabilities needed\n- fs:write:/tmp/cache | Stores short-lived forecast cache data.\n- net:connect:api.weather.gov:443\n- fs:read:/tmp/cache\n- net:dns:api.weather.gov\n";
+        let source = "---\nagent: 'forecast-agent'\ndescription: \"Produces precise forecasts for subscribed cities.\"\nprivilege_tier: 1\nreads: [weather-requests]\nwrites: [weather-reports]\nmessage_schema_versions: [weather-requests=1, weather-reports=2]\nrestart_policy: always\n---\n# Forecast\n\nIgnored description because frontmatter wins.\n\n## Capabilities needed\n- fs:write:/tmp/cache | Stores short-lived forecast cache data.\n- net:connect:api.weather.gov:443\n- fs:read:/tmp/cache\n- net:dns:api.weather.gov\n";
         let skill = parse_skill(source).unwrap();
         assert_eq!(skill.manifest.agent, "forecast-agent");
         assert_eq!(skill.manifest.channels.reads, ["weather-requests"]);
         assert_eq!(skill.manifest.channels.writes, ["weather-reports"]);
+        assert_eq!(
+            skill.manifest.message_schema_version("weather-requests"),
+            Some(1)
+        );
+        assert_eq!(
+            skill.manifest.message_schema_version("weather-reports"),
+            Some(2)
+        );
         assert_eq!(
             skill.deno_permissions,
             [
@@ -522,7 +589,8 @@ mod tests {
         assert!(!skill.instructions.contains("privilege_tier"));
         let json = skill.manifest.to_json().unwrap();
         assert!(json.contains("\"target\": \"/tmp/cache\""));
-        assert!(json.contains("\"reads\": [\n      \"weather-requests\"\n    ]"));
+        assert!(json.contains("\"reads\": {\n      \"weather-requests\": 1\n    }"));
+        assert!(json.contains("\"weather-reports\": 2"));
     }
 
     #[test]
@@ -639,6 +707,37 @@ mod tests {
     }
 
     #[test]
+    fn message_schema_versions_default_to_one_and_fail_closed() {
+        let base = "---\nreads: [request-channel]\nwrites: [response-channel]\n---\n# Valid Agent\n\nLong enough description for a valid agent.\n\n## Capabilities needed\n- none\n";
+        let skill = parse_skill(base).unwrap();
+        assert_eq!(
+            skill.manifest.message_schema_version("request-channel"),
+            Some(1)
+        );
+        assert_eq!(
+            skill.manifest.message_schema_version("response-channel"),
+            Some(1)
+        );
+
+        for declarations in [
+            "[request-channel=1]",
+            "[request-channel=0, response-channel=1]",
+            "[request-channel=x, response-channel=1]",
+            "[request-channel=1, extra-channel=1]",
+            "[request-channel=1, request-channel=2, response-channel=1]",
+        ] {
+            let source = base.replace(
+                "writes: [response-channel]",
+                &format!("writes: [response-channel]\nmessage_schema_versions: {declarations}"),
+            );
+            assert!(matches!(
+                parse_skill(&source),
+                Err(SkillParseError::InvalidMessageSchemaVersion(_))
+            ));
+        }
+    }
+
+    #[test]
     fn rejects_capability_failures() {
         let base = "# Valid Agent\n\nLong enough description for a valid agent.\n\n## Capabilities needed\n";
         assert_eq!(
@@ -699,6 +798,7 @@ mod tests {
             SkillParseError::InvalidPrivilegeTier,
             SkillParseError::InvalidRestartPolicy,
             SkillParseError::InvalidChannel("channel".to_string()),
+            SkillParseError::InvalidMessageSchemaVersion("channel=0".to_string()),
             SkillParseError::MissingCapabilitiesSection,
             SkillParseError::MissingCapabilitiesList,
             SkillParseError::AmbiguousCapabilitiesSection,

--- a/code/scripts/tests/test_capability_taxonomy.py
+++ b/code/scripts/tests/test_capability_taxonomy.py
@@ -93,6 +93,37 @@ class CapabilityTaxonomyTest(unittest.TestCase):
                     )
                     self.assertTrue(errors, "unknown vocabulary must fail closed")
 
+    def test_agent_manifest_schema_versions_are_explicitly_evolved(self) -> None:
+        validator = jsonschema.Draft202012Validator(self.manifest_schemas["agent"])
+        legacy = self.manifest("agent", "net", "connect")
+        validator.validate(legacy)
+
+        current = dict(legacy)
+        current["version"] = 2
+        current["channels"] = {
+            "reads": {},
+            "writes": {"agent-output": 1},
+        }
+        validator.validate(current)
+
+        missing = dict(current)
+        missing["channels"] = {
+            "reads": {},
+            "writes": ["agent-output"],
+        }
+        self.assertTrue(list(validator.iter_errors(missing)))
+
+        legacy_with_current_binding = dict(legacy)
+        legacy_with_current_binding["channels"] = current["channels"]
+        self.assertTrue(list(validator.iter_errors(legacy_with_current_binding)))
+
+        invalid = dict(current)
+        invalid["channels"] = {
+            "reads": {},
+            "writes": {"agent-output": 0},
+        }
+        self.assertTrue(list(validator.iter_errors(invalid)))
+
     def test_repository_required_capabilities_use_only_valid_pairs(self) -> None:
         known_categories = set(self.taxonomy["categories"])
         known_actions = set(self.taxonomy["all_actions"])

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -163,13 +163,19 @@ paragraph, and a `## Capabilities needed` list. Each capability is written as
 `category:action:target`, optionally followed by ` | justification`; `- none`
 declares an explicit empty profile. The title and paragraph provide zero-config
 identity defaults. Optional `---` frontmatter may override `agent`, `description`,
-`privilege_tier`, `reads`, `writes`, and `restart_policy`; unknown or duplicate
-keys fail closed. The parser emits the schema-v1 `agent_manifest.json` shape and
+`privilege_tier`, `reads`, `writes`, `message_schema_versions`, and
+`restart_policy`; unknown or duplicate keys fail closed. The parser emits the
+schema-v2 `agent_manifest.json` shape and
 sorted, deduplicated Deno permission arguments. Time and standard-stream
 capabilities remain manifest declarations but do not widen Deno OS permissions.
-The shared manifest codec accepts version 1 only and rejects malformed JSON,
-duplicate or unknown fields, and invalid nested capability declarations before
-a package can participate in discovery or registration.
+The shared manifest codec continues to accept installed schema-v1 packages and
+rejects malformed JSON, duplicate or unknown fields, and invalid nested
+capability declarations before a package can participate in discovery or
+registration. Schema v2 declares a positive payload-schema version for every
+read/write channel; channel names scope those versions. Pipeline wiring fails
+closed unless the originator's write declaration and receiver's read declaration
+name the same version. Legacy v1 packages remain discoverable, but have no
+implicit message-schema compatibility.
 Discovery supports explicit inspection and stable immediate-child `.agent`
 scans. It parses only authenticated manifest bytes, enforces signing-key tier
 ceilings, and returns inert candidates for explicit control-plane registration.

--- a/code/specs/schemas/agent_manifest.schema.json
+++ b/code/specs/schemas/agent_manifest.schema.json
@@ -6,6 +6,30 @@
   "type": "object",
   "required": ["version", "agent", "description", "privilege_tier", "channels", "capabilities", "justification"],
   "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": {"version": {"const": 1}},
+        "required": ["version"]
+      },
+      "then": {
+        "properties": {
+          "channels": {"$ref": "#/$defs/channelsV1"}
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {"version": {"const": 2}},
+        "required": ["version"]
+      },
+      "then": {
+        "properties": {
+          "channels": {"$ref": "#/$defs/channelsV2"}
+        }
+      }
+    }
+  ],
   "properties": {
     "$schema": {
       "type": "string",
@@ -13,8 +37,8 @@
     },
     "version": {
       "type": "integer",
-      "const": 1,
-      "description": "Schema version. Currently 1. Allows schema evolution without breaking existing manifests."
+      "enum": [1, 2],
+      "description": "Schema version. Version 1 is accepted for installed legacy packages. Version 2 requires an explicit payload-schema version for every declared channel."
     },
     "agent": {
       "type": "string",
@@ -36,28 +60,7 @@
       "description": "The privilege tier for this agent. Tier 0: no approval needed. Tier 1: notification with auto-approve. Tier 2: biometric required. Tier 3: hardware key required. The orchestrator uses the maximum tier across all resources in a pipeline to determine the required approval level."
     },
     "channels": {
-      "type": "object",
-      "required": ["reads", "writes"],
-      "additionalProperties": false,
-      "description": "Declares which channels this agent can read from and write to. An agent cannot read or write channels not listed here. An agent cannot be both reader and writer on the same channel.",
-      "properties": {
-        "reads": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "pattern": "^[a-z][a-z0-9-]*$"
-          },
-          "description": "Channel names this agent subscribes to (receives messages from). The orchestrator provides the decryption key for each listed channel during pipeline wiring."
-        },
-        "writes": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "pattern": "^[a-z][a-z0-9-]*$"
-          },
-          "description": "Channel names this agent publishes to (sends messages to). The orchestrator assigns this agent as the originator for each listed channel during pipeline wiring."
-        }
-      }
+      "description": "Declares which channels this agent can read from and write to. Schema v1 uses legacy string lists. Schema v2 maps each channel name to its positive payload-schema version. An agent cannot be both reader and writer on the same channel."
     },
     "vault_access": {
       "type": "object",
@@ -106,6 +109,50 @@
     }
   },
   "$defs": {
+    "channelName": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$"
+    },
+    "channelsV1": {
+      "type": "object",
+      "required": ["reads", "writes"],
+      "additionalProperties": false,
+      "properties": {
+        "reads": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/channelName"}
+        },
+        "writes": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/channelName"}
+        }
+      }
+    },
+    "channelsV2": {
+      "type": "object",
+      "required": ["reads", "writes"],
+      "additionalProperties": false,
+      "properties": {
+        "reads": {
+          "type": "object",
+          "propertyNames": {"$ref": "#/$defs/channelName"},
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 4294967295
+          }
+        },
+        "writes": {
+          "type": "object",
+          "propertyNames": {"$ref": "#/$defs/channelName"},
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 4294967295
+          }
+        }
+      }
+    },
     "capability": {
       "type": "object",
       "required": ["category", "action", "target", "justification"],


### PR DESCRIPTION
## Summary

- evolve the strict agent manifest to schema v2 while continuing to parse and deterministically render installed schema-v1 packages
- make v2 channel maps declare a positive payload-schema version for every read and write channel, and add a fail-closed originator/receiver compatibility check
- make Level 1 SKILL generation emit v2 with zero-friction version-1 defaults plus complete explicit frontmatter overrides
- update the canonical JSON Schema, D18 contract, documentation, and compatibility tests

## Validation

- 22 focused manifest and SKILL parser tests
- 9 downstream discovery tests
- strict Clippy for manifest, SKILL parser, and discovery
- rustdoc with warnings denied for all three packages
- 7 JSON-Schema conformance tests
- dependency-closed repository plan: 3 changed packages, 38 affected/prerequisite packages built and tested with Clippy, 1,195 skipped

Advances #139 and #128.