### PR TITLE
feat(human-languages): add Persian and Urdu farewells

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,12 +5,12 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-03. Current baseline after the Persian and Urdu
-Chapter 3 shared-spine tranche:
-20 registered tracks, 1,076 Markdown lessons, 20 downloadable LaTeX books, zero
-duration violations, and 20 validated realization maps containing 346 ordered
-path segments, 257 typed extension nodes, and 906 prerequisite-closed mapped
-lessons. Twenty-one mapped non-lexical lessons across 18 tracks now carry
+Last prioritized: 2026-08-04. Current baseline after the Persian and Urdu
+Chapter 5 shared-spine tranche:
+20 registered tracks, 1,096 Markdown lessons, 20 downloadable LaTeX books, zero
+duration violations, and 20 validated realization maps containing 350 ordered
+path segments, 277 typed extension nodes, and 926 prerequisite-closed mapped
+lessons. Twenty-five mapped non-lexical lessons across 18 tracks now carry
 compiled objective activities; 94 mapped non-lexical lessons remain explicit
 activity-coverage debt, including 16 legacy lessons that first need schema-v2
 body contracts. HL-V01 keeps the remaining migration debt reproducible in both
@@ -78,7 +78,7 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-G05 | Queued | Preserve canonical Markdown hyperlinks in generated LaTeX chapters. | Source notes and learner-facing links render as live `\href` targets in PDFs instead of retaining only their labels. |
 | HL-V02 | Complete (#9653) | Validate learner-facing target-language prompts against block-level knowledge declarations and prerequisite closure. | Schema-v2 production and recall blocks cannot ask for an undeclared form or a form absent from the lesson's transitive knowledge frontier. |
 | HL-V03 | Complete (#9900) | Compile individual prompt, answer, accepted-variant, feedback, and response-time contracts from typed activity blocks. | Compact JSON directives compile into validated runtime answer sets; each activity names a non-empty assessed-atom subset, carries feedback/time, and never scrapes prose. |
-| HL-A01 | In progress (#9901 + Russian and Persian/Urdu slices) | Author objective activity coverage for every mapped non-lexical frontier. | The first tranche covers every ready schema-v2 track; later slices cover Russian's naming chain and Persian/Urdu Chapter 3 practice. Coverage is 21 of 115 across 18 tracks; 94 lessons remain, including 16 that first need schema-v2 migration. |
+| HL-A01 | In progress (#9901 + Russian and Persian/Urdu slices) | Author objective activity coverage for every mapped non-lexical frontier. | The first tranche covers every ready schema-v2 track; later slices cover Russian's naming chain and Persian/Urdu Chapters 3–5 practice. Coverage is 25 of 119 across 18 tracks; 94 lessons remain, including 16 that first need schema-v2 migration. |
 | HL-Q01 | Queued | Restore a clean standalone TypeScript typecheck for Language Ladder. | `npx tsc --noEmit` should pass after fixing the pre-existing DOM element type, review-log cast, missing Node test types, and unused/implicit test symbols; HL-V03 introduces no additional type errors. |
 | HL-B04 | Complete (#9661) | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
 | HL-B05 | Complete (#9663) | Remove Marathi's duplicate practice labels and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Devanagari, natural page bottoms, and explicit static-font shapes make the forced six-chapter build warning-free. |
@@ -138,7 +138,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | ID | Status | Work item | Completion signal |
 |---|---|---|---|
 | HL-E01 | Complete (#9906) | Author Persian and Urdu Chapter 3 through the rest of `SPINE-EXCHANGE-NAMES`. | Each track gains prerequisite-safe, schema-v2 micro-lessons for the name question, its formality distinction, and a meeting response; realization maps, objective activities, generated book chapters, and Language Ladder consume the same AST. |
-| HL-E02 | Complete in this PR | Author Persian and Urdu Chapter 4 through `SPINE-CHECK-WELLBEING` and reconcile the older identity-first roadmap. | Both tracks gain a gentle wellbeing exchange before identity grammar, with language-specific register/script extensions, exact review ledgers, objective practice, and generated book chapters from the canonical AST. |
+| HL-E02 | Complete (#9913) | Author Persian and Urdu Chapter 4 through `SPINE-CHECK-WELLBEING` and reconcile the older identity-first roadmap. | Both tracks gain a gentle wellbeing exchange before identity grammar, with language-specific register/script extensions, exact review ledgers, objective practice, and generated book chapters from the canonical AST. |
+| HL-E03 | Complete in this PR | Author Persian and Urdu Chapter 5 through `SPINE-TAKE-LEAVE`. | Both tracks gain prerequisite-safe micro-lessons for ending a short respectful interaction, local script/register/grammar/etymology extensions, objective practice, exact review ledgers, and generated book chapters from the canonical AST. |
 
 - Expand every track toward B1 using the gap report to choose the next missing
   can-do, skill, mode, register, or realization.
@@ -1733,9 +1734,32 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   S25 through S31 at N+1, N+3, N+7, and N+15.
 - The exact-main verification after HL-I04 found a repeated external Lua setup
   outage: every matrix shard received `ECONNREFUSED` from the Lua download host
-  on both the initial attempt and the failed-job rerun. HL-I05 records a
-  cache/fallback hardening item; the consolidated 20-book workflow itself was
-  green at the same revision.
+  on both the initial attempt and the failed-job rerun. HL-I05/#9910 added a
+  pinned cache and checksum-verified source fallback; the consolidated 20-book
+  workflow itself was green at the same revision.
+
+## Findings from HL-E03
+
+- Persian and Urdu each add four prerequisite-safe Chapter 5 micro-lessons:
+  **khodâ/khudā**, **hâfez/hāfiz**, the complete farewell, and cumulative
+  start-versus-end practice. Both tracks now have twenty mapped lessons across
+  five generated-book chapters.
+- The shared phrase keeps different local writing contracts: Persian normally
+  joins **خداحافظ**, while Urdu keeps **خدا حافظ** spaced. Language Ladder may
+  compare them only after each local form has passed its own objective check.
+- The etymology ramp is deliberately layered: the Persian history of
+  **khodâ/khudā** comes first, the Arabic **ḥ-f-ẓ** guard-and-preserve root comes
+  second, and the protective formula is assembled only after both words are
+  independently readable.
+- Every new lesson carries one compiled activity and remains below five minutes.
+  Objective non-lexical coverage rises from 23 of 117 to 25 of 119 while the
+  explicit 94-item debt remains unchanged.
+- Exact review ledgers preserve all older due items and add N+1, N+3, N+7, and
+  N+15 retrieval through S35. Casual, later, soon, tomorrow, and good-night
+  forms remain explicit omissions until their own prerequisites are taught.
+- The corpus report reaches 1,096 lessons, 20 books, zero duration violations,
+  zero unknown prerequisites, and zero lesson-to-book chapter gaps. Both new
+  Chapter 5 files and hashes are generated from the same AST loaded by the app.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -87,8 +87,8 @@ edition is authored.
 | [Latin](./latin/README.md) | Italic / Latin (**taproot**) | Chapters 1–36 authored; Chapters 2–36 canonical/generated for app + book |
 | [Sanskrit](./sanskrit/README.md) | Indo-Aryan / Devanagari (**taproot**) | Chapters 1–6 authored (lessons + book; Chapter 6 canonical/generated) |
 | [Russian](./russian/README.md) | Slavic / Cyrillic | Chapters 1-2 authored (lessons + book) |
-| [Persian](./persian/README.md) | Iranian / Perso-Arabic | Four authored shared-spine chapters; 16 canonical lessons |
-| [Urdu](./urdu/README.md) | Indo-Aryan / Urdu Nastaliq | Four authored shared-spine chapters; 16 canonical lessons |
+| [Persian](./persian/README.md) | Iranian / Perso-Arabic | Five authored shared-spine chapters; 20 canonical lessons |
+| [Urdu](./urdu/README.md) | Indo-Aryan / Urdu Nastaliq | Five authored shared-spine chapters; 20 canonical lessons |
 
 Spanish is the pilot that proved the format; every other track replicates it,
 grounding each word against English plus whatever languages the learner already

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -2082,6 +2082,15 @@
       "scriptCommand": "fa"
     },
     {
+      "language": "persian",
+      "chapter": 5,
+      "title": "Take Leave",
+      "label": "ch:fa-take-leave",
+      "output": "persian/book/chapters/ch05-take-leave.tex",
+      "unicodeScript": "Arabic",
+      "scriptCommand": "fa"
+    },
+    {
       "language": "urdu",
       "chapter": 3,
       "title": "Ask and Answer Names",
@@ -2096,6 +2105,15 @@
       "title": "How Are You?",
       "label": "ch:ur-how-are-you",
       "output": "urdu/book/chapters/ch04-how-are-you.tex",
+      "unicodeScript": "Arabic",
+      "scriptCommand": "ur"
+    },
+    {
+      "language": "urdu",
+      "chapter": 5,
+      "title": "Take Leave",
+      "label": "ch:ur-take-leave",
+      "output": "urdu/book/chapters/ch05-take-leave.tex",
       "unicodeScript": "Arabic",
       "scriptCommand": "ur"
     }

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -1682,6 +1682,18 @@
       "tex": "persian/book/chapters/ch04-how-are-you.tex"
     },
     {
+      "language": "persian",
+      "chapter": 5,
+      "sourceHash": "fnv1a64:def693c2c104b5a0",
+      "lessonIds": [
+        "FA-C05-khoda",
+        "FA-C05-hafez",
+        "FA-C05-khodahafez",
+        "FA-C05-practice"
+      ],
+      "tex": "persian/book/chapters/ch05-take-leave.tex"
+    },
+    {
       "language": "portuguese",
       "chapter": 2,
       "sourceHash": "fnv1a64:b696688c2654a2d3",
@@ -2635,6 +2647,18 @@
         "UR-C04-practice"
       ],
       "tex": "urdu/book/chapters/ch04-how-are-you.tex"
+    },
+    {
+      "language": "urdu",
+      "chapter": 5,
+      "sourceHash": "fnv1a64:5d2065ac9b927c2f",
+      "lessonIds": [
+        "UR-C05-khuda",
+        "UR-C05-hafiz",
+        "UR-C05-khuda-hafiz",
+        "UR-C05-practice"
+      ],
+      "tex": "urdu/book/chapters/ch05-take-leave.tex"
     }
   ]
 }

--- a/code/learning/human-languages/persian/CHANGELOG.md
+++ b/code/learning/human-languages/persian/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.0 — 2026-08-04
+
+- Added four schema-v2 Chapter 5 micro-lessons for **خدا**, **حافظ**, joined
+  **خداحافظ**, and a start-versus-end interaction.
+- Kept Middle Persian and Arabic root histories behind independently readable
+  words, then introduced one broadly polite farewell without a hidden verb.
+- Extended the exact N+1/N+3/N+7/N+15 ledger through S35, with objective
+  activities and a generated five-chapter book.
+
 ## 0.5.0 — 2026-08-04
 
 - Added six schema-v2 Chapter 4 micro-lessons for *hâl*, *chetor*, the careful

--- a/code/learning/human-languages/persian/README.md
+++ b/code/learning/human-languages/persian/README.md
@@ -4,13 +4,14 @@ This track teaches contemporary Iranian Persian through the shared human-languag
 spine. Every lesson is designed for a fresh learner, takes under five minutes,
 and introduces only the script needed for the expression on the page.
 
-The first sixteen lessons now establish a complete miniature meeting: greet,
+The first twenty lessons now establish a complete miniature meeting: greet,
 answer, exchange names, acknowledge the introduction, ask about wellbeing, and
-reply politely. Persian-specific extensions introduce ezafe reuse, **shomâ/to**
+reply politely before taking leave with **خداحافظ**. Persian-specific extensions
+introduce ezafe reuse, **shomâ/to**
 register, Persian **چ**, question punctuation, the layered **khoshvaghtam**
-compound, and the compact **-am** copula exactly where each exchange needs it.
-Later chapters will add colloquial verb forms, present and past stems, and more
-joined shapes.
+compound, the compact **-am** copula, and the inherited-Persian plus Arabic-rooted
+farewell layers exactly where each exchange needs them. Later chapters will add
+colloquial verb forms, present and past stems, and more joined shapes.
 
 The script notes follow the University of Texas Persian Online writing-system
 materials. Romanization is a learning aid, not a substitute for reading Persian.
@@ -18,10 +19,10 @@ materials. Romanization is a learning aid, not a substitute for reading Persian.
 ## Read and practise
 
 - [`roadmap.md`](./roadmap.md) orders the authored and planned chapters toward B1.
-- [`session-map.md`](./session-map.md) composes all sixteen micro-lessons with an
-  exact session-count review ledger through S31.
+- [`session-map.md`](./session-map.md) composes all twenty micro-lessons with an
+  exact session-count review ledger through S35.
 - [`pronunciation-reference.md`](./pronunciation-reference.md) collects the
   script and sound facts for lookup; it is never a prerequisite chapter.
-- [`lessons/`](./lessons/) contains the sixteen canonical short practice lessons.
-- [`book/book.tex`](./book/book.tex) builds the free four-chapter starter edition
+- [`lessons/`](./lessons/) contains the twenty canonical short practice lessons.
+- [`book/book.tex`](./book/book.tex) builds the free five-chapter starter edition
   with XeLaTeX; merged editions appear in the public human-languages book catalog.

--- a/code/learning/human-languages/persian/book/book.tex
+++ b/code/learning/human-languages/persian/book/book.tex
@@ -57,6 +57,7 @@ word easier to remember without replacing its present meaning or use.
 \input{chapters/ch02-give-your-name}
 \input{chapters/ch03-ask-and-answer-names}
 \input{chapters/ch04-how-are-you}
+\input{chapters/ch05-take-leave}
 
 \backmatter
 
@@ -65,8 +66,10 @@ word easier to remember without replacing its present meaning or use.
 
 Script descriptions follow the University of Texas at Austin
 \href{https://sites.la.utexas.edu/persian_online_resources/the-writing-system/}%
-{Persian Online writing-system materials}; its open grammar and vocabulary
-resources ground the Chapter 4 wellbeing forms. The companion Markdown lessons
-are the canonical short-practice source for this edition.
+{Persian Online writing-system materials}; its open
+\href{https://sites.la.utexas.edu/persian_online_resources/vocabulary-lists/meetings-introductions/}%
+{greetings vocabulary} grounds the Chapter 4 wellbeing forms and Chapter 5
+farewell. The companion Markdown lessons carry the inline etymology citations
+and are the canonical short-practice source for this edition.
 
 \end{document}

--- a/code/learning/human-languages/persian/book/chapters/ch05-take-leave.tex
+++ b/code/learning/human-languages/persian/book/chapters/ch05-take-leave.tex
@@ -1,0 +1,140 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:def693c2c104b5a0
+% canonical-lessons: FA-C05-khoda, FA-C05-hafez, FA-C05-khodahafez, FA-C05-practice
+
+\chapter{Take Leave}
+\label{ch:fa-take-leave}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[khodâ]{\fa{خدا} — the Persian half of a farewell}
+
+\label{lesson:FA-C05-khoda}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Run the known wellbeing exchange once. The next chapter adds only the final social move: ending that interaction.
+\end{quote}
+
+\subsection*{You'll want to know first — one word}
+\begin{quote}
+\textbf{\fa{خدا}} — \emph{khodâ} — \textbf{God}
+\end{quote}
+
+Read from right to left: \textbf{\fa{خ}} \emph{kh} + \textbf{\fa{د}} \emph{d} + \textbf{\fa{ا}} long \emph{â}. The short \emph{o} is learned with the word rather than written as a separate letter. Keep the back-of-the-mouth \textbf{kh} gentle; clarity matters more than force.
+
+\begin{cousinweb}
+Modern \textbf{khodâ} continues Middle Persian \emph{xwadây}, “lord.” The everyday farewell will pair this inherited Persian word with an Arabic loan. That mixed history is normal Persian vocabulary, not an exception to memorize away.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: \textbf{khodâ} — God{]}
+  \item {[}YOU READ: \textbf{\fa{خدا}} from the right edge{]}
+  \item {[}YOU CONNECT: modern \textbf{khodâ} $\leftarrow$ Middle Persian \emph{xwadây} “lord”{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Which letter carries the final long \textbf{â}? (\textbf{\fa{ا}}.) Which vowel is heard but not written separately? (The short \emph{o}.)
+
+Source: Wiktionary: \fa{خدا}.
+\end{tcolorbox}
+\section[hâfez]{\fa{حافظ} — “guardian” or “protector”}
+
+\label{lesson:FA-C05-hafez}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Read \textbf{\fa{خدا}} and say \textbf{khodâ}. Keep it separate: this lesson adds only the second word behind the farewell.
+\end{quote}
+
+\subsection*{You'll want to know first — one word}
+\begin{quote}
+\textbf{\fa{حافظ}} — \emph{hâfez} — \textbf{guardian, protector}
+\end{quote}
+
+Read \textbf{\fa{ح} \fa{ا} \fa{ف} \fa{ظ}} from right to left. \textbf{\fa{ا}} carries long \textbf{â}. In contemporary Persian, final \textbf{\fa{ظ}} is pronounced \textbf{z} here, so say \emph{hâ-fez}, not an English \emph{th} sound. The short \emph{e} is part of the learned word and is normally unwritten.
+
+\begin{cousinweb}
+Arabic \textbf{ḥāfiẓ} is an active participle from the root \textbf{ḥ-f-ẓ}, “guard, preserve.” Persian borrowed the word and uses its Persian pronunciation \textbf{hâfez}. Keep the useful meaning first; the root is a memory hook.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: \textbf{hâfez} — guardian, protector{]}
+  \item {[}YOU READ: \textbf{\fa{حافظ}}{]}
+  \item {[}YOU CONNECT: Arabic \textbf{ḥ-f-ẓ} — guard, preserve{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+What does \textbf{hâfez} contribute to the farewell? (The idea of guarding or protecting.)
+
+Source: American Heritage Dictionary: \emph{hafiz}.
+\end{tcolorbox}
+\section[khodâ hâfez]{\fa{خداحافظ} — goodbye}
+
+\label{lesson:FA-C05-khodahafez}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Retrieve \textbf{khodâ} and \textbf{hâfez} separately: “God” + “guardian.” Now let them become one everyday social move.
+\end{quote}
+
+\subsection*{The two words — put the known pieces together}
+\begin{quote}
+\textbf{\fa{خداحافظ}} — \emph{khodâ hâfez} — \textbf{goodbye}
+\end{quote}
+
+Persian normally writes the two spoken pieces together. Start with \textbf{\fa{خدا}}, add \textbf{\fa{حافظ}}, and read the joined spelling \textbf{\fa{خداحافظ}} from the right edge. Keep the two meaning layers available underneath the complete form.
+
+\begin{grammarlens}[title={Grammar Lens — a complete wish without a full sentence}]
+The expression carries the protective sense “God {[}be{]} guardian,” but everyday speakers use the whole formula simply as \textbf{goodbye}. No new verb is required for beginner production. It is a broadly polite, reliable way to end the short respectful interaction built in Chapters 1–4.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU BUILD: \textbf{khodâ} + \textbf{hâfez}{]}
+  \item {[}YOU READ: joined \textbf{\fa{خداحافظ}}{]}
+  \item {[}YOU USE: say it only when the interaction ends{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+When do you use \textbf{khodâ hâfez}? (At parting, not at the opening.)
+
+Source: Persian Online: Greetings List.
+\end{tcolorbox}
+\section[Practice]{Practice — open, check, and close}
+
+\label{lesson:FA-C05-practice}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Without looking ahead, retrieve the expression for the beginning and the expression for the end. Do not add a new middle line.
+\end{quote}
+
+\subsection*{The exchange — the complete interaction}
+\begin{quote}
+A: \textbf{\fa{سلام}! \fa{حال} \fa{شما} \fa{چطور} \fa{است؟}} \emph{Salâm! Hâl-e shomâ chetor ast?} B: \textbf{\fa{خوبم،} \fa{ممنون}.} \emph{Khubam, mamnun.} A: \textbf{\fa{خداحافظ}.} \emph{Khodâ hâfez.} B: \textbf{\fa{خداحافظ}.} \emph{Khodâ hâfez.}
+\end{quote}
+
+Every line is already learned. \textbf{Salâm} opens; \textbf{khodâ hâfez} closes. The same farewell works for both voices, so no pronoun, agreement ending, or new register table is hiding inside the practice.
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU CHOOSE: meeting begins $\to$ \textbf{salâm}{]}
+  \item {[}YOU CHOOSE: interaction ends $\to$ \textbf{khodâ hâfez}{]}
+  \item {[}YOU RUN: both voices once with script, once without romanization{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Run the full exchange once. If the final line stalls, return only to the assembled-farewell lesson rather than rereading the chapter.
+\end{tcolorbox}

--- a/code/learning/human-languages/persian/curriculum.json
+++ b/code/learning/human-languages/persian/curriculum.json
@@ -77,6 +77,24 @@
         "FA-EXT-012-WELLBEING-CONSOLIDATION"
       ],
       "after": []
+    },
+    {
+      "id": "FA-PATH-006",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "FA-C05-khoda",
+        "FA-C05-hafez",
+        "FA-C05-khodahafez",
+        "FA-C05-practice"
+      ],
+      "before": [],
+      "inline": [
+        "FA-EXT-013-KHODA-HISTORY",
+        "FA-EXT-014-HAFEZ-ROOT",
+        "FA-EXT-015-FAREWELL-SCRIPT-REGISTER",
+        "FA-EXT-016-TAKE-LEAVE-CONSOLIDATION"
+      ],
+      "after": []
     }
   ],
   "spine": {
@@ -143,9 +161,10 @@
       "relocates": {}
     },
     "SPINE-TAKE-LEAVE": {
-      "segments": [],
+      "segments": [
+        "FA-PATH-006"
+      ],
       "omits": [
-        "FAREWELL",
         "FAREWELL-CASUAL",
         "FAREWELL-LATER",
         "FAREWELL-SOON",
@@ -345,6 +364,58 @@
       ],
       "lessons": [
         "FA-C04-practice"
+      ]
+    },
+    {
+      "id": "FA-EXT-013-KHODA-HISTORY",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can read khodâ and connect its modern meaning to Middle Persian xwadây without treating etymology as a production burden.",
+      "prerequisites": [
+        "FA-EXT-012-WELLBEING-CONSOLIDATION"
+      ],
+      "lessons": [
+        "FA-C05-khoda"
+      ]
+    },
+    {
+      "id": "FA-EXT-014-HAFEZ-ROOT",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can read hâfez and use the Arabic guard-and-preserve root as a memory hook for protector.",
+      "prerequisites": [
+        "FA-EXT-013-KHODA-HISTORY"
+      ],
+      "lessons": [
+        "FA-C05-hafez"
+      ]
+    },
+    {
+      "id": "FA-EXT-015-FAREWELL-SCRIPT-REGISTER",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can read joined خداحافظ and use it as a broadly polite close without supplying an unlearned verb.",
+      "prerequisites": [
+        "FA-EXT-014-HAFEZ-ROOT"
+      ],
+      "lessons": [
+        "FA-C05-khodahafez"
+      ]
+    },
+    {
+      "id": "FA-EXT-016-TAKE-LEAVE-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "consolidation",
+      "canDo": "I can open and close a short respectful Persian interaction using only independently learned lines.",
+      "prerequisites": [
+        "FA-EXT-015-FAREWELL-SCRIPT-REGISTER"
+      ],
+      "lessons": [
+        "FA-C05-practice"
       ]
     }
   ]

--- a/code/learning/human-languages/persian/lessons/FA-C05-hafez.md
+++ b/code/learning/human-languages/persian/lessons/FA-C05-hafez.md
@@ -1,0 +1,70 @@
+---
+schema_version: 2
+id: FA-C05-hafez
+spine_node: SPINE-TAKE-LEAVE
+sequence: 180
+chapter: 5
+type: word
+headword: حافظ
+romanization: hâfez
+gloss: guardian, protector — the Arabic-rooted half of the farewell
+concept_tag: FA-C05-HAFEZ
+prerequisites: [FA-C05-khoda]
+sounds: [rtl, long-a, short-vowels-unwritten]
+roots: [arabic-h-f-z]
+etymology_hook: Persian hâfez comes from Arabic ḥāfiẓ, an active participle from the root ḥ-f-ẓ “guard, preserve”; Persian pronounces final ظ as z here.
+duration:
+  max_seconds: 210
+requires:
+  knowledge: [FA-LEX-KHODA, FA-SCRIPT-KHODA, FA-ETYMON-KHODA]
+introduces:
+  knowledge: [FA-LEX-HAFEZ, FA-SCRIPT-HAFEZ, FA-ETYMON-HAFEZ]
+practises:
+  knowledge: [FA-LEX-KHODA, FA-SCRIPT-KHODA, FA-LEX-HAFEZ, FA-SCRIPT-HAFEZ, FA-ETYMON-HAFEZ]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: contemporary-iranian-persian
+reviews_of: [FA-C05-khoda]
+---
+
+# حافظ — “guardian” or “protector”
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-KHODA, FA-SCRIPT-KHODA] -->
+
+[PAUSE 2s] Read **خدا** and say **khodâ**. Keep it separate: this lesson adds
+only the second word behind the farewell.
+
+## You'll want to know first — one word
+<!-- hl-knowledge: introduces=[FA-LEX-HAFEZ, FA-SCRIPT-HAFEZ]; assesses=[] -->
+
+> **حافظ** — *hâfez* — **guardian, protector**
+
+Read **ح ا ف ظ** from right to left. **ا** carries long **â**. In contemporary
+Persian, final **ظ** is pronounced **z** here, so say *hâ-fez*, not an English
+*th* sound. The short *e* is part of the learned word and is normally unwritten.
+
+## The word, taken apart — an Arabic root in Persian
+<!-- hl-knowledge: introduces=[FA-ETYMON-HAFEZ]; assesses=[] -->
+
+Arabic **ḥāfiẓ** is an active participle from the root **ḥ-f-ẓ**, “guard,
+preserve.” Persian borrowed the word and uses its Persian pronunciation
+**hâfez**. Keep the useful meaning first; the root is a memory hook.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-HAFEZ, FA-SCRIPT-HAFEZ, FA-ETYMON-HAFEZ] -->
+
+- [YOU SAY: **hâfez** — guardian, protector]
+- [YOU READ: **حافظ**]
+- [YOU CONNECT: Arabic **ḥ-f-ẓ** — guard, preserve]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-HAFEZ, FA-SCRIPT-HAFEZ, FA-ETYMON-HAFEZ] -->
+<!-- hl-activity: {"id":"FA-C05-hafez-meaning","kind":"text","assesses":["FA-LEX-HAFEZ"],"prompt":"Type the Persian word hâfez, meaning 'guardian' or 'protector'.","answer":"حافظ","accepted":["hafez","hâfez","hāfez","hafiz"],"feedback":{"correct":"Right: حافظ hâfez means a guardian or protector in this farewell.","incorrect":"Use حافظ — hâfez."},"response_seconds":8} -->
+
+What does **hâfez** contribute to the farewell? (The idea of guarding or
+protecting.)
+
+Source: [American Heritage Dictionary: *hafiz*](https://www.ahdictionary.com/word/search.html?q=hafiz).

--- a/code/learning/human-languages/persian/lessons/FA-C05-khoda.md
+++ b/code/learning/human-languages/persian/lessons/FA-C05-khoda.md
@@ -1,0 +1,70 @@
+---
+schema_version: 2
+id: FA-C05-khoda
+spine_node: SPINE-TAKE-LEAVE
+sequence: 170
+chapter: 5
+type: word
+headword: خدا
+romanization: khodâ
+gloss: God — the inherited Persian half of the standard farewell
+concept_tag: FA-C05-KHODA
+prerequisites: [FA-C04-practice]
+sounds: [rtl, kh, long-a, short-vowels-unwritten]
+roots: [middle-persian-xwaday]
+etymology_hook: Modern Persian khodâ continues Middle Persian xwadây, earlier “lord”; Chapter 5 meets it inside an everyday farewell rather than as an isolated history fact.
+duration:
+  max_seconds: 200
+requires:
+  knowledge: [FA-DIALOGUE-WELLBEING]
+introduces:
+  knowledge: [FA-LEX-KHODA, FA-SCRIPT-KHODA, FA-ETYMON-KHODA]
+practises:
+  knowledge: [FA-DIALOGUE-WELLBEING, FA-LEX-KHODA, FA-SCRIPT-KHODA, FA-ETYMON-KHODA]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: contemporary-iranian-persian
+reviews_of: [FA-C04-practice]
+---
+
+# خدا — the Persian half of a farewell
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FA-DIALOGUE-WELLBEING] -->
+
+[PAUSE 2s] Run the known wellbeing exchange once. The next chapter adds only
+the final social move: ending that interaction.
+
+## You'll want to know first — one word
+<!-- hl-knowledge: introduces=[FA-LEX-KHODA, FA-SCRIPT-KHODA]; assesses=[] -->
+
+> **خدا** — *khodâ* — **God**
+
+Read from right to left: **خ** *kh* + **د** *d* + **ا** long *â*. The short *o*
+is learned with the word rather than written as a separate letter. Keep the
+back-of-the-mouth **kh** gentle; clarity matters more than force.
+
+## The word, taken apart — an inherited Persian layer
+<!-- hl-knowledge: introduces=[FA-ETYMON-KHODA]; assesses=[] -->
+
+Modern **khodâ** continues Middle Persian *xwadây*, “lord.” The everyday
+farewell will pair this inherited Persian word with an Arabic loan. That mixed
+history is normal Persian vocabulary, not an exception to memorize away.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-KHODA, FA-SCRIPT-KHODA, FA-ETYMON-KHODA] -->
+
+- [YOU SAY: **khodâ** — God]
+- [YOU READ: **خدا** from the right edge]
+- [YOU CONNECT: modern **khodâ** ← Middle Persian *xwadây* “lord”]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-KHODA, FA-SCRIPT-KHODA, FA-ETYMON-KHODA] -->
+<!-- hl-activity: {"id":"FA-C05-khoda-meaning","kind":"text","assesses":["FA-LEX-KHODA"],"prompt":"Type the Persian word khodâ, meaning 'God'.","answer":"خدا","accepted":["khoda","khodâ","xodā","xoda"],"feedback":{"correct":"Right: خدا khodâ is the inherited Persian half of the farewell.","incorrect":"Use خدا — khodâ."},"response_seconds":8} -->
+
+Which letter carries the final long **â**? (**ا**.) Which vowel is heard but not
+written separately? (The short *o*.)
+
+Source: [Wiktionary: خدا](https://en.wiktionary.org/wiki/%D8%AE%D8%AF%D8%A7).

--- a/code/learning/human-languages/persian/lessons/FA-C05-khodahafez.md
+++ b/code/learning/human-languages/persian/lessons/FA-C05-khodahafez.md
@@ -1,0 +1,70 @@
+---
+schema_version: 2
+id: FA-C05-khodahafez
+spine_node: SPINE-TAKE-LEAVE
+sequence: 190
+chapter: 5
+type: phrase
+headword: خداحافظ
+romanization: khodâ hâfez
+gloss: goodbye — the standard Persian farewell
+concept_tag: FAREWELL
+prerequisites: [FA-C05-hafez]
+sounds: [rtl, kh, long-a, short-vowels-unwritten]
+roots: [middle-persian-xwaday, arabic-h-f-z]
+etymology_hook: The standard farewell joins inherited Persian khodâ with Arabic-rooted hâfez in a compact protective wish; Persian normally writes the two spoken pieces together as خداحافظ.
+duration:
+  max_seconds: 220
+requires:
+  knowledge: [FA-LEX-KHODA, FA-SCRIPT-KHODA, FA-LEX-HAFEZ, FA-SCRIPT-HAFEZ, FA-ETYMON-KHODA, FA-ETYMON-HAFEZ]
+introduces:
+  knowledge: [FA-LEX-KHODAHAFEZ, FA-SCRIPT-KHODAHAFEZ-JOINED, FA-GRAMMAR-KHODAHAFEZ-ELLIPSIS, FA-PRAGMATICS-STANDARD-FAREWELL]
+practises:
+  knowledge: [FA-LEX-KHODA, FA-SCRIPT-KHODA, FA-LEX-HAFEZ, FA-SCRIPT-HAFEZ, FA-LEX-KHODAHAFEZ, FA-SCRIPT-KHODAHAFEZ-JOINED, FA-GRAMMAR-KHODAHAFEZ-ELLIPSIS, FA-PRAGMATICS-STANDARD-FAREWELL]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: broadly-polite
+variety: contemporary-iranian-persian
+reviews_of: [FA-C05-khoda, FA-C05-hafez]
+---
+
+# خداحافظ — goodbye
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-KHODA, FA-LEX-HAFEZ, FA-SCRIPT-KHODA, FA-SCRIPT-HAFEZ] -->
+
+[PAUSE 2s] Retrieve **khodâ** and **hâfez** separately: “God” + “guardian.” Now
+let them become one everyday social move.
+
+## The two words — put the known pieces together
+<!-- hl-knowledge: introduces=[FA-LEX-KHODAHAFEZ, FA-SCRIPT-KHODAHAFEZ-JOINED]; assesses=[] -->
+
+> **خداحافظ** — *khodâ hâfez* — **goodbye**
+
+Persian normally writes the two spoken pieces together. Start with **خدا**, add
+**حافظ**, and read the joined spelling **خداحافظ** from the right edge. Keep the
+two meaning layers available underneath the complete form.
+
+## Grammar Lens — a complete wish without a full sentence
+<!-- hl-knowledge: introduces=[FA-GRAMMAR-KHODAHAFEZ-ELLIPSIS, FA-PRAGMATICS-STANDARD-FAREWELL]; assesses=[] -->
+
+The expression carries the protective sense “God [be] guardian,” but everyday
+speakers use the whole formula simply as **goodbye**. No new verb is required
+for beginner production. It is a broadly polite, reliable way to end the short
+respectful interaction built in Chapters 1–4.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-KHODAHAFEZ, FA-SCRIPT-KHODAHAFEZ-JOINED, FA-GRAMMAR-KHODAHAFEZ-ELLIPSIS, FA-PRAGMATICS-STANDARD-FAREWELL] -->
+
+- [YOU BUILD: **khodâ** + **hâfez**]
+- [YOU READ: joined **خداحافظ**]
+- [YOU USE: say it only when the interaction ends]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-KHODAHAFEZ, FA-SCRIPT-KHODAHAFEZ-JOINED, FA-GRAMMAR-KHODAHAFEZ-ELLIPSIS, FA-PRAGMATICS-STANDARD-FAREWELL] -->
+<!-- hl-activity: {"id":"FA-C05-khodahafez-goodbye","kind":"text","assesses":["FA-LEX-KHODAHAFEZ"],"prompt":"Type the standard Persian expression for 'goodbye'.","answer":"خداحافظ","accepted":["khodahafez","khoda hafez","khodâ hâfez","khodā hāfez","xodāhāfez"],"feedback":{"correct":"Right: خداحافظ khodâ hâfez ends the interaction.","incorrect":"Use خداحافظ — khodâ hâfez."},"response_seconds":9} -->
+
+When do you use **khodâ hâfez**? (At parting, not at the opening.)
+
+Source: [Persian Online: Greetings List](https://sites.la.utexas.edu/persian_online_resources/vocabulary-lists/meetings-introductions/).

--- a/code/learning/human-languages/persian/lessons/FA-C05-practice.md
+++ b/code/learning/human-languages/persian/lessons/FA-C05-practice.md
@@ -1,0 +1,68 @@
+---
+schema_version: 2
+id: FA-C05-practice
+spine_node: SPINE-TAKE-LEAVE
+sequence: 200
+chapter: 5
+type: practice-mix
+headword: سلام ... خداحافظ
+romanization: salâm ... khodâ hâfez
+gloss: open and close a short Persian interaction
+concept_tag: FA-C05-PRACTICE
+prerequisites: [FA-C05-khodahafez]
+sounds: [rtl, kh, long-a]
+roots: []
+etymology_hook: The mini-dialogue contrasts known Arabic-rooted salâm at the opening with the mixed Persian-Arabic khodâ hâfez at the close, keeping history attached to communicative position.
+duration:
+  max_seconds: 220
+requires:
+  knowledge: [FA-DIALOGUE-WELLBEING, FA-LEX-KHODAHAFEZ, FA-SCRIPT-KHODAHAFEZ-JOINED, FA-PRAGMATICS-STANDARD-FAREWELL]
+introduces:
+  knowledge: [FA-DIALOGUE-TAKE-LEAVE]
+practises:
+  knowledge: [FA-DIALOGUE-WELLBEING, FA-LEX-KHODAHAFEZ, FA-SCRIPT-KHODAHAFEZ-JOINED, FA-PRAGMATICS-STANDARD-FAREWELL, FA-DIALOGUE-TAKE-LEAVE]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, fluency]
+register: broadly-polite
+variety: contemporary-iranian-persian
+reviews_of: [FA-C05-khoda, FA-C05-hafez, FA-C05-khodahafez]
+---
+
+# Practice — open, check, and close
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FA-DIALOGUE-WELLBEING, FA-LEX-KHODAHAFEZ, FA-PRAGMATICS-STANDARD-FAREWELL] -->
+
+[PAUSE 2s] Without looking ahead, retrieve the expression for the beginning
+and the expression for the end. Do not add a new middle line.
+
+## The exchange — the complete interaction
+<!-- hl-knowledge: introduces=[FA-DIALOGUE-TAKE-LEAVE]; assesses=[] -->
+
+> A: **سلام! حال شما چطور است؟**
+> *Salâm! Hâl-e shomâ chetor ast?*
+> B: **خوبم، ممنون.**
+> *Khubam, mamnun.*
+> A: **خداحافظ.**
+> *Khodâ hâfez.*
+> B: **خداحافظ.**
+> *Khodâ hâfez.*
+
+Every line is already learned. **Salâm** opens; **khodâ hâfez** closes. The
+same farewell works for both voices, so no pronoun, agreement ending, or new
+register table is hiding inside the practice.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FA-DIALOGUE-WELLBEING, FA-LEX-KHODAHAFEZ, FA-DIALOGUE-TAKE-LEAVE] -->
+
+- [YOU CHOOSE: meeting begins → **salâm**]
+- [YOU CHOOSE: interaction ends → **khodâ hâfez**]
+- [YOU RUN: both voices once with script, once without romanization]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FA-DIALOGUE-WELLBEING, FA-LEX-KHODAHAFEZ, FA-SCRIPT-KHODAHAFEZ-JOINED, FA-PRAGMATICS-STANDARD-FAREWELL, FA-DIALOGUE-TAKE-LEAVE] -->
+<!-- hl-activity: {"id":"FA-C05-practice-final-line","kind":"text","assesses":["FA-DIALOGUE-TAKE-LEAVE"],"prompt":"The short Persian interaction is ending. Type the final expression.","answer":"خداحافظ","accepted":["khodahafez","khoda hafez","khodâ hâfez","khodā hāfez"],"feedback":{"correct":"Right: خداحافظ closes the interaction.","incorrect":"Close with خداحافظ — khodâ hâfez."},"response_seconds":9} -->
+
+Run the full exchange once. If the final line stalls, return only to the
+assembled-farewell lesson rather than rereading the chapter.

--- a/code/learning/human-languages/persian/pronunciation-reference.md
+++ b/code/learning/human-languages/persian/pronunciation-reference.md
@@ -52,6 +52,9 @@ lessons will introduce them only when a useful word needs them.
   sounds in **خ/غ** only inside the name exchange.
 - **حال شما چطور است؟** reuses ezafe and the Persian question mark; **چطور**
   gives **و** its learned *o* value, while **خوبم** returns to long-*u* **و**.
+- **خدا** reuses **خ** and long-*â* **ا**; **حافظ** adds a clear initial *h* and
+  a final **ظ** pronounced *z* in modern Persian. The complete farewell is
+  normally joined in Persian as **خداحافظ**.
 
 One spelling symbol can do more than one job in later words—especially **و**
 and **ی**—so read from the word and context rather than assigning each shape one

--- a/code/learning/human-languages/persian/roadmap.md
+++ b/code/learning/human-languages/persian/roadmap.md
@@ -37,7 +37,16 @@ layers, and introduces only the first-person copula **-am** needed for the
 answer. Colloquial contraction is labelled for recognition but not required for
 production yet.
 
-## Chapter 5 — People and simple identity *(planned)*
+## Chapter 5 — Take leave *(authored)*
+
+**خدا** *khodâ* → **حافظ** *hâfez* → **خداحافظ** *khodâ hâfez* → one
+start-versus-end interaction. The sequence keeps inherited Persian *xwadây*
+history separate from the Arabic **ḥ-f-ẓ** “guard, preserve” root until each
+word is readable, then teaches Persian's joined spelling as one reliable,
+broadly polite close. Casual, time-of-day, and “see you” farewells stay later
+rather than hiding untaught time language in the first parting lesson.
+
+## Chapter 6 — People and simple identity *(planned)*
 
 - **man hastam** and the next present-copula forms one at a time;
 - careful written forms versus colloquial Iranian Persian;

--- a/code/learning/human-languages/persian/session-map.md
+++ b/code/learning/human-languages/persian/session-map.md
@@ -1,6 +1,6 @@
-# Persian Session Map — Authored Chapters 1–4
+# Persian Session Map — Authored Chapters 1–5
 
-This is the authoritative order for the sixteen authored Persian lessons. Every
+This is the authoritative order for the twenty authored Persian lessons. Every
 lesson is an independent, prerequisite-safe step of three or four minutes. A
 study session may combine the new step with the reviews shown here, but it never
 turns the combined session into one indivisible lesson.
@@ -50,6 +50,19 @@ copula step. Each lesson remains independently completable in under five minutes
 | **S15** | [`FA-C04-khubam`](./lessons/FA-C04-khubam.md): **خوبم، ممنون** | the name question *(N+7)*; *chetor* *(N+3)*; *khub* *(N+1)* | attach first-person **-am**, then add known thanks |
 | **S16** | [`FA-C04-practice`](./lessons/FA-C04-practice.md): full wellbeing exchange | *salâm* *(N+15)*; *khoshvaghtam* *(N+7)*; the wellbeing question *(N+3)*; *khubam* *(N+1)* | run both voices using only learned forms |
 
+## Chapter 5 — Take leave
+
+Chapter 5 fills four sessions by teaching the two historical pieces separately
+before the joined Persian spelling and the complete interaction. Time-of-day
+farewells remain later spine work.
+
+| Session | New lesson | Reviews due | Cumulative practice |
+|---|---|---|---|
+| **S17** | [`FA-C05-khoda`](./lessons/FA-C05-khoda.md): **خدا** *khodâ* | *mamnun* *(N+15)*; Chapter 3 practice *(N+7)*; *khub* *(N+3)*; Chapter 4 practice *(N+1)* | read the inherited Persian half of the farewell |
+| **S18** | [`FA-C05-hafez`](./lessons/FA-C05-hafez.md): **حافظ** *hâfez* | *bale* *(N+15)*; *hâl* *(N+7)*; *khubam* *(N+3)*; *khodâ* *(N+1)* | read the Arabic-rooted protector word |
+| **S19** | [`FA-C05-khodahafez`](./lessons/FA-C05-khodahafez.md): **خداحافظ** | *na* *(N+15)*; *chetor* *(N+7)*; Chapter 4 practice *(N+3)*; *hâfez* *(N+1)* | join the spelling and end an interaction |
+| **S20** | [`FA-C05-practice`](./lessons/FA-C05-practice.md): open and close | *esm-e man ... ast* *(N+15)*; the wellbeing question *(N+7)*; *khodâ* *(N+3)*; *khodâ hâfez* *(N+1)* | choose **salâm** at the start and **khodâ hâfez** at the end |
+
 ## Carry-forward review ledger
 
 Future chapters may supply the new lesson in these sessions. Until then, use
@@ -58,21 +71,21 @@ with already learned material.
 
 | Session | Fixed review due |
 |---|---|
-| **S17** | *mamnun* *(N+15)*; Chapter 3 practice *(N+7)*; *khub* *(N+3)*; Chapter 4 practice *(N+1)* |
-| **S18** | *bale* *(N+15)*; *hâl* *(N+7)*; *khubam* *(N+3)* |
-| **S19** | *na* *(N+15)*; *chetor* *(N+7)*; Chapter 4 practice *(N+3)* |
-| **S20** | *esm-e man ... ast* *(N+15)*; the wellbeing question *(N+7)* |
-| **S21** | *shomâ / to* *(N+15)*; *khub* *(N+7)* |
-| **S22** | *chist* *(N+15)*; *khubam* *(N+7)* |
-| **S23** | the name question *(N+15)*; Chapter 4 practice *(N+7)* |
-| **S24** | *khoshvaghtam* *(N+15)* |
-| **S25** | Chapter 3 practice *(N+15)* |
-| **S26** | *hâl* *(N+15)* |
-| **S27** | *chetor* *(N+15)* |
+| **S21** | *shomâ / to* *(N+15)*; *khub* *(N+7)*; *hâfez* *(N+3)*; Chapter 5 practice *(N+1)* |
+| **S22** | *chist* *(N+15)*; *khubam* *(N+7)*; *khodâ hâfez* *(N+3)* |
+| **S23** | the name question *(N+15)*; Chapter 4 practice *(N+7)*; Chapter 5 practice *(N+3)* |
+| **S24** | *khoshvaghtam* *(N+15)*; *khodâ* *(N+7)* |
+| **S25** | Chapter 3 practice *(N+15)*; *hâfez* *(N+7)* |
+| **S26** | *hâl* *(N+15)*; *khodâ hâfez* *(N+7)* |
+| **S27** | *chetor* *(N+15)*; Chapter 5 practice *(N+7)* |
 | **S28** | the wellbeing question *(N+15)* |
 | **S29** | *khub* *(N+15)* |
 | **S30** | *khubam* *(N+15)* |
 | **S31** | Chapter 4 practice *(N+15)* |
+| **S32** | *khodâ* *(N+15)* |
+| **S33** | *hâfez* *(N+15)* |
+| **S34** | *khodâ hâfez* *(N+15)* |
+| **S35** | Chapter 5 practice *(N+15)* |
 
 Sessions not listed in the ledger have no fixed starter item due; use their
 bonus queue for adaptive or cumulative retrieval.
@@ -83,7 +96,7 @@ review; the fixed ledger remains the book's no-tracking fallback.
 
 ## Schedule check
 
-Every Chapter 1–4 lesson now has all four fixed resurfacing sessions through
-S31. The app may pull a missed item forward, but it cannot skip the local
-prerequisites. A future Chapter 5 can begin in S17 while this ledger continues
+Every Chapter 1–5 lesson now has all four fixed resurfacing sessions through
+S35. The app may pull a missed item forward, but it cannot skip the local
+prerequisites. A future Chapter 6 can begin in S21 while this ledger continues
 in the review portion of each session.

--- a/code/learning/human-languages/urdu/CHANGELOG.md
+++ b/code/learning/human-languages/urdu/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.0 — 2026-08-04
+
+- Added four schema-v2 Chapter 5 micro-lessons for **خدا**, **حافظ**, spaced
+  **خدا حافظ**, and a start-versus-end interaction.
+- Secured the Urdu form before using its Persian and Arabic history as a bridge;
+  mixed comparison preserves Urdu spacing and Persian joining.
+- Extended the exact N+1/N+3/N+7/N+15 ledger through S35, with objective
+  activities and a generated five-chapter book.
+
 ## 0.5.0 — 2026-08-04
 
 - Added six schema-v2 Chapter 4 micro-lessons for *kaise/kaisī*, respectful

--- a/code/learning/human-languages/urdu/README.md
+++ b/code/learning/human-languages/urdu/README.md
@@ -4,13 +4,15 @@ This track teaches contemporary standard Urdu through the shared
 human-language spine. Lessons are under five minutes and introduce Nastaliq
 script features only as the learner encounters them.
 
-The first sixteen lessons now form a complete miniature meeting: greeting,
+The first twenty lessons now form a complete miniature meeting: greeting,
 answers, exchanging names, acknowledging the introduction, asking about
-wellbeing, and replying politely. Urdu-specific extensions introduce
+wellbeing, replying politely, and taking leave with **خدا حافظ**. Urdu-specific
+extensions introduce
 **āp/tum/tū** register, **kyā**, fixed **āp kā nām**, question punctuation,
-**kaise/kaisī** agreement, honorific **haiṅ**, and first-person **hūṅ** exactly
-where each exchange needs them. Later chapters will add wider agreement,
-postpositions, oblique forms, compound verbs, and more Nastaliq-aware shapes.
+**kaise/kaisī** agreement, honorific **haiṅ**, first-person **hūṅ**, and the
+Persian-plus-Arabic farewell layers exactly where each exchange needs them.
+Later chapters will add wider agreement, postpositions, oblique forms, compound
+verbs, and more Nastaliq-aware shapes.
 
 Urdu and Hindi share a large grammatical core, while the formal lexicon and
 writing systems make their histories visible. Cross-language practice should
@@ -20,10 +22,10 @@ Script conventions are grounded in Northwestern University's *Zero Zabar*.
 ## Read and practise
 
 - [`roadmap.md`](./roadmap.md) orders the authored and planned chapters toward B1.
-- [`session-map.md`](./session-map.md) composes all sixteen micro-lessons with an
-  exact session-count review ledger through S31.
+- [`session-map.md`](./session-map.md) composes all twenty micro-lessons with an
+  exact session-count review ledger through S35.
 - [`pronunciation-reference.md`](./pronunciation-reference.md) gathers Urdu
   script and sound facts on demand and labels the current Naskh fallback.
-- [`lessons/`](./lessons/) contains the sixteen canonical short practice lessons.
-- [`book/book.tex`](./book/book.tex) builds the free four-chapter starter edition
+- [`lessons/`](./lessons/) contains the twenty canonical short practice lessons.
+- [`book/book.tex`](./book/book.tex) builds the free five-chapter starter edition
   with XeLaTeX; merged editions appear in the public human-languages book catalog.

--- a/code/learning/human-languages/urdu/book/book.tex
+++ b/code/learning/human-languages/urdu/book/book.tex
@@ -58,6 +58,7 @@ aid, not a claim that a borrowed word is any less fully Urdu today.
 \input{chapters/ch02-give-your-name}
 \input{chapters/ch03-ask-and-answer-names}
 \input{chapters/ch04-how-are-you}
+\input{chapters/ch05-take-leave}
 
 \backmatter
 
@@ -67,7 +68,9 @@ aid, not a claim that a borrowed word is any less fully Urdu today.
 Script descriptions follow Northwestern University's open
 \href{https://openbooks.library.northwestern.edu/zerozabar/chapter/the-urdu-alphabet/}%
 {Zero Zabar Urdu-alphabet materials}. Chapter 4's wellbeing forms and register
-contrast follow Michigan State University's open \emph{Basic Urdu}. The companion
-Markdown lessons are the canonical short-practice source for this edition.
+contrast, together with Chapter 5's farewell, follow Michigan State University's
+open \href{https://openbooks.lib.msu.edu/urdu/chapter/2-2/}{\emph{Basic Urdu}}.
+The companion Markdown lessons carry the inline etymology citations and are the
+canonical short-practice source for this edition.
 
 \end{document}

--- a/code/learning/human-languages/urdu/book/chapters/ch05-take-leave.tex
+++ b/code/learning/human-languages/urdu/book/chapters/ch05-take-leave.tex
@@ -1,0 +1,143 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:5d2065ac9b927c2f
+% canonical-lessons: UR-C05-khuda, UR-C05-hafiz, UR-C05-khuda-hafiz, UR-C05-practice
+
+\chapter{Take Leave}
+\label{ch:ur-take-leave}
+
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
+
+\section[khudā]{\ur{خدا} — the first half of an Urdu farewell}
+
+\label{lesson:UR-C05-khuda}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Run one known wellbeing exchange. Chapter 5 will add only the move that ends it.
+\end{quote}
+
+\subsection*{You'll want to know first — one word}
+\begin{quote}
+\textbf{\ur{خدا}} — \emph{khudā} — \textbf{God}
+\end{quote}
+
+Read from right to left: \textbf{\ur{خ}} \emph{kh} + \textbf{\ur{د}} \emph{d} + \textbf{\ur{ا}} long \emph{ā}. The short \emph{u} is learned with the word and is normally unwritten. Let \textbf{kh} come from farther back than English \emph{h}, but keep the sound relaxed.
+
+\begin{cousinweb}
+Urdu borrowed \textbf{khudā} from Persian \textbf{khodā}, whose older Middle Persian ancestor \emph{xwadāy} meant “lord.” Learn the Urdu sound and script first; the Persian connection then explains why both tracks will share the phrase's first historical layer.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: \textbf{khudā} — God{]}
+  \item {[}YOU READ: \textbf{\ur{خدا}} from the right edge{]}
+  \item {[}YOU CONNECT: Urdu \textbf{khudā} $\leftarrow$ Persian \textbf{khodā}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Which final letter carries long \textbf{ā}? (\textbf{\ur{ا}}.) Which short vowel must be remembered with the word? (\emph{u}.)
+
+Sources: \emph{Basic Urdu}: Greetings and Introductions; Wiktionary: \ur{خدا}.
+\end{tcolorbox}
+\section[hāfiz]{\ur{حافظ} — “guardian” or “protector”}
+
+\label{lesson:UR-C05-hafiz}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Read \textbf{\ur{خدا}} and say \textbf{khudā}. Keep it separate while one second word is added.
+\end{quote}
+
+\subsection*{You'll want to know first — one word}
+\begin{quote}
+\textbf{\ur{حافظ}} — \emph{hāfiz} — \textbf{guardian, protector}
+\end{quote}
+
+Read \textbf{\ur{ح} \ur{ا} \ur{ف} \ur{ظ}} from right to left. \textbf{\ur{ا}} carries long \textbf{ā}. Final \textbf{\ur{ظ}} is pronounced \textbf{z} in this Urdu word. The short \emph{i} is heard in \textbf{hāfiz} but is normally not written as a separate letter.
+
+\begin{cousinweb}
+Arabic \textbf{ḥāfiẓ} is an active participle from \textbf{ḥ-f-ẓ}, “guard, preserve.” Urdu receives \textbf{hāfiz} through its Persian-Arabic literary layer. Keep “guardian” as the useful meaning; the three-consonant root is a memory hook.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: \textbf{hāfiz} — guardian, protector{]}
+  \item {[}YOU READ: \textbf{\ur{حافظ}}{]}
+  \item {[}YOU CONNECT: Arabic \textbf{ḥ-f-ẓ} — guard, preserve{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+What does \textbf{hāfiz} contribute to the farewell? (The idea of guarding or protecting.)
+
+Source: American Heritage Dictionary: \emph{hafiz}.
+\end{tcolorbox}
+\section[khudā hāfiz]{\ur{خدا} \ur{حافظ} — goodbye}
+
+\label{lesson:UR-C05-khuda-hafiz}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Retrieve \textbf{khudā} and \textbf{hāfiz} separately: “God” + “guardian.” Now use the two known pieces as one parting move.
+\end{quote}
+
+\subsection*{The two words — put the known pieces together}
+\begin{quote}
+\textbf{\ur{خدا} \ur{حافظ}} — \emph{khudā hāfiz} — \textbf{goodbye}
+\end{quote}
+
+Urdu keeps a visible space between the two words. Read \textbf{\ur{خدا}} first, then \textbf{\ur{حافظ}}, and preserve that space in the complete spelling \textbf{\ur{خدا} \ur{حافظ}}. Say the whole expression smoothly.
+
+\begin{grammarlens}[title={Grammar Lens — a whole social move}]
+The protective sense is “God {[}be{]} guardian,” but everyday speakers use the formula simply as \textbf{goodbye}. No new verb or agreement ending is needed. It is a reliable polite close for the short interaction learned so far.
+\end{grammarlens}
+
+\subsection*{Script Bridge — shared history, local spacing}
+Urdu \textbf{\ur{خدا} \ur{حافظ}} and Persian \textbf{\ur{خداحافظ}} share the same historical pieces. Urdu keeps the visible space in this course; Persian normally joins them. Mixed practice may compare the two only now that each local phrase is independently readable.
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU BUILD: \textbf{khudā} + \textbf{hāfiz}{]}
+  \item {[}YOU READ: spaced Urdu \textbf{\ur{خدا} \ur{حافظ}}{]}
+  \item {[}YOU USE: say it when the interaction ends{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Where is the local writing contrast? (Urdu shows a space; Persian joins its spelling.)
+
+Source: \emph{Basic Urdu}: Greetings and Introductions.
+\end{tcolorbox}
+\section[Practice]{Practice — open, check, and close}
+
+\label{lesson:UR-C05-practice}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Retrieve the known expression for the beginning and the new expression for the end. Keep the middle unchanged.
+\end{quote}
+
+\subsection*{The exchange — the complete interaction}
+\begin{quote}
+A: \textbf{\ur{سلام}! \ur{آپ} \ur{کیسے} \ur{ہیں؟}} \emph{Salām! Āp kaise haiṅ?} B: \textbf{\ur{میں} \ur{ٹھیک} \ur{ہوں،} \ur{شکریہ۔}} \emph{Maiṅ ṭhīk hūṅ, shukriyā.} A: \textbf{\ur{خدا} \ur{حافظ۔}} \emph{Khudā hāfiz.} B: \textbf{\ur{خدا} \ur{حافظ۔}} \emph{Khudā hāfiz.}
+\end{quote}
+
+Every line is already learned. \textbf{Salām} opens; \textbf{khudā hāfiz} closes. The same farewell works for both speakers, so this practice adds no gender choice, pronoun, or copula form.
+
+\subsection*{Guided Practice}
+\begin{itemize}
+\raggedright
+  \item {[}YOU CHOOSE: meeting begins $\to$ \textbf{salām}{]}
+  \item {[}YOU CHOOSE: interaction ends $\to$ \textbf{khudā hāfiz}{]}
+  \item {[}YOU RUN: both voices once with script, once without romanization{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+Run the full exchange once. If the final line stalls, return only to the assembled-farewell lesson.
+\end{tcolorbox}

--- a/code/learning/human-languages/urdu/curriculum.json
+++ b/code/learning/human-languages/urdu/curriculum.json
@@ -77,6 +77,24 @@
         "UR-EXT-012-WELLBEING-CONSOLIDATION"
       ],
       "after": []
+    },
+    {
+      "id": "UR-PATH-006",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "UR-C05-khuda",
+        "UR-C05-hafiz",
+        "UR-C05-khuda-hafiz",
+        "UR-C05-practice"
+      ],
+      "before": [],
+      "inline": [
+        "UR-EXT-013-KHUDA-PERSIAN-HISTORY",
+        "UR-EXT-014-HAFIZ-ARABIC-ROOT",
+        "UR-EXT-015-FAREWELL-SPACING-REGISTER",
+        "UR-EXT-016-TAKE-LEAVE-CONSOLIDATION"
+      ],
+      "after": []
     }
   ],
   "spine": {
@@ -143,9 +161,10 @@
       "relocates": {}
     },
     "SPINE-TAKE-LEAVE": {
-      "segments": [],
+      "segments": [
+        "UR-PATH-006"
+      ],
       "omits": [
-        "FAREWELL",
         "FAREWELL-CASUAL",
         "FAREWELL-LATER",
         "FAREWELL-SOON",
@@ -345,6 +364,58 @@
       ],
       "lessons": [
         "UR-C04-practice"
+      ]
+    },
+    {
+      "id": "UR-EXT-013-KHUDA-PERSIAN-HISTORY",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can read Urdu khudā before using Persian history as a memory bridge rather than a substitute for the local form.",
+      "prerequisites": [
+        "UR-EXT-012-WELLBEING-CONSOLIDATION"
+      ],
+      "lessons": [
+        "UR-C05-khuda"
+      ]
+    },
+    {
+      "id": "UR-EXT-014-HAFIZ-ARABIC-ROOT",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "etymology",
+      "canDo": "I can read hāfiz and use the Arabic guard-and-preserve root as a memory hook for protector.",
+      "prerequisites": [
+        "UR-EXT-013-KHUDA-PERSIAN-HISTORY"
+      ],
+      "lessons": [
+        "UR-C05-hafiz"
+      ]
+    },
+    {
+      "id": "UR-EXT-015-FAREWELL-SPACING-REGISTER",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can read spaced خدا حافظ, distinguish its Urdu spelling from Persian's joined form, and use it as a broadly polite close.",
+      "prerequisites": [
+        "UR-EXT-014-HAFIZ-ARABIC-ROOT"
+      ],
+      "lessons": [
+        "UR-C05-khuda-hafiz"
+      ]
+    },
+    {
+      "id": "UR-EXT-016-TAKE-LEAVE-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "consolidation",
+      "canDo": "I can open and close a short respectful Urdu interaction using only independently learned lines.",
+      "prerequisites": [
+        "UR-EXT-015-FAREWELL-SPACING-REGISTER"
+      ],
+      "lessons": [
+        "UR-C05-practice"
       ]
     }
   ]

--- a/code/learning/human-languages/urdu/lessons/UR-C05-hafiz.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C05-hafiz.md
@@ -1,0 +1,70 @@
+---
+schema_version: 2
+id: UR-C05-hafiz
+spine_node: SPINE-TAKE-LEAVE
+sequence: 180
+chapter: 5
+type: word
+headword: حافظ
+romanization: hāfiz
+gloss: guardian, protector — the Arabic-rooted half of the farewell
+concept_tag: UR-C05-HAFIZ
+prerequisites: [UR-C05-khuda]
+sounds: [rtl, long-a, short-vowels-unwritten]
+roots: [arabic-h-f-z]
+etymology_hook: Urdu hāfiz continues Arabic ḥāfiẓ, an active participle from the root ḥ-f-ẓ “guard, preserve”; Urdu pronounces final ظ as z here.
+duration:
+  max_seconds: 210
+requires:
+  knowledge: [UR-LEX-KHUDA, UR-SCRIPT-KHUDA, UR-ETYMON-KHUDA-PERSIAN]
+introduces:
+  knowledge: [UR-LEX-HAFIZ, UR-SCRIPT-HAFIZ, UR-ETYMON-HAFIZ-ARABIC]
+practises:
+  knowledge: [UR-LEX-KHUDA, UR-SCRIPT-KHUDA, UR-LEX-HAFIZ, UR-SCRIPT-HAFIZ, UR-ETYMON-HAFIZ-ARABIC]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: contemporary-standard-urdu
+reviews_of: [UR-C05-khuda]
+---
+
+# حافظ — “guardian” or “protector”
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-KHUDA, UR-SCRIPT-KHUDA] -->
+
+[PAUSE 2s] Read **خدا** and say **khudā**. Keep it separate while one second
+word is added.
+
+## You'll want to know first — one word
+<!-- hl-knowledge: introduces=[UR-LEX-HAFIZ, UR-SCRIPT-HAFIZ]; assesses=[] -->
+
+> **حافظ** — *hāfiz* — **guardian, protector**
+
+Read **ح ا ف ظ** from right to left. **ا** carries long **ā**. Final **ظ** is
+pronounced **z** in this Urdu word. The short *i* is heard in **hāfiz** but is
+normally not written as a separate letter.
+
+## The word, taken apart — the Arabic root
+<!-- hl-knowledge: introduces=[UR-ETYMON-HAFIZ-ARABIC]; assesses=[] -->
+
+Arabic **ḥāfiẓ** is an active participle from **ḥ-f-ẓ**, “guard, preserve.” Urdu
+receives **hāfiz** through its Persian-Arabic literary layer. Keep “guardian” as
+the useful meaning; the three-consonant root is a memory hook.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-HAFIZ, UR-SCRIPT-HAFIZ, UR-ETYMON-HAFIZ-ARABIC] -->
+
+- [YOU SAY: **hāfiz** — guardian, protector]
+- [YOU READ: **حافظ**]
+- [YOU CONNECT: Arabic **ḥ-f-ẓ** — guard, preserve]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-HAFIZ, UR-SCRIPT-HAFIZ, UR-ETYMON-HAFIZ-ARABIC] -->
+<!-- hl-activity: {"id":"UR-C05-hafiz-meaning","kind":"text","assesses":["UR-LEX-HAFIZ"],"prompt":"Type the Urdu word hāfiz, meaning 'guardian' or 'protector'.","answer":"حافظ","accepted":["hafiz","hāfiz","haafiz","hafez"],"feedback":{"correct":"Right: حافظ hāfiz contributes the idea of a guardian or protector.","incorrect":"Use حافظ — hāfiz."},"response_seconds":8} -->
+
+What does **hāfiz** contribute to the farewell? (The idea of guarding or
+protecting.)
+
+Source: [American Heritage Dictionary: *hafiz*](https://www.ahdictionary.com/word/search.html?q=hafiz).

--- a/code/learning/human-languages/urdu/lessons/UR-C05-khuda-hafiz.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C05-khuda-hafiz.md
@@ -1,0 +1,78 @@
+---
+schema_version: 2
+id: UR-C05-khuda-hafiz
+spine_node: SPINE-TAKE-LEAVE
+sequence: 190
+chapter: 5
+type: phrase
+headword: خدا حافظ
+romanization: khudā hāfiz
+gloss: goodbye — a standard Urdu farewell
+concept_tag: FAREWELL
+prerequisites: [UR-C05-hafiz]
+sounds: [rtl, kh, long-a, short-vowels-unwritten]
+roots: [persian-khoda, arabic-h-f-z]
+etymology_hook: The farewell joins Persian-borrowed khudā with Arabic-rooted hāfiz; standard Urdu teaching writes the two words with a space, while Persian normally joins its local spelling.
+duration:
+  max_seconds: 220
+requires:
+  knowledge: [UR-LEX-KHUDA, UR-SCRIPT-KHUDA, UR-LEX-HAFIZ, UR-SCRIPT-HAFIZ, UR-ETYMON-KHUDA-PERSIAN, UR-ETYMON-HAFIZ-ARABIC]
+introduces:
+  knowledge: [UR-LEX-KHUDA-HAFIZ, UR-SCRIPT-KHUDA-HAFIZ-SPACED, UR-GRAMMAR-KHUDA-HAFIZ-ELLIPSIS, UR-PRAGMATICS-STANDARD-FAREWELL, UR-CROSSLINGUAL-KHUDA-HAFIZ-SPELLING]
+practises:
+  knowledge: [UR-LEX-KHUDA, UR-SCRIPT-KHUDA, UR-LEX-HAFIZ, UR-SCRIPT-HAFIZ, UR-LEX-KHUDA-HAFIZ, UR-SCRIPT-KHUDA-HAFIZ-SPACED, UR-GRAMMAR-KHUDA-HAFIZ-ELLIPSIS, UR-PRAGMATICS-STANDARD-FAREWELL, UR-CROSSLINGUAL-KHUDA-HAFIZ-SPELLING]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: broadly-polite
+variety: contemporary-standard-urdu
+reviews_of: [UR-C05-khuda, UR-C05-hafiz]
+---
+
+# خدا حافظ — goodbye
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-KHUDA, UR-LEX-HAFIZ, UR-SCRIPT-KHUDA, UR-SCRIPT-HAFIZ] -->
+
+[PAUSE 2s] Retrieve **khudā** and **hāfiz** separately: “God” + “guardian.” Now
+use the two known pieces as one parting move.
+
+## The two words — put the known pieces together
+<!-- hl-knowledge: introduces=[UR-LEX-KHUDA-HAFIZ, UR-SCRIPT-KHUDA-HAFIZ-SPACED]; assesses=[] -->
+
+> **خدا حافظ** — *khudā hāfiz* — **goodbye**
+
+Urdu keeps a visible space between the two words. Read **خدا** first, then
+**حافظ**, and preserve that space in the complete spelling **خدا حافظ**. Say the
+whole expression smoothly.
+
+## Grammar Lens — a whole social move
+<!-- hl-knowledge: introduces=[UR-GRAMMAR-KHUDA-HAFIZ-ELLIPSIS, UR-PRAGMATICS-STANDARD-FAREWELL]; assesses=[] -->
+
+The protective sense is “God [be] guardian,” but everyday speakers use the
+formula simply as **goodbye**. No new verb or agreement ending is needed. It is
+a reliable polite close for the short interaction learned so far.
+
+## Script Bridge — shared history, local spacing
+<!-- hl-knowledge: introduces=[UR-CROSSLINGUAL-KHUDA-HAFIZ-SPELLING]; assesses=[] -->
+
+Urdu **خدا حافظ** and Persian **خداحافظ** share the same historical pieces.
+Urdu keeps the visible space in this course; Persian normally joins them.
+Mixed practice may compare the two only now that each local phrase is
+independently readable.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-KHUDA-HAFIZ, UR-SCRIPT-KHUDA-HAFIZ-SPACED, UR-GRAMMAR-KHUDA-HAFIZ-ELLIPSIS, UR-PRAGMATICS-STANDARD-FAREWELL, UR-CROSSLINGUAL-KHUDA-HAFIZ-SPELLING] -->
+
+- [YOU BUILD: **khudā** + **hāfiz**]
+- [YOU READ: spaced Urdu **خدا حافظ**]
+- [YOU USE: say it when the interaction ends]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-KHUDA-HAFIZ, UR-SCRIPT-KHUDA-HAFIZ-SPACED, UR-GRAMMAR-KHUDA-HAFIZ-ELLIPSIS, UR-PRAGMATICS-STANDARD-FAREWELL, UR-CROSSLINGUAL-KHUDA-HAFIZ-SPELLING] -->
+<!-- hl-activity: {"id":"UR-C05-khuda-hafiz-goodbye","kind":"text","assesses":["UR-LEX-KHUDA-HAFIZ"],"prompt":"Type the standard Urdu expression for 'goodbye'.","answer":"خدا حافظ","accepted":["khuda hafiz","khudā hāfiz","xuda hafiz","khudahafiz"],"feedback":{"correct":"Right: خدا حافظ khudā hāfiz ends the interaction.","incorrect":"Use خدا حافظ — khudā hāfiz."},"response_seconds":9} -->
+
+Where is the local writing contrast? (Urdu shows a space; Persian joins its
+spelling.)
+
+Source: [*Basic Urdu*: Greetings and Introductions](https://openbooks.lib.msu.edu/urdu/chapter/2-2/).

--- a/code/learning/human-languages/urdu/lessons/UR-C05-khuda.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C05-khuda.md
@@ -1,0 +1,71 @@
+---
+schema_version: 2
+id: UR-C05-khuda
+spine_node: SPINE-TAKE-LEAVE
+sequence: 170
+chapter: 5
+type: word
+headword: خدا
+romanization: khudā
+gloss: God — the Persian-borrowed half of the standard Urdu farewell
+concept_tag: UR-C05-KHUDA
+prerequisites: [UR-C04-practice]
+sounds: [rtl, kh, long-a, short-vowels-unwritten]
+roots: [persian-khoda]
+etymology_hook: Urdu khudā is borrowed from Persian khodā, which continues Middle Persian xwadāy “lord”; Urdu keeps the word inside a familiar parting formula.
+duration:
+  max_seconds: 200
+requires:
+  knowledge: [UR-DIALOGUE-WELLBEING]
+introduces:
+  knowledge: [UR-LEX-KHUDA, UR-SCRIPT-KHUDA, UR-ETYMON-KHUDA-PERSIAN]
+practises:
+  knowledge: [UR-DIALOGUE-WELLBEING, UR-LEX-KHUDA, UR-SCRIPT-KHUDA, UR-ETYMON-KHUDA-PERSIAN]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: contemporary-standard-urdu
+reviews_of: [UR-C04-practice]
+---
+
+# خدا — the first half of an Urdu farewell
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[UR-DIALOGUE-WELLBEING] -->
+
+[PAUSE 2s] Run one known wellbeing exchange. Chapter 5 will add only the move
+that ends it.
+
+## You'll want to know first — one word
+<!-- hl-knowledge: introduces=[UR-LEX-KHUDA, UR-SCRIPT-KHUDA]; assesses=[] -->
+
+> **خدا** — *khudā* — **God**
+
+Read from right to left: **خ** *kh* + **د** *d* + **ا** long *ā*. The short *u*
+is learned with the word and is normally unwritten. Let **kh** come from farther
+back than English *h*, but keep the sound relaxed.
+
+## The word, taken apart — Persian history inside Urdu
+<!-- hl-knowledge: introduces=[UR-ETYMON-KHUDA-PERSIAN]; assesses=[] -->
+
+Urdu borrowed **khudā** from Persian **khodā**, whose older Middle Persian
+ancestor *xwadāy* meant “lord.” Learn the Urdu sound and script first; the
+Persian connection then explains why both tracks will share the phrase's first
+historical layer.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-KHUDA, UR-SCRIPT-KHUDA, UR-ETYMON-KHUDA-PERSIAN] -->
+
+- [YOU SAY: **khudā** — God]
+- [YOU READ: **خدا** from the right edge]
+- [YOU CONNECT: Urdu **khudā** ← Persian **khodā**]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-KHUDA, UR-SCRIPT-KHUDA, UR-ETYMON-KHUDA-PERSIAN] -->
+<!-- hl-activity: {"id":"UR-C05-khuda-meaning","kind":"text","assesses":["UR-LEX-KHUDA"],"prompt":"Type the Urdu word khudā, meaning 'God'.","answer":"خدا","accepted":["khuda","khudā","xuda","xudā"],"feedback":{"correct":"Right: خدا khudā is the Persian-borrowed half of the Urdu farewell.","incorrect":"Use خدا — khudā."},"response_seconds":8} -->
+
+Which final letter carries long **ā**? (**ا**.) Which short vowel must be
+remembered with the word? (*u*.)
+
+Sources: [*Basic Urdu*: Greetings and Introductions](https://openbooks.lib.msu.edu/urdu/chapter/2-2/); [Wiktionary: خدا](https://en.wiktionary.org/wiki/%D8%AE%D8%AF%D8%A7#Urdu).

--- a/code/learning/human-languages/urdu/lessons/UR-C05-practice.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C05-practice.md
@@ -1,0 +1,68 @@
+---
+schema_version: 2
+id: UR-C05-practice
+spine_node: SPINE-TAKE-LEAVE
+sequence: 200
+chapter: 5
+type: practice-mix
+headword: سلام ... خدا حافظ
+romanization: salām ... khudā hāfiz
+gloss: open and close a short Urdu interaction
+concept_tag: UR-C05-PRACTICE
+prerequisites: [UR-C05-khuda-hafiz]
+sounds: [rtl, kh, long-a]
+roots: []
+etymology_hook: The dialogue contrasts Arabic-rooted salām at the opening with Persian-plus-Arabic khudā hāfiz at the close, placing etymology inside communicative sequence.
+duration:
+  max_seconds: 220
+requires:
+  knowledge: [UR-DIALOGUE-WELLBEING, UR-LEX-KHUDA-HAFIZ, UR-SCRIPT-KHUDA-HAFIZ-SPACED, UR-PRAGMATICS-STANDARD-FAREWELL]
+introduces:
+  knowledge: [UR-DIALOGUE-TAKE-LEAVE]
+practises:
+  knowledge: [UR-DIALOGUE-WELLBEING, UR-LEX-KHUDA-HAFIZ, UR-SCRIPT-KHUDA-HAFIZ-SPACED, UR-PRAGMATICS-STANDARD-FAREWELL, UR-DIALOGUE-TAKE-LEAVE]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, fluency]
+register: broadly-polite
+variety: contemporary-standard-urdu
+reviews_of: [UR-C05-khuda, UR-C05-hafiz, UR-C05-khuda-hafiz]
+---
+
+# Practice — open, check, and close
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[UR-DIALOGUE-WELLBEING, UR-LEX-KHUDA-HAFIZ, UR-PRAGMATICS-STANDARD-FAREWELL] -->
+
+[PAUSE 2s] Retrieve the known expression for the beginning and the new
+expression for the end. Keep the middle unchanged.
+
+## The exchange — the complete interaction
+<!-- hl-knowledge: introduces=[UR-DIALOGUE-TAKE-LEAVE]; assesses=[] -->
+
+> A: **سلام! آپ کیسے ہیں؟**
+> *Salām! Āp kaise haiṅ?*
+> B: **میں ٹھیک ہوں، شکریہ۔**
+> *Maiṅ ṭhīk hūṅ, shukriyā.*
+> A: **خدا حافظ۔**
+> *Khudā hāfiz.*
+> B: **خدا حافظ۔**
+> *Khudā hāfiz.*
+
+Every line is already learned. **Salām** opens; **khudā hāfiz** closes. The
+same farewell works for both speakers, so this practice adds no gender choice,
+pronoun, or copula form.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[UR-DIALOGUE-WELLBEING, UR-LEX-KHUDA-HAFIZ, UR-DIALOGUE-TAKE-LEAVE] -->
+
+- [YOU CHOOSE: meeting begins → **salām**]
+- [YOU CHOOSE: interaction ends → **khudā hāfiz**]
+- [YOU RUN: both voices once with script, once without romanization]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[UR-DIALOGUE-WELLBEING, UR-LEX-KHUDA-HAFIZ, UR-SCRIPT-KHUDA-HAFIZ-SPACED, UR-PRAGMATICS-STANDARD-FAREWELL, UR-DIALOGUE-TAKE-LEAVE] -->
+<!-- hl-activity: {"id":"UR-C05-practice-final-line","kind":"text","assesses":["UR-DIALOGUE-TAKE-LEAVE"],"prompt":"The short Urdu interaction is ending. Type the final expression.","answer":"خدا حافظ","accepted":["khuda hafiz","khudā hāfiz","khudahafiz"],"feedback":{"correct":"Right: خدا حافظ closes the interaction.","incorrect":"Close with خدا حافظ — khudā hāfiz."},"response_seconds":9} -->
+
+Run the full exchange once. If the final line stalls, return only to the
+assembled-farewell lesson.

--- a/code/learning/human-languages/urdu/pronunciation-reference.md
+++ b/code/learning/human-languages/urdu/pronunciation-reference.md
@@ -55,6 +55,9 @@ romanization once the Urdu form is familiar.
   broad final **ے** with long-*ī* final **ی**.
 - **ٹھیک** introduces the Indic retroflex-plus-aspiration sequence **ٹھ** only
   when the wellbeing reply needs it.
+- **خدا حافظ** reuses **خ** and long **ا**, adds a clear initial *h* in **حافظ**,
+  and reads final **ظ** as *z*. Urdu keeps the two words visibly spaced in this
+  course even though Persian normally joins its local spelling.
 
 ## The Persian-Arabic and Indo-Aryan layers
 

--- a/code/learning/human-languages/urdu/roadmap.md
+++ b/code/learning/human-languages/urdu/roadmap.md
@@ -36,7 +36,15 @@ The shared wellbeing can-do gets an Urdu-specific extra step for addressee
 agreement, an explicit **āp ... haiṅ** honorific frame, and an Urdu/Hindi script
 bridge only after **ٹھیک** is independently readable.
 
-## Chapter 5 — People and simple identity *(planned)*
+## Chapter 5 — Take leave *(authored)*
+
+**خدا** *khudā* → **حافظ** *hāfiz* → **خدا حافظ** *khudā hāfiz* → one
+start-versus-end interaction. The sequence first secures the Urdu reading,
+then exposes the Persian loan plus Arabic root history, and only then compares
+Urdu's visible space with Persian's joined spelling. Casual, time-of-day, and
+“see you” farewells remain later spine work.
+
+## Chapter 6 — People and simple identity *(planned)*
 
 - extend **میں ... ہوں** *maiṅ ... hūṅ* from state to identity;
 - add further masculine and feminine agreement one contrast at a time;

--- a/code/learning/human-languages/urdu/session-map.md
+++ b/code/learning/human-languages/urdu/session-map.md
@@ -1,6 +1,6 @@
-# Urdu Session Map — Authored Chapters 1–4
+# Urdu Session Map — Authored Chapters 1–5
 
-This is the authoritative order for the sixteen authored Urdu lessons. Each new
+This is the authoritative order for the twenty authored Urdu lessons. Each new
 lesson is a self-contained, prerequisite-safe step of three or four minutes.
 A longer study session may combine the new step with its due reviews while the
 book and app keep every lesson independently completable.
@@ -52,6 +52,19 @@ minutes.
 | **S15** | [`UR-C04-main-thik-hun`](./lessons/UR-C04-main-thik-hun.md): **میں ٹھیک ہوں، شکریہ** | the name question *(N+7)*; the wellbeing question *(N+3)*; *ṭhīk* *(N+1)* | keep *hūṅ* final, then add known thanks |
 | **S16** | [`UR-C04-practice`](./lessons/UR-C04-practice.md): full wellbeing exchange | *salām* *(N+15)*; the meeting response *(N+7)*; *maiṅ ... hūṅ* *(N+3)*; the reply *(N+1)* | run both respectful question variants and one answer |
 
+## Chapter 5 — Take leave
+
+Chapter 5 fills four sessions: the Persian-borrowed first word, the Arabic-rooted
+second word, the spaced Urdu phrase, then a complete start-versus-end practice.
+Time-of-day farewells remain later spine work.
+
+| Session | New lesson | Reviews due | Cumulative practice |
+|---|---|---|---|
+| **S17** | [`UR-C05-khuda`](./lessons/UR-C05-khuda.md): **خدا** *khudā* | *shukriyā* *(N+15)*; Chapter 3 practice *(N+7)*; *ṭhīk* *(N+3)*; Chapter 4 practice *(N+1)* | read the Persian-borrowed half of the farewell |
+| **S18** | [`UR-C05-hafiz`](./lessons/UR-C05-hafiz.md): **حافظ** *hāfiz* | *jī hā̃* *(N+15)*; *kaise / kaisī* *(N+7)*; the reply *(N+3)*; *khudā* *(N+1)* | read the Arabic-rooted protector word |
+| **S19** | [`UR-C05-khuda-hafiz`](./lessons/UR-C05-khuda-hafiz.md): **خدا حافظ** | *nahī̃* *(N+15)*; the wellbeing question *(N+7)*; Chapter 4 practice *(N+3)*; *hāfiz* *(N+1)* | keep the Urdu space and end an interaction |
+| **S20** | [`UR-C05-practice`](./lessons/UR-C05-practice.md): open and close | *merā nām ... hai* *(N+15)*; *maiṅ ... hūṅ* *(N+7)*; *khudā* *(N+3)*; *khudā hāfiz* *(N+1)* | choose **salām** at the start and **khudā hāfiz** at the end |
+
 ## Carry-forward review ledger
 
 Future chapters may supply the new lesson in these sessions. Until then, use
@@ -60,21 +73,21 @@ with already learned material.
 
 | Session | Fixed review due |
 |---|---|
-| **S17** | *shukriyā* *(N+15)*; Chapter 3 practice *(N+7)*; *ṭhīk* *(N+3)*; Chapter 4 practice *(N+1)* |
-| **S18** | *jī hā̃* *(N+15)*; *kaise / kaisī* *(N+7)*; the reply *(N+3)* |
-| **S19** | *nahī̃* *(N+15)*; the wellbeing question *(N+7)*; Chapter 4 practice *(N+3)* |
-| **S20** | *merā nām ... hai* *(N+15)*; *maiṅ ... hūṅ* *(N+7)* |
-| **S21** | the three “you” forms *(N+15)*; *ṭhīk* *(N+7)* |
-| **S22** | *kyā* *(N+15)*; the reply *(N+7)* |
-| **S23** | the name question *(N+15)*; Chapter 4 practice *(N+7)* |
-| **S24** | the meeting response *(N+15)* |
-| **S25** | Chapter 3 practice *(N+15)* |
-| **S26** | *kaise / kaisī* *(N+15)* |
-| **S27** | the wellbeing question *(N+15)* |
+| **S21** | the three “you” forms *(N+15)*; *ṭhīk* *(N+7)*; *hāfiz* *(N+3)*; Chapter 5 practice *(N+1)* |
+| **S22** | *kyā* *(N+15)*; the reply *(N+7)*; *khudā hāfiz* *(N+3)* |
+| **S23** | the name question *(N+15)*; Chapter 4 practice *(N+7)*; Chapter 5 practice *(N+3)* |
+| **S24** | the meeting response *(N+15)*; *khudā* *(N+7)* |
+| **S25** | Chapter 3 practice *(N+15)*; *hāfiz* *(N+7)* |
+| **S26** | *kaise / kaisī* *(N+15)*; *khudā hāfiz* *(N+7)* |
+| **S27** | the wellbeing question *(N+15)*; Chapter 5 practice *(N+7)* |
 | **S28** | *maiṅ ... hūṅ* *(N+15)* |
 | **S29** | *ṭhīk* *(N+15)* |
 | **S30** | the reply *(N+15)* |
 | **S31** | Chapter 4 practice *(N+15)* |
+| **S32** | *khudā* *(N+15)* |
+| **S33** | *hāfiz* *(N+15)* |
+| **S34** | *khudā hāfiz* *(N+15)* |
+| **S35** | Chapter 5 practice *(N+15)* |
 
 Sessions not listed in the ledger have no fixed starter item due; use their
 bonus queue for adaptive or cumulative retrieval.
@@ -85,7 +98,7 @@ review; the fixed ledger remains the book's no-tracking fallback.
 
 ## Schedule check
 
-Every Chapter 1–4 lesson now has all four fixed resurfacing sessions through
-S31. The app may pull a missed item forward, but it cannot skip the local
-prerequisites. A future Chapter 5 can begin in S17 while this ledger continues
+Every Chapter 1–5 lesson now has all four fixed resurfacing sessions through
+S35. The app may pull a missed item forward, but it cannot skip the local
+prerequisites. A future Chapter 6 can begin in S21 while this ledger continues
 in the review portion of each session.

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added — Persian and Urdu take-leave frontiers
+
+- Extend both RTL tracks through `SPINE-TAKE-LEAVE` with four schema-v2
+  Chapter 5 micro-lessons apiece: the two historical word layers, the complete
+  local-script farewell, and cumulative start-versus-end practice.
+- Compile one objective contract for every new lesson, raising mapped
+  non-lexical coverage from the Chapter 4 baseline to 25 of 119 lessons while
+  leaving the 94-item debt unchanged.
+- Generate both Chapter 5 LaTeX files from the same prerequisite-closed lesson
+  AST consumed by Language Ladder, preserving Persian joined **خداحافظ** and
+  Urdu spaced **خدا حافظ**.
+
 ### Added — Persian and Urdu shared name exchange
 
 - Extend both RTL tracks through `SPINE-EXCHANGE-NAMES` with five schema-v2

--- a/code/packages/typescript/human-language-data/tests/integration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/integration.test.ts
@@ -67,12 +67,12 @@ describe("real curriculum", () => {
       books.books
         .find((book) => book.language === "persian")
         ?.chapters.map((chapter) => chapter.chapter),
-    ).toEqual([1, 2, 3, 4]);
+    ).toEqual([1, 2, 3, 4, 5]);
     expect(
       books.books
         .find((book) => book.language === "urdu")
         ?.chapters.map((chapter) => chapter.chapter),
-    ).toEqual([1, 2, 3, 4]);
+    ).toEqual([1, 2, 3, 4, 5]);
     expect(
       books.books
         .find((book) => book.language === "russian")
@@ -113,6 +113,10 @@ describe("real curriculum", () => {
       "FA-C04-khub-good",
       "FA-C04-khubam-reply",
       "FA-C04-practice-next-line",
+      "FA-C05-hafez-meaning",
+      "FA-C05-khoda-meaning",
+      "FA-C05-khodahafez-goodbye",
+      "FA-C05-practice-final-line",
       "GE-C17-kopf-haupt-compound-word",
       "GU-C06-number-histories-be-source",
       "HI-W01-shirorekha-na-ma-drawing-order",
@@ -140,6 +144,10 @@ describe("real curriculum", () => {
       "UR-C04-main-thik-hun-reply",
       "UR-C04-practice-next-line",
       "UR-C04-thik-well",
+      "UR-C05-hafiz-meaning",
+      "UR-C05-khuda-hafiz-goodbye",
+      "UR-C05-khuda-meaning",
+      "UR-C05-practice-final-line",
     ]);
     expect(activities.every((activity) => activity.assesses.length > 0)).toBe(true);
     expect(activities.every((activity) => activity.acceptedResponses.length > 0)).toBe(true);
@@ -209,6 +217,37 @@ describe("real curriculum", () => {
         ),
       ).toEqual([]);
     }
+  });
+
+  it("keeps the Persian and Urdu Chapter 5 farewell chains closed, objective, and under five minutes", () => {
+    const report = buildCurriculumGapReport({ registry, lessons, books });
+    for (const language of ["persian", "urdu"]) {
+      const chapter = lessons.filter(
+        (lesson) => lesson.language === language && lesson.realization.chapter === 5,
+      );
+      expect(chapter).toHaveLength(4);
+      expect(chapter.every((lesson) => lesson.frontmatter.schema_version === "2")).toBe(true);
+      expect(chapter.every((lesson) => compileLessonActivities(lesson.blocks).length === 1)).toBe(true);
+      expect(
+        report.duration.violations.filter(
+          (lesson) => lesson.language === language && lesson.chapter === 5,
+        ),
+      ).toEqual([]);
+      expect(
+        report.prerequisites.laterChapterWithoutPrerequisites.filter(
+          (lesson) => lesson.language === language && lesson.chapter === 5,
+        ),
+      ).toEqual([]);
+    }
+
+    const persianFarewell = lessons.find(
+      (lesson) => lesson.realization.lessonId === "FA-C05-khodahafez",
+    )!;
+    const urduFarewell = lessons.find(
+      (lesson) => lesson.realization.lessonId === "UR-C05-khuda-hafiz",
+    )!;
+    expect(persianFarewell.frontmatter.headword).toBe("خداحافظ");
+    expect(urduFarewell.frontmatter.headword).toBe("خدا حافظ");
   });
 
   it("GREETING-HELLO joins every track (the normalization payoff)", () => {

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased — schema-v2 lesson compatibility
 
+### Changed — Persian and Urdu Chapter 5 frontiers
+
+- Load eight new prerequisite-safe take-leave steps across Persian and Urdu,
+  including each track's local etymology, script, register, and consolidation
+  extensions.
+- Keep the shared historical phrase locally readable before mixed comparison:
+  Persian joined **خداحافظ** and Urdu spaced **خدا حافظ** remain distinct
+  focused answers.
+- Use authored checks on every new step, raising objective non-lexical coverage
+  to 25 of 119 mapped lessons across 18 tracks while retaining independent
+  focused-before-mixed progression.
+
 ### Changed — Persian and Urdu Chapter 3 frontiers
 
 - Load ten new prerequisite-safe name-exchange steps across Persian and Urdu,

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -37,7 +37,7 @@ showing an answer-bearing summary. Other lexical lessons ask for one English
 meaning. A wrong answer leaves the local frontier unchanged; a correct answer
 shows feedback before the learner continues. The first objective non-lexical
 pilots covered Spanish grammatical gender and punctuation spans; the first
-HL-A01 tranches now reach 21 of 115 mapped non-lexical lessons across 18 tracks,
+HL-A01 tranches now reach 25 of 119 mapped non-lexical lessons across 18 tracks,
 including script, grammar, etymology, culture, and cumulative practice. The
 remaining 94 support lessons retain temporary final-recall confirmation while
 HL-A01 fills the measured contract backlog.

--- a/code/programs/typescript/language-ladder/tests/curriculum.test.ts
+++ b/code/programs/typescript/language-ladder/tests/curriculum.test.ts
@@ -60,6 +60,10 @@ describe("per-language shared-spine maps", () => {
       "FA-C04-khub",
       "FA-C04-khubam",
       "FA-C04-practice",
+      "FA-C05-khoda",
+      "FA-C05-hafez",
+      "FA-C05-khodahafez",
+      "FA-C05-practice",
       "UR-C01-salam",
       "UR-C01-shukriya",
       "UR-C01-ji-han",
@@ -76,6 +80,10 @@ describe("per-language shared-spine maps", () => {
       "UR-C04-thik",
       "UR-C04-main-thik-hun",
       "UR-C04-practice",
+      "UR-C05-khuda",
+      "UR-C05-hafiz",
+      "UR-C05-khuda-hafiz",
+      "UR-C05-practice",
     ]));
   });
 


### PR DESCRIPTION
## Summary

- realize `SPINE-TAKE-LEAVE` for Persian and Urdu with four prerequisite-safe micro-lessons per language
- teach the inherited/borrowed `khodā/khudā` layer and Arabic-rooted `hāfez/hāfiz` layer before assembling the farewell
- preserve Persian joined `خداحافظ` and Urdu spaced `خدا حافظ`, with gentle inline script and etymology
- extend the canonical curricula, review ledgers, generated LaTeX books, app coverage, tests, changelogs, and backlog metrics

## Validation

- `npm run check:books`
- `npm test` — human-language-data: 103/103
- `npm test` — Language Ladder: 481/481
- Language Ladder production build
- Persian and Urdu XeLaTeX builds: 29 pages each
- page-by-page visual QA of both new chapters and source pages
- curriculum report: 20 tracks, 1,096 lessons, 350 paths, 277 extensions, 926 mapped lessons; no unknown prerequisites and no lessons at or above five minutes
- `git diff --check`
