### PR TITLE
fix(human-languages): clean Latin book build

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -105,9 +105,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B31 | Complete (#9871) | Remove Hindi's LaTeX layout, duplicate-label, bookmark, font, and header-only-verso warnings. | The forced 114-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; intentionally blank chapter versos are truly empty. |
 | HL-B32 | Complete (#9875) | Publish Tamil Chapters 6–31 and its writing companions from canonical lessons rather than hand-copying another twenty-six book chapters. | Fifty-one lessons now use schema v2; forty-three later lessons generate twenty-six chapters whose source hashes are independently verified against Language Ladder, while eight prerequisite-ordered writing companions remain inside the gentle hand-authored opening chapter. |
 | HL-B33 | Complete (#9880) | Remove Tamil's LaTeX layout, duplicate-label, bookmark, font, and header-only-verso warnings. | The forced 117-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; intentionally blank chapter versos are truly empty. |
-| HL-B34 | Complete in this PR | Publish Latin Chapters 2–36 from canonical lessons rather than hand-copying another thirty-five book chapters. | All 53 Latin lessons now use schema v2; Chapters 2–36 are generated with source hashes independently verified against Language Ladder. |
-| HL-B35 | Next | Remove Latin's remaining LaTeX layout, font, and header-only-verso warnings. | The expanded 113-page book has six overfull lines, six underfull lines, eight underfull header-only pages, and one undefined small-caps shape (two font-warning blocks), with no missing glyphs, duplicate labels, or Hyperref warnings; the clean-build signal is zero of each. |
-| HL-B36 | Queued | Publish Spanish Chapters 19–33 from canonical lessons rather than hand-copying another fifteen book chapters. | The Spanish PDF stops after Chapter 18 while canonical app content continues through Chapter 33; schema-v2 migration plus generation should raise book coverage from 55% to 100%. |
+| HL-B34 | Complete (#9883) | Publish Latin Chapters 2–36 from canonical lessons rather than hand-copying another thirty-five book chapters. | All 53 Latin lessons now use schema v2; Chapters 2–36 are generated with source hashes independently verified against Language Ladder. |
+| HL-B35 | Complete in this PR | Remove Latin's remaining LaTeX layout, font, and header-only-verso warnings. | The forced 115-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; intentionally blank chapter versos are truly empty. |
+| HL-B36 | Next | Publish Spanish Chapters 19–33 from canonical lessons rather than hand-copying another fifteen book chapters. | The Spanish PDF stops after Chapter 18 while canonical app content continues through Chapter 33; schema-v2 migration plus generation should raise book coverage from 55% to 100%. |
 | HL-B37 | Queued | Remove Spanish's remaining legacy LaTeX layout, bookmark, and font warnings. | After Chapters 4–6 generation, a forced build has no missing glyphs or duplicate labels but reports 50 overfull boxes, 14 underfull boxes, 14 Hyperref warnings, and one undefined small-caps shape; the clean-build signal is zero of each. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-M02 | Queued | Extend Telugu's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson needs a scheduled place, and the map must explicitly split or justify Chapter 20's numbers-and-weather topic collision. |
@@ -1039,6 +1039,26 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - The roadmap and authoritative session map still stop at Chapter 1. HL-M08
   continues to own the progression-metadata reconciliation through Chapter 36.
 - HL-B35 is next: remove Latin's remaining layout and font warnings.
+
+## Findings from HL-B35
+
+- Selecting Latin Modern Caps explicitly supplies the book's small-caps shape
+  without adding a system-font or vendored-font dependency.
+- Natural page bottoms, a two-em emergency stretch, and compact numeric section
+  marks remove every overfull and underfull line while keeping generated prose
+  readable.
+- A true-empty `\cleardoublepage` preserves open-right chapter starts while
+  leaving intentionally blank versos free of running heads and page numbers.
+- Three dense canonical recall paragraphs now use scannable bullet lists. Their
+  generated Chapters 16, 17, and 20 retain independently checked lesson ids and
+  source hashes, so the readability improvement reaches both app and book from
+  the same source.
+- The forced 115-page XeLaTeX build has correct title and author metadata, 38
+  top-level and 91 total outline entries, zero schema leaks, and zero missing
+  glyphs, overfull or underfull boxes, duplicate destinations, Hyperref
+  warnings, LaTeX warnings, or font warnings. Every rendered page was visually
+  inspected for clipping, collisions, broken tables, and malformed callouts.
+- HL-B36 is next: publish Spanish Chapters 19–33 from the canonical app corpus.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -1212,7 +1212,7 @@
     {
       "language": "latin",
       "chapter": 16,
-      "sourceHash": "fnv1a64:e837b83ec32bb5ad",
+      "sourceHash": "fnv1a64:b99e5996a77b8d8d",
       "lessonIds": [
         "LA-C16-undecim-viginti"
       ],
@@ -1221,7 +1221,7 @@
     {
       "language": "latin",
       "chapter": 17,
-      "sourceHash": "fnv1a64:46fa833e7f3a6f21",
+      "sourceHash": "fnv1a64:ae99ab2bc2171e5f",
       "lessonIds": [
         "LA-C17-canis-feles-cattus"
       ],
@@ -1249,7 +1249,7 @@
     {
       "language": "latin",
       "chapter": 20,
-      "sourceHash": "fnv1a64:a2461bf89cfc590f",
+      "sourceHash": "fnv1a64:b25c55ef1e914d27",
       "lessonIds": [
         "LA-C20-quid-tibi-nomen",
         "LA-C20-name-case-variation"

--- a/code/learning/human-languages/latin/CHANGELOG.md
+++ b/code/learning/human-languages/latin/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Warning-free 36-chapter book
+
+- Supplies Latin Modern's matching small-caps face explicitly, keeps chapter
+  openings on right-hand pages with truly empty versos, and uses compact
+  section running heads.
+- Removes every overfull and underfull box, missing-glyph, duplicate-destination,
+  Hyperref, generic LaTeX, and font warning from a forced 115-page XeLaTeX
+  build.
+- Recasts the dense Chapters 16, 17, and 20 recall blocks as canonical bullet
+  lists so the app and generated book share the same more-scannable review.
+
 ## Chapters 2–36 — canonical app/book publication
 
 - Migrates all 53 Latin lessons to schema v2 with shared-spine placements,

--- a/code/learning/human-languages/latin/README.md
+++ b/code/learning/human-languages/latin/README.md
@@ -34,8 +34,8 @@ book.
 
 ## Book
 
-The 36-chapter book compiles with XeLaTeX (Latin script, Latin Modern font — no
-vendored font needed): `latexmk -xelatex book.tex`.
+The 36-chapter book compiles warning-free with XeLaTeX (Latin script, Latin
+Modern font — no vendored font needed): `latexmk -xelatex book.tex`.
 
 ## Files
 

--- a/code/learning/human-languages/latin/book/chapters/ch16-numbers-11-20.tex
+++ b/code/learning/human-languages/latin/book/chapters/ch16-numbers-11-20.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:e837b83ec32bb5ad
+% canonical-source-hash: fnv1a64:b99e5996a77b8d8d
 % canonical-lessons: LA-C16-undecim-viginti
 
 \chapter{Numbers Eleven to Twenty}
@@ -61,5 +61,12 @@ This is genuinely \textbf{subtractive} counting, not additive — the same logic
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
-{[}PAUSE 3s{]} What pattern do \emph{ūndecim} through \emph{quīndecim} follow? (\textbf{Additive} — number + \emph{decim}, "ten.") What's genuinely odd about Latin's 18 and 19? (They're \textbf{subtractive} — \emph{duodēvīgintī}/\emph{ūndēvīgintī}, literally "two/one FROM twenty," not "eight/nine-ten.") Did Spanish keep this subtractive pattern? (\textbf{No} — \emph{dieciocho}/\emph{diecinueve} are built fresh on plain addition, regularizing away Latin's own quirk.)
+{[}PAUSE 3s{]}
+
+\begin{itemize}
+\raggedright
+  \item What pattern do \emph{ūndecim} through \emph{quīndecim} follow? (\textbf{Additive} — number + \emph{decim}, "ten.")
+  \item What's genuinely odd about Latin's 18 and 19? (They're \textbf{subtractive} — \emph{duodēvīgintī}/\emph{ūndēvīgintī}, literally "two/one FROM twenty," not "eight/nine-ten.")
+  \item Did Spanish keep this pattern? (\textbf{No} — \emph{dieciocho}/\emph{diecinueve} use plain addition, regularizing away Latin's quirk.)
+\end{itemize}
 \end{tcolorbox}

--- a/code/learning/human-languages/latin/book/chapters/ch17-dog-and-cat.tex
+++ b/code/learning/human-languages/latin/book/chapters/ch17-dog-and-cat.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:46fa833e7f3a6f21
+% canonical-source-hash: fnv1a64:ae99ab2bc2171e5f
 % canonical-lessons: LA-C17-canis-feles-cattus
 
 \chapter{Dog and Cat}
@@ -48,5 +48,13 @@ Both "dog" and "cat" show a Latin-inherited word getting pushed aside by a newco
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
-{[}PAUSE 3s{]} What English word is a direct cousin of \textbf{canis}? (\textbf{Canine}.) Which Latin word for "cat" is older — \emph{fēlēs} or \emph{cattus}? (\textbf{Fēlēs} — Classical Latin's own word, later displaced.) Where does \emph{cattus} most likely come from? (An \textbf{Afro-Asiatic} word, probably from \textbf{Egypt}, that traveled with the cat itself.) Is Spanish's \emph{perro}-for-\emph{can} displacement just as well understood as Latin's \emph{cattus}-for-\emph{fēlēs} displacement? (\textbf{No} — \emph{cattus} has a real, sourced history; \emph{perro} remains a genuine, unsolved mystery.)
+{[}PAUSE 3s{]}
+
+\begin{itemize}
+\raggedright
+  \item What English word is a direct cousin of \textbf{canis}? (\textbf{Canine}.)
+  \item Which Latin word for "cat" is older? (\textbf{Fēlēs} — Classical Latin's own word, later displaced by \emph{cattus}.)
+  \item Where does \emph{cattus} most likely come from? (An \textbf{Afro-Asiatic} word, probably from \textbf{Egypt}, that traveled with the cat itself.)
+  \item Are the two displacements equally well understood? (\textbf{No} — \emph{cattus} has a sourced history; Spanish \emph{perro} remains a genuine mystery.)
+\end{itemize}
 \end{tcolorbox}

--- a/code/learning/human-languages/latin/book/chapters/ch20-exchanging-names.tex
+++ b/code/learning/human-languages/latin/book/chapters/ch20-exchanging-names.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:a2461bf89cfc590f
+% canonical-source-hash: fnv1a64:b25c55ef1e914d27
 % canonical-lessons: LA-C20-quid-tibi-nomen, LA-C20-name-case-variation
 
 \chapter{Exchanging Names}
@@ -84,5 +84,13 @@ The underlying dative-of-possession construction is the same. The choice between
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
-{[}PAUSE 3s{]} Which case remains constant for the possessor? (\textbf{Dative.}) Which author tends toward nominative \textbf{Mārcus}? (\textbf{Cicero.}) Which authors more often use matching dative \textbf{Mārcō}? (\textbf{Livy and Sallust.}) Do the two forms represent different possession constructions? (\textbf{No.})
+{[}PAUSE 3s{]}
+
+\begin{itemize}
+\raggedright
+  \item Which case remains constant for the possessor? (\textbf{Dative.})
+  \item Which author tends toward nominative \textbf{Mārcus}? (\textbf{Cicero.})
+  \item Which authors more often use matching dative \textbf{Mārcō}? (\textbf{Livy and Sallust.})
+  \item Do the two forms represent different possession constructions? (\textbf{No.})
+\end{itemize}
 \end{tcolorbox}

--- a/code/learning/human-languages/latin/book/preamble.tex
+++ b/code/learning/human-languages/latin/book/preamble.tex
@@ -8,7 +8,9 @@
 \setdefaultlanguage{english}
 \setotherlanguage{latin}
 
-\setmainfont{Latin Modern Roman}
+\setmainfont{Latin Modern Roman}[
+  SmallCapsFont=lmromancaps10-regular.otf
+]
 \setsansfont{Latin Modern Sans}
 \setmonofont{Latin Modern Mono}
 
@@ -21,6 +23,31 @@
 \usepackage{tabularx}
 \usepackage[hidelinks]{hyperref}
 \usepackage{titlesec}
+
+% Micro-lessons end at natural pause points instead of stretching their
+% callout boxes to force every page to the same depth. The small reserve gives
+% prose a cleaner line break before it exceeds the measure.
+\raggedbottom
+\emergencystretch=2em
+
+% A few canonical headwords deliberately enumerate a whole lexical set (for
+% example, all twelve months). Keep the running head useful without trying to
+% force that entire set into one unbreakable line.
+\renewcommand{\sectionmark}[1]{\markright{\thesection}}
+
+% book.cls inserts a verso before each open-right chapter. Preserve that print
+% layout while suppressing running heads and page numbers on the blank page.
+\makeatletter
+\renewcommand{\cleardoublepage}{%
+  \clearpage
+  \if@twoside
+    \ifodd\c@page\else
+      \hbox{}\thispagestyle{empty}\newpage
+      \if@twocolumn\hbox{}\newpage\fi
+    \fi
+  \fi
+}
+\makeatother
 
 \hypersetup{
   pdftitle={Latin, Step by Step, Root by Root},

--- a/code/learning/human-languages/latin/lessons/LA-C16-undecim-viginti.md
+++ b/code/learning/human-languages/latin/lessons/LA-C16-undecim-viginti.md
@@ -93,9 +93,11 @@ something genuinely odd in Latin's own counting.
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[LA-GRAMMAR-WEATHER-VERBS-01, LA-LEX-WEATHER-VERBS-02, LA-LEX-UNDECIM-VIGINTI-01, LA-LEX-UNDECIM-VIGINTI-02, LA-PRAGMATICS-UNDECIM-VIGINTI-03, LA-LEX-UNDECIM-VIGINTI-04] -->
 
-[PAUSE 3s] What pattern do *ūndecim* through *quīndecim* follow? (**Additive**
-— number + *decim*, "ten.") What's genuinely odd about Latin's 18 and 19?
-(They're **subtractive** — *duodēvīgintī*/*ūndēvīgintī*, literally "two/one
-FROM twenty," not "eight/nine-ten.") Did Spanish keep this subtractive
-pattern? (**No** — *dieciocho*/*diecinueve* are built fresh on plain
-addition, regularizing away Latin's own quirk.)
+[PAUSE 3s]
+- What pattern do *ūndecim* through *quīndecim* follow? (**Additive** — number
+  + *decim*, "ten.")
+- What's genuinely odd about Latin's 18 and 19? (They're **subtractive** —
+  *duodēvīgintī*/*ūndēvīgintī*, literally "two/one FROM twenty," not
+  "eight/nine-ten.")
+- Did Spanish keep this pattern? (**No** — *dieciocho*/*diecinueve* use plain
+  addition, regularizing away Latin's quirk.)

--- a/code/learning/human-languages/latin/lessons/LA-C17-canis-feles-cattus.md
+++ b/code/learning/human-languages/latin/lessons/LA-C17-canis-feles-cattus.md
@@ -87,11 +87,11 @@ simplification for beginners.
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-UNDECIM-VIGINTI-01, LA-LEX-UNDECIM-VIGINTI-02, LA-PRAGMATICS-UNDECIM-VIGINTI-03, LA-LEX-UNDECIM-VIGINTI-04, LA-ETYMON-CANIS-FELES-CATTUS-01, LA-LEX-CANIS-FELES-CATTUS-02, LA-PRAGMATICS-CANIS-FELES-CATTUS-03] -->
 
-[PAUSE 3s] What English word is a direct cousin of **canis**? (**Canine**.)
-Which Latin word for "cat" is older — *fēlēs* or *cattus*? (**Fēlēs** —
-Classical Latin's own word, later displaced.) Where does *cattus* most
-likely come from? (An **Afro-Asiatic** word, probably from **Egypt**, that
-traveled with the cat itself.) Is Spanish's *perro*-for-*can* displacement
-just as well understood as Latin's *cattus*-for-*fēlēs* displacement?
-(**No** — *cattus* has a real, sourced history; *perro* remains a genuine,
-unsolved mystery.)
+[PAUSE 3s]
+- What English word is a direct cousin of **canis**? (**Canine**.)
+- Which Latin word for "cat" is older? (**Fēlēs** — Classical Latin's own
+  word, later displaced by *cattus*.)
+- Where does *cattus* most likely come from? (An **Afro-Asiatic** word,
+  probably from **Egypt**, that traveled with the cat itself.)
+- Are the two displacements equally well understood? (**No** — *cattus* has a
+  sourced history; Spanish *perro* remains a genuine mystery.)

--- a/code/learning/human-languages/latin/lessons/LA-C20-name-case-variation.md
+++ b/code/learning/human-languages/latin/lessons/LA-C20-name-case-variation.md
@@ -75,7 +75,9 @@ one sentence has stopped using the dative of possession.
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-QUID-TIBI-NOMEN-01, LA-LEX-QUID-TIBI-NOMEN-02, LA-GRAMMAR-NAME-CASE-VARIATION-01, LA-GRAMMAR-NAME-CASE-VARIATION-02] -->
 
-[PAUSE 3s] Which case remains constant for the possessor? (**Dative.**)
-Which author tends toward nominative **Mārcus**? (**Cicero.**) Which
-authors more often use matching dative **Mārcō**? (**Livy and Sallust.**)
-Do the two forms represent different possession constructions? (**No.**)
+[PAUSE 3s]
+- Which case remains constant for the possessor? (**Dative.**)
+- Which author tends toward nominative **Mārcus**? (**Cicero.**)
+- Which authors more often use matching dative **Mārcō**? (**Livy and
+  Sallust.**)
+- Do the two forms represent different possession constructions? (**No.**)


### PR DESCRIPTION
## Summary
- make the complete Latin book build warning-free while preserving open-right chapter starts
- keep intentionally blank versos truly blank and use compact, safe running heads
- improve three dense canonical recall blocks so the app and generated book share scannable reviews
- record HL-B35 findings and promote Spanish canonical publication as the next backlog item

## Validation
- `npm run build`, `npm test` (84), `npm run report`, `npm run check:books` in human-language-data
- `npm run build`, `npm test` (464) in Language Ladder
- forced `latexmk -g -xelatex -interaction=nonstopmode -halt-on-error book.tex`
- 115 pages; correct title/author; 38 top-level and 91 total outline entries; zero schema leaks
- zero missing glyphs, overfull/underfull boxes, duplicate destinations, Hyperref, LaTeX, or font warnings
- all 115 rendered pages visually inspected; final forced render is pixel-identical
- `git diff --check`