### PR TITLE
fix(human-languages): clean Spanish book layout

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -107,9 +107,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B33 | Complete (#9880) | Remove Tamil's LaTeX layout, duplicate-label, bookmark, font, and header-only-verso warnings. | The forced 117-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; intentionally blank chapter versos are truly empty. |
 | HL-B34 | Complete (#9883) | Publish Latin Chapters 2–36 from canonical lessons rather than hand-copying another thirty-five book chapters. | All 53 Latin lessons now use schema v2; Chapters 2–36 are generated with source hashes independently verified against Language Ladder. |
 | HL-B35 | Complete (#9885, repaired by #9887) | Remove Latin's remaining LaTeX layout, font, and header-only-verso warnings. | The forced 115-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; intentionally blank chapter versos are truly empty. |
-| HL-B36 | Complete in this PR | Publish Spanish Chapters 19–33 from canonical lessons rather than hand-copying another fifteen book chapters. | The Spanish PDF now includes all 33 canonical chapters; all 21 later lessons use schema v2 and generate fifteen chapters from the same content consumed by Language Ladder. |
-| HL-B37 | Next | Remove Spanish's remaining legacy LaTeX layout, bookmark, font, and header-only-verso warnings. | The expanded forced build has no missing glyphs or duplicate destinations but reports 51 overfull hboxes, 3 underfull hboxes, 19 underfull vboxes, 14 Hyperref warnings, and 2 font-warning matches; the clean-build signal is zero of each and truly empty chapter versos. |
-| HL-P01 | Queued | Make the unified Human Languages Books result a protected merge gate, or add an equivalent gate that auto-merge must await. | #9885 auto-merged after general CI passed while the non-required books job had failed; the portable-font repair in #9887 should have been required before merge. |
+| HL-B36 | Complete (#9890) | Publish Spanish Chapters 19–33 from canonical lessons rather than hand-copying another fifteen book chapters. | The Spanish PDF now includes all 33 canonical chapters; all 21 later lessons use schema v2 and generate fifteen chapters from the same content consumed by Language Ladder. |
+| HL-B37 | Complete in this PR | Remove Spanish's remaining legacy LaTeX layout, bookmark, font, and header-only-verso warnings. | The forced 214-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; all 19 intentionally blank physical pages are truly empty. |
+| HL-P01 | Next | Make the unified Human Languages Books result a protected merge gate, or add an equivalent gate that auto-merge must await. | #9885 auto-merged after general CI passed while the non-required books job had failed; the portable-font repair in #9887 should have been required before merge. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-M02 | Queued | Extend Telugu's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson needs a scheduled place, and the map must explicitly split or justify Chapter 20's numbers-and-weather topic collision. |
 | HL-M03 | Queued | Extend Kannada's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5; every canonical lesson needs a scheduled place, and Chapter 20's unrelated numbers/weather pairing must be split or explicitly justified. |
@@ -1094,6 +1094,30 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   owned by HL-B37 rather than hidden by this publication tranche.
 - HL-B37 is next: remove Spanish's remaining legacy print warnings and
   header-only chapter versos.
+
+## Findings from HL-B37
+
+- Portable Latin Modern small caps remove the final font fallback on both
+  MiKTeX and TeX Live. Natural page bottoms, a two-em emergency stretch,
+  compact numeric running heads, and a true-empty `\cleardoublepage` remove
+  legacy line, page, and header-only-verso warnings without hiding them.
+- Fixed-width legacy grammar tables now use width-aware, ragged-right columns.
+  Dense conjugation, tense, mood, and etymology comparisons wrap within the
+  printed measure instead of protruding into the margin.
+- Plain-text bookmark alternatives preserve the visible vowel-change notation
+  while removing all fourteen math-token warnings from the PDF outline.
+- The dense Chapter 21 weekday recall is now a scannable canonical bullet list.
+  Its generated chapter retains the independently checked lesson id and source
+  hash, so the readability improvement reaches both Language Ladder and the
+  book from the same source.
+- The forced 214-page XeLaTeX build has correct title and author metadata, 35
+  top-level and 155 total outline entries, zero schema leaks, and zero missing
+  glyphs, overfull or underfull boxes, duplicate destinations, Hyperref
+  warnings, LaTeX warnings, or font warnings. All 214 rendered pages were
+  inspected for clipping, collisions, broken tables, malformed callouts, and
+  Arabic shaping; all 19 intentionally blank physical pages are truly empty.
+- HL-P01 is next: make the unified books result a protected merge gate, or add
+  an equivalent gate that auto-merge cannot outrun.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -1974,7 +1974,7 @@
     {
       "language": "spanish",
       "chapter": 21,
-      "sourceHash": "fnv1a64:09f9bc1fc7fc5a64",
+      "sourceHash": "fnv1a64:9f1f17a520fa7add",
       "lessonIds": [
         "ES-C21-lunes-viernes",
         "ES-C21-sabado-domingo"

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Complete book — clean, portable print layout
+
+- Replaced fixed-width legacy grammar tables with width-aware columns, split
+  dense recap prose into scannable lists, and gave long chapter and section
+  titles compact running-head and bookmark forms.
+- Added portable Latin Modern small caps, natural page bottoms, a modest
+  line-break reserve, and truly empty open-right chapter versos.
+- Reworked the canonical Chapter 21 weekday recall as four prerequisite-safe
+  prompts; regenerated book content and Language Ladder's independent source
+  fingerprint from that same lesson.
+- Forced the complete book to 214 pages with zero missing glyphs, overfull or
+  underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings,
+  or font warnings. All rendered pages, including Arabic **لازورد** and all 19
+  intentionally blank physical pages, were visually inspected.
+
 ## Chapters 19–33 — canonical app/book publication
 
 - Migrated all 21 existing lessons from *sí / no* through *verde / amarillo*

--- a/code/learning/human-languages/spanish/README.md
+++ b/code/learning/human-languages/spanish/README.md
@@ -76,7 +76,9 @@ consumed by Language Ladder. Run `npm run build && npm run generate:books` from
 `code/packages/typescript/human-language-data` after editing those lessons; CI
 rejects stale generated TeX or source-hash metadata. Chapters 7–18 are still
 handwritten LaTeX during the staged one-source migration. `units/` is legacy
-source material, not a second canonical copy.
+source material, not a second canonical copy. The complete 214-page PDF builds
+without missing glyphs, layout-box warnings, bookmark warnings, duplicate
+destinations, LaTeX warnings, or font fallbacks.
 
 ## Progress
 
@@ -127,7 +129,7 @@ exactly where a word needs it:
   eleven through twenty → dog and cat → green and yellow.
 
 Every noun carries its gender (*el*/*la*) and plural; every pronoun is traced
-to its root. **All 33 chapters are authored and in the book (210 pages);
+to its root. **All 33 chapters are authored and in the book (214 pages);
 Chapters 1–6 and 19–33 are generated from canonical lessons.**
 Lessons are named by **slug** (e.g. `ES-C01-dia`), not numbered — order lives
 in the book (which LaTeX auto-numbers) and in `session-map.md`, so inserting a

--- a/code/learning/human-languages/spanish/book/chapters/ch07-er-ir-verbs.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch07-er-ir-verbs.tex
@@ -34,7 +34,7 @@ exactly like the \emph{-ar} family with the \emph{a}'s swapped for \emph{e}'s.
 Chop the \emph{-er} off \emph{comer} to get the stem \emph{com-}, then add:
 
 \begin{center}
-\begin{tabular}{llll}
+\begin{tabularx}{\linewidth}{Ylll}
 \toprule
 person & \emph{-ar} was & \emph{-er} is & \emph{comer} $\to$\\
 \midrule
@@ -44,7 +44,7 @@ person & \emph{-ar} was & \emph{-er} is & \emph{comer} $\to$\\
 (\emph{nosotros}, we) & \emph{-amos} & \emph{-emos} & \emph{comemos}\\
 (\emph{ellos / ustedes}, they/you all) & \emph{-an} & \emph{-en} & \emph{comen}\\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 So the \emph{yo} form is identical (\emph{-o}), and \emph{t\'{u}}/\emph{\'{e}l}

--- a/code/learning/human-languages/spanish/book/chapters/ch08-numbers-and-age.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch08-numbers-and-age.tex
@@ -19,7 +19,7 @@ American pronunciation of ``butter,'' not an English \emph{r}.
 \end{sounds}
 
 \begin{center}
-\begin{tabular}{lll}
+\begin{tabularx}{\linewidth}{llY}
 \toprule
 Spanish & $\leftarrow$ Latin & English cousins \\
 \midrule
@@ -29,10 +29,11 @@ Spanish & $\leftarrow$ Latin & English cousins \\
 \textbf{cuatro} (4) & \emph{quattuor} & \textbf{quart}, \textbf{quarter}, \textbf{quadrant}, \textbf{square} \\
 \textbf{cinco} (5) & \emph{qu\={\i}nque} & \textbf{quintet}, \textbf{quintessence}, \textbf{quintuplet} \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 \begin{cousinweb}
+\raggedright
 \textbf{Pattern:} Latin \emph{qu-} softens on its way into Spanish ---
 \emph{quattuor} $\to$ \emph{cuatro} (\emph{qu-} $\to$ \emph{cu-}),
 \emph{qu\={\i}nque} $\to$ \emph{cinco} (\emph{qu-} $\to$ \emph{c-}).\\[3pt]
@@ -63,7 +64,7 @@ a Spanish signature; you will meet them again in almost every irregular verb.
 \end{sounds}
 
 \begin{center}
-\begin{tabular}{lll}
+\begin{tabularx}{\linewidth}{YlY}
 \toprule
 Spanish & $\leftarrow$ Latin & English cousins \\
 \midrule
@@ -73,7 +74,7 @@ Spanish & $\leftarrow$ Latin & English cousins \\
 \textbf{nueve} (9) & \emph{novem} & \textbf{November} (9th), \textbf{novena} \\
 \textbf{diez} (10) & \emph{decem} & \textbf{December} (10th), \textbf{decimal}, \textbf{decade}, \textbf{dime}, \textbf{decimate} \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 \begin{culture}
@@ -111,6 +112,7 @@ the stem cracks open you get the \emph{ie} glide again: \textbf{tienes} $=$
 \end{sounds}
 
 \begin{cousinweb}
+\raggedright
 \textbf{tener} (``to have'') $\leftarrow$ Latin \emph{ten\={e}re}, ``to hold,
 to keep, to grasp.'' Having is, at root, \emph{holding}.\\[3pt]
 The bare root: \textbf{tenant} (one who \emph{holds} land), \textbf{tenure},
@@ -131,7 +133,7 @@ Second, the stem vowel breaks \emph{e} $\to$ \emph{ie} in the stressed forms
 \end{grammarlens}
 
 \begin{center}
-\begin{tabular}{lll}
+\begin{tabularx}{\linewidth}{YlY}
 \toprule
 Person & Form & Note \\
 \midrule
@@ -141,7 +143,7 @@ Person & Form & Note \\
 \emph{nosotros} (we) & \textbf{tenemos} & back to plain \emph{e} --- unstressed \\
 \emph{ellos / ustedes} (they, you-plural) & \textbf{tienen} & \emph{e} $\to$ \emph{ie} \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 Notice that \emph{tenemos} keeps the plain \emph{e}: the vowel only cracks to
@@ -214,16 +216,20 @@ $\cdot$ tienen.
 --- Un caf\'{e}, por favor. \textquestiondown Cu\'{a}nto es? --- Dos euros.
 \end{quote}
 
-What you have built: the \textbf{numbers 1--10} ($\leftarrow$ \emph{\={u}nus
-\ldots\ decem}; \emph{cinco}/\textbf{quintet}, \emph{diez}/\textbf{December})
-and the \textbf{teen fusion} \emph{diez y seis} $\to$ \emph{diecis\'{e}is}
-($=$ \textbf{sixteen}); \textbf{tener}, ``to have'' ($\leftarrow$
-\emph{ten\={e}re} ``hold''; \textbf{tenant}, \textbf{retain}, \textbf{contain}),
-your first irregular, stem-changing verb, with its \emph{-go} form
-\emph{tengo} and its \emph{e} $\to$ \emph{ie} crack; and
-\emph{\textquestiondown Cu\'{a}ntos a\~{n}os tienes?}, age given with
-\emph{tener} rather than ``be,'' where \emph{a\~{n}os} $\leftarrow$
-\emph{annus} brings back the \emph{\~{n}}.
+What you have built:
+\begin{itemize}
+  \item the \textbf{numbers 1--10} ($\leftarrow$ \emph{\={u}nus \ldots\
+    decem}), including \emph{cinco}/\textbf{quintet} and
+    \emph{diez}/\textbf{December};
+  \item the \textbf{teen fusion} \emph{diez y seis} $\to$
+    \emph{diecis\'{e}is}, the same construction as \textbf{sixteen};
+  \item \textbf{tener}, ``to have'' ($\leftarrow$ \emph{ten\={e}re},
+    ``hold''), your first irregular, stem-changing verb, with \emph{tengo}
+    and its \emph{e} $\to$ \emph{ie} crack; and
+  \item \emph{\textquestiondown Cu\'{a}ntos a\~{n}os tienes?}, age given with
+    \emph{tener} rather than ``be,'' where \emph{a\~{n}os} $\leftarrow$
+    \emph{annus} brings back the \emph{\~{n}}.
+\end{itemize}
 
 Next chapter: \emph{ser} versus \emph{estar} head-on --- the two ``to be''
 verbs, sorted for good.

--- a/code/learning/human-languages/spanish/book/chapters/ch09-ser-y-estar.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch09-ser-y-estar.tex
@@ -49,7 +49,7 @@ simply learn them as a set.
 \end{grammarlens}
 
 \begin{center}
-\begin{tabular}{lll}
+\begin{tabularx}{\linewidth}{llY}
 \toprule
 person & form & Latin source \\
 \midrule
@@ -63,7 +63,7 @@ nosotros & \textbf{somos} & \emph{sumus} \\
 ellos / ustedes & \textbf{son} & \emph{sunt} --- cognate with the plural
 English \emph{are} \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 Say them as a set: \emph{soy $\cdot$ eres $\cdot$ es $\cdot$ somos $\cdot$
@@ -78,7 +78,7 @@ English word (``to be''). But the choice is not arbitrary --- it is written
 into the \textbf{etymology} of each verb. Get the roots, and the rule follows.
 
 \begin{center}
-\begin{tabular}{llll}
+\begin{tabularx}{\linewidth}{lYYY}
 \toprule
 verb & root & picture & used for \\
 \midrule
@@ -89,7 +89,7 @@ identity, origin, profession, \\
 thing \emph{stands} now & mood, condition, location, \\
  & & & the temporary \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 The mnemonic writes itself: \textbf{\emph{ser} $=$ essence, \emph{estar} $=$
@@ -112,7 +112,7 @@ claims.
 \end{grammarlens}
 
 \begin{center}
-\begin{tabular}{ll}
+\begin{tabularx}{\linewidth}{YY}
 \toprule
 with \textbf{ser} (essence) & with \textbf{estar} (state) \\
 \midrule
@@ -125,7 +125,7 @@ aburrido} --- ``he \emph{is} bored'' (right now) \\
 \emph{es verde} --- ``it \emph{is} green'' (its colour) & \emph{est\'{a}
 verde} --- ``it is \emph{unripe}'' (its state) \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 \begin{culture}
@@ -226,7 +226,7 @@ Put the two questions side by side and the whole chapter snaps into focus.
 \end{grammarlens}
 
 \begin{center}
-\begin{tabular}{lll}
+\begin{tabularx}{\linewidth}{YlY}
 \toprule
 question & verb & why \\
 \midrule
@@ -235,7 +235,7 @@ question & verb & why \\
 \emph{\textquestiondown D\'{o}nde est\'{a}s?} --- ``Where are you \emph{at}?''
 & \emph{estar} (\emph{est\'{a}s}) & location $=$ state \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 Same word \emph{d\'{o}nde}, two different be-verbs --- and each is locked in by

--- a/code/learning/human-languages/spanish/book/chapters/ch10-ir-y-futuro.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch10-ir-y-futuro.tex
@@ -66,7 +66,8 @@ When \emph{a} meets the masculine article \emph{el}, the two contract into
 \textbf{al}: \emph{voy al caf\'{e}}, ``I'm going to the caf\'{e}.''
 \end{grammarlens}
 
-\section{\emph{voy a} $+$ infinitive --- the ``going-to'' future}
+\section[voy a + infinitive --- the ``going-to'' future]
+  {\emph{voy a} $+$ infinitive --- the ``going-to'' future}
 \label{lesson:ir-a-futuro}
 
 Here is a gift. Spanish builds its everyday future \emph{exactly} the way

--- a/code/learning/human-languages/spanish/book/chapters/ch11-stem-changes.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch11-stem-changes.tex
@@ -7,7 +7,8 @@ ancient sound-law, two vowels, and a boot-shaped pattern you can predict. It
 closes with \emph{nuestro}, ``our,'' which carries the very same crack.
 \emph{Practice lessons: \texttt{lessons/ES-C11-*.md}.}
 
-\section{\emph{querer} --- ``to want,'' and the \emph{e}$\to$\emph{ie} crack}
+\section[querer --- ``to want,'' and the e-to-ie crack]
+  {\emph{querer} --- ``to want,'' and the \emph{e}$\to$\emph{ie} crack}
 \label{lesson:querer}
 
 \begin{sounds}
@@ -64,7 +65,8 @@ Say it out loud until the crack is automatic: \emph{quiero} $\cdot$
 \emph{quieren}. Then put it to work: \emph{Quiero un caf\'{e}} (``I want a
 coffee''), \emph{Quiero caf\'{e}, por favor}.
 
-\section{\emph{poder} --- ``to be able,'' and the \emph{o}$\to$\emph{ue} crack}
+\section[poder --- ``to be able,'' and the o-to-ue crack]
+  {\emph{poder} --- ``to be able,'' and the \emph{o}$\to$\emph{ue} crack}
 \label{lesson:poder}
 
 \begin{sounds}
@@ -120,7 +122,8 @@ what you are \emph{able} to do:\\[3pt]
 \emph{\textbf{No puedo.}} --- ``I can't.''
 \end{grammarlens}
 
-\section{\emph{e}$\to$\emph{ie} and \emph{o}$\to$\emph{ue} --- one rule, two vowels}
+\section[e-to-ie and o-to-ue --- one rule, two vowels]
+  {\emph{e}$\to$\emph{ie} and \emph{o}$\to$\emph{ue} --- one rule, two vowels}
 \label{lesson:stem-changes}
 
 You have now seen both cracks: \emph{querer} $\to$ \emph{quiero}
@@ -251,10 +254,14 @@ venir?\\
 --- S\'{i}, puedo. Podemos ir ahora.
 \end{quote}
 
-Every tool of the chapter is in there: \emph{quiero} (want,
-\emph{e}$\to$\emph{ie}), \emph{puedes}/\emph{puedo}/\emph{podemos} (can,
-\emph{o}$\to$\emph{ue}), \emph{nuestros} (our, agreeing), and the near future
-\emph{ir a}.
+Every tool of the chapter is in there:
+\begin{itemize}
+  \item \emph{quiero}: want, with the \emph{e}$\to$\emph{ie} crack;
+  \item \emph{puedes}, \emph{puedo}, and \emph{podemos}: can, with the
+    \emph{o}$\to$\emph{ue} crack;
+  \item \emph{nuestros}: our, with agreement; and
+  \item \emph{ir a}: the near future.
+\end{itemize}
 
 \begin{culture}
 \emph{querer} does double duty: aimed at a thing it means ``to want,'' but aimed

--- a/code/learning/human-languages/spanish/book/chapters/ch12-yo-go-verbs.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch12-yo-go-verbs.tex
@@ -46,7 +46,7 @@ page long after the sound left the mouth.
 ``\emph{-go}'' verbs.
 
 \begin{center}
-\begin{tabular}{lll}
+\begin{tabularx}{\linewidth}{YlY}
 \toprule
 Person & Form & Note \\
 \midrule
@@ -56,7 +56,7 @@ t\'{u} (you, informal) & haces & regular \\
 nosotros (we) & hacemos & regular \\
 ellos / ustedes (they, you-plural) & hacen & regular \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 The \emph{g} appears in \emph{hago} and nowhere else.
@@ -80,6 +80,7 @@ the \emph{-go} ending you just met in \emph{hago}, and a change inside the stem
 system clicks together.
 
 \begin{cousinweb}
+\raggedright
 \textbf{decir} (``to say, to tell'') $\leftarrow$ Latin \emph{d\={\i}cere} (``to
 say, to tell, to point out''). Its root \emph{dic-} / \emph{dict-} (``say'')
 runs straight through English.\\[3pt]
@@ -109,7 +110,7 @@ forms where the stress lands on the stem, that \emph{e} closes to \emph{i} ---
 a tighter shift than the \emph{e} $\to$ \emph{ie} of \emph{querer}.
 
 \begin{center}
-\begin{tabular}{lll}
+\begin{tabularx}{\linewidth}{YlY}
 \toprule
 Person & Form & Note \\
 \midrule
@@ -119,7 +120,7 @@ t\'{u} (you, informal) & \textbf{dices} & \emph{e} $\to$ \emph{i} \\
 nosotros (we) & decimos & plain \emph{e} --- unstressed \\
 ellos / ustedes (they, you-plural) & \textbf{dicen} & \emph{e} $\to$ \emph{i} \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 The \textbf{boot} shape returns: draw a line around the changed forms on the

--- a/code/learning/human-languages/spanish/book/chapters/ch15-completing-preterite.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch15-completing-preterite.tex
@@ -19,7 +19,7 @@ Drop the \emph{-er} or \emph{-ir} from the infinitive, and add
 \emph{-\'{i}, -iste, -i\'{o}, -imos, -ieron}.
 
 \begin{center}
-\begin{tabular}{lll}
+\begin{tabularx}{\linewidth}{lYY}
 \toprule
 person & \emph{comer} (``to eat'') & \emph{vivir} (``to live'')\\
 \midrule
@@ -29,7 +29,7 @@ person & \emph{comer} (``to eat'') & \emph{vivir} (``to live'')\\
 \emph{nosotros} (we) & \textbf{comimos} & \textbf{vivimos}\\
 \emph{ellos / ustedes} (they / you all) & \textbf{comieron} & \textbf{vivieron}\\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 Look down the two columns: the endings are \emph{identical}. That is not true in
@@ -172,7 +172,7 @@ where the stress is on the ending.
 Some forms live in both tenses, and only context decides.
 
 \begin{center}
-\begin{tabular}{lll}
+\begin{tabularx}{\linewidth}{YYY}
 \toprule
 form & could be & which?\\
 \midrule
@@ -181,7 +181,7 @@ form & could be & which?\\
 \emph{comemos} / \emph{comimos} & we eat / we ate & \textbf{distinct} --- the vowel tells you\\
 \emph{fui} & I was / I went & either --- \emph{ser} and \emph{ir} share it\\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 Practise aloud: the \emph{yo} forms straight down all five rows ---

--- a/code/learning/human-languages/spanish/book/chapters/ch16-imperfect.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch16-imperfect.tex
@@ -22,7 +22,7 @@ the language}. Drop the infinitive ending (\emph{-ar}, \emph{-er}, \emph{-ir})
 and add one of two sets of endings.
 
 \begin{center}
-\begin{tabular}{lll}
+\begin{tabularx}{\linewidth}{lYY}
 \toprule
 Person & \emph{-ar} (\emph{hablar}) & \emph{-er} / \emph{-ir} (\emph{comer}, \emph{vivir}) \\
 \midrule
@@ -32,7 +32,7 @@ t\'{u} & habl\textbf{abas} & com\textbf{\'{i}as} \\
 nosotros & habl\textbf{\'{a}bamos} & com\textbf{\'{i}amos} \\
 ellos / ustedes & habl\textbf{aban} & com\textbf{\'{i}an} \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 The \textbf{\emph{-er} and \emph{-ir} verbs share one set again} --- the third
@@ -145,7 +145,7 @@ sometimes, and never with an ending --- so this is a genuinely \textbf{new
 distinction} to think in, not merely new forms to learn.
 
 \begin{center}
-\begin{tabular}{lll}
+\begin{tabularx}{\linewidth}{lYY}
 \toprule
  & preterite & imperfect \\
 \midrule
@@ -154,7 +154,7 @@ shape of time & a \textbf{point} & a \textbf{line} \\
 English & ``I ate'' & ``I \textbf{was} eating'' / ``I \textbf{used to} eat'' \\
 typical clues & \emph{ayer, una vez, de repente} & \emph{siempre, todos los d\'{i}as, mientras} \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 \textbf{Com\'{i}} $=$ the meal happened and ended. \textbf{Com\'{i}a} $=$ I was
@@ -177,7 +177,7 @@ the \emph{instant the state began}. Knowing $\to$ the moment of finding out.
 \end{culture}
 
 \begin{center}
-\begin{tabular}{lll}
+\begin{tabularx}{\linewidth}{lYY}
 \toprule
 verb & imperfect (state) & preterite (the moment it started) \\
 \midrule
@@ -186,7 +186,7 @@ verb & imperfect (state) & preterite (the moment it started) \\
 \emph{tener} & \emph{ten\'{i}a} --- I \textbf{had} & \emph{tuve} --- I \textbf{got, received} \\
 \emph{querer} & \emph{quer\'{i}a} --- I \textbf{wanted} & \emph{quise} --- I \textbf{tried} \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 (And the negative sharpens it further: \emph{no quise} $=$ ``I

--- a/code/learning/human-languages/spanish/book/chapters/ch17-future-conditional.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch17-future-conditional.tex
@@ -145,14 +145,14 @@ past.
 \end{grammarlens}
 
 \begin{center}
-\begin{tabular}{lll}
+\begin{tabularx}{\linewidth}{lYY}
 \toprule
 \textbf{Tense} & \textbf{Infinitive $+$} & \textbf{Result} \\
 \midrule
 future      & \emph{haber} present (\emph{he, has, ha\ldots})       & \emph{hablar\'{e}} \\
 conditional & \emph{haber} imperfect (\emph{hab\'{i}a, hab\'{i}as\ldots}) & \emph{hablar\'{i}a} \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 Strictly, what fused was the older, shorter form \emph{av\'{i}a} --- which is
@@ -170,7 +170,7 @@ so \emph{hablar\'{i}a} is three-and-a-bit syllables --- \emph{ha-bla-R\'{I}-a}
 Now, what the conditional is \emph{for}. Three jobs:
 
 \begin{center}
-\begin{tabular}{lll}
+\begin{tabularx}{\linewidth}{YYY}
 \toprule
 \textbf{Use} & \textbf{Example} & \textbf{English} \\
 \midrule
@@ -178,7 +178,7 @@ Now, what the conditional is \emph{for}. Three jobs:
 \textbf{politeness} --- softening & \emph{\textquestiondown Podr\'{i}as ayudarme?} & ``Could you help me?'' \\
 \textbf{future-in-the-past} & \emph{Dijo que hablar\'{i}a.} & ``He said he would speak.'' \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 \begin{culture}

--- a/code/learning/human-languages/spanish/book/chapters/ch18-subjunctive.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch18-subjunctive.tex
@@ -39,14 +39,14 @@ eat''), \emph{vivo} (``I live'').
 ``Opposite'' is the whole trick. The two verb families swap costumes.
 
 \begin{center}
-\begin{tabular}{lll}
+\begin{tabularx}{\linewidth}{YYl}
 \toprule
 Verb type & Present takes\ldots & Subjunctive takes\ldots \\
 \midrule
 \emph{-ar} & \emph{-a-} (habl\textbf{a}s) & \textbf{-e-} (habl\textbf{e}s) \\
 \emph{-er} / \emph{-ir} & \emph{-e-} / \emph{-i-} (com\textbf{e}s) & \textbf{-a-} (com\textbf{a}s) \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 \begin{center}
@@ -200,14 +200,14 @@ You can now \emph{build} the subjunctive. This section is about what makes it
 wanting a different person to do something.}
 
 \begin{center}
-\begin{tabular}{ll}
+\begin{tabularx}{\linewidth}{YY}
 \toprule
 Spanish & English \\
 \midrule
 \textbf{Quiero hablar} espa\~{n}ol. & I want \textbf{to speak} Spanish. \\
 \textbf{Quiero que hables} espa\~{n}ol. & I want \textbf{you to speak} Spanish. \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 \begin{grammarlens}
@@ -226,14 +226,14 @@ is what I \emph{want} --- which may never happen. The main clause reaches out an
 bends the second one into something unreal, and the mood marks the bend.
 
 \begin{center}
-\begin{tabular}{lll}
+\begin{tabularx}{\linewidth}{YYY}
 \toprule
 Spanish & English & Mood \\
 \midrule
 S\'{e} que \textbf{hablas} espa\~{n}ol. & I know that you speak Spanish. & indicative (a fact) \\
 Quiero que \textbf{hables} espa\~{n}ol. & I want you to speak Spanish. & subjunctive (not yet real) \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 Same \emph{que}, same person, different mood --- because knowing \emph{reports}
@@ -325,7 +325,7 @@ alone.
 have a different subject?}
 
 \begin{center}
-\begin{tabular}{ll}
+\begin{tabularx}{\linewidth}{YY}
 \toprule
 English & Spanish \\
 \midrule
@@ -336,7 +336,7 @@ We want them to live here. & Queremos \textbf{que vivan} aqu\'{i}. \\
 She wants to work. & Quiere \textbf{trabajar}. \\
 She wants me to work. & Quiere \textbf{que yo trabaje}. \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 Say each pair aloud back to back. English switches quietly, from ``to eat'' to

--- a/code/learning/human-languages/spanish/book/chapters/ch21-days-of-the-week.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch21-days-of-the-week.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:09f9bc1fc7fc5a64
+% canonical-source-hash: fnv1a64:9f1f17a520fa7add
 % canonical-lessons: ES-C21-lunes-viernes, ES-C21-sabado-domingo
 
 \chapter{Days of the Week}
@@ -48,7 +48,15 @@ Compare \textbf{French}, which keeps \emph{diēs} as its own visible syllable on
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
-{[}PAUSE 3s{]} What did every Spanish weekday begin life as? (\textbf{"{[}Planet-god{]}'s diēs (day)"} — the same Latin phrase French keeps more visibly with \emph{-di}.) Why do \textbf{martes, jueves, viernes} end in \emph{-s}, and where does \textbf{lunes} get its \emph{-s} from? (\textbf{From the planet's own Latin genitive} — Martis/Iovis/ Veneris already end in \emph{-s}; \emph{lunes} likely picked it up \textbf{by analogy}, since \emph{lūnae} has no \emph{-s} of its own.) What's debated about \textbf{miércoles}? (\textbf{Whether its "‑coles" is a genuine surviving trace of diēs} — unlike the plainer, better-understood story for its four siblings.) Why do \emph{martes} and \emph{Tuesday} line up? (Same day — the war-god's — named \emph{Mars} in Latin, \emph{Tiw} in Germanic.)
+{[}PAUSE 3s{]} Recall the weekday family:
+
+\begin{itemize}
+\raggedright
+  \item What did every Spanish weekday begin life as? (\textbf{"{[}Planet-god{]}'s diēs (day)"} — the same Latin phrase French keeps more visibly with \emph{-di}.)
+  \item Why do \textbf{martes, jueves, viernes} end in \emph{-s}, and where does \textbf{lunes} get its \emph{-s} from? (\textbf{From the planet's own Latin genitive} — Martis/Iovis/ Veneris already end in \emph{-s}; \emph{lunes} likely picked it up \textbf{by analogy}, since \emph{lūnae} has no \emph{-s} of its own.)
+  \item What's debated about \textbf{miércoles}? (\textbf{Whether its "‑coles" is a genuine surviving trace of diēs} — unlike the plainer, better-understood story for its four siblings.)
+  \item Why do \emph{martes} and \emph{Tuesday} line up? (They name the same day for the war-god: \emph{Mars} in Latin, \emph{Tiw} in Germanic.)
+\end{itemize}
 \end{tcolorbox}
 \section[sábado, domingo]{sábado and domingo — the week's religious edge}
 

--- a/code/learning/human-languages/spanish/book/preamble.tex
+++ b/code/learning/human-languages/spanish/book/preamble.tex
@@ -7,7 +7,9 @@
 % Latin Modern ships with every standard TeX distribution (MiKTeX, TeX
 % Live) as OpenType fonts, so this compiles the same way on any machine --
 % no dependency on whatever system fonts happen to be installed locally.
-\setmainfont{Latin Modern Roman}
+\setmainfont{Latin Modern Roman}[
+  SmallCapsFont={Latin Modern Roman Caps}
+]
 \setsansfont{Latin Modern Sans}
 \setmonofont{Latin Modern Mono}
 
@@ -18,6 +20,7 @@
 \usepackage{longtable}
 \usepackage{array}
 \usepackage{tabularx}
+\newcolumntype{Y}{>{\raggedright\arraybackslash}X}
 \usepackage[hidelinks]{hyperref}
 \usepackage{titlesec}
 
@@ -37,6 +40,32 @@
   BoldItalicFont=NotoNaskhArabic-Static.ttf
 ]{NotoNaskhArabic-Static.ttf}
 \newcommand{\esar}[1]{\textarabic{#1}}
+
+% Micro-lessons end at natural pause points instead of stretching their
+% callout boxes to force every page to the same depth. The small reserve gives
+% prose and legacy tables a cleaner line break before they exceed the measure.
+\raggedbottom
+\emergencystretch=2em
+
+% Several legacy chapter and section titles are intentionally descriptive.
+% Keep the running heads useful and stable without forcing those full titles
+% into one unbreakable line at the top of every verso.
+\renewcommand{\chaptermark}[1]{\markboth{\chaptername\ \thechapter}{}}
+\renewcommand{\sectionmark}[1]{\markright{\thesection}}
+
+% book.cls inserts a verso before each open-right chapter. Preserve that print
+% layout while suppressing running heads and page numbers on the blank page.
+\makeatletter
+\renewcommand{\cleardoublepage}{%
+  \clearpage
+  \if@twoside
+    \ifodd\c@page\else
+      \hbox{}\thispagestyle{empty}\newpage
+      \if@twocolumn\hbox{}\newpage\fi
+    \fi
+  \fi
+}
+\makeatother
 
 \hypersetup{
   pdftitle={Spanish, Step by Step, Root by Root},

--- a/code/learning/human-languages/spanish/lessons/ES-C21-lunes-viernes.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C21-lunes-viernes.md
@@ -78,12 +78,16 @@ unlike the plainer, better-understood story for its four siblings.
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-WEEKDAYS-01, ES-ETYMON-WEEKDAYS-02] -->
 
-[PAUSE 3s] What did every Spanish weekday begin life as? (**"[Planet-god]'s
-diēs (day)"** — the same Latin phrase French keeps more visibly with *-di*.)
-Why do **martes, jueves, viernes** end in *-s*, and where does **lunes** get
-its *-s* from? (**From the planet's own Latin genitive** — Martis/Iovis/
-Veneris already end in *-s*; *lunes* likely picked it up **by analogy**, since
-*lūnae* has no *-s* of its own.) What's debated about **miércoles**? (**Whether
-its "‑coles" is a genuine surviving trace of diēs** — unlike the plainer,
-better-understood story for its four siblings.) Why do *martes* and *Tuesday* line up? (Same day — the war-god's —
-named *Mars* in Latin, *Tiw* in Germanic.)
+[PAUSE 3s] Recall the weekday family:
+
+- What did every Spanish weekday begin life as? (**"[Planet-god]'s diēs
+  (day)"** — the same Latin phrase French keeps more visibly with *-di*.)
+- Why do **martes, jueves, viernes** end in *-s*, and where does **lunes** get
+  its *-s* from? (**From the planet's own Latin genitive** — Martis/Iovis/
+  Veneris already end in *-s*; *lunes* likely picked it up **by analogy**,
+  since *lūnae* has no *-s* of its own.)
+- What's debated about **miércoles**? (**Whether its "‑coles" is a genuine
+  surviving trace of diēs** — unlike the plainer, better-understood story for
+  its four siblings.)
+- Why do *martes* and *Tuesday* line up? (They name the same day for the
+  war-god: *Mars* in Latin, *Tiw* in Germanic.)


### PR DESCRIPTION
## Summary

- make Spanish typography portable with explicit Latin Modern small caps, natural page bottoms, compact running heads, and truly empty open-right versos
- replace overflowing fixed-width legacy comparisons with width-aware tables and add plain-text bookmark alternatives for mathematical title notation
- turn the dense Chapter 21 weekday recall into a canonical bullet list shared by Language Ladder and the generated book
- record HL-B37 completion and prioritize the missing protected books gate as HL-P01

## Validation

- `human-language-data`: build; 84 tests; generated-book drift check; curriculum report
- `language-ladder`: production build; 464 tests
- report: 20 tracks, 1,066 lessons, 20 books; zero duration violations, unknown prerequisites, or lesson chapters without book chapters
- forced XeLaTeX build: 214 pages; correct title/author; 35 top-level / 155 total outline entries; zero schema leaks
- zero overfull or underfull boxes, missing glyphs, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings
- rendered and visually inspected all 214 pages, including every changed table, the canonical weekday recall, Arabic `لازورد`, and all 19 intentionally blank physical pages