### PR TITLE
fix(adj): reject formula names the runtime answers itself

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_audit.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_audit.rs
@@ -212,8 +212,19 @@ fn formula_audit_v2_stops_source_replay_at_outer_guard_failure() {
     fs::remove_dir_all(directory).expect("remove temporary source directory");
 }
 
+/// Built-in precedence itself — a formula body that calls `round_to` gets the
+/// RUNTIME's rounding, and the audit's replayed formula sequence says so by
+/// naming only the user formula that really ran.
+///
+/// This used to be asserted with a `formulabook` that also declared its own
+/// `round_to(a, b) … requires nonzero(a)`, to pin down which one won. That
+/// program no longer compiles (`LowerError::ReservedFormulaName` — see the
+/// companion test below), because a declared guard that can never run is a hole
+/// in the precondition contract rather than a precedence question. The precedence
+/// property is real and still worth pinning, so it is asserted here without the
+/// unreachable shadow definition.
 #[test]
-fn formula_audit_v2_preserves_builtin_precedence_over_same_named_export() {
+fn formula_audit_v2_preserves_builtin_precedence() {
     let directory = std::env::temp_dir().join(format!(
         "adj_formula_audit_builtin_precedence_{}",
         std::process::id()
@@ -224,8 +235,6 @@ fn formula_audit_v2_preserves_builtin_precedence_over_same_named_export() {
     fs::write(
         &program,
         "formulabook guarded {\n\
-             formula round_to(a, b) = a + b requires nonzero(a)\n\
-               source \"shadowed export\" trust authoritative\n\
              formula outer(x) = round_to(x, 0) requires nonzero(x)\n\
                source \"outer domain\" trust authoritative\n\
          }\n\
@@ -245,9 +254,54 @@ fn formula_audit_v2_preserves_builtin_precedence_over_same_named_export() {
     );
     let audit: serde_json::Value = serde_json::from_slice(&output.stdout).expect("v2 audit JSON");
     let execution = &audit["executions"][0];
+    // `round_to` is answered by the runtime, so it never enters the replayed
+    // formula sequence — only `outer` did.
     assert_eq!(execution["formula_sequence"].as_array().unwrap().len(), 1);
     assert_eq!(execution["formula_sequence"][0]["name"], "outer");
     assert_eq!(execution["body"]["status"], "evaluated");
+
+    fs::remove_dir_all(directory).expect("remove temporary source directory");
+}
+
+/// The collision the audit no longer has to reason about. A `formulabook` that
+/// declares a built-in's name is rejected at compile time, so the audit binary
+/// fails loudly instead of emitting a witness for an execution in which
+/// `requires nonzero(a)` was silently never evaluated.
+#[test]
+fn formula_audit_rejects_a_formulabook_that_shadows_a_builtin() {
+    let directory = std::env::temp_dir().join(format!(
+        "adj_formula_audit_builtin_collision_{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&directory);
+    fs::create_dir_all(&directory).expect("create temporary source directory");
+    let program = directory.join("builtin_collision.adj");
+    fs::write(
+        &program,
+        "formulabook guarded {\n\
+             formula round_to(a, b) = a + b requires nonzero(a)\n\
+               source \"shadowed export\" trust authoritative\n\
+             formula outer(x) = round_to(x, 0) requires nonzero(x)\n\
+               source \"outer domain\" trust authoritative\n\
+         }\n\
+         observe value(2.4)\n\
+         ? outer(value)\n",
+    )
+    .expect("write built-in collision program");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adj-formula-audit"))
+        .arg(&program)
+        .output()
+        .expect("run formula audit");
+    assert!(
+        !output.status.success(),
+        "a formula book shadowing a built-in must not produce an audit"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ReservedFormulaName"),
+        "expected a reserved-name rejection, got: {stderr}"
+    );
 
     fs::remove_dir_all(directory).expect("remove temporary source directory");
 }

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased - replayable formula guard traces
 
+- A `formulabook` may no longer declare a formula whose name is one of the five runtime
+  built-ins (`round_sig`, `round_to`, `to_currency`, `to_percent`, `to_scientific`), which
+  the `Apply` lowering answers by name *before* it consults the user formula map. Such a
+  definition was previously accepted and then never reached: the built-in reduced every
+  call while the declared body — and its `requires` guards — sat unreachable. A guarded
+  formula could therefore compile clean and produce an answer with its precondition never
+  evaluated, emitting no abstention and no execution trace. The collision is now the typed
+  `LowerError::ReservedFormulaName`.
+- The same hole exists one layer earlier, in the grammar: `factor` lists `agg` before
+  `apply`, so a one-identifier call of an aggregation keyword (`sum`, `count`, `min`,
+  `max`, `avg`) reduces to an `ExprAst::Agg` over a slot at parse time and never becomes an
+  application at all. A one-parameter `formula sum(x) … requires nonzero(x)` was therefore
+  unreachable and its guard unenforced. Such a declaration is now rejected with the same
+  error. The check is arity-aware — `agg` matches exactly one identifier argument, so the
+  shipped two-parameter `formula sum(addend_one, addend_two)` in `arithmetic.adj` is
+  reached normally and stays legal.
+- `RUNTIME_BUILTIN_FORMULAS` and `is_runtime_builtin_formula` are public, so an independent
+  checker replaying built-in-versus-user-formula precedence reads the same list the
+  dispatch enforces instead of maintaining its own copy.
+
 - Direct formula queries retain an ordered execution trace for every passed, failed, or unresolved
   precondition, including its exact rational and `f64` value, substituted computation plan,
   derivation tree, original scope, consumed `FactId`s, predicate identity, and provenance.

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -3054,7 +3054,10 @@ fn arith_op_from_value(v: &str) -> Option<ArithOp> {
     }
 }
 
-fn agg_op_from_keyword(kw: &str) -> Option<AggOp> {
+/// The aggregation keywords, and the single place they are named. `lower`'s
+/// reserved-name gate reads this too, so the set the grammar aggregates over and
+/// the set a formula may not shadow cannot drift apart.
+pub(crate) fn agg_op_from_keyword(kw: &str) -> Option<AggOp> {
     match kw {
         "sum" => Some(AggOp::Sum),
         "count" => Some(AggOp::Count),

--- a/code/packages/rust/adj-lang/src/lib.rs
+++ b/code/packages/rust/adj-lang/src/lib.rs
@@ -64,11 +64,11 @@ pub use ast::{
     Term as AstTerm,
 };
 pub use lower::{
-    lower, replay_formula_source, ComputationBinding, ConstraintSystem, FormulaAbstention,
-    FormulaApplicationTrace, FormulaBodyTrace, FormulaExecutionTrace, FormulaGuardOutcome,
-    FormulaGuardTrace, FormulaSourceReplay, LowerError, LoweredConstraint, LoweredExit,
-    LoweredGuard, LoweredProgram, LoweredRangeLookup, LoweredState, LoweredStateMachine,
-    LoweredTransition,
+    is_runtime_builtin_formula, lower, replay_formula_source, ComputationBinding, ConstraintSystem,
+    FormulaAbstention, FormulaApplicationTrace, FormulaBodyTrace, FormulaExecutionTrace,
+    FormulaGuardOutcome, FormulaGuardTrace, FormulaSourceReplay, LowerError, LoweredConstraint,
+    LoweredExit, LoweredGuard, LoweredProgram, LoweredRangeLookup, LoweredState,
+    LoweredStateMachine, LoweredTransition, RUNTIME_BUILTIN_FORMULAS,
 };
 pub use resolve::{resolve_imports, ImportError, ImportLimits, ImportProvider};
 pub use statemachine::{

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -172,6 +172,21 @@ pub enum LowerError {
     DuplicateFormula {
         formula: String,
     },
+    /// A formula book declared a formula the runtime answers ITSELF, so the
+    /// declared body could never be reached — and, critically, neither could its
+    /// `requires` guards. That is a silent hole in the precondition contract
+    /// ("every declared guard runs before its body"), so the collision is a
+    /// clean compile error instead. Two layers can swallow a name:
+    ///
+    /// - a RUNTIME BUILT-IN ([`RUNTIME_BUILTIN_FORMULAS`]), which the `Apply`
+    ///   lowering recognises before it looks a user formula up — at any arity;
+    /// - an AGGREGATION KEYWORD (`sum`, `count`, `min`, `max`, `avg`) declared
+    ///   with exactly ONE parameter, which the *grammar* reduces to an
+    ///   `ExprAst::Agg` over a slot before lowering ever sees an application.
+    ///   Only arity 1 collides, because `agg` matches one identifier argument.
+    ReservedFormulaName {
+        formula: String,
+    },
     /// A formula declared a precondition predicate outside the lowerer's closed,
     /// typed execution set.
     FormulaUnknownPrecondition {
@@ -502,6 +517,31 @@ struct FormulaGuardDependencies {
 pub enum FormulaBodyTrace {
     Evaluated,
     WithheldPreconditionFailed,
+}
+
+/// The formula-application names the lowerer answers ITSELF, before it consults
+/// the user formula map (see the `ExprAst::Apply` arm of `expand_rec`): the
+/// NUM-6 precision narrowings and the NUM-6c/6d renderings.
+///
+/// This is the single source of truth for that set, and it is deliberately
+/// public: an independent checker (`adj-formula-audit`) has to replay the same
+/// built-in-versus-user-formula precedence the runtime used, and a second
+/// hand-maintained copy of this list in another crate would be free to drift out
+/// of agreement with the dispatch it is supposed to mirror.
+///
+/// Sorted, so a reader can see at a glance that nothing is duplicated.
+pub const RUNTIME_BUILTIN_FORMULAS: &[&str] = &[
+    "round_sig",
+    "round_to",
+    "to_currency",
+    "to_percent",
+    "to_scientific",
+];
+
+/// Whether `name` is answered by the runtime itself rather than by a user
+/// formula. See [`RUNTIME_BUILTIN_FORMULAS`].
+pub fn is_runtime_builtin_formula(name: &str) -> bool {
+    RUNTIME_BUILTIN_FORMULAS.contains(&name)
 }
 
 /// Ordered runtime evidence for one direct formula query.
@@ -2309,6 +2349,57 @@ pub(crate) fn formula_provenance(fd: &FormulaDef) -> Result<Provenance, LowerErr
 /// time; and (2) the **provenance-required lint** — a shipped formula must carry
 /// a non-empty `source`, mirroring the recall-library adversarial write gate.
 fn validate_formula(fd: &FormulaDef) -> Result<(), LowerError> {
+    // (0) The RESERVED-NAME gate, checked before anything else. `expand_rec`
+    // dispatches the five runtime built-ins by NAME before it consults the user
+    // formula map, so a formula that reuses one of those names is dead on
+    // arrival: every `to_percent(x)` in the program would reach the built-in,
+    // never this body, and never this body's `requires` guards. Rejecting the
+    // definition removes the collision rather than leaving it to be resolved
+    // silently at each call site.
+    //
+    // Scope, stated precisely: this gate closes the DECLARATION side. A formula
+    // that survives it cannot be wholly unreachable. It does not by itself make
+    // "a declared guard always runs" true by construction — see (0b) for the
+    // call-side remainder, which is still open.
+    if is_runtime_builtin_formula(&fd.name) {
+        return Err(LowerError::ReservedFormulaName {
+            formula: fd.name.clone(),
+        });
+    }
+    // (0b) The same hole one layer earlier, in the GRAMMAR rather than the
+    // lowerer. `factor` lists `agg` before `apply`, and
+    // `agg = ("sum"|"count"|"min"|"max"|"avg") LPAREN IDENT RPAREN` — so a
+    // ONE-identifier call of an aggregation keyword becomes an `ExprAst::Agg`
+    // over a slot at PARSE time. It never becomes an `Apply`, so it never
+    // reaches the formula map or `enforce_preconditions`, and a one-parameter
+    // `formula sum(x) … requires nonzero(x)` is unreachable exactly the way a
+    // built-in-named one is.
+    //
+    // The check is arity-aware because the collision is: only an arity-1
+    // declaration can be swallowed, since `agg` matches exactly one identifier
+    // argument. The shipped `formula sum(addend_one, addend_two)` in
+    // `arithmetic.adj` takes two and is reached normally, so it stays legal.
+    // (Arity 1 is also reachable from `predicate`/`sm_guard`/`? query`
+    // positions, which use `apply` directly rather than `factor`. Rejecting it
+    // anyway is deliberate: a name that means "apply this formula" in one
+    // position and "aggregate this slot" in another is a footgun regardless of
+    // which position happens to be reached first.)
+    //
+    // STILL OPEN, on the call side: a wrong-arity call of a MULTI-parameter
+    // aggregation-named formula — `sum(a)` where `sum` takes two — also reduces
+    // to an aggregation, so it yields the slot's aggregate instead of the arity
+    // error it should raise, and any guard on that formula does not run. The
+    // derivation tree does record the result honestly as an aggregation, so this
+    // is a missing diagnostic and a plausible wrong number rather than a
+    // fabricated formula witness. Closing it means rejecting an `ExprAst::Agg`
+    // whose keyword also names a registered formula, which needs the formula map
+    // at the `Agg` lowering site (`lower_expr` is currently infallible and takes
+    // no context); tracked in ADJ-STDLIB-COVERAGE.md §9a.
+    if fd.params.len() == 1 && crate::adapter::agg_op_from_keyword(&fd.name).is_some() {
+        return Err(LowerError::ReservedFormulaName {
+            formula: fd.name.clone(),
+        });
+    }
     // Scope grows LEFT-TO-RIGHT (RS-2): the parameters are in scope everywhere;
     // each `let`-step may reference the parameters plus any EARLIER step's name,
     // and after a step it binds its own name; the final body may reference the
@@ -7333,6 +7424,173 @@ rule { head: r(a) when: x(t) }";
                 LowerError::FormulaPreconditionApplicationUnsupported { .. }
             ))
         ));
+    }
+
+    /// The reserved-name gate, one name at a time. `expand_rec` answers each of
+    /// these itself before it ever looks in the user formula map, so a formula
+    /// that reuses the name is unreachable — and, before this gate existed, was
+    /// accepted in silence.
+    #[test]
+    fn builtin_named_formula_exports_are_rejected() {
+        for name in RUNTIME_BUILTIN_FORMULAS {
+            let src = format!(
+                r#"
+                formulabook collide {{
+                    formula {name}(x) = x + 1
+                        requires nonzero(x)
+                        source "collision" trust authoritative
+                }}
+            "#
+            );
+            assert!(
+                matches!(
+                    compile(&src),
+                    Err(crate::CompileError::Lower(LowerError::ReservedFormulaName {
+                        ref formula
+                    })) if formula == name
+                ),
+                "`{name}` is dispatched as a built-in, so declaring it must not compile"
+            );
+        }
+    }
+
+    /// The behaviour the gate exists to prevent, stated as the scenario rather
+    /// than the rule. Before the gate, this program compiled clean and answered
+    /// `to_scientific = 0`: the built-in rendered the observed `a(0)`, the
+    /// declared body never ran, and `requires nonzero(x)` never fired on a zero
+    /// input. No abstention, no execution trace — so no downstream audit had
+    /// anything to disagree with.
+    #[test]
+    fn a_builtin_name_cannot_silently_swallow_a_declared_guard() {
+        let src = r#"
+            formulabook collide {
+                formula to_scientific(x) = x + 1
+                    requires nonzero(x)
+                    source "collision" trust authoritative
+            }
+            prior 0.1 for high
+            contributes 100 from to_scientific(a) >= 1 to high
+                source "comparison rule" trust authoritative
+            observe a(0)
+            ? high
+        "#;
+
+        assert!(
+            matches!(
+                compile(src),
+                Err(crate::CompileError::Lower(LowerError::ReservedFormulaName { .. }))
+            ),
+            "a guard that can never run must be a compile error, not a silent zero"
+        );
+    }
+
+    /// Anti-drift, in the direction the constant can actually be wrong. Adding a
+    /// name here that the runtime does NOT dispatch would reject a perfectly
+    /// legal user formula, so every listed name must really be answered by
+    /// `expand_rec` with no definition in scope. (The other direction — a
+    /// built-in missing from the list — is what `builtin_named_formula_exports_
+    /// are_rejected` above would stop covering, visibly, the moment it happens.)
+    #[test]
+    fn every_reserved_name_is_really_dispatched_by_the_runtime() {
+        // Applications that are well-formed for each built-in's own signature.
+        let applications = [
+            ("round_sig", "round_sig(a, 2)"),
+            ("round_to", "round_to(a, 2)"),
+            // The currency code is a bare identifier read verbatim, and the ADJ
+            // surface lexer accepts only lowercase identifiers — hence `usd`.
+            ("to_currency", "to_currency(a, usd)"),
+            ("to_percent", "to_percent(a)"),
+            ("to_scientific", "to_scientific(a)"),
+        ];
+        assert_eq!(
+            applications.len(),
+            RUNTIME_BUILTIN_FORMULAS.len(),
+            "a built-in was added without extending this dispatch check"
+        );
+        for (name, application) in applications {
+            assert!(
+                RUNTIME_BUILTIN_FORMULAS.contains(&name),
+                "{name} is not in the reserved list"
+            );
+            // No `formulabook` at all: if the runtime did not answer this name
+            // itself, the lookup would fail as an unknown formula.
+            let src = format!(
+                r#"
+                prior 0.1 for high
+                contributes 100 from {application} >= 1 to high
+                    source "comparison rule" trust authoritative
+                observe a(4)
+                ? high
+            "#
+            );
+            assert!(
+                compile(&src).is_ok(),
+                "{name} is listed as a built-in but the runtime did not dispatch it"
+            );
+        }
+    }
+
+    /// The grammar-level twin of the built-in gate. `agg` is listed before
+    /// `apply` in `factor`, so `sum(a)` becomes an aggregation over the slot `a`
+    /// at parse time — the formula map is never consulted. A one-parameter
+    /// `formula sum(x) … requires nonzero(x)` was therefore as unreachable as a
+    /// `to_scientific` one, and compiled just as silently.
+    #[test]
+    fn one_parameter_aggregation_named_formulas_are_rejected() {
+        for name in ["sum", "count", "min", "max", "avg"] {
+            let src = format!(
+                r#"
+                formulabook collide {{
+                    formula {name}(x) = x + 1
+                        requires nonzero(x)
+                        source "collision" trust authoritative
+                }}
+            "#
+            );
+            assert!(
+                matches!(
+                    compile(&src),
+                    Err(crate::CompileError::Lower(LowerError::ReservedFormulaName {
+                        ref formula
+                    })) if formula == name
+                ),
+                "one-parameter `{name}` is swallowed by the `agg` production"
+            );
+        }
+    }
+
+    /// The gate is arity-aware on purpose. `agg` matches exactly ONE identifier
+    /// argument, so a two-parameter `sum` is reached normally — and one is
+    /// shipped (`arithmetic.adj`'s `formula sum(addend_one, addend_two)`).
+    /// Reserving the bare name would have broken a byte-pinned library for a
+    /// collision that cannot occur.
+    #[test]
+    fn multi_parameter_aggregation_named_formulas_stay_legal() {
+        let src = r#"
+            formulabook arith {
+                formula sum(addend_one, addend_two) = addend_one + addend_two
+                    source "addition" trust authoritative
+            }
+            observe a(3)
+            observe b(4)
+            let z = sum(a, b)
+        "#;
+        let lowered = compile(src).expect("a two-parameter `sum` is reachable and must compile");
+        let derived = lowered
+            .kb
+            .derived_bindings()
+            .iter()
+            .find(|binding| binding.name == "z")
+            .expect("z is derived");
+        assert_eq!(derived.value, 7.0, "the user formula ran, not an aggregation");
+    }
+
+    #[test]
+    fn reserved_names_are_sorted_and_unique() {
+        let mut sorted = RUNTIME_BUILTIN_FORMULAS.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.as_slice(), RUNTIME_BUILTIN_FORMULAS);
     }
 
     #[test]

--- a/code/specs/ADJ-STDLIB-COVERAGE.md
+++ b/code/specs/ADJ-STDLIB-COVERAGE.md
@@ -323,6 +323,36 @@ option mapping, or judge/evaluation failure.
    `proportion.adj` requires nonzero `a`, `b`, and `c`, and E2E coverage proves
    each zero position withholds the answer before body evaluation. CAS migration
    remains separate until the worked query's observed inputs receive source IR.
+   A formula name may not collide with a name the runtime answers itself, at
+   either of the two layers that can swallow one. Lowering dispatches the five
+   built-ins (`round_sig`, `round_to`, `to_currency`, `to_percent`,
+   `to_scientific`) by name before the user formula map; and the grammar reduces
+   a one-identifier call of an aggregation keyword (`sum`, `count`, `min`, `max`,
+   `avg`) to an aggregation over a slot before lowering sees an application at
+   all. In both cases a colliding definition was unreachable and its guards
+   unenforced while the program still answered. Both are now typed compile
+   errors, which keeps "a declared guard runs before its body" true by
+   construction rather than by convention. The aggregation check is arity-aware:
+   only a one-parameter declaration can be swallowed, so the shipped
+   two-parameter `sum` in `arithmetic.adj` is unaffected.
+
+   These two gates close the DECLARATION side: a formula that survives them
+   cannot be wholly unreachable. They do not on their own make "a declared guard
+   always runs before its body" true by construction, because the call side has
+   a remaining case.
+
+   Still open (tracked, not closed here): a WRONG-ARITY call of a multi-parameter
+   formula named after an aggregation keyword — `sum(a)` where `sum` takes two —
+   also reduces to an aggregation, so it yields the slot's aggregate instead of
+   raising the arity error it should, and a guard on that formula does not run.
+   The shipped two-parameter `sum` in `arithmetic.adj` makes this reachable in
+   real content. The derivation tree does record the result honestly as an
+   aggregation rather than claiming the formula ran, so this is a missing
+   diagnostic and a plausible wrong number, not a fabricated witness. Closing it
+   means rejecting an aggregation whose keyword also names a registered formula,
+   which requires the formula map at the aggregation lowering site; that site is
+   currently context-free and infallible, so the fix is its own change with its
+   own review rather than a rider on the declaration gates.
 9b. **Complete.** Formula-audit v2 independently replays parser-owned parameter
     binding, nested application order, and every declaration-ordered guard through
     the first failure. The CAS witnesses exact compared values, consumed direct


### PR DESCRIPTION
## Summary

Two layers can swallow a formula name before the user formula map is consulted, and both left a declared `requires` guard unenforced while the program still produced an answer.

1. **The lowerer.** `expand_rec` recognises five application names itself — `round_sig`, `round_to`, `to_currency`, `to_percent`, `to_scientific` — *before* it looks a user formula up. `DuplicateFormula` only catches user-versus-user collisions, so a book could declare one of these names and the definition was then never reached at any arity.
2. **The grammar, one layer earlier.** `factor` lists `agg` before `apply`, and `agg = ( "sum" | "count" | "min" | "max" | "avg" ) LPAREN IDENT RPAREN`. A one-identifier call reduces to an `ExprAst::Agg` over a slot at parse time, so it never becomes an application at all.

Either way the guard silently did not run:

```
formulabook collide {
    formula sum(x) = x + 1
        requires nonzero(x)
        source "..." trust authoritative
}
observe a(0)
let z = sum(a)     # compiled clean; z = 0
```

No abstention, no execution trace — so no downstream witness had anything to disagree with. That is a hole in the `ADJ-STDLIB-COVERAGE.md` §9a contract that a declared guard runs before its body.

## What changed

Both collisions are now the typed `LowerError::ReservedFormulaName`, checked in `validate_formula` at registration — verified to be the only formula-registration path.

The aggregation check is **arity-aware**, because only an arity-1 declaration can be swallowed (`agg` matches exactly one identifier argument). The shipped two-parameter `formula sum(addend_one, addend_two)` in `arithmetic.adj` is reached normally and stays legal — reserving the bare name would have broken a **byte-pinned** library for a collision that cannot occur.

Anti-drift: `agg_op_from_keyword` is now `pub(crate)` so the gate and the grammar's keyword set have one definition, and `RUNTIME_BUILTIN_FORMULAS` / `is_runtime_builtin_formula` are public so an independent checker replaying built-in precedence reads the same list the dispatch enforces rather than keeping a copy.

No shipped `.adj` library declares any of the five built-in names or a one-parameter aggregation name.

## Behaviour change, deliberate

`formula_audit_v2_preserves_builtin_precedence_over_same_named_export` asserted that the audit faithfully mirrored the runtime shadowing a guarded `round_to`. **That program no longer compiles.** The precedence property it pinned is real, so it is re-homed onto an equivalent program with no unreachable shadow definition, plus a companion test asserting the collision is now rejected.

## Explicitly NOT closed here

A **wrong-arity** call of a multi-parameter aggregation-named formula — `sum(a)` where `sum` takes two — also reduces to an aggregation, yielding the slot's aggregate instead of the arity error it should raise, with the guard not running. Reachable via the shipped `sum`. The derivation tree records the result honestly as an aggregation rather than claiming the formula ran, so it is a missing diagnostic and a plausible wrong number, not a fabricated witness.

Closing it means rejecting an aggregation whose keyword also names a registered formula, which needs the formula map at the aggregation lowering site — that site is currently context-free and infallible, so it is its own change with its own review rather than a rider here. Documented in the spec and in code.

## Test plan

- [x] `adj-lang`: 220 lib tests pass (4 new gate tests + 2 aggregation tests), `cargo clippy --all-targets -- -D warnings` clean
- [x] `adj-lang-cli` downstream: **303 test binaries, 778 passed, 0 failed**
- [x] Corpus check: no shipped `.adj` declares a reserved name or a one-parameter aggregation name; no shipped `.adj` uses aggregation call syntax at all
- [x] Security review: 2 rounds. Round 1 found the grammar/aggregation layer (reproduced and fixed here); round 2 confirmed the declaration side complete and no other production reduces an application before `enforce_preconditions`, and caught an overclaiming code comment, now corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)