### PR TITLE
feat(human-languages): extend Persian and Urdu name exchange

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,12 +5,12 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-03. Current baseline after the first cross-language
-and Russian legacy activity-coverage tranches:
-20 registered tracks, 1,066 Markdown lessons, 20 downloadable LaTeX books, zero
+Last prioritized: 2026-08-03. Current baseline after the Persian and Urdu
+Chapter 3 shared-spine tranche:
+20 registered tracks, 1,076 Markdown lessons, 20 downloadable LaTeX books, zero
 duration violations, and 20 validated realization maps containing 346 ordered
-path segments, 247 typed extension nodes, and 896 prerequisite-closed mapped
-lessons. Nineteen mapped non-lexical lessons across 16 tracks now carry
+path segments, 257 typed extension nodes, and 906 prerequisite-closed mapped
+lessons. Twenty-one mapped non-lexical lessons across 18 tracks now carry
 compiled objective activities; 94 mapped non-lexical lessons remain explicit
 activity-coverage debt, including 16 legacy lessons that first need schema-v2
 body contracts. HL-V01 keeps the remaining migration debt reproducible in both
@@ -75,9 +75,10 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-S02 | Complete (#9634) | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | All 27 lessons have typed blocks, unique sequence, transitive knowledge closure, and sub-five-minute duration guarantees. |
 | HL-G03 | Complete (#9646) | Generate Spanish Chapters 4–6 from their canonical schema-v2 lesson ASTs after HL-S02. | All six generated chapters now share lesson hashes with Language Ladder; Markdown tables retain their structure in print. |
 | HL-G04 | Queued | Normalize paired straight quotation marks when canonical prose is rendered into LaTeX. | Generated prose should use true opening and closing marks under every book's language rules without changing the canonical app text or code spans. |
+| HL-G05 | Queued | Preserve canonical Markdown hyperlinks in generated LaTeX chapters. | Source notes and learner-facing links render as live `\href` targets in PDFs instead of retaining only their labels. |
 | HL-V02 | Complete (#9653) | Validate learner-facing target-language prompts against block-level knowledge declarations and prerequisite closure. | Schema-v2 production and recall blocks cannot ask for an undeclared form or a form absent from the lesson's transitive knowledge frontier. |
 | HL-V03 | Complete (#9900) | Compile individual prompt, answer, accepted-variant, feedback, and response-time contracts from typed activity blocks. | Compact JSON directives compile into validated runtime answer sets; each activity names a non-empty assessed-atom subset, carries feedback/time, and never scrapes prose. |
-| HL-A01 | In progress (#9901 + Russian slice) | Author objective activity coverage for every mapped non-lexical frontier. | The first tranche covers every ready schema-v2 track; the Russian slice migrates the minimal six-lesson naming chain and covers its two non-lexical frontiers. 94 lessons remain, including 16 that first need schema-v2 migration. |
+| HL-A01 | In progress (#9901 + Russian and Persian/Urdu slices) | Author objective activity coverage for every mapped non-lexical frontier. | The first tranche covers every ready schema-v2 track; later slices cover Russian's naming chain and Persian/Urdu Chapter 3 practice. Coverage is 21 of 115 across 18 tracks; 94 lessons remain, including 16 that first need schema-v2 migration. |
 | HL-Q01 | Queued | Restore a clean standalone TypeScript typecheck for Language Ladder. | `npx tsc --noEmit` should pass after fixing the pre-existing DOM element type, review-log cast, missing Node test types, and unused/implicit test symbols; HL-V03 introduces no additional type errors. |
 | HL-B04 | Complete (#9661) | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
 | HL-B05 | Complete (#9663) | Remove Marathi's duplicate practice labels and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Devanagari, natural page bottoms, and explicit static-font shapes make the forced six-chapter build warning-free. |
@@ -127,14 +128,15 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-M07 | Queued | Reconcile Tamil's roadmap and authoritative session map with canonical Chapters 1–31 and the eight-step writing sequence. | The roadmap details only Chapters 1–6 and still calls Chapter 7+ planned; the session map stops at Chapter 5 even though prerequisite-ordered canonical lessons continue through Chapter 31. |
 | HL-M08 | Queued | Reconcile Latin's roadmap and authoritative session map with canonical Chapters 1–36. | Both files stop at Chapter 1 and describe Chapter 2+ as planned even though prerequisite-ordered canonical lessons continue through Chapter 36. |
 | HL-M09 | Queued | Reconcile Spanish's roadmap and authoritative session map with canonical Chapters 1–33 and the new support steps. | The roadmap stops at Chapter 18 and calls Chapter 19 next, while the session map stops at Chapter 3; both lag the prerequisite-ordered canonical curriculum. |
-| HL-T01 | Complete in this PR | Complete session maps and pronunciation references for Persian and Urdu. | Both five-lesson prefixes now have authoritative N+1/N+3/N+7/N+15 ledgers and sound-id-keyed references; the Urdu guide explicitly preserves the Naskh fallback debt. |
+| HL-T01 | Complete (#9904) | Complete session maps and pronunciation references for Persian and Urdu. | Both five-lesson prefixes now have authoritative N+1/N+3/N+7/N+15 ledgers and sound-id-keyed references; the Urdu guide explicitly preserves the Naskh fallback debt. |
 | HL-U01 | Queued | Vendor and verify an appropriately licensed static Nastaliq font for normal Urdu presentation. | Naskh remains an explicit accessibility fallback, not the intended printed style. |
 
 ## P2 — corpus growth
 
 | ID | Status | Work item | Completion signal |
 |---|---|---|---|
-| HL-E01 | Next | Author Persian and Urdu Chapter 3 through the rest of `SPINE-EXCHANGE-NAMES`. | Each track gains prerequisite-safe, schema-v2 micro-lessons for the name question, its formality distinction, and a meeting response; realization maps, objective activities, generated book chapters, and Language Ladder consume the same AST. |
+| HL-E01 | Complete in this PR | Author Persian and Urdu Chapter 3 through the rest of `SPINE-EXCHANGE-NAMES`. | Each track gains prerequisite-safe, schema-v2 micro-lessons for the name question, its formality distinction, and a meeting response; realization maps, objective activities, generated book chapters, and Language Ladder consume the same AST. |
+| HL-E02 | Next | Author Persian and Urdu Chapter 4 through `SPINE-CHECK-WELLBEING` and reconcile the older identity-first roadmap. | Both tracks gain a gentle wellbeing exchange before identity grammar, with language-specific register/script extensions, exact review ledgers, objective practice, and generated book chapters from the canonical AST. |
 
 - Expand every track toward B1 using the gap report to choose the next missing
   can-do, skill, mode, register, or realization.
@@ -1684,6 +1686,32 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - The next smallest corpus-growth slice is now explicit as HL-E01: complete the
   shared name exchange in both tracks from one canonical schema-v2 source before
   advancing either language to the wellbeing cluster.
+
+## Findings from HL-E01
+
+- Persian and Urdu each add five prerequisite-safe Chapter 3 micro-lessons:
+  address/register, the question word, the complete name question, a meeting
+  response, and cumulative objective practice. Each track now has ten mapped
+  lessons across three published chapters.
+- The two earlier name-statement lessons now use schema v2, so every Chapter 3
+  prompt closes over explicitly owned knowledge. All twelve touched lessons
+  remain below five minutes, with effective budgets from 210 through 240 seconds.
+- Both realization maps add register, script, grammar, culture, and consolidation
+  extensions without changing the shared path-segment count. Their session maps
+  schedule the new lessons and every N+1, N+3, N+7, and N+15 retrieval through
+  session 25 while allowing Chapter 4 to begin at session 11.
+- Objective activity coverage rises from 19 of 113 to 21 of 115 mapped
+  non-lexical lessons across 18 tracks. The remaining count stays at 94 because
+  the two newly mapped practice lessons arrive with activities; 16 legacy
+  candidates still require schema-v2 migration first.
+- Generated Persian and Urdu Chapter 3 files carry the same canonical lesson
+  hashes consumed by Language Ladder. The audit also found that Markdown link
+  labels survive generation while their URLs do not; HL-G05 records that
+  traceability gap instead of widening this curriculum tranche.
+- The shared spine next calls for `SPINE-CHECK-WELLBEING`, while both older
+  roadmaps currently plan identity grammar for Chapter 4. HL-E02 therefore
+  reconciles that order explicitly rather than silently letting the two tracks
+  drift from the shared spine.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -2062,6 +2062,24 @@
       "output": "sanskrit/book/chapters/ch06-numbers-1-5.tex",
       "unicodeScript": "Devanagari",
       "scriptCommand": "sk"
+    },
+    {
+      "language": "persian",
+      "chapter": 3,
+      "title": "Ask and Answer Names",
+      "label": "ch:fa-ask-and-answer-names",
+      "output": "persian/book/chapters/ch03-ask-and-answer-names.tex",
+      "unicodeScript": "Arabic",
+      "scriptCommand": "fa"
+    },
+    {
+      "language": "urdu",
+      "chapter": 3,
+      "title": "Ask and Answer Names",
+      "label": "ch:ur-ask-and-answer-names",
+      "output": "urdu/book/chapters/ch03-ask-and-answer-names.tex",
+      "unicodeScript": "Arabic",
+      "scriptCommand": "ur"
     }
   ]
 }

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -1655,6 +1655,19 @@
       "tex": "marathi/book/chapters/ch06-numbers-1-5.tex"
     },
     {
+      "language": "persian",
+      "chapter": 3,
+      "sourceHash": "fnv1a64:6079d14592306807",
+      "lessonIds": [
+        "FA-C03-shoma-to",
+        "FA-C03-chist",
+        "FA-C03-esm-e-shoma-chist",
+        "FA-C03-khoshvaghtam",
+        "FA-C03-practice"
+      ],
+      "tex": "persian/book/chapters/ch03-ask-and-answer-names.tex"
+    },
+    {
       "language": "portuguese",
       "chapter": 2,
       "sourceHash": "fnv1a64:b696688c2654a2d3",
@@ -2581,6 +2594,19 @@
         "TE-C31-subha-madhyahnam-register"
       ],
       "tex": "telugu/book/chapters/ch31-good-afternoon.tex"
+    },
+    {
+      "language": "urdu",
+      "chapter": 3,
+      "sourceHash": "fnv1a64:f1d09ed02a13ed81",
+      "lessonIds": [
+        "UR-C03-aap-tum-tu",
+        "UR-C03-kya",
+        "UR-C03-aap-ka-naam-kya-hai",
+        "UR-C03-khushi-hui",
+        "UR-C03-practice"
+      ],
+      "tex": "urdu/book/chapters/ch03-ask-and-answer-names.tex"
     }
   ]
 }

--- a/code/learning/human-languages/persian/CHANGELOG.md
+++ b/code/learning/human-languages/persian/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.4.0 — 2026-08-03
+
+- Added five schema-v2 Chapter 3 micro-lessons for respectful/familiar “you,”
+  *chist*, the full name question, *khoshvaghtam*, and cumulative practice.
+- Added objective activity contracts and prerequisite-closed knowledge atoms for
+  the migrated Chapter 2 name frame and every new lesson.
+- Generated Chapter 3 for the downloadable book from the same canonical lesson
+  AST used by Language Ladder and extended the review ledger through S25.
+
 ## 0.3.0 — 2026-08-03
 
 - Added the authoritative five-lesson session map with exact N+1, N+3, N+7,

--- a/code/learning/human-languages/persian/README.md
+++ b/code/learning/human-languages/persian/README.md
@@ -4,11 +4,12 @@ This track teaches contemporary Iranian Persian through the shared human-languag
 spine. Every lesson is designed for a fresh learner, takes under five minutes,
 and introduces only the script needed for the expression on the page.
 
-The first five lessons establish a complete miniature exchange: greet someone,
-thank them, answer yes or no, and give your name. Persian-specific extensions
-will add the ezafe linker, colloquial verb forms, the present stem, past stems,
-and the Persian script's joined shapes without forcing those topics into every
-other language.
+The first ten lessons now establish a complete miniature meeting: greet, answer,
+give your name, ask someone else's name respectfully, and acknowledge the
+introduction. Persian-specific extensions introduce ezafe reuse, **shomâ/to**
+register, Persian **چ**, question punctuation, and the layered
+**khoshvaghtam** compound exactly where the exchange needs them. Later chapters
+will add colloquial verb forms, present and past stems, and more joined shapes.
 
 The script notes follow the University of Texas Persian Online writing-system
 materials. Romanization is a learning aid, not a substitute for reading Persian.
@@ -16,10 +17,10 @@ materials. Romanization is a learning aid, not a substitute for reading Persian.
 ## Read and practise
 
 - [`roadmap.md`](./roadmap.md) orders the authored and planned chapters toward B1.
-- [`session-map.md`](./session-map.md) composes the five micro-lessons with an
-  exact session-count review ledger and reserves the next open intake.
+- [`session-map.md`](./session-map.md) composes all ten micro-lessons with an
+  exact session-count review ledger through S25.
 - [`pronunciation-reference.md`](./pronunciation-reference.md) collects the
   script and sound facts for lookup; it is never a prerequisite chapter.
-- [`lessons/`](./lessons/) contains the five canonical short practice lessons.
-- [`book/book.tex`](./book/book.tex) builds the free two-chapter starter edition
+- [`lessons/`](./lessons/) contains the ten canonical short practice lessons.
+- [`book/book.tex`](./book/book.tex) builds the free three-chapter starter edition
   with XeLaTeX; merged editions appear in the public human-languages book catalog.

--- a/code/learning/human-languages/persian/book/book.tex
+++ b/code/learning/human-languages/persian/book/book.tex
@@ -18,7 +18,7 @@
   \vspace{1.5cm}
   {\large Adhithya Rajasekaran\par}
   \vfill
-  {\large Starter edition --- five short lessons in two cumulative chapters.\par}
+  {\large Starter edition --- ten short lessons in three cumulative chapters.\par}
   \vspace{1cm}
   {\large Companion practice lessons live alongside this book at\\
   \texttt{code/learning/human-languages/persian/lessons/}\par}
@@ -55,6 +55,7 @@ word easier to remember without replacing its present meaning or use.
 
 \input{chapters/ch01-greetings-and-responses}
 \input{chapters/ch02-give-your-name}
+\input{chapters/ch03-ask-and-answer-names}
 
 \backmatter
 

--- a/code/learning/human-languages/persian/book/chapters/ch03-ask-and-answer-names.tex
+++ b/code/learning/human-languages/persian/book/chapters/ch03-ask-and-answer-names.tex
@@ -1,0 +1,200 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:6079d14592306807
+% canonical-lessons: FA-C03-shoma-to, FA-C03-chist, FA-C03-esm-e-shoma-chist, FA-C03-khoshvaghtam, FA-C03-practice
+
+\chapter{Ask and Answer Names}
+\label{ch:fa-ask-and-answer-names}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[shomâ / to]{\fa{شما} / \fa{تو} — two relationships inside “you”}
+
+\label{lesson:FA-C03-shoma-to}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Say \textbf{esm-e man ... ast} with your own name. To turn that sentence around, you next need a safe word for the other person.
+\end{quote}
+
+\subsection*{The two words}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Persian} & \textbf{read} & \textbf{use} \\
+\midrule
+\textbf{\fa{شما}} & \emph{shomâ} & one person respectfully, or more than one person \\
+\textbf{\fa{تو}} & \emph{to} & one familiar person \\
+\bottomrule
+\end{tabularx}
+
+In \textbf{\fa{شما}}, meet \textbf{\fa{ش}} \emph{sh}; its three dots distinguish it from \textbf{\fa{س}} \emph{s}. Final \textbf{\fa{ا}} carries long \emph{â}. In \textbf{\fa{تو}}, \textbf{\fa{و}} has its \emph{o} value rather than the long \emph{u} it had in \textbf{\fa{ممنون}}. Learn the sound from the whole word.
+
+\begin{grammarlens}[title={Grammar Lens: begin respectfully}]
+Persian uses plural \textbf{shomâ} for respectful singular address, much as Russian uses \emph{vy} and French uses \emph{vous}. Use \textbf{shomâ} with an unfamiliar adult or in a first meeting. Use \textbf{to} after the relationship is familiar. English once made a similar distinction but now uses \emph{you} for both.
+\end{grammarlens}
+
+\begin{cousinweb}
+Persian \textbf{to} belongs to the ancient Indo-European familiar-“you” family: English \textbf{thou}, Latin \emph{tū}, and Sanskrit \emph{tvam} are relatives. The word is old; the social choice carried by it is current.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: a new adult — \textbf{shomâ}{]}
+  \item {[}YOU SAY: a close friend — \textbf{to}{]}
+  \item {[}YOU SAY: the old family — \textbf{to, thou, tū, tvam}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Which form is safest when the relationship is new? (\textbf{Shomâ}.) Which is the relative of English \emph{thou}? (\textbf{To}.)
+
+Source: Persian Online: Pronouns.
+\end{tcolorbox}
+\section[chist]{\fa{چیست} — “what is?” in one joined word}
+
+\label{lesson:FA-C03-chist}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Which “you” is safe for a new adult? (\textbf{\fa{شما}}, \emph{shomâ}.) Now add the question engine that will follow “your name.”
+\end{quote}
+
+\subsection*{You'll want to know first — \fa{چیست}}
+\begin{quote}
+\textbf{\fa{چیست}} — \emph{chist} — \textbf{what is?}
+\end{quote}
+
+Read from the right: \textbf{\fa{چ}} \emph{ch}, \textbf{\fa{ی}} long \emph{i}, \textbf{\fa{س}} \emph{s}, \textbf{\fa{ت}} \emph{t}. \textbf{\fa{چ}} is one of Persian's four additions to the Arabic alphabet: it uses the same base shape as \textbf{\fa{ج}}, with three dots below. Meet only this joined form now.
+
+\begin{grammarlens}[title={Grammar Lens: two words compressed}]
+\textbf{chist} is the careful fusion of \textbf{chi} “what” and \textbf{ast} “is.” The opening vowel of \emph{ast} disappears when the pieces join:
+
+\begin{quote}
+\emph{chi + ast} $\to$ \textbf{chist}
+\end{quote}
+
+You already know full \textbf{ast} from \emph{esm-e man ... ast}. This lesson changes no copula rule; it gives one high-frequency fused question form.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: \textbf{chi + ast $\to$ chist}{]}
+  \item {[}YOU READ: \textbf{\fa{چیست}} from \textbf{\fa{چ}} to \textbf{\fa{ت}}{]}
+  \item {[}YOU SAY: \textbf{chist?} — “what is?”{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+What two pieces make \textbf{chist}? (\textbf{Chi + ast}.) Which new Persian letter opens it? (\textbf{\fa{چ}}, \emph{ch}, with three dots below.)
+\end{tcolorbox}
+\section[esm-e shomâ chist?]{\fa{اسم} \fa{شما} \fa{چیست؟} — ask a name respectfully}
+
+\label{lesson:FA-C03-esm-e-shoma-chist}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Give the three ready pieces: \textbf{esm-e} “name-of,” \textbf{shomâ} respectful “you,” and \textbf{chist} “what is?”
+\end{quote}
+
+\subsection*{The exchange}
+\begin{quote}
+\textbf{\fa{اسم} \fa{شما} \fa{چیست؟}} — \emph{esm-e shomâ chist?} — \textbf{What is your name?}
+\end{quote}
+
+The Persian order is transparent once the pieces are known:
+
+\begin{quote}
+name + \textbf{-e} + you + what-is?
+\end{quote}
+
+The spoken ezafe turns \textbf{esm-e shomâ} into “your name.” \textbf{Chist} stays at the end. No new agreement or verb table is hiding here.
+
+\subsection*{Script: the question mark}
+Persian ends a written question with \textbf{\fa{؟}}. Its curve faces the opposite way from English \textbf{?}, matching the right-to-left line. Read the sentence from its right edge; meet the punctuation at the far left.
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: \textbf{esm-e shomâ chist?}{]}
+  \item {[}YOU SAY: ask, then answer — \textbf{esm-e man ... ast}{]}
+  \item {[}YOU POINT: to \textbf{\fa{؟}} at the end of the right-to-left question{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Ask the question once without reading the romanization. Then answer with the careful name frame you already know.
+
+Source: Persian Online: Introducing Yourself.
+\end{tcolorbox}
+\section[khoshvaghtam]{\fa{خوشوقتم} — pleased to meet you}
+
+\label{lesson:FA-C03-khoshvaghtam}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Ask \textbf{esm-e shomâ chist?} and answer \textbf{esm-e man ... ast}. One warm response now closes that tiny meeting.
+\end{quote}
+
+\subsection*{The exchange}
+\begin{quote}
+\textbf{\fa{خوشوقتم}} — \emph{khoshvaghtam} — \textbf{Pleased to meet you.}
+\end{quote}
+
+Treat the joined word as one social move first. \textbf{\fa{خ}} gives \emph{kh}, like the sound in Scottish \emph{loch}. \textbf{\fa{ش}} gives \emph{sh}. Persian commonly pronounces \textbf{\fa{ق}} here with the merged \emph{gh/q} sound of contemporary Iranian speech.
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{khosh} — pleasant, happy; inherited Persian vocabulary.
+  \item \textbf{vaqt} (pronounced \emph{vaght} here) — time; an Arabic loan fully at home in Persian.
+  \item \textbf{-am} — I am, the first-person ending.
+\end{itemize}
+
+So the word builds “pleasant-time-I-am” into the idiomatic feeling “I am pleased.” The history is layered; the expression is ordinary modern Persian.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: \textbf{khoshvaghtam} as one smooth response{]}
+  \item {[}YOU SAY: the three pieces — \textbf{khosh + vaqt + -am}{]}
+  \item {[}YOU SAY: which piece came from Arabic — \textbf{vaqt}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Which response closes the introduction? (\textbf{Khoshvaghtam}.) Which three layers can you hear inside it? (\textbf{Khosh + vaqt + -am}.)
+
+Source: Persian Online: Introducing Yourself.
+\end{tcolorbox}
+\section[Practice]{Practice — a complete Persian name exchange}
+
+\label{lesson:FA-C03-practice}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Recall the four moves without adding anything: greet, ask, answer, acknowledge.
+\end{quote}
+
+\subsection*{The exchange}
+\begin{quote}
+A: \textbf{\fa{سلام}!} — \emph{Salâm!} B: \textbf{\fa{سلام}!} — \emph{Salâm!} A: \textbf{\fa{اسم} \fa{شما} \fa{چیست؟}} — \emph{Esm-e shomâ chist?} B: \textbf{\fa{اسم} \fa{من} \fa{سارا} \fa{است}.} — \emph{Esm-e man Sârâ ast.} A: \textbf{\fa{خوشوقتم}.} — \emph{Khoshvaghtam.} B: \textbf{\fa{ممنون}.} — \emph{Mamnun.}
+\end{quote}
+
+Every line is already known. \textbf{Shomâ} keeps the first meeting respectful; the answer returns to \textbf{man}. The question mark sits at the left end of the right-to-left question.
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: both voices, using your own name{]}
+  \item {[}YOU SAY: the exchange again without romanization{]}
+  \item {[}YOU SAY: only the three name moves — question, answer, response{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Run the meeting once from \textbf{salâm} to \textbf{mamnun}. If one line stalls, review that single micro-lesson rather than rereading the whole chapter.
+\end{tcolorbox}

--- a/code/learning/human-languages/persian/book/preamble.tex
+++ b/code/learning/human-languages/persian/book/preamble.tex
@@ -5,6 +5,20 @@
 \setmainfont{Latin Modern Roman}
 \setsansfont{Latin Modern Sans}
 \setmonofont{Latin Modern Mono}
+\raggedbottom
+
+% Keep book.cls's open-right blank verso, but remove its running head.
+\makeatletter
+\renewcommand{\cleardoublepage}{%
+  \clearpage
+  \if@twoside
+    \ifodd\c@page\else
+      \hbox{}\thispagestyle{empty}\newpage
+      \if@twocolumn\hbox{}\newpage\fi
+    \fi
+  \fi
+}
+\makeatother
 
 % bidi, loaded by polyglossia for Persian, requires color-related packages to
 % be loaded first on TeX Live.
@@ -13,6 +27,7 @@
 \tcbuselibrary{skins,breakable}
 \usepackage{booktabs}
 \usepackage{array}
+\usepackage{tabularx}
 \usepackage[hidelinks]{hyperref}
 \usepackage{titlesec}
 
@@ -57,6 +72,16 @@
   breakable, skin=enhanced, colback=red!5, colframe=red!40!black,
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
   fonttitle=\bfseries, title={One-minute checkpoint}
+}
+\newtcolorbox{cousinweb}{
+  breakable, skin=enhanced, colback=yellow!8, colframe=yellow!45!black,
+  boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
+  fonttitle=\bfseries, title={The word, taken apart --- and its English cousins}
+}
+\newtcolorbox{grammarlens}[1][]{
+  breakable, skin=enhanced, colback=blue!5, colframe=blue!35!black,
+  boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
+  fonttitle=\bfseries, title={Grammar Lens}, #1
 }
 
 \titleformat{\chapter}[display]

--- a/code/learning/human-languages/persian/curriculum.json
+++ b/code/learning/human-languages/persian/curriculum.json
@@ -39,10 +39,21 @@
       "id": "FA-PATH-004",
       "spine_node": "SPINE-EXCHANGE-NAMES",
       "lessons": [
-        "FA-C02-esm-e-man"
+        "FA-C02-esm-e-man",
+        "FA-C03-shoma-to",
+        "FA-C03-chist",
+        "FA-C03-esm-e-shoma-chist",
+        "FA-C03-khoshvaghtam",
+        "FA-C03-practice"
       ],
       "before": [],
-      "inline": [],
+      "inline": [
+        "FA-EXT-002-REGISTER",
+        "FA-EXT-003-SCRIPT",
+        "FA-EXT-004-GRAMMAR",
+        "FA-EXT-005-ETYMOLOGY",
+        "FA-EXT-006-CONSOLIDATION"
+      ],
       "after": []
     }
   ],
@@ -83,15 +94,11 @@
         "FA-PATH-004"
       ],
       "omits": [
-        "QUESTION-WHAT",
         "PRONOUN-I",
         "PRONOUN-ME",
-        "PRONOUN-YOU",
         "PRONOUN-MY",
         "WORD-NAME",
-        "WORD-IS",
-        "INTRO-WHATS-YOUR-NAME",
-        "INTRO-NICE-TO-MEET-YOU"
+        "WORD-IS"
       ],
       "relocates": {}
     },
@@ -173,6 +180,72 @@
       "prerequisites": [],
       "lessons": [
         "FA-C01-salam"
+      ]
+    },
+    {
+      "id": "FA-EXT-002-REGISTER",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "register",
+      "canDo": "I can choose shomâ for a respectful first meeting and distinguish it from familiar to.",
+      "prerequisites": [
+        "FA-EXT-001-INLINE-SCRIPT"
+      ],
+      "lessons": [
+        "FA-C03-shoma-to"
+      ]
+    },
+    {
+      "id": "FA-EXT-003-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can read Persian che and ye inside chist without completing an alphabet gate.",
+      "prerequisites": [
+        "FA-EXT-001-INLINE-SCRIPT"
+      ],
+      "lessons": [
+        "FA-C03-chist"
+      ]
+    },
+    {
+      "id": "FA-EXT-004-GRAMMAR",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "grammar",
+      "canDo": "I can reuse ezafe and the chi-plus-ast fusion in a respectful name question.",
+      "prerequisites": [
+        "FA-EXT-002-REGISTER",
+        "FA-EXT-003-SCRIPT"
+      ],
+      "lessons": [
+        "FA-C03-esm-e-shoma-chist"
+      ]
+    },
+    {
+      "id": "FA-EXT-005-ETYMOLOGY",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can use khoshvaghtam and recognize its Persian, Arabic-loan, and personal-ending layers.",
+      "prerequisites": [
+        "FA-EXT-004-GRAMMAR"
+      ],
+      "lessons": [
+        "FA-C03-khoshvaghtam"
+      ]
+    },
+    {
+      "id": "FA-EXT-006-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "consolidation",
+      "canDo": "I can complete a respectful Persian name exchange using only independently learned lines.",
+      "prerequisites": [
+        "FA-EXT-005-ETYMOLOGY"
+      ],
+      "lessons": [
+        "FA-C03-practice"
       ]
     }
   ]

--- a/code/learning/human-languages/persian/lessons/FA-C02-esm-e-man.md
+++ b/code/learning/human-languages/persian/lessons/FA-C02-esm-e-man.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: FA-C02-esm-e-man
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 50
 chapter: 2
 type: phrase
 headword: اسم من ... است
@@ -10,13 +13,32 @@ prerequisites: [FA-C01-na]
 sounds: [rtl, ezafe-e, short-vowels-unwritten]
 roots: [ism, indo-iranian-man]
 etymology_hook: Arabic esm joined native Persian man and ast; the tiny ezafe vowel links the words.
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [FA-LEX-ESM-E-MAN-AST, FA-SCRIPT-ESM-MAN-AST, FA-GRAMMAR-EZAFE-OWNER]
+practises:
+  knowledge: [FA-LEX-ESM-E-MAN-AST, FA-SCRIPT-ESM-MAN-AST, FA-GRAMMAR-EZAFE-OWNER]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: careful-neutral
+variety: contemporary-iranian-persian
 reviews_of: []
 ---
 
 # اسم من ... است — my name is ...
 
-## Assemble familiar-sized pieces
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+[PAUSE 2s] Greet once, then answer yes and no. The next line gives you one
+careful sentence for your own name.
+
+## The exchange
+<!-- hl-knowledge: introduces=[FA-LEX-ESM-E-MAN-AST, FA-SCRIPT-ESM-MAN-AST]; assesses=[] -->
 
 Read the phrase from right to left, but say its words in this order:
 
@@ -28,25 +50,36 @@ Read the phrase from right to left, but say its words in this order:
 - **من** *man* = I / me; after the linker it means “my.”
 - **است** *ast* = is.
 
-Only one grammar idea is new: **noun + -e + owner**. Do not generalize further
-yet.
-
-## Meaning and history
+## The word, taken apart
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 **esm** is an Arabic loan related to Arabic *ism*, while **man** and **ast**
 belong to Persian's inherited Iranian core. One tiny sentence can therefore
 show two major layers of Persian vocabulary.
 
-## Say your name
+## Grammar Lens: one spoken link
+<!-- hl-knowledge: introduces=[FA-GRAMMAR-EZAFE-OWNER]; assesses=[] -->
+
+Only one grammar idea is new: **noun + -e + owner**. The spoken **-e** links
+“name” to its owner, so *esm-e man* is literally “name-of me.” Do not turn that
+one pattern into a full grammar table yet.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-ESM-E-MAN-AST, FA-SCRIPT-ESM-MAN-AST, FA-GRAMMAR-EZAFE-OWNER] -->
 
 Replace the dots with your name:
 
 > **اسم من سارا است.** — *esm-e man Sârâ ast.* — My name is Sara.
 
+- [YOU SAY: **esm-e man Sârâ ast**]
+- [YOU SAY: replace **Sârâ** with your own name]
+
 In everyday speech, the ending is often shortened. Keep the careful full form
 for now; it makes every part visible.
 
-## Quick recall
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-ESM-E-MAN-AST, FA-SCRIPT-ESM-MAN-AST, FA-GRAMMAR-EZAFE-OWNER] -->
+<!-- hl-activity: {"id":"FA-C02-esm-e-man-sara","kind":"text","assesses":["FA-LEX-ESM-E-MAN-AST"],"prompt":"Type the careful Persian sentence 'My name is Sara.'","answer":"اسم من سارا است","accepted":["esm-e man Sara ast","esm-e man Sârâ ast"],"feedback":{"correct":"Right: اسم من سارا است keeps the ezafe spoken and the careful copula visible.","incorrect":"Use اسم من سارا است — esm-e man Sârâ ast."},"response_seconds":10} -->
 
 What links *esm* to *man*? The spoken **-e**, or ezafe. Say “My name is …” once
 with your own name.

--- a/code/learning/human-languages/persian/lessons/FA-C03-chist.md
+++ b/code/learning/human-languages/persian/lessons/FA-C03-chist.md
@@ -1,0 +1,72 @@
+---
+schema_version: 2
+id: FA-C03-chist
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 70
+chapter: 3
+type: word
+headword: چیست
+romanization: chist
+gloss: what is?
+concept_tag: QUESTION-WHAT
+prerequisites: [FA-C03-shoma-to]
+sounds: [rtl, long-i, persian-che, short-vowels-unwritten]
+roots: [indo-iranian-question-chi, indo-european-copula-ast]
+etymology_hook: Chist compresses chi what plus ast is; Persian drops the opening vowel of ast and keeps the useful question as one written word.
+duration:
+  max_seconds: 210
+requires:
+  knowledge: [FA-LEX-SHOMA-TO, FA-PRAGMATICS-SHOMA-REGISTER]
+introduces:
+  knowledge: [FA-LEX-CHIST, FA-SCRIPT-CHE-AND-YE, FA-GRAMMAR-CHI-AST-FUSION]
+practises:
+  knowledge: [FA-LEX-SHOMA-TO, FA-PRAGMATICS-SHOMA-REGISTER, FA-LEX-CHIST, FA-SCRIPT-CHE-AND-YE, FA-GRAMMAR-CHI-AST-FUSION]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: careful-neutral
+variety: contemporary-iranian-persian
+reviews_of: [FA-C03-shoma-to, FA-C02-esm-e-man]
+---
+
+# چیست — “what is?” in one joined word
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-SHOMA-TO, FA-PRAGMATICS-SHOMA-REGISTER] -->
+
+[PAUSE 2s] Which “you” is safe for a new adult? (**شما**, *shomâ*.) Now add the
+question engine that will follow “your name.”
+
+## You'll want to know first — چیست
+<!-- hl-knowledge: introduces=[FA-LEX-CHIST, FA-SCRIPT-CHE-AND-YE]; assesses=[] -->
+
+> **چیست** — *chist* — **what is?**
+
+Read from the right: **چ** *ch*, **ی** long *i*, **س** *s*, **ت** *t*.
+**چ** is one of Persian's four additions to the Arabic alphabet: it uses the
+same base shape as **ج**, with three dots below. Meet only this joined form now.
+
+## Grammar Lens: two words compressed
+<!-- hl-knowledge: introduces=[FA-GRAMMAR-CHI-AST-FUSION]; assesses=[] -->
+
+**chist** is the careful fusion of **chi** “what” and **ast** “is.” The opening
+vowel of *ast* disappears when the pieces join:
+
+> *chi + ast* → **chist**
+
+You already know full **ast** from *esm-e man ... ast*. This lesson changes no
+copula rule; it gives one high-frequency fused question form.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-CHIST, FA-SCRIPT-CHE-AND-YE, FA-GRAMMAR-CHI-AST-FUSION] -->
+
+- [YOU SAY: **chi + ast → chist**]
+- [YOU READ: **چیست** from **چ** to **ت**]
+- [YOU SAY: **chist?** — “what is?”]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-CHIST, FA-SCRIPT-CHE-AND-YE, FA-GRAMMAR-CHI-AST-FUSION] -->
+<!-- hl-activity: {"id":"FA-C03-chist-fusion","kind":"text","assesses":["FA-GRAMMAR-CHI-AST-FUSION"],"prompt":"Join Persian chi + ast into the careful form 'what is?'.","answer":"چیست","accepted":["chist","chīst"],"feedback":{"correct":"Right: chi + ast contracts to چیست chist.","incorrect":"The joined careful form is چیست — chist."},"response_seconds":8} -->
+
+What two pieces make **chist**? (**Chi + ast**.) Which new Persian letter opens
+it? (**چ**, *ch*, with three dots below.)

--- a/code/learning/human-languages/persian/lessons/FA-C03-esm-e-shoma-chist.md
+++ b/code/learning/human-languages/persian/lessons/FA-C03-esm-e-shoma-chist.md
@@ -1,0 +1,73 @@
+---
+schema_version: 2
+id: FA-C03-esm-e-shoma-chist
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 80
+chapter: 3
+type: phrase
+headword: اسم شما چیست؟
+romanization: esm-e shomâ chist?
+gloss: What is your name? (respectful)
+concept_tag: INTRO-WHATS-YOUR-NAME
+prerequisites: [FA-C03-chist]
+sounds: [rtl, ezafe-e, persian-question-mark]
+roots: [ism, indo-iranian-question-chi]
+etymology_hook: The question reuses Arabic-loan esm inside native Persian grammar: ezafe links the owner, and chi plus ast compresses to chist.
+duration:
+  max_seconds: 210
+requires:
+  knowledge: [FA-LEX-ESM-E-MAN-AST, FA-GRAMMAR-EZAFE-OWNER, FA-LEX-SHOMA-TO, FA-PRAGMATICS-SHOMA-REGISTER, FA-LEX-CHIST, FA-GRAMMAR-CHI-AST-FUSION]
+introduces:
+  knowledge: [FA-LEX-NAME-QUESTION, FA-GRAMMAR-NAME-QUESTION-ORDER, FA-SCRIPT-PERSIAN-QUESTION-MARK]
+practises:
+  knowledge: [FA-LEX-ESM-E-MAN-AST, FA-GRAMMAR-EZAFE-OWNER, FA-LEX-SHOMA-TO, FA-PRAGMATICS-SHOMA-REGISTER, FA-LEX-CHIST, FA-GRAMMAR-CHI-AST-FUSION, FA-LEX-NAME-QUESTION, FA-GRAMMAR-NAME-QUESTION-ORDER, FA-SCRIPT-PERSIAN-QUESTION-MARK]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: respectful
+variety: contemporary-iranian-persian
+reviews_of: [FA-C03-chist, FA-C03-shoma-to, FA-C02-esm-e-man]
+---
+
+# اسم شما چیست؟ — ask a name respectfully
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-ESM-E-MAN-AST, FA-GRAMMAR-EZAFE-OWNER, FA-LEX-SHOMA-TO, FA-PRAGMATICS-SHOMA-REGISTER, FA-LEX-CHIST, FA-GRAMMAR-CHI-AST-FUSION] -->
+
+[PAUSE 2s] Give the three ready pieces: **esm-e** “name-of,” **shomâ** respectful
+“you,” and **chist** “what is?”
+
+## The exchange
+<!-- hl-knowledge: introduces=[FA-LEX-NAME-QUESTION, FA-GRAMMAR-NAME-QUESTION-ORDER]; assesses=[] -->
+
+> **اسم شما چیست؟** — *esm-e shomâ chist?* — **What is your name?**
+
+The Persian order is transparent once the pieces are known:
+
+> name + **-e** + you + what-is?
+
+The spoken ezafe turns **esm-e shomâ** into “your name.” **Chist** stays at the
+end. No new agreement or verb table is hiding here.
+
+## Script: the question mark
+<!-- hl-knowledge: introduces=[FA-SCRIPT-PERSIAN-QUESTION-MARK]; assesses=[] -->
+
+Persian ends a written question with **؟**. Its curve faces the opposite way
+from English **?**, matching the right-to-left line. Read the sentence from its
+right edge; meet the punctuation at the far left.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-NAME-QUESTION, FA-GRAMMAR-NAME-QUESTION-ORDER, FA-SCRIPT-PERSIAN-QUESTION-MARK] -->
+
+- [YOU SAY: **esm-e shomâ chist?**]
+- [YOU SAY: ask, then answer — **esm-e man ... ast**]
+- [YOU POINT: to **؟** at the end of the right-to-left question]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-NAME-QUESTION, FA-GRAMMAR-NAME-QUESTION-ORDER, FA-SCRIPT-PERSIAN-QUESTION-MARK] -->
+<!-- hl-activity: {"id":"FA-C03-esm-e-shoma-chist-question","kind":"text","assesses":["FA-LEX-NAME-QUESTION"],"prompt":"Type the respectful Persian question 'What is your name?'","answer":"اسم شما چیست؟","accepted":["اسم شما چیست","esm-e shoma chist","esm-e shomâ chist"],"feedback":{"correct":"Right: اسم شما چیست؟ reuses ezafe, respectful شما, and چیست.","incorrect":"Use اسم شما چیست؟ — esm-e shomâ chist?"},"response_seconds":10} -->
+
+Ask the question once without reading the romanization. Then answer with the
+careful name frame you already know.
+
+Source: [Persian Online: Introducing Yourself](https://sites.la.utexas.edu/persian_online_resources/vocabulary-lists/people-places-and-things/).

--- a/code/learning/human-languages/persian/lessons/FA-C03-khoshvaghtam.md
+++ b/code/learning/human-languages/persian/lessons/FA-C03-khoshvaghtam.md
@@ -1,0 +1,74 @@
+---
+schema_version: 2
+id: FA-C03-khoshvaghtam
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 90
+chapter: 3
+type: phrase
+headword: خوشوقتم
+romanization: khoshvaghtam
+gloss: pleased to meet you
+concept_tag: INTRO-NICE-TO-MEET-YOU
+prerequisites: [FA-C03-esm-e-shoma-chist]
+sounds: [rtl, kh, sh, gh, short-vowels-unwritten]
+roots: [persian-khosh, arabic-waqt]
+etymology_hook: Khoshvaghtam layers native Persian khosh pleasant, Arabic-loan vaqt time, and the Persian first-person ending -am into one ordinary social response.
+duration:
+  max_seconds: 230
+requires:
+  knowledge: [FA-LEX-NAME-QUESTION, FA-LEX-ESM-E-MAN-AST]
+introduces:
+  knowledge: [FA-LEX-KHOSHVAGHTAM, FA-MORPH-KHOSH-VAQT-AM, FA-ETYMON-VAQT-ARABIC]
+practises:
+  knowledge: [FA-LEX-NAME-QUESTION, FA-LEX-ESM-E-MAN-AST, FA-LEX-KHOSHVAGHTAM, FA-MORPH-KHOSH-VAQT-AM, FA-ETYMON-VAQT-ARABIC]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: contemporary-iranian-persian
+reviews_of: [FA-C03-esm-e-shoma-chist, FA-C02-esm-e-man]
+---
+
+# خوشوقتم — pleased to meet you
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-NAME-QUESTION, FA-LEX-ESM-E-MAN-AST] -->
+
+[PAUSE 2s] Ask **esm-e shomâ chist?** and answer **esm-e man ... ast**. One
+warm response now closes that tiny meeting.
+
+## The exchange
+<!-- hl-knowledge: introduces=[FA-LEX-KHOSHVAGHTAM]; assesses=[] -->
+
+> **خوشوقتم** — *khoshvaghtam* — **Pleased to meet you.**
+
+Treat the joined word as one social move first. **خ** gives *kh*, like the sound
+in Scottish *loch*. **ش** gives *sh*. Persian commonly pronounces **ق** here
+with the merged *gh/q* sound of contemporary Iranian speech.
+
+## The word, taken apart
+<!-- hl-knowledge: introduces=[FA-MORPH-KHOSH-VAQT-AM, FA-ETYMON-VAQT-ARABIC]; assesses=[] -->
+
+- **khosh** — pleasant, happy; inherited Persian vocabulary.
+- **vaqt** (pronounced *vaght* here) — time; an Arabic loan fully at home in
+  Persian.
+- **-am** — I am, the first-person ending.
+
+So the word builds “pleasant-time-I-am” into the idiomatic feeling “I am
+pleased.” The history is layered; the expression is ordinary modern Persian.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-KHOSHVAGHTAM, FA-MORPH-KHOSH-VAQT-AM, FA-ETYMON-VAQT-ARABIC] -->
+
+- [YOU SAY: **khoshvaghtam** as one smooth response]
+- [YOU SAY: the three pieces — **khosh + vaqt + -am**]
+- [YOU SAY: which piece came from Arabic — **vaqt**]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-KHOSHVAGHTAM, FA-MORPH-KHOSH-VAQT-AM, FA-ETYMON-VAQT-ARABIC] -->
+<!-- hl-activity: {"id":"FA-C03-khoshvaghtam-close","kind":"text","assesses":["FA-LEX-KHOSHVAGHTAM"],"prompt":"Type the Persian response 'Pleased to meet you.'","answer":"خوشوقتم","accepted":["khoshvaghtam","khoshvaqtam"],"feedback":{"correct":"Right: خوشوقتم closes the introduction warmly.","incorrect":"The response is خوشوقتم — khoshvaghtam."},"response_seconds":8} -->
+
+Which response closes the introduction? (**Khoshvaghtam**.) Which three layers
+can you hear inside it? (**Khosh + vaqt + -am**.)
+
+Source: [Persian Online: Introducing Yourself](https://sites.la.utexas.edu/persian_online_resources/vocabulary-lists/people-places-and-things/).

--- a/code/learning/human-languages/persian/lessons/FA-C03-practice.md
+++ b/code/learning/human-languages/persian/lessons/FA-C03-practice.md
@@ -1,0 +1,66 @@
+---
+schema_version: 2
+id: FA-C03-practice
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 100
+chapter: 3
+type: practice-mix
+headword: اسم شما چیست؟ — خوشوقتم
+romanization: esm-e shomâ chist? — khoshvaghtam
+gloss: a complete first name exchange
+concept_tag: FA-C03-PRACTICE
+prerequisites: [FA-C03-khoshvaghtam]
+sounds: [rtl, ezafe-e, persian-question-mark]
+roots: []
+etymology_hook: The practice recombines only the Persian and Arabic-rooted pieces already introduced; it adds no hidden grammar.
+duration:
+  max_seconds: 210
+requires:
+  knowledge: [FA-LEX-ESM-E-MAN-AST, FA-GRAMMAR-EZAFE-OWNER, FA-LEX-SHOMA-TO, FA-PRAGMATICS-SHOMA-REGISTER, FA-LEX-CHIST, FA-LEX-NAME-QUESTION, FA-SCRIPT-PERSIAN-QUESTION-MARK, FA-LEX-KHOSHVAGHTAM]
+introduces:
+  knowledge: [FA-DIALOGUE-NAME-EXCHANGE]
+practises:
+  knowledge: [FA-LEX-ESM-E-MAN-AST, FA-GRAMMAR-EZAFE-OWNER, FA-LEX-SHOMA-TO, FA-PRAGMATICS-SHOMA-REGISTER, FA-LEX-CHIST, FA-LEX-NAME-QUESTION, FA-SCRIPT-PERSIAN-QUESTION-MARK, FA-LEX-KHOSHVAGHTAM, FA-DIALOGUE-NAME-EXCHANGE]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, fluency]
+register: respectful
+variety: contemporary-iranian-persian
+reviews_of: [FA-C03-shoma-to, FA-C03-chist, FA-C03-esm-e-shoma-chist, FA-C03-khoshvaghtam, FA-C02-esm-e-man]
+---
+
+# Practice — a complete Persian name exchange
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-ESM-E-MAN-AST, FA-LEX-SHOMA-TO, FA-PRAGMATICS-SHOMA-REGISTER, FA-LEX-CHIST, FA-LEX-NAME-QUESTION, FA-LEX-KHOSHVAGHTAM] -->
+
+[PAUSE 2s] Recall the four moves without adding anything: greet, ask, answer,
+acknowledge.
+
+## The exchange
+<!-- hl-knowledge: introduces=[FA-DIALOGUE-NAME-EXCHANGE]; assesses=[] -->
+
+> A: **سلام!** — *Salâm!*  
+> B: **سلام!** — *Salâm!*  
+> A: **اسم شما چیست؟** — *Esm-e shomâ chist?*  
+> B: **اسم من سارا است.** — *Esm-e man Sârâ ast.*  
+> A: **خوشوقتم.** — *Khoshvaghtam.*  
+> B: **ممنون.** — *Mamnun.*
+
+Every line is already known. **Shomâ** keeps the first meeting respectful; the
+answer returns to **man**. The question mark sits at the left end of the
+right-to-left question.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-ESM-E-MAN-AST, FA-GRAMMAR-EZAFE-OWNER, FA-LEX-SHOMA-TO, FA-PRAGMATICS-SHOMA-REGISTER, FA-LEX-CHIST, FA-LEX-NAME-QUESTION, FA-SCRIPT-PERSIAN-QUESTION-MARK, FA-LEX-KHOSHVAGHTAM, FA-DIALOGUE-NAME-EXCHANGE] -->
+
+- [YOU SAY: both voices, using your own name]
+- [YOU SAY: the exchange again without romanization]
+- [YOU SAY: only the three name moves — question, answer, response]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-ESM-E-MAN-AST, FA-GRAMMAR-EZAFE-OWNER, FA-LEX-SHOMA-TO, FA-PRAGMATICS-SHOMA-REGISTER, FA-LEX-CHIST, FA-LEX-NAME-QUESTION, FA-SCRIPT-PERSIAN-QUESTION-MARK, FA-LEX-KHOSHVAGHTAM, FA-DIALOGUE-NAME-EXCHANGE] -->
+<!-- hl-activity: {"id":"FA-C03-practice-next-line","kind":"text","assesses":["FA-DIALOGUE-NAME-EXCHANGE"],"prompt":"After someone asks اسم شما چیست؟, type the careful Persian answer using Sara.","answer":"اسم من سارا است","accepted":["esm-e man Sara ast","esm-e man Sârâ ast"],"feedback":{"correct":"Right: answer the respectful question with اسم من سارا است.","incorrect":"The careful answer is اسم من سارا است — esm-e man Sârâ ast."},"response_seconds":10} -->
+
+Run the meeting once from **salâm** to **mamnun**. If one line stalls, review
+that single micro-lesson rather than rereading the whole chapter.

--- a/code/learning/human-languages/persian/lessons/FA-C03-shoma-to.md
+++ b/code/learning/human-languages/persian/lessons/FA-C03-shoma-to.md
@@ -1,0 +1,81 @@
+---
+schema_version: 2
+id: FA-C03-shoma-to
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 60
+chapter: 3
+type: word
+headword: شما / تو
+romanization: shomâ / to
+gloss: you — respectful or plural / familiar singular
+concept_tag: PRONOUN-YOU
+prerequisites: [FA-C02-esm-e-man]
+sounds: [rtl, long-a, short-vowels-unwritten]
+roots: [indo-iranian-tu]
+etymology_hook: Persian to and English thou continue the old Indo-European familiar-you word; shomâ also uses plural as respect, like Russian vy and French vous.
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [FA-LEX-ESM-E-MAN-AST]
+introduces:
+  knowledge: [FA-LEX-SHOMA-TO, FA-SCRIPT-SHOMA-TO, FA-PRAGMATICS-SHOMA-REGISTER, FA-ETYMON-TO-THOU]
+practises:
+  knowledge: [FA-LEX-ESM-E-MAN-AST, FA-LEX-SHOMA-TO, FA-SCRIPT-SHOMA-TO, FA-PRAGMATICS-SHOMA-REGISTER, FA-ETYMON-TO-THOU]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: formal-informal-contrast
+variety: contemporary-iranian-persian
+reviews_of: [FA-C02-esm-e-man]
+---
+
+# شما / تو — two relationships inside “you”
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-ESM-E-MAN-AST] -->
+
+[PAUSE 2s] Say **esm-e man ... ast** with your own name. To turn that sentence
+around, you next need a safe word for the other person.
+
+## The two words
+<!-- hl-knowledge: introduces=[FA-LEX-SHOMA-TO, FA-SCRIPT-SHOMA-TO]; assesses=[] -->
+
+| Persian | read | use |
+|---|---|---|
+| **شما** | *shomâ* | one person respectfully, or more than one person |
+| **تو** | *to* | one familiar person |
+
+In **شما**, meet **ش** *sh*; its three dots distinguish it from **س** *s*.
+Final **ا** carries long *â*. In **تو**, **و** has its *o* value rather than the
+long *u* it had in **ممنون**. Learn the sound from the whole word.
+
+## Grammar Lens: begin respectfully
+<!-- hl-knowledge: introduces=[FA-PRAGMATICS-SHOMA-REGISTER]; assesses=[] -->
+
+Persian uses plural **shomâ** for respectful singular address, much as Russian
+uses *vy* and French uses *vous*. Use **shomâ** with an unfamiliar adult or in
+a first meeting. Use **to** after the relationship is familiar. English once
+made a similar distinction but now uses *you* for both.
+
+## The word, taken apart
+<!-- hl-knowledge: introduces=[FA-ETYMON-TO-THOU]; assesses=[] -->
+
+Persian **to** belongs to the ancient Indo-European familiar-“you” family:
+English **thou**, Latin *tū*, and Sanskrit *tvam* are relatives. The word is
+old; the social choice carried by it is current.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-SHOMA-TO, FA-SCRIPT-SHOMA-TO, FA-PRAGMATICS-SHOMA-REGISTER, FA-ETYMON-TO-THOU] -->
+
+- [YOU SAY: a new adult — **shomâ**]
+- [YOU SAY: a close friend — **to**]
+- [YOU SAY: the old family — **to, thou, tū, tvam**]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-SHOMA-TO, FA-SCRIPT-SHOMA-TO, FA-PRAGMATICS-SHOMA-REGISTER, FA-ETYMON-TO-THOU] -->
+<!-- hl-activity: {"id":"FA-C03-shoma-to-first-meeting","kind":"text","assesses":["FA-PRAGMATICS-SHOMA-REGISTER"],"prompt":"Type the Persian 'you' safest in a first meeting.","answer":"شما","accepted":["shoma","shomâ","shomā"],"feedback":{"correct":"Right: شما shomâ is the respectful first-meeting choice.","incorrect":"Use شما shomâ with an unfamiliar adult or in a first meeting."},"response_seconds":8} -->
+
+Which form is safest when the relationship is new? (**Shomâ**.) Which is the
+relative of English *thou*? (**To**.)
+
+Source: [Persian Online: Pronouns](https://sites.la.utexas.edu/persian_online_resources/pronouns/).

--- a/code/learning/human-languages/persian/roadmap.md
+++ b/code/learning/human-languages/persian/roadmap.md
@@ -18,13 +18,14 @@ Iranian **na** from the Arabic loans **salâm** and **mamnun**.
 the spoken ezafe linker **-e**. The lesson keeps the careful written copula
 **ast** visible before later introducing its conversational reductions.
 
-## Chapter 3 — Ask and answer names *(planned)*
+## Chapter 3 — Ask and answer names *(authored)*
 
-- **اسم شما چیست؟** *esm-e shomâ chist?* — What is your name?
-- **خوشوقتم** *khoshvaghtam* — Pleased to meet you.
-- polite **shomâ** versus familiar **to**;
-- the joined forms needed by these expressions;
-- focused retrieval before the expressions enter mixed Persian/Urdu practice.
+**شما / تو** *shomâ / to* → **چیست** *chist* → **اسم شما چیست؟**
+*esm-e shomâ chist?* → **خوشوقتم** *khoshvaghtam* → one cumulative exchange.
+The schema-v2 chain adds respectful/familiar register, Persian **چ**, the
+*chi + ast* fusion, the right-to-left question mark, and a layered
+*khosh + vaqt + -am* etymology only when each expression needs it. Objective
+focused retrieval comes before the exchange enters mixed-language review.
 
 ## Chapter 4 — People and simple identity *(planned)*
 

--- a/code/learning/human-languages/persian/session-map.md
+++ b/code/learning/human-languages/persian/session-map.md
@@ -23,26 +23,42 @@ The sequence introduces only one new language fact at a time: direction and one
 word, a long **u**, an affirmative, its negative contrast, then the spoken ezafe
 inside a fixed name frame. The final practice uses only those five lessons.
 
+## Chapter 3 — Ask and answer names
+
+Chapter 3 fills the next five sessions without changing the starter prefix.
+Each row still points to one independently resumable lesson.
+
+| Session | New lesson | Reviews due | Cumulative practice |
+|---|---|---|---|
+| **S6** | [`FA-C03-shoma-to`](./lessons/FA-C03-shoma-to.md): **شما / تو** *shomâ / to* | *bale* *(N+3)*; *esm-e man ... ast* *(N+1)* | choose respectful or familiar “you” |
+| **S7** | [`FA-C03-chist`](./lessons/FA-C03-chist.md): **چیست** *chist* | *na* *(N+3)*; *shomâ / to* *(N+1)* | join *chi + ast* before reveal |
+| **S8** | [`FA-C03-esm-e-shoma-chist`](./lessons/FA-C03-esm-e-shoma-chist.md): **اسم شما چیست؟** | *salâm* *(N+7)*; *esm-e man ... ast* *(N+3)*; *chist* *(N+1)* | ask, then answer with your name |
+| **S9** | [`FA-C03-khoshvaghtam`](./lessons/FA-C03-khoshvaghtam.md): **خوشوقتم** | *mamnun* *(N+7)*; *shomâ / to* *(N+3)*; the name question *(N+1)* | close the introduction warmly |
+| **S10** | [`FA-C03-practice`](./lessons/FA-C03-practice.md): full exchange | *bale* *(N+7)*; *chist* *(N+3)*; *khoshvaghtam* *(N+1)* | run both voices using only known lines |
+
 ## Carry-forward review ledger
 
-Future chapters may supply the new lesson in these sessions. Until those
-chapters are authored, use the due item as a short retrieval session and draw
-already learned items into an optional bonus queue.
+Future chapters may supply the new lesson in these sessions. Until then, use
+the due item as a short retrieval session and fill the optional bonus queue only
+with already learned material.
 
 | Session | Fixed review due |
 |---|---|
-| **S6** | *bale* *(N+3)*; *esm-e man ... ast* *(N+1)* |
-| **S7** | *na* *(N+3)* |
-| **S8** | *salâm* *(N+7)*; *esm-e man ... ast* *(N+3)* |
-| **S9** | *mamnun* *(N+7)* |
-| **S10** | *bale* *(N+7)* |
-| **S11** | *na* *(N+7)* |
-| **S12** | *esm-e man ... ast* *(N+7)* |
-| **S16** | *salâm* *(N+15)* |
-| **S17** | *mamnun* *(N+15)* |
+| **S11** | *na* *(N+7)*; the name question *(N+3)*; Chapter 3 practice *(N+1)* |
+| **S12** | *esm-e man ... ast* *(N+7)*; *khoshvaghtam* *(N+3)* |
+| **S13** | *shomâ / to* *(N+7)*; Chapter 3 practice *(N+3)* |
+| **S14** | *chist* *(N+7)* |
+| **S15** | the name question *(N+7)* |
+| **S16** | *salâm* *(N+15)*; *khoshvaghtam* *(N+7)* |
+| **S17** | *mamnun* *(N+15)*; Chapter 3 practice *(N+7)* |
 | **S18** | *bale* *(N+15)* |
 | **S19** | *na* *(N+15)* |
 | **S20** | *esm-e man ... ast* *(N+15)* |
+| **S21** | *shomâ / to* *(N+15)* |
+| **S22** | *chist* *(N+15)* |
+| **S23** | the name question *(N+15)* |
+| **S24** | *khoshvaghtam* *(N+15)* |
+| **S25** | Chapter 3 practice *(N+15)* |
 
 Sessions not listed in the ledger have no fixed starter item due; use their
 bonus queue for adaptive or cumulative retrieval.
@@ -51,9 +67,9 @@ After the fourth successful resurfacing, an item moves into the long-term mixed
 practice pool. A missed item returns sooner in Language Ladder's adaptive
 review; the fixed ledger remains the book's no-tracking fallback.
 
-## Next authored intake
+## Schedule check
 
-Chapter 3 will add the matched question “What is your name?”, a polite/casual
-**you** contrast, and “pleased to meet you” as separate sub-five-minute lessons.
-They will occupy the next open sessions without changing the five-lesson prefix
-above or asking the learner to infer unauthored grammar.
+Every Chapter 1–3 lesson now has all four fixed resurfacing sessions through
+S25. The app may pull a missed item forward, but it cannot skip the local
+prerequisites. Chapter 4 can begin in S11 while the ledger continues in the
+review portion of each session.

--- a/code/learning/human-languages/urdu/CHANGELOG.md
+++ b/code/learning/human-languages/urdu/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.4.0 — 2026-08-03
+
+- Added five schema-v2 Chapter 3 micro-lessons for **āp/tum/tū**, *kyā*, the
+  full name question, the meeting response, and cumulative practice.
+- Added objective activity contracts and prerequisite-closed knowledge atoms for
+  the migrated Chapter 2 name frame and every new lesson.
+- Generated Chapter 3 for the downloadable book from the same canonical lesson
+  AST used by Language Ladder and extended the review ledger through S25.
+
 ## 0.3.0 — 2026-08-03
 
 - Added the authoritative five-lesson session map with exact N+1, N+3, N+7,

--- a/code/learning/human-languages/urdu/README.md
+++ b/code/learning/human-languages/urdu/README.md
@@ -4,10 +4,13 @@ This track teaches contemporary standard Urdu through the shared
 human-language spine. Lessons are under five minutes and introduce Nastaliq
 script features only as the learner encounters them.
 
-The first five lessons form a miniature exchange: greeting, thanks, yes, no,
-and a name introduction. Urdu-specific extensions will grow the spine with
-gender agreement, postpositions, oblique forms, honorific levels, the compound
-verb system, and the distinctive Nastaliq letter shapes.
+The first ten lessons now form a complete miniature meeting: greeting, answers,
+giving your name, asking someone else's name respectfully, and acknowledging
+the introduction. Urdu-specific extensions introduce **āp/tum/tū** register,
+**kyā**, fixed **āp kā nām**, question punctuation, and a gently chunked
+pleased-to-meet-you response exactly where the exchange needs them. Later
+chapters will add gender agreement, postpositions, oblique forms, compound
+verbs, and more Nastaliq-aware shapes.
 
 Urdu and Hindi share a large grammatical core, while the formal lexicon and
 writing systems make their histories visible. Cross-language practice should
@@ -17,10 +20,10 @@ Script conventions are grounded in Northwestern University's *Zero Zabar*.
 ## Read and practise
 
 - [`roadmap.md`](./roadmap.md) orders the authored and planned chapters toward B1.
-- [`session-map.md`](./session-map.md) composes the five micro-lessons with an
-  exact session-count review ledger and reserves the next open intake.
+- [`session-map.md`](./session-map.md) composes all ten micro-lessons with an
+  exact session-count review ledger through S25.
 - [`pronunciation-reference.md`](./pronunciation-reference.md) gathers Urdu
   script and sound facts on demand and labels the current Naskh fallback.
-- [`lessons/`](./lessons/) contains the five canonical short practice lessons.
-- [`book/book.tex`](./book/book.tex) builds the free two-chapter starter edition
+- [`lessons/`](./lessons/) contains the ten canonical short practice lessons.
+- [`book/book.tex`](./book/book.tex) builds the free three-chapter starter edition
   with XeLaTeX; merged editions appear in the public human-languages book catalog.

--- a/code/learning/human-languages/urdu/book/book.tex
+++ b/code/learning/human-languages/urdu/book/book.tex
@@ -18,7 +18,7 @@
   \vspace{1.5cm}
   {\large Adhithya Rajasekaran\par}
   \vfill
-  {\large Starter edition --- five short lessons in two cumulative chapters.\par}
+  {\large Starter edition --- ten short lessons in three cumulative chapters.\par}
   \vspace{1cm}
   {\large Companion practice lessons live alongside this book at\\
   \texttt{code/learning/human-languages/urdu/lessons/}\par}
@@ -56,6 +56,7 @@ aid, not a claim that a borrowed word is any less fully Urdu today.
 
 \input{chapters/ch01-greetings-and-responses}
 \input{chapters/ch02-give-your-name}
+\input{chapters/ch03-ask-and-answer-names}
 
 \backmatter
 

--- a/code/learning/human-languages/urdu/book/chapters/ch03-ask-and-answer-names.tex
+++ b/code/learning/human-languages/urdu/book/chapters/ch03-ask-and-answer-names.tex
@@ -1,0 +1,197 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:f1d09ed02a13ed81
+% canonical-lessons: UR-C03-aap-tum-tu, UR-C03-kya, UR-C03-aap-ka-naam-kya-hai, UR-C03-khushi-hui, UR-C03-practice
+
+\chapter{Ask and Answer Names}
+\label{ch:ur-ask-and-answer-names}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[āp / tum / tū]{\ur{آپ} / \ur{تم} / \ur{تو} — three relationships inside “you”}
+
+\label{lesson:UR-C03-aap-tum-tu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Say \textbf{merā nām ... hai} with your own name. To ask the other person's name, begin with the respectful form.
+\end{quote}
+
+\subsection*{You'll want to know first — three forms}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Urdu} & \textbf{read} & \textbf{use} \\
+\midrule
+\textbf{\ur{آپ}} & \emph{āp} & respectful: a new adult, elder, or anyone you wish to honor \\
+\textbf{\ur{تم}} & \emph{tum} & familiar: friends and peers \\
+\textbf{\ur{تو}} & \emph{tū} & intimate, or downward; unsafe as a beginner default \\
+\bottomrule
+\end{tabularx}
+
+\textbf{\ur{آپ}} begins with \textbf{\ur{آ}}, an alif carrying the long \emph{ā} mark, then \textbf{\ur{پ}} \emph{p}. \textbf{\ur{تم}} and \textbf{\ur{تو}} share \textbf{\ur{ت}} \emph{t}. In \textbf{\ur{تو}}, \textbf{\ur{و}} carries long \emph{ū}.
+
+\begin{grammarlens}[title={Grammar Lens: choose the relationship first}]
+English flattened these choices into one \emph{you}. Urdu keeps three. Use \textbf{āp} in a first meeting. Move to \textbf{tum} when the relationship supports familiarity. Save \textbf{tū} for relationships where you already know it is welcome; used badly, it can sound belittling.
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{Tum/tū} belong to the old Indo-European familiar-“you” family: Sanskrit \emph{tvam}, English \textbf{thou}, and Latin \emph{tū} are relatives. \textbf{Āp} followed another route: a word connected with “self/oneself” became honorific address.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: a new adult — \textbf{āp}{]}
+  \item {[}YOU SAY: a friend — \textbf{tum}{]}
+  \item {[}YOU SAY: the old family — \textbf{tum, tvam, thou}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Which form is safest when unsure? (\textbf{Āp}.) Which familiar forms share history with English \emph{thou}? (\textbf{Tum/tū}.)
+
+Source: \emph{Basic Urdu}: Cultural Notes.
+\end{tcolorbox}
+\section[kyā]{\ur{کیا} — what}
+
+\label{lesson:UR-C03-kya}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Which “you” opens a respectful first meeting? (\textbf{\ur{آپ}}, \emph{āp}.) Now add the question word.
+\end{quote}
+
+\subsection*{You'll want to know first — \ur{کیا}}
+\begin{quote}
+\textbf{\ur{کیا}} — \emph{kyā} — \textbf{what}
+\end{quote}
+
+Read right to left: \textbf{\ur{ک}} \emph{k}, \textbf{\ur{ی}} supplying the \emph{y} glide here, then \textbf{\ur{ا}} long \emph{ā}. The same \textbf{\ur{ی}} carried long \emph{ī} in \textbf{\ur{جی}} and \textbf{\ur{نہیں}}. Its job depends on the word; here the learned shape is \emph{kyā}.
+
+\begin{cousinweb}
+Urdu \textbf{kyā} and Hindi \textbf{kyā} are the same inherited Indo-Aryan word in different scripts. Their history reaches Sanskrit \emph{kim} and the old Indo-European \emph{k/kw-} question family behind English \textbf{wh-} words such as \emph{what, who,} and \emph{which}. The bridge helps memory; Urdu \textbf{\ur{کیا}} remains the form you must read here.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: \textbf{kyā} — what{]}
+  \item {[}YOU READ: \textbf{\ur{کیا}} as \textbf{k + yā}{]}
+  \item {[}YOU SAY: the family — \textbf{kyā, what, who, which}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Which letter acts as \emph{y} here but as long \emph{ī} in \textbf{\ur{جی}}? (\textbf{\ur{ی}}.) What does \textbf{\ur{کیا}} mean? (\textbf{What}.)
+\end{tcolorbox}
+\section[āp kā nām kyā hai?]{\ur{آپ} \ur{کا} \ur{نام} \ur{کیا} \ur{ہے؟} — ask a name respectfully}
+
+\label{lesson:UR-C03-aap-ka-naam-kya-hai}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Recall \textbf{āp} “you,” \textbf{kyā} “what,” and the answer \textbf{merā nām ... hai}. The question reuses all three.
+\end{quote}
+
+\subsection*{The exchange}
+\begin{quote}
+\textbf{\ur{آپ} \ur{کا} \ur{نام} \ur{کیا} \ur{ہے؟}} — \emph{āp kā nām kyā hai?} — \textbf{What is your name?}
+\end{quote}
+
+Build it in spoken order:
+
+\begin{quote}
+you + \textbf{kā} + name + what + is?
+\end{quote}
+
+\textbf{Āp kā} means “your” in this frame. The possessive form agrees with the thing owned: \textbf{nām} is masculine singular, so use \textbf{kā}. Keep that one pairing; the full \emph{kā/kī/ke} system can wait. As in your answer, \textbf{hai} stays at the end.
+
+\subsection*{Script: the question mark}
+Urdu ends the question with \textbf{\ur{؟}}, curved for a right-to-left line. Begin at \textbf{\ur{آپ}} on the right and reach the punctuation at the far left.
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: \textbf{āp kā nām kyā hai?}{]}
+  \item {[}YOU SAY: ask, then answer — \textbf{merā nām ... hai}{]}
+  \item {[}YOU POINT: to \textbf{\ur{؟}} at the end{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Ask once without romanization. Where does \textbf{hai} remain? (At the end.)
+
+Source: \emph{Basic Urdu}: Greetings and Introductions.
+\end{tcolorbox}
+\section[āp se mil kar khushī huī]{\ur{آپ} \ur{سے} \ur{مل} \ur{کر} \ur{خوشی} \ur{ہوئی} — pleased to meet you}
+
+\label{lesson:UR-C03-khushi-hui}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Ask \textbf{āp kā nām kyā hai?} and answer \textbf{merā nām ... hai}. This fixed response now closes the meeting.
+\end{quote}
+
+\subsection*{The exchange}
+\begin{quote}
+\textbf{\ur{آپ} \ur{سے} \ur{مل} \ur{کر} \ur{خوشی} \ur{ہوئی۔}} \emph{āp se mil kar khushī huī} \textbf{Pleased to meet you.}
+\end{quote}
+
+For now, hold three meaning-sized chunks:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{āp se} — with you
+  \item \textbf{mil kar} — having met
+  \item \textbf{khushī huī} — happiness happened
+\end{itemize}
+
+That yields the memorable literal picture: \textbf{“Having met you, happiness happened.”} The phrase is one social move; later lessons can generalize \emph{se}, \emph{-kar}, and past agreement one at a time.
+
+\begin{cousinweb}
+\textbf{Khushī} “happiness” comes from Persian \textbf{khosh/khush} “pleasant, happy.” \textbf{Mil} “meet” and \textbf{huī} “happened” belong to Urdu's inherited Indo-Aryan grammar. The sentence therefore joins Urdu's two major historical layers without becoming any less ordinary Urdu.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: \textbf{āp se | mil kar | khushī huī} in three beats{]}
+  \item {[}YOU SAY: the literal picture — “having met you, happiness happened”{]}
+  \item {[}YOU SAY: which word came through Persian — \textbf{khushī}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Say the response once as a whole. Which chunk means “happiness happened”? (\textbf{Khushī huī}.)
+
+Source: \emph{Basic Urdu}: Greetings and Introductions.
+\end{tcolorbox}
+\section[Practice]{Practice — a complete Urdu name exchange}
+
+\label{lesson:UR-C03-practice}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Recall the four moves without adding anything: greet, ask, answer, acknowledge.
+\end{quote}
+
+\subsection*{The exchange}
+\begin{quote}
+A: \textbf{\ur{سلام}!} — \emph{Salām!} B: \textbf{\ur{سلام}!} — \emph{Salām!} A: \textbf{\ur{آپ} \ur{کا} \ur{نام} \ur{کیا} \ur{ہے؟}} — \emph{Āp kā nām kyā hai?} B: \textbf{\ur{میرا} \ur{نام} \ur{سارا} \ur{ہے۔}} — \emph{Merā nām Sārā hai.} A: \textbf{\ur{آپ} \ur{سے} \ur{مل} \ur{کر} \ur{خوشی} \ur{ہوئی۔}} — \emph{Āp se mil kar khushī huī.} B: \textbf{\ur{شکریہ۔}} — \emph{Shukriyā.}
+\end{quote}
+
+Every line is already known. \textbf{Āp} keeps the meeting respectful; \textbf{hai} stays at the end of both name sentences; \textbf{\ur{؟}} ends the question at the line's left.
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: both voices, using your own name{]}
+  \item {[}YOU SAY: the exchange again without romanization{]}
+  \item {[}YOU SAY: only the three name moves — question, answer, response{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Run the meeting once from \textbf{salām} to \textbf{shukriyā}. If a line stalls, review only that micro-lesson.
+\end{tcolorbox}

--- a/code/learning/human-languages/urdu/book/preamble.tex
+++ b/code/learning/human-languages/urdu/book/preamble.tex
@@ -5,6 +5,20 @@
 \setmainfont{Latin Modern Roman}
 \setsansfont{Latin Modern Sans}
 \setmonofont{Latin Modern Mono}
+\raggedbottom
+
+% Keep book.cls's open-right blank verso, but remove its running head.
+\makeatletter
+\renewcommand{\cleardoublepage}{%
+  \clearpage
+  \if@twoside
+    \ifodd\c@page\else
+      \hbox{}\thispagestyle{empty}\newpage
+      \if@twocolumn\hbox{}\newpage\fi
+    \fi
+  \fi
+}
+\makeatother
 
 % bidi, loaded by polyglossia for Urdu, requires color-related packages to be
 % loaded first on TeX Live.
@@ -13,6 +27,7 @@
 \tcbuselibrary{skins,breakable}
 \usepackage{booktabs}
 \usepackage{array}
+\usepackage{tabularx}
 \usepackage[hidelinks]{hyperref}
 \usepackage{titlesec}
 
@@ -57,6 +72,16 @@
   breakable, skin=enhanced, colback=red!5, colframe=red!40!black,
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
   fonttitle=\bfseries, title={One-minute checkpoint}
+}
+\newtcolorbox{cousinweb}{
+  breakable, skin=enhanced, colback=yellow!8, colframe=yellow!45!black,
+  boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
+  fonttitle=\bfseries, title={The word, taken apart --- and its English cousins}
+}
+\newtcolorbox{grammarlens}[1][]{
+  breakable, skin=enhanced, colback=blue!5, colframe=blue!35!black,
+  boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
+  fonttitle=\bfseries, title={Grammar Lens}, #1
 }
 
 \titleformat{\chapter}[display]

--- a/code/learning/human-languages/urdu/curriculum.json
+++ b/code/learning/human-languages/urdu/curriculum.json
@@ -39,10 +39,21 @@
       "id": "UR-PATH-004",
       "spine_node": "SPINE-EXCHANGE-NAMES",
       "lessons": [
-        "UR-C02-mera-naam"
+        "UR-C02-mera-naam",
+        "UR-C03-aap-tum-tu",
+        "UR-C03-kya",
+        "UR-C03-aap-ka-naam-kya-hai",
+        "UR-C03-khushi-hui",
+        "UR-C03-practice"
       ],
       "before": [],
-      "inline": [],
+      "inline": [
+        "UR-EXT-002-REGISTER",
+        "UR-EXT-003-SCRIPT",
+        "UR-EXT-004-GRAMMAR",
+        "UR-EXT-005-CULTURE",
+        "UR-EXT-006-CONSOLIDATION"
+      ],
       "after": []
     }
   ],
@@ -83,15 +94,11 @@
         "UR-PATH-004"
       ],
       "omits": [
-        "QUESTION-WHAT",
         "PRONOUN-I",
         "PRONOUN-ME",
-        "PRONOUN-YOU",
         "PRONOUN-MY",
         "WORD-NAME",
-        "WORD-IS",
-        "INTRO-WHATS-YOUR-NAME",
-        "INTRO-NICE-TO-MEET-YOU"
+        "WORD-IS"
       ],
       "relocates": {}
     },
@@ -173,6 +180,72 @@
       "prerequisites": [],
       "lessons": [
         "UR-C01-salam"
+      ]
+    },
+    {
+      "id": "UR-EXT-002-REGISTER",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "register",
+      "canDo": "I can choose āp for a respectful first meeting and distinguish it from tum and tū.",
+      "prerequisites": [
+        "UR-EXT-001-INLINE-SCRIPT"
+      ],
+      "lessons": [
+        "UR-C03-aap-tum-tu"
+      ]
+    },
+    {
+      "id": "UR-EXT-003-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can read Urdu kyā and select ye's consonantal value from the learned word.",
+      "prerequisites": [
+        "UR-EXT-001-INLINE-SCRIPT"
+      ],
+      "lessons": [
+        "UR-C03-kya"
+      ]
+    },
+    {
+      "id": "UR-EXT-004-GRAMMAR",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "grammar",
+      "canDo": "I can keep hai final and use the fixed āp kā nām frame to ask a name respectfully.",
+      "prerequisites": [
+        "UR-EXT-002-REGISTER",
+        "UR-EXT-003-SCRIPT"
+      ],
+      "lessons": [
+        "UR-C03-aap-ka-naam-kya-hai"
+      ]
+    },
+    {
+      "id": "UR-EXT-005-CULTURE",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "culture-pragmatics",
+      "canDo": "I can close a first introduction with the conventional respectful pleased-to-meet-you response.",
+      "prerequisites": [
+        "UR-EXT-004-GRAMMAR"
+      ],
+      "lessons": [
+        "UR-C03-khushi-hui"
+      ]
+    },
+    {
+      "id": "UR-EXT-006-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "consolidation",
+      "canDo": "I can complete a respectful Urdu name exchange using only independently learned lines.",
+      "prerequisites": [
+        "UR-EXT-005-CULTURE"
+      ],
+      "lessons": [
+        "UR-C03-practice"
       ]
     }
   ]

--- a/code/learning/human-languages/urdu/lessons/UR-C02-mera-naam.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C02-mera-naam.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: UR-C02-mera-naam
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 50
 chapter: 2
 type: phrase
 headword: میرا نام ... ہے
@@ -10,13 +13,32 @@ prerequisites: [UR-C01-nahin]
 sounds: [rtl, long-vowels, hai-diphthong]
 roots: [indo-aryan-main, indo-european-name]
 etymology_hook: Mera and hai expose Urdu's Indo-Aryan grammar, while nām belongs to the ancient Indo-European name family.
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: []
+introduces:
+  knowledge: [UR-LEX-MERA-NAAM-HAI, UR-SCRIPT-MERA-NAAM-HAI, UR-GRAMMAR-COPULA-FINAL]
+practises:
+  knowledge: [UR-LEX-MERA-NAAM-HAI, UR-SCRIPT-MERA-NAAM-HAI, UR-GRAMMAR-COPULA-FINAL]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: contemporary-standard-urdu
 reviews_of: []
 ---
 
 # میرا نام ... ہے — my name is ...
 
-## Four slots
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+[PAUSE 2s] Greet once, then answer yes and no. The next line gives you one
+reliable Urdu sentence for your own name.
+
+## The exchange
+<!-- hl-knowledge: introduces=[UR-LEX-MERA-NAAM-HAI, UR-SCRIPT-MERA-NAAM-HAI]; assesses=[] -->
 
 Read the line right to left, but keep its spoken order:
 
@@ -27,21 +49,28 @@ Read the line right to left, but keep its spoken order:
 - your name goes in the open slot
 - **ہے** *hai* = is
 
-Urdu puts **hai** at the end. That is the only sentence-pattern fact to learn
-now: **my + name + NAME + is**.
-
 The word **nām** is an old Indo-Aryan relative of Sanskrit *nāman* and distant
 English *name*. **merā** and **hai** show Urdu's inherited grammatical core,
 shared closely with Hindi even though the two languages use different scripts.
 
-## Say your name
+## Grammar Lens: the verb waits
+<!-- hl-knowledge: introduces=[UR-GRAMMAR-COPULA-FINAL]; assesses=[] -->
+
+Urdu puts **hai** at the end. That is the only sentence-pattern fact to learn
+now: **my + name + NAME + is**. Keep this one frame; broader word-order and
+agreement rules can wait.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-MERA-NAAM-HAI, UR-SCRIPT-MERA-NAAM-HAI, UR-GRAMMAR-COPULA-FINAL] -->
 
 > **میرا نام سارا ہے۔** — *merā nām Sārā hai.* — My name is Sara.
 
 Replace **Sārā** with your own name. Do not add agreement rules yet; this exact
 frame is enough for the introduction.
 
-## Quick recall
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-MERA-NAAM-HAI, UR-SCRIPT-MERA-NAAM-HAI, UR-GRAMMAR-COPULA-FINAL] -->
+<!-- hl-activity: {"id":"UR-C02-mera-naam-sara","kind":"text","assesses":["UR-LEX-MERA-NAAM-HAI"],"prompt":"Type the Urdu sentence 'My name is Sara.'","answer":"میرا نام سارا ہے","accepted":["mera naam Sara hai","merā nām Sārā hai"],"feedback":{"correct":"Right: میرا نام سارا ہے keeps ہے at the end.","incorrect":"Use میرا نام سارا ہے — merā nām Sārā hai."},"response_seconds":10} -->
 
 Where does “is” go in this Urdu sentence? At the end. Say the four slots, then
 say the full sentence with your name.

--- a/code/learning/human-languages/urdu/lessons/UR-C03-aap-ka-naam-kya-hai.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C03-aap-ka-naam-kya-hai.md
@@ -1,0 +1,72 @@
+---
+schema_version: 2
+id: UR-C03-aap-ka-naam-kya-hai
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 80
+chapter: 3
+type: phrase
+headword: آپ کا نام کیا ہے؟
+romanization: āp kā nām kyā hai?
+gloss: What is your name? (respectful)
+concept_tag: INTRO-WHATS-YOUR-NAME
+prerequisites: [UR-C03-kya]
+sounds: [rtl, long-vowels, hai-diphthong, urdu-question-mark]
+roots: [sanskrit-kim, indo-european-name]
+etymology_hook: The question keeps Urdu's inherited verb-last order and reuses the ancient nām-name and kyā-what families inside one respectful frame.
+duration:
+  max_seconds: 230
+requires:
+  knowledge: [UR-LEX-MERA-NAAM-HAI, UR-GRAMMAR-COPULA-FINAL, UR-LEX-AAP-TUM-TU, UR-PRAGMATICS-YOU-REGISTER, UR-LEX-KYA]
+introduces:
+  knowledge: [UR-LEX-NAME-QUESTION, UR-GRAMMAR-AAP-KA, UR-SCRIPT-URDU-QUESTION-MARK]
+practises:
+  knowledge: [UR-LEX-MERA-NAAM-HAI, UR-GRAMMAR-COPULA-FINAL, UR-LEX-AAP-TUM-TU, UR-PRAGMATICS-YOU-REGISTER, UR-LEX-KYA, UR-LEX-NAME-QUESTION, UR-GRAMMAR-AAP-KA, UR-SCRIPT-URDU-QUESTION-MARK]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: respectful
+variety: contemporary-standard-urdu
+reviews_of: [UR-C03-kya, UR-C03-aap-tum-tu, UR-C02-mera-naam]
+---
+
+# آپ کا نام کیا ہے؟ — ask a name respectfully
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-MERA-NAAM-HAI, UR-GRAMMAR-COPULA-FINAL, UR-LEX-AAP-TUM-TU, UR-PRAGMATICS-YOU-REGISTER, UR-LEX-KYA] -->
+
+[PAUSE 2s] Recall **āp** “you,” **kyā** “what,” and the answer **merā nām ...
+hai**. The question reuses all three.
+
+## The exchange
+<!-- hl-knowledge: introduces=[UR-LEX-NAME-QUESTION, UR-GRAMMAR-AAP-KA]; assesses=[] -->
+
+> **آپ کا نام کیا ہے؟** — *āp kā nām kyā hai?* — **What is your name?**
+
+Build it in spoken order:
+
+> you + **kā** + name + what + is?
+
+**Āp kā** means “your” in this frame. The possessive form agrees with the thing
+owned: **nām** is masculine singular, so use **kā**. Keep that one pairing; the
+full *kā/kī/ke* system can wait. As in your answer, **hai** stays at the end.
+
+## Script: the question mark
+<!-- hl-knowledge: introduces=[UR-SCRIPT-URDU-QUESTION-MARK]; assesses=[] -->
+
+Urdu ends the question with **؟**, curved for a right-to-left line. Begin at
+**آپ** on the right and reach the punctuation at the far left.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-NAME-QUESTION, UR-GRAMMAR-AAP-KA, UR-SCRIPT-URDU-QUESTION-MARK] -->
+
+- [YOU SAY: **āp kā nām kyā hai?**]
+- [YOU SAY: ask, then answer — **merā nām ... hai**]
+- [YOU POINT: to **؟** at the end]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-NAME-QUESTION, UR-GRAMMAR-AAP-KA, UR-SCRIPT-URDU-QUESTION-MARK] -->
+<!-- hl-activity: {"id":"UR-C03-aap-ka-naam-kya-hai-question","kind":"text","assesses":["UR-LEX-NAME-QUESTION"],"prompt":"Type the respectful Urdu question 'What is your name?'","answer":"آپ کا نام کیا ہے؟","accepted":["آپ کا نام کیا ہے","aap ka naam kya hai","āp kā nām kyā hai"],"feedback":{"correct":"Right: آپ کا نام کیا ہے؟ keeps respectful آپ and final ہے.","incorrect":"Use آپ کا نام کیا ہے؟ — āp kā nām kyā hai?"},"response_seconds":10} -->
+
+Ask once without romanization. Where does **hai** remain? (At the end.)
+
+Source: [*Basic Urdu*: Greetings and Introductions](https://openbooks.lib.msu.edu/urdu/chapter/2-2/).

--- a/code/learning/human-languages/urdu/lessons/UR-C03-aap-tum-tu.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C03-aap-tum-tu.md
@@ -1,0 +1,81 @@
+---
+schema_version: 2
+id: UR-C03-aap-tum-tu
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 60
+chapter: 3
+type: word
+headword: آپ / تم / تو
+romanization: āp / tum / tū
+gloss: you — respectful / familiar / intimate
+concept_tag: PRONOUN-YOU
+prerequisites: [UR-C02-mera-naam]
+sounds: [rtl, alif-madd, short-vowels-unwritten, long-u]
+roots: [indo-aryan-aap, sanskrit-tvam]
+etymology_hook: Tum and tū continue the ancient tvam-tu familiar-you family behind English thou; āp grew from a self-word into respectful address.
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [UR-LEX-MERA-NAAM-HAI]
+introduces:
+  knowledge: [UR-LEX-AAP-TUM-TU, UR-SCRIPT-AAP-TUM-TU, UR-PRAGMATICS-YOU-REGISTER, UR-ETYMON-TUM-THOU]
+practises:
+  knowledge: [UR-LEX-MERA-NAAM-HAI, UR-LEX-AAP-TUM-TU, UR-SCRIPT-AAP-TUM-TU, UR-PRAGMATICS-YOU-REGISTER, UR-ETYMON-TUM-THOU]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: formal-familiar-intimate-contrast
+variety: contemporary-standard-urdu
+reviews_of: [UR-C02-mera-naam]
+---
+
+# آپ / تم / تو — three relationships inside “you”
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-MERA-NAAM-HAI] -->
+
+[PAUSE 2s] Say **merā nām ... hai** with your own name. To ask the other
+person's name, begin with the respectful form.
+
+## You'll want to know first — three forms
+<!-- hl-knowledge: introduces=[UR-LEX-AAP-TUM-TU, UR-SCRIPT-AAP-TUM-TU]; assesses=[] -->
+
+| Urdu | read | use |
+|---|---|---|
+| **آپ** | *āp* | respectful: a new adult, elder, or anyone you wish to honor |
+| **تم** | *tum* | familiar: friends and peers |
+| **تو** | *tū* | intimate, or downward; unsafe as a beginner default |
+
+**آپ** begins with **آ**, an alif carrying the long *ā* mark, then **پ** *p*.
+**تم** and **تو** share **ت** *t*. In **تو**, **و** carries long *ū*.
+
+## Grammar Lens: choose the relationship first
+<!-- hl-knowledge: introduces=[UR-PRAGMATICS-YOU-REGISTER]; assesses=[] -->
+
+English flattened these choices into one *you*. Urdu keeps three. Use **āp** in
+a first meeting. Move to **tum** when the relationship supports familiarity.
+Save **tū** for relationships where you already know it is welcome; used badly,
+it can sound belittling.
+
+## The word, taken apart
+<!-- hl-knowledge: introduces=[UR-ETYMON-TUM-THOU]; assesses=[] -->
+
+**Tum/tū** belong to the old Indo-European familiar-“you” family: Sanskrit
+*tvam*, English **thou**, and Latin *tū* are relatives. **Āp** followed another
+route: a word connected with “self/oneself” became honorific address.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-AAP-TUM-TU, UR-SCRIPT-AAP-TUM-TU, UR-PRAGMATICS-YOU-REGISTER, UR-ETYMON-TUM-THOU] -->
+
+- [YOU SAY: a new adult — **āp**]
+- [YOU SAY: a friend — **tum**]
+- [YOU SAY: the old family — **tum, tvam, thou**]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-AAP-TUM-TU, UR-SCRIPT-AAP-TUM-TU, UR-PRAGMATICS-YOU-REGISTER, UR-ETYMON-TUM-THOU] -->
+<!-- hl-activity: {"id":"UR-C03-aap-tum-tu-first-meeting","kind":"text","assesses":["UR-PRAGMATICS-YOU-REGISTER"],"prompt":"Type the Urdu 'you' safest in a first meeting.","answer":"آپ","accepted":["aap","āp"],"feedback":{"correct":"Right: آپ āp is the respectful first-meeting choice.","incorrect":"Use آپ āp with an unfamiliar adult or anyone you wish to address respectfully."},"response_seconds":8} -->
+
+Which form is safest when unsure? (**Āp**.) Which familiar forms share history
+with English *thou*? (**Tum/tū**.)
+
+Source: [*Basic Urdu*: Cultural Notes](https://openbooks.lib.msu.edu/urdu/chapter/2-8/).

--- a/code/learning/human-languages/urdu/lessons/UR-C03-khushi-hui.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C03-khushi-hui.md
@@ -1,0 +1,79 @@
+---
+schema_version: 2
+id: UR-C03-khushi-hui
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 90
+chapter: 3
+type: phrase
+headword: آپ سے مل کر خوشی ہوئی
+romanization: āp se mil kar khushī huī
+gloss: pleased to meet you
+concept_tag: INTRO-NICE-TO-MEET-YOU
+prerequisites: [UR-C03-aap-ka-naam-kya-hai]
+sounds: [rtl, kh, sh, long-i]
+roots: [persian-khosh, indo-aryan-mil, indo-aryan-ho]
+etymology_hook: Urdu pairs Persian khush happiness vocabulary with inherited Indo-Aryan mil meet and huī happened, making its layered history audible in one welcome.
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [UR-LEX-NAME-QUESTION, UR-LEX-MERA-NAAM-HAI, UR-LEX-AAP-TUM-TU]
+introduces:
+  knowledge: [UR-LEX-NICE-TO-MEET, UR-CHUNK-AAP-SE-MIL-KAR, UR-ETYMON-KHUSH-PERSIAN]
+practises:
+  knowledge: [UR-LEX-NAME-QUESTION, UR-LEX-MERA-NAAM-HAI, UR-LEX-AAP-TUM-TU, UR-LEX-NICE-TO-MEET, UR-CHUNK-AAP-SE-MIL-KAR, UR-ETYMON-KHUSH-PERSIAN]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: respectful
+variety: contemporary-standard-urdu
+reviews_of: [UR-C03-aap-ka-naam-kya-hai, UR-C02-mera-naam]
+---
+
+# آپ سے مل کر خوشی ہوئی — pleased to meet you
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-NAME-QUESTION, UR-LEX-MERA-NAAM-HAI, UR-LEX-AAP-TUM-TU] -->
+
+[PAUSE 2s] Ask **āp kā nām kyā hai?** and answer **merā nām ... hai**. This
+fixed response now closes the meeting.
+
+## The exchange
+<!-- hl-knowledge: introduces=[UR-LEX-NICE-TO-MEET, UR-CHUNK-AAP-SE-MIL-KAR]; assesses=[] -->
+
+> **آپ سے مل کر خوشی ہوئی۔**  
+> *āp se mil kar khushī huī*  
+> **Pleased to meet you.**
+
+For now, hold three meaning-sized chunks:
+
+- **āp se** — with you
+- **mil kar** — having met
+- **khushī huī** — happiness happened
+
+That yields the memorable literal picture: **“Having met you, happiness
+happened.”** The phrase is one social move; later lessons can generalize *se*,
+*-kar*, and past agreement one at a time.
+
+## The word, taken apart
+<!-- hl-knowledge: introduces=[UR-ETYMON-KHUSH-PERSIAN]; assesses=[] -->
+
+**Khushī** “happiness” comes from Persian **khosh/khush** “pleasant, happy.”
+**Mil** “meet” and **huī** “happened” belong to Urdu's inherited Indo-Aryan
+grammar. The sentence therefore joins Urdu's two major historical layers
+without becoming any less ordinary Urdu.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-NICE-TO-MEET, UR-CHUNK-AAP-SE-MIL-KAR, UR-ETYMON-KHUSH-PERSIAN] -->
+
+- [YOU SAY: **āp se | mil kar | khushī huī** in three beats]
+- [YOU SAY: the literal picture — “having met you, happiness happened”]
+- [YOU SAY: which word came through Persian — **khushī**]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-NICE-TO-MEET, UR-CHUNK-AAP-SE-MIL-KAR, UR-ETYMON-KHUSH-PERSIAN] -->
+<!-- hl-activity: {"id":"UR-C03-khushi-hui-close","kind":"text","assesses":["UR-LEX-NICE-TO-MEET"],"prompt":"Type the Urdu response 'Pleased to meet you.'","answer":"آپ سے مل کر خوشی ہوئی","accepted":["aap se mil kar khushi hui","āp se mil kar khushī huī"],"feedback":{"correct":"Right: آپ سے مل کر خوشی ہوئی closes the introduction warmly.","incorrect":"Use آپ سے مل کر خوشی ہوئی — āp se mil kar khushī huī."},"response_seconds":12} -->
+
+Say the response once as a whole. Which chunk means “happiness happened”?
+(**Khushī huī**.)
+
+Source: [*Basic Urdu*: Greetings and Introductions](https://openbooks.lib.msu.edu/urdu/chapter/2-2/).

--- a/code/learning/human-languages/urdu/lessons/UR-C03-kya.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C03-kya.md
@@ -1,0 +1,70 @@
+---
+schema_version: 2
+id: UR-C03-kya
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 70
+chapter: 3
+type: word
+headword: کیا
+romanization: kyā
+gloss: what
+concept_tag: QUESTION-WHAT
+prerequisites: [UR-C03-aap-tum-tu]
+sounds: [rtl, consonantal-ye, long-a]
+roots: [sanskrit-kim, pie-question-kwo]
+etymology_hook: Urdu kyā continues the Indo-Aryan question family from Sanskrit kim and the ancient k-question root related to English wh- words.
+duration:
+  max_seconds: 210
+requires:
+  knowledge: [UR-LEX-AAP-TUM-TU, UR-PRAGMATICS-YOU-REGISTER]
+introduces:
+  knowledge: [UR-LEX-KYA, UR-SCRIPT-KYA, UR-ETYMON-KYA-QUESTION-FAMILY]
+practises:
+  knowledge: [UR-LEX-AAP-TUM-TU, UR-PRAGMATICS-YOU-REGISTER, UR-LEX-KYA, UR-SCRIPT-KYA, UR-ETYMON-KYA-QUESTION-FAMILY]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: contemporary-standard-urdu
+reviews_of: [UR-C03-aap-tum-tu, UR-C02-mera-naam]
+---
+
+# کیا — what
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-AAP-TUM-TU, UR-PRAGMATICS-YOU-REGISTER] -->
+
+[PAUSE 2s] Which “you” opens a respectful first meeting? (**آپ**, *āp*.) Now
+add the question word.
+
+## You'll want to know first — کیا
+<!-- hl-knowledge: introduces=[UR-LEX-KYA, UR-SCRIPT-KYA]; assesses=[] -->
+
+> **کیا** — *kyā* — **what**
+
+Read right to left: **ک** *k*, **ی** supplying the *y* glide here, then **ا**
+long *ā*. The same **ی** carried long *ī* in **جی** and **نہیں**. Its job
+depends on the word; here the learned shape is *kyā*.
+
+## The word, taken apart
+<!-- hl-knowledge: introduces=[UR-ETYMON-KYA-QUESTION-FAMILY]; assesses=[] -->
+
+Urdu **kyā** and Hindi **kyā** are the same inherited Indo-Aryan word in
+different scripts. Their history reaches Sanskrit *kim* and the old
+Indo-European *k/kw-* question family behind English **wh-** words such as
+*what, who,* and *which*. The bridge helps memory; Urdu **کیا** remains the form
+you must read here.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-KYA, UR-SCRIPT-KYA, UR-ETYMON-KYA-QUESTION-FAMILY] -->
+
+- [YOU SAY: **kyā** — what]
+- [YOU READ: **کیا** as **k + yā**]
+- [YOU SAY: the family — **kyā, what, who, which**]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-KYA, UR-SCRIPT-KYA, UR-ETYMON-KYA-QUESTION-FAMILY] -->
+<!-- hl-activity: {"id":"UR-C03-kya-what","kind":"text","assesses":["UR-LEX-KYA"],"prompt":"Type Urdu for 'what'.","answer":"کیا","accepted":["kya","kyā"],"feedback":{"correct":"Right: کیا is kyā, 'what.'","incorrect":"The Urdu word is کیا — kyā."},"response_seconds":8} -->
+
+Which letter acts as *y* here but as long *ī* in **جی**? (**ی**.) What does
+**کیا** mean? (**What**.)

--- a/code/learning/human-languages/urdu/lessons/UR-C03-practice.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C03-practice.md
@@ -1,0 +1,65 @@
+---
+schema_version: 2
+id: UR-C03-practice
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 100
+chapter: 3
+type: practice-mix
+headword: آپ کا نام کیا ہے؟ — خوشی ہوئی
+romanization: āp kā nām kyā hai? — khushī huī
+gloss: a complete first name exchange
+concept_tag: UR-C03-PRACTICE
+prerequisites: [UR-C03-khushi-hui]
+sounds: [rtl, hai-diphthong, urdu-question-mark]
+roots: []
+etymology_hook: The practice recombines only independently learned Urdu chunks; shared Hindi and Persian history becomes an interleaving bridge after each track is learned.
+duration:
+  max_seconds: 220
+requires:
+  knowledge: [UR-LEX-MERA-NAAM-HAI, UR-GRAMMAR-COPULA-FINAL, UR-LEX-AAP-TUM-TU, UR-PRAGMATICS-YOU-REGISTER, UR-LEX-KYA, UR-LEX-NAME-QUESTION, UR-GRAMMAR-AAP-KA, UR-SCRIPT-URDU-QUESTION-MARK, UR-LEX-NICE-TO-MEET]
+introduces:
+  knowledge: [UR-DIALOGUE-NAME-EXCHANGE]
+practises:
+  knowledge: [UR-LEX-MERA-NAAM-HAI, UR-GRAMMAR-COPULA-FINAL, UR-LEX-AAP-TUM-TU, UR-PRAGMATICS-YOU-REGISTER, UR-LEX-KYA, UR-LEX-NAME-QUESTION, UR-GRAMMAR-AAP-KA, UR-SCRIPT-URDU-QUESTION-MARK, UR-LEX-NICE-TO-MEET, UR-DIALOGUE-NAME-EXCHANGE]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, fluency]
+register: respectful
+variety: contemporary-standard-urdu
+reviews_of: [UR-C03-aap-tum-tu, UR-C03-kya, UR-C03-aap-ka-naam-kya-hai, UR-C03-khushi-hui, UR-C02-mera-naam]
+---
+
+# Practice — a complete Urdu name exchange
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-MERA-NAAM-HAI, UR-LEX-AAP-TUM-TU, UR-PRAGMATICS-YOU-REGISTER, UR-LEX-KYA, UR-LEX-NAME-QUESTION, UR-LEX-NICE-TO-MEET] -->
+
+[PAUSE 2s] Recall the four moves without adding anything: greet, ask, answer,
+acknowledge.
+
+## The exchange
+<!-- hl-knowledge: introduces=[UR-DIALOGUE-NAME-EXCHANGE]; assesses=[] -->
+
+> A: **سلام!** — *Salām!*  
+> B: **سلام!** — *Salām!*  
+> A: **آپ کا نام کیا ہے؟** — *Āp kā nām kyā hai?*  
+> B: **میرا نام سارا ہے۔** — *Merā nām Sārā hai.*  
+> A: **آپ سے مل کر خوشی ہوئی۔** — *Āp se mil kar khushī huī.*  
+> B: **شکریہ۔** — *Shukriyā.*
+
+Every line is already known. **Āp** keeps the meeting respectful; **hai** stays
+at the end of both name sentences; **؟** ends the question at the line's left.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-MERA-NAAM-HAI, UR-GRAMMAR-COPULA-FINAL, UR-LEX-AAP-TUM-TU, UR-PRAGMATICS-YOU-REGISTER, UR-LEX-KYA, UR-LEX-NAME-QUESTION, UR-GRAMMAR-AAP-KA, UR-SCRIPT-URDU-QUESTION-MARK, UR-LEX-NICE-TO-MEET, UR-DIALOGUE-NAME-EXCHANGE] -->
+
+- [YOU SAY: both voices, using your own name]
+- [YOU SAY: the exchange again without romanization]
+- [YOU SAY: only the three name moves — question, answer, response]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-MERA-NAAM-HAI, UR-GRAMMAR-COPULA-FINAL, UR-LEX-AAP-TUM-TU, UR-PRAGMATICS-YOU-REGISTER, UR-LEX-KYA, UR-LEX-NAME-QUESTION, UR-GRAMMAR-AAP-KA, UR-SCRIPT-URDU-QUESTION-MARK, UR-LEX-NICE-TO-MEET, UR-DIALOGUE-NAME-EXCHANGE] -->
+<!-- hl-activity: {"id":"UR-C03-practice-next-line","kind":"text","assesses":["UR-DIALOGUE-NAME-EXCHANGE"],"prompt":"After someone asks آپ کا نام کیا ہے؟, type the Urdu answer using Sara.","answer":"میرا نام سارا ہے","accepted":["mera naam Sara hai","merā nām Sārā hai"],"feedback":{"correct":"Right: answer with میرا نام سارا ہے.","incorrect":"The answer is میرا نام سارا ہے — merā nām Sārā hai."},"response_seconds":10} -->
+
+Run the meeting once from **salām** to **shukriyā**. If a line stalls, review
+only that micro-lesson.

--- a/code/learning/human-languages/urdu/roadmap.md
+++ b/code/learning/human-languages/urdu/roadmap.md
@@ -18,12 +18,14 @@ Persian-Arabic vocabulary with inherited Indo-Aryan **nahī̃**.
 extension is the final copula **hai**. The phrase is learned as one reliable
 frame before possessive agreement or broader copula tables are introduced.
 
-## Chapter 3 — Ask and answer names *(planned)*
+## Chapter 3 — Ask and answer names *(authored)*
 
-- **آپ کا نام کیا ہے؟** *āp kā nām kyā hai?* — What is your name?
-- respectful **آپ** *āp* before familiar pronouns;
-- question intonation and the Urdu question mark;
-- focused retrieval before the expressions enter mixed Urdu/Hindi practice.
+**آپ / تم / تو** *āp / tum / tū* → **کیا** *kyā* → **آپ کا نام کیا ہے؟**
+*āp kā nām kyā hai?* → **آپ سے مل کر خوشی ہوئی** *āp se mil kar khushī huī*
+→ one cumulative exchange. The schema-v2 chain adds register, the consonantal
+job of **ی**, fixed **āp kā nām**, the Urdu question mark, and a gently chunked
+meeting response. Every objective retrieval happens in Urdu script before the
+lesson can enter mixed Urdu/Hindi or Urdu/Persian review.
 
 ## Chapter 4 — People and simple identity *(planned)*
 

--- a/code/learning/human-languages/urdu/session-map.md
+++ b/code/learning/human-languages/urdu/session-map.md
@@ -24,26 +24,42 @@ short vowels, respectful affirmation with nasalization, its negative contrast,
 then one fixed sentence with the copula at the end. The final practice asks for
 nothing outside that chain.
 
+## Chapter 3 — Ask and answer names
+
+Chapter 3 fills the next five sessions without changing the starter prefix.
+Each row still points to one independently resumable lesson.
+
+| Session | New lesson | Reviews due | Cumulative practice |
+|---|---|---|---|
+| **S6** | [`UR-C03-aap-tum-tu`](./lessons/UR-C03-aap-tum-tu.md): **آپ / تم / تو** | *jī hā̃* *(N+3)*; *merā nām ... hai* *(N+1)* | choose the safe relationship level |
+| **S7** | [`UR-C03-kya`](./lessons/UR-C03-kya.md): **کیا** *kyā* | *nahī̃* *(N+3)*; the three “you” forms *(N+1)* | read *k + yā* and answer “what” |
+| **S8** | [`UR-C03-aap-ka-naam-kya-hai`](./lessons/UR-C03-aap-ka-naam-kya-hai.md): **آپ کا نام کیا ہے؟** | *salām* *(N+7)*; *merā nām ... hai* *(N+3)*; *kyā* *(N+1)* | ask, then answer with your name |
+| **S9** | [`UR-C03-khushi-hui`](./lessons/UR-C03-khushi-hui.md): **آپ سے مل کر خوشی ہوئی** | *shukriyā* *(N+7)*; the three “you” forms *(N+3)*; the name question *(N+1)* | close the introduction warmly |
+| **S10** | [`UR-C03-practice`](./lessons/UR-C03-practice.md): full exchange | *jī hā̃* *(N+7)*; *kyā* *(N+3)*; the meeting response *(N+1)* | run both voices using only known lines |
+
 ## Carry-forward review ledger
 
 Future chapters may supply the new lesson in these sessions. Until then, use
-the due item as a short retrieval session and fill an optional bonus queue only
+the due item as a short retrieval session and fill the optional bonus queue only
 with already learned material.
 
 | Session | Fixed review due |
 |---|---|
-| **S6** | *jī hā̃* *(N+3)*; *merā nām ... hai* *(N+1)* |
-| **S7** | *nahī̃* *(N+3)* |
-| **S8** | *salām* *(N+7)*; *merā nām ... hai* *(N+3)* |
-| **S9** | *shukriyā* *(N+7)* |
-| **S10** | *jī hā̃* *(N+7)* |
-| **S11** | *nahī̃* *(N+7)* |
-| **S12** | *merā nām ... hai* *(N+7)* |
-| **S16** | *salām* *(N+15)* |
-| **S17** | *shukriyā* *(N+15)* |
+| **S11** | *nahī̃* *(N+7)*; the name question *(N+3)*; Chapter 3 practice *(N+1)* |
+| **S12** | *merā nām ... hai* *(N+7)*; the meeting response *(N+3)* |
+| **S13** | the three “you” forms *(N+7)*; Chapter 3 practice *(N+3)* |
+| **S14** | *kyā* *(N+7)* |
+| **S15** | the name question *(N+7)* |
+| **S16** | *salām* *(N+15)*; the meeting response *(N+7)* |
+| **S17** | *shukriyā* *(N+15)*; Chapter 3 practice *(N+7)* |
 | **S18** | *jī hā̃* *(N+15)* |
 | **S19** | *nahī̃* *(N+15)* |
 | **S20** | *merā nām ... hai* *(N+15)* |
+| **S21** | the three “you” forms *(N+15)* |
+| **S22** | *kyā* *(N+15)* |
+| **S23** | the name question *(N+15)* |
+| **S24** | the meeting response *(N+15)* |
+| **S25** | Chapter 3 practice *(N+15)* |
 
 Sessions not listed in the ledger have no fixed starter item due; use their
 bonus queue for adaptive or cumulative retrieval.
@@ -52,9 +68,9 @@ After the fourth successful resurfacing, an item moves into the long-term mixed
 practice pool. A missed item returns sooner in Language Ladder's adaptive
 review; the fixed ledger remains the book's no-tracking fallback.
 
-## Next authored intake
+## Schedule check
 
-Chapter 3 will add the matched question “What is your name?”, respectful
-**آپ** *āp*, the Urdu question mark, and “pleased to meet you” as separate
-sub-five-minute lessons. They will fill the next open sessions without changing
-the five-lesson prefix or treating Hindi spelling as an Urdu prerequisite.
+Every Chapter 1–3 lesson now has all four fixed resurfacing sessions through
+S25. The app may pull a missed item forward, but it cannot skip the local
+prerequisites. Chapter 4 can begin in S11 while the ledger continues in the
+review portion of each session.

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added — Persian and Urdu shared name exchange
+
+- Extend both RTL tracks through `SPINE-EXCHANGE-NAMES` with five schema-v2
+  Chapter 3 micro-lessons apiece: address/register, question word, complete
+  name question, meeting response, and cumulative practice.
+- Compile one objective practice contract per track, raising coverage to 21 of
+  115 mapped non-lexical lessons across 18 tracks while leaving the 94-item debt
+  unchanged.
+- Generate both Chapter 3 LaTeX files from the same prerequisite-closed lesson
+  AST consumed by Language Ladder and verify their combined source hashes.
+
 ### Added — Russian activity prerequisite closure
 
 - Migrate the six-lesson Russian pronoun and naming chain to schema v2 so its

--- a/code/packages/typescript/human-language-data/tests/integration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/integration.test.ts
@@ -67,12 +67,12 @@ describe("real curriculum", () => {
       books.books
         .find((book) => book.language === "persian")
         ?.chapters.map((chapter) => chapter.chapter),
-    ).toEqual([1, 2]);
+    ).toEqual([1, 2, 3]);
     expect(
       books.books
         .find((book) => book.language === "urdu")
         ?.chapters.map((chapter) => chapter.chapter),
-    ).toEqual([1, 2]);
+    ).toEqual([1, 2, 3]);
     expect(
       books.books
         .find((book) => book.language === "russian")
@@ -101,6 +101,12 @@ describe("real curriculum", () => {
       "ES-C01-genero-gramatical-class-count",
       "ES-C01-practice-buenos-agreement",
       "ES-W03-question-span-roberto-outside",
+      "FA-C02-esm-e-man-sara",
+      "FA-C03-chist-fusion",
+      "FA-C03-esm-e-shoma-chist-question",
+      "FA-C03-khoshvaghtam-close",
+      "FA-C03-practice-next-line",
+      "FA-C03-shoma-to-first-meeting",
       "GE-C17-kopf-haupt-compound-word",
       "GU-C06-number-histories-be-source",
       "HI-W01-shirorekha-na-ma-drawing-order",
@@ -116,6 +122,12 @@ describe("real curriculum", () => {
       "SA-C06-number-cognates-inheritance",
       "TA-W01-curves-va-ka-writing-surface",
       "TE-C31-subha-madhyahnam-register-source-scope",
+      "UR-C02-mera-naam-sara",
+      "UR-C03-aap-ka-naam-kya-hai-question",
+      "UR-C03-aap-tum-tu-first-meeting",
+      "UR-C03-khushi-hui-close",
+      "UR-C03-kya-what",
+      "UR-C03-practice-next-line",
     ]);
     expect(activities.every((activity) => activity.assesses.length > 0)).toBe(true);
     expect(activities.every((activity) => activity.acceptedResponses.length > 0)).toBe(true);
@@ -141,6 +153,28 @@ describe("real curriculum", () => {
         (lesson) => lesson.language === "spanish" && (lesson.chapter ?? 0) <= 3,
       ),
     ).toEqual([]);
+  });
+
+  it("keeps the Persian and Urdu Chapter 3 chains closed, objective, and under five minutes", () => {
+    const report = buildCurriculumGapReport({ registry, lessons, books });
+    for (const language of ["persian", "urdu"]) {
+      const chapter = lessons.filter(
+        (lesson) => lesson.language === language && lesson.realization.chapter === 3,
+      );
+      expect(chapter).toHaveLength(5);
+      expect(chapter.every((lesson) => lesson.frontmatter.schema_version === "2")).toBe(true);
+      expect(chapter.every((lesson) => compileLessonActivities(lesson.blocks).length === 1)).toBe(true);
+      expect(
+        report.duration.violations.filter(
+          (lesson) => lesson.language === language && lesson.chapter === 3,
+        ),
+      ).toEqual([]);
+      expect(
+        report.prerequisites.laterChapterWithoutPrerequisites.filter(
+          (lesson) => lesson.language === language && lesson.chapter === 3,
+        ),
+      ).toEqual([]);
+    }
   });
 
   it("GREETING-HELLO joins every track (the normalization payoff)", () => {

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased — schema-v2 lesson compatibility
 
+### Changed — Persian and Urdu Chapter 3 frontiers
+
+- Load ten new prerequisite-safe name-exchange steps across Persian and Urdu,
+  including each track's inline register, script, grammar, culture, and
+  consolidation extensions.
+- Use the authored cumulative-practice checks for both tracks, raising objective
+  coverage to 21 of 115 mapped non-lexical lessons across 18 tracks while
+  retaining independent focused-before-mixed progression.
+
 ### Changed — objective Russian naming progression
 
 - Replace temporary confirmation on both mapped Russian non-lexical frontiers

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -37,7 +37,7 @@ showing an answer-bearing summary. Other lexical lessons ask for one English
 meaning. A wrong answer leaves the local frontier unchanged; a correct answer
 shows feedback before the learner continues. The first objective non-lexical
 pilots covered Spanish grammatical gender and punctuation spans; the first
-HL-A01 tranches now reach 19 of 113 mapped non-lexical lessons across 16 tracks,
+HL-A01 tranches now reach 21 of 115 mapped non-lexical lessons across 18 tracks,
 including script, grammar, etymology, culture, and cumulative practice. The
 remaining 94 support lessons retain temporary final-recall confirmation while
 HL-A01 fills the measured contract backlog.

--- a/code/programs/typescript/language-ladder/tests/curriculum.test.ts
+++ b/code/programs/typescript/language-ladder/tests/curriculum.test.ts
@@ -49,11 +49,21 @@ describe("per-language shared-spine maps", () => {
       "FA-C01-bale",
       "FA-C01-na",
       "FA-C02-esm-e-man",
+      "FA-C03-shoma-to",
+      "FA-C03-chist",
+      "FA-C03-esm-e-shoma-chist",
+      "FA-C03-khoshvaghtam",
+      "FA-C03-practice",
       "UR-C01-salam",
       "UR-C01-shukriya",
       "UR-C01-ji-han",
       "UR-C01-nahin",
       "UR-C02-mera-naam",
+      "UR-C03-aap-tum-tu",
+      "UR-C03-kya",
+      "UR-C03-aap-ka-naam-kya-hai",
+      "UR-C03-khushi-hui",
+      "UR-C03-practice",
     ]));
   });
 


### PR DESCRIPTION
## Summary

- extend Persian and Urdu through `SPINE-EXCHANGE-NAMES` with five prerequisite-safe, schema-v2 Chapter 3 micro-lessons per track
- migrate the two Chapter 2 name statements to schema v2, add typed local extensions and exact N+1/N+3/N+7/N+15 session reviews, and expose all ten new frontiers in Language Ladder
- add one objective cumulative-practice activity per track, moving measured coverage to 21 of 115 mapped non-lexical lessons across 18 tracks
- generate both Chapter 3 LaTeX files from the canonical lesson AST, update source hashes, and make the RTL starter preambles compatible with generated tables/callouts and truly blank versos
- reprioritize the repository backlog: HL-E02 is the next shared-spine corpus slice; HL-G05 records preservation of Markdown link targets in generated PDFs

## Validation

- `@coding-adventures/human-language-data`: 101 tests passed
- generated-book drift check passed
- corpus report: 20 tracks, 1,076 lessons, 20 books; zero duration, unknown-prerequisite, missing-book, or lesson/book-chapter gaps
- Language Ladder: 481 tests passed
- Persian and Urdu XeLaTeX builds: 19 pages each; zero missing glyph, overfull/underfull box, font, Hyperref, or LaTeX warnings
- rendered Chapter 3 openers, middle pages, practice endings, and blank versos inspected
- changed JSON parsed, changed Markdown local links resolved, and `git diff --check` passed

## Editorial sources

- [Persian Online: introducing yourself](https://sites.la.utexas.edu/persian_online_resources/vocabulary-lists/people-places-and-things/)
- [Persian Online: pronouns](https://sites.la.utexas.edu/persian_online_resources/pronouns/)
- [Persian Online: ezafe](https://sites.la.utexas.edu/persian_online_resources/language-specific-grammar/ezfe/)
- [Basic Urdu: greetings and introductions](https://openbooks.lib.msu.edu/urdu/chapter/2-2/)
- [Basic Urdu: cultural context and register](https://openbooks.lib.msu.edu/urdu/chapter/2-8/)