### PR TITLE
Add sealed packages for Level 1 skills

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -1031,6 +1031,7 @@ members = [
   "chief-of-staff-agent-manifest",
   "chief-of-staff-agent-discovery",
   "chief-of-staff-skill-parser",
+  "chief-of-staff-skill-package",
   "chief-of-staff-skill-runtime",
   "chief-of-staff-agent-stdio-protocol",
   "chief-of-staff-agent-stdio-host",

--- a/code/packages/rust/chief-of-staff-agent-discovery/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-agent-discovery/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Discover signed Level 1 `SKILL.md` packages through the same verified catalog
+  and registration contract as Deno packages.
 - Add bounded, deterministic reload plans between complete verified snapshots.
 - Reject scans and externally supplied snapshots above 4,096 packages.
 

--- a/code/packages/rust/chief-of-staff-agent-discovery/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-agent-discovery/Cargo.toml
@@ -12,4 +12,5 @@ chief-of-staff-service-registry = { path = "../chief-of-staff-service-registry" 
 chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
 
 [dev-dependencies]
+chief-of-staff-skill-package = { path = "../chief-of-staff-skill-package" }
 coding_adventures_ed25519 = { path = "../ed25519" }

--- a/code/packages/rust/chief-of-staff-agent-discovery/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-agent-discovery/src/lib.rs
@@ -383,8 +383,10 @@ fn restart_policy(value: &str) -> RestartPolicy {
 mod tests {
     use super::*;
     use chief_of_staff_host_runtime::{
-        hash_package_contents, DenoLaunchPlan, PackageKeyType, TrustedPackageKey,
+        hash_package_contents, AgentPackageRuntime, DenoLaunchPlan, PackageKeyType,
+        TrustedPackageKey,
     };
+    use chief_of_staff_skill_package::build_signed_skill_package;
     use coding_adventures_ed25519::{generate_keypair, sign};
     use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -454,6 +456,17 @@ mod tests {
             &found.package().digest()
         );
         assert!(Path::new(found.registration().package_path().as_str()).is_absolute());
+    }
+
+    #[test]
+    fn explicit_candidate_discovers_a_sealed_skill_only_package() {
+        let f = Fixture::new(PrivilegeTier::Tier1);
+        let path = f.root.join("weather-skill.agent");
+        let source = "---\nagent: weather-skill\ndescription: Reports friendly forecasts for requested cities.\nprivilege_tier: 0\nreads: [weather-requests]\nwrites: [weather-reports]\nmessage_schema_versions: [weather-requests=1, weather-reports=1]\n---\n# Weather Skill\n\nReport a concise forecast for the requested city.\n\n## Capabilities needed\n- none\n";
+        build_signed_skill_package(&path, source, "test", &f.secret).unwrap();
+        let found = inspect_agent_package(&path, &f.keyring).unwrap();
+        assert_eq!(found.manifest().agent, "weather-skill");
+        assert_eq!(found.package().runtime(), AgentPackageRuntime::Skill);
     }
     #[test]
     fn scan_is_sorted_and_ignores_siblings() {

--- a/code/packages/rust/chief-of-staff-host-runtime/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host-runtime/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Support a distinct signed, code-free `SKILL.md` package layout alongside the
+  canonical deny-all Deno layout.
+- Add no-overwrite package signing and retain authenticated Level 1 source bytes
+  for race-free trusted loading.
 - Retain authenticated manifest bytes for race-free package discovery.
 - Expose read-only trusted public-key lookup for daemon composition and audits.
 - Add a canonical deny-all Deno launch plan shared by package generation,

--- a/code/packages/rust/chief-of-staff-host-runtime/README.md
+++ b/code/packages/rust/chief-of-staff-host-runtime/README.md
@@ -22,15 +22,18 @@ JSON-lines stdio channel. Neither direction introduces a second tool-routing
 policy.
 
 Supervised activation is now verified-only. `verify_agent_package` walks the
-sealed package without following symlinks, requires `manifest.json`, `launch.sh`,
-and at least one `code/` file, and hashes every signed file in sorted path order.
+sealed package without following symlinks and hashes every signed file in sorted
+path order. Deno packages require `manifest.json`, canonical `launch.sh`, and
+`code/agent_runtime.ts`. Zero-code Level 1 packages instead contain exactly
+`manifest.json` and `SKILL.md`; executable or auxiliary files are rejected.
 Each path and payload is length-framed under the `chief-agent-package-v1` domain
 before SHA-256, preventing concatenation ambiguity. `SIGNATURE` is 64 raw
 Ed25519 bytes over that digest, while `PUBKEY_ID` selects a reviewed key from the
 orchestrator keyring. Production, developer, and third-party keys carry explicit
 privilege ceilings; developer keys are structurally capped at Tier 1.
 The verified result retains the exact authenticated manifest bytes so discovery
-does not re-read policy through a verify/read race.
+does not re-read policy through a verify/read race. For Level 1 it also retains
+the authenticated skill bytes for the same reason.
 
 `spawn_deno_verified` closes the next launch boundary. It re-verifies the sealed
 package immediately before creating processes, requires the signed

--- a/code/packages/rust/chief-of-staff-host-runtime/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host-runtime/src/lib.rs
@@ -5,8 +5,9 @@
 mod package;
 
 pub use package::{
-    hash_package_contents, verify_agent_package, DenoLaunchPlan, PackageKeyType, PackageKeyring,
-    PackageVerificationError, TrustedPackageKey, VerifiedAgentPackage,
+    hash_package_contents, sign_agent_package, verify_agent_package, AgentPackageRuntime,
+    DenoLaunchPlan, PackageKeyType, PackageKeyring, PackageVerificationError, TrustedPackageKey,
+    VerifiedAgentPackage,
 };
 
 use chief_of_staff_tool_api::{
@@ -446,6 +447,12 @@ impl HostProcessSpec {
         package: &VerifiedAgentPackage,
         restart_policy: StdioWorkerRestartPolicy,
     ) -> Result<Self, HostRuntimeError> {
+        if package.runtime() != AgentPackageRuntime::Deno {
+            return Err(HostRuntimeError::PackageRuntimeMismatch {
+                expected: AgentPackageRuntime::Deno,
+                actual: package.runtime(),
+            });
+        }
         let entrypoint = package.path().join(DenoLaunchPlan::entrypoint_relative());
         if !entrypoint.is_file() {
             return Err(HostRuntimeError::MissingDenoEntrypoint(entrypoint));
@@ -959,6 +966,10 @@ pub enum HostRuntimeError {
         maximum: PrivilegeTier,
     },
     PackageVerification(String),
+    PackageRuntimeMismatch {
+        expected: AgentPackageRuntime,
+        actual: AgentPackageRuntime,
+    },
     MissingDenoEntrypoint(std::path::PathBuf),
     InvalidDenoEntrypoint(std::path::PathBuf),
     ToolApi(ToolApiError),
@@ -1051,6 +1062,10 @@ impl Display for HostRuntimeError {
             Self::PackageVerification(message) => {
                 write!(f, "agent package failed launch-time verification: {message}")
             }
+            Self::PackageRuntimeMismatch { expected, actual } => write!(
+                f,
+                "agent package runtime mismatch: expected {expected:?}, found {actual:?}"
+            ),
             Self::MissingDenoEntrypoint(path) => {
                 write!(f, "signed package is missing Deno entrypoint '{}'", path.display())
             }
@@ -1326,6 +1341,40 @@ while (true) {
         (path, keyring)
     }
 
+    fn signed_skill_package() -> (std::path::PathBuf, PackageKeyring) {
+        let path = std::env::temp_dir().join(format!(
+            "chief-skill-package-{}-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+            NEXT_PACKAGE_ID.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        std::fs::write(path.join("manifest.json"), b"{}").unwrap();
+        std::fs::write(
+            path.join("SKILL.md"),
+            b"# Weather\n\nReport forecasts.\n\n## Capabilities needed\n- none\n",
+        )
+        .unwrap();
+        let (public_key, secret_key) = generate_keypair(&[29; 32]);
+        sign_agent_package(&path, "dev-skill", &secret_key).unwrap();
+        let mut keyring = PackageKeyring::new();
+        keyring
+            .trust(
+                TrustedPackageKey::new(
+                    "dev-skill",
+                    PackageKeyType::Developer,
+                    public_key,
+                    PrivilegeTier::Tier1,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        (path, keyring)
+    }
+
     fn signed_deno_agent_package(code: &str) -> (std::path::PathBuf, PackageKeyring) {
         let path = std::env::temp_dir().join(format!(
             "chief-deno-agent-package-{}-{}-{}",
@@ -1468,6 +1517,25 @@ while (true) {
             .last()
             .unwrap()
             .ends_with(expected.last().unwrap()));
+        std::fs::remove_dir_all(package_path).unwrap();
+    }
+
+    #[test]
+    fn deno_launch_rejects_a_verified_skill_runtime() {
+        let (package_path, keyring) = signed_skill_package();
+        let package = verify_agent_package(&package_path, &keyring).unwrap();
+        assert!(matches!(
+            HostProcessSpec::deny_all_deno(
+                "skill_host",
+                "deno",
+                &package,
+                StdioWorkerRestartPolicy::Never,
+            ),
+            Err(HostRuntimeError::PackageRuntimeMismatch {
+                expected: AgentPackageRuntime::Deno,
+                actual: AgentPackageRuntime::Skill,
+            })
+        ));
         std::fs::remove_dir_all(package_path).unwrap();
     }
 
@@ -1667,6 +1735,8 @@ for line in sys.stdin:
             key_id: "dev-1".to_string(),
             key_type: PackageKeyType::Developer,
             maximum_tier: PrivilegeTier::Tier1,
+            runtime: AgentPackageRuntime::Deno,
+            skill_source_bytes: None,
         };
         let runtime = SupervisedOrchestratorRuntime::spawn_verified(
             profile,
@@ -1738,6 +1808,8 @@ for line in sys.stdin:
             key_id: "dev-1".to_string(),
             key_type: PackageKeyType::Developer,
             maximum_tier: PrivilegeTier::Tier1,
+            runtime: AgentPackageRuntime::Deno,
+            skill_source_bytes: None,
         };
         assert!(matches!(
             SupervisedOrchestratorRuntime::spawn_verified(profile, vec![], &package),

--- a/code/packages/rust/chief-of-staff-host-runtime/src/package.rs
+++ b/code/packages/rust/chief-of-staff-host-runtime/src/package.rs
@@ -4,12 +4,14 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt::{self, Display, Formatter};
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 const SIGNATURE_FILE: &str = "SIGNATURE";
 const KEY_ID_FILE: &str = "PUBKEY_ID";
 const HASH_DOMAIN: &[u8] = b"chief-agent-package-v1\0";
 const DENO_ENTRYPOINT: &str = "code/agent_runtime.ts";
+const SKILL_ENTRYPOINT: &str = "SKILL.md";
 const DENO_FLAGS: &[&str] = &[
     "run",
     "--quiet",
@@ -57,6 +59,15 @@ impl DenoLaunchPlan {
         fs::write(package_path.join("launch.sh"), Self::launch_script())
             .map_err(PackageVerificationError::Io)
     }
+}
+
+/// Authenticated runtime kind selected by a sealed agent package.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentPackageRuntime {
+    /// A deny-all Deno subprocess using the canonical trusted launch plan.
+    Deno,
+    /// A zero-code Level 1 skill executed by the trusted in-process runtime.
+    Skill,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -126,6 +137,8 @@ pub struct VerifiedAgentPackage {
     pub(crate) key_id: String,
     pub(crate) key_type: PackageKeyType,
     pub(crate) maximum_tier: PrivilegeTier,
+    pub(crate) runtime: AgentPackageRuntime,
+    pub(crate) skill_source_bytes: Option<Vec<u8>>,
 }
 
 impl VerifiedAgentPackage {
@@ -153,6 +166,16 @@ impl VerifiedAgentPackage {
     pub fn maximum_tier(&self) -> PrivilegeTier {
         self.maximum_tier
     }
+
+    /// Return the authenticated runtime kind selected by the package layout.
+    pub fn runtime(&self) -> AgentPackageRuntime {
+        self.runtime
+    }
+
+    /// Borrow the exact authenticated `SKILL.md` bytes for a Level 1 package.
+    pub fn skill_source_bytes(&self) -> Option<&[u8]> {
+        self.skill_source_bytes.as_deref()
+    }
 }
 
 pub fn verify_agent_package(
@@ -177,23 +200,8 @@ pub fn verify_agent_package(
         .try_into()
         .map_err(|_| PackageVerificationError::InvalidSignatureLength)?;
     let entries = package_contents(package_path)?;
-    let (digest, files) = hash_contents(&entries);
-    for required in ["manifest.json", "launch.sh"] {
-        if !files.contains(required) {
-            return Err(PackageVerificationError::MissingRequiredFile(required));
-        }
-    }
-    if !files.iter().any(|path| path.starts_with("code/")) {
-        return Err(PackageVerificationError::MissingCode);
-    }
-    if !files.contains(DENO_ENTRYPOINT) {
-        return Err(PackageVerificationError::MissingDenoEntrypoint);
-    }
-    let launch_script = file_bytes(&entries, "launch.sh")
-        .expect("required launch script must be present in collected package files");
-    if launch_script != DenoLaunchPlan::launch_script().as_bytes() {
-        return Err(PackageVerificationError::UntrustedLaunchScript);
-    }
+    let (digest, _) = hash_contents(&entries);
+    let (runtime, skill_source_bytes) = validate_package_layout(&entries)?;
     if !coding_adventures_ed25519::verify(&digest, &signature, &key.public_key) {
         return Err(PackageVerificationError::SignatureMismatch);
     }
@@ -206,7 +214,68 @@ pub fn verify_agent_package(
         key_id,
         key_type: key.key_type,
         maximum_tier: key.maximum_tier,
+        runtime,
+        skill_source_bytes,
     })
+}
+
+/// Validate and sign one already-populated package directory.
+///
+/// Authentication metadata is written only after the unsigned contents match
+/// one supported runtime layout. Existing authentication files are never
+/// overwritten.
+pub fn sign_agent_package(
+    package_path: &Path,
+    key_id: &str,
+    secret_key: &[u8; 64],
+) -> Result<[u8; 32], PackageVerificationError> {
+    validate_key_id(key_id)?;
+    let metadata = fs::symlink_metadata(package_path).map_err(PackageVerificationError::Io)?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err(PackageVerificationError::InvalidPackageRoot);
+    }
+    for authentication_file in [KEY_ID_FILE, SIGNATURE_FILE] {
+        match fs::symlink_metadata(package_path.join(authentication_file)) {
+            Ok(_) => return Err(PackageVerificationError::AlreadySigned),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(PackageVerificationError::Io(error)),
+        }
+    }
+    let entries = package_contents(package_path)?;
+    validate_package_layout(&entries)?;
+    let (digest, _) = hash_contents(&entries);
+    let signature = coding_adventures_ed25519::sign(&digest, secret_key);
+    write_new_authentication_file(package_path.join(SIGNATURE_FILE), &signature)?;
+    if let Err(error) =
+        write_new_authentication_file(package_path.join(KEY_ID_FILE), key_id.as_bytes())
+    {
+        let _ = fs::remove_file(package_path.join(SIGNATURE_FILE));
+        return Err(error);
+    }
+    Ok(digest)
+}
+
+fn write_new_authentication_file(
+    path: PathBuf,
+    bytes: &[u8],
+) -> Result<(), PackageVerificationError> {
+    let mut file = match fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            return Err(PackageVerificationError::AlreadySigned);
+        }
+        Err(error) => return Err(PackageVerificationError::Io(error)),
+    };
+    if let Err(error) = file.write_all(bytes) {
+        drop(file);
+        let _ = fs::remove_file(path);
+        return Err(PackageVerificationError::Io(error));
+    }
+    Ok(())
 }
 
 pub fn hash_package_contents(
@@ -237,6 +306,46 @@ fn hash_contents(entries: &[(String, Vec<u8>)]) -> ([u8; 32], BTreeSet<String>) 
         hasher.update(bytes);
     }
     (hasher.digest(), paths)
+}
+
+fn validate_package_layout(
+    entries: &[(String, Vec<u8>)],
+) -> Result<(AgentPackageRuntime, Option<Vec<u8>>), PackageVerificationError> {
+    let files = entries
+        .iter()
+        .map(|(path, _)| path.as_str())
+        .collect::<BTreeSet<_>>();
+    if !files.contains("manifest.json") {
+        return Err(PackageVerificationError::MissingRequiredFile(
+            "manifest.json",
+        ));
+    }
+    if let Some(skill_source) = file_bytes(entries, SKILL_ENTRYPOINT) {
+        if let Some(unexpected) = files
+            .iter()
+            .find(|path| !matches!(**path, "manifest.json" | SKILL_ENTRYPOINT))
+        {
+            return Err(PackageVerificationError::UnexpectedSkillPackageFile(
+                (*unexpected).to_string(),
+            ));
+        }
+        return Ok((AgentPackageRuntime::Skill, Some(skill_source.to_vec())));
+    }
+    if !files.contains("launch.sh") {
+        return Err(PackageVerificationError::MissingRequiredFile("launch.sh"));
+    }
+    if !files.iter().any(|path| path.starts_with("code/")) {
+        return Err(PackageVerificationError::MissingCode);
+    }
+    if !files.contains(DENO_ENTRYPOINT) {
+        return Err(PackageVerificationError::MissingDenoEntrypoint);
+    }
+    let launch_script = file_bytes(entries, "launch.sh")
+        .expect("required launch script must be present in collected package files");
+    if launch_script != DenoLaunchPlan::launch_script().as_bytes() {
+        return Err(PackageVerificationError::UntrustedLaunchScript);
+    }
+    Ok((AgentPackageRuntime::Deno, None))
 }
 
 fn file_bytes<'a>(entries: &'a [(String, Vec<u8>)], path: &str) -> Option<&'a [u8]> {
@@ -299,10 +408,12 @@ pub enum PackageVerificationError {
     DeveloperTierTooHigh(PrivilegeTier),
     UntrustedKey(String),
     InvalidSignatureLength,
+    AlreadySigned,
     MissingRequiredFile(&'static str),
     MissingCode,
     MissingDenoEntrypoint,
     UntrustedLaunchScript,
+    UnexpectedSkillPackageFile(String),
     Symlink(PathBuf),
     NonUtf8Path(PathBuf),
     SignatureMismatch,
@@ -320,6 +431,7 @@ impl Display for PackageVerificationError {
             }
             Self::UntrustedKey(key_id) => write!(f, "package key '{key_id}' is not trusted"),
             Self::InvalidSignatureLength => f.write_str("package signature must be 64 raw bytes"),
+            Self::AlreadySigned => f.write_str("agent package authentication files already exist"),
             Self::MissingRequiredFile(path) => write!(f, "agent package is missing '{path}'"),
             Self::MissingCode => f.write_str("agent package must contain at least one code file"),
             Self::MissingDenoEntrypoint => {
@@ -327,6 +439,12 @@ impl Display for PackageVerificationError {
             }
             Self::UntrustedLaunchScript => {
                 f.write_str("agent package launch.sh does not match the trusted deny-all plan")
+            }
+            Self::UnexpectedSkillPackageFile(path) => {
+                write!(
+                    f,
+                    "SKILL.md package contains unexpected signed file '{path}'"
+                )
             }
             Self::Symlink(path) => write!(
                 f,
@@ -374,6 +492,17 @@ mod tests {
         fs::write(path.join(SIGNATURE_FILE), sign(&digest, secret_key)).unwrap();
     }
 
+    fn write_signed_skill_package(path: &Path, key_id: &str, secret_key: &[u8; 64]) {
+        fs::create_dir_all(path).unwrap();
+        fs::write(path.join("manifest.json"), b"{\"runtime\":\"skill\"}").unwrap();
+        fs::write(
+            path.join(SKILL_ENTRYPOINT),
+            b"# Weather\n\nReport friendly forecasts.\n\n## Capabilities needed\n- none\n",
+        )
+        .unwrap();
+        sign_agent_package(path, key_id, secret_key).unwrap();
+    }
+
     #[test]
     fn verifies_signed_package_and_rejects_byte_tampering() {
         let path = package_dir("tamper");
@@ -395,11 +524,60 @@ mod tests {
         let verified = verify_agent_package(&path, &keyring).unwrap();
         assert_eq!(verified.key_id(), "prod-1");
         assert_eq!(verified.key_type(), PackageKeyType::Production);
+        assert_eq!(verified.runtime(), AgentPackageRuntime::Deno);
+        assert_eq!(verified.skill_source_bytes(), None);
         assert_eq!(verified.manifest_bytes(), b"{\"runtime\":\"typescript\"}");
         fs::write(path.join("code/agent.ts"), b"console.log('tampered');\n").unwrap();
         assert!(matches!(
             verify_agent_package(&path, &keyring),
             Err(PackageVerificationError::SignatureMismatch)
+        ));
+        fs::remove_dir_all(path).unwrap();
+    }
+
+    #[test]
+    fn verifies_signed_skill_package_without_a_deno_entrypoint() {
+        let path = package_dir("skill");
+        let (public_key, secret_key) = generate_keypair(&[41; 32]);
+        write_signed_skill_package(&path, "dev-skill", &secret_key);
+        let mut keyring = PackageKeyring::new();
+        keyring
+            .trust(
+                TrustedPackageKey::new(
+                    "dev-skill",
+                    PackageKeyType::Developer,
+                    public_key,
+                    PrivilegeTier::Tier1,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+
+        let verified = verify_agent_package(&path, &keyring).unwrap();
+        assert_eq!(verified.runtime(), AgentPackageRuntime::Skill);
+        assert!(verified
+            .skill_source_bytes()
+            .unwrap()
+            .starts_with(b"# Weather\n"));
+        assert!(matches!(
+            sign_agent_package(&path, "dev-skill", &secret_key),
+            Err(PackageVerificationError::AlreadySigned)
+        ));
+        fs::remove_dir_all(path).unwrap();
+    }
+
+    #[test]
+    fn skill_package_rejects_any_executable_file() {
+        let path = package_dir("skill-extra-code");
+        fs::create_dir_all(path.join("code")).unwrap();
+        fs::write(path.join("manifest.json"), b"{}").unwrap();
+        fs::write(path.join(SKILL_ENTRYPOINT), b"# Skill\n").unwrap();
+        fs::write(path.join(DENO_ENTRYPOINT), b"console.log('no');\n").unwrap();
+        let (_, secret_key) = generate_keypair(&[43; 32]);
+        assert!(matches!(
+            sign_agent_package(&path, "dev-skill", &secret_key),
+            Err(PackageVerificationError::UnexpectedSkillPackageFile(path))
+                if path == DENO_ENTRYPOINT
         ));
         fs::remove_dir_all(path).unwrap();
     }

--- a/code/packages/rust/chief-of-staff-skill-package/BUILD
+++ b/code/packages/rust/chief-of-staff-skill-package/BUILD
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+cargo test -p chief-of-staff-skill-package -- --nocapture
+cargo clippy -p chief-of-staff-skill-package --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-skill-package --no-deps

--- a/code/packages/rust/chief-of-staff-skill-package/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-skill-package/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Build signed, SKILL-only Level 1 agent packages without overwriting paths.
+- Load parsed skills from the exact authenticated package snapshot and require
+  the signed manifest to equal the manifest derived from `SKILL.md`.

--- a/code/packages/rust/chief-of-staff-skill-package/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-skill-package/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "chief-of-staff-skill-package"
+version = "0.1.0"
+edition = "2021"
+description = "Build and load sealed Level 1 SKILL.md agent packages"
+license = "MIT"
+
+[dependencies]
+chief-of-staff-host-runtime = { path = "../chief-of-staff-host-runtime" }
+chief-of-staff-skill-parser = { path = "../chief-of-staff-skill-parser" }
+
+[dev-dependencies]
+chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
+coding_adventures_ed25519 = { path = "../ed25519" }

--- a/code/packages/rust/chief-of-staff-skill-package/README.md
+++ b/code/packages/rust/chief-of-staff-skill-package/README.md
@@ -1,0 +1,17 @@
+# chief-of-staff-skill-package
+
+This package closes the trusted boundary between a zero-code Level 1
+`SKILL.md` and Chief's sealed agent catalog. A build produces exactly two
+signed content files: the original `SKILL.md` and its canonical generated
+`manifest.json`. Authentication metadata is then added by the shared host
+package signer.
+
+Level 1 is intentionally a distinct package runtime from deny-all Deno. The
+trusted Rust skill runtime already owns provider-neutral LLM execution, so a
+generated Deno shim would introduce a second, undeclared LLM API. Discovery
+still sees one `VerifiedAgentPackage` contract for both layouts.
+
+Loading never re-reads package files. It parses the `SKILL.md` bytes retained
+by verification and requires its newly derived canonical manifest to match the
+authenticated `manifest.json` byte-for-byte. This prevents a package from
+signing different instructions and policy metadata.

--- a/code/packages/rust/chief-of-staff-skill-package/required_capabilities.json
+++ b/code/packages/rust/chief-of-staff-skill-package/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/chief-of-staff-skill-package",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "write",
+      "target": "caller-selected-new-package-directory",
+      "justification": "Writes canonical SKILL.md, manifest, and authentication files into a newly created package directory without overwriting existing paths."
+    }
+  ],
+  "justification": "Trusted build-time packaging writes only to a new caller-selected directory. Loading uses bytes retained by prior sealed-package verification."
+}

--- a/code/packages/rust/chief-of-staff-skill-package/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-skill-package/src/lib.rs
@@ -1,0 +1,249 @@
+//! Build and load sealed D18 Level 1 `SKILL.md` agent packages.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use chief_of_staff_host_runtime::{
+    sign_agent_package, AgentPackageRuntime, PackageVerificationError, VerifiedAgentPackage,
+};
+use chief_of_staff_skill_parser::{parse_skill, ParsedSkill, SkillParseError};
+use core::fmt::{self, Display, Formatter};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Build one signed Level 1 package in a new caller-selected directory.
+///
+/// The target must not exist and is never overwritten. If a write or signing
+/// step fails, only the directory created by this call is removed.
+pub fn build_signed_skill_package(
+    target: &Path,
+    source: &str,
+    key_id: &str,
+    secret_key: &[u8; 64],
+) -> Result<ParsedSkill, SkillPackageError> {
+    let skill = parse_skill(source).map_err(SkillPackageError::Parse)?;
+    let manifest = skill
+        .manifest
+        .to_json()
+        .map_err(|error| SkillPackageError::Manifest(error.to_string()))?;
+    match fs::create_dir(target) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            return Err(SkillPackageError::TargetExists(target.to_path_buf()));
+        }
+        Err(error) => return Err(SkillPackageError::Io(error)),
+    }
+    let result = (|| {
+        fs::write(target.join("SKILL.md"), source).map_err(SkillPackageError::Io)?;
+        fs::write(target.join("manifest.json"), manifest).map_err(SkillPackageError::Io)?;
+        sign_agent_package(target, key_id, secret_key).map_err(SkillPackageError::Package)?;
+        Ok(())
+    })();
+    if let Err(error) = result {
+        let _ = fs::remove_dir_all(target);
+        return Err(error);
+    }
+    Ok(skill)
+}
+
+/// Parse the exact authenticated instructions from a verified Level 1 package.
+///
+/// The signed manifest must be the canonical manifest generated from those
+/// instructions. No package path is re-read after verification.
+pub fn load_verified_skill(
+    package: &VerifiedAgentPackage,
+) -> Result<ParsedSkill, SkillPackageError> {
+    if package.runtime() != AgentPackageRuntime::Skill {
+        return Err(SkillPackageError::WrongRuntime(package.runtime()));
+    }
+    let source = std::str::from_utf8(
+        package
+            .skill_source_bytes()
+            .expect("verified Skill packages retain authenticated source bytes"),
+    )
+    .map_err(|_| SkillPackageError::NonUtf8Skill)?;
+    let skill = parse_skill(source).map_err(SkillPackageError::Parse)?;
+    let canonical_manifest = skill
+        .manifest
+        .to_json()
+        .map_err(|error| SkillPackageError::Manifest(error.to_string()))?;
+    if canonical_manifest.as_bytes() != package.manifest_bytes() {
+        return Err(SkillPackageError::ManifestMismatch);
+    }
+    Ok(skill)
+}
+
+/// Stable failures from Level 1 package construction and loading.
+#[derive(Debug)]
+pub enum SkillPackageError {
+    /// The caller-selected output path already exists.
+    TargetExists(PathBuf),
+    /// Filesystem access failed while creating a new package.
+    Io(std::io::Error),
+    /// The skill document is malformed.
+    Parse(SkillParseError),
+    /// Canonical manifest serialization failed.
+    Manifest(String),
+    /// Shared package layout validation or signing failed.
+    Package(PackageVerificationError),
+    /// A non-Level 1 package was passed to the Level 1 loader.
+    WrongRuntime(AgentPackageRuntime),
+    /// The authenticated `SKILL.md` is not UTF-8.
+    NonUtf8Skill,
+    /// Signed instructions and signed generated policy disagree.
+    ManifestMismatch,
+}
+
+impl Display for SkillPackageError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TargetExists(path) => {
+                write!(formatter, "skill package target already exists: {}", path.display())
+            }
+            Self::Io(error) => write!(formatter, "skill package I/O failed: {error}"),
+            Self::Parse(error) => write!(formatter, "invalid packaged skill: {error}"),
+            Self::Manifest(error) => write!(formatter, "manifest serialization failed: {error}"),
+            Self::Package(error) => write!(formatter, "package signing failed: {error}"),
+            Self::WrongRuntime(runtime) => {
+                write!(formatter, "expected Skill package runtime, found {runtime:?}")
+            }
+            Self::NonUtf8Skill => formatter.write_str("authenticated SKILL.md is not UTF-8"),
+            Self::ManifestMismatch => formatter.write_str(
+                "authenticated manifest does not match the manifest derived from SKILL.md",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SkillPackageError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chief_of_staff_host_runtime::{
+        verify_agent_package, DenoLaunchPlan, PackageKeyType, PackageKeyring, TrustedPackageKey,
+    };
+    use chief_of_staff_tool_api::PrivilegeTier;
+    use coding_adventures_ed25519::generate_keypair;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    const SKILL: &str = "---\nagent: weather-reporter\ndescription: Reports friendly forecasts for requested cities.\nprivilege_tier: 0\nreads: [weather-requests]\nwrites: [weather-reports]\nmessage_schema_versions: [weather-requests=1, weather-reports=1]\n---\n# Weather Reporter\n\nReport a brief forecast for the requested city.\n\n## Capabilities needed\n- none\n";
+
+    fn package_dir(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "chief-skill-package-{label}-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    #[test]
+    fn builds_verifies_and_loads_one_skill_only_package() {
+        let path = package_dir("round-trip");
+        let (public_key, secret_key) = generate_keypair(&[51; 32]);
+        let built = build_signed_skill_package(&path, SKILL, "dev-weather", &secret_key).unwrap();
+        assert_eq!(built.manifest.agent, "weather-reporter");
+        let mut keyring = PackageKeyring::new();
+        keyring
+            .trust(
+                TrustedPackageKey::new(
+                    "dev-weather",
+                    PackageKeyType::Developer,
+                    public_key,
+                    PrivilegeTier::Tier1,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        let package = verify_agent_package(&path, &keyring).unwrap();
+        assert_eq!(package.runtime(), AgentPackageRuntime::Skill);
+        assert_eq!(load_verified_skill(&package).unwrap(), built);
+        let signed_files = fs::read_dir(&path)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(
+            signed_files,
+            ["PUBKEY_ID", "SIGNATURE", "SKILL.md", "manifest.json"]
+                .into_iter()
+                .map(str::to_string)
+                .collect()
+        );
+        fs::remove_dir_all(path).unwrap();
+    }
+
+    #[test]
+    fn never_overwrites_an_existing_target() {
+        let path = package_dir("existing");
+        fs::create_dir(&path).unwrap();
+        fs::write(path.join("keep.txt"), "preserve").unwrap();
+        let (_, secret_key) = generate_keypair(&[53; 32]);
+        assert!(matches!(
+            build_signed_skill_package(&path, SKILL, "dev-weather", &secret_key),
+            Err(SkillPackageError::TargetExists(found)) if found == path
+        ));
+        assert_eq!(fs::read_to_string(path.join("keep.txt")).unwrap(), "preserve");
+        fs::remove_dir_all(path).unwrap();
+    }
+
+    #[test]
+    fn rejects_a_deno_package_at_the_skill_loader_boundary() {
+        let path = package_dir("deno");
+        fs::create_dir(&path).unwrap();
+        fs::create_dir(path.join("code")).unwrap();
+        fs::write(path.join("manifest.json"), "{}").unwrap();
+        DenoLaunchPlan::write_launch_script(&path).unwrap();
+        fs::write(path.join("code/agent_runtime.ts"), "console.log('ready');\n").unwrap();
+        let (public_key, secret_key) = generate_keypair(&[55; 32]);
+        sign_agent_package(&path, "dev-deno", &secret_key).unwrap();
+        let mut keyring = PackageKeyring::new();
+        keyring
+            .trust(
+                TrustedPackageKey::new(
+                    "dev-deno",
+                    PackageKeyType::Developer,
+                    public_key,
+                    PrivilegeTier::Tier1,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        let package = verify_agent_package(&path, &keyring).unwrap();
+        assert!(matches!(
+            load_verified_skill(&package),
+            Err(SkillPackageError::WrongRuntime(AgentPackageRuntime::Deno))
+        ));
+        fs::remove_dir_all(path).unwrap();
+    }
+
+    #[test]
+    fn rejects_signed_policy_that_does_not_match_signed_instructions() {
+        let path = package_dir("manifest-mismatch");
+        fs::create_dir(&path).unwrap();
+        fs::write(path.join("SKILL.md"), SKILL).unwrap();
+        fs::write(path.join("manifest.json"), "{}\n").unwrap();
+        let (public_key, secret_key) = generate_keypair(&[57; 32]);
+        sign_agent_package(&path, "dev-mismatch", &secret_key).unwrap();
+        let mut keyring = PackageKeyring::new();
+        keyring
+            .trust(
+                TrustedPackageKey::new(
+                    "dev-mismatch",
+                    PackageKeyType::Developer,
+                    public_key,
+                    PrivilegeTier::Tier1,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        let package = verify_agent_package(&path, &keyring).unwrap();
+        assert!(matches!(
+            load_verified_skill(&package),
+            Err(SkillPackageError::ManifestMismatch)
+        ));
+        fs::remove_dir_all(path).unwrap();
+    }
+}

--- a/code/packages/rust/chief-of-staff-skill-runtime/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-skill-runtime/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Construct Level 1 runtimes directly from authenticated, policy-matched sealed
+  SKILL packages.
+
 ## 0.1.0 - 2026-08-03
 
 - Add a provider-neutral Level 1 `SKILL.md` turn executor.

--- a/code/packages/rust/chief-of-staff-skill-runtime/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-skill-runtime/Cargo.toml
@@ -9,4 +9,10 @@ license = "MIT"
 chief-of-staff-channel-crypto = { path = "../chief-of-staff-channel-crypto" }
 chief-of-staff-channel-endpoints = { path = "../chief-of-staff-channel-endpoints" }
 chief-of-staff-skill-parser = { path = "../chief-of-staff-skill-parser" }
+chief-of-staff-skill-package = { path = "../chief-of-staff-skill-package" }
+chief-of-staff-host-runtime = { path = "../chief-of-staff-host-runtime" }
 llm-gateway = { path = "../llm-gateway" }
+
+[dev-dependencies]
+chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
+coding_adventures_ed25519 = { path = "../ed25519" }

--- a/code/packages/rust/chief-of-staff-skill-runtime/README.md
+++ b/code/packages/rust/chief-of-staff-skill-runtime/README.md
@@ -5,6 +5,11 @@ the parsed skill instructions and each verified channel message through the
 repository `LlmClient`, publishes the text response, and acknowledges the input
 only after publication succeeds.
 
+`LevelOneSkillRuntime::from_verified_package` binds the exact instructions
+retained by sealed-package verification. Loading rejects non-Skill runtimes and
+packages whose signed manifest differs from the policy derived from the signed
+`SKILL.md`.
+
 The package performs no operating-system access. Channel endpoints and the LLM
 provider are injected, so tests remain deterministic and deployments can swap
 storage, transport, crypto, and model implementations independently.

--- a/code/packages/rust/chief-of-staff-skill-runtime/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-skill-runtime/src/lib.rs
@@ -10,6 +10,8 @@ use chief_of_staff_channel_crypto::Sequence;
 use chief_of_staff_channel_endpoints::{
     ChannelEndpointError, MessageId, Originator, PublishedMessage, Receiver,
 };
+use chief_of_staff_host_runtime::VerifiedAgentPackage;
+use chief_of_staff_skill_package::{load_verified_skill, SkillPackageError};
 use chief_of_staff_skill_parser::ParsedSkill;
 use llm_gateway::{
     CompletionRequest, CompletionResponse, FinishReason, LlmClient, LlmError, Message,
@@ -108,6 +110,8 @@ pub enum LevelOneRuntimeError {
     Llm(Box<LlmError>),
     /// An injected channel endpoint rejected receive, publish, or acknowledge.
     Channel(ChannelEndpointError),
+    /// A verified package did not contain matching Level 1 instructions and policy.
+    Package(Box<SkillPackageError>),
 }
 
 impl Display for LevelOneRuntimeError {
@@ -118,6 +122,7 @@ impl Display for LevelOneRuntimeError {
             Self::EmptyResponse => formatter.write_str("Level 1 model response is empty"),
             Self::Llm(error) => write!(formatter, "Level 1 model call failed: {error}"),
             Self::Channel(error) => write!(formatter, "Level 1 channel operation failed: {error}"),
+            Self::Package(error) => write!(formatter, "Level 1 package rejected: {error}"),
         }
     }
 }
@@ -133,6 +138,12 @@ impl From<LlmError> for LevelOneRuntimeError {
 impl From<ChannelEndpointError> for LevelOneRuntimeError {
     fn from(error: ChannelEndpointError) -> Self {
         Self::Channel(error)
+    }
+}
+
+impl From<SkillPackageError> for LevelOneRuntimeError {
+    fn from(error: SkillPackageError) -> Self {
+        Self::Package(Box::new(error))
     }
 }
 
@@ -156,6 +167,15 @@ impl<'a> LevelOneSkillRuntime<'a> {
             client,
             config,
         })
+    }
+
+    /// Bind the exact instructions retained by sealed-package verification.
+    pub fn from_verified_package(
+        package: &VerifiedAgentPackage,
+        client: &'a dyn LlmClient,
+        config: LevelOneRuntimeConfig,
+    ) -> Result<Self, LevelOneRuntimeError> {
+        Self::new(load_verified_skill(package)?, client, config)
     }
 
     /// Borrow the parsed skill that supplies instructions and manifest identity.
@@ -238,9 +258,17 @@ mod tests {
     use super::*;
     use chief_of_staff_channel_crypto::{ChannelId, Sequence};
     use chief_of_staff_channel_endpoints::{AgentId, ReceivedMessage};
+    use chief_of_staff_host_runtime::{
+        verify_agent_package, PackageKeyType, PackageKeyring, TrustedPackageKey,
+    };
+    use chief_of_staff_skill_package::build_signed_skill_package;
     use chief_of_staff_skill_parser::parse_skill;
+    use chief_of_staff_tool_api::PrivilegeTier;
+    use coding_adventures_ed25519::generate_keypair;
     use llm_gateway::{MockLlmClient, MockResponse, RequestFingerprint};
     use std::cell::{Cell, RefCell};
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     const SKILL: &str = "# Weather Reporter\n\nYou are a friendly weather reporting agent.\n\n## Capabilities needed\n- none\n\n## Output format\nKeep the forecast brief.\n";
     const MODEL: &str = "test-model";
@@ -275,6 +303,17 @@ mod tests {
         ));
         LevelOneSkillRuntime::new(skill, client, LevelOneRuntimeConfig::deterministic(MODEL))
             .unwrap()
+    }
+
+    fn package_dir(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "chief-skill-runtime-{label}-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
     }
 
     struct FakeReceiver {
@@ -389,6 +428,45 @@ mod tests {
         assert_eq!(response.text, "Rain is likely; bring an umbrella.");
         assert_eq!(response.model, MODEL);
         assert_eq!(runtime.skill().manifest.agent, "weather-reporter");
+    }
+
+    #[test]
+    fn verified_skill_package_executes_through_the_level_one_runtime() {
+        let path = package_dir("verified");
+        let (public_key, secret_key) = generate_keypair(&[61; 32]);
+        let built = build_signed_skill_package(&path, SKILL, "dev-level-one", &secret_key).unwrap();
+        let mut keyring = PackageKeyring::new();
+        keyring
+            .trust(
+                TrustedPackageKey::new(
+                    "dev-level-one",
+                    PackageKeyType::Developer,
+                    public_key,
+                    PrivilegeTier::Tier1,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        let package = verify_agent_package(&path, &keyring).unwrap();
+        let fingerprint = RequestFingerprint::new(
+            MODEL,
+            Some(&built.instructions),
+            &[Message::user("Seattle")],
+        );
+        let client = MockLlmClient::new()
+            .with_response(fingerprint, MockResponse::Text("Clear skies.".to_string()))
+            .with_strict_default();
+        let runtime = LevelOneSkillRuntime::from_verified_package(
+            &package,
+            &client,
+            LevelOneRuntimeConfig::deterministic(MODEL),
+        )
+        .unwrap();
+        assert_eq!(
+            runtime.respond("Seattle", "text/plain").unwrap().text,
+            "Clear skies."
+        );
+        std::fs::remove_dir_all(path).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a distinct signed, code-free `SKILL.md` runtime layout to the shared verified agent-package contract
- add a no-overwrite Level 1 package builder and race-free loader that requires signed instructions and generated policy to match
- discover Level 1 packages through the existing verified catalog and bind them directly to the provider-neutral Rust runtime
- keep canonical deny-all Deno launch restricted to Deno packages

## Security properties

- Level 1 packages contain exactly `SKILL.md` and `manifest.json` as signed content; executable or auxiliary files fail closed
- authentication files use create-new semantics and are never overwritten
- loading uses only bytes retained during signature verification, avoiding verify/read races
- the signed manifest must byte-match the canonical manifest regenerated from the signed skill

## Validation

- 46 focused tests across host verification, skill packaging, discovery, and Level 1 execution
- strict Clippy and warnings-as-errors rustdoc for all four focused packages
- 7 repository capability-taxonomy/schema tests
- repository dependency-closed plan: 4 changed, 99 built with strict Clippy, 1,567 skipped

Advances #139 and #128.

Follow-up: route the daemon's configured host executable by authenticated package runtime, then land the SKILL-only weather reference agent in #142.
