### PR TITLE
fix(swift/zstd): decode Repeated-Offset (R1/R2/R3) sequences per RFC 8878

### DIFF
--- a/code/packages/swift/zstd/CHANGELOG.md
+++ b/code/packages/swift/zstd/CHANGELOG.md
@@ -3,6 +3,71 @@
 All notable changes to the `swift/zstd` package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.1.3] — 2026-08-05
+
+### Fixed
+
+- **Repeated-Offset (R1/R2/R3) sequence decoding (RFC 8878 §3.1.1.3.2.1.1)**
+  — see `lessons.md` Lesson 98, found while implementing `c/zstd` (PR #9941).
+  This decoder previously treated every decoded Offset_Value as an explicit
+  offset (`offset = ofRaw - 3`), which underflows for Offset_Value in
+  `{1, 2, 3}`. Those three values are not literal offsets: RFC 8878 §3.1.1.1
+  defines a 3-entry offset history (`Repeated_Offset1/2/3`, seeded `1/4/8`
+  at the start of a frame) that a sequence with `Offset_Value <= 3` reuses
+  instead — one of the format's principal entropy wins, and something real
+  `zstd` encoders reach for constantly (periodic/repetitive data especially).
+  This package's own encoder deliberately never emits repeat-offset codes
+  (its minimum possible LZ77 offset guarantees `ofCode >= 2` always), so no
+  self-round-trip test — including the existing `testTC9CliInterop*` suite's
+  fixed corpora — ever exercised this decode path; the gap was invisible
+  until decoding real `zstd`-CLI-compressed data that happens to use
+  repeat-offsets, which is common.
+  - Reproduced first: added `testTC16RepeatedOffsetDecode`, which failed
+    with `decodingError("decoded offset underflow: ofRaw=1")` against the
+    unfixed decoder — the same underflow signature documented in Lesson 98's
+    `c/zstd` repro (a long run of one repeated byte, which real `zstd`
+    encodes as one Compressed block whose sequences reuse
+    `Repeated_Offset1 = 1` over and over).
+  - Fixed in `decompressBlock`: `rep1`/`rep2`/`rep3` (the three
+    Repeated_Offset registers) are now threaded through as `inout`
+    parameters, frame-scoped (seeded `1/4/8` once per `decompress()` call,
+    carried unmodified across Raw/RLE blocks, updated after every
+    Compressed block's sequences — not reset per block). For each sequence,
+    `ofCode >= 2` still means an explicit offset (and rotates the history:
+    `rep3, rep2, rep1 = rep2, rep1, offset`); `ofCode <= 1` (so
+    `ofRaw` in `{1, 2, 3}`) now resolves via the repeat-offset selector
+    `(llIsZero ? 1 : 0) + ofRaw - 1`, matching the RFC's "when
+    Literals_Length is 0, repeated offsets are shifted by 1" rule and its
+    four cases (reuse `rep1` unchanged / swap in `rep2` / rotate in `rep3` /
+    rotate in `rep1 - 1`). Algorithm cross-checked against both the RFC 8878
+    prose (fetched directly, not recalled from memory) and the literal
+    reference C source (`ZSTD_decodeSequence` in
+    `zstd_decompress_block.c`, `github.com/facebook/zstd`), and against the
+    already-verified `c/zstd` fix (PR #9941) — same selector arithmetic and
+    register-rotation shape in both.
+  - The encoder is unchanged (still never emits repeat-offset codes; this
+    is a decode-only fix, mirroring the `c/zstd` precedent).
+
+### Tests
+
+- Added `testTC16RepeatedOffsetDecode`: real `zstd` CLI interop (compress
+  with `zstd -c -19`, decompress with ours) against two payloads chosen to
+  force repeat-offset usage — a long run of one repeated byte (Lesson 98's
+  exact repro shape) and two interleaved fixed-period runs (forcing reuse
+  of more than one recent distance, exercising `Repeated_Offset2`/`3` as
+  well as `Repeated_Offset1`). Confirmed failing before the fix
+  (`decodingError("decoded offset underflow: ofRaw=1")`) and passing after.
+- Re-ran the full existing suite (25 tests, including `testTC9CliInterop`
+  and `testTC9CliInteropCorpus`) after the fix: all pass, confirming the
+  Lesson 96 FSE-codec conformance work is unaffected.
+- Additionally verified out-of-suite against real `zstd -c` output at
+  compression levels 1/3/9/19 for repetitive source-code-like and
+  JSON-like corpora (both heavy repeat-offset users at higher levels):
+  byte-exact decode in every case that used only Predefined-mode FSE
+  tables and Raw literals; the only failures were the pre-existing,
+  already-documented scope boundary (`unsupportedFSEModes` / Huffman
+  literals), unrelated to this fix.
+
 ## [0.1.2] — 2026-08-03
 
 ### Fixed

--- a/code/packages/swift/zstd/Sources/Zstd/Zstd.swift
+++ b/code/packages/swift/zstd/Sources/Zstd/Zstd.swift
@@ -990,8 +990,35 @@ private func compressBlock(_ block: [UInt8]) -> [UInt8]? {
 /// - Parameters:
 ///   - data: The block payload (after the 3-byte block header).
 ///   - out:  Output buffer; decoded bytes are appended here.
-/// - Throws: `ZstdError` on malformed input.
-private func decompressBlock(_ data: [UInt8], out: inout [UInt8]) throws {
+///   - rep1, rep2, rep3: The three Repeated_Offset registers (RFC 8878
+///     §3.1.1.3.2.1.1) — IN/OUT, because they are FRAME-scoped, not
+///     block-scoped. "For the first block, the starting offset history is
+///     populated with Repeated_Offset1=1, Repeated_Offset2=4,
+///     Repeated_Offset3=8" (RFC 8878), and every later Compressed block in
+///     the same frame continues from wherever the previous one left them.
+///     The caller (`decompress`) owns the registers and threads them
+///     through every Compressed block in the frame; Raw/RLE blocks don't
+///     touch them.
+///
+/// WHY THIS DECODER NEEDS THIS EVEN THOUGH THIS PACKAGE'S OWN ENCODER NEVER
+/// EMITS REPEAT-OFFSET SEQUENCES: `encodeSequencesSection`'s minimum
+/// possible LZ77 match offset is 1, so `rawOff = offset + 3 >= 4` always —
+/// `ofCode` is always >= 2, an explicit offset. That means this package's
+/// own `compress()`/`decompress()` round trip never touches the
+/// repeat-offset path. But the real `zstd` CLI's encoder uses repeat
+/// offsets constantly — reusing the previous match's distance is one of the
+/// format's principal entropy wins, especially for periodic/repetitive data
+/// — so a decoder that only understands explicit offset codes will
+/// systematically fail to decode a meaningful fraction of real-world `.zst`
+/// files. Algorithm cross-checked against both the RFC 8878 prose and the
+/// literal reference C source (`ZSTD_decodeSequence` in
+/// `zstd_decompress_block.c`, github.com/facebook/zstd) and against the
+/// already-verified fix in `code/packages/c/zstd` (PR #9941) — see
+/// lessons.md Lesson 98.
+private func decompressBlock(
+    _ data: [UInt8], out: inout [UInt8],
+    rep1: inout UInt32, rep2: inout UInt32, rep3: inout UInt32
+) throws {
     // ── Literals section ─────────────────────────────────────────────────
     let (lits, litConsumed) = try decodeLiteralsSection(data)
     var pos = litConsumed
@@ -1069,18 +1096,68 @@ private func decompressBlock(_ data: [UInt8], out: inout [UInt8]) throws {
         let llInfo = llCodes[Int(llCode)]
         let mlInfo = mlCodes[Int(mlCode)]
 
+        // `llIsZero` feeds the Repeated_Offset "shifted by 1" rule below
+        // (RFC 8878 §3.1.1.3.2.1.1) and is knowable right now, from the
+        // PEEKED `llCode` alone — LL code 0 is the only code with baseline 0
+        // and 0 extra bits, so `llCode == 0` iff the eventual decoded `ll`
+        // value is 0. No extra bits need to be read yet to know this.
+        let llIsZero = (llCode == 0)
+
         // Step 2 — read the VALUE extra bits, order OF, ML, LL (RFC 8878
         // §3.1.1.3.2.1.2 — decoding starts by reading the bits needed for
-        // offset, then match length, then literals length).
-        // Offset: raw = (1 << ofCode) | extra; offset = raw - 3.
+        // offset, then match length, then literals length). The NUMBER of
+        // bits read for the offset field is always exactly `ofCode`
+        // regardless of the Repeated_Offset interpretation below — the
+        // reference decoder never varies bit-consumption on `llIsZero`, only
+        // how the resulting value maps to an actual offset changes.
         let ofExtra = br.readBits(Int(ofCode))
         let ofRaw = (UInt32(1) << Int(ofCode)) | UInt32(ofExtra)
-        guard ofRaw >= 3 else {
-            throw ZstdError.decodingError("decoded offset underflow: ofRaw=\(ofRaw)")
-        }
-        let offset = ofRaw - 3
         let ml = mlInfo.0 + UInt32(br.readBits(Int(mlInfo.1)))
         let ll = llInfo.0 + UInt32(br.readBits(Int(llInfo.1)))
+
+        // Offset_Value -> actual offset (RFC 8878 §3.1.1.3.2.1.1), including
+        // the Repeated_Offset (R1/R2/R3) mechanism this decoder must
+        // understand even though its own encoder never emits it — see the
+        // doc comment on `decompressBlock`.
+        //
+        // `ofCode >= 2` guarantees `ofRaw = (1 << ofCode) + extra >= 4`,
+        // i.e. Offset_Value > 3: an ordinary explicit offset. `ofCode <= 1`
+        // guarantees `ofRaw` in {1, 2, 3}: a repeat-offset reference.
+        //
+        // The repeat case collapses to one selector in [0, 3] (derived from,
+        // and verified against, the reference decoder's
+        // `ofBase + ll0 + extra_bit`, and against the PR #9941 `c/zstd` fix):
+        //   0 -> reuse rep1 unchanged (no rotation)
+        //   1 -> use rep2 (rep1, rep2 swap; rep3 untouched)
+        //   2 -> use rep3 (full rotate: rep1,rep2,rep3 <- new,old_rep1,old_rep2)
+        //   3 -> use rep1-1 (full rotate, same shape as selector 2)
+        let offset: UInt32
+        if ofCode >= 2 {
+            offset = ofRaw - 3
+            rep3 = rep2
+            rep2 = rep1
+            rep1 = offset
+        } else {
+            let selector = (llIsZero ? 1 : 0) + Int(ofRaw) - 1
+            switch selector {
+            case 0:
+                offset = rep1
+            case 1:
+                offset = rep2
+                rep2 = rep1
+                rep1 = offset
+            case 2:
+                offset = rep3
+                rep3 = rep2
+                rep2 = rep1
+                rep1 = offset
+            default:  // 3
+                offset = rep1 > 0 ? rep1 - 1 : 0
+                rep3 = rep2
+                rep2 = rep1
+                rep1 = offset
+            }
+        }
 
         // Step 3 — update FSE states (consumes bits), order LL, ML, OF (RFC
         // 8878 §3.1.1.3.2.1.2), preparing the states the NEXT sequence's
@@ -1339,6 +1416,15 @@ public func decompress(_ data: [UInt8]) throws -> [UInt8] {
     // ── Blocks ────────────────────────────────────────────────────────────
     var out: [UInt8] = []
 
+    // Repeated_Offset registers (RFC 8878 §3.1.1.3.2.1.1): frame-scoped —
+    // default 1/4/8 "for the first block", then threaded unmodified through
+    // every Compressed block's sequences for the rest of the frame (Raw/RLE
+    // blocks don't touch them). See `decompressBlock`'s doc comment and
+    // lessons.md Lesson 98.
+    var rep1: UInt32 = 1
+    var rep2: UInt32 = 4
+    var rep3: UInt32 = 8
+
     while true {
         guard pos + 3 <= data.count else { throw ZstdError.blockTruncated }
 
@@ -1373,7 +1459,7 @@ public func decompress(_ data: [UInt8]) throws -> [UInt8] {
             guard pos + bsize <= data.count else { throw ZstdError.blockTruncated }
             let blockData = Array(data[pos..<(pos + bsize)])
             pos += bsize
-            try decompressBlock(blockData, out: &out)
+            try decompressBlock(blockData, out: &out, rep1: &rep1, rep2: &rep2, rep3: &rep3)
             guard out.count <= maxOutput else { throw ZstdError.outputLimitExceeded }
 
         default:  // 3 = Reserved

--- a/code/packages/swift/zstd/Tests/ZstdTests/ZstdTests.swift
+++ b/code/packages/swift/zstd/Tests/ZstdTests/ZstdTests.swift
@@ -578,4 +578,99 @@ final class ZstdTests: XCTestCase {
             try assertCliInterop(data, zstdPath: zstdPath, label: label)
         }
     }
+
+    // =========================================================================
+    // TC-16: Repeated-Offset (R1/R2/R3) decode — lessons.md Lesson 98
+    // =========================================================================
+    //
+    // RFC 8878 §3.1.1.3.2.1.1 defines a Repeated_Offset mechanism: when the
+    // decoded Offset_Value for a sequence is 1, 2, or 3, the actual match
+    // offset is NOT `Offset_Value - 3` (which would underflow) — it is looked
+    // up from a 3-entry offset HISTORY (Repeated_Offset1/2/3, seeded 1/4/8 at
+    // the start of a frame and updated after every sequence). Real `zstd`
+    // encoders reach for this constantly: reusing the previous match's
+    // distance is one of the format's principal entropy wins, especially for
+    // periodic or highly repetitive data.
+    //
+    // This package's own ENCODER intentionally never emits repeat-offset
+    // codes — `encodeSequencesSection`'s minimum possible LZ77 offset is 1,
+    // so `rawOff = offset + 3 >= 4` always, meaning `ofCode` is always >= 2.
+    // That is a deliberate educational simplification on the ENCODE side
+    // only (see `code/packages/c/zstd`'s `zstd.h` for the same documented
+    // choice). But a DECODER that only understands explicit offset codes
+    // will fail on a meaningful fraction of real-world `.zst` files, because
+    // it can never round-trip through this package's own encoder/decoder
+    // pair — no internal self-consistency test can catch the gap. It only
+    // shows up against an INDEPENDENT, spec-conformant encoder: the real
+    // `zstd` CLI. See lessons.md Lesson 98 (found while implementing
+    // `code/packages/c/zstd`, PR #9941) for the sibling bug in the C port,
+    // which this package inherited from the same design lineage (Lesson 96's
+    // FSE codec was fixed repo-wide, but repeat-offset decode was never
+    // implemented in any port to begin with).
+    //
+    // Lesson 98's own minimal repro (4713 bytes of a single repeated byte
+    // compressed by the real CLI) picks a single Compressed block containing
+    // one sequence with `Offset_Value = 1` — "reuse Repeated_Offset1", which
+    // starts at its default value of 1 — an unmistakable RLE-via-repeat-
+    // offset pattern that a naive `offset = Offset_Value - 3` decode
+    // corrupts into a huge bogus offset (correctly rejected by the
+    // offset-bounds guard, but for the wrong reason: the frame was valid).
+    //
+    // `runLengths` below repeats that repro at a size chosen so real `zstd`
+    // picks a Compressed block (not RLE, which sidesteps the sequences
+    // codec entirely), and `periodicOffsets` adds a case built from two
+    // interleaved periods so the encoder is likely to reuse more than one
+    // distance, exercising Repeated_Offset2/3 as well as Repeated_Offset1.
+
+    func testTC16RepeatedOffsetDecode() throws {
+        guard let zstdPath = findZstdCLI() else {
+            throw XCTSkip("real `zstd` CLI not found on PATH; skipping interop test")
+        }
+
+        var cases: [(String, [UInt8])] = []
+
+        // Lesson 98's exact repro shape: a long run of one repeated byte.
+        // Large enough, and with just enough entropy noise (a handful of
+        // distinct bytes) that the real CLI is not guaranteed to fold the
+        // whole thing into a single RLE block, while still being dominated
+        // by one back-reference distance reused sequence after sequence.
+        do {
+            var data = [UInt8](repeating: UInt8(ascii: "Z"), count: 4713)
+            // Sprinkle a few different bytes in so the block has more than
+            // one literal run, forcing multiple sequences (each reusing the
+            // same distance) rather than one giant match.
+            for i in stride(from: 100, to: data.count, by: 137) {
+                data[i] = UInt8(ascii: "Q")
+            }
+            cases.append(("lesson98-repeated-byte", data))
+        }
+
+        // Two interleaved back-to-back-match periods: forces the encoder to
+        // alternate between (at least) two distinct recent offsets, which
+        // real zstd encodes via Repeated_Offset1 AND Repeated_Offset2/3
+        // shortcuts once each distance has been used before.
+        do {
+            let a = Array("ABCDEFGHIJ".utf8)   // period-10 run
+            let b = Array("0123456789012".utf8) // period-13 run
+            var data: [UInt8] = []
+            for _ in 0..<300 {
+                data.append(contentsOf: a)
+                data.append(contentsOf: b)
+            }
+            cases.append(("interleaved-periods", data))
+        }
+
+        for (label, data) in cases {
+            // Compress with the REAL zstd CLI (an independent, spec-
+            // conformant encoder that uses repeat-offsets freely), decompress
+            // with OUR decoder. This is the direction Lesson 98 lives in.
+            let cliCompressed = try runZstdCLI(zstdPath, args: ["-c", "-19"], stdin: Data(data))
+            let decodedByOurs = try decompress([UInt8](cliCompressed))
+            XCTAssertEqual(
+                decodedByOurs, data,
+                "[\(label)] our decoder failed to correctly decode real `zstd` output " +
+                "using Repeated-Offset (R1/R2/R3) sequences — RFC 8878 §3.1.1.3.2.1.1 " +
+                "(lessons.md Lesson 98)")
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- The `swift/zstd` decoder treated every decoded `Offset_Value` as an explicit offset (`offset = ofRaw - 3`), which underflows for `Offset_Value` in `{1, 2, 3}`. RFC 8878 §3.1.1.3.2.1.1 defines those three values as references into a 3-entry offset history (`Repeated_Offset1/2/3`, seeded `1/4/8` per frame) — one of the format's principal entropy wins, and something real `zstd` encoders use constantly (periodic/repetitive data especially).
- This package's own encoder deliberately never emits repeat-offset codes (its minimum LZ77 offset guarantees `ofCode >= 2` always), so no internal round-trip test — including the existing `testTC9CliInterop*` suite — ever exercised this decode path. The gap was invisible until decoding real `zstd`-CLI-compressed data.
- Found while implementing the `c/zstd` port (#9941), which hit the identical gap via a 200-trial fuzz harness against the real `zstd` CLI (see `lessons.md` Lesson 98). This PR ports that already-verified algorithm to Swift, cross-checked against both the RFC 8878 prose (fetched directly) and the literal reference C source (`ZSTD_decodeSequence` in `zstd_decompress_block.c`, `github.com/facebook/zstd`).
- `decompressBlock` now threads `rep1`/`rep2`/`rep3` (frame-scoped, seeded `1/4/8`, carried across blocks) and resolves `ofCode <= 1` via the selector `(llIsZero ? 1 : 0) + ofRaw - 1`, matching the RFC's "`Literals_Length == 0` shifts repeated offsets by 1" rule and its four cases.
- Encoder is unchanged — decode-only fix, mirroring the `c/zstd` precedent.

## Test plan

- [x] Added `testTC16RepeatedOffsetDecode`: real `zstd` CLI interop against two payloads chosen to force repeat-offset usage (a long run of one repeated byte — Lesson 98's exact repro shape — and two interleaved fixed-period runs exercising `Repeated_Offset2`/`3`). Confirmed **failing before the fix** (`decodingError("decoded offset underflow: ofRaw=1")`) and **passing after**.
- [x] Re-ran the full existing suite (25 tests, including `testTC9CliInterop`/`testTC9CliInteropCorpus`) — all pass, confirming the Lesson 96 FSE-codec conformance work is unaffected.
- [x] Additionally verified out-of-suite against real `zstd -c` output at compression levels 1/3/9/19 for repetitive source-code-like and JSON-like corpora: byte-exact decode in every Predefined-mode/Raw-literals case; only failures were the pre-existing, already-documented scope boundary (`unsupportedFSEModes`/Huffman literals), unrelated to this fix.
- [x] Security review passed (no vulnerabilities found — traced integer-underflow safety of the new `rep1 - 1` path and confirmed the existing offset-bounds guard still gates every code path).
- [x] CHANGELOG.md updated (`code/packages/swift/zstd/CHANGELOG.md`, `[0.1.3]`).

References: #9941 (reference fix in `c/zstd`), `lessons.md` Lesson 98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)