### PR TITLE
docs(human-languages): complete Persian and Urdu track guides

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -127,12 +127,15 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-M07 | Queued | Reconcile Tamil's roadmap and authoritative session map with canonical Chapters 1–31 and the eight-step writing sequence. | The roadmap details only Chapters 1–6 and still calls Chapter 7+ planned; the session map stops at Chapter 5 even though prerequisite-ordered canonical lessons continue through Chapter 31. |
 | HL-M08 | Queued | Reconcile Latin's roadmap and authoritative session map with canonical Chapters 1–36. | Both files stop at Chapter 1 and describe Chapter 2+ as planned even though prerequisite-ordered canonical lessons continue through Chapter 36. |
 | HL-M09 | Queued | Reconcile Spanish's roadmap and authoritative session map with canonical Chapters 1–33 and the new support steps. | The roadmap stops at Chapter 18 and calls Chapter 19 next, while the session map stops at Chapter 3; both lag the prerequisite-ordered canonical curriculum. |
-| HL-T01 | Queued | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
+| HL-T01 | Complete in this PR | Complete session maps and pronunciation references for Persian and Urdu. | Both five-lesson prefixes now have authoritative N+1/N+3/N+7/N+15 ledgers and sound-id-keyed references; the Urdu guide explicitly preserves the Naskh fallback debt. |
 | HL-U01 | Queued | Vendor and verify an appropriately licensed static Nastaliq font for normal Urdu presentation. | Naskh remains an explicit accessibility fallback, not the intended printed style. |
 
 ## P2 — corpus growth
 
-- Extend Persian and Urdu through the first three shared-spine clusters.
+| ID | Status | Work item | Completion signal |
+|---|---|---|---|
+| HL-E01 | Next | Author Persian and Urdu Chapter 3 through the rest of `SPINE-EXCHANGE-NAMES`. | Each track gains prerequisite-safe, schema-v2 micro-lessons for the name question, its formality distinction, and a meeting response; realization maps, objective activities, generated book chapters, and Language Ladder consume the same AST. |
+
 - Expand every track toward B1 using the gap report to choose the next missing
   can-do, skill, mode, register, or realization.
 - Add controlled dialogues and micro-stories whose tokens are validated against
@@ -1665,6 +1668,22 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   through canonical Chapter 33 and the new micro-lesson chains.
 - With duration debt closed, HL-S02 is next: migrate Spanish Chapters 4–6 to the
   strict one-source schema, then generate the same content for the book and app.
+
+## Findings from HL-T01
+
+- Persian and Urdu each had a valid five-lesson dependency chain and a roadmap,
+  but neither had the standard session map or on-demand pronunciation reference.
+- Both new maps preserve the exact authored prefix and place every N+1, N+3,
+  N+7, and N+15 retrieval through session 20 without inventing future lessons.
+- Both references are keyed to the sound ids already declared in lesson
+  frontmatter, teach script inside known words, and keep transliteration as
+  temporary scaffolding rather than a reading prerequisite.
+- The Urdu reference distinguishes Nastaliq as the intended presentation from
+  the current vendored Noto Naskh Arabic fallback. HL-U01 remains open; this
+  documentation does not silently claim that type-style work is complete.
+- The next smallest corpus-growth slice is now explicit as HL-E01: complete the
+  shared name exchange in both tracks from one canonical schema-v2 source before
+  advancing either language to the wellbeing cluster.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/persian/CHANGELOG.md
+++ b/code/learning/human-languages/persian/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.0 — 2026-08-03
+
+- Added the authoritative five-lesson session map with exact N+1, N+3, N+7,
+  and N+15 review placements.
+- Added an on-demand Persian pronunciation and script reference keyed to the
+  sound ids used by the starter lessons.
+
 ## 0.2.0 — 2026-08-02
 
 - Added the first downloadable LaTeX edition.

--- a/code/learning/human-languages/persian/README.md
+++ b/code/learning/human-languages/persian/README.md
@@ -16,6 +16,10 @@ materials. Romanization is a learning aid, not a substitute for reading Persian.
 ## Read and practise
 
 - [`roadmap.md`](./roadmap.md) orders the authored and planned chapters toward B1.
+- [`session-map.md`](./session-map.md) composes the five micro-lessons with an
+  exact session-count review ledger and reserves the next open intake.
+- [`pronunciation-reference.md`](./pronunciation-reference.md) collects the
+  script and sound facts for lookup; it is never a prerequisite chapter.
 - [`lessons/`](./lessons/) contains the five canonical short practice lessons.
 - [`book/book.tex`](./book/book.tex) builds the free two-chapter starter edition
   with XeLaTeX; merged editions appear in the public human-languages book catalog.

--- a/code/learning/human-languages/persian/pronunciation-reference.md
+++ b/code/learning/human-languages/persian/pronunciation-reference.md
@@ -1,0 +1,53 @@
+# Persian — Pronunciation & Script Reference
+
+A **reference**, not a chapter. Look up a sound when a lesson names it; do not
+memorize this page first. The lessons introduce Persian script inside language
+the learner can already understand, one word-sized pattern at a time.
+
+This track uses a learner romanization: **â** marks long *a*; **u** marks the
+long vowel in *mamnun*. Romanization is temporary scaffolding. Train your eye
+on the Persian form and gradually cover the Latin line.
+
+## The script in three facts
+
+1. **Read right to left** (`rtl`). Words and sentences begin at the right edge.
+2. **Most letters join**, and their shape responds to position. Some letters do
+   not connect leftward to the next letter. In **سلام**, **ا** creates the
+   visible break before final **م**.
+3. **Short vowels are normally unwritten** (`short-vowels-unwritten`). Learn
+   the vowel pattern with the word. The long vowels are represented with
+   **ا** *â*, **و** *u*, and **ی** *i*.
+
+Persian has no uppercase/lowercase distinction. Its alphabet adds **پ** *p*,
+**چ** *ch*, **ژ** *zh*, and **گ** *g* to the inherited Arabic inventory; the
+lessons will introduce them only when a useful word needs them.
+
+## Sound ids used by the starter lessons
+
+| Sound id | What to do | First anchor |
+|---|---|---|
+| `rtl` | start at the right edge and follow the word leftward | **سلام** *salâm* |
+| `long-a` | hold **ا** as a steady *â*, near the vowel in “father” | **سلام** *salâm* |
+| `long-u` | hold **و** as *u*, near “oo” in “food,” without an English off-glide | **ممنون** *mamnun* |
+| `short-vowels-unwritten` | supply learned *a, e,* or *o* even when no separate vowel letter appears | **بله** *bale*, **نه** *na* |
+| `ezafe-e` | say a light linking *-e* after a noun before its owner or description; ordinary text often leaves it unmarked | **اسمِ من** *esm-e man* |
+
+## Read the current word before the whole alphabet
+
+- **سلام** gives **س ل ا م**, right-to-left direction, joining, and long *â*.
+- **ممنون** reuses **م**, adds **ن و**, and assigns **و** its long-*u* job in
+  this word.
+- **بله** and **نه** make the missing short vowels visible by contrast: the
+  spelling supplies a consonantal frame; the learned word supplies *a/e*.
+- **اسم من ... است** recombines familiar letters and adds one spoken grammar
+  cue, ezafe **-e**. The cue is often heard but not printed.
+
+One spelling symbol can do more than one job in later words—especially **و**
+and **ی**—so read from the word and context rather than assigning each shape one
+English value forever.
+
+## Sources
+
+- [Persian Online: The Writing System](https://sites.la.utexas.edu/persian_online_resources/the-writing-system/)
+- [Persian Online: Connecting Characters](https://sites.la.utexas.edu/persian_online_resources/the-writing-system/initial-medial-final-and-freestanding-letters/)
+- [Persian Online: Vowels](https://sites.la.utexas.edu/persian_online_resources/phonology/phonology-1/)

--- a/code/learning/human-languages/persian/session-map.md
+++ b/code/learning/human-languages/persian/session-map.md
@@ -1,0 +1,59 @@
+# Persian Session Map — Authored Chapters 1–2
+
+This is the authoritative order for the five authored Persian lessons. Every
+lesson is an independent, prerequisite-safe step of three or four minutes. A
+study session may combine the new step with the reviews shown here, but it never
+turns the combined session into one indivisible lesson.
+
+Reviews use the session-count intervals in
+[`HL00`](../../../specs/HL00-human-language-curriculum-framework.md): a lesson
+introduced in session *N* returns at *N+1, N+3, N+7,* and *N+15*.
+
+## New-lesson sessions
+
+| Session | New lesson | Reviews due | Cumulative practice |
+|---|---|---|---|
+| **S1** | [`FA-C01-salam`](./lessons/FA-C01-salam.md): **سلام** *salâm* | — | read right to left; greet once |
+| **S2** | [`FA-C01-mamnoon`](./lessons/FA-C01-mamnoon.md): **ممنون** *mamnun* | *salâm* *(N+1)* | greeting → thanks |
+| **S3** | [`FA-C01-bale`](./lessons/FA-C01-bale.md): **بله** *bale* | *mamnun* *(N+1)* | answer yes; then **bale, mamnun** |
+| **S4** | [`FA-C01-na`](./lessons/FA-C01-na.md): **نه** *na* | *salâm* *(N+3)*; *bale* *(N+1)* | choose **bale** or **na** before reveal |
+| **S5** | [`FA-C02-esm-e-man`](./lessons/FA-C02-esm-e-man.md): **اسم من ... است** *esm-e man ... ast* | *mamnun* *(N+3)*; *na* *(N+1)* | greet, give your name, and close with thanks |
+
+The sequence introduces only one new language fact at a time: direction and one
+word, a long **u**, an affirmative, its negative contrast, then the spoken ezafe
+inside a fixed name frame. The final practice uses only those five lessons.
+
+## Carry-forward review ledger
+
+Future chapters may supply the new lesson in these sessions. Until those
+chapters are authored, use the due item as a short retrieval session and draw
+already learned items into an optional bonus queue.
+
+| Session | Fixed review due |
+|---|---|
+| **S6** | *bale* *(N+3)*; *esm-e man ... ast* *(N+1)* |
+| **S7** | *na* *(N+3)* |
+| **S8** | *salâm* *(N+7)*; *esm-e man ... ast* *(N+3)* |
+| **S9** | *mamnun* *(N+7)* |
+| **S10** | *bale* *(N+7)* |
+| **S11** | *na* *(N+7)* |
+| **S12** | *esm-e man ... ast* *(N+7)* |
+| **S16** | *salâm* *(N+15)* |
+| **S17** | *mamnun* *(N+15)* |
+| **S18** | *bale* *(N+15)* |
+| **S19** | *na* *(N+15)* |
+| **S20** | *esm-e man ... ast* *(N+15)* |
+
+Sessions not listed in the ledger have no fixed starter item due; use their
+bonus queue for adaptive or cumulative retrieval.
+
+After the fourth successful resurfacing, an item moves into the long-term mixed
+practice pool. A missed item returns sooner in Language Ladder's adaptive
+review; the fixed ledger remains the book's no-tracking fallback.
+
+## Next authored intake
+
+Chapter 3 will add the matched question “What is your name?”, a polite/casual
+**you** contrast, and “pleased to meet you” as separate sub-five-minute lessons.
+They will occupy the next open sessions without changing the five-lesson prefix
+above or asking the learner to infer unauthored grammar.

--- a/code/learning/human-languages/urdu/CHANGELOG.md
+++ b/code/learning/human-languages/urdu/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.0 — 2026-08-03
+
+- Added the authoritative five-lesson session map with exact N+1, N+3, N+7,
+  and N+15 review placements.
+- Added an on-demand Urdu pronunciation and script reference that labels the
+  current Naskh presentation fallback without weakening the Nastaliq goal.
+
 ## 0.2.0 — 2026-08-02
 
 - Added the first downloadable LaTeX edition.

--- a/code/learning/human-languages/urdu/README.md
+++ b/code/learning/human-languages/urdu/README.md
@@ -17,6 +17,10 @@ Script conventions are grounded in Northwestern University's *Zero Zabar*.
 ## Read and practise
 
 - [`roadmap.md`](./roadmap.md) orders the authored and planned chapters toward B1.
+- [`session-map.md`](./session-map.md) composes the five micro-lessons with an
+  exact session-count review ledger and reserves the next open intake.
+- [`pronunciation-reference.md`](./pronunciation-reference.md) gathers Urdu
+  script and sound facts on demand and labels the current Naskh fallback.
 - [`lessons/`](./lessons/) contains the five canonical short practice lessons.
 - [`book/book.tex`](./book/book.tex) builds the free two-chapter starter edition
   with XeLaTeX; merged editions appear in the public human-languages book catalog.

--- a/code/learning/human-languages/urdu/pronunciation-reference.md
+++ b/code/learning/human-languages/urdu/pronunciation-reference.md
@@ -1,0 +1,59 @@
+# Urdu — Pronunciation & Script Reference
+
+A **reference**, not a chapter. Use it when a lesson names a sound; do not clear
+it as an alphabet gate. Urdu script is introduced through useful expressions,
+with only the shapes and sound contrasts needed on that page.
+
+The track shows a learner romanization beside new Urdu. A line above a vowel
+marks length (**ā, ī**), and a tilde marks nasalization (**ā̃, ī̃**). Cover the
+romanization once the Urdu form is familiar.
+
+## Script, spelling, and type style
+
+- **Read right to left** (`rtl`). Start each word at its right edge.
+- **Letters usually join** and change shape by position. Some letters, including
+  **ا** and **ر** in current words, break the connection to the following shape
+  on their left.
+- Urdu is an **abjad**: some vowels are unwritten and inferred from the learned
+  word (`short-vowels-unwritten`). Long vowels use letter shapes such as **ا**,
+  **و**, and **ی**; **ے** can carry *e/ai*.
+- Urdu is traditionally printed in **Nastaliq**, whose connected words descend
+  in a flowing slope. The current book and app deliberately use the vendored
+  Noto Naskh Arabic face as a deterministic, legible fallback until a licensed
+  static Nastaliq font is verified. The fallback changes type style, not Urdu
+  spelling, joining order, or lesson sequence.
+
+## Sound ids used by the starter lessons
+
+| Sound id | What to do | First anchor |
+|---|---|---|
+| `rtl` | follow the word from its right edge leftward | **سلام** *salām* |
+| `long-a` | hold *ā* steady; **ا** carries it in **سلام** | **سلام** *salām* |
+| `short-vowels-unwritten` | supply the learned short vowels even when vowel marks are absent | **شکریہ** *shukriyā* |
+| `long-i` | hold **ی** as *ī* in this word | **جی** *jī* |
+| `nasal-vowel` | let air pass through the nose; final **ں** does not add a full English *n* | **ہاں** *hā̃*, **نہیں** *nahī̃* |
+| `long-vowels` | read the word's written long-vowel cues rather than stretching every vowel | **میرا نام** *merā nām* |
+| `hai-diphthong` | say **ہے** as one *hai* syllable, ending in an *ai* glide | **ہے** *hai* |
+
+## Shape families already in use
+
+- **س** *s* and **ش** *sh* share a skeleton; three dots distinguish **ش**.
+- **ن** is consonantal *n*. Final dotless **ں** is *nūn-e ghunna* and marks
+  nasalization in **ہاں** and **نہیں**.
+- **ی** supplies the long *ī* in **جی** and **نہیں**. Final **ے** participates
+  in *hai* in **ہے**. Learn each role in its word before generalizing.
+- Urdu will later add its Indic sound distinctions—retroflex consonants and
+  aspirated pairs—inline when a communicative expression first needs them.
+
+## The Persian-Arabic and Indo-Aryan layers
+
+Script does not determine a word's history. **سلام** and **شکریہ** expose the
+Persian-Arabic literary layer; **نہیں**, **میرا**, **نام**, and **ہے** expose the
+inherited Indo-Aryan core that Urdu shares with Hindi. Mixed-language practice
+may use that relationship as a bridge, but the Urdu script remains the assessed
+form for this track.
+
+## Sources
+
+- [*Zero Zabar*: How the Urdu script works](https://openbooks.library.northwestern.edu/zerozabar/front-matter/introduction/)
+- [*Zero Zabar*: The Urdu alphabet](https://openbooks.library.northwestern.edu/zerozabar/chapter/the-urdu-alphabet/)

--- a/code/learning/human-languages/urdu/session-map.md
+++ b/code/learning/human-languages/urdu/session-map.md
@@ -1,0 +1,60 @@
+# Urdu Session Map — Authored Chapters 1–2
+
+This is the authoritative order for the five authored Urdu lessons. Each new
+lesson is a self-contained, prerequisite-safe step of three or four minutes.
+A longer study session may combine the new step with its due reviews while the
+book and app keep every lesson independently completable.
+
+Reviews use the session-count intervals in
+[`HL00`](../../../specs/HL00-human-language-curriculum-framework.md): a lesson
+introduced in session *N* returns at *N+1, N+3, N+7,* and *N+15*.
+
+## New-lesson sessions
+
+| Session | New lesson | Reviews due | Cumulative practice |
+|---|---|---|---|
+| **S1** | [`UR-C01-salam`](./lessons/UR-C01-salam.md): **سلام** *salām* | — | read right to left; greet once |
+| **S2** | [`UR-C01-shukriya`](./lessons/UR-C01-shukriya.md): **شکریہ** *shukriyā* | *salām* *(N+1)* | greeting → thanks |
+| **S3** | [`UR-C01-ji-han`](./lessons/UR-C01-ji-han.md): **جی ہاں** *jī hā̃* | *shukriyā* *(N+1)* | answer yes; then **jī hā̃, shukriyā** |
+| **S4** | [`UR-C01-nahin`](./lessons/UR-C01-nahin.md): **نہیں** *nahī̃* | *salām* *(N+3)*; *jī hā̃* *(N+1)* | choose respectful yes or no before reveal |
+| **S5** | [`UR-C02-mera-naam`](./lessons/UR-C02-mera-naam.md): **میرا نام ... ہے** *merā nām ... hai* | *shukriyā* *(N+3)*; *nahī̃* *(N+1)* | greet, give your name, and close with thanks |
+
+The chain adds one manageable feature at a time: direction and one word, hidden
+short vowels, respectful affirmation with nasalization, its negative contrast,
+then one fixed sentence with the copula at the end. The final practice asks for
+nothing outside that chain.
+
+## Carry-forward review ledger
+
+Future chapters may supply the new lesson in these sessions. Until then, use
+the due item as a short retrieval session and fill an optional bonus queue only
+with already learned material.
+
+| Session | Fixed review due |
+|---|---|
+| **S6** | *jī hā̃* *(N+3)*; *merā nām ... hai* *(N+1)* |
+| **S7** | *nahī̃* *(N+3)* |
+| **S8** | *salām* *(N+7)*; *merā nām ... hai* *(N+3)* |
+| **S9** | *shukriyā* *(N+7)* |
+| **S10** | *jī hā̃* *(N+7)* |
+| **S11** | *nahī̃* *(N+7)* |
+| **S12** | *merā nām ... hai* *(N+7)* |
+| **S16** | *salām* *(N+15)* |
+| **S17** | *shukriyā* *(N+15)* |
+| **S18** | *jī hā̃* *(N+15)* |
+| **S19** | *nahī̃* *(N+15)* |
+| **S20** | *merā nām ... hai* *(N+15)* |
+
+Sessions not listed in the ledger have no fixed starter item due; use their
+bonus queue for adaptive or cumulative retrieval.
+
+After the fourth successful resurfacing, an item moves into the long-term mixed
+practice pool. A missed item returns sooner in Language Ladder's adaptive
+review; the fixed ledger remains the book's no-tracking fallback.
+
+## Next authored intake
+
+Chapter 3 will add the matched question “What is your name?”, respectful
+**آپ** *āp*, the Urdu question mark, and “pleased to meet you” as separate
+sub-five-minute lessons. They will fill the next open sessions without changing
+the five-lesson prefix or treating Hindi spelling as an Urdu prerequisite.


### PR DESCRIPTION
## Summary

- add authoritative Persian and Urdu session maps for the five authored lessons
- place every starter lesson at exact N+1, N+3, N+7, and N+15 review intervals without inventing future content
- add sound-id-keyed, on-demand pronunciation/script references
- document Urdu's intended Nastaliq presentation and current Naskh fallback honestly
- mark HL-T01 complete and prioritize HL-E01, the shared Chapter 3 name-exchange expansion

## Validation

- `npm run build` (`@coding-adventures/human-language-data`)
- `npm test` — 13 files, 100 tests passed
- `npm run check:books`
- local Markdown link audit
- `git diff --check`