### PR TITLE
fix(fsharp/zstd): decode Repeated-Offset (R1/R2/R3) sequences per RFC 8878

### DIFF
--- a/code/packages/fsharp/zstd/CHANGELOG.md
+++ b/code/packages/fsharp/zstd/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.1.2] - 2026-08-05
+
+Audited against a second, independent RFC 8878 conformance gap — this one a
+decode-only FEATURE GAP rather than the FSE-codec class fixed in 0.1.1 —
+first found and fixed in `code/packages/c/zstd` (PR #9941, `lessons.md`
+Lesson 98). This package inherited the identical gap.
+
+### Fixed
+
+- **`DecompressBlock` never implemented Repeated-Offset (R1/R2/R3) sequence
+  decoding (RFC 8878 §3.1.1.3.2.1.1).** An `Offset_Value` of 1, 2, or 3 is a
+  reference into a three-entry offset history (`Repeated_Offset1/2/3`,
+  frame-scoped, defaulting to 1/4/8 for the first block and updated after
+  every Compressed block's sequences), not a literal `Offset_Value - 3`
+  computation. `DecompressBlock` computed `matchOffset = rawOffset - 3`
+  unconditionally, so any `rawOffset` of 1-3 underflowed to a bogus huge
+  offset — rejected by the existing offset-bounds check as "malformed" even
+  though the frame was perfectly valid, just encoded via a mechanism the
+  decoder didn't understand.
+- Why this package's own round-trip tests never caught it: `EncodeSequences`
+  is, by design, incapable of emitting `Offset_Value <= 3` (the minimum
+  LZSS match offset is 1, so `rawOffset = offset + 3 >= 4` always) — the
+  "no repeat-offset shortcuts" educational simplification is entirely an
+  ENCODER-side choice. But the real `zstd` CLI's encoder uses repeat offsets
+  constantly (one of its principal entropy wins, especially for
+  periodic/repetitive data), so this package's decoder systematically failed
+  to decode a meaningful fraction of real-world `.zst` files. Even the
+  existing TC-9 CLI-interop tests (added in 0.1.1) never exercised this path
+  — their fixed prose corpus never happened to produce a real-`zstd`-encoded
+  sequence with `Offset_Value <= 3`.
+- Fixed by threading the three `Repeated_Offset` registers (frame-scoped, as
+  `byref<int>` parameters) from `Decompress` through every Compressed
+  block's `DecompressBlock` call, and implementing the full
+  peek-then-select-then-rotate mechanism per RFC 8878 §3.1.1.3.2.1.1 —
+  including the "when `Literals_Length` is 0, repeated offsets are shifted
+  by 1" special case (using the peeked, not-yet-extra-bit-read literal-length
+  code, which is sufficient to know whether the eventual literal length is
+  zero). Cross-checked against both the RFC 8878 prose and the literal
+  reference C source (`ZSTD_decodeSequence` in `zstd_decompress_block.c`
+  from github.com/facebook/zstd), per the Lesson-96/98 playbook of never
+  re-deriving wire-format semantics from memory alone. The encoder is
+  deliberately left unchanged — still never emits repeat-offset codes; this
+  is a decode-only fix.
+
+### Added
+
+- Two new TC-9 regression tests: `4713` bytes of a single repeated byte
+  (real `zstd` compresses this to one Compressed block whose one sequence is
+  2 literal bytes + a match with `Offset_Value=1`, i.e. "reuse
+  `Repeated_Offset1`" — an unmistakable RLE-via-repeat-offset pattern that
+  reproduced the pre-fix bug directly), and a periodic 6-byte-cycle pattern
+  as an independent repro not dependent on real zstd's constant-byte
+  heuristic specifically.
+- Ad hoc (not committed) verification: a 42-case fuzz sweep against the real
+  `zstd` CLI (constant, periodic at several cycle lengths, ramp, random, and
+  prose patterns, at sizes from 16 bytes to 20 KB) — all round-tripped
+  byte-exact after the fix.
+
 ## [0.1.1] - 2026-08-03
 
 Audited against a real RFC 8878 conformance bug confirmed present in

--- a/code/packages/fsharp/zstd/CodingAdventures.Zstd.fsproj
+++ b/code/packages/fsharp/zstd/CodingAdventures.Zstd.fsproj
@@ -3,7 +3,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>CodingAdventures.Zstd.FSharp</PackageId>
-    <Version>0.1.1</Version>
+    <Version>0.1.2</Version>
     <Authors>Adhithya Rajasekaran</Authors>
     <Description>Pure F# educational Zstandard codec</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/code/packages/fsharp/zstd/Zstd.fs
+++ b/code/packages/fsharp/zstd/Zstd.fs
@@ -490,7 +490,46 @@ type Zstd private () =
             let result = output.ToArray()
             if result.Length < block.Length then Some result else None
 
-    static member private DecompressBlock(data: byte array, output: ResizeArray<byte>) =
+    /// Decodes one Compressed block's payload, appending to `output`.
+    ///
+    /// `rep1`/`rep2`/`rep3` are the three Repeated_Offset registers (RFC
+    /// 8878 §3.1.1.3.2.1.1) — passed by reference because they are
+    /// FRAME-scoped, not block-scoped: "For the first block, the starting
+    /// offset history is populated with Repeated_Offset1=1,
+    /// Repeated_Offset2=4, Repeated_Offset3=8", and every later Compressed
+    /// block in the same frame continues from wherever the previous one's
+    /// sequences left them (Raw and RLE blocks don't touch the registers at
+    /// all). The caller (Decompress) owns the three registers and threads
+    /// them through every Compressed block in a frame.
+    ///
+    /// WHY THIS DECODER NEEDS REPEAT-OFFSET SUPPORT EVEN THOUGH THIS
+    /// PACKAGE'S OWN ENCODER NEVER EMITS IT: EncodeSequences always writes
+    /// an explicit offset code (offsetCode >= 2, since the minimum LZSS
+    /// match offset is 1, giving rawOffset = offset + 3 >= 4), so this
+    /// package's own Compress/Decompress round trip never touches the
+    /// repeat-offset path — "no repeat-offset shortcuts" is entirely an
+    /// ENCODER-side simplification. But the real `zstd` CLI's encoder uses
+    /// repeat offsets constantly (they are one of its main entropy wins,
+    /// especially for periodic/repetitive data), so a decoder that only
+    /// understands explicit offset codes will systematically fail to decode
+    /// a meaningful fraction of real-world `.zst` files — confirmed here by
+    /// a TC-9 regression using 4713 bytes of a single repeated byte, which
+    /// real `zstd` compresses to one Compressed block whose one sequence is
+    /// 2 literal bytes ("ZZ") + a match with Offset_Value=1 (i.e. "reuse
+    /// Repeated_Offset1", which starts at its default value of 1 — an
+    /// unmistakable RLE-via-repeat-offset pattern). See lessons.md Lesson
+    /// 98 (originally found and fixed in `code/packages/c/zstd`, PR #9941;
+    /// this port's fix mirrors that one, cross-checked against both the RFC
+    /// 8878 prose and the literal reference C source, `ZSTD_decodeSequence`
+    /// in `zstd_decompress_block.c` from github.com/facebook/zstd).
+    static member private DecompressBlock
+        (
+            data: byte array,
+            output: ResizeArray<byte>,
+            rep1: byref<int>,
+            rep2: byref<int>,
+            rep3: byref<int>
+        ) =
         let literals, literalBytes = Zstd.DecodeLiterals data
         let mutable position = literalBytes
         if position >= data.Length then
@@ -534,15 +573,74 @@ type Zstd private () =
                     if literalCode < 0 || literalCode >= literalCodes.Length || matchCode < 0 || matchCode >= matchCodes.Length then
                         raise (InvalidDataException("invalid sequence code"))
 
+                    // literalLengthIsZero is needed for the repeat-offset
+                    // interpretation below (RFC 8878's "when Literals_Length
+                    // is 0, repeated offsets are shifted by 1" rule) and is
+                    // knowable right now, from the PEEKED literalCode alone
+                    // — literal-length code 0 is the only code with
+                    // baseline 0 and 0 extra bits, so literalCode = 0 iff
+                    // the eventual decoded literalLength is 0. No extra
+                    // bits need to be read yet to know this.
+                    let literalLengthIsZero = literalCode = 0
+
                     // Step 2 — read the value extra bits, order OF, ML, LL
                     // (RFC 8878 §3.1.1.3.2.1.2: "Decoding starts by reading
                     // the Number_of_Bits required to decode offset. It does
                     // the same for Match_Length and then for
-                    // Literals_Length.").
+                    // Literals_Length."). The NUMBER of bits read for the
+                    // offset field is always exactly `offsetCode`
+                    // regardless of the repeat-offset interpretation below —
+                    // the reference decoder never varies bit-consumption on
+                    // literalLengthIsZero, only how the resulting value maps
+                    // to an actual offset changes.
                     let rawOffset = (1 <<< offsetCode) ||| reader.ReadBits offsetCode
                     let matchLength = matchCodes[matchCode].Baseline + reader.ReadBits matchCodes[matchCode].ExtraBits
                     let literalLength = literalCodes[literalCode].Baseline + reader.ReadBits literalCodes[literalCode].ExtraBits
-                    let matchOffset = rawOffset - 3
+
+                    // Offset_Value -> actual offset (RFC 8878
+                    // §3.1.1.3.2.1.1), including the Repeated_Offset
+                    // (R1/R2/R3) mechanism (lessons.md Lesson 98):
+                    //
+                    // offsetCode >= 2 guarantees rawOffset =
+                    // (1<<<offsetCode)+extra >= 4, i.e. Offset_Value > 3: an
+                    // ordinary explicit offset. offsetCode <= 1 guarantees
+                    // rawOffset in {1, 2, 3}: a repeat-offset reference.
+                    //
+                    // The repeat case collapses to one selector in [0, 3]
+                    // (derived from, and verified against, the reference
+                    // decoder's `ofBase + ll0 + extra_bit`):
+                    //   0 -> reuse rep1 unchanged (no rotation)
+                    //   1 -> use rep2 (rep1,rep2 swap; rep3 untouched)
+                    //   2 -> use rep3 (full rotate: rep1,rep2,rep3 <- new,old_rep1,old_rep2)
+                    //   3 -> use rep1-1 (full rotate, same shape as selector 2)
+                    let matchOffset =
+                        if offsetCode >= 2 then
+                            let explicitOffset = rawOffset - 3
+                            rep3 <- rep2
+                            rep2 <- rep1
+                            rep1 <- explicitOffset
+                            explicitOffset
+                        else
+                            let selector = (if literalLengthIsZero then 1 else 0) + rawOffset - 1
+                            match selector with
+                            | 0 -> rep1
+                            | 1 ->
+                                let value = rep2
+                                rep2 <- rep1
+                                rep1 <- value
+                                value
+                            | 2 ->
+                                let value = rep3
+                                rep3 <- rep2
+                                rep2 <- rep1
+                                rep1 <- value
+                                value
+                            | _ ->
+                                let value = if rep1 > 0 then rep1 - 1 else 0
+                                rep3 <- rep2
+                                rep2 <- rep1
+                                rep1 <- value
+                                value
 
                     // Step 3 — update FSE states (consumes bits), order LL,
                     // ML, OF, preparing the states the NEXT sequence's peek
@@ -663,6 +761,14 @@ type Zstd private () =
 
         let output = ResizeArray<byte>()
         let mutable last = false
+        // Repeated_Offset registers (RFC 8878 §3.1.1.3.2.1.1): frame-scoped
+        // — default 1/4/8 "for the first block", then threaded unmodified
+        // through every Compressed block's sequences for the rest of the
+        // frame (Raw/RLE blocks don't touch them). See DecompressBlock's
+        // doc comment and lessons.md Lesson 98.
+        let mutable rep1 = 1
+        let mutable rep2 = 4
+        let mutable rep3 = 8
         while not last do
             Zstd.RequireAvailable(data.Length, position, 3, "block header")
             let blockHeader = int data[position] ||| (int data[position + 1] <<< 8) ||| (int data[position + 2] <<< 16)
@@ -686,7 +792,7 @@ type Zstd private () =
                 for _ in 1..blockSize do output.Add value
             | 2 ->
                 Zstd.RequireAvailable(data.Length, position, blockSize, "compressed block")
-                Zstd.DecompressBlock(data[position..position + blockSize - 1], output)
+                Zstd.DecompressBlock(data[position..position + blockSize - 1], output, &rep1, &rep2, &rep3)
                 position <- position + blockSize
             | _ -> raise (InvalidDataException("reserved block type 3"))
 

--- a/code/packages/fsharp/zstd/tests/CodingAdventures.Zstd.Tests/ZstdTests.fs
+++ b/code/packages/fsharp/zstd/tests/CodingAdventures.Zstd.Tests/ZstdTests.fs
@@ -283,6 +283,52 @@ type ZstdTests() =
             Assert.Equal<byte array>(input, decompressedByCli)
 
     [<Fact>]
+    member _.``TC-9: real zstd CLI Repeated-Offset (R1/R2/R3) sequences decode correctly``() =
+        // Regression coverage for lessons.md Lesson 98 (see PR #9941,
+        // c/zstd): this package's own encoder is, by design, incapable of
+        // emitting an Offset_Value <= 3 (the minimum LZSS match offset is
+        // 1, so `rawOffset = offset + 3 >= 4` always) — so a self round
+        // trip, and every existing TC-9 test above (which only compresses
+        // WITH this package's own encoder, or decompresses a real-CLI frame
+        // built from non-repetitive prose), never exercises the decoder's
+        // handling of Offset_Value 1/2/3 as a Repeated-Offset reference
+        // (RFC 8878 §3.1.1.3.2.1.1) rather than a literal `code - 3`.
+        //
+        // Real `zstd`'s own encoder uses repeat offsets constantly — long
+        // constant-byte runs are an easy, reliable way to force it: 4713
+        // bytes of a single repeated byte compresses (at the default level,
+        // WITHOUT --no-check so the interop path also covers a real
+        // checksum trailer) to a single Compressed block whose one sequence
+        // is 2 literal bytes ("ZZ") + a match with Offset_Value=1 — i.e.
+        // "reuse Repeated_Offset1", which starts at its RFC-mandated
+        // default of 1. Before the Lesson-98 fix, DecompressBlock computed
+        // `matchOffset = rawOffset - 3` unconditionally, so `rawOffset = 1`
+        // underflowed to a huge bogus offset that the existing
+        // offset-bounds check (`matchOffset > output.Count`) correctly
+        // rejected as malformed — even though the frame is perfectly valid,
+        // just encoded via a mechanism the decoder didn't understand yet.
+        if ZstdCli.isAvailable () then
+            let input = Array.create 4713 (byte 'Z')
+            let compressedByCli = ZstdCli.run [ "-c" ] input
+            Assert.Equal<byte array>(input, Zstd.Decompress compressedByCli)
+
+    [<Fact>]
+    member _.``TC-9: real zstd CLI Repeated-Offset sequences decode correctly across a periodic pattern``() =
+        // A second, independent Repeated-Offset repro using a periodic
+        // (non-constant) pattern rather than a single repeated byte, so the
+        // regression coverage doesn't depend on real zstd's RLE-via-
+        // repeat-offset heuristic for constant-byte runs specifically.
+        // Six-byte cycles over many repetitions give real zstd's encoder
+        // many equal-distance matches, which its cost model strongly
+        // favours encoding as Repeated-Offset (R1) references once the same
+        // offset has been used twice in a row.
+        if ZstdCli.isAvailable () then
+            let cycle = Encoding.ASCII.GetBytes "ABCDEF"
+            let input = Array.init 3000 (fun index -> cycle[index % cycle.Length])
+            let compressedByCli = ZstdCli.run [ "-c" ] input
+            Assert.Equal<byte array>(input, Zstd.Decompress compressedByCli)
+
+    [<Fact>]
     member _.``malformed frames are rejected``() =
         let malformed =
             [| [||]

--- a/lessons.md
+++ b/lessons.md
@@ -2161,3 +2161,83 @@ regression test at the `Number_of_Sequences` 1-byte/2-byte wire-encoding
 boundary — 115 checks passed under both g++ and clang++ with no `zstd` CLI
 skip (the binary was available in the dev environment), confirming actual
 RFC 8878 wire-format conformance rather than just internal self-consistency.
+
+---
+
+## Lesson 99 — `fsharp/zstd` inherited the same Repeated-Offset (R1/R2/R3) decode gap as `c/zstd` (Lesson 98), confirmed via real `zstd` CLI interop
+
+**Date:** 2026-08-05
+
+**What happened:** While implementing `c/zstd` (CMP07, PR #9941), an ad hoc
+fuzz sweep against the real `zstd` CLI found that its decoder never
+implemented Repeated-Offset (R1/R2/R3) sequence decoding (RFC 8878
+§3.1.1.3.2.1.1) — an `Offset_Value` of 1, 2, or 3 is a reference into a
+three-entry offset history, not a literal `Offset_Value - 3` computation.
+That PR flagged every other language's `zstd` port as "suspect of the same
+gap until specifically checked against varied real-world `zstd`-CLI-encoded
+input" (documented as that PR's own Lesson 98). Auditing
+`code/packages/fsharp/zstd/Zstd.fs`'s `DecompressBlock` confirmed it: the
+line `let matchOffset = rawOffset - 3` computed the actual match offset
+unconditionally, with no repeat-offset interpretation for `rawOffset` values
+1-3, and no offset-history registers threaded through the frame at all.
+
+A regression test (added to `ZstdTests.fs` BEFORE the fix, to prove the gap
+rather than assume it): compressing 4713 bytes of a single repeated byte
+`'Z'` with the real `zstd` CLI (no `--no-check`, exercising the checksum
+trailer too) and decompressing with this package's `Zstd.Decompress`
+raised `System.IO.InvalidDataException: match offset exceeds decoded
+output` — real `zstd` chose a Compressed block whose one sequence is 2
+literal bytes ("ZZ") + a match with `Offset_Value=1` (i.e. "reuse
+`Repeated_Offset1`", which starts at its RFC-mandated default of 1, an
+unmistakable RLE-via-repeat-offset pattern); the pre-fix decoder computed
+`rawOffset - 3 = 1 - 3` which underflows a `let` binding typed as `int` to a
+large negative-then-implicitly-huge value once used as an array/offset
+computation, correctly rejected by the existing offset-bounds check as
+malformed — even though the frame was perfectly valid.
+
+**Why it went unnoticed:** Identical shape to the `c/zstd` finding. This
+package's own `EncodeSequences` is, by design, incapable of emitting
+`Offset_Value <= 3` (the minimum LZSS match offset is 1, so
+`rawOffset = offset + 3 >= 4` always), so a self round-trip — and every
+pre-existing TC-9 CLI-interop test in this package (added in 0.1.1 for the
+Lesson 96 FSE-codec bugs), whose fixed prose corpus never happened to
+produce a real-`zstd`-encoded sequence with `Offset_Value <= 3` — never
+exercised this decode path.
+
+**Rule (same as Lesson 98, reconfirmed cross-language):**
+- Decode-side feature scope and encode-side feature scope are separate
+  decisions. An "educational subset" simplification stated as "we don't
+  emit repeat-offset sequences" must not be silently read as "we don't need
+  to decode them," when the decoder's job is to accept output from the real,
+  independent `zstd` CLI ecosystem — which uses repeat offsets constantly,
+  as one of its principal entropy wins.
+- A single fixed TC-9 corpus is necessary but not sufficient evidence of
+  decoder conformance. Before trusting "TC-9 passes," fuzz the same
+  interop check across varied inputs (constant-byte runs are the cheapest,
+  most reliable way to force real zstd into a repeat-offset-heavy encoding).
+- Fixed in `code/packages/fsharp/zstd/Zstd.fs`: `DecompressBlock` now takes
+  `rep1`/`rep2`/`rep3` as `byref<int>` (frame-scoped, threaded from
+  `Decompress` through every Compressed block, default 1/4/8 for the first
+  block per RFC 8878), and implements the full peek-then-select-then-rotate
+  mechanism for `Offset_Value` 1-3 — including the "when `Literals_Length`
+  is 0, repeated offsets are shifted by 1" special case, using the peeked
+  (not-yet-extra-bit-read) literal-length code to know whether the eventual
+  literal length is zero. Ported from, and cross-checked against, both the
+  literal reference C source (`ZSTD_decodeSequence` in
+  `zstd_decompress_block.c`, github.com/facebook/zstd) transcribed in
+  `c/zstd`'s fix (`gh pr diff 9941`) and an independent RFC 8878 §3.1.1.3.2.1.1
+  fetch — not re-derived from memory. The encoder is unchanged (still never
+  emits repeat-offset codes; decode-only fix). semantic package version
+  bumped 0.1.1 -> 0.1.2.
+- Verified via two new TC-9 regression tests (the 4713-byte constant-run
+  repro above, plus an independent periodic-6-byte-cycle repro not
+  dependent on the constant-byte-specific heuristic) — all 26 existing +
+  new tests pass, line coverage 91.16% (threshold 80%) — plus an ad hoc
+  42-case fuzz sweep against the real `zstd` CLI (constant, periodic at
+  several cycle lengths, ramp, random, and prose patterns, 16 bytes to
+  20 KB), all byte-exact.
+- Every other language's `zstd` port in this repo remains suspect of the
+  same gap until specifically audited — this PR only covers `fsharp/zstd`.
+
+See also `gh pr diff 9941` (`c/zstd`, Lesson 98) for the original finding
+and reference fix this port's fix was cross-checked against.


### PR DESCRIPTION
## Summary

- `code/packages/fsharp/zstd`'s `DecompressBlock` computed `matchOffset = rawOffset - 3` unconditionally, never treating `Offset_Value` 1/2/3 as a reference into the three-entry Repeated_Offset history (RFC 8878 §3.1.1.3.2.1.1). Real `zstd`'s encoder uses repeat offsets constantly (one of its principal entropy wins, especially for periodic/repetitive data); this package's own encoder never emits them by design, so no self round-trip test ever exercised the decode path.
- Same gap independently found and fixed in `code/packages/c/zstd` (PR #9941, `lessons.md` Lesson 98) via real `zstd` CLI fuzzing. Auditing `fsharp/zstd` against that finding — rather than assuming it was fine or automatically broken — confirmed it inherited the identical bug.
- Fixed by threading the three `Repeated_Offset` registers (frame-scoped, `byref<int>`, default 1/4/8 for the first block) from `Decompress` through every Compressed block's `DecompressBlock` call, and implementing the full peek-then-select-then-rotate mechanism, including the "when `Literals_Length` is 0, repeated offsets are shifted by 1" special case. Cross-checked against **both** the RFC 8878 prose and the literal reference C source (`ZSTD_decodeSequence`, `github.com/facebook/zstd` — transcribed via `gh pr diff 9941`), not re-derived from memory, per the Lesson-96/98 playbook. The encoder is unchanged — still never emits repeat-offset codes; this is a decode-only fix.
- Documented as `lessons.md` Lesson 99, cross-referencing PR #9941's Lesson 98.

## Test plan

- [x] New TC-9 regression test proving the gap pre-fix: 4713 bytes of a single repeated byte, real `zstd -c` output (real zstd encodes this as one Compressed block whose one sequence is 2 literal bytes + a match with `Offset_Value=1`, i.e. "reuse `Repeated_Offset1`"). Confirmed failing on the pre-fix code with `System.IO.InvalidDataException: match offset exceeds decoded output` before implementing the fix.
- [x] Second, independent TC-9 regression test: a periodic 6-byte-cycle pattern, not dependent on real zstd's constant-byte-specific heuristic.
- [x] `dotnet test` — all 26 tests pass (24 pre-existing + 2 new), line coverage 91.16% (threshold 80%)
- [x] Ad hoc (not committed) 42-case fuzz sweep against the real `zstd` CLI — constant, periodic (several cycle lengths), ramp, random, and prose patterns, sizes 16 bytes to 20 KB — all byte-exact after the fix
- [x] Security review (sub-agent, F#/.NET focus, decompression-bomb and OOB-read/write emphasis) — PASSED, no vulnerabilities found
- [x] `CHANGELOG.md` updated (0.1.1 -> 0.1.2), `lessons.md` updated (Lesson 99)

Refs #9941 (`c/zstd`, the original finding and reference fix this port was cross-checked against).

🤖 Generated with [Claude Code](https://claude.com/claude-code)