### PR TITLE
fix(csharp/zstd): decode Repeated-Offset (R1/R2/R3) sequences per RFC 8878

### DIFF
--- a/code/packages/csharp/zstd/CHANGELOG.md
+++ b/code/packages/csharp/zstd/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.1.2] - 2026-08-05
+
+### Fixed
+
+- **The sequences decoder never implemented Repeated-Offset (R1/R2/R3)
+  sequence decoding** (RFC 8878 §3.1.1.3.2.1.1). Real `zstd` encoders use
+  repeat offsets constantly — they are one of the format's principal
+  entropy wins, especially for periodic or highly repetitive data — but
+  this package's own encoder, by design, never emits an offset code below
+  2 (the minimum LZSS match offset is 1, so raw offset = offset + 3 is
+  always >= 4). That made the "no repeat-offset shortcuts" simplification
+  entirely an encoder-side choice, and meant `Decompress`'s own round trip
+  with `Compress` — and every existing CLI-interop test's specific input —
+  never exercised the repeat-offset decode path. `DecompressBlock`
+  computed `matchOffset = rawOffset - 3` unconditionally, which underflows
+  for any `Offset_Value <= 3` (a repeat-offset reference, not a literal
+  offset), producing a bogus offset that the existing bounds check
+  correctly rejected as malformed — even though the frame was valid and
+  encoded using a mechanism the decoder simply didn't understand.
+  - This gap was first found and fixed in the new `c/zstd` port (PR #9941)
+    via ad hoc fuzzing against the real `zstd` CLI, and documented as
+    `lessons.md` Lesson 98 there. This package inherited the identical gap
+    (confirmed independently in this session: the pre-fix decoder failed
+    real-CLI-compressed input of a single repeated byte, and of an
+    alternating-literal/long-match pattern, both with
+    `InvalidDataException: match offset exceeds decoded output`).
+  - Fixed by threading three frame-scoped Repeated_Offset registers
+    (`repeatOffset1`/`2`/`3`, defaulting to 1/4/8 per RFC 8878) through
+    `Decompress`'s block loop into `DecompressBlock`, and implementing the
+    full offset-code-to-actual-offset mapping: offset codes >= 2 are
+    ordinary explicit offsets (`rawOffset - 3`, which also rotates the
+    repeat-offset history); offset codes 0-1 (`rawOffset` in `{1, 2, 3}`)
+    are repeat-offset references, resolved via a 4-way selector
+    (`literalIsZero + rawOffset - 1`) that also implements the RFC's
+    "when Literals_Length is 0, repeated offsets are shifted by 1" special
+    case and the corresponding history rotation (no rotation, swap, or
+    full 3-way rotate depending on which register was referenced).
+    Algorithm cross-checked against both the RFC 8878 prose and the
+    literal reference C source (`ZSTD_decodeSequence` in
+    `zstd_decompress_block.c`, fetched directly from
+    `github.com/facebook/zstd`, per the Lesson-96 playbook of not trusting
+    a paraphrase alone) and against the already-fuzz-tested `c/zstd`
+    implementation from PR #9941.
+  - Verified with the real `zstd` CLI: a 60-case fuzz corpus (random,
+    periodic, constant-byte, cyclic, prose-like, and mixed literal/repeat
+    patterns) that failed 24/60 before the fix (11 with this exact
+    underflow signature) now fails only on the 13 cases that hit this
+    package's pre-existing, unrelated, documented scope limits (Huffman
+    literals / FSE-compressed literals / non-predefined FSE modes — out of
+    scope for this educational codec, unrelated to repeat offsets). Two new
+    permanent tests added: `RepeatOffsetCliInterop` (alternating literal
+    run / long same-byte match, forcing the real CLI to reuse a distance
+    across sequences) and `SingleByteRunCliInterop` (the exact minimal
+    repro from `c/zstd`'s Lesson 98: 4713 bytes of one repeated byte).
+    Both reproduce the pre-fix failure and pass byte-exact after the fix.
+    All 32 pre-existing tests continue to pass unmodified — this package's
+    own encoder never emits repeat-offset codes, so its self-consistency
+    round trip is untouched by this fix.
+
 ## [0.1.1] - 2026-08-03
 
 ### Fixed

--- a/code/packages/csharp/zstd/CodingAdventures.Zstd.csproj
+++ b/code/packages/csharp/zstd/CodingAdventures.Zstd.csproj
@@ -6,7 +6,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <PackageId>CodingAdventures.Zstd.CSharp</PackageId>
-    <Version>0.1.1</Version>
+    <Version>0.1.2</Version>
     <Authors>Adhithya Rajasekaran</Authors>
     <Description>Pure C# educational Zstandard codec</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/code/packages/csharp/zstd/README.md
+++ b/code/packages/csharp/zstd/README.md
@@ -8,6 +8,10 @@ Pure C# implementation of the repository's CMP07 educational Zstandard format.
 - Raw, run-length encoded, and compressed blocks
 - Raw literal sections and predefined FSE sequence tables
 - LZSS-generated literal and match sequences through the native C# `lzss` package
+- Repeated-Offset (R1/R2/R3) sequence **decoding** (RFC 8878 §3.1.1.3.2.1.1)
+  — needed to read real-world `.zst` files, which use repeat offsets
+  constantly, even though this package's own **encoder** never emits them
+  (see `CHANGELOG.md` and lessons.md Lesson 98)
 - A 256 MiB decompression limit and strict malformed-frame checks
 
 This package follows the repository's established CMP07 teaching format. It is

--- a/code/packages/csharp/zstd/Zstd.cs
+++ b/code/packages/csharp/zstd/Zstd.cs
@@ -276,6 +276,18 @@ public static class Zstd
         position += contentSizeBytes;
 
         var output = new List<byte>();
+
+        // Repeated_Offset registers (RFC 8878 §3.1.1.3.2.1.1): FRAME-scoped,
+        // not block-scoped. "For the first block, the starting offset
+        // history is populated with Repeated_Offset1=1, Repeated_Offset2=4,
+        // Repeated_Offset3=8" (RFC 8878), and every later Compressed block in
+        // the same frame continues from wherever the previous Compressed
+        // block's sequences left them (Raw/RLE blocks don't touch them). See
+        // DecompressBlock's doc comment and lessons.md Lesson 98.
+        var repeatOffset1 = 1;
+        var repeatOffset2 = 4;
+        var repeatOffset3 = 8;
+
         var last = false;
         while (!last)
         {
@@ -310,7 +322,7 @@ public static class Zstd
                     break;
                 case 2:
                     RequireAvailable(data, position, blockSize, "compressed block");
-                    DecompressBlock(data.AsSpan(position, blockSize), output);
+                    DecompressBlock(data.AsSpan(position, blockSize), output, ref repeatOffset1, ref repeatOffset2, ref repeatOffset3);
                     position += blockSize;
                     break;
                 default:
@@ -367,7 +379,41 @@ public static class Zstd
         return result.Length < block.Length ? result : null;
     }
 
-    private static void DecompressBlock(ReadOnlySpan<byte> data, List<byte> output)
+    /// <summary>
+    /// Decodes one Compressed block's payload, appending decoded bytes to
+    /// <paramref name="output"/>.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="repeatOffset1"/>/<paramref name="repeatOffset2"/>/
+    /// <paramref name="repeatOffset3"/> are the three Repeated_Offset
+    /// registers (RFC 8878 §3.1.1.3.2.1.1) — passed by <c>ref</c> because
+    /// they are FRAME-scoped, not block-scoped: the caller
+    /// (<see cref="Decompress"/>) owns them and threads them, unmodified
+    /// across Raw/RLE blocks, through every Compressed block in a frame.
+    ///
+    /// <para>
+    /// WHY THIS DECODER NEEDS REPEAT-OFFSET SUPPORT EVEN THOUGH THIS
+    /// PACKAGE'S OWN ENCODER NEVER EMITS IT: <see cref="EncodeSequences"/>
+    /// always writes an explicit offset code (offset code &gt;= 2, since the
+    /// minimum possible LZSS match offset is 1, giving raw offset
+    /// = offset + 3 &gt;= 4), so this package's own Compress()/Decompress()
+    /// round trip never touches the repeat-offset path — the "no
+    /// repeat-offset shortcuts" simplification is entirely an ENCODER-side
+    /// choice (see the module doc comment on <see cref="EncodeSequences"/>).
+    /// But the real <c>zstd</c> CLI's encoder uses repeat offsets
+    /// constantly — they are one of its principal entropy wins, especially
+    /// for periodic or highly repetitive data — so a decoder that only
+    /// understands explicit offset codes systematically fails to decode a
+    /// meaningful fraction of real-world <c>.zst</c> files. Confirmed with
+    /// the real CLI: 4713 bytes of a single repeated byte compress (via a
+    /// Compressed, not RLE, block) to one sequence with Offset_Value=1 —
+    /// "reuse Repeated_Offset1", which starts at its default value of 1, an
+    /// unmistakable RLE-via-repeat-offset pattern. See lessons.md Lesson 98
+    /// (ported from <c>c/zstd</c>, PR #9941, which found and fixed the same
+    /// gap first) and the <c>RepeatOffsetCliInterop</c> test.
+    /// </para>
+    /// </remarks>
+    private static void DecompressBlock(ReadOnlySpan<byte> data, List<byte> output, ref int repeatOffset1, ref int repeatOffset2, ref int repeatOffset3)
     {
         var (literals, literalBytes) = DecodeLiterals(data);
         var position = literalBytes;
@@ -432,13 +478,79 @@ public static class Zstd
                 throw new InvalidDataException("invalid sequence code");
             }
 
-            // Step 2 — read extra value bits, in order OF, ML, LL.
+            // literalIsZero is needed for the repeat-offset interpretation
+            // below (RFC 8878's "when Literals_Length is 0, repeated offsets
+            // are shifted by 1" rule) and is knowable right now, from the
+            // PEEKED literalCode alone — LL code 0 is the only code with
+            // baseline 0 and 0 extra bits, so literalCode == 0 iff the
+            // eventual decoded literalLength is 0. No extra bits need to be
+            // read yet to know this.
+            var literalIsZero = literalCode == 0;
+
+            // Step 2 — read extra value bits, in order OF, ML, LL. The
+            // NUMBER of bits read for the offset field is always exactly
+            // offsetCode regardless of the repeat-offset interpretation
+            // below (a real decoder never varies bit-consumption on
+            // literalIsZero — only how the resulting value maps to an
+            // actual offset changes).
             var rawOffset = (1 << offsetCode) | reader.ReadBits(offsetCode);
             var matchLength = MatchLengthCodes[matchCode].Baseline
                 + reader.ReadBits(MatchLengthCodes[matchCode].ExtraBits);
             var literalLength = LiteralLengthCodes[literalCode].Baseline
                 + reader.ReadBits(LiteralLengthCodes[literalCode].ExtraBits);
-            var matchOffset = rawOffset - 3;
+
+            // Offset_Value -> actual offset (RFC 8878 §3.1.1.3.2.1.1),
+            // including the Repeated_Offset (R1/R2/R3) mechanism — see the
+            // doc comment on DecompressBlock.
+            //
+            // offsetCode >= 2 guarantees rawOffset = (1<<offsetCode)+extra
+            // >= 4, i.e. Offset_Value > 3: an ordinary explicit offset.
+            // offsetCode <= 1 guarantees rawOffset in {1, 2, 3}: a
+            // repeat-offset reference.
+            //
+            // The repeat case collapses to one selector in [0, 3]:
+            //     selector = literalIsZero + rawOffset - 1
+            // (derived from, and verified against, the reference decoder's
+            // ofBase + ll0 + extra_bit — see DecompressBlock's doc comment):
+            //   0 -> reuse repeatOffset1 unchanged (no rotation)
+            //   1 -> use repeatOffset2 (repeatOffset1/2 swap; 3 untouched)
+            //   2 -> use repeatOffset3 (full rotate: 1,2,3 <- new,old1,old2)
+            //   3 -> use repeatOffset1-1 (full rotate, same shape as 2)
+            int matchOffset;
+            if (offsetCode >= 2)
+            {
+                matchOffset = rawOffset - 3;
+                repeatOffset3 = repeatOffset2;
+                repeatOffset2 = repeatOffset1;
+                repeatOffset1 = matchOffset;
+            }
+            else
+            {
+                var selector = (literalIsZero ? 1 : 0) + rawOffset - 1;
+                switch (selector)
+                {
+                    case 0:
+                        matchOffset = repeatOffset1;
+                        break;
+                    case 1:
+                        matchOffset = repeatOffset2;
+                        repeatOffset2 = repeatOffset1;
+                        repeatOffset1 = matchOffset;
+                        break;
+                    case 2:
+                        matchOffset = repeatOffset3;
+                        repeatOffset3 = repeatOffset2;
+                        repeatOffset2 = repeatOffset1;
+                        repeatOffset1 = matchOffset;
+                        break;
+                    default: // 3
+                        matchOffset = repeatOffset1 > 0 ? repeatOffset1 - 1 : 0;
+                        repeatOffset3 = repeatOffset2;
+                        repeatOffset2 = repeatOffset1;
+                        repeatOffset1 = matchOffset;
+                        break;
+                }
+            }
 
             // Step 3 — update FSE states (consumes bits), in order LL, ML,
             // OF, preparing the states the NEXT sequence's peek will use —

--- a/code/packages/csharp/zstd/tests/CodingAdventures.Zstd.Tests/ZstdTests.cs
+++ b/code/packages/csharp/zstd/tests/CodingAdventures.Zstd.Tests/ZstdTests.cs
@@ -290,6 +290,102 @@ public sealed class ZstdTests
         }
     }
 
+    /// <summary>
+    /// Real `zstd` CLI interop proving Repeated-Offset (R1/R2/R3) sequence
+    /// decoding (RFC 8878 §3.1.1.3.2.1.1, lessons.md Lesson 98).
+    /// </summary>
+    /// <remarks>
+    /// This package's OWN encoder never emits an offset code below 2 (the
+    /// minimum LZSS match offset is 1, so raw offset = offset + 3 is always
+    /// &gt;= 4) — the "no repeat-offset shortcuts" simplification documented
+    /// in the module doc comment on <c>EncodeSequences</c>/<c>DecompressBlock</c>
+    /// is entirely an encoder-side choice. So neither this package's own
+    /// Compress()/Decompress() round trip, nor <see cref="Tc9CliInterop"/>'s
+    /// prose corpus, nor <see cref="RepeatingPatternCliInterop"/>'s single
+    /// long repeat (which the real CLI encodes as one giant match, never
+    /// needing to reuse a distance across sequences), ever exercises the
+    /// repeat-offset DECODE path — a self-consistency gap this test closes
+    /// by compressing with the real CLI, whose encoder uses repeat offsets
+    /// constantly.
+    ///
+    /// <para>
+    /// The input alternates a fixed 8-byte literal run with a long run of a
+    /// single repeated byte, over and over — "repeated back-to-back matches
+    /// at the same distance" in the literal sense: each `X` run is a match
+    /// against the immediately preceding byte (distance 1), and the real
+    /// `zstd` CLI's encoder represents a run like that as a sequence whose
+    /// Offset_Value is a repeat-offset code (reusing distance 1 across
+    /// repeats) rather than re-encoding the explicit offset every time. On
+    /// the pre-fix decoder (this exact scenario, minus the register
+    /// plumbing) this reliably threw
+    /// <c>InvalidDataException: match offset exceeds decoded output</c>,
+    /// because `rawOffset - 3` underflows for any Offset_Value &lt;= 3 —
+    /// confirmed against the pre-fix code in this session (and independently
+    /// in `c/zstd`, PR #9941, whose fuzz harness found the same gap first
+    /// with a simpler single-repeated-byte input).
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void RepeatOffsetCliInterop()
+    {
+        if (!IsZstdCliAvailable())
+        {
+            return;
+        }
+
+        var bytes = new List<byte>(Encoding.ASCII.GetBytes("ABCDEFGH"));
+        for (var index = 0; index < 20; index++)
+        {
+            bytes.AddRange(Enumerable.Repeat((byte)'X', 128));
+            bytes.AddRange(Encoding.ASCII.GetBytes("ABCDEFGH"));
+        }
+
+        var original = bytes.ToArray();
+        var theirsInput = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(theirsInput, original);
+            var theirCompressed = RunZstd(["-q", "-c", theirsInput]);
+            var decodedByUs = Zstd.Decompress(theirCompressed);
+            Assert.Equal(original, decodedByUs);
+        }
+        finally
+        {
+            File.Delete(theirsInput);
+        }
+    }
+
+    /// <summary>
+    /// Same proof as <see cref="RepeatOffsetCliInterop"/>, using a single
+    /// long run of one repeated byte — the exact minimal repro that
+    /// surfaced this gap in `c/zstd` (PR #9941, lessons.md Lesson 98): the
+    /// real CLI encodes 4713+ bytes of one repeated byte as a Compressed
+    /// (not RLE) block containing one sequence with Offset_Value=1 — "reuse
+    /// Repeated_Offset1", which starts at its default value of 1.
+    /// </summary>
+    [Fact]
+    public void SingleByteRunCliInterop()
+    {
+        if (!IsZstdCliAvailable())
+        {
+            return;
+        }
+
+        var original = Enumerable.Repeat((byte)'Z', 4713).ToArray();
+        var theirsInput = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(theirsInput, original);
+            var theirCompressed = RunZstd(["-q", "-c", theirsInput]);
+            var decodedByUs = Zstd.Decompress(theirCompressed);
+            Assert.Equal(original, decodedByUs);
+        }
+        finally
+        {
+            File.Delete(theirsInput);
+        }
+    }
+
     private static bool IsZstdCliAvailable()
     {
         try


### PR DESCRIPTION
## Summary

- Audited `code/packages/csharp/zstd` for the Repeated-Offset (R1/R2/R3) decode gap first found and fixed in the new `c/zstd` port (PR #9941, `lessons.md` Lesson 98), and confirmed this package inherited the identical gap.
- `DecompressBlock` computed `matchOffset = rawOffset - 3` unconditionally for every sequence. Per RFC 8878 §3.1.1.3.2.1.1, `Offset_Value <= 3` is a repeat-offset reference into a 3-slot history of recently used offsets (R1/R2/R3, defaulting to 1/4/8), not `Offset_Value - 3`. This package's own encoder, by design, never emits an offset code below 2 (minimum LZSS match offset is 1, so raw offset = offset + 3 is always >= 4) — so the bug was invisible to every internal round-trip test and to the two existing CLI-interop tests' specific inputs, but real `zstd` encoders use repeat offsets constantly.
- Fixed by threading three frame-scoped Repeated_Offset registers through `Decompress`'s block loop into `DecompressBlock`, and implementing the full offset-code-to-actual-offset mapping (explicit offsets >= 4 rotate the history; offset codes 0-1 resolve via a 4-way selector that also implements the RFC's "Literals_Length == 0 shifts repeat-offset interpretation by 1" special case). Algorithm cross-checked against both the RFC 8878 prose and the literal `ZSTD_decodeSequence` reference C source (fetched directly from `github.com/facebook/zstd`), and against the already-fuzz-tested `c/zstd` implementation from #9941 — decoder-only fix, this package's encoder is unchanged.

## Test plan

- [x] Reproduced the gap first: a small C# harness decompressing real-`zstd`-CLI-compressed input (a single repeated byte, and an alternating literal-run/long-match pattern) failed with `InvalidDataException: match offset exceeds decoded output` on the pre-fix decoder — confirmed by stashing the fix and re-running.
- [x] 60-case ad hoc fuzz corpus (random/periodic/constant-byte/cyclic/prose-like/mixed patterns) against the real `zstd` CLI: 24/60 failed before the fix (11 with this exact underflow signature); after the fix, only the 13 cases hitting this package's pre-existing, unrelated, documented scope limits (non-predefined FSE modes) still fail — zero mismatches, all successes byte-exact.
- [x] Two new permanent tests added (`RepeatOffsetCliInterop`, `SingleByteRunCliInterop`) reproduce the pre-fix failure and pass byte-exact after the fix.
- [x] All 32 pre-existing unit tests pass unmodified (34/34 total).
- [x] Coverage: 90.2% line / 83.02% branch / 100% method on the `CodingAdventures.Zstd` module (well above the 80% bar).
- [x] `CHANGELOG.md` updated (0.1.2) and `README.md` updated to document repeat-offset decode support.
- [x] Security review (sub-agent) passed — no vulnerabilities found; specifically checked the new selector arithmetic and `repeatOffset1 - 1` case for integer underflow/OOB, confirmed the existing bounds check still gates every code path.

See `gh pr diff 9941` for the original reference fix in `c/zstd`, and `lessons.md` Lesson 98 (landing via that PR) for the full writeup of why this bug class was invisible to self-consistency testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)