### PR TITLE
Compile typed human-language activities

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,11 +5,13 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-03. Current baseline after independent Learn frontiers:
+Last prioritized: 2026-08-03. Current baseline after typed activity compilation:
 20 registered tracks, 1,066 Markdown lessons, 20 downloadable LaTeX books, zero
 duration violations, and 20 validated realization maps containing 346 ordered
 path segments, 247 typed extension nodes, and 896 prerequisite-closed mapped
-lessons. HL-V01 keeps the remaining migration debt reproducible in both JSON and
+lessons. Two mapped non-lexical Spanish lessons now carry compiled objective
+activities; 111 mapped non-lexical lessons remain explicit activity-coverage
+debt. HL-V01 keeps the remaining migration debt reproducible in both JSON and
 human-readable reports; the canonical schema-v2 tranches prove one typed source
 across Language Ladder and generated book chapters without discarding deep
 content.
@@ -72,7 +74,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-G03 | Complete (#9646) | Generate Spanish Chapters 4–6 from their canonical schema-v2 lesson ASTs after HL-S02. | All six generated chapters now share lesson hashes with Language Ladder; Markdown tables retain their structure in print. |
 | HL-G04 | Queued | Normalize paired straight quotation marks when canonical prose is rendered into LaTeX. | Generated prose should use true opening and closing marks under every book's language rules without changing the canonical app text or code spans. |
 | HL-V02 | Complete (#9653) | Validate learner-facing target-language prompts against block-level knowledge declarations and prerequisite closure. | Schema-v2 production and recall blocks cannot ask for an undeclared form or a form absent from the lesson's transitive knowledge frontier. |
-| HL-V03 | Next | Compile individual prompt, answer, accepted-variant, feedback, and response-time contracts from typed activity blocks. | Every compiled activity names a non-empty subset of its block's assessed atoms and resolves all answer variants without scraping prose; Language Ladder can replace non-lexical self-check confirmation with objective script/grammar retrieval. |
+| HL-V03 | Complete in this PR | Compile individual prompt, answer, accepted-variant, feedback, and response-time contracts from typed activity blocks. | Compact JSON directives compile into validated runtime answer sets; each activity names a non-empty assessed-atom subset, carries feedback/time, and never scrapes prose. |
+| HL-A01 | Next | Author objective activity coverage for every mapped non-lexical frontier. | Replace temporary learner confirmation across the 111 remaining non-lexical lessons; migrate the 18 legacy lessons to schema v2 and give each contract at least one prerequisite-closed objective retrieval. |
+| HL-Q01 | Queued | Restore a clean standalone TypeScript typecheck for Language Ladder. | `npx tsc --noEmit` should pass after fixing the pre-existing DOM element type, review-log cast, missing Node test types, and unused/implicit test symbols; HL-V03 introduces no additional type errors. |
 | HL-B04 | Complete (#9661) | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
 | HL-B05 | Complete (#9663) | Remove Marathi's duplicate practice labels and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Devanagari, natural page bottoms, and explicit static-font shapes make the forced six-chapter build warning-free. |
 | HL-B06 | Complete (#9669) | Publish Gujarati Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
@@ -112,7 +116,7 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B37 | Complete (#9891) | Remove Spanish's remaining legacy LaTeX layout, bookmark, font, and header-only-verso warnings. | The forced 214-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, LaTeX warnings, or font warnings; all 19 intentionally blank physical pages are truly empty. |
 | HL-P01 | Complete (#9893) | Make the unified Human Languages Books result a protected merge gate, or add an equivalent gate that auto-merge must await. | Every pull request now receives a stable books gate; relevant changes run the one all-books build, unrelated changes receive a checked fast-path, and pull-request and push contexts remain distinct. |
 | HL-M01 | Complete (#9894) | Add per-track spine realization maps and language-specific extension nodes. | All 20 tracks have validated repeated-segment local paths, explicit omissions/relocations, typed extensions, and a pure prerequisite-safe frontier planner. |
-| HL-M10 | Complete in this PR | Replace Learn's global concept cursor with per-language frontier progression and focused-before-mixed eligibility. | Stable per-language completed prefixes drive each next lesson; wrong focused answers cannot advance; only independently passed, visually distinguishable lessons enter mixed review. |
+| HL-M10 | Complete (#9896) | Replace Learn's global concept cursor with per-language frontier progression and focused-before-mixed eligibility. | Stable per-language completed prefixes drive each next lesson; wrong focused answers cannot advance; only independently passed, visually distinguishable lessons enter mixed review. |
 | HL-M02 | Queued | Extend Telugu's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson needs a scheduled place, and the map must explicitly split or justify Chapter 20's numbers-and-weather topic collision. |
 | HL-M03 | Queued | Extend Kannada's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5; every canonical lesson needs a scheduled place, and Chapter 20's unrelated numbers/weather pairing must be split or explicitly justified. |
 | HL-M04 | Queued | Extend Malayalam's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the four new support steps, needs a scheduled place. |
@@ -1186,6 +1190,29 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - HL-V03 is next because objective prompt/answer contracts are the remaining
   prerequisite for replacing non-lexical self-confirmation without scraping
   lesson prose or inventing accepted answers.
+
+## Findings from HL-V03
+
+- A typed block can now carry one or more compact JSON `hl-activity` directives
+  immediately after `hl-knowledge`. The canonical AST retains their stable id,
+  text-response kind, assessed atoms, prompt, answer, variants, feedback, and
+  response budget while book and app learner copy omits the metadata.
+- Validation rejects malformed or misplaced JSON, non-lesson-prefixed or
+  duplicate ids, empty/out-of-block assessment sets, ambiguous normalized
+  variants, missing feedback, and response budgets outside 1–299 seconds.
+  Runtime compilation therefore resolves every accepted response once without
+  recovering answers from Markdown prose.
+- Duration model v2 adds each activity's authored response budget. The first
+  grammar and script pilots remain at 180 and 240 effective seconds, the full
+  curriculum keeps zero errors and zero duration violations, and regenerated
+  Spanish Chapters 1 and 4 retain identical learner prose with refreshed hashes.
+- Language Ladder prefers a final-recall activity when present, hides the
+  answer-bearing lesson summary during retrieval, shows authored corrective or
+  success feedback, and advances only after a correct response plus explicit
+  continue. Existing lexical meaning checks remain available.
+- The measured follow-up is HL-A01: 113 mapped non-lexical lessons exist, these
+  two pilots leave 111 without objective activities, and 18 of those still need
+  schema-v2 body contracts before an activity can be attached honestly.
 
 ## Findings from HL-D01C
 

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -1856,7 +1856,7 @@
     {
       "language": "spanish",
       "chapter": 1,
-      "sourceHash": "fnv1a64:ad881fd61b3c4d60",
+      "sourceHash": "fnv1a64:3d70ae827d573f36",
       "lessonIds": [
         "ES-C01-hola",
         "ES-C01-bien",
@@ -1904,7 +1904,7 @@
     {
       "language": "spanish",
       "chapter": 4,
-      "sourceHash": "fnv1a64:d12c066ed597921d",
+      "sourceHash": "fnv1a64:c113ab52f6dfbba9",
       "lessonIds": [
         "ES-C04-gracias",
         "ES-C04-de-nada",

--- a/code/learning/human-languages/spanish/book/chapters/ch01-first-words.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch01-first-words.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:ad881fd61b3c4d60
+% canonical-source-hash: fnv1a64:3d70ae827d573f36
 % canonical-lessons: ES-C01-hola, ES-C01-bien, ES-C01-el-la, ES-C01-genero-gramatical, ES-C01-dia, ES-C01-buenos-dias, ES-C01-practice
 
 \chapter{Hola and Buenos Días}

--- a/code/learning/human-languages/spanish/book/chapters/ch04-how-are-you.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch04-how-are-you.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:d12c066ed597921d
+% canonical-source-hash: fnv1a64:c113ab52f6dfbba9
 % canonical-lessons: ES-C04-gracias, ES-C04-de-nada, ES-C04-estar, ES-C04-como-esta, ES-C04-como-estas-register, ES-C04-regular, ES-C04-y, ES-W01-acento, ES-W01-tilde-diacritica, ES-W02-enye, ES-W03-inverted, ES-W03-question-span, ES-C04-practice
 
 \chapter{How Are You?}

--- a/code/learning/human-languages/spanish/lessons/ES-C01-genero-gramatical.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C01-genero-gramatical.md
@@ -63,6 +63,7 @@ with its article, as one small unit: *el + noun* or *la + noun*.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-DEFINITE-ARTICLES, ES-GRAMMAR-NOUN-GENDER] -->
+<!-- hl-activity: {"id":"ES-C01-genero-gramatical-class-count","kind":"text","assesses":["ES-GRAMMAR-NOUN-GENDER"],"prompt":"How many grammatical noun classes does Spanish keep?","answer":"two","accepted":["2"],"feedback":{"correct":"Right: Spanish keeps masculine and feminine noun classes.","incorrect":"Spanish reduced Latin's three classes to two: masculine and feminine."},"response_seconds":8} -->
 
 [PAUSE 3s] How many noun classes did Latin have? (Three.) How many does
 Spanish keep? (Two.) What should travel with every new noun you learn? (Its

--- a/code/learning/human-languages/spanish/lessons/ES-W03-question-span.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W03-question-span.md
@@ -60,6 +60,7 @@ exactly where to begin and end a change in spoken melody.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[ES-ORTHOGRAPHY-PUNCTUATION-SPAN, ES-SCRIPT-INVERTED-QUESTION, ES-SCRIPT-INVERTED-EXCLAMATION] -->
+<!-- hl-activity: {"id":"ES-W03-question-span-roberto-outside","kind":"text","assesses":["ES-ORTHOGRAPHY-PUNCTUATION-SPAN"],"prompt":"In 'Roberto, ¿cómo estás?', is Roberto inside the question?","answer":"no","accepted":["no it is not","it is not"],"feedback":{"correct":"Correct: Roberto is outside the question; ¿ begins where the questioning voice begins.","incorrect":"No. Roberto is outside the question because the inverted mark comes after the name."},"response_seconds":8} -->
 
 [PAUSE 3s] In **Roberto, ¿cómo estás?**, is **Roberto** inside the
 question? (**No.**) Where does the inverted mark go? (**At the start of the

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added — compiled activity contracts
+
+- Parse compact JSON `hl-activity` directives beside typed block knowledge and
+  keep prompts, canonical answers, accepted variants, corrective feedback, and
+  response budgets in the canonical AST while omitting metadata from learner copy.
+- Compile normalized answer sets once for browser consumers and validate stable
+  activity ids, non-empty assessed-atom subsets, block-bound assessment closure,
+  unique variants, complete feedback, and 1–299 second response budgets.
+- Count authored activity response time in duration model v2 and add objective
+  grammar and script pilots to two Spanish lessons without changing book prose.
+
 ### Added — per-track shared-spine realization maps
 
 - Load and validate one ordered `curriculum.json` for every registered track,

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -35,11 +35,15 @@ import {
   languagesForConcept,
   loadEverything,
   mixedCurriculumFrontier,
+  compileLessonActivities,
   validate,
   validateCurriculum,
 } from "@coding-adventures/human-language-data";
 
 const { curricula, dataset, lessons, registry, scripts, spine, taxonomy } = loadEverything();
+
+// Typed activities compile directly from block metadata, never from prose.
+const activities = compileLessonActivities(lessons[0].blocks);
 
 // The cross-language join:
 languagesForConcept(dataset, "GREETING-HELLO");
@@ -88,7 +92,7 @@ wraps matching Unicode runs in the book's existing font macro and uses each
 lesson's `romanization` for a PDF-bookmark-safe short title.
 
 The duration estimator uses instructional word count, explicit pauses, repeat
-cues, learner-response prompts, and a safety margin. Its effective duration is
+cues, prose prompts, authored activity response budgets, and a safety margin. Its effective duration is
 the greater of that estimate and the lesson's declared budget. A value of 300
 seconds or more is reported as migration debt; the report remains non-blocking
 until the existing corpus has been split.
@@ -99,6 +103,7 @@ until the existing corpus has been split.
 |---|---|---|
 | `frontmatter.ts` | tiny zero-dep frontmatter reader with one nested-map level | ✅ |
 | `parse.ts` | frontmatter + Markdown → typed lesson AST; realizations → `Dataset` | ✅ |
+| `activity.ts` | typed block activities → normalized runtime answer contracts | ✅ |
 | `hash.ts` | stable canonical lesson serialization and deterministic fingerprints | ✅ |
 | `book.ts` | typed lesson AST → LaTeX chapter | ✅ |
 | `curriculum.ts` | spine, realization-map, prerequisite, schema-v2 duration/block/knowledge validation | ✅ |
@@ -134,6 +139,12 @@ transitive knowledge closure. Each typed block must also author an
 `hl-knowledge` directive. Block introductions must exactly account for the
 lesson's introduced atoms; production and recall assessments must be declared by
 the lesson and available from transitive prerequisites or an earlier block.
+Blocks may also author compact JSON `hl-activity` directives immediately after
+their knowledge boundary. Each compiled activity must use a stable lesson-prefixed
+id, assess a non-empty subset of that block's atoms, provide an unambiguous
+canonical answer plus explicit variants, include correct and incorrect feedback,
+and declare a 1–299 second response budget. The compiler resolves those variants
+without reading learner-facing Markdown.
 Schema-v1 tracks remain readable during migration.
 
 When `curricula` are supplied, the same validator also requires exactly one

--- a/code/packages/typescript/human-language-data/src/activity.ts
+++ b/code/packages/typescript/human-language-data/src/activity.ts
@@ -1,0 +1,162 @@
+// Pure HL-V03 activity parsing, compilation, and answer matching.
+//
+// Runtime consumers use only the typed AST. They never recover prompts or
+// answers from learner-facing Markdown, so prose edits cannot silently change
+// what counts as a correct response.
+
+import type {
+  CompiledLessonActivity,
+  LessonActivity,
+  LessonActivityFeedback,
+  LessonBodyBlock,
+} from "./types.js";
+
+const ACTIVITY_ID = /^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$/;
+const ACTIVITY_KEYS = new Set([
+  "id",
+  "kind",
+  "assesses",
+  "prompt",
+  "answer",
+  "accepted",
+  "feedback",
+  "response_seconds",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringArray(value: unknown): string[] | undefined {
+  return Array.isArray(value) && value.every((item) => typeof item === "string")
+    ? value
+    : undefined;
+}
+
+function feedback(value: unknown): LessonActivityFeedback | undefined {
+  if (!isRecord(value)) return undefined;
+  const keys = Object.keys(value);
+  if (keys.some((key) => key !== "correct" && key !== "incorrect")) return undefined;
+  return typeof value.correct === "string" && typeof value.incorrect === "string"
+    ? { correct: value.correct, incorrect: value.incorrect }
+    : undefined;
+}
+
+export interface ParsedActivityValue {
+  activity?: LessonActivity;
+  error?: string;
+}
+
+/** Convert one JSON value from an `hl-activity` comment into the typed AST. */
+export function parseLessonActivityValue(value: unknown): ParsedActivityValue {
+  if (!isRecord(value)) return { error: "must contain one JSON object" };
+  const unknownKeys = Object.keys(value).filter((key) => !ACTIVITY_KEYS.has(key));
+  if (unknownKeys.length > 0) {
+    return { error: `contains unknown field(s): ${unknownKeys.sort().join(", ")}` };
+  }
+  const assesses = stringArray(value.assesses);
+  const accepted = stringArray(value.accepted);
+  const authoredFeedback = feedback(value.feedback);
+  if (
+    typeof value.id !== "string" ||
+    value.kind !== "text" ||
+    assesses === undefined ||
+    typeof value.prompt !== "string" ||
+    typeof value.answer !== "string" ||
+    accepted === undefined ||
+    authoredFeedback === undefined ||
+    typeof value.response_seconds !== "number"
+  ) {
+    return {
+      error:
+        "requires id, kind='text', assesses[], prompt, answer, accepted[], " +
+        "feedback.correct, feedback.incorrect, and numeric response_seconds",
+    };
+  }
+  return {
+    activity: {
+      id: value.id,
+      kind: value.kind,
+      assesses,
+      prompt: value.prompt,
+      answer: value.answer,
+      accepted,
+      feedback: authoredFeedback,
+      responseSeconds: value.response_seconds,
+    },
+  };
+}
+
+/** Stable, deliberately conservative normalization for authored text answers. */
+export function normalizeActivityResponse(value: string): string {
+  return value
+    .normalize("NFKC")
+    .toLowerCase()
+    .replace(/[‘’]/g, "'")
+    .replace(/[“”]/g, '"')
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Shape and answer-resolution errors independent of a containing block. */
+export function activityContractErrors(activity: LessonActivity): string[] {
+  const errors: string[] = [];
+  if (!ACTIVITY_ID.test(activity.id)) errors.push("id must be a stable hyphenated token");
+  if (activity.assesses.length === 0) errors.push("assesses must not be empty");
+  if (new Set(activity.assesses).size !== activity.assesses.length) {
+    errors.push("assesses must not contain duplicates");
+  }
+  for (const field of ["prompt", "answer"] as const) {
+    if (activity[field].trim() === "") errors.push(`${field} must not be empty`);
+  }
+  for (const field of ["correct", "incorrect"] as const) {
+    if (activity.feedback[field].trim() === "") errors.push(`feedback.${field} must not be empty`);
+  }
+  if (!Number.isInteger(activity.responseSeconds) || activity.responseSeconds < 1 || activity.responseSeconds >= 300) {
+    errors.push("response_seconds must be an integer from 1 through 299");
+  }
+
+  const authoredResponses = [activity.answer, ...activity.accepted];
+  const normalized = authoredResponses.map(normalizeActivityResponse);
+  if (normalized.some((response) => response === "")) {
+    errors.push("answer and accepted variants must normalize to non-empty responses");
+  }
+  if (new Set(normalized).size !== normalized.length) {
+    errors.push("answer and accepted variants must resolve to unique responses");
+  }
+  return errors;
+}
+
+/** Compile one already-validated activity into its runtime answer set. */
+export function compileLessonActivity(
+  activity: LessonActivity,
+  block: Pick<LessonBodyBlock, "type" | "title">,
+  blockIndex: number,
+): CompiledLessonActivity {
+  const errors = activityContractErrors(activity);
+  if (errors.length > 0) throw new Error(`${activity.id}: ${errors.join("; ")}`);
+  return {
+    ...activity,
+    blockIndex,
+    blockType: block.type,
+    blockTitle: block.title,
+    acceptedResponses: [activity.answer, ...activity.accepted].map(normalizeActivityResponse),
+  };
+}
+
+/** Flatten block-bound contracts in authored order for books and applications. */
+export function compileLessonActivities(
+  blocks: readonly LessonBodyBlock[],
+): CompiledLessonActivity[] {
+  return blocks.flatMap((block, blockIndex) =>
+    (block.activities ?? []).map((activity) => compileLessonActivity(activity, block, blockIndex)),
+  );
+}
+
+export function activityAnswerIsCorrect(
+  answer: string,
+  activity: Pick<CompiledLessonActivity, "acceptedResponses">,
+): boolean {
+  const normalized = normalizeActivityResponse(answer);
+  return normalized !== "" && activity.acceptedResponses.includes(normalized);
+}

--- a/code/packages/typescript/human-language-data/src/curriculum.ts
+++ b/code/packages/typescript/human-language-data/src/curriculum.ts
@@ -2,6 +2,7 @@
 
 import { CONTENT_TYPES, hasOwn } from "./constants.js";
 import { DURATION_THRESHOLD_SECONDS, estimateLessonDuration } from "./report.js";
+import { activityContractErrors } from "./activity.js";
 import type {
   BookCorpus,
   CurriculumSpine,
@@ -504,9 +505,21 @@ export function validateCurriculum(input: CurriculumValidationInput): Issue[] {
   const schema2Lessons = lessons.filter(
     (lesson) => stringValue(lesson.frontmatter.schema_version) === "2",
   );
+  for (const lesson of lessons) {
+    if (stringValue(lesson.frontmatter.schema_version) === "2") continue;
+    if (lesson.blocks.some((block) =>
+      (block.activities?.length ?? 0) > 0 || (block.activityDirectiveErrors?.length ?? 0) > 0
+    )) {
+      error(
+        "activity-requires-schema-v2",
+        `${lesson.realization.lessonId}: hl-activity directives require schema_version 2`,
+      );
+    }
+  }
   const sequences = new Map<string, Map<number, string>>();
   const introducedByLesson = new Map<string, string[]>();
   const atomOwner = new Map<string, Map<string, string>>();
+  const activityOwner = new Map<string, string>();
   for (const lesson of schema2Lessons) {
     const id = lesson.realization.lessonId;
     const fm = lesson.frontmatter;
@@ -598,6 +611,35 @@ export function validateCurriculum(input: CurriculumValidationInput): Issue[] {
       }
       if (block.markdown.trim() === "") {
         error("schema-v2-empty-block", `${id}: block '${block.title}' is empty`);
+      }
+      for (const directiveError of block.activityDirectiveErrors ?? []) {
+        error(
+          "schema-v2-invalid-activity-directive",
+          `${id}: block '${block.title}' ${directiveError}`,
+        );
+      }
+      for (const activity of block.activities ?? []) {
+        if (!activity.id.startsWith(`${id}-`)) {
+          error(
+            "schema-v2-activity-id-prefix",
+            `${id}: activity '${activity.id}' must begin with '${id}-'`,
+          );
+        }
+        const previousOwner = activityOwner.get(activity.id);
+        if (previousOwner) {
+          error(
+            "schema-v2-duplicate-activity-id",
+            `${id}: activity '${activity.id}' is already authored by ${previousOwner}`,
+          );
+        } else {
+          activityOwner.set(activity.id, id);
+        }
+        for (const contractError of activityContractErrors(activity)) {
+          error(
+            "schema-v2-invalid-activity-contract",
+            `${id}: activity '${activity.id}' ${contractError}`,
+          );
+        }
       }
     }
 
@@ -730,6 +772,23 @@ export function validateCurriculum(input: CurriculumValidationInput): Issue[] {
             "schema-v2-block-knowledge-not-closed",
             `${id}: block '${block.title}' assesses '${atom}' before it is available`,
           );
+        }
+      }
+      const blockAssessments = new Set(block.knowledge.assesses);
+      for (const activity of block.activities ?? []) {
+        for (const atom of activity.assesses) {
+          if (!KNOWLEDGE_ATOM.test(atom)) {
+            error(
+              "schema-v2-invalid-activity-knowledge-atom",
+              `${id}: activity '${activity.id}' contains invalid knowledge atom '${atom}'`,
+            );
+          }
+          if (!blockAssessments.has(atom)) {
+            error(
+              "schema-v2-activity-assessment-outside-block",
+              `${id}: activity '${activity.id}' assesses '${atom}' outside block '${block.title}'`,
+            );
+          }
         }
       }
       if (

--- a/code/packages/typescript/human-language-data/src/index.ts
+++ b/code/packages/typescript/human-language-data/src/index.ts
@@ -9,6 +9,15 @@ export * from "./constants.js";
 export { splitFrontmatter, type Frontmatter } from "./frontmatter.js";
 export { parseBodyBlocks, parseLesson, buildDataset, type ParsedLesson } from "./parse.js";
 export {
+  parseLessonActivityValue,
+  normalizeActivityResponse,
+  activityContractErrors,
+  compileLessonActivity,
+  compileLessonActivities,
+  activityAnswerIsCorrect,
+  type ParsedActivityValue,
+} from "./activity.js";
+export {
   fnv1a64,
   canonicalLessonSource,
   canonicalLessonHash,

--- a/code/packages/typescript/human-language-data/src/parse.ts
+++ b/code/packages/typescript/human-language-data/src/parse.ts
@@ -6,6 +6,7 @@
 import { splitFrontmatter, type Frontmatter } from "./frontmatter.js";
 import { LANGUAGE_SCRIPT, CONTENT_TYPES, hasOwn } from "./constants.js";
 import { canonicalLessonHash } from "./hash.js";
+import { parseLessonActivityValue } from "./activity.js";
 import type {
   Concept,
   Dataset,
@@ -68,6 +69,7 @@ function classifyBlock(title: string): LessonBlockType {
 
 const KNOWLEDGE_DIRECTIVE =
   /^<!--\s*hl-knowledge:\s*introduces=\[([^\]]*)\];\s*assesses=\[([^\]]*)\]\s*-->$/;
+const ACTIVITY_DIRECTIVE = /^<!--\s*hl-activity:\s*(\{.*\})\s*-->$/;
 
 function directiveList(value: string): string[] {
   return value
@@ -76,37 +78,100 @@ function directiveList(value: string): string[] {
     .filter((item) => item !== "");
 }
 
-function parseBlockKnowledge(markdown: string): {
+function parseBlockMetadata(markdown: string): {
   markdown: string;
   knowledge?: LessonBlockKnowledge;
   knowledgeDirectiveError?: string;
+  activities?: LessonBodyBlock["activities"];
+  activityDirectiveErrors?: string[];
 } {
   const lines = markdown.split("\n");
-  const directiveIndexes = lines
+  const knowledgeIndexes = lines
     .map((line, index) => (line.includes("hl-knowledge") ? index : -1))
     .filter((index) => index >= 0);
-  if (directiveIndexes.length === 0) return { markdown };
+  const activityIndexes = lines
+    .map((line, index) => (line.includes("hl-activity") ? index : -1))
+    .filter((index) => index >= 0);
+  if (knowledgeIndexes.length === 0 && activityIndexes.length === 0) return { markdown };
 
   const firstContent = lines.findIndex((line) => line.trim() !== "");
-  const directiveIndex = directiveIndexes[0] ?? -1;
-  const directive = lines[directiveIndex]?.trim() ?? "";
-  const match = KNOWLEDGE_DIRECTIVE.exec(directive);
-  if (directiveIndexes.length !== 1 || directiveIndex !== firstContent || !match) {
-    return {
-      markdown,
-      knowledgeDirectiveError:
-        "expected one first-line '<!-- hl-knowledge: introduces=[...]; assesses=[...] -->' directive",
-    };
+  const knowledgeIndex = knowledgeIndexes[0] ?? -1;
+  const knowledgeDirective = lines[knowledgeIndex]?.trim() ?? "";
+  const knowledgeMatch = KNOWLEDGE_DIRECTIVE.exec(knowledgeDirective);
+  const validKnowledge =
+    knowledgeIndexes.length === 1 && knowledgeIndex === firstContent && knowledgeMatch !== null;
+  const removeIndexes = new Set<number>();
+  let knowledge: LessonBlockKnowledge | undefined;
+  let knowledgeDirectiveError: string | undefined;
+  if (knowledgeIndexes.length > 0) {
+    if (!validKnowledge || !knowledgeMatch) {
+      knowledgeDirectiveError =
+        "expected one first-line '<!-- hl-knowledge: introduces=[...]; assesses=[...] -->' directive";
+    } else {
+      knowledge = {
+        introduces: directiveList(knowledgeMatch[1] ?? ""),
+        assesses: directiveList(knowledgeMatch[2] ?? ""),
+      };
+      removeIndexes.add(knowledgeIndex);
+    }
   }
 
-  lines.splice(directiveIndex, 1);
-  return {
-    markdown: lines.join("\n").replace(/^\n|\n$/g, ""),
-    knowledge: {
-      introduces: directiveList(match[1] ?? ""),
-      assesses: directiveList(match[2] ?? ""),
-    },
+  const activities: NonNullable<LessonBodyBlock["activities"]> = [];
+  const activityDirectiveErrors: string[] = [];
+  if (activityIndexes.length > 0) {
+    const firstDisplayIndex = lines.findIndex((line, index) =>
+      line.trim() !== "" && index !== knowledgeIndex && !activityIndexes.includes(index),
+    );
+    for (const index of activityIndexes) {
+      const positionIsValid =
+        validKnowledge &&
+        index > knowledgeIndex &&
+        (firstDisplayIndex === -1 || index < firstDisplayIndex);
+      if (!positionIsValid) {
+        activityDirectiveErrors.push(
+          "activity directives must follow the first-line hl-knowledge directive before learner copy",
+        );
+        continue;
+      }
+      const directive = lines[index]?.trim() ?? "";
+      const match = ACTIVITY_DIRECTIVE.exec(directive);
+      if (!match) {
+        activityDirectiveErrors.push("expected '<!-- hl-activity: {...} -->'");
+        continue;
+      }
+      let value: unknown;
+      try {
+        value = JSON.parse(match[1] ?? "");
+      } catch {
+        activityDirectiveErrors.push("contains invalid JSON");
+        continue;
+      }
+      const parsed = parseLessonActivityValue(value);
+      if (!parsed.activity) {
+        activityDirectiveErrors.push(parsed.error ?? "contains an invalid activity object");
+        continue;
+      }
+      activities.push(parsed.activity);
+      removeIndexes.add(index);
+    }
+  }
+
+  const result = {
+    markdown: lines
+      .filter((_line, index) => !removeIndexes.has(index))
+      .join("\n")
+      .replace(/^\n|\n$/g, ""),
+    knowledge,
+    knowledgeDirectiveError,
+    activities: activities.length > 0 ? activities : undefined,
+    activityDirectiveErrors:
+      activityDirectiveErrors.length > 0 ? activityDirectiveErrors : undefined,
   };
+  if (result.knowledge === undefined) delete result.knowledge;
+  if (result.knowledgeDirectiveError === undefined) delete result.knowledgeDirectiveError;
+  if (result.activities === undefined) delete result.activities;
+  if (result.activityDirectiveErrors === undefined) delete result.activityDirectiveErrors;
+  return result;
 }
 
 /** Parse level-two lesson sections into the stable HL04 body-block vocabulary. */
@@ -121,14 +186,18 @@ export function parseBodyBlocks(body: string): {
   const blockLines: string[] = [];
   const finish = (): void => {
     if (!current) return;
-    const parsedKnowledge = parseBlockKnowledge(
+    const parsedMetadata = parseBlockMetadata(
       blockLines.join("\n").replace(/^\n|\n$/g, ""),
     );
-    current.markdown = parsedKnowledge.markdown;
-    current.knowledge = parsedKnowledge.knowledge;
-    current.knowledgeDirectiveError = parsedKnowledge.knowledgeDirectiveError;
+    current.markdown = parsedMetadata.markdown;
+    current.knowledge = parsedMetadata.knowledge;
+    current.knowledgeDirectiveError = parsedMetadata.knowledgeDirectiveError;
+    current.activities = parsedMetadata.activities;
+    current.activityDirectiveErrors = parsedMetadata.activityDirectiveErrors;
     if (current.knowledge === undefined) delete current.knowledge;
     if (current.knowledgeDirectiveError === undefined) delete current.knowledgeDirectiveError;
+    if (current.activities === undefined) delete current.activities;
+    if (current.activityDirectiveErrors === undefined) delete current.activityDirectiveErrors;
     blocks.push(current);
     blockLines.length = 0;
   };

--- a/code/packages/typescript/human-language-data/src/report.ts
+++ b/code/packages/typescript/human-language-data/src/report.ts
@@ -15,6 +15,8 @@ export interface DurationEstimate {
   repeatCueCount: number;
   explicitPauseSeconds: number;
   authoredAudioSeconds: number;
+  /** Sum of explicit `response_seconds` budgets on compiled activities. */
+  activityResponseSeconds: number;
   reasons: Array<"declared" | "computed">;
 }
 
@@ -52,7 +54,7 @@ export interface TrackSchemaCoverage {
 export interface CurriculumGapReport {
   schemaVersion: 1;
   durationModel: {
-    version: 1;
+    version: 2;
     thresholdSeconds: number;
     spokenWordsPerMinute: number;
     learnerResponseSecondsPerPrompt: number;
@@ -250,7 +252,7 @@ function explicitPauseSeconds(markdown: string): number {
 export function estimateLessonDuration(lesson: ParsedLesson): DurationEstimate {
   const text = instructionalText(lesson.body);
   const wordCount = countWords(text);
-  const promptCount = countPromptLines(lesson.body);
+  const promptCount = countPromptLines(stripHtmlComments(lesson.body));
   const repeatCueCount = text.match(/\b(?:repeat|again|twice|three\s+times)\b/giu)?.length ?? 0;
   const pauseSeconds = explicitPauseSeconds(lesson.body);
   const authoredAudioSeconds = Math.ceil(
@@ -259,7 +261,12 @@ export function estimateLessonDuration(lesson: ParsedLesson): DurationEstimate {
       0,
   );
   const spokenSeconds = Math.ceil((wordCount / SPOKEN_WORDS_PER_MINUTE) * 60);
-  const responseSeconds = promptCount * RESPONSE_SECONDS_PER_PROMPT;
+  const activityResponseSeconds = lesson.blocks.reduce(
+    (total, block) =>
+      total + (block.activities ?? []).reduce((sum, activity) => sum + activity.responseSeconds, 0),
+    0,
+  );
+  const responseSeconds = promptCount * RESPONSE_SECONDS_PER_PROMPT + activityResponseSeconds;
   const repeatSeconds = repeatCueCount * REPEAT_CUE_SECONDS;
   const subtotal = Math.max(spokenSeconds, authoredAudioSeconds) + responseSeconds + repeatSeconds + pauseSeconds;
   const computedSeconds = Math.ceil(subtotal * (1 + SAFETY_MARGIN));
@@ -281,6 +288,7 @@ export function estimateLessonDuration(lesson: ParsedLesson): DurationEstimate {
     repeatCueCount,
     explicitPauseSeconds: pauseSeconds,
     authoredAudioSeconds,
+    activityResponseSeconds,
     reasons,
   };
 }
@@ -368,7 +376,7 @@ export function buildCurriculumGapReport(input: CurriculumGapReportInput): Curri
   return {
     schemaVersion: 1,
     durationModel: {
-      version: 1,
+      version: 2,
       thresholdSeconds: DURATION_THRESHOLD_SECONDS,
       spokenWordsPerMinute: SPOKEN_WORDS_PER_MINUTE,
       learnerResponseSecondsPerPrompt: RESPONSE_SECONDS_PER_PROMPT,

--- a/code/packages/typescript/human-language-data/src/types.ts
+++ b/code/packages/typescript/human-language-data/src/types.ts
@@ -233,6 +233,44 @@ export interface LessonBlockKnowledge {
   assesses: string[];
 }
 
+/** The first executable activity contract supported by HL-V03. */
+export type LessonActivityKind = "text";
+
+export interface LessonActivityFeedback {
+  correct: string;
+  incorrect: string;
+}
+
+/**
+ * One authored retrieval activity attached to a typed lesson-body block.
+ *
+ * Authors store this as compact JSON in an `hl-activity` comment immediately
+ * after the block's `hl-knowledge` directive. The parser removes the comment
+ * from learner copy while keeping this typed value in the canonical AST.
+ */
+export interface LessonActivity {
+  id: string;
+  kind: LessonActivityKind;
+  /** Non-empty subset of the containing block's assessed knowledge atoms. */
+  assesses: string[];
+  prompt: string;
+  /** Canonical display answer. */
+  answer: string;
+  /** Additional authored responses accepted after deterministic normalization. */
+  accepted: string[];
+  feedback: LessonActivityFeedback;
+  responseSeconds: number;
+}
+
+/** A runtime-ready activity with every accepted response resolved up front. */
+export interface CompiledLessonActivity extends LessonActivity {
+  blockIndex: number;
+  blockType: LessonBlockType;
+  blockTitle: string;
+  /** Canonical answer followed by authored variants, all normalized and unique. */
+  acceptedResponses: string[];
+}
+
 export interface LessonBodyBlock {
   type: LessonBlockType;
   /** Original level-two heading, kept for book/app presentation. */
@@ -243,6 +281,10 @@ export interface LessonBodyBlock {
   knowledge?: LessonBlockKnowledge;
   /** Present when an author attempted a directive whose shape is invalid. */
   knowledgeDirectiveError?: string;
+  /** Ordered executable retrieval contracts authored at this block boundary. */
+  activities?: LessonActivity[];
+  /** Present when one or more `hl-activity` directives are invalid or misplaced. */
+  activityDirectiveErrors?: string[];
 }
 
 // ---- Script / character-breakdown data (data/scripts/<script>.json) ----

--- a/code/packages/typescript/human-language-data/tests/activity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/activity.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  activityAnswerIsCorrect,
+  activityContractErrors,
+  compileLessonActivities,
+  normalizeActivityResponse,
+} from "../src/activity.js";
+import { parseBodyBlocks } from "../src/parse.js";
+
+const DIRECTIVE = `<!-- hl-activity: {"id":"ES-G01-class-count","kind":"text","assesses":["ES-GRAMMAR-NOUN-GENDER"],"prompt":"How many noun classes does Spanish keep?","answer":"two","accepted":["2"],"feedback":{"correct":"Right: masculine and feminine.","incorrect":"Spanish keeps two noun classes."},"response_seconds":8} -->`;
+
+describe("typed lesson activities", () => {
+  it("parses compact JSON beside block knowledge and omits it from learner copy", () => {
+    const [block] = parseBodyBlocks([
+      "## Wrap-up Recall",
+      "<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-NOUN-GENDER] -->",
+      DIRECTIVE,
+      "",
+      "Recall the two classes.",
+    ].join("\n")).blocks;
+
+    expect(block?.markdown).toBe("Recall the two classes.");
+    expect(block?.activityDirectiveErrors).toBeUndefined();
+    expect(block?.activities).toEqual([{
+      id: "ES-G01-class-count",
+      kind: "text",
+      assesses: ["ES-GRAMMAR-NOUN-GENDER"],
+      prompt: "How many noun classes does Spanish keep?",
+      answer: "two",
+      accepted: ["2"],
+      feedback: {
+        correct: "Right: masculine and feminine.",
+        incorrect: "Spanish keeps two noun classes.",
+      },
+      responseSeconds: 8,
+    }]);
+  });
+
+  it("compiles answer variants once and matches normalized runtime responses", () => {
+    const blocks = parseBodyBlocks([
+      "## Wrap-up Recall",
+      "<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-NOUN-GENDER] -->",
+      DIRECTIVE,
+      "Recall the two classes.",
+    ].join("\n")).blocks;
+    const [activity] = compileLessonActivities(blocks);
+
+    expect(activity).toMatchObject({
+      id: "ES-G01-class-count",
+      blockIndex: 0,
+      blockType: "recall",
+      acceptedResponses: ["two", "2"],
+    });
+    expect(activityAnswerIsCorrect("  TWO  ", activity!)).toBe(true);
+    expect(activityAnswerIsCorrect("three", activity!)).toBe(false);
+    expect(normalizeActivityResponse("It’s  TWO")).toBe("it's two");
+  });
+
+  it("flags malformed, misplaced, and ambiguous authored contracts", () => {
+    const [misplaced] = parseBodyBlocks([
+      "## Wrap-up Recall",
+      "<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-NOUN-GENDER] -->",
+      "Learner copy first.",
+      DIRECTIVE,
+    ].join("\n")).blocks;
+    expect(misplaced?.activityDirectiveErrors).toEqual([
+      "activity directives must follow the first-line hl-knowledge directive before learner copy",
+    ]);
+    expect(misplaced?.markdown).toContain("hl-activity");
+
+    const [malformed] = parseBodyBlocks([
+      "## Wrap-up Recall",
+      "<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-NOUN-GENDER] -->",
+      "<!-- hl-activity: {not-json} -->",
+      "Learner copy.",
+    ].join("\n")).blocks;
+    expect(malformed?.activityDirectiveErrors).toEqual(["contains invalid JSON"]);
+
+    const parsed = parseBodyBlocks([
+      "## Wrap-up Recall",
+      "<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-NOUN-GENDER] -->",
+      DIRECTIVE,
+      "Learner copy.",
+    ].join("\n")).blocks[0]!.activities![0]!;
+    expect(activityContractErrors({ ...parsed, accepted: ["TWO"] })).toContain(
+      "answer and accepted variants must resolve to unique responses",
+    );
+  });
+});

--- a/code/packages/typescript/human-language-data/tests/curriculum.test.ts
+++ b/code/packages/typescript/human-language-data/tests/curriculum.test.ts
@@ -198,6 +198,21 @@ describe("per-language realization-map validation", () => {
 });
 
 describe("schema-v2 lesson validation", () => {
+  it("requires schema version 2 before an activity contract can compile", () => {
+    const legacy = source("A", "word", "GREETING-HELLO", []).replace(
+      "# A real body",
+      `## Wrap-up Recall
+<!-- hl-activity: {"id":"A-recall","kind":"text","assesses":["TEST-LEX-HELLO"],"prompt":"Type hello.","answer":"hello","accepted":[],"feedback":{"correct":"Right.","incorrect":"Try again."},"response_seconds":8} -->
+Recall it.`,
+    );
+    expect(validateCurriculum({
+      registry,
+      taxonomy,
+      spine,
+      lessons: [parseLesson(legacy, "test")],
+    }).map((issue) => issue.code)).toContain("activity-requires-schema-v2");
+  });
+
   it("accepts a dependency-ordered transitive knowledge chain", () => {
     const lessons = [
       parseLesson(sourceV2("A", 10, [], [], ["TEST-LEX-HELLO"], ["TEST-LEX-HELLO"]), "test"),
@@ -347,6 +362,52 @@ describe("schema-v2 lesson validation", () => {
       spine,
       lessons: [parseLesson(malformed, "test")],
     }).map((issue) => issue.code)).toContain("schema-v2-invalid-block-knowledge");
+  });
+
+  it("accepts a compiled activity whose atoms are a subset of its block assessment", () => {
+    const activity = `<!-- hl-activity: {"id":"A-recall","kind":"text","assesses":["TEST-LEX-HELLO"],"prompt":"Type the greeting.","answer":"hello","accepted":["hi"],"feedback":{"correct":"Correct.","incorrect":"Recall the greeting."},"response_seconds":8} -->`;
+    const authored = sourceV2("A", 10, [], [], ["TEST-LEX-HELLO"], ["TEST-LEX-HELLO"])
+      .replace(
+        "<!-- hl-knowledge: introduces=[]; assesses=[TEST-LEX-HELLO] -->\n\nSay hello once.",
+        `<!-- hl-knowledge: introduces=[]; assesses=[TEST-LEX-HELLO] -->\n${activity}\n\nSay hello once.`,
+      );
+    expect(validateCurriculum({
+      registry,
+      taxonomy,
+      spine,
+      lessons: [parseLesson(authored, "test")],
+    }).filter((issue) => issue.level === "error")).toEqual([]);
+  });
+
+  it("rejects invalid activity variants, ids, and atoms outside the containing block", () => {
+    const activity = `<!-- hl-activity: {"id":"other","kind":"text","assesses":["TEST-GRAMMAR-FUTURE"],"prompt":"Type the greeting.","answer":"hello","accepted":["HELLO"],"feedback":{"correct":"Correct.","incorrect":"Recall the greeting."},"response_seconds":8} -->`;
+    const authored = sourceV2("A", 10, [], [], ["TEST-LEX-HELLO"], ["TEST-LEX-HELLO"])
+      .replace(
+        "<!-- hl-knowledge: introduces=[]; assesses=[TEST-LEX-HELLO] -->\n\nSay hello once.",
+        `<!-- hl-knowledge: introduces=[]; assesses=[TEST-LEX-HELLO] -->\n${activity}\n\nSay hello once.`,
+      );
+    const codes = validateCurriculum({
+      registry,
+      taxonomy,
+      spine,
+      lessons: [parseLesson(authored, "test")],
+    }).map((issue) => issue.code);
+    expect(codes).toEqual(expect.arrayContaining([
+      "schema-v2-activity-id-prefix",
+      "schema-v2-invalid-activity-contract",
+      "schema-v2-activity-assessment-outside-block",
+    ]));
+  });
+
+  it("rejects malformed or misplaced activity directives", () => {
+    const malformed = sourceV2("A", 10, [], [], ["TEST-LEX-HELLO"], ["TEST-LEX-HELLO"])
+      .replace("Say hello once.", "Say hello once.\n<!-- hl-activity: {not-json} -->");
+    expect(validateCurriculum({
+      registry,
+      taxonomy,
+      spine,
+      lessons: [parseLesson(malformed, "test")],
+    }).map((issue) => issue.code)).toContain("schema-v2-invalid-activity-directive");
   });
 
   it("rejects malformed duration, coverage, sequence, and body blocks", () => {

--- a/code/packages/typescript/human-language-data/tests/integration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/integration.test.ts
@@ -8,6 +8,7 @@ import { validate, hasErrors } from "../src/validate.js";
 import { validateCurriculum } from "../src/curriculum.js";
 import { buildCurriculumGapReport } from "../src/report.js";
 import { languagesForConcept } from "../src/queries.js";
+import { compileLessonActivities } from "../src/activity.js";
 
 const { taxonomy, registry, spine, curricula, books, lessons, scripts, dataset } = loadEverything();
 
@@ -83,6 +84,7 @@ describe("real curriculum", () => {
   it("produces a machine-readable migration gap baseline", () => {
     const report = buildCurriculumGapReport({ registry, lessons, books });
     expect(report.schemaVersion).toBe(1);
+    expect(report.durationModel.version).toBe(2);
     expect(report.summary.registeredTracks).toBe(20);
     expect(report.summary.totalLessons).toBe(lessons.length);
     expect(report.summary.authoredBooks).toBe(20);
@@ -90,6 +92,16 @@ describe("real curriculum", () => {
     expect(report.summary.unknownPrerequisites).toBe(0);
     expect(report.schemas.tracks).toHaveLength(20);
     expect(report.books.tracks).toHaveLength(20);
+  });
+
+  it("compiles the first objective grammar and script activities from canonical blocks", () => {
+    const activities = lessons.flatMap((lesson) => compileLessonActivities(lesson.blocks));
+    expect(activities.map((activity) => activity.id).sort()).toEqual([
+      "ES-C01-genero-gramatical-class-count",
+      "ES-W03-question-span-roberto-outside",
+    ]);
+    expect(activities.every((activity) => activity.assesses.length > 0)).toBe(true);
+    expect(activities.every((activity) => activity.acceptedResponses.length > 0)).toBe(true);
   });
 
   it("keeps the Spanish Chapters 1-3 schema-v2 pilot closed and under five minutes", () => {

--- a/code/packages/typescript/human-language-data/tests/report.test.ts
+++ b/code/packages/typescript/human-language-data/tests/report.test.ts
@@ -64,6 +64,24 @@ describe("curriculum gap report", () => {
     expect(audio.computedSeconds).toBeGreaterThan(300);
   });
 
+  it("adds authored activity response budgets without counting metadata as prose prompts", () => {
+    const estimate = estimateLessonDuration(lesson({
+      id: "AL-ACTIVITY",
+      language: "alpha",
+      chapter: 1,
+      minutes: 1,
+      body: [
+        "## Wrap-up Recall",
+        "<!-- hl-knowledge: introduces=[]; assesses=[TEST-LEX-HELLO] -->",
+        '<!-- hl-activity: {"id":"AL-ACTIVITY-recall","kind":"text","assesses":["TEST-LEX-HELLO"],"prompt":"What?","answer":"hello","accepted":[],"feedback":{"correct":"Yes.","incorrect":"Try again."},"response_seconds":17} -->',
+        "Type the greeting.",
+      ].join("\n"),
+    }));
+
+    expect(estimate.activityResponseSeconds).toBe(17);
+    expect(estimate.promptCount).toBe(0);
+  });
+
   it("strips closed and adversarial unclosed HTML comments without a regex backtrack", () => {
     const closed = estimateLessonDuration(
       lesson({

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased — schema-v2 lesson compatibility
 
+### Changed — typed objective focused activities
+
+- Load compiled `hl-activity` contracts from the shared lesson AST and prefer
+  their authored prompt, canonical answer, accepted variants, feedback, and
+  response budget over lexical inference or self-confirmation.
+- Hide answer-bearing lesson summaries while an authored activity is active,
+  show corrective feedback without advancing after a wrong answer, and require
+  an explicit continue after correct feedback before completing that language's
+  frontier.
+- Keep both knowledge and activity metadata out of the readable lesson view;
+  Spanish grammatical gender and punctuation-span lessons are the first
+  objective non-lexical pilots.
+
 ### Changed — independent local frontiers and focused-before-mixed review
 
 - Replace the global concept cursor and unrestricted jump controls with one
@@ -10,9 +23,10 @@
 - Persist completed prefixes by stable lesson id independently per language;
   corrupt, unknown, out-of-order, and stale saved ids fail closed at the first
   missing local prerequisite.
-- Require a focused check before advancing: objective English-meaning retrieval
-  for lexical lessons and authored final-recall confirmation for script,
-  grammar, and other support lessons. Wrong answers do not advance.
+- Require a focused check before advancing: compiled activities when authored,
+  objective English-meaning retrieval for other lexical lessons, and temporary
+  final-recall confirmation for remaining support lessons. Wrong answers do not
+  advance.
 - Build mixed SRS review only from independently passed shared lessons and wait
   for two visually distinct eligible answers, preventing unseen lessons and
   identical one-option quizzes from entering the pool.

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -30,11 +30,16 @@ at the same shared ability. Script notes come from explicit local script
 extensions and the canonical script data, so Persian and Urdu keep distinct
 identities and no global concept cursor guesses where a script belongs.
 
-Before advancing, the learner starts a **focused check**. Lexical lessons ask
-for one English meaning without showing another language's card; a wrong answer
-reveals feedback and leaves the local frontier unchanged. Grammar, script, and
-other support lessons require the learner to complete the authored final recall
-from memory. One successful check completes exactly the current frontier lesson.
+Before advancing, the learner starts a **focused check**. When a canonical block
+has an `hl-activity` contract, the app uses its authored prompt, normalized answer
+variants, corrective feedback, and response budget without scraping prose or
+showing an answer-bearing summary. Other lexical lessons ask for one English
+meaning. A wrong answer leaves the local frontier unchanged; a correct answer
+shows feedback before the learner continues. The first objective non-lexical
+pilots cover Spanish grammatical gender and punctuation spans. Remaining support
+lessons retain their temporary final-recall confirmation while HL-A01 fills the
+measured contract backlog.
+One successful check completes exactly the current frontier lesson.
 `learnprogress.ts` persists stable lesson IDs independently per language and,
 on load, keeps only the longest valid local prefix. A newly inserted prerequisite
 therefore becomes the frontier instead of being skipped by stale saved state.

--- a/code/programs/typescript/language-ladder/src/focused.ts
+++ b/code/programs/typescript/language-ladder/src/focused.ts
@@ -1,15 +1,33 @@
 // Pure focused-retrieval checks used before a lesson joins mixed review.
 
 import type { Lesson } from "./lessons.ts";
+import {
+  activityAnswerIsCorrect,
+} from "@coding-adventures/human-language-data/src/activity.ts";
+import type { CompiledLessonActivity } from "@coding-adventures/human-language-data/src/types.ts";
+
+export { activityAnswerIsCorrect };
 
 const MEANING_CHECK_TYPES = new Set(["word", "phrase", "new"]);
 
-export type FocusedCheckKind = "meaning" | "self-check";
+export type FocusedCheckKind = "activity" | "meaning" | "self-check";
 
-export function focusedCheckKind(lesson: Pick<Lesson, "type" | "gloss">): FocusedCheckKind {
+export function focusedCheckKind(
+  lesson: Pick<Lesson, "type" | "gloss"> & Partial<Pick<Lesson, "activities">>,
+): FocusedCheckKind {
+  if ((lesson.activities?.length ?? 0) > 0) return "activity";
   return MEANING_CHECK_TYPES.has(lesson.type) && lesson.gloss.trim() !== ""
     ? "meaning"
     : "self-check";
+}
+
+/** Prefer the authored final recall; fall back to the last typed activity. */
+export function focusedActivity(
+  lesson: Partial<Pick<Lesson, "activities">>,
+): CompiledLessonActivity | undefined {
+  const activities = lesson.activities ?? [];
+  const recalls = activities.filter((activity) => activity.blockType === "recall");
+  return recalls[recalls.length - 1] ?? activities[activities.length - 1];
 }
 
 export function normalizeFocusedAnswer(value: string): string {

--- a/code/programs/typescript/language-ladder/src/lessonbody.ts
+++ b/code/programs/typescript/language-ladder/src/lessonbody.ts
@@ -33,7 +33,7 @@ export function lessonSections(markdown: string): LessonSection[] {
   for (const raw of markdown.replace(/\r\n/g, "\n").split("\n")) {
     const line = raw.trim();
     if (/^#\s+/.test(line)) continue; // card already displays the lesson title
-    if (/^<!--\s*hl-knowledge:/.test(line)) continue; // canonical AST metadata, not learner copy
+    if (/^<!--\s*hl-(?:knowledge|activity):/.test(line)) continue; // canonical AST metadata, not learner copy
     const heading = /^##\s+(.+)$/.exec(line);
     if (heading) {
       flushSection();

--- a/code/programs/typescript/language-ladder/src/lessons.ts
+++ b/code/programs/typescript/language-ladder/src/lessons.ts
@@ -22,6 +22,10 @@
 // loaded fine and then died at startup with "process is not defined". Reaching
 // straight for the pure parsing module keeps Node out of the browser bundle.
 import { parseLesson, type ParsedLesson } from "@coding-adventures/human-language-data/src/parse.ts";
+import {
+  compileLessonActivities,
+} from "@coding-adventures/human-language-data/src/activity.ts";
+import type { CompiledLessonActivity } from "@coding-adventures/human-language-data/src/types.ts";
 
 /**
  * Every lesson markdown file, as raw text, keyed by path. Vite inlines these at
@@ -65,6 +69,8 @@ export interface Lesson {
   etymologyHook: string;
   /** Lossless authored lesson Markdown, shared with the book corpus. */
   body: string;
+  /** Typed, block-bound retrieval contracts; never inferred from lesson prose. */
+  activities: CompiledLessonActivity[];
   /** Canonical AST fingerprint; generated books combine these in authored order. */
   sourceHash?: string;
   /** Explicit schema-v2 local order. Legacy lessons omit it. */
@@ -127,6 +133,7 @@ export function toLesson(parsed: ParsedLesson): Lesson | null {
     script: r.script,
     etymologyHook: r.etymologyHook,
     body: parsed.body,
+    activities: compileLessonActivities(parsed.blocks),
     sourceHash: parsed.sourceHash,
     sequence:
       typeof fm.sequence === "string" && Number.isFinite(Number(fm.sequence))

--- a/code/programs/typescript/language-ladder/src/main.ts
+++ b/code/programs/typescript/language-ladder/src/main.ts
@@ -81,7 +81,12 @@ import {
   saveLearnProgress,
   type LearnCompletion,
 } from "./learnprogress.ts";
-import { focusedCheckKind, meaningAnswerIsCorrect } from "./focused.ts";
+import {
+  activityAnswerIsCorrect,
+  focusedActivity,
+  focusedCheckKind,
+  meaningAnswerIsCorrect,
+} from "./focused.ts";
 import { loadLanguages, saveLanguages } from "./languagestore.ts";
 import { lessonSections } from "./lessonbody.ts";
 import { bookHashStatus } from "./bookhashes.ts";
@@ -173,7 +178,7 @@ let reviewCell: GridCell | null = null; // the question currently on screen
 let reviewOptions: GridCell[] = []; // its answer options (one is `reviewCell`)
 let reviewChosen: string | null = null; // cellKey of the picked option; null = unanswered
 let learnCompletion: LearnCompletion = loadLearnProgress(REVIEW_STORAGE, LANGUAGE_CURRICULA);
-type FocusedAttempt = { lessonId: string; state: "check" | "wrong" };
+type FocusedAttempt = { lessonId: string; state: "check" | "wrong" | "correct" };
 let focusedAttempt: FocusedAttempt | null = null;
 let learnNotice: string | null = null;
 
@@ -1052,9 +1057,23 @@ function renderFocusedCheck(
   card.appendChild(head);
 
   const attempt = focusedAttempt?.lessonId === lesson.id ? focusedAttempt : null;
+  const kind = focusedCheckKind(lesson);
+  const activity = focusedActivity(lesson);
+  if (attempt?.state === "correct") {
+    const verdict = el("p", "focused-check__feedback yes");
+    verdict.textContent = activity?.feedback.correct
+      ?? "Correct. This lesson is ready to join independently unlocked review.";
+    const advance = el("button", "next") as HTMLButtonElement;
+    advance.textContent = `Continue ${languageName(step.language)}`;
+    advance.onclick = () => finishFocusedCheck(step);
+    card.append(verdict, advance);
+    return card;
+  }
   if (attempt?.state === "wrong") {
     const verdict = el("p", "focused-check__feedback no");
-    verdict.textContent = `Not yet. One accepted meaning is “${lesson.gloss}”. Review the lesson, then try again.`;
+    verdict.textContent = activity
+      ? `${activity.feedback.incorrect} Accepted answer: “${activity.answer}”.`
+      : `Not yet. One accepted meaning is “${lesson.gloss}”. Review the lesson, then try again.`;
     card.appendChild(verdict);
     const again = el("button", "next") as HTMLButtonElement;
     again.textContent = "Review lesson again";
@@ -1066,17 +1085,46 @@ function renderFocusedCheck(
     return card;
   }
 
-  const glyph = el("div", "focused-check__glyph");
-  glyph.textContent = lesson.headword;
-  glyph.dir = SCRIPTS_BY_ID.get(lesson.script)?.direction ?? "auto";
-  card.appendChild(glyph);
-  if (lesson.romanization && lesson.romanization !== lesson.headword) {
-    const romanization = el("p", "step__rom");
-    romanization.textContent = lesson.romanization;
-    card.appendChild(romanization);
+  // An authored activity may ask the learner to produce the headword itself,
+  // so its prompt is shown without the lesson's answer-bearing summary card.
+  if (kind !== "activity") {
+    const glyph = el("div", "focused-check__glyph");
+    glyph.textContent = lesson.headword;
+    glyph.dir = SCRIPTS_BY_ID.get(lesson.script)?.direction ?? "auto";
+    card.appendChild(glyph);
+    if (lesson.romanization && lesson.romanization !== lesson.headword) {
+      const romanization = el("p", "step__rom");
+      romanization.textContent = lesson.romanization;
+      card.appendChild(romanization);
+    }
   }
 
-  if (focusedCheckKind(lesson) === "meaning") {
+  if (kind === "activity" && activity) {
+    const form = el("form", "focused-check__form") as HTMLFormElement;
+    const label = el("label", "focused-check__prompt");
+    label.textContent = activity.prompt;
+    const budget = el("span", "focused-check__budget");
+    budget.textContent = `Authored response budget: ${activity.responseSeconds}s`;
+    const input = document.createElement("input");
+    input.className = "focused-check__input";
+    input.type = "text";
+    input.autocomplete = "off";
+    input.setAttribute("aria-label", activity.prompt);
+    const submit = el("button", "next") as HTMLButtonElement;
+    submit.type = "submit";
+    submit.textContent = "Check answer";
+    form.append(label, budget, input, submit);
+    form.onsubmit = (event) => {
+      event.preventDefault();
+      focusedAttempt = {
+        lessonId: lesson.id,
+        state: activityAnswerIsCorrect(input.value, activity) ? "correct" : "wrong",
+      };
+      learnNotice = null;
+      render();
+    };
+    card.appendChild(form);
+  } else if (kind === "meaning") {
     const form = el("form", "focused-check__form") as HTMLFormElement;
     const label = el("label", "focused-check__prompt");
     label.textContent = `Without reopening the lesson, type one English meaning for “${lesson.headword}”.`;
@@ -1091,12 +1139,12 @@ function renderFocusedCheck(
     form.append(label, input, submit);
     form.onsubmit = (event) => {
       event.preventDefault();
-      if (meaningAnswerIsCorrect(input.value, lesson.gloss)) finishFocusedCheck(step);
-      else {
-        focusedAttempt = { lessonId: lesson.id, state: "wrong" };
-        learnNotice = null;
-        render();
-      }
+      focusedAttempt = {
+        lessonId: lesson.id,
+        state: meaningAnswerIsCorrect(input.value, lesson.gloss) ? "correct" : "wrong",
+      };
+      learnNotice = null;
+      render();
     };
     card.appendChild(form);
   } else {

--- a/code/programs/typescript/language-ladder/src/styles.css
+++ b/code/programs/typescript/language-ladder/src/styles.css
@@ -472,6 +472,13 @@ body {
 .focused-check__input:focus { outline: 2px solid var(--accent); outline-offset: 1px; }
 .focused-check__feedback { margin: 10px 0; font-weight: 650; line-height: 1.5; }
 .focused-check__feedback.no { color: #c53030; }
+.focused-check__feedback.yes { color: #247a43; }
+.focused-check__budget {
+  display: block;
+  color: var(--muted);
+  font-size: 0.78rem;
+  margin: -2px 0 8px;
+}
 .focused-check__actions { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; }
 .focused-check__secondary {
   margin-top: 12px;

--- a/code/programs/typescript/language-ladder/tests/concepts.test.ts
+++ b/code/programs/typescript/language-ladder/tests/concepts.test.ts
@@ -39,6 +39,7 @@ function lesson(over: Partial<Lesson> & { id: string }): Lesson {
     body: "",
     estMinutes: 5,
     ...over,
+    activities: over.activities ?? [],
   };
 }
 

--- a/code/programs/typescript/language-ladder/tests/focused.test.ts
+++ b/code/programs/typescript/language-ladder/tests/focused.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   acceptedMeanings,
+  activityAnswerIsCorrect,
+  focusedActivity,
   focusedCheckKind,
   meaningAnswerIsCorrect,
   normalizeFocusedAnswer,
@@ -26,5 +28,26 @@ describe("focused retrieval checks", () => {
     expect(focusedCheckKind({ type: "phrase", gloss: "my name is" })).toBe("meaning");
     expect(focusedCheckKind({ type: "writing", gloss: "the first joined shape" }))
       .toBe("self-check");
+  });
+
+  it("prefers an authored recall activity over lexical inference or self-confirmation", () => {
+    const activity = {
+      id: "ES-G01-count",
+      kind: "text" as const,
+      assesses: ["ES-GRAMMAR-NOUN-GENDER"],
+      prompt: "How many classes?",
+      answer: "two",
+      accepted: ["2"],
+      feedback: { correct: "Right.", incorrect: "Try again." },
+      responseSeconds: 8,
+      blockIndex: 3,
+      blockType: "recall" as const,
+      blockTitle: "Wrap-up Recall",
+      acceptedResponses: ["two", "2"],
+    };
+    const lesson = { type: "grammar", gloss: "noun gender", activities: [activity] };
+    expect(focusedCheckKind(lesson)).toBe("activity");
+    expect(focusedActivity(lesson)).toBe(activity);
+    expect(activityAnswerIsCorrect(" 2 ", activity)).toBe(true);
   });
 });

--- a/code/programs/typescript/language-ladder/tests/learnprogress.test.ts
+++ b/code/programs/typescript/language-ladder/tests/learnprogress.test.ts
@@ -51,6 +51,7 @@ const lesson = (id: string, language: string, concept: string): Lesson => ({
   script: "latin",
   etymologyHook: "",
   body: "",
+  activities: [],
   estMinutes: 3,
 });
 

--- a/code/programs/typescript/language-ladder/tests/lessonbody.test.ts
+++ b/code/programs/typescript/language-ladder/tests/lessonbody.test.ts
@@ -18,4 +18,16 @@ Say *hola*.`)).toEqual([
       { title: "Guided Practice", blocks: ["Say hola."] },
     ]);
   });
+
+  it("keeps compiled activity metadata out of learner copy", () => {
+    expect(lessonSections(`# Title
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-NOUN-GENDER] -->
+<!-- hl-activity: {"id":"ES-G01-count","kind":"text"} -->
+
+Recall the two classes.`)).toEqual([
+      { title: "Wrap-up Recall", blocks: ["Recall the two classes."] },
+    ]);
+  });
 });

--- a/code/programs/typescript/language-ladder/tests/lessons.test.ts
+++ b/code/programs/typescript/language-ladder/tests/lessons.test.ts
@@ -88,6 +88,21 @@ describe("toLesson", () => {
     expect(lesson!.headword).toBe("-உக்கு");
     expect(lesson!.id).toBe("TA-C06-dative-ukku");
   });
+
+  it("carries compiled block activities without scraping lesson prose", () => {
+    const source = SPANISH.replace("# body", `## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-FUTURE] -->
+<!-- hl-activity: {"id":"ES-C17-futuro-recall","kind":"text","assesses":["ES-GRAMMAR-FUTURE"],"prompt":"Type the answer.","answer":"future","accepted":[],"feedback":{"correct":"Right.","incorrect":"Try again."},"response_seconds":8} -->
+
+Recall it.`);
+    const lesson = toLesson(parseLesson(source, "spanish"));
+    expect(lesson!.activities).toHaveLength(1);
+    expect(lesson!.activities![0]).toMatchObject({
+      id: "ES-C17-futuro-recall",
+      acceptedResponses: ["future"],
+      blockType: "recall",
+    });
+  });
 });
 
 describe("loadLessons", () => {
@@ -143,6 +158,7 @@ export function lesson(over: Partial<Lesson> & { id: string }): Lesson {
     body: "",
     estMinutes: 5,
     ...over,
+    activities: over.activities ?? [],
   };
 }
 

--- a/code/programs/typescript/language-ladder/tests/quiz.test.ts
+++ b/code/programs/typescript/language-ladder/tests/quiz.test.ts
@@ -19,6 +19,7 @@ function L(language: string, concept: string, id: string, chapter = 1): Lesson {
     script: language,
     etymologyHook: "",
     body: "",
+    activities: [],
     estMinutes: 5,
   };
 }

--- a/code/programs/typescript/language-ladder/tests/sequence.test.ts
+++ b/code/programs/typescript/language-ladder/tests/sequence.test.ts
@@ -31,6 +31,7 @@ function L(language: string, concept: string, chapter: number, id?: string): Les
     script: language,
     etymologyHook: "",
     body: "",
+    activities: [],
     estMinutes: 5,
   };
 }

--- a/code/programs/typescript/language-ladder/tests/session.test.ts
+++ b/code/programs/typescript/language-ladder/tests/session.test.ts
@@ -21,6 +21,7 @@ function L(language: string, concept: string, roots: string[], chapter = 1): Les
     script: language,
     etymologyHook: "",
     body: "",
+    activities: [],
     estMinutes: 5,
   };
 }

--- a/code/programs/typescript/language-ladder/tests/sessionplan.test.ts
+++ b/code/programs/typescript/language-ladder/tests/sessionplan.test.ts
@@ -8,7 +8,7 @@ function L(language: string, concept: string, id: string, roots: string[] = []):
   return {
     id, language, headword: `${language}:${concept}`, gloss: concept, type: "word",
     chapter: 1, concept, prerequisites: [], reviewsOf: [], roots,
-    romanization: "x", script: language, etymologyHook: "", body: "", estMinutes: 5,
+    romanization: "x", script: language, etymologyHook: "", body: "", activities: [], estMinutes: 5,
   };
 }
 

--- a/code/specs/HL03-unified-language-learning-app.md
+++ b/code/specs/HL03-unified-language-learning-app.md
@@ -34,9 +34,11 @@ source for book and app delivery.
 HL04 governs when its local-path rules conflict with the earlier global
 concept-sweep model below. Learn now presents one prerequisite-safe frontier per
 selected language and stores stable completed lesson-id prefixes independently.
-A focused check advances only that language; mixed review includes only lessons
-that independently passed and waits for at least two visually distinct eligible
-answers. A shared concept sweep is therefore a comparison available when local
+A focused check advances only that language. It prefers a compiled block-bound
+activity with authored variants and feedback, otherwise uses lexical meaning
+retrieval or a temporary non-lexical confirmation. Mixed review includes only
+lessons that independently passed and waits for at least two visually distinct
+eligible answers. A shared concept sweep is therefore a comparison available when local
 frontiers and eligibility align, not a cursor that can pull another language
 past its own script, grammar, register, or vocabulary prerequisite.
 
@@ -240,13 +242,16 @@ All of the above shipped as the app **`language-ladder`** (renamed from
   in the gloss text), so showing it would be inconsistent rather than helpful.
 - **HL04 local-frontier migration** — all 20 realization maps now drive Learn.
   `learnprogress.ts` stores only prerequisite-safe per-language prefixes;
-  lexical meaning retrieval and authored non-lexical recall gate advancement;
+  compiled activities now gate the first objective grammar/script pilots,
+  lexical meaning retrieval covers uncontracted vocabulary, and temporary
+  authored non-lexical recall confirmation covers the measured migration debt;
   explicit local extension nodes place script and grammar support; and mixed SRS
   review draws only from independently focused-successful lessons. The old
   `cursorstore.ts` key remains resettable only as legacy state.
 
-The two honest non-builds (grammar intro, romanization) can return if the
-curriculum grows the metadata they need.
+The earlier grammar-note non-build has been replaced by full canonical lesson
+bodies, typed local extensions, and compiled activities. Quiz-option
+romanization remains parked until coverage is consistent enough to be honest.
 
 ## Verification
 

--- a/code/specs/HL04-shared-spine-and-content-pipeline.md
+++ b/code/specs/HL04-shared-spine-and-content-pipeline.md
@@ -70,14 +70,14 @@ experience.
 | One atomic lesson | Strong: most content lessons teach one word or phrase. | Some lessons are long enough to contain several independent teaching steps. |
 | Strictly less than five minutes | The deterministic duration report now measures zero lessons at or above 300 effective seconds; schema-v2 lessons fail validation outside 1–299 seconds. | Keep the gate green as the corpus grows and finish migrating legacy lesson contracts. |
 | Etymology and morphology | Strong prose tradition and root metadata. | Normalize etymons, record sources/confidence, and deliver the full explanation to the app. |
-| Inline grammar | Typed local extension nodes place grammar lessons in prerequisite-safe paths; the app advances through those lessons inline. | Compile objective prompt/answer contracts so non-lexical focused checks do not rely on learner confirmation. |
-| Inline script | Typed local script extensions, writing lessons, and script JSON now participate in each language's visible frontier. | Complete grapheme-level knowledge closure, progressive transliteration fading, and a true Nastaliq presentation font. |
+| Inline grammar | Typed local extension nodes place grammar lessons in prerequisite-safe paths; compiled activity contracts now supply the first objective grammar check. | Author contracts across the remaining non-lexical frontiers instead of relying on temporary learner confirmation. |
+| Inline script | Typed local script extensions, writing lessons, and script JSON now participate in each language's visible frontier; the punctuation-span pilot uses an objective script activity. | Complete activity coverage, grapheme-level knowledge closure, progressive transliteration fading, and a true Nastaliq presentation font. |
 | Shared cross-language concepts | 42 concepts are shared by two or more languages. | The shared layer is mostly greetings and A0 vocabulary; 385 concepts remain language-namespaced. |
 | Safe progression | All 20 maps cover mapped prerequisites in earlier local positions; Learn stores only completed prefixes and cannot jump ahead. | Finish knowledge-atom and activity-contract migration for legacy lessons so every assessed token, construction, sound, and glyph is closure-checked. |
 | Single content source | The parser preserves typed Markdown bodies; the app renders them and generated book chapters carry the same source hashes. | Continue replacing the remaining handwritten chapter copies and legacy lesson contracts. |
 | Four skills and communicative use | Audio-script cues and guided prompts exist. | There is no structured listening, interaction, writing, or can-do coverage model, and no audio asset contract. |
 | Graded input and sustained reading | Isolated example sentences occur. | There is no controlled micro-story/dialogue corpus or known-token validation. |
-| Mixed-language practice | Learn advances independent local frontiers, persists safe lesson-id prefixes, blocks advancement after a wrong focused check, and admits only independently passed, visually distinguishable lessons to mixed SRS review. | Compile objective focused activities for non-lexical lessons and expand prompt directions beyond meaning recognition. |
+| Mixed-language practice | Learn advances independent local frontiers, prefers compiled objective activities, blocks advancement after a wrong focused check, and admits only independently passed, visually distinguishable lessons to mixed SRS review. | Extend objective activity coverage across the measured 111 remaining non-lexical frontiers and expand prompt directions beyond text entry. |
 | Register, dialect, and culture | Often explained in lesson prose. | These distinctions are not typed, so the app can silently compare non-equivalent registers or varieties. |
 | Proficiency target | Roadmaps generally point toward B1. | No CEFR/ACTFL-aligned outcome matrix shows which reception, production, interaction, or mediation abilities are covered. |
 
@@ -258,15 +258,19 @@ copy:
 
 ## Guided Practice
 <!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-GRACIAS-PRODUCTIVE] -->
+<!-- hl-activity: {"id":"ES-C01-gracias-production","kind":"text","assesses":["ES-LEX-GRACIAS-PRODUCTIVE"],"prompt":"Type the Spanish for 'thank you'.","answer":"gracias","accepted":[],"feedback":{"correct":"Right: gracias.","incorrect":"The everyday form is gracias."},"response_seconds":8} -->
 
 - [YOU SAY: "gracias"]
 ```
 
 The body is parsed into stable, named blocks: `warmup`, `input`, `notice`,
 `pronunciation`, `script`, `etymology`, `grammar`, `culture-pragmatics`,
-`guided-production`, `comprehension`, `fluency`, and `recall`. A block may declare
-prompts, accepted answers, feedback, and response time. The app and book render the
-same block; medium-specific presentation belongs in renderers, not a second copy.
+`guided-production`, `comprehension`, `fluency`, and `recall`. After its knowledge
+boundary, a block may declare zero or more compact JSON `hl-activity` comments.
+Each names a stable id, response kind, non-empty assessed-atom subset, prompt,
+canonical answer, explicit accepted variants, correct/incorrect feedback, and
+response time. The app and book consume the same block; medium-specific
+presentation belongs in renderers, not a second copy.
 Every schema-v2 block authors both lists, including explicit empty lists. The
 union of block introductions must equal `introduces.knowledge`; every assessed
 atom must be declared in `practises.knowledge`; and guided-production and recall
@@ -283,7 +287,9 @@ The validator computes this set at every block boundary. It checks assessments
 before adding that block's introductions, so a form must be established by a
 prerequisite or by an earlier block rather than introduced and tested in one
 opaque step. Unknown atoms, cycles, forward references, missing or malformed
-directives, undeclared assessments, and assessed unavailable forms are errors.
+directives, undeclared assessments, assessed unavailable forms, activities whose
+atoms are outside their containing block, and ambiguous normalized answer variants
+are errors.
 Runtime scheduling fails closed and reports a curriculum defect; it never unlocks
 everything as a fallback.
 
@@ -291,7 +297,8 @@ everything as a fallback.
 
 `max_seconds` must be `1..299`. CI independently estimates delivery time from
 spoken word count, explicit pauses, repeat count and audio duration, a learner-
-response budget for every prompt, and a safety margin. The greater of the declared
+response budget for every prose prompt, each activity's authored response budget,
+and a safety margin. The greater of the declared
 and computed values is used. A lesson at 300 seconds or more fails validation.
 
 One session may chain several lessons, but each lesson is independently resumable.
@@ -478,12 +485,15 @@ measurable.
 3. **Mixed-practice correction** — implemented: learner-selected languages,
    persistent per-language completed prefixes, visible local frontiers, wrong-
    answer blocking, and independently gated mixed eligibility.
-4. **Persian and Urdu pilots** — build script composition and the first three spine
+4. **Objective activity compiler** — implemented: block-bound JSON contracts,
+   normalized variants, assessed-atom subset validation, authored feedback/time,
+   and Language Ladder consumption; expand coverage from the two pilots next.
+5. **Persian and Urdu pilots** — build script composition and the first three spine
    clusters in each language with appropriate typography and variety metadata.
-5. **Existing-track migration** — all tracks now have explicit paths and extension
+6. **Existing-track migration** — all tracks now have explicit paths and extension
    ledgers; continue schema migration, etymon normalization, roadmap alignment,
    and removal of handwritten book copies.
-6. **Corpus expansion** — grow through B1 while coverage reports select the next
+7. **Corpus expansion** — grow through B1 while coverage reports select the next
    missing can-do, skill, mode, register, or language realization.
 
 ## First milestone acceptance criteria


### PR DESCRIPTION
## Summary

- add a typed, block-bound activity contract with parser, compiler, validator, normalization, and duration accounting
- add Spanish grammar and script/orthography pilot activities
- wire Language Ladder focused checks to authored objective activities
- record the measured HL-A01 activity-coverage backlog and pre-existing HL-Q01 TypeScript cleanup

## Validation

- `npm run build` and 100 package tests across 13 files
- `npm run check:books`
- Language Ladder `npm run build` and 481 app tests across 30 files
- real-corpus validation across 1,066 lessons with zero validation or duration errors
- `git diff --check`

The standalone Language Ladder `npx tsc --noEmit` command still reports only the pre-existing issues now recorded as HL-Q01; this change introduces no additional TypeScript errors.