### PR TITLE
fix(adj): read each provenance input once, not twice

### DIFF
--- a/code/scripts/build_adj_arithmetic_provenance.py
+++ b/code/scripts/build_adj_arithmetic_provenance.py
@@ -85,9 +85,17 @@ def partition(data: bytes, start: int, end: int, item_claim: dict) -> list[dict]
 
 
 def local_source(
-    cas: provenance.Cas, repo_path: str, ranges: list[tuple[str, int, int]], label: str
+    cas: provenance.Cas,
+    repo_path: str,
+    ranges: list[tuple[str, int, int]],
+    label: str,
+    *,
+    data: bytes | None = None,
 ) -> tuple[dict, dict[str, dict]]:
-    data = provenance._read_regular_file(REPO_ROOT / repo_path)
+    # Accepting already-read bytes is what lets the caller pin offsets and quotes
+    # to ONE read of the file. Re-reading here would leave the two a swap apart.
+    if data is None:
+        data = provenance._read_regular_file(REPO_ROOT / repo_path)
     raw_hash = cas.put(data, kind="raw_source", label=label)
     receipt = provenance.build_input_receipt(
         repo_path=repo_path,
@@ -399,10 +407,18 @@ def build(
             (f"adj.question.arithmetic.{name}", question_start, question_end)
         )
     fixture_source, fixture_claims = local_source(
-        cas, fixture_path, fixture_ranges, "arithmetic input fixture"
+        cas,
+        fixture_path,
+        fixture_ranges,
+        "arithmetic input fixture",
+        data=fixture_bytes,
     )
     query_source, query_claims = local_source(
-        cas, query_path, query_ranges, "arithmetic.query.adj input"
+        cas,
+        query_path,
+        query_ranges,
+        "arithmetic.query.adj input",
+        data=query_bytes,
     )
     query_clauses = []
     fixture_locator = f"repo://{fixture_path}"

--- a/code/scripts/build_adj_percent_of_provenance.py
+++ b/code/scripts/build_adj_percent_of_provenance.py
@@ -281,6 +281,7 @@ def build(
             "explanatory comments, separators, or closing syntax outside the "
             "selected import, vocabulary, use, and formula rules"
         ),
+        data=library_bytes,
     )
     formula_inventory_hash = provenance.put_formula_parser_inventory(
         cas,
@@ -347,6 +348,7 @@ def build(
         fixture_ranges,
         "percent-of input fixture",
         discarded_reason="newline record separators outside the accepted fact bytes",
+        data=fixture_bytes,
     )
 
     def _disabled_example(data: bytes, question_end: int):

--- a/code/scripts/build_adj_proportion_provenance.py
+++ b/code/scripts/build_adj_proportion_provenance.py
@@ -450,6 +450,7 @@ def build(
             "explanatory comments, separators, or closing syntax outside the "
             "selected import, vocabulary, use, and formula rules"
         ),
+        data=library_bytes,
     )
     formula_inventory_hash = provenance.put_formula_parser_inventory(
         cas,
@@ -506,6 +507,7 @@ def build(
         _fixture_ranges(fixture_bytes),
         "proportion input fixture",
         discarded_reason="newline record separators outside the accepted fact bytes",
+        data=fixture_bytes,
     )
     roots = {bundle["bundle_id"]: bundle_hash}
     for bundle_id, query_path, facts in QUERY_SPECS:

--- a/code/scripts/build_adj_ratio_provenance.py
+++ b/code/scripts/build_adj_ratio_provenance.py
@@ -274,6 +274,7 @@ def build(
             "explanatory comments, separators, or closing syntax outside the "
             "selected import, vocabulary, use, and formula rules"
         ),
+        data=library_bytes,
     )
     formula_inventory_hash = provenance.put_formula_parser_inventory(
         cas,
@@ -332,6 +333,7 @@ def build(
         fixture_ranges,
         "ratio input fixture",
         discarded_reason="newline record separators outside the accepted fact bytes",
+        data=fixture_bytes,
     )
     query_bundle_id, query_bundle_hash = builder.build_query_bundle(
         cas,


### PR DESCRIPTION
## Summary

Every builder computed byte offsets from one read of a file and then let `local_source` read the **same file again** to cut the quotes. Offsets came from read #1; `quote` and `quote_sha256` came from read #2.

A same-length replacement between the two reads pins a claim to a range that no longer contains what the claim says — and it **still verifies**, because the stored IR is self-consistent with the second read and the on-disk hash check compares against that same second read. A length change is caught; a same-length swap is not.

This is the failure the byte-provenance subsystem exists to prevent, sitting inside the code that implements it.

## Sweeping beat working from the list

#9926 closed this on the query side of `proportion` and `ratio`. Review of #9927 flagged three more on the fixture side. Sweeping for the pattern rather than fixing those three found three more again:

```
fixture:          ratio, percent-of, proportion     (from the review)
library:          ratio, percent-of, proportion     (found by sweep)
fixture + query:  arithmetic                        (found by sweep)
```

`arithmetic.local_source` did not accept `data=` at all and now does, so all four builders share one signature. Its LIBRARY path was already correct — it reads once and uses those bytes throughout.

After the change, a scan for `local_source(` calls that don't forward `data=` returns **zero**. Every offset and every quote in the corpus now comes from a single read of the file it describes.

## Verification

No behaviour change when the file is stable, which is what makes this checkable: all four builders rebuilt against the real repository and the checked-in CAS did not move.

```
arithmetic, ratio, percent-of, proportion → rebuilt
git status -- adj-stdlib-provenance       → 0 files changed
```

The rebuild is the load-bearing check here — `verify.sh` validates the checked-in CAS and does not re-run the builders, so it would not exercise these paths either way. It was run too, and stays `"valid": true`.

The reviewer traced all 8 changed call sites individually, confirming each `data=` variable was read from the same path as that call's `repo_path` and that the offsets came from the same variable — no crossed wires, and no remaining double-read anywhere in the four builders or the shared helper.

## Test plan

In-container (Linux):

- [x] All four builders rebuilt → **0 CAS files changed**
- [x] `test_adj_stdlib_provenance.py` — **205 passed**, 11 skipped
- [x] `test_build_adj_proportion_provenance.py` — 6 passed
- [x] `ruff check` / `ruff format --check` clean
- [x] Security review: **PASSED**

## Follow-up identified

The verifier's workspace cross-check covers only `bundle["library"]` inputs, so a fixture receipt is validated for self-consistency against CAS bytes but not against the file on disk. That means the correctness of `data=fixture_bytes` rests on the builder — the invariant this PR establishes. A `sha256(data) == sha256(file at repo_path)` assertion inside `local_source` (a *check*, not a second source of quotes) would make a mispaired `data=` fail loudly. Queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)