### PR TITLE
refactor(adj): share the worked-query bundle builder

### DIFF
--- a/code/scripts/adj_provenance_builder.py
+++ b/code/scripts/adj_provenance_builder.py
@@ -20,6 +20,8 @@ builder must leave the checked-in CAS unchanged.
 
 from __future__ import annotations
 
+import dataclasses
+
 import adj_stdlib_provenance as provenance
 
 
@@ -105,3 +107,168 @@ def source_segments(
 
 def input_claim_payload(item: dict) -> dict:
     return {key: item[key] for key in ("end", "quote", "quote_sha256", "start")}
+
+
+@dataclasses.dataclass(frozen=True)
+class QueryLibrarySpec:
+    """The per-library data a worked-query bundle needs.
+
+    Everything here is a value that genuinely differs between libraries. The
+    logic that consumes it — scanning the query for its observations, import and
+    question, assembling the accepted-fact clauses, and registering the execution
+    evidence — is identical, and lives in `build_query_bundle`.
+
+    `claim_prefix` + `qualify_by_value` deserve a note, because they look like two
+    knobs and are really one. A library either identifies an input by NAME
+    (`…ratio.numerator`, matching `observe numerator(`) or by NAME AND VALUE
+    (`…proportion.first_term.2`, matching `observe first_term(2)`). The claim id
+    and the byte pattern must agree — a library that qualified one and not the
+    other would look up a claim it never recorded — so one flag drives both.
+    """
+
+    bundle_id: str
+    query_path: str
+    fixture_path: str
+    claim_prefix: str
+    import_literal: bytes
+    import_claim_id: str
+    question_prefix: bytes
+    question_claim_id: str
+    accepted_fact_reason: str
+    discarded_reason: str
+    input_description: str
+    witness_label: str
+    qualify_by_value: bool = False
+    scan_bindings: bool = False
+
+    def input_claim_id(self, name: str, value: str) -> str:
+        return (
+            f"{self.claim_prefix}.{name}.{value}"
+            if self.qualify_by_value
+            else f"{self.claim_prefix}.{name}"
+        )
+
+    def observe_pattern(self, name: str, value: str) -> bytes:
+        body = f"{name}({value})" if self.qualify_by_value else f"{name}("
+        return f"observe {body}".encode()
+
+
+def build_query_bundle(
+    cas: provenance.Cas,
+    *,
+    spec: QueryLibrarySpec,
+    repo_root,
+    facts: tuple[tuple[str, str], ...],
+    library_hash: str,
+    fixture_source: dict,
+    fixture_claims: dict[str, dict],
+    formula_audit_command,
+    local_source,
+    query_bytes: bytes | None = None,
+) -> tuple[str, str]:
+    """Register one worked query's provenance bundle.
+
+    `local_source` is injected rather than shared: each builder decomposes its
+    own files differently, and forcing one implementation would change which
+    bytes are represented versus discarded — the one thing a provenance refactor
+    must never do silently.
+    """
+    # Read ONCE, and hand those exact bytes to `local_source` below. The offsets
+    # in `query_ranges` are computed from this read; if `local_source` re-read the
+    # file, a same-length replacement in between would pin a claim to a byte range
+    # that no longer contains what the claim says — and the result would still
+    # verify, because the stored IR would be self-consistent with the second read.
+    if query_bytes is None:
+        query_bytes = provenance._read_regular_file(repo_root / spec.query_path)
+
+    query_ranges = []
+    for name, value in facts:
+        start = query_bytes.index(spec.observe_pattern(name, value))
+        trust = query_bytes.index(b"    trust authoritative", start)
+        end = query_bytes.index(b"\n", trust) + 1
+        query_ranges.append((spec.input_claim_id(name, value), start, end))
+
+    import_start = query_bytes.index(spec.import_literal)
+    import_end = query_bytes.index(b"\n", import_start) + 1
+    query_ranges.append((spec.import_claim_id, import_start, import_end))
+
+    question_start = query_bytes.index(spec.question_prefix)
+    question_end = query_bytes.index(b"\n", question_start) + 1
+    query_ranges.append((spec.question_claim_id, question_start, question_end))
+
+    # Multi-step queries name each intermediate `let`, so the witness can bind a
+    # computation to the authored line that produced it. Single-expression
+    # queries have none, and scanning them would emit claims for nothing.
+    if spec.scan_bindings:
+        binding_cursor = 0
+        binding_index = 0
+        while True:
+            binding_start = query_bytes.find(b"let ", binding_cursor)
+            if binding_start < 0:
+                break
+            binding_end = query_bytes.index(b"\n", binding_start) + 1
+            query_ranges.append(
+                (
+                    f"{spec.bundle_id}.binding.{binding_index}",
+                    binding_start,
+                    binding_end,
+                )
+            )
+            binding_cursor = binding_end
+            binding_index += 1
+
+    query_source, query_claims = local_source(
+        cas,
+        spec.query_path,
+        query_ranges,
+        spec.input_description,
+        discarded_reason=spec.discarded_reason,
+        data=query_bytes,
+    )
+
+    fixture_locator = f"repo://{spec.fixture_path}"
+    clauses = []
+    for name, value in facts:
+        claim_id = spec.input_claim_id(name, value)
+        clauses.append(
+            {
+                **fixture_claims[claim_id],
+                "input_claim": input_claim_payload(query_claims[claim_id]),
+                "locator": fixture_locator,
+                "resolution": {
+                    "authority_receipt_sha256": fixture_source["receipt_sha256"],
+                    "authority_source_sha256": fixture_source["raw_source_sha256"],
+                    "classification": "accepted_fact",
+                    "kind": "accepted_root",
+                    "reason": spec.accepted_fact_reason,
+                },
+                "snapshot_sha256": fixture_source["raw_source_sha256"],
+                "source_ir_sha256": fixture_source["source_ir_sha256"],
+            }
+        )
+
+    query_name = spec.query_path.rsplit("/", 1)[-1]
+    bundle = {
+        "bundle_id": spec.bundle_id,
+        "clauses": clauses,
+        "dependencies": [library_hash],
+        "input": {
+            key: query_source[key]
+            for key in ("raw_source_sha256", "receipt_sha256", "source_ir_sha256")
+        },
+        "kind": "provenance_bundle",
+        "library": spec.query_path,
+        "sources": [query_source, fixture_source],
+    }
+    derivations, witnesses = provenance.put_formula_execution_evidence(
+        cas, bundle, formula_audit_command, label=spec.witness_label
+    )
+    bundle["formula_derivation_sha256s"] = derivations
+    bundle["execution_witness_sha256s"] = witnesses
+    bundle_hash = cas.put_json(
+        bundle,
+        kind="provenance_bundle",
+        label=f"{query_name} provenance bundle",
+        links=provenance._bundle_declared_links(bundle),
+    )
+    return spec.bundle_id, bundle_hash

--- a/code/scripts/build_adj_proportion_provenance.py
+++ b/code/scripts/build_adj_proportion_provenance.py
@@ -360,96 +360,39 @@ def _query_bundle(
     formula_audit_command: Sequence[str],
     query_bytes: bytes | None = None,
 ) -> tuple[str, str]:
-    if query_bytes is None:
-        query_bytes = provenance._read_regular_file(REPO_ROOT / query_path)
-    query_ranges = []
-    for name, value in facts:
-        claim_id = f"adj.input.arithmetic.proportion.{name}.{value}"
-        start = query_bytes.index(f"observe {name}({value})".encode())
-        trust = query_bytes.index(b"    trust authoritative", start)
-        end = query_bytes.index(b"\n", trust) + 1
-        query_ranges.append((claim_id, start, end))
-    import_start = query_bytes.index(b'import "proportion.adj"')
-    import_end = query_bytes.index(b"\n", import_start) + 1
-    query_ranges.append(
-        ("adj.code.arithmetic.proportion.query.import", import_start, import_end)
-    )
-    question_start = query_bytes.index(b"? fourth_proportional(")
-    question_end = query_bytes.index(b"\n", question_start) + 1
-    query_ranges.append((QUESTION_CLAIM, question_start, question_end))
-    binding_cursor = 0
-    binding_index = 0
-    while True:
-        binding_start = query_bytes.find(b"let ", binding_cursor)
-        if binding_start < 0:
-            break
-        binding_end = query_bytes.index(b"\n", binding_start) + 1
-        query_ranges.append(
-            (f"{bundle_id}.binding.{binding_index}", binding_start, binding_end)
-        )
-        binding_cursor = binding_end
-        binding_index += 1
-    query_source, query_claims = local_source(
+    return builder.build_query_bundle(
         cas,
-        query_path,
-        query_ranges,
-        f"{Path(query_path).name} input",
-        discarded_reason=(
-            "comments, spacing, or human-readable explanation outside the selected "
-            "import, observations, and executable question"
+        spec=builder.QueryLibrarySpec(
+            bundle_id=bundle_id,
+            query_path=query_path,
+            fixture_path=FIXTURE,
+            claim_prefix="adj.input.arithmetic.proportion",
+            qualify_by_value=True,
+            import_literal=b'import "proportion.adj"',
+            import_claim_id="adj.code.arithmetic.proportion.query.import",
+            question_prefix=b"? fourth_proportional(",
+            question_claim_id=QUESTION_CLAIM,
+            accepted_fact_reason=(
+                "deterministic proportion query input retained as the "
+                "explicit accepted fact"
+            ),
+            discarded_reason=(
+                "comments, spacing, or human-readable explanation outside the selected "
+                "import, observations, and executable question"
+            ),
+            input_description=f"{Path(query_path).name} input",
+            witness_label=f"{Path(query_path).name} v2 execution witness",
+            scan_bindings=True,
         ),
-        data=query_bytes,
+        repo_root=REPO_ROOT,
+        facts=facts,
+        library_hash=library_hash,
+        fixture_source=fixture_source,
+        fixture_claims=fixture_claims,
+        formula_audit_command=formula_audit_command,
+        local_source=local_source,
+        query_bytes=query_bytes,
     )
-    fixture_locator = f"repo://{FIXTURE}"
-    clauses = []
-    for name, value in facts:
-        claim_id = f"adj.input.arithmetic.proportion.{name}.{value}"
-        clauses.append(
-            {
-                **fixture_claims[claim_id],
-                "input_claim": builder.input_claim_payload(query_claims[claim_id]),
-                "locator": fixture_locator,
-                "resolution": {
-                    "authority_receipt_sha256": fixture_source["receipt_sha256"],
-                    "authority_source_sha256": fixture_source["raw_source_sha256"],
-                    "classification": "accepted_fact",
-                    "kind": "accepted_root",
-                    "reason": (
-                        "deterministic proportion query input retained as the "
-                        "explicit accepted fact"
-                    ),
-                },
-                "snapshot_sha256": fixture_source["raw_source_sha256"],
-                "source_ir_sha256": fixture_source["source_ir_sha256"],
-            }
-        )
-    bundle = {
-        "bundle_id": bundle_id,
-        "clauses": clauses,
-        "dependencies": [library_hash],
-        "input": {
-            key: query_source[key]
-            for key in ("raw_source_sha256", "receipt_sha256", "source_ir_sha256")
-        },
-        "kind": "provenance_bundle",
-        "library": query_path,
-        "sources": [query_source, fixture_source],
-    }
-    derivations, witnesses = provenance.put_formula_execution_evidence(
-        cas,
-        bundle,
-        formula_audit_command,
-        label=f"{Path(query_path).name} v2 execution witness",
-    )
-    bundle["formula_derivation_sha256s"] = derivations
-    bundle["execution_witness_sha256s"] = witnesses
-    bundle_hash = cas.put_json(
-        bundle,
-        kind="provenance_bundle",
-        label=f"{Path(query_path).name} provenance bundle",
-        links=provenance._bundle_declared_links(bundle),
-    )
-    return bundle_id, bundle_hash
 
 
 def build(

--- a/code/scripts/build_adj_ratio_provenance.py
+++ b/code/scripts/build_adj_ratio_provenance.py
@@ -36,8 +36,12 @@ def local_source(
     label: str,
     *,
     discarded_reason: str,
+    data: bytes | None = None,
 ) -> tuple[dict, dict[str, dict]]:
-    data = provenance._read_regular_file(REPO_ROOT / repo_path)
+    # Accepting already-read bytes is what lets the caller pin offsets and quotes
+    # to ONE read of the file. Re-reading here would leave the two a swap apart.
+    if data is None:
+        data = provenance._read_regular_file(REPO_ROOT / repo_path)
     raw_hash = cas.put(data, kind="raw_source", label=label)
     receipt = provenance.build_input_receipt(
         repo_path=repo_path,
@@ -313,32 +317,13 @@ def build(
     )
 
     fixture_bytes = provenance._read_regular_file(REPO_ROOT / FIXTURE)
-    query_bytes = provenance._read_regular_file(REPO_ROOT / QUERY)
     facts = (("numerator", "3"), ("denominator", "4"))
     fixture_ranges = []
-    query_ranges = []
     for name, value in facts:
         claim_id = f"adj.input.arithmetic.ratio.{name}"
         sentence = f"{name} is {value}.".encode()
         fixture_start = fixture_bytes.index(sentence)
         fixture_ranges.append((claim_id, fixture_start, fixture_start + len(sentence)))
-        query_start = query_bytes.index(f"observe {name}(".encode())
-        query_trust = query_bytes.index(b"    trust authoritative", query_start)
-        query_end = query_bytes.index(b"\n", query_trust) + 1
-        query_ranges.append((claim_id, query_start, query_end))
-    query_import_start = query_bytes.index(b'import "ratio.adj"')
-    query_import_end = query_bytes.index(b"\n", query_import_start) + 1
-    query_ranges.append(
-        (
-            "adj.code.arithmetic.ratio.query.import",
-            query_import_start,
-            query_import_end,
-        )
-    )
-    question_start = query_bytes.index(b"? ratio(")
-    question_end = query_bytes.index(b"\n", question_start) + 1
-    query_ranges.append((QUESTION_CLAIM, question_start, question_end))
-
     fixture_source, fixture_claims = local_source(
         cas,
         FIXTURE,
@@ -346,69 +331,38 @@ def build(
         "ratio input fixture",
         discarded_reason="newline record separators outside the accepted fact bytes",
     )
-    query_source, query_claims = local_source(
+    query_bundle_id, query_bundle_hash = builder.build_query_bundle(
         cas,
-        QUERY,
-        query_ranges,
-        "ratio.query.adj input",
-        discarded_reason=(
-            "introductory comment, spacing, or human-readable test oracle outside "
-            "the selected import, facts, and executable question"
+        spec=builder.QueryLibrarySpec(
+            bundle_id="adj.math.arithmetic.ratio.query.v1",
+            query_path=QUERY,
+            fixture_path=FIXTURE,
+            claim_prefix="adj.input.arithmetic.ratio",
+            import_literal=b'import "ratio.adj"',
+            import_claim_id="adj.code.arithmetic.ratio.query.import",
+            question_prefix=b"? ratio(",
+            question_claim_id=QUESTION_CLAIM,
+            accepted_fact_reason=(
+                "deterministic ratio-query input retained as the explicit accepted fact"
+            ),
+            discarded_reason=(
+                "introductory comment, spacing, or human-readable test oracle outside "
+                "the selected import, facts, and executable question"
+            ),
+            input_description="ratio.query.adj input",
+            witness_label="ratio.query.adj execution witness",
         ),
-    )
-    fixture_locator = f"repo://{FIXTURE}"
-    query_clauses = []
-    for name, _value in facts:
-        claim_id = f"adj.input.arithmetic.ratio.{name}"
-        fact = fixture_claims[claim_id]
-        query_clauses.append(
-            {
-                **fact,
-                "input_claim": builder.input_claim_payload(query_claims[claim_id]),
-                "locator": fixture_locator,
-                "resolution": {
-                    "authority_receipt_sha256": fixture_source["receipt_sha256"],
-                    "authority_source_sha256": fixture_source["raw_source_sha256"],
-                    "classification": "accepted_fact",
-                    "kind": "accepted_root",
-                    "reason": (
-                        "deterministic ratio-query input retained as the explicit "
-                        "accepted fact"
-                    ),
-                },
-                "snapshot_sha256": fixture_source["raw_source_sha256"],
-                "source_ir_sha256": fixture_source["source_ir_sha256"],
-            }
-        )
-    query_bundle = {
-        "bundle_id": "adj.math.arithmetic.ratio.query.v1",
-        "clauses": query_clauses,
-        "dependencies": [bundle_hash],
-        "input": {
-            key: query_source[key]
-            for key in ("raw_source_sha256", "receipt_sha256", "source_ir_sha256")
-        },
-        "kind": "provenance_bundle",
-        "library": QUERY,
-        "sources": [query_source, fixture_source],
-    }
-    derivations, witnesses = provenance.put_formula_execution_evidence(
-        cas,
-        query_bundle,
-        formula_audit_command,
-        label="ratio.query.adj execution witness",
-    )
-    query_bundle["formula_derivation_sha256s"] = derivations
-    query_bundle["execution_witness_sha256s"] = witnesses
-    query_bundle_hash = cas.put_json(
-        query_bundle,
-        kind="provenance_bundle",
-        label="ratio.query.adj provenance bundle",
-        links=provenance._bundle_declared_links(query_bundle),
+        repo_root=REPO_ROOT,
+        facts=facts,
+        library_hash=bundle_hash,
+        fixture_source=fixture_source,
+        fixture_claims=fixture_claims,
+        formula_audit_command=formula_audit_command,
+        local_source=local_source,
     )
     return {
         bundle["bundle_id"]: bundle_hash,
-        query_bundle["bundle_id"]: query_bundle_hash,
+        query_bundle_id: query_bundle_hash,
     }
 
 


### PR DESCRIPTION
## Summary

`proportion` already had a parameterized `_query_bundle`; `ratio` carried the same logic inline in `build()`. Both scan the query for its observations, import line and question, decompose it with `local_source`, assemble accepted-fact clauses, and register execution evidence — the same ~100 lines, twice.

Extracted to `builder.build_query_bundle` with a `QueryLibrarySpec` holding what genuinely differs. `proportion` was the design **template** rather than a case to fold in: it was the more evolved of the two, and its existing seams are what made the shape visible.

## Two knobs collapsed into one

A library identifies a query input either by NAME (`…ratio.numerator`, matching `observe numerator(`) or by NAME AND VALUE (`…proportion.first_term.2`, matching `observe first_term(2)`). The claim id and the byte pattern **must** agree — qualifying one and not the other would look up a claim that was never recorded — so `qualify_by_value` drives both, rather than two callables that could disagree.

## Read once

The helper reads the query file a single time and hands those exact bytes to `local_source`.

An earlier draft forwarded them only when the caller supplied a snapshot, which meant `proportion`'s default path read the file **twice**: offsets from the first read, quote bytes and `quote_sha256` from the second. A same-length replacement in between would pin a claim to a range that no longer contains what the claim says — and it would **still verify**, because the stored IR would be self-consistent with the second read.

Caught in security review. That is the exact failure this subsystem exists to prevent, so it is now structurally impossible rather than merely unlikely: `ratio.local_source` gained the same `data=` parameter `proportion`'s already had, and the forward is unconditional.

## What stays per-library

- **`local_source` is injected, not shared.** Each builder decomposes its own files differently, and unifying it would change which bytes are represented versus discarded.
- **`witness_label` is a parameter** because the two differ in substance — `proportion` labels its witness "v2", `ratio` doesn't. Deriving it would have silently rewritten a CAS label.

## Verified byte-exactly

At every step — after routing `proportion`, after routing `ratio`, and again after the read-once fix. The checked-in CAS never moved.

```
ratio, proportion → rebuilt
git status -- adj-stdlib-provenance → 0 files changed
verify.sh → "valid": true
```

That oracle is the only real evidence here. Unlike #9925, which moved textually identical code, this changes what `ratio` **executes**, so each increment was rebuilt rather than reasoned about.

The reviewer independently confirmed faithfulness with a differential harness running both versions' real `build()` against identical CAS copies — comparing every `Cas.put` (kind, label, links, sha256, size, order), every bundle's canonical JSON, and the final index — across three scenarios including a workspace snapshot deliberately diverging from disk. Byte-identical in all three.

## Not in this change

`percent_of` is the third caller and belongs in its own increment against the same oracle. It will need the same `data=` parameter on its `local_source`.

## Test plan

In-container (Linux), since the verifier requires cgroup containment:

- [x] `test_adj_stdlib_provenance.py` — **205 passed**, 11 skipped
- [x] `test_build_adj_proportion_provenance.py` — 6 passed
- [x] `ratio` + `proportion` rebuilt → **0 CAS files changed**
- [x] `verify.sh` → `"valid": true`
- [x] `ruff check` and `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)