### PR TITLE
fix(lua/zstd): decode Repeated-Offset (R1/R2/R3) sequences per RFC 8878

### DIFF
--- a/code/packages/lua/zstd/CHANGELOG.md
+++ b/code/packages/lua/zstd/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## [0.1.3] - 2026-08-05
+
+### Fixed
+
+- **`decompress` now implements Repeated-Offset (R1/R2/R3) sequence decoding**
+  (RFC 8878 §3.1.1.3.2.1.1). Previously every decoded `Offset_Value` was
+  treated as an explicit offset (`offset = of_raw - 3` unconditionally), which
+  underflows for `of_raw` in `{1, 2, 3}` — the reserved range that instead
+  means "reuse one of the three most-recently-used match offsets" (default
+  `1/4/8`, threaded frame-scoped through every Compressed block). The old code
+  rejected these as `"decoded offset underflow"`, even though the frame was
+  perfectly valid. This package's own `compress()` never emits offset codes
+  below 2 (an intentional encoder-side simplification — the minimum LZ77
+  match offset here is 1, so `raw_off = offset + 3 >= 4` always), so no
+  internal round-trip test, and not even the existing pangram-x25 Spec TC-9
+  corpus, ever exercised this decode path. But the real `zstd` CLI's encoder
+  uses repeat offsets constantly — they're one of its principal entropy wins,
+  especially for periodic or highly repetitive input — so any decoder that
+  only understood explicit offsets would systematically fail to decode a
+  meaningful fraction of real-world `.zst` files. Confirmed with a direct
+  repro: 4713 bytes of a single repeated byte, compressed with the real
+  `zstd` CLI, produces one Compressed block with a single sequence at
+  `Offset_Value = 1` ("reuse Repeated_Offset1"), which the old decoder
+  rejected outright.
+
+  Found via an independent audit after the sibling `c/zstd` port (PR #9941)
+  hit and fixed the identical gap while fuzzing itself against the real
+  `zstd` CLI — see lessons.md Lesson 98. The fix here was cross-checked
+  against both that PR's verified reference implementation and the RFC 8878
+  prose directly (fetched live), including the "when `Literals_Length == 0`,
+  the repeat-offset codes shift by one, and `Offset_Value == 3` means
+  `Repeated_Offset1 - 1`" special case, and the exact history-rotation rule
+  (no rotation on R1 reuse; swap-to-front on R2; full rotate on R3 / the
+  `LL==0` "R1-1" case). The three offset registers are now frame-scoped (not
+  block-scoped): `M.decompress` owns a `{rep1, rep2, rep3}` table, initialized
+  to `{1, 4, 8}` per RFC 8878, and threads it (mutated in place) through every
+  Compressed block's `decompress_block` call for the rest of the frame;
+  Raw/RLE blocks don't touch it. `compress()` is intentionally unchanged —
+  this is a decode-only fix, since the encoder-side "no repeat-offset
+  shortcuts" simplification remains valid and doesn't affect interop with
+  real `zstd -d`.
+
+### Added
+
+- Two new Spec TC-9 tests: decoding real `zstd`-CLI-produced output that uses
+  a Repeated-Offset R1 sequence (a long constant-byte run — the exact input
+  that surfaced the bug), and output that rotates through all three offset
+  registers (several distinct repeated-content regions at different
+  distances back to back). Both skip gracefully when `zstd` isn't on `PATH`.
+  Also verified ad hoc (outside the committed suite) with a 180-trial fuzz
+  sweep — random, periodic, constant-run, and ramp byte patterns across nine
+  sizes from 1 byte to 5000 bytes — compressed by the real `zstd` CLI and
+  decoded by this package, all byte-exact; and against the existing fixed
+  TC-1..TC-11 and Spec TC-9 suite (all 21 checks, unaffected, since this
+  package's own round trip never touches the new code path).
+
 ## [0.1.2] - 2026-08-03
 
 ### Fixed

--- a/code/packages/lua/zstd/src/coding_adventures/zstd/init.lua
+++ b/code/packages/lua/zstd/src/coding_adventures/zstd/init.lua
@@ -1079,12 +1079,40 @@ end
 --
 -- decompress_block decodes one ZStd compressed block and appends output bytes
 -- to the `out` array. Calls error() on any format violation.
-
-local function decompress_block(data, start, bsize, out)
+--
+-- `rep` is the three-element Repeated_Offset register array (RFC 8878
+-- §3.1.1.3.2.1.1) — {rep[1], rep[2], rep[3]} — passed by reference (Lua
+-- tables are references) because these registers are FRAME-scoped, not
+-- block-scoped: "For the first block, the starting offset history is
+-- populated with Repeated_Offset1=1, Repeated_Offset2=4, Repeated_Offset3=8"
+-- (RFC 8878), and every later Compressed block in the same frame continues
+-- from wherever the previous Compressed block's sequences left them. The
+-- caller (M.decompress) owns `rep` and threads it through every Compressed
+-- block in the frame; Raw/RLE blocks don't touch it.
+--
+-- WHY THIS DECODER NEEDS THIS EVEN THOUGH ITS OWN ENCODER NEVER EMITS
+-- REPEAT-OFFSET SEQUENCES: encode_sequences_section always writes an
+-- explicit offset code (raw_off = offset + 3 >= 4, since our minimum LZ77
+-- match offset is 1), so this port's own compress()/decompress() round trip
+-- never exercises the repeat-offset path — the "no repeat-offset shortcuts"
+-- simplification documented on the encoder side is entirely an ENCODER
+-- choice. But the real `zstd` CLI's encoder uses repeat offsets constantly
+-- (one of its main entropy wins, especially for periodic/repetitive data),
+-- so a decoder that only understands explicit offset codes will
+-- systematically fail to decode real-world `.zst` output — e.g. 4713 bytes
+-- of a single repeated byte compresses (via the real CLI) to a single
+-- Compressed block whose one sequence has Offset_Value=1, i.e. "reuse
+-- Repeated_Offset1" (which starts at its default value of 1). See
+-- lessons.md Lesson 98 and c/zstd's PR #9941, which found and fixed the
+-- identical gap; this port's fix was cross-checked against both that PR's
+-- reference implementation and the RFC 8878 prose directly (fetched live,
+-- not recalled from memory).
+local function decompress_block(data, start, bsize, out, rep)
     -- data:  full frame byte array (integers 0-255)
     -- start: 1-indexed start of this block's payload within data
     -- bsize: number of bytes in the block payload
     -- out:   output byte array (appended in-place)
+    -- rep:   {rep1, rep2, rep3} Repeated_Offset registers, mutated in place
 
     local block_end = start + bsize - 1
 
@@ -1186,24 +1214,76 @@ local function decompress_block(data, start, bsize, out)
             error("zstd: of_code out of range: " .. of_code)
         end
 
+        -- ll_is_zero is needed below for the repeat-offset interpretation
+        -- (RFC 8878's "when Literals_Length is 0, repeated offsets are
+        -- shifted by 1" rule) and is knowable right now, from the PEEKED
+        -- ll_code alone: LL code 0 is the only code with baseline 0 and 0
+        -- extra bits (see LL_CODES), so ll_code == 0 iff the eventual
+        -- decoded `ll` value (computed below, after extra bits are read) is
+        -- 0. No extra bits need to be read yet to know this.
+        local ll_is_zero = (ll_code == 0)
+
         local ll_info = LL_CODES[ll_code + 1]  -- 1-indexed
         local ml_info = ML_CODES[ml_code + 1]
 
         -- Step 2: read the VALUE extra bits, order OF, ML, LL (RFC 8878
         -- §3.1.1.3.2.1.2 — "Decoding starts by reading the Number_of_Bits
         -- required to decode offset. It does the same for Match_Length and
-        -- then for Literals_Length.").
-        -- Offset: raw = (1 << of_code) | extra_bits; offset = raw - 3.
-        -- The "- 3" adjusts for ZStd's repeat-offset encoding baseline.
+        -- then for Literals_Length."). The NUMBER of bits read for the
+        -- offset field is always exactly `of_code`, regardless of whether
+        -- the resulting value ends up interpreted as an explicit offset or
+        -- a repeat-offset reference below (RFC 8878 / the reference decoder
+        -- never varies bit-consumption on ll_is_zero — only how the
+        -- resulting value maps to an actual offset changes).
         local of_raw = (1 << of_code) | br:read_bits(of_code)
         local ml = ml_info[1] + br:read_bits(ml_info[2])
         local ll = ll_info[1] + br:read_bits(ll_info[2])
 
-        if of_raw < 3 then
-            error(string.format(
-                "zstd: decoded offset underflow: of_raw=%d (of_code=%d)", of_raw, of_code))
+        -- Offset_Value -> actual offset (RFC 8878 §3.1.1.3.2.1.1), including
+        -- the Repeated_Offset (R1/R2/R3) mechanism: `of_code >= 2` guarantees
+        -- of_raw = (1<<of_code)+extra >= 4, i.e. Offset_Value > 3 — an
+        -- ordinary explicit offset (raw_off - 3). `of_code <= 1` guarantees
+        -- of_raw in {1, 2, 3} — a repeat-offset reference into `rep`.
+        --
+        -- The repeat case collapses to one selector in [0, 3]:
+        --     selector = (ll_is_zero and 1 or 0) + of_raw - 1
+        --   0 -> reuse rep[1] unchanged (no rotation)
+        --   1 -> use rep[2] (rep[1],rep[2] swap; rep[3] untouched)
+        --   2 -> use rep[3] (full rotate: rep[1],rep[2],rep[3] <- new,old rep[1],old rep[2])
+        --   3 -> use rep[1]-1 (full rotate, same shape as selector 2)
+        -- This mapping is cross-checked against BOTH RFC 8878's prose
+        -- ("Repeat Offsets" — offset codes 1-3 select Repeated_Offset1/2/3
+        -- normally, but shift by one when Literals_Length is 0, with
+        -- Offset_Value 3 in that case meaning "Repeated_Offset1 - 1") and
+        -- the already-verified c/zstd reference fix (PR #9941,
+        -- decompress_block / lessons.md Lesson 98).
+        local offset
+        if of_code >= 2 then
+            offset = of_raw - 3
+            rep[3] = rep[2]
+            rep[2] = rep[1]
+            rep[1] = offset
+        else
+            local selector = (ll_is_zero and 1 or 0) + of_raw - 1
+            if selector == 0 then
+                offset = rep[1]
+                -- no rotation
+            elseif selector == 1 then
+                offset = rep[2]
+                rep[2] = rep[1]
+                rep[1] = offset
+            elseif selector == 2 then
+                offset = rep[3]
+                rep[3] = rep[2]
+                rep[2] = rep[1]
+                rep[1] = offset
+            else -- selector == 3
+                offset = (rep[1] > 0) and (rep[1] - 1) or 0
+                rep[3] = rep[2]
+                rep[2] = rep[1]
+                rep[1] = offset
+            end
         end
-        local offset = of_raw - 3
 
         -- Step 3: update FSE states (consumes bits), order LL, ML, OF (RFC
         -- 8878 §3.1.1.3.2.1.2 — "Literals_Length_State is updated, followed
@@ -1520,6 +1600,13 @@ function M.decompress(data)
     -- ── Blocks ────────────────────────────────────────────────────────────
     local out = {}  -- output byte array, accumulated in-place
 
+    -- Repeated_Offset registers (RFC 8878 §3.1.1.3.2.1.1): FRAME-scoped —
+    -- default 1/4/8 "for the first block", then threaded (and mutated) by
+    -- decompress_block through every Compressed block's sequences for the
+    -- rest of the frame. Raw/RLE blocks don't touch them. See lessons.md
+    -- Lesson 98 and decompress_block's doc comment.
+    local rep = {1, 4, 8}
+
     while true do
         -- Each block begins with a 3-byte little-endian header.
         if pos + 2 > #data then
@@ -1569,7 +1656,7 @@ function M.decompress(data)
                     "zstd: compressed block truncated: need %d bytes at pos %d",
                     bsize, pos))
             end
-            decompress_block(data, pos, bsize, out)
+            decompress_block(data, pos, bsize, out, rep)
             pos = pos + bsize
 
         else  -- btype == 3

--- a/code/packages/lua/zstd/tests/test_zstd.lua
+++ b/code/packages/lua/zstd/tests/test_zstd.lua
@@ -513,15 +513,15 @@ describe("CodingAdventures.Zstd", function()
 
             -- The pangram repeated 25 times — deliberately the same corpus
             -- code/specs/CMP07-zstd.md's TC-9 example uses, and what the
-            -- sibling java/zstd port's tc9CliInterop test uses. Avoid inputs
-            -- with a long run at a single fixed offset (e.g. many repeated
-            -- identical characters back to back): the real zstd CLI's
-            -- encoder will use RFC 8878's Repeat_Offset (R1/R2/R3) shortcut
-            -- codes for those, which this educational codec deliberately
-            -- doesn't implement on either the encode or the decode side
-            -- (matching java/zstd's documented "no repeat-offset shortcuts"
-            -- scope) — decoding one raises a clear "decoded offset
-            -- underflow" error rather than silently misinterpreting it.
+            -- sibling java/zstd port's tc9CliInterop test uses.
+            --
+            -- NOTE: this codec's ENCODER still never emits RFC 8878's
+            -- Repeat_Offset (R1/R2/R3) shortcut codes (matching the
+            -- documented "no repeat-offset shortcuts" scope) — but the
+            -- DECODER now fully understands them (see lessons.md Lesson 98
+            -- and the dedicated "Repeated-Offset (R1/R2/R3) decode" describe
+            -- block below), so inputs that make the real zstd CLI's encoder
+            -- choose repeat-offset sequences are no longer a problem here.
             local text = ("the quick brown fox jumps over the lazy dog "):rep(25)
 
             -- ours -> CLI
@@ -550,6 +550,97 @@ describe("CodingAdventures.Zstd", function()
             os.remove(cli_zst)
             assert.is_true(ok2, "real zstd CLI failed to compress the input")
             assert.are.equal(text, zstd.decompress(cli_bytes))
+        end)
+
+        -- =====================================================================
+        -- Repeated-Offset (R1/R2/R3) decode — lessons.md Lesson 98
+        -- =====================================================================
+        --
+        -- This codec's encoder never emits RFC 8878's Offset_Value <= 3
+        -- repeat-offset shortcut codes (every offset it writes is explicit),
+        -- so a round trip through ONLY this codec's own compress()/
+        -- decompress() pair — and even the fixed prose corpus used by the
+        -- interop tests above — can never exercise the decoder's
+        -- repeat-offset path. But the real `zstd` CLI's encoder uses repeat
+        -- offsets constantly (one of its principal entropy wins), so any
+        -- decoder that only understands explicit offset codes will
+        -- systematically fail to decode a meaningful fraction of real-world
+        -- `.zst` files.
+        --
+        -- These tests feed the real zstd CLI's compressor inputs specifically
+        -- shaped to trigger repeat-offset sequences (long constant-byte runs
+        -- and content with several distinct repeating distances), then
+        -- decode the CLI's actual output with our decoder — proving the gap
+        -- described in lessons.md Lesson 98 (and originally found while
+        -- building `c/zstd`, PR #9941) is fixed here too.
+        it("decodes real zstd CLI output using a Repeated-Offset (R1) sequence "
+            .. "(long constant-byte run)", function()
+            if not zstd_available then
+                pending("zstd CLI not found on PATH; skipping interop test")
+                return
+            end
+
+            -- 4713 bytes of a single repeated byte: empirically (see
+            -- lessons.md Lesson 98) the real zstd CLI encodes this as a
+            -- single Compressed block containing one sequence with
+            -- Offset_Value=1 ("reuse Repeated_Offset1", default value 1) —
+            -- NOT the RLE block type this port's own encoder would choose
+            -- for constant data. This is exactly the input that first
+            -- surfaced the gap.
+            local text = ("Z"):rep(4713)
+
+            local plain_path = os.tmpname()
+            local cli_zst    = os.tmpname()
+            write_file(plain_path, text)
+            local ok = shell_ok(string.format(
+                "zstd -f -q -o %s %s 2>/dev/null",
+                shell_quote(cli_zst), shell_quote(plain_path)))
+            local cli_bytes = ok and read_file(cli_zst) or nil
+            os.remove(plain_path)
+            os.remove(cli_zst)
+
+            assert.is_true(ok, "real zstd CLI failed to compress the input")
+            assert.is_string(cli_bytes)
+
+            local decompressed = zstd.decompress(cli_bytes)
+            assert.are.equal(text, decompressed,
+                "our decompress() failed on real zstd's Repeat-Offset (R1) output "
+                .. "(RFC 8878 §3.1.1.3.2.1.1 non-conformance — see lessons.md Lesson 98)")
+        end)
+
+        it("decodes real zstd CLI output using multiple distinct Repeated-Offset "
+            .. "registers (R1/R2/R3 rotation across several match distances)", function()
+            if not zstd_available then
+                pending("zstd CLI not found on PATH; skipping interop test")
+                return
+            end
+
+            -- Several distinct repeated-content regions at different
+            -- distances, back to back, so the real zstd CLI's encoder has
+            -- reason to populate and rotate through all three offset-history
+            -- registers (not just R1) as it moves between them.
+            local text = ("AAAA"):rep(50)
+                .. ("the quick brown fox "):rep(80)
+                .. ("BBBBBBBB"):rep(40)
+                .. ("abcdefgh"):rep(60)
+                .. ("AAAA"):rep(30)
+
+            local plain_path = os.tmpname()
+            local cli_zst    = os.tmpname()
+            write_file(plain_path, text)
+            local ok = shell_ok(string.format(
+                "zstd -f -q -o %s %s 2>/dev/null",
+                shell_quote(cli_zst), shell_quote(plain_path)))
+            local cli_bytes = ok and read_file(cli_zst) or nil
+            os.remove(plain_path)
+            os.remove(cli_zst)
+
+            assert.is_true(ok, "real zstd CLI failed to compress the input")
+            assert.is_string(cli_bytes)
+
+            local decompressed = zstd.decompress(cli_bytes)
+            assert.are.equal(text, decompressed,
+                "our decompress() failed on real zstd's multi-offset Repeat-Offset output")
         end)
     end)
 


### PR DESCRIPTION
## Summary

`lua/zstd`'s decoder treated every decoded `Offset_Value` as an explicit offset (`offset = of_raw - 3` unconditionally), which underflows for `of_raw` in `{1, 2, 3}` — the reserved range RFC 8878 §3.1.1.3.2.1.1 defines as a **Repeated-Offset** reference into the three most-recently-used match offsets (R1/R2/R3, default `1/4/8`). The old code rejected these as `"decoded offset underflow"`, even on perfectly valid frames.

This mirrors the gap found and fixed in the sibling `c/zstd` port — see `gh pr diff 9941` and `lessons.md` Lesson 98. This package's own `compress()` never emits offset codes below 2 (an intentional encoder-side simplification: minimum LZ77 match offset here is 1, so `raw_off = offset + 3 >= 4` always), so no internal round-trip test — and not even the existing pangram-x25 Spec TC-9 corpus — ever exercised this decode path. But the real `zstd` CLI's encoder uses repeat offsets constantly, so any decoder that only understood explicit offsets would systematically fail to decode a meaningful fraction of real-world `.zst` files.

Direct repro: 4713 bytes of a single repeated byte, compressed with the real `zstd` CLI, produces one Compressed block with a single sequence at `Offset_Value = 1` ("reuse Repeated_Offset1"), which the old decoder rejected outright.

- Cross-checked the exact repeat-offset selector/rotation logic against **both** `c/zstd`'s verified reference fix (PR #9941) **and** the RFC 8878 prose fetched live, including the "when `Literals_Length == 0`, repeat-offset codes shift by one, and `Offset_Value == 3` means `Repeated_Offset1 - 1`" special case.
- The three offset registers are now frame-scoped: `M.decompress` owns `{rep1, rep2, rep3}` initialized to `{1, 4, 8}` per RFC 8878, threaded (mutated in place) through every Compressed block's `decompress_block` call.
- `compress()` is intentionally unchanged — decode-only fix.
- `code/packages/lua/zstd/CHANGELOG.md` updated (0.1.3).

## Test plan

- [x] 21/21 tests pass (19 existing + 2 new Spec TC-9 tests: single R1 constant-run repro, and multi-register R1/R2/R3 rotation across several distinct match distances)
- [x] Ad hoc 180-trial fuzz sweep (random / periodic / constant-run / ramp patterns, sizes 1–5000 bytes) against the real `zstd` CLI — byte-exact, zero failures
- [x] `luac -p` syntax check clean
- [x] Security review passed (offset-history state machine bounds/underflow specifically checked — no out-of-bounds or stale-value issues found; existing `offset == 0 or offset > #out` check still gates every path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)