### PR TITLE
fix(human-languages): preserve generated book links

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -74,9 +74,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-D01 | Complete (#9624) | Split or rewrite every lesson whose computed duration is at least 300 seconds. | The deterministic report now reaches zero effective-duration violations across all twenty tracks. |
 | HL-S02 | Complete (#9634) | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | All 27 lessons have typed blocks, unique sequence, transitive knowledge closure, and sub-five-minute duration guarantees. |
 | HL-G03 | Complete (#9646) | Generate Spanish Chapters 4–6 from their canonical schema-v2 lesson ASTs after HL-S02. | All six generated chapters now share lesson hashes with Language Ladder; Markdown tables retain their structure in print. |
-| HL-G04 | Complete in this PR | Normalize paired straight quotation marks when canonical prose is rendered into LaTeX. | Generated prose uses true opening and closing marks under every book's language rules without changing the canonical app text, code spans, escaped literals, or link destinations. |
-| HL-G05 | Queued | Preserve canonical Markdown hyperlinks in generated LaTeX chapters. | Source notes and learner-facing links render as live `\href` targets in PDFs instead of retaining only their labels. |
-| HL-G06 | Complete in this PR | Preserve indented continuation lines inside generated Markdown blockquotes. | Multiline learner examples remain inside one LaTeX quote/callout, so typography and layout do not split halfway through a canonical example. |
+| HL-G04 | Complete (#9915) | Normalize paired straight quotation marks when canonical prose is rendered into LaTeX. | Generated prose uses true opening and closing marks under every book's language rules without changing the canonical app text, code spans, escaped literals, or link destinations. |
+| HL-G05 | Complete in this PR | Preserve canonical Markdown hyperlinks in generated LaTeX chapters. | Source notes and learner-facing links render as live `\href` targets in PDFs instead of retaining only their labels. |
+| HL-G06 | Complete (#9915) | Preserve indented continuation lines inside generated Markdown blockquotes. | Multiline learner examples remain inside one LaTeX quote/callout, so typography and layout do not split halfway through a canonical example. |
 | HL-V02 | Complete (#9653) | Validate learner-facing target-language prompts against block-level knowledge declarations and prerequisite closure. | Schema-v2 production and recall blocks cannot ask for an undeclared form or a form absent from the lesson's transitive knowledge frontier. |
 | HL-V03 | Complete (#9900) | Compile individual prompt, answer, accepted-variant, feedback, and response-time contracts from typed activity blocks. | Compact JSON directives compile into validated runtime answer sets; each activity names a non-empty assessed-atom subset, carries feedback/time, and never scrapes prose. |
 | HL-A01 | In progress (#9901 + Russian and Persian/Urdu slices) | Author objective activity coverage for every mapped non-lexical frontier. | The first tranche covers every ready schema-v2 track; later slices cover Russian's naming chain and Persian/Urdu Chapters 3–5 practice. Coverage is 25 of 119 across 18 tracks; 94 lessons remain, including 16 that first need schema-v2 migration. |
@@ -1780,6 +1780,24 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   nested Arabic/RTL glosses, and a continued Telugu example without clipping.
 - HL-G05 remains the next queued one-source book gap: generated link labels are
   readable, but their canonical destinations are not yet live PDF links.
+
+## Findings from HL-G05
+
+- The generator now preserves all 55 canonical links in the nine configured
+  chapters that contain them: Spanish Chapters 1–3 and Persian/Urdu Chapters
+  3–5. Absolute research citations stay on their authored HTTP(S) targets.
+- Relative prerequisite and pronunciation-reference links resolve against the
+  lesson's stable GitHub source URL. This keeps links useful after a book is
+  downloaded, instead of emitting paths relative to an arbitrary PDF folder.
+- Link labels still pass through the same emphasis, script-font, and quotation
+  renderer as surrounding prose, while destinations use their own LaTeX-safe
+  escaping and remain outside typography transformations.
+- Generation fails closed when a relative link has no canonical source base or
+  when a destination uses a non-HTTP(S) protocol. All lesson filenames match
+  their canonical ids, so no additional source-path metadata is needed.
+- The audit found 117 authored links across the wider lesson corpus. The 62 not
+  yet represented in generated targets remain canonical app content and will
+  become live automatically when those chapters migrate to book generation.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -1,5 +1,6 @@
 {
   "version": 1,
+  "sourceBaseUrl": "https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/",
   "scriptSets": {
     "telugu-comparisons": [
       { "unicodeScript": "Telugu", "scriptCommand": "te" },

--- a/code/learning/human-languages/persian/book/chapters/ch03-ask-and-answer-names.tex
+++ b/code/learning/human-languages/persian/book/chapters/ch03-ask-and-answer-names.tex
@@ -50,7 +50,7 @@ Persian \textbf{to} belongs to the ancient Indo-European familiar-“you” fami
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
 Which form is safest when the relationship is new? (\textbf{Shomâ}.) Which is the relative of English \emph{thou}? (\textbf{To}.)
 
-Source: Persian Online: Pronouns.
+Source: \href{https://sites.la.utexas.edu/persian\_online\_resources/pronouns/}{Persian Online: Pronouns}.
 \end{tcolorbox}
 \section[chist]{\fa{چیست} — “what is?” in one joined word}
 
@@ -127,7 +127,7 @@ Persian ends a written question with \textbf{\fa{؟}}. Its curve faces the oppos
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
 Ask the question once without reading the romanization. Then answer with the careful name frame you already know.
 
-Source: Persian Online: Introducing Yourself.
+Source: \href{https://sites.la.utexas.edu/persian\_online\_resources/vocabulary-lists/people-places-and-things/}{Persian Online: Introducing Yourself}.
 \end{tcolorbox}
 \section[khoshvaghtam]{\fa{خوشوقتم} — pleased to meet you}
 
@@ -168,7 +168,7 @@ So the word builds “pleasant-time-I-am” into the idiomatic feeling “I am p
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
 Which response closes the introduction? (\textbf{Khoshvaghtam}.) Which three layers can you hear inside it? (\textbf{Khosh + vaqt + -am}.)
 
-Source: Persian Online: Introducing Yourself.
+Source: \href{https://sites.la.utexas.edu/persian\_online\_resources/vocabulary-lists/people-places-and-things/}{Persian Online: Introducing Yourself}.
 \end{tcolorbox}
 \section[Practice]{Practice — a complete Persian name exchange}
 

--- a/code/learning/human-languages/persian/book/chapters/ch04-how-are-you.tex
+++ b/code/learning/human-languages/persian/book/chapters/ch04-how-are-you.tex
@@ -40,7 +40,7 @@ Persian borrowed \textbf{hâl} from Arabic, then uses it with Persian grammar. Y
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
 What does \textbf{hâl} name? (A state or condition.) Which familiar linker will attach an owner to it? (Ezafe \textbf{-e}.)
 
-Source: Persian Online: Greetings List.
+Source: \href{https://sites.la.utexas.edu/persian\_online\_resources/vocabulary-lists/meetings-introductions/}{Persian Online: Greetings List}.
 \end{tcolorbox}
 \section[chetor]{\fa{چطور} — “how?” one layer at a time}
 
@@ -74,7 +74,7 @@ Persian Online takes \textbf{\fa{چطور}} apart as Persian \textbf{\fa{چه}} 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
 Which part means “what”? (\textbf{Che}.) Which borrowed part means “manner”? (\textbf{Tor}.)
 
-Source: Persian Online: Interrogatives.
+Source: \href{https://sites.la.utexas.edu/persian\_online\_resources/5-ws-h/}{Persian Online: Interrogatives}.
 \end{tcolorbox}
 \section[hâl-e shomâ chetor ast?]{\fa{حال} \fa{شما} \fa{چطور} \fa{است؟} — ask “How are you?” respectfully}
 
@@ -114,7 +114,7 @@ This chapter asks you to produce the careful written form with \textbf{ast}. Eve
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
 Ask once from memory. What already-known grammar holds \textbf{hâl} and \textbf{shomâ} together? (Ezafe \textbf{-e}.)
 
-Source: Persian Online: Greetings List.
+Source: \href{https://sites.la.utexas.edu/persian\_online\_resources/vocabulary-lists/meetings-introductions/}{Persian Online: Greetings List}.
 \end{tcolorbox}
 \section[khub]{\fa{خوب} — “good” and “well”}
 
@@ -148,7 +148,7 @@ Persian's everyday vocabulary is layered. \textbf{Hâl} and the \textbf{tor} ins
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
 Give the answer word once without romanization. Which letter carries its long \emph{u}? (\textbf{\fa{و}}.)
 
-Source: Persian Online: Greetings List.
+Source: \href{https://sites.la.utexas.edu/persian\_online\_resources/vocabulary-lists/meetings-introductions/}{Persian Online: Greetings List}.
 \end{tcolorbox}
 \section[khubam, mamnun]{\fa{خوبم،} \fa{ممنون} — “I am well, thank you”}
 
@@ -182,7 +182,7 @@ The attached ending \textbf{-am} means “I am” here. Persian Online notes tha
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
 What does final \textbf{-am} contribute? (“I am.”) Do you need a separate \textbf{man} in this answer? (No.)
 
-Sources: Persian Online: Verb “To Be” and Greetings List.
+Sources: \href{https://sites.la.utexas.edu/persian\_online\_resources/verbs/verb-to-be/}{Persian Online: Verb “To Be”} and \href{https://sites.la.utexas.edu/persian\_online\_resources/vocabulary-lists/meetings-introductions/}{Greetings List}.
 \end{tcolorbox}
 \section[Practice]{Practice — a Persian wellbeing exchange}
 

--- a/code/learning/human-languages/persian/book/chapters/ch05-take-leave.tex
+++ b/code/learning/human-languages/persian/book/chapters/ch05-take-leave.tex
@@ -40,7 +40,7 @@ Modern \textbf{khodâ} continues Middle Persian \emph{xwadây}, “lord.” The 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
 Which letter carries the final long \textbf{â}? (\textbf{\fa{ا}}.) Which vowel is heard but not written separately? (The short \emph{o}.)
 
-Source: Wiktionary: \fa{خدا}.
+Source: \href{https://en.wiktionary.org/wiki/\%D8\%AE\%D8\%AF\%D8\%A7}{Wiktionary: \fa{خدا}}.
 \end{tcolorbox}
 \section[hâfez]{\fa{حافظ} — “guardian” or “protector”}
 
@@ -74,7 +74,7 @@ Arabic \textbf{ḥāfiẓ} is an active participle from the root \textbf{ḥ-f-�
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
 What does \textbf{hâfez} contribute to the farewell? (The idea of guarding or protecting.)
 
-Source: American Heritage Dictionary: \emph{hafiz}.
+Source: \href{https://www.ahdictionary.com/word/search.html?q=hafiz}{American Heritage Dictionary: \emph{hafiz}}.
 \end{tcolorbox}
 \section[khodâ hâfez]{\fa{خداحافظ} — goodbye}
 
@@ -108,7 +108,7 @@ The expression carries the protective sense “God {[}be{]} guardian,” but eve
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
 When do you use \textbf{khodâ hâfez}? (At parting, not at the opening.)
 
-Source: Persian Online: Greetings List.
+Source: \href{https://sites.la.utexas.edu/persian\_online\_resources/vocabulary-lists/meetings-introductions/}{Persian Online: Greetings List}.
 \end{tcolorbox}
 \section[Practice]{Practice — open, check, and close}
 

--- a/code/learning/human-languages/spanish/book/chapters/ch01-first-words.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch01-first-words.tex
@@ -21,7 +21,7 @@ Each section stays independently resumable and preserves the authored prerequisi
 \begin{sounds}
 \begin{itemize}
 \raggedright
-  \item \texttt{silent-h} — the \textbf{h is silent}. \emph{hola} is said \emph{OH-la}, never \emph{HOH-la}. The letter is written but makes no sound at all. This is true of every Spanish \emph{h} you'll ever meet. $\to$ pronunciation reference
+  \item \texttt{silent-h} — the \textbf{h is silent}. \emph{hola} is said \emph{OH-la}, never \emph{HOH-la}. The letter is written but makes no sound at all. This is true of every Spanish \emph{h} you'll ever meet. $\to$ \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/pronunciation-reference.md}{pronunciation reference}
   \item \texttt{vowel-o}, \texttt{vowel-a} — two pure vowels: \emph{OH}, \emph{AH}. No glide, no drift.
 \end{itemize}
 \end{sounds}
@@ -69,13 +69,13 @@ Note the written form: an exclamation gets an \textbf{upside-down mark} at the f
 \subsection*{You'll want to know first}
 \begin{itemize}
 \raggedright
-  \item hola — your first word; \emph{bien} is what you say back when someone asks how you are.
+  \item \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C01-hola.md}{hola} — your first word; \emph{bien} is what you say back when someone asks how you are.
 \end{itemize}
 
 \begin{sounds}
 \begin{itemize}
 \raggedright
-  \item \texttt{diphthong-ie} — \textbf{ie} is a quick \emph{YEH}: \emph{bien} is said \emph{byen}, one syllable. $\to$ reference
+  \item \texttt{diphthong-ie} — \textbf{ie} is a quick \emph{YEH}: \emph{bien} is said \emph{byen}, one syllable. $\to$ \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/pronunciation-reference.md}{reference}
   \item \texttt{v-b} — the \textbf{b} is soft, halfway to a \emph{v}.
 \end{itemize}
 \end{sounds}
@@ -135,13 +135,13 @@ So \emph{bien} is the Spanish member of the \emph{bene-} family you've owned in 
 \subsection*{You'll want to know first}
 \begin{itemize}
 \raggedright
-  \item bien / bueno — you saw \emph{bueno} change to \emph{buena}; this lesson explains the gender that made it happen.
+  \item \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C01-bien.md}{bien / bueno} — you saw \emph{bueno} change to \emph{buena}; this lesson explains the gender that made it happen.
 \end{itemize}
 
 \begin{sounds}
 \begin{itemize}
 \raggedright
-  \item \texttt{vowel-e}, \texttt{vowel-a} — two clean vowels: \emph{el} (\emph{ehl}), \emph{la} (\emph{lah}). $\to$ reference
+  \item \texttt{vowel-e}, \texttt{vowel-a} — two clean vowels: \emph{el} (\emph{ehl}), \emph{la} (\emph{lah}). $\to$ \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/pronunciation-reference.md}{reference}
 \end{itemize}
 \end{sounds}
 
@@ -190,7 +190,7 @@ Over centuries the pointing force faded and the initial \emph{i-} dropped: \emph
 \subsection*{You'll want to know first}
 \begin{itemize}
 \raggedright
-  \item el / la — the two definite articles.
+  \item \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C01-el-la.md}{el / la} — the two definite articles.
 \end{itemize}
 
 \begin{grammarlens}[title={Grammar Lens: grammatical gender}]
@@ -227,13 +227,13 @@ You cannot always predict a noun's class from its ending. Learn each new noun wi
 \subsection*{You'll want to know first}
 \begin{itemize}
 \raggedright
-  \item el / la — grammatical gender and the two \textquotedblleft{}the\textquotedblright{}s; \emph{día} is where you apply them.
+  \item \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C01-el-la.md}{el / la} — grammatical gender and the two \textquotedblleft{}the\textquotedblright{}s; \emph{día} is where you apply them.
 \end{itemize}
 
 \begin{sounds}
 \begin{itemize}
 \raggedright
-  \item \texttt{accent-i} — the accent sits on the \textbf{í}: \emph{día} is \emph{DEE-a}, two beats. $\to$ reference
+  \item \texttt{accent-i} — the accent sits on the \textbf{í}: \emph{día} is \emph{DEE-a}, two beats. $\to$ \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/pronunciation-reference.md}{reference}
   \item \texttt{d-soft} — the \textbf{d} between vowels is soft, toward the \emph{th} in \emph{this}.
 \end{itemize}
 \end{sounds}
@@ -287,8 +287,8 @@ Gender isn't a passive label — it \emph{forces} the words around the noun to m
 \subsection*{You'll want to know first}
 \begin{itemize}
 \raggedright
-  \item bien / bueno — the adjective \emph{bueno}.
-  \item día — the noun \emph{días}, and that it's masculine.
+  \item \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C01-bien.md}{bien / bueno} — the adjective \emph{bueno}.
+  \item \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C01-dia.md}{día} — the noun \emph{días}, and that it's masculine.
 \end{itemize}
 
 \begin{sounds}

--- a/code/learning/human-languages/spanish/book/chapters/ch02-greetings.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch02-greetings.tex
@@ -21,13 +21,13 @@ Each section stays independently resumable and preserves the authored prerequisi
 \subsection*{You'll want to know first}
 \begin{itemize}
 \raggedright
-  \item buenos días — you'll pair \emph{tarde} with \emph{buena} the same way you paired \emph{días} with \emph{bueno}.
+  \item \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C01-buenos-dias.md}{buenos días} — you'll pair \emph{tarde} with \emph{buena} the same way you paired \emph{días} with \emph{bueno}.
 \end{itemize}
 
 \begin{sounds}
 \begin{itemize}
 \raggedright
-  \item Regular stress: \emph{TAR-de} — ends in a vowel, so the stress falls on the second-to-last syllable. $\to$ reference
+  \item Regular stress: \emph{TAR-de} — ends in a vowel, so the stress falls on the second-to-last syllable. $\to$ \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/pronunciation-reference.md}{reference}
 \end{itemize}
 
 \textbf{la tarde} (feminine) — \textquotedblleft{}afternoon.\textquotedblright{} Root: Latin \textbf{tardus} — which did \emph{not} mean afternoon. It meant \textbf{\textquotedblleft{}slow, late.\textquotedblright{}} And \emph{that} is the meaning English kept:
@@ -70,8 +70,8 @@ How did \textquotedblleft{}late\textquotedblright{} become \textquotedblleft{}af
 \subsection*{You'll want to know first}
 \begin{itemize}
 \raggedright
-  \item bien / bueno — the adjective \emph{bueno} and its four shapes.
-  \item tarde — the noun \emph{tardes}.
+  \item \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C01-bien.md}{bien / bueno} — the adjective \emph{bueno} and its four shapes.
+  \item \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C02-tarde.md}{tarde} — the noun \emph{tardes}.
 \end{itemize}
 
 \begin{cousinweb}
@@ -120,13 +120,13 @@ Same fossil blessing as the morning greeting: \emph{buenas tardes} is short for 
 \subsection*{You'll want to know first}
 \begin{itemize}
 \raggedright
-  \item tarde — same build ahead: word first, then \emph{buenas} + it.
+  \item \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C02-tarde.md}{tarde} — same build ahead: word first, then \emph{buenas} + it.
 \end{itemize}
 
 \begin{sounds}
 \begin{itemize}
 \raggedright
-  \item \texttt{soft-c} — the \textbf{ch} in \emph{noche} is the \emph{ch} of English \emph{church}: \emph{NO-cheh}. $\to$ reference
+  \item \texttt{soft-c} — the \textbf{ch} in \emph{noche} is the \emph{ch} of English \emph{church}: \emph{NO-cheh}. $\to$ \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/pronunciation-reference.md}{reference}
 \end{itemize}
 \end{sounds}
 
@@ -169,8 +169,8 @@ Same fossil blessing as the morning greeting: \emph{buenas tardes} is short for 
 \subsection*{You'll want to know first}
 \begin{itemize}
 \raggedright
-  \item buenas tardes — feminine agreement (\emph{buenas}); \emph{noche} is feminine too, so the same shape applies.
-  \item noche — the noun \emph{noches}.
+  \item \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C02-buenas-tardes.md}{buenas tardes} — feminine agreement (\emph{buenas}); \emph{noche} is feminine too, so the same shape applies.
+  \item \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C02-noche.md}{noche} — the noun \emph{noches}.
 \end{itemize}
 
 \begin{cousinweb}

--- a/code/learning/human-languages/spanish/book/chapters/ch03-introductions.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch03-introductions.tex
@@ -60,13 +60,13 @@ A \textbf{pronoun} is a stand-in word that points to a person or thing without n
 \subsection*{You'll want to know first}
 \begin{itemize}
 \raggedright
-  \item me — you'll bolt \emph{me} onto \emph{llamo} next lesson.
+  \item \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C03-me.md}{me} — you'll bolt \emph{me} onto \emph{llamo} next lesson.
 \end{itemize}
 
 \begin{sounds}
 \begin{itemize}
 \raggedright
-  \item \texttt{ll-y} — \textbf{ll} sounds like English \textbf{y}: \emph{llamo} is \emph{YA-mo}, not \emph{LA-mo}. $\to$ reference
+  \item \texttt{ll-y} — \textbf{ll} sounds like English \textbf{y}: \emph{llamo} is \emph{YA-mo}, not \emph{LA-mo}. $\to$ \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/pronunciation-reference.md}{reference}
 \end{itemize}
 \end{sounds}
 
@@ -110,7 +110,7 @@ A \textbf{pronoun} is a stand-in word that points to a person or thing without n
 \subsection*{You'll want to know first}
 \begin{itemize}
 \raggedright
-  \item me · llamo
+  \item \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C03-me.md}{me} · \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C03-llamar.md}{llamo}
 \end{itemize}
 
 \begin{cousinweb}
@@ -191,7 +191,7 @@ One structural surprise, because it explains the next lessons: \textbf{usted tak
 \subsection*{You'll want to know first}
 \begin{itemize}
 \raggedright
-  \item tú / usted — the informal and formal choices.
+  \item \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C03-tu-usted.md}{tú / usted} — the informal and formal choices.
 \end{itemize}
 
 \begin{cousinweb}
@@ -292,7 +292,7 @@ English has no such marker — it relies on word order and context. Spanish puts
 \subsection*{You'll want to know first}
 \begin{itemize}
 \raggedright
-  \item cómo — \textquotedblleft{}how,\textquotedblright{} from Latin \emph{quomodo}.
+  \item \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C03-como.md}{cómo} — \textquotedblleft{}how,\textquotedblright{} from Latin \emph{quomodo}.
 \end{itemize}
 
 \begin{cousinweb}
@@ -341,8 +341,8 @@ These are previews, not vocabulary to produce today. For now, use the family onl
 \subsection*{You'll want to know first}
 \begin{itemize}
 \raggedright
-  \item me llamo — the reflexive \textquotedblleft{}I call myself.\textquotedblright{}
-  \item tú / usted — and the key fact that \emph{usted} takes \emph{he/she} verb forms.
+  \item \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C03-me-llamo.md}{me llamo} — the reflexive \textquotedblleft{}I call myself.\textquotedblright{}
+  \item \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C03-tu-usted.md}{tú / usted} — and the key fact that \emph{usted} takes \emph{he/she} verb forms.
 \end{itemize}
 
 \begin{cousinweb}
@@ -400,7 +400,7 @@ Three persons, three pronouns: \emph{me / te / se}. That \emph{se} is exactly wh
 \subsection*{You'll want to know first}
 \begin{itemize}
 \raggedright
-  \item cómo · se llama · usted
+  \item \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C03-como.md}{cómo} · \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C03-se-llama.md}{se llama} · \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C03-tu-usted.md}{usted}
 \end{itemize}
 
 \begin{cousinweb}
@@ -491,7 +491,7 @@ You already have the answer from the \emph{me llamo} lesson: \textbf{Me llamo \_
 \subsection*{You'll want to know first}
 \begin{itemize}
 \raggedright
-  \item mucho — \textquotedblleft{}much,\textquotedblright{} about to modify \emph{gusto}.
+  \item \href{https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/spanish/lessons/ES-C03-mucho.md}{mucho} — \textquotedblleft{}much,\textquotedblright{} about to modify \emph{gusto}.
 \end{itemize}
 
 \begin{cousinweb}

--- a/code/learning/human-languages/urdu/book/chapters/ch03-ask-and-answer-names.tex
+++ b/code/learning/human-languages/urdu/book/chapters/ch03-ask-and-answer-names.tex
@@ -51,7 +51,7 @@ English flattened these choices into one \emph{you}. Urdu keeps three. Use \text
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
 Which form is safest when unsure? (\textbf{Āp}.) Which familiar forms share history with English \emph{thou}? (\textbf{Tum/tū}.)
 
-Source: \emph{Basic Urdu}: Cultural Notes.
+Source: \href{https://openbooks.lib.msu.edu/urdu/chapter/2-8/}{\emph{Basic Urdu}: Cultural Notes}.
 \end{tcolorbox}
 \section[kyā]{\ur{کیا} — what}
 
@@ -122,7 +122,7 @@ Urdu ends the question with \textbf{\ur{؟}}, curved for a right-to-left line. B
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
 Ask once without romanization. Where does \textbf{hai} remain? (At the end.)
 
-Source: \emph{Basic Urdu}: Greetings and Introductions.
+Source: \href{https://openbooks.lib.msu.edu/urdu/chapter/2-2/}{\emph{Basic Urdu}: Greetings and Introductions}.
 \end{tcolorbox}
 \section[āp se mil kar khushī huī]{\ur{آپ} \ur{سے} \ur{مل} \ur{کر} \ur{خوشی} \ur{ہوئی} — pleased to meet you}
 
@@ -165,7 +165,7 @@ That yields the memorable literal picture: \textbf{“Having met you, happiness 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
 Say the response once as a whole. Which chunk means “happiness happened”? (\textbf{Khushī huī}.)
 
-Source: \emph{Basic Urdu}: Greetings and Introductions.
+Source: \href{https://openbooks.lib.msu.edu/urdu/chapter/2-2/}{\emph{Basic Urdu}: Greetings and Introductions}.
 \end{tcolorbox}
 \section[Practice]{Practice — a complete Urdu name exchange}
 

--- a/code/learning/human-languages/urdu/book/chapters/ch04-how-are-you.tex
+++ b/code/learning/human-languages/urdu/book/chapters/ch04-how-are-you.tex
@@ -46,7 +46,7 @@ English keeps \emph{how} unchanged. Urdu makes this describing form agree with t
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
 Which form addresses a man? (\textbf{Kaise}.) A woman? (\textbf{Kaisī}.)
 
-Source: \emph{Basic Urdu}: Formal Conversation.
+Source: \href{https://openbooks.lib.msu.edu/urdu/chapter/2-4/}{\emph{Basic Urdu}: Formal Conversation}.
 \end{tcolorbox}
 \section[āp kaise haiṅ? / āp kaisī haiṅ?]{\ur{آپ} \ur{کیسے} \ur{ہیں؟} / \ur{آپ} \ur{کیسی} \ur{ہیں؟} — ask respectfully}
 
@@ -80,7 +80,7 @@ Both lines are respectful. The choice between \textbf{kaise} and \textbf{kaisī}
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
 What stays the same in both lines? (\textbf{Āp ... haiṅ}.) What changes? (\textbf{Kaise / kaisī}.)
 
-Sources: \emph{Basic Urdu}: Formal Conversation and Personal Pronouns with “To Be”.
+Sources: \href{https://openbooks.lib.msu.edu/urdu/chapter/2-4/}{\emph{Basic Urdu}: Formal Conversation} and \href{https://openbooks.lib.msu.edu/urdu/chapter/2-7/}{Personal Pronouns with “To Be”}.
 \end{tcolorbox}
 \section[maiṅ ... hūṅ]{\ur{میں} ... \ur{ہوں} — one frame for “I am ...”}
 
@@ -120,7 +120,7 @@ Learn only this first-person frame. You do not need the full copula chart to ans
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
 Which word opens the answer? (\textbf{Maiṅ}.) Which copula closes it? (\textbf{Hūṅ}.)
 
-Source: \emph{Basic Urdu}: Personal Pronouns with “To Be”.
+Source: \href{https://openbooks.lib.msu.edu/urdu/chapter/2-7/}{\emph{Basic Urdu}: Personal Pronouns with “To Be”}.
 \end{tcolorbox}
 \section[ṭhīk]{\ur{ٹھیک} — “fine,” “well,” and “correct”}
 
@@ -154,7 +154,7 @@ Urdu \textbf{\ur{ٹھیک}} and Hindi \emph{ṭhīk} are the same everyday Hindu
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
 Where will \textbf{ṭhīk} go in the frame \textbf{maiṅ ... hūṅ}? (In the middle.)
 
-Source: \emph{Basic Urdu}: Greetings and Introductions.
+Source: \href{https://openbooks.lib.msu.edu/urdu/chapter/2-2/}{\emph{Basic Urdu}: Greetings and Introductions}.
 \end{tcolorbox}
 \section[maiṅ ṭhīk hūṅ, shukriyā]{\ur{میں} \ur{ٹھیک} \ur{ہوں،} \ur{شکریہ} — “I am fine, thank you”}
 
@@ -194,7 +194,7 @@ English places “am” after “I”; Urdu closes the clause with \textbf{hū�
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
 Which word must close the core answer? (\textbf{Hūṅ}.)
 
-Source: \emph{Basic Urdu}: Formal Conversation.
+Source: \href{https://openbooks.lib.msu.edu/urdu/chapter/2-4/}{\emph{Basic Urdu}: Formal Conversation}.
 \end{tcolorbox}
 \section[Practice]{Practice — an Urdu wellbeing exchange}
 

--- a/code/learning/human-languages/urdu/book/chapters/ch05-take-leave.tex
+++ b/code/learning/human-languages/urdu/book/chapters/ch05-take-leave.tex
@@ -40,7 +40,7 @@ Urdu borrowed \textbf{khudā} from Persian \textbf{khodā}, whose older Middle P
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
 Which final letter carries long \textbf{ā}? (\textbf{\ur{ا}}.) Which short vowel must be remembered with the word? (\emph{u}.)
 
-Sources: \emph{Basic Urdu}: Greetings and Introductions; Wiktionary: \ur{خدا}.
+Sources: \href{https://openbooks.lib.msu.edu/urdu/chapter/2-2/}{\emph{Basic Urdu}: Greetings and Introductions}; \href{https://en.wiktionary.org/wiki/\%D8\%AE\%D8\%AF\%D8\%A7\#Urdu}{Wiktionary: \ur{خدا}}.
 \end{tcolorbox}
 \section[hāfiz]{\ur{حافظ} — “guardian” or “protector”}
 
@@ -74,7 +74,7 @@ Arabic \textbf{ḥāfiẓ} is an active participle from \textbf{ḥ-f-ẓ}, “g
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
 What does \textbf{hāfiz} contribute to the farewell? (The idea of guarding or protecting.)
 
-Source: American Heritage Dictionary: \emph{hafiz}.
+Source: \href{https://www.ahdictionary.com/word/search.html?q=hafiz}{American Heritage Dictionary: \emph{hafiz}}.
 \end{tcolorbox}
 \section[khudā hāfiz]{\ur{خدا} \ur{حافظ} — goodbye}
 
@@ -111,7 +111,7 @@ Urdu \textbf{\ur{خدا} \ur{حافظ}} and Persian \textbf{\ur{خداحافظ}}
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
 Where is the local writing contrast? (Urdu shows a space; Persian joins its spelling.)
 
-Source: \emph{Basic Urdu}: Greetings and Introductions.
+Source: \href{https://openbooks.lib.msu.edu/urdu/chapter/2-2/}{\emph{Basic Urdu}: Greetings and Introductions}.
 \end{tcolorbox}
 \section[Practice]{Practice — open, check, and close}
 

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Fixed — live generated curriculum links
+
+- Preserve canonical Markdown links as live LaTeX `\href` targets instead of
+  dropping every destination during book generation.
+- Resolve relative lesson and pronunciation-reference links against stable
+  GitHub source URLs while preserving absolute source citations and rich link
+  labels from the same canonical blocks consumed by Language Ladder.
+- Reject missing relative-link bases and non-HTTP(S) destinations, escape URL
+  metacharacters for LaTeX, and regenerate the nine affected chapters with 55
+  working links.
+
 ### Fixed — generated quotation typography
 
 - Render paired straight double quotes in canonical lesson prose with explicit

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -87,6 +87,9 @@ npm run check:books
 orders schema-v2 lessons by `sequence`, writes the LaTeX chapter, and records a
 stable FNV-1a fingerprint in `core/generated-book-hashes.json`. The fingerprint
 detects drift between book and app inputs; it is not a security hash.
+The config's `sourceBaseUrl` gives every lesson a stable canonical URL, so
+absolute citations and relative prerequisite/reference links remain live after
+the generated PDF is downloaded.
 Non-Latin targets also declare `unicodeScript` and `scriptCommand`; the renderer
 wraps matching Unicode runs in the book's existing font macro and uses each
 lesson's `romanization` for a PDF-bookmark-safe short title.

--- a/code/packages/typescript/human-language-data/src/book-cli.ts
+++ b/code/packages/typescript/human-language-data/src/book-cli.ts
@@ -15,6 +15,7 @@ interface ConfiguredBookGenerationTarget extends BookGenerationTarget {
 
 interface BookGenerationConfig {
   version: 1;
+  sourceBaseUrl: string;
   scriptSets?: Record<string, InlineRenderOptions[]>;
   targets: ConfiguredBookGenerationTarget[];
 }
@@ -58,12 +59,23 @@ export function generatedBookOutputs(root = defaultCurriculumRoot()): Map<string
   if (config.version !== 1 || config.targets.length === 0) {
     throw new Error("book-generation.json must declare version 1 and at least one target");
   }
+  let sourceBaseUrl: string;
+  try {
+    const parsed = new URL(config.sourceBaseUrl);
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") throw new Error();
+    parsed.search = "";
+    parsed.hash = "";
+    if (!parsed.pathname.endsWith("/")) parsed.pathname += "/";
+    sourceBaseUrl = parsed.href;
+  } catch {
+    throw new Error("book-generation.json must declare an HTTP(S) sourceBaseUrl");
+  }
   const lessons = loadLessons(root);
   const outputs = new Map<string, string>();
   const manifest: GeneratedBookHashManifest = { version: 1, algorithm: "fnv1a64", chapters: [] };
   for (const configuredTarget of config.targets) {
     const { scriptSet, ...plainTarget } = configuredTarget;
-    let target: BookGenerationTarget = plainTarget;
+    let target: BookGenerationTarget = { ...plainTarget, sourceBaseUrl };
     if (scriptSet !== undefined) {
       if (
         target.inlineScripts !== undefined ||

--- a/code/packages/typescript/human-language-data/src/book.ts
+++ b/code/packages/typescript/human-language-data/src/book.ts
@@ -14,6 +14,8 @@ export interface BookGenerationTarget {
   scriptCommand?: string;
   /** Multiple script/font mappings for lessons that compare writing systems inline. */
   inlineScripts?: InlineRenderOptions[];
+  /** Canonical HTTP(S) directory containing the language-track sources. */
+  sourceBaseUrl?: string;
 }
 
 export interface InlineRenderOptions {
@@ -22,6 +24,10 @@ export interface InlineRenderOptions {
 }
 
 type InlineRenderOptionsInput = InlineRenderOptions | readonly InlineRenderOptions[];
+
+export interface MarkdownRenderContext {
+  linkBaseUrl?: string;
+}
 
 export interface GeneratedBookChapter {
   tex: string;
@@ -64,6 +70,41 @@ function escapeLatexCharacter(character: string): string {
     "ⁿ": "\\textsuperscript{n}",
   };
   return escaped[character] ?? character;
+}
+
+function resolveMarkdownLink(destination: string, baseUrl: string | undefined): string {
+  const trimmed = destination.trim();
+  if (trimmed === "") throw new Error("Markdown link destination must not be empty");
+  let resolved: URL;
+  try {
+    resolved = baseUrl === undefined ? new URL(trimmed) : new URL(trimmed, baseUrl);
+  } catch {
+    if (baseUrl === undefined) {
+      throw new Error(`relative Markdown link '${trimmed}' requires a source base URL`);
+    }
+    throw new Error(`invalid Markdown link destination '${trimmed}'`);
+  }
+  if (resolved.protocol !== "https:" && resolved.protocol !== "http:") {
+    throw new Error(`unsupported Markdown link protocol '${resolved.protocol}'`);
+  }
+  return resolved.href;
+}
+
+/** Escape URL characters that TeX would otherwise interpret inside `\href`'s first argument. */
+function escapeLatexLinkDestination(destination: string): string {
+  const escaped: Record<string, string> = {
+    "\\": "\\%5C",
+    "{": "\\%7B",
+    "}": "\\%7D",
+    "$": "\\%24",
+    "^": "\\%5E",
+    "~": "\\%7E",
+    "%": "\\%",
+    "#": "\\#",
+    "_": "\\_",
+    "&": "\\&",
+  };
+  return destination.replace(/[\\{}$^~%#_&]/g, (character) => escaped[character] ?? character);
 }
 
 function scriptMatchers(options: InlineRenderOptionsInput | undefined): Array<{
@@ -158,6 +199,7 @@ function pairedStraightQuoteRoles(markdown: string): Map<number, StraightQuoteRo
 export function renderInlineMarkdown(
   markdown: string,
   options?: InlineRenderOptionsInput,
+  context: MarkdownRenderContext = {},
 ): string {
   markdown = markdown.normalize("NFC");
   const output: string[] = [];
@@ -224,7 +266,16 @@ export function renderInlineMarkdown(
       const labelEnd = markdown.indexOf("](", cursor + 1);
       const destinationEnd = labelEnd === -1 ? -1 : markdown.indexOf(")", labelEnd + 2);
       if (labelEnd !== -1 && destinationEnd !== -1) {
-        output.push(renderInlineMarkdown(markdown.slice(cursor + 1, labelEnd), options));
+        const destination = resolveMarkdownLink(
+          markdown.slice(labelEnd + 2, destinationEnd),
+          context.linkBaseUrl,
+        );
+        const label = renderInlineMarkdown(
+          markdown.slice(cursor + 1, labelEnd),
+          options,
+          context,
+        );
+        output.push(`\\href{${escapeLatexLinkDestination(destination)}}{${label}}`);
         cursor = destinationEnd + 1;
         continue;
       }
@@ -269,7 +320,11 @@ export function renderInlineMarkdown(
   return output.join("");
 }
 
-function renderMarkdown(markdown: string, options?: InlineRenderOptionsInput): string {
+function renderMarkdown(
+  markdown: string,
+  options?: InlineRenderOptionsInput,
+  context: MarkdownRenderContext = {},
+): string {
   const output: string[] = [];
   const paragraph: string[] = [];
   const quote: string[] = [];
@@ -279,14 +334,14 @@ function renderMarkdown(markdown: string, options?: InlineRenderOptionsInput): s
 
   const flushParagraph = (): void => {
     if (paragraph.length === 0) return;
-    output.push(renderInlineMarkdown(paragraph.join(" "), options), "");
+    output.push(renderInlineMarkdown(paragraph.join(" "), options, context), "");
     paragraph.length = 0;
   };
   const flushQuote = (): void => {
     if (quote.length === 0) return;
     output.push(
       "\\begin{quote}",
-      renderInlineMarkdown(quote.join(" "), options),
+      renderInlineMarkdown(quote.join(" "), options, context),
       "\\end{quote}",
       "",
     );
@@ -294,7 +349,7 @@ function renderMarkdown(markdown: string, options?: InlineRenderOptionsInput): s
   };
   const flushListItem = (): void => {
     if (listItem.length === 0) return;
-    output.push(`  \\item ${renderInlineMarkdown(listItem.join(" "), options)}`);
+    output.push(`  \\item ${renderInlineMarkdown(listItem.join(" "), options, context)}`);
     listItem = [];
   };
   const closeList = (): void => {
@@ -313,7 +368,7 @@ function renderMarkdown(markdown: string, options?: InlineRenderOptionsInput): s
     if (!isSeparator || header.length === 0) {
       output.push(
         ...tableRows.flatMap((row) => [
-          renderInlineMarkdown(`| ${row.join(" | ")} |`, options),
+          renderInlineMarkdown(`| ${row.join(" | ")} |`, options, context),
           "",
         ]),
       );
@@ -326,7 +381,7 @@ function renderMarkdown(markdown: string, options?: InlineRenderOptionsInput): s
     ).join("");
     const cells = (row: string[]): string[] =>
       Array.from({ length: header.length }, (_, index) =>
-        renderInlineMarkdown(row[index] ?? "", options),
+        renderInlineMarkdown(row[index] ?? "", options, context),
       );
     output.push(
       "\\noindent",
@@ -404,9 +459,13 @@ function renderMarkdown(markdown: string, options?: InlineRenderOptionsInput): s
   return output.join("\n").trimEnd();
 }
 
-function renderBlock(block: LessonBodyBlock, options?: InlineRenderOptionsInput): string {
-  const content = renderMarkdown(block.markdown, options);
-  const title = renderInlineMarkdown(block.title, options);
+function renderBlock(
+  block: LessonBodyBlock,
+  options?: InlineRenderOptionsInput,
+  context: MarkdownRenderContext = {},
+): string {
+  const content = renderMarkdown(block.markdown, options, context);
+  const title = renderInlineMarkdown(block.title, options, context);
   if (block.type === "pronunciation") return `\\begin{sounds}\n${content}\n\\end{sounds}`;
   if (block.type === "etymology") return `\\begin{cousinweb}\n${content}\n\\end{cousinweb}`;
   if (block.type === "grammar" || block.type === "notice") {
@@ -468,6 +527,24 @@ function targetRenderOptions(target: BookGenerationTarget): InlineRenderOptionsI
   return { unicodeScript: target.unicodeScript, scriptCommand: target.scriptCommand };
 }
 
+function lessonSourceUrl(target: BookGenerationTarget, lesson: ParsedLesson): string | undefined {
+  if (target.sourceBaseUrl === undefined) return undefined;
+  let root: URL;
+  try {
+    root = new URL(
+      target.sourceBaseUrl.endsWith("/") ? target.sourceBaseUrl : `${target.sourceBaseUrl}/`,
+    );
+  } catch {
+    throw new Error(`${target.language} chapter ${target.chapter}: invalid sourceBaseUrl`);
+  }
+  if (root.protocol !== "https:" && root.protocol !== "http:") {
+    throw new Error(`${target.language} chapter ${target.chapter}: sourceBaseUrl must use HTTP(S)`);
+  }
+  const language = encodeURIComponent(target.language);
+  const lessonId = encodeURIComponent(lesson.realization.lessonId);
+  return new URL(`${language}/lessons/${lessonId}.md`, root).href;
+}
+
 /** Render one configured chapter from the same typed lesson AST the app receives. */
 export function renderBookChapter(
   target: BookGenerationTarget,
@@ -500,11 +577,12 @@ export function renderBookChapter(
   const sourceHash = canonicalChapterHash(lessons);
   const sections = lessons.map((lesson) => {
     const id = lesson.realization.lessonId;
+    const context = { linkBaseUrl: lessonSourceUrl(target, lesson) };
     return [
       `\\section[${sectionShortTitle(lesson, renderOptions)}]{${renderInlineMarkdown(lessonTitle(lesson), renderOptions)}}`,
       `\\label{lesson:${id}}`,
       "",
-      ...lesson.blocks.map((block) => renderBlock(block, renderOptions)),
+      ...lesson.blocks.map((block) => renderBlock(block, renderOptions, context)),
     ].join("\n\n");
   });
   const tex = [

--- a/code/packages/typescript/human-language-data/tests/book-cli.test.ts
+++ b/code/packages/typescript/human-language-data/tests/book-cli.test.ts
@@ -22,6 +22,7 @@ function fixture(output = "test/book/chapters/ch01-first.tex"): string {
     join(root, "core", "book-generation.json"),
     `${JSON.stringify({
       version: 1,
+      sourceBaseUrl: "https://example.test/curriculum",
       targets: [{ language: "test", chapter: 1, title: "Hello", label: "ch:hello", output }],
     })}\n`,
   );
@@ -49,7 +50,7 @@ Say hello.
 
 ## Wrap-up Recall
 
-Say hello again.
+Read the [curriculum guide](../guide.md), then say hello again.
 `,
   );
   return root;
@@ -71,6 +72,9 @@ describe("canonical book generator filesystem shell", () => {
     const manifest = join(root, "core", "generated-book-hashes.json");
     expect(existsSync(chapter)).toBe(true);
     expect(readFileSync(manifest, "utf8")).toContain('"algorithm": "fnv1a64"');
+    expect(readFileSync(chapter, "utf8")).toContain(
+      "\\href{https://example.test/curriculum/test/guide.md}{curriculum guide}",
+    );
     expect(runBookGeneration(["--check"], root)).toBe(0);
 
     writeFileSync(chapter, "stale\n");
@@ -93,6 +97,7 @@ describe("canonical book generator filesystem shell", () => {
       join(root, "core", "book-generation.json"),
       `${JSON.stringify({
         version: 1,
+        sourceBaseUrl: "https://example.test/curriculum/",
         scriptSets: {
           comparisons: [
             { unicodeScript: "Telugu", scriptCommand: "te" },
@@ -135,5 +140,18 @@ describe("canonical book generator filesystem shell", () => {
     vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     expect(runBookGeneration([], root)).toBe(2);
     expect(process.stderr.write).toHaveBeenCalledWith("usage: book-cli (--check | --write)\n");
+  });
+
+  it("requires a canonical HTTP(S) source base URL", () => {
+    const root = fixture();
+    const config = join(root, "core", "book-generation.json");
+    writeFileSync(
+      config,
+      readFileSync(config, "utf8").replace(
+        '"sourceBaseUrl":"https://example.test/curriculum"',
+        '"sourceBaseUrl":"../curriculum"',
+      ),
+    );
+    expect(() => generatedBookOutputs(root)).toThrow(/must declare an HTTP\(S\) sourceBaseUrl/);
   });
 });

--- a/code/packages/typescript/human-language-data/tests/book.test.ts
+++ b/code/packages/typescript/human-language-data/tests/book.test.ts
@@ -132,7 +132,9 @@ describe("canonical LaTeX chapter rendering", () => {
         'Keep `"code"`, ["label"](https://example.test/"raw"), and \\"literal\\".',
       ),
     ).toBe(
-      "Keep \\texttt{\"code\"}, \\textquotedblleft{}label\\textquotedblright{}, and " +
+      "Keep \\texttt{\"code\"}, " +
+        "\\href{https://example.test/\\%22raw\\%22}" +
+        "{\\textquotedblleft{}label\\textquotedblright{}}, and " +
         '\"literal\".',
     );
     expect(renderInlineMarkdown('Keep a 5" mark before "paired" prose.')).toBe(
@@ -153,6 +155,31 @@ describe("canonical LaTeX chapter rendering", () => {
     );
     expect(renderInlineMarkdown('Existing “curly quotes” stay unchanged.')).toBe(
       'Existing “curly quotes” stay unchanged.',
+    );
+  });
+
+  it("preserves absolute links and resolves relative curriculum links", () => {
+    expect(renderInlineMarkdown("[source](https://example.test/a_b?q=x&y=z#frag)")).toBe(
+      "\\href{https://example.test/a\\_b?q=x\\&y=z\\#frag}{source}",
+    );
+    expect(renderInlineMarkdown("[draft](https://example.test/$value~draft)")).toBe(
+      "\\href{https://example.test/\\%24value\\%7Edraft}{draft}",
+    );
+    expect(
+      renderInlineMarkdown("Read [the next lesson](./TEST-C01-next.md).", undefined, {
+        linkBaseUrl:
+          "https://github.com/example/repo/blob/main/curriculum/test/lessons/TEST-C01-now.md",
+      }),
+    ).toBe(
+      "Read \\href{https://github.com/example/repo/blob/main/curriculum/test/lessons/" +
+        "TEST-C01-next.md}{the next lesson}.",
+    );
+  });
+
+  it("fails closed for relative links without a source base and unsupported protocols", () => {
+    expect(() => renderInlineMarkdown("[next](./next.md)")).toThrow(/requires a source base URL/);
+    expect(() => renderInlineMarkdown("[mail](mailto:hello@example.test)")).toThrow(
+      /unsupported Markdown link protocol 'mailto:'/,
     );
   });
 


### PR DESCRIPTION
## Summary
- preserve canonical Markdown links as live LaTeX `\href` targets
- resolve relative lesson/reference links against stable per-lesson GitHub source URLs
- regenerate the nine affected Spanish, Persian, and Urdu chapters and record HL-G05 completion

## Validation
- `npm test` (108/108)
- `npm run build`
- `npm run check:books`
- all 20 LaTeX books rebuilt in one forced pass with zero warning matches
- 117-link corpus audit: zero broken relative targets
- PDF annotation audit confirms exact GitHub, Persian citation, and Urdu fragment targets
- visual QA on Spanish, Persian, and Urdu linked pages
- `git diff --check`