### PR TITLE
feat(build-tool): make TypeScript resolution field-aware

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/adhithyan15/coding-adventures/pull/9902",
     "branch": "codex/build-tool-haskell-typescript-field-aware-resolution",
     "implementation_head": "6fecdd0aaa7b67c524fb24068c694215f4958005",
-    "last_ci_repair": null
+    "last_ci_repair": "CodeQL detection exposed the newly affected typescript/rom-bios BUILD front doors missing their five-package transitive standalone closure; both Unix and Windows metadata now materialize transistors, logic-gates, arithmetic, cpu-simulator, and riscv-simulator. Focused validation and the rom-bios 7-test coverage suite pass."
   },
   "last_inventory": {
     "revision": "658184b11299b3b5b87cb30cb5896a5f7a45a573",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,15 +11,9 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": {
-    "number": 9898,
-    "url": "https://github.com/adhithyan15/coding-adventures/pull/9898",
-    "branch": "codex/build-tool-haskell-dotnet-field-aware-resolution",
-    "implementation_head": "78b9ced142f838bcd30c2d0fd1999ca2c2e7e9d4",
-    "last_ci_repair": null
-  },
+  "active_pr": null,
   "last_inventory": {
-    "revision": "28df5db2b85deeaa564cb02fc80f6f81b086937c",
+    "revision": "658184b11299b3b5b87cb30cb5896a5f7a45a573",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1264,
@@ -502,20 +496,29 @@
     {
       "id": "build-tool-post-gradle-dotnet-field-aware-manifest-resolution",
       "title": "Make C# and F# project-reference resolution field-aware",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-post-dart-field-aware-manifest-resolution"],
       "branch": "codex/build-tool-haskell-dotnet-field-aware-resolution",
       "pr_number": 9898,
-      "notes": "Materialized by the exact post-Dart audit as the next independent shared grammar after Gradle. The implemented contract reads only literal Include attributes on unqualified ProjectReference elements in root project files, matches lexically normalized exact root-project paths across the shared .NET scope, and never opens referenced files. Three shared fixtures cover C#, F#, and cross-language references plus XML, MSBuild, nested-project, absolute-path, and unknown-target decoys. The repaired real graphs match edge-for-edge at 198 C# packages/238 edges and 197 F# packages/239 edges with zero one-sided drift. Representative C# and F# MiniSqlite plus F# GFM, Deflate, and Parser downstream tests pass; both front doors validate and dry-run every package in both lanes. Full implementation, coverage, warning, conformance, inventory, diff, and security gates pass. Ready-for-review PR #9898 opened at exact implementation head 78b9ced142f838bcd30c2d0fd1999ca2c2e7e9d4. TypeScript and standalone BUILD debt remain independently pending."
+      "notes": "Materialized by the exact post-Dart audit as the next independent shared grammar after Gradle. The implemented contract reads only literal Include attributes on unqualified ProjectReference elements in root project files, matches lexically normalized exact root-project paths across the shared .NET scope, and never opens referenced files. Three shared fixtures cover C#, F#, and cross-language references plus XML, MSBuild, nested-project, absolute-path, and unknown-target decoys. The repaired real graphs match edge-for-edge at 198 C# packages/238 edges and 197 F# packages/239 edges with zero one-sided drift. Representative C# and F# MiniSqlite plus F# GFM, Deflate, and Parser downstream tests pass; both front doors validate and dry-run every package in both lanes. Full implementation, coverage, warning, conformance, inventory, diff, and security gates pass. Guarded squash auto-completion merged PR #9898 at exact head c5b07229126a8b096a980df8eddb7cac0d0f4dbb as e78c9986c2fef1823ffe32b1a018a70b6fe9e8ca after all 20 exact-head checks were terminal acceptable and two consecutive mergeability readings were MERGEABLE/CLEAN. TypeScript and standalone BUILD debt remain independently pending."
     },
     {
       "id": "build-tool-post-dotnet-typescript-field-aware-manifest-resolution",
       "title": "Make TypeScript package metadata resolution field-aware",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-post-gradle-dotnet-field-aware-manifest-resolution"],
+      "branch": "codex/build-tool-haskell-typescript-field-aware-resolution",
+      "pr_number": null,
+      "notes": "Materialized by the exact post-Dart audit as a separate broad grammar and selected after guarded PR #9898 merged as e78c9986c2fef1823ffe32b1a018a70b6fe9e8ca. The red direct resolver-API baseline found both engines at 470 TypeScript packages, with Go at 1,075 edges and Haskell at 275, leaving 948 Go-only and 148 Haskell-only edges. The implemented shared contract parses root package.json objects, registers exact top-level name aliases, accepts direct root dependencies and devDependencies keys, and rejects peer, optional, script, nested-tool, nested-name, non-object-table, and malformed-JSON decoys. The repaired real graph is exact between Go and Haskell at 470 packages and 1,076 edges with zero one-sided drift; Go recovered one dependency missed by its prior line scanner. A conflict-free rebase onto package-neutral human-languages main 658184b11299b3b5b87cb30cb5896a5f7a45a573 leaves the collision-checked inventory unchanged at 1,264 identities and 4,419 slots with zero collisions or unknown buckets. The separately owned 58-package TypeScript BUILD_windows prerequisite debt remains outside this tranche."
+    },
+    {
+      "id": "typescript-shared-tsconfig-rootdir-portability",
+      "title": "Make shared TypeScript compiler paths package-relative",
+      "status": "pending",
+      "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "Materialized by the exact post-Dart audit as a separate broad grammar. Both engines discover 470 TypeScript packages, but Go emits 1,075 edges versus Haskell's 275, with 948 Go-only and 148 Haskell-only edges. Audit package.json workspace and dependency semantics separately after the smaller JVM and .NET shared grammars, preserving the separately owned TypeScript BUILD_windows debt boundary."
+      "notes": "Discovered during representative downstream validation for the TypeScript field-aware resolver tranche. On unchanged origin/main metadata, code/packages/typescript/tsconfig.base.json declares rootDir and outDir relative to the shared config rather than each extending package. A clean npm run build in typescript/transistors fails with TS6059 because its src/index.ts is outside code/packages/typescript/src. Corpus audit finds 458 TypeScript package/program tsconfig files with build scripts: 293 override rootDir locally and 165 retain this shared-root risk. The real BUILD_windows recipes remain test-oriented and pass for the transistors, logic-gates, and arithmetic dependency chain. Audit the 165-package compiler boundary and repair it in dependency-shaped waves without mixing the separately owned 58-package BUILD_windows prerequisite debt or resolver semantics."
     },
     {
       "id": "build-tool-elixir-engine-rockspec-utf8-conformance",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,13 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": {
+    "number": 9902,
+    "url": "https://github.com/adhithyan15/coding-adventures/pull/9902",
+    "branch": "codex/build-tool-haskell-typescript-field-aware-resolution",
+    "implementation_head": "6fecdd0aaa7b67c524fb24068c694215f4958005",
+    "last_ci_repair": null
+  },
   "last_inventory": {
     "revision": "658184b11299b3b5b87cb30cb5896a5f7a45a573",
     "schema_version": 3,
@@ -505,11 +511,11 @@
     {
       "id": "build-tool-post-dotnet-typescript-field-aware-manifest-resolution",
       "title": "Make TypeScript package metadata resolution field-aware",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-post-gradle-dotnet-field-aware-manifest-resolution"],
       "branch": "codex/build-tool-haskell-typescript-field-aware-resolution",
-      "pr_number": null,
-      "notes": "Materialized by the exact post-Dart audit as a separate broad grammar and selected after guarded PR #9898 merged as e78c9986c2fef1823ffe32b1a018a70b6fe9e8ca. The red direct resolver-API baseline found both engines at 470 TypeScript packages, with Go at 1,075 edges and Haskell at 275, leaving 948 Go-only and 148 Haskell-only edges. The implemented shared contract parses root package.json objects, registers exact top-level name aliases, accepts direct root dependencies and devDependencies keys, and rejects peer, optional, script, nested-tool, nested-name, non-object-table, and malformed-JSON decoys. The repaired real graph is exact between Go and Haskell at 470 packages and 1,076 edges with zero one-sided drift; Go recovered one dependency missed by its prior line scanner. A conflict-free rebase onto package-neutral human-languages main 658184b11299b3b5b87cb30cb5896a5f7a45a573 leaves the collision-checked inventory unchanged at 1,264 identities and 4,419 slots with zero collisions or unknown buckets. The separately owned 58-package TypeScript BUILD_windows prerequisite debt remains outside this tranche."
+      "pr_number": 9902,
+      "notes": "Materialized by the exact post-Dart audit as a separate broad grammar and selected after guarded PR #9898 merged as e78c9986c2fef1823ffe32b1a018a70b6fe9e8ca. The red direct resolver-API baseline found both engines at 470 TypeScript packages, with Go at 1,075 edges and Haskell at 275, leaving 948 Go-only and 148 Haskell-only edges. The implemented shared contract parses root package.json objects, registers exact top-level name aliases, accepts direct root dependencies and devDependencies keys, and rejects peer, optional, script, nested-tool, nested-name, non-object-table, and malformed-JSON decoys. The repaired real graph is exact between Go and Haskell at 470 packages and 1,076 edges with zero one-sided drift; Go recovered one dependency missed by its prior line scanner. A conflict-free rebase onto package-neutral human-languages main 658184b11299b3b5b87cb30cb5896a5f7a45a573 leaves the collision-checked inventory unchanged at 1,264 identities and 4,419 slots with zero collisions or unknown buckets. Full implementation, coverage, warning, conformance, downstream, inventory, diff, and security gates pass. Ready-for-review PR #9902 opened at exact implementation head 6fecdd0aaa7b67c524fb24068c694215f4958005. The separately owned 58-package TypeScript BUILD_windows prerequisite debt remains outside this tranche."
     },
     {
       "id": "typescript-shared-tsconfig-rootdir-portability",

--- a/code/packages/typescript/rom-bios/BUILD
+++ b/code/packages/typescript/rom-bios/BUILD
@@ -1,2 +1,7 @@
+cd ../transistors && npm ci --quiet
+cd ../logic-gates && npm ci --quiet
+cd ../arithmetic && npm ci --quiet
+cd ../cpu-simulator && npm ci --quiet
+cd ../riscv-simulator && npm ci --quiet
 npm install --silent
 npx vitest run --coverage

--- a/code/packages/typescript/rom-bios/BUILD_windows
+++ b/code/packages/typescript/rom-bios/BUILD_windows
@@ -1,2 +1,7 @@
+cd ../transistors && npm ci --quiet
+cd ../logic-gates && npm ci --quiet
+cd ../arithmetic && npm ci --quiet
+cd ../cpu-simulator && npm ci --quiet
+cd ../riscv-simulator && npm ci --quiet
 npm install --silent
 npx vitest run --coverage

--- a/code/programs/go/build-tool/CHANGELOG.md
+++ b/code/programs/go/build-tool/CHANGELOG.md
@@ -32,6 +32,11 @@ All notable changes to the Go build tool will be documented in this file.
 
 ### Fixed
 
+- TypeScript dependency resolution now parses root `package.json` objects,
+  registers only the exact top-level `name` alias, and accepts only direct
+  keys from `dependencies` and `devDependencies`. Single-line tables resolve
+  correctly while peer, optional, nested tool, script, and malformed-JSON
+  decoys cannot invent partial graph edges.
 - C#, F#, and shared .NET resolution now reads only literal `Include`
   attributes on unqualified `ProjectReference` elements in root project files,
   matches lexically normalized paths to exact project files across the shared

--- a/code/programs/go/build-tool/README.md
+++ b/code/programs/go/build-tool/README.md
@@ -117,6 +117,15 @@ directory-derived snake-case aliases identify packages. The shared
 field-boundary fixture covers these boundaries, and the complete 82-package
 lane resolves exactly 67 edges.
 
+TypeScript dependency resolution parses the root `package.json` and reads only
+direct property names from `dependencies` and `devDependencies`. Exact
+top-level `name` strings and directory-derived scoped or unscoped names supply
+aliases. Dependency values are not followed, and peer or optional dependency
+tables, scripts, nested tool configuration, nested names, and malformed JSON
+cannot invent partial graph edges. The shared field-boundary fixture covers
+single-line objects and adversarial decoys; the complete 470-package lane
+resolves exactly 1,076 edges.
+
 Java and Kotlin dependency resolution reads only `includeBuild("...")` calls
 from root `settings.gradle.kts` files. Calls may span lines; their quoted
 relative paths are normalized lexically and must exactly match a discovered

--- a/code/programs/go/build-tool/internal/resolver/resolver.go
+++ b/code/programs/go/build-tool/internal/resolver/resolver.go
@@ -40,6 +40,7 @@
 package resolver
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -379,46 +380,19 @@ func parseGoDeps(pkg discovery.Package, knownNames map[string]string) []string {
 //	    "@coding-adventures/logic-gates": "file:../logic-gates"
 //	}
 //
-// We scan for lines matching the @coding-adventures/ prefix and map them
-// to our internal package names. Version specifiers and file: references
-// are ignored — we only care about the package name.
+// Only direct keys of the root dependencies and devDependencies objects are
+// authoritative. Version specifiers and file:/workspace: references are
+// ignored -- we only care about the package name.
 func parseTypescriptDeps(pkg discovery.Package, knownNames map[string]string) []string {
 	packageJSON := filepath.Join(pkg.Path, "package.json")
-	data, err := os.ReadFile(packageJSON)
-	if err != nil {
+	manifest, ok := readPackageJSON(packageJSON)
+	if !ok {
 		return nil
 	}
 
-	text := string(data)
 	var internalDeps []string
-
-	// We look inside both "dependencies" and "devDependencies" blocks so the
-	// graph reflects local build/test prerequisites too.
-	inDeps := false
-	re := regexp.MustCompile(`"([^"]+)"\s*:`)
-	for _, line := range strings.Split(text, "\n") {
-		trimmed := strings.TrimSpace(line)
-
-		if !inDeps {
-			if (strings.Contains(trimmed, `"dependencies"`) ||
-				strings.Contains(trimmed, `"devDependencies"`)) &&
-				strings.Contains(trimmed, "{") {
-				inDeps = true
-			}
-			continue
-		}
-
-		// Inside dependencies block.
-		if strings.Contains(trimmed, "}") {
-			inDeps = false
-			continue
-		}
-
-		for _, match := range re.FindAllStringSubmatch(trimmed, -1) {
-			if len(match) < 2 {
-				continue
-			}
-			depName := strings.ToLower(strings.TrimSpace(match[1]))
+	for _, field := range []string{"dependencies", "devDependencies"} {
+		for _, depName := range packageJSONDependencyNames(manifest[field]) {
 			if pkgName, ok := knownNames[depName]; ok {
 				internalDeps = append(internalDeps, pkgName)
 			}
@@ -426,6 +400,41 @@ func parseTypescriptDeps(pkg discovery.Package, knownNames map[string]string) []
 	}
 
 	return internalDeps
+}
+
+func readPackageJSON(path string) (map[string]json.RawMessage, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+
+	var manifest map[string]json.RawMessage
+	if err := json.Unmarshal(data, &manifest); err != nil || manifest == nil {
+		return nil, false
+	}
+	return manifest, true
+}
+
+func packageJSONName(manifest map[string]json.RawMessage) string {
+	var name string
+	if err := json.Unmarshal(manifest["name"], &name); err != nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+func packageJSONDependencyNames(raw json.RawMessage) []string {
+	var dependencies map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &dependencies); err != nil || dependencies == nil {
+		return nil
+	}
+
+	names := make([]string, 0, len(dependencies))
+	for name := range dependencies {
+		names = append(names, strings.ToLower(strings.TrimSpace(name)))
+	}
+	sort.Strings(names)
+	return names
 }
 
 // parseDartDeps extracts internal dependencies from a Dart pubspec.yaml file.
@@ -1786,11 +1795,9 @@ func buildKnownNamesForLanguage(packages []discovery.Package, language string) m
 			setKnown(strings.ToLower(filepath.Base(pkg.Path)), pkg.Name, pkg.Path, pkg.Language)
 
 			packageJSON := filepath.Join(pkg.Path, "package.json")
-			data, err := os.ReadFile(packageJSON)
-			if err == nil {
-				re := regexp.MustCompile(`"name"\s*:\s*"([^"]+)"`)
-				if match := re.FindStringSubmatch(string(data)); len(match) == 2 {
-					setKnown(strings.ToLower(strings.TrimSpace(match[1])), pkg.Name, pkg.Path, pkg.Language)
+			if manifest, ok := readPackageJSON(packageJSON); ok {
+				if declaredName := packageJSONName(manifest); declaredName != "" {
+					setKnown(declaredName, pkg.Name, pkg.Path, pkg.Language)
 				}
 			}
 

--- a/code/programs/go/build-tool/internal/resolver/resolver_test.go
+++ b/code/programs/go/build-tool/internal/resolver/resolver_test.go
@@ -1057,6 +1057,22 @@ func TestParseTypescriptDepsExternalSkipped(t *testing.T) {
 	}
 }
 
+func TestTypescriptResolutionConformanceFixture(t *testing.T) {
+	fixture := loadResolutionFixture(t, "resolution-typescript-field-aware.json")
+	_, packages := materializeResolutionFixture(t, fixture)
+	graph := mustResolveDependencies(t, packages)
+
+	edges := graph.Edges()
+	if len(edges) != len(fixture.Expected.Result.Edges) {
+		t.Fatalf("dependency edge count = %d, want %d: %v", len(edges), len(fixture.Expected.Result.Edges), edges)
+	}
+	for _, edge := range fixture.Expected.Result.Edges {
+		if len(edge) != 2 || !graph.HasEdge(edge[0], edge[1]) {
+			t.Fatalf("missing expected dependency edge %v in %v", edge, edges)
+		}
+	}
+}
+
 func TestBuildKnownNamesDart(t *testing.T) {
 	packages := []discovery.Package{
 		{Name: "dart/logic-gates", Path: "/repo/packages/dart/logic-gates", Language: "dart"},

--- a/code/programs/haskell/build-tool/CHANGELOG.md
+++ b/code/programs/haskell/build-tool/CHANGELOG.md
@@ -43,6 +43,9 @@ All notable changes to this package will be documented in this file.
 - Shared C#, F#, and cross-language .NET field-boundary coverage for exact root
   project paths, portable separators, XML decoys, MSBuild dynamic paths,
   nested projects, and unknown targets.
+- Shared TypeScript field-boundary coverage for root runtime and development
+  dependency objects, exact top-level package-name aliases, single-line
+  tables, and representative peer, optional, script, nested, and name decoys.
 
 ### Changed
 
@@ -68,6 +71,9 @@ All notable changes to this package will be documented in this file.
   on unqualified `ProjectReference` elements in root project files, matching
   lexically normalized paths to exact project aliases across the shared .NET
   scope without opening referenced files.
+- Parse TypeScript `package.json` with Aeson, register only its exact root
+  top-level `name`, and resolve only direct keys of root `dependencies` and
+  `devDependencies` objects instead of tokenizing the complete manifest.
 - Resolve Lua edges only from quoted values in the rockspec `dependencies`
   table, merge qualified `# build-tool: deps=` entries from the selected BUILD
   file, preserve program identity segments, and prefer package aliases over

--- a/code/programs/haskell/build-tool/README.md
+++ b/code/programs/haskell/build-tool/README.md
@@ -59,6 +59,15 @@ directory-derived snake-case forms supply aliases, and hashing includes
 `pubspec.yaml` plus `.dart` source. The shared field-boundary fixture and the
 complete 82-package lane match the Go resolver exactly at 67 edges.
 
+TypeScript dependency resolution parses the root `package.json` and reads only
+direct property names from `dependencies` and `devDependencies`. Exact
+top-level `name` strings and directory-derived scoped or unscoped names supply
+aliases. Dependency values are not followed, and peer or optional dependency
+tables, scripts, nested tool configuration, nested names, and malformed JSON
+cannot invent partial graph edges. The shared field-boundary fixture covers
+single-line objects and adversarial decoys; the complete 470-package lane
+matches the Go resolver edge-for-edge at 1,076 edges.
+
 Java and Kotlin dependency resolution reads only `includeBuild("...")` calls
 from root `settings.gradle.kts` files. Calls may span lines; their quoted
 relative paths are normalized lexically and must exactly match a discovered

--- a/code/programs/haskell/build-tool/coding-adventures-build-tool.cabal
+++ b/code/programs/haskell/build-tool/coding-adventures-build-tool.cabal
@@ -13,7 +13,8 @@ extra-doc-files: README.md
 
 library
     exposed-modules:  BuildTool
-    build-depends:    base >=4.14 && <5
+    build-depends:    aeson >=2.0 && <3
+                    , base >=4.14 && <5
                     , bytestring >=0.10 && <0.13
                     , containers >=0.6 && <0.8
                     , directed-graph ==0.1.*

--- a/code/programs/haskell/build-tool/src/BuildTool.hs
+++ b/code/programs/haskell/build-tool/src/BuildTool.hs
@@ -17,6 +17,9 @@ module BuildTool
 
 import Control.Exception (Exception, IOException, catch, evaluate, throwIO, try)
 import Control.Monad (filterM, foldM, forM, when)
+import Data.Aeson (Value(..), eitherDecodeStrict')
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import Data.Char (isAlpha, isAlphaNum, isSpace, ord, toLower)
@@ -579,6 +582,16 @@ packageAliases pkg = do
     let kebab = map (\char -> if char == '_' then '-' else char) dirName
     let snake = map (\char -> if char == '-' then '_' else char) dirName
     let perlDistributionAliases = if packageLanguage pkg == "perl" then ["coding-adventures-" ++ dirName] else []
+    let conventionalAliases =
+            if packageLanguage pkg == "typescript"
+                then [dirName, "@coding-adventures/" ++ dirName]
+                else
+                    [ dirName
+                    , kebab
+                    , snake
+                    , "coding-adventures-" ++ kebab
+                    , "coding_adventures_" ++ snake
+                    ]
     let gradlePathAliases =
             if packageLanguage pkg `elem` ["java", "kotlin"]
                 then [normalizeGradlePackagePath (packagePath pkg)]
@@ -593,12 +606,7 @@ packageAliases pkg = do
             ( filter
                 (not . null)
                 ( map (map toLower)
-                    ( [ dirName
-                      , kebab
-                      , snake
-                      , "coding-adventures-" ++ kebab
-                      , "coding_adventures_" ++ snake
-                      ]
+                    ( conventionalAliases
                         ++ perlDistributionAliases
                         ++ gradlePathAliases
                         ++ dotnetProjectAliases
@@ -694,12 +702,12 @@ dartRootName rawLine
 readPackageJsonNames :: FilePath -> IO [String]
 readPackageJsonNames root = do
     let packageJson = root </> "package.json"
-    exists <- doesFileExist packageJson
-    if not exists
-        then pure []
-        else do
-            contents <- readFileStrict packageJson
-            pure (parseJsonLikeField "name" contents)
+    manifest <- readPackageJsonObject packageJson
+    pure
+        ( case manifest >>= KeyMap.lookup (Key.fromString "name") of
+            Just (String name) -> [map toLower (Text.unpack (Text.strip name))]
+            _ -> []
+        )
 
 readGemspecNames :: FilePath -> IO [String]
 readGemspecNames root = do
@@ -783,23 +791,6 @@ parseQuotedField fieldName contents =
 parseAssignmentField :: String -> String -> [String]
 parseAssignmentField = parseQuotedField
 
-parseJsonLikeField :: String -> String -> [String]
-parseJsonLikeField fieldName contents =
-    nub
-        [ map toLower value
-        | line <- lines contents
-        , let stripped = trim line
-        , let prefix = "\"" ++ fieldName ++ "\""
-        , prefix `isPrefixOf` stripped
-        , let afterColon = dropWhile (/= ':') stripped
-        , not (null afterColon)
-        , let rhs = trim (drop 1 afterColon)
-        , not (null rhs)
-        , take 1 rhs == "\""
-        , let value = takeWhile (/= '"') (drop 1 rhs)
-        , not (null value)
-        ]
-
 resolvePackageDeps :: Map String (Map String String) -> Package -> IO [String]
 resolvePackageDeps aliasScopes pkg = do
     tokens <- readManifestTokens pkg
@@ -858,9 +849,45 @@ readManifestTokens pkg
     | packageLanguage pkg == "ruby" = readRubyDependencyTokens pkg
     | packageLanguage pkg == "rust" = readRustDependencyTokens pkg
     | packageLanguage pkg == "swift" = readSwiftDependencyTokens pkg
+    | packageLanguage pkg == "typescript" = readTypescriptDependencyTokens pkg
     | packageLanguage pkg `elem` ["java", "kotlin"] = readGradleDependencyTokens pkg
     | packageLanguage pkg `elem` ["csharp", "fsharp", "dotnet"] = readDotnetDependencyTokens pkg
     | otherwise = readGenericManifestTokens pkg
+
+readPackageJsonObject :: FilePath -> IO (Maybe (KeyMap.KeyMap Value))
+readPackageJsonObject path = do
+    exists <- doesFileExist path
+    if not exists
+        then pure Nothing
+        else do
+            bytes <- BS.readFile path
+            pure
+                ( case eitherDecodeStrict' bytes of
+                    Right (Object manifest) -> Just manifest
+                    _ -> Nothing
+                )
+
+readTypescriptDependencyTokens :: Package -> IO [String]
+readTypescriptDependencyTokens pkg = do
+    manifest <- readPackageJsonObject (packagePath pkg </> "package.json")
+    pure
+        ( nub
+            ( concatMap
+                (typescriptDependencyNames manifest)
+                ["dependencies", "devDependencies"]
+            )
+        )
+
+typescriptDependencyNames :: Maybe (KeyMap.KeyMap Value) -> String -> [String]
+typescriptDependencyNames manifest fieldName =
+    case manifest >>= KeyMap.lookup (Key.fromString fieldName) of
+        Just (Object dependencies) ->
+            sort
+                ( map
+                    (map toLower . Text.unpack . Text.strip . Key.toText)
+                    (KeyMap.keys dependencies)
+                )
+        _ -> []
 
 readDartDependencyTokens :: Package -> IO [String]
 readDartDependencyTokens pkg = do

--- a/code/programs/haskell/build-tool/test/ResolutionUtf8Spec.hs
+++ b/code/programs/haskell/build-tool/test/ResolutionUtf8Spec.hs
@@ -12,6 +12,7 @@ module ResolutionUtf8Spec
     , resolutionRubySpec
     , resolutionRustSpec
     , resolutionSwiftSpec
+    , resolutionTypescriptSpec
     , resolutionUtf8Spec
     )
 where
@@ -410,6 +411,33 @@ resolutionSwiftSpec = describe "Swift resolution conformance" $ do
                     Right
                         [ ["swift/beta-helper", "swift/delta_name", "swift/gamma"]
                         , ["swift/alpha"]
+                        ]
+
+resolutionTypescriptSpec :: Spec
+resolutionTypescriptSpec = describe "TypeScript resolution conformance" $ do
+    it "reads only direct root dependency tables through exact manifest aliases" $
+        withFixture "resolution-typescript-field-aware.json" $ \root fixture -> do
+            graph <- resolveFixtureFor "typescript" root
+            graphEdges graph `shouldBe` fixtureExpectedEdges fixture
+            DG.nodes graph
+                `shouldBe`
+                    [ "typescript/alpha"
+                    , "typescript/beta-helper"
+                    , "typescript/delta_name"
+                    , "typescript/gamma"
+                    , "typescript/malformed"
+                    , "typescript/wrong-shape"
+                    ]
+            DG.independentGroups graph
+                `shouldBe`
+                    Right
+                        [ [ "typescript/beta-helper"
+                          , "typescript/delta_name"
+                          , "typescript/gamma"
+                          , "typescript/malformed"
+                          , "typescript/wrong-shape"
+                          ]
+                        , ["typescript/alpha"]
                         ]
 
 assertMetadataError :: FilePath -> MetadataEncodingError -> Expectation

--- a/code/programs/haskell/build-tool/test/Spec.hs
+++ b/code/programs/haskell/build-tool/test/Spec.hs
@@ -14,6 +14,7 @@ import ResolutionUtf8Spec
     , resolutionRubySpec
     , resolutionRustSpec
     , resolutionSwiftSpec
+    , resolutionTypescriptSpec
     , resolutionUtf8Spec
     )
 
@@ -36,3 +37,4 @@ spec = do
     resolutionRubySpec
     resolutionPerlSpec
     resolutionSwiftSpec
+    resolutionTypescriptSpec

--- a/code/scripts/tests/test_build_tool_conformance_runner.py
+++ b/code/scripts/tests/test_build_tool_conformance_runner.py
@@ -131,7 +131,7 @@ class CorpusTests(unittest.TestCase):
         summary = runner.validate_corpus(FIXTURE_ROOT)
 
         self.assertEqual(summary["schema_version"], 1)
-        self.assertEqual(summary["case_count"], 55)
+        self.assertEqual(summary["case_count"], 56)
         self.assertEqual(summary["implementation_count"], 16)
         self.assertEqual(summary["established_languages"], 15)
         self.assertEqual(summary["execution_case_count"], 0)
@@ -851,7 +851,7 @@ class CommandLineTests(unittest.TestCase):
 
         self.assertEqual(exit_code, 0)
         summary = json.loads(stdout.getvalue())
-        self.assertEqual(summary["case_count"], 55)
+        self.assertEqual(summary["case_count"], 56)
 
     def test_validate_result_reports_match_and_rejects_execution_override(self) -> None:
         case_path = CASES_ROOT / "graph-diamond.json"

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -331,6 +331,19 @@ dependencies. Resolvers ignore package descriptions, environment constraints,
 lockfiles, and every other root field. A local `path:` value identifies source
 metadata only; resolvers do not follow or read the referenced path.
 
+For TypeScript `package.json` manifests, dependency candidates come only from
+the direct property names of the root `dependencies` and `devDependencies`
+objects. Each property name is matched case-insensitively against known
+directory aliases and the exact string value of another package's root
+top-level `name` property. Dependency values, including registry constraints,
+`workspace:` ranges, and `file:` paths, do not form part of the identity and
+are not followed. Resolvers ignore `peerDependencies`,
+`optionalDependencies`, scripts, tool configuration, nested objects whose
+property names resemble dependency tables, nested `name` properties, lock
+files, descriptions, and every other root field. A dependency field whose
+value is not an object contributes no candidates, and malformed JSON must not
+produce a partial graph.
+
 For Java and Kotlin Gradle composite builds, dependency candidates come only
 from `includeBuild("...")` call expressions in the package root's
 `settings.gradle.kts`. The call may span lines, and its sole argument is a

--- a/code/specs/fixtures/build-tool-v1/cases/resolution-typescript-field-aware.json
+++ b/code/specs/fixtures/build-tool-v1/cases/resolution-typescript-field-aware.json
@@ -1,0 +1,103 @@
+{
+  "schema_version": 1,
+  "id": "resolution/typescript-field-aware",
+  "domain": "resolution",
+  "summary": "TypeScript resolution reads only direct root dependencies and devDependencies keys and honors exact root package names.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "resolution"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/typescript/alpha/BUILD",
+        "content_utf8": "echo build alpha\n"
+      },
+      {
+        "path": "code/packages/typescript/alpha/package.json",
+        "content_utf8": "{\n  \"name\": \"@coding-adventures/alpha\",\n  \"dependencies\": {\"@coding-adventures/custom-beta\": \"workspace:*\"},\n  \"devDependencies\": {\n    \"delta_name\": \"file:../delta_name\"\n  },\n  \"peerDependencies\": {\n    \"@coding-adventures/gamma\": \"^1.0.0\"\n  },\n  \"optionalDependencies\": {\n    \"@coding-adventures/gamma\": \"^1.0.0\"\n  },\n  \"scripts\": {\n    \"@coding-adventures/gamma\": \"ignored\"\n  },\n  \"tool\": {\n    \"dependencies\": {\n      \"@coding-adventures/gamma\": \"ignored\"\n    },\n    \"name\": \"@coding-adventures/not-alpha\"\n  }\n}\n"
+      },
+      {
+        "path": "code/packages/typescript/beta-helper/BUILD",
+        "content_utf8": "echo build beta-helper\n"
+      },
+      {
+        "path": "code/packages/typescript/beta-helper/package.json",
+        "content_utf8": "{\n  \"name\": \"@coding-adventures/custom-beta\"\n}\n"
+      },
+      {
+        "path": "code/packages/typescript/delta_name/BUILD",
+        "content_utf8": "echo build delta_name\n"
+      },
+      {
+        "path": "code/packages/typescript/delta_name/package.json",
+        "content_utf8": "{\n  \"name\": \"delta_name\"\n}\n"
+      },
+      {
+        "path": "code/packages/typescript/gamma/BUILD",
+        "content_utf8": "echo build gamma\n"
+      },
+      {
+        "path": "code/packages/typescript/gamma/package.json",
+        "content_utf8": "{\n  \"name\": \"@coding-adventures/gamma\"\n}\n"
+      },
+      {
+        "path": "code/packages/typescript/malformed/BUILD",
+        "content_utf8": "echo build malformed\n"
+      },
+      {
+        "path": "code/packages/typescript/malformed/package.json",
+        "content_utf8": "{\n  \"name\": \"@coding-adventures/malformed\",\n  \"dependencies\": {\n    \"@coding-adventures/gamma\": \"workspace:*\"\n  }\n"
+      },
+      {
+        "path": "code/packages/typescript/wrong-shape/BUILD",
+        "content_utf8": "echo build wrong-shape\n"
+      },
+      {
+        "path": "code/packages/typescript/wrong-shape/package.json",
+        "content_utf8": "{\n  \"name\": \"@coding-adventures/wrong-shape\",\n  \"dependencies\": [\"@coding-adventures/gamma\"],\n  \"devDependencies\": \"@coding-adventures/gamma\"\n}\n"
+      }
+    ]
+  },
+  "input": {
+    "operation": "resolution",
+    "options": {
+      "code_root": "code",
+      "language": "typescript"
+    },
+    "arguments": [],
+    "environment": {},
+    "changed_paths": []
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "resolution/typescript-field-aware",
+    "domain": "resolution",
+    "outcome": "ok",
+    "result": {
+      "edges": [
+        [
+          "typescript/beta-helper",
+          "typescript/alpha"
+        ],
+        [
+          "typescript/delta_name",
+          "typescript/alpha"
+        ]
+      ]
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 5000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 256,
+    "cpu_time_ms": 5000
+  }
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -645,6 +645,41 @@ packages with 11,396 missing slots, 618 Rust singletons, and zero collisions or
 unknown buckets, so no new package work is added and the active priority does
 not move.
 
+Guarded squash auto-completion merged the .NET resolver PR #9898 at exact head
+`c5b0722912` as `e78c9986c2` after all 20 exact-head checks were terminal
+acceptable and two consecutive mergeability readings were `MERGEABLE/CLEAN`.
+The refreshed collision-checked schema-3 inventory is unchanged at 1,264
+implementation identities, 4,419 established-lane slots, 173 high-consensus
+packages with 270 missing slots, 814 singleton packages with 11,396 missing
+slots, 618 Rust singletons, and zero collisions or unknown buckets.
+
+The post-.NET dependency/leverage pass therefore selects the separately owned
+TypeScript package-metadata grammar. A direct resolver-API audit reconfirms
+both engines discover 470 packages, while Go emits 1,075 edges and Haskell 275,
+leaving 948 Go-only and 148 Haskell-only edges. This is now the largest bounded
+remaining established-lane resolver repair. Its package.json name and runtime
+dependency tables stay one coherent metadata contract; the 58-package
+TypeScript `BUILD_windows` standalone-prerequisite debt reproduced by the real
+front door remains independently owned and must not widen this tranche.
+
+The implemented TypeScript contract parses valid root `package.json` objects,
+registers only exact top-level `name` aliases, and admits direct keys from root
+`dependencies` and `devDependencies` objects. It ignores dependency values,
+peer and optional tables, scripts, nested tool objects, nested names, and
+malformed JSON rather than inventing a partial graph. The shared adversarial
+fixture proves single-line runtime tables, development dependencies, declared
+aliases, and every excluded decoy. The repaired real repository graphs now
+match edge-for-edge between Go and Haskell at 470 TypeScript packages and
+1,076 edges, with zero one-sided drift; the Go field parser also recovers one
+real dependency that its previous line scanner missed.
+
+A conflict-free rebase onto package-neutral human-languages main
+`658184b112` leaves the refreshed collision-checked schema-3 inventory
+unchanged at 1,264 implementation identities, 4,419 established-lane slots,
+173 high-consensus packages with 270 missing slots, 814 singleton packages
+with 11,396 missing slots, 618 Rust singletons, and zero collisions or unknown
+buckets. No new package identity displaces the implemented resolver repair.
+
 This loop delivers only deterministic, authority-free package contracts and
 implementations. DNS/UDP/TCP/TLS, endpoint review, credentials and Vault,
 capability approval, runtime mutation, native executors, and host hardening are
@@ -692,6 +727,13 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   related packages in dependency-shaped waves. The Python validator now also
   materializes a 10-file Lua wave covering the compiler, serializer, language
   server, QR, and compression dependency chains;
+- repair the shared TypeScript compiler-path boundary discovered by the
+  field-aware resolver tranche. `npm run build` for `typescript/transistors`
+  reproduces TS6059 on unchanged `origin/main` because the shared
+  `tsconfig.base.json` makes `rootDir: "src"` relative to the shared config.
+  Of 458 TypeScript package/program configs with build scripts, 293 override
+  `rootDir` and 165 retain this risk. This is a pending dependency-shaped
+  portability wave, separate from the 58-package `BUILD_windows` debt;
 - keep the Python build tool's Lua rockspec decoding deterministic. Merged PR
   #9495 normalized the three CP1252 metadata bytes, added positive and invalid-
   UTF-8 fixtures, and returns `METADATA_INVALID_UTF8`; its refreshed full scan


### PR DESCRIPTION
## Summary
- define a language-neutral TypeScript resolver contract and shared adversarial fixture for root `package.json` fields
- replace Go and Haskell whole-line/token scanning with parsed root `dependencies` and `devDependencies` objects plus exact top-level `name` aliases
- converge the real 470-package TypeScript graph at 1,076 edges in both engines, with zero one-sided drift

## Validation
- Go: `go test ./...`, 77.2% total statement coverage and 89.7% resolver coverage, `go vet ./...`, `go build ./...`, `go mod verify`
- Haskell: all build-tool/graph/directed-graph suites, 34 build-tool examples, HPC 59% definitions / 66% alternatives / 73% expressions, `-Wall -Werror`, `cabal check`, and Haddock
- shared contract: 17 schema tests, 40 runner tests, corpus validation at 56 cases / 217 files
- real differential: 470 packages and exactly 1,076 edges in each engine; 0 Go-only and 0 Haskell-only edges
- parity inventory: schema 3, 1,264 identities, 4,419 slots, 0 collisions, 0 unknown buckets
- downstream TypeScript chain: transistors 130 tests, logic-gates 170 tests, arithmetic 62 tests, all with coverage and zero npm advisories
- build-file gate: reproduced only the separately owned 58 TypeScript `BUILD_windows` prerequisite gaps
- security/diff: clean JSON/state invariants, `git diff --check`, changed-scope credential scan, module verification, and direct no-authority review

## Newly logged follow-up
Representative `npm run build` exposed the unchanged shared `tsconfig.base.json` rootDir boundary (TS6059). The backlog now records a separate pending audit covering 165 build-script configs without local rootDir overrides; it does not widen this resolver PR or the independent 58-package BUILD debt.