### PR TITLE
feat(human-languages): map per-track spine realizations

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,13 +5,14 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-03. Current baseline after schema-v2 block-boundary
-validation: 20 registered tracks, 1,066 Markdown lessons, 20 downloadable LaTeX
-books, and zero duration violations. HL-V01 keeps the remaining migration debt
-reproducible in both JSON and human-readable reports; the first 51 Spanish
-lessons now prove one typed, knowledge-closed source across Language Ladder and
-six generated book chapters, and the completed HL-D01 tranches prove duration
-remediation without discarding deep content.
+Last prioritized: 2026-08-03. Current baseline after per-track spine mapping:
+20 registered tracks, 1,066 Markdown lessons, 20 downloadable LaTeX books, zero
+duration violations, and 20 validated realization maps containing 346 ordered
+path segments, 247 typed extension nodes, and 896 prerequisite-closed mapped
+lessons. HL-V01 keeps the remaining migration debt reproducible in both JSON and
+human-readable reports; the canonical schema-v2 tranches prove one typed source
+across Language Ladder and generated book chapters without discarding deep
+content.
 
 ## Priority rules
 
@@ -109,8 +110,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B35 | Complete (#9885, repaired by #9887) | Remove Latin's remaining LaTeX layout, font, and header-only-verso warnings. | The forced 115-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; intentionally blank chapter versos are truly empty. |
 | HL-B36 | Complete (#9890) | Publish Spanish Chapters 19–33 from canonical lessons rather than hand-copying another fifteen book chapters. | The Spanish PDF now includes all 33 canonical chapters; all 21 later lessons use schema v2 and generate fifteen chapters from the same content consumed by Language Ladder. |
 | HL-B37 | Complete (#9891) | Remove Spanish's remaining legacy LaTeX layout, bookmark, font, and header-only-verso warnings. | The forced 214-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; all 19 intentionally blank physical pages are truly empty. |
-| HL-P01 | Complete in this PR | Make the unified Human Languages Books result a protected merge gate, or add an equivalent gate that auto-merge must await. | Every pull request now receives a stable books gate; relevant changes run the one all-books build, unrelated changes receive a checked fast-path, and pull-request and push contexts remain distinct. |
-| HL-M01 | Next | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
+| HL-P01 | Complete (#9893) | Make the unified Human Languages Books result a protected merge gate, or add an equivalent gate that auto-merge must await. | Every pull request now receives a stable books gate; relevant changes run the one all-books build, unrelated changes receive a checked fast-path, and pull-request and push contexts remain distinct. |
+| HL-M01 | Complete in this PR | Add per-track spine realization maps and language-specific extension nodes. | All 20 tracks have validated repeated-segment local paths, explicit omissions/relocations, typed extensions, and a pure prerequisite-safe frontier planner. |
+| HL-M10 | Next | Replace Learn's global concept cursor with per-language frontier progression and focused-before-mixed eligibility. | Persist independent local cursors, teach each language's next mapped lesson without skipping prerequisites, and interleave only after its focused success threshold; reuse the pure planner delivered by HL-M01. |
 | HL-M02 | Queued | Extend Telugu's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson needs a scheduled place, and the map must explicitly split or justify Chapter 20's numbers-and-weather topic collision. |
 | HL-M03 | Queued | Extend Kannada's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5; every canonical lesson needs a scheduled place, and Chapter 20's unrelated numbers/weather pairing must be split or explicitly justified. |
 | HL-M04 | Queued | Extend Malayalam's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the four new support steps, needs a scheduled place. |
@@ -1116,8 +1118,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   warnings, LaTeX warnings, or font warnings. All 214 rendered pages were
   inspected for clipping, collisions, broken tables, malformed callouts, and
   Arabic shaping; all 19 intentionally blank physical pages are truly empty.
-- HL-P01 is next: make the unified books result a protected merge gate, or add
-  an equivalent gate that auto-merge cannot outrun.
+- That audit led to HL-P01, which made the unified books result a protected
+  merge gate that auto-merge cannot outrun.
 
 ## Findings from HL-P01
 
@@ -1132,10 +1134,35 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - Main pushes and manual runs publish `Human Languages Books push gate`, so a
   push result cannot satisfy the protected pull-request context while its book
   build is still in progress.
-- After this workflow is proven on the pull request and exact `main`, repository
-  protection must require both `CI gate` and `Human Languages Books gate`.
-- HL-M01 is next: model how each language realizes the shared spine and where
-  script, grammar, and other track-specific extension nodes fit.
+- Pull request #9893 and the exact merged `main` revision both passed the full
+  20-book job. Repository protection now requires both `CI gate` and the
+  pull-request-only `Human Languages Books gate`; the exact-main bundle is live
+  in the public catalog.
+- HL-M01 follows by making the shared/local curriculum relationship executable.
+
+## Findings from HL-M01
+
+- All 20 registered tracks now have an explicit `curriculum.json`: 346 ordered
+  path segments map 896 lessons and attach 247 required, supporting, reference,
+  or not-applicable extension nodes. All 11 current spine nodes are present in
+  every map, including planned/empty ledgers.
+- A shared node may recur in a track's path. Contracting each node to one
+  contiguous occurrence creates false cycles because real curricula revisit
+  greetings, time, definiteness, and other abilities after intervening grammar
+  or script work.
+- Validation proves canonical and schema-v2 lesson coverage, recursive
+  prerequisite closure and topological order, exact extension attachment, and
+  explicit omissions. Persian and Urdu each place a required script-entry
+  extension inline with the first greeting lesson.
+- Spanish, Kannada, Latin, Malayalam, Tamil, and Telugu intentionally teach
+  `GREETING-GOODNIGHT` under `SPINE-TIME-OF-DAY` even though the canonical
+  concept belongs to `SPINE-TAKE-LEAVE`; those six relocations are now data,
+  not exceptions hidden in consumer code.
+- The pure planner returns one safe local frontier per selected language and
+  groups only frontiers currently ready at the same shared node. Language
+  Ladder loads and reports the maps and constrains shared-walk admission, but
+  its visible Learn cursor remains global. HL-M10 is therefore the next
+  learner-visible tranche.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -17,6 +17,7 @@ Every track shares the same shape:
 <language>/
   README.md                  what this track is, how to use it, current progress
   CHANGELOG.md                per-chapter content additions
+  curriculum.json            ordered shared-spine realization path + local extensions
   roadmap.md                  themed-chapter skeleton
   session-map.md              how lessons compose into commute sessions + review schedule
   pronunciation-reference.md   the sounds, to look up on demand (never a gate)
@@ -32,6 +33,14 @@ core/spine.json                 ordered, language-independent can-do spine
 concepts/taxonomy.json          cross-language semantic join keys
 data/scripts/*.json             writing-system inventories and teaching metadata
 ```
+
+Every registered track has one `curriculum.json`. Its ordered path can revisit a
+shared spine node, attaches required/supporting/reference extensions before,
+inline with, or after a local segment, and explicitly records canonical concepts
+that the track omits or deliberately teaches elsewhere. The data-package gate
+proves that all 20 maps cover their schema-v2 and canonical lessons without
+jumping over a prerequisite. Books and the app still read the lesson Markdown;
+the map is the shared scheduling contract, not a second copy of the content.
 
 The unified publication job also emits `curriculum-gaps.json` and
 `curriculum-gaps.txt` beside the books. They record the effective duration budget

--- a/code/learning/human-languages/arabic/curriculum.json
+++ b/code/learning/human-languages/arabic/curriculum.json
@@ -1,0 +1,728 @@
+{
+  "version": 1,
+  "language": "arabic",
+  "path": [
+    {
+      "id": "AR-PATH-001",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "AR-C01-salam"
+      ],
+      "before": [],
+      "inline": [
+        "AR-EXT-001-INLINE-SCRIPT"
+      ],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-002",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "AR-C01-al"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-003",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "AR-C01-as-salamu-alaykum",
+        "AR-C01-marhaba"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-004",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "AR-C01-sabah-al-khayr",
+        "AR-C01-masa-al-khayr"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-005",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "AR-C01-shukran"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-006",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "AR-W01-direction-and-alif",
+        "AR-W01-abjad-short-vowels",
+        "AR-W02-joining-sin-lam",
+        "AR-W02-lam-alif-joins",
+        "AR-W03-dots-mim-ba-salam",
+        "AR-W03-write-salam"
+      ],
+      "before": [],
+      "inline": [
+        "AR-EXT-006-SCRIPT"
+      ],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-007",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "AR-C02-ism",
+        "AR-C02-anta-anti",
+        "AR-C02-ii-my",
+        "AR-C02-ismii",
+        "AR-C02-maa",
+        "AR-C02-maa-ismuka",
+        "AR-C02-tasharrafna"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-008",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "AR-W04-dots-family-nun-ta",
+        "AR-W05-ya-and-my-name",
+        "AR-W06-harakat-and-hamza",
+        "AR-W06-hamza",
+        "AR-W07-hook-family-ha-kha",
+        "AR-W08-kaf-and-ra",
+        "AR-W09-khayr-bikhayr",
+        "AR-C03-kayfa",
+        "AR-C03-hal",
+        "AR-C03-kayfa-haluka",
+        "AR-C03-bi-khayr",
+        "AR-C03-al-hamdu-lillah",
+        "AR-C03-practice"
+      ],
+      "before": [
+        "AR-EXT-008-SCRIPT"
+      ],
+      "inline": [
+        "AR-EXT-008-LANGUAGE-SPECIFIC"
+      ],
+      "after": [
+        "AR-EXT-008-CONSOLIDATION"
+      ]
+    },
+    {
+      "id": "AR-PATH-009",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "AR-W10-ayn",
+        "AR-W11-ha-and-ta-marbuta",
+        "AR-W12-maa-salama",
+        "AR-C04-maa-with",
+        "AR-C04-al-salama",
+        "AR-C04-maa-salama",
+        "AR-C04-ila-liqaa",
+        "AR-C04-practice"
+      ],
+      "before": [
+        "AR-EXT-009-SCRIPT",
+        "AR-EXT-009-LANGUAGE-SPECIFIC"
+      ],
+      "inline": [],
+      "after": [
+        "AR-EXT-009-CONSOLIDATION"
+      ]
+    },
+    {
+      "id": "AR-PATH-010",
+      "spine_node": "SPINE-RESPOND-BASIC",
+      "lessons": [
+        "AR-C05-naam",
+        "AR-C05-la"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-011",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "AR-C06-min-fadlik",
+        "AR-C07-asif"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-012",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "AR-C08-al-ahad-al-khamis",
+        "AR-C08-al-jumua-as-sabt"
+      ],
+      "before": [],
+      "inline": [
+        "AR-EXT-012-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-013",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "AR-C09-aswad-abyad",
+        "AR-C09-ahmar-azraq"
+      ],
+      "before": [],
+      "inline": [
+        "AR-EXT-013-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-014",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "AR-C10-ab-umm",
+        "AR-C10-akh-ukht"
+      ],
+      "before": [],
+      "inline": [
+        "AR-EXT-014-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-015",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "AR-C11-ras",
+        "AR-C11-yad"
+      ],
+      "before": [],
+      "inline": [
+        "AR-EXT-015-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-016",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "AR-C12-al-fusul"
+      ],
+      "before": [],
+      "inline": [
+        "AR-EXT-016-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-017",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "AR-C13-maa-khubz"
+      ],
+      "before": [],
+      "inline": [
+        "AR-EXT-017-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-018",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "AR-C14-ashhur",
+        "AR-C15-ad-duhr-muntasaf-al-layl",
+        "AR-C16-al-saa"
+      ],
+      "before": [],
+      "inline": [
+        "AR-EXT-018-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-019",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "AR-C17-kam-umruka"
+      ],
+      "before": [],
+      "inline": [
+        "AR-EXT-019-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-020",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "AR-C18-al-taqs"
+      ],
+      "before": [],
+      "inline": [
+        "AR-EXT-020-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-021",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "AR-C19-wahid-khamsa",
+        "AR-C20-ahada-ashar-ishrun"
+      ],
+      "before": [],
+      "inline": [
+        "AR-EXT-021-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-022",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "AR-C21-kalb-qitt",
+        "AR-C22-akhdar-asfar"
+      ],
+      "before": [],
+      "inline": [
+        "AR-EXT-022-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-023",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "AR-C23-afwan"
+      ],
+      "before": [],
+      "inline": [
+        "AR-EXT-023-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-024",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "AR-C24-ila-al-ghad"
+      ],
+      "before": [],
+      "inline": [
+        "AR-EXT-024-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-025",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "AR-C25-yawm",
+        "AR-C26-layl"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-026",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "AR-C27-tusbih-ala-khayr"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    }
+  ],
+  "spine": {
+    "SPINE-MEET-GREET": {
+      "segments": [
+        "AR-PATH-001",
+        "AR-PATH-003"
+      ],
+      "omits": [
+        "GREETING-WELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COURTESY-THANK": {
+      "segments": [
+        "AR-PATH-005",
+        "AR-PATH-023"
+      ],
+      "omits": [
+        "COURTESY-THANKS-CASUAL",
+        "COURTESY-YOUREWELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-RESPOND-BASIC": {
+      "segments": [
+        "AR-PATH-010"
+      ],
+      "omits": [
+        "RESPONSE-YESNO",
+        "RESPONSE-OKAY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXCHANGE-NAMES": {
+      "segments": [
+        "AR-PATH-007",
+        "AR-PATH-014",
+        "AR-PATH-019"
+      ],
+      "omits": [
+        "PRONOUN-I",
+        "PRONOUN-ME",
+        "WORD-IS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-CHECK-WELLBEING": {
+      "segments": [
+        "AR-PATH-006",
+        "AR-PATH-008",
+        "AR-PATH-015"
+      ],
+      "omits": [
+        "WORD-GOOD",
+        "WORD-SOSO"
+      ],
+      "relocates": {}
+    },
+    "SPINE-POLITE-REQUEST-REPAIR": {
+      "segments": [
+        "AR-PATH-011",
+        "AR-PATH-017"
+      ],
+      "omits": [],
+      "relocates": {}
+    },
+    "SPINE-TAKE-LEAVE": {
+      "segments": [
+        "AR-PATH-009",
+        "AR-PATH-024",
+        "AR-PATH-026"
+      ],
+      "omits": [
+        "FAREWELL-CASUAL",
+        "FAREWELL-SOON",
+        "FAREWELL-TOMORROW"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TIME-OF-DAY": {
+      "segments": [
+        "AR-PATH-004",
+        "AR-PATH-012",
+        "AR-PATH-016",
+        "AR-PATH-018",
+        "AR-PATH-020",
+        "AR-PATH-025"
+      ],
+      "omits": [
+        "TIME-MORNING",
+        "TIME-AFTERNOON",
+        "TIME-EVENING",
+        "GREETING-DAY",
+        "GREETING-AFTERNOON"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ASK-LOCATION": {
+      "segments": [],
+      "omits": [
+        "QUESTION-WHERE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DEFINITE-REFERENCE": {
+      "segments": [
+        "AR-PATH-002",
+        "AR-PATH-013",
+        "AR-PATH-022"
+      ],
+      "omits": [],
+      "relocates": {}
+    },
+    "SPINE-COUNT-ONE-TO-FIVE": {
+      "segments": [
+        "AR-PATH-021"
+      ],
+      "omits": [
+        "NUMBER-ONE-TO-FIVE"
+      ],
+      "relocates": {}
+    }
+  },
+  "extensions": [
+    {
+      "id": "AR-EXT-006-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can recognize and use the Arabic script features introduced inside these words.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-W01-direction-and-alif",
+        "AR-W01-abjad-short-vowels",
+        "AR-W02-joining-sin-lam",
+        "AR-W02-lam-alif-joins",
+        "AR-W03-dots-mim-ba-salam",
+        "AR-W03-write-salam"
+      ]
+    },
+    {
+      "id": "AR-EXT-008-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can recognize and use the Arabic script features introduced inside these words.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-W04-dots-family-nun-ta",
+        "AR-W05-ya-and-my-name",
+        "AR-W06-harakat-and-hamza",
+        "AR-W06-hamza",
+        "AR-W07-hook-family-ha-kha",
+        "AR-W08-kaf-and-ra",
+        "AR-W09-khayr-bikhayr"
+      ]
+    },
+    {
+      "id": "AR-EXT-008-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Arabic material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-C03-hal",
+        "AR-C03-al-hamdu-lillah"
+      ]
+    },
+    {
+      "id": "AR-EXT-008-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "consolidation",
+      "canDo": "I can retrieve and combine the Arabic material introduced in this part of the path.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-C03-practice"
+      ]
+    },
+    {
+      "id": "AR-EXT-009-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can recognize and use the Arabic script features introduced inside these words.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-W10-ayn",
+        "AR-W11-ha-and-ta-marbuta",
+        "AR-W12-maa-salama"
+      ]
+    },
+    {
+      "id": "AR-EXT-009-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Arabic material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-C04-maa-with",
+        "AR-C04-al-salama"
+      ]
+    },
+    {
+      "id": "AR-EXT-009-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "consolidation",
+      "canDo": "I can retrieve and combine the Arabic material introduced in this part of the path.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-C04-practice"
+      ]
+    },
+    {
+      "id": "AR-EXT-012-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Arabic material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-C08-al-ahad-al-khamis",
+        "AR-C08-al-jumua-as-sabt"
+      ]
+    },
+    {
+      "id": "AR-EXT-013-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Arabic material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-C09-aswad-abyad",
+        "AR-C09-ahmar-azraq"
+      ]
+    },
+    {
+      "id": "AR-EXT-014-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Arabic material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-C10-ab-umm",
+        "AR-C10-akh-ukht"
+      ]
+    },
+    {
+      "id": "AR-EXT-015-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Arabic material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-C11-ras",
+        "AR-C11-yad"
+      ]
+    },
+    {
+      "id": "AR-EXT-016-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Arabic material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-C12-al-fusul"
+      ]
+    },
+    {
+      "id": "AR-EXT-017-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Arabic material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-C13-maa-khubz"
+      ]
+    },
+    {
+      "id": "AR-EXT-018-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Arabic material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-C14-ashhur",
+        "AR-C15-ad-duhr-muntasaf-al-layl",
+        "AR-C16-al-saa"
+      ]
+    },
+    {
+      "id": "AR-EXT-019-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Arabic material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-C17-kam-umruka"
+      ]
+    },
+    {
+      "id": "AR-EXT-020-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Arabic material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-C18-al-taqs"
+      ]
+    },
+    {
+      "id": "AR-EXT-021-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Arabic material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-C19-wahid-khamsa",
+        "AR-C20-ahada-ashar-ishrun"
+      ]
+    },
+    {
+      "id": "AR-EXT-022-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Arabic material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-C21-kalb-qitt",
+        "AR-C22-akhdar-asfar"
+      ]
+    },
+    {
+      "id": "AR-EXT-023-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Arabic material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-C23-afwan"
+      ]
+    },
+    {
+      "id": "AR-EXT-024-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Arabic material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-C24-ila-al-ghad"
+      ]
+    },
+    {
+      "id": "AR-EXT-001-INLINE-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can recognize the first Arabic script pattern inside a greeting I already understand.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-C01-salam"
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/bengali/curriculum.json
+++ b/code/learning/human-languages/bengali/curriculum.json
@@ -1,0 +1,272 @@
+{
+  "version": 1,
+  "language": "bengali",
+  "path": [
+    {
+      "id": "BN-PATH-001",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "BN-C01-nomoshkar"
+      ],
+      "before": [],
+      "inline": [
+        "BN-EXT-001-INLINE-SCRIPT"
+      ],
+      "after": []
+    },
+    {
+      "id": "BN-PATH-002",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "BN-C01-dhonnobad"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "BN-PATH-003",
+      "spine_node": "SPINE-RESPOND-BASIC",
+      "lessons": [
+        "BN-C01-hyan-na",
+        "BN-C01-achchha"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "BN-PATH-004",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "BN-C01-ashi"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "BN-PATH-005",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "BN-C02-naam",
+        "BN-C02-amar",
+        "BN-C02-amar-naam",
+        "BN-C02-alaap",
+        "BN-C02-ki",
+        "BN-C02-tumi-apni",
+        "BN-C02-tomar-naam-ki",
+        "BN-C03-ami"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "BN-PATH-006",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "BN-C03-kemon"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "BN-PATH-007",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "BN-C03-kono-bepar-na"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "BN-PATH-008",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "BN-C03-tumi-kemon-achho",
+        "BN-C03-bhalo"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "BN-PATH-009",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "BN-C04-abar",
+        "BN-C04-dekha-hobe",
+        "BN-C04-abar-dekha-hobe",
+        "BN-C04-kal-dekha-hobe"
+      ],
+      "before": [
+        "BN-EXT-009-LANGUAGE-SPECIFIC"
+      ],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "BN-PATH-010",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "BN-C06-numbers-1-5"
+      ],
+      "before": [],
+      "inline": [
+        "BN-EXT-010-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    }
+  ],
+  "spine": {
+    "SPINE-MEET-GREET": {
+      "segments": [
+        "BN-PATH-001"
+      ],
+      "omits": [
+        "GREETING-FORMAL",
+        "GREETING-PEACE",
+        "GREETING-WELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COURTESY-THANK": {
+      "segments": [
+        "BN-PATH-002",
+        "BN-PATH-007"
+      ],
+      "omits": [
+        "COURTESY-THANKS-CASUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-RESPOND-BASIC": {
+      "segments": [
+        "BN-PATH-003"
+      ],
+      "omits": [
+        "RESPONSE-YES",
+        "RESPONSE-NO"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXCHANGE-NAMES": {
+      "segments": [
+        "BN-PATH-005"
+      ],
+      "omits": [
+        "PRONOUN-ME",
+        "WORD-IS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-CHECK-WELLBEING": {
+      "segments": [
+        "BN-PATH-006",
+        "BN-PATH-008"
+      ],
+      "omits": [
+        "WORD-GOOD",
+        "WORD-SOSO"
+      ],
+      "relocates": {}
+    },
+    "SPINE-POLITE-REQUEST-REPAIR": {
+      "segments": [],
+      "omits": [
+        "COURTESY-PLEASE",
+        "COURTESY-SORRY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TAKE-LEAVE": {
+      "segments": [
+        "BN-PATH-004",
+        "BN-PATH-009"
+      ],
+      "omits": [
+        "FAREWELL-CASUAL",
+        "FAREWELL-SOON",
+        "GREETING-GOODNIGHT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TIME-OF-DAY": {
+      "segments": [],
+      "omits": [
+        "TIME-DAY",
+        "TIME-MORNING",
+        "TIME-AFTERNOON",
+        "TIME-EVENING",
+        "TIME-NIGHT",
+        "GREETING-DAY",
+        "GREETING-MORNING",
+        "GREETING-AFTERNOON",
+        "GREETING-EVENING"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ASK-LOCATION": {
+      "segments": [],
+      "omits": [
+        "QUESTION-WHERE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DEFINITE-REFERENCE": {
+      "segments": [],
+      "omits": [
+        "GRAMMAR-THE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COUNT-ONE-TO-FIVE": {
+      "segments": [
+        "BN-PATH-010"
+      ],
+      "omits": [
+        "NUMBER-ONE-TO-FIVE"
+      ],
+      "relocates": {}
+    }
+  },
+  "extensions": [
+    {
+      "id": "BN-EXT-009-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Bengali material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "BN-C04-abar",
+        "BN-C04-dekha-hobe"
+      ]
+    },
+    {
+      "id": "BN-EXT-010-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Bengali material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "BN-C06-numbers-1-5"
+      ]
+    },
+    {
+      "id": "BN-EXT-001-INLINE-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can recognize the first Bengali script pattern inside a greeting I already understand.",
+      "prerequisites": [],
+      "lessons": [
+        "BN-C01-nomoshkar"
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/french/curriculum.json
+++ b/code/learning/human-languages/french/curriculum.json
@@ -1,0 +1,428 @@
+{
+  "version": 1,
+  "language": "french",
+  "path": [
+    {
+      "id": "FR-PATH-001",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "FR-C01-salut"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "FR-PATH-002",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "FR-C01-bien",
+        "FR-C01-bon"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "FR-PATH-003",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "FR-C01-le-la"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "FR-PATH-004",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "FR-C01-jour",
+        "FR-C01-bonjour",
+        "FR-C01-nuit"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "FR-PATH-005",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "FR-C01-bonne-nuit"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "FR-PATH-006",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "FR-C01-soir",
+        "FR-C01-bonsoir"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "FR-PATH-007",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "FR-C02-je",
+        "FR-C02-appeler",
+        "FR-C02-me",
+        "FR-C02-je-mappelle",
+        "FR-C02-enchante",
+        "FR-C02-tu-vous"
+      ],
+      "before": [],
+      "inline": [
+        "FR-EXT-007-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "FR-PATH-008",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "FR-C02-comment"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "FR-PATH-009",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "FR-C02-comment-vous-appelez-vous"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "FR-PATH-010",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "FR-C03-aller",
+        "FR-C03-comment-ca-va",
+        "FR-C03-comme-ci-comme-ca"
+      ],
+      "before": [
+        "FR-EXT-010-LANGUAGE-SPECIFIC"
+      ],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "FR-PATH-011",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "FR-C03-merci",
+        "FR-C03-de-rien"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "FR-PATH-012",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "FR-C04-au-revoir",
+        "FR-C04-a-plus-tard",
+        "FR-C04-a-bientot",
+        "FR-C04-a-demain"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "FR-PATH-013",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "FR-C05-parler",
+        "FR-C05-habiter",
+        "FR-C06-nombres-1-5",
+        "FR-C06-nombres-6-10",
+        "FR-C07-jours-1",
+        "FR-C09-mois",
+        "FR-C09-saisons",
+        "FR-C10-parents",
+        "FR-C10-freres-soeurs",
+        "FR-C11-pain",
+        "FR-C11-eau-vin",
+        "FR-C12-nombres-11-16",
+        "FR-C12-nombres-17-20",
+        "FR-C13-noir-blanc",
+        "FR-C13-rouge-bleu",
+        "FR-C14-avoir",
+        "FR-C14-age"
+      ],
+      "before": [],
+      "inline": [
+        "FR-EXT-013-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "FR-PATH-014",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "FR-C17-tete",
+        "FR-C17-main"
+      ],
+      "before": [],
+      "inline": [
+        "FR-EXT-014-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "FR-PATH-015",
+      "spine_node": "SPINE-RESPOND-BASIC",
+      "lessons": [
+        "FR-C18-oui",
+        "FR-C18-non"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "FR-PATH-016",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "FR-C19-sil-vous-plait",
+        "FR-C20-je-suis-desole"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "FR-PATH-017",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "FR-C21-le-temps"
+      ],
+      "before": [],
+      "inline": [
+        "FR-EXT-017-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "FR-PATH-018",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "FR-C22-chien-chat",
+        "FR-C23-vert-jaune"
+      ],
+      "before": [],
+      "inline": [
+        "FR-EXT-018-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    }
+  ],
+  "spine": {
+    "SPINE-MEET-GREET": {
+      "segments": [
+        "FR-PATH-001"
+      ],
+      "omits": [
+        "GREETING-FORMAL",
+        "GREETING-PEACE",
+        "GREETING-WELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COURTESY-THANK": {
+      "segments": [
+        "FR-PATH-011"
+      ],
+      "omits": [
+        "COURTESY-THANKS-CASUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-RESPOND-BASIC": {
+      "segments": [
+        "FR-PATH-015"
+      ],
+      "omits": [
+        "RESPONSE-YESNO",
+        "RESPONSE-OKAY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXCHANGE-NAMES": {
+      "segments": [
+        "FR-PATH-007",
+        "FR-PATH-009"
+      ],
+      "omits": [
+        "QUESTION-WHAT",
+        "PRONOUN-MY",
+        "WORD-NAME",
+        "WORD-IS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-CHECK-WELLBEING": {
+      "segments": [
+        "FR-PATH-002",
+        "FR-PATH-008",
+        "FR-PATH-010",
+        "FR-PATH-014"
+      ],
+      "omits": [],
+      "relocates": {}
+    },
+    "SPINE-POLITE-REQUEST-REPAIR": {
+      "segments": [
+        "FR-PATH-016"
+      ],
+      "omits": [],
+      "relocates": {}
+    },
+    "SPINE-TAKE-LEAVE": {
+      "segments": [
+        "FR-PATH-005",
+        "FR-PATH-012"
+      ],
+      "omits": [
+        "FAREWELL-CASUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TIME-OF-DAY": {
+      "segments": [
+        "FR-PATH-004",
+        "FR-PATH-006",
+        "FR-PATH-013",
+        "FR-PATH-017"
+      ],
+      "omits": [
+        "TIME-MORNING",
+        "TIME-AFTERNOON",
+        "GREETING-MORNING",
+        "GREETING-AFTERNOON"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ASK-LOCATION": {
+      "segments": [],
+      "omits": [
+        "QUESTION-WHERE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DEFINITE-REFERENCE": {
+      "segments": [
+        "FR-PATH-003",
+        "FR-PATH-018"
+      ],
+      "omits": [],
+      "relocates": {}
+    },
+    "SPINE-COUNT-ONE-TO-FIVE": {
+      "segments": [],
+      "omits": [
+        "NUMBER-ONE-TO-FIVE"
+      ],
+      "relocates": {}
+    }
+  },
+  "extensions": [
+    {
+      "id": "FR-EXT-007-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional French material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "FR-C02-appeler"
+      ]
+    },
+    {
+      "id": "FR-EXT-010-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional French material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "FR-C03-aller"
+      ]
+    },
+    {
+      "id": "FR-EXT-013-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional French material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "FR-C05-parler",
+        "FR-C05-habiter",
+        "FR-C06-nombres-1-5",
+        "FR-C06-nombres-6-10",
+        "FR-C07-jours-1",
+        "FR-C09-mois",
+        "FR-C09-saisons",
+        "FR-C10-parents",
+        "FR-C10-freres-soeurs",
+        "FR-C11-pain",
+        "FR-C11-eau-vin",
+        "FR-C12-nombres-11-16",
+        "FR-C12-nombres-17-20",
+        "FR-C13-noir-blanc",
+        "FR-C13-rouge-bleu",
+        "FR-C14-avoir",
+        "FR-C14-age"
+      ]
+    },
+    {
+      "id": "FR-EXT-014-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional French material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "FR-C17-tete",
+        "FR-C17-main"
+      ]
+    },
+    {
+      "id": "FR-EXT-017-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional French material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "FR-C21-le-temps"
+      ]
+    },
+    {
+      "id": "FR-EXT-018-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional French material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "FR-C22-chien-chat",
+        "FR-C23-vert-jaune"
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/german/curriculum.json
+++ b/code/learning/human-languages/german/curriculum.json
@@ -1,0 +1,485 @@
+{
+  "version": 1,
+  "language": "german",
+  "path": [
+    {
+      "id": "GE-PATH-001",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "GE-C01-hallo"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-002",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "GE-C01-gut"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-003",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "GE-C01-der-die-das"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-004",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "GE-C01-nacht"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-005",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "GE-C01-gute-nacht"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-006",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "GE-C01-tag",
+        "GE-C01-abend",
+        "GE-C01-guten-tag",
+        "GE-C01-guten-abend",
+        "GE-C01-morgen",
+        "GE-C01-guten-morgen"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-007",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "GE-C02-ich",
+        "GE-C02-du-sie",
+        "GE-C02-heissen",
+        "GE-C02-ich-heisse",
+        "GE-C02-freut-mich"
+      ],
+      "before": [],
+      "inline": [
+        "GE-EXT-007-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-008",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "GE-C02-wie"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-009",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "GE-C02-wie-heissen-sie"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-010",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "GE-C03-danke",
+        "GE-C03-bitte"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-011",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "GE-C03-gehen",
+        "GE-C03-wie-geht-es",
+        "GE-C03-es-geht"
+      ],
+      "before": [
+        "GE-EXT-011-LANGUAGE-SPECIFIC"
+      ],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-012",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "GE-C04-auf-wiedersehen",
+        "GE-C04-tschuss",
+        "GE-C04-bis-bald",
+        "GE-C04-bis-morgen",
+        "GE-C04-bis-spater"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-013",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "GE-C05-wohnen",
+        "GE-C05-machen",
+        "GE-C06-zahlen-1-5",
+        "GE-C06-zahlen-6-10"
+      ],
+      "before": [],
+      "inline": [
+        "GE-EXT-013-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-014",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "GE-C08-uhr",
+        "GE-C09-monate",
+        "GE-C09-jahreszeiten",
+        "GE-C10-eltern",
+        "GE-C10-geschwister",
+        "GE-C11-brot",
+        "GE-C11-wasser-wein"
+      ],
+      "before": [],
+      "inline": [
+        "GE-EXT-014-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-015",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "GE-C12-elf-zwoelf",
+        "GE-C12-zahlen-13-20",
+        "GE-C13-schwarz-weiss",
+        "GE-C13-rot-blau",
+        "GE-C14-haben",
+        "GE-C14-alter"
+      ],
+      "before": [],
+      "inline": [
+        "GE-EXT-015-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-016",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "GE-C17-kopf",
+        "GE-C17-kopf-haupt",
+        "GE-C17-hand"
+      ],
+      "before": [],
+      "inline": [
+        "GE-EXT-016-LANGUAGE-SPECIFIC",
+        "GE-EXT-016-ETYMOLOGY"
+      ],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-017",
+      "spine_node": "SPINE-RESPOND-BASIC",
+      "lessons": [
+        "GE-C18-ja",
+        "GE-C18-nein"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-018",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "GE-C19-bitte-requests",
+        "GE-C20-entschuldigung"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-019",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "GE-C21-das-wetter"
+      ],
+      "before": [],
+      "inline": [
+        "GE-EXT-019-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-020",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "GE-C22-hund-katze",
+        "GE-C23-gruen-gelb"
+      ],
+      "before": [],
+      "inline": [
+        "GE-EXT-020-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    }
+  ],
+  "spine": {
+    "SPINE-MEET-GREET": {
+      "segments": [
+        "GE-PATH-001"
+      ],
+      "omits": [
+        "GREETING-FORMAL",
+        "GREETING-PEACE",
+        "GREETING-WELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COURTESY-THANK": {
+      "segments": [
+        "GE-PATH-010"
+      ],
+      "omits": [
+        "COURTESY-THANKS-CASUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-RESPOND-BASIC": {
+      "segments": [
+        "GE-PATH-017"
+      ],
+      "omits": [
+        "RESPONSE-YESNO",
+        "RESPONSE-OKAY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXCHANGE-NAMES": {
+      "segments": [
+        "GE-PATH-007",
+        "GE-PATH-009"
+      ],
+      "omits": [
+        "QUESTION-WHAT",
+        "PRONOUN-ME",
+        "PRONOUN-MY",
+        "WORD-NAME",
+        "WORD-IS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-CHECK-WELLBEING": {
+      "segments": [
+        "GE-PATH-002",
+        "GE-PATH-008",
+        "GE-PATH-011",
+        "GE-PATH-016"
+      ],
+      "omits": [
+        "WORD-WELL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-POLITE-REQUEST-REPAIR": {
+      "segments": [
+        "GE-PATH-014",
+        "GE-PATH-018"
+      ],
+      "omits": [],
+      "relocates": {}
+    },
+    "SPINE-TAKE-LEAVE": {
+      "segments": [
+        "GE-PATH-005",
+        "GE-PATH-012"
+      ],
+      "omits": [],
+      "relocates": {}
+    },
+    "SPINE-TIME-OF-DAY": {
+      "segments": [
+        "GE-PATH-004",
+        "GE-PATH-006",
+        "GE-PATH-013",
+        "GE-PATH-015",
+        "GE-PATH-019"
+      ],
+      "omits": [
+        "TIME-AFTERNOON",
+        "GREETING-AFTERNOON"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ASK-LOCATION": {
+      "segments": [],
+      "omits": [
+        "QUESTION-WHERE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DEFINITE-REFERENCE": {
+      "segments": [
+        "GE-PATH-003",
+        "GE-PATH-020"
+      ],
+      "omits": [],
+      "relocates": {}
+    },
+    "SPINE-COUNT-ONE-TO-FIVE": {
+      "segments": [],
+      "omits": [
+        "NUMBER-ONE-TO-FIVE"
+      ],
+      "relocates": {}
+    }
+  },
+  "extensions": [
+    {
+      "id": "GE-EXT-007-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional German material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "GE-C02-heissen"
+      ]
+    },
+    {
+      "id": "GE-EXT-011-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional German material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "GE-C03-gehen"
+      ]
+    },
+    {
+      "id": "GE-EXT-013-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional German material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "GE-C05-wohnen",
+        "GE-C05-machen",
+        "GE-C06-zahlen-1-5",
+        "GE-C06-zahlen-6-10"
+      ]
+    },
+    {
+      "id": "GE-EXT-014-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional German material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "GE-C08-uhr",
+        "GE-C09-monate",
+        "GE-C09-jahreszeiten",
+        "GE-C10-eltern",
+        "GE-C10-geschwister",
+        "GE-C11-brot",
+        "GE-C11-wasser-wein"
+      ]
+    },
+    {
+      "id": "GE-EXT-015-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional German material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "GE-C12-elf-zwoelf",
+        "GE-C12-zahlen-13-20",
+        "GE-C13-schwarz-weiss",
+        "GE-C13-rot-blau",
+        "GE-C14-haben",
+        "GE-C14-alter"
+      ]
+    },
+    {
+      "id": "GE-EXT-016-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional German material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "GE-C17-kopf",
+        "GE-C17-hand"
+      ]
+    },
+    {
+      "id": "GE-EXT-016-ETYMOLOGY",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can use this German word history as a memory hook without confusing origin and current use.",
+      "prerequisites": [],
+      "lessons": [
+        "GE-C17-kopf-haupt"
+      ]
+    },
+    {
+      "id": "GE-EXT-019-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional German material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "GE-C21-das-wetter"
+      ]
+    },
+    {
+      "id": "GE-EXT-020-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional German material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "GE-C22-hund-katze",
+        "GE-C23-gruen-gelb"
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/gujarati/curriculum.json
+++ b/code/learning/human-languages/gujarati/curriculum.json
@@ -1,0 +1,275 @@
+{
+  "version": 1,
+  "language": "gujarati",
+  "path": [
+    {
+      "id": "GU-PATH-001",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "GU-C01-namaste"
+      ],
+      "before": [],
+      "inline": [
+        "GU-EXT-001-INLINE-SCRIPT"
+      ],
+      "after": []
+    },
+    {
+      "id": "GU-PATH-002",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "GU-C01-aabhaar"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GU-PATH-003",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "GU-C01-aavjo"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GU-PATH-004",
+      "spine_node": "SPINE-RESPOND-BASIC",
+      "lessons": [
+        "GU-C01-haa-naa",
+        "GU-C01-saarun"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GU-PATH-005",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "GU-C02-naam",
+        "GU-C02-chhe",
+        "GU-C02-maarun",
+        "GU-C02-maarun-naam-chhe",
+        "GU-C02-anand",
+        "GU-C02-shun",
+        "GU-C02-tu-tame",
+        "GU-C02-tamarun-naam-shun-chhe",
+        "GU-C03-hun"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GU-PATH-006",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "GU-C03-kem",
+        "GU-C03-tame-kem-chho",
+        "GU-C03-majaa"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GU-PATH-007",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "GU-C03-vandho-nahi"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GU-PATH-008",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "GU-C04-malishun",
+        "GU-C04-kaale",
+        "GU-C04-pachha",
+        "GU-C04-pachha-malishun"
+      ],
+      "before": [],
+      "inline": [
+        "GU-EXT-008-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "GU-PATH-009",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "GU-C06-numbers-1-5",
+        "GU-C06-number-histories"
+      ],
+      "before": [],
+      "inline": [
+        "GU-EXT-009-LANGUAGE-SPECIFIC",
+        "GU-EXT-009-ETYMOLOGY"
+      ],
+      "after": []
+    }
+  ],
+  "spine": {
+    "SPINE-MEET-GREET": {
+      "segments": [
+        "GU-PATH-001"
+      ],
+      "omits": [
+        "GREETING-FORMAL",
+        "GREETING-PEACE",
+        "GREETING-WELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COURTESY-THANK": {
+      "segments": [
+        "GU-PATH-002",
+        "GU-PATH-007"
+      ],
+      "omits": [
+        "COURTESY-THANKS-CASUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-RESPOND-BASIC": {
+      "segments": [
+        "GU-PATH-004"
+      ],
+      "omits": [
+        "RESPONSE-YES",
+        "RESPONSE-NO"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXCHANGE-NAMES": {
+      "segments": [
+        "GU-PATH-005"
+      ],
+      "omits": [
+        "PRONOUN-ME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-CHECK-WELLBEING": {
+      "segments": [
+        "GU-PATH-006"
+      ],
+      "omits": [
+        "WORD-GOOD",
+        "WORD-SOSO"
+      ],
+      "relocates": {}
+    },
+    "SPINE-POLITE-REQUEST-REPAIR": {
+      "segments": [],
+      "omits": [
+        "COURTESY-PLEASE",
+        "COURTESY-SORRY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TAKE-LEAVE": {
+      "segments": [
+        "GU-PATH-003",
+        "GU-PATH-008"
+      ],
+      "omits": [
+        "FAREWELL-CASUAL",
+        "FAREWELL-SOON",
+        "GREETING-GOODNIGHT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TIME-OF-DAY": {
+      "segments": [],
+      "omits": [
+        "TIME-DAY",
+        "TIME-MORNING",
+        "TIME-AFTERNOON",
+        "TIME-EVENING",
+        "TIME-NIGHT",
+        "GREETING-DAY",
+        "GREETING-MORNING",
+        "GREETING-AFTERNOON",
+        "GREETING-EVENING"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ASK-LOCATION": {
+      "segments": [],
+      "omits": [
+        "QUESTION-WHERE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DEFINITE-REFERENCE": {
+      "segments": [],
+      "omits": [
+        "GRAMMAR-THE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COUNT-ONE-TO-FIVE": {
+      "segments": [
+        "GU-PATH-009"
+      ],
+      "omits": [
+        "NUMBER-ONE-TO-FIVE"
+      ],
+      "relocates": {}
+    }
+  },
+  "extensions": [
+    {
+      "id": "GU-EXT-008-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Gujarati material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "GU-C04-malishun",
+        "GU-C04-pachha"
+      ]
+    },
+    {
+      "id": "GU-EXT-009-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Gujarati material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "GU-C06-numbers-1-5"
+      ]
+    },
+    {
+      "id": "GU-EXT-009-ETYMOLOGY",
+      "stage": "A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can use this Gujarati word history as a memory hook without confusing origin and current use.",
+      "prerequisites": [],
+      "lessons": [
+        "GU-C06-number-histories"
+      ]
+    },
+    {
+      "id": "GU-EXT-001-INLINE-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can recognize the first Gujarati script pattern inside a greeting I already understand.",
+      "prerequisites": [],
+      "lessons": [
+        "GU-C01-namaste"
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/hindi/curriculum.json
+++ b/code/learning/human-languages/hindi/curriculum.json
@@ -1,0 +1,720 @@
+{
+  "version": 1,
+  "language": "hindi",
+  "path": [
+    {
+      "id": "HI-PATH-001",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "HI-C01-namaste",
+        "HI-W01-shirorekha-na-ma",
+        "HI-W01-na-ma",
+        "HI-W02-abugida-ka-ta",
+        "HI-W02-ka-ta-mouth-order",
+        "HI-C01-namaskar"
+      ],
+      "before": [],
+      "inline": [
+        "HI-EXT-001-SCRIPT"
+      ],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-002",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "HI-C01-dhanyavad",
+        "HI-C01-shukriya"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-003",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "HI-C01-alvida"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-004",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "HI-W03-matras-naam",
+        "HI-W03-preposed-i",
+        "HI-W04-ra-sa-mera-naam",
+        "HI-W04-write-mera-naam",
+        "HI-W05-virama-namaste",
+        "HI-W05-conjuncts",
+        "HI-W05-write-namaste",
+        "HI-C02-naam",
+        "HI-C02-aap-tum",
+        "HI-C02-hai",
+        "HI-C02-kya",
+        "HI-C02-aapka-naam-kya-hai",
+        "HI-C02-meraa",
+        "HI-C02-mera-naam-hai",
+        "HI-C02-khushi"
+      ],
+      "before": [
+        "HI-EXT-004-SCRIPT"
+      ],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-005",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "HI-C03-aapka-swagat-hai"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-006",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "HI-C03-kaise",
+        "HI-C03-aap-kaise-hain"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-007",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "HI-C03-main"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-008",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "HI-C03-hun",
+        "HI-C03-thik"
+      ],
+      "before": [
+        "HI-EXT-008-LANGUAGE-SPECIFIC"
+      ],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-009",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "HI-C04-chalta-hun",
+        "HI-C04-milenge",
+        "HI-C04-kal-milte-hain",
+        "HI-C04-phir",
+        "HI-C04-phir-milenge"
+      ],
+      "before": [],
+      "inline": [
+        "HI-EXT-009-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-010",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "HI-C06-numbers-1-5",
+        "HI-C06-tin-char-history",
+        "HI-C06-paanch-nasal"
+      ],
+      "before": [],
+      "inline": [
+        "HI-EXT-010-LANGUAGE-SPECIFIC",
+        "HI-EXT-010-ETYMOLOGY"
+      ],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-011",
+      "spine_node": "SPINE-RESPOND-BASIC",
+      "lessons": [
+        "HI-C07-haan",
+        "HI-C07-nahin"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-012",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "HI-C08-kripaya",
+        "HI-C09-maaf-kijiye"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-013",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "HI-C10-somavaar-shukravaar",
+        "HI-C10-shanivaar-ravivaar"
+      ],
+      "before": [],
+      "inline": [
+        "HI-EXT-013-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-014",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "HI-C11-kaalaa-safed",
+        "HI-C11-laal-niila"
+      ],
+      "before": [],
+      "inline": [
+        "HI-EXT-014-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-015",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "HI-C12-pitaa-maataa",
+        "HI-C12-bhaai-bahin"
+      ],
+      "before": [],
+      "inline": [
+        "HI-EXT-015-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-016",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "HI-C13-sir",
+        "HI-C13-haath"
+      ],
+      "before": [],
+      "inline": [
+        "HI-EXT-016-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-017",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "HI-C14-ritu"
+      ],
+      "before": [],
+      "inline": [
+        "HI-EXT-017-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-018",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "HI-C15-paani-roti"
+      ],
+      "before": [],
+      "inline": [
+        "HI-EXT-018-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-019",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "HI-C16-mahine",
+        "HI-C17-dopahar-aadhi-raat",
+        "HI-C18-ghanta"
+      ],
+      "before": [],
+      "inline": [
+        "HI-EXT-019-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-020",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "HI-C19-umr",
+        "HI-C19-age-grammar"
+      ],
+      "before": [],
+      "inline": [
+        "HI-EXT-020-LANGUAGE-SPECIFIC",
+        "HI-EXT-020-GRAMMAR"
+      ],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-021",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "HI-C20-mausam"
+      ],
+      "before": [],
+      "inline": [
+        "HI-EXT-021-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-022",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "HI-C21-numbers-6-10",
+        "HI-C21-six-nine-ten-history",
+        "HI-C22-gyarah-bees"
+      ],
+      "before": [],
+      "inline": [
+        "HI-EXT-022-LANGUAGE-SPECIFIC",
+        "HI-EXT-022-ETYMOLOGY"
+      ],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-023",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "HI-C23-kutta-billi",
+        "HI-C23-billi-history",
+        "HI-C24-hara-pila",
+        "HI-C24-pila-history"
+      ],
+      "before": [],
+      "inline": [
+        "HI-EXT-023-LANGUAGE-SPECIFIC",
+        "HI-EXT-023-ETYMOLOGY"
+      ],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-024",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "HI-C25-din",
+        "HI-C26-raat"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-025",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "HI-C27-shubh-raatri"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-026",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "HI-C28-subah",
+        "HI-C29-shaam",
+        "HI-C30-dopahar-widened",
+        "HI-C31-suprabhat",
+        "HI-C32-shubh-sandhya",
+        "HI-C32-evening-register",
+        "HI-C33-shubh-dopahar"
+      ],
+      "before": [],
+      "inline": [
+        "HI-EXT-026-REGISTER"
+      ],
+      "after": []
+    }
+  ],
+  "spine": {
+    "SPINE-MEET-GREET": {
+      "segments": [
+        "HI-PATH-001"
+      ],
+      "omits": [
+        "GREETING-PEACE",
+        "GREETING-WELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COURTESY-THANK": {
+      "segments": [
+        "HI-PATH-002",
+        "HI-PATH-005"
+      ],
+      "omits": [],
+      "relocates": {}
+    },
+    "SPINE-RESPOND-BASIC": {
+      "segments": [
+        "HI-PATH-011"
+      ],
+      "omits": [
+        "RESPONSE-YESNO",
+        "RESPONSE-OKAY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXCHANGE-NAMES": {
+      "segments": [
+        "HI-PATH-004",
+        "HI-PATH-007",
+        "HI-PATH-015",
+        "HI-PATH-020"
+      ],
+      "omits": [
+        "PRONOUN-ME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-CHECK-WELLBEING": {
+      "segments": [
+        "HI-PATH-006",
+        "HI-PATH-008",
+        "HI-PATH-016"
+      ],
+      "omits": [
+        "WORD-GOOD",
+        "WORD-SOSO"
+      ],
+      "relocates": {}
+    },
+    "SPINE-POLITE-REQUEST-REPAIR": {
+      "segments": [
+        "HI-PATH-012",
+        "HI-PATH-018"
+      ],
+      "omits": [],
+      "relocates": {}
+    },
+    "SPINE-TAKE-LEAVE": {
+      "segments": [
+        "HI-PATH-003",
+        "HI-PATH-009",
+        "HI-PATH-025"
+      ],
+      "omits": [
+        "FAREWELL-SOON"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TIME-OF-DAY": {
+      "segments": [
+        "HI-PATH-013",
+        "HI-PATH-017",
+        "HI-PATH-019",
+        "HI-PATH-021",
+        "HI-PATH-024",
+        "HI-PATH-026"
+      ],
+      "omits": [
+        "GREETING-DAY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ASK-LOCATION": {
+      "segments": [],
+      "omits": [
+        "QUESTION-WHERE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DEFINITE-REFERENCE": {
+      "segments": [
+        "HI-PATH-014",
+        "HI-PATH-023"
+      ],
+      "omits": [
+        "GRAMMAR-THE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COUNT-ONE-TO-FIVE": {
+      "segments": [
+        "HI-PATH-010",
+        "HI-PATH-022"
+      ],
+      "omits": [
+        "NUMBER-ONE-TO-FIVE"
+      ],
+      "relocates": {}
+    }
+  },
+  "extensions": [
+    {
+      "id": "HI-EXT-001-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can recognize and use the Hindi script features introduced inside these words.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-W01-shirorekha-na-ma",
+        "HI-W01-na-ma",
+        "HI-W02-abugida-ka-ta",
+        "HI-W02-ka-ta-mouth-order"
+      ]
+    },
+    {
+      "id": "HI-EXT-004-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can recognize and use the Hindi script features introduced inside these words.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-W03-matras-naam",
+        "HI-W03-preposed-i",
+        "HI-W04-ra-sa-mera-naam",
+        "HI-W04-write-mera-naam",
+        "HI-W05-virama-namaste",
+        "HI-W05-conjuncts",
+        "HI-W05-write-namaste"
+      ]
+    },
+    {
+      "id": "HI-EXT-008-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Hindi material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C03-hun"
+      ]
+    },
+    {
+      "id": "HI-EXT-009-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Hindi material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C04-milenge",
+        "HI-C04-phir"
+      ]
+    },
+    {
+      "id": "HI-EXT-010-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Hindi material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C06-numbers-1-5"
+      ]
+    },
+    {
+      "id": "HI-EXT-010-ETYMOLOGY",
+      "stage": "A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can use this Hindi word history as a memory hook without confusing origin and current use.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C06-tin-char-history",
+        "HI-C06-paanch-nasal"
+      ]
+    },
+    {
+      "id": "HI-EXT-013-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Hindi material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C10-somavaar-shukravaar",
+        "HI-C10-shanivaar-ravivaar"
+      ]
+    },
+    {
+      "id": "HI-EXT-014-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Hindi material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C11-kaalaa-safed",
+        "HI-C11-laal-niila"
+      ]
+    },
+    {
+      "id": "HI-EXT-015-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Hindi material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C12-pitaa-maataa",
+        "HI-C12-bhaai-bahin"
+      ]
+    },
+    {
+      "id": "HI-EXT-016-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Hindi material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C13-sir",
+        "HI-C13-haath"
+      ]
+    },
+    {
+      "id": "HI-EXT-017-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Hindi material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C14-ritu"
+      ]
+    },
+    {
+      "id": "HI-EXT-018-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Hindi material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C15-paani-roti"
+      ]
+    },
+    {
+      "id": "HI-EXT-019-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Hindi material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C16-mahine",
+        "HI-C17-dopahar-aadhi-raat",
+        "HI-C18-ghanta"
+      ]
+    },
+    {
+      "id": "HI-EXT-020-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Hindi material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C19-umr"
+      ]
+    },
+    {
+      "id": "HI-EXT-020-GRAMMAR",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "grammar",
+      "canDo": "I can use the Hindi-specific grammar needed for this part of the shared ability.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C19-age-grammar"
+      ]
+    },
+    {
+      "id": "HI-EXT-021-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Hindi material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C20-mausam"
+      ]
+    },
+    {
+      "id": "HI-EXT-022-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Hindi material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C21-numbers-6-10",
+        "HI-C22-gyarah-bees"
+      ]
+    },
+    {
+      "id": "HI-EXT-022-ETYMOLOGY",
+      "stage": "A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can use this Hindi word history as a memory hook without confusing origin and current use.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C21-six-nine-ten-history"
+      ]
+    },
+    {
+      "id": "HI-EXT-023-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Hindi material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C23-kutta-billi",
+        "HI-C24-hara-pila"
+      ]
+    },
+    {
+      "id": "HI-EXT-023-ETYMOLOGY",
+      "stage": "A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can use this Hindi word history as a memory hook without confusing origin and current use.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C23-billi-history",
+        "HI-C24-pila-history"
+      ]
+    },
+    {
+      "id": "HI-EXT-026-REGISTER",
+      "stage": "A1",
+      "kind": "required",
+      "category": "register",
+      "canDo": "I can choose the Hindi form that fits this relationship and setting.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C32-evening-register"
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/italian/curriculum.json
+++ b/code/learning/human-languages/italian/curriculum.json
@@ -1,0 +1,595 @@
+{
+  "version": 1,
+  "language": "italian",
+  "path": [
+    {
+      "id": "IT-PATH-001",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "IT-C01-ciao"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "IT-PATH-002",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "IT-C01-buono"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "IT-PATH-003",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "IT-C01-grazie"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "IT-PATH-004",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "IT-C01-il-la-lo"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "IT-PATH-005",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "IT-C01-giorno",
+        "IT-C01-buongiorno",
+        "IT-C01-sera"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "IT-PATH-006",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "IT-C01-notte"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "IT-PATH-007",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "IT-C02-prego"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "IT-PATH-008",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "IT-C02-come",
+        "IT-C02-stare",
+        "IT-C02-come-stai",
+        "IT-C02-come-sta",
+        "IT-C02-come-va",
+        "IT-C02-cosi-cosi",
+        "IT-C02-practice"
+      ],
+      "before": [],
+      "inline": [
+        "IT-EXT-008-LANGUAGE-SPECIFIC"
+      ],
+      "after": [
+        "IT-EXT-008-CONSOLIDATION"
+      ]
+    },
+    {
+      "id": "IT-PATH-009",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "IT-C03-io",
+        "IT-C03-mi-chiamo",
+        "IT-C03-come-ti-chiami",
+        "IT-C03-piacere",
+        "IT-C03-practice"
+      ],
+      "before": [],
+      "inline": [],
+      "after": [
+        "IT-EXT-009-CONSOLIDATION"
+      ]
+    },
+    {
+      "id": "IT-PATH-010",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "IT-C04-arrivederci",
+        "IT-C04-a-domani",
+        "IT-C04-a-presto",
+        "IT-C04-a-piu-tardi",
+        "IT-C04-practice"
+      ],
+      "before": [],
+      "inline": [],
+      "after": [
+        "IT-EXT-010-CONSOLIDATION"
+      ]
+    },
+    {
+      "id": "IT-PATH-011",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "IT-C05-parlare",
+        "IT-C05-abitare",
+        "IT-C05-lavorare",
+        "IT-C05-parlo-italiano",
+        "IT-C05-practice"
+      ],
+      "before": [],
+      "inline": [
+        "IT-EXT-011-LANGUAGE-SPECIFIC",
+        "IT-EXT-011-CONSOLIDATION"
+      ],
+      "after": []
+    },
+    {
+      "id": "IT-PATH-012",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "IT-C06-numeri-1-5",
+        "IT-C06-numeri-6-10"
+      ],
+      "before": [],
+      "inline": [
+        "IT-EXT-012-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "IT-PATH-013",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "IT-C07-giorni-1",
+        "IT-C07-giorni-2",
+        "IT-C08-ora",
+        "IT-C08-mezzogiorno-mezzanotte",
+        "IT-C09-mesi",
+        "IT-C09-stagioni"
+      ],
+      "before": [],
+      "inline": [
+        "IT-EXT-013-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "IT-PATH-014",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "IT-C10-genitori",
+        "IT-C10-fratello-sorella"
+      ],
+      "before": [],
+      "inline": [
+        "IT-EXT-014-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "IT-PATH-015",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "IT-C11-pane",
+        "IT-C11-acqua-vino"
+      ],
+      "before": [],
+      "inline": [
+        "IT-EXT-015-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "IT-PATH-016",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "IT-C12-numeri-11-16",
+        "IT-C12-numeri-17-20"
+      ],
+      "before": [],
+      "inline": [
+        "IT-EXT-016-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "IT-PATH-017",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "IT-C13-nero-bianco",
+        "IT-C13-rosso-blu"
+      ],
+      "before": [],
+      "inline": [
+        "IT-EXT-017-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "IT-PATH-018",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "IT-C14-avere",
+        "IT-C14-eta",
+        "IT-C15-passato-prossimo",
+        "IT-C15-passato-remoto"
+      ],
+      "before": [],
+      "inline": [
+        "IT-EXT-018-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "IT-PATH-019",
+      "spine_node": "SPINE-ASK-LOCATION",
+      "lessons": [
+        "IT-C16-essere",
+        "IT-C16-essere-stato",
+        "IT-C16-andare",
+        "IT-C16-passato-prossimo-essere"
+      ],
+      "before": [],
+      "inline": [
+        "IT-EXT-019-LANGUAGE-SPECIFIC",
+        "IT-EXT-019-ETYMOLOGY"
+      ],
+      "after": []
+    },
+    {
+      "id": "IT-PATH-020",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "IT-C17-testa",
+        "IT-C17-mano"
+      ],
+      "before": [],
+      "inline": [
+        "IT-EXT-020-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    }
+  ],
+  "spine": {
+    "SPINE-MEET-GREET": {
+      "segments": [
+        "IT-PATH-001"
+      ],
+      "omits": [
+        "GREETING-FORMAL",
+        "GREETING-PEACE",
+        "GREETING-WELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COURTESY-THANK": {
+      "segments": [
+        "IT-PATH-003",
+        "IT-PATH-007"
+      ],
+      "omits": [
+        "COURTESY-THANKS-CASUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-RESPOND-BASIC": {
+      "segments": [],
+      "omits": [
+        "RESPONSE-YES",
+        "RESPONSE-NO",
+        "RESPONSE-YESNO",
+        "RESPONSE-OKAY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXCHANGE-NAMES": {
+      "segments": [
+        "IT-PATH-009",
+        "IT-PATH-014",
+        "IT-PATH-018"
+      ],
+      "omits": [
+        "QUESTION-WHAT",
+        "PRONOUN-ME",
+        "PRONOUN-YOU",
+        "PRONOUN-MY",
+        "WORD-NAME",
+        "WORD-IS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-CHECK-WELLBEING": {
+      "segments": [
+        "IT-PATH-002",
+        "IT-PATH-008",
+        "IT-PATH-020"
+      ],
+      "omits": [
+        "WORD-WELL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-POLITE-REQUEST-REPAIR": {
+      "segments": [
+        "IT-PATH-011",
+        "IT-PATH-015"
+      ],
+      "omits": [
+        "COURTESY-PLEASE",
+        "COURTESY-SORRY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TAKE-LEAVE": {
+      "segments": [
+        "IT-PATH-006",
+        "IT-PATH-010"
+      ],
+      "omits": [
+        "FAREWELL-CASUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TIME-OF-DAY": {
+      "segments": [
+        "IT-PATH-005",
+        "IT-PATH-013"
+      ],
+      "omits": [
+        "TIME-MORNING",
+        "TIME-AFTERNOON",
+        "TIME-EVENING",
+        "TIME-NIGHT",
+        "GREETING-MORNING",
+        "GREETING-AFTERNOON"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ASK-LOCATION": {
+      "segments": [
+        "IT-PATH-019"
+      ],
+      "omits": [
+        "QUESTION-WHERE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DEFINITE-REFERENCE": {
+      "segments": [
+        "IT-PATH-004",
+        "IT-PATH-017"
+      ],
+      "omits": [],
+      "relocates": {}
+    },
+    "SPINE-COUNT-ONE-TO-FIVE": {
+      "segments": [
+        "IT-PATH-012",
+        "IT-PATH-016"
+      ],
+      "omits": [
+        "NUMBER-ONE-TO-FIVE"
+      ],
+      "relocates": {}
+    }
+  },
+  "extensions": [
+    {
+      "id": "IT-EXT-008-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Italian material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "IT-C02-stare",
+        "IT-C02-come-sta",
+        "IT-C02-come-va"
+      ]
+    },
+    {
+      "id": "IT-EXT-008-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "consolidation",
+      "canDo": "I can retrieve and combine the Italian material introduced in this part of the path.",
+      "prerequisites": [],
+      "lessons": [
+        "IT-C02-practice"
+      ]
+    },
+    {
+      "id": "IT-EXT-009-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "consolidation",
+      "canDo": "I can retrieve and combine the Italian material introduced in this part of the path.",
+      "prerequisites": [],
+      "lessons": [
+        "IT-C03-practice"
+      ]
+    },
+    {
+      "id": "IT-EXT-010-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "consolidation",
+      "canDo": "I can retrieve and combine the Italian material introduced in this part of the path.",
+      "prerequisites": [],
+      "lessons": [
+        "IT-C04-practice"
+      ]
+    },
+    {
+      "id": "IT-EXT-011-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Italian material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "IT-C05-parlare",
+        "IT-C05-abitare",
+        "IT-C05-lavorare",
+        "IT-C05-parlo-italiano"
+      ]
+    },
+    {
+      "id": "IT-EXT-011-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "consolidation",
+      "canDo": "I can retrieve and combine the Italian material introduced in this part of the path.",
+      "prerequisites": [],
+      "lessons": [
+        "IT-C05-practice"
+      ]
+    },
+    {
+      "id": "IT-EXT-012-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Italian material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "IT-C06-numeri-1-5",
+        "IT-C06-numeri-6-10"
+      ]
+    },
+    {
+      "id": "IT-EXT-013-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Italian material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "IT-C07-giorni-1",
+        "IT-C07-giorni-2",
+        "IT-C08-ora",
+        "IT-C08-mezzogiorno-mezzanotte",
+        "IT-C09-mesi",
+        "IT-C09-stagioni"
+      ]
+    },
+    {
+      "id": "IT-EXT-014-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Italian material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "IT-C10-genitori",
+        "IT-C10-fratello-sorella"
+      ]
+    },
+    {
+      "id": "IT-EXT-015-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Italian material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "IT-C11-pane",
+        "IT-C11-acqua-vino"
+      ]
+    },
+    {
+      "id": "IT-EXT-016-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Italian material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "IT-C12-numeri-11-16",
+        "IT-C12-numeri-17-20"
+      ]
+    },
+    {
+      "id": "IT-EXT-017-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Italian material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "IT-C13-nero-bianco",
+        "IT-C13-rosso-blu"
+      ]
+    },
+    {
+      "id": "IT-EXT-018-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Italian material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "IT-C14-avere",
+        "IT-C14-eta",
+        "IT-C15-passato-prossimo",
+        "IT-C15-passato-remoto"
+      ]
+    },
+    {
+      "id": "IT-EXT-019-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Italian material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "IT-C16-essere",
+        "IT-C16-andare",
+        "IT-C16-passato-prossimo-essere"
+      ]
+    },
+    {
+      "id": "IT-EXT-019-ETYMOLOGY",
+      "stage": "A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can use this Italian word history as a memory hook without confusing origin and current use.",
+      "prerequisites": [],
+      "lessons": [
+        "IT-C16-essere-stato"
+      ]
+    },
+    {
+      "id": "IT-EXT-020-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Italian material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "IT-C17-testa",
+        "IT-C17-mano"
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/kannada/curriculum.json
+++ b/code/learning/human-languages/kannada/curriculum.json
@@ -1,0 +1,639 @@
+{
+  "version": 1,
+  "language": "kannada",
+  "path": [
+    {
+      "id": "KA-PATH-001",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "KA-C01-namaskara"
+      ],
+      "before": [],
+      "inline": [
+        "KA-EXT-001-INLINE-SCRIPT"
+      ],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-002",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "KA-C01-dhanyavada"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-003",
+      "spine_node": "SPINE-RESPOND-BASIC",
+      "lessons": [
+        "KA-C01-haudu",
+        "KA-C01-illa",
+        "KA-C01-sari"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-004",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "KA-C02-hesaru",
+        "KA-C02-nanna",
+        "KA-C02-nanna-hesaru",
+        "KA-C02-niinu-niivu",
+        "KA-C02-enu",
+        "KA-C02-nimma-hesaru-enu",
+        "KA-C02-santosha"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-005",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "KA-C03-hege"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-006",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "KA-C03-naanu"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-007",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "KA-C03-niivu-hegiddiira",
+        "KA-C03-cennaagi"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-008",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "KA-C03-paravaagilla"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-009",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "KA-C04-hoogu",
+        "KA-C04-hoogi-baruttene",
+        "KA-C04-naale-sigona",
+        "KA-C04-matte-sigona"
+      ],
+      "before": [
+        "KA-EXT-009-LANGUAGE-SPECIFIC"
+      ],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-010",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "KA-C05-maatanaadu",
+        "KA-C05-iru",
+        "KA-C05-kelasa-maadu",
+        "KA-C05-naanu-kannada-maatanaaduttene",
+        "KA-C05-practice",
+        "KA-C06-dative-ge",
+        "KA-C06-dative-stacking",
+        "KA-C06-dative-subject"
+      ],
+      "before": [],
+      "inline": [
+        "KA-EXT-010-LANGUAGE-SPECIFIC",
+        "KA-EXT-010-CONSOLIDATION",
+        "KA-EXT-010-GRAMMAR"
+      ],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-011",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "KA-C07-numbers-1-5",
+        "KA-C07-numbers-6-10"
+      ],
+      "before": [],
+      "inline": [
+        "KA-EXT-011-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-012",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "KA-C08-dayavittu",
+        "KA-C09-kshamisi"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-013",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "KA-C10-vaara"
+      ],
+      "before": [],
+      "inline": [
+        "KA-EXT-013-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-014",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "KA-C11-bannagalu"
+      ],
+      "before": [],
+      "inline": [
+        "KA-EXT-014-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-015",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "KA-C12-kutumba"
+      ],
+      "before": [],
+      "inline": [
+        "KA-EXT-015-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-016",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "KA-C13-dehada-bhagagalu"
+      ],
+      "before": [],
+      "inline": [
+        "KA-EXT-016-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-017",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "KA-C14-kaalagalu"
+      ],
+      "before": [],
+      "inline": [
+        "KA-EXT-017-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-018",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "KA-C15-niiru-akki"
+      ],
+      "before": [],
+      "inline": [
+        "KA-EXT-018-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-019",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "KA-C16-tingalugalu",
+        "KA-C17-madhyaahna-madhyaraatri",
+        "KA-C18-gante"
+      ],
+      "before": [],
+      "inline": [
+        "KA-EXT-019-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-020",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "KA-C19-vayassu"
+      ],
+      "before": [],
+      "inline": [
+        "KA-EXT-020-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-021",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "KA-C20-hannondu-ippattu"
+      ],
+      "before": [],
+      "inline": [
+        "KA-EXT-021-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-022",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "KA-C20-havamana"
+      ],
+      "before": [],
+      "inline": [
+        "KA-EXT-022-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-023",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "KA-C21-naayi-bekku",
+        "KA-C22-hasiru-haladi"
+      ],
+      "before": [],
+      "inline": [
+        "KA-EXT-023-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "KA-PATH-024",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "KA-C23-dina",
+        "KA-C24-ratri",
+        "KA-C25-shubha-ratri",
+        "KA-C26-belagge",
+        "KA-C27-sanje",
+        "KA-C28-aparahna",
+        "KA-C29-shubhodaya",
+        "KA-C30-shubha-sanje",
+        "KA-C31-shubha-madhyahna"
+      ],
+      "before": [],
+      "inline": [
+        "KA-EXT-024-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    }
+  ],
+  "spine": {
+    "SPINE-MEET-GREET": {
+      "segments": [
+        "KA-PATH-001"
+      ],
+      "omits": [
+        "GREETING-FORMAL",
+        "GREETING-PEACE",
+        "GREETING-WELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COURTESY-THANK": {
+      "segments": [
+        "KA-PATH-002",
+        "KA-PATH-008"
+      ],
+      "omits": [
+        "COURTESY-THANKS-CASUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-RESPOND-BASIC": {
+      "segments": [
+        "KA-PATH-003"
+      ],
+      "omits": [
+        "RESPONSE-YESNO"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXCHANGE-NAMES": {
+      "segments": [
+        "KA-PATH-004",
+        "KA-PATH-006",
+        "KA-PATH-010",
+        "KA-PATH-015",
+        "KA-PATH-020"
+      ],
+      "omits": [
+        "PRONOUN-ME",
+        "WORD-IS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-CHECK-WELLBEING": {
+      "segments": [
+        "KA-PATH-005",
+        "KA-PATH-007",
+        "KA-PATH-016"
+      ],
+      "omits": [
+        "WORD-GOOD",
+        "WORD-SOSO"
+      ],
+      "relocates": {}
+    },
+    "SPINE-POLITE-REQUEST-REPAIR": {
+      "segments": [
+        "KA-PATH-012",
+        "KA-PATH-018"
+      ],
+      "omits": [],
+      "relocates": {}
+    },
+    "SPINE-TAKE-LEAVE": {
+      "segments": [
+        "KA-PATH-009"
+      ],
+      "omits": [
+        "FAREWELL-CASUAL",
+        "FAREWELL-SOON"
+      ],
+      "relocates": {
+        "GREETING-GOODNIGHT": "SPINE-TIME-OF-DAY"
+      }
+    },
+    "SPINE-TIME-OF-DAY": {
+      "segments": [
+        "KA-PATH-013",
+        "KA-PATH-017",
+        "KA-PATH-019",
+        "KA-PATH-022",
+        "KA-PATH-024"
+      ],
+      "omits": [
+        "GREETING-DAY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ASK-LOCATION": {
+      "segments": [],
+      "omits": [
+        "QUESTION-WHERE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DEFINITE-REFERENCE": {
+      "segments": [
+        "KA-PATH-014",
+        "KA-PATH-023"
+      ],
+      "omits": [
+        "GRAMMAR-THE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COUNT-ONE-TO-FIVE": {
+      "segments": [
+        "KA-PATH-011",
+        "KA-PATH-021"
+      ],
+      "omits": [
+        "NUMBER-ONE-TO-FIVE"
+      ],
+      "relocates": {}
+    }
+  },
+  "extensions": [
+    {
+      "id": "KA-EXT-009-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Kannada material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "KA-C04-hoogu"
+      ]
+    },
+    {
+      "id": "KA-EXT-010-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Kannada material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "KA-C05-maatanaadu",
+        "KA-C05-iru",
+        "KA-C05-kelasa-maadu",
+        "KA-C05-naanu-kannada-maatanaaduttene",
+        "KA-C06-dative-ge",
+        "KA-C06-dative-subject"
+      ]
+    },
+    {
+      "id": "KA-EXT-010-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "consolidation",
+      "canDo": "I can retrieve and combine the Kannada material introduced in this part of the path.",
+      "prerequisites": [],
+      "lessons": [
+        "KA-C05-practice"
+      ]
+    },
+    {
+      "id": "KA-EXT-010-GRAMMAR",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "grammar",
+      "canDo": "I can use the Kannada-specific grammar needed for this part of the shared ability.",
+      "prerequisites": [],
+      "lessons": [
+        "KA-C06-dative-stacking"
+      ]
+    },
+    {
+      "id": "KA-EXT-011-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Kannada material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "KA-C07-numbers-1-5",
+        "KA-C07-numbers-6-10"
+      ]
+    },
+    {
+      "id": "KA-EXT-013-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Kannada material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "KA-C10-vaara"
+      ]
+    },
+    {
+      "id": "KA-EXT-014-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Kannada material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "KA-C11-bannagalu"
+      ]
+    },
+    {
+      "id": "KA-EXT-015-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Kannada material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "KA-C12-kutumba"
+      ]
+    },
+    {
+      "id": "KA-EXT-016-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Kannada material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "KA-C13-dehada-bhagagalu"
+      ]
+    },
+    {
+      "id": "KA-EXT-017-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Kannada material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "KA-C14-kaalagalu"
+      ]
+    },
+    {
+      "id": "KA-EXT-018-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Kannada material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "KA-C15-niiru-akki"
+      ]
+    },
+    {
+      "id": "KA-EXT-019-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Kannada material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "KA-C16-tingalugalu",
+        "KA-C17-madhyaahna-madhyaraatri",
+        "KA-C18-gante"
+      ]
+    },
+    {
+      "id": "KA-EXT-020-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Kannada material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "KA-C19-vayassu"
+      ]
+    },
+    {
+      "id": "KA-EXT-021-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Kannada material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "KA-C20-hannondu-ippattu"
+      ]
+    },
+    {
+      "id": "KA-EXT-022-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Kannada material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "KA-C20-havamana"
+      ]
+    },
+    {
+      "id": "KA-EXT-023-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Kannada material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "KA-C21-naayi-bekku",
+        "KA-C22-hasiru-haladi"
+      ]
+    },
+    {
+      "id": "KA-EXT-024-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Kannada material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "KA-C25-shubha-ratri"
+      ]
+    },
+    {
+      "id": "KA-EXT-001-INLINE-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can recognize the first Kannada script pattern inside a greeting I already understand.",
+      "prerequisites": [],
+      "lessons": [
+        "KA-C01-namaskara"
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/latin/curriculum.json
+++ b/code/learning/human-languages/latin/curriculum.json
@@ -1,0 +1,667 @@
+{
+  "version": 1,
+  "language": "latin",
+  "path": [
+    {
+      "id": "LA-PATH-001",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "LA-C01-salve",
+        "LA-C01-ave"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-002",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "LA-C01-vale"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-003",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "LA-C01-gratias"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-004",
+      "spine_node": "SPINE-RESPOND-BASIC",
+      "lessons": [
+        "LA-C01-ita-non"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-005",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "LA-C01-practice"
+      ],
+      "before": [],
+      "inline": [
+        "LA-EXT-005-CONSOLIDATION"
+      ],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-006",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "LA-C02-numbers-1-5",
+        "LA-C02-numbers-6-10"
+      ],
+      "before": [],
+      "inline": [
+        "LA-EXT-006-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-007",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "LA-C03-quaeso",
+        "LA-C04-ignosce-mihi"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-008",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "LA-C05-dies-lunae-veneris",
+        "LA-C05-saturni-solis"
+      ],
+      "before": [],
+      "inline": [
+        "LA-EXT-008-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-009",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "LA-C06-niger-albus",
+        "LA-C06-ruber-caeruleus"
+      ],
+      "before": [],
+      "inline": [
+        "LA-EXT-009-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-010",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "LA-C07-pater-mater",
+        "LA-C07-frater-soror"
+      ],
+      "before": [],
+      "inline": [
+        "LA-EXT-010-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-011",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "LA-C08-caput",
+        "LA-C08-manus"
+      ],
+      "before": [],
+      "inline": [
+        "LA-EXT-011-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-012",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "LA-C09-anni-tempora"
+      ],
+      "before": [],
+      "inline": [
+        "LA-EXT-012-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-013",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "LA-C10-aqua-vinum",
+        "LA-C10-panis"
+      ],
+      "before": [],
+      "inline": [
+        "LA-EXT-013-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-014",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "LA-C11-menses",
+        "LA-C12-medius-dies-nox",
+        "LA-C13-hora"
+      ],
+      "before": [],
+      "inline": [
+        "LA-EXT-014-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-015",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "LA-C14-annos-natus"
+      ],
+      "before": [],
+      "inline": [
+        "LA-EXT-015-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-016",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "LA-C15-tempestas-pluit",
+        "LA-C15-weather-verbs"
+      ],
+      "before": [],
+      "inline": [
+        "LA-EXT-016-LANGUAGE-SPECIFIC",
+        "LA-EXT-016-GRAMMAR"
+      ],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-017",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "LA-C16-undecim-viginti"
+      ],
+      "before": [],
+      "inline": [
+        "LA-EXT-017-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-018",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "LA-C17-canis-feles-cattus",
+        "LA-C18-viridis-flavus"
+      ],
+      "before": [],
+      "inline": [
+        "LA-EXT-018-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-019",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "LA-C19-quid-agis",
+        "LA-C19-valeo-family"
+      ],
+      "before": [],
+      "inline": [],
+      "after": [
+        "LA-EXT-019-ETYMOLOGY"
+      ]
+    },
+    {
+      "id": "LA-PATH-020",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "LA-C20-quid-tibi-nomen",
+        "LA-C20-name-case-variation",
+        "LA-C21-volup-est-convenisse",
+        "LA-C21-meeting-phrase-context",
+        "LA-C22-tu-vos"
+      ],
+      "before": [],
+      "inline": [
+        "LA-EXT-020-GRAMMAR",
+        "LA-EXT-020-CULTURE-PRAGMATICS"
+      ],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-021",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "LA-C23-nihil-est"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-022",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "LA-C24-propediem-te-videbo",
+        "LA-C25-cras-te-videbo"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-023",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "LA-C26-quomodo",
+        "LA-C27-bene"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-024",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "LA-C28-dies",
+        "LA-C29-nox",
+        "LA-C30-bonam-noctem",
+        "LA-C31-mane",
+        "LA-C32-bonum-mane",
+        "LA-C33-vesper",
+        "LA-C33-vesper-afterlives",
+        "LA-C34-bonum-vesperum",
+        "LA-C35-meridies",
+        "LA-C36-salve-post-meridiem",
+        "LA-C36-timeless-salve"
+      ],
+      "before": [],
+      "inline": [
+        "LA-EXT-024-LANGUAGE-SPECIFIC",
+        "LA-EXT-024-ETYMOLOGY"
+      ],
+      "after": [
+        "LA-EXT-024-CULTURE-PRAGMATICS"
+      ]
+    }
+  ],
+  "spine": {
+    "SPINE-MEET-GREET": {
+      "segments": [
+        "LA-PATH-001",
+        "LA-PATH-005"
+      ],
+      "omits": [
+        "GREETING-PEACE",
+        "GREETING-WELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COURTESY-THANK": {
+      "segments": [
+        "LA-PATH-003",
+        "LA-PATH-021"
+      ],
+      "omits": [
+        "COURTESY-THANKS-CASUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-RESPOND-BASIC": {
+      "segments": [
+        "LA-PATH-004"
+      ],
+      "omits": [
+        "RESPONSE-YES",
+        "RESPONSE-NO",
+        "RESPONSE-OKAY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXCHANGE-NAMES": {
+      "segments": [
+        "LA-PATH-010",
+        "LA-PATH-015",
+        "LA-PATH-020"
+      ],
+      "omits": [
+        "QUESTION-WHAT",
+        "PRONOUN-I",
+        "PRONOUN-ME",
+        "PRONOUN-MY",
+        "WORD-NAME",
+        "WORD-IS",
+        "INTRO-MY-NAME-IS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-CHECK-WELLBEING": {
+      "segments": [
+        "LA-PATH-011",
+        "LA-PATH-019",
+        "LA-PATH-023"
+      ],
+      "omits": [
+        "WORD-GOOD",
+        "WORD-SOSO"
+      ],
+      "relocates": {}
+    },
+    "SPINE-POLITE-REQUEST-REPAIR": {
+      "segments": [
+        "LA-PATH-007",
+        "LA-PATH-013"
+      ],
+      "omits": [],
+      "relocates": {}
+    },
+    "SPINE-TAKE-LEAVE": {
+      "segments": [
+        "LA-PATH-002",
+        "LA-PATH-022"
+      ],
+      "omits": [
+        "FAREWELL-CASUAL",
+        "FAREWELL-SOON"
+      ],
+      "relocates": {
+        "GREETING-GOODNIGHT": "SPINE-TIME-OF-DAY"
+      }
+    },
+    "SPINE-TIME-OF-DAY": {
+      "segments": [
+        "LA-PATH-008",
+        "LA-PATH-012",
+        "LA-PATH-014",
+        "LA-PATH-016",
+        "LA-PATH-024"
+      ],
+      "omits": [
+        "GREETING-DAY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ASK-LOCATION": {
+      "segments": [],
+      "omits": [
+        "QUESTION-WHERE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DEFINITE-REFERENCE": {
+      "segments": [
+        "LA-PATH-009",
+        "LA-PATH-018"
+      ],
+      "omits": [
+        "GRAMMAR-THE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COUNT-ONE-TO-FIVE": {
+      "segments": [
+        "LA-PATH-006",
+        "LA-PATH-017"
+      ],
+      "omits": [
+        "NUMBER-ONE-TO-FIVE"
+      ],
+      "relocates": {}
+    }
+  },
+  "extensions": [
+    {
+      "id": "LA-EXT-005-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "consolidation",
+      "canDo": "I can retrieve and combine the Latin material introduced in this part of the path.",
+      "prerequisites": [],
+      "lessons": [
+        "LA-C01-practice"
+      ]
+    },
+    {
+      "id": "LA-EXT-006-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Latin material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "LA-C02-numbers-1-5",
+        "LA-C02-numbers-6-10"
+      ]
+    },
+    {
+      "id": "LA-EXT-008-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Latin material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "LA-C05-dies-lunae-veneris",
+        "LA-C05-saturni-solis"
+      ]
+    },
+    {
+      "id": "LA-EXT-009-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Latin material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "LA-C06-niger-albus",
+        "LA-C06-ruber-caeruleus"
+      ]
+    },
+    {
+      "id": "LA-EXT-010-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Latin material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "LA-C07-pater-mater",
+        "LA-C07-frater-soror"
+      ]
+    },
+    {
+      "id": "LA-EXT-011-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Latin material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "LA-C08-caput",
+        "LA-C08-manus"
+      ]
+    },
+    {
+      "id": "LA-EXT-012-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Latin material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "LA-C09-anni-tempora"
+      ]
+    },
+    {
+      "id": "LA-EXT-013-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Latin material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "LA-C10-aqua-vinum",
+        "LA-C10-panis"
+      ]
+    },
+    {
+      "id": "LA-EXT-014-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Latin material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "LA-C11-menses",
+        "LA-C12-medius-dies-nox",
+        "LA-C13-hora"
+      ]
+    },
+    {
+      "id": "LA-EXT-015-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Latin material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "LA-C14-annos-natus"
+      ]
+    },
+    {
+      "id": "LA-EXT-016-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Latin material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "LA-C15-tempestas-pluit"
+      ]
+    },
+    {
+      "id": "LA-EXT-016-GRAMMAR",
+      "stage": "A1",
+      "kind": "required",
+      "category": "grammar",
+      "canDo": "I can use the Latin-specific grammar needed for this part of the shared ability.",
+      "prerequisites": [],
+      "lessons": [
+        "LA-C15-weather-verbs"
+      ]
+    },
+    {
+      "id": "LA-EXT-017-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Latin material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "LA-C16-undecim-viginti"
+      ]
+    },
+    {
+      "id": "LA-EXT-018-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Latin material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "LA-C17-canis-feles-cattus",
+        "LA-C18-viridis-flavus"
+      ]
+    },
+    {
+      "id": "LA-EXT-019-ETYMOLOGY",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can use this Latin word history as a memory hook without confusing origin and current use.",
+      "prerequisites": [],
+      "lessons": [
+        "LA-C19-valeo-family"
+      ]
+    },
+    {
+      "id": "LA-EXT-020-GRAMMAR",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "grammar",
+      "canDo": "I can use the Latin-specific grammar needed for this part of the shared ability.",
+      "prerequisites": [],
+      "lessons": [
+        "LA-C20-name-case-variation"
+      ]
+    },
+    {
+      "id": "LA-EXT-020-CULTURE-PRAGMATICS",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "culture-pragmatics",
+      "canDo": "I can use this Latin expression with the cultural and pragmatic distinction it requires.",
+      "prerequisites": [],
+      "lessons": [
+        "LA-C21-meeting-phrase-context"
+      ]
+    },
+    {
+      "id": "LA-EXT-024-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Latin material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "LA-C30-bonam-noctem"
+      ]
+    },
+    {
+      "id": "LA-EXT-024-ETYMOLOGY",
+      "stage": "A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can use this Latin word history as a memory hook without confusing origin and current use.",
+      "prerequisites": [],
+      "lessons": [
+        "LA-C33-vesper-afterlives"
+      ]
+    },
+    {
+      "id": "LA-EXT-024-CULTURE-PRAGMATICS",
+      "stage": "A1",
+      "kind": "supporting",
+      "category": "culture-pragmatics",
+      "canDo": "I can use this Latin expression with the cultural and pragmatic distinction it requires.",
+      "prerequisites": [],
+      "lessons": [
+        "LA-C36-timeless-salve"
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/malayalam/curriculum.json
+++ b/code/learning/human-languages/malayalam/curriculum.json
@@ -1,0 +1,655 @@
+{
+  "version": 1,
+  "language": "malayalam",
+  "path": [
+    {
+      "id": "ML-PATH-001",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "ML-C01-namaskaram"
+      ],
+      "before": [],
+      "inline": [
+        "ML-EXT-001-INLINE-SCRIPT"
+      ],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-002",
+      "spine_node": "SPINE-RESPOND-BASIC",
+      "lessons": [
+        "ML-C01-athe",
+        "ML-C01-illa"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-003",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "ML-C01-nandi"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-004",
+      "spine_node": "SPINE-RESPOND-BASIC",
+      "lessons": [
+        "ML-C01-sari"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-005",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "ML-C02-peru",
+        "ML-C02-aanu",
+        "ML-C02-enre",
+        "ML-C02-enre-peru-aanu",
+        "ML-C02-nii-ningal",
+        "ML-C02-entu",
+        "ML-C02-ninre-peru-entaanu",
+        "ML-C02-santosham"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-006",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "ML-C03-engane"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-007",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "ML-C03-njaan"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-008",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "ML-C03-saaramilla"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-009",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "ML-C03-sukhamaano",
+        "ML-C03-sukham"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-010",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "ML-C04-pokuka",
+        "ML-C04-poyi-varaam",
+        "ML-C04-naale-kaanaam",
+        "ML-C04-veendum-kaanaam"
+      ],
+      "before": [
+        "ML-EXT-010-LANGUAGE-SPECIFIC"
+      ],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-011",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "ML-C05-samsaarikkuka",
+        "ML-C05-joli-ceyyuka",
+        "ML-C05-njaan-malayalam-samsaarikkunnu",
+        "ML-C05-taamasikkuka",
+        "ML-C05-practice",
+        "ML-C06-dative-ikku",
+        "ML-C06-dative-subject"
+      ],
+      "before": [],
+      "inline": [
+        "ML-EXT-011-LANGUAGE-SPECIFIC",
+        "ML-EXT-011-CONSOLIDATION"
+      ],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-012",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "ML-C07-numbers-1-5",
+        "ML-C07-numbers-6-10"
+      ],
+      "before": [],
+      "inline": [
+        "ML-EXT-012-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-013",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "ML-C08-dayavayi",
+        "ML-C09-kshamikkanam"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-014",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "ML-C10-azhcha"
+      ],
+      "before": [],
+      "inline": [
+        "ML-EXT-014-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-015",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "ML-C11-nirangal"
+      ],
+      "before": [],
+      "inline": [
+        "ML-EXT-015-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-016",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "ML-C12-kudumbam"
+      ],
+      "before": [],
+      "inline": [
+        "ML-EXT-016-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-017",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "ML-C13-shareera-bhaagangal"
+      ],
+      "before": [],
+      "inline": [
+        "ML-EXT-017-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-018",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "ML-C14-kaalangal"
+      ],
+      "before": [],
+      "inline": [
+        "ML-EXT-018-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-019",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "ML-C15-vellam-ari"
+      ],
+      "before": [],
+      "inline": [
+        "ML-EXT-019-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-020",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "ML-C16-kollavarsham-maasangal",
+        "ML-C17-ucha-paathira",
+        "ML-C17-paathira",
+        "ML-C18-mani"
+      ],
+      "before": [],
+      "inline": [
+        "ML-EXT-020-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-021",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "ML-C19-vayassu"
+      ],
+      "before": [],
+      "inline": [
+        "ML-EXT-021-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-022",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "ML-C20-pathinonnu-irupathu"
+      ],
+      "before": [],
+      "inline": [
+        "ML-EXT-022-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-023",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "ML-C20-kalavastha"
+      ],
+      "before": [],
+      "inline": [
+        "ML-EXT-023-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-024",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "ML-C21-naaya-poocha",
+        "ML-C22-paccha-manja"
+      ],
+      "before": [],
+      "inline": [
+        "ML-EXT-024-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ML-PATH-025",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "ML-C23-divasam",
+        "ML-C23-naal",
+        "ML-C24-rathri",
+        "ML-C24-native-night-words",
+        "ML-C25-shubha-rathri",
+        "ML-C26-raavile",
+        "ML-C27-vaikunneram",
+        "ML-C28-uchakazhinju",
+        "ML-C29-suprabhaatham",
+        "ML-C30-shubha-sayaahnam",
+        "ML-C31-shubha-madhyaahnam",
+        "ML-C31-afternoon-convergence"
+      ],
+      "before": [],
+      "inline": [
+        "ML-EXT-025-ETYMOLOGY",
+        "ML-EXT-025-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    }
+  ],
+  "spine": {
+    "SPINE-MEET-GREET": {
+      "segments": [
+        "ML-PATH-001"
+      ],
+      "omits": [
+        "GREETING-FORMAL",
+        "GREETING-PEACE",
+        "GREETING-WELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COURTESY-THANK": {
+      "segments": [
+        "ML-PATH-003",
+        "ML-PATH-008"
+      ],
+      "omits": [
+        "COURTESY-THANKS-CASUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-RESPOND-BASIC": {
+      "segments": [
+        "ML-PATH-002",
+        "ML-PATH-004"
+      ],
+      "omits": [
+        "RESPONSE-YESNO"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXCHANGE-NAMES": {
+      "segments": [
+        "ML-PATH-005",
+        "ML-PATH-007",
+        "ML-PATH-011",
+        "ML-PATH-016",
+        "ML-PATH-021"
+      ],
+      "omits": [
+        "PRONOUN-ME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-CHECK-WELLBEING": {
+      "segments": [
+        "ML-PATH-006",
+        "ML-PATH-009",
+        "ML-PATH-017"
+      ],
+      "omits": [
+        "WORD-GOOD",
+        "WORD-SOSO"
+      ],
+      "relocates": {}
+    },
+    "SPINE-POLITE-REQUEST-REPAIR": {
+      "segments": [
+        "ML-PATH-013",
+        "ML-PATH-019"
+      ],
+      "omits": [],
+      "relocates": {}
+    },
+    "SPINE-TAKE-LEAVE": {
+      "segments": [
+        "ML-PATH-010"
+      ],
+      "omits": [
+        "FAREWELL-CASUAL",
+        "FAREWELL-SOON"
+      ],
+      "relocates": {
+        "GREETING-GOODNIGHT": "SPINE-TIME-OF-DAY"
+      }
+    },
+    "SPINE-TIME-OF-DAY": {
+      "segments": [
+        "ML-PATH-014",
+        "ML-PATH-018",
+        "ML-PATH-020",
+        "ML-PATH-023",
+        "ML-PATH-025"
+      ],
+      "omits": [
+        "GREETING-DAY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ASK-LOCATION": {
+      "segments": [],
+      "omits": [
+        "QUESTION-WHERE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DEFINITE-REFERENCE": {
+      "segments": [
+        "ML-PATH-015",
+        "ML-PATH-024"
+      ],
+      "omits": [
+        "GRAMMAR-THE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COUNT-ONE-TO-FIVE": {
+      "segments": [
+        "ML-PATH-012",
+        "ML-PATH-022"
+      ],
+      "omits": [
+        "NUMBER-ONE-TO-FIVE"
+      ],
+      "relocates": {}
+    }
+  },
+  "extensions": [
+    {
+      "id": "ML-EXT-010-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Malayalam material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ML-C04-pokuka"
+      ]
+    },
+    {
+      "id": "ML-EXT-011-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Malayalam material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ML-C05-samsaarikkuka",
+        "ML-C05-joli-ceyyuka",
+        "ML-C05-njaan-malayalam-samsaarikkunnu",
+        "ML-C05-taamasikkuka",
+        "ML-C06-dative-ikku",
+        "ML-C06-dative-subject"
+      ]
+    },
+    {
+      "id": "ML-EXT-011-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "consolidation",
+      "canDo": "I can retrieve and combine the Malayalam material introduced in this part of the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ML-C05-practice"
+      ]
+    },
+    {
+      "id": "ML-EXT-012-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Malayalam material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ML-C07-numbers-1-5",
+        "ML-C07-numbers-6-10"
+      ]
+    },
+    {
+      "id": "ML-EXT-014-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Malayalam material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ML-C10-azhcha"
+      ]
+    },
+    {
+      "id": "ML-EXT-015-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Malayalam material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ML-C11-nirangal"
+      ]
+    },
+    {
+      "id": "ML-EXT-016-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Malayalam material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ML-C12-kudumbam"
+      ]
+    },
+    {
+      "id": "ML-EXT-017-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Malayalam material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ML-C13-shareera-bhaagangal"
+      ]
+    },
+    {
+      "id": "ML-EXT-018-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Malayalam material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ML-C14-kaalangal"
+      ]
+    },
+    {
+      "id": "ML-EXT-019-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Malayalam material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ML-C15-vellam-ari"
+      ]
+    },
+    {
+      "id": "ML-EXT-020-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Malayalam material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ML-C16-kollavarsham-maasangal",
+        "ML-C17-ucha-paathira",
+        "ML-C17-paathira",
+        "ML-C18-mani"
+      ]
+    },
+    {
+      "id": "ML-EXT-021-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Malayalam material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ML-C19-vayassu"
+      ]
+    },
+    {
+      "id": "ML-EXT-022-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Malayalam material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ML-C20-pathinonnu-irupathu"
+      ]
+    },
+    {
+      "id": "ML-EXT-023-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Malayalam material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ML-C20-kalavastha"
+      ]
+    },
+    {
+      "id": "ML-EXT-024-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Malayalam material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ML-C21-naaya-poocha",
+        "ML-C22-paccha-manja"
+      ]
+    },
+    {
+      "id": "ML-EXT-025-ETYMOLOGY",
+      "stage": "A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can use this Malayalam word history as a memory hook without confusing origin and current use.",
+      "prerequisites": [],
+      "lessons": [
+        "ML-C23-naal",
+        "ML-C24-native-night-words",
+        "ML-C31-afternoon-convergence"
+      ]
+    },
+    {
+      "id": "ML-EXT-025-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Malayalam material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ML-C25-shubha-rathri"
+      ]
+    },
+    {
+      "id": "ML-EXT-001-INLINE-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can recognize the first Malayalam script pattern inside a greeting I already understand.",
+      "prerequisites": [],
+      "lessons": [
+        "ML-C01-namaskaram"
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/marathi/curriculum.json
+++ b/code/learning/human-languages/marathi/curriculum.json
@@ -1,0 +1,295 @@
+{
+  "version": 1,
+  "language": "marathi",
+  "path": [
+    {
+      "id": "MR-PATH-001",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "MR-C01-namaskar"
+      ],
+      "before": [],
+      "inline": [
+        "MR-EXT-001-INLINE-SCRIPT"
+      ],
+      "after": []
+    },
+    {
+      "id": "MR-PATH-002",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "MR-C01-dhanyavad"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "MR-PATH-003",
+      "spine_node": "SPINE-RESPOND-BASIC",
+      "lessons": [
+        "MR-C01-ho",
+        "MR-C01-baram",
+        "MR-C01-nahi"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "MR-PATH-004",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "MR-C01-yeto"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "MR-PATH-005",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "MR-C02-naav",
+        "MR-C02-majhe",
+        "MR-C02-aahe",
+        "MR-C02-majhe-naav-aahe",
+        "MR-C02-tu-tumhi",
+        "MR-C02-kaay",
+        "MR-C02-tumche-naav-kaay-aahe",
+        "MR-C02-anand"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "MR-PATH-006",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "MR-C03-kasa",
+        "MR-C03-tumhi-kase-aahat"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "MR-PATH-007",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "MR-C03-mi"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "MR-PATH-008",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "MR-C03-mi-bara-aahe"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "MR-PATH-009",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "MR-C03-kaahi-harkat-nahi"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "MR-PATH-010",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "MR-C04-punha",
+        "MR-C04-bhetu",
+        "MR-C04-punha-bhetu",
+        "MR-C04-udya-bhetu"
+      ],
+      "before": [
+        "MR-EXT-010-LANGUAGE-SPECIFIC"
+      ],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "MR-PATH-011",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "MR-C06-numbers-1-5",
+        "MR-C06-number-differences"
+      ],
+      "before": [],
+      "inline": [
+        "MR-EXT-011-LANGUAGE-SPECIFIC",
+        "MR-EXT-011-ETYMOLOGY"
+      ],
+      "after": []
+    }
+  ],
+  "spine": {
+    "SPINE-MEET-GREET": {
+      "segments": [
+        "MR-PATH-001"
+      ],
+      "omits": [
+        "GREETING-FORMAL",
+        "GREETING-PEACE",
+        "GREETING-WELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COURTESY-THANK": {
+      "segments": [
+        "MR-PATH-002",
+        "MR-PATH-009"
+      ],
+      "omits": [
+        "COURTESY-THANKS-CASUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-RESPOND-BASIC": {
+      "segments": [
+        "MR-PATH-003"
+      ],
+      "omits": [
+        "RESPONSE-YESNO"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXCHANGE-NAMES": {
+      "segments": [
+        "MR-PATH-005",
+        "MR-PATH-007"
+      ],
+      "omits": [
+        "PRONOUN-ME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-CHECK-WELLBEING": {
+      "segments": [
+        "MR-PATH-006",
+        "MR-PATH-008"
+      ],
+      "omits": [
+        "WORD-GOOD",
+        "WORD-SOSO"
+      ],
+      "relocates": {}
+    },
+    "SPINE-POLITE-REQUEST-REPAIR": {
+      "segments": [],
+      "omits": [
+        "COURTESY-PLEASE",
+        "COURTESY-SORRY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TAKE-LEAVE": {
+      "segments": [
+        "MR-PATH-004",
+        "MR-PATH-010"
+      ],
+      "omits": [
+        "FAREWELL-CASUAL",
+        "FAREWELL-SOON",
+        "GREETING-GOODNIGHT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TIME-OF-DAY": {
+      "segments": [],
+      "omits": [
+        "TIME-DAY",
+        "TIME-MORNING",
+        "TIME-AFTERNOON",
+        "TIME-EVENING",
+        "TIME-NIGHT",
+        "GREETING-DAY",
+        "GREETING-MORNING",
+        "GREETING-AFTERNOON",
+        "GREETING-EVENING"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ASK-LOCATION": {
+      "segments": [],
+      "omits": [
+        "QUESTION-WHERE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DEFINITE-REFERENCE": {
+      "segments": [],
+      "omits": [
+        "GRAMMAR-THE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COUNT-ONE-TO-FIVE": {
+      "segments": [
+        "MR-PATH-011"
+      ],
+      "omits": [
+        "NUMBER-ONE-TO-FIVE"
+      ],
+      "relocates": {}
+    }
+  },
+  "extensions": [
+    {
+      "id": "MR-EXT-010-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Marathi material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "MR-C04-punha",
+        "MR-C04-bhetu"
+      ]
+    },
+    {
+      "id": "MR-EXT-011-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Marathi material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "MR-C06-numbers-1-5"
+      ]
+    },
+    {
+      "id": "MR-EXT-011-ETYMOLOGY",
+      "stage": "A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can use this Marathi word history as a memory hook without confusing origin and current use.",
+      "prerequisites": [],
+      "lessons": [
+        "MR-C06-number-differences"
+      ]
+    },
+    {
+      "id": "MR-EXT-001-INLINE-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can recognize the first Marathi script pattern inside a greeting I already understand.",
+      "prerequisites": [],
+      "lessons": [
+        "MR-C01-namaskar"
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/persian/curriculum.json
+++ b/code/learning/human-languages/persian/curriculum.json
@@ -1,0 +1,179 @@
+{
+  "version": 1,
+  "language": "persian",
+  "path": [
+    {
+      "id": "FA-PATH-001",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "FA-C01-salam"
+      ],
+      "before": [],
+      "inline": [
+        "FA-EXT-001-INLINE-SCRIPT"
+      ],
+      "after": []
+    },
+    {
+      "id": "FA-PATH-002",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "FA-C01-mamnoon"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "FA-PATH-003",
+      "spine_node": "SPINE-RESPOND-BASIC",
+      "lessons": [
+        "FA-C01-bale",
+        "FA-C01-na"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "FA-PATH-004",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "FA-C02-esm-e-man"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    }
+  ],
+  "spine": {
+    "SPINE-MEET-GREET": {
+      "segments": [
+        "FA-PATH-001"
+      ],
+      "omits": [
+        "GREETING-FORMAL",
+        "GREETING-PEACE",
+        "GREETING-WELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COURTESY-THANK": {
+      "segments": [
+        "FA-PATH-002"
+      ],
+      "omits": [
+        "COURTESY-THANKS-CASUAL",
+        "COURTESY-YOUREWELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-RESPOND-BASIC": {
+      "segments": [
+        "FA-PATH-003"
+      ],
+      "omits": [
+        "RESPONSE-YESNO",
+        "RESPONSE-OKAY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXCHANGE-NAMES": {
+      "segments": [
+        "FA-PATH-004"
+      ],
+      "omits": [
+        "QUESTION-WHAT",
+        "PRONOUN-I",
+        "PRONOUN-ME",
+        "PRONOUN-YOU",
+        "PRONOUN-MY",
+        "WORD-NAME",
+        "WORD-IS",
+        "INTRO-WHATS-YOUR-NAME",
+        "INTRO-NICE-TO-MEET-YOU"
+      ],
+      "relocates": {}
+    },
+    "SPINE-CHECK-WELLBEING": {
+      "segments": [],
+      "omits": [
+        "QUESTION-HOW",
+        "STATE-HOW-ARE-YOU",
+        "WORD-GOOD",
+        "WORD-WELL",
+        "WORD-SOSO"
+      ],
+      "relocates": {}
+    },
+    "SPINE-POLITE-REQUEST-REPAIR": {
+      "segments": [],
+      "omits": [
+        "COURTESY-PLEASE",
+        "COURTESY-SORRY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TAKE-LEAVE": {
+      "segments": [],
+      "omits": [
+        "FAREWELL",
+        "FAREWELL-CASUAL",
+        "FAREWELL-LATER",
+        "FAREWELL-SOON",
+        "FAREWELL-TOMORROW",
+        "GREETING-GOODNIGHT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TIME-OF-DAY": {
+      "segments": [],
+      "omits": [
+        "TIME-DAY",
+        "TIME-MORNING",
+        "TIME-AFTERNOON",
+        "TIME-EVENING",
+        "TIME-NIGHT",
+        "GREETING-DAY",
+        "GREETING-MORNING",
+        "GREETING-AFTERNOON",
+        "GREETING-EVENING"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ASK-LOCATION": {
+      "segments": [],
+      "omits": [
+        "QUESTION-WHERE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DEFINITE-REFERENCE": {
+      "segments": [],
+      "omits": [
+        "GRAMMAR-THE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COUNT-ONE-TO-FIVE": {
+      "segments": [],
+      "omits": [
+        "NUMBER-ONE-TO-FIVE"
+      ],
+      "relocates": {}
+    }
+  },
+  "extensions": [
+    {
+      "id": "FA-EXT-001-INLINE-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can recognize the first Persian script pattern inside a greeting I already understand.",
+      "prerequisites": [],
+      "lessons": [
+        "FA-C01-salam"
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/portuguese/curriculum.json
+++ b/code/learning/human-languages/portuguese/curriculum.json
@@ -1,0 +1,640 @@
+{
+  "version": 1,
+  "language": "portuguese",
+  "path": [
+    {
+      "id": "PT-PATH-001",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "PT-C01-ola"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "PT-PATH-002",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "PT-C01-bom"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "PT-PATH-003",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "PT-C01-o-a"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "PT-PATH-004",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "PT-C01-dia",
+        "PT-C01-bom-dia"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "PT-PATH-005",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "PT-C01-obrigado"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "PT-PATH-006",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "PT-C01-tarde"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "PT-PATH-007",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "PT-C01-noite"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "PT-PATH-008",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "PT-C02-de-nada"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "PT-PATH-009",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "PT-C02-como",
+        "PT-C02-tudo",
+        "PT-C02-tudo-bem",
+        "PT-C02-como-vai-esta",
+        "PT-C02-mais-ou-menos",
+        "PT-C02-practice",
+        "PT-C02-formal-practice"
+      ],
+      "before": [],
+      "inline": [
+        "PT-EXT-009-LANGUAGE-SPECIFIC"
+      ],
+      "after": [
+        "PT-EXT-009-CONSOLIDATION",
+        "PT-EXT-009-REGISTER"
+      ]
+    },
+    {
+      "id": "PT-PATH-010",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "PT-C03-eu",
+        "PT-C03-me-chamo",
+        "PT-C03-como-se-chama",
+        "PT-C03-prazer",
+        "PT-C03-practice"
+      ],
+      "before": [],
+      "inline": [],
+      "after": [
+        "PT-EXT-010-CONSOLIDATION"
+      ]
+    },
+    {
+      "id": "PT-PATH-011",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "PT-C04-adeus",
+        "PT-C04-ate-logo",
+        "PT-C04-ate-amanha",
+        "PT-C04-ate-breve",
+        "PT-C04-practice"
+      ],
+      "before": [],
+      "inline": [],
+      "after": [
+        "PT-EXT-011-CONSOLIDATION"
+      ]
+    },
+    {
+      "id": "PT-PATH-012",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "PT-C05-falar",
+        "PT-C05-morar",
+        "PT-C05-trabalhar",
+        "PT-C05-falo-portugues",
+        "PT-C05-practice"
+      ],
+      "before": [],
+      "inline": [
+        "PT-EXT-012-LANGUAGE-SPECIFIC",
+        "PT-EXT-012-CONSOLIDATION"
+      ],
+      "after": []
+    },
+    {
+      "id": "PT-PATH-013",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "PT-C06-numeros-1-5",
+        "PT-C06-numeros-6-10"
+      ],
+      "before": [],
+      "inline": [
+        "PT-EXT-013-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "PT-PATH-014",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "PT-C07-dias-1",
+        "PT-C07-dias-2",
+        "PT-C08-hora",
+        "PT-C08-meio-dia-meia-noite",
+        "PT-C09-meses",
+        "PT-C09-estacoes"
+      ],
+      "before": [],
+      "inline": [
+        "PT-EXT-014-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "PT-PATH-015",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "PT-C10-pais",
+        "PT-C10-irmaos"
+      ],
+      "before": [],
+      "inline": [
+        "PT-EXT-015-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "PT-PATH-016",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "PT-C11-pao",
+        "PT-C11-agua-vinho"
+      ],
+      "before": [],
+      "inline": [
+        "PT-EXT-016-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "PT-PATH-017",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "PT-C12-numeros-11-15",
+        "PT-C12-numeros-16-20"
+      ],
+      "before": [],
+      "inline": [
+        "PT-EXT-017-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "PT-PATH-018",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "PT-C13-preto-branco",
+        "PT-C13-vermelho-azul"
+      ],
+      "before": [],
+      "inline": [
+        "PT-EXT-018-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "PT-PATH-019",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "PT-C14-ter",
+        "PT-C14-idade",
+        "PT-C15-preterito-perfeito",
+        "PT-C15-tenho-falado"
+      ],
+      "before": [],
+      "inline": [
+        "PT-EXT-019-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "PT-PATH-020",
+      "spine_node": "SPINE-ASK-LOCATION",
+      "lessons": [
+        "PT-C16-ser",
+        "PT-C16-ser-roots",
+        "PT-C16-ser-vs-estar",
+        "PT-C16-ser-estar-meaning"
+      ],
+      "before": [],
+      "inline": [
+        "PT-EXT-020-LANGUAGE-SPECIFIC",
+        "PT-EXT-020-ETYMOLOGY",
+        "PT-EXT-020-GRAMMAR"
+      ],
+      "after": []
+    },
+    {
+      "id": "PT-PATH-021",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "PT-C17-cabeca",
+        "PT-C17-cabeca-caput",
+        "PT-C17-mao"
+      ],
+      "before": [],
+      "inline": [
+        "PT-EXT-021-LANGUAGE-SPECIFIC",
+        "PT-EXT-021-ETYMOLOGY"
+      ],
+      "after": []
+    }
+  ],
+  "spine": {
+    "SPINE-MEET-GREET": {
+      "segments": [
+        "PT-PATH-001"
+      ],
+      "omits": [
+        "GREETING-FORMAL",
+        "GREETING-PEACE",
+        "GREETING-WELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COURTESY-THANK": {
+      "segments": [
+        "PT-PATH-005",
+        "PT-PATH-008"
+      ],
+      "omits": [
+        "COURTESY-THANKS-CASUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-RESPOND-BASIC": {
+      "segments": [],
+      "omits": [
+        "RESPONSE-YES",
+        "RESPONSE-NO",
+        "RESPONSE-YESNO",
+        "RESPONSE-OKAY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXCHANGE-NAMES": {
+      "segments": [
+        "PT-PATH-010",
+        "PT-PATH-015",
+        "PT-PATH-019"
+      ],
+      "omits": [
+        "QUESTION-WHAT",
+        "PRONOUN-ME",
+        "PRONOUN-YOU",
+        "PRONOUN-MY",
+        "WORD-NAME",
+        "WORD-IS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-CHECK-WELLBEING": {
+      "segments": [
+        "PT-PATH-002",
+        "PT-PATH-009",
+        "PT-PATH-021"
+      ],
+      "omits": [
+        "WORD-WELL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-POLITE-REQUEST-REPAIR": {
+      "segments": [
+        "PT-PATH-012",
+        "PT-PATH-016"
+      ],
+      "omits": [
+        "COURTESY-PLEASE",
+        "COURTESY-SORRY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TAKE-LEAVE": {
+      "segments": [
+        "PT-PATH-007",
+        "PT-PATH-011"
+      ],
+      "omits": [
+        "FAREWELL-CASUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TIME-OF-DAY": {
+      "segments": [
+        "PT-PATH-004",
+        "PT-PATH-006",
+        "PT-PATH-014"
+      ],
+      "omits": [
+        "TIME-MORNING",
+        "TIME-AFTERNOON",
+        "TIME-EVENING",
+        "TIME-NIGHT",
+        "GREETING-MORNING",
+        "GREETING-EVENING"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ASK-LOCATION": {
+      "segments": [
+        "PT-PATH-020"
+      ],
+      "omits": [
+        "QUESTION-WHERE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DEFINITE-REFERENCE": {
+      "segments": [
+        "PT-PATH-003",
+        "PT-PATH-018"
+      ],
+      "omits": [],
+      "relocates": {}
+    },
+    "SPINE-COUNT-ONE-TO-FIVE": {
+      "segments": [
+        "PT-PATH-013",
+        "PT-PATH-017"
+      ],
+      "omits": [
+        "NUMBER-ONE-TO-FIVE"
+      ],
+      "relocates": {}
+    }
+  },
+  "extensions": [
+    {
+      "id": "PT-EXT-009-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Portuguese material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "PT-C02-tudo",
+        "PT-C02-como-vai-esta"
+      ]
+    },
+    {
+      "id": "PT-EXT-009-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "consolidation",
+      "canDo": "I can retrieve and combine the Portuguese material introduced in this part of the path.",
+      "prerequisites": [],
+      "lessons": [
+        "PT-C02-practice"
+      ]
+    },
+    {
+      "id": "PT-EXT-009-REGISTER",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "register",
+      "canDo": "I can choose the Portuguese form that fits this relationship and setting.",
+      "prerequisites": [],
+      "lessons": [
+        "PT-C02-formal-practice"
+      ]
+    },
+    {
+      "id": "PT-EXT-010-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "consolidation",
+      "canDo": "I can retrieve and combine the Portuguese material introduced in this part of the path.",
+      "prerequisites": [],
+      "lessons": [
+        "PT-C03-practice"
+      ]
+    },
+    {
+      "id": "PT-EXT-011-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "consolidation",
+      "canDo": "I can retrieve and combine the Portuguese material introduced in this part of the path.",
+      "prerequisites": [],
+      "lessons": [
+        "PT-C04-practice"
+      ]
+    },
+    {
+      "id": "PT-EXT-012-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Portuguese material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "PT-C05-falar",
+        "PT-C05-morar",
+        "PT-C05-trabalhar",
+        "PT-C05-falo-portugues"
+      ]
+    },
+    {
+      "id": "PT-EXT-012-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "consolidation",
+      "canDo": "I can retrieve and combine the Portuguese material introduced in this part of the path.",
+      "prerequisites": [],
+      "lessons": [
+        "PT-C05-practice"
+      ]
+    },
+    {
+      "id": "PT-EXT-013-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Portuguese material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "PT-C06-numeros-1-5",
+        "PT-C06-numeros-6-10"
+      ]
+    },
+    {
+      "id": "PT-EXT-014-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Portuguese material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "PT-C07-dias-1",
+        "PT-C07-dias-2",
+        "PT-C08-hora",
+        "PT-C08-meio-dia-meia-noite",
+        "PT-C09-meses",
+        "PT-C09-estacoes"
+      ]
+    },
+    {
+      "id": "PT-EXT-015-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Portuguese material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "PT-C10-pais",
+        "PT-C10-irmaos"
+      ]
+    },
+    {
+      "id": "PT-EXT-016-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Portuguese material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "PT-C11-pao",
+        "PT-C11-agua-vinho"
+      ]
+    },
+    {
+      "id": "PT-EXT-017-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Portuguese material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "PT-C12-numeros-11-15",
+        "PT-C12-numeros-16-20"
+      ]
+    },
+    {
+      "id": "PT-EXT-018-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Portuguese material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "PT-C13-preto-branco",
+        "PT-C13-vermelho-azul"
+      ]
+    },
+    {
+      "id": "PT-EXT-019-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Portuguese material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "PT-C14-ter",
+        "PT-C14-idade",
+        "PT-C15-preterito-perfeito",
+        "PT-C15-tenho-falado"
+      ]
+    },
+    {
+      "id": "PT-EXT-020-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Portuguese material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "PT-C16-ser",
+        "PT-C16-ser-vs-estar"
+      ]
+    },
+    {
+      "id": "PT-EXT-020-ETYMOLOGY",
+      "stage": "A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can use this Portuguese word history as a memory hook without confusing origin and current use.",
+      "prerequisites": [],
+      "lessons": [
+        "PT-C16-ser-roots"
+      ]
+    },
+    {
+      "id": "PT-EXT-020-GRAMMAR",
+      "stage": "A1",
+      "kind": "required",
+      "category": "grammar",
+      "canDo": "I can use the Portuguese-specific grammar needed for this part of the shared ability.",
+      "prerequisites": [],
+      "lessons": [
+        "PT-C16-ser-estar-meaning"
+      ]
+    },
+    {
+      "id": "PT-EXT-021-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Portuguese material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "PT-C17-cabeca",
+        "PT-C17-mao"
+      ]
+    },
+    {
+      "id": "PT-EXT-021-ETYMOLOGY",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can use this Portuguese word history as a memory hook without confusing origin and current use.",
+      "prerequisites": [],
+      "lessons": [
+        "PT-C17-cabeca-caput"
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/punjabi/curriculum.json
+++ b/code/learning/human-languages/punjabi/curriculum.json
@@ -1,0 +1,288 @@
+{
+  "version": 1,
+  "language": "punjabi",
+  "path": [
+    {
+      "id": "PA-PATH-001",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "PA-C01-sat-sri-akal",
+        "PA-C01-namaste"
+      ],
+      "before": [],
+      "inline": [
+        "PA-EXT-001-INLINE-SCRIPT"
+      ],
+      "after": []
+    },
+    {
+      "id": "PA-PATH-002",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "PA-C01-dhanvaad",
+        "PA-C01-shukriya"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "PA-PATH-003",
+      "spine_node": "SPINE-RESPOND-BASIC",
+      "lessons": [
+        "PA-C01-han-nahin"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "PA-PATH-004",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "PA-C02-naam",
+        "PA-C02-hai",
+        "PA-C02-ki",
+        "PA-C02-mera",
+        "PA-C02-mera-naam-hai",
+        "PA-C02-khushi",
+        "PA-C02-tu-tusi",
+        "PA-C02-tuhada-naam-ki-hai"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "PA-PATH-005",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "PA-C03-kivein"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "PA-PATH-006",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "PA-C03-koi-gall-nahin"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "PA-PATH-007",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "PA-C03-main"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "PA-PATH-008",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "PA-C03-thik",
+        "PA-C03-tusi-kivein-ho"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "PA-PATH-009",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "PA-C04-milaange",
+        "PA-C04-phir",
+        "PA-C04-phir-milaange",
+        "PA-C04-rab-raakha"
+      ],
+      "before": [
+        "PA-EXT-009-LANGUAGE-SPECIFIC"
+      ],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "PA-PATH-010",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "PA-C05-bolna",
+        "PA-C05-main-punjabi-bolda-han",
+        "PA-C06-numbers-1-5",
+        "PA-C06-panj-convergence"
+      ],
+      "before": [],
+      "inline": [
+        "PA-EXT-010-LANGUAGE-SPECIFIC",
+        "PA-EXT-010-ETYMOLOGY"
+      ],
+      "after": []
+    }
+  ],
+  "spine": {
+    "SPINE-MEET-GREET": {
+      "segments": [
+        "PA-PATH-001"
+      ],
+      "omits": [
+        "GREETING-PEACE",
+        "GREETING-WELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COURTESY-THANK": {
+      "segments": [
+        "PA-PATH-002",
+        "PA-PATH-006"
+      ],
+      "omits": [],
+      "relocates": {}
+    },
+    "SPINE-RESPOND-BASIC": {
+      "segments": [
+        "PA-PATH-003"
+      ],
+      "omits": [
+        "RESPONSE-YES",
+        "RESPONSE-NO",
+        "RESPONSE-OKAY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXCHANGE-NAMES": {
+      "segments": [
+        "PA-PATH-004",
+        "PA-PATH-007"
+      ],
+      "omits": [
+        "PRONOUN-ME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-CHECK-WELLBEING": {
+      "segments": [
+        "PA-PATH-005",
+        "PA-PATH-008"
+      ],
+      "omits": [
+        "WORD-GOOD",
+        "WORD-SOSO"
+      ],
+      "relocates": {}
+    },
+    "SPINE-POLITE-REQUEST-REPAIR": {
+      "segments": [],
+      "omits": [
+        "COURTESY-PLEASE",
+        "COURTESY-SORRY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TAKE-LEAVE": {
+      "segments": [
+        "PA-PATH-009"
+      ],
+      "omits": [
+        "FAREWELL-CASUAL",
+        "FAREWELL-SOON",
+        "FAREWELL-TOMORROW",
+        "GREETING-GOODNIGHT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TIME-OF-DAY": {
+      "segments": [],
+      "omits": [
+        "TIME-DAY",
+        "TIME-MORNING",
+        "TIME-AFTERNOON",
+        "TIME-EVENING",
+        "TIME-NIGHT",
+        "GREETING-DAY",
+        "GREETING-MORNING",
+        "GREETING-AFTERNOON",
+        "GREETING-EVENING"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ASK-LOCATION": {
+      "segments": [],
+      "omits": [
+        "QUESTION-WHERE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DEFINITE-REFERENCE": {
+      "segments": [],
+      "omits": [
+        "GRAMMAR-THE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COUNT-ONE-TO-FIVE": {
+      "segments": [
+        "PA-PATH-010"
+      ],
+      "omits": [
+        "NUMBER-ONE-TO-FIVE"
+      ],
+      "relocates": {}
+    }
+  },
+  "extensions": [
+    {
+      "id": "PA-EXT-009-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Punjabi material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "PA-C04-milaange",
+        "PA-C04-phir"
+      ]
+    },
+    {
+      "id": "PA-EXT-010-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Punjabi material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "PA-C05-bolna",
+        "PA-C05-main-punjabi-bolda-han",
+        "PA-C06-numbers-1-5"
+      ]
+    },
+    {
+      "id": "PA-EXT-010-ETYMOLOGY",
+      "stage": "A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can use this Punjabi word history as a memory hook without confusing origin and current use.",
+      "prerequisites": [],
+      "lessons": [
+        "PA-C06-panj-convergence"
+      ]
+    },
+    {
+      "id": "PA-EXT-001-INLINE-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can recognize the first Punjabi script pattern inside a greeting I already understand.",
+      "prerequisites": [],
+      "lessons": [
+        "PA-C01-sat-sri-akal"
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/russian/curriculum.json
+++ b/code/learning/human-languages/russian/curriculum.json
@@ -1,0 +1,227 @@
+{
+  "version": 1,
+  "language": "russian",
+  "path": [
+    {
+      "id": "RU-PATH-001",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "RU-C01-privet"
+      ],
+      "before": [],
+      "inline": [
+        "RU-EXT-001-INLINE-SCRIPT"
+      ],
+      "after": []
+    },
+    {
+      "id": "RU-PATH-002",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "RU-C01-spasibo"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "RU-PATH-003",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "RU-C01-pozhaluysta"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "RU-PATH-004",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "RU-C01-zdravstvuyte"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "RU-PATH-005",
+      "spine_node": "SPINE-RESPOND-BASIC",
+      "lessons": [
+        "RU-C01-da",
+        "RU-C01-net"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "RU-PATH-006",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "RU-C02-ya",
+        "RU-C02-ty-vy",
+        "RU-C02-vy-formality",
+        "RU-C02-menya-zovut",
+        "RU-C02-kak-vas-zovut",
+        "RU-C02-kak-cross-language",
+        "RU-C02-ochen-priyatno"
+      ],
+      "before": [],
+      "inline": [
+        "RU-EXT-006-REGISTER",
+        "RU-EXT-006-GRAMMAR"
+      ],
+      "after": []
+    }
+  ],
+  "spine": {
+    "SPINE-MEET-GREET": {
+      "segments": [
+        "RU-PATH-001",
+        "RU-PATH-004"
+      ],
+      "omits": [
+        "GREETING-PEACE",
+        "GREETING-WELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COURTESY-THANK": {
+      "segments": [
+        "RU-PATH-002"
+      ],
+      "omits": [
+        "COURTESY-THANKS-CASUAL",
+        "COURTESY-YOUREWELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-RESPOND-BASIC": {
+      "segments": [
+        "RU-PATH-005"
+      ],
+      "omits": [
+        "RESPONSE-YESNO",
+        "RESPONSE-OKAY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXCHANGE-NAMES": {
+      "segments": [
+        "RU-PATH-006"
+      ],
+      "omits": [
+        "QUESTION-WHAT",
+        "PRONOUN-ME",
+        "PRONOUN-MY",
+        "WORD-NAME",
+        "WORD-IS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-CHECK-WELLBEING": {
+      "segments": [],
+      "omits": [
+        "QUESTION-HOW",
+        "STATE-HOW-ARE-YOU",
+        "WORD-GOOD",
+        "WORD-WELL",
+        "WORD-SOSO"
+      ],
+      "relocates": {}
+    },
+    "SPINE-POLITE-REQUEST-REPAIR": {
+      "segments": [
+        "RU-PATH-003"
+      ],
+      "omits": [
+        "COURTESY-SORRY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TAKE-LEAVE": {
+      "segments": [],
+      "omits": [
+        "FAREWELL",
+        "FAREWELL-CASUAL",
+        "FAREWELL-LATER",
+        "FAREWELL-SOON",
+        "FAREWELL-TOMORROW",
+        "GREETING-GOODNIGHT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TIME-OF-DAY": {
+      "segments": [],
+      "omits": [
+        "TIME-DAY",
+        "TIME-MORNING",
+        "TIME-AFTERNOON",
+        "TIME-EVENING",
+        "TIME-NIGHT",
+        "GREETING-DAY",
+        "GREETING-MORNING",
+        "GREETING-AFTERNOON",
+        "GREETING-EVENING"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ASK-LOCATION": {
+      "segments": [],
+      "omits": [
+        "QUESTION-WHERE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DEFINITE-REFERENCE": {
+      "segments": [],
+      "omits": [
+        "GRAMMAR-THE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COUNT-ONE-TO-FIVE": {
+      "segments": [],
+      "omits": [
+        "NUMBER-ONE-TO-FIVE"
+      ],
+      "relocates": {}
+    }
+  },
+  "extensions": [
+    {
+      "id": "RU-EXT-006-REGISTER",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "register",
+      "canDo": "I can choose the Russian form that fits this relationship and setting.",
+      "prerequisites": [],
+      "lessons": [
+        "RU-C02-vy-formality"
+      ]
+    },
+    {
+      "id": "RU-EXT-006-GRAMMAR",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "grammar",
+      "canDo": "I can use the Russian-specific grammar needed for this part of the shared ability.",
+      "prerequisites": [],
+      "lessons": [
+        "RU-C02-kak-cross-language"
+      ]
+    },
+    {
+      "id": "RU-EXT-001-INLINE-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can recognize the first Russian script pattern inside a greeting I already understand.",
+      "prerequisites": [],
+      "lessons": [
+        "RU-C01-privet"
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/sanskrit/curriculum.json
+++ b/code/learning/human-languages/sanskrit/curriculum.json
@@ -1,0 +1,275 @@
+{
+  "version": 1,
+  "language": "sanskrit",
+  "path": [
+    {
+      "id": "SA-PATH-001",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "SA-C01-namaste",
+        "SA-C01-namaskara"
+      ],
+      "before": [],
+      "inline": [
+        "SA-EXT-001-INLINE-SCRIPT"
+      ],
+      "after": []
+    },
+    {
+      "id": "SA-PATH-002",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "SA-C01-dhanyavada"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "SA-PATH-003",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "SA-C01-svagatam"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "SA-PATH-004",
+      "spine_node": "SPINE-RESPOND-BASIC",
+      "lessons": [
+        "SA-C01-am-na"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "SA-PATH-005",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "SA-C02-nama",
+        "SA-C02-asti",
+        "SA-C02-bhavan-tvam",
+        "SA-C02-kim",
+        "SA-C02-mama",
+        "SA-C02-mama-nama-asti",
+        "SA-C02-anandah",
+        "SA-C02-tava-nama-kim",
+        "SA-C03-aham"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "SA-PATH-006",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "SA-C03-katham",
+        "SA-C03-bhavan-katham-asti",
+        "SA-C03-kushalam"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "SA-PATH-007",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "SA-C03-na-cinta"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "SA-PATH-008",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "SA-C04-gacchami",
+        "SA-C04-punah",
+        "SA-C04-punar-darshanaya",
+        "SA-C04-shvah"
+      ],
+      "before": [],
+      "inline": [
+        "SA-EXT-008-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "SA-PATH-009",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "SA-C06-numbers-1-5",
+        "SA-C06-number-cognates",
+        "SA-C06-pancha-travels"
+      ],
+      "before": [],
+      "inline": [
+        "SA-EXT-009-LANGUAGE-SPECIFIC",
+        "SA-EXT-009-ETYMOLOGY"
+      ],
+      "after": []
+    }
+  ],
+  "spine": {
+    "SPINE-MEET-GREET": {
+      "segments": [
+        "SA-PATH-001",
+        "SA-PATH-003"
+      ],
+      "omits": [
+        "GREETING-PEACE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COURTESY-THANK": {
+      "segments": [
+        "SA-PATH-002",
+        "SA-PATH-007"
+      ],
+      "omits": [
+        "COURTESY-THANKS-CASUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-RESPOND-BASIC": {
+      "segments": [
+        "SA-PATH-004"
+      ],
+      "omits": [
+        "RESPONSE-YES",
+        "RESPONSE-NO",
+        "RESPONSE-OKAY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXCHANGE-NAMES": {
+      "segments": [
+        "SA-PATH-005"
+      ],
+      "omits": [
+        "PRONOUN-ME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-CHECK-WELLBEING": {
+      "segments": [
+        "SA-PATH-006"
+      ],
+      "omits": [
+        "WORD-GOOD",
+        "WORD-SOSO"
+      ],
+      "relocates": {}
+    },
+    "SPINE-POLITE-REQUEST-REPAIR": {
+      "segments": [],
+      "omits": [
+        "COURTESY-PLEASE",
+        "COURTESY-SORRY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TAKE-LEAVE": {
+      "segments": [
+        "SA-PATH-008"
+      ],
+      "omits": [
+        "FAREWELL-CASUAL",
+        "FAREWELL-SOON",
+        "GREETING-GOODNIGHT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TIME-OF-DAY": {
+      "segments": [],
+      "omits": [
+        "TIME-DAY",
+        "TIME-MORNING",
+        "TIME-AFTERNOON",
+        "TIME-EVENING",
+        "TIME-NIGHT",
+        "GREETING-DAY",
+        "GREETING-MORNING",
+        "GREETING-AFTERNOON",
+        "GREETING-EVENING"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ASK-LOCATION": {
+      "segments": [],
+      "omits": [
+        "QUESTION-WHERE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DEFINITE-REFERENCE": {
+      "segments": [],
+      "omits": [
+        "GRAMMAR-THE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COUNT-ONE-TO-FIVE": {
+      "segments": [
+        "SA-PATH-009"
+      ],
+      "omits": [
+        "NUMBER-ONE-TO-FIVE"
+      ],
+      "relocates": {}
+    }
+  },
+  "extensions": [
+    {
+      "id": "SA-EXT-008-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Sanskrit material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "SA-C04-punah"
+      ]
+    },
+    {
+      "id": "SA-EXT-009-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Sanskrit material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "SA-C06-numbers-1-5"
+      ]
+    },
+    {
+      "id": "SA-EXT-009-ETYMOLOGY",
+      "stage": "A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can use this Sanskrit word history as a memory hook without confusing origin and current use.",
+      "prerequisites": [],
+      "lessons": [
+        "SA-C06-number-cognates",
+        "SA-C06-pancha-travels"
+      ]
+    },
+    {
+      "id": "SA-EXT-001-INLINE-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can recognize the first Sanskrit script pattern inside a greeting I already understand.",
+      "prerequisites": [],
+      "lessons": [
+        "SA-C01-namaste"
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/spanish/curriculum.json
+++ b/code/learning/human-languages/spanish/curriculum.json
@@ -1,0 +1,861 @@
+{
+  "version": 1,
+  "language": "spanish",
+  "path": [
+    {
+      "id": "ES-PATH-001",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "ES-C01-hola"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-002",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "ES-C01-bien"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-003",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "ES-C01-el-la",
+        "ES-C01-genero-gramatical"
+      ],
+      "before": [],
+      "inline": [],
+      "after": [
+        "ES-EXT-003-GRAMMAR"
+      ]
+    },
+    {
+      "id": "ES-PATH-004",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "ES-C01-dia",
+        "ES-C01-buenos-dias"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-005",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "ES-C01-practice"
+      ],
+      "before": [],
+      "inline": [
+        "ES-EXT-005-CONSOLIDATION"
+      ],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-006",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "ES-C02-tarde",
+        "ES-C02-buenas-tardes",
+        "ES-C02-noche",
+        "ES-C02-buenas-noches",
+        "ES-C02-practice"
+      ],
+      "before": [],
+      "inline": [],
+      "after": [
+        "ES-EXT-006-LANGUAGE-SPECIFIC",
+        "ES-EXT-006-CONSOLIDATION"
+      ]
+    },
+    {
+      "id": "ES-PATH-007",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "ES-C03-me",
+        "ES-C03-llamar",
+        "ES-C03-me-llamo",
+        "ES-C03-tu-usted",
+        "ES-C03-usted-origin"
+      ],
+      "before": [],
+      "inline": [
+        "ES-EXT-007-LANGUAGE-SPECIFIC"
+      ],
+      "after": [
+        "ES-EXT-007-ETYMOLOGY"
+      ]
+    },
+    {
+      "id": "ES-PATH-008",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "ES-C03-como",
+        "ES-C03-familia-qu"
+      ],
+      "before": [],
+      "inline": [],
+      "after": [
+        "ES-EXT-008-ETYMOLOGY"
+      ]
+    },
+    {
+      "id": "ES-PATH-009",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "ES-C03-se-llama",
+        "ES-C03-como-se-llama",
+        "ES-C03-mucho",
+        "ES-C03-gusto",
+        "ES-C03-practice"
+      ],
+      "before": [],
+      "inline": [
+        "ES-EXT-009-LANGUAGE-SPECIFIC"
+      ],
+      "after": [
+        "ES-EXT-009-CONSOLIDATION"
+      ]
+    },
+    {
+      "id": "ES-PATH-010",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "ES-C04-gracias",
+        "ES-C04-de-nada"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-011",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "ES-C04-estar",
+        "ES-C04-como-esta",
+        "ES-C04-como-estas-register",
+        "ES-C04-regular",
+        "ES-C04-y",
+        "ES-W01-acento",
+        "ES-W01-tilde-diacritica",
+        "ES-W02-enye",
+        "ES-W03-inverted",
+        "ES-W03-question-span",
+        "ES-C04-practice"
+      ],
+      "before": [],
+      "inline": [
+        "ES-EXT-011-LANGUAGE-SPECIFIC",
+        "ES-EXT-011-REGISTER"
+      ],
+      "after": [
+        "ES-EXT-011-SCRIPT",
+        "ES-EXT-011-CONSOLIDATION"
+      ]
+    },
+    {
+      "id": "ES-PATH-012",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "ES-C05-adios",
+        "ES-C05-hasta",
+        "ES-C05-hasta-limits",
+        "ES-C05-hasta-luego",
+        "ES-C05-hasta-manana",
+        "ES-C05-hasta-pronto",
+        "ES-C05-practice"
+      ],
+      "before": [],
+      "inline": [
+        "ES-EXT-012-LANGUAGE-SPECIFIC",
+        "ES-EXT-012-GRAMMAR"
+      ],
+      "after": [
+        "ES-EXT-012-CONSOLIDATION"
+      ]
+    },
+    {
+      "id": "ES-PATH-013",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "ES-C06-cafe",
+        "ES-C06-por-favor",
+        "ES-C06-hablar",
+        "ES-C06-trabajar",
+        "ES-C06-estudiar",
+        "ES-C06-espanol",
+        "ES-C06-practice"
+      ],
+      "before": [],
+      "inline": [
+        "ES-EXT-013-LANGUAGE-SPECIFIC"
+      ],
+      "after": [
+        "ES-EXT-013-CONSOLIDATION"
+      ]
+    },
+    {
+      "id": "ES-PATH-014",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "ES-C07-comer",
+        "ES-C07-que"
+      ],
+      "before": [
+        "ES-EXT-014-LANGUAGE-SPECIFIC"
+      ],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-015",
+      "spine_node": "SPINE-ASK-LOCATION",
+      "lessons": [
+        "ES-C07-vivir",
+        "ES-C07-donde"
+      ],
+      "before": [
+        "ES-EXT-015-LANGUAGE-SPECIFIC"
+      ],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-016",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "ES-C08-numeros-1-5",
+        "ES-C08-numeros-6-10",
+        "ES-C08-tener",
+        "ES-C12-hacer"
+      ],
+      "before": [],
+      "inline": [
+        "ES-EXT-016-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-017",
+      "spine_node": "SPINE-RESPOND-BASIC",
+      "lessons": [
+        "ES-C19-si",
+        "ES-C19-no"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-018",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "ES-C20-lo-siento"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-019",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "ES-C21-lunes-viernes",
+        "ES-C21-sabado-domingo"
+      ],
+      "before": [],
+      "inline": [
+        "ES-EXT-019-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-020",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "ES-C22-negro-blanco",
+        "ES-C22-rojo-azul"
+      ],
+      "before": [],
+      "inline": [
+        "ES-EXT-020-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-021",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "ES-C23-padre-madre",
+        "ES-C23-hermano-hermana"
+      ],
+      "before": [],
+      "inline": [
+        "ES-EXT-021-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-022",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "ES-C24-cabeza",
+        "ES-C24-mano"
+      ],
+      "before": [],
+      "inline": [
+        "ES-EXT-022-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-023",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "ES-C25-las-estaciones"
+      ],
+      "before": [],
+      "inline": [
+        "ES-EXT-023-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-024",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "ES-C26-agua-vino",
+        "ES-C26-pan"
+      ],
+      "before": [],
+      "inline": [
+        "ES-EXT-024-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-025",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "ES-C27-los-meses",
+        "ES-C28-mediodia-medianoche",
+        "ES-C29-la-hora",
+        "ES-C30-el-tiempo"
+      ],
+      "before": [],
+      "inline": [
+        "ES-EXT-025-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-026",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "ES-C31-numeros-11-20"
+      ],
+      "before": [],
+      "inline": [
+        "ES-EXT-026-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-027",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "ES-C32-perro-gato",
+        "ES-C33-verde-amarillo"
+      ],
+      "before": [],
+      "inline": [
+        "ES-EXT-027-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    }
+  ],
+  "spine": {
+    "SPINE-MEET-GREET": {
+      "segments": [
+        "ES-PATH-001",
+        "ES-PATH-005"
+      ],
+      "omits": [
+        "GREETING-FORMAL",
+        "GREETING-PEACE",
+        "GREETING-WELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COURTESY-THANK": {
+      "segments": [
+        "ES-PATH-010"
+      ],
+      "omits": [
+        "COURTESY-THANKS-CASUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-RESPOND-BASIC": {
+      "segments": [
+        "ES-PATH-017"
+      ],
+      "omits": [
+        "RESPONSE-YESNO",
+        "RESPONSE-OKAY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXCHANGE-NAMES": {
+      "segments": [
+        "ES-PATH-007",
+        "ES-PATH-009",
+        "ES-PATH-014",
+        "ES-PATH-021"
+      ],
+      "omits": [
+        "PRONOUN-I",
+        "PRONOUN-MY",
+        "WORD-NAME",
+        "WORD-IS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-CHECK-WELLBEING": {
+      "segments": [
+        "ES-PATH-002",
+        "ES-PATH-008",
+        "ES-PATH-011",
+        "ES-PATH-022"
+      ],
+      "omits": [
+        "WORD-GOOD"
+      ],
+      "relocates": {}
+    },
+    "SPINE-POLITE-REQUEST-REPAIR": {
+      "segments": [
+        "ES-PATH-013",
+        "ES-PATH-018",
+        "ES-PATH-024"
+      ],
+      "omits": [],
+      "relocates": {}
+    },
+    "SPINE-TAKE-LEAVE": {
+      "segments": [
+        "ES-PATH-012"
+      ],
+      "omits": [
+        "FAREWELL-CASUAL"
+      ],
+      "relocates": {
+        "GREETING-GOODNIGHT": "SPINE-TIME-OF-DAY"
+      }
+    },
+    "SPINE-TIME-OF-DAY": {
+      "segments": [
+        "ES-PATH-004",
+        "ES-PATH-006",
+        "ES-PATH-016",
+        "ES-PATH-019",
+        "ES-PATH-023",
+        "ES-PATH-025"
+      ],
+      "omits": [
+        "TIME-MORNING",
+        "TIME-EVENING",
+        "GREETING-DAY",
+        "GREETING-EVENING"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ASK-LOCATION": {
+      "segments": [
+        "ES-PATH-015"
+      ],
+      "omits": [],
+      "relocates": {}
+    },
+    "SPINE-DEFINITE-REFERENCE": {
+      "segments": [
+        "ES-PATH-003",
+        "ES-PATH-020",
+        "ES-PATH-027"
+      ],
+      "omits": [],
+      "relocates": {}
+    },
+    "SPINE-COUNT-ONE-TO-FIVE": {
+      "segments": [
+        "ES-PATH-026"
+      ],
+      "omits": [
+        "NUMBER-ONE-TO-FIVE"
+      ],
+      "relocates": {}
+    }
+  },
+  "extensions": [
+    {
+      "id": "ES-EXT-003-GRAMMAR",
+      "stage": "A1",
+      "kind": "required",
+      "category": "grammar",
+      "canDo": "I can use the Spanish-specific grammar needed for this part of the shared ability.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C01-genero-gramatical"
+      ]
+    },
+    {
+      "id": "ES-EXT-005-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "consolidation",
+      "canDo": "I can retrieve and combine the Spanish material introduced in this part of the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C01-practice"
+      ]
+    },
+    {
+      "id": "ES-EXT-006-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Spanish material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C02-buenas-noches"
+      ]
+    },
+    {
+      "id": "ES-EXT-006-CONSOLIDATION",
+      "stage": "A1",
+      "kind": "supporting",
+      "category": "consolidation",
+      "canDo": "I can retrieve and combine the Spanish material introduced in this part of the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C02-practice"
+      ]
+    },
+    {
+      "id": "ES-EXT-007-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Spanish material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C03-llamar"
+      ]
+    },
+    {
+      "id": "ES-EXT-007-ETYMOLOGY",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can use this Spanish word history as a memory hook without confusing origin and current use.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C03-usted-origin"
+      ]
+    },
+    {
+      "id": "ES-EXT-008-ETYMOLOGY",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can use this Spanish word history as a memory hook without confusing origin and current use.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C03-familia-qu"
+      ]
+    },
+    {
+      "id": "ES-EXT-009-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Spanish material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C03-se-llama",
+        "ES-C03-mucho"
+      ]
+    },
+    {
+      "id": "ES-EXT-009-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "consolidation",
+      "canDo": "I can retrieve and combine the Spanish material introduced in this part of the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C03-practice"
+      ]
+    },
+    {
+      "id": "ES-EXT-011-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Spanish material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C04-estar",
+        "ES-C04-y"
+      ]
+    },
+    {
+      "id": "ES-EXT-011-REGISTER",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "register",
+      "canDo": "I can choose the Spanish form that fits this relationship and setting.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C04-como-estas-register"
+      ]
+    },
+    {
+      "id": "ES-EXT-011-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can recognize and use the Spanish script features introduced inside these words.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-W01-acento",
+        "ES-W01-tilde-diacritica",
+        "ES-W02-enye",
+        "ES-W03-inverted",
+        "ES-W03-question-span"
+      ]
+    },
+    {
+      "id": "ES-EXT-011-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "consolidation",
+      "canDo": "I can retrieve and combine the Spanish material introduced in this part of the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C04-practice"
+      ]
+    },
+    {
+      "id": "ES-EXT-012-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Spanish material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C05-hasta"
+      ]
+    },
+    {
+      "id": "ES-EXT-012-GRAMMAR",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "grammar",
+      "canDo": "I can use the Spanish-specific grammar needed for this part of the shared ability.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C05-hasta-limits"
+      ]
+    },
+    {
+      "id": "ES-EXT-012-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "consolidation",
+      "canDo": "I can retrieve and combine the Spanish material introduced in this part of the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C05-practice"
+      ]
+    },
+    {
+      "id": "ES-EXT-013-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Spanish material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C06-cafe",
+        "ES-C06-hablar",
+        "ES-C06-trabajar",
+        "ES-C06-estudiar",
+        "ES-C06-espanol"
+      ]
+    },
+    {
+      "id": "ES-EXT-013-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "consolidation",
+      "canDo": "I can retrieve and combine the Spanish material introduced in this part of the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C06-practice"
+      ]
+    },
+    {
+      "id": "ES-EXT-014-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Spanish material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C07-comer"
+      ]
+    },
+    {
+      "id": "ES-EXT-015-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Spanish material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C07-vivir"
+      ]
+    },
+    {
+      "id": "ES-EXT-016-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Spanish material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C08-numeros-1-5",
+        "ES-C08-numeros-6-10",
+        "ES-C08-tener",
+        "ES-C12-hacer"
+      ]
+    },
+    {
+      "id": "ES-EXT-019-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Spanish material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C21-lunes-viernes",
+        "ES-C21-sabado-domingo"
+      ]
+    },
+    {
+      "id": "ES-EXT-020-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Spanish material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C22-negro-blanco",
+        "ES-C22-rojo-azul"
+      ]
+    },
+    {
+      "id": "ES-EXT-021-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Spanish material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C23-padre-madre",
+        "ES-C23-hermano-hermana"
+      ]
+    },
+    {
+      "id": "ES-EXT-022-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Spanish material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C24-cabeza",
+        "ES-C24-mano"
+      ]
+    },
+    {
+      "id": "ES-EXT-023-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Spanish material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C25-las-estaciones"
+      ]
+    },
+    {
+      "id": "ES-EXT-024-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Spanish material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C26-agua-vino",
+        "ES-C26-pan"
+      ]
+    },
+    {
+      "id": "ES-EXT-025-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Spanish material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C27-los-meses",
+        "ES-C28-mediodia-medianoche",
+        "ES-C29-la-hora",
+        "ES-C30-el-tiempo"
+      ]
+    },
+    {
+      "id": "ES-EXT-026-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Spanish material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C31-numeros-11-20"
+      ]
+    },
+    {
+      "id": "ES-EXT-027-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Spanish material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C32-perro-gato",
+        "ES-C33-verde-amarillo"
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/tamil/curriculum.json
+++ b/code/learning/human-languages/tamil/curriculum.json
@@ -1,0 +1,818 @@
+{
+  "version": 1,
+  "language": "tamil",
+  "path": [
+    {
+      "id": "TA-PATH-001",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "TA-C01-vanakkam"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-001-INLINE-SCRIPT"
+      ],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-002",
+      "spine_node": "SPINE-RESPOND-BASIC",
+      "lessons": [
+        "TA-C01-vanakkam-family-register"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-002-REGISTER"
+      ],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-003",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "TA-W01-curves-va-ka",
+        "TA-W01-abugida-va-ka",
+        "TA-W02-ma-retroflex-na",
+        "TA-W02-three-ns",
+        "TA-W03-pulli-vanakkam",
+        "TA-W03-write-vanakkam",
+        "TA-W04-vowel-signs-nandri",
+        "TA-W04-i-sign-write-nandri"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-003-SCRIPT"
+      ],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-004",
+      "spine_node": "SPINE-RESPOND-BASIC",
+      "lessons": [
+        "TA-C01-aam",
+        "TA-C01-illai"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-005",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "TA-C01-nandri",
+        "TA-C01-nandri-family-register"
+      ],
+      "before": [],
+      "inline": [],
+      "after": [
+        "TA-EXT-005-REGISTER"
+      ]
+    },
+    {
+      "id": "TA-PATH-006",
+      "spine_node": "SPINE-RESPOND-BASIC",
+      "lessons": [
+        "TA-C01-sari"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-007",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "TA-C02-peyar",
+        "TA-C02-en",
+        "TA-C02-en-peyar",
+        "TA-C02-magizhcci",
+        "TA-C02-nii-niingal",
+        "TA-C02-enna",
+        "TA-C02-ungal-peyar-enna"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-008",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "TA-C03-eppadi",
+        "TA-C03-eppadi-irukkirirgal"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-009",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "TA-C03-naan"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-010",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "TA-C03-nalam"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-011",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "TA-C03-paravayillai"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-012",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "TA-C04-po",
+        "TA-C04-poy-varugiren",
+        "TA-C04-mindum-sandippom",
+        "TA-C04-naalai"
+      ],
+      "before": [
+        "TA-EXT-012-LANGUAGE-SPECIFIC"
+      ],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-013",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "TA-C05-pesu",
+        "TA-C05-naan-tamizh-pesugiren",
+        "TA-C05-vaazh",
+        "TA-C05-velai-sey",
+        "TA-C05-practice",
+        "TA-C06-dative-ukku",
+        "TA-C06-dative-stacking",
+        "TA-C06-dative-subject",
+        "TA-C06-dative-subject-family"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-013-LANGUAGE-SPECIFIC",
+        "TA-EXT-013-CONSOLIDATION",
+        "TA-EXT-013-GRAMMAR"
+      ],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-014",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "TA-C07-numbers-1-5",
+        "TA-C07-numbers-1-5-family",
+        "TA-C07-numbers-6-10",
+        "TA-C07-numbers-6-10-family"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-014-LANGUAGE-SPECIFIC",
+        "TA-EXT-014-ETYMOLOGY"
+      ],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-015",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "TA-C08-tayavuseytu",
+        "TA-C08-please-register",
+        "TA-C09-mannikkavum",
+        "TA-C09-sorry-register"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-015-REGISTER"
+      ],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-016",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "TA-C10-vaara-kizhamai"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-016-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-017",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "TA-C11-nirangal"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-017-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-018",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "TA-C12-kudumbam"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-018-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-019",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "TA-C13-udal-uruppugal"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-019-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-020",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "TA-C14-kaalangal"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-020-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-021",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "TA-C15-thanneer-arisi"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-021-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-022",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "TA-C16-thamizh-maadangal",
+        "TA-C17-nanpakal-nalliravu",
+        "TA-C17-transparent-middle-synonyms",
+        "TA-C18-mani",
+        "TA-C18-mani-homophone-time"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-022-LANGUAGE-SPECIFIC",
+        "TA-EXT-022-ETYMOLOGY"
+      ],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-023",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "TA-C19-vayathu",
+        "TA-C19-age-register-grammar"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-023-LANGUAGE-SPECIFIC",
+        "TA-EXT-023-REGISTER"
+      ],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-024",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "TA-C20-pathinondru-irupathu"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-024-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-025",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "TA-C20-vaanilai"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-025-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-026",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "TA-C21-naay-poonai",
+        "TA-C22-paccai-manjal"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-026-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-027",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "TA-C23-naal",
+        "TA-C23-day-family-register",
+        "TA-C24-iravu",
+        "TA-C24-night-register-darkness",
+        "TA-C25-iniya-iravu",
+        "TA-C25-goodnight-alternatives",
+        "TA-C26-kaalai",
+        "TA-C27-maalai",
+        "TA-C28-pirpakal",
+        "TA-C28-afternoon-boundary",
+        "TA-C29-kaalai-vanakkam",
+        "TA-C30-maalai-vanakkam",
+        "TA-C31-matiya-vanakkam",
+        "TA-C31-afternoon-greeting-root"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-027-REGISTER",
+        "TA-EXT-027-LANGUAGE-SPECIFIC",
+        "TA-EXT-027-ETYMOLOGY"
+      ],
+      "after": []
+    }
+  ],
+  "spine": {
+    "SPINE-MEET-GREET": {
+      "segments": [
+        "TA-PATH-001",
+        "TA-PATH-003"
+      ],
+      "omits": [
+        "GREETING-FORMAL",
+        "GREETING-PEACE",
+        "GREETING-WELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COURTESY-THANK": {
+      "segments": [
+        "TA-PATH-005",
+        "TA-PATH-011"
+      ],
+      "omits": [
+        "COURTESY-THANKS-CASUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-RESPOND-BASIC": {
+      "segments": [
+        "TA-PATH-002",
+        "TA-PATH-004",
+        "TA-PATH-006"
+      ],
+      "omits": [
+        "RESPONSE-YESNO"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXCHANGE-NAMES": {
+      "segments": [
+        "TA-PATH-007",
+        "TA-PATH-009",
+        "TA-PATH-013",
+        "TA-PATH-018",
+        "TA-PATH-023"
+      ],
+      "omits": [
+        "PRONOUN-ME",
+        "WORD-IS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-CHECK-WELLBEING": {
+      "segments": [
+        "TA-PATH-008",
+        "TA-PATH-010",
+        "TA-PATH-019"
+      ],
+      "omits": [
+        "WORD-GOOD",
+        "WORD-SOSO"
+      ],
+      "relocates": {}
+    },
+    "SPINE-POLITE-REQUEST-REPAIR": {
+      "segments": [
+        "TA-PATH-015",
+        "TA-PATH-021"
+      ],
+      "omits": [],
+      "relocates": {}
+    },
+    "SPINE-TAKE-LEAVE": {
+      "segments": [
+        "TA-PATH-012"
+      ],
+      "omits": [
+        "FAREWELL-CASUAL",
+        "FAREWELL-SOON"
+      ],
+      "relocates": {
+        "GREETING-GOODNIGHT": "SPINE-TIME-OF-DAY"
+      }
+    },
+    "SPINE-TIME-OF-DAY": {
+      "segments": [
+        "TA-PATH-016",
+        "TA-PATH-020",
+        "TA-PATH-022",
+        "TA-PATH-025",
+        "TA-PATH-027"
+      ],
+      "omits": [
+        "GREETING-DAY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ASK-LOCATION": {
+      "segments": [],
+      "omits": [
+        "QUESTION-WHERE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DEFINITE-REFERENCE": {
+      "segments": [
+        "TA-PATH-017",
+        "TA-PATH-026"
+      ],
+      "omits": [
+        "GRAMMAR-THE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COUNT-ONE-TO-FIVE": {
+      "segments": [
+        "TA-PATH-014",
+        "TA-PATH-024"
+      ],
+      "omits": [
+        "NUMBER-ONE-TO-FIVE"
+      ],
+      "relocates": {}
+    }
+  },
+  "extensions": [
+    {
+      "id": "TA-EXT-002-REGISTER",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "register",
+      "canDo": "I can choose the Tamil form that fits this relationship and setting.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C01-vanakkam-family-register"
+      ]
+    },
+    {
+      "id": "TA-EXT-003-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can recognize and use the Tamil script features introduced inside these words.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-W01-curves-va-ka",
+        "TA-W01-abugida-va-ka",
+        "TA-W02-ma-retroflex-na",
+        "TA-W02-three-ns",
+        "TA-W03-pulli-vanakkam",
+        "TA-W03-write-vanakkam",
+        "TA-W04-vowel-signs-nandri",
+        "TA-W04-i-sign-write-nandri"
+      ]
+    },
+    {
+      "id": "TA-EXT-005-REGISTER",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "register",
+      "canDo": "I can choose the Tamil form that fits this relationship and setting.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C01-nandri-family-register"
+      ]
+    },
+    {
+      "id": "TA-EXT-012-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Tamil material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C04-po"
+      ]
+    },
+    {
+      "id": "TA-EXT-013-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Tamil material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C05-pesu",
+        "TA-C05-naan-tamizh-pesugiren",
+        "TA-C05-vaazh",
+        "TA-C05-velai-sey",
+        "TA-C06-dative-ukku",
+        "TA-C06-dative-subject"
+      ]
+    },
+    {
+      "id": "TA-EXT-013-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "consolidation",
+      "canDo": "I can retrieve and combine the Tamil material introduced in this part of the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C05-practice"
+      ]
+    },
+    {
+      "id": "TA-EXT-013-GRAMMAR",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "grammar",
+      "canDo": "I can use the Tamil-specific grammar needed for this part of the shared ability.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C06-dative-stacking",
+        "TA-C06-dative-subject-family"
+      ]
+    },
+    {
+      "id": "TA-EXT-014-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Tamil material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C07-numbers-1-5",
+        "TA-C07-numbers-6-10"
+      ]
+    },
+    {
+      "id": "TA-EXT-014-ETYMOLOGY",
+      "stage": "A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can use this Tamil word history as a memory hook without confusing origin and current use.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C07-numbers-1-5-family",
+        "TA-C07-numbers-6-10-family"
+      ]
+    },
+    {
+      "id": "TA-EXT-015-REGISTER",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "register",
+      "canDo": "I can choose the Tamil form that fits this relationship and setting.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C08-please-register",
+        "TA-C09-sorry-register"
+      ]
+    },
+    {
+      "id": "TA-EXT-016-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Tamil material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C10-vaara-kizhamai"
+      ]
+    },
+    {
+      "id": "TA-EXT-017-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Tamil material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C11-nirangal"
+      ]
+    },
+    {
+      "id": "TA-EXT-018-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Tamil material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C12-kudumbam"
+      ]
+    },
+    {
+      "id": "TA-EXT-019-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Tamil material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C13-udal-uruppugal"
+      ]
+    },
+    {
+      "id": "TA-EXT-020-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Tamil material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C14-kaalangal"
+      ]
+    },
+    {
+      "id": "TA-EXT-021-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Tamil material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C15-thanneer-arisi"
+      ]
+    },
+    {
+      "id": "TA-EXT-022-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Tamil material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C16-thamizh-maadangal",
+        "TA-C17-nanpakal-nalliravu",
+        "TA-C18-mani"
+      ]
+    },
+    {
+      "id": "TA-EXT-022-ETYMOLOGY",
+      "stage": "A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can use this Tamil word history as a memory hook without confusing origin and current use.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C17-transparent-middle-synonyms",
+        "TA-C18-mani-homophone-time"
+      ]
+    },
+    {
+      "id": "TA-EXT-023-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Tamil material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C19-vayathu"
+      ]
+    },
+    {
+      "id": "TA-EXT-023-REGISTER",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "register",
+      "canDo": "I can choose the Tamil form that fits this relationship and setting.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C19-age-register-grammar"
+      ]
+    },
+    {
+      "id": "TA-EXT-024-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Tamil material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C20-pathinondru-irupathu"
+      ]
+    },
+    {
+      "id": "TA-EXT-025-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Tamil material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C20-vaanilai"
+      ]
+    },
+    {
+      "id": "TA-EXT-026-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Tamil material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C21-naay-poonai",
+        "TA-C22-paccai-manjal"
+      ]
+    },
+    {
+      "id": "TA-EXT-027-REGISTER",
+      "stage": "A1",
+      "kind": "required",
+      "category": "register",
+      "canDo": "I can choose the Tamil form that fits this relationship and setting.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C23-day-family-register",
+        "TA-C24-night-register-darkness"
+      ]
+    },
+    {
+      "id": "TA-EXT-027-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Tamil material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C25-iniya-iravu"
+      ]
+    },
+    {
+      "id": "TA-EXT-027-ETYMOLOGY",
+      "stage": "A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can use this Tamil word history as a memory hook without confusing origin and current use.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C25-goodnight-alternatives",
+        "TA-C28-afternoon-boundary",
+        "TA-C31-afternoon-greeting-root"
+      ]
+    },
+    {
+      "id": "TA-EXT-001-INLINE-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can recognize the first Tamil script pattern inside a greeting I already understand.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C01-vanakkam"
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/telugu/curriculum.json
+++ b/code/learning/human-languages/telugu/curriculum.json
@@ -1,0 +1,650 @@
+{
+  "version": 1,
+  "language": "telugu",
+  "path": [
+    {
+      "id": "TE-PATH-001",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "TE-C01-namaskaram"
+      ],
+      "before": [],
+      "inline": [
+        "TE-EXT-001-INLINE-SCRIPT"
+      ],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-002",
+      "spine_node": "SPINE-RESPOND-BASIC",
+      "lessons": [
+        "TE-C01-avunu"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-003",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "TE-C01-dhanyavadamulu"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-004",
+      "spine_node": "SPINE-RESPOND-BASIC",
+      "lessons": [
+        "TE-C01-ledu",
+        "TE-C01-sare"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-005",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "TE-C02-peru",
+        "TE-C02-naa",
+        "TE-C02-naa-peru",
+        "TE-C02-nuvvu-miiru",
+        "TE-C02-emiti",
+        "TE-C02-mii-peru-emiti",
+        "TE-C02-santosham"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-006",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "TE-C03-elaa",
+        "TE-C03-miiru-elaa-unnaaru"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-007",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "TE-C03-nenu"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-008",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "TE-C03-baagaa"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-009",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "TE-C03-paravaaledu"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-010",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "TE-C04-vellu",
+        "TE-C04-velli-vastaanu",
+        "TE-C04-reepu-kaluddaam",
+        "TE-C04-malli-kaluddaam"
+      ],
+      "before": [
+        "TE-EXT-010-LANGUAGE-SPECIFIC"
+      ],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-011",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "TE-C05-maatlaadu",
+        "TE-C05-nenu-telugu-maatlaadataanu",
+        "TE-C05-pani-ceyu",
+        "TE-C05-undu",
+        "TE-C05-practice",
+        "TE-C06-dative-ku",
+        "TE-C06-dative-subject"
+      ],
+      "before": [],
+      "inline": [
+        "TE-EXT-011-LANGUAGE-SPECIFIC",
+        "TE-EXT-011-CONSOLIDATION"
+      ],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-012",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "TE-C07-numbers-1-5",
+        "TE-C07-numbers-6-10"
+      ],
+      "before": [],
+      "inline": [
+        "TE-EXT-012-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-013",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "TE-C08-dayachesi",
+        "TE-C09-kshaminchandi"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-014",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "TE-C10-vaaram"
+      ],
+      "before": [],
+      "inline": [
+        "TE-EXT-014-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-015",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "TE-C11-rangulu"
+      ],
+      "before": [],
+      "inline": [
+        "TE-EXT-015-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-016",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "TE-C12-kutumbam"
+      ],
+      "before": [],
+      "inline": [
+        "TE-EXT-016-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-017",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "TE-C13-sharira-bhagalu"
+      ],
+      "before": [],
+      "inline": [
+        "TE-EXT-017-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-018",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "TE-C14-rutuvulu"
+      ],
+      "before": [],
+      "inline": [
+        "TE-EXT-018-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-019",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "TE-C15-neellu-biyyam"
+      ],
+      "before": [],
+      "inline": [
+        "TE-EXT-019-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-020",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "TE-C16-nelalu",
+        "TE-C17-madhyaahnam-ardharaatri",
+        "TE-C18-ganta"
+      ],
+      "before": [],
+      "inline": [
+        "TE-EXT-020-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-021",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "TE-C19-vayasu"
+      ],
+      "before": [],
+      "inline": [
+        "TE-EXT-021-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-022",
+      "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
+      "lessons": [
+        "TE-C20-padakondu-iravai"
+      ],
+      "before": [],
+      "inline": [
+        "TE-EXT-022-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-023",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "TE-C20-vatavaranam"
+      ],
+      "before": [],
+      "inline": [
+        "TE-EXT-023-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-024",
+      "spine_node": "SPINE-DEFINITE-REFERENCE",
+      "lessons": [
+        "TE-C21-kukka-pilli",
+        "TE-C22-pacha-pasupu"
+      ],
+      "before": [],
+      "inline": [
+        "TE-EXT-024-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TE-PATH-025",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "TE-C23-roju",
+        "TE-C24-ratri",
+        "TE-C25-shubha-ratri",
+        "TE-C26-udayam",
+        "TE-C27-sayantram",
+        "TE-C28-madhyahnam-widened",
+        "TE-C29-subhodayam",
+        "TE-C30-subha-sayantram",
+        "TE-C31-subha-madhyahnam",
+        "TE-C31-subha-madhyahnam-register"
+      ],
+      "before": [],
+      "inline": [
+        "TE-EXT-025-LANGUAGE-SPECIFIC"
+      ],
+      "after": [
+        "TE-EXT-025-REGISTER"
+      ]
+    }
+  ],
+  "spine": {
+    "SPINE-MEET-GREET": {
+      "segments": [
+        "TE-PATH-001"
+      ],
+      "omits": [
+        "GREETING-FORMAL",
+        "GREETING-PEACE",
+        "GREETING-WELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COURTESY-THANK": {
+      "segments": [
+        "TE-PATH-003",
+        "TE-PATH-009"
+      ],
+      "omits": [
+        "COURTESY-THANKS-CASUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-RESPOND-BASIC": {
+      "segments": [
+        "TE-PATH-002",
+        "TE-PATH-004"
+      ],
+      "omits": [
+        "RESPONSE-YESNO"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXCHANGE-NAMES": {
+      "segments": [
+        "TE-PATH-005",
+        "TE-PATH-007",
+        "TE-PATH-011",
+        "TE-PATH-016",
+        "TE-PATH-021"
+      ],
+      "omits": [
+        "PRONOUN-ME",
+        "WORD-IS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-CHECK-WELLBEING": {
+      "segments": [
+        "TE-PATH-006",
+        "TE-PATH-008",
+        "TE-PATH-017"
+      ],
+      "omits": [
+        "WORD-GOOD",
+        "WORD-SOSO"
+      ],
+      "relocates": {}
+    },
+    "SPINE-POLITE-REQUEST-REPAIR": {
+      "segments": [
+        "TE-PATH-013",
+        "TE-PATH-019"
+      ],
+      "omits": [],
+      "relocates": {}
+    },
+    "SPINE-TAKE-LEAVE": {
+      "segments": [
+        "TE-PATH-010"
+      ],
+      "omits": [
+        "FAREWELL-CASUAL",
+        "FAREWELL-SOON"
+      ],
+      "relocates": {
+        "GREETING-GOODNIGHT": "SPINE-TIME-OF-DAY"
+      }
+    },
+    "SPINE-TIME-OF-DAY": {
+      "segments": [
+        "TE-PATH-014",
+        "TE-PATH-018",
+        "TE-PATH-020",
+        "TE-PATH-023",
+        "TE-PATH-025"
+      ],
+      "omits": [
+        "GREETING-DAY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ASK-LOCATION": {
+      "segments": [],
+      "omits": [
+        "QUESTION-WHERE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DEFINITE-REFERENCE": {
+      "segments": [
+        "TE-PATH-015",
+        "TE-PATH-024"
+      ],
+      "omits": [
+        "GRAMMAR-THE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COUNT-ONE-TO-FIVE": {
+      "segments": [
+        "TE-PATH-012",
+        "TE-PATH-022"
+      ],
+      "omits": [
+        "NUMBER-ONE-TO-FIVE"
+      ],
+      "relocates": {}
+    }
+  },
+  "extensions": [
+    {
+      "id": "TE-EXT-010-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Telugu material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TE-C04-vellu"
+      ]
+    },
+    {
+      "id": "TE-EXT-011-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Telugu material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TE-C05-maatlaadu",
+        "TE-C05-nenu-telugu-maatlaadataanu",
+        "TE-C05-pani-ceyu",
+        "TE-C05-undu",
+        "TE-C06-dative-ku",
+        "TE-C06-dative-subject"
+      ]
+    },
+    {
+      "id": "TE-EXT-011-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "consolidation",
+      "canDo": "I can retrieve and combine the Telugu material introduced in this part of the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TE-C05-practice"
+      ]
+    },
+    {
+      "id": "TE-EXT-012-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Telugu material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TE-C07-numbers-1-5",
+        "TE-C07-numbers-6-10"
+      ]
+    },
+    {
+      "id": "TE-EXT-014-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Telugu material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TE-C10-vaaram"
+      ]
+    },
+    {
+      "id": "TE-EXT-015-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Telugu material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TE-C11-rangulu"
+      ]
+    },
+    {
+      "id": "TE-EXT-016-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Telugu material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TE-C12-kutumbam"
+      ]
+    },
+    {
+      "id": "TE-EXT-017-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Telugu material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TE-C13-sharira-bhagalu"
+      ]
+    },
+    {
+      "id": "TE-EXT-018-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Telugu material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TE-C14-rutuvulu"
+      ]
+    },
+    {
+      "id": "TE-EXT-019-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Telugu material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TE-C15-neellu-biyyam"
+      ]
+    },
+    {
+      "id": "TE-EXT-020-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Telugu material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TE-C16-nelalu",
+        "TE-C17-madhyaahnam-ardharaatri",
+        "TE-C18-ganta"
+      ]
+    },
+    {
+      "id": "TE-EXT-021-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Telugu material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TE-C19-vayasu"
+      ]
+    },
+    {
+      "id": "TE-EXT-022-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Telugu material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TE-C20-padakondu-iravai"
+      ]
+    },
+    {
+      "id": "TE-EXT-023-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Telugu material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TE-C20-vatavaranam"
+      ]
+    },
+    {
+      "id": "TE-EXT-024-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Telugu material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TE-C21-kukka-pilli",
+        "TE-C22-pacha-pasupu"
+      ]
+    },
+    {
+      "id": "TE-EXT-025-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Telugu material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "TE-C25-shubha-ratri"
+      ]
+    },
+    {
+      "id": "TE-EXT-025-REGISTER",
+      "stage": "A1",
+      "kind": "required",
+      "category": "register",
+      "canDo": "I can choose the Telugu form that fits this relationship and setting.",
+      "prerequisites": [],
+      "lessons": [
+        "TE-C31-subha-madhyahnam-register"
+      ]
+    },
+    {
+      "id": "TE-EXT-001-INLINE-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can recognize the first Telugu script pattern inside a greeting I already understand.",
+      "prerequisites": [],
+      "lessons": [
+        "TE-C01-namaskaram"
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/urdu/curriculum.json
+++ b/code/learning/human-languages/urdu/curriculum.json
@@ -1,0 +1,179 @@
+{
+  "version": 1,
+  "language": "urdu",
+  "path": [
+    {
+      "id": "UR-PATH-001",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "UR-C01-salam"
+      ],
+      "before": [],
+      "inline": [
+        "UR-EXT-001-INLINE-SCRIPT"
+      ],
+      "after": []
+    },
+    {
+      "id": "UR-PATH-002",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "UR-C01-shukriya"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "UR-PATH-003",
+      "spine_node": "SPINE-RESPOND-BASIC",
+      "lessons": [
+        "UR-C01-ji-han",
+        "UR-C01-nahin"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "UR-PATH-004",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "UR-C02-mera-naam"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    }
+  ],
+  "spine": {
+    "SPINE-MEET-GREET": {
+      "segments": [
+        "UR-PATH-001"
+      ],
+      "omits": [
+        "GREETING-FORMAL",
+        "GREETING-PEACE",
+        "GREETING-WELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COURTESY-THANK": {
+      "segments": [
+        "UR-PATH-002"
+      ],
+      "omits": [
+        "COURTESY-THANKS-CASUAL",
+        "COURTESY-YOUREWELCOME"
+      ],
+      "relocates": {}
+    },
+    "SPINE-RESPOND-BASIC": {
+      "segments": [
+        "UR-PATH-003"
+      ],
+      "omits": [
+        "RESPONSE-YESNO",
+        "RESPONSE-OKAY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXCHANGE-NAMES": {
+      "segments": [
+        "UR-PATH-004"
+      ],
+      "omits": [
+        "QUESTION-WHAT",
+        "PRONOUN-I",
+        "PRONOUN-ME",
+        "PRONOUN-YOU",
+        "PRONOUN-MY",
+        "WORD-NAME",
+        "WORD-IS",
+        "INTRO-WHATS-YOUR-NAME",
+        "INTRO-NICE-TO-MEET-YOU"
+      ],
+      "relocates": {}
+    },
+    "SPINE-CHECK-WELLBEING": {
+      "segments": [],
+      "omits": [
+        "QUESTION-HOW",
+        "STATE-HOW-ARE-YOU",
+        "WORD-GOOD",
+        "WORD-WELL",
+        "WORD-SOSO"
+      ],
+      "relocates": {}
+    },
+    "SPINE-POLITE-REQUEST-REPAIR": {
+      "segments": [],
+      "omits": [
+        "COURTESY-PLEASE",
+        "COURTESY-SORRY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TAKE-LEAVE": {
+      "segments": [],
+      "omits": [
+        "FAREWELL",
+        "FAREWELL-CASUAL",
+        "FAREWELL-LATER",
+        "FAREWELL-SOON",
+        "FAREWELL-TOMORROW",
+        "GREETING-GOODNIGHT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TIME-OF-DAY": {
+      "segments": [],
+      "omits": [
+        "TIME-DAY",
+        "TIME-MORNING",
+        "TIME-AFTERNOON",
+        "TIME-EVENING",
+        "TIME-NIGHT",
+        "GREETING-DAY",
+        "GREETING-MORNING",
+        "GREETING-AFTERNOON",
+        "GREETING-EVENING"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ASK-LOCATION": {
+      "segments": [],
+      "omits": [
+        "QUESTION-WHERE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DEFINITE-REFERENCE": {
+      "segments": [],
+      "omits": [
+        "GRAMMAR-THE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-COUNT-ONE-TO-FIVE": {
+      "segments": [],
+      "omits": [
+        "NUMBER-ONE-TO-FIVE"
+      ],
+      "relocates": {}
+    }
+  },
+  "extensions": [
+    {
+      "id": "UR-EXT-001-INLINE-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can recognize the first Urdu script pattern inside a greeting I already understand.",
+      "prerequisites": [],
+      "lessons": [
+        "UR-C01-salam"
+      ]
+    }
+  ]
+}

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added — per-track shared-spine realization maps
+
+- Load and validate one ordered `curriculum.json` for every registered track,
+  with repeatable spine segments, explicit omission/relocation ledgers, and
+  typed language-specific extensions placed before, inline, or after a segment.
+- Require canonical and schema-v2 lesson coverage, prerequisite-closed local
+  order, and exact support-lesson extension classification across all 20 maps.
+- Add pure local-path and independent mixed-frontier queries so downstream apps
+  can schedule the next safe lesson without borrowing another language's
+  progress.
+
 ### Added — non-Latin canonical book chapters
 
 - Let a generated-book target declare a Unicode Script property and its existing

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -18,8 +18,9 @@ lesson AST.
 
 ```
 lessons/*.md frontmatter  ─┐
-concepts/taxonomy.json     ─┼─►  Dataset { concepts, byLanguage, languages }
-data/scripts/*.json        ─┘         + validate() → Issue[]
+curriculum.json × 20       ─┼─►  Dataset + local realization paths
+concepts/taxonomy.json     ─┤         + validate() / validateCurriculum()
+data/scripts/*.json        ─┘         + independent frontier planning
 ```
 
 The core is the **concept**: a language-independent idea (`GREETING-HELLO`). Each
@@ -30,16 +31,36 @@ learning."
 ## Usage
 
 ```ts
-import { loadEverything, languagesForConcept, validate } from "@coding-adventures/human-language-data";
+import {
+  languagesForConcept,
+  loadEverything,
+  mixedCurriculumFrontier,
+  validate,
+  validateCurriculum,
+} from "@coding-adventures/human-language-data";
 
-const { dataset, taxonomy, lessons, scripts } = loadEverything();
+const { curricula, dataset, lessons, registry, scripts, spine, taxonomy } = loadEverything();
 
 // The cross-language join:
 languagesForConcept(dataset, "GREETING-HELLO");
 //  → [{ language: "spanish", headword: "hola", … }, { language: "telugu", … }, …]
 
 // The consistency gate:
-const issues = validate({ taxonomy, lessons, scripts });
+const issues = [
+  ...validate({ taxonomy, lessons, scripts }),
+  ...validateCurriculum({ curricula, lessons, registry, spine, taxonomy }),
+];
+
+// Each language advances on its own prerequisite-closed path. Only frontiers
+// that are simultaneously ready at the same shared node are grouped.
+mixedCurriculumFrontier(
+  curricula,
+  ["persian", "urdu"],
+  new Map([
+    ["persian", new Set(["FA-C01-salaam"])],
+    ["urdu", new Set()],
+  ]),
+);
 ```
 
 Build the JSON and readable gap reports locally with:
@@ -80,7 +101,8 @@ until the existing corpus has been split.
 | `parse.ts` | frontmatter + Markdown → typed lesson AST; realizations → `Dataset` | ✅ |
 | `hash.ts` | stable canonical lesson serialization and deterministic fingerprints | ✅ |
 | `book.ts` | typed lesson AST → LaTeX chapter | ✅ |
-| `curriculum.ts` | spine, prerequisite, schema-v2 duration/block/knowledge validation | ✅ |
+| `curriculum.ts` | spine, realization-map, prerequisite, schema-v2 duration/block/knowledge validation | ✅ |
+| `plans.ts` | ordered local paths, extension placement, next lessons, and mixed ready frontiers | ✅ |
 | `validate.ts` | the round-trip validator (errors fail CI; warnings tolerated) | ✅ |
 | `queries.ts` | `allConcepts` / `conceptsByLanguage` / `languagesForConcept` / `coverageByLanguage` | ✅ |
 | `report.ts` | deterministic duration, prerequisite, book, and schema gap report | ✅ |
@@ -113,6 +135,14 @@ transitive knowledge closure. Each typed block must also author an
 lesson's introduced atoms; production and recall assessments must be declared by
 the lesson and available from transitive prerequisites or an earlier block.
 Schema-v1 tracks remain readable during migration.
+
+When `curricula` are supplied, the same validator also requires exactly one
+`curriculum.json` per registered language. Every shared node must have an
+explicit segment/omission/relocation ledger; every canonical realization and
+schema-v2 lesson must be mapped; mapped prerequisite closure must be complete
+and topologically earlier; and every non-shared support lesson in the path must
+belong to exactly one typed extension. Repeated visits to the same shared node
+remain legal through distinct ordered path segments.
 
 ## Scope note
 

--- a/code/packages/typescript/human-language-data/src/cli.ts
+++ b/code/packages/typescript/human-language-data/src/cli.ts
@@ -4,11 +4,15 @@
 
 import { loadEverything } from "./loader.js";
 import { validate, hasErrors, summarize } from "./validate.js";
+import { validateCurriculum } from "./curriculum.js";
 import { coverageByLanguage } from "./queries.js";
 
 export function runValidate(root?: string): number {
-  const { taxonomy, lessons, scripts, dataset } = loadEverything(root);
-  const issues = validate({ taxonomy, lessons, scripts });
+  const { taxonomy, registry, spine, curricula, books, lessons, scripts, dataset } = loadEverything(root);
+  const issues = [
+    ...validate({ taxonomy, lessons, scripts }),
+    ...validateCurriculum({ registry, spine, curricula, taxonomy, lessons, books }),
+  ];
 
   for (const issue of issues) {
     const tag = issue.level.toUpperCase().padEnd(7);

--- a/code/packages/typescript/human-language-data/src/curriculum.ts
+++ b/code/packages/typescript/human-language-data/src/curriculum.ts
@@ -6,6 +6,7 @@ import type {
   BookCorpus,
   CurriculumSpine,
   Issue,
+  LanguageCurriculum,
   LanguageRegistry,
   Taxonomy,
 } from "./types.js";
@@ -30,6 +31,7 @@ export interface CurriculumValidationInput {
   spine: CurriculumSpine;
   taxonomy: Taxonomy;
   lessons: ParsedLesson[];
+  curricula?: LanguageCurriculum[];
   books?: BookCorpus;
 }
 
@@ -180,6 +182,322 @@ export function validateCurriculum(input: CurriculumValidationInput): Issue[] {
     visited.add(id);
   };
   for (const id of nodeIds) visit(id);
+
+  if (input.curricula) {
+    const curriculaByLanguage = new Map<string, LanguageCurriculum>();
+    for (const curriculum of input.curricula) {
+      if (curriculum.version !== 1) {
+        error(
+          "unsupported-language-curriculum-version",
+          `${curriculum.language}: curriculum.json version must be 1, got '${curriculum.version}'`,
+        );
+      }
+      if (curriculaByLanguage.has(curriculum.language)) {
+        error(
+          "duplicate-language-curriculum",
+          `${curriculum.language}: more than one curriculum.json was loaded`,
+        );
+      } else {
+        curriculaByLanguage.set(curriculum.language, curriculum);
+      }
+      if (!languageIds.has(curriculum.language)) {
+        error(
+          "unregistered-language-curriculum",
+          `${curriculum.language}: curriculum.json has no language registry entry`,
+        );
+      }
+    }
+    for (const language of registry.languages) {
+      if (!curriculaByLanguage.has(language.id)) {
+        error("missing-language-curriculum", `${language.id}: curriculum.json is missing`);
+      }
+    }
+
+    const allowedExtensionKinds = new Set([
+      "required",
+      "supporting",
+      "reference",
+      "not-applicable",
+    ]);
+    const lessonLanguage = new Map(
+      lessons.map((lesson) => [lesson.realization.lessonId, lesson.language]),
+    );
+
+    for (const curriculum of input.curricula) {
+      if (!languageIds.has(curriculum.language)) continue;
+      const segmentById = new Map<string, LanguageCurriculum["path"][number]>();
+      const lessonPlacement = new Map<string, { node: string; position: number }>();
+      let position = 0;
+
+      for (const segment of curriculum.path ?? []) {
+        if (segmentById.has(segment.id)) {
+          error(
+            "duplicate-curriculum-segment",
+            `${curriculum.language}: path segment '${segment.id}' occurs twice`,
+          );
+        } else {
+          segmentById.set(segment.id, segment);
+        }
+        if (!nodeIds.has(segment.spine_node)) {
+          error(
+            "unknown-curriculum-spine-node",
+            `${curriculum.language}: ${segment.id} uses unknown node '${segment.spine_node}'`,
+          );
+        }
+        if (!Array.isArray(segment.lessons) || segment.lessons.length === 0) {
+          error(
+            "empty-curriculum-segment",
+            `${curriculum.language}: ${segment.id} must contain at least one lesson`,
+          );
+        }
+        for (const lessonId of segment.lessons ?? []) {
+          const owner = lessonPlacement.get(lessonId);
+          if (owner) {
+            error(
+              "duplicate-curriculum-lesson",
+              `${curriculum.language}: ${lessonId} occurs in both ${owner.node} and ${segment.id}`,
+            );
+            continue;
+          }
+          if (!lessonById.has(lessonId)) {
+            error(
+              "unknown-curriculum-lesson",
+              `${curriculum.language}: ${segment.id} names unknown lesson '${lessonId}'`,
+            );
+          } else if (lessonLanguage.get(lessonId) !== curriculum.language) {
+            error(
+              "cross-language-curriculum-lesson",
+              `${curriculum.language}: ${segment.id} includes ${lessonId} from ${lessonLanguage.get(lessonId)}`,
+            );
+          }
+          lessonPlacement.set(lessonId, { node: segment.spine_node, position });
+          position += 1;
+        }
+      }
+
+      for (const node of spine.nodes) {
+        const realization = curriculum.spine?.[node.id];
+        if (!realization) {
+          error(
+            "missing-curriculum-spine-node",
+            `${curriculum.language}: spine map omits '${node.id}'`,
+          );
+          continue;
+        }
+        const actualSegments = (curriculum.path ?? [])
+          .filter((segment) => segment.spine_node === node.id)
+          .map((segment) => segment.id);
+        if (JSON.stringify(realization.segments) !== JSON.stringify(actualSegments)) {
+          error(
+            "curriculum-segment-ledger-drift",
+            `${curriculum.language}: ${node.id} segment ledger does not match the authored path`,
+          );
+        }
+        const realizedConcepts = new Set(
+          lessons
+            .filter(
+              (lesson) =>
+                lesson.language === curriculum.language &&
+                CONTENT_TYPES.has(lesson.realization.type),
+            )
+            .map((lesson) => lesson.realization.concept),
+        );
+        const expectedOmits = node.concepts.filter((concept) => !realizedConcepts.has(concept));
+        if (JSON.stringify(realization.omits) !== JSON.stringify(expectedOmits)) {
+          error(
+            "curriculum-omission-ledger-drift",
+            `${curriculum.language}: ${node.id} omissions must be ${expectedOmits.join(", ") || "empty"}`,
+          );
+        }
+        const expectedRelocations = Object.fromEntries(
+          lessons
+            .filter(
+              (lesson) =>
+                lesson.language === curriculum.language &&
+                CONTENT_TYPES.has(lesson.realization.type) &&
+                node.concepts.includes(lesson.realization.concept) &&
+                stringValue(lesson.frontmatter.spine_node) !== "" &&
+                stringValue(lesson.frontmatter.spine_node) !== node.id &&
+                nodeIds.has(stringValue(lesson.frontmatter.spine_node)),
+            )
+            .map((lesson) => [
+              lesson.realization.concept,
+              stringValue(lesson.frontmatter.spine_node),
+            ]),
+        );
+        if (JSON.stringify(realization.relocates) !== JSON.stringify(expectedRelocations)) {
+          error(
+            "curriculum-relocation-ledger-drift",
+            `${curriculum.language}: ${node.id} relocation ledger does not match lesson metadata`,
+          );
+        }
+      }
+      for (const nodeId of Object.keys(curriculum.spine ?? {})) {
+        if (!nodeIds.has(nodeId)) {
+          error(
+            "unknown-curriculum-spine-ledger",
+            `${curriculum.language}: spine map contains unknown node '${nodeId}'`,
+          );
+        }
+      }
+
+      for (const lesson of lessons.filter((item) => item.language === curriculum.language)) {
+        const lessonId = lesson.realization.lessonId;
+        const canonicalOwner = conceptOwner.get(lesson.realization.concept);
+        const explicitNode = stringValue(lesson.frontmatter.spine_node);
+        const placement = lessonPlacement.get(lessonId);
+        if (canonicalOwner && CONTENT_TYPES.has(lesson.realization.type)) {
+          const expectedNode = explicitNode !== "" && nodeIds.has(explicitNode)
+            ? explicitNode
+            : canonicalOwner;
+          if (!placement) {
+            error(
+              "unmapped-shared-realization",
+              `${curriculum.language}: ${lessonId} realizes ${canonicalOwner} but is absent from the local path`,
+            );
+          } else if (placement.node !== expectedNode) {
+            error(
+              "misplaced-shared-realization",
+              `${curriculum.language}: ${lessonId} belongs to ${expectedNode}, not ${placement.node}`,
+            );
+          }
+        }
+        if (explicitNode !== "" && nodeIds.has(explicitNode)) {
+          if (!placement) {
+            error(
+              "unmapped-schema-v2-lesson",
+              `${curriculum.language}: ${lessonId} declares ${explicitNode} but is absent from the local path`,
+            );
+          } else if (placement.node !== explicitNode) {
+            error(
+              "misplaced-schema-v2-lesson",
+              `${curriculum.language}: ${lessonId} declares ${explicitNode}, not ${placement.node}`,
+            );
+          }
+        }
+      }
+
+      for (const [lessonId, placement] of lessonPlacement) {
+        const lesson = lessonById.get(lessonId);
+        if (!lesson) continue;
+        for (const prerequisite of prerequisites(lesson)) {
+          const required = lessonPlacement.get(prerequisite);
+          if (!required) {
+            error(
+              "curriculum-prerequisite-omitted",
+              `${curriculum.language}: ${lessonId} requires ${prerequisite}, which is absent from the local path`,
+            );
+          } else if (required.position >= placement.position) {
+            error(
+              "curriculum-prerequisite-order",
+              `${curriculum.language}: ${prerequisite} must precede ${lessonId} in curriculum.json`,
+            );
+          }
+        }
+      }
+
+      const extensionById = new Map<string, LanguageCurriculum["extensions"][number]>();
+      for (const extension of curriculum.extensions ?? []) {
+        if (extensionById.has(extension.id)) {
+          error(
+            "duplicate-curriculum-extension",
+            `${curriculum.language}: extension '${extension.id}' occurs twice`,
+          );
+        } else {
+          extensionById.set(extension.id, extension);
+        }
+        if (!allowedExtensionKinds.has(extension.kind)) {
+          error(
+            "unknown-curriculum-extension-kind",
+            `${curriculum.language}: ${extension.id} has unknown kind '${extension.kind}'`,
+          );
+        }
+        if (!spine.stages.includes(extension.stage)) {
+          error(
+            "unknown-curriculum-extension-stage",
+            `${curriculum.language}: ${extension.id} uses undeclared stage '${extension.stage}'`,
+          );
+        }
+        if (extension.canDo.trim() === "") {
+          error(
+            "missing-curriculum-extension-can-do",
+            `${curriculum.language}: ${extension.id} has an empty canDo`,
+          );
+        }
+        for (const prerequisite of extension.prerequisites ?? []) {
+          if (!nodeIds.has(prerequisite) && !(curriculum.extensions ?? []).some((item) => item.id === prerequisite)) {
+            error(
+              "unknown-curriculum-extension-prerequisite",
+              `${curriculum.language}: ${extension.id} requires unknown '${prerequisite}'`,
+            );
+          }
+        }
+      }
+
+      const attachment = new Map<string, { segment: string; relation: string }>();
+      const extensionLessonCount = new Map<string, number>();
+      for (const segment of curriculum.path ?? []) {
+        const segmentLessons = new Set(segment.lessons ?? []);
+        for (const relation of ["before", "inline", "after"] as const) {
+          for (const extensionId of segment[relation] ?? []) {
+            const previous = attachment.get(extensionId);
+            if (previous) {
+              error(
+                "duplicate-curriculum-extension-attachment",
+                `${curriculum.language}: ${extensionId} is attached to both ${previous.segment} and ${segment.id}`,
+              );
+              continue;
+            }
+            attachment.set(extensionId, { segment: segment.id, relation });
+            const extension = extensionById.get(extensionId);
+            if (!extension) {
+              error(
+                "unknown-curriculum-extension",
+                `${curriculum.language}: ${segment.id} attaches unknown extension '${extensionId}'`,
+              );
+              continue;
+            }
+            for (const lessonId of extension.lessons ?? []) {
+              if (!segmentLessons.has(lessonId)) {
+                error(
+                  "curriculum-extension-outside-segment",
+                  `${curriculum.language}: ${extensionId} uses ${lessonId} outside ${segment.id}`,
+                );
+              }
+              extensionLessonCount.set(lessonId, (extensionLessonCount.get(lessonId) ?? 0) + 1);
+            }
+          }
+        }
+      }
+      for (const extensionId of extensionById.keys()) {
+        if (!attachment.has(extensionId)) {
+          error(
+            "unattached-curriculum-extension",
+            `${curriculum.language}: ${extensionId} is not attached to a path segment`,
+          );
+        }
+      }
+      for (const [lessonId, placement] of lessonPlacement) {
+        const lesson = lessonById.get(lessonId);
+        if (!lesson) continue;
+        const isSharedContent =
+          CONTENT_TYPES.has(lesson.realization.type) &&
+          conceptOwner.get(lesson.realization.concept) === placement.node;
+        const count = extensionLessonCount.get(lessonId) ?? 0;
+        if (!isSharedContent && count === 0) {
+          error(
+            "unclassified-curriculum-extension-lesson",
+            `${curriculum.language}: ${lessonId} is local support but belongs to no extension node`,
+          );
+        } else if (!isSharedContent && count > 1) {
+          error(
+            "duplicate-curriculum-extension-lesson",
+            `${curriculum.language}: ${lessonId} belongs to ${count} extension nodes`,
+          );
+        }
+      }
+    }
+  }
 
   // Schema v1 remains readable during migration. Version 2 is the strict HL04
   // contract used by both books and apps, so every declared field is executable.

--- a/code/packages/typescript/human-language-data/src/index.ts
+++ b/code/packages/typescript/human-language-data/src/index.ts
@@ -34,11 +34,22 @@ export {
   type CurriculumValidationInput,
 } from "./curriculum.js";
 export {
+  orderedCurriculumLessonIds,
+  extensionsForSegment,
+  nextCurriculumLesson,
+  mixedCurriculumFrontier,
+  type ExtensionRelation,
+  type AttachedExtension,
+  type CurriculumFrontierStep,
+  type MixedCurriculumFrontier,
+} from "./plans.js";
+export {
   defaultCurriculumRoot,
   trackScript,
   loadTaxonomy,
   loadLanguageRegistry,
   loadCurriculumSpine,
+  loadLanguageCurricula,
   loadBookCorpus,
   loadLessons,
   loadScripts,

--- a/code/packages/typescript/human-language-data/src/loader.ts
+++ b/code/packages/typescript/human-language-data/src/loader.ts
@@ -11,6 +11,7 @@ import type {
   BookCorpus,
   CurriculumSpine,
   Dataset,
+  LanguageCurriculum,
   LanguageRegistry,
   Script,
   ScriptData,
@@ -39,6 +40,18 @@ export function loadCurriculumSpine(root = defaultCurriculumRoot()): CurriculumS
   return JSON.parse(
     readFileSync(join(root, "core", "spine.json"), "utf8"),
   ) as CurriculumSpine;
+}
+
+/** Read each track's authored shared-spine realization map. */
+export function loadLanguageCurricula(root = defaultCurriculumRoot()): LanguageCurriculum[] {
+  const out: LanguageCurriculum[] = [];
+  for (const track of readdirSync(root, { withFileTypes: true })) {
+    if (!track.isDirectory()) continue;
+    const path = join(root, track.name, "curriculum.json");
+    if (!existsSync(path)) continue;
+    out.push(JSON.parse(readFileSync(path, "utf8")) as LanguageCurriculum);
+  }
+  return out.sort((left, right) => left.language.localeCompare(right.language));
 }
 
 /**
@@ -131,6 +144,7 @@ export function loadEverything(root = defaultCurriculumRoot()): {
   taxonomy: Taxonomy;
   registry: LanguageRegistry;
   spine: CurriculumSpine;
+  curricula: LanguageCurriculum[];
   books: BookCorpus;
   lessons: ParsedLesson[];
   scripts: Record<string, ScriptData>;
@@ -139,6 +153,7 @@ export function loadEverything(root = defaultCurriculumRoot()): {
   const taxonomy = loadTaxonomy(root);
   const registry = loadLanguageRegistry(root);
   const spine = loadCurriculumSpine(root);
+  const curricula = loadLanguageCurricula(root);
   const books = loadBookCorpus(root);
   const lessons = loadLessons(root);
   const scripts = loadScripts(root);
@@ -146,6 +161,7 @@ export function loadEverything(root = defaultCurriculumRoot()): {
     taxonomy,
     registry,
     spine,
+    curricula,
     books,
     lessons,
     scripts,

--- a/code/packages/typescript/human-language-data/src/plans.ts
+++ b/code/packages/typescript/human-language-data/src/plans.ts
@@ -1,0 +1,109 @@
+// Pure queries over per-language shared-spine realization maps.
+
+import type {
+  CurriculumExtensionNode,
+  CurriculumPathSegment,
+  LanguageCurriculum,
+} from "./types.js";
+
+export type ExtensionRelation = "before" | "inline" | "after";
+
+export interface AttachedExtension {
+  relation: ExtensionRelation;
+  extension: CurriculumExtensionNode;
+}
+
+/** The next prerequisite-safe local lesson for one language. */
+export interface CurriculumFrontierStep {
+  language: string;
+  segmentId: string;
+  spineNode: string;
+  lessonId: string;
+  extensions: AttachedExtension[];
+}
+
+/** Flatten a track path without losing its authored segment order. */
+export function orderedCurriculumLessonIds(curriculum: LanguageCurriculum): string[] {
+  return curriculum.path.flatMap((segment) => segment.lessons);
+}
+
+/** Every extension attached to a segment, preserving before/inline/after order. */
+export function extensionsForSegment(
+  curriculum: LanguageCurriculum,
+  segment: CurriculumPathSegment,
+): AttachedExtension[] {
+  const byId = new Map(curriculum.extensions.map((extension) => [extension.id, extension]));
+  const out: AttachedExtension[] = [];
+  for (const relation of ["before", "inline", "after"] as const) {
+    for (const id of segment[relation]) {
+      const extension = byId.get(id);
+      if (extension) out.push({ relation, extension });
+    }
+  }
+  return out;
+}
+
+/**
+ * Return the first unfinished lesson in the authored local path.
+ *
+ * Validation proves that every declared prerequisite occurs earlier in this
+ * path. Choosing the first unfinished item therefore cannot jump over a local
+ * grammar, vocabulary, register, or script dependency.
+ */
+export function nextCurriculumLesson(
+  curriculum: LanguageCurriculum,
+  completed: ReadonlySet<string>,
+): CurriculumFrontierStep | undefined {
+  for (const segment of curriculum.path) {
+    for (const lessonId of segment.lessons) {
+      if (completed.has(lessonId)) continue;
+      return {
+        language: curriculum.language,
+        segmentId: segment.id,
+        spineNode: segment.spine_node,
+        lessonId,
+        extensions: extensionsForSegment(curriculum, segment).filter(({ extension }) =>
+          extension.lessons.includes(lessonId),
+        ),
+      };
+    }
+  }
+  return undefined;
+}
+
+export interface MixedCurriculumFrontier {
+  /** One safe next step per selected language, in caller-selected order. */
+  steps: CurriculumFrontierStep[];
+  /** Steps currently sharing a spine ability and therefore safe to compare. */
+  bySpineNode: Map<string, CurriculumFrontierStep[]>;
+}
+
+/**
+ * Compute independent per-language frontiers, then group only the abilities
+ * that are ready on both sides. Progress never leaks from one language into
+ * another language's prerequisite state.
+ */
+export function mixedCurriculumFrontier(
+  curricula: readonly LanguageCurriculum[],
+  selectedLanguages: readonly string[],
+  completedByLanguage: ReadonlyMap<string, ReadonlySet<string>>,
+): MixedCurriculumFrontier {
+  const byLanguage = new Map(curricula.map((curriculum) => [curriculum.language, curriculum]));
+  const steps: CurriculumFrontierStep[] = [];
+  for (const language of selectedLanguages) {
+    const curriculum = byLanguage.get(language);
+    if (!curriculum) continue;
+    const step = nextCurriculumLesson(
+      curriculum,
+      completedByLanguage.get(language) ?? new Set<string>(),
+    );
+    if (step) steps.push(step);
+  }
+  const bySpineNode = new Map<string, CurriculumFrontierStep[]>();
+  for (const step of steps) {
+    const group = bySpineNode.get(step.spineNode) ?? [];
+    group.push(step);
+    bySpineNode.set(step.spineNode, group);
+  }
+  return { steps, bySpineNode };
+}

--- a/code/packages/typescript/human-language-data/src/types.ts
+++ b/code/packages/typescript/human-language-data/src/types.ts
@@ -110,6 +110,76 @@ export interface CurriculumSpine {
   nodes: SpineNode[];
 }
 
+/** How strongly a language-specific extension participates in the local path. */
+export type CurriculumExtensionKind =
+  | "required"
+  | "supporting"
+  | "reference"
+  | "not-applicable";
+
+/** Open so a track can name a genuinely language-specific concern. */
+export type CurriculumExtensionCategory =
+  | "script"
+  | "grammar"
+  | "register"
+  | "culture-pragmatics"
+  | "etymology"
+  | "consolidation"
+  | "language-specific"
+  | string;
+
+/** A grammar, script, register, or other local node attached to one path segment. */
+export interface CurriculumExtensionNode {
+  id: string;
+  stage: CurriculumStage;
+  kind: CurriculumExtensionKind;
+  category: CurriculumExtensionCategory;
+  canDo: string;
+  /** Extension ids and/or shared spine-node ids. */
+  prerequisites: string[];
+  /** Existing micro-lessons that realize this extension. */
+  lessons: string[];
+}
+
+/**
+ * One contiguous visit to a shared ability in a language's real local order.
+ *
+ * A node may occur in several segments. That is deliberate: a track can greet,
+ * move on, and later return for a formal greeting without flattening its actual
+ * prerequisite path into one fictional chapter.
+ */
+export interface CurriculumPathSegment {
+  id: string;
+  spine_node: string;
+  /** Exact prerequisite-safe lesson order inside this segment. */
+  lessons: string[];
+  /** Extension ids classified by their relationship to the shared material. */
+  before: string[];
+  inline: string[];
+  after: string[];
+}
+
+/** Coverage ledger for one shared node in one language. */
+export interface SpineRealizationMap {
+  /** Segment ids in their authored local order. */
+  segments: string[];
+  /** Canonical concepts deliberately absent from the current track corpus. */
+  omits: string[];
+  /** Canonical concepts this track deliberately teaches under another node. */
+  relocates: Record<string, string>;
+}
+
+/** One track's executable realization of the shared spine. */
+export interface LanguageCurriculum {
+  version: number;
+  language: string;
+  /** The local, prerequisite-safe walk; shared nodes may repeat. */
+  path: CurriculumPathSegment[];
+  /** Every shared node is explicit, including empty/planned coverage. */
+  spine: Record<string, SpineRealizationMap>;
+  extensions: CurriculumExtensionNode[];
+}
+
 /** One authored chapter from an existing LaTeX book. */
 export interface BookChapter {
   language: string;

--- a/code/packages/typescript/human-language-data/tests/curriculum.test.ts
+++ b/code/packages/typescript/human-language-data/tests/curriculum.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { validateCurriculum } from "../src/curriculum.js";
 import { parseLesson } from "../src/parse.js";
-import type { CurriculumSpine, LanguageRegistry, Taxonomy } from "../src/types.js";
+import type {
+  CurriculumSpine,
+  LanguageCurriculum,
+  LanguageRegistry,
+  Taxonomy,
+} from "../src/types.js";
 
 const registry: LanguageRegistry = {
   version: 1,
@@ -102,6 +107,93 @@ describe("curriculum prerequisite validation", () => {
     ];
     expect(validateCurriculum({ registry, taxonomy, spine, lessons }).map((issue) => issue.code))
       .toContain("lesson-prerequisite-cycle");
+  });
+});
+
+describe("per-language realization-map validation", () => {
+  const lessons = [
+    parseLesson(source("A", "word", "GREETING-HELLO", []), "test"),
+    parseLesson(source("B", "practice", "TEST-PRACTICE", ["A"]), "test"),
+  ];
+  const curriculum = (): LanguageCurriculum => ({
+    version: 1,
+    language: "test",
+    path: [
+      {
+        id: "TEST-HELLO-1",
+        spine_node: "HELLO",
+        lessons: ["A"],
+        before: [],
+        inline: [],
+        after: [],
+      },
+      {
+        id: "TEST-HELLO-2",
+        spine_node: "HELLO",
+        lessons: ["B"],
+        before: [],
+        inline: ["TEST-EXT-PRACTICE"],
+        after: [],
+      },
+    ],
+    spine: {
+      HELLO: {
+        segments: ["TEST-HELLO-1", "TEST-HELLO-2"],
+        omits: [],
+        relocates: {},
+      },
+    },
+    extensions: [
+      {
+        id: "TEST-EXT-PRACTICE",
+        stage: "pre-A1",
+        kind: "supporting",
+        category: "consolidation",
+        canDo: "I can retrieve the greeting once more.",
+        prerequisites: ["HELLO"],
+        lessons: ["B"],
+      },
+    ],
+  });
+
+  it("accepts repeated spine visits with classified local support", () => {
+    expect(validateCurriculum({
+      registry,
+      taxonomy,
+      spine,
+      lessons,
+      curricula: [curriculum()],
+    }).filter((issue) => issue.level === "error")).toEqual([]);
+  });
+
+  it("rejects an unsupported map version and a drifted segment ledger", () => {
+    const broken = curriculum();
+    broken.version = 2;
+    broken.spine.HELLO.segments = ["TEST-HELLO-1"];
+    const codes = validateCurriculum({
+      registry,
+      taxonomy,
+      spine,
+      lessons,
+      curricula: [broken],
+    }).map((issue) => issue.code);
+    expect(codes).toContain("unsupported-language-curriculum-version");
+    expect(codes).toContain("curriculum-segment-ledger-drift");
+  });
+
+  it("rejects omitted prerequisites and extension lessons outside their segment", () => {
+    const broken = curriculum();
+    broken.path[0].lessons = ["B"];
+    broken.path[1].lessons = ["A"];
+    const codes = validateCurriculum({
+      registry,
+      taxonomy,
+      spine,
+      lessons,
+      curricula: [broken],
+    }).map((issue) => issue.code);
+    expect(codes).toContain("curriculum-prerequisite-order");
+    expect(codes).toContain("curriculum-extension-outside-segment");
   });
 });
 

--- a/code/packages/typescript/human-language-data/tests/integration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/integration.test.ts
@@ -9,7 +9,7 @@ import { validateCurriculum } from "../src/curriculum.js";
 import { buildCurriculumGapReport } from "../src/report.js";
 import { languagesForConcept } from "../src/queries.js";
 
-const { taxonomy, registry, spine, books, lessons, scripts, dataset } = loadEverything();
+const { taxonomy, registry, spine, curricula, books, lessons, scripts, dataset } = loadEverything();
 
 describe("real curriculum", () => {
   it("has zero validation errors", () => {
@@ -28,12 +28,34 @@ describe("real curriculum", () => {
   });
 
   it("has a valid shared spine covering every registered language", () => {
-    const issues = validateCurriculum({ registry, spine, taxonomy, lessons, books });
+    const issues = validateCurriculum({ registry, spine, curricula, taxonomy, lessons, books });
     expect(issues.filter((issue) => issue.level === "error").map((issue) => issue.message)).toEqual([]);
     expect(registry.languages.map((language) => language.id)).toEqual(dataset.languages.sort((a, b) => {
       const order = new Map(registry.languages.map((language, index) => [language.id, index]));
       return order.get(a)! - order.get(b)!;
     }));
+  });
+
+  it("loads one prerequisite-safe realization map for every language", () => {
+    expect(curricula.map((curriculum) => curriculum.language).sort())
+      .toEqual(registry.languages.map((language) => language.id).sort());
+    expect(curricula.flatMap((curriculum) => curriculum.path).length).toBeGreaterThan(300);
+    expect(
+      curricula.flatMap((curriculum) => curriculum.path.flatMap((segment) => segment.lessons)).length,
+    ).toBeGreaterThan(800);
+    expect(curricula.every((curriculum) =>
+      spine.nodes.every((node) => curriculum.spine[node.id] !== undefined),
+    )).toBe(true);
+
+    const spanish = curricula.find((curriculum) => curriculum.language === "spanish")!;
+    expect(spanish.spine["SPINE-MEET-GREET"]?.segments.length).toBeGreaterThan(1);
+    expect(spanish.spine["SPINE-TAKE-LEAVE"]?.relocates["GREETING-GOODNIGHT"])
+      .toBe("SPINE-TIME-OF-DAY");
+
+    for (const language of ["persian", "urdu"]) {
+      const curriculum = curricula.find((item) => item.language === language)!;
+      expect(curriculum.extensions.some((extension) => extension.category === "script")).toBe(true);
+    }
   });
 
   it("preserves every existing LaTeX book and maps each chapter to short lessons", () => {

--- a/code/packages/typescript/human-language-data/tests/plans.test.ts
+++ b/code/packages/typescript/human-language-data/tests/plans.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  extensionsForSegment,
+  mixedCurriculumFrontier,
+  nextCurriculumLesson,
+  orderedCurriculumLessonIds,
+} from "../src/plans.js";
+import type { LanguageCurriculum } from "../src/types.js";
+
+const track = (language: string, secondNode = "THANK"): LanguageCurriculum => ({
+  version: 1,
+  language,
+  path: [
+    {
+      id: `${language}-1`,
+      spine_node: "GREET",
+      lessons: [`${language}-script`, `${language}-hello`],
+      before: [`${language}-script-extension`],
+      inline: [],
+      after: [],
+    },
+    {
+      id: `${language}-2`,
+      spine_node: secondNode,
+      lessons: [`${language}-thanks`],
+      before: [],
+      inline: [],
+      after: [],
+    },
+    {
+      id: `${language}-3`,
+      spine_node: "GREET",
+      lessons: [`${language}-formal-hello`],
+      before: [],
+      inline: [],
+      after: [],
+    },
+  ],
+  spine: {
+    GREET: { segments: [`${language}-1`, `${language}-3`], omits: [], relocates: {} },
+    [secondNode]: { segments: [`${language}-2`], omits: [], relocates: {} },
+  },
+  extensions: [{
+    id: `${language}-script-extension`,
+    stage: "pre-A1",
+    kind: "required",
+    category: "script",
+    canDo: "I can read the first shape.",
+    prerequisites: [],
+    lessons: [`${language}-script`],
+  }],
+});
+
+describe("per-language curriculum plans", () => {
+  it("preserves repeated spine-node visits in exact local lesson order", () => {
+    const curriculum = track("fa");
+    expect(orderedCurriculumLessonIds(curriculum)).toEqual([
+      "fa-script",
+      "fa-hello",
+      "fa-thanks",
+      "fa-formal-hello",
+    ]);
+    expect(curriculum.spine.GREET?.segments).toEqual(["fa-1", "fa-3"]);
+  });
+
+  it("advances one local lesson at a time and surfaces its attached extension", () => {
+    const curriculum = track("ur");
+    const first = nextCurriculumLesson(curriculum, new Set());
+    expect(first).toMatchObject({ lessonId: "ur-script", spineNode: "GREET" });
+    expect(first?.extensions.map(({ relation, extension }) => [relation, extension.category]))
+      .toEqual([["before", "script"]]);
+
+    const second = nextCurriculumLesson(curriculum, new Set(["ur-script"]));
+    expect(second).toMatchObject({ lessonId: "ur-hello", spineNode: "GREET" });
+    expect(second?.extensions).toEqual([]);
+    expect(extensionsForSegment(curriculum, curriculum.path[0]!)).toHaveLength(1);
+  });
+
+  it("keeps progress independent and groups only simultaneously ready abilities", () => {
+    const fa = track("fa");
+    const ur = track("ur", "NAMES");
+    const progress = new Map<string, ReadonlySet<string>>([
+      ["fa", new Set(["fa-script", "fa-hello"])],
+      ["ur", new Set()],
+    ]);
+    const frontier = mixedCurriculumFrontier([fa, ur], ["ur", "fa"], progress);
+    expect(frontier.steps.map((step) => [step.language, step.lessonId])).toEqual([
+      ["ur", "ur-script"],
+      ["fa", "fa-thanks"],
+    ]);
+    expect(frontier.bySpineNode.get("GREET")?.map((step) => step.language)).toEqual(["ur"]);
+    expect(frontier.bySpineNode.get("THANK")?.map((step) => step.language)).toEqual(["fa"]);
+  });
+});

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased — schema-v2 lesson compatibility
 
+- Load all 20 per-track realization maps at build time and admit Learn/script
+  steps through their explicit mapped lesson sets while keeping legacy material
+  available in Lessons mode.
+- Show mapped micro-lesson and language-specific extension totals for the
+  learner's selected mix, including Persian and Urdu's required inline script
+  entry nodes.
+- Expose a browser-safe independent frontier planner for the forthcoming
+  per-language Learn cursor; the current concept cursor remains unchanged.
 - Hide canonical `hl-knowledge` comments from learner-facing lesson sections;
   the shared parser and source hash still retain their block-boundary meaning.
 - Keep the browser's lightweight dataset adapter compatible with the canonical

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -18,7 +18,11 @@ For each concept in the explicit `core/spine.json` order, the
 engine's *teaching pass* (`sessionplan.ts` → `planSession`) is rendered as a
 numbered sweep — one card per selected language that teaches it, in registry
 order. The picker includes every current track, including Russian, Persian, and
-Urdu. Each card carries the word in its own script, its etymology hook, its full
+Urdu. Learn and inline script admission are now constrained by each track's
+validated `curriculum.json`; unmapped legacy material remains available in
+Lessons mode instead of silently entering the shared walk. The picker reports
+the exact mapped micro-lesson and extension totals for the selected mix. Each
+card carries the word in its own script, its etymology hook, its full
 authored Markdown micro-lesson, and the **connections back** to earlier
 languages that share a root, so the cross-language memory the interleaving is
 meant to build is made visible rather than left implicit. Prev / Next walk the
@@ -26,6 +30,13 @@ spine, and a **jump picker** (a `<select>` of the whole book-ordered spine) leap
 straight to any concept; a slim **progress bar** shows progress through the
 selected portion of the shared spine. Consolidation lessons (`practice`/`review`) are left to the
 review quiz, not the teaching sweep.
+
+`curriculum.ts` also exposes the browser-safe form of the pure independent
+frontier planner: one prerequisite-safe next lesson per selected language,
+grouped only when those local frontiers currently share a spine node. The
+current Learn screen still uses its global concept cursor; moving the visible
+progression, persistence, and focused-before-mixed eligibility onto the local
+frontiers is the next UI migration rather than a claim made by this tranche.
 
 The session **introduces writing systems as-needed** (`scriptintro.ts`): the
 first time the walk reaches a non-Latin script — including Persian and Urdu's

--- a/code/programs/typescript/language-ladder/src/curriculum.ts
+++ b/code/programs/typescript/language-ladder/src/curriculum.ts
@@ -3,6 +3,16 @@
 
 import registryJson from "../../../../learning/human-languages/core/languages.json";
 import spineJson from "../../../../learning/human-languages/core/spine.json";
+import {
+  mixedCurriculumFrontier as buildMixedCurriculumFrontier,
+  type MixedCurriculumFrontier,
+} from "@coding-adventures/human-language-data/src/plans.ts";
+import type { LanguageCurriculum } from "@coding-adventures/human-language-data/src/types.ts";
+
+const CURRICULUM_MODULES = import.meta.glob(
+  "../../../../learning/human-languages/*/curriculum.json",
+  { eager: true, import: "default" },
+) as Record<string, LanguageCurriculum>;
 
 export interface LanguageDefinition {
   id: string;
@@ -27,8 +37,13 @@ export const LANGUAGE_ORDER: string[] = LANGUAGE_REGISTRY
   .map((language) => language.id);
 export const SPINE_NODES = spineJson.nodes as SpineNode[];
 export const SPINE_CONCEPTS: string[] = SPINE_NODES.flatMap((node) => node.concepts);
+export const LANGUAGE_CURRICULA: LanguageCurriculum[] = Object.values(CURRICULUM_MODULES)
+  .sort((left, right) => LANGUAGE_ORDER.indexOf(left.language) - LANGUAGE_ORDER.indexOf(right.language));
 
 const LANGUAGE_BY_ID = new Map(LANGUAGE_REGISTRY.map((language) => [language.id, language]));
+const CURRICULUM_BY_LANGUAGE = new Map(
+  LANGUAGE_CURRICULA.map((curriculum) => [curriculum.language, curriculum]),
+);
 const NODE_BY_CONCEPT = new Map(
   SPINE_NODES.flatMap((node) => node.concepts.map((concept) => [concept, node] as const)),
 );
@@ -43,4 +58,31 @@ export function languageName(id: string): string {
 
 export function spineNodeForConcept(concept: string): SpineNode | undefined {
   return NODE_BY_CONCEPT.get(concept);
+}
+
+export function curriculumForLanguage(language: string): LanguageCurriculum | undefined {
+  return CURRICULUM_BY_LANGUAGE.get(language);
+}
+
+/** Lesson ids admitted to Learn mode by the selected tracks' authored maps. */
+export function mappedLessonIds(languages: readonly string[]): Set<string> {
+  const out = new Set<string>();
+  for (const language of languages) {
+    for (const segment of curriculumForLanguage(language)?.path ?? []) {
+      for (const lessonId of segment.lessons) out.add(lessonId);
+    }
+  }
+  return out;
+}
+
+/** Browser-safe access to the pure, per-language frontier planner. */
+export function mixedCurriculumFrontier(
+  selectedLanguages: readonly string[],
+  completedByLanguage: ReadonlyMap<string, ReadonlySet<string>>,
+): MixedCurriculumFrontier {
+  return buildMixedCurriculumFrontier(
+    LANGUAGE_CURRICULA,
+    selectedLanguages,
+    completedByLanguage,
+  );
 }

--- a/code/programs/typescript/language-ladder/src/main.ts
+++ b/code/programs/typescript/language-ladder/src/main.ts
@@ -69,7 +69,14 @@ import {
   unlockedIndices,
   type ConceptCard,
 } from "./concepts.ts";
-import { LANGUAGE_REGISTRY, SPINE_CONCEPTS, languageName, spineNodeForConcept } from "./curriculum.ts";
+import {
+  LANGUAGE_CURRICULA,
+  LANGUAGE_REGISTRY,
+  SPINE_CONCEPTS,
+  languageName,
+  mappedLessonIds,
+  spineNodeForConcept,
+} from "./curriculum.ts";
 import { loadLanguages, saveLanguages } from "./languagestore.ts";
 import { lessonSections } from "./lessonbody.ts";
 import { bookHashStatus } from "./bookhashes.ts";
@@ -130,13 +137,21 @@ let selectedLanguages = loadLanguages(REVIEW_STORAGE, AVAILABLE_LANGUAGE_IDS);
 // grammar, one concept at a time, not land on "(practice)".
 const CONSOLIDATION_TYPES = new Set(["practice", "practice-mix", "review"]);
 const CONCEPT_LESSONS = LESSONS.filter((l) => !CONSOLIDATION_TYPES.has(l.type));
+const SHARED_CONCEPTS = new Set(SPINE_CONCEPTS);
+const ALL_MAPPED_LESSON_IDS = mappedLessonIds(LANGUAGE_CURRICULA.map((item) => item.language));
+// Learn mode is now admitted by the explicit per-track maps. Namespaced and
+// not-yet-mapped legacy material remains available in Lessons mode.
+const MAPPED_SPINE_LESSONS = CONCEPT_LESSONS.filter(
+  (lesson) => ALL_MAPPED_LESSON_IDS.has(lesson.id) && SHARED_CONCEPTS.has(lesson.concept),
+);
 // The explicit shared spine, filtered to concepts represented in the selected
 // languages. Language-local extensions remain available in Lessons mode.
 function activeConceptSpine(): string[] {
   const selected = new Set(selectedLanguages);
+  const admitted = mappedLessonIds(selectedLanguages);
   const realized = new Set(
-    CONCEPT_LESSONS
-      .filter((lesson) => selected.has(lesson.language))
+    MAPPED_SPINE_LESSONS
+      .filter((lesson) => selected.has(lesson.language) && admitted.has(lesson.id))
       .map((lesson) => lesson.concept),
   );
   return SPINE_CONCEPTS.filter((concept) => realized.has(concept));
@@ -149,7 +164,7 @@ function activeConceptSpine(): string[] {
 const SCRIPTS_BY_ID = scriptsById(SCRIPTS);
 const SCRIPT_INTRO_AT = firstIntroductionByScript(
   SPINE_CONCEPTS,
-  CONCEPT_LESSONS,
+  MAPPED_SPINE_LESSONS,
   new Set(SCRIPTS_BY_ID.keys()),
 );
 
@@ -871,11 +886,19 @@ function renderLanguagePicker(): HTMLElement {
   details.appendChild(summary);
 
   const note = el("p", "muted language-picker__note");
-  note.textContent = "Choose any mix. The shared spine stays in the same order; each language contributes its own realization and extensions.";
+  const selected = new Set(selectedLanguages);
+  const selectedPlans = LANGUAGE_CURRICULA.filter((curriculum) => selected.has(curriculum.language));
+  const mappedLessons = selectedPlans.reduce(
+    (sum, curriculum) => sum + curriculum.path.reduce((count, segment) => count + segment.lessons.length, 0),
+    0,
+  );
+  const extensions = selectedPlans.reduce((sum, curriculum) => sum + curriculum.extensions.length, 0);
+  note.textContent =
+    `Choose any mix. The selected local paths currently map ${mappedLessons} micro-lessons` +
+    ` and ${extensions} script, grammar, register, etymology, or consolidation extensions.`;
   details.appendChild(note);
 
   const grid = el("div", "language-picker__grid");
-  const selected = new Set(selectedLanguages);
   for (const definition of LANGUAGE_REGISTRY.filter((language) =>
     AVAILABLE_LANGUAGE_IDS.includes(language.id),
   )) {
@@ -1071,7 +1094,7 @@ function renderLearn(): HTMLElement {
   // quiz (a later slice) draws from exactly this. Here we render the teaching
   // pass: the current concept alone, swept across the chain.
   const covered = conceptSpine.slice(0, conceptCursor + 1);
-  const plan = planSession(concept, covered, CONCEPT_LESSONS, selectedLanguages);
+  const plan = planSession(concept, covered, MAPPED_SPINE_LESSONS, selectedLanguages);
 
   const progress = el("p", "score");
   progress.textContent =

--- a/code/programs/typescript/language-ladder/tests/curriculum.test.ts
+++ b/code/programs/typescript/language-ladder/tests/curriculum.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  LANGUAGE_CURRICULA,
+  LANGUAGE_ORDER,
+  SPINE_NODES,
+  curriculumForLanguage,
+  mappedLessonIds,
+  mixedCurriculumFrontier,
+} from "../src/curriculum";
+
+describe("per-language shared-spine maps", () => {
+  it("bundles one complete map for every active language", () => {
+    expect(LANGUAGE_CURRICULA.map((curriculum) => curriculum.language)).toEqual(LANGUAGE_ORDER);
+    expect(LANGUAGE_CURRICULA).toHaveLength(20);
+    for (const curriculum of LANGUAGE_CURRICULA) {
+      expect(Object.keys(curriculum.spine)).toEqual(SPINE_NODES.map((node) => node.id));
+    }
+  });
+
+  it("keeps repeated local visits and explicit relocations", () => {
+    const spanish = curriculumForLanguage("spanish")!;
+    expect(spanish.spine["SPINE-MEET-GREET"]?.segments.length).toBeGreaterThan(1);
+    expect(spanish.spine["SPINE-TAKE-LEAVE"]?.relocates["GREETING-GOODNIGHT"])
+      .toBe("SPINE-TIME-OF-DAY");
+  });
+
+  it("makes Persian and Urdu script introduction an inline local extension", () => {
+    for (const language of ["persian", "urdu"]) {
+      const curriculum = curriculumForLanguage(language)!;
+      const script = curriculum.extensions.find((extension) => extension.category === "script");
+      expect(script?.kind).toBe("required");
+      expect(script?.lessons).toHaveLength(1);
+      const segment = curriculum.path.find((item) => item.inline.includes(script!.id));
+      expect(segment?.spine_node).toBe("SPINE-MEET-GREET");
+    }
+  });
+
+  it("exposes only mapped lessons for a selected mix", () => {
+    const ids = mappedLessonIds(["persian", "urdu"]);
+    expect(ids).toEqual(new Set([
+      "FA-C01-salam",
+      "FA-C01-mamnoon",
+      "FA-C01-bale",
+      "FA-C01-na",
+      "FA-C02-esm-e-man",
+      "UR-C01-salam",
+      "UR-C01-shukriya",
+      "UR-C01-ji-han",
+      "UR-C01-nahin",
+      "UR-C02-mera-naam",
+    ]));
+  });
+
+  it("computes independent next steps before grouping shareable abilities", () => {
+    const progress = new Map<string, ReadonlySet<string>>([
+      ["persian", new Set(["FA-C01-salam"])],
+      ["urdu", new Set()],
+    ]);
+    const frontier = mixedCurriculumFrontier(["persian", "urdu"], progress);
+    expect(frontier.steps.map((step) => [step.language, step.lessonId])).toEqual([
+      ["persian", "FA-C01-mamnoon"],
+      ["urdu", "UR-C01-salam"],
+    ]);
+    expect(frontier.bySpineNode.get("SPINE-COURTESY-THANK")?.map((step) => step.language))
+      .toEqual(["persian"]);
+    expect(frontier.bySpineNode.get("SPINE-MEET-GREET")?.map((step) => step.language))
+      .toEqual(["urdu"]);
+  });
+});

--- a/code/specs/HL04-shared-spine-and-content-pipeline.md
+++ b/code/specs/HL04-shared-spine-and-content-pipeline.md
@@ -60,13 +60,15 @@ No single course tradition covers the whole target. The useful design is a synth
 
 ## Current coverage and gaps
 
-The 2026-08 audit of `origin/main` found 18 tracks and 963 lesson files. The
-foundation is real, but the governing promises are not yet enforceable.
+The 2026-08 audit now covers 20 tracks, 1,066 lesson files, 20 downloadable
+books, and one explicit local realization map per track. The foundation is real,
+but several governing promises still need end-to-end enforcement in the learner
+experience.
 
 | Requirement | Current coverage | Migration gap |
 |---|---|---|
 | One atomic lesson | Strong: most content lessons teach one word or phrase. | Some lessons are long enough to contain several independent teaching steps. |
-| Strictly less than five minutes | Not enforced: 364 lessons declare 5 minutes and 104 declare 6. | Add a computed duration budget and split every lesson at or above 300 seconds. |
+| Strictly less than five minutes | The deterministic duration report now measures zero lessons at or above 300 effective seconds; schema-v2 lessons fail validation outside 1–299 seconds. | Keep the gate green as the corpus grows and finish migrating legacy lesson contracts. |
 | Etymology and morphology | Strong prose tradition and root metadata. | Normalize etymons, record sources/confidence, and deliver the full explanation to the app. |
 | Inline grammar | Present in Markdown prose. | Grammar has almost no structured metadata, cannot be ordered or practised by the app, and cannot be closure-checked. |
 | Inline script | Writing lessons and script JSON exist. | Writing lessons do not participate in the concept sweep; the app gives a one-time script signature rather than a cumulative reading path. |
@@ -75,7 +77,7 @@ foundation is real, but the governing promises are not yet enforceable.
 | Single content source | Claimed by HL00. | The Markdown body is discarded by the parser, LaTeX chapters are handwritten copies, and the app consumes frontmatter summaries only. |
 | Four skills and communicative use | Audio-script cues and guided prompts exist. | There is no structured listening, interaction, writing, or can-do coverage model, and no audio asset contract. |
 | Graded input and sustained reading | Isolated example sentences occur. | There is no controlled micro-story/dialogue corpus or known-token validation. |
-| Mixed-language practice | Concept sweeps, cumulative review, and mixed-script drills exist. | Learn mode hard-codes 10 languages, learners cannot choose a set, and a concept can expose a late lesson early in another language. |
+| Mixed-language practice | Learners can choose any of the 20 tracks; every track now has a prerequisite-closed realization path, and a pure planner computes independent local frontiers. | Learn still presents a global concept cursor. Move its visible progression and focused-before-mixed eligibility onto the per-language frontier planner. |
 | Register, dialect, and culture | Often explained in lesson prose. | These distinctions are not typed, so the app can silently compare non-equivalent registers or varieties. |
 | Proficiency target | Roadmaps generally point toward B1. | No CEFR/ACTFL-aligned outcome matrix shows which reception, production, interaction, or mediation abilities are covered. |
 
@@ -89,15 +91,16 @@ tracks:
   shared-spine order;
 - Persian and Urdu starter tracks, each with five dependency-ordered, under-five-
   minute lessons and language-specific script metadata;
-- lossless Markdown bodies and lossless discovery of all 17 existing LaTeX books
+- lossless Markdown bodies and lossless discovery of all 20 existing LaTeX books
   in `human-language-data`, with chapter-to-lesson alignment validation;
 - a registry-driven app language picker, the structured spine in Learn mode,
   rendered authored lesson bodies, and fail-closed declared prerequisites.
 
-This slice does not claim the full acceptance criteria below. Per-track spine
-maps, typed body blocks, computed duration, book generation, independently gated
-focused-to-mixed retrieval, a true Nastaliq font, and B1 corpus expansion remain
-explicit migration work.
+Subsequent slices added typed body blocks, computed-duration enforcement,
+canonical book generation, and the 20 per-track spine maps described below.
+This foundation still does not claim independently gated focused-to-mixed
+retrieval in the visible Learn flow, a true Nastaliq font, complete schema-v2
+migration, or B1 corpus depth.
 
 ## The curriculum model
 
@@ -157,27 +160,58 @@ with radically different structures.
 
 ### Per-language plan and extensions
 
-Each track gains a `curriculum.json` that maps spine nodes to an ordered local
-path:
+Each track has a `curriculum.json` that maps the shared graph onto an ordered
+local path. A node may recur in several path segments: real tracks often return
+to greetings after identity, time, or register work, so forcing one contiguous
+occurrence per spine node would create false ordering cycles.
 
 ```jsonc
 {
+  "version": 1,
   "language": "urdu",
-  "spine": {
-    "SPINE-INTRO-EXCHANGE-NAMES": {
-      "lessons": ["UR-C02-aap", "UR-C02-naam", "UR-C02-mera-naam"],
-      "before": ["UR-SCRIPT-BE-FAMILY", "UR-GRAMMAR-POSSESSIVE-AGREEMENT"],
-      "after": ["UR-REGISTER-TUM-AAP"],
-      "omits": []
+  "path": [
+    {
+      "id": "UR-PATH-001",
+      "spine_node": "SPINE-GREETING-MEET",
+      "lessons": ["UR-C01-salaam"],
+      "before": [],
+      "inline": ["UR-EXT-SCRIPT-ENTRY"],
+      "after": []
     }
-  }
+  ],
+  "spine": {
+    "SPINE-GREETING-MEET": {
+      "segments": ["UR-PATH-001"],
+      "omits": ["GREETING-FORMAL", "GREETING-PEACE", "GREETING-WELCOME"],
+      "relocates": {}
+    }
+  },
+  "extensions": [
+    {
+      "id": "UR-EXT-SCRIPT-ENTRY",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can recognize the joined Nastaliq shapes in سلام.",
+      "prerequisites": [],
+      "lessons": ["UR-C01-salaam"]
+    }
+  ]
 }
 ```
 
+`path` is the executable local order. `before`, `inline`, and `after` place typed
+extension nodes around each segment. The `spine` ledger makes every canonical
+node explicit, including its segment visits, intentionally omitted concepts, and
+deliberate relocations. For example, several tracks teach *good night* with time
+of day even though its canonical concept belongs to taking leave; that difference
+is recorded rather than silently accepted.
+
 An extension may be **required**, **supporting**, **reference**, or explicitly
-**not applicable**. No tool infers order from the minimum chapter number found in
-another language. The shared node orders abilities; each `curriculum.json` orders
-the realization.
+**not applicable**, and is categorized as script, grammar, register,
+culture-pragmatics, etymology, consolidation, or language-specific. No tool
+infers order from another language's chapter numbers. The shared graph orders
+abilities; each `curriculum.json` orders the actual realization.
 
 ## Canonical lesson contract
 
@@ -427,6 +461,9 @@ once a track declares version 2, these are hard errors:
 10. book and app lesson hashes match the canonical AST;
 11. mixed practice includes only independently unlocked realizations;
 12. stage assessment tests production or interaction as well as recognition.
+13. every registered track has one map; every spine node, schema-v2 lesson, and
+    canonical realization is represented exactly once through a segment,
+    omission, or explicit relocation; mapped prerequisites appear earlier.
 
 The validator emits human-readable and JSON gap reports so corpus expansion is
 measurable.
@@ -437,12 +474,14 @@ measurable.
    duration types while preserving version-1 compatibility.
 2. **Spanish vertical slice** — migrate Chapters 1–3, render book and app, and
    prove strict duration plus closed-world progression.
-3. **Mixed-practice correction** — add learner-selected languages, per-language
-   cursors, focused-before-interleaved eligibility, and fail-closed scheduling.
+3. **Mixed-practice correction** — learner-selected languages and the pure
+   per-language frontier planner are implemented; move the visible Learn cursor,
+   focused-before-interleaved eligibility, and persistence onto that planner.
 4. **Persian and Urdu pilots** — build script composition and the first three spine
    clusters in each language with appropriate typography and variety metadata.
-5. **Existing-track migration** — map every track onto the spine, insert extensions,
-   normalize etymons, and eliminate handwritten book copies.
+5. **Existing-track migration** — all tracks now have explicit paths and extension
+   ledgers; continue schema migration, etymon normalization, roadmap alignment,
+   and removal of handwritten book copies.
 6. **Corpus expansion** — grow through B1 while coverage reports select the next
    missing can-do, skill, mode, register, or language realization.
 


### PR DESCRIPTION
## Summary

- add one validated `curriculum.json` realization map for each of the 20 registered language tracks
- model repeated shared-spine visits, explicit omissions and relocations, plus typed before/inline/after extensions
- add pure prerequisite-safe local and mixed-frontier planners
- admit Language Ladder Learn/script content through the explicit maps and surface selected-map counts
- record the follow-on per-language Learn cursor as HL-M10

## Validation

- `@coding-adventures/human-language-data`: build; 12 files / 91 tests; real-corpus validation; generated-book drift check
- `language-ladder`: production build; 28 files / 469 tests
- all 20 curriculum maps parse; `git diff --check`
- rendered local browser QA with Persian + Urdu: 10 mapped lessons, 2 inline extensions, correct RTL display, zero browser errors