### PR TITLE
fix(human-languages): resolve Latin caps by family

### DIFF
--- a/code/learning/human-languages/latin/book/preamble.tex
+++ b/code/learning/human-languages/latin/book/preamble.tex
@@ -9,7 +9,7 @@
 \setotherlanguage{latin}
 
 \setmainfont{Latin Modern Roman}[
-  SmallCapsFont=lmromancaps10-regular.otf
+  SmallCapsFont={Latin Modern Roman Caps}
 ]
 \setsansfont{Latin Modern Sans}
 \setmonofont{Latin Modern Mono}


### PR DESCRIPTION
## Summary
- repair the Latin all-books CI failure introduced by #9885
- resolve the already-installed Latin Modern Caps face by cross-platform family name instead of a MiKTeX-specific font filename

## Evidence
- failed job 91885662649: `fontspec` could not find `lmromancaps10-regular.otf` on Ubuntu/TeX Live
- the workflow already installs the `lmodern` package, which exposes the `Latin Modern Roman Caps` family
- clean local XeLaTeX build: 115 pages and zero missing glyphs, overfull/underfull boxes, duplicate destinations, Hyperref, LaTeX, or font warnings
- rendered output remains pixel-identical to the fully inspected #9885 PDF
- `git diff --check`