### PR TITLE
fix(rust/zstd): decode Repeated-Offset (R1/R2/R3) sequences per RFC 8878

### DIFF
--- a/code/packages/rust/zstd/CHANGELOG.md
+++ b/code/packages/rust/zstd/CHANGELOG.md
@@ -4,6 +4,38 @@
 
 ### Fixed
 
+- **Decoder never implemented Repeated-Offset (R1/R2/R3) sequence decoding
+  (RFC 8878 §3.1.1.3.2.1.1)** — `decompress_block` computed
+  `offset = of_raw - 3` unconditionally for every sequence, treating offset
+  codes 1/2/3 as literal (tiny, usually invalid) offsets instead of
+  references into a 3-slot history of recently-used offsets. This crate's
+  own encoder never emits offset codes below 4 by design (an explicit
+  "no repeat-offset shortcuts" educational simplification —
+  `raw_off = offset + 3 >= 4` always, since the minimum LZ77 match offset is
+  1), so this crate's own `compress()`/`decompress()` round trip — and every
+  existing unit/interop test, including `tc9_cli_interop` and the
+  misleadingly-named `tc8_repeat_offset` (which only exercises OUR encoder's
+  explicit-offset path on repetitive input, never the repeat-offset decode
+  path) — never exercised this code at all. But real `zstd` encoders use
+  repeat offsets constantly, especially on periodic or constant data; a
+  decoder that only understands explicit offset codes fails on a large
+  fraction of real-world `.zst` files. Found and root-caused while building
+  the sibling `code/packages/c/zstd` port (PR #9941) via fuzzing against the
+  real CLI — see lessons.md Lesson 98. Fixed by threading a frame-scoped
+  `(rep1, rep2, rep3)` offset-history triple (default `1/4/8` at the start
+  of a frame, persisting across Raw/RLE blocks, updated after every
+  Compressed block's sequences — explicit-offset or repeat-offset alike)
+  through `decompress()`/`decompress_block()`, and interpreting offset codes
+  0/1 (`of_raw` in `{1, 2, 3}`) as a repeat-offset reference selected by
+  `ll_is_zero + of_raw - 1`, including the RFC's "when Literals_Length == 0,
+  the repeat-offset interpretation shifts by 1, and slot 3 means `rep1 - 1`"
+  special case. Algorithm cross-checked against both RFC 8878 prose and the
+  literal reference C source (`ZSTD_decodeSequence` in
+  `zstd_decompress_block.c`, fetched directly rather than recalled from
+  memory), matching the already-verified fix in `code/packages/c/zstd`. The
+  encoder is intentionally left unchanged (still never emits repeat-offset
+  codes — this is a decode-only fix, matching the educational subset's
+  documented scope).
 - **FSE sequences-section codec: three compounding RFC 8878 non-conformance
   bugs**, found via a repo-wide zstd conformance audit (companion fixes:
   java/zstd #9780, kotlin/zstd #9774) and confirmed with the minimal repro
@@ -58,6 +90,19 @@
 
 ### Added
 
+- **`tc11_repeat_offset_cli_interop_constant_byte` / `tc11_repeat_offset_cli_interop_periodic`**:
+  real `zstd` CLI interop tests targeting the Repeated-Offset decode gap
+  above. The constant-byte case reproduces the exact Lesson 98 repro (4713
+  bytes of a single repeated byte, which real `zstd` encodes as one
+  Compressed block with a single Offset_Value=1 sequence — "reuse
+  Repeated_Offset1") and fails with `decoded offset underflow: of_raw=1`
+  against the pre-fix decoder, proving the gap was real before it was fixed.
+  Verified beyond the committed suite via real `zstd`-CLI-produced files
+  covering prose, a numeric ramp, log-like text, and semi-random content
+  (several hit this crate's pre-existing, documented, out-of-scope
+  limitations — Huffman literals, non-Predefined FSE modes — unrelated to
+  this fix; every file that used only the supported feature subset decoded
+  byte-exact).
 - **Real `zstd` CLI interop test (`tc9_cli_interop`)**, per spec TC-9: shells
   out to the system `zstd` binary via `std::process::Command` to verify both
   directions — compress with this crate and decompress with `zstd -d`, and

--- a/code/packages/rust/zstd/src/lib.rs
+++ b/code/packages/rust/zstd/src/lib.rs
@@ -12,6 +12,16 @@
 //! - **Predefined decode tables** (RFC 8878 Appendix B) so short frames
 //!   need no table description overhead.
 //!
+//! This crate's own encoder never emits **Repeated-Offset (R1/R2/R3)**
+//! sequence shortcuts (RFC 8878 §3.1.1.3.2.1.1) — an explicit educational
+//! simplification, since every offset it writes is coded in full. The
+//! *decoder*, however, fully understands them: real `zstd` encoders use
+//! repeat offsets constantly (one of their main entropy wins, especially
+//! for periodic or constant data), so a decoder that didn't accept them
+//! would fail to decode a large fraction of real-world `.zst` files despite
+//! passing every self-consistency test. See `decompress_block`'s doc
+//! comment below and lessons.md Lesson 98.
+//!
 //! # Frame layout (RFC 8878 §3)
 //!
 //! ```text
@@ -1109,7 +1119,43 @@ fn compress_block(block: &[u8]) -> Option<Vec<u8>> {
 ///
 /// Reads the literals section, sequences section, and applies the sequences
 /// to the output buffer to reconstruct the original data.
-fn decompress_block(data: &[u8], out: &mut Vec<u8>) -> Result<(), String> {
+///
+/// `rep1`/`rep2`/`rep3` are the three Repeated_Offset registers (RFC 8878
+/// §3.1.1.3.2.1.1) — IN/OUT, because they are FRAME-scoped, not
+/// block-scoped: "For the first block, the starting offset history is
+/// populated with Repeated_Offset1=1, Repeated_Offset2=4,
+/// Repeated_Offset3=8" (RFC 8878), and every later Compressed block in the
+/// same frame continues from wherever the previous Compressed block's
+/// sequences left them. The caller ([`decompress`]) owns the three
+/// registers and threads them through every Compressed block in a frame
+/// (Raw/RLE blocks don't touch them).
+///
+/// WHY THIS DECODER NEEDS THIS EVEN THOUGH ITS OWN ENCODER NEVER EMITS
+/// REPEAT-OFFSET SEQUENCES: [`encode_sequences_section`] always writes an
+/// explicit offset code (`raw_off = offset + 3 >= 4` always, since the
+/// minimum LZ77 match offset is 1), so this crate's own compress()/
+/// decompress() round trip never touches the repeat-offset path — the "no
+/// repeat-offset shortcuts" simplification is entirely an ENCODER-side
+/// choice (see the module doc comment). But the real `zstd` CLI's encoder
+/// uses repeat offsets constantly (one of its main entropy wins, especially
+/// for periodic/repetitive data), so a decoder that only understands
+/// explicit offset codes will systematically fail to decode a large
+/// fraction of real-world `.zst` files — caught here by real CLI interop
+/// (see `tc11_repeat_offset_cli_interop_constant_byte`, which reproduces the
+/// exact repro found while building `code/packages/c/zstd`: 4713 bytes of a
+/// single repeated byte compresses to one Compressed block whose one
+/// sequence has Offset_Value=1, i.e. "reuse Repeated_Offset1"). Algorithm
+/// cross-checked against both RFC 8878 §3.1.1.3.2.1.1 and the literal
+/// reference C source (`ZSTD_decodeSequence` in `zstd_decompress_block.c`,
+/// fetched directly rather than recalled from memory) — see lessons.md
+/// Lesson 98.
+fn decompress_block(
+    data: &[u8],
+    out: &mut Vec<u8>,
+    rep1: &mut u32,
+    rep2: &mut u32,
+    rep3: &mut u32,
+) -> Result<(), String> {
     // ── Literals section ─────────────────────────────────────────────────
     let (lits, lit_consumed) = decode_literals_section(data)?;
     let mut pos = lit_consumed;
@@ -1190,17 +1236,81 @@ fn decompress_block(data: &[u8], out: &mut Vec<u8>) -> Result<(), String> {
         let ll_info = LL_CODES[ll_code as usize];
         let ml_info = ML_CODES[ml_code as usize];
 
+        // `ll_is_zero` is needed for the repeat-offset interpretation below
+        // (RFC 8878's "when Literals_Length is 0, repeated offsets are
+        // shifted by 1" rule) and is knowable right now, from the PEEKED
+        // `ll_code` alone — LL code 0 is the only code with baseline 0 and 0
+        // extra bits, so `ll_code == 0` iff the eventual decoded `ll` value
+        // is 0. No extra bits need to be read yet to know this.
+        let ll_is_zero = ll_code == 0;
+
         // Step 2 — read the VALUE extra bits, order OF, ML, LL (RFC 8878
         // §3.1.1.3.2.1.2 — "Decoding starts by reading the Number_of_Bits
         // required to decode offset. It does the same for Match_Length and
-        // then for Literals_Length.").
-        // Offset: raw = (1 << of_code) | extra_bits; offset = raw - 3
+        // then for Literals_Length."). The NUMBER of bits read for the
+        // offset field is always exactly `of_code` regardless of the
+        // repeat-offset interpretation below (the reference decoder never
+        // varies bit-consumption on `ll_is_zero` — only how the resulting
+        // value maps to an actual offset changes).
         let of_raw = (1u32 << of_code) | br.read_bits(of_code) as u32;
         let ml = ml_info.0 + br.read_bits(ml_info.1) as u32;
         let ll = ll_info.0 + br.read_bits(ll_info.1) as u32;
-        let offset = of_raw.checked_sub(3).ok_or_else(|| {
-            format!("decoded offset underflow: of_raw={of_raw}")
-        })?;
+
+        // Offset_Value -> actual offset (RFC 8878 §3.1.1.3.2.1.1), including
+        // the Repeated_Offset (R1/R2/R3) mechanism — see the doc comment on
+        // `decompress_block` and lessons.md Lesson 98.
+        //
+        // `of_code >= 2` guarantees `of_raw = (1<<of_code)+extra >= 4`, i.e.
+        // Offset_Value > 3: an ordinary explicit offset. `of_code <= 1`
+        // guarantees `of_raw` in `{1, 2, 3}`: a repeat-offset reference.
+        //
+        // The repeat case collapses to one selector in `[0, 3]`:
+        //     selector = ll_is_zero + of_raw - 1
+        // (cross-checked against both RFC 8878 prose and the reference
+        // decoder's `ofBase + ll0 + extra_bit` in `ZSTD_decodeSequence`):
+        //   0 -> reuse rep1 unchanged (no rotation)
+        //   1 -> use rep2 (rep1,rep2 swap; rep3 untouched)
+        //   2 -> use rep3 (full rotate: rep1,rep2,rep3 <- new,old_rep1,old_rep2)
+        //   3 -> use rep1-1 (full rotate, same shape as selector 2)
+        let offset = if of_code >= 2 {
+            let offset = of_raw - 3;
+            *rep3 = *rep2;
+            *rep2 = *rep1;
+            *rep1 = offset;
+            offset
+        } else {
+            let selector = ll_is_zero as u32 + of_raw - 1;
+            match selector {
+                0 => *rep1,
+                1 => {
+                    // rep1 <- old rep2, rep2 <- old rep1; the returned
+                    // offset is the new rep1 (== old rep2).
+                    std::mem::swap(rep1, rep2);
+                    *rep1
+                }
+                2 => {
+                    let offset = *rep3;
+                    *rep3 = *rep2;
+                    *rep2 = *rep1;
+                    *rep1 = offset;
+                    offset
+                }
+                _ => {
+                    // selector == 3: "rep1 - 1" — the RFC's special case for
+                    // when the ordinary rep1/rep2/rep3 slots would otherwise
+                    // collide with Literals_Length==0. Real zstd's decoder
+                    // saturates at 0 rather than underflowing (an offset of
+                    // 0 is then rejected below by the ordinary
+                    // offset-bounds check, same as any other malformed
+                    // offset would be).
+                    let offset = rep1.saturating_sub(1);
+                    *rep3 = *rep2;
+                    *rep2 = *rep1;
+                    *rep1 = offset;
+                    offset
+                }
+            }
+        };
 
         // Step 3 — update FSE states (consumes bits), order LL, ML, OF (RFC
         // 8878 §3.1.1.3.2.1.2 — "Literals_Length_State is updated, followed
@@ -1436,6 +1546,15 @@ pub fn decompress(data: &[u8]) -> Result<Vec<u8>, String> {
     // not just once per Raw/RLE block here.
     let mut out = Vec::new();
 
+    // Repeated_Offset registers (RFC 8878 §3.1.1.3.2.1.1): frame-scoped —
+    // default 1/4/8 "for the first block", then threaded unmodified through
+    // every Compressed block's sequences for the rest of the frame (Raw/RLE
+    // blocks don't touch them). See `decompress_block`'s doc comment and
+    // lessons.md Lesson 98.
+    let mut rep1: u32 = 1;
+    let mut rep2: u32 = 4;
+    let mut rep3: u32 = 8;
+
     loop {
         if pos + 3 > data.len() {
             return Err("truncated block header".into());
@@ -1476,7 +1595,7 @@ pub fn decompress(data: &[u8]) -> Result<Vec<u8>, String> {
                 }
                 let block_data = &data[pos..pos + bsize];
                 pos += bsize;
-                decompress_block(block_data, &mut out)?;
+                decompress_block(block_data, &mut out, &mut rep1, &mut rep2, &mut rep3)?;
             }
             3 => {
                 return Err("reserved block type 3".into());
@@ -1604,6 +1723,17 @@ mod tests {
     }
 
     // ── TC-8: repeat-offset pattern ───────────────────────────────────────────
+    //
+    // NOTE on the name: per spec TC-8, this input is constructed so a
+    // repeat-offset-AWARE encoder could compress it efficiently — but this
+    // crate's own encoder never emits repeat-offset codes (see the crate
+    // doc comment / lessons.md Lesson 98), so this test only exercises our
+    // encoder's ordinary explicit-offset path, self round-tripped through
+    // our own decoder. It does NOT exercise repeat-offset DECODING at all.
+    // For a test that actually proves this decoder understands
+    // repeat-offset sequences (as emitted by a real repeat-offset-aware
+    // encoder), see `tc11_repeat_offset_cli_interop_constant_byte` /
+    // `_periodic` below, which decode real `zstd`-CLI output.
 
     #[test]
     fn tc8_repeat_offset() {
@@ -1739,6 +1869,86 @@ mod tests {
         assert_eq!(
             decoded_by_us, original,
             "our decompress() failed to decode real `zstd`'s compressed output"
+        );
+    }
+
+    // ── Repeated-Offset (R1/R2/R3) decode interop ─────────────────────────────
+    //
+    // This crate's own encoder (`encode_sequences_section`, via
+    // `raw_off = seq.off + 3 >= 4` always) never emits an Offset_Value <= 3,
+    // so it never emits a repeat-offset code — an explicit "no repeat-offset
+    // shortcuts" educational simplification. That means TC-8 above (and any
+    // other self round-trip test in this file) NEVER exercises the
+    // repeat-offset DECODE path, no matter how repetitive its input is: our
+    // own round trip is blind to this by construction, same as it was blind
+    // to the FSE-codec bugs in Lesson 96 until real CLI interop (TC-9) was
+    // added. But the real `zstd` CLI's encoder uses repeat offsets
+    // constantly — they're one of its main entropy wins, especially for
+    // periodic/constant data — so a decoder that only understands explicit
+    // offset codes (`offset = of_raw - 3` unconditionally) will fail on a
+    // large fraction of real-world `.zst` files. See lessons.md Lesson 98
+    // (found while building `code/packages/c/zstd`, PR #9941) for the full
+    // writeup and the reference-C-source cross-check
+    // (`ZSTD_decodeSequence` in `zstd_decompress_block.c`).
+    #[test]
+    fn tc11_repeat_offset_cli_interop_constant_byte() {
+        // The exact Lesson 98 repro: 4713 bytes of a single repeated byte.
+        // Real `zstd` picks a Compressed block (not RLE) with one sequence:
+        // 2 literal bytes ("ZZ") + a match with Offset_Value=1 — "reuse
+        // Repeated_Offset1", whose default value (1) happens to already be
+        // the right distance for constant data, an unmistakable
+        // RLE-via-repeat-offset pattern.
+        if !is_zstd_cli_available() {
+            eprintln!("zstd CLI not found on PATH — skipping interop test");
+            return;
+        }
+
+        let original = vec![b'Z'; 4713];
+        let theirs_input = write_temp_file("tc11-repoff-const-input", &original);
+        let _guard = TempFileGuard(theirs_input.clone());
+        let their_compressed =
+            run_zstd_capture_stdout(&["-q", "-c", theirs_input.to_str().unwrap()]);
+
+        let decoded_by_us = decompress(&their_compressed).expect(
+            "our decompress() failed on real zstd's repeat-offset output — \
+             this is Lesson 98's gap: offset codes 1-3 must be interpreted as \
+             Repeated_Offset (R1/R2/R3) references, not as of_raw - 3",
+        );
+        assert_eq!(
+            decoded_by_us, original,
+            "our decompress() decoded real zstd's repeat-offset output to the \
+             wrong bytes"
+        );
+    }
+
+    #[test]
+    fn tc11_repeat_offset_cli_interop_periodic() {
+        // A periodic pattern at a FIXED distance is the other classic
+        // repeat-offset trigger: after the first match establishes the
+        // distance, every subsequent match at that same distance is cheaper
+        // to encode as "reuse R1" than as a fresh explicit offset. Real
+        // `zstd`'s encoder is very likely to do exactly that here.
+        if !is_zstd_cli_available() {
+            eprintln!("zstd CLI not found on PATH — skipping interop test");
+            return;
+        }
+
+        let pattern = b"ABCDEFGHIJ0123456789";
+        let mut original = Vec::new();
+        for _ in 0..300 {
+            original.extend_from_slice(pattern);
+        }
+        let theirs_input = write_temp_file("tc11-repoff-periodic-input", &original);
+        let _guard = TempFileGuard(theirs_input.clone());
+        let their_compressed =
+            run_zstd_capture_stdout(&["-q", "-c", theirs_input.to_str().unwrap()]);
+
+        let decoded_by_us = decompress(&their_compressed)
+            .expect("our decompress() failed on real zstd's periodic-pattern output");
+        assert_eq!(
+            decoded_by_us, original,
+            "our decompress() decoded real zstd's periodic-pattern output to \
+             the wrong bytes"
         );
     }
 

--- a/code/specs/CMP07-zstd.md
+++ b/code/specs/CMP07-zstd.md
@@ -105,15 +105,42 @@ After literals are extracted, the LZ77 back-references are encoded as **sequence
 each sequence is a triple `(literal_length, match_length, offset)`. Three separate FSE
 streams encode these three fields simultaneously.
 
-**Repeat Offsets:** ZStd tracks the three most-recently-used offsets in slots R1, R2, R3.
-Referencing a recent offset costs only 2 bits instead of encoding the full distance:
+**Repeat Offsets:** ZStd tracks the three most-recently-used offsets in slots R1, R2, R3
+(RFC 8878 §3.1.1.3.2.1.1). Referencing a recent offset costs only 2 bits instead of
+encoding the full distance. The history is **frame-scoped**, not block-scoped: it starts
+at `R1=1, R2=4, R3=8` for the first block of a frame and is threaded, unmodified across
+Raw/RLE blocks, through every Compressed block's sequences for the rest of the frame.
+
+The mapping from `Offset_Value` (the raw FSE-decoded value, `of_raw` below) to an actual
+offset — including the one genuinely easy-to-miss special case — is:
 
 ```
-offset code 1 → R1 (most recent)
-offset code 2 → R2
-offset code 3 → R3
-offset code ≥ 4 → (value - 3) is the actual offset; update R1, shift others
+Offset_Value ≥ 4        → actual offset = Offset_Value - 3 (explicit); then push it onto
+                           the history: R3←R2, R2←R1, R1←new_offset
+Offset_Value ∈ {1, 2, 3} → a repeat-offset reference, chosen by
+                           selector = (Literals_Length == 0 ? 1 : 0) + Offset_Value - 1:
+                             selector 0 → reuse R1 (no rotation)
+                             selector 1 → use R2 (R1,R2 swap; R3 untouched)
+                             selector 2 → use R3 (rotate: R1,R2,R3 ← new,old_R1,old_R2)
+                             selector 3 → use R1-1 (same rotation shape as selector 2)
 ```
+
+> **Correction (2026-08):** the history-selection rule is NOT simply "offset code N
+> selects Rn" — that description (an earlier revision of this section) omits the
+> `Literals_Length == 0` shift, which changes which slot codes 1/2/3 select and, for
+> `Offset_Value == 3` with `Literals_Length == 0`, replaces the slot lookup entirely with
+> `R1 - 1`. Every language port's DECODER in this repo initially implemented `offset =
+> Offset_Value - 3` unconditionally for every code — including code 1/2/3 — because this
+> repo's own ENCODERS never emit repeat-offset codes by design (an explicit "no
+> repeat-offset shortcuts" educational simplification: every offset an encoder here
+> writes is `>= 4` on the wire), so a self round trip never exercises this path, and even
+> the spec's own TC-8 (built to be repeat-offset-*friendly* input, not repeat-offset-*
+> aware* output) doesn't catch it. Real `zstd` encoders use repeat offsets constantly, so
+> a decoder missing this fails to decode a large fraction of real-world `.zst` files. See
+> `lessons.md` Lesson 98 and the `rust/zstd` / `c/zstd` conformance fixes; cross-checked
+> against the reference C source (`ZSTD_decodeSequence` in `zstd_decompress_block.c`).
+> Implementing this remains DECODE-only — encoders in this repo are not required to emit
+> repeat-offset codes.
 
 ### ZStd vs DEFLATE vs Brotli
 
@@ -459,6 +486,13 @@ assert output == input
 # The repeat-offset mechanism should make this compress efficiently
 assert len(compressed) < len(input) * 0.70
 ```
+> Note: this test only requires the compressed round trip to be correct and reasonably
+> small — it does NOT, by itself, prove an implementation's *decoder* understands
+> repeat-offset sequences (offset codes 1/2/3), since an implementation whose own encoder
+> never emits repeat-offset codes at all (this repo's educational encoders don't) can pass
+> TC-8 while still failing to decode a real repeat-offset-aware encoder's output. See the
+> Repeat Offsets correction above (Lesson 98) — that gap is only caught by real
+> cross-implementation interop (TC-9-style), not by this test.
 
 ### TC-9: Cross-language / interoperability
 ```


### PR DESCRIPTION
## Summary

- `rust/zstd`'s decoder computed `offset = of_raw - 3` unconditionally for every sequence, treating FSE offset codes 1/2/3 as literal offsets instead of references into a 3-slot history of recently-used offsets (RFC 8878 §3.1.1.3.2.1.1 — Repeated-Offset / R1/R2/R3).
- This crate's own encoder never emits offset codes below 4 (an explicit "no repeat-offset shortcuts" educational simplification), so this crate's own compress→decompress round trip — and every existing test, including the real-CLI `tc9_cli_interop` — never exercised the repeat-offset decode path at all. Real `zstd` encoders use repeat offsets constantly (periodic/constant data especially), so this decoder failed to decode a large fraction of real-world `.zst` files.
- Found while building the sibling `code/packages/c/zstd` port (#9941), which hit the identical gap via CLI fuzzing; see `lessons.md` Lesson 98 for the full writeup and reference-C-source cross-check.
- Fix: thread a frame-scoped `(rep1, rep2, rep3)` offset-history triple (default `1/4/8`, persisting across Raw/RLE blocks, updated after every Compressed block's sequences) through `decompress()`/`decompress_block()`, and interpret offset codes 0/1 as a repeat-offset reference per RFC 8878, including the `Literals_Length == 0` shift special case. Algorithm cross-checked against both RFC 8878 prose and the reference C source (`ZSTD_decodeSequence`), matching the already-verified `c/zstd` fix. Encoder is intentionally unchanged (decode-only fix, matching scope of #9941).
- Updated `CMP07-zstd.md`'s Repeat Offsets section and TC-8 note to document the shift rule and clarify TC-8 alone doesn't prove repeat-offset decode support.

## Test plan

- [x] Added `tc11_repeat_offset_cli_interop_constant_byte`, which reproduces the exact Lesson 98 repro (4713 bytes of one repeated byte) — confirmed it **fails** against the pre-fix decoder with `decoded offset underflow: of_raw=1`, proving the gap was real, before implementing the fix
- [x] Added `tc11_repeat_offset_cli_interop_periodic` for additional real-CLI coverage
- [x] All 30 unit/interop tests + 3 doctests pass after the fix (`cargo test --release`)
- [x] `cargo clippy --release -- -D warnings` clean
- [x] Ad hoc verification beyond the committed suite: decompressed several real `zstd`-CLI-produced files (prose, numeric ramp, log-like text, semi-random) — all files using only this crate's supported feature subset (Predefined FSE tables, Raw literals) decoded byte-exact; a few hit this crate's pre-existing, documented, out-of-scope limitations (Huffman literals, non-Predefined FSE modes) unrelated to this fix
- [x] Security review passed (sub-agent review of the diff — offset-bounds check funnels all repeat-offset paths through the existing `offset == 0` guard; `rep1.saturating_sub(1)` can't underflow/panic; decompression-bomb guard is independent of offset value; no `unsafe` code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)