### PR TITLE
fix(adj): ground average.adj and percent.adj in byte-present sentences

### DIFF
--- a/code/specs/data/adj-formula-stdlib/arithmetic/average.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/average.adj
@@ -56,14 +56,14 @@ formulabook averages {
 
     % The arithmetic mean of two quantities — their sum shared evenly in two.
     formula mean_two(value_one, value_two) = quotient(sum(value_one, value_two), 2)
-        source "The arithmetic mean of a set of numbers is the sum of the numbers divided by how many numbers there are in the set."
+        source "Given a set of samples {x_i}, the arithmetic mean is  x^_=1/Nsum_(i=1)^Nx_i."
         locator "https://mathworld.wolfram.com/ArithmeticMean.html"
         trust authoritative
 
     % The arithmetic mean of three quantities — their pooled sum shared evenly in
     % three. Composes `sum` twice (associatively) then `quotient`.
     formula mean_three(value_one, value_two, value_three) = quotient(sum(sum(value_one, value_two), value_three), 3)
-        source "The arithmetic mean of a set of numbers is the sum of the numbers divided by how many numbers there are in the set."
+        source "Given a set of samples {x_i}, the arithmetic mean is  x^_=1/Nsum_(i=1)^Nx_i."
         locator "https://mathworld.wolfram.com/ArithmeticMean.html"
         trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/arithmetic/percent.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/percent.adj
@@ -58,7 +58,7 @@ formulabook percentages {
 
     % A percentage — the part as a share of the whole, expressed per hundred.
     formula percent(part, whole) = quotient(part, whole) * 100
-        source "A percentage is a number or ratio expressed as a fraction of 100; it is often denoted by the percent sign, %."
+        source "A ratio or fraction is converted to a percentage by multiplying by 100 and appending a \"percentage sign\" %."
         locator "https://mathworld.wolfram.com/Percent.html"
         trust authoritative
 


### PR DESCRIPTION
## Summary

An audit classified all 20 arithmetic formulas against the standard the migrated libraries already meet. Of the **13 unmigrated formulas, 8 were defective**. Three are fixed here — the ones whose correct, byte-present sentence was already on the page being cited.

| library | was | now |
|---|---|---|
| `average.adj` (both formulas, same label) | "The arithmetic mean of a set of numbers is the sum of the numbers divided by how many numbers there are in the set." — **zero occurrences** on `ArithmeticMean.html` in any accepted form | "Given a set of samples {x_i}, the arithmetic mean is  x^_=1/Nsum_(i=1)^Nx_i." |
| `percent.adj` (`percent` only) | "A percentage is a number or ratio expressed as a fraction of 100…" — **zero occurrences** on `Percent.html`; reads as the Wikipedia wording | "A ratio or fraction is converted to a percentage by multiplying by 100 and appending a \"percentage sign\" %." |

The mean identity states the property, so `mean_two` and `mean_three` both follow by instantiating N — the same derivation `proportion.adj` makes from its cross-products property. The percent sentence states the multiply-by-100 property `quotient(part, whole) * 100` needs.

## Why the metadata

Both labels come from each page's `<meta name="DC.Description">`, which is **the pinning surface `arithmetic.adj` already uses** — its builder requires exactly one `DC.Description` marker and pins claims relative to it. This is the established pattern, not a new one.

It's necessary here: the equations on these pages are served as SVG images, unreachable by any accepted transform. The metadata carries a plain-text linearization of the same statement.

Exact bytes preserved, including the double space before `x^_`. Verified by compiling both worked queries and reading the parsed `source` back out of the emitted JSON, escapes and all.

## Not fixed here — each for its own reason

| formula | why |
|---|---|
| `powers.square` | MathWorld's byte-present text is "x^2 is the square of x" — fixes **notation**, not the product expansion `product(base, base)` needs. An audit summary called this a cheap relabel; its own detail contradicted that, and the detail was right. |
| `powers.cube` | `Cube.html` is the **Platonic solid** page. "third power" and "x^3" appear zero times; every "cube of" is "cube of edge length". Already flagged in §11. |
| `speed` ×2 | `distance = v·t` and `time = d/v` are rearrangements the cited prose never states. The page *does* display `v = ∆s/∆t` — but as an HTML `<table>`, not MathML, so `mathml_to_infix` cannot reach it and a discard-only transform would flatten it to `v = ∆s∆t`. That locator cannot yield the equation. |
| `percent_change` | The locator is a Census PDF with LZWDecode-compressed streams; the formula appears zero times in the served bytes. PDF text extraction is not an accepted transform. |

Two of those four are **publisher format** problems rather than formula problems, which is why a corpus-wide audit is running to measure the real distribution instead of extrapolating from arithmetic.

## Test plan

- [x] Both labels verified byte-present in the served `DC.Description` (percent after entity decoding)
- [x] Both worked queries compile; parsed `source` read back from emitted JSON, double space and escapes intact
- [x] No test or fixture pinned the old text
- [x] Full suite: **303 binaries, 787 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)