### PR TITLE
feat(adj): decide audit strictness from source, not the runtime trace

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased - formula audit v2 guard witnesses
 
+- `adj-formula-audit` now decides whether to take the strict, guard-replaying v2 path from
+  the PARSED SOURCE rather than from the runtime's own execution trace. If a query's
+  formula closure declares a `requires` anywhere — including on a nested callee — v2 is
+  required whether or not the trace reported a guard, and `validate_guard_prefix` then
+  fails closed on the mismatch. Previously the choice read `formula_executions`, so a
+  producer that emitted no guard trace selected the unguarded v1 shape, and v1 never
+  replays source against execution — the discrepancy the strict path exists to catch was
+  the discrepancy that routed around it. This is hardening: with the reserved-name gates
+  in adj-lang there is no currently-constructible program that reaches the old behaviour.
+  A program declaring no precondition anywhere still emits v1.
+- `is_runtime_builtin_application` now calls `adj_lang::is_runtime_builtin_formula`
+  instead of restating the five built-in names. The audit has to replay the runtime's
+  built-in-versus-user-formula precedence exactly; a second hand-maintained copy could
+  drift from the dispatch it mirrors, and the resulting disagreement would be silent.
+
 - `adj-formula-audit` emits `adj-lang/formula_audit/v2` for executed guards or plans containing
   exact literals. V2 records ordered query executions, parser-backed guard byte identities, exact
   comparisons, stable consumed-fact identities, independent direct-observation rechecks, and a

--- a/code/packages/rust/adj-lang-cli/src/formula_audit.rs
+++ b/code/packages/rust/adj-lang-cli/src/formula_audit.rs
@@ -1355,11 +1355,115 @@ struct SourceExecutionReplay {
     outcomes: Vec<FormulaGuardOutcome>,
 }
 
+/// Whether the runtime answers `name` itself rather than applying a user
+/// formula, mirroring the precedence the lowerer used.
+///
+/// This delegates to `adj-lang` rather than restating the five names. A second
+/// hand-maintained copy would be free to drift from the dispatch it exists to
+/// mirror, and the direction that matters is silent: if the audit thought a name
+/// were a user formula while the runtime answered it as a built-in, the replay
+/// would expect a formula application the trace never contains.
 fn is_runtime_builtin_application(name: &str) -> bool {
-    matches!(
-        name,
-        "round_to" | "round_sig" | "to_scientific" | "to_percent" | "to_currency"
-    )
+    adj_lang::is_runtime_builtin_formula(name)
+}
+
+/// Collect the names applied anywhere in one expression, without substituting.
+///
+/// This is deliberately a plain syntactic walk rather than a reuse of
+/// [`replay_source_expression`]: that one replays an EXECUTION (it substitutes
+/// arguments and follows the runtime's guard short-circuiting), and the whole
+/// point here is to learn what the SOURCE declares before trusting any runtime
+/// evidence at all.
+fn collect_applied_names(expr: &ExprAst, into: &mut Vec<String>) {
+    match expr {
+        ExprAst::Apply(name, arguments) => {
+            into.push(name.clone());
+            for argument in arguments {
+                collect_applied_names(argument, into);
+            }
+        }
+        ExprAst::Bin(_, left, right) | ExprAst::Call2(_, left, right) => {
+            collect_applied_names(left, into);
+            collect_applied_names(right, into);
+        }
+        ExprAst::Abs(operand)
+        | ExprAst::Floor(operand)
+        | ExprAst::Ceil(operand)
+        | ExprAst::Round(operand)
+        | ExprAst::Trunc(operand)
+        | ExprAst::Sign(operand)
+        | ExprAst::Call(_, operand)
+        | ExprAst::RoundTo(operand, _)
+        | ExprAst::ToScientific(operand, _)
+        | ExprAst::ToPercent(operand, _)
+        | ExprAst::ToCurrency(operand, _, _) => collect_applied_names(operand, into),
+        ExprAst::Ref(_) | ExprAst::Lit(_) | ExprAst::ExactLit(_) | ExprAst::Agg(_, _) => {}
+    }
+}
+
+/// Whether `export`, or anything it transitively applies, DECLARES a
+/// precondition in its parsed source.
+///
+/// The audit's strict (v2) path is what independently replays guards. Choosing
+/// that path from `lowered.formula_executions` alone would mean the checker asks
+/// the runtime how strict to be about the runtime: a producer that emits no
+/// guard trace — because of a bug, or because the name it should have applied was
+/// answered by something else — silently selects the unguarded v1 shape, and the
+/// v1 shape never calls [`replay_source_execution`], so nothing compares source
+/// against execution. The discrepancy the strict path exists to catch is exactly
+/// the discrepancy that would route around it.
+///
+/// So strictness is decided HERE, from bytes the parser produced, and the runtime
+/// gets no vote. If the source says a guard should have run, v2 is required; if
+/// no guard then appears in the trace, [`validate_guard_prefix`] fails closed
+/// rather than the audit quietly downgrading.
+/// The walk runs against a name index rather than rescanning `exports`. A linear
+/// search per visited name would make this quadratic in the number of exports,
+/// on input the audit binary reads from a file — so an adversarial formula book
+/// with many mutually-applying exports would cost time the checker has no reason
+/// to spend. `build_exports` rejects duplicate names, so one entry per name is
+/// faithful.
+fn export_closure_declares_precondition(export: &ExportRecord, exports: &[ExportRecord]) -> bool {
+    let by_name: BTreeMap<&str, &ExportRecord> = exports
+        .iter()
+        .map(|item| (item.identity.name.as_str(), item))
+        .collect();
+    let mut pending = vec![export.identity.name.as_str()];
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    let mut applied = Vec::new();
+    while let Some(name) = pending.pop() {
+        if !seen.insert(name) {
+            continue;
+        }
+        let Some(candidate) = by_name.get(name) else {
+            continue;
+        };
+        if !candidate.formula.preconditions.is_empty() {
+            return true;
+        }
+        // Dead `let` steps are walked too. A guard declared in a step the
+        // runtime folds away is still a guard the SOURCE declares, and this
+        // function answers what the source says — over-approximating here costs
+        // a stricter audit shape, never a weaker one.
+        applied.clear();
+        for step in &candidate.formula.steps {
+            collect_applied_names(&step.expr, &mut applied);
+        }
+        collect_applied_names(&candidate.formula.body, &mut applied);
+        for applied_name in &applied {
+            // Built-ins are answered by the runtime and declare nothing, so they
+            // cannot contribute a guard. A user formula can no longer take one of
+            // those names (adj-lang rejects the declaration), so skipping them
+            // cannot hide a guarded callee.
+            if is_runtime_builtin_application(applied_name) {
+                continue;
+            }
+            if let Some(found) = by_name.get(applied_name.as_str()) {
+                pending.push(found.identity.name.as_str());
+            }
+        }
+    }
+    false
 }
 
 fn validate_guard_prefix(
@@ -2491,6 +2595,11 @@ fn build_audit(
             )));
         }
         requires_v2 |= contains_exact_literal(plan.expr);
+        // Strictness comes from the SOURCE, not from the runtime's own trace.
+        // If this query's formula closure declares a guard, the strict path is
+        // required whether or not the runtime reported executing one — a trace
+        // that is missing the guard is precisely the thing worth failing on.
+        requires_v2 |= export_closure_declares_precondition(export, &exports);
 
         let checked = verify_derived(derived, &lowered.kb, snapshots);
         if checked.name != derived.name || checked.is_query_answer != plan.is_query_answer {

--- a/code/packages/rust/adj-lang-cli/tests/formula_audit.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_audit.rs
@@ -1034,3 +1034,100 @@ fn formula_audit_accepts_a_zero_input_constant_formula() {
 
     fs::remove_dir_all(directory).expect("remove temporary source directory");
 }
+
+/// The strict path is chosen from the SOURCE, and the closure walk reaches a
+/// guard declared on a nested callee rather than only on the queried formula.
+///
+/// `outer` declares no precondition of its own; the guard is on `inner`, two
+/// applications down. The audit must still take the guard-replaying v2 path,
+/// and it must do so because the parsed source says a guard exists — not
+/// because the runtime happened to report one.
+#[test]
+fn formula_audit_requires_v2_for_a_guard_declared_in_the_closure() {
+    let directory = std::env::temp_dir().join(format!(
+        "adj_formula_audit_closure_guard_{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&directory);
+    fs::create_dir_all(&directory).expect("create temporary source directory");
+    let program = directory.join("closure_guard.adj");
+    fs::write(
+        &program,
+        "formulabook nested {\n\
+             formula inner(a, b) = a / b\n\
+               requires nonzero(b)\n\
+               source \"division domain\" trust authoritative\n\
+             formula outer(x, y) = inner(x, y)\n\
+               source \"outer domain\" trust authoritative\n\
+         }\n\
+         observe numerator(8)\n\
+         observe denominator(2)\n\
+         ? outer(numerator, denominator)\n",
+    )
+    .expect("write closure guard program");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adj-formula-audit"))
+        .arg(&program)
+        .output()
+        .expect("run formula audit");
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let audit: serde_json::Value = serde_json::from_slice(&output.stdout).expect("v2 audit JSON");
+    assert_eq!(audit["contract"], "adj-lang/formula_audit/v2");
+    let execution = &audit["executions"][0];
+    assert_eq!(execution["guards"].as_array().expect("guards").len(), 1);
+    assert_eq!(execution["guards"][0]["outcome"], "passed");
+    assert_eq!(execution["body"]["status"], "evaluated");
+
+    fs::remove_dir_all(directory).expect("remove temporary source directory");
+}
+
+/// The other direction, and the one that would show over-reach: a program whose
+/// source declares NO precondition anywhere must still take the v1 path.
+///
+/// Deciding strictness from the source is only an improvement if it stays
+/// scoped to programs that actually declare a guard; forcing every program onto
+/// v2 would be a silent, sweeping change of output shape.
+#[test]
+fn formula_audit_stays_v1_when_no_guard_is_declared() {
+    let directory = std::env::temp_dir().join(format!(
+        "adj_formula_audit_unguarded_{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&directory);
+    fs::create_dir_all(&directory).expect("create temporary source directory");
+    let program = directory.join("unguarded.adj");
+    fs::write(
+        &program,
+        "formulabook plain {\n\
+             formula inner(a, b) = a / b\n\
+               source \"division definition\" trust authoritative\n\
+             formula outer(x, y) = inner(x, y)\n\
+               source \"outer domain\" trust authoritative\n\
+         }\n\
+         observe numerator(8)\n\
+         observe denominator(2)\n\
+         ? outer(numerator, denominator)\n",
+    )
+    .expect("write unguarded program");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adj-formula-audit"))
+        .arg(&program)
+        .output()
+        .expect("run formula audit");
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let audit: serde_json::Value = serde_json::from_slice(&output.stdout).expect("v1 audit JSON");
+    assert_eq!(
+        audit["contract"], "adj-lang/formula_audit/v1",
+        "an unguarded program must not be pushed onto the strict path"
+    );
+
+    fs::remove_dir_all(directory).expect("remove temporary source directory");
+}


### PR DESCRIPTION
## Summary

`build_audit` chose between the v1 and the strict, guard-replaying v2 shape by reading `lowered.formula_executions` — **the runtime's own trace**. The checker was asking the runtime how strict to be about the runtime.

The consequence is specific: a producer that emits no guard trace selects v1, and v1 never calls `replay_source_execution`, so nothing ever compares parsed source against execution. A missing guard is exactly what the strict path is built to catch, and a missing guard is what routed around it.

Strictness now comes from bytes the parser produced. If a query's formula closure declares a `requires` anywhere — including on a nested callee reached through the body or a `let` step — v2 is required regardless of what the trace says, and `validate_guard_prefix` fails closed on the mismatch instead of the audit quietly downgrading.

## Honest scope: this is hardening, not a bug fix

With the reserved-name gates from #9919 and #9920 in place, **I could not construct a program that reaches the old behaviour.** A guarded formula that appears as an application in an executed closure is applied by the runtime and does emit a guard trace, so old and new agree on every input I could build.

What it buys is that the checker no longer depends on the audited component for its own strictness, so a future divergence fails closed rather than silently selecting the weaker shape. **Both new tests pass on the old code too** — they pin the contract rather than catching a regression. The v1 test is the one that earns its place: it asserts an unguarded program still emits v1, which is the direction that would show over-reach.

## Notes on the implementation

The closure walk is a plain syntactic scan for applied names, deliberately **not** a reuse of `replay_source_expression` — that one replays an *execution*, substituting arguments and following the runtime's short-circuiting, and the whole point here is to learn what the source declares before trusting any runtime evidence. It matches every `ExprAst` variant with no wildcard arm, so a new variant breaks the build rather than silently hiding a guarded callee.

Names resolve through a prebuilt index. A linear rescan of `exports` per visited name made this quadratic in the number of exports, on input the audit binary reads from a file.

Also folds in the duplicate-list cleanup this makes possible: `is_runtime_builtin_application` now calls `adj_lang::is_runtime_builtin_formula` (public since #9919) rather than restating the five names. The audit must replay built-in-versus-user-formula precedence exactly, and a second hand-maintained copy could drift from the dispatch it mirrors — silently, since the audit would then expect a formula application the trace never contains.

## Security review, including a stale finding worth recording

An adversarial pass reproduced what looked like a live evasion through the `agg`-before-`apply` grammar swallow: a v1 witness attesting `12/1` for a source reading as a guarded division whose `requires` never ran.

**It had run against a base rebased before #9920.** Re-tested on current main, that program is a compile error (`AggregationShadowsFormula`) and the audit never runs:

```
formula min(a, b) = a / b requires nonzero(b)
formula outer(x) = min(x)
→ compile failed: Lower(AggregationShadowsFormula { keyword: "min", slot: "numerator" })
```

So the finding was stale, and is independent confirmation that #9920 was load-bearing — the declaration gate, the call gate, and this routing change are complementary rather than redundant. The review's *other* finding, the quadratic scan, was real on current main and is fixed here.

## Test plan

- [x] `adj-lang-cli`: **303 test binaries, 780 passed, 0 failed**
- [x] `formula_audit`: 22 passed — 2 new (a guard declared two applications deep still forces v2; a program declaring no precondition anywhere still emits v1)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Reviewer confirmed no availability regression: the `"v2 program produced no formula query executions"` error is unreachable via the new flag, since the only producer of query-answer bindings always pushes a trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)