### PR TITLE
fix(adj): make a mispaired local_source buffer fail loudly

### DIFF
--- a/code/scripts/adj_provenance_builder.py
+++ b/code/scripts/adj_provenance_builder.py
@@ -183,6 +183,7 @@ def build_query_bundle(
     # file, a same-length replacement in between would pin a claim to a byte range
     # that no longer contains what the claim says — and the result would still
     # verify, because the stored IR would be self-consistent with the second read.
+    caller_supplied_bytes = query_bytes is not None
     if query_bytes is None:
         query_bytes = provenance._read_regular_file(repo_root / spec.query_path)
 
@@ -229,6 +230,12 @@ def build_query_bundle(
         spec.input_description,
         discarded_reason=spec.discarded_reason,
         data=query_bytes,
+        # A caller-supplied snapshot may legitimately differ from the working
+        # tree (that is what a workspace snapshot IS), so the on-disk equality
+        # check applies only when we read the file ourselves. Note this gates a
+        # CHECK, not which bytes are used — the bytes are the same either way,
+        # unlike the conditional forwarding that caused the #9926 double-read.
+        on_disk=not caller_supplied_bytes,
         reasoned_discards=(
             spec.reasoned_discards(query_bytes, question_end)
             if spec.reasoned_discards is not None

--- a/code/scripts/build_adj_arithmetic_provenance.py
+++ b/code/scripts/build_adj_arithmetic_provenance.py
@@ -91,11 +91,25 @@ def local_source(
     label: str,
     *,
     data: bytes | None = None,
+    on_disk: bool = True,
 ) -> tuple[dict, dict[str, dict]]:
     # Accepting already-read bytes is what lets the caller pin offsets and quotes
     # to ONE read of the file. Re-reading here would leave the two a swap apart.
     if data is None:
         data = provenance._read_regular_file(REPO_ROOT / repo_path)
+    elif on_disk:
+        # The supplied buffer must be THIS file's bytes. Nothing else checks it:
+        # the receipt, the IR and every quote are all derived from `data`, so a
+        # mispaired variable would hash one file while claiming another and stay
+        # perfectly self-consistent. A re-read here is a CHECK, never a second
+        # source of quotes. Callers passing a snapshot that may legitimately
+        # differ from disk opt out with `on_disk=False`.
+        actual = provenance._read_regular_file(REPO_ROOT / repo_path)
+        if actual != data:
+            raise provenance.ProvenanceError(
+                f"{repo_path}: supplied bytes do not match the file on disk "
+                f"({provenance.sha256_bytes(data)} vs {provenance.sha256_bytes(actual)})"
+            )
     raw_hash = cas.put(data, kind="raw_source", label=label)
     receipt = provenance.build_input_receipt(
         repo_path=repo_path,

--- a/code/scripts/build_adj_percent_of_provenance.py
+++ b/code/scripts/build_adj_percent_of_provenance.py
@@ -46,12 +46,26 @@ def local_source(
     *,
     discarded_reason: str,
     data: bytes | None = None,
+    on_disk: bool = True,
     reasoned_discards: list[tuple[int, int, str]] | None = None,
 ) -> tuple[dict, dict[str, dict]]:
     # Accepting already-read bytes is what lets the caller pin offsets and quotes
     # to ONE read of the file. Re-reading here would leave the two a swap apart.
     if data is None:
         data = provenance._read_regular_file(REPO_ROOT / repo_path)
+    elif on_disk:
+        # The supplied buffer must be THIS file's bytes. Nothing else checks it:
+        # the receipt, the IR and every quote are all derived from `data`, so a
+        # mispaired variable would hash one file while claiming another and stay
+        # perfectly self-consistent. A re-read here is a CHECK, never a second
+        # source of quotes. Callers passing a snapshot that may legitimately
+        # differ from disk opt out with `on_disk=False`.
+        actual = provenance._read_regular_file(REPO_ROOT / repo_path)
+        if actual != data:
+            raise provenance.ProvenanceError(
+                f"{repo_path}: supplied bytes do not match the file on disk "
+                f"({provenance.sha256_bytes(data)} vs {provenance.sha256_bytes(actual)})"
+            )
     raw_hash = cas.put(data, kind="raw_source", label=label)
     receipt = provenance.build_input_receipt(
         repo_path=repo_path,

--- a/code/scripts/build_adj_proportion_provenance.py
+++ b/code/scripts/build_adj_proportion_provenance.py
@@ -85,10 +85,24 @@ def local_source(
     *,
     discarded_reason: str,
     data: bytes | None = None,
+    on_disk: bool = True,
     reasoned_discards: list[tuple[int, int, str]] | None = None,
 ) -> tuple[dict, dict[str, dict]]:
     if data is None:
         data = provenance._read_regular_file(REPO_ROOT / repo_path)
+    elif on_disk:
+        # The supplied buffer must be THIS file's bytes. Nothing else checks it:
+        # the receipt, the IR and every quote are all derived from `data`, so a
+        # mispaired variable would hash one file while claiming another and stay
+        # perfectly self-consistent. A re-read here is a CHECK, never a second
+        # source of quotes. Callers passing a snapshot that may legitimately
+        # differ from disk opt out with `on_disk=False`.
+        actual = provenance._read_regular_file(REPO_ROOT / repo_path)
+        if actual != data:
+            raise provenance.ProvenanceError(
+                f"{repo_path}: supplied bytes do not match the file on disk "
+                f"({provenance.sha256_bytes(data)} vs {provenance.sha256_bytes(actual)})"
+            )
     raw_hash = cas.put(data, kind="raw_source", label=label)
     receipt = provenance.build_input_receipt(
         repo_path=repo_path,

--- a/code/scripts/build_adj_ratio_provenance.py
+++ b/code/scripts/build_adj_ratio_provenance.py
@@ -37,12 +37,26 @@ def local_source(
     *,
     discarded_reason: str,
     data: bytes | None = None,
+    on_disk: bool = True,
     reasoned_discards: list[tuple[int, int, str]] | None = None,
 ) -> tuple[dict, dict[str, dict]]:
     # Accepting already-read bytes is what lets the caller pin offsets and quotes
     # to ONE read of the file. Re-reading here would leave the two a swap apart.
     if data is None:
         data = provenance._read_regular_file(REPO_ROOT / repo_path)
+    elif on_disk:
+        # The supplied buffer must be THIS file's bytes. Nothing else checks it:
+        # the receipt, the IR and every quote are all derived from `data`, so a
+        # mispaired variable would hash one file while claiming another and stay
+        # perfectly self-consistent. A re-read here is a CHECK, never a second
+        # source of quotes. Callers passing a snapshot that may legitimately
+        # differ from disk opt out with `on_disk=False`.
+        actual = provenance._read_regular_file(REPO_ROOT / repo_path)
+        if actual != data:
+            raise provenance.ProvenanceError(
+                f"{repo_path}: supplied bytes do not match the file on disk "
+                f"({provenance.sha256_bytes(data)} vs {provenance.sha256_bytes(actual)})"
+            )
     raw_hash = cas.put(data, kind="raw_source", label=label)
     receipt = provenance.build_input_receipt(
         repo_path=repo_path,


### PR DESCRIPTION
## Summary

#9928 made every builder pass its already-read bytes to `local_source` as `data=`, so each file is read once and offsets and quotes come from the same read. That fixed a TOCTOU but introduced a quieter risk in its place: **eight call sites now hand over a buffer, and nothing checked the buffer belongs to the file being cited.**

A mispaired variable — `fixture_bytes` handed to the query call, say — would hash one file while claiming another, and stay perfectly self-consistent doing it. The receipt, the source IR and every `quote_sha256` all derive from `data`, so they'd agree with each other and disagree only with reality.

The verifier wouldn't catch it either: its workspace cross-check covers only `bundle["library"]` inputs, so a fixture receipt is validated for self-consistency against CAS bytes and never against the file on disk. (Identified in #9928's review.)

## The fix

`local_source` re-reads the file and compares when a buffer is supplied. This is a **check, never a second source of quotes** — the quotes still come from the caller's single read, so the property #9928 established is untouched.

## Verified in both directions

Not just the happy one:

**Negative** — deliberately handed the fixture call `library_bytes`:
```
ProvenanceError: code/specs/data/adj-stdlib-provenance/fixtures/ratio-inputs.txt:
supplied bytes do not match the file on disk
(d2e0802dc3ae4d99… vs 192a5bb5978b842c…)
```

**Positive** — all four builders rebuilt, CAS unchanged (`0 files`), 205 + 6 tests pass.

## The one opt-out

`on_disk=False`, for `proportion`'s workspace snapshot, whose whole purpose is to differ from the working tree.

Worth being precise about why this flag is safe where #9926's wasn't: **it gates only the check — the bytes used are identical either way.** The #9926 regression came from a conditional that decided which *bytes* were used, which silently changed behaviour. A conditional over an assertion does not.

## Test plan

- [x] Negative test: mispaired buffer rejected with file name and both hashes
- [x] All four builders rebuilt → **0 CAS files changed**
- [x] `test_adj_stdlib_provenance.py` — 205 passed, 11 skipped
- [x] `test_build_adj_proportion_provenance.py` — 6 passed
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)