### PR TITLE
feat(task-app): board (kanban) view — the first real use of the drag kernel

### DIFF
--- a/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
@@ -1116,6 +1116,22 @@ fn emit_compose_tree(
             for_payload,
             injected_width,
         ),
+        // UI35 — the drag family. This backend does not implement dragging yet, so
+        // both lower to a plain vertical container: the content still renders, it
+        // just isn't draggable here. Erroring instead would mean a layout using drag
+        // cannot be emitted to this backend AT ALL. See UI35-host-drag-drop.md.
+        "HostDraggable" | "HostDropTarget" => emit_container(
+            node,
+            "Column",
+            depth,
+            component_name,
+            emits,
+            part_styles,
+            table_ctx,
+            text_ctx,
+            for_payload,
+            injected_width,
+        ),
         "Column" => emit_container(
             node,
             "Column",

--- a/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
@@ -1008,6 +1008,11 @@ fn emit_widget_tree(
         "Box" => Some("Container"),
         "Row" => Some("Row"),
         "Column" => Some("Column"),
+        // UI35 — the drag family. This backend does not implement dragging yet, so
+        // both lower to a Column: the content still renders, it
+        // just isn't draggable here. Erroring instead would mean a layout using drag
+        // cannot be emitted to this backend AT ALL. See UI35-host-drag-drop.md.
+        "HostDraggable" | "HostDropTarget" => Some("Column"),
         "Stack" => Some("Stack"),
         // UI28-1 / U29-D1 — HostTable structural sub-tags lower to
         // `Column` containers on Flutter (Flutter has no semantic

--- a/code/packages/rust/mosaic-emit-html/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-html/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Fixed - expression drag keys are no longer silently dropped
+
+`append_drag_value` matched only a string literal or a slot ref, so once a layout used
+an expression key (`drop-key: ( col[1] )`, as a board must) this backend emitted the
+`<div>`s with **no** `data-mosaic-drop-key` / `data-mosaic-drag-key` at all. The runtime
+then found no targets and nothing was draggable — an inert board with no diagnostic.
+
+An expression is now rendered as a mustache over the same binding, with index access
+lowered to the dotted path the template engine resolves (`col[1]` → `{{col.1}}`).
+Deliberately narrow: anything with an operator in it is not a path, and is passed
+through to fail visibly rather than resolve to something wrong.
+
+
 ### Fixed - project-shell node-slot hydration
 
 The generated `main.js` runtime now evaluates triple-mustache node markers

--- a/code/packages/rust/mosaic-emit-html/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-html/src/pipeline.rs
@@ -3044,8 +3044,38 @@ fn append_drag_value(attrs: &mut String, node: &LayoutNode, prop: &str, attr: &s
         Some(LayoutPropValue::SlotRef(slot)) => {
             write!(attrs, " {attr}=\"{{{{{}}}}}\"", camel(slot)).unwrap();
         }
+        // An expression — how a key comes from a loop binding, which is what a board
+        // needs (`drop-key: ( col[1] )` per column). The React backend accepts this;
+        // silently dropping it here would emit a board with no drag attributes at all,
+        // so the runtime would find no targets and nothing would be draggable — an
+        // inert board with no diagnostic.
+        //
+        // This backend's template engine substitutes `{{path}}`, so an expression is
+        // rendered as a mustache over the same binding. Index access (`col[1]`) becomes
+        // the dotted path (`col.1`) the runtime's `readPath` understands.
+        Some(LayoutPropValue::Expr(text)) => {
+            let path = expr_to_mustache_path(text);
+            write!(attrs, " {attr}=\"{{{{{path}}}}}\"").unwrap();
+        }
         _ => {}
     }
+}
+
+/// Turn a simple index/field expression into the dotted path this backend's template
+/// engine resolves: `col[1]` → `col.1`, `card[2]` → `card.2`, `a.b` → `a.b`.
+///
+/// Deliberately narrow. Anything with an operator in it is not a path and is passed
+/// through unchanged, which the template engine will fail to resolve — visibly empty
+/// rather than silently wrong.
+fn expr_to_mustache_path(text: &str) -> String {
+    let cleaned: String = text
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect::<String>()
+        .trim_start_matches('(')
+        .trim_end_matches(')')
+        .to_string();
+    cleaned.replace("][", ".").replace('[', ".").replace(']', "")
 }
 
 /// Write a boolean drag prop. `false` is omitted rather than written out, so the
@@ -4904,6 +4934,29 @@ mod tests {
     // ===================================================================
     // UI35 — the drag-and-drop family
     // ===================================================================
+
+    /// An expression key — how a board's per-column key arrives, from a loop binding.
+    /// Silently dropping it (the previous behaviour) emitted a board with no drag
+    /// attributes at all: the runtime would find no targets and nothing would drag,
+    /// with no diagnostic.
+    #[test]
+    fn ui35_expression_drag_keys_become_mustache_paths() {
+        let l = layout(
+            "B",
+            node_with_props(
+                "HostDropTarget",
+                vec![prop_expr("drop-key", "( col[1] )")],
+            ),
+        );
+        let out = from_pipeline(&component("B", vec![]), &l, &empty_style("B"))
+            .unwrap()
+            .output;
+        assert!(
+            out.contains("data-mosaic-drop-key=\"{{col.1}}\""),
+            "expression key not lowered to a template path:
+{out}"
+        );
+    }
 
     /// A board-shaped layout: a drop target (the column) wrapping a draggable
     /// (the card). This is the exact structure a kanban lowering produces.

--- a/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
@@ -1602,6 +1602,16 @@ fn primitive_to_qml(tag: &str) -> Result<QmlElement, PipelineEmitError> {
             is_text: false,
             is_image: false,
         },
+        // UI35 — the drag family. This backend does not implement dragging yet, so
+        // both lower to a ColumnLayout: the content still renders, it just isn't
+        // draggable here. Erroring instead would mean a layout using drag cannot be
+        // emitted to this backend AT ALL. See UI35-host-drag-drop.md.
+        "HostDraggable" | "HostDropTarget" => QmlElement {
+            element_name: "ColumnLayout",
+            builtin_lines: vec![],
+            is_text: false,
+            is_image: false,
+        },
         "Text" => QmlElement {
             element_name: "Text",
             builtin_lines: vec![],

--- a/code/packages/rust/mosaic-emit-react/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-react/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Changed - drag keys may come from an expression
+
+`drag-key` / `drop-key` / `drag-kind` / `drag-label` now accept an **expression**, not
+just a string literal or a slot ref. This is how a key arrives from a loop binding —
+`drop-key: ( col[1] )` per column, `drag-key: ( card[2] )` per card — which is to say:
+it is what a kanban board needs.
+
+The original code rejected anything that wasn't a literal or a slot, on the reasoning
+that an unhandled shape should fail loudly rather than degrade to an empty key. That
+half was right and is kept (an emit ref is still an error). Refusing the *expression*
+was not: it made the drag family unusable from inside a `For`, i.e. unusable for the
+one layout it was designed for. Found by building that board.
+
+### Fixed - hook imports are narrowed to what a component uses
+
+`useEffect` was imported whenever any hook was needed, including for a component whose
+only hook consumer is the drag controller — which uses none. That trips
+`noUnusedLocals` (TS6133) and breaks `tsc -b` under a strict host tsconfig, the same
+trap already documented for unread slots. Now: `useRef` always, `useEffect` only for
+dialogs and indeterminate checkboxes, `useState`/`useId` only for drag.
+
+
 ### Added - host-owned surface composition
 
 `HostSurface ( content: slot: ... )` now mounts the supplied `ReactNode` in a

--- a/code/packages/rust/mosaic-emit-react/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-react/src/pipeline.rs
@@ -554,23 +554,23 @@ pub fn from_pipeline(
         writeln!(out, "import React from \"react\";").unwrap();
     }
     if needs_hook_imports {
-        // Always include both `useRef` and `useEffect`: every HostDialog
-        // needs the ref (for the imperative `showModal()` call) AND an
-        // effect (to react to `open` flipping). Splitting the import based
-        // on which hook a particular dialog *might* not need would only
-        // matter for dead-code elimination, and modern bundlers already
-        // tree-shake unused named imports.
-        // UI35 adds `useState`: the drag controller keeps the hovered drop target in
-        // state (it drives rendering) while the in-flight drag itself lives in a ref.
-        if has_drag {
-            writeln!(
-                out,
-                "import {{ useRef, useEffect, useState, useId }} from \"react\";"
-            )
-            .unwrap();
-        } else {
-            writeln!(out, "import {{ useRef, useEffect }} from \"react\";").unwrap();
+        // Import exactly the hooks this component uses. Importing a hook it doesn't
+        // trips `noUnusedLocals` (TS6133) under a strict host tsconfig and breaks
+        // `tsc -b` — the same trap documented on `emit_function` for unread slots.
+        //
+        //   useRef            dialogs, indeterminate checkboxes, and the drag controller
+        //   useEffect         dialogs and checkboxes only — the drag controller has none
+        //   useState / useId  the drag controller only
+        let needs_effect = !dialog_nodes.is_empty() || !indeterminate_checkbox_nodes.is_empty();
+        let mut hooks: Vec<&str> = vec!["useRef"];
+        if needs_effect {
+            hooks.push("useEffect");
         }
+        if has_drag {
+            hooks.push("useState");
+            hooks.push("useId");
+        }
+        writeln!(out, "import {{ {} }} from \"react\";", hooks.join(", ")).unwrap();
     }
     writeln!(out).unwrap();
 
@@ -2521,14 +2521,23 @@ fn drag_value_expr(
         validate_slot_or_field_name(&camel).map_err(PipelineEmitError::UnsafeSlotName)?;
         return Ok(Some(camel));
     }
-    // Present but in a shape we do not lower — fail loudly rather than silently
-    // degrading to an empty key. A silent `""` produces a drop target that still
-    // registers and can be matched against any *other* keyless target, so a
-    // mis-typed key would surface as cards landing in the wrong column rather
-    // than as an error. Same stance as `emit_for_jsx`'s `each:` handling.
-    if node.props.iter().any(|p| p.name == prop) {
+    // An expression — which is how a key comes from a loop binding, and therefore the
+    // shape a real board needs: `drop-key: ( col[1] )` per column, `drag-key:
+    // ( card[2] )` per card. This was originally rejected, on the reasoning that an
+    // unhandled shape should fail loudly rather than degrade to an empty key. That
+    // half was right; refusing the expression outright was not, and it made the drag
+    // family unusable from inside a `For` — i.e. unusable for the one layout it was
+    // designed for. Same trust model as every other Expr in this emitter.
+    if let Some(prop_ref) = node.props.iter().find(|p| p.name == prop) {
+        if let LayoutPropValue::Expr(text) = &prop_ref.value {
+            return Ok(Some(text.clone()));
+        }
+        // Still loud for a genuinely unusable shape (an emit ref, say): a silent `""`
+        // produces a drop target that registers and can be matched against any OTHER
+        // keyless target, so a mis-typed key would surface as cards landing in the
+        // wrong column rather than as an error.
         return Err(PipelineEmitError::UnsafeSlotName(format!(
-            "drag prop `{prop}:` must be a string literal or a slot ref"
+            "drag prop `{prop}:` must be a string literal, a slot ref, or an expression"
         )));
     }
     Ok(None)
@@ -7570,9 +7579,15 @@ mod tests {
             out.contains("ref={mosaic$live}") && out.contains("aria-live=\"polite\""),
             "no live region bound, so announcements would go nowhere:\n{out}"
         );
+        // Exactly the hooks the drag controller uses — and NOT useEffect, which it
+        // has none of and which would trip noUnusedLocals under a strict tsconfig.
         assert!(
-            out.contains("import { useRef, useEffect, useState, useId }"),
+            out.contains("import { useRef, useState, useId }"),
             "drag needs useState for hover and useId for instance scoping:\n{out}"
+        );
+        assert!(
+            !out.contains("useEffect"),
+            "an unused useEffect import breaks `tsc -b`:\n{out}"
         );
     }
 

--- a/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
@@ -2176,6 +2176,25 @@ fn emit_view_tree(
         // view modifier on the wrapped child (macOS / iOS 16+), and
         // `HostNumberInput` to `TextField` with the `.number`
         // format binding (iOS 15+/macOS 12+).
+        // UI35 — the drag family. This backend does not implement dragging yet, so
+        // both lower to a plain vertical container: the card and the column still
+        // render, they just aren't draggable here.
+        //
+        // The alternative — erroring on an unknown primitive — means a layout that
+        // uses drag cannot be emitted to this backend AT ALL, which took down the
+        // task-app cross-backend tests the moment the app grew a board. Degrading to
+        // the content is the behaviour UI35 asks for: the view is still usable, minus
+        // the interaction. See `code/specs/UI35-host-drag-drop.md`.
+        "HostDraggable" | "HostDropTarget" => container(
+            "VStack",
+            node,
+            indent,
+            part_styles,
+            emits,
+            table_ctx,
+            for_payload,
+        )?,
+
         "HostLink" => emit_host_link(node, indent, emits, for_payload)?,
         "HostTooltip" => emit_host_tooltip(node, indent, part_styles, emits, for_payload)?,
         "HostNumberInput" => emit_host_number_input(node, indent)?,

--- a/code/packages/rust/mosaic-emit-webcomponent/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-webcomponent/src/pipeline.rs
@@ -2456,6 +2456,16 @@ fn primitive_to_html_tag(tag: &str) -> Result<HtmlTag, PipelineEmitError> {
             false,
             "display: flex; flex-direction: column;",
         ),
+        // UI35 — the drag family. This backend does not implement dragging yet, so
+        // both lower to a plain vertical container: the content still renders, it
+        // just isn't draggable here. Erroring instead would mean a layout using drag
+        // cannot be emitted to this backend AT ALL. See UI35-host-drag-drop.md.
+        "HostDraggable" | "HostDropTarget" => mk(
+            "<div>",
+            "</div>",
+            false,
+            "display: flex; flex-direction: column;",
+        ),
         "Text" => mk("<span>", "</span>", false, ""),
         "Image" => {
             // Image is a void element. Future PRs can wire in `src` /

--- a/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
@@ -2032,6 +2032,17 @@ fn emit_xaml_node(
         // attached property on the wrapped child. HostNumberInput
         // uses `<NumberBox>` (WinUI 3 numeric input with built-in Â±
         // stepper).
+        // UI35 — the drag family. This backend does not implement dragging yet, so
+        // both lower to a vertical StackPanel: the card and the column still render,
+        // they just aren't draggable here.
+        //
+        // Erroring instead would mean a layout using drag cannot be emitted to this
+        // backend at all, which took down the task-app cross-backend tests the moment
+        // the app grew a board. Degrading to the content is what UI35 asks for.
+        "HostDraggable" | "HostDropTarget" => {
+            emit_stack_panel(node, indent, part_styles, "Vertical", ctx)
+        }
+
         "HostLink" => emit_host_link(node, indent, part_styles, ctx),
         "HostTooltip" => emit_host_tooltip(node, indent, part_styles, ctx),
         "HostNumberInput" => emit_host_number_input(node, indent, part_styles, ctx),

--- a/code/packages/rust/mosaic-emit-xaml/tests/task_app_hover_compiles_to_xaml.rs
+++ b/code/packages/rust/mosaic-emit-xaml/tests/task_app_hover_compiles_to_xaml.rs
@@ -1,8 +1,12 @@
 //! Complex-app acceptance gate for native MSL hover activation.
 //!
 //! Task App deliberately authors all interaction styling in Mosaic. Its light
-//! theme exercises nine independently named HostButton hover surfaces,
-//! including controls inside repeated project and task DataTemplates.
+//! theme exercises thirteen independently named HostButton hover surfaces,
+//! including controls inside repeated project and task DataTemplates. (The
+//! board view's HostDraggable card hover is authored in Mosaic too, but the
+//! XAML backend doesn't lower HostDraggable pointer states yet — native
+//! shells for the board are a later roadmap phase — so it isn't counted
+//! here.)
 
 use std::fs;
 use std::path::PathBuf;
@@ -45,7 +49,7 @@ fn task_app_hover_states_lower_to_native_row_local_xaml() {
 
     assert_eq!(
         output.matches("Binding IsPointerOver").count(),
-        12,
+        16,
         "each property-scoped hover state must use native pointer state:\n{output}"
     );
     for target in [
@@ -53,7 +57,11 @@ fn task_app_hover_states_lower_to_native_row_local_xaml() {
         "ProjectAdd",
         "ProjectSub",
         "SegListOff",
+        "SegListOff2",
+        "SegBoardOff",
+        "SegBoardOff2",
         "SegTlOff",
+        "SegTlOff2",
         "AddBtn",
         "Toggle",
         "TaskName",

--- a/code/programs/mosaic/task-app/CHANGELOG.md
+++ b/code/programs/mosaic/task-app/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to the `task-app` web program are documented here.
 
 ## [0.1.0] - Unreleased
 
+### Added - board (kanban) view
+
+- **A third view: a board**, with Up next / In progress / Done columns. Cards drag
+  between them by **pointer or keyboard** — this is the first real use of the UI35 drag
+  kernel, and building it is what proved the kernel end-to-end in a running app.
+- A drop is a **proposal**: the card doesn't move itself. The host translates "landed in
+  this column" into the engine operation that expresses it, and the engine decides.
+- The columns come from the same classification the grouped list uses, so the two views
+  can never disagree about a task's state.
+
+Three bugs found while getting this working, each of which made the board look finished
+while being broken:
+
+- **"Up next" was permanently empty.** The column was derived from *"is it scheduled"*,
+  but the engine schedules every task that has a duration — so everything landed in "In
+  progress" and one column, plus its drop zone, was dead. It now reads **progress**,
+  which is both what a person means by "I've started this" and something that can
+  actually be set, which is what makes dragging between those columns work at all.
+- **`percentComplete` came back `undefined` for every task**: it's on `todos()`, not
+  `checklist()`. Reading the wrong projection scored every task 0. The map is now built
+  once per render from the right projection instead of issuing an engine query per card.
+- **`setPercentComplete` takes `percent`, not `percentComplete`** — the latter is what
+  the projections *return*. The call was failing the parse and coming back as an error
+  envelope that nothing read, so cards silently sprang back. Every board operation now
+  checks its result and logs a failure rather than assuming success.
+
+Also from security review: a drop's `targetKey` is validated against the known columns
+(an unrecognised one previously fell through and silently un-completed the task), and
+`HostDropTarget` is given a flex direction so its `gap` isn't inert — it lowers to a
+bare `<div>`, unlike `Column`, so cards were stacking flush.
+
+
 ### Added - native pressed feedback through Mosaic
 
 The add-task button now declares its pressed background in the shared MSL

--- a/code/programs/mosaic/task-app/host/web/src/main.tsx
+++ b/code/programs/mosaic/task-app/host/web/src/main.tsx
@@ -80,7 +80,9 @@ function makeController(engine: any, init: ControllerInit = {}) {
   let newName = "";
   let newDue = "";
   let newProject = "";
-  let showTimeline = false;
+  // Which view is showing. A string rather than a pair of booleans, so the three
+  // states can't contradict each other.
+  let view: "list" | "board" | "timeline" = "list";
   // Which row is expanded, by task id (not index — an index would follow the wrong
   // task the moment the list is re-sorted or something above it is deleted).
   let expanded: string | null = null;
@@ -150,6 +152,42 @@ function makeController(engine: any, init: ControllerInit = {}) {
     for (const id of Object.keys(all)) walk(id);
 
     return { ids, names: ids.map((id) => all[id]?.name || id), depths, activeId };
+  };
+
+  // The board's columns. Status is the engine's own vocabulary; these are the three
+  // states this app exposes today.
+  const BOARD_COLUMNS: Array<{ title: string; key: string }> = [
+    { title: "Up next", key: "next" },
+    { title: "In progress", key: "doing" },
+    { title: "Done", key: "done" },
+  ];
+
+  // Percent-complete per task, read ONCE.
+  //
+  // It comes from `todos()`, not `checklist()` — only todos carries
+  // `percentComplete`. Reading the wrong projection returned `undefined` for every
+  // task, so everything scored 0 and the board put the whole project in "Up next"
+  // with "In progress" permanently empty. Building the map once also keeps this off
+  // the per-card path, which was issuing an engine query per rendered card.
+  const progress = (): Map<string, number> =>
+    new Map(
+      ((engine.todos().data ?? []) as any[]).map((t) => [
+        t.task as string,
+        (t.percentComplete ?? 0) as number,
+      ]),
+    );
+
+  // Which column a task belongs in.
+  //
+  // This reads PROGRESS, not "is it scheduled". Scheduling is not a signal of intent:
+  // the engine schedules every task that has a duration, so keying off a start date
+  // put *everything* in "In progress" and left "Up next" permanently empty — a dead
+  // column whose drop zone did nothing. Percent-complete is what a person actually
+  // means by "I've started this", and it is settable, which is what makes dragging
+  // between those two columns work at all.
+  const columnOf = (id: string, byTask: Map<string, any>, pct: Map<string, number>): string => {
+    if (byTask.get(id)?.value[DONE]?.value === true) return "done";
+    return (pct.get(id) ?? 0) > 0 ? "doing" : "next";
   };
 
   // The timeline: hand the engine's own gantt bars to the geometry module. Every
@@ -287,7 +325,20 @@ function makeController(engine: any, init: ControllerInit = {}) {
         // top-level row stays flush left.
         p.depths[i] > 0 ? `${" ".repeat((p.depths[i] - 1) * 2)}↳` : "",
       ]);
-      const tl = showTimeline ? timeline() : { scale: "", rows: [] };
+      const tl = view === "timeline" ? timeline() : { scale: "", rows: [] };
+      const boardCards: string[][] = (() => {
+        if (view !== "board") return [];
+        const pct = progress();
+        return displayIds().map((id) => {
+          const c = byTask.get(id)!;
+          return [
+            c.display[NAME],
+            columnOf(id, byTask, pct),
+            id,
+            c.value[OVERDUE]?.value === true ? "overdue" : "",
+          ];
+        });
+      })();
       // The engine's verdict on the plan. Overdue work is the one thing worth
       // colouring red in the header; everything else reads as on track.
       const overdue = ids.filter(
@@ -297,7 +348,10 @@ function makeController(engine: any, init: ControllerInit = {}) {
         appTitle: "Tasks — auto-scheduled",
         statusLabel: overdue > 0 ? `${overdue} overdue` : "On track",
         statusWarn: overdue > 0 ? "warn" : "",
-        timelineMode: showTimeline ? "timeline" : "",
+        timelineMode: view === "timeline" ? "timeline" : "",
+        boardMode: view === "board" ? "board" : "",
+        boardColumns: BOARD_COLUMNS.map((c) => [c.title, c.key]),
+        boardCards,
         timelineScale: tl.scale,
         timelineRows: tl.rows,
         newTaskName: newName,
@@ -327,11 +381,59 @@ function makeController(engine: any, init: ControllerInit = {}) {
           break;
         }
         case "showList":
-          showTimeline = false;
+          view = "list";
+          break;
+        case "showBoard":
+          view = "board";
           break;
         case "showTimeline":
-          showTimeline = true;
+          view = "timeline";
           break;
+        case "cardDropped": {
+          // A drop is a PROPOSAL. The engine owns what a status change means; the host
+          // only translates "landed in this column" into the operation expressing it.
+          const { byTask } = rows();
+          // Validate BOTH ends. The key guards a stale id (a card from a project you
+          // have since switched away from); the target guards an unknown column —
+          // without it an unrecognised target fell through to the "leaving done"
+          // branch and silently un-completed the task.
+          if (!byTask.has(event.key)) break;
+          if (!BOARD_COLUMNS.some((c) => c.key === event.targetKey)) break;
+
+          const from = columnOf(event.key, byTask, progress());
+          if (from === event.targetKey) break; // dropped where it already was
+
+          // The ABI's field is `percent`, not `percentComplete` — the latter is what
+          // the *projections* return, and passing it here failed the parse and came
+          // back as an error envelope. Check every result rather than assuming: a
+          // rejected op that nobody reads is a card that silently springs back.
+          const ran = (label: string, res: any): boolean => {
+            if (res?.ok === false) {
+              console.error(`Board move failed (${label}):`, res.error ?? res);
+              return false;
+            }
+            return true;
+          };
+
+          let ok = true;
+          // Leaving Done must clear the completed flag first, or the card springs
+          // straight back — `columnOf` checks completion before progress.
+          if (from === "done" && event.targetKey !== "done") {
+            ok = ran("clear completed", engine.setCompleted({ id: event.key, completed: false }));
+          }
+          if (ok && event.targetKey === "done") {
+            ok = ran("complete", engine.setCompleted({ id: event.key, completed: true }));
+          } else if (ok && event.targetKey === "doing") {
+            // "Started" is any progress at all; the exact figure is the user's to
+            // refine later, so claim the minimum rather than inventing one.
+            ok = ran("start", engine.setPercentComplete({ id: event.key, percent: 1 }));
+          } else if (ok) {
+            ok = ran("un-start", engine.setPercentComplete({ id: event.key, percent: 0 }));
+          }
+          if (!ok) break;
+          persist();
+          break;
+        }
         case "newProjectNameChange":
           newProject = event.value;
           break;

--- a/code/programs/mosaic/task-app/src/TaskApp.dark.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.dark.msl
@@ -218,6 +218,60 @@ style TaskApp {
     border-radius : 7 ;
     box-shadow : "0 1px 2px rgba(0,0,0,.4)" ;
   }
+  part seg-board-on {
+    background : "#252019" ;
+    color : "#f1ebe1" ;
+    font-size : 13 ;
+    font-weight : bold ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    box-shadow : "0 1px 2px rgba(0,0,0,.4)" ;
+  }
+  part seg-board-off {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+  part seg-board-off2 {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+  part seg-list-off2 {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+  part seg-tl-off2 {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
   part seg-list-off {
     background : "transparent" ;
     color : "#b3a99c" ;
@@ -241,6 +295,60 @@ style TaskApp {
     }
   }
 
+  // ── board (kanban) ──────────────────────────────────────────────────────
+  part board {
+    gap : 14 ;
+  }
+  part board-col {
+    width : 260 ;
+    flex-shrink : 0 ;
+    background : "#2d271f" ;
+    padding : 12 ;
+    gap : 10 ;
+    border-width : 1 ;
+    border-color : "#2c2620" ;
+    border-radius : 13 ;
+  }
+  part col-head {
+    font-size : 11 ;
+    font-weight : bold ;
+    color : "#b3a99c" ;
+    letter-spacing : "0.07em" ;
+    text-transform : "uppercase" ;
+  }
+  // The drop target fills its column, so the whole column is a landing zone rather
+  // than only the strip of cards already in it — dropping into an empty column has
+  // to work.
+  part col-drop {
+    min-height : 60 ;
+    gap : 9 ;
+    // HostDropTarget lowers to a bare <div> with no built-in display, unlike Column —
+    // so without these the gap is inert and the cards stack flush against each other.
+    display : "flex" ;
+    flex-direction : "column" ;
+  }
+  part board-card {
+    background : "#252019" ;
+    padding : 11 ;
+    gap : 6 ;
+    border-width : 1 ;
+    border-color : "#352e25" ;
+    border-radius : 9 ;
+    box-shadow : "0 1px 2px rgba(0,0,0,.35), 0 4px 14px rgba(0,0,0,.35)" ;
+    cursor : "grab" ;
+    state hover {
+      border-color : "#eaa63f" ;
+    }
+  }
+  part card-name {
+    font-size : 13 ;
+    color : "#f1ebe1" ;
+  }
+  part card-crit {
+    font-size : 11 ;
+    font-weight : bold ;
+    color : "#e26a52" ;
+  }
   // ── list ────────────────────────────────────────────────────────────────
   part list-wrap {
     max-width : 760 ;
@@ -289,7 +397,7 @@ style TaskApp {
       background : "#d4922f" ;
     }
     state pressed {
-      background : "#b87822" ;
+      background : "#a96816" ;
     }
   }
 

--- a/code/programs/mosaic/task-app/src/TaskApp.dark.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.dark.msl
@@ -397,7 +397,7 @@ style TaskApp {
       background : "#d4922f" ;
     }
     state pressed {
-      background : "#a96816" ;
+      background : "#b87822" ;
     }
   }
 

--- a/code/programs/mosaic/task-app/src/TaskApp.light.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.light.msl
@@ -218,6 +218,60 @@ style TaskApp {
     border-radius : 7 ;
     box-shadow : "0 1px 2px rgba(60,45,25,.07)" ;
   }
+  part seg-board-on {
+    background : "#fffdfa" ;
+    color : "#2b2723" ;
+    font-size : 13 ;
+    font-weight : bold ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    box-shadow : "0 1px 2px rgba(60,45,25,.07)" ;
+  }
+  part seg-board-off {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+  part seg-board-off2 {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+  part seg-list-off2 {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+  part seg-tl-off2 {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
   part seg-list-off {
     background : "transparent" ;
     color : "#6a625a" ;
@@ -241,6 +295,60 @@ style TaskApp {
     }
   }
 
+  // ── board (kanban) ──────────────────────────────────────────────────────
+  part board {
+    gap : 14 ;
+  }
+  part board-col {
+    width : 260 ;
+    flex-shrink : 0 ;
+    background : "#f7f2ea" ;
+    padding : 12 ;
+    gap : 10 ;
+    border-width : 1 ;
+    border-color : "#efe8dd" ;
+    border-radius : 13 ;
+  }
+  part col-head {
+    font-size : 11 ;
+    font-weight : bold ;
+    color : "#6a625a" ;
+    letter-spacing : "0.07em" ;
+    text-transform : "uppercase" ;
+  }
+  // The drop target fills its column, so the whole column is a landing zone rather
+  // than only the strip of cards already in it — dropping into an empty column has
+  // to work.
+  part col-drop {
+    min-height : 60 ;
+    gap : 9 ;
+    // HostDropTarget lowers to a bare <div> with no built-in display, unlike Column —
+    // so without these the gap is inert and the cards stack flush against each other.
+    display : "flex" ;
+    flex-direction : "column" ;
+  }
+  part board-card {
+    background : "#fffdfa" ;
+    padding : 11 ;
+    gap : 6 ;
+    border-width : 1 ;
+    border-color : "#e6ded3" ;
+    border-radius : 9 ;
+    box-shadow : "0 1px 2px rgba(60,45,25,.05), 0 4px 14px rgba(60,45,25,.05)" ;
+    cursor : "grab" ;
+    state hover {
+      border-color : "#e0942a" ;
+    }
+  }
+  part card-name {
+    font-size : 13 ;
+    color : "#2b2723" ;
+  }
+  part card-crit {
+    font-size : 11 ;
+    font-weight : bold ;
+    color : "#cf4b34" ;
+  }
   // ── list ────────────────────────────────────────────────────────────────
   part list-wrap {
     max-width : 760 ;

--- a/code/programs/mosaic/task-app/src/TaskApp.mil
+++ b/code/programs/mosaic/task-app/src/TaskApp.mil
@@ -39,6 +39,22 @@ component TaskApp {
   // data-driven sizing (`width: ( t[n] )`). `timeline-scale` is the matching date
   // ruler, and a non-empty `critical-marker` means the row is on the critical path.
   slot timeline-mode     : text ;
+
+  // Board (kanban). `board-mode` is non-empty when the board is showing.
+  //
+  //   board-columns : one per status column, [ title, key ]
+  //   board-cards   : one per task,          [ name, column-key, task-id, critical ]
+  //
+  // A card is placed by comparing its column-key with the column's, rather than by
+  // nesting a list inside a list — the layout can express that with a single `If`,
+  // and it keeps both loops flat enough to read.
+  //
+  // Dropping carries KEYS, never indices: that is what makes the drag kernel usable
+  // from a nested loop at all, since an inner loop's index would otherwise shadow the
+  // outer one and a card would report the wrong row.
+  slot board-mode    : text ;
+  slot board-columns : list<list<text>> ;
+  slot board-cards   : list<list<text>> ;
   slot timeline-scale    : text ;
   slot timeline-rows     : list<list<text>> ;
 
@@ -72,7 +88,13 @@ component TaskApp {
   // Choose a view. Two explicit events rather than one toggle, so clicking the view
   // you are already on is a no-op instead of switching away from it.
   emit onShowList ;
+  emit onShowBoard ;
   emit onShowTimeline ;
+
+  // A drop is a PROPOSAL: the engine decides whether the move is legal and performs
+  // it. The payload is the UI35 contract — what moved, of what kind, onto which
+  // target, and where within it.
+  emit onCardDropped ( key : text , kind : text , targetKey : text , position : text ) ;
 
   // Expand (or collapse) a task row to reveal its scheduling detail.
   emit onExpandTask ( index : number ) ;

--- a/code/programs/mosaic/task-app/src/TaskApp.mll
+++ b/code/programs/mosaic/task-app/src/TaskApp.mll
@@ -71,11 +71,20 @@ layout TaskApp {
           // branches, so each of the four states gets its own name.
           If ( when: slot: timeline-mode ) {
             HostButton [ seg-list-off ] ( label : "List" , onClick : emit: onShowList )
+            HostButton [ seg-board-off ] ( label : "Board" , onClick : emit: onShowBoard )
             HostButton [ seg-tl-on ] ( label : "Timeline" , onClick : emit: onShowTimeline )
           }
           Else {
-            HostButton [ seg-list-on ] ( label : "List" , onClick : emit: onShowList )
-            HostButton [ seg-tl-off ] ( label : "Timeline" , onClick : emit: onShowTimeline )
+            If ( when: slot: board-mode ) {
+              HostButton [ seg-list-off2 ] ( label : "List" , onClick : emit: onShowList )
+              HostButton [ seg-board-on ] ( label : "Board" , onClick : emit: onShowBoard )
+              HostButton [ seg-tl-off2 ] ( label : "Timeline" , onClick : emit: onShowTimeline )
+            }
+            Else {
+              HostButton [ seg-list-on ] ( label : "List" , onClick : emit: onShowList )
+              HostButton [ seg-board-off2 ] ( label : "Board" , onClick : emit: onShowBoard )
+              HostButton [ seg-tl-off ] ( label : "Timeline" , onClick : emit: onShowTimeline )
+            }
           }
         }
       }
@@ -101,6 +110,41 @@ layout TaskApp {
                   }
                 }
                 Text [ tl-window ] ( content : ( t[3] ) )
+              }
+            }
+          }
+        }
+        Else {
+        If ( when: slot: board-mode ) {
+          // The board is what the UI35 drag family exists for: each column is a drop
+          // target, each card a draggable. A drop dispatches a PROPOSAL — the engine
+          // decides whether the move is legal and performs it; the UI never moves a
+          // card itself.
+          Row [ board ] {
+            For ( each: slot: board-columns , as: col , index: ci ) {
+              Column [ board-col ] {
+                Text [ col-head ] ( content : ( col[0] ) )
+                HostDropTarget [ col-drop ] (
+                  drop-key : ( col[1] ) ,
+                  onDrop : emit: onCardDropped
+                ) {
+                  For ( each: slot: board-cards , as: card , index: cdi ) {
+                    // Place a card by comparing keys rather than nesting a list in a
+                    // list — one `If` says everything, and both loops stay flat.
+                    If ( when: ( card[1] == col[1] ) ) {
+                      HostDraggable [ board-card ] (
+                        drag-key : ( card[2] ) ,
+                        drag-kind : "task" ,
+                        drag-label : ( card[0] )
+                      ) {
+                        Text [ card-name ] ( content : ( card[0] ) )
+                        If ( when: ( card[3] ) ) {
+                          Text [ card-crit ] ( content : ( card[3] ) )
+                        }
+                      }
+                    }
+                  }
+                }
               }
             }
           }
@@ -164,6 +208,7 @@ layout TaskApp {
               }
             }
           }
+        }
         }
       }
     }

--- a/code/specs/UI35-host-drag-drop.md
+++ b/code/specs/UI35-host-drag-drop.md
@@ -219,3 +219,24 @@ Each step: tests → `/security-review` → PR → `/babysit-pr`.
   worth its own primitive later; the calendar ships drag-to-*move* first.
 - Any engine change. This spec is purely the UI kernel; the task-side operations it feeds
   (`move_task`, `set_status`, `reparent`) already exist.
+
+## A backend that hasn't implemented drag must still render the content
+
+Adding a board to `task-app` broke the SwiftUI and XAML builds outright:
+`UnknownPrimitive("HostDropTarget")`. Those backends hadn't implemented the family, so
+a layout that merely *contained* a draggable could not be emitted to them **at all** —
+the app became un-buildable everywhere the moment one view used drag.
+
+That is the wrong failure mode. A primitive the kernel defines is part of the shared
+vocabulary, and an app author cannot be expected to maintain a different layout per
+host. Every backend therefore lowers `HostDraggable` / `HostDropTarget` to its plain
+vertical container until it implements the real thing: the card and the column still
+render and are still readable, they simply aren't draggable there.
+
+> **Requirement.** A backend must never fail to emit because it lacks drag support.
+> Lower the two primitives to a plain container and carry on. Implementing the real
+> interaction is then a strict upgrade, not a prerequisite for the app to build.
+
+Status: **react** and **html** implement the interaction; **swiftui**, **xaml**, **qt**,
+**compose**, **flutter** and **webcomponent** degrade to a container.
+


### PR DESCRIPTION
A third view — **Up next / In progress / Done**, with cards that drag between columns by **pointer or keyboard**. Building it is what finally proved the UI35 drag kernel end-to-end in a running app, and it turned up three bugs that each let the board *look* finished while being broken.

A drop stays a **proposal**: the card never moves itself. The host translates "landed in this column" into the engine operation expressing it, and the engine decides. The columns use the same classification the grouped list does, so the two views can't disagree about a task's state.

## Bugs found by actually using it

- **"Up next" was permanently empty.** The column was derived from *"is it scheduled"* — but the engine schedules every task with a duration, so everything landed in "In progress" and one column *plus its drop zone* was dead. It now reads **progress**, which is both what a person means by "I've started this" and something that can actually be set — which is what makes dragging between those columns work at all.
- **`percentComplete` came back `undefined` for every task**: it's on `todos()`, not `checklist()`. The map is now built once per render from the right projection, instead of issuing an engine query *per rendered card*.
- **`setPercentComplete` takes `percent`, not `percentComplete`** — the latter is what the projections *return*. The call was failing the parse and coming back as an error envelope nothing read, so cards silently sprang back. Every board operation now checks its result.

## Emitter changes this required

- **`mosaic-emit-react`: drag keys may come from an expression.** That's how a key arrives from a loop binding. Rejecting it made the drag family unusable from inside a `For` — unusable for the one layout it was designed for. An emit ref is still a loud error.
- **`mosaic-emit-react`: hook imports narrowed.** `useEffect` was imported for drag-only components, which have none — tripping `noUnusedLocals` and breaking `tsc -b` under a strict tsconfig.
- **`mosaic-emit-html`: the same expression keys were being silently *dropped*** there, so the same layout emitted a board with no drag attributes at all — inert, with no diagnostic. Now lowered to a mustache path.

## Also from security review

A drop's `targetKey` is validated against the known columns (an unrecognised one previously fell through and silently **un-completed** the task), and `HostDropTarget` gets a flex direction so its `gap` isn't inert — it lowers to a bare `<div>`, unlike `Column`, so cards were stacking flush.

## Verification

Driven in a real browser, **keyboard-only**: Up next → In progress → Done both land and persist; counts move 9/0/3 → 8/1/3 → 8/0/4; the live region announces each grab and drop; no console errors. 196 react + 128 html + 86 moslayout tests, clippy clean, both themes compile.

## Known, not fixed here

The kernel announces "Dropped X" unconditionally, before the host has decided — so a rejected drop still reads as success to a screen reader. Now that every column transition is real, the only rejection left is dropping a card where it already was, but the structure is still wrong and worth a follow-up in the UI35 spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)