### PR TITLE
feat(adj): structure state-machine failures (ADJ-STDLIB-COVERAGE 9d)

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased - formula audit v2 guard witnesses
 
+- State-machine failure JSON is keyed on discriminants rather than prose. `precision_loss`
+  gains `"phase"` and renames `"guard"` to `"expression"`; `computation_error` gains
+  `"failure"` alongside the unchanged `"detail"`. `--explain` names the phase and the
+  failure kind. Previously a yield precision loss was distinguishable from a guard one only
+  by the `"yield "` prefix inside the `"guard"` string.
+
 - `adj-formula-audit` now decides whether to take the strict, guard-replaying v2 path from
   the PARSED SOURCE rather than from the runtime's own execution trace. If a query's
   formula closure declares a `requires` anywhere — including on a nested callee — v2 is

--- a/code/packages/rust/adj-lang-cli/src/explain.rs
+++ b/code/packages/rust/adj-lang-cli/src/explain.rs
@@ -187,14 +187,24 @@ fn render_state_machines(runs: &[(&LoweredStateMachine, StateMachineRun)]) -> St
                 format!("  => NonTerminating (cycle at {state})")
             }
             StateMachineOutcome::Stuck { state } => format!("  => Stuck in {state}"),
-            StateMachineOutcome::PrecisionLoss { state, guard } => {
-                format!("  => Precision loss in {state}: {guard}")
-            }
+            StateMachineOutcome::PrecisionLoss {
+                state,
+                phase,
+                expression,
+            } => format!(
+                "  => Precision loss in {state} during {}: {expression}",
+                phase.type_tag()
+            ),
             StateMachineOutcome::ComputationError {
                 state,
                 phase,
+                failure,
                 detail,
-            } => format!("  => Computation error in {state} during {phase}: {detail}"),
+            } => format!(
+                "  => Computation error in {state} during {} [{}]: {detail}",
+                phase.type_tag(),
+                failure.type_tag()
+            ),
         };
         out.push(outcome);
     }

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -1372,19 +1372,26 @@ fn state_machine_outcome_json(outcome: &StateMachineOutcome, kb: &KnowledgeBase)
         StateMachineOutcome::Stuck { state } => {
             format!("{{\"type\":\"stuck\",\"state\":\"{}\"}}", esc(state))
         }
-        StateMachineOutcome::PrecisionLoss { state, guard } => format!(
-            "{{\"type\":\"precision_loss\",\"state\":\"{}\",\"guard\":\"{}\"}}",
+        StateMachineOutcome::PrecisionLoss {
+            state,
+            phase,
+            expression,
+        } => format!(
+            "{{\"type\":\"precision_loss\",\"state\":\"{}\",\"phase\":\"{}\",\"expression\":\"{}\"}}",
             esc(state),
-            esc(guard)
+            phase.type_tag(),
+            esc(expression)
         ),
         StateMachineOutcome::ComputationError {
             state,
             phase,
+            failure,
             detail,
         } => format!(
-            "{{\"type\":\"computation_error\",\"state\":\"{}\",\"phase\":\"{}\",\"detail\":\"{}\"}}",
+            "{{\"type\":\"computation_error\",\"state\":\"{}\",\"phase\":\"{}\",\"failure\":\"{}\",\"detail\":\"{}\"}}",
             esc(state),
-            esc(phase),
+            phase.type_tag(),
+            failure.type_tag(),
             esc(detail)
         ),
     }

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased - replayable formula guard traces
 
+- State-machine failures are structured (ADJ-STDLIB-COVERAGE §9d). `StateMachineOutcome`
+  now carries a typed `FailurePhase` (`TransitionGuard` / `ExitGuard` / `Yield`) instead of
+  a `phase: String`, and `ComputationError` carries a `ComputationFailure` discriminant
+  alongside the existing human `detail`. `PrecisionLoss` gained the same typed phase and
+  renamed `guard` to `expression`: a yield abstention previously reported itself by
+  prefixing the rendering with `"yield "` and placing it in a field named `guard`, so a
+  consumer telling a guard abstention from a yield one had to sniff that prefix.
+- `detail` keeps its exact previous wording, so a consumer that only prints it is
+  unaffected; one that branches now keys off `FailurePhase::type_tag()` /
+  `ComputationFailure::type_tag()`. The engine-to-outcome translation matches every
+  `ComputeError` variant with no wildcard arm, so a new engine variant breaks the build
+  here rather than collapsing into a generic string downstream.
+
 - An aggregation is now rejected when the program also declares a FORMULA of that name
   (`LowerError::AggregationShadowsFormula`). `factor` lists `agg` before `apply`, so
   `sum(a)` became an aggregation over the slot `a` regardless of what `sum` was declared

--- a/code/packages/rust/adj-lang/src/lib.rs
+++ b/code/packages/rust/adj-lang/src/lib.rs
@@ -72,7 +72,8 @@ pub use lower::{
 };
 pub use resolve::{resolve_imports, ImportError, ImportLimits, ImportProvider};
 pub use statemachine::{
-    run_state_machine, RunStep, StateMachineOutcome, StateMachineRun, YieldValue,
+    run_state_machine, ComputationFailure, FailurePhase, RunStep, StateMachineOutcome,
+    StateMachineRun, YieldValue,
 };
 
 /// Result of compilation. Either the typed program produced by the

--- a/code/packages/rust/adj-lang/src/statemachine.rs
+++ b/code/packages/rust/adj-lang/src/statemachine.rs
@@ -82,17 +82,109 @@ pub enum StateMachineOutcome {
     /// In `state`, no transition guard holds and no exit criterion holds — a dead
     /// end; a grounded abstention ("no transition applies in state …").
     Stuck { state: String },
-    /// A comparison guard could only be decided after discarding exact input
-    /// identity, so the machine abstained at that guard.
-    PrecisionLoss { state: String, guard: String },
+    /// An expression could only be decided after discarding exact input
+    /// identity, so the machine abstained there.
+    ///
+    /// `phase` says WHICH expression, typed. This used to be inferable only by
+    /// noticing that a yield's rendering had been prefixed with `"yield "` and
+    /// stuffed into a field named `guard` — a checker distinguishing a guard
+    /// abstention from a yield abstention had to sniff that prefix.
+    PrecisionLoss {
+        state: String,
+        phase: FailurePhase,
+        expression: String,
+    },
     /// A guard or yield expression failed in the shared computation engine.
-    /// `phase` identifies where evaluation stopped and `detail` preserves the
-    /// typed engine failure as a stable, human-readable diagnostic.
+    ///
+    /// `phase` identifies where evaluation stopped and `failure` carries the
+    /// engine's typed reason. `detail` remains the same human-readable rendering
+    /// it always was, so a consumer that only prints it is unaffected — but a
+    /// consumer that needs to BRANCH on the reason keys off `failure` instead of
+    /// parsing prose.
     ComputationError {
         state: String,
-        phase: String,
+        phase: FailurePhase,
+        failure: ComputationFailure,
         detail: String,
     },
+}
+
+/// Where in a step evaluation stopped. Typed rather than a bare string, so a
+/// checker cannot silently disagree with the producer about spelling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailurePhase {
+    /// Evaluating a `transition`'s guard.
+    TransitionGuard,
+    /// Evaluating an `exit` criterion's guard.
+    ExitGuard,
+    /// Evaluating an `exit`'s `yield` expression, after its guard held.
+    Yield,
+}
+
+impl FailurePhase {
+    /// The stable JSON/`--explain` discriminant. Fixed identifiers a checker
+    /// keys off — not `Debug`.
+    pub fn type_tag(&self) -> &'static str {
+        match self {
+            FailurePhase::TransitionGuard => "transition_guard",
+            FailurePhase::ExitGuard => "exit_guard",
+            FailurePhase::Yield => "yield",
+        }
+    }
+}
+
+/// The engine failure behind a [`StateMachineOutcome::ComputationError`],
+/// preserved as a discriminant rather than only as formatted prose.
+///
+/// This mirrors `logic_engine::ComputeError` at the state-machine boundary
+/// instead of re-exporting it, so the outcome type stays owned by this module
+/// and a new engine variant is a compile error here rather than a silently
+/// reworded string downstream.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ComputationFailure {
+    UnknownSlot { slot: String },
+    EmptyAggregation { slot: String },
+    DivisionByZero,
+    MalformedExpr { detail: String },
+    TooDeep { limit: usize },
+    NonFinite { op: String },
+    PrecisionLoss { op: String },
+    DimensionMismatch { op: String, lhs: String, rhs: String },
+}
+
+impl ComputationFailure {
+    /// The stable JSON/`--explain` discriminant.
+    pub fn type_tag(&self) -> &'static str {
+        match self {
+            ComputationFailure::UnknownSlot { .. } => "unknown_slot",
+            ComputationFailure::EmptyAggregation { .. } => "empty_aggregation",
+            ComputationFailure::DivisionByZero => "division_by_zero",
+            ComputationFailure::MalformedExpr { .. } => "malformed_expr",
+            ComputationFailure::TooDeep { .. } => "too_deep",
+            ComputationFailure::NonFinite { .. } => "non_finite",
+            ComputationFailure::PrecisionLoss { .. } => "precision_loss",
+            ComputationFailure::DimensionMismatch { .. } => "dimension_mismatch",
+        }
+    }
+
+    /// The human-readable rendering — byte-identical to what `detail` carried
+    /// before this became structured, so existing output does not shift.
+    pub fn message(&self) -> String {
+        match self {
+            ComputationFailure::UnknownSlot { slot } => format!("unknown slot: {slot}"),
+            ComputationFailure::EmptyAggregation { slot } => format!("empty aggregation: {slot}"),
+            ComputationFailure::DivisionByZero => "division by zero".to_string(),
+            ComputationFailure::MalformedExpr { detail } => {
+                format!("malformed expression: {detail}")
+            }
+            ComputationFailure::TooDeep { limit } => format!("expression depth exceeds {limit}"),
+            ComputationFailure::NonFinite { op } => format!("non-finite result from {op}"),
+            ComputationFailure::PrecisionLoss { op } => format!("precision loss in {op}"),
+            ComputationFailure::DimensionMismatch { op, lhs, rhs } => {
+                format!("dimension mismatch for {op}: {lhs} versus {rhs}")
+            }
+        }
+    }
 }
 
 impl StateMachineOutcome {
@@ -206,15 +298,17 @@ pub fn run_state_machine(sm: &LoweredStateMachine, base_kb: &KnowledgeBase) -> S
                         YieldEvaluation::PrecisionLoss => StateMachineRun {
                             outcome: StateMachineOutcome::PrecisionLoss {
                                 state: state.clone(),
-                                guard: format!("yield {}", render_expr(&exit.yield_expr)),
+                                phase: FailurePhase::Yield,
+                                expression: render_expr(&exit.yield_expr),
                             },
                             steps: trace,
                         },
-                        YieldEvaluation::ComputationError(detail) => StateMachineRun {
+                        YieldEvaluation::ComputationError(failure) => StateMachineRun {
                             outcome: StateMachineOutcome::ComputationError {
                                 state: state.clone(),
-                                phase: "yield".to_string(),
-                                detail,
+                                phase: FailurePhase::Yield,
+                                detail: failure.message(),
+                                failure,
                             },
                             steps: trace,
                         },
@@ -224,17 +318,19 @@ pub fn run_state_machine(sm: &LoweredStateMachine, base_kb: &KnowledgeBase) -> S
                     return StateMachineRun {
                         outcome: StateMachineOutcome::PrecisionLoss {
                             state: state.clone(),
-                            guard: render_guard(&exit.guard),
+                            phase: FailurePhase::ExitGuard,
+                            expression: render_guard(&exit.guard),
                         },
                         steps: trace,
                     };
                 }
-                GuardEvaluation::ComputationError(detail) => {
+                GuardEvaluation::ComputationError(failure) => {
                     return StateMachineRun {
                         outcome: StateMachineOutcome::ComputationError {
                             state: state.clone(),
-                            phase: "exit_guard".to_string(),
-                            detail,
+                            phase: FailurePhase::ExitGuard,
+                            detail: failure.message(),
+                            failure,
                         },
                         steps: trace,
                     };
@@ -296,17 +392,19 @@ pub fn run_state_machine(sm: &LoweredStateMachine, base_kb: &KnowledgeBase) -> S
                     return StateMachineRun {
                         outcome: StateMachineOutcome::PrecisionLoss {
                             state: state.clone(),
-                            guard: render_guard(&transition.guard),
+                            phase: FailurePhase::TransitionGuard,
+                            expression: render_guard(&transition.guard),
                         },
                         steps: trace,
                     };
                 }
-                GuardEvaluation::ComputationError(detail) => {
+                GuardEvaluation::ComputationError(failure) => {
                     return StateMachineRun {
                         outcome: StateMachineOutcome::ComputationError {
                             state: state.clone(),
-                            phase: "transition_guard".to_string(),
-                            detail,
+                            phase: FailurePhase::TransitionGuard,
+                            detail: failure.message(),
+                            failure,
                         },
                         steps: trace,
                     };
@@ -349,12 +447,12 @@ pub fn run_state_machine(sm: &LoweredStateMachine, base_kb: &KnowledgeBase) -> S
 /// (ADJ-STATEMACHINE §3) lives in this function: a comparison guard is the
 /// predicate-gated-contribution comparison, a presence guard is an SLD "any proof?"
 /// check, and the bare atom `true` is the always-holds special case.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 enum GuardEvaluation {
     Holds,
     DoesNotHold,
     PrecisionLoss,
-    ComputationError(String),
+    ComputationError(ComputationFailure),
 }
 
 fn evaluate_guard(g: &LoweredGuard, kb: &KnowledgeBase) -> GuardEvaluation {
@@ -376,7 +474,7 @@ fn evaluate_guard(g: &LoweredGuard, kb: &KnowledgeBase) -> GuardEvaluation {
             let r = match compute("__sm_guard_rhs", rhs, kb) {
                 Ok(result) => result,
                 Err(error) => {
-                    return GuardEvaluation::ComputationError(compute_error_detail(&error));
+                    return GuardEvaluation::ComputationError(compute_failure(&error));
                 }
             };
             if r.precision_loss {
@@ -441,7 +539,7 @@ fn is_true_atom(subject: &CoreTerm) -> bool {
 enum YieldEvaluation {
     Value(YieldValue),
     PrecisionLoss,
-    ComputationError(String),
+    ComputationError(ComputationFailure),
 }
 
 fn eval_yield(expr: &logic_engine::ComputeExpr, kb: &KnowledgeBase) -> YieldEvaluation {
@@ -453,21 +551,38 @@ fn eval_yield(expr: &logic_engine::ComputeExpr, kb: &KnowledgeBase) -> YieldEval
         {
             YieldEvaluation::Value(YieldValue::Symbol(expr_symbol(expr)))
         }
-        Err(error) => YieldEvaluation::ComputationError(compute_error_detail(&error)),
+        Err(error) => YieldEvaluation::ComputationError(compute_failure(&error)),
     }
 }
 
-fn compute_error_detail(error: &ComputeError) -> String {
+/// Translate the engine's failure into this module's owned discriminant. The
+/// match is exhaustive with no wildcard, so a new `ComputeError` variant breaks
+/// the build here rather than collapsing into a generic string downstream.
+fn compute_failure(error: &ComputeError) -> ComputationFailure {
     match error {
-        ComputeError::UnknownSlot { slot } => format!("unknown slot: {slot}"),
-        ComputeError::EmptyAggregation { slot } => format!("empty aggregation: {slot}"),
-        ComputeError::DivisionByZero => "division by zero".to_string(),
-        ComputeError::MalformedExpr { detail } => format!("malformed expression: {detail}"),
-        ComputeError::TooDeep { limit } => format!("expression depth exceeds {limit}"),
-        ComputeError::NonFinite { op } => format!("non-finite result from {op:?}"),
-        ComputeError::PrecisionLoss { op } => format!("precision loss in {op:?}"),
+        ComputeError::UnknownSlot { slot } => ComputationFailure::UnknownSlot {
+            slot: slot.clone(),
+        },
+        ComputeError::EmptyAggregation { slot } => ComputationFailure::EmptyAggregation {
+            slot: slot.clone(),
+        },
+        ComputeError::DivisionByZero => ComputationFailure::DivisionByZero,
+        ComputeError::MalformedExpr { detail } => ComputationFailure::MalformedExpr {
+            detail: (*detail).to_string(),
+        },
+        ComputeError::TooDeep { limit } => ComputationFailure::TooDeep { limit: *limit },
+        ComputeError::NonFinite { op } => ComputationFailure::NonFinite {
+            op: format!("{op:?}"),
+        },
+        ComputeError::PrecisionLoss { op } => ComputationFailure::PrecisionLoss {
+            op: format!("{op:?}"),
+        },
         ComputeError::DimensionMismatch { op, lhs, rhs } => {
-            format!("dimension mismatch for {op:?}: {lhs} versus {rhs}")
+            ComputationFailure::DimensionMismatch {
+                op: format!("{op:?}"),
+                lhs: lhs.clone(),
+                rhs: rhs.clone(),
+            }
         }
     }
 }
@@ -617,10 +732,15 @@ mod tests {
             StateMachineOutcome::ComputationError {
                 state,
                 phase,
+                failure,
                 detail,
             } => {
                 assert_eq!(state, "start");
-                assert_eq!(phase, "transition_guard");
+                assert_eq!(phase, FailurePhase::TransitionGuard);
+                // The discriminant is what a checker branches on; `detail`
+                // stays the same prose it always was.
+                assert_eq!(failure, ComputationFailure::DivisionByZero);
+                assert_eq!(failure.type_tag(), "division_by_zero");
                 assert_eq!(detail, "division by zero");
             }
             other => panic!("expected typed computation error, got {other:?}"),
@@ -649,10 +769,15 @@ mod tests {
             StateMachineOutcome::ComputationError {
                 state,
                 phase,
+                failure,
                 detail,
             } => {
                 assert_eq!(state, "start");
-                assert_eq!(phase, "exit_guard");
+                assert_eq!(phase, FailurePhase::ExitGuard);
+                // The discriminant is what a checker branches on; `detail`
+                // stays the same prose it always was.
+                assert_eq!(failure, ComputationFailure::DivisionByZero);
+                assert_eq!(failure.type_tag(), "division_by_zero");
                 assert_eq!(detail, "division by zero");
             }
             other => panic!("expected typed computation error, got {other:?}"),
@@ -676,10 +801,15 @@ mod tests {
             StateMachineOutcome::ComputationError {
                 state,
                 phase,
+                failure,
                 detail,
             } => {
                 assert_eq!(state, "start");
-                assert_eq!(phase, "yield");
+                assert_eq!(phase, FailurePhase::Yield);
+                // The discriminant is what a checker branches on; `detail`
+                // stays the same prose it always was.
+                assert_eq!(failure, ComputationFailure::DivisionByZero);
+                assert_eq!(failure.type_tag(), "division_by_zero");
                 assert_eq!(detail, "division by zero");
             }
             other => panic!("expected typed computation error, got {other:?}"),
@@ -704,9 +834,18 @@ mod tests {
 
         let run = run_state_machine(&sm, &kb);
         match run.outcome {
-            StateMachineOutcome::PrecisionLoss { state, guard } => {
+            StateMachineOutcome::PrecisionLoss {
+                state,
+                phase,
+                expression,
+            } => {
                 assert_eq!(state, "start");
-                assert_eq!(guard, "yield tainted");
+                // This used to read `guard == "yield tainted"` — the phase was
+                // recoverable only by noticing the `"yield "` prefix on a field
+                // named `guard`. The phase is now typed and the expression is
+                // just the expression.
+                assert_eq!(phase, FailurePhase::Yield);
+                assert_eq!(expression, "tainted");
             }
             other => panic!("expected typed precision loss, got {other:?}"),
         }

--- a/code/specs/ADJ-STDLIB-COVERAGE.md
+++ b/code/specs/ADJ-STDLIB-COVERAGE.md
@@ -376,8 +376,17 @@ option mapping, or judge/evaluation failure.
     inputs. Same-name rebinding resolves within each predecessor scope. The positive
     proportion query exercises this derived path; its three zero controls remain
     direct-observation abstention witnesses.
-9d. Replace state-machine failure detail strings with a structured error
-    discriminant and typed phase on both guard and yield precision failures.
+9d. **Complete.** State-machine failures carry a typed `FailurePhase`
+    (`transition_guard` / `exit_guard` / `yield`) and, for computation errors, a
+    `ComputationFailure` discriminant mirroring the engine's own error at this
+    boundary. Precision-loss outcomes carry the same typed phase and name their
+    expression directly; previously a yield abstention was distinguishable from a
+    guard abstention only by noticing that the rendering had been prefixed with
+    `"yield "` and placed in a field named `guard`. The human `detail` string is
+    unchanged, so a consumer that only prints it is unaffected, while one that
+    branches keys off the discriminant instead of parsing prose. The translation
+    from the engine error is exhaustive with no wildcard, so a new engine variant
+    is a compile error here rather than a silently reworded string downstream.
 10. Use the first-class derivation and execution-witness contract to execute every
     exported formula before migrating `average.adj`; prose cannot prove its `N=2`
     and `N=3` specializations.


### PR DESCRIPTION
## Summary

Implements the unstarted spec item **9d**. State-machine failures reported themselves as prose:

- `ComputationError` carried `phase: String` and a formatted `detail: String`.
- `PrecisionLoss` carried `guard: String` — into which a **yield** abstention wrote `format!("yield {}", render_expr(..))`.

So a consumer telling a guard abstention from a yield abstention had to notice the `"yield "` prefix on a field named `guard`, and one branching on *why* a computation failed had to parse `"division by zero"` out of English. A test pinned exactly that: `assert_eq!(guard, "yield tainted")`.

## What changed

`FailurePhase` (`TransitionGuard` / `ExitGuard` / `Yield`) is now a typed field on both outcomes, and `PrecisionLoss` names its `expression` directly instead of smuggling the phase into the rendering. `ComputationError` gains a `ComputationFailure` discriminant mirroring the engine's error at this boundary.

`detail` keeps its exact previous wording, so a consumer that only prints it sees no change — the addition is structural, for consumers that branch. Both new types expose `type_tag()`, the same stable-identifier convention `StateMachineOutcome` already used, and are re-exported from the crate root.

`compute_failure` matches every `ComputeError` variant with **no wildcard arm**, so a new engine variant is a compile error here rather than collapsing into a generic string downstream. `ComputationFailure` deliberately mirrors `ComputeError` rather than re-exporting it, keeping the outcome type owned by this module.

## Breaking for JSON consumers

`precision_loss` gains `"phase"` and renames `"guard"` → `"expression"`; `computation_error` gains `"failure"` beside the unchanged `"detail"`. No golden test pinned either shape, and the only in-tree consumers are `--explain` and the JSON emitter, both updated.

Incidentally a tightening: `"phase"` was previously a runtime `String` passed through `esc()`; it is now a fixed literal from a total match.

## Test plan

- [x] `adj-lang`: **235 passed, 0 failed** — the four affected tests now assert the typed phase and discriminant instead of the string
- [x] `adj-lang-cli`: **303 test binaries, 780 passed, 0 failed**
- [x] `cargo clippy --all-targets -- -D warnings` clean in both crates
- [x] Security review: **PASSED**. Confirmed the branch base was current before judging; verified no redaction bypass (the outcome JSON never routed through `ADJ_SENSITIVE_INPUT` on main either, and `expression` emits strictly *less* text than the old `guard`), all attacker-influenceable fields still pass through `esc()`, `detail` is byte-identical across all 8 variants, and no failure path was dropped or reordered.

## Spec

`ADJ-STDLIB-COVERAGE.md` 9d marked complete with what it now guarantees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)