### PR TITLE
docs(human-languages): specify the Step-by-Step capability program (HL05–HL08)

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,8 +5,9 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-04. Current baseline after the Persian and Urdu
-Chapter 5 shared-spine tranche:
+Last prioritized: 2026-08-06, when the Step-by-Step capability program (HL05–HL07)
+was specified and placed ahead of the remaining roadmap and migration work. Current
+baseline after the Persian and Urdu Chapter 5 shared-spine tranche:
 20 registered tracks, 1,096 Markdown lessons, 20 downloadable LaTeX books, zero
 duration violations, and 20 validated realization maps containing 350 ordered
 path segments, 277 typed extension nodes, and 926 prerequisite-closed mapped
@@ -24,6 +25,48 @@ discarding deep content.
 2. Prefer work that makes later corpus growth measurable or generated.
 3. Finish a small vertical slice before starting the same migration everywhere.
 4. Keep the application, book, and canonical lesson content aligned.
+
+## P0 — Step-by-Step capability program (HL05–HL07)
+
+Specified in [HL05](../../specs/HL05-chapter-capability-and-step-by-step-shape.md),
+[HL06](../../specs/HL06-visual-system.md), and
+[HL07](../../specs/HL07-spine-expansion-to-b1.md). This program adds a chapter-level
+capability layer above the existing lessons, gives the books a visual system including
+inline script-writing instruction, and grows the spine far enough to carry a complete
+book. It rewrites no authored lesson content.
+
+The measured starting point: 379 chapters, **zero** of which declare a goal or a
+payoff; 11 spine nodes with **zero** at A2 or B1; **zero** images in any of the 20
+books; and a complete, font-validated stroke-path model in `strokes.ts` that holds one
+letter and is rendered nowhere.
+
+| ID | Status | Work item | Completion signal |
+|---|---|---|---|
+| HL-C01 | Complete in this PR | Specify the chapter capability layer, the visual system, and spine expansion to B1. | HL05, HL06 and HL07 are committed before any implementation, per repo policy. |
+| HL-C02 | Queued | Add the `chapters.json` schema, loader, and `core/chapter-policy.json`. | Types, loader beside `loadLanguageCurricula`, and the representativeness threshold load and round-trip; no gates yet. |
+| HL-C03 | Queued | Land the nine HL05 gates as report-only output and publish the first chapter snapshot. | The gap report measures all 379 chapters for missing capability, payoff closure, and representativeness without failing CI on recorded debt. |
+| HL-C04 | Queued | Derive book chapter titles and labels from `chapters.json`. | `core/book-generation.json` stops owning `title`/`label`; `chapter-title-drift` proves the two agree through the transition. |
+| HL-C05 | Queued | Add the `pattern` lesson type with slot-closure and production gates. | A `pattern` lesson introduces one `*-PATTERN-*` atom, declares only in-closure slot fillers, and instantiates at least three in a `guided-production` block. |
+| HL-C06 | Queued | Add the figure pipeline: SVG generation, `graphicx`, SVG→PDF in CI, and a `--check` hash gate. | A generated figure round-trips from canonical data into a compiled PDF and fails CI on drift, reusing `paint-vm-svg`'s `renderToSvgString`. |
+| HL-C07 | Queued | Add the log-scanning warning gate with recorded per-track baselines. | Overfull/underfull boxes, missing glyphs, hyperref warnings, and duplicate destinations are machine-checked; today only prose asserts this. |
+| HL-C08 | Queued | Render the ductus in Language Ladder. | `penPathD`/`penTip` drive an SVG stroke build-up in the app; book and app teach handwriting from one source. |
+| HL-C09 | Queued | Expand `DUCTUS` to cover the nine scripts with cited prose stroke order. | ~190 letters authored, each passing the on-ink, join-tolerance, and coverage invariants with citation and URL. |
+| HL-C10 | Queued | Complete A1 and add the A2 and B1 spine tranches with all 20 realization ledgers. | Every declared stage carries nodes; every track has a non-drifting ledger entry for every node. |
+| HL-C11 | Queued | Author chapter capabilities and payoffs across all 20 tracks. | All 379 chapters declare a `canDo` and a closed, representative payoff; gates flip to errors per track as debt clears. |
+| HL-C12 | Queued | Add the Class C illustration pipeline with provenance sidecars and a size budget. | Every asset carries generator, model, prompt, date, and licence; CI fails any asset without a recorded licence in `_assets/LICENSE.md`. |
+| HL-C13 | Queued | Deploy Language Ladder to GitHub Pages. | The app is reachable at `/coding-adventures/language-ladder/`; it is currently referenced by no workflow and has never been published. |
+
+Open decision for the project owner, recorded rather than assumed: the books are
+CC BY-SA 4.0, and the licence and attribution stance for generated illustrations is
+not yet set. HL06 proposes matching the book's licence with full per-asset provenance,
+following the `_fonts/OFL.txt` precedent, and requires CI to reject Class C assets
+until the decision is written into `_assets/LICENSE.md`.
+
+HL05 also reserves, and deliberately does not implement, a `presents.knowledge` tier
+that would let a payoff use a glossed-but-never-assessed word. Strict closure is kept,
+so early chapters ramp slightly more slowly than a trade step-by-step grammar does.
+Reserving the key now makes enabling it later a flag flip rather than a corpus
+migration.
 
 ## P0 — current publication and validation gaps
 

--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -26,19 +26,30 @@ discarding deep content.
 3. Finish a small vertical slice before starting the same migration everywhere.
 4. Keep the application, book, and canonical lesson content aligned.
 
-## P0 — Step-by-Step capability program (HL05–HL07)
+## P0 — Step-by-Step capability program (HL05–HL08)
 
 Specified in [HL05](../../specs/HL05-chapter-capability-and-step-by-step-shape.md),
-[HL06](../../specs/HL06-visual-system.md), and
-[HL07](../../specs/HL07-spine-expansion-to-b1.md). This program adds a chapter-level
-capability layer above the existing lessons, gives the books a visual system including
-inline script-writing instruction, and grows the spine far enough to carry a complete
-book. It rewrites no authored lesson content.
+[HL06](../../specs/HL06-visual-system.md),
+[HL07](../../specs/HL07-spine-expansion-to-b1.md), and
+[HL08](../../specs/HL08-modality-gentle-ramp-and-the-drivable-course.md). This program
+adds a chapter-level capability layer above the existing lessons, gives the books a
+visual system including inline script-writing instruction, grows the spine far enough
+to carry a complete book, and makes the corpus teachable aloud by a voice assistant
+while the learner drives. It rewrites no authored lesson content.
 
 The measured starting point: 379 chapters, **zero** of which declare a goal or a
 payoff; 11 spine nodes with **zero** at A2 or B1; **zero** images in any of the 20
 books; and a complete, font-validated stroke-path model in `strokes.ts` that holds one
 letter and is rendered nowhere.
+
+On modality and ramp, measured across all 1,096 lessons: 51 need a pen and 7 carry a
+script block, but of the remaining 1,038, some 322 contain a Markdown table and 56 a
+sight cue — so **695 lessons, about 63% of the corpus, are drivable exactly as
+authored**, and the table, not the script, is the main obstacle to the rest. The ramp
+is already gentle in aggregate (mean 2.31 new atoms per lesson, median 2, p90 3) but
+undefended: 52 lessons exceed a budget of 3 and the steepest teaches ten numbers at
+once. Length is explicitly not a cost — splitting for gentleness is the intended
+direction, and no gate may penalise page, lesson, or chapter count.
 
 | ID | Status | Work item | Completion signal |
 |---|---|---|---|
@@ -55,6 +66,11 @@ letter and is rendered nowhere.
 | HL-C11 | Queued | Author chapter capabilities and payoffs across all 20 tracks. | All 379 chapters declare a `canDo` and a closed, representative payoff; gates flip to errors per track as debt clears. |
 | HL-C12 | Queued | Add the Class C illustration pipeline with provenance sidecars and a size budget. | Every asset carries generator, model, prompt, date, and licence; CI fails any asset without a recorded licence in `_assets/LICENSE.md`. |
 | HL-C13 | Queued | Deploy Language Ladder to GitHub Pages. | The app is reachable at `/coding-adventures/language-ladder/`; it is currently referenced by no workflow and has never been published. |
+| HL-C14 | Queued | Derive modality (`voice`/`sight`/`pen`) for every lesson and each chapter's drivable prefix. | The gap report publishes per-track modality counts and the corpus-wide drivable percentage; overrides without a recorded reason are reported. |
+| HL-C15 | Queued | Print modality signs and the drivable prefix at every chapter opening. | The book shows 🚗/👁/✍ beside the HL05 capability, so a reader knows before starting whether a chapter needs eyes or a pen. |
+| HL-C16 | Queued | Build the narration export (`narration-cli`) with `--write`/`--check`. | Plain-text and structured-JSON scripts emit from the canonical AST with `[PAUSE]`/`[REPEAT]`/`[YOU SAY]` preserved as directives and hash-gated against the lesson AST. This implements the audio-script output HL04 named and nothing ever built. |
+| HL-C17 | Queued | Linearise or reclassify the 322 table-bearing lessons. | Every table either reads correctly aloud or its lesson is honestly marked `sight`; the export never silently drops content. |
+| HL-C18 | Queued | Burn down the 52 lessons that exceed the gentle-ramp budget. | No lesson introduces more than `maxNewAtomsPerLesson`; over-budget lessons are split into prerequisite-ordered micro-lessons, longest first, starting with `ES-C31-numeros-11-20` at seven. |
 
 Open decision for the project owner, recorded rather than assumed: the books are
 CC BY-SA 4.0, and the licence and attribution stance for generated illustrations is

--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -8,8 +8,13 @@ in [`HL00`](../../specs/HL00-human-language-curriculum-framework.md) — read
 that first. The migration to an ordered shared spine, strict sub-five-minute
 lessons, Persian and Urdu extensions, and a single book/app/practice content
 pipeline is specified in
-[`HL04`](../../specs/HL04-shared-spine-and-content-pipeline.md). This page is
-just an index.
+[`HL04`](../../specs/HL04-shared-spine-and-content-pipeline.md). The move to
+chapter-sized deployable capability — every chapter promising something the reader can
+use immediately — is specified in
+[`HL05`](../../specs/HL05-chapter-capability-and-step-by-step-shape.md), with the
+book's visual system and inline script-writing figures in
+[`HL06`](../../specs/HL06-visual-system.md) and the spine's growth through B1 in
+[`HL07`](../../specs/HL07-spine-expansion-to-b1.md). This page is just an index.
 
 Every track shares the same shape:
 

--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -14,7 +14,11 @@ use immediately — is specified in
 [`HL05`](../../specs/HL05-chapter-capability-and-step-by-step-shape.md), with the
 book's visual system and inline script-writing figures in
 [`HL06`](../../specs/HL06-visual-system.md) and the spine's growth through B1 in
-[`HL07`](../../specs/HL07-spine-expansion-to-b1.md). This page is just an index.
+[`HL07`](../../specs/HL07-spine-expansion-to-b1.md).
+[`HL08`](../../specs/HL08-modality-gentle-ramp-and-the-drivable-course.md) marks which
+chapters need eyes or a pen and which can be learned entirely by ear, and defines the
+narration export a voice assistant reads aloud on a commute. This page is just an
+index.
 
 Every track shares the same shape:
 

--- a/code/specs/HL05-chapter-capability-and-step-by-step-shape.md
+++ b/code/specs/HL05-chapter-capability-and-step-by-step-shape.md
@@ -100,6 +100,12 @@ Field contracts:
 `chapters.json` is authored intent, unlike `curriculum.json`'s `omits` and
 `relocates` ledgers, which are recomputed caches. A validator may not rewrite it.
 
+Two further chapter properties — its **modality signs** and its **drivable prefix** —
+are defined by [HL08](./HL08-modality-gentle-ramp-and-the-drivable-course.md) and are
+*derived*, never authored here. They print at the chapter opening beside the `canDo`,
+so a reader sees both what the chapter will let them do and whether they can do it in
+the car.
+
 ## Self-sufficiency — the rule that makes a chapter worth finishing
 
 HL04's closed-world rule stands unchanged: a lesson may require only atoms
@@ -117,7 +123,7 @@ the atoms that chapter introduces. This is the load-bearing rule. Without it a p
 is satisfiable by exercising one word, and a chapter can claim a capability it never
 delivered. The threshold is a configured constant, initially **0.5**, recorded in
 `core/chapter-policy.json` so it can be raised as the corpus matures rather than
-hard-coded at a call site.
+hard-coded at a call site. That same policy file carries HL08's gentle-ramp budgets.
 
 ### Why the ramp is slower than the trade book's, and what is deliberately not built
 

--- a/code/specs/HL05-chapter-capability-and-step-by-step-shape.md
+++ b/code/specs/HL05-chapter-capability-and-step-by-step-shape.md
@@ -1,0 +1,204 @@
+# HL05 — Chapter Capability and the Step-by-Step Shape
+
+## Status and purpose
+
+This spec adds a **capability layer above the existing lessons**: every chapter
+declares what the reader can do when they finish it, and proves that claim with a
+payoff the reader can deploy immediately.
+
+It extends [HL00](./HL00-human-language-curriculum-framework.md) and
+[HL04](./HL04-shared-spine-and-content-pipeline.md). It does **not** revise the
+lesson atom. All 1,096 existing lessons keep their shape, their one-word depth, and
+their etymology. Nothing in this spec rewrites authored content.
+
+The design requirements are:
+
+1. Every chapter states one **can-do capability** in the reader's own terms.
+2. Every chapter ends with a **payoff** — a dialogue or task the reader can use today.
+3. A payoff recombines only material the reader has already been taught.
+4. A payoff must exercise a real share of what its own chapter introduced.
+5. Productive constructions get a first-class lesson type, so a chapter can teach
+   *"here is how you build any of these"* rather than only *"here is one more word."*
+6. Nothing gates the reader before value arrives.
+
+## Evidence boundary
+
+The requested shape is the one popularised by step-by-step self-study grammars, of
+which *Complete Spanish Step by Step* is the reference the project was asked to match.
+This spec adopts a **structural pattern** — chapter-sized deployable capability, an
+immediately usable end-of-chapter payoff, no gating preamble — and nothing else. No
+text, example set, exercise, sequence, or table is reproduced, paraphrased, or
+adapted from that book or any other copyrighted course. Every lesson, dialogue,
+pattern, and exercise in this corpus is original and grounded in the project's own
+etymological method.
+
+## The gap this closes
+
+Measured against the corpus at the time of writing:
+
+| Observation | Value |
+|---|---|
+| Chapters across all tracks | 379 |
+| Chapters carrying a declared goal | **0** |
+| Chapters carrying a validated payoff | **0** |
+| Chapter-level objects of any kind | **0** — `chapter` is an integer on each lesson |
+| Nearest existing approximation | 27 `consolidation` extension nodes; 6 of them are genuinely chapter-shaped, the rest are boilerplate |
+
+The only chapter-scoped record in the repository today is a `targets[]` entry in
+`core/book-generation.json` carrying `title`, `label` and `output`. That is a LaTeX
+build manifest. It has no pedagogical content and is not a suitable home for one.
+
+The consequence is structural, not cosmetic: because nothing in the data model knows
+what a chapter is *for*, nothing can check that finishing one leaves the reader able
+to do anything. A reader can complete thirty lessons, hold thirty words with accurate
+etymologies, and still not own a usable exchange.
+
+## The chapter capability object
+
+One file per track, `<track>/chapters.json`, canonical and hand-authored:
+
+```json
+{
+  "version": 1,
+  "language": "spanish",
+  "chapters": [
+    {
+      "chapter": 1,
+      "title": "Hola and Buenos Días",
+      "label": "ch:first-words",
+      "canDo": "I can greet someone at any time of day and respond when greeted.",
+      "spineNodes": ["SPINE-MEET-GREET"],
+      "payoff": {
+        "lesson": "ES-C01-practice",
+        "kind": "dialogue",
+        "summary": "A four-line doorway exchange, start to finish.",
+        "assesses": ["ES-DIALOGUE-GREET"]
+      },
+      "figures": ["fig/es-ch01-greeting-map"]
+    }
+  ]
+}
+```
+
+Field contracts:
+
+- `chapter` — integer, unique per track, must match at least one lesson's frontmatter
+  `chapter`.
+- `title` — the chapter's printed name. **Becomes canonical here.**
+  `core/book-generation.json` stops owning `title` and `label` and derives both from
+  this file, removing the existing duplication.
+- `canDo` — one sentence, first person, in the reader's terms. Same voice as a spine
+  node's `canDo`. This is the chapter's promise.
+- `spineNodes` — the shared spine nodes this chapter realises. May be empty for a
+  chapter made entirely of language-specific extensions.
+- `payoff.lesson` — the lesson id that delivers the payoff. Normally a `practice`,
+  `practice-mix` or `pattern` lesson.
+- `payoff.kind` — `dialogue` | `task` | `production`.
+- `payoff.assesses` — the knowledge atoms the payoff exercises.
+- `figures` — optional figure ids, defined by [HL06](./HL06-visual-system.md).
+
+`chapters.json` is authored intent, unlike `curriculum.json`'s `omits` and
+`relocates` ledgers, which are recomputed caches. A validator may not rewrite it.
+
+## Self-sufficiency — the rule that makes a chapter worth finishing
+
+HL04's closed-world rule stands unchanged: a lesson may require only atoms
+established by a transitive prerequisite. This spec keeps that rule **strictly**, and
+adds a chapter-scoped consequence.
+
+A chapter is **self-sufficient** when its payoff can be performed using only atoms
+introduced by this chapter or an earlier one in the same track. Because lesson-level
+closure already guarantees each lesson's own requirements, self-sufficiency is not a
+new burden on authors — it is the existing rule stated at chapter scope so it can be
+reported per chapter.
+
+A chapter is **representative** when its payoff assesses at least a threshold share of
+the atoms that chapter introduces. This is the load-bearing rule. Without it a payoff
+is satisfiable by exercising one word, and a chapter can claim a capability it never
+delivered. The threshold is a configured constant, initially **0.5**, recorded in
+`core/chapter-policy.json` so it can be raised as the corpus matures rather than
+hard-coded at a call site.
+
+### Why the ramp is slower than the trade book's, and what is deliberately not built
+
+Step-by-step trade grammars routinely drop an untaught word into an early dialogue
+and gloss it in the margin. Strict closure forbids that, so early chapters here ramp
+slightly more slowly: a chapter must actually teach everything its payoff uses.
+
+The escape hatch is a **presented tier** — a `presents.knowledge` list whose atoms may
+appear in a lesson with an inline gloss, are never assessed, and never count as
+taught. It would relax HL04 validation gate 3 for presented-only atoms while leaving
+it fully strict for assessed ones.
+
+**This tier is specified and deliberately not implemented.** The schema reserves the
+`presents` key and validators must reject it as unknown until a later spec enables it.
+Reserving it now means enabling it later is a flag flip, not a corpus migration.
+
+## The `pattern` lesson type
+
+`type: pattern` joins the non-lexical types exempt from `concept_tag` (alongside
+`practice`, `review`, `writing`, `grammar`, `etymology`). It teaches a productive
+construction:
+
+- introduces exactly one `*-PATTERN-*` knowledge atom;
+- declares `slots`, an ordered list of `{ name, fillers[] }` where every filler is a
+  knowledge atom **already in the lesson's closure**;
+- carries a `guided-production` block whose activity instantiates at least three
+  distinct fillers;
+- obeys every existing schema-v2 rule without exception — block directives, the
+  five-minute budget, coverage metadata, block-level knowledge closure.
+
+A `pattern` lesson is what lets a chapter generalise. `## Grammar Lens` stays exactly
+where it is, inside a word lesson, for grammar that belongs to one word. The two are
+complementary: the Lens explains why *this* word behaves this way, the pattern hands
+the reader a productive template.
+
+## Validation gates
+
+Added to `validateCurriculum()` in `human-language-data/src/curriculum.ts`, following
+that module's established multi-pass style — collect every violation, report once,
+never throw on the first.
+
+| Code | Rule |
+|---|---|
+| `chapter-missing-capability` | every chapter in a track's books has an entry with a non-empty `canDo` and a `payoff` |
+| `chapter-unknown-payoff-lesson` | `payoff.lesson` resolves, and its `chapter` matches |
+| `chapter-payoff-not-closed` | payoff atoms ⊆ atoms introduced by this or an earlier chapter in the track |
+| `chapter-payoff-not-representative` | payoff assesses ≥ threshold share of the chapter's introduced atoms |
+| `chapter-duplicate` | one entry per chapter number per track |
+| `chapter-title-drift` | every `book-generation.json` target's title/label matches `chapters.json` |
+| `pattern-slot-not-closed` | every declared slot filler is in the lesson's closure |
+| `pattern-missing-production` | a `pattern` lesson has a `guided-production` block with ≥3 instantiations |
+| `pattern-multiple-atoms` | a `pattern` lesson introduces exactly one `*-PATTERN-*` atom |
+
+### Report first, fail later
+
+Following the HL-V01 precedent, these gates land as **gap-report output over all 379
+chapters**, not as errors. Existing debt is measured and made visible, never
+retroactively treated as a regression. A track flips to hard errors only once its own
+debt reaches zero, tracked per track exactly as the schema-v2 migration is.
+
+The report gains a chapter section beside the existing duration and prerequisite
+sections: chapters without a capability, payoffs that are not closed, payoffs below
+the representativeness threshold, and per-track totals.
+
+## Migration order
+
+1. **Schema and loader** — types, `chapters.json` loader beside `loadLanguageCurricula`,
+   `core/chapter-policy.json`. No gates yet.
+2. **Report** — all nine checks as report-only; publish the first snapshot of all 379
+   chapters.
+3. **Title derivation** — `book-generation.json` stops owning `title`/`label`;
+   `chapter-title-drift` proves the two agree through the transition.
+4. **`pattern` type** — parser, validator rules, first patterns authored.
+5. **Content fan-out** — capabilities and payoffs authored across all 20 tracks in
+   parallel; gates flip to errors per track as debt clears.
+
+## Acceptance criteria
+
+The capability layer is complete when every one of the 379 chapters declares a
+`canDo` and a payoff; every payoff is closed and representative under the configured
+threshold; `book-generation.json` derives its titles rather than owning them; no
+track reports chapter debt; the `pattern` type is in use in at least one chapter per
+track; the book prints each chapter's capability at its opening; and Language Ladder
+gates chapter completion on the payoff rather than on lesson count.

--- a/code/specs/HL06-visual-system.md
+++ b/code/specs/HL06-visual-system.md
@@ -1,0 +1,172 @@
+# HL06 — Visual System: Figures, Script Diagrams, and Illustrations
+
+## Status and purpose
+
+This spec gives the Human Languages books a visual layer: stroke-order diagrams that
+teach the reader to *write* a script, data-derived diagrams that make etymology and
+sound visible, and illustrations that make the books pleasant to read.
+
+It extends [HL00](./HL00-human-language-curriculum-framework.md)'s "Book Format" and
+[HL04](./HL04-shared-spine-and-content-pipeline.md)'s one-source pipeline. Figures are
+a **fourth output view** of the canonical content, not a parallel asset library.
+
+The design requirements are:
+
+1. A reader learning a non-Latin script must see how the pen actually moves.
+2. Book and app must teach handwriting from **one** source, not two.
+3. Every figure that carries a factual claim must be derived from data and verifiable
+   in CI.
+4. Decorative art may never carry a factual claim.
+5. The books stay reproducible: a clean checkout plus CI must rebuild every PDF.
+
+## The gap this closes
+
+| Observation | Value |
+|---|---|
+| Images in any of the 20 books | **0** |
+| Graphics packages loaded in any preamble | **0** |
+| Renderer support for `![alt](src)` | none — silently degrades to `!\href{src}{alt}` |
+| Authored geometric stroke paths (`DUCTUS`) | **1 letter** (Tamil ம) |
+| UI or book consumers of that stroke data | **0** |
+| Scripts with cited prose stroke order | 9 scripts, 190 letters, rendered as a plain `<ol>` |
+
+The most striking of these is the fourth. `strokes.ts` contains a complete, carefully
+reasoned pen-path model — strokes as pen-down runs, segments as labelled parts that
+must meet head-to-tail, `penPathD()` emitting SVG path data, `penTip()` emitting an
+animated pen position — validated against real glyph outlines extracted from the
+vendored fonts by `truetype.ts` to a sub-2-font-unit join tolerance. It is imported by
+nothing but its own test. The machinery for teaching handwriting properly is built,
+tested, and dark.
+
+## Three classes of figure
+
+Figures are separated by **what makes them trustworthy**, because that determines how
+each is produced, verified, and permitted to be used.
+
+### Class A — script figures (generated, font-derived)
+
+Stroke-order build-ups showing how a letter is formed: the finished glyph outline, the
+pen path, the segment labels, the lift points.
+
+- **Source of truth:** `DUCTUS` in `strokes.ts` for the pen path; the vendored font
+  outline via `truetype.ts` for the glyph shape.
+- **Renderer:** `penPathD()` / `penTip()` composed into SVG through
+  `renderToSvgString()` from the existing `@coding-adventures/paint-vm-svg` package.
+- **Verification:** the existing `strokes.test.ts` invariants continue to gate the
+  data — every pen point on real ink, every intra-stroke join under tolerance, the
+  path covering the whole letter — plus provenance (`citation`, `url`) on every entry.
+- **Output:** committed SVG, hash-gated exactly like generated `.tex`; CI converts to
+  PDF at build time.
+
+> **Hard rule — the glyph monopoly.** Class A is the *only* pipeline permitted to
+> depict a letter, glyph, ligature, conjunct, or handwriting stroke, in the book or
+> the app. This generalises the argument `truetype.ts` already makes about hand-drawn
+> shapes: a subtly wrong Tamil ண looks completely correct to precisely the audience
+> that cannot yet read Tamil, so the error would not merely ship — it would ship *as
+> the lesson*. No drawn, traced, or model-generated image may render script. Ever.
+
+Authoring cost is real and should not be understated: `DUCTUS` holds one letter today
+and needs roughly 190 to cover the nine scripts that already carry cited prose stroke
+order. The Dravidian syllabaries (1,378 entries across Kannada, Telugu and Malayalam)
+do **not** need per-syllable ductus — they compose, so only base consonants and vowel
+signs are authored, and the syllable figure is assembled from those parts.
+
+### Class B — data diagrams (generated)
+
+Etymology and cousin-web trees built from lesson `roots`, sound-articulation diagrams
+built from `sounds` ids and the pronunciation reference, gender maps, script-evolution
+charts.
+
+- **Source of truth:** the canonical lesson AST. A diagram may assert only what a
+  lesson already asserts.
+- **Renderer:** deterministic SVG via `paint-vm-svg`, same as Class A.
+- **Verification:** hash-gated; every node in a rendered tree must trace to a `roots`
+  entry or a declared knowledge atom. A diagram may not introduce a claim.
+
+This matters because the cousin web is the project's signature method, and it is
+currently prose-only. An etymology tree is the one diagram this curriculum most
+obviously wants.
+
+### Class C — illustrations (authored assets)
+
+Model-generated raster art for scenes, objects, and cultural context — the "colour"
+the books currently lack.
+
+- **Storage:** `_assets/illustrations/<track>/`, beside the existing `_fonts/`.
+- **Provenance:** each asset carries a sidecar JSON recording generator, model,
+  prompt, date, and licence. CI verifies presence, required fields, and a content hash.
+- **Determinism:** raster art cannot be regenerated byte-identically, so the *asset*
+  is the committed artefact and the hash is the gate — the same posture the repo
+  already takes toward vendored fonts.
+- **Subject restriction:** non-linguistic subjects only. No script, no glyphs, no
+  handwriting, no transliteration, no claim about a language's structure or history.
+  Class A holds the glyph monopoly; Class B holds every factual diagram.
+- **Budget:** a per-track asset-size cap enforced in CI, so the repository does not
+  silently accumulate tens of megabytes of art.
+
+### Licensing
+
+The books are published CC BY-SA 4.0. The licence and attribution stance for
+generated illustrations is a **project-owner decision, not a validator default**. The
+proposed default is to licence them CC BY-SA 4.0 alongside the book with full
+per-asset provenance recorded, following the precedent already set by `_fonts/OFL.txt`.
+Until that decision is recorded in `_assets/LICENSE.md`, CI must fail any Class C
+asset — an unlicensed image in a freely published book is a real problem, not a
+formality.
+
+## Class D — the design system
+
+Figures alone do not make a book colourful. The preambles already load `xcolor` and
+`tcolorbox`, so the foundation exists:
+
+- a named palette, defined once and shared across all 20 preambles;
+- chapter openers that print the chapter's `canDo` from
+  [HL05](./HL05-chapter-capability-and-step-by-step-shape.md);
+- restyled `sounds`, `cousinweb`, `culture` and `grammarlens` boxes;
+- a figure environment with consistent captioning and placement.
+
+Per-track preambles are currently standalone copies. The palette and figure
+environment should land in a shared `_shared/visual.tex` that each preamble inputs,
+rather than being copied 20 times — the repo's own lessons warn specifically against
+hand-written N-fold families.
+
+## Pipeline changes
+
+1. **Preambles** — add `graphicx` and `\graphicspath`; input the shared visual file.
+2. **Renderer** — `book.ts` gains block-level and inline image branches in
+   `renderMarkdown` and `renderInlineMarkdown`, plus a filename-safe path escaper
+   distinct from `escapeLatexLinkDestination`, with a fail-closed allowlist
+   (relative-only, no `..`, extension allowlist) mirroring `safeOutput` in
+   `book-cli.ts`.
+3. **Figure generation** — a `figure-cli` beside `book-cli`, with the same
+   `--write` / `--check` contract and the same manifest-hash discipline.
+4. **CI** — add `graphicx.sty` to the `kpsewhich` preflight and `librsvg2-bin` to the
+   apt closure for SVG→PDF conversion.
+
+**TikZ is explicitly not adopted.** `texlive-pictures` is deliberately excluded from
+the focused CI dependency closure, and pre-rendered vectors are both leaner and more
+deterministic than compile-time drawing. Keep the toolchain lean.
+
+## The warning gate
+
+Every track's README and CHANGELOG asserts its book builds with zero missing glyphs,
+overfull or underfull boxes, duplicate destinations, hyperref warnings, or font
+substitutions. **Nothing enforces this.** CI fails only on hard TeX errors
+(`-halt-on-error`) and generated-content drift; no step reads the `.log`.
+
+Floats fight the existing `\raggedbottom` layout and are the classic source of exactly
+those warnings, so this spec must not add figures without closing the hole it would
+fall through. CI gains a log-scanning step after the `latexmk` loop, checking each
+`.log` for `Overfull`, `Underfull`, `Missing character`, hyperref warnings, and
+duplicate destinations, compared against a **recorded per-track baseline** so existing
+debt is measured rather than newly broken.
+
+## Acceptance criteria
+
+The visual system is complete when every non-Latin track prints a stroke-order figure
+for every letter it teaches, generated from font-validated ductus data; the app renders
+those same paths from the same source; every Class A and B figure is hash-gated and
+regenerable from a clean checkout; every Class C asset carries provenance and a
+recorded licence; the shared palette and figure environment live in one file rather
+than 20; and the log-scanning gate reports zero new warnings against each track's
+baseline.

--- a/code/specs/HL07-spine-expansion-to-b1.md
+++ b/code/specs/HL07-spine-expansion-to-b1.md
@@ -1,0 +1,136 @@
+# HL07 — Spine Expansion to B1
+
+## Status and purpose
+
+This spec grows the shared can-do spine from a greeting-and-introductions prefix into
+a complete pre-A1 → B1 course backbone, so that a "complete" book in any track has
+somewhere to go.
+
+It extends [HL04](./HL04-shared-spine-and-content-pipeline.md), which defined the
+spine, and is a prerequisite for the content fan-out in
+[HL05](./HL05-chapter-capability-and-step-by-step-shape.md).
+
+## The gap this closes
+
+The spine is the smallest load-bearing file in the curriculum, and it is far smaller
+than its role implies:
+
+| Observation | Value |
+|---|---|
+| Spine nodes | **11** |
+| Concepts in the taxonomy | 46 |
+| Nodes at stage pre-A1 | 7 |
+| Nodes at stage A1 | 4 |
+| Nodes at stage **A2** | **0** |
+| Nodes at stage **B1** | **0** |
+| Tracks whose authored chapters exceed the spine's reach | most — Latin has 36 chapters, Hindi 33, Spanish 34 |
+
+`A2` and `B1` are declared in the spine's `stages` array with no nodes beneath them.
+Eleven nodes carry the reader from *hello* to *counting to five*.
+
+This produces a specific, visible failure: tracks have grown well past what the spine
+describes, so their later chapters are held together by language-specific extension
+nodes rather than by shared structure. The spine stops being the thing that makes
+twenty tracks comparable. HL05's capability layer would inherit that weakness —
+chapters beyond the spine's reach would have no shared can-do to realise.
+
+**Eleven nodes cannot carry a complete book.** No amount of additional word lessons
+fixes that; the backbone itself has to grow.
+
+## Node design rules
+
+A spine node keeps its existing six fields — `id`, `stage`, `canDo`, `prerequisites`,
+`core`, `concepts` — and gains no new ones. Growth is in quantity and coverage, not
+in schema.
+
+1. **A node is a capability, not a topic.** `canDo` is one first-person sentence
+   describing something the reader can do with the language. "I can say what I want
+   and ask for it politely" is a node. "Verbs" is not.
+2. **Ordering is by usefulness, not by grammar.** HL00's frequency-driven rule
+   governs: what does a real basic conversation need next? A node earns its place by
+   unlocking conversation, never by completing a paradigm.
+3. **A node is language-independent.** Anything true only of one language belongs in
+   that track's extension nodes, not in the spine. The existing `omits` / `relocates`
+   ledgers absorb genuine mismatches.
+4. **`core` marks the parity set** — nodes every track is expected to realise.
+   Non-core nodes are legitimately skippable where a language does not mark the
+   distinction, exactly as `SPINE-DEFINITE-REFERENCE` already is.
+5. **Prerequisites stay shallow.** Deep chains reintroduce the gating this curriculum
+   exists to avoid. A node should depend on what it genuinely needs and nothing more.
+
+## Target shape
+
+Growth toward roughly 60–80 nodes across the four stages, weighted toward the early
+stages where lesson density is highest:
+
+| Stage | Target | Character |
+|---|---|---|
+| pre-A1 | ~15 | survival exchanges: greeting, naming, courtesy, yes/no, farewell — mostly present |
+| A1 | ~25 | the concrete everyday: wanting, having, going, location, time, number, family, food, simple description |
+| A2 | ~25 | past and future reference, comparison, preference and opinion, sequences of events, transactions, plans |
+| B1 | ~15 | narration at length, explanation and reasoning, hypotheticals, register shifts, sustained conversation repair |
+
+These are planning targets, not quotas. A node is added because a real conversation
+needs it, and the count is an outcome.
+
+The concept taxonomy grows in step. Its 46 concepts are exactly exhausted by the
+current 11 nodes; every new node brings new concepts, each with `family`, `gloss` and
+`core`, and each becoming a cross-language join key.
+
+## Per-track realization
+
+Every one of the 20 `curriculum.json` files carries a `spine` ledger with an entry
+for **every** spine node. Adding a node therefore touches all 20 tracks, and the
+existing drift validators (`curriculum-segment-ledger-drift`,
+`curriculum-omission-ledger-drift`, `curriculum-relocation-ledger-drift`) will fire
+until each is updated.
+
+This is intentional and should not be worked around. It is the mechanism that keeps a
+track from silently falling behind the spine. But it means spine growth must be
+**batched**, not dripped: adding one node at a time creates 20 ledger updates per
+node. Nodes land in stage-sized tranches, with all 20 realizations updated in the same
+change.
+
+A track that genuinely cannot realise a node records it in `omits` with a reason, or
+in `relocates` if it teaches the concept under a different node. Those ledgers are
+recomputed caches — authors change lesson data, and the validator derives the ledger.
+
+## Relationship to authored chapters
+
+Spine expansion does not renumber, move, or rewrite chapters. Existing chapters keep
+their lessons and their order. What changes is that a chapter beyond the current
+spine's reach gains a shared node to point at through its `spineNodes` field in
+`chapters.json`, instead of being describable only by language-specific extensions.
+
+Where an authored chapter turns out to realise a capability the spine did not have,
+that is evidence for a node — the corpus has been running ahead of its backbone, and
+the node should be written to match what the tracks already teach rather than
+inventing a parallel structure they must then be migrated onto.
+
+## Validation
+
+No new validation codes. Spine growth is already covered by the existing rules:
+unknown node ids, cycles in the shared graph, ledger completeness and drift, and
+`schema-v2-unknown-spine-node` on lessons. The gap report gains stage-coverage output
+— nodes per stage, tracks realising each node, and concepts not yet owned by any node
+— so expansion is measurable in the same way duration and prerequisite debt already are.
+
+## Migration order
+
+1. **A1 completion** — fill out A1 to its target and update all 20 ledgers.
+2. **A2 tranche** — the largest single body of new nodes and concepts.
+3. **B1 tranche.**
+4. **Chapter attachment** — HL05 `spineNodes` fields updated across the 379 chapters
+   as nodes become available.
+
+Stages land in order because prerequisites run forward: an A2 node may depend on an A1
+node, so A1 must be complete and realised first.
+
+## Acceptance criteria
+
+Spine expansion is complete when all four declared stages carry nodes; every node has
+a first-person `canDo` and a non-empty concept set; every one of the 20 tracks carries
+a ledger entry for every node, with omissions and relocations explicit and
+non-drifting; every taxonomy concept is owned by exactly one node; the gap report
+publishes stage coverage; and every one of the 379 chapters can name at least one
+shared spine node it realises, or record why it is purely language-specific.

--- a/code/specs/HL08-modality-gentle-ramp-and-the-drivable-course.md
+++ b/code/specs/HL08-modality-gentle-ramp-and-the-drivable-course.md
@@ -1,0 +1,207 @@
+# HL08 — Modality, the Gentle Ramp, and the Drivable Course
+
+## Status and purpose
+
+This spec makes two implicit properties of the curriculum explicit and checkable:
+
+1. **Which channel a lesson needs** — can it be learned by ear alone, does it need
+   eyes, does it need a pen? — marked with signs in the book and exported so a
+   voice assistant can teach the hands-free parts aloud.
+2. **How steep the ramp is** — how much new material a single lesson may introduce,
+   enforced as a budget rather than left to authorial judgement.
+
+It extends [HL00](./HL00-human-language-curriculum-framework.md), whose lessons are
+already written in audio-script style with `[PAUSE Ns]`, `[REPEAT x2]` and
+`[YOU SAY: …]` cues, and implements the **audio-script output** that
+[HL04](./HL04-shared-spine-and-content-pipeline.md)'s one-source pipeline diagram
+names but nothing has ever built. Chapter-level signs attach to the capability object
+defined in [HL05](./HL05-chapter-capability-and-step-by-step-shape.md).
+
+The design requirements are:
+
+1. A learner in a car can be taught, aloud, everything that does not require eyes.
+2. A lesson that needs eyes or a pen says so, visibly, before the learner starts it.
+3. The ramp is gentle by measurement, not by assertion.
+4. Length is not a cost. A longer book made of smaller steps is the preferred outcome.
+
+## The gap this closes
+
+### Modality is real but undeclared
+
+`skills: [listening, speaking, reading, writing]` already exists on every schema-v2
+lesson — but it records what a lesson **develops**, not what it **requires**. 501 of
+the 531 schema-v2 lessons declare `[listening, speaking, reading]`, and a reader can
+learn *hola* perfectly well by ear despite the `reading` entry. Modality therefore
+cannot be derived from `skills`, and treating the two as the same thing would
+mislabel almost the entire corpus.
+
+Deriving instead from lesson type and block structure, measured over all 1,096 lessons:
+
+| Requirement | Lessons |
+|---|---|
+| `type: writing` — needs a pen | 51 |
+| Carries a `script` block — needs eyes | 7 |
+| Neither | 1,038 |
+
+That 1,038 is not the drivable count, because a lesson can be sight-dependent without
+a script block:
+
+| Among those 1,038 | Lessons |
+|---|---|
+| Contain a Markdown table | 322 |
+| Contain a sight cue (*"see the"*, *"look at"*, *"the chart"*, *"column"*) | 56 |
+| **Genuinely free of both** | **695** |
+
+So roughly **63% of the corpus is drivable exactly as authored**, and the single
+largest obstacle to the rest is the table — not the script. That is a tractable
+problem: a two-column word→gloss table reads aloud fine, while a five-column paradigm
+does not.
+
+### The ramp is already gentle, and undefended
+
+Knowledge atoms introduced per schema-v2 lesson:
+
+| Statistic | Value |
+|---|---|
+| Mean | 2.31 |
+| Median | 2 |
+| p90 | 3 |
+| Max | **7** (`ES-C31-numeros-11-20`) |
+| Lessons introducing more than 3 | 52 |
+| Lessons introducing more than 5 | 5 |
+
+The curriculum is already gentle in aggregate. What it lacks is a floor: nothing stops
+the next lesson from introducing nine atoms, and the current worst case teaches ten
+numbers at once — precisely the "drilling ten greetings" antipattern HL00 was written
+to reject.
+
+## Modality
+
+Three channels, each naming what the learner must have available:
+
+| Value | Meaning | Sign |
+|---|---|---|
+| `voice` | Learnable by ear alone. A voice assistant can teach it while the learner drives. | 🚗 |
+| `sight` | Needs eyes — letter shapes, figures, or a table that cannot be read aloud. | 👁 |
+| `pen` | Needs a hand — handwriting formation and practice. | ✍ |
+
+Modality is **monotonic**: `pen` implies `sight`. A chapter's modality is the union of
+its lessons'.
+
+### Derived by default, overridable with a reason
+
+Hand-annotating 1,096 lessons invites drift, so modality is computed:
+
+1. `type: writing` → `pen`;
+2. otherwise a `script` block, a sight cue, or a table wider than the configured
+   linearisable width → `sight`;
+3. otherwise → `voice`.
+
+An author may override with an explicit `modality:` in frontmatter, but an override
+that contradicts the derivation requires a `modality_reason:`. The validator reports
+unexplained overrides. This keeps the common case free and the exceptional case honest.
+
+### The drivable prefix
+
+A chapter reports how many of its lessons, **in authored order**, are `voice` before
+the first one that is not. This is the number that matters to a commuting learner:
+*"you can do the first six of this chapter's nine lessons in the car."*
+
+The book prints it at the chapter opening beside the capability from HL05. It is
+derived, never authored.
+
+## The narration export
+
+A fourth output view beside the book, the app, and the exercise bank — the one HL04's
+pipeline diagram already promises.
+
+For every lesson and chapter, `narration-cli` emits from the canonical AST:
+
+- **Plain text** — a continuous script an AI voice assistant or TTS engine can read.
+- **Structured JSON** — blocks, cues, and prompts with their types preserved, so a
+  voice agent can pause where the lesson says pause, wait for a spoken answer where
+  the lesson says `[YOU SAY: …]`, and score it against the compiled activity contract
+  from HL-V03 rather than against prose.
+
+Rules:
+
+- The existing `[PAUSE Ns]`, `[REPEAT x2]` and `[YOU SAY: …]` cues are preserved as
+  structured directives, not flattened into prose.
+- **Tables are linearised into speech**, not dropped. A two-column table becomes a
+  sequence of *"X means Y"* utterances. A table that cannot be linearised within the
+  configured width marks its lesson `sight` — the export never silently omits content
+  the learner would then not know they had missed.
+- `sight` and `pen` lessons still export, prefixed with a spoken notice naming what
+  the learner will need and what they can safely skip until they stop driving.
+- Target-language text carries its `romanization` alongside, so a voice engine reading
+  a Latin-script transcription is never guessing at the script.
+- The export is hash-gated against the lesson AST exactly like generated `.tex`, so
+  narration cannot drift from the book.
+
+The export is a **script for a voice agent, not a recording**. Producing audio,
+selecting voices, and provenance-labelling recordings remain out of scope, as in HL04.
+
+## The gentle-ramp budget
+
+A new configured limit in `core/chapter-policy.json`:
+
+- `maxNewAtomsPerLesson` — default **3**, at the corpus's existing p90.
+- `maxNewAtomsPerChapter` — a chapter-scoped ceiling, so gentleness cannot be gamed by
+  splitting one steep lesson into two steep ones.
+
+Exceeding the budget is a violation to be **split, not waived**. This is the same move
+the HL-D01 series already made for the five-minute rule: the fix for a lesson that
+introduces seven atoms is more prerequisite-ordered lessons, each teaching less.
+
+52 lessons currently exceed a budget of 3, and 5 exceed 5. That is the burn-down list,
+recorded as debt rather than treated as a new regression.
+
+### Length is explicitly not a cost
+
+Splitting for gentleness makes every book longer, and that is the intended direction.
+A book of thousands of pages made of two-minute steps is a better outcome than a
+compact book that loses the reader in chapter three. No gate in this project may
+penalise page count, lesson count, or chapter count.
+
+## Validation gates
+
+Added to `validateCurriculum()`, multi-pass, collecting every violation before
+reporting.
+
+| Code | Rule |
+|---|---|
+| `modality-unexplained-override` | an authored `modality` contradicting the derivation has no `modality_reason` |
+| `modality-unknown-value` | `modality` is not one of `voice`/`sight`/`pen` |
+| `narration-block-unrenderable` | a block cannot be linearised into speech and the lesson is not marked `sight` |
+| `ramp-budget-exceeded-lesson` | a lesson introduces more than `maxNewAtomsPerLesson` |
+| `ramp-budget-exceeded-chapter` | a chapter introduces more than `maxNewAtomsPerChapter` |
+| `narration-drift` | the committed narration export does not match the lesson AST |
+
+All land **report-first**, per the HL-V01 precedent, and flip to errors per track as
+each track's debt clears.
+
+The gap report gains a modality section: per track, the count of `voice`/`sight`/`pen`
+lessons, each chapter's drivable prefix, and the corpus-wide drivable percentage — so
+"how much of this can I do in the car?" is a measured number, published every build.
+
+## Migration order
+
+1. **Derivation and report** — modality computed for all 1,096 lessons; drivable
+   prefixes and ramp debt published. No gates.
+2. **Signs in the book** — chapter openings print modality and drivable prefix beside
+   the HL05 capability; lessons carry an inline marker.
+3. **Narration export** — `narration-cli` with `--write`/`--check`, table
+   linearisation, and the hash gate.
+4. **Table remediation** — the 322 table-bearing lessons reviewed; each table either
+   linearised or its lesson honestly marked `sight`.
+5. **Ramp burn-down** — the 52 over-budget lessons split into prerequisite-ordered
+   micro-lessons, longest first.
+
+## Acceptance criteria
+
+Complete when every lesson has a derived or explained modality; every chapter reports
+a drivable prefix; the book prints modality signs at every chapter opening; the
+narration export round-trips every lesson and is hash-gated against the AST; every
+table is either linearised for speech or its lesson is marked `sight`; no lesson
+exceeds the ramp budget; and the published gap report states what percentage of each
+track can be learned entirely by ear.


### PR DESCRIPTION
## Why

The corpus is **vocabulary-first**: one word per lesson, excavated etymologically, ~5 minutes, in prerequisite-closed order. 1,096 lessons, 20 tracks, 20 published PDFs, all green.

That produces depth but not *deployable capability*. A reader can finish thirty lessons, hold thirty words with accurate etymologies, and still not own a usable exchange. The goal is the shape of a step-by-step self-study grammar — every chapter hands you something you can use walking out the door, nothing gates you before the value arrives — plus a corpus a voice assistant can teach aloud on a commute.

These four specs add a capability layer **above** the existing lessons. No authored lesson content is rewritten; the one-word lesson atom is unchanged.

## What the measurements showed

| Observation | Value |
|---|---|
| Chapters across all tracks | 379 |
| Chapters declaring a goal or payoff | **0** |
| Chapter-level objects of any kind | **0** — `chapter` is an integer on each lesson |
| Spine nodes | **11** (46 concepts) |
| Spine nodes at A2 / B1 | **0 / 0** — while Latin has 36 chapters, Spanish 34, Hindi 33 |
| Images in any of the 20 books | **0** — no graphics package is even loaded |
| Authored geometric stroke paths (`DUCTUS`) | **1 letter**, rendered nowhere |
| Lessons drivable exactly as authored | **695 of 1,096 (~63%)** |
| New atoms per lesson | mean 2.31, median 2, p90 3, **max 7** |

`strokes.ts` holds a complete pen-path model — validated against real font outlines by `truetype.ts` to sub-2-font-unit join tolerance — imported by nothing but its own test. The machinery for teaching handwriting properly is built, tested, and dark.

## The specs

**HL05 — Chapter Capability and the Step-by-Step Shape**
A canonical per-track `chapters.json` carrying a first-person `canDo` and a payoff the reader can deploy immediately. Two rules do the work: **self-sufficiency** (a payoff uses only already-taught atoms) and **representativeness** (a payoff must exercise a threshold share of what its own chapter introduced). The second is load-bearing — without it a payoff is satisfiable by one word, and a chapter can claim a capability it never delivered. Adds a `pattern` lesson type so a chapter can teach *"here is how you build any of these."*

**HL06 — Visual System**
Three figure classes separated by *what makes each trustworthy*. Establishes the **glyph monopoly** — only the font-derived pipeline may ever depict a letter, generalising the argument `truetype.ts` already makes: a subtly wrong Tamil ண looks correct to precisely the audience that cannot yet read Tamil, so the error would ship *as the lesson*.

It also closes a hole this work would otherwise fall through. Every track asserts a zero-warning build; **nothing enforces it** — no CI step reads the `.log`. Floats are the classic source of exactly those warnings, so the log-scanning gate lands with the figures, baselined against current debt.

**HL07 — Spine Expansion to B1**
Eleven nodes cannot carry a complete book, and no quantity of additional word lessons fixes a backbone problem.

**HL08 — Modality, the Gentle Ramp, and the Drivable Course**
Marks every chapter 🚗 / 👁 / ✍ and reports each chapter's **drivable prefix** — *"you can do the first six of this chapter's nine lessons in the car."*

Modality **cannot** be derived from `skills`, and assuming otherwise would mislabel almost the whole corpus: `skills` records what a lesson *develops*, not what it *requires*. 501 of 531 schema-v2 lessons declare `[listening, speaking, reading]`, yet *hola* is perfectly learnable by ear. HL08 derives from lesson type and block structure instead — and the finding is that **the table, not the script, is the main obstacle to hands-free learning**: 322 lessons carry one.

Also implements the **narration export** HL04's pipeline diagram names and nothing ever built — plain text plus structured JSON preserving `[PAUSE Ns]` / `[REPEAT x2]` / `[YOU SAY: …]` as directives, so a voice agent pauses where the lesson pauses and scores spoken answers against the compiled HL-V03 activity contract rather than against prose. Tables are linearised into speech, never silently dropped.

And makes gentleness a **gate**: a budget of 3 new atoms per lesson, at the corpus's existing p90. The 52 lessons above it are split, not waived — exactly as the HL-D01 series handled the five-minute rule. The current worst case teaches ten numbers at once, precisely the antipattern HL00 was written to reject.

**Length is explicitly not a cost.** Splitting for gentleness makes every book longer, and that is the intended direction. No gate may penalise page, lesson, or chapter count.

## Decisions recorded rather than assumed

- **Strict knowledge closure is kept.** HL05 *reserves but does not implement* a `presents.knowledge` tier. Early chapters therefore ramp more slowly than a trade grammar, which is the explicitly preferred trade-off here. Reserving the key makes enabling it later a flag flip, not a corpus migration.
- **Illustration licensing is the project owner's call.** HL06 proposes matching the book's CC BY-SA 4.0 with per-asset provenance, and requires CI to **reject** Class C assets until the decision is written into `_assets/LICENSE.md`.
- **TikZ is explicitly not adopted** — `texlive-pictures` is deliberately excluded from the focused CI closure.

## Evidence boundary

HL05 carries an explicit boundary, following HL04's precedent. What is adopted is a **structural pattern** — chapter-sized deployable capability, an immediately usable payoff, no gating preamble — and nothing else. No text, example, exercise, sequence, or table is reproduced or adapted from any copyrighted course.

## Scope

**Specs only**, per the repo's specs-before-implementation policy. Zero code changes. The backlog records the measured starting point and eighteen sequenced work items (HL-C01…HL-C18); HL-C02 begins implementation.

`/security-review` was not run: this diff is six Markdown files with no executable content. It will run on HL-C02, the first PR carrying code.

## Verification

- All relative Markdown links across the four new specs and both edited docs resolve to existing files (checked).
- Measurements were taken against the parsed lesson AST via the built `human-language-data` loader, not by grep. An initial modality scan read a non-existent `content` field and reported a meaningless 100% clean; corrected to `markdown`, which produced the 695 / 322 / 56 split above.
- No build artifacts staged — files added by explicit path, per `lessons.md`.