### PR TITLE
feat(human-languages): add Persian and Urdu wellbeing chapters

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -94,7 +94,7 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-I02 | Queued | Update the human-language data package beyond the vulnerable PostCSS 8.5.19 transitive development dependency. | A clean install reports GHSA-fxqj-rqcc-2cmp through Vitest/Vite; PostCSS 8.5.25 is available, but this development-only moderate finding remains behind reader-facing book and app gaps. |
 | HL-I03 | Queued | Derive the top-level track progress table from canonical curriculum and book-generation data. | The hand-maintained table can lag shipped chapters after a generated-book migration; a checked or generated summary should keep every prior language visible without repeating stale progress claims. |
 | HL-I04 | Complete (#9908) | Restore exact-main full CI after `perl/wasm-module-encoder` exposed undeclared local test dependencies. | Its `cpanfile` and `Makefile.PL` declare every local package injected by `BUILD`; clean full-build metadata validation and focused Perl tests pass. |
-| HL-I05 | Complete in this PR | Make the repository's Lua bootstrap resilient to a temporary lua.org connection outage. | All CI platforms install pinned Lua 5.4.7 through an OS-specific cache or checksum-verified byte-identical Debian/Ubuntu source fallback without weakening the Windows MSVC ordering or silently skipping Lua tests. |
+| HL-I05 | Complete (#9910) | Make the repository's Lua bootstrap resilient to a temporary lua.org connection outage. | All CI platforms install pinned Lua 5.4.7 through an OS-specific cache or checksum-verified byte-identical Debian/Ubuntu source fallback without weakening the Windows MSVC ordering or silently skipping Lua tests. |
 | HL-B14 | Complete (#9728) | Publish Italian Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Forty-nine schema-v2 lessons now generate sixteen chapters whose source hashes are independently verified against the Language Ladder corpus. |
 | HL-B15 | Complete (#9735) | Remove Italian's LaTeX layout and Unicode bookmark warnings. | The forced 104-page build now has zero missing glyphs, overfull or underfull boxes, duplicate destinations, Hyperref warnings, or LaTeX warnings. |
 | HL-B16 | Complete (#9744) | Publish Portuguese Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Fifty schema-v2 lessons now generate sixteen chapters whose source hashes are independently verified against the Language Ladder corpus. |
@@ -137,8 +137,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 
 | ID | Status | Work item | Completion signal |
 |---|---|---|---|
-| HL-E01 | Complete in this PR | Author Persian and Urdu Chapter 3 through the rest of `SPINE-EXCHANGE-NAMES`. | Each track gains prerequisite-safe, schema-v2 micro-lessons for the name question, its formality distinction, and a meeting response; realization maps, objective activities, generated book chapters, and Language Ladder consume the same AST. |
-| HL-E02 | Next | Author Persian and Urdu Chapter 4 through `SPINE-CHECK-WELLBEING` and reconcile the older identity-first roadmap. | Both tracks gain a gentle wellbeing exchange before identity grammar, with language-specific register/script extensions, exact review ledgers, objective practice, and generated book chapters from the canonical AST. |
+| HL-E01 | Complete (#9906) | Author Persian and Urdu Chapter 3 through the rest of `SPINE-EXCHANGE-NAMES`. | Each track gains prerequisite-safe, schema-v2 micro-lessons for the name question, its formality distinction, and a meeting response; realization maps, objective activities, generated book chapters, and Language Ladder consume the same AST. |
+| HL-E02 | Complete in this PR | Author Persian and Urdu Chapter 4 through `SPINE-CHECK-WELLBEING` and reconcile the older identity-first roadmap. | Both tracks gain a gentle wellbeing exchange before identity grammar, with language-specific register/script extensions, exact review ledgers, objective practice, and generated book chapters from the canonical AST. |
 
 - Expand every track toward B1 using the gap report to choose the next missing
   can-do, skill, mode, register, or realization.
@@ -1714,6 +1714,28 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   roadmaps currently plan identity grammar for Chapter 4. HL-E02 therefore
   reconciles that order explicitly rather than silently letting the two tracks
   drift from the shared spine.
+
+## Findings from HL-E02
+
+- Persian and Urdu each add six prerequisite-safe Chapter 4 micro-lessons and
+  now reach the same shared wellbeing can-do through sixteen canonical lessons.
+  The spine stays shared while the local teaching order differs where grammar
+  requires it.
+- Persian reuses ezafe in **hâl-e shomâ**, teaches one reliable careful question,
+  and introduces only attached first-person **-am** in **khubam**. Colloquial
+  contraction is visible for recognition but remains outside assessed production.
+- Urdu gives **kaise/kaisī** agreement its own step before honorific
+  **āp ... haiṅ**, then separates **maiṅ ... hūṅ** from **ṭhīk**. The Hindi
+  bridge appears only after the Urdu form is independently readable and
+  retrievable.
+- Every new lesson carries an objective activity, a declared sub-five-minute
+  budget, and closed knowledge prerequisites. Exact review ledgers extend from
+  S25 through S31 at N+1, N+3, N+7, and N+15.
+- The exact-main verification after HL-I04 found a repeated external Lua setup
+  outage: every matrix shard received `ECONNREFUSED` from the Lua download host
+  on both the initial attempt and the failed-job rerun. HL-I05 records a
+  cache/fallback hardening item; the consolidated 20-book workflow itself was
+  green at the same revision.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -87,8 +87,8 @@ edition is authored.
 | [Latin](./latin/README.md) | Italic / Latin (**taproot**) | Chapters 1–36 authored; Chapters 2–36 canonical/generated for app + book |
 | [Sanskrit](./sanskrit/README.md) | Indo-Aryan / Devanagari (**taproot**) | Chapters 1–6 authored (lessons + book; Chapter 6 canonical/generated) |
 | [Russian](./russian/README.md) | Slavic / Cyrillic | Chapters 1-2 authored (lessons + book) |
-| [Persian](./persian/README.md) | Iranian / Perso-Arabic | Shared-spine pilot plus a two-chapter starter book |
-| [Urdu](./urdu/README.md) | Indo-Aryan / Urdu Nastaliq | Shared-spine pilot plus a two-chapter starter book |
+| [Persian](./persian/README.md) | Iranian / Perso-Arabic | Four authored shared-spine chapters; 16 canonical lessons |
+| [Urdu](./urdu/README.md) | Indo-Aryan / Urdu Nastaliq | Four authored shared-spine chapters; 16 canonical lessons |
 
 Spanish is the pilot that proved the format; every other track replicates it,
 grounding each word against English plus whatever languages the learner already

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -2073,11 +2073,29 @@
       "scriptCommand": "fa"
     },
     {
+      "language": "persian",
+      "chapter": 4,
+      "title": "How Are You?",
+      "label": "ch:fa-how-are-you",
+      "output": "persian/book/chapters/ch04-how-are-you.tex",
+      "unicodeScript": "Arabic",
+      "scriptCommand": "fa"
+    },
+    {
       "language": "urdu",
       "chapter": 3,
       "title": "Ask and Answer Names",
       "label": "ch:ur-ask-and-answer-names",
       "output": "urdu/book/chapters/ch03-ask-and-answer-names.tex",
+      "unicodeScript": "Arabic",
+      "scriptCommand": "ur"
+    },
+    {
+      "language": "urdu",
+      "chapter": 4,
+      "title": "How Are You?",
+      "label": "ch:ur-how-are-you",
+      "output": "urdu/book/chapters/ch04-how-are-you.tex",
       "unicodeScript": "Arabic",
       "scriptCommand": "ur"
     }

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -1668,6 +1668,20 @@
       "tex": "persian/book/chapters/ch03-ask-and-answer-names.tex"
     },
     {
+      "language": "persian",
+      "chapter": 4,
+      "sourceHash": "fnv1a64:b6a2b7c1f4986bb4",
+      "lessonIds": [
+        "FA-C04-hal",
+        "FA-C04-chetor",
+        "FA-C04-hal-e-shoma-chetor-ast",
+        "FA-C04-khub",
+        "FA-C04-khubam",
+        "FA-C04-practice"
+      ],
+      "tex": "persian/book/chapters/ch04-how-are-you.tex"
+    },
+    {
       "language": "portuguese",
       "chapter": 2,
       "sourceHash": "fnv1a64:b696688c2654a2d3",
@@ -2607,6 +2621,20 @@
         "UR-C03-practice"
       ],
       "tex": "urdu/book/chapters/ch03-ask-and-answer-names.tex"
+    },
+    {
+      "language": "urdu",
+      "chapter": 4,
+      "sourceHash": "fnv1a64:b1d08b5cbfb9ef33",
+      "lessonIds": [
+        "UR-C04-kaise-kaisi",
+        "UR-C04-aap-kaise-hain",
+        "UR-C04-main-hun",
+        "UR-C04-thik",
+        "UR-C04-main-thik-hun",
+        "UR-C04-practice"
+      ],
+      "tex": "urdu/book/chapters/ch04-how-are-you.tex"
     }
   ]
 }

--- a/code/learning/human-languages/persian/CHANGELOG.md
+++ b/code/learning/human-languages/persian/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.5.0 — 2026-08-04
+
+- Added six schema-v2 Chapter 4 micro-lessons for *hâl*, *chetor*, the careful
+  respectful wellbeing question, *khub*, compact *khubam*, and cumulative
+  practice.
+- Reused ezafe before introducing only the first-person **-am** copula needed
+  for the reply; colloquial contraction stays a labelled recognition preview.
+- Extended the sound-id reference and exact N+1/N+3/N+7/N+15 ledger through
+  S31, with objective activities and a generated four-chapter book.
+
 ## 0.4.0 — 2026-08-03
 
 - Added five schema-v2 Chapter 3 micro-lessons for respectful/familiar “you,”

--- a/code/learning/human-languages/persian/README.md
+++ b/code/learning/human-languages/persian/README.md
@@ -4,12 +4,13 @@ This track teaches contemporary Iranian Persian through the shared human-languag
 spine. Every lesson is designed for a fresh learner, takes under five minutes,
 and introduces only the script needed for the expression on the page.
 
-The first ten lessons now establish a complete miniature meeting: greet, answer,
-give your name, ask someone else's name respectfully, and acknowledge the
-introduction. Persian-specific extensions introduce ezafe reuse, **shomâ/to**
-register, Persian **چ**, question punctuation, and the layered
-**khoshvaghtam** compound exactly where the exchange needs them. Later chapters
-will add colloquial verb forms, present and past stems, and more joined shapes.
+The first sixteen lessons now establish a complete miniature meeting: greet,
+answer, exchange names, acknowledge the introduction, ask about wellbeing, and
+reply politely. Persian-specific extensions introduce ezafe reuse, **shomâ/to**
+register, Persian **چ**, question punctuation, the layered **khoshvaghtam**
+compound, and the compact **-am** copula exactly where each exchange needs it.
+Later chapters will add colloquial verb forms, present and past stems, and more
+joined shapes.
 
 The script notes follow the University of Texas Persian Online writing-system
 materials. Romanization is a learning aid, not a substitute for reading Persian.
@@ -17,10 +18,10 @@ materials. Romanization is a learning aid, not a substitute for reading Persian.
 ## Read and practise
 
 - [`roadmap.md`](./roadmap.md) orders the authored and planned chapters toward B1.
-- [`session-map.md`](./session-map.md) composes all ten micro-lessons with an
-  exact session-count review ledger through S25.
+- [`session-map.md`](./session-map.md) composes all sixteen micro-lessons with an
+  exact session-count review ledger through S31.
 - [`pronunciation-reference.md`](./pronunciation-reference.md) collects the
   script and sound facts for lookup; it is never a prerequisite chapter.
-- [`lessons/`](./lessons/) contains the ten canonical short practice lessons.
-- [`book/book.tex`](./book/book.tex) builds the free three-chapter starter edition
+- [`lessons/`](./lessons/) contains the sixteen canonical short practice lessons.
+- [`book/book.tex`](./book/book.tex) builds the free four-chapter starter edition
   with XeLaTeX; merged editions appear in the public human-languages book catalog.

--- a/code/learning/human-languages/persian/book/book.tex
+++ b/code/learning/human-languages/persian/book/book.tex
@@ -18,7 +18,7 @@
   \vspace{1.5cm}
   {\large Adhithya Rajasekaran\par}
   \vfill
-  {\large Starter edition --- ten short lessons in three cumulative chapters.\par}
+  {\large Starter edition --- sixteen short lessons in four cumulative chapters.\par}
   \vspace{1cm}
   {\large Companion practice lessons live alongside this book at\\
   \texttt{code/learning/human-languages/persian/lessons/}\par}
@@ -56,6 +56,7 @@ word easier to remember without replacing its present meaning or use.
 \input{chapters/ch01-greetings-and-responses}
 \input{chapters/ch02-give-your-name}
 \input{chapters/ch03-ask-and-answer-names}
+\input{chapters/ch04-how-are-you}
 
 \backmatter
 
@@ -64,7 +65,8 @@ word easier to remember without replacing its present meaning or use.
 
 Script descriptions follow the University of Texas at Austin
 \href{https://sites.la.utexas.edu/persian_online_resources/the-writing-system/}%
-{Persian Online writing-system materials}. The companion Markdown lessons are
-the canonical short-practice source for this edition.
+{Persian Online writing-system materials}; its open grammar and vocabulary
+resources ground the Chapter 4 wellbeing forms. The companion Markdown lessons
+are the canonical short-practice source for this edition.
 
 \end{document}

--- a/code/learning/human-languages/persian/book/chapters/ch04-how-are-you.tex
+++ b/code/learning/human-languages/persian/book/chapters/ch04-how-are-you.tex
@@ -1,0 +1,218 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:b6a2b7c1f4986bb4
+% canonical-lessons: FA-C04-hal, FA-C04-chetor, FA-C04-hal-e-shoma-chetor-ast, FA-C04-khub, FA-C04-khubam, FA-C04-practice
+
+\chapter{How Are You?}
+\label{ch:fa-how-are-you}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[hâl]{\fa{حال} — the “state” in a wellbeing question}
+
+\label{lesson:FA-C04-hal}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Run only the opening of the meeting you know: \textbf{salâm} and the name question. The next move asks about the other person's present state.
+\end{quote}
+
+\subsection*{You'll want to know first — one useful word}
+\begin{quote}
+\textbf{\fa{حال}} — \emph{hâl} — \textbf{state, condition}
+\end{quote}
+
+Read from right to left: \textbf{\fa{ح}} \emph{h} + \textbf{\fa{ا}} long \emph{â} + \textbf{\fa{ل}} \emph{l}. The first letter is a breathier \emph{h} than English normally uses; a clear ordinary \emph{h} is a safe beginner approximation. Keep the whole written word attached to its meaning.
+
+\begin{cousinweb}
+Persian borrowed \textbf{hâl} from Arabic, then uses it with Persian grammar. You will soon say \textbf{hâl-e shomâ}, literally “the state of you.” That \textbf{-e} is the same spoken ezafe already learned in \textbf{esm-e shomâ}.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: \textbf{hâl} — state or condition{]}
+  \item {[}YOU READ: \textbf{\fa{حال}} from right to left{]}
+  \item {[}YOU CONNECT: an Arabic-rooted noun inside Persian ezafe grammar{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+What does \textbf{hâl} name? (A state or condition.) Which familiar linker will attach an owner to it? (Ezafe \textbf{-e}.)
+
+Source: Persian Online: Greetings List.
+\end{tcolorbox}
+\section[chetor]{\fa{چطور} — “how?” one layer at a time}
+
+\label{lesson:FA-C04-chetor}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Say the Persian noun for a state or condition. (\textbf{Hâl}.) Now ask about the manner of that state with one question word.
+\end{quote}
+
+\subsection*{You'll want to know first — the question word}
+\begin{quote}
+\textbf{\fa{چطور؟}} — \emph{chetor?} — \textbf{how? / in what manner?}
+\end{quote}
+
+You already met \textbf{\fa{چ}} \emph{ch} in \textbf{\fa{چیست}}. Here it is followed by \textbf{\fa{ط}} \emph{t}, \textbf{\fa{و}} \emph{o}, and \textbf{\fa{ر}} \emph{r}. The short \emph{e} is not written. Learn the sound from the whole word: \emph{che-tor}.
+
+\begin{cousinweb}
+Persian Online takes \textbf{\fa{چطور}} apart as Persian \textbf{\fa{چه}} \emph{che}, “what,” plus the Arabic loan \textbf{\fa{طور}} \emph{tor}, “manner.” The literal picture is “in what manner?” That layered history is useful memory, but \textbf{chetor} is one everyday Persian question word now.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: \textbf{chetor?} — how?{]}
+  \item {[}YOU POINT: to familiar \textbf{\fa{چ}} at the right edge{]}
+  \item {[}YOU REBUILD: \textbf{che} “what” + \textbf{tor} “manner”{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Which part means “what”? (\textbf{Che}.) Which borrowed part means “manner”? (\textbf{Tor}.)
+
+Source: Persian Online: Interrogatives.
+\end{tcolorbox}
+\section[hâl-e shomâ chetor ast?]{\fa{حال} \fa{شما} \fa{چطور} \fa{است؟} — ask “How are you?” respectfully}
+
+\label{lesson:FA-C04-hal-e-shoma-chetor-ast}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Recall \textbf{hâl} “state,” \textbf{shomâ} respectful “you,” \textbf{chetor} “how,” and careful \textbf{ast} “is.” The only assembly move is familiar ezafe.
+\end{quote}
+
+\subsection*{The exchange}
+\begin{quote}
+\textbf{\fa{حال} \fa{شما} \fa{چطور} \fa{است؟}} — \emph{hâl-e shomâ chetor ast?} — \textbf{How are you?}
+\end{quote}
+
+Build it without translating English word for word:
+
+\begin{quote}
+state + \textbf{-e} + respectful-you + how + is?
+\end{quote}
+
+The unwritten ezafe in \textbf{hâl-e shomâ} works exactly like \textbf{esm-e shomâ}. Persian asks, literally, “the state of you, in what manner is?”
+
+\begin{grammarlens}[title={Grammar Lens: one reliable careful form}]
+This chapter asks you to produce the careful written form with \textbf{ast}. Everyday Iranian speech often contracts the end to \textbf{\fa{چطوره؟}} \emph{chetore?}; recognize that preview, but keep the uncontracted line until the careful pattern is secure.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: \textbf{hâl-e shomâ chetor ast?}{]}
+  \item {[}YOU TRACE: \textbf{hâl-e shomâ} — state-of-you{]}
+  \item {[}YOU CHOOSE: careful production now — final \textbf{ast}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Ask once from memory. What already-known grammar holds \textbf{hâl} and \textbf{shomâ} together? (Ezafe \textbf{-e}.)
+
+Source: Persian Online: Greetings List.
+\end{tcolorbox}
+\section[khub]{\fa{خوب} — “good” and “well”}
+
+\label{lesson:FA-C04-khub}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Ask \textbf{hâl-e shomâ chetor ast?} The smallest positive answer begins with one word.
+\end{quote}
+
+\subsection*{You'll want to know first — the answer word}
+\begin{quote}
+\textbf{\fa{خوب}} — \emph{khub} — \textbf{good, well}
+\end{quote}
+
+At the right edge, \textbf{\fa{خ}} is \emph{kh}, made farther back than English \emph{h}. \textbf{\fa{و}} carries long \emph{u}, as it did in \textbf{\fa{ممنون}}; final \textbf{\fa{ب}} closes the word with \emph{b}. Say it as one beat: \emph{khub}.
+
+\begin{cousinweb}
+Persian's everyday vocabulary is layered. \textbf{Hâl} and the \textbf{tor} inside \textbf{chetor} came through Arabic; \textbf{khub} belongs to the inherited Persian layer. All three are fully ordinary Persian now. History helps memory without ranking one layer as more authentic than another.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: \textbf{khub} — good, well{]}
+  \item {[}YOU READ: \textbf{\fa{خ}} + long-\emph{u} \textbf{\fa{و}} + final \textbf{\fa{ب}}{]}
+  \item {[}YOU CONTRAST: inherited \textbf{khub} beside borrowed \textbf{hâl}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Give the answer word once without romanization. Which letter carries its long \emph{u}? (\textbf{\fa{و}}.)
+
+Source: Persian Online: Greetings List.
+\end{tcolorbox}
+\section[khubam, mamnun]{\fa{خوبم،} \fa{ممنون} — “I am well, thank you”}
+
+\label{lesson:FA-C04-khubam}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Say \textbf{khub} “well,” then the thanks you learned in Chapter 1: \textbf{mamnun}. One small ending turns the first word into a full answer.
+\end{quote}
+
+\subsection*{The exchange}
+\begin{quote}
+\textbf{\fa{خوبم،} \fa{ممنون}.} — \emph{Khubam, mamnun.} — \textbf{I am well, thank you.}
+\end{quote}
+
+The new final \textbf{\fa{م}} is \emph{m}. Attach it directly to \textbf{\fa{خوب}}: \textbf{\fa{خوب} + \fa{م} $\to$ \fa{خوبم}}. Persian script and speech both keep the answer compact.
+
+\begin{grammarlens}[title={Grammar Lens: one copula ending, not a table}]
+The attached ending \textbf{-am} means “I am” here. Persian Online notes that \textbf{\fa{خوبم}} by itself already means “I am fine”; the separate pronoun \textbf{man} is unnecessary. Learn only this useful first-person ending today. The rest of the copula set can arrive one form at a time later.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU BUILD: \textbf{khub + -am $\to$ khubam}{]}
+  \item {[}YOU SAY: \textbf{khubam, mamnun}{]}
+  \item {[}YOU POINT: to final \textbf{\fa{م}} carrying “I am”{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+What does final \textbf{-am} contribute? (“I am.”) Do you need a separate \textbf{man} in this answer? (No.)
+
+Sources: Persian Online: Verb “To Be” and Greetings List.
+\end{tcolorbox}
+\section[Practice]{Practice — a Persian wellbeing exchange}
+
+\label{lesson:FA-C04-practice}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Recall the two moves only: ask about the other person's state, then answer “I am well, thank you.”
+\end{quote}
+
+\subsection*{The exchange}
+\begin{quote}
+A: \textbf{\fa{سلام}! \fa{حال} \fa{شما} \fa{چطور} \fa{است؟}} \emph{Salâm! Hâl-e shomâ chetor ast?} B: \textbf{\fa{خوبم،} \fa{ممنون}.} \emph{Khubam, mamnun.}
+\end{quote}
+
+Every piece is already owned. The question reuses respectful \textbf{shomâ}, ezafe, and careful \textbf{ast}. The answer's final \textbf{-am} carries “I am,” so no new pronoun is hiding between the lines.
+
+\begin{grammarlens}[title={Grammar Lens: keep the social choice visible}]
+Use this careful question in a first meeting. You may hear shorter conversational forms, but producing one stable respectful line first prevents script, register, and contraction from arriving as one oversized step.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: both voices with the script visible{]}
+  \item {[}YOU SAY: both voices without romanization{]}
+  \item {[}YOU SWITCH: ask first, then answer after a pause{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Run the exchange once from \textbf{salâm} to \textbf{mamnun}. If one side stalls, return to that single micro-lesson rather than rereading the chapter.
+\end{tcolorbox}

--- a/code/learning/human-languages/persian/curriculum.json
+++ b/code/learning/human-languages/persian/curriculum.json
@@ -55,6 +55,28 @@
         "FA-EXT-006-CONSOLIDATION"
       ],
       "after": []
+    },
+    {
+      "id": "FA-PATH-005",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "FA-C04-hal",
+        "FA-C04-chetor",
+        "FA-C04-hal-e-shoma-chetor-ast",
+        "FA-C04-khub",
+        "FA-C04-khubam",
+        "FA-C04-practice"
+      ],
+      "before": [],
+      "inline": [
+        "FA-EXT-007-STATE-ETYMOLOGY",
+        "FA-EXT-008-QUESTION-SCRIPT",
+        "FA-EXT-009-EZAFE-REGISTER",
+        "FA-EXT-010-INHERITED-LEXICON",
+        "FA-EXT-011-PERSONAL-COPULA",
+        "FA-EXT-012-WELLBEING-CONSOLIDATION"
+      ],
+      "after": []
     }
   ],
   "spine": {
@@ -103,11 +125,10 @@
       "relocates": {}
     },
     "SPINE-CHECK-WELLBEING": {
-      "segments": [],
+      "segments": [
+        "FA-PATH-005"
+      ],
       "omits": [
-        "QUESTION-HOW",
-        "STATE-HOW-ARE-YOU",
-        "WORD-GOOD",
         "WORD-WELL",
         "WORD-SOSO"
       ],
@@ -246,6 +267,84 @@
       ],
       "lessons": [
         "FA-C03-practice"
+      ]
+    },
+    {
+      "id": "FA-EXT-007-STATE-ETYMOLOGY",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can recognize hâl as the state in a Persian wellbeing question and place its Arabic history inside Persian ezafe grammar.",
+      "prerequisites": [
+        "FA-EXT-006-CONSOLIDATION"
+      ],
+      "lessons": [
+        "FA-C04-hal"
+      ]
+    },
+    {
+      "id": "FA-EXT-008-QUESTION-SCRIPT",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can read chetor as the Persian how-question and remember its Persian che plus Arabic-loan tor layers.",
+      "prerequisites": [
+        "FA-EXT-007-STATE-ETYMOLOGY"
+      ],
+      "lessons": [
+        "FA-C04-chetor"
+      ]
+    },
+    {
+      "id": "FA-EXT-009-EZAFE-REGISTER",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "register",
+      "canDo": "I can reuse ezafe and careful ast to ask a respectful wellbeing question before learning colloquial contractions.",
+      "prerequisites": [
+        "FA-EXT-008-QUESTION-SCRIPT"
+      ],
+      "lessons": [
+        "FA-C04-hal-e-shoma-chetor-ast"
+      ]
+    },
+    {
+      "id": "FA-EXT-010-INHERITED-LEXICON",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can use khub for good or well and distinguish its inherited Persian layer from the borrowed words around it.",
+      "prerequisites": [
+        "FA-EXT-009-EZAFE-REGISTER"
+      ],
+      "lessons": [
+        "FA-C04-khub"
+      ]
+    },
+    {
+      "id": "FA-EXT-011-PERSONAL-COPULA",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "grammar",
+      "canDo": "I can attach the single first-person copula -am to khub and answer without learning a full paradigm.",
+      "prerequisites": [
+        "FA-EXT-010-INHERITED-LEXICON"
+      ],
+      "lessons": [
+        "FA-C04-khubam"
+      ]
+    },
+    {
+      "id": "FA-EXT-012-WELLBEING-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "consolidation",
+      "canDo": "I can complete a careful respectful Persian wellbeing exchange using only independently learned pieces.",
+      "prerequisites": [
+        "FA-EXT-011-PERSONAL-COPULA"
+      ],
+      "lessons": [
+        "FA-C04-practice"
       ]
     }
   ]

--- a/code/learning/human-languages/persian/lessons/FA-C04-chetor.md
+++ b/code/learning/human-languages/persian/lessons/FA-C04-chetor.md
@@ -1,0 +1,70 @@
+---
+schema_version: 2
+id: FA-C04-chetor
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 120
+chapter: 4
+type: word
+headword: چطور
+romanization: chetor
+gloss: how; in what manner
+concept_tag: QUESTION-HOW
+prerequisites: [FA-C04-hal]
+sounds: [rtl, short-vowels-unwritten, vav-o]
+roots: [persian-che, arabic-tawr]
+etymology_hook: Chetor is Persian che “what” plus Arabic-loan tor “manner”: literally “in what manner?”
+duration:
+  max_seconds: 220
+requires:
+  knowledge: [FA-LEX-HAL, FA-SCRIPT-HAL, FA-ETYMON-HAL]
+introduces:
+  knowledge: [FA-LEX-CHETOR, FA-SCRIPT-CHETOR, FA-ETYMON-CHE-TOR]
+practises:
+  knowledge: [FA-LEX-HAL, FA-LEX-CHETOR, FA-SCRIPT-CHETOR, FA-ETYMON-CHE-TOR]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: contemporary-iranian-persian
+reviews_of: [FA-C04-hal, FA-C03-chist]
+---
+
+# چطور — “how?” one layer at a time
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-HAL] -->
+
+[PAUSE 2s] Say the Persian noun for a state or condition. (**Hâl**.) Now ask
+about the manner of that state with one question word.
+
+## You'll want to know first — the question word
+<!-- hl-knowledge: introduces=[FA-LEX-CHETOR, FA-SCRIPT-CHETOR]; assesses=[] -->
+
+> **چطور؟** — *chetor?* — **how? / in what manner?**
+
+You already met **چ** *ch* in **چیست**. Here it is followed by **ط** *t*, **و**
+*o*, and **ر** *r*. The short *e* is not written. Learn the sound from the
+whole word: *che-tor*.
+
+## The word, taken apart — a two-language compound
+<!-- hl-knowledge: introduces=[FA-ETYMON-CHE-TOR]; assesses=[] -->
+
+Persian Online takes **چطور** apart as Persian **چه** *che*, “what,” plus the
+Arabic loan **طور** *tor*, “manner.” The literal picture is “in what manner?”
+That layered history is useful memory, but **chetor** is one everyday Persian
+question word now.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-CHETOR, FA-SCRIPT-CHETOR, FA-ETYMON-CHE-TOR] -->
+
+- [YOU SAY: **chetor?** — how?]
+- [YOU POINT: to familiar **چ** at the right edge]
+- [YOU REBUILD: **che** “what” + **tor** “manner”]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-CHETOR, FA-SCRIPT-CHETOR, FA-ETYMON-CHE-TOR] -->
+<!-- hl-activity: {"id":"FA-C04-chetor-how","kind":"text","assesses":["FA-LEX-CHETOR"],"prompt":"Type the Persian question word meaning 'how?'.","answer":"چطور","accepted":["chetor","chetowr"],"feedback":{"correct":"Right: چطور chetor asks 'how?' or literally 'in what manner?'.","incorrect":"Use چطور — chetor."},"response_seconds":8} -->
+
+Which part means “what”? (**Che**.) Which borrowed part means “manner”? (**Tor**.)
+
+Source: [Persian Online: Interrogatives](https://sites.la.utexas.edu/persian_online_resources/5-ws-h/).

--- a/code/learning/human-languages/persian/lessons/FA-C04-hal-e-shoma-chetor-ast.md
+++ b/code/learning/human-languages/persian/lessons/FA-C04-hal-e-shoma-chetor-ast.md
@@ -1,0 +1,73 @@
+---
+schema_version: 2
+id: FA-C04-hal-e-shoma-chetor-ast
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 130
+chapter: 4
+type: phrase
+headword: حال شما چطور است؟
+romanization: hâl-e shomâ chetor ast?
+gloss: How are you? (careful, respectful)
+concept_tag: STATE-HOW-ARE-YOU
+prerequisites: [FA-C04-chetor]
+sounds: [rtl, ezafe-e, short-vowels-unwritten, persian-question-mark]
+roots: [arabic-hal, persian-che, arabic-tawr]
+etymology_hook: The line literally asks “the state of you, in what manner is?” while Persian ezafe quietly links state to respectful you.
+duration:
+  max_seconds: 230
+requires:
+  knowledge: [FA-LEX-HAL, FA-LEX-CHETOR, FA-LEX-SHOMA-TO, FA-PRAGMATICS-SHOMA-REGISTER, FA-GRAMMAR-EZAFE-OWNER, FA-LEX-ESM-E-MAN-AST, FA-SCRIPT-PERSIAN-QUESTION-MARK]
+introduces:
+  knowledge: [FA-LEX-WELLBEING-QUESTION, FA-GRAMMAR-HAL-E-SHOMA, FA-PRAGMATICS-WELLBEING-FORMAL]
+practises:
+  knowledge: [FA-LEX-HAL, FA-LEX-CHETOR, FA-LEX-SHOMA-TO, FA-PRAGMATICS-SHOMA-REGISTER, FA-GRAMMAR-EZAFE-OWNER, FA-LEX-ESM-E-MAN-AST, FA-SCRIPT-PERSIAN-QUESTION-MARK, FA-LEX-WELLBEING-QUESTION, FA-GRAMMAR-HAL-E-SHOMA, FA-PRAGMATICS-WELLBEING-FORMAL]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: careful-respectful
+variety: contemporary-iranian-persian
+reviews_of: [FA-C04-hal, FA-C04-chetor, FA-C03-shoma-to, FA-C03-esm-e-shoma-chist]
+---
+
+# حال شما چطور است؟ — ask “How are you?” respectfully
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-HAL, FA-LEX-CHETOR, FA-LEX-SHOMA-TO, FA-PRAGMATICS-SHOMA-REGISTER, FA-GRAMMAR-EZAFE-OWNER, FA-LEX-ESM-E-MAN-AST, FA-SCRIPT-PERSIAN-QUESTION-MARK] -->
+
+[PAUSE 2s] Recall **hâl** “state,” **shomâ** respectful “you,” **chetor** “how,”
+and careful **ast** “is.” The only assembly move is familiar ezafe.
+
+## The exchange
+<!-- hl-knowledge: introduces=[FA-LEX-WELLBEING-QUESTION, FA-GRAMMAR-HAL-E-SHOMA]; assesses=[] -->
+
+> **حال شما چطور است؟** — *hâl-e shomâ chetor ast?* — **How are you?**
+
+Build it without translating English word for word:
+
+> state + **-e** + respectful-you + how + is?
+
+The unwritten ezafe in **hâl-e shomâ** works exactly like **esm-e shomâ**.
+Persian asks, literally, “the state of you, in what manner is?”
+
+## Grammar Lens: one reliable careful form
+<!-- hl-knowledge: introduces=[FA-PRAGMATICS-WELLBEING-FORMAL]; assesses=[] -->
+
+This chapter asks you to produce the careful written form with **ast**. Everyday
+Iranian speech often contracts the end to **چطوره؟** *chetore?*; recognize that
+preview, but keep the uncontracted line until the careful pattern is secure.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-WELLBEING-QUESTION, FA-GRAMMAR-HAL-E-SHOMA, FA-PRAGMATICS-WELLBEING-FORMAL] -->
+
+- [YOU SAY: **hâl-e shomâ chetor ast?**]
+- [YOU TRACE: **hâl-e shomâ** — state-of-you]
+- [YOU CHOOSE: careful production now — final **ast**]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-WELLBEING-QUESTION, FA-GRAMMAR-HAL-E-SHOMA, FA-PRAGMATICS-WELLBEING-FORMAL] -->
+<!-- hl-activity: {"id":"FA-C04-hal-e-shoma-chetor-ast-question","kind":"text","assesses":["FA-LEX-WELLBEING-QUESTION"],"prompt":"Type the careful respectful Persian question 'How are you?'.","answer":"حال شما چطور است؟","accepted":["حال شما چطور است","hal-e shoma chetor ast","hâl-e shomâ chetor ast"],"feedback":{"correct":"Right: حال شما چطور است؟ reuses ezafe, respectful شما, and careful است.","incorrect":"Use حال شما چطور است؟ — hâl-e shomâ chetor ast?"},"response_seconds":10} -->
+
+Ask once from memory. What already-known grammar holds **hâl** and **shomâ**
+together? (Ezafe **-e**.)
+
+Source: [Persian Online: Greetings List](https://sites.la.utexas.edu/persian_online_resources/vocabulary-lists/meetings-introductions/).

--- a/code/learning/human-languages/persian/lessons/FA-C04-hal.md
+++ b/code/learning/human-languages/persian/lessons/FA-C04-hal.md
@@ -1,0 +1,70 @@
+---
+schema_version: 2
+id: FA-C04-hal
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 110
+chapter: 4
+type: word
+headword: حال
+romanization: hâl
+gloss: state, condition — the state in “How are you?”
+concept_tag: FA-C04-HAL
+prerequisites: [FA-C03-practice]
+sounds: [rtl, long-a, short-vowels-unwritten]
+roots: [arabic-hal]
+etymology_hook: Persian hâl is an Arabic loan meaning state or condition; Persian makes it its own inside the ezafe phrase hâl-e shomâ.
+duration:
+  max_seconds: 210
+requires:
+  knowledge: [FA-DIALOGUE-NAME-EXCHANGE]
+introduces:
+  knowledge: [FA-LEX-HAL, FA-SCRIPT-HAL, FA-ETYMON-HAL]
+practises:
+  knowledge: [FA-DIALOGUE-NAME-EXCHANGE, FA-LEX-HAL, FA-SCRIPT-HAL, FA-ETYMON-HAL]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: contemporary-iranian-persian
+reviews_of: [FA-C03-practice]
+---
+
+# حال — the “state” in a wellbeing question
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FA-DIALOGUE-NAME-EXCHANGE] -->
+
+[PAUSE 2s] Run only the opening of the meeting you know: **salâm** and the name
+question. The next move asks about the other person's present state.
+
+## You'll want to know first — one useful word
+<!-- hl-knowledge: introduces=[FA-LEX-HAL, FA-SCRIPT-HAL]; assesses=[] -->
+
+> **حال** — *hâl* — **state, condition**
+
+Read from right to left: **ح** *h* + **ا** long *â* + **ل** *l*. The first letter
+is a breathier *h* than English normally uses; a clear ordinary *h* is a safe
+beginner approximation. Keep the whole written word attached to its meaning.
+
+## The word, taken apart — Arabic history in Persian grammar
+<!-- hl-knowledge: introduces=[FA-ETYMON-HAL]; assesses=[] -->
+
+Persian borrowed **hâl** from Arabic, then uses it with Persian grammar. You will
+soon say **hâl-e shomâ**, literally “the state of you.” That **-e** is the same
+spoken ezafe already learned in **esm-e shomâ**.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-HAL, FA-SCRIPT-HAL, FA-ETYMON-HAL] -->
+
+- [YOU SAY: **hâl** — state or condition]
+- [YOU READ: **حال** from right to left]
+- [YOU CONNECT: an Arabic-rooted noun inside Persian ezafe grammar]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-HAL, FA-SCRIPT-HAL, FA-ETYMON-HAL] -->
+<!-- hl-activity: {"id":"FA-C04-hal-meaning","kind":"text","assesses":["FA-LEX-HAL"],"prompt":"Type the Persian word meaning 'state' or 'condition'.","answer":"حال","accepted":["hal","hâl","hāl"],"feedback":{"correct":"Right: حال hâl is the state or condition asked about.","incorrect":"Use حال — hâl, 'state, condition'."},"response_seconds":8} -->
+
+What does **hâl** name? (A state or condition.) Which familiar linker will
+attach an owner to it? (Ezafe **-e**.)
+
+Source: [Persian Online: Greetings List](https://sites.la.utexas.edu/persian_online_resources/vocabulary-lists/meetings-introductions/).

--- a/code/learning/human-languages/persian/lessons/FA-C04-khub.md
+++ b/code/learning/human-languages/persian/lessons/FA-C04-khub.md
@@ -1,0 +1,71 @@
+---
+schema_version: 2
+id: FA-C04-khub
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 140
+chapter: 4
+type: word
+headword: خوب
+romanization: khub
+gloss: good, well
+concept_tag: WORD-GOOD
+prerequisites: [FA-C04-hal-e-shoma-chetor-ast]
+sounds: [rtl, kh, long-u]
+roots: [inherited-persian-khub]
+etymology_hook: Khub is inherited Persian vocabulary, set beside the Arabic-rooted hâl and tor already absorbed into the same everyday exchange.
+duration:
+  max_seconds: 200
+requires:
+  knowledge: [FA-LEX-WELLBEING-QUESTION, FA-GRAMMAR-HAL-E-SHOMA, FA-PRAGMATICS-WELLBEING-FORMAL]
+introduces:
+  knowledge: [FA-LEX-KHUB, FA-SCRIPT-KHUB, FA-ETYMON-KHUB]
+practises:
+  knowledge: [FA-LEX-WELLBEING-QUESTION, FA-LEX-KHUB, FA-SCRIPT-KHUB, FA-ETYMON-KHUB]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: contemporary-iranian-persian
+reviews_of: [FA-C04-hal-e-shoma-chetor-ast]
+---
+
+# خوب — “good” and “well”
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-WELLBEING-QUESTION] -->
+
+[PAUSE 2s] Ask **hâl-e shomâ chetor ast?** The smallest positive answer begins
+with one word.
+
+## You'll want to know first — the answer word
+<!-- hl-knowledge: introduces=[FA-LEX-KHUB, FA-SCRIPT-KHUB]; assesses=[] -->
+
+> **خوب** — *khub* — **good, well**
+
+At the right edge, **خ** is *kh*, made farther back than English *h*. **و**
+carries long *u*, as it did in **ممنون**; final **ب** closes the word with *b*.
+Say it as one beat: *khub*.
+
+## The word, taken apart — the inherited layer
+<!-- hl-knowledge: introduces=[FA-ETYMON-KHUB]; assesses=[] -->
+
+Persian's everyday vocabulary is layered. **Hâl** and the **tor** inside
+**chetor** came through Arabic; **khub** belongs to the inherited Persian layer.
+All three are fully ordinary Persian now. History helps memory without ranking
+one layer as more authentic than another.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-KHUB, FA-SCRIPT-KHUB, FA-ETYMON-KHUB] -->
+
+- [YOU SAY: **khub** — good, well]
+- [YOU READ: **خ** + long-*u* **و** + final **ب**]
+- [YOU CONTRAST: inherited **khub** beside borrowed **hâl**]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-KHUB, FA-SCRIPT-KHUB, FA-ETYMON-KHUB] -->
+<!-- hl-activity: {"id":"FA-C04-khub-good","kind":"text","assesses":["FA-LEX-KHUB"],"prompt":"Type the Persian word meaning 'good' or 'well'.","answer":"خوب","accepted":["khub","khūb","khoob"],"feedback":{"correct":"Right: خوب khub means 'good' or 'well'.","incorrect":"Use خوب — khub."},"response_seconds":8} -->
+
+Give the answer word once without romanization. Which letter carries its long
+*u*? (**و**.)
+
+Source: [Persian Online: Greetings List](https://sites.la.utexas.edu/persian_online_resources/vocabulary-lists/meetings-introductions/).

--- a/code/learning/human-languages/persian/lessons/FA-C04-khubam.md
+++ b/code/learning/human-languages/persian/lessons/FA-C04-khubam.md
@@ -1,0 +1,70 @@
+---
+schema_version: 2
+id: FA-C04-khubam
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 150
+chapter: 4
+type: phrase
+headword: خوبم، ممنون
+romanization: khubam, mamnun
+gloss: I am well, thank you
+concept_tag: FA-C04-KHUBAM
+prerequisites: [FA-C04-khub]
+sounds: [rtl, long-u, short-vowels-unwritten]
+roots: [inherited-persian-khub, persian-personal-copula-am]
+etymology_hook: Persian attaches the ancient first-person copula -am directly to khub, so the two written words “khubam, mamnun” already carry “I am well, thank you.”
+duration:
+  max_seconds: 230
+requires:
+  knowledge: [FA-LEX-KHUB, FA-SCRIPT-KHUB, FA-DIALOGUE-NAME-EXCHANGE]
+introduces:
+  knowledge: [FA-LEX-KHUBAM-REPLY, FA-GRAMMAR-PERSONAL-COPULA-AM, FA-SCRIPT-KHUBAM]
+practises:
+  knowledge: [FA-LEX-KHUB, FA-SCRIPT-KHUB, FA-DIALOGUE-NAME-EXCHANGE, FA-LEX-KHUBAM-REPLY, FA-GRAMMAR-PERSONAL-COPULA-AM, FA-SCRIPT-KHUBAM]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral-polite
+variety: contemporary-iranian-persian
+reviews_of: [FA-C04-khub, FA-C01-mamnoon, FA-C02-esm-e-man]
+---
+
+# خوبم، ممنون — “I am well, thank you”
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-KHUB, FA-SCRIPT-KHUB, FA-DIALOGUE-NAME-EXCHANGE] -->
+
+[PAUSE 2s] Say **khub** “well,” then the thanks you learned in Chapter 1:
+**mamnun**. One small ending turns the first word into a full answer.
+
+## The exchange
+<!-- hl-knowledge: introduces=[FA-LEX-KHUBAM-REPLY, FA-SCRIPT-KHUBAM]; assesses=[] -->
+
+> **خوبم، ممنون.** — *Khubam, mamnun.* — **I am well, thank you.**
+
+The new final **م** is *m*. Attach it directly to **خوب**: **خوب + م → خوبم**.
+Persian script and speech both keep the answer compact.
+
+## Grammar Lens: one copula ending, not a table
+<!-- hl-knowledge: introduces=[FA-GRAMMAR-PERSONAL-COPULA-AM]; assesses=[] -->
+
+The attached ending **-am** means “I am” here. Persian Online notes that
+**خوبم** by itself already means “I am fine”; the separate pronoun **man** is
+unnecessary. Learn only this useful first-person ending today. The rest of the
+copula set can arrive one form at a time later.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-KHUBAM-REPLY, FA-GRAMMAR-PERSONAL-COPULA-AM, FA-SCRIPT-KHUBAM] -->
+
+- [YOU BUILD: **khub + -am → khubam**]
+- [YOU SAY: **khubam, mamnun**]
+- [YOU POINT: to final **م** carrying “I am”]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-KHUBAM-REPLY, FA-GRAMMAR-PERSONAL-COPULA-AM, FA-SCRIPT-KHUBAM] -->
+<!-- hl-activity: {"id":"FA-C04-khubam-reply","kind":"text","assesses":["FA-LEX-KHUBAM-REPLY"],"prompt":"Reply in Persian: 'I am well, thank you.'","answer":"خوبم، ممنون","accepted":["خوبم ممنون","khubam mamnun","khūbam mamnūn"],"feedback":{"correct":"Right: خوبم already carries 'I am well'; ممنون adds thanks.","incorrect":"Use خوبم، ممنون — khubam, mamnun."},"response_seconds":10} -->
+
+What does final **-am** contribute? (“I am.”) Do you need a separate **man** in
+this answer? (No.)
+
+Sources: [Persian Online: Verb “To Be”](https://sites.la.utexas.edu/persian_online_resources/verbs/verb-to-be/) and [Greetings List](https://sites.la.utexas.edu/persian_online_resources/vocabulary-lists/meetings-introductions/).

--- a/code/learning/human-languages/persian/lessons/FA-C04-practice.md
+++ b/code/learning/human-languages/persian/lessons/FA-C04-practice.md
@@ -1,0 +1,71 @@
+---
+schema_version: 2
+id: FA-C04-practice
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 160
+chapter: 4
+type: practice-mix
+headword: حال شما چطور است؟ — خوبم، ممنون
+romanization: hâl-e shomâ chetor ast? — khubam, mamnun
+gloss: a respectful Persian wellbeing exchange
+concept_tag: FA-C04-PRACTICE
+prerequisites: [FA-C04-khubam]
+sounds: [rtl, ezafe-e, long-u, persian-question-mark]
+roots: []
+etymology_hook: The exchange joins inherited Persian khub, Arabic-rooted hâl and tor, and Persian ezafe and copula grammar without adding a hidden new form.
+duration:
+  max_seconds: 220
+requires:
+  knowledge: [FA-LEX-WELLBEING-QUESTION, FA-GRAMMAR-HAL-E-SHOMA, FA-PRAGMATICS-WELLBEING-FORMAL, FA-LEX-KHUBAM-REPLY, FA-GRAMMAR-PERSONAL-COPULA-AM, FA-DIALOGUE-NAME-EXCHANGE]
+introduces:
+  knowledge: [FA-DIALOGUE-WELLBEING]
+practises:
+  knowledge: [FA-LEX-WELLBEING-QUESTION, FA-GRAMMAR-HAL-E-SHOMA, FA-PRAGMATICS-WELLBEING-FORMAL, FA-LEX-KHUBAM-REPLY, FA-GRAMMAR-PERSONAL-COPULA-AM, FA-DIALOGUE-NAME-EXCHANGE, FA-DIALOGUE-WELLBEING]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, fluency]
+register: careful-respectful
+variety: contemporary-iranian-persian
+reviews_of: [FA-C04-hal, FA-C04-chetor, FA-C04-hal-e-shoma-chetor-ast, FA-C04-khub, FA-C04-khubam]
+---
+
+# Practice — a Persian wellbeing exchange
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-WELLBEING-QUESTION, FA-LEX-KHUBAM-REPLY, FA-DIALOGUE-NAME-EXCHANGE] -->
+
+[PAUSE 2s] Recall the two moves only: ask about the other person's state, then
+answer “I am well, thank you.”
+
+## The exchange
+<!-- hl-knowledge: introduces=[FA-DIALOGUE-WELLBEING]; assesses=[] -->
+
+> A: **سلام! حال شما چطور است؟**
+> *Salâm! Hâl-e shomâ chetor ast?*
+> B: **خوبم، ممنون.**
+> *Khubam, mamnun.*
+
+Every piece is already owned. The question reuses respectful **shomâ**, ezafe,
+and careful **ast**. The answer's final **-am** carries “I am,” so no new pronoun
+is hiding between the lines.
+
+## Grammar Lens: keep the social choice visible
+<!-- hl-knowledge: introduces=[]; assesses=[FA-GRAMMAR-HAL-E-SHOMA, FA-PRAGMATICS-WELLBEING-FORMAL, FA-GRAMMAR-PERSONAL-COPULA-AM] -->
+
+Use this careful question in a first meeting. You may hear shorter conversational
+forms, but producing one stable respectful line first prevents script, register,
+and contraction from arriving as one oversized step.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-WELLBEING-QUESTION, FA-LEX-KHUBAM-REPLY, FA-DIALOGUE-WELLBEING] -->
+
+- [YOU SAY: both voices with the script visible]
+- [YOU SAY: both voices without romanization]
+- [YOU SWITCH: ask first, then answer after a pause]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-WELLBEING-QUESTION, FA-GRAMMAR-HAL-E-SHOMA, FA-PRAGMATICS-WELLBEING-FORMAL, FA-LEX-KHUBAM-REPLY, FA-GRAMMAR-PERSONAL-COPULA-AM, FA-DIALOGUE-WELLBEING] -->
+<!-- hl-activity: {"id":"FA-C04-practice-next-line","kind":"text","assesses":["FA-DIALOGUE-WELLBEING"],"prompt":"After حال شما چطور است؟, type the polite Persian reply.","answer":"خوبم، ممنون","accepted":["خوبم ممنون","khubam mamnun","khūbam mamnūn"],"feedback":{"correct":"Right: خوبم، ممنون completes the wellbeing exchange with no new grammar.","incorrect":"Reply خوبم، ممنون — khubam, mamnun."},"response_seconds":10} -->
+
+Run the exchange once from **salâm** to **mamnun**. If one side stalls, return
+to that single micro-lesson rather than rereading the chapter.

--- a/code/learning/human-languages/persian/pronunciation-reference.md
+++ b/code/learning/human-languages/persian/pronunciation-reference.md
@@ -29,8 +29,15 @@ lessons will introduce them only when a useful word needs them.
 | `rtl` | start at the right edge and follow the word leftward | **سلام** *salâm* |
 | `long-a` | hold **ا** as a steady *â*, near the vowel in “father” | **سلام** *salâm* |
 | `long-u` | hold **و** as *u*, near “oo” in “food,” without an English off-glide | **ممنون** *mamnun* |
+| `long-i` | hold **ی** as long *i* in the learned word | **چیست** *chist* |
 | `short-vowels-unwritten` | supply learned *a, e,* or *o* even when no separate vowel letter appears | **بله** *bale*, **نه** *na* |
 | `ezafe-e` | say a light linking *-e* after a noun before its owner or description; ordinary text often leaves it unmarked | **اسمِ من** *esm-e man* |
+| `sh` | read three-dotted **ش** as *sh* | **شما** *shomâ* |
+| `persian-che` | read Persian **چ** as *ch* | **چیست** *chist* |
+| `kh` | make **خ** farther back than English *h*; a gentle approximation is acceptable first | **خوب** *khub* |
+| `gh` | use the modern Iranian Persian voiced back-of-the-mouth sound for **غ** | **خوشوقتم** *khoshvaghtam* |
+| `vav-o` | let **و** carry the learned *o* value in this word | **چطور** *chetor* |
+| `persian-question-mark` | recognize **؟** at the left end of a right-to-left question | **اسم شما چیست؟** |
 
 ## Read the current word before the whole alphabet
 
@@ -41,6 +48,10 @@ lessons will introduce them only when a useful word needs them.
   spelling supplies a consonantal frame; the learned word supplies *a/e*.
 - **اسم من ... است** recombines familiar letters and adds one spoken grammar
   cue, ezafe **-e**. The cue is often heard but not printed.
+- **شما**, **چیست**, and **خوشوقتم** add *sh*, Persian **چ**, and the back
+  sounds in **خ/غ** only inside the name exchange.
+- **حال شما چطور است؟** reuses ezafe and the Persian question mark; **چطور**
+  gives **و** its learned *o* value, while **خوبم** returns to long-*u* **و**.
 
 One spelling symbol can do more than one job in later words—especially **و**
 and **ی**—so read from the word and context rather than assigning each shape one

--- a/code/learning/human-languages/persian/roadmap.md
+++ b/code/learning/human-languages/persian/roadmap.md
@@ -27,9 +27,19 @@ The schema-v2 chain adds respectful/familiar register, Persian **چ**, the
 *khosh + vaqt + -am* etymology only when each expression needs it. Objective
 focused retrieval comes before the exchange enters mixed-language review.
 
-## Chapter 4 — People and simple identity *(planned)*
+## Chapter 4 — Ask about wellbeing *(authored)*
 
-- **man hastam** and the present copula endings;
+**حال** *hâl* → **چطور** *chetor* → **حال شما چطور است؟**
+*hâl-e shomâ chetor ast?* → **خوب** *khub* → **خوبم، ممنون**
+*khubam, mamnun* → one cumulative exchange. The sequence reuses ezafe before
+adding a careful respectful question, contrasts inherited and borrowed lexical
+layers, and introduces only the first-person copula **-am** needed for the
+answer. Colloquial contraction is labelled for recognition but not required for
+production yet.
+
+## Chapter 5 — People and simple identity *(planned)*
+
+- **man hastam** and the next present-copula forms one at a time;
 - careful written forms versus colloquial Iranian Persian;
 - one noun at a time with ezafe reuse;
 - Persian additions **پ چ ژ گ** introduced only when a word needs them.

--- a/code/learning/human-languages/persian/session-map.md
+++ b/code/learning/human-languages/persian/session-map.md
@@ -1,6 +1,6 @@
-# Persian Session Map — Authored Chapters 1–2
+# Persian Session Map — Authored Chapters 1–4
 
-This is the authoritative order for the five authored Persian lessons. Every
+This is the authoritative order for the sixteen authored Persian lessons. Every
 lesson is an independent, prerequisite-safe step of three or four minutes. A
 study session may combine the new step with the reviews shown here, but it never
 turns the combined session into one indivisible lesson.
@@ -36,6 +36,20 @@ Each row still points to one independently resumable lesson.
 | **S9** | [`FA-C03-khoshvaghtam`](./lessons/FA-C03-khoshvaghtam.md): **خوشوقتم** | *mamnun* *(N+7)*; *shomâ / to* *(N+3)*; the name question *(N+1)* | close the introduction warmly |
 | **S10** | [`FA-C03-practice`](./lessons/FA-C03-practice.md): full exchange | *bale* *(N+7)*; *chist* *(N+3)*; *khoshvaghtam* *(N+1)* | run both voices using only known lines |
 
+## Chapter 4 — Ask about wellbeing
+
+Chapter 4 fills six sessions because Persian's compact answer deserves its own
+copula step. Each lesson remains independently completable in under five minutes.
+
+| Session | New lesson | Reviews due | Cumulative practice |
+|---|---|---|---|
+| **S11** | [`FA-C04-hal`](./lessons/FA-C04-hal.md): **حال** *hâl* | *na* *(N+7)*; the name question *(N+3)*; Chapter 3 practice *(N+1)* | name the state a wellbeing question asks about |
+| **S12** | [`FA-C04-chetor`](./lessons/FA-C04-chetor.md): **چطور** *chetor* | *esm-e man ... ast* *(N+7)*; *khoshvaghtam* *(N+3)*; *hâl* *(N+1)* | ask “how?” and rebuild *che + tor* |
+| **S13** | [`FA-C04-hal-e-shoma-chetor-ast`](./lessons/FA-C04-hal-e-shoma-chetor-ast.md): **حال شما چطور است؟** | *shomâ / to* *(N+7)*; Chapter 3 practice *(N+3)*; *chetor* *(N+1)* | ask the careful respectful question |
+| **S14** | [`FA-C04-khub`](./lessons/FA-C04-khub.md): **خوب** *khub* | *chist* *(N+7)*; *hâl* *(N+3)*; the wellbeing question *(N+1)* | answer with the positive state word |
+| **S15** | [`FA-C04-khubam`](./lessons/FA-C04-khubam.md): **خوبم، ممنون** | the name question *(N+7)*; *chetor* *(N+3)*; *khub* *(N+1)* | attach first-person **-am**, then add known thanks |
+| **S16** | [`FA-C04-practice`](./lessons/FA-C04-practice.md): full wellbeing exchange | *salâm* *(N+15)*; *khoshvaghtam* *(N+7)*; the wellbeing question *(N+3)*; *khubam* *(N+1)* | run both voices using only learned forms |
+
 ## Carry-forward review ledger
 
 Future chapters may supply the new lesson in these sessions. Until then, use
@@ -44,21 +58,21 @@ with already learned material.
 
 | Session | Fixed review due |
 |---|---|
-| **S11** | *na* *(N+7)*; the name question *(N+3)*; Chapter 3 practice *(N+1)* |
-| **S12** | *esm-e man ... ast* *(N+7)*; *khoshvaghtam* *(N+3)* |
-| **S13** | *shomâ / to* *(N+7)*; Chapter 3 practice *(N+3)* |
-| **S14** | *chist* *(N+7)* |
-| **S15** | the name question *(N+7)* |
-| **S16** | *salâm* *(N+15)*; *khoshvaghtam* *(N+7)* |
-| **S17** | *mamnun* *(N+15)*; Chapter 3 practice *(N+7)* |
-| **S18** | *bale* *(N+15)* |
-| **S19** | *na* *(N+15)* |
-| **S20** | *esm-e man ... ast* *(N+15)* |
-| **S21** | *shomâ / to* *(N+15)* |
-| **S22** | *chist* *(N+15)* |
-| **S23** | the name question *(N+15)* |
+| **S17** | *mamnun* *(N+15)*; Chapter 3 practice *(N+7)*; *khub* *(N+3)*; Chapter 4 practice *(N+1)* |
+| **S18** | *bale* *(N+15)*; *hâl* *(N+7)*; *khubam* *(N+3)* |
+| **S19** | *na* *(N+15)*; *chetor* *(N+7)*; Chapter 4 practice *(N+3)* |
+| **S20** | *esm-e man ... ast* *(N+15)*; the wellbeing question *(N+7)* |
+| **S21** | *shomâ / to* *(N+15)*; *khub* *(N+7)* |
+| **S22** | *chist* *(N+15)*; *khubam* *(N+7)* |
+| **S23** | the name question *(N+15)*; Chapter 4 practice *(N+7)* |
 | **S24** | *khoshvaghtam* *(N+15)* |
 | **S25** | Chapter 3 practice *(N+15)* |
+| **S26** | *hâl* *(N+15)* |
+| **S27** | *chetor* *(N+15)* |
+| **S28** | the wellbeing question *(N+15)* |
+| **S29** | *khub* *(N+15)* |
+| **S30** | *khubam* *(N+15)* |
+| **S31** | Chapter 4 practice *(N+15)* |
 
 Sessions not listed in the ledger have no fixed starter item due; use their
 bonus queue for adaptive or cumulative retrieval.
@@ -69,7 +83,7 @@ review; the fixed ledger remains the book's no-tracking fallback.
 
 ## Schedule check
 
-Every Chapter 1–3 lesson now has all four fixed resurfacing sessions through
-S25. The app may pull a missed item forward, but it cannot skip the local
-prerequisites. Chapter 4 can begin in S11 while the ledger continues in the
-review portion of each session.
+Every Chapter 1–4 lesson now has all four fixed resurfacing sessions through
+S31. The app may pull a missed item forward, but it cannot skip the local
+prerequisites. A future Chapter 5 can begin in S17 while this ledger continues
+in the review portion of each session.

--- a/code/learning/human-languages/urdu/CHANGELOG.md
+++ b/code/learning/human-languages/urdu/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.5.0 — 2026-08-04
+
+- Added six schema-v2 Chapter 4 micro-lessons for *kaise/kaisī*, respectful
+  **āp ... haiṅ**, the first-person **maiṅ ... hūṅ** frame, *ṭhīk*, the polite
+  reply, and cumulative practice.
+- Kept addressee agreement separate from honorific register, introduced the
+  retroflex-aspiration sequence only inside **ٹھیک**, and made the Hindi bridge
+  follow independent Urdu-script retrieval.
+- Extended the sound-id reference and exact N+1/N+3/N+7/N+15 ledger through
+  S31, with objective activities and a generated four-chapter book.
+
 ## 0.4.0 — 2026-08-03
 
 - Added five schema-v2 Chapter 3 micro-lessons for **āp/tum/tū**, *kyā*, the

--- a/code/learning/human-languages/urdu/README.md
+++ b/code/learning/human-languages/urdu/README.md
@@ -4,13 +4,13 @@ This track teaches contemporary standard Urdu through the shared
 human-language spine. Lessons are under five minutes and introduce Nastaliq
 script features only as the learner encounters them.
 
-The first ten lessons now form a complete miniature meeting: greeting, answers,
-giving your name, asking someone else's name respectfully, and acknowledging
-the introduction. Urdu-specific extensions introduce **āp/tum/tū** register,
-**kyā**, fixed **āp kā nām**, question punctuation, and a gently chunked
-pleased-to-meet-you response exactly where the exchange needs them. Later
-chapters will add gender agreement, postpositions, oblique forms, compound
-verbs, and more Nastaliq-aware shapes.
+The first sixteen lessons now form a complete miniature meeting: greeting,
+answers, exchanging names, acknowledging the introduction, asking about
+wellbeing, and replying politely. Urdu-specific extensions introduce
+**āp/tum/tū** register, **kyā**, fixed **āp kā nām**, question punctuation,
+**kaise/kaisī** agreement, honorific **haiṅ**, and first-person **hūṅ** exactly
+where each exchange needs them. Later chapters will add wider agreement,
+postpositions, oblique forms, compound verbs, and more Nastaliq-aware shapes.
 
 Urdu and Hindi share a large grammatical core, while the formal lexicon and
 writing systems make their histories visible. Cross-language practice should
@@ -20,10 +20,10 @@ Script conventions are grounded in Northwestern University's *Zero Zabar*.
 ## Read and practise
 
 - [`roadmap.md`](./roadmap.md) orders the authored and planned chapters toward B1.
-- [`session-map.md`](./session-map.md) composes all ten micro-lessons with an
-  exact session-count review ledger through S25.
+- [`session-map.md`](./session-map.md) composes all sixteen micro-lessons with an
+  exact session-count review ledger through S31.
 - [`pronunciation-reference.md`](./pronunciation-reference.md) gathers Urdu
   script and sound facts on demand and labels the current Naskh fallback.
-- [`lessons/`](./lessons/) contains the ten canonical short practice lessons.
-- [`book/book.tex`](./book/book.tex) builds the free three-chapter starter edition
+- [`lessons/`](./lessons/) contains the sixteen canonical short practice lessons.
+- [`book/book.tex`](./book/book.tex) builds the free four-chapter starter edition
   with XeLaTeX; merged editions appear in the public human-languages book catalog.

--- a/code/learning/human-languages/urdu/book/book.tex
+++ b/code/learning/human-languages/urdu/book/book.tex
@@ -18,7 +18,7 @@
   \vspace{1.5cm}
   {\large Adhithya Rajasekaran\par}
   \vfill
-  {\large Starter edition --- ten short lessons in three cumulative chapters.\par}
+  {\large Starter edition --- sixteen short lessons in four cumulative chapters.\par}
   \vspace{1cm}
   {\large Companion practice lessons live alongside this book at\\
   \texttt{code/learning/human-languages/urdu/lessons/}\par}
@@ -57,6 +57,7 @@ aid, not a claim that a borrowed word is any less fully Urdu today.
 \input{chapters/ch01-greetings-and-responses}
 \input{chapters/ch02-give-your-name}
 \input{chapters/ch03-ask-and-answer-names}
+\input{chapters/ch04-how-are-you}
 
 \backmatter
 
@@ -65,7 +66,8 @@ aid, not a claim that a borrowed word is any less fully Urdu today.
 
 Script descriptions follow Northwestern University's open
 \href{https://openbooks.library.northwestern.edu/zerozabar/chapter/the-urdu-alphabet/}%
-{Zero Zabar Urdu-alphabet materials}. The companion Markdown lessons are the
-canonical short-practice source for this edition.
+{Zero Zabar Urdu-alphabet materials}. Chapter 4's wellbeing forms and register
+contrast follow Michigan State University's open \emph{Basic Urdu}. The companion
+Markdown lessons are the canonical short-practice source for this edition.
 
 \end{document}

--- a/code/learning/human-languages/urdu/book/chapters/ch04-how-are-you.tex
+++ b/code/learning/human-languages/urdu/book/chapters/ch04-how-are-you.tex
@@ -1,0 +1,230 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:b1d08b5cbfb9ef33
+% canonical-lessons: UR-C04-kaise-kaisi, UR-C04-aap-kaise-hain, UR-C04-main-hun, UR-C04-thik, UR-C04-main-thik-hun, UR-C04-practice
+
+\chapter{How Are You?}
+\label{ch:ur-how-are-you}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[kaise / kaisī]{\ur{کیسے} / \ur{کیسی} — “how” follows the addressee}
+
+\label{lesson:UR-C04-kaise-kaisi}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Say \textbf{kyā} “what.” Urdu's next question word begins with the same \textbf{k} family, but its ending changes with the person being addressed.
+\end{quote}
+
+\subsection*{The two words}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Urdu} & \textbf{read} & \textbf{use in the respectful question} \\
+\midrule
+\textbf{\ur{کیسے}} & \emph{kaise} & addressing a man \\
+\textbf{\ur{کیسی}} & \emph{kaisī} & addressing a woman \\
+\bottomrule
+\end{tabularx}
+
+Both begin \textbf{\ur{ک}} \emph{k} + \textbf{\ur{ی}} carrying the \emph{ai} sound. At the left edge, \textbf{\ur{کیسے}} ends in broad \textbf{\ur{ے}} \emph{e}, while \textbf{\ur{کیسی}} ends in \textbf{\ur{ی}} long \emph{ī}. Read the whole word before isolating the final shape.
+
+\begin{grammarlens}[title={Grammar Lens: one agreement contrast}]
+English keeps \emph{how} unchanged. Urdu makes this describing form agree with the person addressed: \textbf{kaise} for a man, \textbf{kaisī} for a woman. Learn only this pair today—not a table of adjective endings. Respectful \textbf{āp} itself remains the same for everyone.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: addressing a man — \textbf{kaise}{]}
+  \item {[}YOU SAY: addressing a woman — \textbf{kaisī}{]}
+  \item {[}YOU POINT: broad final \textbf{\ur{ے}} versus long-\emph{ī} \textbf{\ur{ی}}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Which form addresses a man? (\textbf{Kaise}.) A woman? (\textbf{Kaisī}.)
+
+Source: \emph{Basic Urdu}: Formal Conversation.
+\end{tcolorbox}
+\section[āp kaise haiṅ? / āp kaisī haiṅ?]{\ur{آپ} \ur{کیسے} \ur{ہیں؟} / \ur{آپ} \ur{کیسی} \ur{ہیں؟} — ask respectfully}
+
+\label{lesson:UR-C04-aap-kaise-hain}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Choose respectful \textbf{āp}. Then choose \textbf{kaise} for a man or \textbf{kaisī} for a woman. One final copula completes the question.
+\end{quote}
+
+\subsection*{The exchange}
+\begin{quote}
+to a man: \textbf{\ur{آپ} \ur{کیسے} \ur{ہیں؟}} — \emph{āp kaise haiṅ?} to a woman: \textbf{\ur{آپ} \ur{کیسی} \ur{ہیں؟}} — \emph{āp kaisī haiṅ?}
+\end{quote}
+
+The order is \textbf{you + how + are?} Keep \textbf{\ur{ہیں}} \emph{haiṅ} final, just as \textbf{\ur{ہے}} \emph{hai} stayed final in the name question. Respectful \textbf{āp} takes this plural-shaped copula even when speaking to one person.
+
+\begin{grammarlens}[title={Grammar Lens: respect does not erase agreement}]
+Both lines are respectful. The choice between \textbf{kaise} and \textbf{kaisī} tracks the person addressed, not greater or lesser politeness. If you do not know how a person wishes to be addressed, listen for their usage or ask rather than guess; the grammar lesson does not replace social judgment.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: to a man — \textbf{āp kaise haiṅ?}{]}
+  \item {[}YOU SAY: to a woman — \textbf{āp kaisī haiṅ?}{]}
+  \item {[}YOU KEEP: respectful \textbf{āp} and final \textbf{haiṅ} in both{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+What stays the same in both lines? (\textbf{Āp ... haiṅ}.) What changes? (\textbf{Kaise / kaisī}.)
+
+Sources: \emph{Basic Urdu}: Formal Conversation and Personal Pronouns with “To Be”.
+\end{tcolorbox}
+\section[maiṅ ... hūṅ]{\ur{میں} ... \ur{ہوں} — one frame for “I am ...”}
+
+\label{lesson:UR-C04-main-hun}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Ask \textbf{āp kaise haiṅ?} You know the respectful “you are” ending \textbf{haiṅ}. Your answer needs the first-person pair “I ... am.”
+\end{quote}
+
+\subsection*{You'll want to know first — the frame}
+\begin{quote}
+\textbf{\ur{میں} ... \ur{ہوں}} — \emph{maiṅ ... hūṅ} — \textbf{I am ...}
+\end{quote}
+
+\textbf{\ur{میں}} \emph{maiṅ} means “I.” Final \textbf{\ur{ں}} marks a nasal ending. \textbf{\ur{ہوں}} \emph{hūṅ} means “am” and carries long \emph{ū} with \textbf{\ur{و}}, followed again by nasal \textbf{\ur{ں}}. Leave a space for the state word that comes next.
+
+\begin{grammarlens}[title={Grammar Lens: the verb closes the frame}]
+Urdu puts the copula at the end:
+
+\begin{quote}
+\textbf{maiṅ + {[}state{]} + hūṅ} — I + {[}state{]} + am
+\end{quote}
+
+Learn only this first-person frame. You do not need the full copula chart to answer one wellbeing question. Notice the useful contrast: respectful \textbf{āp ... haiṅ}, but first-person \textbf{maiṅ ... hūṅ}.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: \textbf{maiṅ} — I{]}
+  \item {[}YOU SAY: \textbf{hūṅ} — am{]}
+  \item {[}YOU FRAME: \textbf{maiṅ ... hūṅ}, leaving the middle open{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Which word opens the answer? (\textbf{Maiṅ}.) Which copula closes it? (\textbf{Hūṅ}.)
+
+Source: \emph{Basic Urdu}: Personal Pronouns with “To Be”.
+\end{tcolorbox}
+\section[ṭhīk]{\ur{ٹھیک} — “fine,” “well,” and “correct”}
+
+\label{lesson:UR-C04-thik}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Open and close the answer frame: \textbf{maiṅ ... hūṅ}. The middle now gets one high-frequency state word.
+\end{quote}
+
+\subsection*{You'll want to know first — the word}
+\begin{quote}
+\textbf{\ur{ٹھیک}} — \emph{ṭhīk} — \textbf{fine, well, correct}
+\end{quote}
+
+The first sound is retroflex and aspirated: curl the tongue slightly back for \textbf{\ur{ٹ}} \emph{ṭ}, then release a puff marked by \textbf{\ur{ھ}}. A plain English \emph{t} is a useful first approximation while the contrast settles. \textbf{\ur{ی}} carries long \emph{ī} before final \textbf{\ur{ک}} \emph{k}.
+
+\begin{cousinweb}
+Urdu \textbf{\ur{ٹھیک}} and Hindi \emph{ṭhīk} are the same everyday Hindustani word. Their grammar is closely shared; their scripts make different literary histories visible. This Urdu lesson leaves the Hindi side romanized: mixed-language practice may show both scripts only after each form has been learned in its own track.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: \textbf{ṭhīk} — fine, well{]}
+  \item {[}YOU FEEL: tongue slightly back, then a small puff{]}
+  \item {[}YOU CONNECT: Urdu \textbf{\ur{ٹھیک}} $\leftrightarrow$ Hindi \emph{ṭhīk}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Where will \textbf{ṭhīk} go in the frame \textbf{maiṅ ... hūṅ}? (In the middle.)
+
+Source: \emph{Basic Urdu}: Greetings and Introductions.
+\end{tcolorbox}
+\section[maiṅ ṭhīk hūṅ, shukriyā]{\ur{میں} \ur{ٹھیک} \ur{ہوں،} \ur{شکریہ} — “I am fine, thank you”}
+
+\label{lesson:UR-C04-main-thik-hun}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Fill the frame \textbf{maiṅ ... hūṅ} with \textbf{ṭhīk}, then recall Chapter 1's \textbf{shukriyā}.
+\end{quote}
+
+\subsection*{The exchange}
+\begin{quote}
+\textbf{\ur{میں} \ur{ٹھیک} \ur{ہوں،} \ur{شکریہ۔}} \emph{Maiṅ ṭhīk hūṅ, shukriyā.} \textbf{I am fine, thank you.}
+\end{quote}
+
+No word is new. The step is assembling the words quickly enough to answer a real person.
+
+\begin{grammarlens}[title={Grammar Lens: keep the copula final}]
+The core reply is:
+
+\begin{quote}
+I + fine + am $\to$ \textbf{maiṅ ṭhīk hūṅ}
+\end{quote}
+
+English places “am” after “I”; Urdu closes the clause with \textbf{hūṅ}. \textbf{Shukriyā} comes after the completed answer as the courtesy move you already own.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU BUILD: \textbf{maiṅ + ṭhīk + hūṅ}{]}
+  \item {[}YOU ADD: \textbf{shukriyā}{]}
+  \item {[}YOU SAY: the full reply without translating each word{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Which word must close the core answer? (\textbf{Hūṅ}.)
+
+Source: \emph{Basic Urdu}: Formal Conversation.
+\end{tcolorbox}
+\section[Practice]{Practice — an Urdu wellbeing exchange}
+
+\label{lesson:UR-C04-practice}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Choose the question ending for the person addressed, then retrieve the complete answer before looking below.
+\end{quote}
+
+\subsection*{The exchange}
+\begin{quote}
+A to a man: \textbf{\ur{سلام}! \ur{آپ} \ur{کیسے} \ur{ہیں؟}} \emph{Salām! Āp kaise haiṅ?} A to a woman: \textbf{\ur{سلام}! \ur{آپ} \ur{کیسی} \ur{ہیں؟}} \emph{Salām! Āp kaisī haiṅ?} B: \textbf{\ur{میں} \ur{ٹھیک} \ur{ہوں،} \ur{شکریہ۔}} \emph{Maiṅ ṭhīk hūṅ, shukriyā.}
+\end{quote}
+
+The question keeps respectful \textbf{āp} and final \textbf{haiṅ} while \textbf{kaise/kaisī} agrees with the addressee. The reply is unchanged for the speaker's gender: \textbf{ṭhīk} does not change, and first-person \textbf{hūṅ} closes the line.
+
+\begin{grammarlens}[title={Grammar Lens: separate grammar from guessing}]
+The two question forms are a grammatical contrast, not an instruction to infer someone's identity. In real interaction, follow the person's own language or ask. The stable beginner default is respect: \textbf{āp ... haiṅ}.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the man-addressed exchange{]}
+  \item {[}YOU SAY: the woman-addressed exchange{]}
+  \item {[}YOU ANSWER: \textbf{maiṅ ṭhīk hūṅ, shukriyā} after either question{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Run both question variants once. If the choice stalls, review only \textbf{kaise/kaisī}; if the answer order stalls, review only \textbf{maiṅ ... hūṅ}.
+\end{tcolorbox}

--- a/code/learning/human-languages/urdu/curriculum.json
+++ b/code/learning/human-languages/urdu/curriculum.json
@@ -55,6 +55,28 @@
         "UR-EXT-006-CONSOLIDATION"
       ],
       "after": []
+    },
+    {
+      "id": "UR-PATH-005",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "UR-C04-kaise-kaisi",
+        "UR-C04-aap-kaise-hain",
+        "UR-C04-main-hun",
+        "UR-C04-thik",
+        "UR-C04-main-thik-hun",
+        "UR-C04-practice"
+      ],
+      "before": [],
+      "inline": [
+        "UR-EXT-007-GENDERED-HOW",
+        "UR-EXT-008-HONORIFIC-COPULA",
+        "UR-EXT-009-FIRST-PERSON-FRAME",
+        "UR-EXT-010-SCRIPT-BRIDGE",
+        "UR-EXT-011-WELLBEING-WORD-ORDER",
+        "UR-EXT-012-WELLBEING-CONSOLIDATION"
+      ],
+      "after": []
     }
   ],
   "spine": {
@@ -103,12 +125,11 @@
       "relocates": {}
     },
     "SPINE-CHECK-WELLBEING": {
-      "segments": [],
+      "segments": [
+        "UR-PATH-005"
+      ],
       "omits": [
-        "QUESTION-HOW",
-        "STATE-HOW-ARE-YOU",
         "WORD-GOOD",
-        "WORD-WELL",
         "WORD-SOSO"
       ],
       "relocates": {}
@@ -246,6 +267,84 @@
       ],
       "lessons": [
         "UR-C03-practice"
+      ]
+    },
+    {
+      "id": "UR-EXT-007-GENDERED-HOW",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "grammar",
+      "canDo": "I can choose kaise or kaisī according to the person addressed while keeping respectful āp unchanged.",
+      "prerequisites": [
+        "UR-EXT-006-CONSOLIDATION"
+      ],
+      "lessons": [
+        "UR-C04-kaise-kaisi"
+      ]
+    },
+    {
+      "id": "UR-EXT-008-HONORIFIC-COPULA",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "register",
+      "canDo": "I can pair respectful āp with final haiṅ and keep the addressee agreement choice separate from politeness.",
+      "prerequisites": [
+        "UR-EXT-007-GENDERED-HOW"
+      ],
+      "lessons": [
+        "UR-C04-aap-kaise-hain"
+      ]
+    },
+    {
+      "id": "UR-EXT-009-FIRST-PERSON-FRAME",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "grammar",
+      "canDo": "I can open an Urdu answer with maiṅ and close it with hūṅ without learning the full copula table.",
+      "prerequisites": [
+        "UR-EXT-008-HONORIFIC-COPULA"
+      ],
+      "lessons": [
+        "UR-C04-main-hun"
+      ]
+    },
+    {
+      "id": "UR-EXT-010-SCRIPT-BRIDGE",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "script",
+      "canDo": "I can read Urdu ṭhīk and connect it to Hindi only after recognizing the Urdu retroflex and aspiration sequence.",
+      "prerequisites": [
+        "UR-EXT-009-FIRST-PERSON-FRAME"
+      ],
+      "lessons": [
+        "UR-C04-thik"
+      ]
+    },
+    {
+      "id": "UR-EXT-011-WELLBEING-WORD-ORDER",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "grammar",
+      "canDo": "I can place ṭhīk inside the maiṅ ... hūṅ frame and add known shukriyā after the completed clause.",
+      "prerequisites": [
+        "UR-EXT-010-SCRIPT-BRIDGE"
+      ],
+      "lessons": [
+        "UR-C04-main-thik-hun"
+      ]
+    },
+    {
+      "id": "UR-EXT-012-WELLBEING-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "consolidation",
+      "canDo": "I can complete a respectful Urdu wellbeing exchange while choosing the addressed form deliberately.",
+      "prerequisites": [
+        "UR-EXT-011-WELLBEING-WORD-ORDER"
+      ],
+      "lessons": [
+        "UR-C04-practice"
       ]
     }
   ]

--- a/code/learning/human-languages/urdu/lessons/UR-C04-aap-kaise-hain.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C04-aap-kaise-hain.md
@@ -1,0 +1,72 @@
+---
+schema_version: 2
+id: UR-C04-aap-kaise-hain
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 120
+chapter: 4
+type: phrase
+headword: آپ کیسے ہیں؟ / آپ کیسی ہیں؟
+romanization: āp kaise haiṅ? / āp kaisī haiṅ?
+gloss: How are you? — respectfully to a man / woman
+concept_tag: STATE-HOW-ARE-YOU
+prerequisites: [UR-C04-kaise-kaisi]
+sounds: [rtl, ai-diphthong, nasal-vowel, urdu-question-mark]
+roots: [indo-aryan-k-question-family, indo-aryan-copula]
+etymology_hook: Urdu pairs honorific āp with the plural copula haiṅ while kaise or kaisī keeps the addressee visible.
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [UR-LEX-AAP-TUM-TU, UR-PRAGMATICS-YOU-REGISTER, UR-LEX-KAISE-KAISI, UR-GRAMMAR-HOW-GENDER, UR-SCRIPT-URDU-QUESTION-MARK]
+introduces:
+  knowledge: [UR-LEX-WELLBEING-QUESTION, UR-GRAMMAR-AAP-HAIN, UR-PRAGMATICS-RESPECTFUL-GENDER-CHOICE]
+practises:
+  knowledge: [UR-LEX-AAP-TUM-TU, UR-PRAGMATICS-YOU-REGISTER, UR-LEX-KAISE-KAISI, UR-GRAMMAR-HOW-GENDER, UR-SCRIPT-URDU-QUESTION-MARK, UR-LEX-WELLBEING-QUESTION, UR-GRAMMAR-AAP-HAIN, UR-PRAGMATICS-RESPECTFUL-GENDER-CHOICE]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: respectful-gender-contrast
+variety: contemporary-standard-urdu
+reviews_of: [UR-C04-kaise-kaisi, UR-C03-aap-tum-tu, UR-C03-aap-ka-naam-kya-hai]
+---
+
+# آپ کیسے ہیں؟ / آپ کیسی ہیں؟ — ask respectfully
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-AAP-TUM-TU, UR-PRAGMATICS-YOU-REGISTER, UR-LEX-KAISE-KAISI, UR-GRAMMAR-HOW-GENDER, UR-SCRIPT-URDU-QUESTION-MARK] -->
+
+[PAUSE 2s] Choose respectful **āp**. Then choose **kaise** for a man or **kaisī**
+for a woman. One final copula completes the question.
+
+## The exchange
+<!-- hl-knowledge: introduces=[UR-LEX-WELLBEING-QUESTION, UR-GRAMMAR-AAP-HAIN]; assesses=[] -->
+
+> to a man: **آپ کیسے ہیں؟** — *āp kaise haiṅ?*
+> to a woman: **آپ کیسی ہیں؟** — *āp kaisī haiṅ?*
+
+The order is **you + how + are?** Keep **ہیں** *haiṅ* final, just as **ہے** *hai*
+stayed final in the name question. Respectful **āp** takes this plural-shaped
+copula even when speaking to one person.
+
+## Grammar Lens: respect does not erase agreement
+<!-- hl-knowledge: introduces=[UR-PRAGMATICS-RESPECTFUL-GENDER-CHOICE]; assesses=[] -->
+
+Both lines are respectful. The choice between **kaise** and **kaisī** tracks the
+person addressed, not greater or lesser politeness. If you do not know how a
+person wishes to be addressed, listen for their usage or ask rather than guess;
+the grammar lesson does not replace social judgment.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-WELLBEING-QUESTION, UR-GRAMMAR-AAP-HAIN, UR-PRAGMATICS-RESPECTFUL-GENDER-CHOICE] -->
+
+- [YOU SAY: to a man — **āp kaise haiṅ?**]
+- [YOU SAY: to a woman — **āp kaisī haiṅ?**]
+- [YOU KEEP: respectful **āp** and final **haiṅ** in both]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-WELLBEING-QUESTION, UR-GRAMMAR-AAP-HAIN, UR-PRAGMATICS-RESPECTFUL-GENDER-CHOICE] -->
+<!-- hl-activity: {"id":"UR-C04-aap-kaise-hain-man","kind":"text","assesses":["UR-LEX-WELLBEING-QUESTION"],"prompt":"Type the respectful Urdu question 'How are you?' addressed to a man.","answer":"آپ کیسے ہیں؟","accepted":["آپ کیسے ہیں","aap kaise hain","āp kaise haiṅ"],"feedback":{"correct":"Right: آپ کیسے ہیں؟ keeps respectful آپ and final ہیں.","incorrect":"Use آپ کیسے ہیں؟ — āp kaise haiṅ?"},"response_seconds":10} -->
+
+What stays the same in both lines? (**Āp ... haiṅ**.) What changes? (**Kaise /
+kaisī**.)
+
+Sources: [*Basic Urdu*: Formal Conversation](https://openbooks.lib.msu.edu/urdu/chapter/2-4/) and [Personal Pronouns with “To Be”](https://openbooks.lib.msu.edu/urdu/chapter/2-7/).

--- a/code/learning/human-languages/urdu/lessons/UR-C04-kaise-kaisi.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C04-kaise-kaisi.md
@@ -1,0 +1,73 @@
+---
+schema_version: 2
+id: UR-C04-kaise-kaisi
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 110
+chapter: 4
+type: word
+headword: کیسے / کیسی
+romanization: kaise / kaisī
+gloss: how — addressing a man / addressing a woman
+concept_tag: QUESTION-HOW
+prerequisites: [UR-C03-practice]
+sounds: [rtl, ai-diphthong, long-i, final-ye]
+roots: [indo-aryan-k-question-family]
+etymology_hook: Kaise and kaisī belong to the inherited Indo-Aryan k-question family already visible in kyā; Urdu lets the form agree with the person addressed.
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [UR-DIALOGUE-NAME-EXCHANGE, UR-LEX-KYA]
+introduces:
+  knowledge: [UR-LEX-KAISE-KAISI, UR-SCRIPT-KAISE-KAISI, UR-GRAMMAR-HOW-GENDER]
+practises:
+  knowledge: [UR-DIALOGUE-NAME-EXCHANGE, UR-LEX-KYA, UR-LEX-KAISE-KAISI, UR-SCRIPT-KAISE-KAISI, UR-GRAMMAR-HOW-GENDER]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: respectful-gender-contrast
+variety: contemporary-standard-urdu
+reviews_of: [UR-C03-practice, UR-C03-kya]
+---
+
+# کیسے / کیسی — “how” follows the addressee
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[UR-DIALOGUE-NAME-EXCHANGE, UR-LEX-KYA] -->
+
+[PAUSE 2s] Say **kyā** “what.” Urdu's next question word begins with the same
+**k** family, but its ending changes with the person being addressed.
+
+## The two words
+<!-- hl-knowledge: introduces=[UR-LEX-KAISE-KAISI, UR-SCRIPT-KAISE-KAISI]; assesses=[] -->
+
+| Urdu | read | use in the respectful question |
+|---|---|---|
+| **کیسے** | *kaise* | addressing a man |
+| **کیسی** | *kaisī* | addressing a woman |
+
+Both begin **ک** *k* + **ی** carrying the *ai* sound. At the left edge,
+**کیسے** ends in broad **ے** *e*, while **کیسی** ends in **ی** long *ī*.
+Read the whole word before isolating the final shape.
+
+## Grammar Lens: one agreement contrast
+<!-- hl-knowledge: introduces=[UR-GRAMMAR-HOW-GENDER]; assesses=[] -->
+
+English keeps *how* unchanged. Urdu makes this describing form agree with the
+person addressed: **kaise** for a man, **kaisī** for a woman. Learn only this
+pair today—not a table of adjective endings. Respectful **āp** itself remains
+the same for everyone.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-KAISE-KAISI, UR-SCRIPT-KAISE-KAISI, UR-GRAMMAR-HOW-GENDER] -->
+
+- [YOU SAY: addressing a man — **kaise**]
+- [YOU SAY: addressing a woman — **kaisī**]
+- [YOU POINT: broad final **ے** versus long-*ī* **ی**]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-KAISE-KAISI, UR-SCRIPT-KAISE-KAISI, UR-GRAMMAR-HOW-GENDER] -->
+<!-- hl-activity: {"id":"UR-C04-kaise-kaisi-woman","kind":"text","assesses":["UR-GRAMMAR-HOW-GENDER"],"prompt":"Type the Urdu 'how' form used when respectfully addressing a woman.","answer":"کیسی","accepted":["kaisi","kaisī"],"feedback":{"correct":"Right: کیسی kaisī agrees with a woman being addressed.","incorrect":"Use کیسی kaisī for a woman; کیسے kaise is the corresponding form for a man."},"response_seconds":8} -->
+
+Which form addresses a man? (**Kaise**.) A woman? (**Kaisī**.)
+
+Source: [*Basic Urdu*: Formal Conversation](https://openbooks.lib.msu.edu/urdu/chapter/2-4/).

--- a/code/learning/human-languages/urdu/lessons/UR-C04-main-hun.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C04-main-hun.md
@@ -1,0 +1,73 @@
+---
+schema_version: 2
+id: UR-C04-main-hun
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 130
+chapter: 4
+type: phrase
+headword: میں ... ہوں
+romanization: maiṅ ... hūṅ
+gloss: I am ...
+concept_tag: UR-C04-MAIN-HUN
+prerequisites: [UR-C04-aap-kaise-hain]
+sounds: [rtl, nasal-vowel, long-u, short-vowels-unwritten]
+roots: [indo-aryan-main, indo-aryan-copula]
+etymology_hook: Urdu maiṅ belongs to the old Indo-European me-family, while hūṅ is the first-person present form that closes the Urdu clause.
+duration:
+  max_seconds: 230
+requires:
+  knowledge: [UR-LEX-WELLBEING-QUESTION, UR-GRAMMAR-AAP-HAIN]
+introduces:
+  knowledge: [UR-LEX-MAIN, UR-LEX-HUN, UR-GRAMMAR-MAIN-HUN-FRAME, UR-SCRIPT-MAIN-HUN]
+practises:
+  knowledge: [UR-LEX-WELLBEING-QUESTION, UR-GRAMMAR-AAP-HAIN, UR-LEX-MAIN, UR-LEX-HUN, UR-GRAMMAR-MAIN-HUN-FRAME, UR-SCRIPT-MAIN-HUN]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: contemporary-standard-urdu
+reviews_of: [UR-C04-aap-kaise-hain, UR-C02-mera-naam]
+---
+
+# میں ... ہوں — one frame for “I am ...”
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-WELLBEING-QUESTION, UR-GRAMMAR-AAP-HAIN] -->
+
+[PAUSE 2s] Ask **āp kaise haiṅ?** You know the respectful “you are” ending
+**haiṅ**. Your answer needs the first-person pair “I ... am.”
+
+## You'll want to know first — the frame
+<!-- hl-knowledge: introduces=[UR-LEX-MAIN, UR-LEX-HUN, UR-SCRIPT-MAIN-HUN]; assesses=[] -->
+
+> **میں ... ہوں** — *maiṅ ... hūṅ* — **I am ...**
+
+**میں** *maiṅ* means “I.” Final **ں** marks a nasal ending. **ہوں** *hūṅ* means
+“am” and carries long *ū* with **و**, followed again by nasal **ں**. Leave a
+space for the state word that comes next.
+
+## Grammar Lens: the verb closes the frame
+<!-- hl-knowledge: introduces=[UR-GRAMMAR-MAIN-HUN-FRAME]; assesses=[] -->
+
+Urdu puts the copula at the end:
+
+> **maiṅ + [state] + hūṅ** — I + [state] + am
+
+Learn only this first-person frame. You do not need the full copula chart to
+answer one wellbeing question. Notice the useful contrast: respectful **āp ...
+haiṅ**, but first-person **maiṅ ... hūṅ**.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-MAIN, UR-LEX-HUN, UR-GRAMMAR-MAIN-HUN-FRAME, UR-SCRIPT-MAIN-HUN] -->
+
+- [YOU SAY: **maiṅ** — I]
+- [YOU SAY: **hūṅ** — am]
+- [YOU FRAME: **maiṅ ... hūṅ**, leaving the middle open]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-MAIN, UR-LEX-HUN, UR-GRAMMAR-MAIN-HUN-FRAME, UR-SCRIPT-MAIN-HUN] -->
+<!-- hl-activity: {"id":"UR-C04-main-hun-frame","kind":"text","assesses":["UR-GRAMMAR-MAIN-HUN-FRAME"],"prompt":"Type the Urdu frame 'I am ...', leaving three dots for the state word.","answer":"میں ... ہوں","accepted":["میں ۔۔۔ ہوں","main ... hun","maiṅ ... hūṅ"],"feedback":{"correct":"Right: میں opens the answer and ہوں closes it.","incorrect":"Use میں ... ہوں — maiṅ ... hūṅ."},"response_seconds":10} -->
+
+Which word opens the answer? (**Maiṅ**.) Which copula closes it? (**Hūṅ**.)
+
+Source: [*Basic Urdu*: Personal Pronouns with “To Be”](https://openbooks.lib.msu.edu/urdu/chapter/2-7/).

--- a/code/learning/human-languages/urdu/lessons/UR-C04-main-thik-hun.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C04-main-thik-hun.md
@@ -1,0 +1,73 @@
+---
+schema_version: 2
+id: UR-C04-main-thik-hun
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 150
+chapter: 4
+type: phrase
+headword: میں ٹھیک ہوں، شکریہ
+romanization: maiṅ ṭhīk hūṅ, shukriyā
+gloss: I am fine, thank you
+concept_tag: UR-C04-MAIN-THIK-HUN
+prerequisites: [UR-C04-thik]
+sounds: [rtl, nasal-vowel, retroflex-aspirated-th, long-i, long-u]
+roots: [shared-hindustani-thik, indo-aryan-copula, arabic-shukr]
+etymology_hook: The reply puts shared Hindustani ṭhīk inside inherited Urdu grammar and closes with Persian-shaped Arabic-rooted shukriyā already learned in Chapter 1.
+duration:
+  max_seconds: 220
+requires:
+  knowledge: [UR-LEX-MAIN, UR-LEX-HUN, UR-GRAMMAR-MAIN-HUN-FRAME, UR-LEX-THIK, UR-DIALOGUE-NAME-EXCHANGE]
+introduces:
+  knowledge: [UR-LEX-WELLBEING-REPLY, UR-GRAMMAR-WELLBEING-WORD-ORDER]
+practises:
+  knowledge: [UR-LEX-MAIN, UR-LEX-HUN, UR-GRAMMAR-MAIN-HUN-FRAME, UR-LEX-THIK, UR-DIALOGUE-NAME-EXCHANGE, UR-LEX-WELLBEING-REPLY, UR-GRAMMAR-WELLBEING-WORD-ORDER]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral-polite
+variety: contemporary-standard-urdu
+reviews_of: [UR-C04-main-hun, UR-C04-thik, UR-C01-shukriya]
+---
+
+# میں ٹھیک ہوں، شکریہ — “I am fine, thank you”
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-MAIN, UR-LEX-HUN, UR-GRAMMAR-MAIN-HUN-FRAME, UR-LEX-THIK, UR-DIALOGUE-NAME-EXCHANGE] -->
+
+[PAUSE 2s] Fill the frame **maiṅ ... hūṅ** with **ṭhīk**, then recall Chapter
+1's **shukriyā**.
+
+## The exchange
+<!-- hl-knowledge: introduces=[UR-LEX-WELLBEING-REPLY]; assesses=[] -->
+
+> **میں ٹھیک ہوں، شکریہ۔**
+> *Maiṅ ṭhīk hūṅ, shukriyā.*
+> **I am fine, thank you.**
+
+No word is new. The step is assembling the words quickly enough to answer a
+real person.
+
+## Grammar Lens: keep the copula final
+<!-- hl-knowledge: introduces=[UR-GRAMMAR-WELLBEING-WORD-ORDER]; assesses=[] -->
+
+The core reply is:
+
+> I + fine + am → **maiṅ ṭhīk hūṅ**
+
+English places “am” after “I”; Urdu closes the clause with **hūṅ**. **Shukriyā**
+comes after the completed answer as the courtesy move you already own.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-WELLBEING-REPLY, UR-GRAMMAR-WELLBEING-WORD-ORDER] -->
+
+- [YOU BUILD: **maiṅ + ṭhīk + hūṅ**]
+- [YOU ADD: **shukriyā**]
+- [YOU SAY: the full reply without translating each word]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-WELLBEING-REPLY, UR-GRAMMAR-WELLBEING-WORD-ORDER] -->
+<!-- hl-activity: {"id":"UR-C04-main-thik-hun-reply","kind":"text","assesses":["UR-LEX-WELLBEING-REPLY"],"prompt":"Reply in Urdu: 'I am fine, thank you.'","answer":"میں ٹھیک ہوں، شکریہ","accepted":["میں ٹھیک ہوں شکریہ","main thik hun shukriya","maiṅ ṭhīk hūṅ shukriyā"],"feedback":{"correct":"Right: میں ٹھیک ہوں closes the clause with ہوں; شکریہ adds thanks.","incorrect":"Use میں ٹھیک ہوں، شکریہ — maiṅ ṭhīk hūṅ, shukriyā."},"response_seconds":10} -->
+
+Which word must close the core answer? (**Hūṅ**.)
+
+Source: [*Basic Urdu*: Formal Conversation](https://openbooks.lib.msu.edu/urdu/chapter/2-4/).

--- a/code/learning/human-languages/urdu/lessons/UR-C04-practice.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C04-practice.md
@@ -1,0 +1,73 @@
+---
+schema_version: 2
+id: UR-C04-practice
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 160
+chapter: 4
+type: practice-mix
+headword: آپ کیسے ہیں؟ — میں ٹھیک ہوں، شکریہ
+romanization: āp kaise haiṅ? — maiṅ ṭhīk hūṅ, shukriyā
+gloss: a respectful Urdu wellbeing exchange
+concept_tag: UR-C04-PRACTICE
+prerequisites: [UR-C04-main-thik-hun]
+sounds: [rtl, nasal-vowel, retroflex-aspirated-th, urdu-question-mark]
+roots: []
+etymology_hook: The exchange combines Urdu's inherited grammar, shared Hindustani ṭhīk, and Arabic-rooted shukriyā without adding a hidden form.
+duration:
+  max_seconds: 230
+requires:
+  knowledge: [UR-LEX-WELLBEING-QUESTION, UR-GRAMMAR-AAP-HAIN, UR-PRAGMATICS-RESPECTFUL-GENDER-CHOICE, UR-LEX-WELLBEING-REPLY, UR-GRAMMAR-WELLBEING-WORD-ORDER]
+introduces:
+  knowledge: [UR-DIALOGUE-WELLBEING]
+practises:
+  knowledge: [UR-LEX-WELLBEING-QUESTION, UR-GRAMMAR-AAP-HAIN, UR-PRAGMATICS-RESPECTFUL-GENDER-CHOICE, UR-LEX-WELLBEING-REPLY, UR-GRAMMAR-WELLBEING-WORD-ORDER, UR-DIALOGUE-WELLBEING]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, fluency]
+register: respectful-gender-contrast
+variety: contemporary-standard-urdu
+reviews_of: [UR-C04-kaise-kaisi, UR-C04-aap-kaise-hain, UR-C04-main-hun, UR-C04-thik, UR-C04-main-thik-hun]
+---
+
+# Practice — an Urdu wellbeing exchange
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-WELLBEING-QUESTION, UR-LEX-WELLBEING-REPLY] -->
+
+[PAUSE 2s] Choose the question ending for the person addressed, then retrieve
+the complete answer before looking below.
+
+## The exchange
+<!-- hl-knowledge: introduces=[UR-DIALOGUE-WELLBEING]; assesses=[] -->
+
+> A to a man: **سلام! آپ کیسے ہیں؟**
+> *Salām! Āp kaise haiṅ?*
+> A to a woman: **سلام! آپ کیسی ہیں؟**
+> *Salām! Āp kaisī haiṅ?*
+> B: **میں ٹھیک ہوں، شکریہ۔**
+> *Maiṅ ṭhīk hūṅ, shukriyā.*
+
+The question keeps respectful **āp** and final **haiṅ** while **kaise/kaisī**
+agrees with the addressee. The reply is unchanged for the speaker's gender:
+**ṭhīk** does not change, and first-person **hūṅ** closes the line.
+
+## Grammar Lens: separate grammar from guessing
+<!-- hl-knowledge: introduces=[]; assesses=[UR-GRAMMAR-AAP-HAIN, UR-PRAGMATICS-RESPECTFUL-GENDER-CHOICE, UR-GRAMMAR-WELLBEING-WORD-ORDER] -->
+
+The two question forms are a grammatical contrast, not an instruction to infer
+someone's identity. In real interaction, follow the person's own language or
+ask. The stable beginner default is respect: **āp ... haiṅ**.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-WELLBEING-QUESTION, UR-LEX-WELLBEING-REPLY, UR-DIALOGUE-WELLBEING] -->
+
+- [YOU SAY: the man-addressed exchange]
+- [YOU SAY: the woman-addressed exchange]
+- [YOU ANSWER: **maiṅ ṭhīk hūṅ, shukriyā** after either question]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-WELLBEING-QUESTION, UR-GRAMMAR-AAP-HAIN, UR-PRAGMATICS-RESPECTFUL-GENDER-CHOICE, UR-LEX-WELLBEING-REPLY, UR-GRAMMAR-WELLBEING-WORD-ORDER, UR-DIALOGUE-WELLBEING] -->
+<!-- hl-activity: {"id":"UR-C04-practice-next-line","kind":"text","assesses":["UR-DIALOGUE-WELLBEING"],"prompt":"After آپ کیسے ہیں؟, type the polite Urdu reply.","answer":"میں ٹھیک ہوں، شکریہ","accepted":["میں ٹھیک ہوں شکریہ","main thik hun shukriya","maiṅ ṭhīk hūṅ shukriyā"],"feedback":{"correct":"Right: میں ٹھیک ہوں، شکریہ completes the respectful wellbeing exchange.","incorrect":"Reply میں ٹھیک ہوں، شکریہ — maiṅ ṭhīk hūṅ, shukriyā."},"response_seconds":10} -->
+
+Run both question variants once. If the choice stalls, review only
+**kaise/kaisī**; if the answer order stalls, review only **maiṅ ... hūṅ**.

--- a/code/learning/human-languages/urdu/lessons/UR-C04-thik.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C04-thik.md
@@ -1,0 +1,72 @@
+---
+schema_version: 2
+id: UR-C04-thik
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 140
+chapter: 4
+type: word
+headword: ٹھیک
+romanization: ṭhīk
+gloss: fine, well, correct
+concept_tag: WORD-WELL
+prerequisites: [UR-C04-main-hun]
+sounds: [rtl, retroflex-aspirated-th, long-i]
+roots: [shared-hindustani-thik]
+etymology_hook: Thik is shared everyday Hindustani vocabulary; Urdu writes it ٹھیک, while the Hindi track teaches its own script independently.
+duration:
+  max_seconds: 220
+requires:
+  knowledge: [UR-LEX-MAIN, UR-LEX-HUN, UR-GRAMMAR-MAIN-HUN-FRAME]
+introduces:
+  knowledge: [UR-LEX-THIK, UR-SCRIPT-THIK, UR-CROSSLINGUAL-THIK]
+practises:
+  knowledge: [UR-LEX-MAIN, UR-LEX-HUN, UR-GRAMMAR-MAIN-HUN-FRAME, UR-LEX-THIK, UR-SCRIPT-THIK, UR-CROSSLINGUAL-THIK]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: contemporary-standard-urdu
+reviews_of: [UR-C04-main-hun]
+---
+
+# ٹھیک — “fine,” “well,” and “correct”
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-MAIN, UR-LEX-HUN, UR-GRAMMAR-MAIN-HUN-FRAME] -->
+
+[PAUSE 2s] Open and close the answer frame: **maiṅ ... hūṅ**. The middle now
+gets one high-frequency state word.
+
+## You'll want to know first — the word
+<!-- hl-knowledge: introduces=[UR-LEX-THIK, UR-SCRIPT-THIK]; assesses=[] -->
+
+> **ٹھیک** — *ṭhīk* — **fine, well, correct**
+
+The first sound is retroflex and aspirated: curl the tongue slightly back for
+**ٹ** *ṭ*, then release a puff marked by **ھ**. A plain English *t* is a useful
+first approximation while the contrast settles. **ی** carries long *ī* before
+final **ک** *k*.
+
+## The word, taken apart — one word, two scripts
+<!-- hl-knowledge: introduces=[UR-CROSSLINGUAL-THIK]; assesses=[] -->
+
+Urdu **ٹھیک** and Hindi *ṭhīk* are the same everyday Hindustani word. Their
+grammar is closely shared; their scripts make different literary histories
+visible. This Urdu lesson leaves the Hindi side romanized: mixed-language
+practice may show both scripts only after each form has been learned in its own
+track.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-THIK, UR-SCRIPT-THIK, UR-CROSSLINGUAL-THIK] -->
+
+- [YOU SAY: **ṭhīk** — fine, well]
+- [YOU FEEL: tongue slightly back, then a small puff]
+- [YOU CONNECT: Urdu **ٹھیک** ↔ Hindi *ṭhīk*]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-THIK, UR-SCRIPT-THIK, UR-CROSSLINGUAL-THIK] -->
+<!-- hl-activity: {"id":"UR-C04-thik-well","kind":"text","assesses":["UR-LEX-THIK"],"prompt":"Type the Urdu word meaning 'fine' or 'well'.","answer":"ٹھیک","accepted":["thik","ṭhīk","theek"],"feedback":{"correct":"Right: ٹھیک ṭhīk means 'fine', 'well', or 'correct'.","incorrect":"Use ٹھیک — ṭhīk."},"response_seconds":8} -->
+
+Where will **ṭhīk** go in the frame **maiṅ ... hūṅ**? (In the middle.)
+
+Source: [*Basic Urdu*: Greetings and Introductions](https://openbooks.lib.msu.edu/urdu/chapter/2-2/).

--- a/code/learning/human-languages/urdu/pronunciation-reference.md
+++ b/code/learning/human-languages/urdu/pronunciation-reference.md
@@ -29,11 +29,20 @@ romanization once the Urdu form is familiar.
 |---|---|---|
 | `rtl` | follow the word from its right edge leftward | **سلام** *salām* |
 | `long-a` | hold *ā* steady; **ا** carries it in **سلام** | **سلام** *salām* |
+| `alif-madd` | read **آ** as word-initial long *ā* | **آپ** *āp* |
 | `short-vowels-unwritten` | supply the learned short vowels even when vowel marks are absent | **شکریہ** *shukriyā* |
 | `long-i` | hold **ی** as *ī* in this word | **جی** *jī* |
+| `long-u` | hold **و** as long *ū* in the learned word | **ہوں** *hūṅ* |
 | `nasal-vowel` | let air pass through the nose; final **ں** does not add a full English *n* | **ہاں** *hā̃*, **نہیں** *nahī̃* |
 | `long-vowels` | read the word's written long-vowel cues rather than stretching every vowel | **میرا نام** *merā nām* |
 | `hai-diphthong` | say **ہے** as one *hai* syllable, ending in an *ai* glide | **ہے** *hai* |
+| `sh` | read three-dotted **ش** as *sh* | **شکریہ** *shukriyā* |
+| `kh` | make **خ** farther back than English *h* | **خوشی** *khushī* |
+| `consonantal-ye` | let **ی** supply consonantal *y* before a vowel | **کیا** *kyā* |
+| `ai-diphthong` | say *ai* as one glide in the learned question word | **کیسے** *kaise* |
+| `final-ye` | distinguish broad final **ے** *e* from final **ی** long *ī* | **کیسے / کیسی** *kaise / kaisī* |
+| `retroflex-aspirated-th` | curl the tongue slightly back for **ٹ**, then release the aspiration marked by **ھ** | **ٹھیک** *ṭhīk* |
+| `urdu-question-mark` | recognize **؟** at the left end of a right-to-left question | **آپ کا نام کیا ہے؟** |
 
 ## Shape families already in use
 
@@ -42,8 +51,10 @@ romanization once the Urdu form is familiar.
   nasalization in **ہاں** and **نہیں**.
 - **ی** supplies the long *ī* in **جی** and **نہیں**. Final **ے** participates
   in *hai* in **ہے**. Learn each role in its word before generalizing.
-- Urdu will later add its Indic sound distinctions—retroflex consonants and
-  aspirated pairs—inline when a communicative expression first needs them.
+- **کیا** gives **ی** its consonantal *y* job; **کیسے / کیسی** then contrast
+  broad final **ے** with long-*ī* final **ی**.
+- **ٹھیک** introduces the Indic retroflex-plus-aspiration sequence **ٹھ** only
+  when the wellbeing reply needs it.
 
 ## The Persian-Arabic and Indo-Aryan layers
 

--- a/code/learning/human-languages/urdu/roadmap.md
+++ b/code/learning/human-languages/urdu/roadmap.md
@@ -27,12 +27,21 @@ job of **ی**, fixed **āp kā nām**, the Urdu question mark, and a gently chun
 meeting response. Every objective retrieval happens in Urdu script before the
 lesson can enter mixed Urdu/Hindi or Urdu/Persian review.
 
-## Chapter 4 — People and simple identity *(planned)*
+## Chapter 4 — Ask about wellbeing *(authored)*
 
-- **میں ... ہوں** *maĩ ... hū̃* — I am ...;
-- masculine and feminine agreement one contrast at a time;
-- **ہے** *hai* versus **ہوں** *hū̃* without a full paradigm dump;
-- retroflex and aspirated letters only when the next useful word needs them.
+**کیسے / کیسی** *kaise / kaisī* → **آپ کیسے ہیں؟ / آپ کیسی ہیں؟**
+*āp kaise / kaisī haiṅ?* → **میں ... ہوں** *maiṅ ... hūṅ* → **ٹھیک** *ṭhīk* →
+**میں ٹھیک ہوں، شکریہ** *maiṅ ṭhīk hūṅ, shukriyā* → one cumulative exchange.
+The shared wellbeing can-do gets an Urdu-specific extra step for addressee
+agreement, an explicit **āp ... haiṅ** honorific frame, and an Urdu/Hindi script
+bridge only after **ٹھیک** is independently readable.
+
+## Chapter 5 — People and simple identity *(planned)*
+
+- extend **میں ... ہوں** *maiṅ ... hūṅ* from state to identity;
+- add further masculine and feminine agreement one contrast at a time;
+- contrast **ہے** *hai*, **ہیں** *haiṅ*, and **ہوں** *hūṅ* without a paradigm dump;
+- introduce more retroflex and aspirated letters only when useful words need them.
 
 ## Part II onward *(sketch)*
 

--- a/code/learning/human-languages/urdu/session-map.md
+++ b/code/learning/human-languages/urdu/session-map.md
@@ -1,6 +1,6 @@
-# Urdu Session Map — Authored Chapters 1–2
+# Urdu Session Map — Authored Chapters 1–4
 
-This is the authoritative order for the five authored Urdu lessons. Each new
+This is the authoritative order for the sixteen authored Urdu lessons. Each new
 lesson is a self-contained, prerequisite-safe step of three or four minutes.
 A longer study session may combine the new step with its due reviews while the
 book and app keep every lesson independently completable.
@@ -37,6 +37,21 @@ Each row still points to one independently resumable lesson.
 | **S9** | [`UR-C03-khushi-hui`](./lessons/UR-C03-khushi-hui.md): **آپ سے مل کر خوشی ہوئی** | *shukriyā* *(N+7)*; the three “you” forms *(N+3)*; the name question *(N+1)* | close the introduction warmly |
 | **S10** | [`UR-C03-practice`](./lessons/UR-C03-practice.md): full exchange | *jī hā̃* *(N+7)*; *kyā* *(N+3)*; the meeting response *(N+1)* | run both voices using only known lines |
 
+## Chapter 4 — Ask about wellbeing
+
+Urdu uses six sessions so addressee agreement and the first-person answer frame
+arrive separately. Each lesson remains independently completable in under five
+minutes.
+
+| Session | New lesson | Reviews due | Cumulative practice |
+|---|---|---|---|
+| **S11** | [`UR-C04-kaise-kaisi`](./lessons/UR-C04-kaise-kaisi.md): **کیسے / کیسی** | *nahī̃* *(N+7)*; the name question *(N+3)*; Chapter 3 practice *(N+1)* | choose “how” for the person addressed |
+| **S12** | [`UR-C04-aap-kaise-hain`](./lessons/UR-C04-aap-kaise-hain.md): **آپ کیسے ہیں؟ / آپ کیسی ہیں؟** | *merā nām ... hai* *(N+7)*; the meeting response *(N+3)*; *kaise / kaisī* *(N+1)* | ask respectfully with final *haiṅ* |
+| **S13** | [`UR-C04-main-hun`](./lessons/UR-C04-main-hun.md): **میں ... ہوں** | the three “you” forms *(N+7)*; Chapter 3 practice *(N+3)*; the wellbeing question *(N+1)* | open with *maiṅ* and close with *hūṅ* |
+| **S14** | [`UR-C04-thik`](./lessons/UR-C04-thik.md): **ٹھیک** *ṭhīk* | *kyā* *(N+7)*; *kaise / kaisī* *(N+3)*; *maiṅ ... hūṅ* *(N+1)* | place the state word inside the answer frame |
+| **S15** | [`UR-C04-main-thik-hun`](./lessons/UR-C04-main-thik-hun.md): **میں ٹھیک ہوں، شکریہ** | the name question *(N+7)*; the wellbeing question *(N+3)*; *ṭhīk* *(N+1)* | keep *hūṅ* final, then add known thanks |
+| **S16** | [`UR-C04-practice`](./lessons/UR-C04-practice.md): full wellbeing exchange | *salām* *(N+15)*; the meeting response *(N+7)*; *maiṅ ... hūṅ* *(N+3)*; the reply *(N+1)* | run both respectful question variants and one answer |
+
 ## Carry-forward review ledger
 
 Future chapters may supply the new lesson in these sessions. Until then, use
@@ -45,21 +60,21 @@ with already learned material.
 
 | Session | Fixed review due |
 |---|---|
-| **S11** | *nahī̃* *(N+7)*; the name question *(N+3)*; Chapter 3 practice *(N+1)* |
-| **S12** | *merā nām ... hai* *(N+7)*; the meeting response *(N+3)* |
-| **S13** | the three “you” forms *(N+7)*; Chapter 3 practice *(N+3)* |
-| **S14** | *kyā* *(N+7)* |
-| **S15** | the name question *(N+7)* |
-| **S16** | *salām* *(N+15)*; the meeting response *(N+7)* |
-| **S17** | *shukriyā* *(N+15)*; Chapter 3 practice *(N+7)* |
-| **S18** | *jī hā̃* *(N+15)* |
-| **S19** | *nahī̃* *(N+15)* |
-| **S20** | *merā nām ... hai* *(N+15)* |
-| **S21** | the three “you” forms *(N+15)* |
-| **S22** | *kyā* *(N+15)* |
-| **S23** | the name question *(N+15)* |
+| **S17** | *shukriyā* *(N+15)*; Chapter 3 practice *(N+7)*; *ṭhīk* *(N+3)*; Chapter 4 practice *(N+1)* |
+| **S18** | *jī hā̃* *(N+15)*; *kaise / kaisī* *(N+7)*; the reply *(N+3)* |
+| **S19** | *nahī̃* *(N+15)*; the wellbeing question *(N+7)*; Chapter 4 practice *(N+3)* |
+| **S20** | *merā nām ... hai* *(N+15)*; *maiṅ ... hūṅ* *(N+7)* |
+| **S21** | the three “you” forms *(N+15)*; *ṭhīk* *(N+7)* |
+| **S22** | *kyā* *(N+15)*; the reply *(N+7)* |
+| **S23** | the name question *(N+15)*; Chapter 4 practice *(N+7)* |
 | **S24** | the meeting response *(N+15)* |
 | **S25** | Chapter 3 practice *(N+15)* |
+| **S26** | *kaise / kaisī* *(N+15)* |
+| **S27** | the wellbeing question *(N+15)* |
+| **S28** | *maiṅ ... hūṅ* *(N+15)* |
+| **S29** | *ṭhīk* *(N+15)* |
+| **S30** | the reply *(N+15)* |
+| **S31** | Chapter 4 practice *(N+15)* |
 
 Sessions not listed in the ledger have no fixed starter item due; use their
 bonus queue for adaptive or cumulative retrieval.
@@ -70,7 +85,7 @@ review; the fixed ledger remains the book's no-tracking fallback.
 
 ## Schedule check
 
-Every Chapter 1–3 lesson now has all four fixed resurfacing sessions through
-S25. The app may pull a missed item forward, but it cannot skip the local
-prerequisites. Chapter 4 can begin in S11 while the ledger continues in the
-review portion of each session.
+Every Chapter 1–4 lesson now has all four fixed resurfacing sessions through
+S31. The app may pull a missed item forward, but it cannot skip the local
+prerequisites. A future Chapter 5 can begin in S17 while this ledger continues
+in the review portion of each session.

--- a/code/packages/typescript/human-language-data/tests/integration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/integration.test.ts
@@ -67,12 +67,12 @@ describe("real curriculum", () => {
       books.books
         .find((book) => book.language === "persian")
         ?.chapters.map((chapter) => chapter.chapter),
-    ).toEqual([1, 2, 3]);
+    ).toEqual([1, 2, 3, 4]);
     expect(
       books.books
         .find((book) => book.language === "urdu")
         ?.chapters.map((chapter) => chapter.chapter),
-    ).toEqual([1, 2, 3]);
+    ).toEqual([1, 2, 3, 4]);
     expect(
       books.books
         .find((book) => book.language === "russian")
@@ -107,6 +107,12 @@ describe("real curriculum", () => {
       "FA-C03-khoshvaghtam-close",
       "FA-C03-practice-next-line",
       "FA-C03-shoma-to-first-meeting",
+      "FA-C04-chetor-how",
+      "FA-C04-hal-e-shoma-chetor-ast-question",
+      "FA-C04-hal-meaning",
+      "FA-C04-khub-good",
+      "FA-C04-khubam-reply",
+      "FA-C04-practice-next-line",
       "GE-C17-kopf-haupt-compound-word",
       "GU-C06-number-histories-be-source",
       "HI-W01-shirorekha-na-ma-drawing-order",
@@ -128,6 +134,12 @@ describe("real curriculum", () => {
       "UR-C03-khushi-hui-close",
       "UR-C03-kya-what",
       "UR-C03-practice-next-line",
+      "UR-C04-aap-kaise-hain-man",
+      "UR-C04-kaise-kaisi-woman",
+      "UR-C04-main-hun-frame",
+      "UR-C04-main-thik-hun-reply",
+      "UR-C04-practice-next-line",
+      "UR-C04-thik-well",
     ]);
     expect(activities.every((activity) => activity.assesses.length > 0)).toBe(true);
     expect(activities.every((activity) => activity.acceptedResponses.length > 0)).toBe(true);
@@ -172,6 +184,28 @@ describe("real curriculum", () => {
       expect(
         report.prerequisites.laterChapterWithoutPrerequisites.filter(
           (lesson) => lesson.language === language && lesson.chapter === 3,
+        ),
+      ).toEqual([]);
+    }
+  });
+
+  it("keeps the Persian and Urdu Chapter 4 wellbeing chains closed, objective, and under five minutes", () => {
+    const report = buildCurriculumGapReport({ registry, lessons, books });
+    for (const language of ["persian", "urdu"]) {
+      const chapter = lessons.filter(
+        (lesson) => lesson.language === language && lesson.realization.chapter === 4,
+      );
+      expect(chapter).toHaveLength(6);
+      expect(chapter.every((lesson) => lesson.frontmatter.schema_version === "2")).toBe(true);
+      expect(chapter.every((lesson) => compileLessonActivities(lesson.blocks).length === 1)).toBe(true);
+      expect(
+        report.duration.violations.filter(
+          (lesson) => lesson.language === language && lesson.chapter === 4,
+        ),
+      ).toEqual([]);
+      expect(
+        report.prerequisites.laterChapterWithoutPrerequisites.filter(
+          (lesson) => lesson.language === language && lesson.chapter === 4,
         ),
       ).toEqual([]);
     }

--- a/code/programs/typescript/language-ladder/tests/curriculum.test.ts
+++ b/code/programs/typescript/language-ladder/tests/curriculum.test.ts
@@ -54,6 +54,12 @@ describe("per-language shared-spine maps", () => {
       "FA-C03-esm-e-shoma-chist",
       "FA-C03-khoshvaghtam",
       "FA-C03-practice",
+      "FA-C04-hal",
+      "FA-C04-chetor",
+      "FA-C04-hal-e-shoma-chetor-ast",
+      "FA-C04-khub",
+      "FA-C04-khubam",
+      "FA-C04-practice",
       "UR-C01-salam",
       "UR-C01-shukriya",
       "UR-C01-ji-han",
@@ -64,6 +70,12 @@ describe("per-language shared-spine maps", () => {
       "UR-C03-aap-ka-naam-kya-hai",
       "UR-C03-khushi-hui",
       "UR-C03-practice",
+      "UR-C04-kaise-kaisi",
+      "UR-C04-aap-kaise-hain",
+      "UR-C04-main-hun",
+      "UR-C04-thik",
+      "UR-C04-main-thik-hun",
+      "UR-C04-practice",
     ]));
   });
 


### PR DESCRIPTION
## Summary

- add six prerequisite-safe Chapter 4 wellbeing lessons each for Persian and Urdu
- extend the shared curriculum spine with language-specific RTL, register, agreement, copula, and etymology guidance
- derive both new LaTeX chapters and their source hashes from the same canonical lessons consumed by Language Ladder
- update curricula, practice sessions, pronunciation guidance, roadmap, changelogs, tests, and backlog status

## Validation

- human-language-data: 102 tests passed; TypeScript build passed
- Language Ladder: 481 tests passed; production build passed
- generated book check passed
- curriculum report: 20 tracks, 1,088 lessons, 20 books; no lesson at or above five minutes; no unknown prerequisites; no missing books
- Persian and Urdu XeLaTeX builds: 25 pages each with clean logs
- git diff --check passed