### PR TITLE
fix(adj): ground powers.adj's square and cube in bytes that state them

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/fl4_powers_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/fl4_powers_e2e.rs
@@ -72,7 +72,7 @@ fn square_composes_product_and_carries_both_citations() {
     // BOTH citations: square's own definition (primary) AND the product
     // primitive it composed (corroboration).
     assert!(
-        s.contains("mathworld.wolfram.com/Square.html"),
+        s.contains("openstax.org/books/contemporary-mathematics/pages/3-8-exponents"),
         "primary cites the square definition: {s}"
     );
     assert!(
@@ -106,7 +106,7 @@ fn cube_nests_product_inside_product() {
         "cube(3) = 27: {s}"
     );
     assert!(
-        s.contains("mathworld.wolfram.com/Cube.html"),
+        s.contains("en.wikipedia.org/wiki/Cube_(algebra)"),
         "primary cites the cube definition: {s}"
     );
     assert!(

--- a/code/specs/data/adj-formula-stdlib/arithmetic/powers.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/powers.adj
@@ -25,6 +25,22 @@
 % multiplication through the cited `product`, not as an exponent. Fractional and
 % symbolic powers (e.g. square roots) belong to a later rung that wires the
 % engine's `Pow` op into the surface — they are deliberately out of scope here.
+%
+% On the citations. Both formulas previously cited MathWorld (`Square.html`,
+% `Cube.html`) with sentences those pages do not contain. `Square.html` states
+% the NOTATION only ("x^2 is the square of x") and never the product expansion;
+% `Cube.html` is about the geometric SOLID — every occurrence of "cube of" there
+% reads "cube of edge length". Neither grounds "multiply the number by itself".
+% No MathWorld sibling (Squared, Cubed, SquareNumber, CubicNumber, Power) states
+% the expansion either, so the retarget is off-site by necessity, not preference.
+% Each formula now cites a page that states ITS claim as a product:
+%   square -> OpenStax Contemporary Mathematics §3.8 (the book percent-of.adj
+%             already cites), verbatim prose, `copy` only
+%   cube   -> Wikipedia "Cube (algebra)", tag `discard` only; Wikipedia is
+%             precedented in this corpus at physics/mechanics-laws.adj (Ohm's law)
+% LibreTexts was rejected despite having ideal sentences: its bodies embed a
+% per-request `pageViewId` UUID, so the same page hashes differently on every
+% fetch and cannot be pinned.
 % ============================================================================
 
 % ----------------------------------------------------------------------------
@@ -61,14 +77,14 @@ formulabook powers {
     % The square — the base multiplied by itself. Composes `product`: the square
     % of 5 is 5 × 5 = 25.
     formula square(base) = product(base, base)
-        source "The square of a number is that number multiplied by itself; the square of x is x^2 = x times x."
-        locator "https://mathworld.wolfram.com/Square.html"
+        source "Squaring a number is multiplying it by itself, and has that name because it is the area of a square with that side length."
+        locator "https://openstax.org/books/contemporary-mathematics/pages/3-8-exponents"
         trust authoritative
 
     % The cube — the base multiplied by itself twice. Nests `product` inside
     % `product`: the cube of 3 is (3 × 3) × 3 = 27.
     formula cube(base) = product(product(base, base), base)
-        source "The cube of a number is that number raised to the third power; the cube of x is x^3 = x times x times x."
-        locator "https://mathworld.wolfram.com/Cube.html"
+        source "In arithmetic and algebra, the cube of a number n is its third power, that is, the result of multiplying three instances of n together."
+        locator "https://en.wikipedia.org/wiki/Cube_(algebra)"
         trust authoritative
 }


### PR DESCRIPTION
## What

`square` and `cube` cited MathWorld sentences those pages **do not contain** — the FL-4 §11 blocker. Verified against the served bytes:

| page | probe | count |
| --- | --- | ---: |
| `Square.html` | `x^2 is the square of x` | 4 |
| | `multiplied by itself` / `times itself` | **0 / 0** |
| `Cube.html` | `third power` / `x^3` | **0 / 0** |
| | `cube of` | 3 — all three read *"cube of edge length"* |

`Square.html` states the **notation** only and never the product expansion. `Cube.html` is about the geometric **solid** — the wrong subject entirely.

No MathWorld sibling states the expansion either: `Squared`, `Cubed`, `SquareNumber`, `CubicNumber` and `Power` were each checked, and none gives a product. The retarget is off-site **by necessity, not preference**.

## New citations

| formula | source | transform |
| --- | --- | --- |
| `square` | [OpenStax Contemporary Mathematics §3.8](https://openstax.org/books/contemporary-mathematics/pages/3-8-exponents) — "Squaring a number is multiplying it by itself, and has that name because it is the area of a square with that side length." | `copy` only |
| `cube` | [Wikipedia "Cube (algebra)"](https://en.wikipedia.org/wiki/Cube_(algebra)) — "In arithmetic and algebra, the cube of a number n is its third power, that is, the result of multiplying three instances of n together." | tag `discard` only |

## Verification

Checked against the served bytes, independently of the sourcing pass:

- Both pages **hash-stable** across two fetches — OpenStax `8e607d2b80e1d2e2` (454,113 B), Wikipedia `26d663cacb613e0c` (397,407 B).
- The cube span was projected through tag-discard and the result **equals** the stored sentence exactly — not merely contains it. The 12 discarded tags are 4 `<a>`, 1 `<b>`, 2 `<span>` and their closers.
- Each projected sentence occurs **exactly once** in its document. (`square`'s sentence also appears 4 more times — in `<meta>` and the Next.js JSON blob; the **body** occurrence at offset 117940 is the one pinned.)

### Hazard found while verifying

A naive tag-strip over the Wikipedia page **leaks `data-mw` attribute contents**, because those JSON attribute values contain literal `>` characters, so `<[^>]*>` terminates early. The pinned span is clear of it — checked explicitly, no residual `>` or `{` in the projection — but a wider span on that page would not be. Worth knowing before anyone cites Wikipedia again.

### Why not LibreTexts

It carries ideal sentences for both formulas, but its bodies embed a per-request `pageViewId` UUID, so the same page hashes differently on every fetch and cannot be pinned. Wikipedia is precedented in this corpus at `physics/mechanics-laws.adj` (Ohm's law).

## Coupled change

`fl4_powers_e2e.rs` asserts the primary locator for each formula and would otherwise fail — updated in the same commit.

`geometry-formulas.adj` still cites `Square.html` for `square_area` ("and the area is A=a^2."), which **remains valid** on that page and is untouched.

## Tests

`adj-lang` + `adj-lang-cli`: **1026 passed, 0 failed** across 307 binaries. `fl4_powers_e2e` 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)