### PR TITLE
fix(adj): ground fraction.adj's citations in bytes that state the claim

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/fl4_fraction_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/fl4_fraction_e2e.rs
@@ -71,8 +71,8 @@ fn fraction_of_composes_product_and_carries_both_citations() {
     // BOTH citations: fraction's own definition (primary) AND the product
     // primitive it composed (corroboration).
     assert!(
-        s.contains("mathworld.wolfram.com/Fraction.html"),
-        "primary cites the fraction definition: {s}"
+        s.contains("math.libretexts.org/Bookshelves/PreAlgebra/Fundamentals_of_Mathematics_(Burzynski_and_Ellis)/04%3A_Introduction_to_Fractions_and_Multiplication_and_Division_of_Fractions/4.04%3A_Multiplication_of_Fractions"),
+        "primary cites the bytes grounding \"of\" as multiplication: {s}"
     );
     assert!(
         s.contains("mathworld.wolfram.com/Product.html"),
@@ -111,8 +111,8 @@ fn reciprocal_flips_the_fraction_via_quotient() {
         "the exact value is 5/4, not a lossy decimal: {s}"
     );
     assert!(
-        s.contains("mathworld.wolfram.com/Reciprocal.html"),
-        "primary cites the reciprocal definition: {s}"
+        s.contains("openstax.org/books/prealgebra-2e/pages/4-2-multiply-and-divide-fractions"),
+        "primary cites the bytes stating a reciprocal inverts the fraction: {s}"
     );
     assert!(
         s.contains("mathworld.wolfram.com/Quotient.html"),
@@ -147,8 +147,11 @@ fn mixed_number_composes_sum_and_quotient() {
         "mixed_number(2, 1, 2) = 2.5: {s}"
     );
     assert!(
-        s.contains("mathworld.wolfram.com/MixedFraction.html"),
-        "primary cites the mixed-number definition: {s}"
+        // Assert on the LABEL, not the locator: this page is cited by
+        // `percent-of.adj` too, so a locator match would pass on ITS citation
+        // if a future fixture happened to include that library.
+        s.contains("is another way to represent 5+(6/11)"),
+        "primary cites the bytes stating whole number plus a fraction: {s}"
     );
     // Both composed primitives appear as corroborations.
     assert!(

--- a/code/specs/data/adj-formula-stdlib/arithmetic/fraction.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/fraction.adj
@@ -15,8 +15,9 @@
 %     ? fraction_of(fraction, whole)               % engine → 3, carrying every citation
 %
 % The engine expands `fraction_of` → `product` (from arithmetic.adj) on the CPU
-% and composes the provenance chain, so the answer cites BOTH the fraction
-% definition (primary) and the `product` primitive it builds on (corroboration).
+% and composes the provenance chain, so the answer cites BOTH the bytes grounding
+% "of" as multiplication (primary) and the `product` primitive it builds on
+% (corroboration).
 % The model performs zero arithmetic, and the audit trail names every formula
 % that participated.
 % ============================================================================
@@ -66,22 +67,22 @@ formulabook fractions {
     % A fraction OF a quantity — the fractional part scaling the whole. Composes
     % `product` from arithmetic.adj: a quarter of 12 is 0.25 × 12 = 3.
     formula fraction_of(fraction, whole) = product(fraction, whole)
-        source "A fraction represents a part of a whole; a fraction of a quantity is that quantity multiplied by the fraction."
-        locator "https://mathworld.wolfram.com/Fraction.html"
+        source "The word \"of\" translates to the arithmetic operation \"times.\""
+        locator "https://math.libretexts.org/Bookshelves/PreAlgebra/Fundamentals_of_Mathematics_(Burzynski_and_Ellis)/04%3A_Introduction_to_Fractions_and_Multiplication_and_Division_of_Fractions/4.04%3A_Multiplication_of_Fractions"
         trust authoritative
 
     % The reciprocal — the fraction flipped, numerator and denominator swapped.
     % Composes `quotient` with its arguments exchanged: the reciprocal of a/b is
     % b/a.
     formula reciprocal(numerator, denominator) = quotient(denominator, numerator)
-        source "The reciprocal of a number x is the number which, when multiplied by x, yields 1; the reciprocal of a fraction a/b is b/a."
-        locator "https://mathworld.wolfram.com/Reciprocal.html"
+        source "To find the reciprocal of a fraction, we invert the fraction. This means that we place the numerator in the denominator and the denominator in the numerator."
+        locator "https://openstax.org/books/prealgebra-2e/pages/4-2-multiply-and-divide-fractions"
         trust authoritative
 
     % A mixed number — a whole number plus a proper fraction, read as a single
     % value. Composes `sum` and `quotient`: two and a half is 2 + 1/2 = 2.5.
     formula mixed_number(whole_number, numerator, denominator) = sum(whole_number, quotient(numerator, denominator))
-        source "A mixed number is the sum of an integer and a proper fraction."
-        locator "https://mathworld.wolfram.com/MixedFraction.html"
+        source "To do so, we use the idea that a mixed number, such as 5(6/11), is another way to represent 5+(6/11)."
+        locator "https://openstax.org/books/contemporary-mathematics/pages/3-4-rational-numbers"
         trust authoritative
 }


### PR DESCRIPTION
## Summary

All three formulas in `fraction.adj` cited pages that **do not contain the sentence attributed to them**. Not 404s — all three MathWorld pages load fine. The labels were paraphrases the cited bytes never supported:

| formula | label claimed | page actually says |
|---|---|---|
| `fraction_of` | "…a fraction of a quantity is that quantity multiplied by the fraction." | `Fraction.html` defines only the **notation** `a/b`. |
| `reciprocal` | "…the reciprocal of a fraction a/b is b/a." | `Reciprocal.html` gives only the multiplicative inverse `1/z`. |
| `mixed_number` | "A mixed number is the sum of an integer and a proper fraction." | `MixedFraction.html`: "an improper fraction p/q>1 written in the form n+r/s" — narrower, and about notation rather than the value. |

This is what §4.1 means by *"a source URL is not byte provenance"*, and it's the *"paraphrases that exceed the cited bytes"* gate §4.3 lists as still missing. The library could not have been byte-pinned — there were no bytes to pin to.

## The standard applied

The one the migrated libraries already meet. `percent-of` quotes `"n% of x items is (n/100)*x."` — near-direct transcription. `proportion` quotes `"…its cross products are equal."` and **derives** `d = (b·c)/a`. So the cited bytes must state a property the formula follows from. Derivation is legitimate; topical adjacency isn't.

## Replacements

Each checked under the normalization its future pin will apply — not against a rendered view, which hides markup.

```
fraction_of    LibreTexts, Fundamentals of Mathematics §4.4      raw=0 entity=1
reciprocal     OpenStax Prealgebra 2e §4.2                       raw=1, contiguous
mixed_number   OpenStax Contemporary Mathematics §3.4            transformed region EQUALS label
```

`reciprocal` is the strongest — verbatim, unique, no interior markup, a pure `copy` pin, and literally `quotient(denominator, numerator)`.

## The mixed_number citation took two attempts

Worth stating, because the first failure is the instructive part. I initially cited *"This represents a whole number (2 in this case), plus a fraction (the 5/8)."* Two defects, both caught in review:

- Its subject is an **unbound pronoun** — standing alone it never names a mixed number, which is the same defect class being fixed.
- The stored text was in the served bytes **zero** times. `5/8` is MathML there. I had verified a *truncated prefix* ending `…(the ` and then stored the longer sentence, so my check never covered the ungrounded part.

The replacement names the term and states the identity, and its stored form was **derived by running the corpus's own `_mathml_to_infix`** over that region rather than read off the page — which is why the parentheses in `5(6/11)` and `5+(6/11)` are correct rather than guessed. `percent-of.adj` stores `(n/100)*x` by the same convention.

## Known migration prerequisite (verified here, not left to be discovered)

`math.libretexts.org` injects a per-request `pageViewId` UUID at byte 62638, so its body hash is **not reproducible** — two fetches 3s apart gave identical length (188949) and different sha256. The `fetch_receipt` schema pins `body_sha256`, so byte-pinning `fraction_of` will fail on the receipt even though the cited range is stable (the UUID is fixed-length, so offsets don't shift — the sentence stays at 118287).

Resolve before that clause migrates; a reasoned `discard` over the volatile span fits the existing §7g machinery. Both OpenStax pages are byte-stable, so `reciprocal` and `mixed_number` are unaffected.

## Test plan

- [x] `fl4_fraction_e2e` — 4 passed. Repointed from the three old MathWorld locators, keeping each assertion's intent.
- [x] `mixed_number` asserts on the **label**, not the locator — that page is cited by `percent-of.adj` too with a byte-identical URL, so a locator match could pass on *its* citation if a fixture ever grew.
- [x] Header comment updated — the primary is no longer "the fraction definition".
- [x] Escaped quotes (`\"`) round-trip: verified by compiling the worked query and reading the parsed `source` back out of the emitted JSON.
- [x] Full suite: **303 binaries, 787 passed, 0 failed**
- [x] Two review rounds; the reviewer independently reproduced the stored label through the real `build_text_transform` and confirmed exact equality.

## Residual weaknesses accepted

`fraction_of`'s label grounds the *operator choice* but names neither "fraction" nor "whole" — the context lives in the §4.4 section title, which is in the locator but not the pinned bytes. It over-licenses rather than under-licenses, and multiplication is commutative. `mixed_number`'s claim sits under an attitude report ("we use the idea that P"); standard expository commitment, with an airtight two-sentence alternative on the same page if ever wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)