### PR TITLE
ci(human-languages): require the unified books gate

### DIFF
--- a/.github/workflows/human-languages-books.yml
+++ b/.github/workflows/human-languages-books.yml
@@ -1,6 +1,8 @@
-# Build every Human Languages LaTeX book in one job. Pull requests retain one
-# complete publication bundle as a build artifact; main-branch builds publish
-# that same bundle as a stable download catalog on GitHub Pages.
+# Build every Human Languages LaTeX book in one job. Relevant pull requests
+# retain one complete publication bundle as a build artifact; main-branch
+# builds publish that same bundle as a stable download catalog on GitHub Pages.
+# Every pull request receives one stable gate result, while unrelated changes
+# skip the expensive all-books build after a small change-detection job.
 #
 # Each language track under code/learning/human-languages/<lang>/book/
 # contains a self-contained XeLaTeX book (see HL00 spec). This workflow
@@ -19,23 +21,80 @@ on:
       - ".github/workflows/human-languages-books.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "code/learning/human-languages/**"
-      - "code/packages/typescript/human-language-data/**"
-      - "code/scripts/build_human_language_book_catalog.py"
-      - ".github/workflows/human-languages-books.yml"
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: human-languages-books-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build-and-publish:
+  detect:
+    name: Detect human-language book changes
     runs-on: ubuntu-latest
+    outputs:
+      books: ${{ steps.changes.outputs.books }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect relevant paths
+        id: changes
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "books=true" >> "$GITHUB_OUTPUT"
+            echo "A non-pull-request run always builds the publication bundle."
+            exit 0
+          fi
+
+          if [[ ! "$PR_BASE_SHA" =~ ^[0-9a-f]{40}$ ]] || \
+             [[ ! "$PR_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Pull-request base or head SHA is invalid."
+            exit 1
+          fi
+
+          set +e
+          git diff --quiet "$PR_BASE_SHA...$PR_HEAD_SHA" -- \
+            code/learning/human-languages \
+            code/packages/typescript/human-language-data \
+            code/scripts/build_human_language_book_catalog.py \
+            .github/workflows/human-languages-books.yml
+          diff_status=$?
+          set -e
+
+          case "$diff_status" in
+            0)
+              echo "books=false" >> "$GITHUB_OUTPUT"
+              echo "No human-language book inputs changed; the all-books build will be skipped."
+              ;;
+            1)
+              echo "books=true" >> "$GITHUB_OUTPUT"
+              echo "Human-language book inputs changed; the all-books build is required."
+              ;;
+            *)
+              echo "::error::git diff failed with status $diff_status."
+              exit "$diff_status"
+              ;;
+          esac
+
+  build-and-publish:
+    name: Build and publish all human-language books
+    needs: detect
+    if: ${{ needs.detect.outputs.books == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -150,3 +209,40 @@ jobs:
           publish_dir: dist/human-languages/books
           destination_dir: human-languages/books
           keep_files: true
+
+  books-gate:
+    # Keep the required pull-request context distinct from the push context.
+    # Otherwise a faster main/branch push can satisfy protection while the
+    # pull-request all-books build is still running.
+    name: ${{ github.event_name == 'pull_request' && 'Human Languages Books gate' || 'Human Languages Books push gate' }}
+    needs: [detect, build-and-publish]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify the required book work succeeded
+        shell: bash
+        env:
+          DETECT_RESULT: ${{ needs.detect.result }}
+          BOOKS_RELEVANT: ${{ needs.detect.outputs.books }}
+          BUILD_RESULT: ${{ needs['build-and-publish'].result }}
+        run: |
+          set -euo pipefail
+          echo "detect=$DETECT_RESULT relevant=$BOOKS_RELEVANT build=$BUILD_RESULT"
+
+          if [ "$DETECT_RESULT" != "success" ]; then
+            echo "::error::Human-language book change detection did not succeed."
+            exit 1
+          fi
+
+          case "$BOOKS_RELEVANT:$BUILD_RESULT" in
+            true:success)
+              echo "The required all-books build passed."
+              ;;
+            false:skipped)
+              echo "No book inputs changed; the all-books build was legitimately skipped."
+              ;;
+            *)
+              echo "::error::Unexpected books gate state: relevant=$BOOKS_RELEVANT build=$BUILD_RESULT"
+              exit 1
+              ;;
+          esac

--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -108,9 +108,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B34 | Complete (#9883) | Publish Latin Chapters 2–36 from canonical lessons rather than hand-copying another thirty-five book chapters. | All 53 Latin lessons now use schema v2; Chapters 2–36 are generated with source hashes independently verified against Language Ladder. |
 | HL-B35 | Complete (#9885, repaired by #9887) | Remove Latin's remaining LaTeX layout, font, and header-only-verso warnings. | The forced 115-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; intentionally blank chapter versos are truly empty. |
 | HL-B36 | Complete (#9890) | Publish Spanish Chapters 19–33 from canonical lessons rather than hand-copying another fifteen book chapters. | The Spanish PDF now includes all 33 canonical chapters; all 21 later lessons use schema v2 and generate fifteen chapters from the same content consumed by Language Ladder. |
-| HL-B37 | Complete in this PR | Remove Spanish's remaining legacy LaTeX layout, bookmark, font, and header-only-verso warnings. | The forced 214-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; all 19 intentionally blank physical pages are truly empty. |
-| HL-P01 | Next | Make the unified Human Languages Books result a protected merge gate, or add an equivalent gate that auto-merge must await. | #9885 auto-merged after general CI passed while the non-required books job had failed; the portable-font repair in #9887 should have been required before merge. |
-| HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
+| HL-B37 | Complete (#9891) | Remove Spanish's remaining legacy LaTeX layout, bookmark, font, and header-only-verso warnings. | The forced 214-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; all 19 intentionally blank physical pages are truly empty. |
+| HL-P01 | Complete in this PR | Make the unified Human Languages Books result a protected merge gate, or add an equivalent gate that auto-merge must await. | Every pull request now receives a stable books gate; relevant changes run the one all-books build, unrelated changes receive a checked fast-path, and pull-request and push contexts remain distinct. |
+| HL-M01 | Next | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-M02 | Queued | Extend Telugu's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson needs a scheduled place, and the map must explicitly split or justify Chapter 20's numbers-and-weather topic collision. |
 | HL-M03 | Queued | Extend Kannada's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5; every canonical lesson needs a scheduled place, and Chapter 20's unrelated numbers/weather pairing must be split or explicitly justified. |
 | HL-M04 | Queued | Extend Malayalam's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the four new support steps, needs a scheduled place. |
@@ -1118,6 +1118,24 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   Arabic shaping; all 19 intentionally blank physical pages are truly empty.
 - HL-P01 is next: make the unified books result a protected merge gate, or add
   an equivalent gate that auto-merge cannot outrun.
+
+## Findings from HL-P01
+
+- A path-filtered workflow cannot be required globally: pull requests outside
+  those paths would never receive its status context. The workflow now starts
+  on every pull request, performs a low-cost path decision, and runs the
+  existing single all-books build only when book inputs changed.
+- `Human Languages Books gate` is stable and always present on pull requests.
+  It fails when detection fails, when a relevant all-books build does not pass,
+  or when the build/result combination is inconsistent. A legitimately skipped
+  irrelevant build is the only fast-path success.
+- Main pushes and manual runs publish `Human Languages Books push gate`, so a
+  push result cannot satisfy the protected pull-request context while its book
+  build is still in progress.
+- After this workflow is proven on the pull request and exact `main`, repository
+  protection must require both `CI gate` and `Human Languages Books gate`.
+- HL-M01 is next: model how each language realizes the shared spine and where
+  script, grammar, and other track-specific extension nodes fit.
 
 ## Findings from HL-D01C
 


### PR DESCRIPTION
## Summary

- make the Human Languages Books workflow emit an always-present pull-request gate
- retain one unified all-books build/publish job, with a fast checked skip for unrelated pull requests
- keep pull-request and push gate contexts distinct so push runs cannot satisfy merge protection
- record HL-P01 complete and prioritize shared-spine realization maps next

## Validation

- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/human-languages-books.yml
- relevant and irrelevant commit fixtures exercise both change-detection branches
- gate truth table accepts only 	rue:success and alse:skipped
- git diff --check

## Rollout

After this PR and its exact-main books run pass, branch protection will be updated to require both CI gate and Human Languages Books gate.