### PR TITLE
refactor(adj): share the identical provenance-builder helpers

### DIFF
--- a/code/scripts/adj_provenance_builder.py
+++ b/code/scripts/adj_provenance_builder.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Shared helpers for the per-library provenance builders.
+
+Every `build_adj_*_provenance.py` script materializes one library's CAS bundle.
+They differ in WHICH bytes they cite and how those bytes decompose, but three
+helpers were copied verbatim between them, and a copied helper in a provenance
+builder is worse than ordinary duplication: these functions decide the exact
+`start`/`end`/`quote_sha256` a claim is pinned to, so two copies drifting apart
+would mean two libraries disagreeing about what "cited" means while both
+reporting success.
+
+Scope note: this deliberately does NOT try to generalize `build()`. The four
+builders split into two shapes — a ROOT builder decomposing an external source
+(inherently document-specific) and DEPENDENT builders composing an
+already-verified root. Only the pieces that are provably identical move here.
+
+Every extraction in this module is verified byte-exactly: re-running each
+builder must leave the checked-in CAS unchanged.
+"""
+
+from __future__ import annotations
+
+import adj_stdlib_provenance as provenance
+
+
+def claim(claim_id: str, data: bytes, start: int, end: int) -> dict:
+    cited = data[start:end]
+    return {
+        "claim_id": claim_id,
+        "end": end,
+        "quote": cited.decode("utf-8"),
+        "quote_sha256": provenance.sha256_bytes(cited),
+        "start": start,
+    }
+
+
+# The `reasoned_discards` parameter is what made this the superset version.
+# `ratio` carried a variant without it; called with the default, the loop below
+# never runs and the two are equivalent — verified by rebuild, not by reading.
+def source_segments(
+    data: bytes,
+    represented: list[tuple[int, int, list[dict]]],
+    *,
+    discarded_reason: str,
+    reasoned_discards: list[tuple[int, int, str]] | None = None,
+) -> list[dict]:
+    segments = []
+    cursor = 0
+
+    def discard(start: int, end: int) -> None:
+        discard_cursor = start
+        for special_start, special_end, reason in reasoned_discards or []:
+            if special_end <= start or special_start >= end:
+                continue
+            if special_start < start or special_end > end:
+                raise provenance.ProvenanceError(
+                    "reasoned discard crosses a represented byte range"
+                )
+            if discard_cursor < special_start:
+                segments.append(
+                    {
+                        "disposition": "discarded",
+                        "end": special_start,
+                        "reason": discarded_reason,
+                        "start": discard_cursor,
+                    }
+                )
+            segments.append(
+                {
+                    "disposition": "discarded",
+                    "end": special_end,
+                    "reason": reason,
+                    "start": special_start,
+                }
+            )
+            discard_cursor = special_end
+        if discard_cursor < end:
+            segments.append(
+                {
+                    "disposition": "discarded",
+                    "end": end,
+                    "reason": discarded_reason,
+                    "start": discard_cursor,
+                }
+            )
+
+    for start, end, claims in sorted(represented, key=lambda item: (item[0], item[1])):
+        if start < cursor:
+            raise provenance.ProvenanceError("source claim ranges overlap")
+        if cursor < start:
+            discard(cursor, start)
+        segments.append(
+            {
+                "claims": claims,
+                "disposition": "represented",
+                "end": end,
+                "start": start,
+            }
+        )
+        cursor = end
+    if cursor < len(data):
+        discard(cursor, len(data))
+    return segments
+
+
+def input_claim_payload(item: dict) -> dict:
+    return {key: item[key] for key in ("end", "quote", "quote_sha256", "start")}

--- a/code/scripts/build_adj_arithmetic_provenance.py
+++ b/code/scripts/build_adj_arithmetic_provenance.py
@@ -7,6 +7,7 @@ import argparse
 from collections.abc import Sequence
 from pathlib import Path
 
+import adj_provenance_builder as builder
 import adj_stdlib_provenance as provenance
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -60,17 +61,6 @@ SOURCES = (
 )
 
 
-def claim(claim_id: str, data: bytes, start: int, end: int) -> dict:
-    cited = data[start:end]
-    return {
-        "claim_id": claim_id,
-        "end": end,
-        "quote": cited.decode("utf-8"),
-        "quote_sha256": provenance.sha256_bytes(cited),
-        "start": start,
-    }
-
-
 def partition(data: bytes, start: int, end: int, item_claim: dict) -> list[dict]:
     return [
         {
@@ -122,7 +112,7 @@ def local_source(
                     "start": cursor,
                 }
             )
-        item_claim = claim(claim_id, data, start, end)
+        item_claim = builder.claim(claim_id, data, start, end)
         claims[claim_id] = item_claim
         segments.append(
             {
@@ -176,7 +166,7 @@ def build(
             raise provenance.ProvenanceError(
                 f"MathWorld {item['name']} cited span is not the DC.Description value"
             )
-        raw_claim = claim(item["id"], raw, item["start"], item["end"])
+        raw_claim = builder.claim(item["id"], raw, item["start"], item["end"])
         raw_ir = provenance.build_source_ir(
             source_sha256=item["raw"],
             source=raw,
@@ -195,7 +185,7 @@ def build(
             label=f"MathWorld {item['name']} definition",
             links=[item["raw"]],
         )
-        rendered_claim = claim(item["id"], rendered, 0, len(rendered))
+        rendered_claim = builder.claim(item["id"], rendered, 0, len(rendered))
         rendered_ir = provenance.build_source_ir(
             source_sha256=rendered_hash,
             source=rendered,
@@ -288,7 +278,7 @@ def build(
                     "start": cursor,
                 }
             )
-        item_claim = claim(item["id"], input_bytes, start, end)
+        item_claim = builder.claim(item["id"], input_bytes, start, end)
         input_claims[item["id"]] = item_claim
         input_segments.append(
             {

--- a/code/scripts/build_adj_percent_of_provenance.py
+++ b/code/scripts/build_adj_percent_of_provenance.py
@@ -7,6 +7,7 @@ import argparse
 from collections.abc import Sequence
 from pathlib import Path
 
+import adj_provenance_builder as builder
 import adj_stdlib_provenance as provenance
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -35,83 +36,6 @@ TRANSFORM_OPERATIONS = (
     ("mathml_to_infix", 396_075, 396_368, 17, 26),
     ("copy", 396_375, 396_376, 26, 27),
 )
-
-
-def claim(claim_id: str, data: bytes, start: int, end: int) -> dict:
-    cited = data[start:end]
-    return {
-        "claim_id": claim_id,
-        "end": end,
-        "quote": cited.decode("utf-8"),
-        "quote_sha256": provenance.sha256_bytes(cited),
-        "start": start,
-    }
-
-
-def source_segments(
-    data: bytes,
-    represented: list[tuple[int, int, list[dict]]],
-    *,
-    discarded_reason: str,
-    reasoned_discards: list[tuple[int, int, str]] | None = None,
-) -> list[dict]:
-    segments = []
-    cursor = 0
-
-    def discard(start: int, end: int) -> None:
-        discard_cursor = start
-        for special_start, special_end, reason in reasoned_discards or []:
-            if special_end <= start or special_start >= end:
-                continue
-            if special_start < start or special_end > end:
-                raise provenance.ProvenanceError(
-                    "reasoned discard crosses a represented byte range"
-                )
-            if discard_cursor < special_start:
-                segments.append(
-                    {
-                        "disposition": "discarded",
-                        "end": special_start,
-                        "reason": discarded_reason,
-                        "start": discard_cursor,
-                    }
-                )
-            segments.append(
-                {
-                    "disposition": "discarded",
-                    "end": special_end,
-                    "reason": reason,
-                    "start": special_start,
-                }
-            )
-            discard_cursor = special_end
-        if discard_cursor < end:
-            segments.append(
-                {
-                    "disposition": "discarded",
-                    "end": end,
-                    "reason": discarded_reason,
-                    "start": discard_cursor,
-                }
-            )
-
-    for start, end, claims in sorted(represented, key=lambda item: (item[0], item[1])):
-        if start < cursor:
-            raise provenance.ProvenanceError("source claim ranges overlap")
-        if cursor < start:
-            discard(cursor, start)
-        segments.append(
-            {
-                "claims": claims,
-                "disposition": "represented",
-                "end": end,
-                "start": start,
-            }
-        )
-        cursor = end
-    if cursor < len(data):
-        discard(cursor, len(data))
-    return segments
 
 
 def local_source(
@@ -143,14 +67,14 @@ def local_source(
     for (start, end), claim_ids in sorted(grouped.items()):
         range_claims = []
         for claim_id in sorted(claim_ids):
-            item = claim(claim_id, data, start, end)
+            item = builder.claim(claim_id, data, start, end)
             claims[claim_id] = item
             range_claims.append(item)
         represented.append((start, end, range_claims))
     ir = provenance.build_source_ir(
         source_sha256=raw_hash,
         source=data,
-        segments=source_segments(
+        segments=builder.source_segments(
             data,
             represented,
             discarded_reason=discarded_reason,
@@ -215,11 +139,11 @@ def retained_external_source(
     raw_claim_bytes = captured[CLAIM_START:CLAIM_END]
     if provenance.sha256_bytes(raw_claim_bytes) != CLAIM_RAW_HASH:
         raise provenance.ProvenanceError("reviewed OpenStax formula bytes drifted")
-    raw_claim = claim(PERCENT_OF_CLAIM, captured, CLAIM_START, CLAIM_END)
+    raw_claim = builder.claim(PERCENT_OF_CLAIM, captured, CLAIM_START, CLAIM_END)
     raw_ir = provenance.build_source_ir(
         source_sha256=raw_hash,
         source=captured,
-        segments=source_segments(
+        segments=builder.source_segments(
             captured,
             [(CLAIM_START, CLAIM_END, [raw_claim])],
             discarded_reason=(
@@ -243,7 +167,9 @@ def retained_external_source(
     )
     if rendered_hash != RENDERED_HASH:
         raise provenance.ProvenanceError("rendered percent_of definition hash drifted")
-    rendered_claim = claim(PERCENT_OF_CLAIM, SELECTED_TEXT, 0, len(SELECTED_TEXT))
+    rendered_claim = builder.claim(
+        PERCENT_OF_CLAIM, SELECTED_TEXT, 0, len(SELECTED_TEXT)
+    )
     rendered_ir = provenance.build_source_ir(
         source_sha256=rendered_hash,
         source=SELECTED_TEXT,
@@ -299,10 +225,6 @@ def retained_external_source(
         },
         {PERCENT_OF_CLAIM: rendered_claim},
     )
-
-
-def input_claim_payload(item: dict) -> dict:
-    return {key: item[key] for key in ("end", "quote", "quote_sha256", "start")}
 
 
 def build(
@@ -369,7 +291,9 @@ def build(
         "clauses": [
             {
                 **percent_of_claim,
-                "input_claim": input_claim_payload(input_claims[PERCENT_OF_CLAIM]),
+                "input_claim": builder.input_claim_payload(
+                    input_claims[PERCENT_OF_CLAIM]
+                ),
                 "locator": LOCATOR,
                 "resolution": {
                     "authority_receipt_sha256": external_source["receipt_sha256"],
@@ -470,7 +394,7 @@ def build(
         query_clauses.append(
             {
                 **fact,
-                "input_claim": input_claim_payload(query_claims[claim_id]),
+                "input_claim": builder.input_claim_payload(query_claims[claim_id]),
                 "locator": fixture_locator,
                 "resolution": {
                     "authority_receipt_sha256": fixture_source["receipt_sha256"],

--- a/code/scripts/build_adj_proportion_provenance.py
+++ b/code/scripts/build_adj_proportion_provenance.py
@@ -7,6 +7,7 @@ import argparse
 from collections.abc import Sequence
 from pathlib import Path
 
+import adj_provenance_builder as builder
 import adj_stdlib_provenance as provenance
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -76,83 +77,6 @@ QUERY_SPECS = (
 )
 
 
-def claim(claim_id: str, data: bytes, start: int, end: int) -> dict:
-    cited = data[start:end]
-    return {
-        "claim_id": claim_id,
-        "end": end,
-        "quote": cited.decode("utf-8"),
-        "quote_sha256": provenance.sha256_bytes(cited),
-        "start": start,
-    }
-
-
-def source_segments(
-    data: bytes,
-    represented: list[tuple[int, int, list[dict]]],
-    *,
-    discarded_reason: str,
-    reasoned_discards: list[tuple[int, int, str]] | None = None,
-) -> list[dict]:
-    segments = []
-    cursor = 0
-
-    def discard(start: int, end: int) -> None:
-        discard_cursor = start
-        for special_start, special_end, reason in reasoned_discards or []:
-            if special_end <= start or special_start >= end:
-                continue
-            if special_start < start or special_end > end:
-                raise provenance.ProvenanceError(
-                    "reasoned discard crosses a represented byte range"
-                )
-            if discard_cursor < special_start:
-                segments.append(
-                    {
-                        "disposition": "discarded",
-                        "end": special_start,
-                        "reason": discarded_reason,
-                        "start": discard_cursor,
-                    }
-                )
-            segments.append(
-                {
-                    "disposition": "discarded",
-                    "end": special_end,
-                    "reason": reason,
-                    "start": special_start,
-                }
-            )
-            discard_cursor = special_end
-        if discard_cursor < end:
-            segments.append(
-                {
-                    "disposition": "discarded",
-                    "end": end,
-                    "reason": discarded_reason,
-                    "start": discard_cursor,
-                }
-            )
-
-    for start, end, claims in sorted(represented, key=lambda item: (item[0], item[1])):
-        if start < cursor:
-            raise provenance.ProvenanceError("source claim ranges overlap")
-        if cursor < start:
-            discard(cursor, start)
-        segments.append(
-            {
-                "claims": claims,
-                "disposition": "represented",
-                "end": end,
-                "start": start,
-            }
-        )
-        cursor = end
-    if cursor < len(data):
-        discard(cursor, len(data))
-    return segments
-
-
 def local_source(
     cas: provenance.Cas,
     repo_path: str,
@@ -184,14 +108,14 @@ def local_source(
     for (start, end), claim_ids in sorted(grouped.items()):
         range_claims = []
         for claim_id in sorted(claim_ids):
-            item = claim(claim_id, data, start, end)
+            item = builder.claim(claim_id, data, start, end)
             claims[claim_id] = item
             range_claims.append(item)
         represented.append((start, end, range_claims))
     ir = provenance.build_source_ir(
         source_sha256=raw_hash,
         source=data,
-        segments=source_segments(
+        segments=builder.source_segments(
             data,
             represented,
             discarded_reason=discarded_reason,
@@ -322,13 +246,13 @@ def retained_external_source(
             raise provenance.ProvenanceError(
                 f"reviewed OpenStax {claim_id} byte span drifted"
             )
-        item = claim(claim_id, captured, start, end)
+        item = builder.claim(claim_id, captured, start, end)
         raw_claims[claim_id] = item
         represented.append((start, end, [item]))
     raw_ir = provenance.build_source_ir(
         source_sha256=raw_hash,
         source=captured,
-        segments=source_segments(
+        segments=builder.source_segments(
             captured,
             represented,
             discarded_reason=(
@@ -361,7 +285,7 @@ def retained_external_source(
             raise provenance.ProvenanceError(
                 f"rendered OpenStax proportion {label} hash drifted"
             )
-        rendered_claim = claim(claim_id, rendered, 0, len(rendered))
+        rendered_claim = builder.claim(claim_id, rendered, 0, len(rendered))
         rendered_claims[claim_id] = rendered_claim
         rendered_ir = provenance.build_source_ir(
             source_sha256=rendered_hash,
@@ -410,10 +334,6 @@ def retained_external_source(
         },
         rendered_claims,
     )
-
-
-def input_claim_payload(item: dict) -> dict:
-    return {key: item[key] for key in ("end", "quote", "quote_sha256", "start")}
 
 
 def _fixture_ranges(fixture_bytes: bytes) -> list[tuple[str, int, int]]:
@@ -487,7 +407,7 @@ def _query_bundle(
         clauses.append(
             {
                 **fixture_claims[claim_id],
-                "input_claim": input_claim_payload(query_claims[claim_id]),
+                "input_claim": builder.input_claim_payload(query_claims[claim_id]),
                 "locator": fixture_locator,
                 "resolution": {
                     "authority_receipt_sha256": fixture_source["receipt_sha256"],
@@ -599,7 +519,9 @@ def build(
         "clauses": [
             {
                 **external_claims[PROPORTION_CLAIM],
-                "input_claim": input_claim_payload(input_claims[PROPORTION_CLAIM]),
+                "input_claim": builder.input_claim_payload(
+                    input_claims[PROPORTION_CLAIM]
+                ),
                 "locator": LOCATOR,
                 "resolution": {
                     "authority_receipt_sha256": external_source["receipt_sha256"],

--- a/code/scripts/build_adj_ratio_provenance.py
+++ b/code/scripts/build_adj_ratio_provenance.py
@@ -7,6 +7,7 @@ import argparse
 from collections.abc import Sequence
 from pathlib import Path
 
+import adj_provenance_builder as builder
 import adj_stdlib_provenance as provenance
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -26,58 +27,6 @@ SELECTED_TEXT = (
     b"and s is the denominator. The ratio of r to s is equivalent to the quotient "
     b"r/s."
 )
-
-
-def claim(claim_id: str, data: bytes, start: int, end: int) -> dict:
-    cited = data[start:end]
-    return {
-        "claim_id": claim_id,
-        "end": end,
-        "quote": cited.decode("utf-8"),
-        "quote_sha256": provenance.sha256_bytes(cited),
-        "start": start,
-    }
-
-
-def source_segments(
-    data: bytes,
-    represented: list[tuple[int, int, list[dict]]],
-    *,
-    discarded_reason: str,
-) -> list[dict]:
-    segments = []
-    cursor = 0
-    for start, end, claims in sorted(represented, key=lambda item: (item[0], item[1])):
-        if start < cursor:
-            raise provenance.ProvenanceError("source claim ranges overlap")
-        if cursor < start:
-            segments.append(
-                {
-                    "disposition": "discarded",
-                    "end": start,
-                    "reason": discarded_reason,
-                    "start": cursor,
-                }
-            )
-        segments.append(
-            {
-                "claims": claims,
-                "disposition": "represented",
-                "end": end,
-                "start": start,
-            }
-        )
-        cursor = end
-    if cursor < len(data):
-        segments.append(
-            {
-                "disposition": "discarded",
-                "end": len(data),
-                "reason": discarded_reason,
-                "start": cursor,
-            }
-        )
-    return segments
 
 
 def local_source(
@@ -108,14 +57,14 @@ def local_source(
     for (start, end), claim_ids in sorted(grouped.items()):
         range_claims = []
         for claim_id in sorted(claim_ids):
-            item = claim(claim_id, data, start, end)
+            item = builder.claim(claim_id, data, start, end)
             claims[claim_id] = item
             range_claims.append(item)
         represented.append((start, end, range_claims))
     ir = provenance.build_source_ir(
         source_sha256=raw_hash,
         source=data,
-        segments=source_segments(
+        segments=builder.source_segments(
             data,
             represented,
             discarded_reason=discarded_reason,
@@ -183,11 +132,11 @@ def retained_external_source(
     if captured[selected_start:selected_end] != SELECTED_TEXT:
         raise provenance.ProvenanceError("reviewed Ratio.html definition drifted")
 
-    raw_claim = claim(RATIO_CLAIM, captured, selected_start, selected_end)
+    raw_claim = builder.claim(RATIO_CLAIM, captured, selected_start, selected_end)
     raw_ir = provenance.build_source_ir(
         source_sha256=raw_hash,
         source=captured,
-        segments=source_segments(
+        segments=builder.source_segments(
             captured,
             [
                 (
@@ -216,7 +165,7 @@ def retained_external_source(
     )
     if rendered_hash != RENDERED_HASH:
         raise provenance.ProvenanceError("rendered ratio definition hash drifted")
-    rendered_claim = claim(RATIO_CLAIM, SELECTED_TEXT, 0, len(SELECTED_TEXT))
+    rendered_claim = builder.claim(RATIO_CLAIM, SELECTED_TEXT, 0, len(SELECTED_TEXT))
     rendered_ir = provenance.build_source_ir(
         source_sha256=rendered_hash,
         source=SELECTED_TEXT,
@@ -271,10 +220,6 @@ def retained_external_source(
         },
         {RATIO_CLAIM: rendered_claim},
     )
-
-
-def input_claim_payload(item: dict) -> dict:
-    return {key: item[key] for key in ("end", "quote", "quote_sha256", "start")}
 
 
 def build(
@@ -337,7 +282,7 @@ def build(
         "clauses": [
             {
                 **ratio_claim,
-                "input_claim": input_claim_payload(input_claims[RATIO_CLAIM]),
+                "input_claim": builder.input_claim_payload(input_claims[RATIO_CLAIM]),
                 "locator": LOCATOR,
                 "resolution": {
                     "bundle_sha256": arithmetic_bundle_sha256,
@@ -419,7 +364,7 @@ def build(
         query_clauses.append(
             {
                 **fact,
-                "input_claim": input_claim_payload(query_claims[claim_id]),
+                "input_claim": builder.input_claim_payload(query_claims[claim_id]),
                 "locator": fixture_locator,
                 "resolution": {
                     "authority_receipt_sha256": fixture_source["receipt_sha256"],

--- a/code/scripts/tests/test_adj_stdlib_provenance.py
+++ b/code/scripts/tests/test_adj_stdlib_provenance.py
@@ -26,6 +26,7 @@ SCRIPTS_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 provenance = importlib.import_module("adj_stdlib_provenance")
+provenance_builder = importlib.import_module("adj_provenance_builder")
 guardian = importlib.import_module("adj_process_guardian")
 arithmetic_builder = importlib.import_module("build_adj_arithmetic_provenance")
 ratio_builder = importlib.import_module("build_adj_ratio_provenance")
@@ -5609,7 +5610,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             ) -> dict[str, object]:
                 return {
                     **external_claim,
-                    "input_claim": ratio_builder.input_claim_payload(input_claim),
+                    "input_claim": provenance_builder.input_claim_payload(input_claim),
                     "locator": f"repo://{repo_path}",
                     "resolution": {
                         "authority_receipt_sha256": external["receipt_sha256"],


### PR DESCRIPTION
## Summary

Each `build_adj_*_provenance.py` materializes one library's CAS bundle. They legitimately differ in which bytes they cite and how those bytes decompose — but three helpers had been copied verbatim between them.

**A copied helper in a provenance builder is worse than ordinary duplication.** These functions decide the exact `start`/`end`/`quote_sha256` a claim is pinned to, so two copies drifting apart would mean two libraries disagreeing about what "cited" means *while both reporting success*. That is the failure this subsystem exists to make impossible.

Extracted to `adj_provenance_builder.py`, chosen by AST comparison rather than by eye:

| helper | status before |
| --- | --- |
| `claim` | byte-identical across **all four** builders |
| `input_claim_payload` | byte-identical across the three dependent builders |
| `source_segments` | byte-identical in `percent-of` and `proportion`; `ratio` carried a variant without the optional `reasoned_discards` parameter |

The larger `source_segments` is a strict superset — called with the default, the loop never runs — so `ratio` adopts it.

## Deliberately not generalized

`build()`, `local_source()` and `retained_external_source()` genuinely differ per library, and the four builders split into two shapes that should not be forced together:

- **Root** (`arithmetic`) decomposes an external document into IR — inherently document-specific. §8's outstanding PDF decomposition for `percent.adj` is the proof that each root is its own problem.
- **Dependent** compose an already-verified root.

Only provably identical code moved.

## Verified byte-exactly

This is the point of the change, and it is what makes a refactor here defensible at all. All four builders were re-run against the real repository inside the Linux container:

```
arithmetic, ratio, percent-of, proportion  → rebuilt
git status -- adj-stdlib-provenance        → 0 files changed
verify.sh                                  → "valid": true
```

That oracle is stronger than a passing suite — not "nothing broke" but "the content-addressed bytes are identical." It only became available with #9924; CI never re-runs these scripts, which is both why the duplication went unnoticed and why this refactor previously looked unverifiable.

## A caller the rewrite missed

`test_adj_stdlib_provenance.py` reaches into `build_adj_ratio_provenance` **by attribute** for `input_claim_payload`. My call-site rewrite covered the builder scripts and missed that caller, leaving `test_transitive_imported_fact_witness_passes_strict_replay` — the guard that a transitive imported-fact witness survives strict replay — dying on `AttributeError` before its first assertion. Caught in review and repointed to the shared module.

The lesson worth keeping: a symbol's consumers are not the files you happen to be editing.

## Test plan

All run on Linux in the container, since the verifier requires cgroup containment:

- [x] `test_adj_stdlib_provenance.py` — **205 passed**, 11 skipped
- [x] `test_build_adj_proportion_provenance.py` — 6 passed
- [x] All four builders rebuilt → **0 CAS files changed**
- [x] `verify.sh` → `"valid": true`
- [x] `ruff check` and `ruff format --check` clean on every touched file
- [x] Security review: confirmed the `source_segments` unification is behaviour-preserving for `ratio` by differential harness (37,519 exhaustive + 20,000 randomized cases, zero mismatches), and that `claim`/`input_claim_payload` moved verbatim

Net **-150 lines**. Groundwork for the declarative migration driver: with the shared floor in place, what remains per-library is genuinely per-library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)