### PR TITLE
refactor(adj): route percent-of through the shared query builder

### DIFF
--- a/code/scripts/adj_provenance_builder.py
+++ b/code/scripts/adj_provenance_builder.py
@@ -140,6 +140,11 @@ class QueryLibrarySpec:
     witness_label: str
     qualify_by_value: bool = False
     scan_bindings: bool = False
+    # Optional: given the query bytes and the offset just past the question,
+    # return spans to discard WITH A STATED REASON rather than under the blanket
+    # `discarded_reason`. A query that ships a deliberately disabled example owes
+    # the reader why those bytes are unrepresented, not merely that they are.
+    reasoned_discards: object | None = None
 
     def input_claim_id(self, name: str, value: str) -> str:
         return (
@@ -224,6 +229,11 @@ def build_query_bundle(
         spec.input_description,
         discarded_reason=spec.discarded_reason,
         data=query_bytes,
+        reasoned_discards=(
+            spec.reasoned_discards(query_bytes, question_end)
+            if spec.reasoned_discards is not None
+            else None
+        ),
     )
 
     fixture_locator = f"repo://{spec.fixture_path}"

--- a/code/scripts/build_adj_percent_of_provenance.py
+++ b/code/scripts/build_adj_percent_of_provenance.py
@@ -45,9 +45,13 @@ def local_source(
     label: str,
     *,
     discarded_reason: str,
+    data: bytes | None = None,
     reasoned_discards: list[tuple[int, int, str]] | None = None,
 ) -> tuple[dict, dict[str, dict]]:
-    data = provenance._read_regular_file(REPO_ROOT / repo_path)
+    # Accepting already-read bytes is what lets the caller pin offsets and quotes
+    # to ONE read of the file. Re-reading here would leave the two a swap apart.
+    if data is None:
+        data = provenance._read_regular_file(REPO_ROOT / repo_path)
     raw_hash = cas.put(data, kind="raw_source", label=label)
     receipt = provenance.build_input_receipt(
         repo_path=repo_path,
@@ -329,35 +333,13 @@ def build(
     )
 
     fixture_bytes = provenance._read_regular_file(REPO_ROOT / FIXTURE)
-    query_bytes = provenance._read_regular_file(REPO_ROOT / QUERY)
     facts = (("whole", "50"), ("rate", "20"))
     fixture_ranges = []
-    query_ranges = []
     for name, value in facts:
         claim_id = f"adj.input.arithmetic.percent_of.{name}"
         sentence = f"{name} is {value}.".encode()
         fixture_start = fixture_bytes.index(sentence)
         fixture_ranges.append((claim_id, fixture_start, fixture_start + len(sentence)))
-        query_start = query_bytes.index(f"observe {name}(".encode())
-        query_trust = query_bytes.index(b"    trust authoritative", query_start)
-        query_end = query_bytes.index(b"\n", query_trust) + 1
-        query_ranges.append((claim_id, query_start, query_end))
-    query_import_start = query_bytes.index(b'import "percent-of.adj"')
-    query_import_end = query_bytes.index(b"\n", query_import_start) + 1
-    query_ranges.append(
-        (
-            "adj.code.arithmetic.percent_of.query.import",
-            query_import_start,
-            query_import_end,
-        )
-    )
-    question_start = query_bytes.index(b"? percent_of(")
-    question_end = query_bytes.index(b"\n", question_start) + 1
-    query_ranges.append((QUESTION_CLAIM, question_start, question_end))
-    disabled_start = query_bytes.index(
-        b"% ----------------------------------------------------------------------------",
-        question_end,
-    )
 
     fixture_source, fixture_claims = local_source(
         cas,
@@ -366,79 +348,60 @@ def build(
         "percent-of input fixture",
         discarded_reason="newline record separators outside the accepted fact bytes",
     )
-    query_source, query_claims = local_source(
-        cas,
-        QUERY,
-        query_ranges,
-        "percent-of.query.adj input",
-        discarded_reason=(
-            "introductory comment, spacing, or human-readable test oracle outside "
-            "the selected import, facts, and executable question"
-        ),
-        reasoned_discards=[
+
+    def _disabled_example(data: bytes, question_end: int):
+        # The query ships a deliberately disabled edge-case example. Those bytes
+        # are unrepresented on purpose, so they carry their own reason rather
+        # than falling under the blanket discard.
+        disabled_start = data.index(
+            b"% ----------------------------------------------------------------------------",
+            question_end,
+        )
+        return [
             (
                 disabled_start,
-                len(query_bytes),
+                len(data),
                 (
                     "disabled edge-case example deliberately excluded from the "
                     "executable worked query"
                 ),
             )
-        ],
-    )
-    fixture_locator = f"repo://{FIXTURE}"
-    query_clauses = []
-    for name, _value in facts:
-        claim_id = f"adj.input.arithmetic.percent_of.{name}"
-        fact = fixture_claims[claim_id]
-        query_clauses.append(
-            {
-                **fact,
-                "input_claim": builder.input_claim_payload(query_claims[claim_id]),
-                "locator": fixture_locator,
-                "resolution": {
-                    "authority_receipt_sha256": fixture_source["receipt_sha256"],
-                    "authority_source_sha256": fixture_source["raw_source_sha256"],
-                    "classification": "accepted_fact",
-                    "kind": "accepted_root",
-                    "reason": (
-                        "deterministic percent-of query input retained as the explicit "
-                        "accepted fact"
-                    ),
-                },
-                "snapshot_sha256": fixture_source["raw_source_sha256"],
-                "source_ir_sha256": fixture_source["source_ir_sha256"],
-            }
-        )
-    query_bundle = {
-        "bundle_id": "adj.math.arithmetic.percent_of.query.v1",
-        "clauses": query_clauses,
-        "dependencies": [bundle_hash],
-        "input": {
-            key: query_source[key]
-            for key in ("raw_source_sha256", "receipt_sha256", "source_ir_sha256")
-        },
-        "kind": "provenance_bundle",
-        "library": QUERY,
-        "sources": [query_source, fixture_source],
-    }
-    derivations, witnesses = provenance.put_formula_execution_evidence(
+        ]
+
+    query_bundle_id, query_bundle_hash = builder.build_query_bundle(
         cas,
-        query_bundle,
-        formula_audit_command,
-        label="percent-of.query.adj execution witness",
-    )
-    query_bundle["formula_derivation_sha256s"] = derivations
-    query_bundle["execution_witness_sha256s"] = witnesses
-    query_bundle_hash = cas.put_json(
-        query_bundle,
-        kind="provenance_bundle",
-        label="percent-of.query.adj provenance bundle",
-        links=provenance._bundle_declared_links(query_bundle),
+        spec=builder.QueryLibrarySpec(
+            bundle_id="adj.math.arithmetic.percent_of.query.v1",
+            query_path=QUERY,
+            fixture_path=FIXTURE,
+            claim_prefix="adj.input.arithmetic.percent_of",
+            import_literal=b'import "percent-of.adj"',
+            import_claim_id="adj.code.arithmetic.percent_of.query.import",
+            question_prefix=b"? percent_of(",
+            question_claim_id=QUESTION_CLAIM,
+            accepted_fact_reason=(
+                "deterministic percent-of query input retained as the explicit "
+                "accepted fact"
+            ),
+            discarded_reason=(
+                "introductory comment, spacing, or human-readable test oracle outside "
+                "the selected import, facts, and executable question"
+            ),
+            input_description="percent-of.query.adj input",
+            witness_label="percent-of.query.adj execution witness",
+            reasoned_discards=_disabled_example,
+        ),
+        repo_root=REPO_ROOT,
+        facts=facts,
+        library_hash=bundle_hash,
+        fixture_source=fixture_source,
+        fixture_claims=fixture_claims,
+        formula_audit_command=formula_audit_command,
+        local_source=local_source,
     )
     return {
         bundle["bundle_id"]: bundle_hash,
-        query_bundle["bundle_id"]: query_bundle_hash,
+        query_bundle_id: query_bundle_hash,
     }
 
 

--- a/code/scripts/build_adj_ratio_provenance.py
+++ b/code/scripts/build_adj_ratio_provenance.py
@@ -37,6 +37,7 @@ def local_source(
     *,
     discarded_reason: str,
     data: bytes | None = None,
+    reasoned_discards: list[tuple[int, int, str]] | None = None,
 ) -> tuple[dict, dict[str, dict]]:
     # Accepting already-read bytes is what lets the caller pin offsets and quotes
     # to ONE read of the file. Re-reading here would leave the two a swap apart.
@@ -72,6 +73,7 @@ def local_source(
             data,
             represented,
             discarded_reason=discarded_reason,
+            reasoned_discards=reasoned_discards,
         ),
     )
     ir_hash = cas.put_json(ir, kind="source_ir", label=f"{label} IR", links=[raw_hash])


### PR DESCRIPTION
## Summary

The third and last dependent caller. `percent_of` carried the same query scanning, clause assembly and evidence registration that `ratio` and `proportion` already share (#9926), so it now uses `builder.build_query_bundle` too.

## One thing percent-of needed

It ships a deliberately **disabled** edge-case example after the executable question, and those bytes are unrepresented on purpose. The spec gains an optional `reasoned_discards` hook — given the query bytes and the offset past the question, return spans to discard *with a stated reason* rather than under the blanket discard.

A query that deliberately excludes bytes owes the reader why they are unrepresented, not merely that they are.

## Uniform signatures, not conditional calls

The three `local_source` implementations had drifted: `proportion` took `data=` and `reasoned_discards=`, `percent_of` took only `reasoned_discards=`, `ratio` took neither.

The tempting fix is to forward each argument only when the callee accepts it — and that is exactly the mistake caught in #9926, where conditional forwarding of `data=` left `proportion` reading its query file twice and pinning claims to offsets from a different read than the quotes. So all three now accept both, defaulting to `None`, and the helper forwards unconditionally. A signature mismatch becomes a loud `TypeError` rather than a silently divergent code path.

## Verified byte-exactly

```
arithmetic, ratio, percent-of, proportion → rebuilt
git status -- adj-stdlib-provenance       → 0 files changed
verify.sh                                 → "valid": true
```

The reviewer confirmed equivalence programmatically rather than by reading — re-running main's inline range computation against the new path: `question_end` 1280 in both, all four query ranges identical, the disabled span identical, `source_segments` JSON identical (1640/1640 bytes, passes `validate_segments`), bundle canonical JSON and key order identical. They also fuzzed the hook with nine malformed spans (straddling a represented range, out-of-bounds, inverted, zero-length, empty reason) — every one rejected, and `validate_segments` runs on both the build path and the verifier's re-derivation, so the hook cannot widen, shift, or drop a citation.

## Follow-up identified (not in this PR)

The **fixture** file is still read twice in all three builders — offsets from `fixture_bytes`, then `local_source` re-reads it. Same TOCTOU class this refactor exists to eliminate, identical on `origin/main`, so neither introduced nor worsened here. Now that every `local_source` accepts `data=`, it is one keyword argument per call site. Queued as the next change.

## Test plan

In-container (Linux), since the verifier requires cgroup containment:

- [x] All four builders rebuilt → **0 CAS files changed**
- [x] `verify.sh` → `"valid": true`
- [x] `test_adj_stdlib_provenance.py` — **205 passed**, 11 skipped
- [x] `test_build_adj_proportion_provenance.py` — 6 passed
- [x] `ruff check` / `ruff format --check` clean
- [x] Security review: **PASSED**

With all three dependent builders on one path, what remains in each is genuinely per-library: its sources, its byte ranges, and its own `local_source`. That is the floor the declarative migration driver needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)