### PR TITLE
feat(adj): run provenance verification locally in a Linux container

### DIFF
--- a/.claude/adj-provenance-container/Dockerfile
+++ b/.claude/adj-provenance-container/Dockerfile
@@ -1,0 +1,24 @@
+# Linux host for `adj_stdlib_provenance.py verify`.
+#
+# The verifier requires cgroup v2 delegation (ADJ-STDLIB-COVERAGE 13i) and hard-
+# refuses to run without it — `_PosixGuardian` fails unless the platform is
+# Linux. That boundary is deliberate, so rather than weaken it, this image
+# reproduces the Linux the verifier expects. It also builds the trusted
+# parser/audit binaries INSIDE the container: the verifier execs them, and a
+# macOS build cannot run here.
+#
+# PINNED BY DIGEST, not by the floating `1-slim` tag. These binaries are
+# *trusted* — the verifier believes their output — so the toolchain that compiles
+# them is part of the trust boundary and must not drift silently.
+FROM rust:1-slim@sha256:b5b16ce96388d90eb217e162d4729b05c964c5c2388db28f70fbb8a4a66e1d26
+
+# jsonschema is pinned to the SAME version CI installs. Debian's
+# python3-jsonschema is 4.19.2 while CI uses 4.26.0, and validator behaviour
+# changed between them — a manifest could validate here and fail in CI, which
+# would make this harness actively misleading rather than merely different.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends python3 python3-pip ca-certificates \
+ && pip3 install --break-system-packages --no-cache-dir jsonschema==4.26.0 \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /repo

--- a/.claude/adj-provenance-container/README.md
+++ b/.claude/adj-provenance-container/README.md
@@ -1,0 +1,77 @@
+# Local provenance verification
+
+`adj_stdlib_provenance.py verify` only runs on Linux. `_PosixGuardian.__init__`
+fails outright unless `sys.platform.startswith("linux")` — there is no flag and
+no environment override. That is deliberate: ADJ-STDLIB-COVERAGE §13i chose to
+*reject* off-Linux rather than "silently weaken the claim", because macOS and
+generic POSIX have no equivalent unprivileged hard container for the cgroup-v2
+containment the verifier depends on.
+
+So on a Mac the whole Wave-1 provenance track — and every library migration —
+is CI-only-verifiable, and each iteration costs a full CI round trip.
+
+This harness removes that cost **without touching the containment code**. It
+reproduces the Linux the verifier already expects, rather than relaxing what the
+verifier will accept.
+
+## Use
+
+```
+./.claude/adj-provenance-container/verify.sh
+```
+
+Expected on a clean tree:
+
+```json
+{ "bundles": 11, "objects": 125, "snapshots": 11, "valid": true }
+```
+
+Prerequisite: any Docker-compatible runtime. On macOS:
+
+```
+brew install colima docker && colima start --cpu 4 --memory 8
+```
+
+## Two things that are not obvious
+
+**The verifier execs the trusted binaries.** `adj-formula-inventory` and
+`adj-formula-audit` are launched as subprocesses, so a macOS build cannot be
+reused — the script builds them *inside* the container. It uses a separate
+`CARGO_TARGET_DIR=/tmp/adj-target` so a host build is never clobbered by a Linux
+one (or vice versa).
+
+**The guardian needs a writable cgroup tree, and nothing more.** It only ever
+does `mkdir`, writes `cgroup.procs` and `cgroup.kill`, and `rmdir`s — ordinary
+file I/O as uid 0 in the container. So it gets `--cgroupns=host` plus a bind
+mount of `/sys/fs/cgroup`, and the script then mirrors
+`.github/workflows/ci.yml`: create a cgroup, move the shell in, export
+`ADJ_PROVENANCE_CGROUP_ROOT`, remove it on exit.
+
+**Deliberately not `--privileged`.** An earlier version used it, and that was a
+real hole rather than a theoretical one: `--privileged` grants CAP_SYS_ADMIN and
+unmasks `/proc` and `/sys`, which is enough for the container to mount the host
+share itself — under colima it reaches the developer's entire home directory,
+SSH keys included, regardless of what is bind-mounted. That matters here
+specifically because `cargo build` executes build scripts and proc macros from
+the crates.io dependency tree as root. The narrower flags run the identical
+workload to the identical result.
+
+## What this does and does not change
+
+It changes nothing about what the verifier accepts. The invocation matches CI's
+apart from the binary paths, every strict default is left alone, and the only
+environment variable the verifier reads is `ADJ_PROVENANCE_CGROUP_ROOT`, set to
+a genuine delegated root that the guardian re-validates by `statfs`.
+
+For that claim to hold, two things are pinned rather than left to drift:
+
+- **The base image, by digest.** These binaries are trusted — the verifier
+  believes their output — so the toolchain compiling them is inside the trust
+  boundary.
+- **`jsonschema==4.26.0`, matching CI.** Debian's `python3-jsonschema` is
+  4.19.2, and validator behaviour changed between the two. Left alone, a
+  manifest could validate here and fail in CI, which would make this harness
+  actively misleading rather than merely different.
+
+`Cargo.lock` is gitignored in this repo, so `--locked` is used when a lockfile is
+present and the run says so when one is not.

--- a/.claude/adj-provenance-container/verify.sh
+++ b/.claude/adj-provenance-container/verify.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Run the ADJ provenance verifier on a Linux host with a delegated cgroup v2 root.
+#
+# Mirrors .github/workflows/ci.yml: create a cgroup, hand it to the current
+# process, export ADJ_PROVENANCE_CGROUP_ROOT, verify, clean up.
+#
+# NOT `--privileged`. That grants CAP_SYS_ADMIN and unmasks /proc and /sys, which
+# is enough for the container to mount the host's virtiofs share itself and read
+# the developer's entire home directory — SSH keys included. It matters here
+# because `cargo build` below executes build scripts and proc macros from the
+# crates.io dependency tree as root. All the guardian actually needs is ordinary
+# file I/O on a writable cgroup tree, so it gets exactly that: a bind mount of
+# /sys/fs/cgroup plus the host cgroup namespace.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IMAGE="adj-provenance-verify:local"
+
+docker build --pull -q -t "$IMAGE" "$REPO_ROOT/.claude/adj-provenance-container" >/dev/null
+
+docker run --rm --cgroupns=host \
+  -v /sys/fs/cgroup:/sys/fs/cgroup \
+  -v "$REPO_ROOT":/repo -w /repo \
+  "$IMAGE" bash -c '
+set -euo pipefail
+
+# The verifier execs these, so they must be Linux binaries. Built into a
+# container-local target dir so a host build is never clobbered by a Linux one.
+# These are TRUSTED binaries — the verifier believes their output — so their
+# dependency set should not be re-resolved from the network on every run. But
+# this repo gitignores Cargo.lock deliberately, so --locked cannot be
+# unconditional: it would fail outright on a fresh clone. Use it when a lockfile
+# is actually there, and say so when it is not, rather than silently resolving.
+export CARGO_TARGET_DIR=/tmp/adj-target
+LOCKED=""
+if [ -f code/packages/rust/Cargo.lock ]; then
+  LOCKED="--locked"
+else
+  echo "note: no Cargo.lock present; dependencies will be resolved fresh" >&2
+fi
+cargo build --quiet $LOCKED --manifest-path code/packages/rust/Cargo.toml \
+  -p adj-lang-cli --bin adj-formula-inventory --bin adj-formula-audit
+
+# A UUID, not $$: inside `docker run ... bash -c` the PID is always 1, so $$
+# would name one fixed path and two concurrent runs (routine here — this repo is
+# worked in several worktrees at once) would share a delegated root, with the
+# first to finish rmdir-ing it out from under the second. Plain mkdir, no -p, so
+# a collision or a stale root from a crashed run is an error rather than a silent
+# adoption. CI takes the same care via GITHUB_RUN_ID/RUN_ATTEMPT.
+ROOT="/sys/fs/cgroup/adj-provenance-$(cat /proc/sys/kernel/random/uuid)"
+mkdir "$ROOT"
+
+# Captured BEFORE moving: cleanup must return the shell to the cgroup it came
+# from, not to the VM root. Restoring to the root would leave cargo, python and
+# the guardian outside the container cgroup, so Docker limits and accounting
+# would stop applying to them.
+ORIGINAL="$(awk -F: '"'"'$1 == "0" { print $3 }'"'"' /proc/self/cgroup)"
+cleanup() {
+  echo $$ > "/sys/fs/cgroup${ORIGINAL}/cgroup.procs" 2>/dev/null || true
+  rmdir "$ROOT" 2>/dev/null || true
+}
+# Registered immediately after mkdir, so a failure in the move below still
+# removes the cgroup instead of leaking it into the VM.
+trap cleanup EXIT
+
+echo $$ > "$ROOT/cgroup.procs"
+export ADJ_PROVENANCE_CGROUP_ROOT="$ROOT"
+
+python3 code/scripts/adj_stdlib_provenance.py verify \
+  --formula-inventory-binary /tmp/adj-target/debug/adj-formula-inventory \
+  --formula-audit-binary /tmp/adj-target/debug/adj-formula-audit
+'


### PR DESCRIPTION
## Summary

`adj_stdlib_provenance.py verify` refuses to run off Linux — `_PosixGuardian` fails unless the platform is Linux, with no flag and no env override. `ADJ-STDLIB-COVERAGE` §13i made that choice deliberately: macOS and generic POSIX have no equivalent unprivileged hard container, so the verifier rejects rather than "silently weakening the claim."

The cost lands on anyone developing on a Mac. Wave-1 provenance and all ~355 remaining library migrations become CI-only-verifiable, so every iteration is a full CI round trip — the shape of feedback loop that makes a 355-item backlog not happen.

This reproduces the Linux the verifier already expects **instead of relaxing what the verifier accepts**. The containment code is untouched.

```
./.claude/adj-provenance-container/verify.sh
→ {"bundles": 11, "objects": 125, "snapshots": 11, "valid": true}
```

## Two non-obvious requirements

- The verifier **execs** `adj-formula-inventory` and `adj-formula-audit` as trusted subprocesses, so a macOS build is unusable inside the container. The script builds them there, into a separate `CARGO_TARGET_DIR` so host and Linux builds never clobber each other.
- The guardian needs a writable cgroup tree and nothing more — only `mkdir`, writes to `cgroup.procs`/`cgroup.kill`, and `rmdir`. So it gets `--cgroupns=host` plus a bind mount of `/sys/fs/cgroup`.

## Deliberately not `--privileged`

The first version of this used it. Security review showed that was a real hole rather than a theoretical one: `--privileged` grants CAP_SYS_ADMIN and unmasks `/proc` and `/sys`, which is enough for the container to **mount the host share itself** and read the developer's entire home directory — SSH keys included — regardless of what is bind-mounted. That matters here specifically because `cargo build` executes build scripts and proc macros from the crates.io dependency tree as root.

Verified after the change: the mount syscall is denied, and the narrower flags run the identical workload to the identical result.

## Pinned so "identical to CI" is true rather than aspirational

- **Base image by digest.** These binaries are trusted — the verifier believes their output — so the toolchain compiling them is inside the trust boundary.
- **`jsonschema==4.26.0`, matching CI exactly.** Debian's `python3-jsonschema` is 4.19.2 and validator behaviour changed between them, so a manifest could have validated here and failed in CI, making the harness actively misleading rather than merely different.

## Smaller fixes from the same review

The cgroup root is a UUID rather than `$$` — inside `docker run bash -c` the PID is always 1, so concurrent runs from different worktrees (routine in this repo) would have shared one delegated root and `rmdir`'d it out from under each other. `mkdir` without `-p`, so a stale root from a crashed run is an error rather than a silent adoption. Cleanup restores the shell to its *original* cgroup rather than the VM root, so Docker's limits keep applying to cargo and the guardian. The trap is registered immediately after `mkdir` so a later failure cannot leak a cgroup. `--locked` is conditional, because this repo gitignores `Cargo.lock` and unconditional would break a fresh clone.

## Test plan

- [x] Full run end to end, before and after hardening: `valid: true`, identical 11 snapshot hashes both times
- [x] Escape closed: `mount -t virtiofs` inside the container now returns `permission denied`
- [x] Invocation compared line by line against `.github/workflows/ci.yml` — same strict defaults, no permissive flag, no override
- [x] Security review: 5 findings (1 HIGH, 1 MEDIUM, 3 LOW), all addressed

Tooling only — no library, spec, or CAS content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)