### PR TITLE
fix(adj): cite NIST B.9 by the heading that page actually prints

### DIFF
--- a/code/specs/data/adj-formula-stdlib/reference/absorbed-dose-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/absorbed-dose-conversions.adj
@@ -19,7 +19,7 @@
 % `table` and not a hand-written `relate` clause: this is exactly the shape reference data
 % comes in — a published table, not prose. The citable artifact IS the NIST conversion-
 % factors table at the `locator` below; the factor here is a CELL of NIST Special
-% Publication 811, Appendix B.9 ("Factors for units listed alphabetically"), defended by
+% Publication 811, Appendix B.9 ("Factors for units listed by kind of quantity or field of science"), defended by
 % one provenance envelope. Each `row` lowers to a ground relation
 % `absorbed_dose_to_gray(unit, gy)`, so the exact lookup above is the ordinary SLD binding
 % query — the engine returns the factor WITH this table's citation as its proof, on the
@@ -50,7 +50,7 @@ table absorbed_dose_to_gray {
 
     row (rad, 0.01)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/acceleration-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/acceleration-conversions.adj
@@ -18,7 +18,7 @@
 % several hand-written `relate` clauses: this is exactly the shape reference data
 % comes in — a published table, not prose. The citable artifact IS the NIST
 % conversion-factors table at the `locator` below; every factor here is a CELL of NIST
-% Special Publication 811, Appendix B.9 ("Factors for units listed alphabetically"),
+% Special Publication 811, Appendix B.9 ("Factors for units listed by kind of quantity or field of science"),
 % and the whole table is defended by one provenance envelope rather than repeating
 % `source`/`locator`/`trust` on every row. Each `row` lowers to a ground relation
 % `acceleration_to_metres_per_second_squared(unit, mpss)`, so the exact lookup above is
@@ -59,7 +59,7 @@ table acceleration_to_metres_per_second_squared {
     row (gal, 0.01)
     row (free_fall_standard, 9.80665)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/density-of-heat-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/density-of-heat-conversions.adj
@@ -62,7 +62,7 @@ table density_of_heat_to_joule_per_square_metre {
     row (calorie_th_per_square_centimetre, 41840)
     row (langley, 41840)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/dose-equivalent-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/dose-equivalent-conversions.adj
@@ -22,7 +22,7 @@
 % `table` and not a hand-written `relate` clause: this is exactly the shape reference data
 % comes in — a published table, not prose. The citable artifact IS the NIST conversion-
 % factors table at the `locator` below; the factor here is a CELL of NIST Special
-% Publication 811, Appendix B.9 ("Factors for units listed alphabetically"), defended by
+% Publication 811, Appendix B.9 ("Factors for units listed by kind of quantity or field of science"), defended by
 % one provenance envelope. Each `row` lowers to a ground relation
 % `dose_equivalent_to_sievert(unit, sv)`, so the exact lookup above is the ordinary SLD
 % binding query — the engine returns the factor WITH this table's citation as its proof, on
@@ -55,7 +55,7 @@ table dose_equivalent_to_sievert {
 
     row (rem, 0.01)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/dynamic-viscosity-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/dynamic-viscosity-conversions.adj
@@ -18,8 +18,7 @@
 % use-many). Why a `table` and not several hand-written `relate` clauses: this is
 % exactly the shape reference data comes in — a published table, not prose. The
 % citable artifact IS the NIST conversion-factors table at the `locator` below; every
-% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors for
-% units listed alphabetically"), and the whole table is defended by one provenance
+% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors for units listed by kind of quantity or field of science"), and the whole table is defended by one provenance
 % envelope rather than repeating `source`/`locator`/`trust` on every row. Each `row`
 % lowers to a ground relation `dynamic_viscosity_to_pascal_seconds(unit, pas)`, so the
 % exact lookup above is the ordinary SLD binding query — the engine returns the factor
@@ -55,7 +54,7 @@ table dynamic_viscosity_to_pascal_seconds {
     row (poise, 0.1)
     row (centipoise, 0.001)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/electric-capacitance-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/electric-capacitance-conversions.adj
@@ -22,7 +22,7 @@
 % first, then reason (write-once-use-many). Why a `table` and not a hand-written `relate` clause:
 % this is exactly the shape reference data comes in — a published table, not prose. The citable
 % artifact IS the NIST conversion-factors table at the `locator` below; the factor here is a CELL
-% of NIST Special Publication 811, Appendix B.9 ("Factors for units listed alphabetically"),
+% of NIST Special Publication 811, Appendix B.9 ("Factors for units listed by kind of quantity or field of science"),
 % defended by one provenance envelope. Each `row` lowers to a ground relation
 % `electric_capacitance_to_farad(unit, v)`, so the exact lookup above is the ordinary SLD binding
 % query — the engine returns the factor WITH this table's citation as its proof, on the CPU, with
@@ -52,7 +52,7 @@ table electric_capacitance_to_farad {
 
     row (abfarad, 1000000000)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/electric-charge-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/electric-charge-conversions.adj
@@ -20,8 +20,7 @@
 % in abcoulombs into SI first, then reason (write-once-use-many). Why a `table` and not a
 % hand-written `relate` clause: this is exactly the shape reference data comes in — a published
 % table, not prose. The citable artifact IS the NIST conversion-factors table at the `locator`
-% below; the factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors for
-% units listed alphabetically"), defended by one provenance envelope. Each `row` lowers to a
+% below; the factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors for units listed by kind of quantity or field of science"), defended by one provenance envelope. Each `row` lowers to a
 % ground relation `electric_charge_to_coulomb(unit, c)`, so the exact lookup above is the
 % ordinary SLD binding query — the engine returns the factor WITH this table's citation as its
 % proof, on the CPU, with zero model calls.
@@ -55,7 +54,7 @@ table electric_charge_to_coulomb {
 
     row (abcoulomb, 10)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/electric-conductance-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/electric-conductance-conversions.adj
@@ -56,7 +56,7 @@ table electric_conductance_to_siemens {
 
     row (abmho, 1000000000)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/electric-current-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/electric-current-conversions.adj
@@ -57,7 +57,7 @@ table electric_current_to_ampere {
 
     row (abampere, 10)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/electric-inductance-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/electric-inductance-conversions.adj
@@ -23,7 +23,7 @@
 % `table` and not a hand-written `relate` clause: this is exactly the shape reference data comes
 % in — a published table, not prose. The citable artifact IS the NIST conversion-factors table at
 % the `locator` below; the factor here is a CELL of NIST Special Publication 811, Appendix B.9
-% ("Factors for units listed alphabetically"), defended by one provenance envelope. Each `row`
+% ("Factors for units listed by kind of quantity or field of science"), defended by one provenance envelope. Each `row`
 % lowers to a ground relation `electric_inductance_to_henry(unit, v)`, so the exact lookup above
 % is the ordinary SLD binding query — the engine returns the factor WITH this table's citation as
 % its proof, on the CPU, with zero model calls.
@@ -53,7 +53,7 @@ table electric_inductance_to_henry {
 
     row (abhenry, 0.000000001)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/electric-potential-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/electric-potential-conversions.adj
@@ -20,7 +20,7 @@
 % not a hand-written `relate` clause: this is exactly the shape reference data comes in — a
 % published table, not prose. The citable artifact IS the NIST conversion-factors table at the
 % `locator` below; the factor here is a CELL of NIST Special Publication 811, Appendix B.9
-% ("Factors for units listed alphabetically"), defended by one provenance envelope. Each `row`
+% ("Factors for units listed by kind of quantity or field of science"), defended by one provenance envelope. Each `row`
 % lowers to a ground relation `electric_potential_to_volt(unit, v)`, so the exact lookup above is
 % the ordinary SLD binding query — the engine returns the factor WITH this table's citation as its
 % proof, on the CPU, with zero model calls.
@@ -49,7 +49,7 @@ table electric_potential_to_volt {
 
     row (abvolt, 0.00000001)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/electric-resistance-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/electric-resistance-conversions.adj
@@ -20,7 +20,7 @@
 % reason (write-once-use-many). Why a `table` and not a hand-written `relate` clause: this is
 % exactly the shape reference data comes in — a published table, not prose. The citable artifact
 % IS the NIST conversion-factors table at the `locator` below; the factor here is a CELL of NIST
-% Special Publication 811, Appendix B.9 ("Factors for units listed alphabetically"), defended by
+% Special Publication 811, Appendix B.9 ("Factors for units listed by kind of quantity or field of science"), defended by
 % one provenance envelope. Each `row` lowers to a ground relation
 % `electric_resistance_to_ohm(unit, v)`, so the exact lookup above is the ordinary SLD binding
 % query — the engine returns the factor WITH this table's citation as its proof, on the CPU, with
@@ -51,7 +51,7 @@ table electric_resistance_to_ohm {
 
     row (abohm, 0.000000001)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/energy-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/energy-conversions.adj
@@ -11,8 +11,7 @@
 % Why a `table` and not several hand-written `relate` clauses: this is exactly the
 % shape reference data comes in — a published table, not prose. The citable
 % artifact IS the NIST conversion-factors table at the `locator` below; every
-% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors
-% for units listed alphabetically"), and the whole table is defended by one
+% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors for units listed by kind of quantity or field of science"), and the whole table is defended by one
 % provenance envelope rather than repeating `source`/`locator`/`trust` on every
 % row. Each `row` lowers to a ground relation `energy_to_joules(unit, joules)`, so
 % the exact lookup above is the ordinary SLD binding query — the engine returns
@@ -55,7 +54,7 @@ table energy_to_joules {
     row (watt_hour, 3600)
     row (kilowatt_hour, 3600000)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/exposure-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/exposure-conversions.adj
@@ -24,7 +24,7 @@
 % hand-written `relate` clause: this is exactly the shape reference data comes in — a
 % published table, not prose. The citable artifact IS the NIST conversion-factors table at the
 % `locator` below; the factor here is a CELL of NIST Special Publication 811, Appendix B.9
-% ("Factors for units listed alphabetically"), defended by one provenance envelope. Each `row`
+% ("Factors for units listed by kind of quantity or field of science"), defended by one provenance envelope. Each `row`
 % lowers to a ground relation `exposure_to_coulomb_per_kilogram(unit, ckg)`, so the exact
 % lookup above is the ordinary SLD binding query — the engine returns the factor WITH this
 % table's citation as its proof, on the CPU, with zero model calls.
@@ -56,7 +56,7 @@ table exposure_to_coulomb_per_kilogram {
 
     row (roentgen, 0.000258)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/force-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/force-conversions.adj
@@ -14,8 +14,7 @@
 % `table` and not several hand-written `relate` clauses: this is exactly the shape
 % reference data comes in — a published table, not prose. The citable artifact IS the
 % NIST conversion-factors table at the `locator` below; every factor here is a CELL of
-% NIST Special Publication 811, Appendix B.9 ("Factors for units listed
-% alphabetically"), and the whole table is defended by one provenance envelope rather
+% NIST Special Publication 811, Appendix B.9 ("Factors for units listed by kind of quantity or field of science"), and the whole table is defended by one provenance envelope rather
 % than repeating `source`/`locator`/`trust` on every row. Each `row` lowers to a
 % ground relation `force_to_newtons(unit, newtons)`, so the exact lookup above is the
 % ordinary SLD binding query — the engine returns the factor WITH this table's
@@ -53,7 +52,7 @@ table force_to_newtons {
     row (kilogram_force, 9.80665)
     row (kilopond, 9.80665)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/heat-flux-density-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/heat-flux-density-conversions.adj
@@ -63,7 +63,7 @@ table heat_flux_density_to_watt_per_square_metre {
 
     row (calorie_th_per_square_centimetre_second, 41840)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/illuminance-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/illuminance-conversions.adj
@@ -16,8 +16,7 @@
 % use-many). Why a `table` and not a hand-written `relate` clause: this is exactly the
 % shape reference data comes in — a published table, not prose. The citable artifact IS
 % the NIST conversion-factors table at the `locator` below; the factor here is a CELL of
-% NIST Special Publication 811, Appendix B.9 ("Factors for units listed
-% alphabetically"), defended by one provenance envelope. Each `row` lowers to a ground
+% NIST Special Publication 811, Appendix B.9 ("Factors for units listed by kind of quantity or field of science"), defended by one provenance envelope. Each `row` lowers to a ground
 % relation `illuminance_to_lux(unit, lux)`, so the exact lookup above is the ordinary SLD
 % binding query — the engine returns the factor WITH this table's citation as its proof,
 % on the CPU, with zero model calls.
@@ -47,7 +46,7 @@ table illuminance_to_lux {
 
     row (phot, 10000)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/kinematic-viscosity-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/kinematic-viscosity-conversions.adj
@@ -19,8 +19,7 @@
 % (write-once-use-many). Why a `table` and not several hand-written `relate` clauses:
 % this is exactly the shape reference data comes in — a published table, not prose.
 % The citable artifact IS the NIST conversion-factors table at the `locator` below;
-% every factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors
-% for units listed alphabetically"), and the whole table is defended by one provenance
+% every factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors for units listed by kind of quantity or field of science"), and the whole table is defended by one provenance
 % envelope rather than repeating `source`/`locator`/`trust` on every row. Each `row`
 % lowers to a ground relation
 % `kinematic_viscosity_to_square_metres_per_second(unit, m2s)`, so the exact lookup
@@ -54,7 +53,7 @@ table kinematic_viscosity_to_square_metres_per_second {
     row (stokes, 0.0001)
     row (centistokes, 0.000001)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/linear-mass-density-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/linear-mass-density-conversions.adj
@@ -54,7 +54,7 @@ table linear_mass_density_to_kilogram_per_metre {
 
     row (tex, 0.000001)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/luminance-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/luminance-conversions.adj
@@ -18,8 +18,7 @@
 % first, then reason (write-once-use-many). Why a `table` and not a hand-written `relate`
 % clause: this is exactly the shape reference data comes in — a published table, not prose.
 % The citable artifact IS the NIST conversion-factors table at the `locator` below; the
-% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors for units
-% listed alphabetically"), defended by one provenance envelope. Each `row` lowers to a
+% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors for units listed by kind of quantity or field of science"), defended by one provenance envelope. Each `row` lowers to a
 % ground relation `luminance_to_candela_per_square_metre(unit, cd_per_m2)`, so the exact
 % lookup above is the ordinary SLD binding query — the engine returns the factor WITH this
 % table's citation as its proof, on the CPU, with zero model calls.
@@ -49,7 +48,7 @@ table luminance_to_candela_per_square_metre {
 
     row (stilb, 10000)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/magnetic-flux-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/magnetic-flux-conversions.adj
@@ -21,8 +21,7 @@
 % first, then reason (write-once-use-many). Why a `table` and not a hand-written `relate`
 % clause: this is exactly the shape reference data comes in — a published table, not prose.
 % The citable artifact IS the NIST conversion-factors table at the `locator` below; the
-% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors for units
-% listed alphabetically"), defended by one provenance envelope. Each `row` lowers to a ground
+% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors for units listed by kind of quantity or field of science"), defended by one provenance envelope. Each `row` lowers to a ground
 % relation `magnetic_flux_to_weber(unit, wb)`, so the exact lookup above is the ordinary SLD
 % binding query — the engine returns the factor WITH this table's citation as its proof, on
 % the CPU, with zero model calls.
@@ -53,7 +52,7 @@ table magnetic_flux_to_weber {
 
     row (maxwell, 0.00000001)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/magnetic-flux-density-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/magnetic-flux-density-conversions.adj
@@ -19,8 +19,7 @@
 % `table` and not several hand-written `relate` clauses: this is exactly the shape
 % reference data comes in — a published table, not prose. The citable artifact IS the
 % NIST conversion-factors table at the `locator` below; every factor here is a CELL of
-% NIST Special Publication 811, Appendix B.9 ("Factors for units listed
-% alphabetically"), and the whole table is defended by one provenance envelope rather
+% NIST Special Publication 811, Appendix B.9 ("Factors for units listed by kind of quantity or field of science"), and the whole table is defended by one provenance envelope rather
 % than repeating `source`/`locator`/`trust` on every row. Each `row` lowers to a ground
 % relation `magnetic_flux_density_to_teslas(unit, teslas)`, so the exact lookup above is
 % the ordinary SLD binding query — the engine returns the factor WITH this table's
@@ -52,7 +51,7 @@ table magnetic_flux_density_to_teslas {
     row (gauss, 0.0001)
     row (gamma, 0.000000001)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/mass-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/mass-conversions.adj
@@ -11,8 +11,7 @@
 % Why a `table` and not six hand-written `relate` clauses: this is exactly the
 % shape reference data comes in — a published table, not prose. The citable
 % artifact IS the NIST conversion-factors table at the `locator` below; every
-% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors
-% for units listed alphabetically"), and the whole table is defended by one
+% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors for units listed by kind of quantity or field of science"), and the whole table is defended by one
 % provenance envelope rather than repeating `source`/`locator`/`trust` on every
 % row. Each `row` lowers to a ground relation `mass_to_kilograms(unit, kg)`, so
 % the exact lookup above is the ordinary SLD binding query — the engine returns
@@ -52,7 +51,7 @@ table mass_to_kilograms {
     row (slug, 14.5939)
     row (troy_pound, 0.3732417)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/mass-density-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/mass-density-conversions.adj
@@ -54,7 +54,7 @@ table mass_density_to_kilogram_per_cubic_metre {
 
     row (gram_per_cubic_centimetre, 1000)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/moment-of-force-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/moment-of-force-conversions.adj
@@ -60,7 +60,7 @@ table moment_of_force_to_newton_metre {
     row (dyne_centimetre, 0.0000001)
     row (kilogram_force_metre, 9.80665)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/power-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/power-conversions.adj
@@ -21,7 +21,7 @@
 % and not a hand-written `relate` clause: this is exactly the shape reference data comes in —
 % a published table, not prose. The citable artifact IS the NIST conversion-factors table at
 % the `locator` below; the factor here is a CELL of NIST Special Publication 811,
-% Appendix B.9 ("Factors for units listed alphabetically"), defended by one provenance
+% Appendix B.9 ("Factors for units listed by kind of quantity or field of science"), defended by one provenance
 % envelope. Each `row` lowers to a ground relation `power_to_watt(unit, w)`, so the exact
 % lookup above is the ordinary SLD binding query — the engine returns the factor WITH this
 % table's citation as its proof, on the CPU, with zero model calls.
@@ -55,7 +55,7 @@ table power_to_watt {
 
     row (erg_per_second, 0.0000001)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/pressure-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/pressure-conversions.adj
@@ -12,8 +12,7 @@
 % Why a `table` and not several hand-written `relate` clauses: this is exactly the
 % shape reference data comes in — a published table, not prose. The citable
 % artifact IS the NIST conversion-factors table at the `locator` below; every
-% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors
-% for units listed alphabetically"), and the whole table is defended by one
+% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors for units listed by kind of quantity or field of science"), and the whole table is defended by one
 % provenance envelope rather than repeating `source`/`locator`/`trust` on every
 % row. Each `row` lowers to a ground relation `pressure_to_pascals(unit, pascals)`,
 % so the exact lookup above is the ordinary SLD binding query — the engine returns
@@ -59,7 +58,7 @@ table pressure_to_pascals {
     row (kilogram_force_per_square_centimeter, 98066.5)
     row (kilogram_force_per_square_meter, 9.80665)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/radioactivity-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/radioactivity-conversions.adj
@@ -18,7 +18,7 @@
 % `table` and not a hand-written `relate` clause: this is exactly the shape reference data
 % comes in — a published table, not prose. The citable artifact IS the NIST conversion-
 % factors table at the `locator` below; the factor here is a CELL of NIST Special
-% Publication 811, Appendix B.9 ("Factors for units listed alphabetically"), defended by
+% Publication 811, Appendix B.9 ("Factors for units listed by kind of quantity or field of science"), defended by
 % one provenance envelope. Each `row` lowers to a ground relation
 % `activity_to_becquerel(unit, bq)`, so the exact lookup above is the ordinary SLD binding
 % query — the engine returns the factor WITH this table's citation as its proof, on the
@@ -48,7 +48,7 @@ table activity_to_becquerel {
 
     row (curie, 37000000000)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/specific-energy-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/specific-energy-conversions.adj
@@ -62,7 +62,7 @@ table specific_energy_to_joule_per_kilogram {
     row (calorie_it_per_gram, 4186.8)
     row (calorie_th_per_gram, 4184)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/specific-heat-capacity-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/specific-heat-capacity-conversions.adj
@@ -72,7 +72,7 @@ table specific_heat_capacity_to_joule_per_kilogram_kelvin {
     row (btu_it_per_pound_fahrenheit, 4186.8)
     row (btu_th_per_pound_fahrenheit, 4184)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/speed-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/speed-conversions.adj
@@ -15,8 +15,7 @@
 % (write-once-use-many). Why a `table` and not several hand-written `relate` clauses:
 % this is exactly the shape reference data comes in — a published table, not prose.
 % The citable artifact IS the NIST conversion-factors table at the `locator` below;
-% every factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors
-% for units listed alphabetically"), and the whole table is defended by one provenance
+% every factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors for units listed by kind of quantity or field of science"), and the whole table is defended by one provenance
 % envelope rather than repeating `source`/`locator`/`trust` on every row. Each `row`
 % lowers to a ground relation `speed_to_metres_per_second(unit, mps)`, so the exact
 % lookup above is the ordinary SLD binding query — the engine returns the factor WITH
@@ -59,7 +58,7 @@ table speed_to_metres_per_second {
     row (mile_per_minute, 26.8224)
     row (mile_per_second, 1609.344)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/temperature-interval-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/temperature-interval-conversions.adj
@@ -58,7 +58,7 @@ table temperature_interval_to_kelvin {
 
     row (degree_celsius, 1)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/thermal-conductivity-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/thermal-conductivity-conversions.adj
@@ -58,7 +58,7 @@ table thermal_conductivity_to_watt_per_metre_kelvin {
 
     row (calorie_th_per_centimetre_second_celsius, 418.4)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/time-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/time-conversions.adj
@@ -13,8 +13,7 @@
 % Why a `table` and not three hand-written `relate` clauses: this is exactly the
 % shape reference data comes in — a published table, not prose. The citable
 % artifact IS the NIST conversion-factors table at the `locator` below; every
-% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors
-% for units listed alphabetically"), and the whole table is defended by one
+% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors for units listed by kind of quantity or field of science"), and the whole table is defended by one
 % provenance envelope rather than repeating `source`/`locator`/`trust` on every
 % row. Each `row` lowers to a ground relation `time_to_seconds(unit, seconds)`, so
 % the exact lookup above is the ordinary SLD binding query — the engine returns
@@ -51,7 +50,7 @@ table time_to_seconds {
     row (hour, 3600)
     row (day, 86400)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/volume-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/volume-conversions.adj
@@ -12,8 +12,7 @@
 % Why a `table` and not ten hand-written `relate` clauses: this is exactly the
 % shape reference data comes in — a published table, not prose. The citable
 % artifact IS the NIST conversion-factors table at the `locator` below; every
-% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors
-% for units listed alphabetically"), and the whole table is defended by one
+% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors for units listed by kind of quantity or field of science"), and the whole table is defended by one
 % provenance envelope rather than repeating `source`/`locator`/`trust` on every
 % row. Each `row` lowers to a ground relation `volume_to_cubic_metres(unit, m3)`,
 % so the exact lookup above is the ordinary SLD binding query — the engine returns
@@ -62,7 +61,7 @@ table volume_to_cubic_metres {
     row (teaspoon, 0.000004928922)
     row (barrel, 0.1589873)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }

--- a/code/specs/data/adj-formula-stdlib/reference/wave-number-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/wave-number-conversions.adj
@@ -51,7 +51,7 @@ table wave_number_to_reciprocal_metre {
 
     row (kayser, 100)
 
-    source "Factors for units listed alphabetically"
+    source "NIST Guide to the SI, Appendix B.9: Factors for units listed by kind of quantity or field of science"
     locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
     trust authoritative
 }


### PR DESCRIPTION
## What

All 36 NIST conversion tables carried

```
source "Factors for units listed alphabetically"
```

against a locator pointing at **Appendix B.9**. That sentence appears **zero times** on the cited page — and zero times on B.8 either, so this was not a near-miss in casing or whitespace. Verified against the served bytes of both pages.

The phrase describes the **wrong appendix**, and the mistake is in the `source`, not the `locator`. NIST splits the conversion factors two ways:

| page | real `<h1>` | contents |
| --- | --- | --- |
| B.8 | "NIST Guide to the SI, Appendix B.8: Factors for **Units Listed Alphabetically**" | abampere, abcoulomb, abfarad… |
| B.9 | "NIST Guide to the SI, Appendix B.9: Factors for **units listed by kind of quantity or field of science**" | `<h3>` Force, Power, Light, Radiology… |

Every one of these 36 tables is a **single quantity** — force, power, illuminance, kinematic viscosity — so **B.9 is correct and all 36 locators are unchanged**. Only the sentence changes, to the heading B.9 actually prints.

Worth noting: B.8's real heading is *Title Case* ("Units Listed Alphabetically"), so even a straight repoint to B.8 would still have cited absent text. The stored string matched **neither** page.

## Verification

The string was extracted back **out of a file** rather than retyped, then checked against the served bytes:

- Present **8 times** on the B.9 page, and **equal to that page's `<h1>`**
- Pure ASCII, `copy` only — no entities, no tags, no transform needed
- All 36 files: exactly one `source`, exactly one `locator`, locator unchanged and still B.9

Suite: `adj-lang` + `adj-lang-cli`, **1026 passed / 0 failed** across 307 binaries. No test or fixture anywhere asserts this string.

## What this does NOT claim

A page **heading** identifies the table but does not state that, say, one dyne is `1.0E-05` newton. Real grounding for these is **per-row provenance (RS-5e)**, which is backlogged. This change is the honest intermediate step — it moves 36 clauses from citing text that *does not exist* to citing text that *does* — and nothing here should be read as the rows now being individually grounded.

## Method note, because it bit me

The first two passes selected files with a **line-oriented `grep -rl`** while the replacement itself was **multi-line**. Three files wrap the phrase as `listed\n% alphabetically`, so grep never listed them and they were silently skipped — and my residual check, being the same line-oriented grep, could not see them either. Security review caught it.

The final pass scans **every** `.adj` with the same multi-line regex it edits with, and asserts the file list is non-empty. Selection has to be at least as capable as the transform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)