### PR TITLE
feat(human-languages): publish complete Spanish book

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -106,9 +106,10 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B32 | Complete (#9875) | Publish Tamil Chapters 6–31 and its writing companions from canonical lessons rather than hand-copying another twenty-six book chapters. | Fifty-one lessons now use schema v2; forty-three later lessons generate twenty-six chapters whose source hashes are independently verified against Language Ladder, while eight prerequisite-ordered writing companions remain inside the gentle hand-authored opening chapter. |
 | HL-B33 | Complete (#9880) | Remove Tamil's LaTeX layout, duplicate-label, bookmark, font, and header-only-verso warnings. | The forced 117-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; intentionally blank chapter versos are truly empty. |
 | HL-B34 | Complete (#9883) | Publish Latin Chapters 2–36 from canonical lessons rather than hand-copying another thirty-five book chapters. | All 53 Latin lessons now use schema v2; Chapters 2–36 are generated with source hashes independently verified against Language Ladder. |
-| HL-B35 | Complete in this PR | Remove Latin's remaining LaTeX layout, font, and header-only-verso warnings. | The forced 115-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; intentionally blank chapter versos are truly empty. |
-| HL-B36 | Next | Publish Spanish Chapters 19–33 from canonical lessons rather than hand-copying another fifteen book chapters. | The Spanish PDF stops after Chapter 18 while canonical app content continues through Chapter 33; schema-v2 migration plus generation should raise book coverage from 55% to 100%. |
-| HL-B37 | Queued | Remove Spanish's remaining legacy LaTeX layout, bookmark, and font warnings. | After Chapters 4–6 generation, a forced build has no missing glyphs or duplicate labels but reports 50 overfull boxes, 14 underfull boxes, 14 Hyperref warnings, and one undefined small-caps shape; the clean-build signal is zero of each. |
+| HL-B35 | Complete (#9885, repaired by #9887) | Remove Latin's remaining LaTeX layout, font, and header-only-verso warnings. | The forced 115-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; intentionally blank chapter versos are truly empty. |
+| HL-B36 | Complete in this PR | Publish Spanish Chapters 19–33 from canonical lessons rather than hand-copying another fifteen book chapters. | The Spanish PDF now includes all 33 canonical chapters; all 21 later lessons use schema v2 and generate fifteen chapters from the same content consumed by Language Ladder. |
+| HL-B37 | Next | Remove Spanish's remaining legacy LaTeX layout, bookmark, font, and header-only-verso warnings. | The expanded forced build has no missing glyphs or duplicate destinations but reports 51 overfull hboxes, 3 underfull hboxes, 19 underfull vboxes, 14 Hyperref warnings, and 2 font-warning matches; the clean-build signal is zero of each and truly empty chapter versos. |
+| HL-P01 | Queued | Make the unified Human Languages Books result a protected merge gate, or add an equivalent gate that auto-merge must await. | #9885 auto-merged after general CI passed while the non-required books job had failed; the portable-font repair in #9887 should have been required before merge. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-M02 | Queued | Extend Telugu's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson needs a scheduled place, and the map must explicitly split or justify Chapter 20's numbers-and-weather topic collision. |
 | HL-M03 | Queued | Extend Kannada's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5; every canonical lesson needs a scheduled place, and Chapter 20's unrelated numbers/weather pairing must be split or explicitly justified. |
@@ -1058,7 +1059,41 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   glyphs, overfull or underfull boxes, duplicate destinations, Hyperref
   warnings, LaTeX warnings, or font warnings. Every rendered page was visually
   inspected for clipping, collisions, broken tables, and malformed callouts.
+- The original cleanup in #9885 exposed a cross-platform font-name mismatch in
+  the unified books job after auto-merge had already completed. #9887 replaced
+  the MiKTeX-specific font filename with the portable family name and verified
+  the exact `main` artifact in production. HL-P01 records the missing protected
+  books gate so a publication failure cannot lose that race again.
 - HL-B36 is next: publish Spanish Chapters 19–33 from the canonical app corpus.
+
+## Findings from HL-B36
+
+- All 21 Spanish lessons in Chapters 19–33 now use schema v2, with unique
+  sequences, shared-spine placement, explicit prerequisite and knowledge
+  boundaries, stable typed blocks, and effective durations below five minutes.
+  The *mano* and *agua / vino* lessons now explicitly require the grammatical-
+  gender concept they already assumed.
+- Fifteen generation targets turn the canonical later lessons into book-ready
+  LaTeX while retaining each lesson id and deterministic source hash. The
+  generated-chapter check independently guards the same AST loaded by Language
+  Ladder instead of maintaining a second content copy.
+- The curriculum report remains at 1,066 lessons, 20 tracks, 20 books, zero
+  duration violations, and zero unknown prerequisites. Publishing Chapters
+  19–33 reduces the lesson-to-book chapter gap from 15 to zero.
+- Spanish book generation now supports an inline Arabic script command backed
+  by the repository's static Naskh font. Chapter 22 preserves **لازورد** with
+  correct right-to-left shaping and no missing glyphs on a clean machine.
+- A forced XeLaTeX build expands the Spanish volume to 210 pages with correct
+  title and author metadata, 35 top-level and 155 total outline entries, zero
+  schema leaks, zero missing glyphs, and zero duplicate destinations. Every
+  rendered page was inspected for clipping, collisions, broken tables, and
+  malformed callouts.
+- The expanded warning baseline is 51 overfull hboxes, 3 underfull hboxes, 19
+  underfull vboxes, 14 Hyperref warnings, 2 font-warning matches, and zero
+  generic LaTeX warnings. These are concentrated in the legacy layout and are
+  owned by HL-B37 rather than hidden by this publication tranche.
+- HL-B37 is next: remove Spanish's remaining legacy print warnings and
+  header-only chapter versos.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -87,6 +87,113 @@
       "output": "spanish/book/chapters/ch06-first-verbs.tex"
     },
     {
+      "language": "spanish",
+      "chapter": 19,
+      "title": "Yes and No",
+      "label": "ch:spanish-basic-responses",
+      "output": "spanish/book/chapters/ch19-yes-and-no.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 20,
+      "title": "Lo Siento",
+      "label": "ch:spanish-sorry",
+      "output": "spanish/book/chapters/ch20-lo-siento.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 21,
+      "title": "Days of the Week",
+      "label": "ch:spanish-days-of-the-week",
+      "output": "spanish/book/chapters/ch21-days-of-the-week.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 22,
+      "title": "Black, White, Red, and Blue",
+      "label": "ch:spanish-black-white-red-blue",
+      "output": "spanish/book/chapters/ch22-black-white-red-blue.tex",
+      "unicodeScript": "Arabic",
+      "scriptCommand": "esar"
+    },
+    {
+      "language": "spanish",
+      "chapter": 23,
+      "title": "Parents and Siblings",
+      "label": "ch:spanish-family",
+      "output": "spanish/book/chapters/ch23-family.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 24,
+      "title": "Head and Hand",
+      "label": "ch:spanish-head-and-hand",
+      "output": "spanish/book/chapters/ch24-head-and-hand.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 25,
+      "title": "The Seasons",
+      "label": "ch:spanish-seasons",
+      "output": "spanish/book/chapters/ch25-seasons.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 26,
+      "title": "Water, Wine, and Bread",
+      "label": "ch:spanish-water-wine-bread",
+      "output": "spanish/book/chapters/ch26-water-wine-bread.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 27,
+      "title": "The Months",
+      "label": "ch:spanish-months",
+      "output": "spanish/book/chapters/ch27-months.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 28,
+      "title": "Noon and Midnight",
+      "label": "ch:spanish-noon-midnight",
+      "output": "spanish/book/chapters/ch28-noon-midnight.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 29,
+      "title": "Telling Time",
+      "label": "ch:spanish-telling-time",
+      "output": "spanish/book/chapters/ch29-telling-time.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 30,
+      "title": "The Weather",
+      "label": "ch:spanish-weather",
+      "output": "spanish/book/chapters/ch30-weather.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 31,
+      "title": "Numbers Eleven to Twenty",
+      "label": "ch:spanish-numbers-eleven-to-twenty",
+      "output": "spanish/book/chapters/ch31-numbers-11-20.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 32,
+      "title": "Dog and Cat",
+      "label": "ch:spanish-dog-and-cat",
+      "output": "spanish/book/chapters/ch32-dog-and-cat.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 33,
+      "title": "Green and Yellow",
+      "label": "ch:spanish-green-and-yellow",
+      "output": "spanish/book/chapters/ch33-green-and-yellow.tex"
+    },
+    {
       "language": "italian",
       "chapter": 2,
       "title": "How Are You?",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -1953,6 +1953,147 @@
       "tex": "spanish/book/chapters/ch06-first-verbs.tex"
     },
     {
+      "language": "spanish",
+      "chapter": 19,
+      "sourceHash": "fnv1a64:348146303665aa93",
+      "lessonIds": [
+        "ES-C19-si",
+        "ES-C19-no"
+      ],
+      "tex": "spanish/book/chapters/ch19-yes-and-no.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 20,
+      "sourceHash": "fnv1a64:4aa44d79b283395f",
+      "lessonIds": [
+        "ES-C20-lo-siento"
+      ],
+      "tex": "spanish/book/chapters/ch20-lo-siento.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 21,
+      "sourceHash": "fnv1a64:09f9bc1fc7fc5a64",
+      "lessonIds": [
+        "ES-C21-lunes-viernes",
+        "ES-C21-sabado-domingo"
+      ],
+      "tex": "spanish/book/chapters/ch21-days-of-the-week.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 22,
+      "sourceHash": "fnv1a64:2d63daa51e93ecdf",
+      "lessonIds": [
+        "ES-C22-negro-blanco",
+        "ES-C22-rojo-azul"
+      ],
+      "tex": "spanish/book/chapters/ch22-black-white-red-blue.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 23,
+      "sourceHash": "fnv1a64:c2679458c2100cb6",
+      "lessonIds": [
+        "ES-C23-padre-madre",
+        "ES-C23-hermano-hermana"
+      ],
+      "tex": "spanish/book/chapters/ch23-family.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 24,
+      "sourceHash": "fnv1a64:bcdb0fd59edf434d",
+      "lessonIds": [
+        "ES-C24-cabeza",
+        "ES-C24-mano"
+      ],
+      "tex": "spanish/book/chapters/ch24-head-and-hand.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 25,
+      "sourceHash": "fnv1a64:b76c71606e7c1944",
+      "lessonIds": [
+        "ES-C25-las-estaciones"
+      ],
+      "tex": "spanish/book/chapters/ch25-seasons.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 26,
+      "sourceHash": "fnv1a64:0643114246dbca23",
+      "lessonIds": [
+        "ES-C26-agua-vino",
+        "ES-C26-pan"
+      ],
+      "tex": "spanish/book/chapters/ch26-water-wine-bread.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 27,
+      "sourceHash": "fnv1a64:3c0241436ecab0b0",
+      "lessonIds": [
+        "ES-C27-los-meses"
+      ],
+      "tex": "spanish/book/chapters/ch27-months.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 28,
+      "sourceHash": "fnv1a64:67c5930a2b05b153",
+      "lessonIds": [
+        "ES-C28-mediodia-medianoche"
+      ],
+      "tex": "spanish/book/chapters/ch28-noon-midnight.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 29,
+      "sourceHash": "fnv1a64:ba45be8faf01ca69",
+      "lessonIds": [
+        "ES-C29-la-hora"
+      ],
+      "tex": "spanish/book/chapters/ch29-telling-time.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 30,
+      "sourceHash": "fnv1a64:063f578621dab785",
+      "lessonIds": [
+        "ES-C30-el-tiempo"
+      ],
+      "tex": "spanish/book/chapters/ch30-weather.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 31,
+      "sourceHash": "fnv1a64:f2267035c33491e1",
+      "lessonIds": [
+        "ES-C31-numeros-11-20"
+      ],
+      "tex": "spanish/book/chapters/ch31-numbers-11-20.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 32,
+      "sourceHash": "fnv1a64:2a0d1e66cf7f557a",
+      "lessonIds": [
+        "ES-C32-perro-gato"
+      ],
+      "tex": "spanish/book/chapters/ch32-dog-and-cat.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 33,
+      "sourceHash": "fnv1a64:d7715072b975cbc3",
+      "lessonIds": [
+        "ES-C33-verde-amarillo"
+      ],
+      "tex": "spanish/book/chapters/ch33-green-and-yellow.tex"
+    },
+    {
       "language": "tamil",
       "chapter": 6,
       "sourceHash": "fnv1a64:f39b57f3b08140c4",

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Chapters 19–33 — canonical app/book publication
+
+- Migrated all 21 existing lessons from *sí / no* through *verde / amarillo*
+  to the executable schema-v2 contract: shared-spine placement, stable order,
+  explicit prerequisite and knowledge flow, typed teaching blocks, and honest
+  sub-five-minute duration budgets.
+- Added the missing grammatical-gender prerequisites to *mano* and *agua /
+  vino*, so each new step depends only on material the learner has already
+  completed.
+- Generated fifteen new LaTeX chapters from the same canonical lesson ASTs
+  consumed by Language Ladder. The Spanish book now reaches Chapter 33, and
+  the corpus-wide lesson-to-book chapter gap is zero.
+- Added repository-backed inline Arabic shaping for the **لازورد** etymology in
+  the colors chapter, preserving the original script without a machine-local
+  font dependency.
+- Forced and visually inspected the complete 210-page book. Metadata, outline,
+  generated hashes, Unicode coverage, and destinations pass; the legacy layout
+  warning baseline is recorded as the next focused cleanup tranche.
+
 ## Chapters 1–6 — block-boundary prompt closure
 
 - Declared introductions and assessments at every typed block boundary across

--- a/code/learning/human-languages/spanish/README.md
+++ b/code/learning/human-languages/spanish/README.md
@@ -33,10 +33,10 @@ README is "how to actually use this."
 6. **Grammar from zero, contrasted with English.** Grammar concepts are
    introduced in context on the first word that needs them, explained with no
    assumed terminology.
-7. **An executable five-minute progression.** Chapters 1–3 use HL04 schema v2:
-   each lesson has a stable local sequence, a shared-spine node, declared
-   knowledge inputs and outputs, typed body blocks, and an independently checked
-   duration below 300 seconds.
+7. **An executable five-minute progression.** Chapters 1–6 and 19–33 use HL04
+   schema v2: each lesson has a stable local sequence, a shared-spine node,
+   declared knowledge inputs and outputs, typed body blocks, and an
+   independently checked duration below 300 seconds.
 
 ## How to use this in the car
 
@@ -71,10 +71,10 @@ Requires a LaTeX distribution with `xelatex`/`latexmk` on PATH (MiKTeX or
 TeX Live). The compiled PDF isn't committed — it's regenerated from source,
 same as build artifacts elsewhere in this repo.
 
-Chapters 1–3 are generated from the same 24 canonical lesson ASTs consumed by
-Language Ladder. Run `npm run build && npm run generate:books` from
+Chapters 1–6 and 19–33 are generated from the same 72 canonical lesson ASTs
+consumed by Language Ladder. Run `npm run build && npm run generate:books` from
 `code/packages/typescript/human-language-data` after editing those lessons; CI
-rejects stale generated TeX or source-hash metadata. Chapters 4–18 are still
+rejects stale generated TeX or source-hash metadata. Chapters 7–18 are still
 handwritten LaTeX during the staged one-source migration. `units/` is legacy
 source material, not a second canonical copy.
 
@@ -119,16 +119,24 @@ exactly where a word needs it:
   weld, twice).
 - **Chapter 18 — The Subjunctive**: subjuntivo → quiero que (the mood of the
   not-yet-real).
+- **Chapters 19–23 — Everyday building blocks**: yes/no → apology and empathy →
+  weekdays → colors → parents and siblings.
+- **Chapters 24–28 — Body, seasons, food, and time**: head and hand → seasons →
+  water, wine, and bread → months → noon and midnight.
+- **Chapters 29–33 — Daily description**: telling time → weather → numbers
+  eleven through twenty → dog and cat → green and yellow.
 
 Every noun carries its gender (*el*/*la*) and plural; every pronoun is traced
-to its root. **All 18 chapters are authored and in the book (138 pages); Chapters
-1–3 are generated from canonical lessons.**
+to its root. **All 33 chapters are authored and in the book (210 pages);
+Chapters 1–6 and 19–33 are generated from canonical lessons.**
 Lessons are named by **slug** (e.g. `ES-C01-dia`), not numbered — order lives
 in the book (which LaTeX auto-numbers) and in `session-map.md`, so inserting a
 lesson never renumbers anything.
 - **Pronunciation**: [`pronunciation-reference.md`](./pronunciation-reference.md)
   (look-up reference, not a chapter).
-- **Later chapters**: skeleton in [`roadmap.md`](./roadmap.md).
+- **Progression metadata**: [`roadmap.md`](./roadmap.md) and
+  [`session-map.md`](./session-map.md) still need reconciliation through
+  Chapter 33; this is tracked as HL-M09 in the shared backlog.
 - **`units/` (legacy)**: the pre-redesign coarse-grained content (old Part 0
   + Part I). Kept as source material to be re-excavated into deep lessons;
   **superseded**, not the current model. Being migrated `units/` → `lessons/`.

--- a/code/learning/human-languages/spanish/book/book.tex
+++ b/code/learning/human-languages/spanish/book/book.tex
@@ -97,5 +97,20 @@ adapt, and pass it on.
 \input{chapters/ch16-imperfect}
 \input{chapters/ch17-future-conditional}
 \input{chapters/ch18-subjunctive}
+\input{chapters/ch19-yes-and-no}
+\input{chapters/ch20-lo-siento}
+\input{chapters/ch21-days-of-the-week}
+\input{chapters/ch22-black-white-red-blue}
+\input{chapters/ch23-family}
+\input{chapters/ch24-head-and-hand}
+\input{chapters/ch25-seasons}
+\input{chapters/ch26-water-wine-bread}
+\input{chapters/ch27-months}
+\input{chapters/ch28-noon-midnight}
+\input{chapters/ch29-telling-time}
+\input{chapters/ch30-weather}
+\input{chapters/ch31-numbers-11-20}
+\input{chapters/ch32-dog-and-cat}
+\input{chapters/ch33-green-and-yellow}
 
 \end{document}

--- a/code/learning/human-languages/spanish/book/chapters/ch19-yes-and-no.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch19-yes-and-no.tex
@@ -1,0 +1,116 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:348146303665aa93
+% canonical-lessons: ES-C19-si, ES-C19-no
+
+\chapter{Yes and No}
+\label{ch:spanish-basic-responses}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[sí]{sí — yes}
+
+\label{lesson:ES-C19-si}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The smallest useful word — and the accent on it is doing real work.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{sí} = \textbf{yes}. One syllable, said \emph{see}.
+
+The written accent is not decoration — it is the \textbf{whole difference} between two words:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{sí} (with the accent) = \textbf{yes}
+  \item \textbf{si} (no accent) = \textbf{if}
+\end{itemize}
+
+They sound almost identical, so Spanish uses the mark to tell them apart on the page: \emph{Sí, si quieres} = "Yes, if you want." Miss the accent and you've written "if" where you meant "yes."
+\end{cousinweb}
+
+\begin{cousinweb}
+\textbf{sí} is Latin \textbf{sīc}, "thus, so" — answering a question with "just so," exactly the move Latin also made with \textbf{ita} ("thus" = yes, from the Latin yes/no lesson). Its Romance cousins kept the same root:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Latin \emph{sīc}} & \textbf{$\to$} \\
+\midrule
+Spanish & \textbf{sí} \\
+Italian & \textbf{sì} \\
+Portuguese & \textbf{sim} \\
+\bottomrule
+\end{tabularx}
+
+French is the odd one out — it went a completely different way for "yes" (\emph{oui}), which its own lesson tells. But say \emph{sí, sì, sim} in a row and you hear one Latin word answering across three countries.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "sí" — \emph{see}, and picture the accent{]}
+  \item {[}YOU SAY: the pair — "sí" (yes) vs "si" (if){]}
+  \item {[}YOU SAY: the cousins — "sí, sì, sim" — all from Latin \emph{sīc}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} How do you say yes in Spanish? (\textbf{sí}.) What is the \emph{only} difference between \textbf{sí} "yes" and \textbf{si} "if"? (The \textbf{written accent}.) What Latin word is \emph{sí} from, and what did it mean? (\textbf{sīc} — "thus, so".)
+\end{tcolorbox}
+\section[no]{no — no / not}
+
+\label{lesson:ES-C19-no}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The easiest word yet — and it quietly does two jobs Spanish never splits apart.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{no} = \textbf{no}. Said \emph{noh}, a clean single vowel.
+
+It is Latin \textbf{nōn} with almost nothing worn off — just the final consonant gone. Compare the family, all from the same \emph{nōn}:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Latin \emph{nōn}} & \textbf{$\to$} \\
+\midrule
+Spanish & \textbf{no} \\
+Italian & \textbf{no} \\
+French & \textbf{non} \\
+\bottomrule
+\end{tabularx}
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: one word, two jobs}]
+Here's the thing English splits and Spanish doesn't. English has \textbf{"no"} (the answer) and \textbf{"not"} (inside a sentence) — two different words. Spanish uses \textbf{no} for \textbf{both}:
+
+\begin{itemize}
+\raggedright
+  \item as the \textbf{answer}: \emph{¿Hablas inglés?} — \textbf{No.}
+  \item as the \textbf{negator}, placed right before the verb: \emph{\textbf{No} hablo inglés} = "I do \textbf{not} speak English."
+\end{itemize}
+
+So learning \emph{no} gives you the whole of Spanish negation for free: to make any sentence negative, drop \textbf{no} in front of the verb. One little word, two everyday jobs.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "no" — \emph{noh}{]}
+  \item {[}YOU SAY: as an answer — "¿Hablas inglés? No."{]}
+  \item {[}YOU SAY: as a negator — "No hablo inglés"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} How do you say no in Spanish? (\textbf{no}.) What Latin word is it from? (\textbf{nōn}.) Spanish \emph{no} does the work of which \textbf{two} English words? (\textbf{"no"} the answer and \textbf{"not"} the negator — \emph{No hablo} = "I do not speak.") Where does \emph{no} go to negate a sentence? (\textbf{Right before the verb}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/chapters/ch20-lo-siento.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch20-lo-siento.tex
@@ -1,0 +1,55 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:4aa44d79b283395f
+% canonical-lessons: ES-C20-lo-siento
+
+\chapter{Lo Siento}
+\label{ch:spanish-sorry}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[lo siento]{lo siento — "I'm sorry," i.e. "I feel it"}
+
+\label{lesson:ES-C20-lo-siento}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You already know \textbf{por favor}, "please" — the fourth courtesy word is \textbf{lo siento}, "I'm sorry." Spanish doesn't say "I am sorry" as an adjective; it says something closer to \textbf{"I feel this."}
+\end{quote}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{lo} = "it" — a neuter pronoun pointing at the situation itself, not a specific noun.
+  \item \textbf{siento} = "I feel," from the verb \textbf{sentir}, "to feel," from Latin \textbf{sentīre}. That root gave English a whole family: \textbf{sentiment}, \textbf{sense}, \textbf{consent} ("feel together"), and \textbf{resent} ("feel again/against").
+\end{itemize}
+
+So \textbf{lo siento} is literally \emph{"I feel it"} — you're naming the feeling (regret, sympathy) rather than declaring a state. It's the Spanish you reach for both to apologize ("\emph{lo siento}, I stepped on your foot") and to console ("\emph{lo siento mucho}," I'm so sorry, on hearing sad news).
+\end{cousinweb}
+
+\begin{culture}
+Spanish keeps a \textbf{second} word for a different job. \textbf{Perdón} ("pardon"), from \textbf{perdonar} — Latin \textbf{per-} ("thoroughly") + \textbf{dōnāre} ("to give," the same root as English \textbf{donate} and \textbf{condone}) — literally "\textbf{to give completely}," i.e. to forgive. \textbf{Perdón} is what you say to:
+
+\begin{itemize}
+\raggedright
+  \item get someone's \textbf{attention} or squeeze past them (like English "excuse me"),
+  \item ask forgiveness for something \textbf{you did wrong} (a real apology, often stronger than \emph{lo siento}).
+\end{itemize}
+
+\textbf{Lo siento} leans toward \textbf{regret/sympathy} ("I'm sorry that happened"), while \textbf{perdón} leans toward \textbf{fault and forgiveness} ("excuse me / forgive me"). Native speakers reach for whichever fits — the boundary is soft, and mixing them up is not a real mistake, just a shade off.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "siento" — I feel — then "lo siento," I feel it / I'm sorry{]}
+  \item {[}YOU SAY: the cousin word — "perdón," pardon / excuse me{]}
+  \item {[}YOU SAY: both together in your head: regret vs. forgiveness{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \textbf{lo siento} literally mean? (\textbf{"I feel it"} — \emph{siento} "I feel," from Latin \emph{sentīre}, like English \emph{sentiment}.) What's the other Spanish word for sorry/excuse-me, and how is it different? (\textbf{Perdón}, "pardon" — leans toward fault and forgiveness, or getting someone's attention, while \emph{lo siento} leans toward regret and sympathy.)
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/chapters/ch21-days-of-the-week.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch21-days-of-the-week.tex
@@ -1,0 +1,95 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:09f9bc1fc7fc5a64
+% canonical-lessons: ES-C21-lunes-viernes, ES-C21-sabado-domingo
+
+\chapter{Days of the Week}
+\label{ch:spanish-days-of-the-week}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[lunes, martes, miércoles, jueves, viernes]{lunes to viernes — the planets of the week, worn down}
+
+\label{lesson:ES-C21-lunes-viernes}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The Romans mapped the seven-day week onto the seven visible "wandering stars" — the planet-gods. Spanish kept that map, but handled the word "day" differently from its Romance cousins: where French still spells out "\textbf{-di}" (day) on every weekday, Spanish mostly just \textbf{dropped it}.
+\end{quote}
+
+\begin{cousinweb}
+Each weekday began life as \textbf{"{[}planet-god{]}'s }diēs\textbf{ (day)."} In Vulgar Latin, \emph{diēs} was simply \textbf{dropped as a separate word} in most of these — what survived is just the planet's own Latin genitive form. That's why \textbf{martes, jueves, viernes} already end in \textbf{‑s}: not because \emph{diēs} wore down into one, but because \textbf{Martis, Iovis, Veneris} — the planets' own genitive forms — end in \emph{‑s} in Latin already. \textbf{Lunes} has no such \emph{‑s} to inherit (\emph{lūnae} doesn't end in one), so it likely picked up the ending by \textbf{analogy} with its four siblings:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Spanish} & \textbf{$\leftarrow$ Latin} & \textbf{planet-god} & \textbf{English echo} \\
+\midrule
+\textbf{lunes} & \emph{lūnae diēs} & the \textbf{Moon} (\emph{luna}) & \emph{Mon}day = Moon-day \\
+\textbf{martes} & \emph{Martis diēs} & \textbf{Mars} & \emph{Tues}day (Tiw, the Germanic war-god = Mars) \\
+\textbf{miércoles} & \emph{Mercuriī diēs} & \textbf{Mercury} & \emph{Wednes}day (Woden = Mercury) \\
+\textbf{jueves} & \emph{Jovis diēs} & \textbf{Jupiter} (\emph{Jove}) & \emph{Thurs}day (\textbf{Thor} = Jupiter) \\
+\textbf{viernes} & \emph{Veneris diēs} & \textbf{Venus} & \emph{Fri}day (Frigg/Freya = Venus) \\
+\bottomrule
+\end{tabularx}
+
+Compare \textbf{French}, which keeps \emph{diēs} as its own visible syllable on every day — \textbf{lundi}, \textbf{mardi}, \textbf{jeudi} — while Spanish dropped it from four of its five weekdays. \textbf{miércoles} is the odd one out: some historians of the language think its extra "\textbf{‑coles}" is a genuine surviving trace of \emph{diēs} itself (fused in and reshaped) — though the exact sound changes are debated, unlike the plainer, better-understood story for its four siblings.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "lunes, martes, miércoles, jueves, viernes" — the work week{]}
+  \item {[}YOU SAY: each as "{[}planet{]}'s day, worn down" — "lunes = Moon, jueves = Jupiter"{]}
+  \item {[}YOU SAY: the bridge — "martes / Tuesday, both the war-god's day (Mars / Tiw)"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What did every Spanish weekday begin life as? (\textbf{"{[}Planet-god{]}'s diēs (day)"} — the same Latin phrase French keeps more visibly with \emph{-di}.) Why do \textbf{martes, jueves, viernes} end in \emph{-s}, and where does \textbf{lunes} get its \emph{-s} from? (\textbf{From the planet's own Latin genitive} — Martis/Iovis/ Veneris already end in \emph{-s}; \emph{lunes} likely picked it up \textbf{by analogy}, since \emph{lūnae} has no \emph{-s} of its own.) What's debated about \textbf{miércoles}? (\textbf{Whether its "‑coles" is a genuine surviving trace of diēs} — unlike the plainer, better-understood story for its four siblings.) Why do \emph{martes} and \emph{Tuesday} line up? (Same day — the war-god's — named \emph{Mars} in Latin, \emph{Tiw} in Germanic.)
+\end{tcolorbox}
+\section[sábado, domingo]{sábado and domingo — the week's religious edge}
+
+\label{lesson:ES-C21-sabado-domingo}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Five days named for planets — then two that broke the pattern entirely. The weekend is where \textbf{religion overwrote astronomy}, and Spanish keeps both rewrites in plain view.
+\end{quote}
+
+\begin{cousinweb}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Spanish} & \textbf{$\leftarrow$ Latin} & \textbf{meaning} & \textbf{note} \\
+\midrule
+\textbf{sábado} & \emph{sabbatum} & "\textbf{Sabbath}" & the planet-god (Saturn) is gone — replaced by the Hebrew \emph{shabbāt}, "to rest" \\
+\textbf{domingo} & \emph{diēs Dominica} & "the \textbf{Lord's} day" & \emph{Dominica} $\leftarrow$ \emph{Dominus}, "lord/master" — Spanish kept this one much less worn-down than French's \emph{dimanche} \\
+\bottomrule
+\end{tabularx}
+
+Two different rewrites:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{sábado} would have been "Saturn's day" (as English \textbf{Satur}day still is — the one weekday English kept a Roman god for). Instead, Latin Christians borrowed the Jewish \textbf{Sabbath} (\emph{Sabbatum} $\leftarrow$ Hebrew \emph{shabbāt}), and it became \emph{sábado}. So English \textbf{Saturday} and Spanish \textbf{sábado} are the \textbf{same day, two different names} — the planet vs. the Sabbath.
+  \item \textbf{domingo} drops Sun-worship entirely: where English keeps \textbf{Sun}day, Spanish made it \emph{diēs Dominica}, "the Lord's day" (\emph{Dominus} $\to$ English \textbf{dominion}, \textbf{dominate}, \textbf{dame}). Spanish kept \textbf{domingo} recognizably close to \emph{Dominica} — compare French's more worn-down \textbf{dimanche}, where the \emph{di-} (day) fossil jumped to the front of the word.
+\end{itemize}
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the full week — "lunes, martes, miércoles, jueves, viernes, sábado, domingo"{]}
+  \item {[}YOU SAY: "sábado = Sabbath, domingo = the Lord's day" — religion, not planets{]}
+  \item {[}YOU SAY: the pair-ups — "sábado / Saturday (Sabbath vs. Saturn)", "domingo / Sunday (Lord vs. Sun)"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Give all seven Spanish days. (\emph{Lunes … domingo}.) Where does \textbf{sábado} come from, and its English contrast? (The \textbf{Sabbath}, \emph{Sabbatum}; English kept \emph{Saturday} = Saturn's day.) What does \textbf{domingo} mean literally? ("The \textbf{Lord's} day," \emph{diēs Dominica}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/chapters/ch22-black-white-red-blue.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch22-black-white-red-blue.tex
@@ -1,0 +1,94 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:2d63daa51e93ecdf
+% canonical-lessons: ES-C22-negro-blanco, ES-C22-rojo-azul
+
+\chapter{Black, White, Red, and Blue}
+\label{ch:spanish-black-white-red-blue}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[negro, blanco]{negro, blanco — one inherited, one borrowed}
+
+\label{lesson:ES-C22-negro-blanco}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Two colors, two very different histories. One is straight-line Latin. The other arrived with \textbf{Germanic settlers} — and Spanish isn't even alone in borrowing it that way.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{negro} ("black") $\leftarrow$ Latin \textbf{niger}. Nothing surprising here: the same Latin root that gives English \textbf{denigrate} ("to blacken someone's name") and the Romance family's other words for black (French \emph{noir}, Italian \emph{nero}).
+\end{cousinweb}
+
+\begin{cousinweb}
+You'd expect Latin \textbf{albus} ("white"). Spanish doesn't use it. Instead it says \textbf{blanco}, from \textbf{Germanic \emph{blank}} — "\textbf{shining, gleaming}" — a loan traditionally attributed to contact with the \textbf{Visigoths}, the Germanic people who ruled Spain for centuries after Rome's collapse (though, unlike French's case below, no surviving Gothic text actually preserves this exact word, so the precise route in is a plausible traditional account rather than a directly documented one). French, meanwhile, took the very \textbf{same} Germanic word (\emph{blanc}) — this time \textbf{well-attested} as a borrowing from a \textbf{different} Germanic people, the \textbf{Franks}. Either way, two Romance sister languages ended up with the same borrowed word for white.
+
+Why would a "shining" word beat Latin's own "white"? Color words often lose out to something more \textbf{vivid} — \emph{blank} didn't just mean pale, it meant \textbf{bright, gleaming} — a flashier idea than plain \emph{albus}.
+\end{cousinweb}
+
+\begin{culture}
+Latin's own white didn't vanish — it just stopped being the everyday color word:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{word} & \textbf{meaning} & \textbf{the white inside} \\
+\midrule
+\textbf{alba} & dawn & the sky going \emph{white} \\
+\emph{albo} (rare, poetic) & white, pale & a fossil use, mostly literary now \\
+\emph{álbum} (Eng. \emph{album}) & album & a \emph{blank white} tablet \\
+\emph{albino} (Eng./Sp.) & albino & white-skinned \\
+\bottomrule
+\end{tabularx}
+
+So Latin's white is still around — tucked into \emph{alba} and \emph{álbum}, just not where a learner would first look.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "negro, blanco"{]}
+  \item {[}YOU SAY: the pairing — "negro from Latin, blanco from the Visigoths"{]}
+  \item {[}YOU SAY: "el alba" — dawn — and hear the old Latin white inside it{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which of the two is inherited from Latin? (\textbf{Negro} $\leftarrow$ \emph{niger}.) Where does \textbf{blanco} come from? (\textbf{Germanic \emph{blank}}, "shining" — brought by the \textbf{Visigoths}.) Which other language borrowed the very same Germanic word, from a different tribe? (\textbf{French} \emph{blanc}, via the \textbf{Franks}.) Where did Latin's \emph{albus} end up? (\textbf{Alba}, "dawn" — no longer the everyday color word.)
+\end{tcolorbox}
+\section[rojo, azul]{rojo, azul — an old word (taken a different path) and a borrowed one}
+
+\label{lesson:ES-C22-rojo-azul}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Last lesson: one inherited color, one borrowed. This lesson repeats the shape — but \textbf{red} takes a subtly different road than you might expect from French, and \textbf{blue} flips which word is "the everyday one."
+\end{quote}
+
+\begin{cousinweb}
+\textbf{rojo} ("red") $\leftarrow$ Latin \textbf{russus} — a more everyday, expressive Latin color-word for red. That's a \textbf{different specific Latin word} from the one behind French \emph{rouge} ($\leftarrow$ \textbf{rubeus}). Both \textbf{russus} and \textbf{rubeus}, though, descend from the very same ancient root: PIE \emph{\textbf{h\textsubscript{1}rewd\textsuperscript{h}-}} — the root behind English \textbf{red}, \textbf{rust}, \textbf{ruddy}, and Latin \emph{ruber} itself. So \emph{rojo} and \emph{rouge} (and English \emph{red}) are all \textbf{cousins} — just via two different branches of the same very old family, not one borrowed from the other.
+\end{cousinweb}
+
+\begin{cousinweb}
+\textbf{azul} ("blue") $\leftarrow$ Arabic \textbf{\esar{لازورد}} (\emph{lāzaward}), "\textbf{lapis lazuli}" — the same ultimate source as the English word \textbf{azure}. Spanish picked this up during centuries of Arabic-speaking rule in Iberia (al-Andalus).
+
+Here's the honest contrast worth knowing: in \textbf{French}, \emph{azur} exists too — but only as a \textbf{secondary, poetic} word (the sky's blue, the \emph{Côte d'Azur}), while the \textbf{everyday} French blue is the Germanic loan \emph{bleu}. In \textbf{Spanish}, it's the reverse: \textbf{azul is the plain, everyday word for blue} — there's no separate Germanic blue-word competing with it.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "rojo, azul"{]}
+  \item {[}YOU SAY: the cousins — "rojo · rouge · red," three descendants of one PIE root{]}
+  \item {[}YOU SAY: the contrast — "azul is Spanish's everyday blue; French's azur is only poetic"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Is \textbf{rojo} the same Latin word as French's \emph{rouge}? (\textbf{No} — \emph{rojo} $\leftarrow$ \emph{russus}, \emph{rouge} $\leftarrow$ \emph{rubeus} — different Latin words, but true \textbf{cousins} via the shared PIE root \emph{h\textsubscript{1}rewd\textsuperscript{h}-}.) Where does \textbf{azul} come from? (\textbf{Arabic} \emph{lāzaward}, "lapis lazuli" — the same root as English \emph{azure}.) How does azul's role in Spanish differ from azur's role in French? (\textbf{Azul is Spanish's everyday blue}; French's \emph{azur} is only a secondary, poetic word, with \emph{bleu} as the everyday one.)
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/chapters/ch23-family.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch23-family.tex
@@ -1,0 +1,100 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:c2679458c2100cb6
+% canonical-lessons: ES-C23-padre-madre, ES-C23-hermano-hermana
+
+\chapter{Parents and Siblings}
+\label{ch:spanish-family}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[el padre, la madre]{el padre, la madre — among the oldest words there are}
+
+\label{lesson:ES-C23-padre-madre}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} "Father" and "mother" are some of the \textbf{oldest reconstructible words in human language} — older than Latin, older than Rome. Spanish kept them close to the Latin original, and they are secretly the \emph{same words} as English \textbf{father} and \textbf{mother}.
+\end{quote}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{el padre} ("father") $\leftarrow$ Latin \textbf{pater} $\leftarrow$ PIE \emph{\textbf{ph\textsubscript{2}t\'{\={e}}r}}.
+  \item \textbf{la madre} ("mother") $\leftarrow$ Latin \textbf{māter} $\leftarrow$ PIE \emph{\textbf{méh\textsubscript{2}tēr}}.
+\end{itemize}
+\end{cousinweb}
+
+\begin{culture}
+\emph{Padre} and English \emph{father} both descend independently from the \textbf{same} PIE word — they're siblings, not parent and child. Latin (and Spanish after it) kept the original \emph{p} and \emph{t} largely intact; the Germanic branch that gave English took a separate road through \textbf{Grimm's Law}, which shifted the \textbf{inherited p $\to$ f} and \textbf{t $\to$ th}:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{PIE ancestor} & \textbf{Latin $\to$ Spanish} & \textbf{Germanic $\to$ English} \\
+\midrule
+\emph{ph\textsubscript{2}t\'{\={e}}r} & \emph{pater} $\to$ \textbf{padre} & \textbf{f}a\textbf{th}er \\
+\emph{méh\textsubscript{2}tēr} & \emph{māter} $\to$ \textbf{madre} & \textbf{m}o\textbf{th}er \\
+\bottomrule
+\end{tabularx}
+
+So \emph{padre} and \emph{father} aren't lookalikes borrowed late, and neither one comes \emph{from} the other — they're the \textbf{same inherited PIE word}, one branch keeping the \emph{p}, the other shifting it to \emph{f}. The Latin root also gives Spanish and English their "of a parent" adjectives: \textbf{paternal, paternidad, patrón} and \textbf{maternal, maternidad}. (A further Latin-only offshoot, \emph{māter} $\to$ \emph{māteria}, "the stuff a tree-mother produces," gives Spanish \emph{materia} and, separately, \emph{matriz} — "womb" — via Latin \emph{mātrix}.)
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "el padre, la madre"{]}
+  \item {[}YOU SAY: the sound-law — "padre keeps p; father shifts to f — same word"{]}
+  \item {[}YOU SAY: "padre $\to$ paternal; madre $\to$ maternal"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Give "father" and "mother" with their articles. (\textbf{el padre, la madre}.) Does \emph{padre} turn into English \emph{father} directly? (\textbf{No} — both descend independently from the same PIE word; the Germanic branch shifted p $\to$ f and t $\to$ th via \textbf{Grimm's Law}, while Latin/Spanish kept the original sounds.) Name an English cousin of each. (\emph{padre} $\to$ paternal; \emph{madre} $\to$ maternal.)
+\end{tcolorbox}
+\section[el hermano, la hermana]{el hermano, la hermana — brother and sister, from a different word entirely}
+
+\label{lesson:ES-C23-hermano-hermana}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You might expect Spanish "brother" to come from Latin \textbf{frāter}, the way French's \emph{frère} does. It doesn't. Spanish's siblings took a completely different word — one about \textbf{seeds}.
+\end{quote}
+
+\begin{cousinweb}
+Classical Latin could say \textbf{frāter germānus}, literally "a brother \textbf{of the same stock/blood}" — distinguishing a \emph{full} brother from a half-brother or a "brother" in a looser sense. Over time, in everyday Latin, the \textbf{adjective} \emph{germānus} took over the whole job and the noun \emph{frāter} quietly dropped out. That adjective is where Spanish's words come from:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{el hermano} ("brother") $\leftarrow$ Latin \textbf{germānus}.
+  \item \textbf{la hermana} ("sister") $\leftarrow$ Latin \textbf{germāna}.
+\end{itemize}
+\end{cousinweb}
+
+\begin{culture}
+\textbf{Germānus} traces back to \textbf{germen}, "\textbf{sprout, bud, seed}" — the same root that gives English \textbf{germ}, \textbf{germinate}, and \textbf{germane} (originally "closely related," from the same "seed," before it loosened to just "relevant"). So calling someone your \emph{hermano} is, at the etymological root, calling them "\textbf{sprung from the same seed}."
+\end{culture}
+
+\begin{culture}
+You may already know that Spanish sometimes turns a Latin initial \textbf{f} into a silent \textbf{h} — \emph{filius} $\to$ \textbf{hijo} ("son"), \emph{facere} $\to$ \textbf{hacer} ("to do"). \textbf{Hermano is NOT that.} Its story is different, and worth getting right:
+
+\emph{Germānus} is stressed on its \textbf{third} syllable (\emph{ger‑MĀ‑nus}), which leaves the opening \textbf{ger‑} unstressed. Latin's \textbf{g} before a front vowel (\emph{e}, here) had already softened toward a \emph{y}-like sound in everyday speech — and in this \textbf{unstressed} position, that soft opening simply \textbf{fell away entirely}, giving Old Spanish \emph{\textbf{ermano}} (no \emph{h} at all — this is the form actually recorded centuries ago). The \textbf{h} you see in today's \emph{hermano} was added \textbf{later, in spelling only}, to visually mark the word's old connection to Latin \emph{g‑} — unlike \emph{hijo} and \emph{hacer}, where the \emph{h} really was \textbf{pronounced} for a long stretch of Spanish's history before falling silent. Same letter today, two completely different backstories.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "hermano, hermana" — brother, sister{]}
+  \item {[}YOU SAY: the root — "germen, seed" $\to$ "germanus, of the same seed" $\to$ "hermano"{]}
+  \item {[}YOU SAY: the honest distinction — hijo/hacer's h was once truly spoken; hermano's h never was{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Does Spanish "hermano" come from Latin \emph{frāter}? (\textbf{No} — from \textbf{germānus}, "of the same stock/seed," which replaced \emph{frāter} over time.) What English words share \emph{germānus}'s root, and what does that root mean? (\textbf{Germ, germinate, germane} — from \emph{germen}, "seed/sprout.") Is \emph{hermano}'s \emph{h} the same kind of sound-change as \emph{hijo}'s or \emph{hacer}'s? (\textbf{No} — \emph{hijo/hacer}'s \emph{h} was once genuinely pronounced; \emph{germānus}'s opening sound simply \textbf{dropped} in an unstressed syllable, and \emph{hermano}'s \emph{h} is a later, purely written addition that was never spoken.)
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/chapters/ch24-head-and-hand.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch24-head-and-hand.tex
@@ -1,0 +1,110 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:bcdb0fd59edf434d
+% canonical-lessons: ES-C24-cabeza, ES-C24-mano
+
+\chapter{Head and Hand}
+\label{ch:spanish-head-and-hand}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[la cabeza]{la cabeza — "the head"}
+
+\label{lesson:ES-C24-cabeza}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Spanish's word for "head" is the boring, expected one — and that's exactly what makes it interesting, once you see what French did instead.
+\end{quote}
+
+\subsection*{You'll want to know: la cabeza}
+\begin{quote}
+\textbf{la cabeza} — the head. Feminine, so \textbf{la}.
+\end{quote}
+
+\begin{cousinweb}
+Latin's word for "head" was \textbf{caput}. Spanish's \emph{cabeza} comes straight from it (by way of Vulgar Latin \emph{capitia}), and \emph{caput} shows up all over English too:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{English} & \textbf{literally} \\
+\midrule
+\textbf{cap}tain & the "head" of a ship/unit \\
+\textbf{cap}ital & the "head" city, or "head" sum of money \\
+de\textbf{cap}itate & to remove the head \\
+\textbf{cap}itulate & to arrange under "headings" — hence, to yield \\
+\bottomrule
+\end{tabularx}
+\end{cousinweb}
+
+\begin{culture}
+French had the exact same Latin word available — and \textbf{dropped it}. French \emph{tête} ("head") comes instead from \textbf{testa}, Latin for an \textbf{earthenware pot}: Roman soldiers joked about the skull the way English speakers say "noggin" (a small mug), and in Gaul that joke eventually \textbf{replaced} the real word entirely. Spanish never made that swap — \emph{cabeza} is \emph{caput}, plain and simple, still standing after two thousand years.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "la cabeza" — the head{]}
+  \item {[}YOU SAY: "me duele la cabeza" — "my head hurts"{]}
+  \item {[}YOU SAY: the English family — "captain, capital, decapitate"{]}
+  \item {[}YOU SAY: the contrast — Spanish kept caput; French swapped it for a pot joke{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Say "the head." (\emph{La cabeza} — feminine.) What Latin word is it from? (\textbf{Caput}.) Give an English word from the same root. (\textbf{Captain, capital, decapitate}...) What did French do instead? (\textbf{Replaced caput with \emph{testa}, "pot"} — soldiers' slang for the skull that took over completely.)
+\end{tcolorbox}
+\section[la mano]{la mano — "the hand"}
+
+\label{lesson:ES-C24-mano}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You've been trusting "-o words are masculine, -a words are feminine" since Chapter 1. Here's the word that breaks it — and everyone learning Spanish has to memorize this one by name.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: la mano and its gender}]
+\begin{quote}
+\textbf{la mano} — the hand. \textbf{Feminine}, despite ending in \textbf{-o}.
+\end{quote}
+
+Almost every Spanish noun ending in \emph{-o} is masculine (\emph{el libro, el gato}...). \emph{Mano} is the single most common exception, and it's actually \textbf{doubly} irregular. Latin \textbf{manus} ("hand") belonged to the \textbf{4th declension} — a group of \emph{-us} nouns that were mostly \textbf{masculine} (\emph{frūctus} "fruit," \emph{exercitus} "army," \emph{senātus} "senate"). \emph{Manus} was one of a small handful of exceptions that were \textbf{feminine} instead (alongside \emph{domus} "house" and \emph{anus} "old woman"). So \emph{mano} broke the rule \textbf{twice over}: an exception within Latin's own mostly-masculine 4th declension, and then an exception again against Spanish's usual \emph{-o} = masculine pattern.
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{Mano} comes from Latin \textbf{manus}, "hand" — and that root is buried inside an enormous number of English words:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{English} & \textbf{literally} \\
+\midrule
+\textbf{manual} & done by hand \\
+\textbf{manufacture} & made by hand (\emph{manus} + \emph{facere}, "to make") \\
+\textbf{manuscript} & written by hand (\emph{manus} + \emph{scrībere}) \\
+\textbf{maintain} & hold in the hand (\emph{manū tenēre}) \\
+\textbf{manage} & to handle \\
+\bottomrule
+\end{tabularx}
+
+\textbf{Manufacture} is worth pausing on: it literally means "made by hand" — and today it names precisely the opposite.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "la mano" — feminine, despite the -o{]}
+  \item {[}YOU SAY: "me duele la mano" — "my hand hurts"{]}
+  \item {[}YOU SAY: the family — "manual, manufacture, maintain — all a hand"{]}
+  \item {[}YOU SAY: the irony — "manufacture = made by hand"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Say "the hand," and name its gender. (\emph{La mano} — \textbf{feminine}, despite ending in \emph{-o}.) Why is \emph{mano} feminine when most \emph{-o} words aren't? (\textbf{It's doubly irregular} — Latin's 4th declension, where \emph{manus} belongs, was mostly \textbf{masculine}; \emph{manus} was one of a few feminine exceptions there, and then an exception again against Spanish's usual -o=masculine rule.) Give an English word built on \emph{manus}. (\textbf{Manual, manufacture, manuscript, maintain, manage}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/chapters/ch25-seasons.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch25-seasons.tex
@@ -1,0 +1,49 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:b76c71606e7c1944
+% canonical-lessons: ES-C25-las-estaciones
+
+\chapter{The Seasons}
+\label{ch:spanish-seasons}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[la primavera, el verano, el otoño, el invierno]{la primavera, el verano, el otoño, el invierno — three plain, one surprising}
+
+\label{lesson:ES-C25-las-estaciones}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Three of Spanish's four seasons are exactly what you'd expect from Latin. The fourth hides a genuine surprise: its \textbf{meaning itself} drifted from one season to another.
+\end{quote}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{la primavera} ("spring") $\leftarrow$ Latin \emph{\textbf{prīma vēra}}, literally "\textbf{first spring}" (\emph{vēr}, "spring," + \emph{prīma}, "first"). Italian still says the identical phrase, \emph{primavera}, unchanged. (Old French once said \emph{primevère} too, before switching to \emph{printemps}.)
+  \item \textbf{el otoño} ("autumn") $\leftarrow$ Latin \emph{\textbf{autumnus}} — the same root behind French \emph{automne} and English \emph{autumn} itself.
+  \item \textbf{el invierno} ("winter") $\leftarrow$ Latin \emph{\textbf{hībernum}} (\emph{tempus}), "the \textbf{wintry} {[}season{]}" — the same root as French \emph{hiver} and English \textbf{hibernate}, "to spend the winter."
+\end{itemize}
+\end{cousinweb}
+
+\begin{culture}
+You might expect \emph{verano} ("summer") to come from Latin \textbf{aestas}, "heat" — the way French \emph{été} does. It doesn't. The standard account (per Spanish etymological dictionaries) traces \textbf{verano} to Latin \emph{\textbf{vērānum}} (\emph{tempus}), "\textbf{of spring}" — built on the very same \emph{vēr}, "spring," behind \emph{primavera}.
+
+So how did a word meaning "spring-ish" end up naming \textbf{summer}? The honest answer is a \textbf{shift in meaning over time}, not a sound change — though the exact story is murkier than a tidy one-line explanation. The traditional, simplified account says that as \emph{primavera} ("first spring") rose to become the standard word for spring, \emph{verano}'s meaning drifted forward into the season right after, summer; the fuller picture likely also involves Vulgar Latin agricultural usage (a "vernal" grazing or working period that stretched from late spring into early summer), so the drift may not be purely a case of one word simply vacating a job for the other. Either way, two Spanish words both rooted in \emph{vēr}, "spring," ended up naming two different seasons.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "primavera, verano, otoño, invierno" — the four seasons{]}
+  \item {[}YOU SAY: "primavera = prima vera, first spring"{]}
+  \item {[}YOU SAY: the surprise — "verano ALSO comes from vēr, 'spring' — but its meaning moved to summer"{]}
+  \item {[}YOU SAY: "invierno \textasciitilde{} hibernate"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \textbf{primavera} literally mean? (\textbf{"First spring"} — \emph{prīma vēra}.) Does \textbf{verano} come from Latin \emph{aestas}, like French \emph{été}? (\textbf{No} — from \emph{vērānum}, "of spring," the same \emph{vēr} root as \emph{primavera}; its meaning \textbf{shifted} toward summer over time — traditionally linked to \emph{primavera} taking over the job of naming spring, though the fuller history is murkier than that alone.) What English word is \textbf{invierno} the cousin of? (\textbf{Hibernate}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/chapters/ch26-water-wine-bread.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch26-water-wine-bread.tex
@@ -1,0 +1,87 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:0643114246dbca23
+% canonical-lessons: ES-C26-agua-vino, ES-C26-pan
+
+\chapter{Water, Wine, and Bread}
+\label{ch:spanish-water-wine-bread}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[el agua, el vino]{el agua, el vino — water and wine}
+
+\label{lesson:ES-C26-agua-vino}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Two drinks, two very different journeys from Latin. One barely changed at all. And the "masculine-looking" article on a feminine word isn't a mistake — it's a real, well-documented rule.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{agua} ("water") $\leftarrow$ Latin \textbf{aqua} — almost unchanged. Compare French, where the very same word was worn all the way down to a bare \textbf{"eau,"} just the sound "oh." Spanish kept nearly the whole thing.
+
+English kept the \textbf{original}, whole Latin word too, just as a learned borrowing rather than an everyday one: \textbf{aquatic, aquarium, aqueduct, aqualung} all come straight from \emph{aqua}.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: el agua's article and gender}]
+Notice: \textbf{el agua}, not \emph{la agua} — but \emph{agua} is genuinely \textbf{feminine} (you'll see it in \emph{el agua fría}, "the cold water," where \emph{fría} keeps its feminine ending). This isn't an exception to gender; it's a \textbf{pronunciation rule}: Spanish swaps \emph{la} for \emph{el} right before any \textbf{singular} feminine noun that \textbf{starts with a stressed \emph{a}-sound} (to avoid running two identical vowel sounds together, \emph{la agua}) — the plural goes right back to \emph{las}: \emph{las aguas}, never \emph{los aguas}. You'll meet the singular swap again with words like \emph{el águila} ("the eagle," still feminine) and \emph{el hacha} ("the axe," still feminine). It's only the article that changes, never the noun's actual gender.
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{vino} ("wine") $\leftarrow$ Latin \textbf{vīnum} — held its shape, the way French \emph{vin} did too. English shares the very same root, by more than one road: \textbf{wine} itself is \emph{vīnum} borrowed directly into old Germanic; \textbf{vine} and \textbf{vinegar} arrived centuries later, secondhand, via \textbf{French} (\emph{vin + aigre}, "sour wine," for vinegar); and \textbf{vineyard} isn't a borrowing at all — English built it at home, from the already-borrowed "wine" plus native "yard."
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "el agua" — water, feminine, but takes el{]}
+  \item {[}YOU SAY: "el vino" — wine{]}
+  \item {[}YOU SAY: the contrast — "agua barely changed from aqua; French's eau wore all the way down"{]}
+  \item {[}YOU SAY: "el águila, el hacha" — the same el-before-stressed-a pattern{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Is \textbf{agua} masculine or feminine, and why does it take \emph{el}? (\textbf{Feminine} — \emph{el} replaces \emph{la} only because \emph{agua} starts with a \textbf{stressed a}, a pronunciation rule, not a gender change.) How does \emph{agua}'s erosion from Latin \emph{aqua} compare to French's \emph{eau}? (\textbf{Much less} — Spanish kept nearly the whole word; French wore it down to a bare "oh.") Give an English cousin of \emph{vino}. (\textbf{Wine, vine, vinegar, vintage}.)
+\end{tcolorbox}
+\section[el pan]{el pan — bread, and the friend who shares it}
+
+\label{lesson:ES-C26-pan}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Spanish's word for bread hides the same lovely word-story you'd find in English's "companion" — except Spanish kept \textbf{both halves}, the bread and the friendship.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{el pan} ("bread") $\leftarrow$ Latin \textbf{pānis}. Masculine: \emph{el pan}.
+\end{cousinweb}
+
+\begin{culture}
+The Latin root \textbf{pān-} ("bread") gives Spanish its own word for a close friend:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{compañero / compañera} ("companion, friend, partner") $\leftarrow$ \emph{com-} ("with") + \emph{pānis} — literally "\textbf{one you share bread with}." Spanish built this word from the very same recipe as English \textbf{companion} and \textbf{company} (which come from the identical Latin pieces) — but where English only kept the \emph{friendship} sense, Spanish still visibly uses the \textbf{same root} for the actual \textbf{bread} (\emph{pan}) too.
+  \item \textbf{panadería} ("bakery") and \textbf{panadero} ("baker") — both transparently built on \emph{pan}.
+\end{itemize}
+
+So \emph{pan} and \emph{compañero} are the same word-family doing double duty in Spanish: name the food, and name the friend you'd share it with.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "el pan" — bread{]}
+  \item {[}YOU SAY: "compañero" — literally, one you share bread with{]}
+  \item {[}YOU SAY: "panadería, panadero" — bakery, baker{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Give "bread" with its article. (\textbf{El pan}.) What does \emph{compañero} literally mean, and what's it built from? ("\textbf{One you share bread with}" — \emph{com-} + \emph{pānis}.) Does English keep this same double meaning? (\textbf{No} — English's \emph{companion} only kept the friendship sense; Spanish still uses the same root for the actual bread, \emph{pan}, too.)
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/chapters/ch27-months.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch27-months.tex
@@ -1,0 +1,63 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:3c0241436ecab0b0
+% canonical-lessons: ES-C27-los-meses
+
+\chapter{The Months}
+\label{ch:spanish-months}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[los meses]{los meses — the calendar's gods and Caesars}
+
+\label{lesson:ES-C27-los-meses}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Spanish's twelve months are a \textbf{procession of Roman gods and emperors}, barely changed from Latin. Two things you already know pay off immediately: \emph{marzo} is the war-god you met in \emph{martes}, and \emph{septiembre–diciembre} are the Latin numbers 7–10 from the counting chapters.
+\end{quote}
+
+\begin{cousinweb}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Spanish} & \textbf{$\leftarrow$ Latin} & \textbf{who / what} \\
+\midrule
+\textbf{enero} & \emph{Iānuārius} & \textbf{Janus}, the two-faced god of doors \& beginnings \\
+\textbf{febrero} & \emph{Februārius} & \emph{Februa}, the Roman \textbf{purification} festival \\
+\textbf{marzo} & \emph{Martius} & \textbf{Mars}, the war-god — \emph{the same Mars as} \textbf{martes} (Tuesday)! \\
+\textbf{abril} & \emph{Aprīlis} & perhaps \emph{aperīre}, "to \textbf{open}" (buds opening) \\
+\textbf{mayo} & \emph{Māius} & \textbf{Maia}, goddess of growth \\
+\textbf{junio} & \emph{Iūnius} & \textbf{Juno}, queen of the gods \\
+\textbf{julio} & \emph{Iūlius} & originally \emph{Quīntīlis}, "the 5th {[}month{]}" — \textbf{renamed} for \textbf{Julius Caesar} after his death \\
+\textbf{agosto} & \emph{Augustus} & originally \emph{Sextīlis}, "the 6th {[}month{]}" — \textbf{renamed} for the emperor \textbf{Augustus} \\
+\textbf{septiembre} & \emph{september} & "\textbf{7th}" (\emph{septem}) \\
+\textbf{octubre} & \emph{octōber} & "\textbf{8th}" (\emph{octō}) \\
+\textbf{noviembre} & \emph{november} & "\textbf{9th}" (\emph{novem}) \\
+\textbf{diciembre} & \emph{december} & "\textbf{10th}" (\emph{decem}) \\
+\bottomrule
+\end{tabularx}
+
+Two payoffs land at once:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{marzo = Mars = martes.} The month and the weekday honor the \emph{same} war-god — \emph{Martius} (his month) and \emph{Martis diēs} (his day). Spot one, you know the other.
+  \item \textbf{The 7–10 months.} \emph{Septiembre} through \emph{diciembre} still carry \emph{septem, octō, novem, decem} — because the old Roman year originally began in \textbf{March}, with September genuinely the 7th month. Centuries before Caesar, two new months (Januarius, Februarius) were added at the front to cover the winter, which pushed every later month's number out of step with its name — September became the \emph{9th} month while still being \emph{named} "7th." \textbf{Julius} and \textbf{Augustus} had nothing to do with that shift: they simply got two already-existing months — \emph{Quintilis} and \emph{Sextilis}, literally "5th" and "6th" — \textbf{renamed} in their honor after the fact. The names stuck; the months themselves were never new.
+\end{itemize}
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the twelve — "enero, febrero, marzo, abril, mayo, junio, julio, agosto, septiembre, octubre, noviembre, diciembre"{]}
+  \item {[}YOU SAY: the tie-back — "marzo / martes — both Mars, the war-god"{]}
+  \item {[}YOU SAY: "septiembre = 7, diciembre = 10" — the old March-start year{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which god links \emph{marzo} and \emph{martes}? (\textbf{Mars}, the war-god — his month and his day.) Why is \emph{diciembre} Latin for "ten"? (\textbf{The Roman year began in March}, and adding January/February at the front later pushed every month's number out of step with its name.) Did Julius Caesar and Augustus \textbf{add} new months to the calendar? (\textbf{No} — \emph{julio} and \emph{agosto} were already-existing months, \emph{Quintilis} and \emph{Sextilis} ("5th"/"6th"), simply \textbf{renamed} in their honor.)
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/chapters/ch28-noon-midnight.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch28-noon-midnight.tex
@@ -1,0 +1,56 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:67c5930a2b05b153
+% canonical-lessons: ES-C28-mediodia-medianoche
+
+\chapter{Noon and Midnight}
+\label{ch:spanish-noon-midnight}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[mediodía, medianoche]{mediodía, medianoche — noon and midnight, spelled out in full}
+
+\label{lesson:ES-C28-mediodia-medianoche}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Two hours that don't get a number — they get a name. And Spanish keeps that name far more transparent than its French cousin does.
+\end{quote}
+
+\begin{cousinweb}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Spanish} & \textbf{$\leftarrow$ Latin} & \textbf{literally} \\
+\midrule
+\textbf{mediodía} & \emph{medius diēs} & "\textbf{mid}-\textbf{day}" (\emph{medio} "middle" + \emph{día} "day") \\
+\textbf{medianoche} & \emph{media nox} & "\textbf{mid}-\textbf{night}" (\emph{media} "middle" + \emph{noche} "night") \\
+\bottomrule
+\end{tabularx}
+
+Both halves are \textbf{fully alive, ordinary Spanish words on their own}: \textbf{medio/media} ("middle" — cousin of English \emph{medium, mid, middle}) and \textbf{día/noche} ("day/night," words you already know). Compare French, which took the same Latin phrase down a bumpier road: \emph{minuit}'s second half, \textbf{-nuit}, is still the plain, everyday French word for "night" — just as recognizable as Spanish's \emph{noche}. But \emph{midi}'s second half, \textbf{-di}, wore down into an opaque fragment: the ordinary French word for "day" is \emph{jour}, not \emph{di} — that piece survives only as a fossil, tucked inside weekday names like \emph{lundi} and \emph{mardi}. So the erosion split unevenly: French kept "night" transparent and lost "day," while Spanish kept both.
+
+They don't need \emph{horas} the way a normal Spanish time (\emph{son las tres}) never does either — they simply stand in for the hour on their own:
+
+\begin{quote}
+\textbf{Es mediodía.} — "It is noon." \textbf{Es medianoche.} — "It is midnight."
+\end{quote}
+
+(Fun aside: English \textbf{noon} comes from Latin \emph{nōna hōra}, "the \textbf{ninth} hour" — originally mid-afternoon, it drifted earlier over the centuries to mean midday. Spanish kept the tidier, transparent "mid-day" instead.)
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "mediodía" (noon), "medianoche" (midnight){]}
+  \item {[}YOU SAY: break them — "medio + día", "media + noche" — both halves still ordinary words{]}
+  \item {[}YOU SAY: "Es mediodía. Es medianoche." — they stand in for the hour{]}
+  \item {[}YOU SAY: the contrast — French kept "night" (nuit) but wore "day" down to a fossil (-di){]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What do \emph{mediodía} and \emph{medianoche} literally mean, and from what Latin? ("Mid-day" $\leftarrow$ \emph{medius diēs}; "mid-night" $\leftarrow$ \emph{media nox}.) Are both halves still recognizable, ordinary Spanish words? (\textbf{Yes} — \emph{medio/ media} "middle," \emph{día/noche} "day/night.") Did French erode its phrase evenly? (\textbf{No} — French's \emph{-nuit} stayed just as transparent as Spanish's \emph{noche}, but its \emph{-di} wore down to an opaque fossil, since the everyday French word for "day" is actually \emph{jour}.) How do you say "it is noon"? (\emph{Es mediodía}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/chapters/ch29-telling-time.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch29-telling-time.tex
@@ -1,0 +1,59 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:ba45be8faf01ca69
+% canonical-lessons: ES-C29-la-hora
+
+\chapter{Telling Time}
+\label{ch:spanish-telling-time}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[la hora]{la hora — Spanish's barely-changed Latin hour}
+
+\label{lesson:ES-C29-la-hora}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You've now seen this Latin word take three different paths: French wore it down to \emph{heure}, German borrowed it centuries later as \emph{Uhr}. Spanish's path is the simplest of all — it barely changed.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{hora} $\leftarrow$ Latin \textbf{hōra} $\leftarrow$ Greek \textbf{h\'{\={o}}rā}, "a season, a time of day" (the Greek goddesses of the seasons were the \emph{Hōrai}). Spanish kept the word almost exactly as Latin had it — just a silent \textbf{h} in spelling, a fossil of a Latin \emph{h} that was already weak and barely pronounced by the time Spanish inherited the word (the same non-story as French \emph{heure} or English \emph{hour}'s silent \emph{h}). Be careful not to confuse this with \emph{hijo} and \emph{hacer}'s silent \emph{h} — those come from a completely different, later Spanish sound change (Latin \textbf{f-} $\to$ Old Spanish aspirated \emph{h-} $\to$ eventual silence), not from an already-weak Latin \emph{h} the way \emph{hora}'s is. Two different roads to the same "silent letter" result. Compare its cousins: French wore \emph{hōra} down further to \emph{heure}; German didn't inherit the word at all, but borrowed it later as \emph{Uhr}; English took the same Latin \emph{hōra} and made \emph{hour}.
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{word} & \textbf{what happened} \\
+\midrule
+\textbf{Spanish} & \textbf{hora} & inherited almost unchanged, just a silent \emph{h} \\
+French & \emph{heure} & inherited, but worn down further \\
+German & \emph{Uhr} & not inherited — borrowed later, separately \\
+English & \emph{hour} & inherited via French, silent \emph{h} \\
+\bottomrule
+\end{tabularx}
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: Son las and telling time}]
+Spanish uses \textbf{ser} ("to be") plus the \textbf{feminine plural article} (agreeing with the unspoken \emph{horas}) to tell time — and famously switches number for "one":
+
+\begin{quote}
+\textbf{Es la una.} — "It is one o'clock." (singular — \emph{la una}, "the one") \textbf{Son las dos.} — "It is two o'clock." (plural — \emph{las dos}, "the two") \textbf{Son las diez.} — "It is ten o'clock."
+\end{quote}
+
+Literally "\textbf{it is the one}" / "\textbf{they are the two/ten}" — the hour count itself is implied by the article and number, without needing to say \emph{hora(s)} at all in everyday speech (unlike French's \emph{il est deux heures}, which spells out "hours" every time).
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "hora" — silent h, a fossil of an already-weak Latin h{]}
+  \item {[}YOU SAY: "Es la una. Son las dos. Son las diez."{]}
+  \item {[}YOU SAY: "hora / heure / hour" — one Latin root, three different fates{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What Latin (and Greek) word is \emph{hora} from? (\emph{hōra} $\leftarrow$ Greek \emph{h\'{\={o}}rā}.) How did Spanish's path differ from French's and German's? (\textbf{Spanish} inherited it almost unchanged; \textbf{French} wore it down further to \emph{heure}; \textbf{German} didn't inherit it at all and borrowed \emph{Uhr} separately, much later.) How do you say "it is one o'clock" vs. "it is two o'clock"? (\emph{Es la una} — singular; \emph{Son las dos} — plural.)
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/chapters/ch30-weather.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch30-weather.tex
@@ -1,0 +1,52 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:063f578621dab785
+% canonical-lessons: ES-C30-el-tiempo
+
+\chapter{The Weather}
+\label{ch:spanish-weather}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[el tiempo, llueve]{el tiempo — weather, and a word that means two things at once}
+
+\label{lesson:ES-C30-el-tiempo}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Ask a Spanish speaker "¿qué tiempo hace?" and you're literally asking "what time does it make?" — because \emph{tiempo} doesn't distinguish "time" from "weather" the way English does.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{el tiempo} = both "\textbf{time}" and "\textbf{weather}" — from Latin \textbf{tempus}, which already covered this same double sense (English kept only the "time" half: \textbf{temporal, contemporary, tempo}). So \textbf{¿qué tiempo hace?} ("what's the weather like?") is literally "\textbf{what time does it make}?" — context alone tells a Spanish speaker which sense is meant.
+\end{cousinweb}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{calor} $\leftarrow$ Latin \textbf{calor}, "heat, warmth" $\to$ English \textbf{calorie, caloric}.
+  \item \textbf{frío} $\leftarrow$ Latin \textbf{frigidus}, "cold" (with the middle syncopated away over time) $\to$ English \textbf{frigid, refrigerate}.
+  \item \textbf{sol} $\leftarrow$ Latin \textbf{sol}, "sun," unchanged $\to$ English \textbf{solar, solstice, parasol}.
+\end{itemize}
+
+You've already met \textbf{hace calor} and \textbf{hace frío} ("it's hot/cold," literally "it \textbf{makes} heat/cold") back when you learned \emph{hacer} — the same \textbf{hacer} ("to make") that reports weather this way also covers "sunny": \textbf{hace sol} ("it's sunny," literally "it makes sun").
+\end{cousinweb}
+
+\begin{culture}
+\textbf{Rain} breaks the \emph{hacer} pattern entirely: \textbf{llueve} ("it's raining") comes from its own verb, \textbf{llover} $\leftarrow$ Latin \textbf{pluere}, "to rain." Recognize that \textbf{pl- $\to$ ll-} shift? It's the \textbf{same} regular sound change you met with \emph{llamar} ($\leftarrow$ \emph{clamāre}), \emph{llave} ($\leftarrow$ \emph{clāvem}), and \emph{llama} ($\leftarrow$ \emph{flamma}) — Latin \emph{cl-}, \emph{fl-}, and \emph{pl-} clusters all regularly became Spanish \emph{ll-}. So while \emph{calor/frío/sol} just need \textbf{hacer} in front of them, \emph{rain} gets its own dedicated, impersonal verb — much like English's own dedicated "it \textbf{rains}" versus "it \textbf{is} hot."
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "el tiempo" — time, or weather, depending on context{]}
+  \item {[}YOU SAY: "hace calor. hace frío. hace sol." — it's hot/cold/sunny{]}
+  \item {[}YOU SAY: "llueve" — it's raining, its own verb, not hacer{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What two things does \textbf{el tiempo} mean, and what Latin word covers both? (\textbf{"Time"} and \textbf{"weather"} — Latin \textbf{tempus}.) Which weather word does NOT use \emph{hacer}? (\textbf{Llueve} — "it's raining," its own verb \emph{llover}.) What Latin cluster did \emph{llover}'s \emph{ll-} come from, and what other word taught you this same sound change? (\textbf{pl-}, the same shift as \emph{llamar} $\leftarrow$ \emph{clamāre}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/chapters/ch31-numbers-11-20.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch31-numbers-11-20.tex
@@ -1,0 +1,73 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:f2267035c33491e1
+% canonical-lessons: ES-C31-numeros-11-20
+
+\chapter{Numbers Eleven to Twenty}
+\label{ch:spanish-numbers-eleven-to-twenty}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[once — veinte]{once, veinte — five fused Latins, then Spanish fixes Latin's own quirk}
+
+\label{lesson:ES-C31-numeros-11-20}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Eleven through twenty splits into two very different stories: five numbers worn down almost past recognition, and five that Spanish built fresh — fixing a genuine oddity in Latin's own counting system along the way.
+\end{quote}
+
+\begin{cousinweb}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Spanish} & \textbf{$\leftarrow$ Latin} \\
+\midrule
+\textbf{once} & \emph{undecim} ("one-ten") \\
+\textbf{doce} & \emph{duodecim} ("two-ten") \\
+\textbf{trece} & \emph{tredecim} ("three-ten") \\
+\textbf{catorce} & \emph{quattuordecim} ("four-ten") \\
+\textbf{quince} & \emph{quindecim} ("five-ten") \\
+\bottomrule
+\end{tabularx}
+
+Each of these was originally a compound — number + \emph{-decim} ("ten," the same root as \emph{diez}) — but centuries of everyday use fused them into single, opaque words. You can still faintly hear \emph{-ce} as the worn-down echo of \emph{-decim} in all five.
+\end{cousinweb}
+
+\begin{cousinweb}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Spanish} & \textbf{literally} \\
+\midrule
+\textbf{dieciséis} & \emph{diez y seis}, "ten and six" \\
+\textbf{diecisiete} & \emph{diez y siete}, "ten and seven" \\
+\textbf{dieciocho} & \emph{diez y ocho}, "ten and eight" \\
+\textbf{diecinueve} & \emph{diez y nueve}, "ten and nine" \\
+\bottomrule
+\end{tabularx}
+
+No fusion here — these are fully transparent "ten-and-X" compounds, and you can hear \emph{diez} plainly in every one.
+\end{cousinweb}
+
+\begin{culture}
+Here's the genuinely interesting part. You might expect \emph{dieciocho} and \emph{diecinueve} to simply continue whatever Latin did for 18 and 19 — but Latin's own words for those two numbers were \textbf{subtractive}, not additive: \textbf{duodēvīgintī} ("\textbf{two from twenty}") for 18, and \textbf{ūndēvīgintī} ("\textbf{one from twenty}") for 19. Spanish didn't inherit that pattern at all — it built \emph{dieciocho} and \emph{diecinueve} fresh, on the same simple "ten-and-X" template as 16 and 17, quietly \textbf{regularizing away} a genuine irregularity that existed in Latin itself.
+\end{culture}
+
+\subsection*{You'll want to know: veinte}
+\textbf{veinte} ("twenty") $\leftarrow$ Latin \textbf{vīgintī} — worn down by ordinary sound change, but never fused from two separate words the way \emph{once}-\emph{quince} were.
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "once, doce, trece, catorce, quince" — the five fused Latins{]}
+  \item {[}YOU SAY: "dieciséis, diecisiete, dieciocho, diecinueve" — transparent "ten-and-X"{]}
+  \item {[}YOU SAY: "veinte" — twenty{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What are \emph{once} through \emph{quince}, structurally? (\textbf{Fused Latin compounds} — number + \emph{-decim}, "ten," worn down to \emph{-ce}.) Are \emph{dieciséis} through \emph{diecinueve} fused or transparent? (\textbf{Transparent} — plain "ten and X.") Did Spanish inherit Latin's own words for 18 and 19? (\textbf{No} — Latin's \emph{duodēvīgintī}/\emph{ūndēvīgintī} were \textbf{subtractive} {[}"two/one FROM twenty"{]}; Spanish replaced that with straightforward addition instead.)
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/chapters/ch32-dog-and-cat.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch32-dog-and-cat.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:2a0d1e66cf7f557a
+% canonical-lessons: ES-C32-perro-gato
+
+\chapter{Dog and Cat}
+\label{ch:spanish-dog-and-cat}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[perro, gato]{perro, gato — one sourced etymology, one genuine mystery}
+
+\label{lesson:ES-C32-perro-gato}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Two everyday animal words, two completely different kinds of history: one traces all the way back to ancient Egypt. The other is a real, unsolved puzzle that linguists still argue about.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{gato} ("\textbf{cat}") $\leftarrow$ Latin \textbf{cattus} — but \emph{cattus} itself wasn't the original Latin word for cat at all. Classical Latin's word was \textbf{fēlēs} (still surviving in the scientific name \emph{Felis catus}). \emph{Cattus} only entered Latin later, as domestic cats spread out along \textbf{Roman trade routes} from their point of domestication — \textbf{Egypt}, around 2000 BCE. \emph{Cattus} is most likely ultimately an \textbf{Afro-Asiatic} word (compare Nubian \textbf{kadis}, "cat") — so the word, like the animal, \textbf{traveled} into Europe from Africa, eventually pushing out \emph{fēlēs} almost everywhere (the same \emph{cattus} gives Italian \emph{gatto}, French \emph{chat}, even Old Irish \emph{cat} and Welsh \emph{cath}).
+\end{cousinweb}
+
+\begin{cousinweb}
+\textbf{perro} ("\textbf{dog}") is honestly different: nobody knows for certain where it comes from. The word Spanish "should" have inherited from Latin is \textbf{canis} — the same root as English \textbf{canine}, French \textbf{chien}, Italian \textbf{cane} — and that word did survive into Spanish, as the now-archaic \textbf{can}. But at some point, \textbf{perro} pushed \emph{can} almost entirely out of everyday use, and \emph{perro} itself has \textbf{no agreed etymology}. Serious proposals include: an onomatopoeic imitation of a dog's growl or a shepherd's calling-sound (\emph{"perr perr"}); a pre-Roman, pre-Latin word from the Iberian substrate (the \emph{-rro} ending is itself a marker of likely pre-Latin origin in Spanish); and even a possible link to Persian \emph{persus}, a hunting-dog breed that became popular in the late Roman Empire. None of these is confirmed — \emph{perro} remains one of Spanish's genuinely open etymological puzzles.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "gato" — cat, traced all the way back to Egypt via Latin cattus{]}
+  \item {[}YOU SAY: "perro" — dog, a real unsolved mystery{]}
+  \item {[}YOU SAY: "can" — the archaic Spanish word perro replaced, from Latin canis{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What was Classical Latin's actual word for "cat," and where did \emph{cattus} most likely come from instead? (\textbf{Fēlēs}; \emph{cattus} is probably \textbf{Afro-Asiatic}, traveling with the domesticated cat out of \textbf{Egypt}.) Does \emph{perro} have a confirmed etymology? (\textbf{No} — it's a genuine, unsolved mystery, with competing onomatopoeic, pre-Latin substrate, and Persian theories.) What archaic Spanish word did \emph{perro} replace, and what's its Latin source? (\textbf{can}, from Latin \textbf{canis} — the same root as English \emph{canine}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/chapters/ch33-green-and-yellow.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch33-green-and-yellow.tex
@@ -1,0 +1,41 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:d7715072b975cbc3
+% canonical-lessons: ES-C33-verde-amarillo
+
+\chapter{Green and Yellow}
+\label{ch:spanish-green-and-yellow}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[verde, amarillo]{verde, amarillo — the expected inheritance, and a real surprise}
+
+\label{lesson:ES-C33-verde-amarillo}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} One of these colors is exactly what you'd expect from Latin. The other one will genuinely surprise you — it has nothing to do with any Latin word for "yellow" at all.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{verde} ("\textbf{green}") $\leftarrow$ Latin \textbf{viridis} (worn down via \textbf{virdis}), from the verb \textbf{virēre}, "\textbf{to be green, to flourish, to be vigorous}." This is a cousin of English \textbf{verdant} and \textbf{verdure} — though \textbf{not} of English \textbf{green} itself, which comes from a completely separate Germanic root. A clean, expected Latin inheritance.
+\end{cousinweb}
+
+\begin{cousinweb}
+Here's the honest surprise: \textbf{amarillo} ("\textbf{yellow}") does \textbf{not} trace to any of Latin's actual words for yellow (\emph{flāvus}, \emph{gilvus}, \emph{lūteus}). Instead, it comes from Late Latin \textbf{amarellus}, "\textbf{a little bitter}" — a diminutive of \textbf{amarus}, "\textbf{bitter}." The connection runs through an old association between the color yellow and \textbf{bitterness} — bile, jaundice, and many bitter-tasting plants all share a yellowish cast. Over centuries, "a little bitter" softened into simply "yellowish," and by Spanish's Golden Age the word had shed its bitter meaning entirely, leaving just the color. \emph{Amarillo} is a genuine cousin of Spanish's own \textbf{amargo} ("bitter") — both descend from the same \emph{amarus}.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "verde" — green, from "to flourish"{]}
+  \item {[}YOU SAY: "amarillo" — yellow, literally "a little bitter"{]}
+  \item {[}YOU SAY: the cousins — "amarillo, amargo" — yellow and bitter, same Latin root{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What Latin verb gives \textbf{verde}, and what does it mean? (\textbf{Virēre}, "to be green/flourish" — cousin of English \emph{verdant}, \emph{verdure}, not of English \emph{green} itself.) Does \textbf{amarillo} come from a Latin "yellow" word? (\textbf{No} — from \emph{amarellus}, "a little bitter," a diminutive of \emph{amarus}, "bitter.") What everyday Spanish word is \textbf{amarillo}'s cousin? (\textbf{Amargo}, "bitter.")
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/preamble.tex
+++ b/code/learning/human-languages/spanish/book/preamble.tex
@@ -3,9 +3,6 @@
 % support that later tracks (Arabic, Devanagari, Dravidian scripts) require.
 
 \usepackage{fontspec}
-\usepackage{polyglossia}
-\setdefaultlanguage{english}
-\setotherlanguage{spanish}
 
 % Latin Modern ships with every standard TeX distribution (MiKTeX, TeX
 % Live) as OpenType fonts, so this compiles the same way on any machine --
@@ -23,6 +20,23 @@
 \usepackage{tabularx}
 \usepackage[hidelinks]{hyperref}
 \usepackage{titlesec}
+
+% polyglossia loads bidi for Arabic, so color-related packages must come first.
+\usepackage{polyglossia}
+\setdefaultlanguage{english}
+\setotherlanguage{spanish}
+\setotherlanguage{arabic}
+
+% Chapter 22 preserves the Arabic source of azul. Use the repository's static
+% Naskh font so the source script is deterministic and never dropped in print.
+\newfontfamily\arabicfont[
+  Path=../../_fonts/,
+  Script=Arabic,
+  BoldFont=NotoNaskhArabic-Static.ttf,
+  ItalicFont=NotoNaskhArabic-Static.ttf,
+  BoldItalicFont=NotoNaskhArabic-Static.ttf
+]{NotoNaskhArabic-Static.ttf}
+\newcommand{\esar}[1]{\textarabic{#1}}
 
 \hypersetup{
   pdftitle={Spanish, Step by Step, Root by Root},

--- a/code/learning/human-languages/spanish/lessons/ES-C19-no.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C19-no.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C19-no
+spine_node: SPINE-RESPOND-BASIC
+sequence: 650
 chapter: 19
 type: word
 headword: no
@@ -9,18 +12,32 @@ prerequisites: [ES-C19-si]
 sounds: [vowel-o]
 roots: [non]
 etymology_hook: "no is Latin nōn barely touched — and does double duty: both 'no' the answer and 'not' the negator (no hablo)"
-est_minutes: 3
+duration:
+  max_seconds: 180
+requires:
+  knowledge: []
+introduces:
+  knowledge: [ES-LEX-NO-01, ES-GRAMMAR-NO-02]
+practises:
+  knowledge: [ES-LEX-NO-01, ES-GRAMMAR-NO-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C19-si, ES-C01-hola]
 ---
 
 # no — no / not
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The easiest word yet — and it quietly does two jobs Spanish never
 splits apart.
 
-## The word
+## The word, taken apart: no
+<!-- hl-knowledge: introduces=[ES-LEX-NO-01]; assesses=[] -->
 
 **no** = **no**. Said *noh*, a clean single vowel.
 
@@ -33,7 +50,8 @@ gone. Compare the family, all from the same *nōn*:
 | Italian | **no** |
 | French | **non** |
 
-## One word, two jobs
+## Grammar Lens: one word, two jobs
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-NO-02]; assesses=[] -->
 
 Here's the thing English splits and Spanish doesn't. English has **"no"** (the
 answer) and **"not"** (inside a sentence) — two different words. Spanish uses
@@ -48,6 +66,7 @@ sentence negative, drop **no** in front of the verb. One little word, two
 everyday jobs.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-NO-01, ES-GRAMMAR-NO-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "no" — *noh*]
@@ -55,6 +74,7 @@ everyday jobs.
 - [YOU SAY: as a negator — "No hablo inglés"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-NO-01, ES-GRAMMAR-NO-02] -->
 
 [PAUSE 3s] How do you say no in Spanish? (**no**.) What Latin word is it from?
 (**nōn**.) Spanish *no* does the work of which **two** English words? (**"no"**

--- a/code/learning/human-languages/spanish/lessons/ES-C19-si.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C19-si.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C19-si
+spine_node: SPINE-RESPOND-BASIC
+sequence: 640
 chapter: 19
 type: word
 headword: sí
@@ -9,17 +12,31 @@ prerequisites: [ES-C01-hola]
 sounds: [vowel-i, written-accent]
 roots: [sic]
 etymology_hook: "sí 'yes' is Latin sīc 'thus, so' — the accent is the whole word: sí (yes) vs si (if) are a minimal pair"
-est_minutes: 3
+duration:
+  max_seconds: 180
+requires:
+  knowledge: []
+introduces:
+  knowledge: [ES-LEX-SI-01, ES-ETYMON-SI-02]
+practises:
+  knowledge: [ES-LEX-SI-01, ES-ETYMON-SI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C01-hola]
 ---
 
 # sí — yes
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The smallest useful word — and the accent on it is doing real work.
 
-## The word
+## The word, taken apart: sí and si
+<!-- hl-knowledge: introduces=[ES-LEX-SI-01]; assesses=[] -->
 
 **sí** = **yes**. One syllable, said *see*.
 
@@ -33,7 +50,8 @@ They sound almost identical, so Spanish uses the mark to tell them apart on the
 page: *Sí, si quieres* = "Yes, if you want." Miss the accent and you've written
 "if" where you meant "yes."
 
-## Where it comes from
+## The word, taken apart: where sí comes from
+<!-- hl-knowledge: introduces=[ES-ETYMON-SI-02]; assesses=[] -->
 
 **sí** is Latin **sīc**, "thus, so" — answering a question with "just so,"
 exactly the move Latin also made with **ita** ("thus" = yes, from the Latin
@@ -50,6 +68,7 @@ French is the odd one out — it went a completely different way for "yes"
 one Latin word answering across three countries.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-SI-01, ES-ETYMON-SI-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "sí" — *see*, and picture the accent]
@@ -57,6 +76,7 @@ one Latin word answering across three countries.
 - [YOU SAY: the cousins — "sí, sì, sim" — all from Latin *sīc*]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-SI-01, ES-ETYMON-SI-02] -->
 
 [PAUSE 3s] How do you say yes in Spanish? (**sí**.) What is the *only* difference
 between **sí** "yes" and **si** "if"? (The **written accent**.) What Latin word

--- a/code/learning/human-languages/spanish/lessons/ES-C20-lo-siento.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C20-lo-siento.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C20-lo-siento
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 660
 chapter: 20
 type: phrase
 headword: lo siento
@@ -9,19 +12,33 @@ prerequisites: [ES-C06-por-favor]
 sounds: [r-tap, s-clear]
 roots: [sentire-latin]
 etymology_hook: "siento ← Latin sentīre 'to feel' → English sentiment, sense, consent, resent"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-POR-FAVOR]
+introduces:
+  knowledge: [ES-LEX-LO-SIENTO-01, ES-ETYMON-SENTIR-02, ES-PRAGMATICS-SORRY-03, ES-ETYMON-PERDON-04]
+practises:
+  knowledge: [ES-LEX-POR-FAVOR, ES-LEX-LO-SIENTO-01, ES-ETYMON-SENTIR-02, ES-PRAGMATICS-SORRY-03, ES-ETYMON-PERDON-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C06-por-favor]
 ---
 
 # lo siento — "I'm sorry," i.e. "I feel it"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-POR-FAVOR] -->
 
 [PAUSE 2s] You already know **por favor**, "please" — the fourth courtesy word
 is **lo siento**, "I'm sorry." Spanish doesn't say "I am sorry" as an
 adjective; it says something closer to **"I feel this."**
 
 ## The phrase, taken apart
+<!-- hl-knowledge: introduces=[ES-LEX-LO-SIENTO-01, ES-ETYMON-SENTIR-02]; assesses=[] -->
 
 - **lo** = "it" — a neuter pronoun pointing at the situation itself, not a
   specific noun.
@@ -34,7 +51,8 @@ So **lo siento** is literally *"I feel it"* — you're naming the feeling
 for both to apologize ("*lo siento*, I stepped on your foot") and to console
 ("*lo siento mucho*," I'm so sorry, on hearing sad news).
 
-## Be honest about the other word: perdón
+## Why it's said this way: lo siento and perdón
+<!-- hl-knowledge: introduces=[ES-PRAGMATICS-SORRY-03, ES-ETYMON-PERDON-04]; assesses=[] -->
 
 Spanish keeps a **second** word for a different job. **Perdón** ("pardon"),
 from **perdonar** — Latin **per-** ("thoroughly") + **dōnāre** ("to give," the
@@ -51,6 +69,7 @@ me"). Native speakers reach for whichever fits — the boundary is soft, and
 mixing them up is not a real mistake, just a shade off.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-POR-FAVOR, ES-LEX-LO-SIENTO-01, ES-ETYMON-SENTIR-02, ES-PRAGMATICS-SORRY-03, ES-ETYMON-PERDON-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "siento" — I feel — then "lo siento," I feel it / I'm sorry]
@@ -58,6 +77,7 @@ mixing them up is not a real mistake, just a shade off.
 - [YOU SAY: both together in your head: regret vs. forgiveness]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-POR-FAVOR, ES-LEX-LO-SIENTO-01, ES-ETYMON-SENTIR-02, ES-PRAGMATICS-SORRY-03, ES-ETYMON-PERDON-04] -->
 
 [PAUSE 3s] What does **lo siento** literally mean? (**"I feel it"** — *siento*
 "I feel," from Latin *sentīre*, like English *sentiment*.) What's the other

--- a/code/learning/human-languages/spanish/lessons/ES-C21-lunes-viernes.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C21-lunes-viernes.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C21-lunes-viernes
+spine_node: SPINE-TIME-OF-DAY
+sequence: 670
 chapter: 21
 type: word
 headword: lunes, martes, miércoles, jueves, viernes
@@ -9,20 +12,34 @@ prerequisites: [ES-C08-numeros-6-10]
 sounds: [r-tap, diphthong-ie]
 roots: [dies-latin, planet-gods]
 etymology_hook: "Spanish weekdays mostly just DROPPED diēs 'day' — martes 'Mars's [day]' keeps its trailing -s from Martis itself, not from diēs — where French still spells 'day' out loud as -di"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [ES-LEX-WEEKDAYS-01, ES-ETYMON-WEEKDAYS-02]
+practises:
+  knowledge: [ES-LEX-WEEKDAYS-01, ES-ETYMON-WEEKDAYS-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C08-numeros-6-10]
 ---
 
 # lunes to viernes — the planets of the week, worn down
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] The Romans mapped the seven-day week onto the seven visible
 "wandering stars" — the planet-gods. Spanish kept that map, but handled the
 word "day" differently from its Romance cousins: where French still spells
 out "**-di**" (day) on every weekday, Spanish mostly just **dropped it**.
 
-## The pattern: [planet's name], with "day" mostly gone
+## The words, taken apart: the planet weekdays
+<!-- hl-knowledge: introduces=[ES-LEX-WEEKDAYS-01, ES-ETYMON-WEEKDAYS-02]; assesses=[] -->
 
 Each weekday began life as **"[planet-god]'s **diēs** (day)."** In Vulgar
 Latin, *diēs* was simply **dropped as a separate word** in most of these —
@@ -49,6 +66,7 @@ itself (fused in and reshaped) — though the exact sound changes are debated,
 unlike the plainer, better-understood story for its four siblings.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-WEEKDAYS-01, ES-ETYMON-WEEKDAYS-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "lunes, martes, miércoles, jueves, viernes" — the work week]
@@ -58,6 +76,7 @@ unlike the plainer, better-understood story for its four siblings.
   Tiw)"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-WEEKDAYS-01, ES-ETYMON-WEEKDAYS-02] -->
 
 [PAUSE 3s] What did every Spanish weekday begin life as? (**"[Planet-god]'s
 diēs (day)"** — the same Latin phrase French keeps more visibly with *-di*.)

--- a/code/learning/human-languages/spanish/lessons/ES-C21-sabado-domingo.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C21-sabado-domingo.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C21-sabado-domingo
+spine_node: SPINE-TIME-OF-DAY
+sequence: 680
 chapter: 21
 type: word
 headword: sábado, domingo
@@ -9,19 +12,33 @@ prerequisites: [ES-C21-lunes-viernes]
 sounds: [r-tap, stress-accent]
 roots: [sabbatum-latin, dominica-latin]
 etymology_hook: "sábado ← Sabbatum (the Sabbath), domingo ← diēs Dominica ('the Lord's day') — the two days that broke the planet-god pattern"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-WEEKDAYS-01, ES-ETYMON-WEEKDAYS-02]
+introduces:
+  knowledge: [ES-LEX-WEEKEND-01, ES-ETYMON-WEEKEND-02]
+practises:
+  knowledge: [ES-LEX-WEEKDAYS-01, ES-ETYMON-WEEKDAYS-02, ES-LEX-WEEKEND-01, ES-ETYMON-WEEKEND-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C21-lunes-viernes, ES-C08-numeros-6-10]
 ---
 
 # sábado and domingo — the week's religious edge
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-WEEKDAYS-01, ES-ETYMON-WEEKDAYS-02] -->
 
 [PAUSE 2s] Five days named for planets — then two that broke the pattern
 entirely. The weekend is where **religion overwrote astronomy**, and Spanish
 keeps both rewrites in plain view.
 
 ## The two days, taken apart
+<!-- hl-knowledge: introduces=[ES-LEX-WEEKEND-01, ES-ETYMON-WEEKEND-02]; assesses=[] -->
 
 | Spanish | ← Latin | meaning | note |
 |---|---|---|---|
@@ -42,6 +59,7 @@ Two different rewrites:
   the *di-* (day) fossil jumped to the front of the word.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-WEEKDAYS-01, ES-ETYMON-WEEKDAYS-02, ES-LEX-WEEKEND-01, ES-ETYMON-WEEKEND-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: the full week — "lunes, martes, miércoles, jueves, viernes,
@@ -52,6 +70,7 @@ Two different rewrites:
   / Sunday (Lord vs. Sun)"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-WEEKDAYS-01, ES-ETYMON-WEEKDAYS-02, ES-LEX-WEEKEND-01, ES-ETYMON-WEEKEND-02] -->
 
 [PAUSE 3s] Give all seven Spanish days. (*Lunes … domingo*.) Where does
 **sábado** come from, and its English contrast? (The **Sabbath**, *Sabbatum*;

--- a/code/learning/human-languages/spanish/lessons/ES-C22-negro-blanco.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C22-negro-blanco.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C22-negro-blanco
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 690
 chapter: 22
 type: word
 headword: negro, blanco
@@ -9,26 +12,41 @@ prerequisites: [ES-C21-sabado-domingo]
 sounds: [r-tap, nasal-n]
 roots: [latin-niger, germanic-blank]
 etymology_hook: "negro ← Latin niger, but blanco is NOT from Latin albus — it's Germanic *blank 'shining', traditionally linked to Visigothic-era contact, the same word French borrowed (more firmly attested) via the Franks"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [ES-LEX-NEGRO-01, ES-ETYMON-NEGRO-02, ES-LEX-BLANCO-03, ES-ETYMON-BLANCO-04, ES-ETYMON-ALBUS-05]
+practises:
+  knowledge: [ES-LEX-NEGRO-01, ES-ETYMON-NEGRO-02, ES-LEX-BLANCO-03, ES-ETYMON-BLANCO-04, ES-ETYMON-ALBUS-05]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C21-sabado-domingo, ES-C21-lunes-viernes]
 ---
 
 # negro, blanco — one inherited, one borrowed
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Two colors, two very different histories. One is straight-line
 Latin. The other arrived with **Germanic settlers** — and Spanish isn't even
 alone in borrowing it that way.
 
-## negro — the expected one
+## The words, taken apart: negro
+<!-- hl-knowledge: introduces=[ES-LEX-NEGRO-01, ES-ETYMON-NEGRO-02]; assesses=[] -->
 
 **negro** ("black") ← Latin **niger**. Nothing surprising here: the same
 Latin root that gives English **denigrate** ("to blacken someone's name")
 and the Romance family's other words for black (French *noir*, Italian
 *nero*).
 
-## blanco — the imported one
+## The words, taken apart: blanco
+<!-- hl-knowledge: introduces=[ES-LEX-BLANCO-03, ES-ETYMON-BLANCO-04]; assesses=[] -->
 
 You'd expect Latin **albus** ("white"). Spanish doesn't use it. Instead it
 says **blanco**, from **Germanic *blank*** — "**shining, gleaming**" — a loan
@@ -45,7 +63,8 @@ Why would a "shining" word beat Latin's own "white"? Color words often lose
 out to something more **vivid** — *blank* didn't just mean pale, it meant
 **bright, gleaming** — a flashier idea than plain *albus*.
 
-## Where albus went
+## Why it's said this way: where albus went
+<!-- hl-knowledge: introduces=[ES-ETYMON-ALBUS-05]; assesses=[] -->
 
 Latin's own white didn't vanish — it just stopped being the everyday color
 word:
@@ -61,6 +80,7 @@ So Latin's white is still around — tucked into *alba* and *álbum*, just not
 where a learner would first look.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-NEGRO-01, ES-ETYMON-NEGRO-02, ES-LEX-BLANCO-03, ES-ETYMON-BLANCO-04, ES-ETYMON-ALBUS-05] -->
 
 [PAUSE 1s]
 - [YOU SAY: "negro, blanco"]
@@ -68,6 +88,7 @@ where a learner would first look.
 - [YOU SAY: "el alba" — dawn — and hear the old Latin white inside it]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-NEGRO-01, ES-ETYMON-NEGRO-02, ES-LEX-BLANCO-03, ES-ETYMON-BLANCO-04, ES-ETYMON-ALBUS-05] -->
 
 [PAUSE 3s] Which of the two is inherited from Latin? (**Negro** ← *niger*.)
 Where does **blanco** come from? (**Germanic *blank***, "shining" — brought

--- a/code/learning/human-languages/spanish/lessons/ES-C22-rojo-azul.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C22-rojo-azul.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C22-rojo-azul
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 700
 chapter: 22
 type: word
 headword: rojo, azul
@@ -9,19 +12,33 @@ prerequisites: [ES-C22-negro-blanco]
 sounds: [r-tap, palatal-j]
 roots: [pie-rewdh-russus, arabic-lazaward]
 etymology_hook: "rojo ← Latin russus, a cousin (not a copy) of French's rouge (← rubeus) — both ultimately from PIE *h₁rewdʰ-; azul ← Arabic lāzaward, and unlike French, this IS Spanish's everyday word for blue"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-ETYMON-NEGRO-02, ES-ETYMON-BLANCO-04]
+introduces:
+  knowledge: [ES-LEX-ROJO-01, ES-ETYMON-ROJO-02, ES-LEX-AZUL-03, ES-ETYMON-AZUL-04]
+practises:
+  knowledge: [ES-ETYMON-NEGRO-02, ES-ETYMON-BLANCO-04, ES-LEX-ROJO-01, ES-ETYMON-ROJO-02, ES-LEX-AZUL-03, ES-ETYMON-AZUL-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C22-negro-blanco]
 ---
 
 # rojo, azul — an old word (taken a different path) and a borrowed one
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-ETYMON-NEGRO-02, ES-ETYMON-BLANCO-04] -->
 
 [PAUSE 2s] Last lesson: one inherited color, one borrowed. This lesson
 repeats the shape — but **red** takes a subtly different road than you might
 expect from French, and **blue** flips which word is "the everyday one."
 
-## rojo — old, but not the SAME old word as French
+## The words, taken apart: rojo
+<!-- hl-knowledge: introduces=[ES-LEX-ROJO-01, ES-ETYMON-ROJO-02]; assesses=[] -->
 
 **rojo** ("red") ← Latin **russus** — a more everyday, expressive Latin
 color-word for red. That's a **different specific Latin word** from the one
@@ -32,7 +49,8 @@ So *rojo* and *rouge* (and English *red*) are all **cousins** — just via two
 different branches of the same very old family, not one borrowed from the
 other.
 
-## azul — borrowed, and here it's the MAIN word
+## The words, taken apart: azul
+<!-- hl-knowledge: introduces=[ES-LEX-AZUL-03, ES-ETYMON-AZUL-04]; assesses=[] -->
 
 **azul** ("blue") ← Arabic **لازورد** (*lāzaward*), "**lapis lazuli**" — the
 same ultimate source as the English word **azure**. Spanish picked this up
@@ -45,6 +63,7 @@ while the **everyday** French blue is the Germanic loan *bleu*. In
 — there's no separate Germanic blue-word competing with it.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-ETYMON-NEGRO-02, ES-ETYMON-BLANCO-04, ES-LEX-ROJO-01, ES-ETYMON-ROJO-02, ES-LEX-AZUL-03, ES-ETYMON-AZUL-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "rojo, azul"]
@@ -54,6 +73,7 @@ while the **everyday** French blue is the Germanic loan *bleu*. In
   only poetic"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-ETYMON-NEGRO-02, ES-ETYMON-BLANCO-04, ES-LEX-ROJO-01, ES-ETYMON-ROJO-02, ES-LEX-AZUL-03, ES-ETYMON-AZUL-04] -->
 
 [PAUSE 3s] Is **rojo** the same Latin word as French's *rouge*? (**No** —
 *rojo* ← *russus*, *rouge* ← *rubeus* — different Latin words, but true

--- a/code/learning/human-languages/spanish/lessons/ES-C23-hermano-hermana.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C23-hermano-hermana.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C23-hermano-hermana
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 720
 chapter: 23
 type: word
 headword: el hermano, la hermana
@@ -9,19 +12,33 @@ prerequisites: [ES-C23-padre-madre]
 sounds: [silent-h, r-tap]
 roots: [germanus-latin, germen-latin]
 etymology_hook: "hermano is NOT Spanish for frater — it's from germanus, 'of the same stock/seed' (→ English germ, germinate, germane); its initial g simply dropped in an unstressed syllable, and the h you see today was added later, purely in spelling"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [ES-LEX-SIBLINGS-01, ES-ETYMON-GERMANUS-02, ES-ETYMON-GERMEN-03, ES-SOUND-HERMANO-04]
+practises:
+  knowledge: [ES-LEX-SIBLINGS-01, ES-ETYMON-GERMANUS-02, ES-ETYMON-GERMEN-03, ES-SOUND-HERMANO-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C23-padre-madre]
 ---
 
 # el hermano, la hermana — brother and sister, from a different word entirely
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You might expect Spanish "brother" to come from Latin **frāter**,
 the way French's *frère* does. It doesn't. Spanish's siblings took a
 completely different word — one about **seeds**.
 
-## Not frāter — germanus
+## The words, taken apart: hermano and hermana
+<!-- hl-knowledge: introduces=[ES-LEX-SIBLINGS-01, ES-ETYMON-GERMANUS-02]; assesses=[] -->
 
 Classical Latin could say **frāter germānus**, literally "a brother **of the
 same stock/blood**" — distinguishing a *full* brother from a half-brother or
@@ -32,7 +49,8 @@ quietly dropped out. That adjective is where Spanish's words come from:
 - **el hermano** ("brother") ← Latin **germānus**.
 - **la hermana** ("sister") ← Latin **germāna**.
 
-## Where germanus itself comes from
+## Why it's said this way: where germanus comes from
+<!-- hl-knowledge: introduces=[ES-ETYMON-GERMEN-03]; assesses=[] -->
 
 **Germānus** traces back to **germen**, "**sprout, bud, seed**" — the same
 root that gives English **germ**, **germinate**, and **germane** (originally
@@ -40,7 +58,8 @@ root that gives English **germ**, **germinate**, and **germane** (originally
 "relevant"). So calling someone your *hermano* is, at the etymological root,
 calling them "**sprung from the same seed**."
 
-## Be honest about that silent h — it's a different story than hijo/hacer
+## Why it's said this way: the silent h
+<!-- hl-knowledge: introduces=[ES-SOUND-HERMANO-04]; assesses=[] -->
 
 You may already know that Spanish sometimes turns a Latin initial **f** into
 a silent **h** — *filius* → **hijo** ("son"), *facere* → **hacer** ("to
@@ -59,6 +78,7 @@ was **pronounced** for a long stretch of Spanish's history before falling
 silent. Same letter today, two completely different backstories.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-SIBLINGS-01, ES-ETYMON-GERMANUS-02, ES-ETYMON-GERMEN-03, ES-SOUND-HERMANO-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "hermano, hermana" — brother, sister]
@@ -68,6 +88,7 @@ silent. Same letter today, two completely different backstories.
   hermano's h never was]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-SIBLINGS-01, ES-ETYMON-GERMANUS-02, ES-ETYMON-GERMEN-03, ES-SOUND-HERMANO-04] -->
 
 [PAUSE 3s] Does Spanish "hermano" come from Latin *frāter*? (**No** — from
 **germānus**, "of the same stock/seed," which replaced *frāter* over time.)

--- a/code/learning/human-languages/spanish/lessons/ES-C23-padre-madre.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C23-padre-madre.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C23-padre-madre
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 710
 chapter: 23
 type: word
 headword: el padre, la madre
@@ -9,25 +12,40 @@ prerequisites: [ES-C22-rojo-azul]
 sounds: [r-tap, d-soft]
 roots: [pater-latin, mater-latin]
 etymology_hook: "padre ← pater, madre ← mater — the same PIE *ph2ter/*meh2ter that gave English father/mother via Grimm's law (p→f, t→th)"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [ES-LEX-PARENTS-01, ES-ETYMON-PARENTS-02, ES-ETYMON-PARENTS-SOUND-LAW-03]
+practises:
+  knowledge: [ES-LEX-PARENTS-01, ES-ETYMON-PARENTS-02, ES-ETYMON-PARENTS-SOUND-LAW-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C22-rojo-azul, ES-C22-negro-blanco]
 ---
 
 # el padre, la madre — among the oldest words there are
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] "Father" and "mother" are some of the **oldest reconstructible
 words in human language** — older than Latin, older than Rome. Spanish kept
 them close to the Latin original, and they are secretly the *same words* as
 English **father** and **mother**.
 
-## Taken apart
+## The words, taken apart: padre and madre
+<!-- hl-knowledge: introduces=[ES-LEX-PARENTS-01, ES-ETYMON-PARENTS-02]; assesses=[] -->
 
 - **el padre** ("father") ← Latin **pater** ← PIE ***ph₂tḗr***.
 - **la madre** ("mother") ← Latin **māter** ← PIE ***méh₂tēr***.
 
-## The English connection — one sound-law
+## Why it's said this way: the English sound-law
+<!-- hl-knowledge: introduces=[ES-ETYMON-PARENTS-SOUND-LAW-03]; assesses=[] -->
 
 *Padre* and English *father* both descend independently from the **same**
 PIE word — they're siblings, not parent and child. Latin (and Spanish after
@@ -49,6 +67,7 @@ patrón** and **maternal, maternidad**. (A further Latin-only offshoot,
 *materia* and, separately, *matriz* — "womb" — via Latin *mātrix*.)
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-PARENTS-01, ES-ETYMON-PARENTS-02, ES-ETYMON-PARENTS-SOUND-LAW-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "el padre, la madre"]
@@ -56,6 +75,7 @@ patrón** and **maternal, maternidad**. (A further Latin-only offshoot,
 - [YOU SAY: "padre → paternal; madre → maternal"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-PARENTS-01, ES-ETYMON-PARENTS-02, ES-ETYMON-PARENTS-SOUND-LAW-03] -->
 
 [PAUSE 3s] Give "father" and "mother" with their articles. (**el padre, la
 madre**.) Does *padre* turn into English *father* directly? (**No** — both

--- a/code/learning/human-languages/spanish/lessons/ES-C24-cabeza.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C24-cabeza.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C24-cabeza
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 730
 chapter: 24
 type: word
 headword: la cabeza
@@ -9,23 +12,38 @@ prerequisites: [ES-C23-hermano-hermana]
 sounds: [z-as-th-or-s, feminine-a-ending]
 roots: [latin-caput]
 etymology_hook: "cabeza IS Latin caput (via capitia) — English captain/capital/decapitate too — where French tête abandoned caput entirely for testa, slang for 'pot'"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [ES-LEX-CABEZA-01, ES-ETYMON-CABEZA-02, ES-ETYMON-TETE-COMPARISON-03]
+practises:
+  knowledge: [ES-LEX-CABEZA-01, ES-ETYMON-CABEZA-02, ES-ETYMON-TETE-COMPARISON-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C23-hermano-hermana, ES-C23-padre-madre]
 ---
 
 # la cabeza — "the head"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Spanish's word for "head" is the boring, expected one — and
 that's exactly what makes it interesting, once you see what French did
 instead.
 
-## The word
+## You'll want to know: la cabeza
+<!-- hl-knowledge: introduces=[ES-LEX-CABEZA-01]; assesses=[] -->
 
 > **la cabeza** — the head. Feminine, so **la**.
 
-## caput — the word Spanish kept
+## The word, taken apart: caput
+<!-- hl-knowledge: introduces=[ES-ETYMON-CABEZA-02]; assesses=[] -->
 
 Latin's word for "head" was **caput**. Spanish's *cabeza* comes straight
 from it (by way of Vulgar Latin *capitia*), and *caput* shows up all over
@@ -38,7 +56,8 @@ English too:
 | de**cap**itate | to remove the head |
 | **cap**itulate | to arrange under "headings" — hence, to yield |
 
-## Be honest about French's very different choice
+## Why it's said this way: French made a different choice
+<!-- hl-knowledge: introduces=[ES-ETYMON-TETE-COMPARISON-03]; assesses=[] -->
 
 French had the exact same Latin word available — and **dropped it**. French
 *tête* ("head") comes instead from **testa**, Latin for an **earthenware
@@ -48,6 +67,7 @@ real word entirely. Spanish never made that swap — *cabeza* is *caput*,
 plain and simple, still standing after two thousand years.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CABEZA-01, ES-ETYMON-CABEZA-02, ES-ETYMON-TETE-COMPARISON-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "la cabeza" — the head]
@@ -57,6 +77,7 @@ plain and simple, still standing after two thousand years.
   joke]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CABEZA-01, ES-ETYMON-CABEZA-02, ES-ETYMON-TETE-COMPARISON-03] -->
 
 [PAUSE 3s] Say "the head." (*La cabeza* — feminine.) What Latin word is it
 from? (**Caput**.) Give an English word from the same root. (**Captain,

--- a/code/learning/human-languages/spanish/lessons/ES-C24-mano.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C24-mano.md
@@ -1,27 +1,44 @@
 ---
+schema_version: 2
 id: ES-C24-mano
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 740
 chapter: 24
 type: word
 headword: la mano
 gloss: the hand — feminine despite ending in -o, Spanish's most famous gender exception
 concept_tag: ES-BODY-HAND
-prerequisites: [ES-C24-cabeza, ES-C23-hermano-hermana]
+prerequisites: [ES-C24-cabeza, ES-C23-hermano-hermana, ES-C01-genero-gramatical]
 sounds: [feminine-o-exception]
 roots: [latin-manus]
 etymology_hook: "mano is feminine despite ending in -o (manus was 4th-declension feminine in Latin) — Spanish's most famous exception to the -o=masculine/-a=feminine rule; the same manus behind manual, manufacture, maintain"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-GRAMMAR-NOUN-GENDER]
+introduces:
+  knowledge: [ES-LEX-MANO-01, ES-GRAMMAR-MANO-GENDER-02, ES-ETYMON-MANUS-03]
+practises:
+  knowledge: [ES-GRAMMAR-NOUN-GENDER, ES-LEX-MANO-01, ES-GRAMMAR-MANO-GENDER-02, ES-ETYMON-MANUS-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C24-cabeza]
 ---
 
 # la mano — "the hand"
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-NOUN-GENDER] -->
 
 [PAUSE 2s] You've been trusting "-o words are masculine, -a words are
 feminine" since Chapter 1. Here's the word that breaks it — and everyone
 learning Spanish has to memorize this one by name.
 
-## The word — and the exception
+## Grammar Lens: la mano and its gender
+<!-- hl-knowledge: introduces=[ES-LEX-MANO-01, ES-GRAMMAR-MANO-GENDER-02]; assesses=[] -->
 
 > **la mano** — the hand. **Feminine**, despite ending in **-o**.
 
@@ -35,7 +52,8 @@ of a small handful of exceptions that were **feminine** instead (alongside
 over**: an exception within Latin's own mostly-masculine 4th declension, and
 then an exception again against Spanish's usual *-o* = masculine pattern.
 
-## manus — one of the most productive roots in English
+## The word, taken apart: manus
+<!-- hl-knowledge: introduces=[ES-ETYMON-MANUS-03]; assesses=[] -->
 
 **Mano** comes from Latin **manus**, "hand" — and that root is buried inside
 an enormous number of English words:
@@ -52,6 +70,7 @@ an enormous number of English words:
 today it names precisely the opposite.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-NOUN-GENDER, ES-LEX-MANO-01, ES-GRAMMAR-MANO-GENDER-02, ES-ETYMON-MANUS-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "la mano" — feminine, despite the -o]
@@ -60,6 +79,7 @@ today it names precisely the opposite.
 - [YOU SAY: the irony — "manufacture = made by hand"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-NOUN-GENDER, ES-LEX-MANO-01, ES-GRAMMAR-MANO-GENDER-02, ES-ETYMON-MANUS-03] -->
 
 [PAUSE 3s] Say "the hand," and name its gender. (*La mano* — **feminine**,
 despite ending in *-o*.) Why is *mano* feminine when most *-o* words aren't?

--- a/code/learning/human-languages/spanish/lessons/ES-C25-las-estaciones.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C25-las-estaciones.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C25-las-estaciones
+spine_node: SPINE-TIME-OF-DAY
+sequence: 750
 chapter: 25
 type: word
 headword: la primavera, el verano, el otoño, el invierno
@@ -9,19 +12,33 @@ prerequisites: [ES-C24-mano, ES-C24-cabeza]
 sounds: [r-tap, diphthong-ie]
 roots: [latin-prima-vera, latin-autumnus, latin-hibernum, latin-veranum]
 etymology_hook: "primavera = prima vera 'first spring' (Italian keeps the same word); otoño ← autumnus; invierno ← hibernum ('wintry') — but verano did NOT come from aestas like French été; it's veranum, 'of spring,' whose MEANING drifted to summer once primavera took over spring's job"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [ES-LEX-SEASONS-01, ES-ETYMON-SEASONS-02, ES-ETYMON-VERANO-03]
+practises:
+  knowledge: [ES-LEX-SEASONS-01, ES-ETYMON-SEASONS-02, ES-ETYMON-VERANO-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C24-mano, ES-C24-cabeza]
 ---
 
 # la primavera, el verano, el otoño, el invierno — three plain, one surprising
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Three of Spanish's four seasons are exactly what you'd expect
 from Latin. The fourth hides a genuine surprise: its **meaning itself**
 drifted from one season to another.
 
-## The three straightforward ones
+## The words, taken apart: three straightforward seasons
+<!-- hl-knowledge: introduces=[ES-LEX-SEASONS-01, ES-ETYMON-SEASONS-02]; assesses=[] -->
 
 - **la primavera** ("spring") ← Latin ***prīma vēra***, literally "**first
   spring**" (*vēr*, "spring," + *prīma*, "first"). Italian still says the
@@ -33,7 +50,8 @@ drifted from one season to another.
   **wintry** [season]" — the same root as French *hiver* and English
   **hibernate**, "to spend the winter."
 
-## The surprising one: verano
+## Why it's said this way: verano
+<!-- hl-knowledge: introduces=[ES-ETYMON-VERANO-03]; assesses=[] -->
 
 You might expect *verano* ("summer") to come from Latin **aestas**, "heat" —
 the way French *été* does. It doesn't. The standard account (per Spanish
@@ -54,6 +72,7 @@ two Spanish words both rooted in *vēr*, "spring," ended up naming two
 different seasons.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-SEASONS-01, ES-ETYMON-SEASONS-02, ES-ETYMON-VERANO-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "primavera, verano, otoño, invierno" — the four seasons]
@@ -63,6 +82,7 @@ different seasons.
 - [YOU SAY: "invierno ~ hibernate"]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-SEASONS-01, ES-ETYMON-SEASONS-02, ES-ETYMON-VERANO-03] -->
 
 [PAUSE 3s] What does **primavera** literally mean? (**"First spring"** —
 *prīma vēra*.) Does **verano** come from Latin *aestas*, like French *été*?

--- a/code/learning/human-languages/spanish/lessons/ES-C26-agua-vino.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C26-agua-vino.md
@@ -1,27 +1,44 @@
 ---
+schema_version: 2
 id: ES-C26-agua-vino
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 760
 chapter: 26
 type: word
 headword: el agua, el vino
 gloss: water and wine — agua kept its Latin shape almost whole, unlike French's worn-down eau
 concept_tag: ES-FOOD-DRINKS
-prerequisites: [ES-C25-las-estaciones]
+prerequisites: [ES-C25-las-estaciones, ES-C01-genero-gramatical]
 sounds: [stressed-a-el-not-la, nasal-none]
 roots: [aqua-latin, vinum-latin]
 etymology_hook: "agua ← Latin aqua, barely changed at all — where French wore aqua all the way down to just 'eau' (a bare 'oh'); agua also takes EL despite being feminine, a purely phonological rule (avoiding la agua), not a gender change like mano's"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-GRAMMAR-DEFINITE-ARTICLES, ES-GRAMMAR-NOUN-GENDER]
+introduces:
+  knowledge: [ES-LEX-AGUA-01, ES-ETYMON-AGUA-02, ES-GRAMMAR-AGUA-ARTICLE-03, ES-LEX-VINO-04, ES-ETYMON-VINO-05]
+practises:
+  knowledge: [ES-GRAMMAR-DEFINITE-ARTICLES, ES-GRAMMAR-NOUN-GENDER, ES-LEX-AGUA-01, ES-ETYMON-AGUA-02, ES-GRAMMAR-AGUA-ARTICLE-03, ES-LEX-VINO-04, ES-ETYMON-VINO-05]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C25-las-estaciones]
 ---
 
 # el agua, el vino — water and wine
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-DEFINITE-ARTICLES, ES-GRAMMAR-NOUN-GENDER] -->
 
 [PAUSE 2s] Two drinks, two very different journeys from Latin. One barely
 changed at all. And the "masculine-looking" article on a feminine word
 isn't a mistake — it's a real, well-documented rule.
 
-## el agua (water) — Latin aqua, barely touched
+## The words, taken apart: agua
+<!-- hl-knowledge: introduces=[ES-LEX-AGUA-01, ES-ETYMON-AGUA-02]; assesses=[] -->
 
 **agua** ("water") ← Latin **aqua** — almost unchanged. Compare French,
 where the very same word was worn all the way down to a bare **"eau,"**
@@ -31,7 +48,8 @@ English kept the **original**, whole Latin word too, just as a learned
 borrowing rather than an everyday one: **aquatic, aquarium, aqueduct,
 aqualung** all come straight from *aqua*.
 
-## Be honest about el agua's gender
+## Grammar Lens: el agua's article and gender
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-AGUA-ARTICLE-03]; assesses=[] -->
 
 Notice: **el agua**, not *la agua* — but *agua* is genuinely **feminine**
 (you'll see it in *el agua fría*, "the cold water," where *fría* keeps its
@@ -44,7 +62,8 @@ with words like *el águila* ("the eagle," still feminine) and *el hacha*
 ("the axe," still feminine). It's only the article that changes, never the
 noun's actual gender.
 
-## el vino (wine) — Latin vīnum, kept whole
+## The words, taken apart: vino
+<!-- hl-knowledge: introduces=[ES-LEX-VINO-04, ES-ETYMON-VINO-05]; assesses=[] -->
 
 **vino** ("wine") ← Latin **vīnum** — held its shape, the way French *vin*
 did too. English shares the very same root, by more than one road: **wine**
@@ -55,6 +74,7 @@ all — English built it at home, from the already-borrowed "wine" plus
 native "yard."
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-DEFINITE-ARTICLES, ES-GRAMMAR-NOUN-GENDER, ES-LEX-AGUA-01, ES-ETYMON-AGUA-02, ES-GRAMMAR-AGUA-ARTICLE-03, ES-LEX-VINO-04, ES-ETYMON-VINO-05] -->
 
 [PAUSE 1s]
 - [YOU SAY: "el agua" — water, feminine, but takes el]
@@ -64,6 +84,7 @@ native "yard."
 - [YOU SAY: "el águila, el hacha" — the same el-before-stressed-a pattern]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-DEFINITE-ARTICLES, ES-GRAMMAR-NOUN-GENDER, ES-LEX-AGUA-01, ES-ETYMON-AGUA-02, ES-GRAMMAR-AGUA-ARTICLE-03, ES-LEX-VINO-04, ES-ETYMON-VINO-05] -->
 
 [PAUSE 3s] Is **agua** masculine or feminine, and why does it take *el*?
 (**Feminine** — *el* replaces *la* only because *agua* starts with a

--- a/code/learning/human-languages/spanish/lessons/ES-C26-pan.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C26-pan.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C26-pan
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 770
 chapter: 26
 type: word
 headword: el pan
@@ -9,23 +12,38 @@ prerequisites: [ES-C26-agua-vino]
 sounds: [nasal-none, short-vowel]
 roots: [panis-latin]
 etymology_hook: "pan ← Latin panis 'bread' → compañero ('one you share bread with', com- + panis) — the very same word-story as English companion, and Spanish keeps BOTH the bread and the friendship"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [ES-LEX-PAN-01, ES-ETYMON-PAN-02, ES-ETYMON-COMPANION-03]
+practises:
+  knowledge: [ES-LEX-PAN-01, ES-ETYMON-PAN-02, ES-ETYMON-COMPANION-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C26-agua-vino]
 ---
 
 # el pan — bread, and the friend who shares it
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Spanish's word for bread hides the same lovely word-story you'd
 find in English's "companion" — except Spanish kept **both halves**, the
 bread and the friendship.
 
-## The word
+## The word, taken apart: pan
+<!-- hl-knowledge: introduces=[ES-LEX-PAN-01, ES-ETYMON-PAN-02]; assesses=[] -->
 
 **el pan** ("bread") ← Latin **pānis**. Masculine: *el pan*.
 
-## The "bread" family — bread AND friendship, both in Spanish
+## Why it's said this way: bread and friendship
+<!-- hl-knowledge: introduces=[ES-ETYMON-COMPANION-03]; assesses=[] -->
 
 The Latin root **pān-** ("bread") gives Spanish its own word for a close
 friend:
@@ -43,6 +61,7 @@ So *pan* and *compañero* are the same word-family doing double duty in
 Spanish: name the food, and name the friend you'd share it with.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-PAN-01, ES-ETYMON-PAN-02, ES-ETYMON-COMPANION-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "el pan" — bread]
@@ -50,6 +69,7 @@ Spanish: name the food, and name the friend you'd share it with.
 - [YOU SAY: "panadería, panadero" — bakery, baker]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-PAN-01, ES-ETYMON-PAN-02, ES-ETYMON-COMPANION-03] -->
 
 [PAUSE 3s] Give "bread" with its article. (**El pan**.) What does
 *compañero* literally mean, and what's it built from? ("**One you share

--- a/code/learning/human-languages/spanish/lessons/ES-C27-los-meses.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C27-los-meses.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C27-los-meses
+spine_node: SPINE-TIME-OF-DAY
+sequence: 780
 chapter: 27
 type: word
 headword: los meses
@@ -9,13 +12,26 @@ prerequisites: [ES-C21-lunes-viernes, ES-C08-numeros-6-10]
 sounds: [r-tap, diphthong-ie]
 roots: [latin-months, roman-gods]
 etymology_hook: "marzo ← Martius ← Mars, the SAME war-god behind martes; septiembre–diciembre still mean Latin 7–10 because the year once started in March — Julius and Augustus didn't ADD months, they just got two already-existing ones (Quintilis, Sextilis) RENAMED after them"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-WEEKDAYS-01, ES-ETYMON-WEEKDAYS-02]
+introduces:
+  knowledge: [ES-LEX-MONTHS-01, ES-ETYMON-MONTHS-02]
+practises:
+  knowledge: [ES-LEX-WEEKDAYS-01, ES-ETYMON-WEEKDAYS-02, ES-LEX-MONTHS-01, ES-ETYMON-MONTHS-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C21-lunes-viernes, ES-C08-numeros-6-10]
 ---
 
 # los meses — the calendar's gods and Caesars
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-WEEKDAYS-01, ES-ETYMON-WEEKDAYS-02] -->
 
 [PAUSE 2s] Spanish's twelve months are a **procession of Roman gods and
 emperors**, barely changed from Latin. Two things you already know pay off
@@ -24,6 +40,7 @@ immediately: *marzo* is the war-god you met in *martes*, and
 chapters.
 
 ## The months, taken apart
+<!-- hl-knowledge: introduces=[ES-LEX-MONTHS-01, ES-ETYMON-MONTHS-02]; assesses=[] -->
 
 | Spanish | ← Latin | who / what |
 |---|---|---|
@@ -57,6 +74,7 @@ Two payoffs land at once:
   after the fact. The names stuck; the months themselves were never new.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-WEEKDAYS-01, ES-ETYMON-WEEKDAYS-02, ES-LEX-MONTHS-01, ES-ETYMON-MONTHS-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: the twelve — "enero, febrero, marzo, abril, mayo, junio, julio,
@@ -65,6 +83,7 @@ Two payoffs land at once:
 - [YOU SAY: "septiembre = 7, diciembre = 10" — the old March-start year]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-WEEKDAYS-01, ES-ETYMON-WEEKDAYS-02, ES-LEX-MONTHS-01, ES-ETYMON-MONTHS-02] -->
 
 [PAUSE 3s] Which god links *marzo* and *martes*? (**Mars**, the war-god —
 his month and his day.) Why is *diciembre* Latin for "ten"? (**The Roman

--- a/code/learning/human-languages/spanish/lessons/ES-C28-mediodia-medianoche.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C28-mediodia-medianoche.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C28-mediodia-medianoche
+spine_node: SPINE-TIME-OF-DAY
+sequence: 790
 chapter: 28
 type: word
 headword: mediodía, medianoche
@@ -9,18 +12,32 @@ prerequisites: [ES-C27-los-meses]
 sounds: [diphthong-ia, nasal-none]
 roots: [medius-dies-latin, media-nox-latin]
 etymology_hook: "mediodía ← medius diēs, medianoche ← media nox — Spanish kept día/noche fully alive as ordinary words; French's -di (in midi) wore down to an opaque fragment, though its -nuit (in minuit) stayed just as recognizable as Spanish's noche"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [ES-LEX-NOON-MIDNIGHT-01, ES-ETYMON-NOON-MIDNIGHT-02]
+practises:
+  knowledge: [ES-LEX-NOON-MIDNIGHT-01, ES-ETYMON-NOON-MIDNIGHT-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C27-los-meses]
 ---
 
 # mediodía, medianoche — noon and midnight, spelled out in full
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Two hours that don't get a number — they get a name. And
 Spanish keeps that name far more transparent than its French cousin does.
 
 ## The two words, taken apart
+<!-- hl-knowledge: introduces=[ES-LEX-NOON-MIDNIGHT-01, ES-ETYMON-NOON-MIDNIGHT-02]; assesses=[] -->
 
 | Spanish | ← Latin | literally |
 |---|---|---|
@@ -48,6 +65,7 @@ hour" — originally mid-afternoon, it drifted earlier over the centuries to
 mean midday. Spanish kept the tidier, transparent "mid-day" instead.)
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-NOON-MIDNIGHT-01, ES-ETYMON-NOON-MIDNIGHT-02] -->
 
 [PAUSE 1s]
 - [YOU SAY: "mediodía" (noon), "medianoche" (midnight)]
@@ -58,6 +76,7 @@ mean midday. Spanish kept the tidier, transparent "mid-day" instead.)
   to a fossil (-di)]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-NOON-MIDNIGHT-01, ES-ETYMON-NOON-MIDNIGHT-02] -->
 
 [PAUSE 3s] What do *mediodía* and *medianoche* literally mean, and from
 what Latin? ("Mid-day" ← *medius diēs*; "mid-night" ← *media nox*.) Are

--- a/code/learning/human-languages/spanish/lessons/ES-C29-la-hora.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C29-la-hora.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C29-la-hora
+spine_node: SPINE-TIME-OF-DAY
+sequence: 800
 chapter: 29
 type: word
 headword: la hora
@@ -9,19 +12,33 @@ prerequisites: [ES-C28-mediodia-medianoche]
 sounds: [silent-h, article-la-las]
 roots: [hora-latin, hora-greek]
 etymology_hook: "hora ← Latin hōra ← Greek hṓrā, 'a season, a time of day' — Spanish inherited it almost unchanged, with a silent h that's a fossil of an already-weak Latin h (NOT the same story as hijo/hacer's silent h, which comes from Spanish's own later f- → h- sound change); the same Latin source as French heure, German's separately-borrowed Uhr, and English hour"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [ES-LEX-HORA-01, ES-ETYMON-HORA-02, ES-GRAMMAR-TELLING-TIME-03]
+practises:
+  knowledge: [ES-LEX-HORA-01, ES-ETYMON-HORA-02, ES-GRAMMAR-TELLING-TIME-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C28-mediodia-medianoche]
 ---
 
 # la hora — Spanish's barely-changed Latin hour
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You've now seen this Latin word take three different paths: French wore
 it down to *heure*, German borrowed it centuries later as *Uhr*. Spanish's path is
 the simplest of all — it barely changed.
 
-## The word, taken apart
+## The word, taken apart: hora
+<!-- hl-knowledge: introduces=[ES-LEX-HORA-01, ES-ETYMON-HORA-02]; assesses=[] -->
 
 **hora** ← Latin **hōra** ← Greek **hṓrā**, "a season, a time of day" (the Greek
 goddesses of the seasons were the *Hōrai*). Spanish kept the word almost exactly as
@@ -42,7 +59,8 @@ borrowed it later as *Uhr*; English took the same Latin *hōra* and made *hour*.
 | German | *Uhr* | not inherited — borrowed later, separately |
 | English | *hour* | inherited via French, silent *h* |
 
-## Grammar Lens: "Son las…" — telling the time
+## Grammar Lens: Son las and telling time
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-TELLING-TIME-03]; assesses=[] -->
 
 Spanish uses **ser** ("to be") plus the **feminine plural article** (agreeing with
 the unspoken *horas*) to tell time — and famously switches number for "one":
@@ -57,6 +75,7 @@ everyday speech (unlike French's *il est deux heures*, which spells out "hours"
 every time).
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HORA-01, ES-ETYMON-HORA-02, ES-GRAMMAR-TELLING-TIME-03] -->
 
 [PAUSE 1s]
 - [YOU SAY: "hora" — silent h, a fossil of an already-weak Latin h]
@@ -64,6 +83,7 @@ every time).
 - [YOU SAY: "hora / heure / hour" — one Latin root, three different fates]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-HORA-01, ES-ETYMON-HORA-02, ES-GRAMMAR-TELLING-TIME-03] -->
 
 [PAUSE 3s] What Latin (and Greek) word is *hora* from? (*hōra* ← Greek *hṓrā*.) How
 did Spanish's path differ from French's and German's? (**Spanish** inherited it

--- a/code/learning/human-languages/spanish/lessons/ES-C30-el-tiempo.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C30-el-tiempo.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C30-el-tiempo
+spine_node: SPINE-TIME-OF-DAY
+sequence: 810
 chapter: 30
 type: phrase
 headword: el tiempo, llueve
@@ -9,19 +12,33 @@ prerequisites: [ES-C12-hacer, ES-C03-llamar]
 sounds: [ll-digraph, diphthong-ue]
 roots: [tempus-latin, calor-latin, frigidus-latin, sol-latin, pluere-latin]
 etymology_hook: "el tiempo means BOTH 'time' and 'weather' — from Latin tempus, which already covered both senses; hace calor/frío/sol reuse hacer ('it makes'), but llueve ('it's raining') is its own dedicated verb, llover ← Latin pluere, the SAME cl-/fl-/pl- → ll- sound change you met in llamar/llave/llama"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-LLAMO]
+introduces:
+  knowledge: [ES-LEX-TIEMPO-01, ES-ETYMON-TIEMPO-02, ES-LEX-WEATHER-03, ES-ETYMON-WEATHER-04, ES-GRAMMAR-WEATHER-05, ES-ETYMON-LLOVER-06]
+practises:
+  knowledge: [ES-LEX-LLAMO, ES-LEX-TIEMPO-01, ES-ETYMON-TIEMPO-02, ES-LEX-WEATHER-03, ES-ETYMON-WEATHER-04, ES-GRAMMAR-WEATHER-05, ES-ETYMON-LLOVER-06]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C12-hacer, ES-C03-llamar]
 ---
 
 # el tiempo — weather, and a word that means two things at once
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Ask a Spanish speaker "¿qué tiempo hace?" and you're literally
 asking "what time does it make?" — because *tiempo* doesn't distinguish
 "time" from "weather" the way English does.
 
-## el tiempo — one word, two meanings
+## The word, taken apart: el tiempo
+<!-- hl-knowledge: introduces=[ES-LEX-TIEMPO-01, ES-ETYMON-TIEMPO-02]; assesses=[] -->
 
 **el tiempo** = both "**time**" and "**weather**" — from Latin **tempus**,
 which already covered this same double sense (English kept only the "time"
@@ -29,7 +46,8 @@ half: **temporal, contemporary, tempo**). So **¿qué tiempo hace?** ("what's
 the weather like?") is literally "**what time does it make**?" — context alone
 tells a Spanish speaker which sense is meant.
 
-## calor, frío, sol — three Latin words for the weather itself
+## The words, taken apart: calor, frío, and sol
+<!-- hl-knowledge: introduces=[ES-LEX-WEATHER-03, ES-ETYMON-WEATHER-04]; assesses=[] -->
 
 - **calor** ← Latin **calor**, "heat, warmth" → English **calorie, caloric**.
 - **frío** ← Latin **frigidus**, "cold" (with the middle syncopated away over
@@ -42,7 +60,8 @@ You've already met **hace calor** and **hace frío** ("it's hot/cold," literally
 ("to make") that reports weather this way also covers "sunny": **hace sol**
 ("it's sunny," literally "it makes sun").
 
-## llueve — a dedicated verb, not hacer
+## Why it's said this way: llueve uses its own verb
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-WEATHER-05, ES-ETYMON-LLOVER-06]; assesses=[ES-LEX-LLAMO] -->
 
 **Rain** breaks the *hacer* pattern entirely: **llueve** ("it's raining") comes
 from its own verb, **llover** ← Latin **pluere**, "to rain." Recognize that
@@ -54,6 +73,7 @@ dedicated, impersonal verb — much like English's own dedicated "it **rains**"
 versus "it **is** hot."
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-LLAMO, ES-LEX-TIEMPO-01, ES-ETYMON-TIEMPO-02, ES-LEX-WEATHER-03, ES-ETYMON-WEATHER-04, ES-GRAMMAR-WEATHER-05, ES-ETYMON-LLOVER-06] -->
 
 [PAUSE 1s]
 - [YOU SAY: "el tiempo" — time, or weather, depending on context]
@@ -61,6 +81,7 @@ versus "it **is** hot."
 - [YOU SAY: "llueve" — it's raining, its own verb, not hacer]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-LLAMO, ES-LEX-TIEMPO-01, ES-ETYMON-TIEMPO-02, ES-LEX-WEATHER-03, ES-ETYMON-WEATHER-04, ES-GRAMMAR-WEATHER-05, ES-ETYMON-LLOVER-06] -->
 
 [PAUSE 3s] What two things does **el tiempo** mean, and what Latin word covers
 both? (**"Time"** and **"weather"** — Latin **tempus**.) Which weather word

--- a/code/learning/human-languages/spanish/lessons/ES-C31-numeros-11-20.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C31-numeros-11-20.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C31-numeros-11-20
+spine_node: SPINE-COUNT-ONE-TO-FIVE
+sequence: 820
 chapter: 31
 type: word
 headword: once — veinte
@@ -9,19 +12,33 @@ prerequisites: [ES-C08-numeros-6-10]
 sounds: [diphthong-ie, silent-none]
 roots: [latin-undecim-quindecim, latin-viginti]
 etymology_hook: "once-quince (11-15) are Latin's ūndecim-quīndecim, fused down almost past recognition; dieciséis-diecinueve (16-19) are perfectly transparent 'diez y seis' compounds — but Latin's OWN 18 and 19 were subtractive oddities, duodēvīgintī ('two from twenty') and ūndēvīgintī ('one from twenty'); Spanish didn't inherit that quirk, it replaced it with plain addition"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [ES-LEX-NUMBERS-11-15-01, ES-ETYMON-NUMBERS-11-15-02, ES-LEX-NUMBERS-16-19-03, ES-GRAMMAR-NUMBER-FORMATION-04, ES-ETYMON-LATIN-TEENS-05, ES-LEX-VEINTE-06, ES-ETYMON-VEINTE-07]
+practises:
+  knowledge: [ES-LEX-NUMBERS-11-15-01, ES-ETYMON-NUMBERS-11-15-02, ES-LEX-NUMBERS-16-19-03, ES-GRAMMAR-NUMBER-FORMATION-04, ES-ETYMON-LATIN-TEENS-05, ES-LEX-VEINTE-06, ES-ETYMON-VEINTE-07]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C08-numeros-6-10]
 ---
 
 # once, veinte — five fused Latins, then Spanish fixes Latin's own quirk
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Eleven through twenty splits into two very different stories: five
 numbers worn down almost past recognition, and five that Spanish built fresh
 — fixing a genuine oddity in Latin's own counting system along the way.
 
-## once–quince — five fused Latin compounds
+## The words, taken apart: once through quince
+<!-- hl-knowledge: introduces=[ES-LEX-NUMBERS-11-15-01, ES-ETYMON-NUMBERS-11-15-02]; assesses=[] -->
 
 | Spanish | ← Latin |
 |---|---|
@@ -36,7 +53,8 @@ root as *diez*) — but centuries of everyday use fused them into single,
 opaque words. You can still faintly hear *-ce* as the worn-down echo of
 *-decim* in all five.
 
-## dieciséis–diecinueve — transparent, built fresh
+## The words, taken apart: dieciséis through diecinueve
+<!-- hl-knowledge: introduces=[ES-LEX-NUMBERS-16-19-03, ES-GRAMMAR-NUMBER-FORMATION-04]; assesses=[] -->
 
 | Spanish | literally |
 |---|---|
@@ -48,7 +66,8 @@ opaque words. You can still faintly hear *-ce* as the worn-down echo of
 No fusion here — these are fully transparent "ten-and-X" compounds, and you
 can hear *diez* plainly in every one.
 
-## Be honest: Spanish fixed a real quirk in Latin's own teens
+## Why it's said this way: Spanish regularized the Latin teens
+<!-- hl-knowledge: introduces=[ES-ETYMON-LATIN-TEENS-05]; assesses=[] -->
 
 Here's the genuinely interesting part. You might expect *dieciocho* and
 *diecinueve* to simply continue whatever Latin did for 18 and 19 — but Latin's
@@ -59,12 +78,14 @@ from twenty**") for 19. Spanish didn't inherit that pattern at all — it built
 16 and 17, quietly **regularizing away** a genuine irregularity that existed
 in Latin itself.
 
-## veinte
+## You'll want to know: veinte
+<!-- hl-knowledge: introduces=[ES-LEX-VEINTE-06, ES-ETYMON-VEINTE-07]; assesses=[] -->
 
 **veinte** ("twenty") ← Latin **vīgintī** — worn down by ordinary sound
 change, but never fused from two separate words the way *once*-*quince* were.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-NUMBERS-11-15-01, ES-ETYMON-NUMBERS-11-15-02, ES-LEX-NUMBERS-16-19-03, ES-GRAMMAR-NUMBER-FORMATION-04, ES-ETYMON-LATIN-TEENS-05, ES-LEX-VEINTE-06, ES-ETYMON-VEINTE-07] -->
 
 [PAUSE 1s]
 - [YOU SAY: "once, doce, trece, catorce, quince" — the five fused Latins]
@@ -73,6 +94,7 @@ change, but never fused from two separate words the way *once*-*quince* were.
 - [YOU SAY: "veinte" — twenty]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-NUMBERS-11-15-01, ES-ETYMON-NUMBERS-11-15-02, ES-LEX-NUMBERS-16-19-03, ES-GRAMMAR-NUMBER-FORMATION-04, ES-ETYMON-LATIN-TEENS-05, ES-LEX-VEINTE-06, ES-ETYMON-VEINTE-07] -->
 
 [PAUSE 3s] What are *once* through *quince*, structurally? (**Fused Latin
 compounds** — number + *-decim*, "ten," worn down to *-ce*.) Are *dieciséis*

--- a/code/learning/human-languages/spanish/lessons/ES-C32-perro-gato.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C32-perro-gato.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C32-perro-gato
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 830
 chapter: 32
 type: word
 headword: perro, gato
@@ -9,19 +12,33 @@ prerequisites: [ES-C08-numeros-6-10]
 sounds: [rolled-rr, silent-none]
 roots: [latin-cattus-afroasiatic, unknown-perro]
 etymology_hook: "gato ← Latin cattus, itself probably from an Afro-Asiatic word (compare Nubian kadis) that traveled along Roman trade routes as domestic cats spread out of Egypt — a real, sourced etymology; perro, by honest contrast, is a genuine UNSOLVED mystery with no confirmed origin at all, and it quietly REPLACED Latin's own word for dog, canis (which survives as archaic Spanish can)"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [ES-LEX-GATO-01, ES-ETYMON-GATO-02, ES-LEX-PERRO-03, ES-EVIDENCE-PERRO-04]
+practises:
+  knowledge: [ES-LEX-GATO-01, ES-ETYMON-GATO-02, ES-LEX-PERRO-03, ES-EVIDENCE-PERRO-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C08-numeros-6-10]
 ---
 
 # perro, gato — one sourced etymology, one genuine mystery
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Two everyday animal words, two completely different kinds of
 history: one traces all the way back to ancient Egypt. The other is a real,
 unsolved puzzle that linguists still argue about.
 
-## gato — a word that traveled with the cat itself
+## The words, taken apart: gato
+<!-- hl-knowledge: introduces=[ES-LEX-GATO-01, ES-ETYMON-GATO-02]; assesses=[] -->
 
 **gato** ("**cat**") ← Latin **cattus** — but *cattus* itself wasn't the
 original Latin word for cat at all. Classical Latin's word was **fēlēs**
@@ -34,7 +51,8 @@ from Africa, eventually pushing out *fēlēs* almost everywhere (the same
 *cattus* gives Italian *gatto*, French *chat*, even Old Irish *cat* and Welsh
 *cath*).
 
-## perro — a genuine, unsolved mystery
+## The words, taken apart: perro
+<!-- hl-knowledge: introduces=[ES-LEX-PERRO-03, ES-EVIDENCE-PERRO-04]; assesses=[] -->
 
 **perro** ("**dog**") is honestly different: nobody knows for certain where
 it comes from. The word Spanish "should" have inherited from Latin is
@@ -50,6 +68,7 @@ the late Roman Empire. None of these is confirmed — *perro* remains one of
 Spanish's genuinely open etymological puzzles.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-GATO-01, ES-ETYMON-GATO-02, ES-LEX-PERRO-03, ES-EVIDENCE-PERRO-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "gato" — cat, traced all the way back to Egypt via Latin
@@ -59,6 +78,7 @@ Spanish's genuinely open etymological puzzles.
   canis]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-GATO-01, ES-ETYMON-GATO-02, ES-LEX-PERRO-03, ES-EVIDENCE-PERRO-04] -->
 
 [PAUSE 3s] What was Classical Latin's actual word for "cat," and where did
 *cattus* most likely come from instead? (**Fēlēs**; *cattus* is probably

--- a/code/learning/human-languages/spanish/lessons/ES-C33-verde-amarillo.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C33-verde-amarillo.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C33-verde-amarillo
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 840
 chapter: 33
 type: word
 headword: verde, amarillo
@@ -9,19 +12,33 @@ prerequisites: [ES-C22-rojo-azul]
 sounds: [rolled-none, double-l-y]
 roots: [latin-viridis-vireo, latin-amarus-bitter]
 etymology_hook: "verde ← Latin viridis, 'green,' from virere, 'to be green/vigorous' (cousin of English verdant, verdure — NOT of English green itself, a separate Germanic root); amarillo is the real surprise — it does NOT come from any Latin word for yellow at all, but from amarellus, 'a little bitter,' a diminutive of amarus, 'bitter' — the same root as Spanish's own amargo, 'bitter'"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [ES-LEX-VERDE-01, ES-ETYMON-VERDE-02, ES-LEX-AMARILLO-03, ES-ETYMON-AMARILLO-04]
+practises:
+  knowledge: [ES-LEX-VERDE-01, ES-ETYMON-VERDE-02, ES-LEX-AMARILLO-03, ES-ETYMON-AMARILLO-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C22-rojo-azul]
 ---
 
 # verde, amarillo — the expected inheritance, and a real surprise
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] One of these colors is exactly what you'd expect from Latin.
 The other one will genuinely surprise you — it has nothing to do with any
 Latin word for "yellow" at all.
 
-## verde — straightforward, from "to flourish"
+## The words, taken apart: verde
+<!-- hl-knowledge: introduces=[ES-LEX-VERDE-01, ES-ETYMON-VERDE-02]; assesses=[] -->
 
 **verde** ("**green**") ← Latin **viridis** (worn down via **virdis**), from
 the verb **virēre**, "**to be green, to flourish, to be vigorous**." This is
@@ -29,7 +46,8 @@ a cousin of English **verdant** and **verdure** — though **not** of English
 **green** itself, which comes from a completely separate Germanic root. A
 clean, expected Latin inheritance.
 
-## amarillo — genuinely NOT from a "yellow" word at all
+## The words, taken apart: amarillo
+<!-- hl-knowledge: introduces=[ES-LEX-AMARILLO-03, ES-ETYMON-AMARILLO-04]; assesses=[] -->
 
 Here's the honest surprise: **amarillo** ("**yellow**") does **not** trace
 to any of Latin's actual words for yellow (*flāvus*, *gilvus*, *lūteus*).
@@ -43,6 +61,7 @@ Age the word had shed its bitter meaning entirely, leaving just the color.
 both descend from the same *amarus*.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-VERDE-01, ES-ETYMON-VERDE-02, ES-LEX-AMARILLO-03, ES-ETYMON-AMARILLO-04] -->
 
 [PAUSE 1s]
 - [YOU SAY: "verde" — green, from "to flourish"]
@@ -51,6 +70,7 @@ both descend from the same *amarus*.
   Latin root]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-VERDE-01, ES-ETYMON-VERDE-02, ES-LEX-AMARILLO-03, ES-ETYMON-AMARILLO-04] -->
 
 [PAUSE 3s] What Latin verb gives **verde**, and what does it mean? (**Virēre**,
 "to be green/flourish" — cousin of English *verdant*, *verdure*, not of

--- a/code/packages/typescript/human-language-data/tests/integration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/integration.test.ts
@@ -39,7 +39,7 @@ describe("real curriculum", () => {
   it("preserves every existing LaTeX book and maps each chapter to short lessons", () => {
     expect(books.books.length).toBeGreaterThanOrEqual(20);
     expect(books.books.reduce((sum, book) => sum + book.chapters.length, 0)).toBeGreaterThanOrEqual(100);
-    expect(books.books.find((book) => book.language === "spanish")?.chapters.length).toBe(18);
+    expect(books.books.find((book) => book.language === "spanish")?.chapters.length).toBe(33);
     expect(
       books.books
         .find((book) => book.language === "persian")


### PR DESCRIPTION
## Summary

- migrate the 21 existing Spanish lessons in Chapters 19–33 to the prerequisite-safe schema-v2 contract
- generate fifteen LaTeX chapters from the same canonical AST consumed by Language Ladder, closing the corpus-wide lesson-to-book chapter gap
- preserve the Arabic root `لازورد` with repository-backed Naskh shaping and record the exact remaining legacy Spanish print-warning debt
- update the Spanish guide, changelog, and shared backlog, including the newly discovered non-required books-check race

## Validation

- `human-language-data`: build; 84 tests; generated-book drift check; curriculum report
- `language-ladder`: production build; 464 tests
- report: 20 tracks, 1,066 lessons, 20 books; zero duration violations, unknown prerequisites, or lesson chapters without book chapters
- forced XeLaTeX build: 210 pages; correct title/author; 35 top-level / 155 total outline entries; zero schema leaks, missing glyphs, or duplicate destinations
- rendered all 210 pages and visually inspected every page; final rebased build is pixel-identical to the inspected render

## Follow-up debt

HL-B37 owns the existing Spanish legacy-layout baseline: 51 overfull hboxes, 3 underfull hboxes, 19 underfull vboxes, 14 Hyperref warnings, and 2 font-warning matches. HL-P01 records making the unified Human Languages Books result a protected merge gate after #9885 exposed an auto-merge race.