### PR TITLE
Advance Learn through independent language frontiers

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,7 +5,7 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-03. Current baseline after per-track spine mapping:
+Last prioritized: 2026-08-03. Current baseline after independent Learn frontiers:
 20 registered tracks, 1,066 Markdown lessons, 20 downloadable LaTeX books, zero
 duration violations, and 20 validated realization maps containing 346 ordered
 path segments, 247 typed extension nodes, and 896 prerequisite-closed mapped
@@ -72,7 +72,7 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-G03 | Complete (#9646) | Generate Spanish Chapters 4–6 from their canonical schema-v2 lesson ASTs after HL-S02. | All six generated chapters now share lesson hashes with Language Ladder; Markdown tables retain their structure in print. |
 | HL-G04 | Queued | Normalize paired straight quotation marks when canonical prose is rendered into LaTeX. | Generated prose should use true opening and closing marks under every book's language rules without changing the canonical app text or code spans. |
 | HL-V02 | Complete (#9653) | Validate learner-facing target-language prompts against block-level knowledge declarations and prerequisite closure. | Schema-v2 production and recall blocks cannot ask for an undeclared form or a form absent from the lesson's transitive knowledge frontier. |
-| HL-V03 | Queued | Compile individual prompt, answer, accepted-variant, feedback, and response-time contracts from typed activity blocks. | Every compiled activity names a non-empty subset of its block's assessed atoms and resolves all answer variants without scraping prose. |
+| HL-V03 | Next | Compile individual prompt, answer, accepted-variant, feedback, and response-time contracts from typed activity blocks. | Every compiled activity names a non-empty subset of its block's assessed atoms and resolves all answer variants without scraping prose; Language Ladder can replace non-lexical self-check confirmation with objective script/grammar retrieval. |
 | HL-B04 | Complete (#9661) | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
 | HL-B05 | Complete (#9663) | Remove Marathi's duplicate practice labels and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Devanagari, natural page bottoms, and explicit static-font shapes make the forced six-chapter build warning-free. |
 | HL-B06 | Complete (#9669) | Publish Gujarati Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
@@ -111,8 +111,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B36 | Complete (#9890) | Publish Spanish Chapters 19–33 from canonical lessons rather than hand-copying another fifteen book chapters. | The Spanish PDF now includes all 33 canonical chapters; all 21 later lessons use schema v2 and generate fifteen chapters from the same content consumed by Language Ladder. |
 | HL-B37 | Complete (#9891) | Remove Spanish's remaining legacy LaTeX layout, bookmark, font, and header-only-verso warnings. | The forced 214-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; all 19 intentionally blank physical pages are truly empty. |
 | HL-P01 | Complete (#9893) | Make the unified Human Languages Books result a protected merge gate, or add an equivalent gate that auto-merge must await. | Every pull request now receives a stable books gate; relevant changes run the one all-books build, unrelated changes receive a checked fast-path, and pull-request and push contexts remain distinct. |
-| HL-M01 | Complete in this PR | Add per-track spine realization maps and language-specific extension nodes. | All 20 tracks have validated repeated-segment local paths, explicit omissions/relocations, typed extensions, and a pure prerequisite-safe frontier planner. |
-| HL-M10 | Next | Replace Learn's global concept cursor with per-language frontier progression and focused-before-mixed eligibility. | Persist independent local cursors, teach each language's next mapped lesson without skipping prerequisites, and interleave only after its focused success threshold; reuse the pure planner delivered by HL-M01. |
+| HL-M01 | Complete (#9894) | Add per-track spine realization maps and language-specific extension nodes. | All 20 tracks have validated repeated-segment local paths, explicit omissions/relocations, typed extensions, and a pure prerequisite-safe frontier planner. |
+| HL-M10 | Complete in this PR | Replace Learn's global concept cursor with per-language frontier progression and focused-before-mixed eligibility. | Stable per-language completed prefixes drive each next lesson; wrong focused answers cannot advance; only independently passed, visually distinguishable lessons enter mixed review. |
 | HL-M02 | Queued | Extend Telugu's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson needs a scheduled place, and the map must explicitly split or justify Chapter 20's numbers-and-weather topic collision. |
 | HL-M03 | Queued | Extend Kannada's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5; every canonical lesson needs a scheduled place, and Chapter 20's unrelated numbers/weather pairing must be split or explicitly justified. |
 | HL-M04 | Queued | Extend Malayalam's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the four new support steps, needs a scheduled place. |
@@ -1159,10 +1159,33 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   concept belongs to `SPINE-TAKE-LEAVE`; those six relocations are now data,
   not exceptions hidden in consumer code.
 - The pure planner returns one safe local frontier per selected language and
-  groups only frontiers currently ready at the same shared node. Language
-  Ladder loads and reports the maps and constrains shared-walk admission, but
-  its visible Learn cursor remains global. HL-M10 is therefore the next
-  learner-visible tranche.
+  groups only frontiers currently ready at the same shared node. HL-M10 follows
+  by moving the visible Learn flow and review eligibility onto those frontiers.
+
+## Findings from HL-M10
+
+- Learn no longer has one global concept index or a jump control that can expose
+  a late local realization. Every selected language contributes exactly its
+  first incomplete mapped lesson, so Persian can advance while Urdu remains at
+  its own greeting frontier.
+- Progress persists by stable lesson id per language. On every load, saved data
+  is reduced to the longest valid local prefix; unknown ids, gaps, and a newly
+  inserted prerequisite cannot grant progress past the first missing lesson.
+- Lexical lessons require an English-meaning retrieval with the lesson and all
+  other language cards hidden. Wrong answers reveal feedback but do not advance.
+  Script, grammar, and other support lessons use their authored final recall as
+  a self-check until HL-V03 compiles objective typed activity contracts.
+- Mixed review contains only independently focused-successful shared lessons.
+  It waits for two visually distinct answers, so Persian and Urdu's identical
+  `سلام` cannot produce a fake one-option quiz; once another form is unlocked,
+  the existing adaptive SRS and confusion log operate on the safe grid.
+- Rendered Persian/Urdu QA proved wrong-answer blocking, independent advancement,
+  persistence across reload, explicit RTL/script treatment, and delayed mixed
+  eligibility with zero browser errors. The app build passes 30 test files and
+  478 tests after this tranche.
+- HL-V03 is next because objective prompt/answer contracts are the remaining
+  prerequisite for replacing non-lexical self-confirmation without scraping
+  lesson prose or inventing accepted answers.
 
 ## Findings from HL-D01C
 

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -2,14 +2,32 @@
 
 ## Unreleased — schema-v2 lesson compatibility
 
+### Changed — independent local frontiers and focused-before-mixed review
+
+- Replace the global concept cursor and unrestricted jump controls with one
+  prerequisite-safe next lesson per selected language, driven by the 20
+  validated realization maps.
+- Persist completed prefixes by stable lesson id independently per language;
+  corrupt, unknown, out-of-order, and stale saved ids fail closed at the first
+  missing local prerequisite.
+- Require a focused check before advancing: objective English-meaning retrieval
+  for lexical lessons and authored final-recall confirmation for script,
+  grammar, and other support lessons. Wrong answers do not advance.
+- Build mixed SRS review only from independently passed shared lessons and wait
+  for two visually distinct eligible answers, preventing unseen lessons and
+  identical one-option quizzes from entering the pool.
+- Introduce script notes at explicit local script-extension nodes, retain
+  grounded root links among simultaneously ready paths, and include the new
+  Learn-progress key in the two-click reset.
+
 - Load all 20 per-track realization maps at build time and admit Learn/script
   steps through their explicit mapped lesson sets while keeping legacy material
   available in Lessons mode.
 - Show mapped micro-lesson and language-specific extension totals for the
   learner's selected mix, including Persian and Urdu's required inline script
   entry nodes.
-- Expose a browser-safe independent frontier planner for the forthcoming
-  per-language Learn cursor; the current concept cursor remains unchanged.
+- Expose the browser-safe independent frontier planner now consumed by Learn's
+  per-language progression.
 - Hide canonical `hl-knowledge` comments from learner-facing lesson sections;
   the shared parser and source hash still retain their block-boundary meaning.
 - Keep the browser's lightweight dataset adapter compatible with the canonical

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -2,66 +2,51 @@
 
 **The HL03 unified curriculum learning app** (it began life as the HL02
 `script-writing-visualizer` and has subsumed that app's modes). Five modes.
-**Learn** (the default) walks the structured shared spine — one concept
-at a time, across the learner's selected language mix, each new language showing its
-threads back to the ones already learned, then reviewing it all with a
-randomised SRS quiz. **Browse** and **Practice** work on *script letters*;
+**Learn** (the default) walks each selected language's validated local path —
+one prerequisite-safe micro-lesson at a time — and admits a lesson to mixed
+review only after focused retrieval in that language. Shared-spine abilities
+and grounded roots still show where independently ready paths connect.
+**Browse** and **Practice** work on *script letters*;
 **Lessons** drills the *written curriculum* — every lesson in every track — on a
 spaced-repetition schedule that persists between visits; and **Concepts** shows
 one idea in every language that has it, side by side.
 
 ## Learn mode (the curriculum session)
 
-The spine of the app: [HL03](../../../specs/HL03-unified-language-learning-app.md)
-and [HL04](../../../specs/HL04-shared-spine-and-content-pipeline.md) in one screen.
-For each concept in the explicit `core/spine.json` order, the
-engine's *teaching pass* (`sessionplan.ts` → `planSession`) is rendered as a
-numbered sweep — one card per selected language that teaches it, in registry
-order. The picker includes every current track, including Russian, Persian, and
-Urdu. Learn and inline script admission are now constrained by each track's
-validated `curriculum.json`; unmapped legacy material remains available in
-Lessons mode instead of silently entering the shared walk. The picker reports
-the exact mapped micro-lesson and extension totals for the selected mix. Each
-card carries the word in its own script, its etymology hook, its full
-authored Markdown micro-lesson, and the **connections back** to earlier
-languages that share a root, so the cross-language memory the interleaving is
-meant to build is made visible rather than left implicit. Prev / Next walk the
-spine, and a **jump picker** (a `<select>` of the whole book-ordered spine) leaps
-straight to any concept; a slim **progress bar** shows progress through the
-selected portion of the shared spine. Consolidation lessons (`practice`/`review`) are left to the
-review quiz, not the teaching sweep.
+The spine of the app is [HL03](../../../specs/HL03-unified-language-learning-app.md)
+plus the stricter [HL04](../../../specs/HL04-shared-spine-and-content-pipeline.md)
+progression contract. `curriculum.ts` loads all 20 `curriculum.json` maps and
+the pure frontier planner returns exactly one safe next lesson per selected
+language. A language advances independently; paths are grouped only when their
+current lessons share a spine ability. The picker includes every track,
+including Russian, Persian, and Urdu, and reports the exact mapped lesson and
+extension totals for the mix.
 
-`curriculum.ts` also exposes the browser-safe form of the pure independent
-frontier planner: one prerequisite-safe next lesson per selected language,
-grouped only when those local frontiers currently share a spine node. The
-current Learn screen still uses its global concept cursor; moving the visible
-progression, persistence, and focused-before-mixed eligibility onto the local
-frontiers is the next UI migration rather than a claim made by this tranche.
+Each frontier card shows the target form, romanization, etymology hook, complete
+authored Markdown micro-lesson, shared can-do, local `N of M` position, and any
+typed script/grammar/register/etymology extension attached at that point.
+Grounded root connections are shown only among languages simultaneously ready
+at the same shared ability. Script notes come from explicit local script
+extensions and the canonical script data, so Persian and Urdu keep distinct
+identities and no global concept cursor guesses where a script belongs.
 
-The session **introduces writing systems as-needed** (`scriptintro.ts`): the
-first time the walk reaches a non-Latin script — including Persian and Urdu's
-distinct script identities — that step gets a compact *"New script"* note (name, system, and how to
-recognise it, from the script data's `signature`), shown once at the earliest
-concept that teaches it. It's grounded: a script with no data (Kannada / Telugu
-/ Malayalam today) gets no note rather than an invented one.
+Before advancing, the learner starts a **focused check**. Lexical lessons ask
+for one English meaning without showing another language's card; a wrong answer
+reveals feedback and leaves the local frontier unchanged. Grammar, script, and
+other support lessons require the learner to complete the authored final recall
+from memory. One successful check completes exactly the current frontier lesson.
+`learnprogress.ts` persists stable lesson IDs independently per language and,
+on load, keeps only the longest valid local prefix. A newly inserted prerequisite
+therefore becomes the frontier instead of being skipped by stale saved state.
 
-Below the sweep sits the **review pass** — the second mechanism. A randomised,
-SRS-weighted quiz draws over everything covered so far (`plan.reviewGrid`, the
-concept×language grid up to the cursor), leaning on what you keep missing
-(`pickNext`). Each question is *"‹meaning› — in ‹language›?"* with options drawn
-from the **same concept in other languages** — the cross-language look-alikes
-the interleaving targets (Telugu ధన్యవాద vs Hindi धन्यवाद). Answers thread
-through `applyAnswer` (promote a hit, demote + log a miss), and a *"what you keep
-confusing"* panel rolls the mistakes up from `confusions(log)`. The review
-**persists** (`reviewstore.ts`): its SRS state and answer log are saved to
-`localStorage` after every answer and restored at startup — the same pattern
-`progress.ts` uses for the lesson schedule, with the same defensive parse (a
-corrupt or wrong-version blob restores as empty, never throws).
-
-The **teaching cursor persists too** (`cursorstore.ts`): the concept you walked
-to is saved on each Prev/Next and restored at startup, so the app resumes where
-you left off rather than back at the first concept. The restored index is
-clamped to the current spine, and a bad blob falls back to the start.
+Below the frontiers, the randomised SRS review draws only from independently
+focused-successful shared lessons. It waits until at least two visually distinct
+answers are eligible, then asks *"‹meaning› — in ‹language›?"* with options from
+that safe grid. A cross-language comparison can appear only after both local
+realizations have passed their own check. Answers still flow through
+`applyAnswer`; misses are demoted and recorded for *"what you keep confusing"*.
+`reviewstore.ts` persists that SRS state and answer log separately from local
+path completion.
 
 A quiet **"Reset progress"** control at the foot of the Learn view clears it all,
 including the saved language mix,
@@ -78,7 +63,7 @@ This mode is that join, and it is the data package's own
 `languagesForConcept` — a function shipped from the start, documented as "what
 the companion app calls," which until now had **no caller**.
 
-- **42 concepts are shared by two or more tracks**, from 973 lessons. A concept
+- **42 concepts are shared by two or more tracks**, from 1,066 lessons. A concept
   only one language tags is filtered out: there is nothing to compare it with,
   which also removes almost every namespaced (`ES-…`) tag without a special case.
 - Each row shows the **headword**, a **romanization** where it differs, and the
@@ -90,7 +75,7 @@ the companion app calls," which until now had **no caller**.
 
 ## Lessons mode
 
-Reads all **973 lessons across 20 languages** straight from the curriculum via
+Reads all **1,066 lessons across 20 languages** straight from the curriculum via
 `@coding-adventures/human-language-data`, and schedules them with the same
 Leitner machinery the letter drills use (`scheduler.ts` is generic over an
 index; it never needed to know what an item is).

--- a/code/programs/typescript/language-ladder/src/curriculum.ts
+++ b/code/programs/typescript/language-ladder/src/curriculum.ts
@@ -47,6 +47,7 @@ const CURRICULUM_BY_LANGUAGE = new Map(
 const NODE_BY_CONCEPT = new Map(
   SPINE_NODES.flatMap((node) => node.concepts.map((concept) => [concept, node] as const)),
 );
+const NODE_BY_ID = new Map(SPINE_NODES.map((node) => [node.id, node]));
 
 export function languageDefinition(id: string): LanguageDefinition | undefined {
   return LANGUAGE_BY_ID.get(id);
@@ -58,6 +59,10 @@ export function languageName(id: string): string {
 
 export function spineNodeForConcept(concept: string): SpineNode | undefined {
   return NODE_BY_CONCEPT.get(concept);
+}
+
+export function spineNodeById(id: string): SpineNode | undefined {
+  return NODE_BY_ID.get(id);
 }
 
 export function curriculumForLanguage(language: string): LanguageCurriculum | undefined {

--- a/code/programs/typescript/language-ladder/src/focused.ts
+++ b/code/programs/typescript/language-ladder/src/focused.ts
@@ -1,0 +1,36 @@
+// Pure focused-retrieval checks used before a lesson joins mixed review.
+
+import type { Lesson } from "./lessons.ts";
+
+const MEANING_CHECK_TYPES = new Set(["word", "phrase", "new"]);
+
+export type FocusedCheckKind = "meaning" | "self-check";
+
+export function focusedCheckKind(lesson: Pick<Lesson, "type" | "gloss">): FocusedCheckKind {
+  return MEANING_CHECK_TYPES.has(lesson.type) && lesson.gloss.trim() !== ""
+    ? "meaning"
+    : "self-check";
+}
+
+export function normalizeFocusedAnswer(value: string): string {
+  return value
+    .normalize("NFKD")
+    .replace(/\p{M}/gu, "")
+    .toLocaleLowerCase("en")
+    .replace(/[’']/g, "")
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+/** One complete gloss or any top-level slash/semicolon/or alternative. */
+export function acceptedMeanings(gloss: string): string[] {
+  const withoutNotes = gloss.replace(/\s*\([^)]*\)\s*/g, " ").trim();
+  const candidates = [withoutNotes, ...withoutNotes.split(/\s+(?:\/|;|or)\s+/i)];
+  return [...new Set(candidates.map(normalizeFocusedAnswer).filter((value) => value !== ""))];
+}
+
+export function meaningAnswerIsCorrect(answer: string, gloss: string): boolean {
+  const normalized = normalizeFocusedAnswer(answer);
+  return normalized !== "" && acceptedMeanings(gloss).includes(normalized);
+}

--- a/code/programs/typescript/language-ladder/src/learnprogress.ts
+++ b/code/programs/typescript/language-ladder/src/learnprogress.ts
@@ -1,0 +1,204 @@
+// Per-language Learn progression and focused-before-mixed eligibility.
+//
+// Progress is stored by stable lesson id, not by array index. On load, each
+// language is reduced to the longest completed prefix of its validated local
+// path. If the curriculum inserts a new prerequisite, that new lesson becomes
+// the frontier instead of allowing stale saved data to jump over it.
+
+import {
+  nextCurriculumLesson,
+  orderedCurriculumLessonIds,
+} from "@coding-adventures/human-language-data/src/plans.ts";
+import type { LanguageCurriculum } from "@coding-adventures/human-language-data/src/types.ts";
+import type { Lesson } from "./lessons.ts";
+import type { GridCell } from "./quiz.ts";
+import { type StorageLike, browserStorage } from "./progress.ts";
+
+export { browserStorage };
+export type { StorageLike };
+
+export const LEARN_PROGRESS_SCHEMA_VERSION = 1;
+export const LEARN_PROGRESS_STORAGE_KEY = "language-ladder:learn-progress:v1";
+
+export type LearnCompletion = Map<string, Set<string>>;
+
+export interface SavedLearnProgress {
+  version: number;
+  completed: Array<[string, string[]]>;
+}
+
+/** Keep only the longest completed prefix of one validated local path. */
+export function completedPrefix(
+  curriculum: LanguageCurriculum,
+  candidate: ReadonlySet<string>,
+): Set<string> {
+  const prefix = new Set<string>();
+  for (const lessonId of orderedCurriculumLessonIds(curriculum)) {
+    if (!candidate.has(lessonId)) break;
+    prefix.add(lessonId);
+  }
+  return prefix;
+}
+
+/** Normalize untrusted completion data against the currently bundled maps. */
+export function normalizeLearnCompletion(
+  candidates: ReadonlyMap<string, ReadonlySet<string>>,
+  curricula: readonly LanguageCurriculum[],
+): LearnCompletion {
+  const normalized: LearnCompletion = new Map();
+  for (const curriculum of curricula) {
+    const prefix = completedPrefix(
+      curriculum,
+      candidates.get(curriculum.language) ?? new Set<string>(),
+    );
+    if (prefix.size > 0) normalized.set(curriculum.language, prefix);
+  }
+  return normalized;
+}
+
+/** Convert the persisted transport shape into safe in-memory sets. */
+export function fromSavedLearnProgress(
+  saved: SavedLearnProgress,
+  curricula: readonly LanguageCurriculum[],
+): LearnCompletion {
+  if (saved.version !== LEARN_PROGRESS_SCHEMA_VERSION || !Array.isArray(saved.completed)) {
+    return new Map();
+  }
+  const candidates = new Map<string, Set<string>>();
+  for (const entry of saved.completed) {
+    if (!Array.isArray(entry) || entry.length !== 2) continue;
+    const [language, ids] = entry;
+    if (typeof language !== "string" || !Array.isArray(ids)) continue;
+    const strings = ids.filter((id): id is string => typeof id === "string");
+    candidates.set(language, new Set(strings));
+  }
+  return normalizeLearnCompletion(candidates, curricula);
+}
+
+/** Serialize only safe prefixes, in curriculum registry order. */
+export function toSavedLearnProgress(
+  completion: ReadonlyMap<string, ReadonlySet<string>>,
+  curricula: readonly LanguageCurriculum[],
+): SavedLearnProgress {
+  const normalized = normalizeLearnCompletion(completion, curricula);
+  const completed: Array<[string, string[]]> = [];
+  for (const curriculum of curricula) {
+    const prefix = normalized.get(curriculum.language);
+    if (prefix && prefix.size > 0) completed.push([curriculum.language, [...prefix]]);
+  }
+  return { version: LEARN_PROGRESS_SCHEMA_VERSION, completed };
+}
+
+/** Load fail-closed: malformed, unavailable, or wrong-version storage is empty. */
+export function loadLearnProgress(
+  storage: StorageLike | null,
+  curricula: readonly LanguageCurriculum[],
+): LearnCompletion {
+  if (!storage) return new Map();
+  try {
+    const raw = storage.getItem(LEARN_PROGRESS_STORAGE_KEY);
+    if (!raw) return new Map();
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return new Map();
+    return fromSavedLearnProgress(parsed as SavedLearnProgress, curricula);
+  } catch {
+    return new Map();
+  }
+}
+
+/** Persist safe prefixes immediately; storage failure never blocks learning. */
+export function saveLearnProgress(
+  storage: StorageLike | null,
+  completion: ReadonlyMap<string, ReadonlySet<string>>,
+  curricula: readonly LanguageCurriculum[],
+): boolean {
+  if (!storage) return false;
+  try {
+    storage.setItem(
+      LEARN_PROGRESS_STORAGE_KEY,
+      JSON.stringify(toSavedLearnProgress(completion, curricula)),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface CompletionResult {
+  completion: LearnCompletion;
+  changed: boolean;
+}
+
+/** Complete exactly the current frontier lesson; reject skips and replays. */
+export function completeFrontierLesson(
+  completion: ReadonlyMap<string, ReadonlySet<string>>,
+  curriculum: LanguageCurriculum,
+  lessonId: string,
+): CompletionResult {
+  const safe = completedPrefix(
+    curriculum,
+    completion.get(curriculum.language) ?? new Set<string>(),
+  );
+  if (nextCurriculumLesson(curriculum, safe)?.lessonId !== lessonId) {
+    const unchanged: LearnCompletion = new Map();
+    for (const [language, ids] of completion) unchanged.set(language, new Set(ids));
+    unchanged.set(curriculum.language, safe);
+    return { completion: unchanged, changed: false };
+  }
+  safe.add(lessonId);
+  const next: LearnCompletion = new Map();
+  for (const [language, ids] of completion) next.set(language, new Set(ids));
+  next.set(curriculum.language, safe);
+  return { completion: next, changed: true };
+}
+
+/** Completed and total local lesson counts for a progress read-out. */
+export function localPathProgress(
+  curriculum: LanguageCurriculum,
+  completion: ReadonlyMap<string, ReadonlySet<string>>,
+): { completed: number; total: number } {
+  const total = orderedCurriculumLessonIds(curriculum).length;
+  const completed = completedPrefix(
+    curriculum,
+    completion.get(curriculum.language) ?? new Set<string>(),
+  ).size;
+  return { completed, total };
+}
+
+/**
+ * The mixed review pool contains only lessons that independently passed their
+ * focused check in their own language. A later saved id cannot leak through a
+ * missing prerequisite because completion is reduced to a local prefix first.
+ */
+export function eligibleReviewGrid(
+  lessons: readonly Lesson[],
+  curricula: readonly LanguageCurriculum[],
+  selectedLanguages: readonly string[],
+  completion: ReadonlyMap<string, ReadonlySet<string>>,
+): GridCell[] {
+  const curriculumByLanguage = new Map(
+    curricula.map((curriculum) => [curriculum.language, curriculum]),
+  );
+  const lessonById = new Map(lessons.map((lesson) => [lesson.id, lesson]));
+  const grid: GridCell[] = [];
+  for (const language of selectedLanguages) {
+    const curriculum = curriculumByLanguage.get(language);
+    if (!curriculum) continue;
+    const prefix = completedPrefix(
+      curriculum,
+      completion.get(language) ?? new Set<string>(),
+    );
+    for (const lessonId of orderedCurriculumLessonIds(curriculum)) {
+      if (!prefix.has(lessonId)) break;
+      const lesson = lessonById.get(lessonId);
+      if (!lesson || lesson.concept === "") continue;
+      grid.push({ concept: lesson.concept, language, lesson });
+    }
+  }
+  return grid;
+}
+
+/** A mixed question needs at least two visually distinct eligible answers. */
+export function mixedReviewReady(grid: readonly GridCell[]): boolean {
+  return new Set(grid.map((cell) => cell.lesson.headword)).size >= 2;
+}

--- a/code/programs/typescript/language-ladder/src/main.ts
+++ b/code/programs/typescript/language-ladder/src/main.ts
@@ -42,26 +42,19 @@ import { crossScriptSiblings, type Sibling } from "./siblings.ts";
 import type { Letter } from "./types.ts";
 import { loadLessons, indicesByLanguage, nextDue } from "./lessons.ts";
 import {
-  planSession,
   applyAnswer,
   type Progress,
 } from "./sessionplan.ts";
 import { pickNext as pickReviewCell, makeRng, cellKey, type GridCell } from "./quiz.ts";
 import { confusions } from "./mistakes.ts";
 import { loadReview, saveReview } from "./reviewstore.ts";
-import { loadCursor, saveCursor } from "./cursorstore.ts";
 import { clearProgress, removableStorage } from "./reset.ts";
 import {
   scriptsById,
-  firstIntroductionByScript,
-  scriptIntroFor,
   scriptOf,
   type ScriptIntro,
 } from "./scriptintro.ts";
-import {
-  LANGUAGE_CHAIN,
-  spineProgress,
-} from "./sequence.ts";
+import { LANGUAGE_CHAIN } from "./sequence.ts";
 import type { SessionStep } from "./session.ts";
 import {
   crossLanguageConcepts,
@@ -73,10 +66,22 @@ import {
   LANGUAGE_CURRICULA,
   LANGUAGE_REGISTRY,
   SPINE_CONCEPTS,
+  curriculumForLanguage,
   languageName,
   mappedLessonIds,
-  spineNodeForConcept,
+  mixedCurriculumFrontier,
+  spineNodeById,
 } from "./curriculum.ts";
+import {
+  completeFrontierLesson,
+  eligibleReviewGrid,
+  loadLearnProgress,
+  localPathProgress,
+  mixedReviewReady,
+  saveLearnProgress,
+  type LearnCompletion,
+} from "./learnprogress.ts";
+import { focusedCheckKind, meaningAnswerIsCorrect } from "./focused.ts";
 import { loadLanguages, saveLanguages } from "./languagestore.ts";
 import { lessonSections } from "./lessonbody.ts";
 import { bookHashStatus } from "./bookhashes.ts";
@@ -100,20 +105,10 @@ let mode: Mode = "learn";
 
 // --- the curriculum session (HL03 phase 6) ----------------------------------
 //
-// The whole app is really ONE thing: walk the curriculum the way the book does —
-// concept by concept, forward along the language chain — and let every new
-// language connect back to the ones already learned. `sequence.ts` gives the
-// book-ordered spine of concepts; `sessionplan.ts` assembles one concept into a
-// teaching sweep across the active chain, each stop carrying its connections
-// back to earlier languages that share a root.
-//
-// Languages are selected explicitly by the learner from the complete registry.
-// The authored registry order remains the stable order of every mixed sweep.
-// How far along the spine the learner has walked. Everything up to and including
-// this concept is "covered" (what the review quiz will later draw from); this
-// concept is the one currently being taught. The spine is filtered from the
-// structured curriculum once lessons and the learner's language mix are known.
-let conceptCursor = 0;
+// The whole app walks each selected language's authored local path. Progress is
+// independent: a correct focused check advances only that language and makes
+// only that lesson eligible for mixed review. The shared spine groups frontiers
+// that happen to be ready together; it never overrides local prerequisites.
 
 // --- lesson review state ----------------------------------------------------
 //
@@ -144,29 +139,10 @@ const ALL_MAPPED_LESSON_IDS = mappedLessonIds(LANGUAGE_CURRICULA.map((item) => i
 const MAPPED_SPINE_LESSONS = CONCEPT_LESSONS.filter(
   (lesson) => ALL_MAPPED_LESSON_IDS.has(lesson.id) && SHARED_CONCEPTS.has(lesson.concept),
 );
-// The explicit shared spine, filtered to concepts represented in the selected
-// languages. Language-local extensions remain available in Lessons mode.
-function activeConceptSpine(): string[] {
-  const selected = new Set(selectedLanguages);
-  const admitted = mappedLessonIds(selectedLanguages);
-  const realized = new Set(
-    MAPPED_SPINE_LESSONS
-      .filter((lesson) => selected.has(lesson.language) && admitted.has(lesson.id))
-      .map((lesson) => lesson.concept),
-  );
-  return SPINE_CONCEPTS.filter((concept) => realized.has(concept));
-}
 
-// Script introductions (phase 7). Index the script data by id, then precompute
-// which concept is the FIRST (in book order) to teach each non-Latin script we
-// have data for — the single place its "new script" note should appear. Both
-// are constant for the page's lifetime and grounded in the real scripts JSON.
+// Script metadata is indexed once. A local map's explicit script extension,
+// rather than a global concept position, decides where its introduction appears.
 const SCRIPTS_BY_ID = scriptsById(SCRIPTS);
-const SCRIPT_INTRO_AT = firstIntroductionByScript(
-  SPINE_CONCEPTS,
-  MAPPED_SPINE_LESSONS,
-  new Set(SCRIPTS_BY_ID.keys()),
-);
 
 // --- the Learn-mode review quiz (HL03 phase 6, slice 6b-2) ------------------
 //
@@ -196,11 +172,10 @@ let reviewSession = restoredReview.session; // advances once per answered questi
 let reviewCell: GridCell | null = null; // the question currently on screen
 let reviewOptions: GridCell[] = []; // its answer options (one is `reviewCell`)
 let reviewChosen: string | null = null; // cellKey of the picked option; null = unanswered
-
-// Resume the teaching walk where it was left off: restore the concept cursor
-// from storage, clamped to the current spine (the curriculum may have grown or
-// shrunk since the save). A missing/corrupt value starts at 0.
-conceptCursor = loadCursor(REVIEW_STORAGE, activeConceptSpine().length);
+let learnCompletion: LearnCompletion = loadLearnProgress(REVIEW_STORAGE, LANGUAGE_CURRICULA);
+type FocusedAttempt = { lessonId: string; state: "check" | "wrong" };
+let focusedAttempt: FocusedAttempt | null = null;
+let learnNotice: string | null = null;
 
 // "Reset progress" is a two-click confirm: the first click ARMS it (so a stray
 // tap can't wipe everything), the second executes. This flag is that arming.
@@ -294,7 +269,7 @@ function syllabaryGate(): SyllabaryGate | null {
 
 const SUBTITLES: Record<Mode, string> = {
   learn:
-    "Walk the shared spine one concept at a time, across the languages you choose, with the threads back to what you already know.",
+    "Walk each language's local path one short lesson at a time, then mix only what you have independently unlocked.",
   browse:
     "Pick a script and a letter to see its pieces and stroke order — for pen-and-paper practice.",
   practice:
@@ -858,25 +833,11 @@ function gradeLesson(wasCorrect: boolean): void {
 
 // --- learn mode — the curriculum session -----------------------------------
 //
-// This is the app's spine made visible: a single concept, taught across every
-// active language that has it, in chain order, each stop showing the word and —
-// the whole point — the threads back to the languages already learned. The
-// learner walks the concept spine forward one step at a time; "covered" grows
-// with the cursor, which is what the review quiz (a later slice) will draw from.
-//
-// All the sequencing is in the engine (`planSession` → teaching sweep with
-// connections); this function only lays it out. Everything goes in via
-// textContent — the corpus is repo-authored, but it is still data.
-
-/** Humanize a concept tag ("COURTESY-THANKS") for a heading ("courtesy · thanks"). */
-function conceptTitle(tag: string): string {
-  return tag.toLowerCase().replace(/_/g, " ").replace(/-/g, " · ");
-}
-
-/** The gloss of the first lesson taught in the sweep, for the concept subhead. */
-function firstGloss(teaching: SessionStep[]): string {
-  return teaching[0]?.lessons[0]?.gloss ?? "";
-}
+// This is the app's authored curriculum made visible. Each selected language
+// contributes exactly its next prerequisite-safe local
+// lesson. A focused check advances that language; independently completed
+// shared lessons become the mixed review pool below. Everything enters the DOM
+// through textContent — the corpus is repo-authored, but remains data.
 
 /** The complete registry-backed language mixer shared by Learn and practice views. */
 function renderLanguagePicker(): HTMLElement {
@@ -912,7 +873,8 @@ function renderLanguagePicker(): HTMLElement {
       if (input.checked) next.add(definition.id);
       else next.delete(definition.id);
       selectedLanguages = saveLanguages(REVIEW_STORAGE, next, AVAILABLE_LANGUAGE_IDS);
-      conceptCursor = Math.max(0, Math.min(conceptCursor, activeConceptSpine().length - 1));
+      focusedAttempt = null;
+      learnNotice = null;
       reviewCell = null;
       lessonIndex = null;
       pickLesson();
@@ -954,6 +916,7 @@ function renderTeachingStep(
   step: SessionStep,
   ordinal: number,
   intro: ScriptIntro | null,
+  badgeText: string | null = ordinal === 0 ? "introduced here" : null,
 ): HTMLElement {
   const card = el("div", "step");
   card.dataset.language = step.language;
@@ -964,10 +927,9 @@ function renderTeachingStep(
   const lang = el("span", "step__lang");
   lang.textContent = languageName(step.language);
   head.append(num, lang);
-  if (ordinal === 0) {
-    // The first stop has no connections — it is where the concept enters.
+  if (badgeText) {
     const badge = el("span", "step__badge");
-    badge.textContent = "introduced here";
+    badge.textContent = badgeText;
     head.appendChild(badge);
   }
   card.appendChild(head);
@@ -1027,129 +989,255 @@ function renderTeachingStep(
   return card;
 }
 
-/** Prev / Next along the concept spine — walking the curriculum forward. */
-/**
- * Move the teaching cursor to `index` (clamped), the one place all navigation
- * funnels through — Prev, Next, and the jump picker. Resets the review draw
- * (the covered set changed), persists so the app resumes here, and re-renders.
- * A no-op if the target is where we already are.
- */
-function jumpToConcept(index: number, spine = activeConceptSpine()): void {
-  const target = Math.max(0, Math.min(index, spine.length - 1));
-  if (target === conceptCursor) return;
-  conceptCursor = target;
+type FrontierStep = ReturnType<typeof mixedCurriculumFrontier>["steps"][number];
+
+function frontierLesson(step: FrontierStep): (typeof LESSONS)[number] | undefined {
+  return LESSON_BY_ID.get(step.lessonId);
+}
+
+function frontierScriptIntro(step: FrontierStep): ScriptIntro | null {
+  if (!step.extensions.some(({ extension }) => extension.category === "script")) return null;
+  const data = SCRIPTS_BY_ID.get(scriptOf(step.language));
+  return data
+    ? { name: data.name, system: data.system, signature: data.signature ?? "" }
+    : null;
+}
+
+/** Grounded root links among languages simultaneously ready at one ability. */
+function frontierConnections(
+  step: FrontierStep,
+  lesson: (typeof LESSONS)[number],
+  earlier: Array<{ step: FrontierStep; lesson: (typeof LESSONS)[number] }>,
+): SessionStep["connections"] {
+  const roots = new Set(lesson.roots);
+  return earlier
+    .filter((item) => item.step.spineNode === step.spineNode)
+    .map((item) => ({
+      to: item.step.language,
+      sharedRoots: [...new Set(item.lesson.roots.filter((root) => roots.has(root)))].sort(),
+    }))
+    .filter((connection) => connection.sharedRoots.length > 0);
+}
+
+function finishFocusedCheck(step: FrontierStep): void {
+  const curriculum = curriculumForLanguage(step.language);
+  if (!curriculum) return;
+  const result = completeFrontierLesson(learnCompletion, curriculum, step.lessonId);
+  if (!result.changed) return;
+  learnCompletion = result.completion;
+  saveLearnProgress(REVIEW_STORAGE, learnCompletion, LANGUAGE_CURRICULA);
+  focusedAttempt = null;
   reviewCell = null;
-  saveCursor(REVIEW_STORAGE, conceptCursor);
+  reviewOptions = [];
+  reviewChosen = null;
+  learnNotice = `${languageName(step.language)} passed focused retrieval; this lesson is now eligible for mixed review.`;
   render();
 }
 
-function renderLearnNav(spine: readonly string[]): HTMLElement {
-  const nav = el("div", "learn__nav");
+function renderFocusedCheck(
+  step: FrontierStep,
+  lesson: (typeof LESSONS)[number],
+  ordinal: number,
+): HTMLElement {
+  const card = el("div", "step focused-check");
+  card.dataset.language = step.language;
+  const head = el("div", "step__head");
+  const num = el("span", "step__num");
+  num.textContent = String(ordinal + 1);
+  const lang = el("span", "step__lang");
+  lang.textContent = languageName(step.language);
+  const badge = el("span", "step__badge");
+  badge.textContent = "focused check";
+  head.append(num, lang, badge);
+  card.appendChild(head);
 
-  const prev = el("button", "opt") as HTMLButtonElement;
-  prev.textContent = "← Previous";
-  prev.disabled = conceptCursor === 0;
-  prev.onclick = () => jumpToConcept(conceptCursor - 1);
+  const attempt = focusedAttempt?.lessonId === lesson.id ? focusedAttempt : null;
+  if (attempt?.state === "wrong") {
+    const verdict = el("p", "focused-check__feedback no");
+    verdict.textContent = `Not yet. One accepted meaning is “${lesson.gloss}”. Review the lesson, then try again.`;
+    card.appendChild(verdict);
+    const again = el("button", "next") as HTMLButtonElement;
+    again.textContent = "Review lesson again";
+    again.onclick = () => {
+      focusedAttempt = null;
+      render();
+    };
+    card.appendChild(again);
+    return card;
+  }
 
-  // Jump anywhere in the spine — 186 concepts is a long walk to Next through.
-  // A native <select> gives free keyboard type-ahead over the book-ordered list.
-  const jump = el("select", "learn__jump") as HTMLSelectElement;
-  jump.title = "Jump to concept";
-  spine.forEach((concept, i) => {
-    const opt = el("option", "") as HTMLOptionElement;
-    opt.value = String(i);
-    opt.textContent = `${i + 1}. ${conceptTitle(concept)}`;
-    if (i === conceptCursor) opt.selected = true;
-    jump.appendChild(opt);
-  });
-  jump.onchange = () => jumpToConcept(Number(jump.value), spine);
+  const glyph = el("div", "focused-check__glyph");
+  glyph.textContent = lesson.headword;
+  glyph.dir = SCRIPTS_BY_ID.get(lesson.script)?.direction ?? "auto";
+  card.appendChild(glyph);
+  if (lesson.romanization && lesson.romanization !== lesson.headword) {
+    const romanization = el("p", "step__rom");
+    romanization.textContent = lesson.romanization;
+    card.appendChild(romanization);
+  }
 
-  const next = el("button", "opt") as HTMLButtonElement;
-  next.textContent = "Next →";
-  next.disabled = conceptCursor >= spine.length - 1;
-  next.onclick = () => jumpToConcept(conceptCursor + 1, spine);
+  if (focusedCheckKind(lesson) === "meaning") {
+    const form = el("form", "focused-check__form") as HTMLFormElement;
+    const label = el("label", "focused-check__prompt");
+    label.textContent = `Without reopening the lesson, type one English meaning for “${lesson.headword}”.`;
+    const input = document.createElement("input");
+    input.className = "focused-check__input";
+    input.type = "text";
+    input.autocomplete = "off";
+    input.setAttribute("aria-label", `English meaning for ${languageName(step.language)} ${lesson.headword}`);
+    const submit = el("button", "next") as HTMLButtonElement;
+    submit.type = "submit";
+    submit.textContent = "Check answer";
+    form.append(label, input, submit);
+    form.onsubmit = (event) => {
+      event.preventDefault();
+      if (meaningAnswerIsCorrect(input.value, lesson.gloss)) finishFocusedCheck(step);
+      else {
+        focusedAttempt = { lessonId: lesson.id, state: "wrong" };
+        learnNotice = null;
+        render();
+      }
+    };
+    card.appendChild(form);
+  } else {
+    const prompt = el("p", "focused-check__prompt");
+    prompt.textContent = "Complete the lesson's final recall from memory, without reopening its explanation.";
+    const actions = el("div", "focused-check__actions");
+    const pass = el("button", "next") as HTMLButtonElement;
+    pass.textContent = "I completed it from memory";
+    pass.onclick = () => finishFocusedCheck(step);
+    const again = el("button", "focused-check__secondary") as HTMLButtonElement;
+    again.textContent = "Review lesson again";
+    again.onclick = () => {
+      focusedAttempt = null;
+      render();
+    };
+    actions.append(pass, again);
+    card.append(prompt, actions);
+  }
+  return card;
+}
 
-  nav.append(prev, jump, next);
-  return nav;
+function renderFrontierEncounter(
+  step: FrontierStep,
+  lesson: (typeof LESSONS)[number],
+  ordinal: number,
+  connections: SessionStep["connections"],
+  readyTogether: number,
+): HTMLElement {
+  const sessionStep: SessionStep = {
+    language: step.language,
+    lessons: [lesson],
+    connections,
+  };
+  const card = renderTeachingStep(
+    sessionStep,
+    ordinal,
+    frontierScriptIntro(step),
+    readyTogether > 1 ? `${readyTogether} ready together` : "focused first",
+  );
+  const curriculum = curriculumForLanguage(step.language)!;
+  const progress = localPathProgress(curriculum, learnCompletion);
+  const context = el("p", "frontier__context");
+  const node = spineNodeById(step.spineNode);
+  context.textContent =
+    `Local lesson ${progress.completed + 1} of ${progress.total}` +
+    (node ? ` · ${node.stage} · ${node.canDo}` : "");
+  card.appendChild(context);
+
+  if (step.extensions.length > 0) {
+    const extensionList = el("p", "frontier__extensions");
+    extensionList.textContent = step.extensions
+      .map(({ relation, extension }) => `${relation} ${extension.category}: ${extension.canDo}`)
+      .join(" · ");
+    card.appendChild(extensionList);
+  }
+
+  const start = el("button", "next focused-check__start") as HTMLButtonElement;
+  start.textContent = "Start focused check";
+  start.onclick = () => {
+    focusedAttempt = { lessonId: lesson.id, state: "check" };
+    learnNotice = null;
+    render();
+  };
+  card.appendChild(start);
+  return card;
 }
 
 function renderLearn(): HTMLElement {
   const wrap = el("div", "learn");
   wrap.appendChild(renderLanguagePicker());
-  const conceptSpine = activeConceptSpine();
-
-  if (conceptSpine.length === 0) {
-    const empty = el("p", "muted");
-    empty.textContent = "No concepts to walk yet.";
-    wrap.appendChild(empty);
-    return wrap;
-  }
-
-  // The cursor only moves via the nav buttons, but clamp defensively so a stray
-  // value can never index off the end of the spine.
-  conceptCursor = Math.max(0, Math.min(conceptCursor, conceptSpine.length - 1));
-
-  const concept = conceptSpine[conceptCursor]!;
-  // Everything up to and including the current concept is "covered" — the review
-  // quiz (a later slice) draws from exactly this. Here we render the teaching
-  // pass: the current concept alone, swept across the chain.
-  const covered = conceptSpine.slice(0, conceptCursor + 1);
-  const plan = planSession(concept, covered, MAPPED_SPINE_LESSONS, selectedLanguages);
-
+  const selectedCurricula = selectedLanguages
+    .map((language) => curriculumForLanguage(language))
+    .filter((curriculum) => curriculum !== undefined);
+  const counts = selectedCurricula.map((curriculum) => localPathProgress(curriculum, learnCompletion));
+  const completed = counts.reduce((sum, item) => sum + item.completed, 0);
+  const total = counts.reduce((sum, item) => sum + item.total, 0);
   const progress = el("p", "score");
   progress.textContent =
-    `Concept ${conceptCursor + 1} of ${conceptSpine.length}` +
-    ` · taught in ${plan.teaching.length} language${plan.teaching.length === 1 ? "" : "s"}`;
+    `${completed} of ${total} local lessons passed focused retrieval` +
+    ` · ${selectedLanguages.length} independent path${selectedLanguages.length === 1 ? "" : "s"}`;
   wrap.appendChild(progress);
-
-  // A slim bar for how far along the spine you are — a sense of the whole
-  // journey that the bare "N of M" count doesn't convey at a glance.
   const track = el("div", "progress");
   const fill = el("div", "progress__fill");
-  const pct = spineProgress(conceptCursor, conceptSpine.length) * 100;
+  const pct = total === 0 ? 0 : (completed / total) * 100;
   fill.style.width = `${pct}%`;
   track.appendChild(fill);
   wrap.appendChild(track);
 
-  const heading = el("h2", "learn__concept");
-  heading.textContent = conceptTitle(concept);
-  wrap.appendChild(heading);
-  const node = spineNodeForConcept(concept);
-  if (node) {
-    const canDo = el("p", "learn__can-do");
-    canDo.textContent = `${node.stage} · ${node.canDo}`;
-    wrap.appendChild(canDo);
-  }
-  const gloss = firstGloss(plan.teaching);
-  if (gloss) {
-    const g = el("p", "muted learn__gloss");
-    g.textContent = gloss;
-    wrap.appendChild(g);
+  if (learnNotice) {
+    const notice = el("p", "learn__notice");
+    notice.textContent = learnNotice;
+    wrap.appendChild(notice);
   }
 
-  if (plan.teaching.length === 0) {
-    const none = el("p", "muted");
-    none.textContent = "No active language teaches this concept yet.";
-    wrap.appendChild(none);
-  } else {
+  const frontier = mixedCurriculumFrontier(selectedLanguages, learnCompletion);
+  const activeAttempt = focusedAttempt && frontier.steps.some((step) => step.lessonId === focusedAttempt!.lessonId);
+  if (!activeAttempt) focusedAttempt = null;
+  const heading = el("h2", "learn__concept");
+  heading.textContent = frontier.steps.length > 0 ? "Your next local lessons" : "Selected paths complete";
+  wrap.appendChild(heading);
+  const explanation = el("p", "muted learn__gloss");
+  explanation.textContent = frontier.steps.length > 0
+    ? "Study one short lesson, then pass its focused check. Only that language advances; only passed lessons enter mixed review."
+    : "Every mapped lesson in the selected languages has passed its focused check.";
+  wrap.appendChild(explanation);
+
+  if (frontier.steps.length > 0) {
     const sweep = el("div", "sweep");
-    plan.teaching.forEach((step, i) => {
-      const scriptAlreadyIntroduced = plan.teaching
-        .slice(0, i)
-        .some((earlier) => scriptOf(earlier.language) === scriptOf(step.language));
-      const intro = scriptAlreadyIntroduced
-        ? null
-        : scriptIntroFor(concept, step.language, SCRIPT_INTRO_AT, SCRIPTS_BY_ID);
-      sweep.appendChild(renderTeachingStep(step, i, intro));
+    const earlier: Array<{ step: FrontierStep; lesson: (typeof LESSONS)[number] }> = [];
+    const visibleSteps = focusedAttempt
+      ? frontier.steps.filter((step) => step.lessonId === focusedAttempt!.lessonId)
+      : frontier.steps;
+    visibleSteps.forEach((step, index) => {
+      const lesson = frontierLesson(step);
+      if (!lesson) return;
+      const attempt = focusedAttempt?.lessonId === lesson.id;
+      const readyTogether = frontier.bySpineNode.get(step.spineNode)?.length ?? 1;
+      const card = attempt
+        ? renderFocusedCheck(step, lesson, index)
+        : renderFrontierEncounter(
+          step,
+          lesson,
+          index,
+          frontierConnections(step, lesson, earlier),
+          readyTogether,
+        );
+      sweep.appendChild(card);
+      earlier.push({ step, lesson });
     });
     wrap.appendChild(sweep);
+  } else {
+    focusedAttempt = null;
   }
 
-  wrap.appendChild(renderLearnNav(conceptSpine));
-
-  // The review pass: a cumulative, SRS-weighted quiz over everything covered so
-  // far (this concept and all before it). `plan.reviewGrid` is exactly that grid.
-  wrap.appendChild(renderReview(plan.reviewGrid));
+  const reviewGrid = eligibleReviewGrid(
+    MAPPED_SPINE_LESSONS,
+    LANGUAGE_CURRICULA,
+    selectedLanguages,
+    learnCompletion,
+  );
+  wrap.appendChild(renderReview(reviewGrid));
 
   // A quiet way to start over — clears every persisted key, two-click confirmed.
   wrap.appendChild(renderReset());
@@ -1159,13 +1247,15 @@ function renderLearn(): HTMLElement {
 /** Clear all persisted progress and reset the in-memory session to the start. */
 function executeReset(): void {
   clearProgress(removableStorage());
-  // Review + teaching cursor.
+  // Review + independent local-path progress.
   reviewProgress = { states: new Map(), log: [] };
   reviewSession = 0;
   reviewCell = null;
   reviewOptions = [];
   reviewChosen = null;
-  conceptCursor = 0;
+  learnCompletion = new Map();
+  focusedAttempt = null;
+  learnNotice = null;
   selectedLanguages = [...AVAILABLE_LANGUAGE_IDS];
   // The Lessons-mode schedule is one of the cleared keys, so its in-memory state
   // must be zeroed too — otherwise Lessons still shows the old stats and the next
@@ -1199,7 +1289,7 @@ function renderReset(): HTMLElement {
     return wrap;
   }
   const warn = el("span", "reset-warn");
-  warn.textContent = "Clear all progress — review, mistakes, and your place in the walk?";
+  warn.textContent = "Clear all progress — local paths, review, mistakes, and language mix?";
   const yes = el("button", "reset-yes") as HTMLButtonElement;
   yes.textContent = "Yes, reset";
   yes.onclick = () => executeReset();
@@ -1226,7 +1316,7 @@ function shuffleWith<T>(items: T[], rng: () => number): T[] {
 }
 
 /**
- * Draw the next review question from the covered grid.
+ * Draw the next review question from the independently eligible grid.
  *
  * The cell is chosen by the engine's SRS-weighted `pickNext` (missed/overdue
  * cells rise, mastered ones sink). The options are the SAME concept in other
@@ -1315,18 +1405,27 @@ function renderConfusions(): HTMLElement | null {
 function renderReview(grid: GridCell[]): HTMLElement {
   const wrap = el("div", "review");
   const title = el("h3", "review__title");
-  title.textContent = "Review — everything so far";
+  title.textContent = "Review — independently unlocked";
   wrap.appendChild(title);
 
   if (grid.length === 0) {
     const empty = el("p", "muted");
-    empty.textContent = "Nothing to review yet — keep walking the concepts.";
+    empty.textContent = "Nothing is eligible yet — pass a focused check above first.";
     wrap.appendChild(empty);
     return wrap;
   }
 
+  if (!mixedReviewReady(grid)) {
+    const waiting = el("p", "muted");
+    waiting.textContent =
+      `${grid.length} lesson${grid.length === 1 ? " is" : "s are"} eligible` +
+      "; pass another focused check with a different answer to start mixed review.";
+    wrap.appendChild(waiting);
+    return wrap;
+  }
+
   // Draw lazily: a null cell means "need a fresh question" (first entry, after
-  // Next, or after the covered set changed when the concept cursor moved).
+  // Next, or after a focused success changed the eligible local-prefix set).
   if (!reviewCell) nextReviewQuestion(grid);
   const cell = reviewCell;
   if (!cell) return wrap; // grid non-empty, so this is unreachable, but keeps TS happy
@@ -1334,7 +1433,7 @@ function renderReview(grid: GridCell[]): HTMLElement {
   const stat = el("p", "score");
   const conceptCount = new Set(grid.map((c) => c.concept)).size;
   stat.textContent =
-    `${grid.length} items · ${conceptCount} concept${conceptCount === 1 ? "" : "s"}` +
+    `${grid.length} item${grid.length === 1 ? "" : "s"} · ${conceptCount} concept${conceptCount === 1 ? "" : "s"}` +
     ` · ${reviewProgress.log.length} answered`;
   wrap.appendChild(stat);
 
@@ -1383,7 +1482,7 @@ function renderReview(grid: GridCell[]): HTMLElement {
     const next = el("button", "next") as HTMLButtonElement;
     next.textContent = "Next →";
     next.onclick = () => {
-      reviewCell = null; // force a fresh draw from the current covered grid
+      reviewCell = null; // force a fresh draw from the current eligible grid
       render();
     };
     reveal.appendChild(next);

--- a/code/programs/typescript/language-ladder/src/reset.ts
+++ b/code/programs/typescript/language-ladder/src/reset.ts
@@ -2,8 +2,9 @@
 // reset.ts — starting over.
 //
 // The app now remembers a lot between visits: the review quiz's SRS state and
-// answer log (reviewstore.ts), the teaching cursor (cursorstore.ts), and the
-// lesson schedule (progress.ts). That is good — until you want a clean slate
+// answer log (reviewstore.ts), per-language Learn paths (learnprogress.ts), the
+// legacy teaching cursor (cursorstore.ts), and the lesson schedule (progress.ts).
+// That is good — until you want a clean slate
 // (you're handing the tab to someone else, or you want to re-walk from the top).
 // There was no way to clear it. This is that way.
 //
@@ -18,6 +19,7 @@ import { STORAGE_KEY as LESSON_SCHEDULE_KEY } from "./progress.ts";
 import { REVIEW_STORAGE_KEY } from "./reviewstore.ts";
 import { CURSOR_STORAGE_KEY } from "./cursorstore.ts";
 import { LANGUAGE_STORAGE_KEY } from "./languagestore.ts";
+import { LEARN_PROGRESS_STORAGE_KEY } from "./learnprogress.ts";
 
 /**
  * Every localStorage key this app owns. Sourced from the owning modules'
@@ -27,6 +29,7 @@ import { LANGUAGE_STORAGE_KEY } from "./languagestore.ts";
 export const OWNED_STORAGE_KEYS: readonly string[] = [
   REVIEW_STORAGE_KEY,
   CURSOR_STORAGE_KEY,
+  LEARN_PROGRESS_STORAGE_KEY,
   LESSON_SCHEDULE_KEY,
   LANGUAGE_STORAGE_KEY,
 ];

--- a/code/programs/typescript/language-ladder/src/styles.css
+++ b/code/programs/typescript/language-ladder/src/styles.css
@@ -419,6 +419,72 @@ body {
 }
 .step__script-sig { margin: 5px 0 0; font-size: 0.85rem; line-height: 1.5; color: var(--ink); }
 
+/* Independent local frontiers and the focused check before mixed review. */
+.learn__notice {
+  margin: 12px 0 16px;
+  padding: 9px 12px;
+  border-left: 3px solid #2f855a;
+  background: #e6f6ec;
+  color: #22543d;
+  border-radius: 0 6px 6px 0;
+  font-size: 0.9rem;
+}
+.frontier__context {
+  margin: 12px 0 0;
+  padding-top: 10px;
+  border-top: 1px solid var(--line);
+  color: var(--ink);
+  font-size: 0.85rem;
+  line-height: 1.45;
+}
+.frontier__extensions {
+  margin: 8px 0 0;
+  padding: 7px 10px;
+  background: #fff8ec;
+  border-left: 3px solid var(--ff);
+  border-radius: 0 5px 5px 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+.focused-check__start { margin-top: 10px; }
+.focused-check__glyph {
+  margin: 12px 0 4px;
+  font-size: 2.2rem;
+  line-height: 1.25;
+}
+.focused-check[data-language="persian"] .focused-check__glyph,
+.focused-check[data-language="urdu"] .focused-check__glyph {
+  font-family: "Curriculum Naskh", serif;
+}
+.focused-check__form { display: grid; gap: 9px; margin-top: 14px; }
+.focused-check__prompt { color: var(--ink); font-size: 0.9rem; line-height: 1.5; }
+.focused-check__input {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  padding: 9px 11px;
+  color: var(--ink);
+  background: var(--card);
+  font: inherit;
+}
+.focused-check__input:focus { outline: 2px solid var(--accent); outline-offset: 1px; }
+.focused-check__feedback { margin: 10px 0; font-weight: 650; line-height: 1.5; }
+.focused-check__feedback.no { color: #c53030; }
+.focused-check__actions { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; }
+.focused-check__secondary {
+  margin-top: 12px;
+  border: 1px solid var(--line);
+  background: var(--card);
+  color: var(--ink);
+  padding: 8px 14px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+.focused-check__secondary:hover { border-color: var(--accent); color: var(--accent); }
+
 .learn__nav { display: flex; align-items: center; gap: 10px; margin-top: 20px; }
 /* The jump picker grows to fill the space between Prev and Next. */
 .learn__jump {

--- a/code/programs/typescript/language-ladder/tests/curriculum.test.ts
+++ b/code/programs/typescript/language-ladder/tests/curriculum.test.ts
@@ -6,6 +6,7 @@ import {
   curriculumForLanguage,
   mappedLessonIds,
   mixedCurriculumFrontier,
+  spineNodeById,
 } from "../src/curriculum";
 
 describe("per-language shared-spine maps", () => {
@@ -22,6 +23,11 @@ describe("per-language shared-spine maps", () => {
     expect(spanish.spine["SPINE-MEET-GREET"]?.segments.length).toBeGreaterThan(1);
     expect(spanish.spine["SPINE-TAKE-LEAVE"]?.relocates["GREETING-GOODNIGHT"])
       .toBe("SPINE-TIME-OF-DAY");
+  });
+
+  it("resolves a shared ability by its stable node id", () => {
+    expect(spineNodeById("SPINE-MEET-GREET")?.canDo).toContain("greeting");
+    expect(spineNodeById("MISSING")).toBeUndefined();
   });
 
   it("makes Persian and Urdu script introduction an inline local extension", () => {

--- a/code/programs/typescript/language-ladder/tests/focused.test.ts
+++ b/code/programs/typescript/language-ladder/tests/focused.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  acceptedMeanings,
+  focusedCheckKind,
+  meaningAnswerIsCorrect,
+  normalizeFocusedAnswer,
+} from "../src/focused";
+
+describe("focused retrieval checks", () => {
+  it("accepts a full gloss or one top-level alternative", () => {
+    expect(acceptedMeanings("hello / peace (formal note)")).toEqual([
+      "hello peace",
+      "hello",
+      "peace",
+    ]);
+    expect(meaningAnswerIsCorrect("Peace", "hello / peace (formal note)")).toBe(true);
+    expect(meaningAnswerIsCorrect("goodbye", "hello / peace (formal note)")).toBe(false);
+  });
+
+  it("normalizes case, punctuation, apostrophes, and accents", () => {
+    expect(normalizeFocusedAnswer("  YOU’RE-wélcome! ")).toBe("youre welcome");
+  });
+
+  it("uses objective meaning checks only for lexical lessons", () => {
+    expect(focusedCheckKind({ type: "word", gloss: "hello" })).toBe("meaning");
+    expect(focusedCheckKind({ type: "phrase", gloss: "my name is" })).toBe("meaning");
+    expect(focusedCheckKind({ type: "writing", gloss: "the first joined shape" }))
+      .toBe("self-check");
+  });
+});

--- a/code/programs/typescript/language-ladder/tests/learnprogress.test.ts
+++ b/code/programs/typescript/language-ladder/tests/learnprogress.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import type { LanguageCurriculum } from "@coding-adventures/human-language-data/src/types.ts";
+import type { Lesson } from "../src/lessons";
+import {
+  LEARN_PROGRESS_SCHEMA_VERSION,
+  LEARN_PROGRESS_STORAGE_KEY,
+  completeFrontierLesson,
+  eligibleReviewGrid,
+  fromSavedLearnProgress,
+  loadLearnProgress,
+  mixedReviewReady,
+  saveLearnProgress,
+  toSavedLearnProgress,
+} from "../src/learnprogress";
+
+const curriculum = (language: string): LanguageCurriculum => ({
+  version: 1,
+  language,
+  path: [{
+    id: `${language}-path`,
+    spine_node: "GREET",
+    lessons: [`${language}-a`, `${language}-b`, `${language}-support`],
+    before: [],
+    inline: [`${language}-extension`],
+    after: [],
+  }],
+  spine: { GREET: { segments: [`${language}-path`], omits: [], relocates: {} } },
+  extensions: [{
+    id: `${language}-extension`,
+    stage: "pre-A1",
+    kind: "supporting",
+    category: "grammar",
+    canDo: "I can use the support step.",
+    prerequisites: [],
+    lessons: [`${language}-support`],
+  }],
+});
+
+const lesson = (id: string, language: string, concept: string): Lesson => ({
+  id,
+  language,
+  headword: id,
+  gloss: `meaning ${id}`,
+  type: "word",
+  chapter: 1,
+  concept,
+  prerequisites: [],
+  reviewsOf: [],
+  roots: [],
+  romanization: id,
+  script: "latin",
+  etymologyHook: "",
+  body: "",
+  estMinutes: 3,
+});
+
+describe("per-language Learn progress", () => {
+  it("keeps only prerequisite-safe prefixes from untrusted saved ids", () => {
+    const fa = curriculum("fa");
+    const restored = fromSavedLearnProgress({
+      version: LEARN_PROGRESS_SCHEMA_VERSION,
+      completed: [["fa", ["fa-a", "fa-support"]], ["unknown", ["x"]]],
+    }, [fa]);
+    expect([...restored.get("fa") ?? []]).toEqual(["fa-a"]);
+    expect(restored.has("unknown")).toBe(false);
+  });
+
+  it("completes only the current local frontier", () => {
+    const fa = curriculum("fa");
+    const skipped = completeFrontierLesson(new Map(), fa, "fa-b");
+    expect(skipped.changed).toBe(false);
+
+    const first = completeFrontierLesson(new Map(), fa, "fa-a");
+    expect(first.changed).toBe(true);
+    expect([...first.completion.get("fa") ?? []]).toEqual(["fa-a"]);
+
+    const second = completeFrontierLesson(first.completion, fa, "fa-b");
+    expect([...second.completion.get("fa") ?? []]).toEqual(["fa-a", "fa-b"]);
+  });
+
+  it("admits only independently completed prefixes to mixed review", () => {
+    const fa = curriculum("fa");
+    const ur = curriculum("ur");
+    const lessons = [
+      lesson("fa-a", "fa", "HELLO"),
+      lesson("fa-b", "fa", "THANKS"),
+      lesson("fa-support", "fa", ""),
+      lesson("ur-a", "ur", "HELLO"),
+      lesson("ur-b", "ur", "THANKS"),
+      lesson("ur-support", "ur", ""),
+    ];
+    const completion = new Map<string, ReadonlySet<string>>([
+      ["fa", new Set(["fa-a", "fa-b"])],
+      ["ur", new Set(["ur-b"])],
+    ]);
+    expect(eligibleReviewGrid(lessons, [fa, ur], ["ur", "fa"], completion)
+      .map((cell) => cell.lesson.id)).toEqual(["fa-a", "fa-b"]);
+  });
+
+  it("waits for two visually distinct eligible answers before mixing", () => {
+    const shared = lesson("fa-a", "fa", "HELLO");
+    const identical = { ...lesson("ur-a", "ur", "HELLO"), headword: shared.headword };
+    expect(mixedReviewReady([
+      { concept: "HELLO", language: "fa", lesson: shared },
+      { concept: "HELLO", language: "ur", lesson: identical },
+    ])).toBe(false);
+    expect(mixedReviewReady([
+      { concept: "HELLO", language: "fa", lesson: shared },
+      { concept: "THANKS", language: "ur", lesson: lesson("ur-b", "ur", "THANKS") },
+    ])).toBe(true);
+  });
+
+  it("round-trips stable ids and fails closed on corrupt storage", () => {
+    const fa = curriculum("fa");
+    const completion = new Map<string, ReadonlySet<string>>([
+      ["fa", new Set(["fa-a", "fa-b"])],
+    ]);
+    const saved = toSavedLearnProgress(completion, [fa]);
+    expect(saved.completed).toEqual([["fa", ["fa-a", "fa-b"]]]);
+
+    const data = new Map<string, string>();
+    const store = {
+      getItem: (key: string) => data.get(key) ?? null,
+      setItem: (key: string, value: string) => void data.set(key, value),
+    };
+    expect(saveLearnProgress(store, completion, [fa])).toBe(true);
+    expect([...loadLearnProgress(store, [fa]).get("fa") ?? []]).toEqual(["fa-a", "fa-b"]);
+    data.set(LEARN_PROGRESS_STORAGE_KEY, "not-json");
+    expect(loadLearnProgress(store, [fa])).toEqual(new Map());
+  });
+});

--- a/code/programs/typescript/language-ladder/tests/reset.test.ts
+++ b/code/programs/typescript/language-ladder/tests/reset.test.ts
@@ -8,6 +8,7 @@ import { REVIEW_STORAGE_KEY } from "../src/reviewstore";
 import { CURSOR_STORAGE_KEY } from "../src/cursorstore";
 import { STORAGE_KEY as LESSON_SCHEDULE_KEY } from "../src/progress";
 import { LANGUAGE_STORAGE_KEY } from "../src/languagestore";
+import { LEARN_PROGRESS_STORAGE_KEY } from "../src/learnprogress";
 
 function fakeStore(seed: Record<string, string> = {}): RemovableStorage & {
   data: Map<string, string>;
@@ -17,11 +18,17 @@ function fakeStore(seed: Record<string, string> = {}): RemovableStorage & {
 }
 
 describe("OWNED_STORAGE_KEYS", () => {
-  it("lists exactly the four keys the app persists, sourced from their owners", () => {
+  it("lists every key the app persists, sourced from its owner", () => {
     // If a persisted key were forgotten here, a reset would silently leave state
     // behind — so pin the set explicitly.
     expect(new Set(OWNED_STORAGE_KEYS)).toEqual(
-      new Set([REVIEW_STORAGE_KEY, CURSOR_STORAGE_KEY, LESSON_SCHEDULE_KEY, LANGUAGE_STORAGE_KEY]),
+      new Set([
+        REVIEW_STORAGE_KEY,
+        CURSOR_STORAGE_KEY,
+        LEARN_PROGRESS_STORAGE_KEY,
+        LESSON_SCHEDULE_KEY,
+        LANGUAGE_STORAGE_KEY,
+      ]),
     );
   });
 });
@@ -31,6 +38,7 @@ describe("clearProgress", () => {
     const store = fakeStore({
       [REVIEW_STORAGE_KEY]: "r",
       [CURSOR_STORAGE_KEY]: "c",
+      [LEARN_PROGRESS_STORAGE_KEY]: "p",
       [LESSON_SCHEDULE_KEY]: "l",
       [LANGUAGE_STORAGE_KEY]: "g",
     });

--- a/code/specs/HL03-unified-language-learning-app.md
+++ b/code/specs/HL03-unified-language-learning-app.md
@@ -29,6 +29,17 @@ gets its own authored spine realization and knowledge closure, new material rece
 focused acquisition before mixed review, and the full lesson body becomes the one
 source for book and app delivery.
 
+### Current progression contract
+
+HL04 governs when its local-path rules conflict with the earlier global
+concept-sweep model below. Learn now presents one prerequisite-safe frontier per
+selected language and stores stable completed lesson-id prefixes independently.
+A focused check advances only that language; mixed review includes only lessons
+that independently passed and waits for at least two visually distinct eligible
+answers. A shared concept sweep is therefore a comparison available when local
+frontiers and eligibility align, not a cursor that can pull another language
+past its own script, grammar, register, or vocabulary prerequisite.
+
 ## The learner's model — a spiral with cumulative concept-sweeps
 
 HL02 stated the pattern in miniature (Spanish → French → German). The real model
@@ -227,6 +238,12 @@ All of the above shipped as the app **`language-ladder`** (renamed from
   romanization under the quiz options — the `romanization` field is populated for
   only ~54 of ~700 lessons (and not the Indic vocabulary, whose romanization lives
   in the gloss text), so showing it would be inconsistent rather than helpful.
+- **HL04 local-frontier migration** — all 20 realization maps now drive Learn.
+  `learnprogress.ts` stores only prerequisite-safe per-language prefixes;
+  lexical meaning retrieval and authored non-lexical recall gate advancement;
+  explicit local extension nodes place script and grammar support; and mixed SRS
+  review draws only from independently focused-successful lessons. The old
+  `cursorstore.ts` key remains resettable only as legacy state.
 
 The two honest non-builds (grammar intro, romanization) can return if the
 curriculum grows the metadata they need.

--- a/code/specs/HL04-shared-spine-and-content-pipeline.md
+++ b/code/specs/HL04-shared-spine-and-content-pipeline.md
@@ -70,14 +70,14 @@ experience.
 | One atomic lesson | Strong: most content lessons teach one word or phrase. | Some lessons are long enough to contain several independent teaching steps. |
 | Strictly less than five minutes | The deterministic duration report now measures zero lessons at or above 300 effective seconds; schema-v2 lessons fail validation outside 1–299 seconds. | Keep the gate green as the corpus grows and finish migrating legacy lesson contracts. |
 | Etymology and morphology | Strong prose tradition and root metadata. | Normalize etymons, record sources/confidence, and deliver the full explanation to the app. |
-| Inline grammar | Present in Markdown prose. | Grammar has almost no structured metadata, cannot be ordered or practised by the app, and cannot be closure-checked. |
-| Inline script | Writing lessons and script JSON exist. | Writing lessons do not participate in the concept sweep; the app gives a one-time script signature rather than a cumulative reading path. |
+| Inline grammar | Typed local extension nodes place grammar lessons in prerequisite-safe paths; the app advances through those lessons inline. | Compile objective prompt/answer contracts so non-lexical focused checks do not rely on learner confirmation. |
+| Inline script | Typed local script extensions, writing lessons, and script JSON now participate in each language's visible frontier. | Complete grapheme-level knowledge closure, progressive transliteration fading, and a true Nastaliq presentation font. |
 | Shared cross-language concepts | 42 concepts are shared by two or more languages. | The shared layer is mostly greetings and A0 vocabulary; 385 concepts remain language-namespaced. |
-| Safe progression | Lesson-id prerequisites have no cycles or unknown ids. | Sixty lessons have no prerequisites, including 42 later-chapter lessons; assumed vocabulary, grammar, sounds, and glyphs are not represented. |
-| Single content source | Claimed by HL00. | The Markdown body is discarded by the parser, LaTeX chapters are handwritten copies, and the app consumes frontmatter summaries only. |
+| Safe progression | All 20 maps cover mapped prerequisites in earlier local positions; Learn stores only completed prefixes and cannot jump ahead. | Finish knowledge-atom and activity-contract migration for legacy lessons so every assessed token, construction, sound, and glyph is closure-checked. |
+| Single content source | The parser preserves typed Markdown bodies; the app renders them and generated book chapters carry the same source hashes. | Continue replacing the remaining handwritten chapter copies and legacy lesson contracts. |
 | Four skills and communicative use | Audio-script cues and guided prompts exist. | There is no structured listening, interaction, writing, or can-do coverage model, and no audio asset contract. |
 | Graded input and sustained reading | Isolated example sentences occur. | There is no controlled micro-story/dialogue corpus or known-token validation. |
-| Mixed-language practice | Learners can choose any of the 20 tracks; every track now has a prerequisite-closed realization path, and a pure planner computes independent local frontiers. | Learn still presents a global concept cursor. Move its visible progression and focused-before-mixed eligibility onto the per-language frontier planner. |
+| Mixed-language practice | Learn advances independent local frontiers, persists safe lesson-id prefixes, blocks advancement after a wrong focused check, and admits only independently passed, visually distinguishable lessons to mixed SRS review. | Compile objective focused activities for non-lexical lessons and expand prompt directions beyond meaning recognition. |
 | Register, dialect, and culture | Often explained in lesson prose. | These distinctions are not typed, so the app can silently compare non-equivalent registers or varieties. |
 | Proficiency target | Roadmaps generally point toward B1. | No CEFR/ACTFL-aligned outcome matrix shows which reception, production, interaction, or mediation abilities are covered. |
 
@@ -98,9 +98,10 @@ tracks:
 
 Subsequent slices added typed body blocks, computed-duration enforcement,
 canonical book generation, and the 20 per-track spine maps described below.
-This foundation still does not claim independently gated focused-to-mixed
-retrieval in the visible Learn flow, a true Nastaliq font, complete schema-v2
-migration, or B1 corpus depth.
+Subsequent app work also moved visible progression and mixed eligibility onto
+independent per-language frontiers with a focused-success gate. This foundation
+still does not claim compiled objective activities for every non-lexical lesson,
+a true Nastaliq font, complete schema-v2 migration, or B1 corpus depth.
 
 ## The curriculum model
 
@@ -474,9 +475,9 @@ measurable.
    duration types while preserving version-1 compatibility.
 2. **Spanish vertical slice** — migrate Chapters 1–3, render book and app, and
    prove strict duration plus closed-world progression.
-3. **Mixed-practice correction** — learner-selected languages and the pure
-   per-language frontier planner are implemented; move the visible Learn cursor,
-   focused-before-interleaved eligibility, and persistence onto that planner.
+3. **Mixed-practice correction** — implemented: learner-selected languages,
+   persistent per-language completed prefixes, visible local frontiers, wrong-
+   answer blocking, and independently gated mixed eligibility.
 4. **Persian and Urdu pilots** — build script composition and the first three spine
    clusters in each language with appropriate typography and variety metadata.
 5. **Existing-track migration** — all tracks now have explicit paths and extension


### PR DESCRIPTION
## Summary

- replace the global Learn concept cursor with prerequisite-safe, independently persisted per-language frontiers
- require a focused check before each local lesson can advance or enter mixed-language review
- introduce script/grammar/register extensions inline from the authored realization maps
- make mixed review wait for independently unlocked, visually distinct answers
- update HL03, HL04, the Language Ladder docs, and the prioritized human-languages backlog

## Validation

- `npm run build`
- `npm test -- --run` — 30 test files, 478 tests
- `git diff --check`
- rendered Persian/Urdu QA: wrong-answer blocking, independent advancement, reload persistence, RTL/script rendering, and delayed mixed-review eligibility; zero browser errors