### PR TITLE
fix(adj): abstain instead of dropping a tied lookup breakpoint

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased - formula audit v2 guard witnesses
 
+- A lookup abstains with `ambiguous_breakpoint` when two rows of the table relation tie the
+  breakpoint it selected, instead of keeping whichever row proof enumeration reached first
+  and dropping the other along with its RS-5e citation. This is where the invariant is
+  actually held: `adj-lang` rejects a `table` DECLARATION that repeats a key, but selection
+  does not read declarations — it enumerates every fact with the table's functor and arity,
+  so a second `table` block of the same name or a colliding `relate` fact contributes rows
+  the declaration check never saw. Both routes were reproducible and are covered by tests.
+- All three modes. `interpolated` is the sharpest case, because the dropped row's VALUE feeds
+  the blend: the same knowledge base emitted `150` or `599.5`, each fully cited and neither
+  abstaining, depending only on whether the smuggled row was declared before or after the
+  table. Both bracket endpoints and the exact-hit path are gated.
+- Ambiguity is decided AFTER selection, against the key that actually won, never against a
+  running best. Keying off the best-so-far made abstention depend on enumeration order — a
+  duplicate at a key the query did not select could abstain it or not — which both
+  contradicted the reproducibility this code promises and was a false positive, since a
+  duplicate on an unselected row costs the answer nothing.
+- `nearest`'s tie-break to the smaller key still settles a genuine tie between rows either
+  side of the query, which is a different thing from two rows at one key.
+
 - State-machine failure JSON is keyed on discriminants rather than prose. `precision_loss`
   gains `"phase"` and renames `"guard"` to `"expression"`; `computation_error` gains
   `"failure"` alongside the unchanged `"detail"`. `--explain` names the phase and the

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -566,6 +566,12 @@ fn abstention_json(reason: &AbstentionReason) -> String {
             payload(column),
             payload(key)
         ),
+        AbstentionReason::AmbiguousBreakpoint { table, column, key } => format!(
+            "{{\"reason\":\"ambiguous_breakpoint\",\"table\":\"{}\",\"column\":\"{}\",\"key\":\"{}\",\"explanation\":\"two rows of this relation share that breakpoint, so the interval has two differently-sourced answers; selecting either would drop the other's citation without a word\"}}",
+            payload(table),
+            payload(column),
+            payload(key)
+        ),
         AbstentionReason::SearchLimitExceeded { goal } => format!(
             "{{\"reason\":\"search_limit_exceeded\",\"goal\":\"{}\",\"explanation\":\"the proof search hit its depth or width limit and stopped; this is NOT evidence that no proof exists\"}}",
             payload(goal)
@@ -606,6 +612,23 @@ enum AbstentionReason {
     },
     /// The search stopped at a resolution limit. **Not** an absence.
     SearchLimitExceeded { goal: String },
+    /// Two rows of the table relation share the breakpoint this lookup selected,
+    /// so the interval has two differently-sourced answers and no ground to
+    /// prefer either.
+    ///
+    /// The lowerer rejects a table DECLARATION that repeats a key, but the
+    /// runtime does not read the declaration — it enumerates every fact with the
+    /// table's functor and arity. A second `table` block of the same name, or a
+    /// `relate` fact colliding with the relation, contributes rows the
+    /// declaration-time check never saw. So the invariant is enforced HERE too,
+    /// over exactly the set selection walks. Picking one and dropping the other
+    /// would emit a fully-cited answer while contradicting, separately-sourced
+    /// evidence vanished.
+    AmbiguousBreakpoint {
+        table: String,
+        column: String,
+        key: String,
+    },
 }
 
 fn trace_steps_json(proof: &Proof, kb: &KnowledgeBase) -> String {
@@ -1505,6 +1528,32 @@ fn recall_json(query: &Term, kb: &KnowledgeBase) -> String {
     )
 }
 
+/// Whether more than one row of the enumerated relation carries `target` in the
+/// key column — i.e. whether the breakpoint a lookup SELECTED is shared.
+///
+/// Asked AFTER selection, about the key that actually won, and never about a
+/// running best. An earlier version set a flag whenever an incoming key tied the
+/// best-so-far, which made the answer depend on enumeration order: a duplicate at
+/// a key that ultimately LOST could abstain the query or not, depending only on
+/// which row the resolver reached first. That contradicted the reproducibility
+/// this code promises, and it is a false positive besides — a duplicate on a row
+/// that was not selected costs the answer nothing.
+///
+/// Deciding after the fact is order-independent by construction and costs one
+/// extra linear pass over an already-materialized proof list.
+fn breakpoint_is_shared(
+    dag: &logic_engine::ProofDAG,
+    key_var: &LogicVar,
+    target: &logic_engine::compute::ExactRational,
+) -> bool {
+    dag.proofs
+        .iter()
+        .filter_map(|proof| numeric_exact_magnitude(&proof.bindings.walk_var(key_var)))
+        .filter(|k| k.as_ratio() == target.as_ratio())
+        .count()
+        > 1
+}
+
 /// Resolve a RANGE / BRACKET lookup (ADJ-TABLES RS-5c) against the grounded
 /// table and render it as JSON. The table's rows are its facts, so enumerating
 /// `<table>($c0, …, $cn)` binds every column of every row **and** yields that
@@ -1572,6 +1621,24 @@ fn range_lookup_json(rl: &LoweredRangeLookup, kb: &KnowledgeBase) -> String {
         };
         if take {
             best = Some((proof, key_term, value_term, k));
+        }
+    }
+    // The selected breakpoint must identify ONE row. The declaration-time gate
+    // cannot guarantee that: it reads one `table` block, while enumeration reads
+    // every fact with this functor and arity — a second block of the same name or
+    // a colliding `relate` fact contributes rows it never saw.
+    if let Some((_, key_term, _, best_k)) = &best {
+        if breakpoint_is_shared(&dag, &cols[rl.key_index], best_k) {
+            return format!(
+                "{{\"query\":\"{}\",\"mode\":\"{}\",\"answers\":[],\"abstained\":true,\"abstention\":{}}}",
+                query_echo(&query_str),
+                esc(&rl.mode),
+                abstention_json(&AbstentionReason::AmbiguousBreakpoint {
+                    table: rl.table.clone(),
+                    column: rl.key_col.clone(),
+                    key: format!("{key_term}"),
+                })
+            );
         }
     }
 
@@ -1736,6 +1803,21 @@ fn nearest_lookup_json(rl: &LoweredRangeLookup, kb: &KnowledgeBase) -> String {
         };
         if take {
             best = Some((proof, key_term, value_term, k));
+        }
+    }
+
+    // A tie on the SELECTED KEY is not the tie `nearest` resolves. Two rows
+    // equidistant on opposite sides are a real choice, settled deterministically
+    // toward the smaller key. Two rows AT that key are one breakpoint with two
+    // differently-sourced answers, and snapping to either drops the other's
+    // citation.
+    if let Some((_, key_term, _, best_k)) = &best {
+        if breakpoint_is_shared(&dag, &cols[rl.key_index], best_k) {
+            return abstain(AbstentionReason::AmbiguousBreakpoint {
+                table: rl.table.clone(),
+                column: rl.key_col.clone(),
+                key: format!("{key_term}"),
+            });
         }
     }
 
@@ -1921,6 +2003,21 @@ fn interpolated_lookup_json(rl: &LoweredRangeLookup, kb: &KnowledgeBase) -> Stri
             max_key: extremal(true),
         }),
         (Some((lp, k0, v0)), Some((up, k1, v1))) => {
+            // BOTH bracket endpoints must identify one row each. This mode is the
+            // sharpest case of the shared-breakpoint problem: the dropped row's
+            // VALUE feeds the blend, so the emitted number itself changes with
+            // which row enumeration happened to reach first. The same knowledge
+            // base produced `150` or `599.5`, each fully cited and neither
+            // abstaining, depending only on declaration order.
+            for endpoint in [&k0, &k1] {
+                if breakpoint_is_shared(&dag, &cols[rl.key_index], endpoint) {
+                    return abstain(AbstentionReason::AmbiguousBreakpoint {
+                        table: rl.table.clone(),
+                        column: rl.key_col.clone(),
+                        key: render(endpoint),
+                    });
+                }
+            }
             // Exact hit on a breakpoint (`k0 == k1 == q`): the blend is `0/0`, so
             // return that row's value verbatim with its single citation.
             if k0.as_ratio() == k1.as_ratio() {

--- a/code/packages/rust/adj-lang-cli/tests/rs5c_range_lookup_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5c_range_lookup_e2e.rs
@@ -216,3 +216,284 @@ fn range_lookup_non_numeric_key_column_is_rejected() {
         "diag: {diag}"
     );
 }
+
+/// A duplicate breakpoint reaching selection through a route the DECLARATION
+/// gate cannot see.
+///
+/// `lower` rejects a `table` block that repeats a key, but the runtime never
+/// reads that block — `range_lookup_json` enumerates every fact with the table's
+/// functor and arity. A `relate` fact colliding with the relation contributes a
+/// row the declaration-time check never examined, so before the runtime gate
+/// this answered `first_ten` and cited only that row, while the separately
+/// sourced `rogue_ten` vanished with `abstained: false`.
+#[test]
+fn a_relate_fact_cannot_smuggle_in_a_duplicate_breakpoint() {
+    let dir = scratch("relate_dup");
+    write(
+        &dir,
+        "p.adj",
+        r#"
+table band {
+    columns min_v, label
+    row (0, low) { source "zero band" }
+    row (10, first_ten) { source "first ten band" }
+    source "framing"
+    locator "https://example.test/one"
+    trust authoritative
+}
+relate band(10, rogue_ten) source "rogue row" locator "https://example.test/rogue" trust authoritative
+? lookup band min_v = 12 mode range give label
+"#,
+    );
+    let (ok, out, err) = run_full(&dir.join("p.adj"));
+    assert!(ok, "{err}");
+    assert!(
+        out.contains("\"abstained\":true") && out.contains("\"ambiguous_breakpoint\""),
+        "a smuggled duplicate breakpoint must abstain, not pick one: {out}"
+    );
+    assert!(
+        !out.contains("first_ten") && !out.contains("rogue_ten"),
+        "neither tied row may be answered: {out}"
+    );
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+/// The same hole through a second `table` block of the same name — now closed
+/// one layer EARLIER than the abstention above.
+///
+/// The lowerer kept only the last declaration while every block's rows were
+/// lowered into the KB, so a shadowed block was invisible to the declaration
+/// gate and fully visible to enumeration. That is now `LowerError::DuplicateTable`,
+/// so this program never runs at all; the assertion is the compile error rather
+/// than the runtime abstention it used to reach.
+///
+/// The runtime abstention is still the guarantee and still exercised — see the
+/// `relate`-smuggling tests, which remain reachable because a `relate` fact is a
+/// legitimate second producer of a relation rather than a name collision.
+#[test]
+fn a_second_table_block_cannot_smuggle_in_a_duplicate_breakpoint() {
+    let dir = scratch("dup_table_block");
+    write(
+        &dir,
+        "p.adj",
+        r#"
+table band {
+    columns min_v, label
+    row (0, low) { source "zero band" }
+    row (10, first_ten) { source "first ten band" }
+    source "framing one"
+    locator "https://example.test/one"
+    trust authoritative
+}
+table band {
+    columns min_v, label
+    row (10, shadow_ten) { source "shadow ten band" }
+    source "framing two"
+    locator "https://example.test/two"
+    trust authoritative
+}
+? lookup band min_v = 12 mode range give label
+"#,
+    );
+    let (_ok, out, err) = run_full(&dir.join("p.adj"));
+    let reported = format!("{out}{err}");
+    assert!(
+        reported.contains("DuplicateTable"),
+        "a shadowed table block must be rejected outright: {reported}"
+    );
+    assert!(
+        !reported.contains("first_ten") && !reported.contains("shadow_ten"),
+        "no row may be answered from a collided relation: {reported}"
+    );
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+/// `nearest` snaps to the closest key, and its documented tie-break (toward the
+/// smaller key) settles two rows sitting either side of the query. A tie on the
+/// KEY ITSELF is a different thing — one breakpoint with two differently sourced
+/// answers — and must abstain rather than snap.
+#[test]
+fn nearest_abstains_on_a_duplicated_key_rather_than_snapping() {
+    let dir = scratch("nearest_dup");
+    write(
+        &dir,
+        "p.adj",
+        r#"
+table band {
+    columns min_v, label
+    row (0, low) { source "zero band" }
+    row (10, first_ten) { source "first ten band" }
+    source "framing"
+    locator "https://example.test/one"
+    trust authoritative
+}
+relate band(10, rogue_ten) source "rogue row" locator "https://example.test/rogue" trust authoritative
+? lookup band min_v = 12 mode nearest give label
+"#,
+    );
+    let (ok, out, err) = run_full(&dir.join("p.adj"));
+    assert!(ok, "{err}");
+    assert!(
+        out.contains("\"abstained\":true") && out.contains("\"ambiguous_breakpoint\""),
+        "nearest must abstain on a duplicated key: {out}"
+    );
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+/// The gate stays scoped: an ordinary table with distinct breakpoints still
+/// answers, and `nearest`'s genuine either-side tie-break is untouched.
+#[test]
+fn distinct_breakpoints_are_unaffected_by_the_ambiguity_gate() {
+    let dir = scratch("distinct_ok");
+    write(
+        &dir,
+        "p.adj",
+        r#"
+table band {
+    columns min_v, label
+    row (0, low) { source "zero band" }
+    row (10, mid) { source "ten band" }
+    row (20, high) { source "twenty band" }
+    source "framing"
+    locator "https://example.test/one"
+    trust authoritative
+}
+? lookup band min_v = 12 mode range give label
+"#,
+    );
+    let (ok, out, err) = run_full(&dir.join("p.adj"));
+    assert!(ok, "{err}");
+    assert!(
+        out.contains("\"abstained\":false") && out.contains("mid"),
+        "a distinct-breakpoint table must still answer: {out}"
+    );
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+/// `interpolated` is the sharpest form of the shared-breakpoint problem: the
+/// dropped row's VALUE feeds the blend, so the emitted NUMBER changes with which
+/// row enumeration reached first. Before the fix this same knowledge base
+/// answered `150` or `599.5` — each fully cited, neither abstaining — depending
+/// only on whether the smuggled row was declared before or after the table.
+///
+/// The test runs both orders precisely because a mode-parity gap in this file is
+/// what let the bug through: `range` and `nearest` had smuggling coverage and
+/// `interpolated` did not.
+#[test]
+fn interpolated_abstains_on_a_smuggled_duplicate_in_either_order() {
+    for (tag, before, after) in [
+        ("rogue_after", "", ROGUE_TEN),
+        ("rogue_before", ROGUE_TEN, ""),
+    ] {
+        let dir = scratch(tag);
+        write(
+            &dir,
+            "p.adj",
+            &format!(
+                r#"
+{before}
+table band {{
+    columns min_v, val
+    row (0, 0) {{ source "zero band" }}
+    row (10, 100) {{ source "first ten band" }}
+    row (20, 200) {{ source "twenty band" }}
+    source "framing"
+    locator "https://example.test/one"
+    trust authoritative
+}}
+{after}
+? lookup band min_v = 15 mode interpolated give val
+"#
+            ),
+        );
+        let (ok, out, err) = run_full(&dir.join("p.adj"));
+        assert!(ok, "{err}");
+        assert!(
+            out.contains("\"abstained\":true") && out.contains("\"ambiguous_breakpoint\""),
+            "{tag}: a tied bracket endpoint must abstain: {out}"
+        );
+        assert!(
+            !out.contains("150") && !out.contains("599.5"),
+            "{tag}: no blended number may be emitted from a tied bracket: {out}"
+        );
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+}
+
+/// A duplicate at a key the selection did NOT choose costs the answer nothing,
+/// and must not abstain it.
+///
+/// The first version of this gate flagged ambiguity whenever an incoming key tied
+/// the best-SO-FAR, so a duplicate on a losing key poisoned the query or not
+/// purely by enumeration order — the same knowledge base answering `high` in one
+/// declaration order and abstaining in the other. Ambiguity is now decided after
+/// selection, against the key that actually won.
+#[test]
+fn a_duplicate_on_an_unselected_key_does_not_abstain_the_answer() {
+    for (tag, before, after) in [
+        ("losing_after", "", ROGUE_TEN_LABEL),
+        ("losing_before", ROGUE_TEN_LABEL, ""),
+    ] {
+        let dir = scratch(tag);
+        write(
+            &dir,
+            "p.adj",
+            &format!(
+                r#"
+{before}
+table band {{
+    columns min_v, label
+    row (0, low) {{ source "zero band" }}
+    row (10, ten_a) {{ source "ten a" }}
+    row (20, high) {{ source "twenty band" }}
+    source "framing"
+    locator "https://example.test/one"
+    trust authoritative
+}}
+{after}
+? lookup band min_v = 25 mode range give label
+"#
+            ),
+        );
+        let (ok, out, err) = run_full(&dir.join("p.adj"));
+        assert!(ok, "{err}");
+        assert!(
+            out.contains("\"abstained\":false") && out.contains("high"),
+            "{tag}: a duplicate at the unselected key 10 must not abstain a query that selected 20: {out}"
+        );
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+}
+
+/// `nearest`'s documented tie-break survives: two rows equidistant on OPPOSITE
+/// sides are a genuine choice, settled toward the smaller key, not an ambiguous
+/// breakpoint.
+#[test]
+fn nearest_equidistant_tie_break_is_not_treated_as_ambiguous() {
+    let dir = scratch("near_equidistant");
+    write(
+        &dir,
+        "p.adj",
+        r#"
+table band {
+    columns min_v, label
+    row (8, eight) { source "eight band" }
+    row (12, twelve) { source "twelve band" }
+    source "framing"
+    locator "https://example.test/one"
+    trust authoritative
+}
+? lookup band min_v = 10 mode nearest give label
+"#,
+    );
+    let (ok, out, err) = run_full(&dir.join("p.adj"));
+    assert!(ok, "{err}");
+    assert!(
+        out.contains("\"abstained\":false") && out.contains("eight"),
+        "an equidistant tie between DIFFERENT keys still resolves to the smaller: {out}"
+    );
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+const ROGUE_TEN: &str = r#"relate band(10, 999) source "rogue row" locator "https://example.test/rogue" trust authoritative"#;
+const ROGUE_TEN_LABEL: &str = r#"relate band(10, ten_b) source "rogue ten" locator "https://example.test/rogue" trust authoritative"#;

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## Unreleased - replayable formula guard traces
 
+- A table used as a `range`/`interpolated`/`nearest` lookup may no longer contain two rows
+  sharing a breakpoint in the key column (`LowerError::LookupDuplicateKey`, carrying both
+  row indices). `range` selects the greatest key `<= q`; with the key tied, that was
+  whichever row proof enumeration reached first, so the other row was dropped — along with
+  its own RS-5e per-row citation — with no ambiguity flag and no abstention. Verified before
+  the fix: a table with two rows keyed `10` answered `first_ten` and cited only that row,
+  while an equally-applicable `second_ten` row went unmentioned. Breakpoints are compared as
+  exact rationals, so `10` and `10.0` are one breakpoint.
+- Scoped to the key column of tables actually referenced by a lookup, so a categorical table
+  with repeated first-column values (an ordinary relation) is unaffected. `nearest` keeps its
+  documented deterministic tie-break, which resolves a genuine either-side tie rather than a
+  table defining two answers for one interval.
+- Two `table` blocks declaring the same name are now rejected (`LowerError::DuplicateTable`).
+  The registry kept the last block while every block's rows went into the KB, and a lookup
+  builds its goal — arity, key column position — from the winner alone. A shadowed block whose
+  `columns` differ therefore had its rows become *unreachable* rather than tied: wrong arity
+  fails to unify, and a reordered key column reads a non-numeric cell that selection skips. The
+  lookup then answered from a subset of the relation and cited it confidently. Reproduced: a
+  three-band table plus a one-row shadowing block with an extra column answered `rogue` at key
+  `0` for a query of 15 whose correct answer was `mid` at breakpoint `10`. This is also what
+  lets the selection-time breakpoint check assume the enumerated relation *is* the declared
+  table.
+- The declaration check is a diagnostic, not the guarantee — see the `adj-lang-cli` entry for
+  the selection-time abstention that actually holds the invariant. The duplicate scan sorts
+  once instead of searching pairwise; the nested version was O(n²) and re-ran a
+  `BigDecimal::to_rational()` allocation per comparison, taking ~8s on a 4000-row table (an
+  ordinary size for the calibration and growth-chart cases) once per lookup statement.
+
 - State-machine failures are structured (ADJ-STDLIB-COVERAGE §9d). `StateMachineOutcome`
   now carries a typed `FailurePhase` (`TransitionGuard` / `ExitGuard` / `Yield`) instead of
   a `phase: String`, and `ComputationError` carries a `ComputationFailure` discriminant

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -206,6 +206,29 @@ pub enum LowerError {
         keyword: String,
         slot: String,
     },
+    /// Two `table` blocks in one program declare the same name.
+    ///
+    /// The registry keeps the LAST declaration, but every block's rows are
+    /// lowered into the KB, and a lookup takes its goal shape — arity and key
+    /// column position — from the winning block alone. So a shadowed block whose
+    /// `columns` differ does not merely lose: its rows become unreachable to
+    /// selection (wrong arity fails to unify; a reordered key column reads a
+    /// non-numeric cell and is skipped), and the lookup answers from a subset of
+    /// the relation while citing it confidently. Two same-named tables are a
+    /// naming collision, not a merge.
+    DuplicateTable {
+        table: String,
+    },
+    /// Two rows of a table used as a `range`/`interpolated`/`nearest` lookup
+    /// share a breakpoint in the key column, so the interval they define has two
+    /// different answers. Selection would pick whichever row enumeration reached
+    /// first and drop the other — including its citation — without a word.
+    /// Carries the two row indices so the table can be fixed at the source.
+    LookupDuplicateKey {
+        table: String,
+        column: String,
+        rows: (usize, usize),
+    },
     /// A formula declared a precondition predicate outside the lowerer's closed,
     /// typed execution set.
     FormulaUnknownPrecondition {
@@ -826,7 +849,17 @@ pub(crate) fn lower_with_binding_origins(
             ..
         } = stmt
         {
-            tables.insert(name.as_str(), (columns.as_slice(), rows.as_slice()));
+            // Last-declaration-wins would leave the earlier block's rows in the
+            // KB but outside the goal shape a lookup builds from the winner, so
+            // they would be silently unreachable rather than merged.
+            if tables
+                .insert(name.as_str(), (columns.as_slice(), rows.as_slice()))
+                .is_some()
+            {
+                return Err(LowerError::DuplicateTable {
+                    table: name.clone(),
+                });
+            }
         }
     }
     // ADJ-TABLES RS-5c: the validated range/bracket lookups, run by the CLI tactic.
@@ -1174,6 +1207,62 @@ pub(crate) fn lower_with_binding_origins(
                             row: i,
                         });
                     }
+                }
+                // Two rows may not share a breakpoint. `range` selects the
+                // GREATEST key `<= q`, and with the key tied that "greatest" is
+                // whichever row the proof enumeration reached first — so one row
+                // answered and the other vanished, silently, carrying its own
+                // citation with it. In a system whose answers ARE their
+                // citations, quietly discarding an equally-applicable row is the
+                // worst shape a wrong answer can take: it looks fully sourced.
+                //
+                // `nearest` already breaks ties deterministically (to the smaller
+                // key) and says so. That is right for nearest, where two rows can
+                // legitimately sit either side of a query. A duplicate BREAKPOINT
+                // is different: it is not a tie to resolve, it is a table that
+                // defines two different answers for one interval. Reject it here,
+                // where the row indices are still available to name, rather than
+                // picking one at query time.
+                //
+                // Compared as exact rationals, so `10` and `10.0` are the same
+                // breakpoint — an `f64` compare would be the lossy shortcut this
+                // path exists to avoid.
+                let key_rational = |cell: Option<&crate::ast::TableCell>| match cell {
+                    Some(crate::ast::TableCell::Number(NumLit::Int(value))) => {
+                        Some(ExactRational::from_i128(*value as i128))
+                    }
+                    Some(crate::ast::TableCell::Number(NumLit::Exact(value))) => {
+                        Some(ExactRational::from_ratio(value.to_rational()))
+                    }
+                    _ => None,
+                };
+                // Sort-then-scan, not a nested search: each key is converted to a
+                // rational ONCE and compared O(n log n) times. The obvious nested
+                // version is O(n²) AND re-runs a `BigDecimal::to_rational()`
+                // allocation per comparison, which on a 4000-row calibration
+                // table — an ordinary size for the growth-chart and tax-table
+                // cases this feature exists for — turned a 1s compile into 8s,
+                // once per lookup statement over that table.
+                let mut keyed: Vec<(usize, ExactRational)> = rows
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(index, row)| {
+                        key_rational(row.cells.get(key_index)).map(|key| (index, key))
+                    })
+                    .collect();
+                keyed.sort_by(|left, right| left.1.as_ratio().cmp(right.1.as_ratio()));
+                if let Some(pair) = keyed
+                    .windows(2)
+                    .find(|pair| pair[0].1.as_ratio() == pair[1].1.as_ratio())
+                {
+                    // Report in source order, so the message points at the rows
+                    // the way the file reads.
+                    let (earlier, later) = (pair[0].0.min(pair[1].0), pair[0].0.max(pair[1].0));
+                    return Err(LowerError::LookupDuplicateKey {
+                        table: table.clone(),
+                        column: key_col.clone(),
+                        rows: (earlier, later),
+                    });
                 }
                 // `interpolated` additionally computes on the VALUE column, so it
                 // too must be numeric in every row (RS-5d). `range` returns the value
@@ -7762,6 +7851,134 @@ rule { head: r(a) when: x(t) }";
             .find(|binding| binding.name == "total")
             .expect("total is derived");
         assert_eq!(derived.value, 6.0, "sum over the slot, as written");
+    }
+
+    /// Two `table` blocks with one name is a collision, not a merge.
+    ///
+    /// The registry kept the LAST block while every block's rows went into the
+    /// KB, and a lookup builds its goal — arity, key column position — from the
+    /// winner alone. So a shadowed block whose `columns` differ had its rows
+    /// become unreachable rather than tied: wrong arity fails to unify, and a
+    /// reordered key column reads a non-numeric cell that selection skips. The
+    /// lookup then answered from a subset of the relation and cited it
+    /// confidently. Reproduced before this gate: a three-band table plus a
+    /// one-row shadowing block with an extra column answered `rogue` at key `0`
+    /// for a query of 15 whose correct answer was `mid` at breakpoint `10`.
+    ///
+    /// This is also what lets the selection-time breakpoint check assume the
+    /// enumerated relation IS the declared table.
+    #[test]
+    fn a_second_table_block_of_the_same_name_is_rejected() {
+        let src = r#"
+            table band {
+                columns min_v, label
+                row (0, low) { source "zero band" }
+                row (10, mid) { source "ten band" }
+                source "framing one"
+                locator "https://example.invalid/one"
+                trust authoritative
+            }
+            table band {
+                columns min_v, label, extra
+                row (0, rogue, x) { source "rogue row" }
+                source "framing two"
+                locator "https://example.invalid/two"
+                trust authoritative
+            }
+            ? lookup band min_v = 15 mode range give label
+        "#;
+        assert!(
+            matches!(
+                compile(src),
+                Err(crate::CompileError::Lower(LowerError::DuplicateTable { ref table }))
+                    if table == "band"
+            ),
+            "two tables of one name must not silently merge"
+        );
+    }
+
+    /// A duplicate breakpoint is a table that defines two answers for one
+    /// interval. Before this gate, `range` selected the greatest key `<= q` and,
+    /// with the key tied, that was whichever row enumeration reached first —
+    /// the other row was dropped along with its citation, silently. Verified
+    /// end-to-end before the fix: a table with two rows keyed `10` answered
+    /// `first_ten` and cited only that row.
+    #[test]
+    fn duplicate_lookup_breakpoints_are_rejected() {
+        let src = r#"
+            table band {
+                columns min_v, label
+                row (0, low) { source "zero band" }
+                row (10, first_ten) { source "first ten band" }
+                row (10, second_ten) { source "second ten band" }
+                source "framing"
+                locator "https://example.invalid/spec"
+                trust authoritative
+            }
+            ? lookup band min_v = 12 mode range give label
+        "#;
+        assert!(
+            matches!(
+                compile(src),
+                Err(crate::CompileError::Lower(LowerError::LookupDuplicateKey {
+                    ref table,
+                    ref column,
+                    rows,
+                })) if table == "band" && column == "min_v" && rows == (1, 2)
+            ),
+            "two rows sharing a breakpoint must not compile"
+        );
+    }
+
+    /// The comparison is on VALUE, not on how the literal was written — `10` and
+    /// `10.0` are one breakpoint. An `f64` compare would happen to agree here;
+    /// the point is that the check uses the exact rational path this codebase
+    /// requires of every numeric decision.
+    #[test]
+    fn duplicate_breakpoints_are_compared_exactly_not_textually() {
+        let src = r#"
+            table band {
+                columns min_v, label
+                row (0, low) { source "zero band" }
+                row (10, ten_int) { source "ten as int" }
+                row (10.0, ten_dec) { source "ten as decimal" }
+                source "framing"
+                locator "https://example.invalid/spec"
+                trust authoritative
+            }
+            ? lookup band min_v = 12 mode range give label
+        "#;
+        assert!(
+            matches!(
+                compile(src),
+                Err(crate::CompileError::Lower(
+                    LowerError::LookupDuplicateKey { .. }
+                ))
+            ),
+            "`10` and `10.0` are the same breakpoint"
+        );
+    }
+
+    /// The gate is scoped to genuine duplicates: an ordinary step-function table
+    /// with distinct breakpoints still compiles and still brackets downward.
+    #[test]
+    fn distinct_breakpoints_still_compile() {
+        let src = r#"
+            table band {
+                columns min_v, label
+                row (0, low) { source "zero band" }
+                row (10, mid) { source "ten band" }
+                row (20, high) { source "twenty band" }
+                source "framing"
+                locator "https://example.invalid/spec"
+                trust authoritative
+            }
+            ? lookup band min_v = 12 mode range give label
+        "#;
+        assert!(
+            compile(src).is_ok(),
+            "distinct breakpoints are an ordinary table"
+        );
     }
 
     #[test]

--- a/code/specs/ADJ-TABLES.md
+++ b/code/specs/ADJ-TABLES.md
@@ -226,7 +226,34 @@ same exact-`BigRational` arithmetic, and the same per-row citation path.
   for an exact hit and `FromRangeBracket { table, key, matched_key, mode }` for a bracket select.
   `matched_key` is recorded explicitly because *which breakpoint you landed on* is the entire
   content of a bracket decision, and RS-5e is what lets that step quote a span defending the row
-  it names. Abstention below a table's floor is likewise a typed reason there
+  it names. For that citation to mean anything, a breakpoint must identify **one** row.
+  Otherwise selection resolves the tie by enumeration order and the losing row disappears
+  together with its own span — an answer that looks fully sourced while an equally applicable,
+  differently-sourced row went unmentioned.
+
+  This is enforced in **two places, and the second is the load-bearing one**:
+
+  - A `table` declaration used as a `range`/`interpolated`/`nearest` lookup may not repeat a key
+    in the lookup's key column. That is a compile error naming both row indices — a fast, precise
+    diagnostic pointing at the source.
+  - Selection itself abstains (`ambiguous_breakpoint`) when two rows tie the selected key. This
+    is the guarantee, because the runtime does **not** read the declaration: it enumerates every
+    fact carrying the table's functor and arity. A second `table` block of the same name, or a
+    `relate` fact colliding with the relation, contributes rows the declaration check never saw.
+    A gate that inspects only the parse tree is not co-total with the set selection walks, and a
+    check that is not co-total with its consumer is a check that can be walked around.
+
+  All three modes are gated, and `interpolated` is the sharpest case: its dropped row's *value*
+  feeds the blend, so the emitted number itself moves — one knowledge base yielded two different
+  fully-cited answers depending only on declaration order. Both bracket endpoints are checked.
+  The question is asked **after** selection, about the key that won: asking it against a running
+  best would make abstention depend on enumeration order, and would fire on a duplicate at a key
+  the query never selected, which costs the answer nothing.
+
+  Keys are compared as exact rationals, so `10` and `10.0` are one breakpoint. All of this is
+  distinct from `nearest`'s documented tie-break to the smaller key, which resolves a genuine tie
+  between rows either side of a query; a tie on the key itself is not a choice to settle but a
+  relation defining two answers for one interval. Abstention below a table's floor is likewise a typed reason there
   (`BelowTableDomain { table, key, min_key }`), distinct from a malformed key
   (`NonNumericKey`) — the two are opposite failures and must never render alike.
 - Every lookup answer (exact, range, or interpolated) carries the table's citation. For


### PR DESCRIPTION
## Summary

A lookup could select a breakpoint two rows share, keep whichever row proof enumeration reached first, and discard the other — **along with its own RS-5e citation**. Confirmed end to end, on a relation with two rows keyed `10`:

```
? lookup band min_v = 12 mode range give label
→ {"label":"first_ten"}, citations: ["first band starting at ten"], "abstained": false
```

The losing row didn't merely lose, it vanished: no ambiguity flag, no abstention, nothing in the audit suggesting a choice was made. RS-5e exists so a lookup quotes *the row it selected* — `ADJ-TABLES` puts it plainly, "which breakpoint you landed on is the entire content of a bracket decision." An answer that silently drops a contradicting, separately-sourced row still reads as fully sourced. That's the worst shape a wrong answer can take in a system whose answers *are* their citations.

## Three gates, and the middle one is the guarantee

1. `lower` rejects a `table` **declaration** repeating a key in a lookup's key column (`LookupDuplicateKey`, naming both rows) — a precise diagnostic at the source.
2. **Selection abstains** (`ambiguous_breakpoint`) when the key it chose is shared.
3. `lower` rejects two `table` blocks sharing a **name** (`DuplicateTable`).

**(2) exists because (1) is not co-total with its consumer.** `lower` scans the syntactic rows of one block; selection calls `enumerate_all` over `band(C0, C1)` — every KB fact with that functor and arity, a strictly larger set. A `relate` fact colliding with the relation walks straight past (1). In a KB-backed language a declaration is one *producer* of a relation, not its definition.

**(3) closes a distinct pre-existing hole with the same signature.** The registry kept the last same-named block while *every* block's rows entered the KB, and a lookup takes its goal shape — arity, key column position — from the winner alone. A shadowed block whose `columns` differ therefore had its rows become **unreachable** rather than tied: wrong arity never unifies, a reordered key column reads a non-numeric cell selection skips. Reproduced: a three-band table plus a one-row shadowing block answered `rogue` at key `0` for a query of 15 whose correct answer was `mid` at breakpoint `10`. This is also what lets (2) assume the enumerated relation *is* the declared table. No shipped program is affected — the one repeated table name lives in two files that don't import each other.

## All three modes

`interpolated` is the sharpest case and was missed in the first pass: the dropped row's **value** feeds the blend, so the emitted number itself moves. The same knowledge base yielded `150` or `599.5` — each fully cited, neither abstaining — depending only on declaration order. Both bracket endpoints and the exact-hit path are gated.

Ambiguity is decided **after** selection, against the key that actually won, never against a running best. Keying off the best-so-far made abstention depend on enumeration order (a duplicate at a key the query *didn't* select could abstain it or not), contradicting the reproducibility promised a few lines above it, and firing on a row whose duplication cost the answer nothing.

`nearest` keeps its documented tie-break to the smaller key — a genuine tie between rows either side of a query, which is not the same as two rows at one key.

## Details

Keys compare as exact rationals, so `10` and `10.0` are one breakpoint; an `f64` compare would have agreed here by luck, and this path shouldn't decide numbers approximately.

The declaration scan sorts once rather than searching pairwise. The nested version was O(n²) with a `BigDecimal::to_rational()` allocation per comparison — **~7.7s on a 4000-row table** (an ordinary size for the calibration and growth-chart cases this feature exists for), once per lookup statement over it. Now **0.99s**, matching the no-gate baseline.

## Test plan

- [x] `adj-lang` **239 passed / 0 failed**; `adj-lang-cli` **303 binaries / 787 passed / 0 failed**; clippy `-D warnings` clean in both
- [x] Eight new tests: each smuggling route, `nearest` on a duplicated key, `interpolated` in **both** declaration orders, a duplicate on an unselected key still answering, `nearest`'s equidistant tie-break intact, a distinct-breakpoint table unaffected, and the same-named-block rejection
- [x] Security review, 3 rounds plus a focused pass on the final delta. Round 1 found the gate was bypassable (declaration-time only); round 2 found `interpolated` unfixed and the tie detection order-dependent; round 3 verified **18/18 orderings stable** and surfaced the pre-existing same-name hole, fixed here. Final pass on the `DuplicateTable` delta: PASSED, with diamond-import and rulebook-nesting compat checked against the corpus.

## Spec

`ADJ-TABLES.md` states the requirement, all enforcement points, which one is load-bearing, and why the question is asked after selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)