### PR TITLE
feat(adj): render MathML mspace/mtext, and make the renderer fail closed

### DIFF
--- a/code/scripts/adj_stdlib_provenance.py
+++ b/code/scripts/adj_stdlib_provenance.py
@@ -29,6 +29,7 @@ import sys
 import tempfile
 import threading
 import time
+import unicodedata
 import xml.etree.ElementTree as ET
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, replace
@@ -715,6 +716,154 @@ def build_source_ir(
     }
 
 
+# Per-element ALLOWLIST of attributes, not a denylist of dangerous ones.
+#
+# A denylist loses: `style`/`hidden` are the CSS-flavoured way to hide content,
+# but MathML has NATIVE equivalents honoured with no stylesheet at all —
+# `mathcolor="transparent"`, `mathsize="0"`, `scriptlevel="+9"` each make an
+# element invisible while its text still reaches the projection. Enumerating
+# those one at a time is a losing race, so anything not known-harmless raises.
+#
+# Every entry below is grounded in a census of the pinned CAS: these are the
+# attributes that actually occur inside a <math> element, and nothing else does.
+# `class` survives only on <mrow>, which emits no text of its own; the
+# text-emitting leaves never carry it in the corpus, so they reject it — that
+# closes `class="sr-only"`-style hiding on exactly the elements that can inject
+# prose. A hidden <mrow> remains genuinely unclosable from the bytes alone,
+# because it needs a stylesheet we never fetched; see the backlog.
+_ALLOWED_MATHML_ATTRIBUTES: dict[str, frozenset[str]] = {
+    "math": frozenset({"display", "alttext"}),
+    "semantics": frozenset(),
+    "annotation-xml": frozenset({"encoding"}),
+    "mrow": frozenset({"class"}),
+    "mi": frozenset({"mathvariant"}),
+    "mn": frozenset({"mathvariant"}),
+    "mo": frozenset({"mathvariant", "stretchy", "accent", "lspace", "rspace"}),
+    "mtext": frozenset({"mathvariant"}),
+    "mspace": frozenset({"width"}),
+    "mfrac": frozenset(),
+}
+
+# `mathvariant` values that change how a character LOOKS without changing WHICH
+# character a reader sees. The remapping values are rejected instead: MathML
+# maps `double-struck` R onto ℝ (U+211D), `fraktur` onto 𝔑, `script` onto 𝒮 and
+# so on, so rendering them as bare ASCII would pin a claim about ℝ to the byte
+# "R" — two different mathematical objects sharing one projection. The corpus
+# only ever uses `normal` and `italic`.
+_NON_REMAPPING_MATHVARIANTS = frozenset({"normal", "italic", "bold"})
+
+# MathML named spaces that render as a POSITIVE gap. The `negative*` siblings
+# are deliberately absent — they close space up rather than open it.
+_NAMED_POSITIVE_SPACES = frozenset(
+    {
+        "veryverythinmathspace",
+        "verythinmathspace",
+        "thinmathspace",
+        "mediummathspace",
+        "thickmathspace",
+        "verythickmathspace",
+        "veryverythickmathspace",
+    }
+)
+
+# Units that resolve to a real length. `%` is excluded ON PURPOSE: a MathML
+# percentage is a percentage OF THE ATTRIBUTE'S DEFAULT, and `mspace`'s default
+# width is 0em, so EVERY percentage resolves to zero — `width="100%"` is no gap
+# at all. An unknown unit is discarded by browsers and likewise falls back to
+# the 0em default, so both must fail rather than emit a space.
+_MSPACE_WIDTH_UNITS = frozenset(
+    {"em", "ex", "px", "in", "cm", "mm", "pt", "pc", "ch", "rem"}
+)
+
+_MATHML_LENGTH = re.compile(r"^\+?(\d+(?:\.\d*)?|\.\d+)([a-z%]*)$")
+
+
+def _mspace_width_renders_as_a_gap(width: str) -> bool:
+    """True only when `width` is a length a reader would actually see."""
+    if width in _NAMED_POSITIVE_SPACES:
+        return True
+    match = _MATHML_LENGTH.match(width)
+    if match is None:
+        return False
+    # A unit is REQUIRED: a bare number is not a valid MathML length, so a
+    # browser falls back to the 0em default and shows no gap.
+    if (match.group(2) or "") not in _MSPACE_WIDTH_UNITS:
+        return False
+    # A floor, not merely `> 0`. `width="0.0001em"` is positive but
+    # sub-perceptual, so emitting a space for it fabricates a separator exactly
+    # as `0em` did — a page showing the product `rt` would project `r t`, which
+    # in formula-land is a change of meaning. The threshold is not arbitrary:
+    # MathML's own smallest NAMED gap, `veryverythinmathspace`, is 1/18 em ≈
+    # 0.0556em, and the smallest width in the pinned corpus is 0.056em — the
+    # same quantity written numerically. So 0.05 admits every value the corpus
+    # actually uses and rejects everything below the smallest gap MathML is
+    # itself willing to name.
+    return float(match.group(1)) >= 0.05
+
+
+def _reject_unexpected_attributes(node: ET.Element, tag: str, prefix: str) -> None:
+    # Membership and VALUE checks must read the same key space. Reading the
+    # allowlist off namespace-stripped local names while looking values up by
+    # the raw key would let `<mi m:mathvariant="double-struck">` satisfy the
+    # allowlist and then skip the value check entirely. Harmless today — a
+    # browser only honours these in the null namespace — but it is a trap for
+    # the next value-checked attribute, so both are driven from one mapping.
+    local = {name.rsplit("}", 1)[-1]: value for name, value in node.attrib.items()}
+    unexpected = set(local) - _ALLOWED_MATHML_ATTRIBUTES.get(tag, frozenset())
+    if unexpected:
+        raise ProvenanceError(
+            f"{prefix} MathML element {tag!r} carries unsupported "
+            f"attributes {sorted(unexpected)!r}"
+        )
+    variant = local.get("mathvariant")
+    if variant is not None and variant not in _NON_REMAPPING_MATHVARIANTS:
+        raise ProvenanceError(
+            f"{prefix} MathML element {tag!r} uses character-remapping "
+            f"mathvariant {variant!r}"
+        )
+    # `encoding="text/html"` turns <annotation-xml> into an HTML integration
+    # point, changing how a browser parses that subtree. The corpus only ever
+    # uses MathML-Content (669 occurrences, no other value), so pinning it
+    # costs nothing and removes the parsing-mode question entirely.
+    encoding = local.get("encoding")
+    if encoding is not None and encoding != "MathML-Content":
+        raise ProvenanceError(
+            f"{prefix} MathML annotation-xml encoding {encoding!r} is unsupported"
+        )
+
+
+def _reject_unrenderable_text(text: str, tag: str, prefix: str) -> None:
+    """Reject control/format/separator characters in text that becomes evidence.
+
+    A claim quotes the projection byte-for-byte, so a bidi override (U+202E), a
+    zero-width joiner, or a line/paragraph separator inside the quoted range
+    makes the DISPLAYED evidence differ from the bytes that were pinned. These
+    have no legitimate place in a cited sentence, so they fail closed.
+
+    `Co` (private use) is included because a PUA codepoint renders as whatever a
+    webfont happens to map it to, so nothing about it can be claimed to match
+    what a reader sees.
+
+    This is deliberately BROADER than the deceptive set: ZWJ (U+200D), ZWNJ
+    (U+200C) and SOFT HYPHEN are orthographically load-bearing in Indic and
+    Arabic scripts, and this repo has active work in both, so a legitimate page
+    will eventually trip this. That is over-rejection which fails LOUDLY, which
+    is the right side to err on. When it happens, narrow to the deceptive subset
+    — bidi controls U+202A-202E / U+2066-2069, invisible operators U+2061-2064,
+    U+200B, U+FEFF — rather than dropping the check.
+
+    `Mn` combining marks are intentionally absent: they are needed to spell real
+    words. `Zs` is absent because NBSP and friends are already caught by the
+    whitespace-normalization check on `mtext`.
+    """
+    for character in text:
+        if unicodedata.category(character) in {"Cc", "Cf", "Co", "Zl", "Zp"}:
+            raise ProvenanceError(
+                f"{prefix} MathML {tag} contains a control or format character "
+                f"(U+{ord(character):04X})"
+            )
+
+
 def _mathml_to_infix(source: bytes, prefix: str) -> bytes:
     upper_source = source.upper()
     if b"<!DOCTYPE" in upper_source or b"<!ENTITY" in upper_source:
@@ -727,6 +876,9 @@ def _mathml_to_infix(source: bytes, prefix: str) -> bytes:
     def render(node: ET.Element) -> str:
         tag = node.tag.rsplit("}", 1)[-1]
         children = list(node)
+        # Applied to EVERY element, container and leaf alike: hiding an <mrow>
+        # suppresses everything inside it just as effectively as hiding a token.
+        _reject_unexpected_attributes(node, tag, prefix)
         for child in children:
             if child.tail is not None and child.tail.strip():
                 raise ProvenanceError(f"{prefix} MathML contains mixed tail text")
@@ -752,8 +904,71 @@ def _mathml_to_infix(source: bytes, prefix: str) -> bytes:
         if tag in {"mi", "mn", "mo"}:
             if children or node.text is None:
                 raise ProvenanceError(f"{prefix} MathML token is not canonical")
+            _reject_unrenderable_text(node.text, tag, prefix)
             return node.text.replace("×", "*")
+        if tag == "mtext":
+            # `mtext` is PROSE embedded in the formula — "and", "for", a unit
+            # name. It is emitted verbatim: unlike `mi`/`mn`/`mo` it is not an
+            # operator, so the `×`→`*` rewrite must NOT apply to it (a literal
+            # "×" inside mtext is the word, not a multiplication sign).
+            if children or node.text is None:
+                raise ProvenanceError(f"{prefix} MathML token is not canonical")
+            _reject_unrenderable_text(node.text, tag, prefix)
+            # MathML collapses whitespace inside a token element, so raw text
+            # that is not ALREADY collapsed would project bytes the reader does
+            # not see — and would make the projection hash depend on how the
+            # origin happens to indent its HTML. Fail closed instead of
+            # rewriting: a rewrite would quietly move the pinned bytes.
+            #
+            # This DOES reject a real idiom — `<mtext> and </mtext>`, padding
+            # carried inside the token instead of via `mspace`. If that ever
+            # blocks a citation, do NOT "fix" it by switching to a silent
+            # rewrite: that reintroduces exactly the silent-drop this guards.
+            # Either keep rejecting and record the blocked citation, or add
+            # normalization as its own transform operation with its own byte
+            # accounting, so the collapse is itself auditable.
+            if node.text != " ".join(node.text.split()):
+                raise ProvenanceError(
+                    f"{prefix} MathML mtext is not whitespace-normalized"
+                )
+            return node.text
+        if tag == "mspace":
+            # `mspace` is typeset spacing with no content. It renders as ONE
+            # space, not as nothing. The distinction is load-bearing: OpenStax
+            # writes an inline variable list as
+            #     <mi>r</mi><mspace/><mtext>and</mtext><mspace/><mi>t</mi>
+            # whose reading is "r and t". Dropping mspace would yield "randt"
+            # and the projection would no longer equal the sentence a reader
+            # sees, which is exactly what claims pin into.
+            #
+            # `node.text is not None` rather than `.strip()`: str.strip() treats
+            # NBSP and the ideographic space as whitespace, so a `.strip()` test
+            # would silently DISCARD visible, non-collapsing spacing characters
+            # and map many distinct sources onto one projection byte.
+            if children or node.text is not None:
+                raise ProvenanceError(f"{prefix} MathML spacer is not empty")
+            # An EXPLICIT positive width is required. `mspace`'s default width is
+            # 0em, so a bare <mspace/> shows no gap at all and emitting a space
+            # for it would fabricate a separator — the same defect as
+            # width="0em", reached by omission instead of by value.
+            width = node.attrib.get("width", "").strip()
+            if not width:
+                raise ProvenanceError(
+                    f"{prefix} MathML spacer has no width and defaults to no gap"
+                )
+            if not _mspace_width_renders_as_a_gap(width):
+                raise ProvenanceError(
+                    f"{prefix} MathML spacer width {width!r} does not render "
+                    "as a gap"
+                )
+            return " "
         if tag == "mfrac":
+            # Character data directly inside <mfrac> is rendered by browsers as
+            # anonymous text. Without this guard it is silently DROPPED, so two
+            # different documents project identically while the dropped span is
+            # still certified "represented" by the caller's byte accounting.
+            if node.text is not None and node.text.strip():
+                raise ProvenanceError(f"{prefix} MathML contains mixed fraction text")
             if len(children) != 2:
                 raise ProvenanceError(
                     f"{prefix} MathML fraction must have two operands"

--- a/code/scripts/tests/test_adj_stdlib_provenance.py
+++ b/code/scripts/tests/test_adj_stdlib_provenance.py
@@ -8678,6 +8678,329 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         )
         self.assertEqual(transform["result_size"], len(result))
 
+    def test_mathml_transform_renders_spacer_separated_variable_list(self) -> None:
+        # The exact block OpenStax uses for an inline variable list. Its reading
+        # is "r and t" — three tokens separated by typeset spacing. If `mspace`
+        # rendered as nothing the projection would read "randt" and no claim
+        # could pin the sentence a reader actually sees.
+        source = (
+            b"<math><semantics><mrow><mi>r</mi>"
+            b'<mspace width="0.2em"></mspace><mtext>and</mtext>'
+            b'<mspace width="0.2em"></mspace><mi>t</mi></mrow>'
+            b'<annotation-xml encoding="MathML-Content"><mrow><mi>r</mi>'
+            b'<mspace width="0.2em"></mspace><mtext>and</mtext>'
+            b'<mspace width="0.2em"></mspace><mi>t</mi></mrow>'
+            b"</annotation-xml></semantics></math>"
+        )
+        result = b"r and t"
+        transform = provenance.build_text_transform(
+            source_sha256=provenance.sha256_bytes(source),
+            source=source,
+            result_sha256=provenance.sha256_bytes(result),
+            result=result,
+            operations=[
+                {
+                    "operation": "mathml_to_infix",
+                    "result_end": len(result),
+                    "result_start": 0,
+                    "source_end": len(source),
+                    "source_start": 0,
+                }
+            ],
+        )
+        self.assertEqual(transform["result_size"], len(result))
+
+    def test_mathml_transform_emits_mtext_verbatim(self) -> None:
+        # `mtext` is prose, not an operator, so the `×`→`*` rewrite that applies
+        # to mi/mn/mo must NOT apply to it: inside mtext a "×" is the word.
+        source = (
+            b"<math><semantics><mrow><mtext>3 \xc3\x97 4</mtext></mrow>"
+            b'<annotation-xml encoding="MathML-Content">'
+            b"<mrow><mtext>3 \xc3\x97 4</mtext></mrow>"
+            b"</annotation-xml></semantics></math>"
+        )
+        result = "3 × 4".encode("utf-8")
+        transform = provenance.build_text_transform(
+            source_sha256=provenance.sha256_bytes(source),
+            source=source,
+            result_sha256=provenance.sha256_bytes(result),
+            result=result,
+            operations=[
+                {
+                    "operation": "mathml_to_infix",
+                    "result_end": len(result),
+                    "result_start": 0,
+                    "source_end": len(source),
+                    "source_start": 0,
+                }
+            ],
+        )
+        self.assertEqual(transform["result_size"], len(result))
+
+    def test_mathml_transform_rejects_non_empty_spacer(self) -> None:
+        # `mspace` is defined as empty. Anything carrying content is not the
+        # element we agreed to render as one space, so it must fail loudly
+        # rather than silently drop the content.
+        source = b"<math><mspace><mi>x</mi></mspace></math>"
+        with self.assertRaisesRegex(provenance.ProvenanceError, "spacer is not empty"):
+            provenance.build_text_transform(
+                source_sha256=provenance.sha256_bytes(source),
+                source=source,
+                result_sha256=provenance.sha256_bytes(b" "),
+                result=b" ",
+                operations=[
+                    {
+                        "operation": "mathml_to_infix",
+                        "result_end": 1,
+                        "result_start": 0,
+                        "source_end": len(source),
+                        "source_start": 0,
+                    }
+                ],
+            )
+
+    def _mathml_raises(self, source: bytes, pattern: str) -> None:
+        with self.assertRaisesRegex(provenance.ProvenanceError, pattern):
+            provenance.build_text_transform(
+                source_sha256=provenance.sha256_bytes(source),
+                source=source,
+                result_sha256=provenance.sha256_bytes(b"x"),
+                result=b"x",
+                operations=[
+                    {
+                        "operation": "mathml_to_infix",
+                        "result_end": 1,
+                        "result_start": 0,
+                        "source_end": len(source),
+                        "source_start": 0,
+                    }
+                ],
+            )
+
+    def test_mathml_transform_rejects_hidden_prose(self) -> None:
+        # The sharpest failure this guard prevents: the page reads "d=rt", the
+        # projection would read "d=rt is false", and a claim could be pinned to
+        # a sentence no reader of the source can see.
+        self._mathml_raises(
+            b"<math><mrow><mtext>d=rt</mtext>"
+            b"<mtext style=\"display:none\">is false</mtext></mrow></math>",
+            r"unsupported attributes \['style'\]",
+        )
+        self._mathml_raises(
+            b'<math><mtext hidden="hidden">SECRET</mtext></math>',
+            r"unsupported attributes \['hidden'\]",
+        )
+
+    def test_mathml_transform_rejects_hidden_container(self) -> None:
+        # Hiding a container suppresses everything inside it, so the guard has
+        # to run for every element, not only for leaves.
+        self._mathml_raises(
+            b'<math><mrow style="display:none"><mi>x</mi></mrow></math>',
+            r"unsupported attributes \['style'\]",
+        )
+
+    def test_mathml_transform_rejects_spacer_that_renders_no_gap(self) -> None:
+        # A zero-width spacer is the mirror image of the bug that motivated
+        # rendering mspace at all: here emitting a space FABRICATES a separator
+        # the reader never sees.
+        for width in (b"0em", b"0", b"0.0em", b"-3em"):
+            self._mathml_raises(
+                b'<math><mrow><mi>r</mi><mspace width="'
+                + width
+                + b'"></mspace><mi>t</mi></mrow></math>',
+                "does not render as a gap",
+            )
+
+    def test_mathml_transform_rejects_spacer_with_unhandled_attributes(self) -> None:
+        # `linebreak` renders as a line break, not a gap, so the emitted single
+        # space would be a fiction.
+        self._mathml_raises(
+            b'<math><mspace linebreak="newline"></mspace></math>',
+            r"unsupported attributes \['linebreak'\]",
+        )
+
+    def test_mathml_transform_rejects_spacer_holding_visible_whitespace(self) -> None:
+        # NBSP is whitespace to str.strip() but VISIBLE, non-collapsing spacing
+        # to a reader. A `.strip()`-based emptiness test would silently drop it.
+        self._mathml_raises(
+            "<math><mspace>  </mspace></math>".encode(),
+            "spacer is not empty",
+        )
+
+    def test_mathml_transform_rejects_unnormalized_mtext(self) -> None:
+        # Otherwise the projection carries bytes the reader does not see, and
+        # its hash moves when the origin merely re-indents its HTML.
+        self._mathml_raises(
+            b"<math><mtext>d=rt </mtext></math>",
+            "not whitespace-normalized",
+        )
+
+    def test_mathml_transform_rejects_bidi_override_in_text(self) -> None:
+        # A bidi override inside quoted evidence makes the DISPLAYED text differ
+        # from the bytes that were pinned.
+        self._mathml_raises(
+            "<math><mtext>a‮b</mtext></math>".encode(),
+            "control or format character",
+        )
+
+    def test_mathml_transform_rejects_private_use_character(self) -> None:
+        # A private-use codepoint renders as whatever a webfont maps it to, so
+        # nothing about it can be claimed to match what a reader sees.
+        self._mathml_raises(
+            "<math><mtext>a\ue000b</mtext></math>".encode(),
+            "control or format character",
+        )
+
+    def test_mathml_transform_rejects_native_hiding_attributes(self) -> None:
+        # MathML can hide content with NO stylesheet at all, which is why the
+        # attribute policy is an allowlist rather than a list of bad names:
+        # `mathcolor="transparent"`, `mathsize="0"` and a deep `scriptlevel`
+        # each render the text invisible while it still reaches the projection.
+        for attribute, value in (
+            (b"mathcolor", b"transparent"),
+            (b"mathsize", b"0"),
+            (b"scriptlevel", b"+9"),
+        ):
+            self._mathml_raises(
+                b"<math><mrow><mtext>d=rt</mtext><mtext "
+                + attribute
+                + b'="'
+                + value
+                + b'">is false</mtext></mrow></math>',
+                r"unsupported attributes \['%s'\]" % attribute.decode(),
+            )
+
+    def test_mathml_transform_rejects_hiding_by_indirection_on_leaves(self) -> None:
+        # `class` and `id` hide only via a stylesheet we never fetched. They
+        # never appear on a text-emitting leaf in the corpus, so rejecting them
+        # there costs nothing and closes `class="sr-only"`-style hiding on
+        # exactly the elements that can inject prose.
+        for attribute in (b"class", b"id"):
+            self._mathml_raises(
+                b"<math><mtext " + attribute + b'="x">SECRET</mtext></math>',
+                r"unsupported attributes \['%s'\]" % attribute.decode(),
+            )
+
+    def test_mathml_transform_rejects_character_remapping_mathvariant(self) -> None:
+        # `double-struck` R renders as ℝ (U+211D), not "R". Emitting bare ASCII
+        # would pin a claim about ℝ to the byte "R" — a different mathematical
+        # object sharing one projection.
+        for variant in (b"double-struck", b"fraktur", b"script", b"monospace"):
+            self._mathml_raises(
+                b'<math><mi mathvariant="' + variant + b'">R</mi></math>',
+                "character-remapping mathvariant",
+            )
+
+    def test_mathml_transform_accepts_non_remapping_mathvariant(self) -> None:
+        # The two values the corpus actually uses must keep working.
+        for variant in (b"normal", b"italic"):
+            source = b'<math><mi mathvariant="' + variant + b'">d</mi></math>'
+            result = b"d"
+            transform = provenance.build_text_transform(
+                source_sha256=provenance.sha256_bytes(source),
+                source=source,
+                result_sha256=provenance.sha256_bytes(result),
+                result=result,
+                operations=[
+                    {
+                        "operation": "mathml_to_infix",
+                        "result_end": len(result),
+                        "result_start": 0,
+                        "source_end": len(source),
+                        "source_start": 0,
+                    }
+                ],
+            )
+            self.assertEqual(transform["result_size"], len(result))
+
+    def test_mathml_transform_rejects_widths_that_resolve_to_no_gap(self) -> None:
+        # A MathML percentage is a percentage OF THE DEFAULT, and mspace's
+        # default width is 0em — so every percentage is zero, `100%` included.
+        # An unknown unit is discarded and falls back to the same default, and a
+        # bare number is not a valid length at all.
+        for width in (b"1%", b"100%", b"5xyz", b"5", b"negativethinmathspace"):
+            self._mathml_raises(
+                b'<math><mrow><mi>r</mi><mspace width="'
+                + width
+                + b'"></mspace><mi>t</mi></mrow></math>',
+                "does not render as a gap",
+            )
+
+    def test_mathml_transform_rejects_sub_perceptual_width(self) -> None:
+        # The continuous tail of the width="0em" defect: positive but invisible,
+        # so emitting a space still fabricates a separator. The floor is
+        # MathML's own smallest named gap (1/18 em) — the corpus minimum,
+        # 0.056em, is that same quantity written numerically and must survive.
+        for width in (b"0.0001em", b"0.01em", b"0.049em"):
+            self._mathml_raises(
+                b'<math><mrow><mi>d</mi><mspace width="'
+                + width
+                + b'"></mspace><mi>t</mi></mrow></math>',
+                "does not render as a gap",
+            )
+
+    def test_mathml_transform_rejects_namespaced_remapping_mathvariant(self) -> None:
+        # The allowlist reads namespace-stripped local names, so the VALUE check
+        # has to read the same key space or a namespaced attribute slips past it.
+        self._mathml_raises(
+            b'<math xmlns:m="urn:x">'
+            b'<mi m:mathvariant="double-struck">R</mi></math>',
+            "character-remapping mathvariant",
+        )
+
+    def test_mathml_transform_rejects_html_annotation_encoding(self) -> None:
+        # encoding="text/html" makes <annotation-xml> an HTML integration point
+        # and changes how a browser parses the subtree.
+        self._mathml_raises(
+            b"<math><semantics><mrow><mi>x</mi></mrow>"
+            b'<annotation-xml encoding="text/html"><mrow><mi>x</mi></mrow>'
+            b"</annotation-xml></semantics></math>",
+            "encoding 'text/html' is unsupported",
+        )
+
+    def test_mathml_transform_rejects_spacer_without_width(self) -> None:
+        # mspace defaults to width 0, so a bare <mspace/> shows no gap and
+        # emitting a space for it fabricates a separator by OMISSION rather
+        # than by value.
+        self._mathml_raises(
+            b"<math><mrow><mi>r</mi><mspace></mspace><mi>t</mi></mrow></math>",
+            "no width and defaults to no gap",
+        )
+
+    def test_mathml_transform_accepts_named_positive_space(self) -> None:
+        # `thinmathspace` occurs 14 times in the pinned corpus; a digits-only
+        # length check would wrongly reject it.
+        source = (
+            b'<math><mrow><mi>a</mi><mspace width="thinmathspace"></mspace>'
+            b"<mi>b</mi></mrow></math>"
+        )
+        result = b"a b"
+        transform = provenance.build_text_transform(
+            source_sha256=provenance.sha256_bytes(source),
+            source=source,
+            result_sha256=provenance.sha256_bytes(result),
+            result=result,
+            operations=[
+                {
+                    "operation": "mathml_to_infix",
+                    "result_end": len(result),
+                    "result_start": 0,
+                    "source_end": len(source),
+                    "source_start": 0,
+                }
+            ],
+        )
+        self.assertEqual(transform["result_size"], len(result))
+
+    def test_mathml_transform_rejects_mixed_fraction_text(self) -> None:
+        # Browsers render stray character data inside <mfrac> as anonymous text.
+        # Unguarded it is silently dropped, so two different documents project
+        # identically while the dropped span is still certified "represented".
+        self._mathml_raises(
+            b"<math><mfrac>NOT <mi>a</mi><mi>b</mi></mfrac></math>",
+            "mixed fraction text",
+        )
+
     def test_mathml_transform_rejects_unsupported_semantics(self) -> None:
         source = b"<math><msqrt><mi>x</mi></msqrt></math>"
         with self.assertRaisesRegex(provenance.ProvenanceError, "unsupported"):


### PR DESCRIPTION
## Why

`_mathml_to_infix` supported only `math`/`semantics`/`mrow`/`annotation-xml`/`mi`/`mn`/`mo`/`mfrac`. OpenStax typesets an inline variable list as

```
<mi>r</mi><mspace/><mtext>and</mtext><mspace/><mi>t</mi>
```

so **any sentence naming two variables together was unrenderable, and therefore uncitable**. Measured cost: `speed.adj`'s two rearrangements (#9932) are pinned to sentences that name `d=rt` without binding `d`/`r`/`t` to distance/rate/time — because the sentence that *does* bind them is blocked by exactly this.

`mspace` renders as one space, `mtext` as its literal text. `mspace` is **not** dropped: the reading of the block above is `r and t`, and dropping it would project `randt`.

## The small part was adding the elements

Security review found the renderer — which consumes untrusted third-party HTML and emits the projection that claims are pinned into — would **silently drop or fabricate content in eight distinct ways**. Every one was reproduced before being fixed:

| input | projected | reality |
| --- | --- | --- |
| `<mtext style="display:none">is false</mtext>` | `d=rt is false` | page reads `d=rt` |
| `<mtext mathcolor="transparent">` | same | no stylesheet needed |
| `<mtext mathsize="0">` / `scriptlevel="+9"` | same | native MathML hiding |
| `<mtext class="sr-only">` | same | via stylesheet |
| `<mfrac>NOT <mi>a</mi><mi>b</mi></mfrac>` | `(a/b)` | `NOT ` dropped — identical to the document without it |
| `<mspace width="0em"‖"100%"‖"5xyz"‖bare/>` | a space | page shows **no gap at all** |
| `<mspace>&#160;&#160;</mspace>` | one space | visible NBSP dropped (`str.strip()` calls it whitespace) |
| `<mi mathvariant="double-struck">R</mi>` | `R` | renders **ℝ** (U+211D) |

A claim pinned to any of these quotes bytes **no reader of the source can see** — the precise failure this system exists to prevent.

## Allowlist, not denylist

A denylist loses. `style`/`hidden` are the CSS spelling, but MathML has native equivalents honoured with no stylesheet at all, and enumerating them one at a time is a losing race. Inverting to a per-element allowlist also closed `linethickness="0"` and `bevelled` on `mfrac` **for free** — neither was on anyone's list.

Every entry is grounded in a census of the pinned CAS rather than guessed:

```
math/display 679 · annotation-xml/encoding 679 · mrow/class 160 · math/alttext 94
mspace/width 79 · mo/stretchy 42 · mi/mathvariant 30 · mo/accent 7
mtext/mathvariant 4 · mo/lspace 2 · mo/rspace 2
```

No `style`, no `hidden`, no `visibility` anywhere — so rejecting them costs nothing. The census also corrected two things a name-only allowlist got **wrong**:

- **`thinmathspace`** is a width in the corpus **14 times**. A digits-plus-unit check would have rejected live pinned content.
- **A bare `<mspace/>` defaults to width 0**, so it shows no gap — emitting a space for it fabricated a separator *by omission*, the same defect as `width="0em"` reached from the other side.

### The width floor is 0.05em, not `> 0`

`width="0.0001em"` is positive but sub-perceptual, so a page showing the product `rt` would project `r t` — in formula-land a change of meaning. The threshold is not arbitrary: MathML's smallest **named** gap, `veryverythinmathspace`, is 1/18 em ≈ 0.0556em, and the corpus minimum is `0.056em` — the same quantity written numerically.

## Known residuals, recorded not hidden

- **`class` on `<mrow>`** stays allowed. It hides only via a stylesheet that was never fetched, and appears 160 times in real content; the text-emitting leaves reject it. Genuinely unclosable at the byte level.
- **`alttext`** is what a screen-reader user hears *instead of* the math, so "the projection is what a reader sees" holds only for a *visual* reader.
- **Unbounded `render` recursion** — ~65 KB of nested `<mrow>` raises `RecursionError` rather than `ProvenanceError`. Pre-existing, DoS-class rather than integrity-class, and depth guards compose badly enough to deserve their own adversarial repro. Backlogged with the invariant that makes deferring it safe, which review confirmed holds today: *no caller maps a non-`ProvenanceError` to a verification pass.*

The `mtext` whitespace rule **fails closed rather than normalizing**, because a silent rewrite would move the pinned bytes. This does reject the real idiom `<mtext> and </mtext>`; the file says so, and says not to "fix" it with a rewrite later.

## Verification

macOS trips the link guard via `/var`, so this was gated in the Linux container:

- **229 unittests OK**
- **All four builders rebuilt with 0 CAS files changed** — byte-identical, so the change is *provably* additive and no `RENDERED_HASH` moved
- Verifier `"valid": true`, 11 bundles / 125 objects
- **15/15 attack cases blocked; 8/8 legitimate cases still render**, including `r and t`, the pinned `(n/100)*x`, `thinmathspace`, `mrow class`, `mo stretchy`

Three rounds of security review; every finding reproduced before fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)