### PR TITLE
fix(elixir/zstd): decode Repeated-Offset (R1/R2/R3) sequences per RFC 8878

### DIFF
--- a/code/packages/elixir/zstd/CHANGELOG.md
+++ b/code/packages/elixir/zstd/CHANGELOG.md
@@ -5,6 +5,74 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.1.4] — 2026-08-05
+
+Repo-wide audit follow-up: while implementing the first `c/zstd` port
+(PR #9941), that effort found a second, independent gap in the sequence
+decoder — separate from Lesson 96's FSE-codec bug class fixed in 0.1.3 —
+and traced it into every other language port, including this one. See
+lessons.md Lesson 98 for the full incident report.
+
+### Fixed
+
+- **Decoder never implemented Repeated-Offset (R1/R2/R3) sequence decoding**
+  (RFC 8878 §3.1.1.3.2.1.1). `apply_sequences/14` computed
+  `offset = of_raw - 3` for every sequence, treating offset codes 1–3 as a
+  literal (and, for `of_raw` in `{1, 2, 3}`, *negative*) distance instead of
+  a reference into the 3-slot Repeated_Offset history (`R1`/`R2`/`R3`,
+  default `1`/`4`/`8`). Real `zstd` encoders use repeat offsets constantly —
+  one of their principal entropy wins, especially on periodic or
+  highly-repetitive data — so any `.zst` frame from the real CLI using this
+  mechanism would either crash (`:binary.at/2` `ArgumentError` from the
+  negative offset slipping past the `offset == 0 or offset > out_len` guard
+  — confirmed by temporarily reverting the fix and re-running the new test
+  below) or silently decode wrong bytes if it didn't crash. This package's
+  own encoder never emits repeat-offset codes (by design — minimum LZ77
+  match offset is 1, so `raw_off = offset + 3 >= 4` always), and TC-9's
+  fixed prose/pattern corpus never happened to trigger the real CLI's use
+  of the mechanism either, so no test in this package's history had ever
+  exercised the decode path.
+  - Fixed by threading three frame-scoped Repeated_Offset registers
+    (`rep1`/`rep2`/`rep3`, defaulting to `1`/`4`/`8`) through
+    `decompress_blocks/6` → `decompress_block/5` → `decompress_block_seqs/8`
+    → `apply_sequences/14`. Raw and RLE blocks pass the registers through
+    unchanged (they carry no sequences); every Compressed block's sequences
+    both consume and update them, offset code `>= 2` (explicit) alike with
+    the repeat case.
+  - Offset_Value → actual offset now follows RFC 8878 exactly, including
+    the "when Literals_Length is 0, repeated offsets are shifted by 1"
+    special case: `selector = ll_is_zero + of_raw - 1` where `of_raw in {1,
+    2, 3}` selects, respectively, "reuse R1 unchanged", "use R2 (swap with
+    R1)", "use R3 (full rotate)", or "use R1 − 1 (full rotate)".
+  - Cross-checked against three independent sources before implementing, per
+    the Lesson-96 playbook of not trusting any single one: RFC 8878
+    §3.1.1.3.2.1.1's prose (fetched directly), the real `ZSTD_decodeSequence`
+    reference C source (`zstd_decompress_block.c` from
+    github.com/facebook/zstd, fetched directly), and PR #9941's
+    already-reviewed `code/packages/c/zstd` fix — all three agree on the
+    exact selector mapping and register-rotation shape used here.
+
+### Added
+
+- **Repeat-offset interop test** (`test/zstd_test.exs`): compresses a
+  constant-byte run (the Lesson-98 minimal repro — 4713 bytes of `'Z'`,
+  which the real `zstd` CLI encodes as a Compressed block with one
+  Offset_Value=1 sequence rather than the RLE block type this port's own
+  encoder would choose), a fixed-distance repeating pattern (this package's
+  spec `CMP07-zstd.md` TC-8 shape), and two more repeat-offset-prone shapes,
+  with the real `zstd` CLI, then decodes them with `decompress/1`. Confirmed
+  this test fails (crashes with an `ArgumentError` from the underflowed
+  offset) against the pre-fix decoder before the fix was applied, and
+  passes after. A companion test round-trips the same inputs through this
+  package's own encoder/decoder pair for regression coverage of the
+  ordinary explicit-offset path (not evidence of the repeat-offset decode
+  path, since this package's own encoder never emits it).
+- Corrected a stale comment in the TC-9 test group that had claimed
+  repeat-offset inputs were "a pre-existing, spec-documented limitation" per
+  `code/specs/CMP07-zstd.md`'s "Educational Simplification" note — that
+  table lists no such carve-out; the limitation was an undocumented decoder
+  gap, now fixed.
+
 ## [0.1.3] — 2026-08-03
 
 Repo-wide audit follow-up: a sibling effort fixing `java/zstd` (PR #9780,

--- a/code/packages/elixir/zstd/lib/coding_adventures/zstd.ex
+++ b/code/packages/elixir/zstd/lib/coding_adventures/zstd.ex
@@ -945,9 +945,17 @@ defmodule CodingAdventures.Zstd do
   # ─── Block-level decompress ────────────────────────────────────────────────────
   #
   # Decompress one ZStd compressed block, appending output to `acc` (reversed list).
-  # Returns {:ok, new_acc} or {:error, reason}.
+  # Returns {:ok, new_acc, new_rep1, new_rep2, new_rep3} or {:error, reason}.
+  #
+  # `rep1`/`rep2`/`rep3` are the three Repeated_Offset registers (RFC 8878
+  # §3.1.1.3.2.1.1), threaded in from the caller and threaded back out —
+  # they are FRAME-scoped, so a block with no sequences (or this block's
+  # sequences, once decoded) must pass through/return whatever the running
+  # values are. See the module doc on apply_sequences/14 for why the decoder
+  # needs this even though this codec's own encoder never emits repeat-offset
+  # sequences (lessons.md Lesson 98).
 
-  defp decompress_block(data, acc) when is_binary(data) do
+  defp decompress_block(data, acc, rep1, rep2, rep3) when is_binary(data) do
     # ── Literals section ─────────────────────────────────────────────────────
     case decode_literals_section(data) do
       {:error, reason} ->
@@ -960,25 +968,26 @@ defmodule CodingAdventures.Zstd do
 
         # ── Sequences count ─────────────────────────────────────────────────
         if pos >= byte_size(data) do
-          # Block has only literals, no sequences — append directly.
-          {:ok, acc <> lits_bin}
+          # Block has only literals, no sequences — append directly. No
+          # sequences means the Repeated_Offset registers are untouched.
+          {:ok, acc <> lits_bin, rep1, rep2, rep3}
         else
           case decode_seq_count(data, pos) do
             {:error, reason} -> {:error, reason}
 
             {:ok, n_seqs, pos2} ->
               if n_seqs == 0 do
-                # No sequences — all content is literals.
-                {:ok, acc <> lits_bin}
+                # No sequences — all content is literals. Registers untouched.
+                {:ok, acc <> lits_bin, rep1, rep2, rep3}
               else
-                decompress_block_seqs(data, pos2, lits_bin, n_seqs, acc)
+                decompress_block_seqs(data, pos2, lits_bin, n_seqs, acc, rep1, rep2, rep3)
               end
           end
         end
     end
   end
 
-  defp decompress_block_seqs(data, pos, lits_bin, n_seqs, acc) do
+  defp decompress_block_seqs(data, pos, lits_bin, n_seqs, acc, rep1, rep2, rep3) do
     # ── Symbol compression modes ───────────────────────────────────────────
     if pos >= byte_size(data) do
       {:error, "missing symbol compression modes byte"}
@@ -1018,13 +1027,13 @@ defmodule CodingAdventures.Zstd do
             # Use binaries for the output buffer so back-references can use
             # binary_part/3 (O(1)) instead of Enum.at/2 (O(n)).
             # `acc` is the output so far from previous blocks.
-            apply_sequences(n_seqs, lits_bin, 0, acc, s_ll, s_ml, s_of, br, dt_ll, dt_ml, dt_of)
+            apply_sequences(n_seqs, lits_bin, 0, acc, s_ll, s_ml, s_of, br, dt_ll, dt_ml, dt_of, rep1, rep2, rep3)
         end
       end
     end
   end
 
-  defp apply_sequences(0, lits_bin, lit_pos, out, _s_ll, _s_ml, _s_of, _br, _dt_ll, _dt_ml, _dt_of) do
+  defp apply_sequences(0, lits_bin, lit_pos, out, _s_ll, _s_ml, _s_of, _br, _dt_ll, _dt_ml, _dt_of, rep1, rep2, rep3) do
     # Append any remaining trailing literals.
     n_lits = byte_size(lits_bin)
     if lit_pos < n_lits do
@@ -1033,14 +1042,14 @@ defmodule CodingAdventures.Zstd do
       if byte_size(out) + trailing_len > @max_output do
         {:error, "zstd: decompressed size exceeds limit of #{@max_output} bytes"}
       else
-        {:ok, out <> binary_part(lits_bin, lit_pos, trailing_len)}
+        {:ok, out <> binary_part(lits_bin, lit_pos, trailing_len), rep1, rep2, rep3}
       end
     else
-      {:ok, out}
+      {:ok, out, rep1, rep2, rep3}
     end
   end
 
-  defp apply_sequences(remaining, lits_bin, lit_pos, out, s_ll, s_ml, s_of, br, dt_ll, dt_ml, dt_of) do
+  defp apply_sequences(remaining, lits_bin, lit_pos, out, s_ll, s_ml, s_of, br, dt_ll, dt_ml, dt_of, rep1, rep2, rep3) do
     # Step 1 — PEEK all 3 symbols (LL, ML, OF) from the CURRENT states. This
     # is a bare table lookup (dt[state]) and consumes NO bits — the FSE
     # state itself already IS the decode-table index. Only the subsequent
@@ -1059,21 +1068,77 @@ defmodule CodingAdventures.Zstd do
         {ll_base, ll_extra_bits} = Enum.at(@ll_codes, ll_code)
         {ml_base, ml_extra_bits} = Enum.at(@ml_codes, ml_code)
 
+        # ll_is_zero is needed for the Repeated-Offset interpretation below
+        # (RFC 8878: "when Literals_Length is 0, repeated offsets are
+        # shifted by 1") and is knowable right now, from the PEEKED ll_code
+        # alone — LL code 0 is the only code with baseline 0 and 0 extra
+        # bits, so ll_code == 0 iff the eventual decoded `ll` value is 0. No
+        # extra bits need to be read yet to know this.
+        ll_is_zero = ll_code == 0
+
         # Step 2 — read the VALUE extra bits, order OF, ML, LL (RFC 8878
         # §3.1.1.3.2.1.2: "Decoding starts by reading the Number_of_Bits
         # required to decode offset. It does the same for Match_Length and
         # then for Literals_Length."). An earlier revision of this codec
         # read these LL, ML, OF (and interleaved with the state updates
         # below in the wrong relative order) — see lessons.md Lesson 96.
+        #
+        # The NUMBER of bits read for the offset field is always exactly
+        # `of_code`, regardless of the Repeated-Offset interpretation below
+        # — the reference decoder never varies bit-consumption on
+        # `ll_is_zero`, only how the resulting value maps to an actual
+        # offset changes.
         {of_extra, br} = rbr_read_bits(br, of_code)
         {ml_extra, br} = rbr_read_bits(br, ml_extra_bits)
         {ll_extra, br} = rbr_read_bits(br, ll_extra_bits)
 
         ll = ll_base + ll_extra
         ml = ml_base + ml_extra
-        # Offset: of_raw = (1 << of_code) | of_extra; offset = of_raw - 3
+
+        # Offset_Value → actual offset (RFC 8878 §3.1.1.3.2.1.1), including
+        # the Repeated-Offset (R1/R2/R3) mechanism: real `zstd` encoders use
+        # repeat offsets constantly (one of their principal entropy wins,
+        # especially for periodic/repetitive data), even though THIS
+        # codec's own encoder never emits them (encode_sequences_section
+        # always writes an explicit offset code >= 2, since the minimum
+        # possible LZ77 match offset is 1, giving raw_off = offset + 3 >=
+        # 4 always) — so a decoder that only understood the explicit-offset
+        # path would silently mis-decode any real-world `.zst` frame that
+        # uses repeat offsets. See lessons.md Lesson 98 (found via the same
+        # audit that produced Lesson 96, and cross-checked here against
+        # RFC 8878 §3.1.1.3.2.1.1's prose, the real `ZSTD_decodeSequence`
+        # reference source, and the already-reviewed `code/packages/c/zstd`
+        # fix in PR #9941 — all three agree).
+        #
+        # of_raw = (1 << of_code) | of_extra. of_code >= 2 guarantees
+        # of_raw >= 4, i.e. Offset_Value > 3: an ordinary explicit offset.
+        # of_code <= 1 guarantees of_raw in {1, 2, 3}: a repeat-offset
+        # reference.
+        #
+        # The repeat case collapses to one selector in [0, 3]:
+        #     selector = ll_is_zero + of_raw - 1
+        #   0 -> reuse rep1 unchanged (no rotation)
+        #   1 -> use rep2 (rep1,rep2 swap; rep3 untouched)
+        #   2 -> use rep3 (full rotate: rep1,rep2,rep3 <- new,old_rep1,old_rep2)
+        #   3 -> use rep1-1 (full rotate, same shape as selector 2)
         of_raw = (1 <<< of_code) ||| of_extra
-        offset = of_raw - 3
+
+        {offset, new_rep1, new_rep2, new_rep3} =
+          if of_code >= 2 do
+            off = of_raw - 3
+            {off, off, rep1, rep2}
+          else
+            selector = (if ll_is_zero, do: 1, else: 0) + of_raw - 1
+
+            case selector do
+              0 -> {rep1, rep1, rep2, rep3}
+              1 -> {rep2, rep2, rep1, rep3}
+              2 -> {rep3, rep3, rep1, rep2}
+              _ ->
+                off = if rep1 > 0, do: rep1 - 1, else: 0
+                {off, off, rep1, rep2}
+            end
+          end
 
         # Step 3 — UPDATE states (consumes bits), order LL, ML, OF (RFC 8878
         # §3.1.1.3.2.1.2: "Literals_Length_State is updated, followed by
@@ -1131,7 +1196,7 @@ defmodule CodingAdventures.Zstd do
                 copy_chunk = copy_with_overlap(out2, copy_start, offset, ml)
                 out3 = out2 <> copy_chunk
 
-                apply_sequences(remaining - 1, lits_bin, lit_end, out3, new_s_ll, new_s_ml, new_s_of, br, dt_ll, dt_ml, dt_of)
+                apply_sequences(remaining - 1, lits_bin, lit_end, out3, new_s_ll, new_s_ml, new_s_of, br, dt_ll, dt_ml, dt_of, new_rep1, new_rep2, new_rep3)
               end
             end
           end
@@ -1396,10 +1461,19 @@ defmodule CodingAdventures.Zstd do
 
     # ── Blocks ─────────────────────────────────────────────────────────────────
     # Use a binary accumulator for O(1) back-reference access and efficient append.
-    decompress_blocks(data, pos, <<>>)
+    #
+    # Repeated_Offset registers (RFC 8878 §3.1.1.3.2.1.1): FRAME-scoped, not
+    # block-scoped. "For the first block, the starting offset history is
+    # populated with Repeated_Offset1=1, Repeated_Offset2=4, Repeated_Offset3=8"
+    # — then every later Compressed block in the same frame continues from
+    # wherever the previous Compressed block's sequences left them. Raw and
+    # RLE blocks pass the registers through unchanged (they carry no
+    # sequences). See decompress_block/6 and apply_sequences/14 below, and
+    # lessons.md Lesson 98.
+    decompress_blocks(data, pos, <<>>, 1, 4, 8)
   end
 
-  defp decompress_blocks(data, pos, acc) do
+  defp decompress_blocks(data, pos, acc, rep1, rep2, rep3) do
     if pos + 3 > byte_size(data) do
       {:error, "truncated block header"}
     else
@@ -1415,7 +1489,7 @@ defmodule CodingAdventures.Zstd do
 
       case btype do
         0 ->
-          # Raw block: verbatim content.
+          # Raw block: verbatim content. Repeated_Offset registers untouched.
           if pos + bsize > byte_size(data) do
             {:error, "raw block truncated: need #{bsize} bytes at pos #{pos}"}
           else
@@ -1425,12 +1499,12 @@ defmodule CodingAdventures.Zstd do
               {:error, "decompressed size exceeds limit of #{@max_output} bytes"}
             else
               if is_last, do: {:ok, new_acc},
-                          else: decompress_blocks(data, pos + bsize, new_acc)
+                          else: decompress_blocks(data, pos + bsize, new_acc, rep1, rep2, rep3)
             end
           end
 
         1 ->
-          # RLE block: 1 byte repeated bsize times.
+          # RLE block: 1 byte repeated bsize times. Repeated_Offset registers untouched.
           if pos >= byte_size(data) do
             {:error, "RLE block missing byte"}
           else
@@ -1445,24 +1519,27 @@ defmodule CodingAdventures.Zstd do
               rle_chunk = :binary.copy(<<byte_val>>, bsize)
               new_acc = acc <> rle_chunk
               if is_last, do: {:ok, new_acc},
-                          else: decompress_blocks(data, pos + 1, new_acc)
+                          else: decompress_blocks(data, pos + 1, new_acc, rep1, rep2, rep3)
             end
           end
 
         2 ->
-          # Compressed block.
+          # Compressed block. Threads the Repeated_Offset registers through —
+          # decompress_block/6 both consumes and returns them, since its
+          # sequences may reference AND update R1/R2/R3.
           if pos + bsize > byte_size(data) do
             {:error, "compressed block truncated: need #{bsize} bytes"}
           else
             block_data = binary_part(data, pos, bsize)
-            case decompress_block(block_data, acc) do
+            case decompress_block(block_data, acc, rep1, rep2, rep3) do
               {:error, reason} -> {:error, reason}
-              {:ok, new_acc} ->
+              {:ok, new_acc, new_rep1, new_rep2, new_rep3} ->
                 if byte_size(new_acc) > @max_output do
                   {:error, "decompressed size exceeds limit of #{@max_output} bytes"}
                 else
-                  if is_last, do: {:ok, new_acc},
-                              else: decompress_blocks(data, pos + bsize, new_acc)
+                  if is_last,
+                    do: {:ok, new_acc},
+                    else: decompress_blocks(data, pos + bsize, new_acc, new_rep1, new_rep2, new_rep3)
                 end
             end
           end

--- a/code/packages/elixir/zstd/mix.exs
+++ b/code/packages/elixir/zstd/mix.exs
@@ -4,7 +4,7 @@ defmodule CodingAdventures.Zstd.MixProject do
   def project do
     [
       app: :coding_adventures_zstd,
-      version: "0.1.3",
+      version: "0.1.4",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/code/packages/elixir/zstd/test/zstd_test.exs
+++ b/code/packages/elixir/zstd/test/zstd_test.exs
@@ -157,13 +157,17 @@ defmodule CodingAdventures.ZstdTest do
   # rust/zstd ports of this same test.
   #
   # Repeat-offset inputs (where the SAME 8-byte pattern recurs at a FIXED
-  # distance) are deliberately avoided here: per code/specs/CMP07-zstd.md's
-  # "Educational Simplification" note, this implementation's decoder does
-  # not resolve the real zstd Repeat_Offset_1/2/3 mechanism, so a frame the
-  # real `zstd` CLI compresses USING repeat-offset shortcuts cannot be
-  # decoded by `Zstd.decompress/1` — that is a pre-existing, spec-documented
-  # limitation shared by every language port in this repo, not part of the
-  # FSE-codec bug this test targets.
+  # distance, or a long constant-byte run) are now INCLUDED below — see the
+  # dedicated "repeat-offset" test group further down. They used to be
+  # deliberately avoided here on the theory that this codec's decoder
+  # couldn't resolve the real zstd Repeated_Offset (R1/R2/R3) mechanism
+  # (RFC 8878 §3.1.1.3.2.1.1). That theory was correct as a description of
+  # a real, independent gap — but it was NOT documented in
+  # code/specs/CMP07-zstd.md's "Educational Simplification" table (which
+  # lists no repeat-offset carve-out), and the decoder now implements the
+  # mechanism in full. See lessons.md Lesson 98 for how this class of gap
+  # was found (in `code/packages/c/zstd`, via PR #9941) and audited into
+  # every other language port, including this one.
 
   defp zstd_cli_available? do
     case System.cmd("zstd", ["--version"], stderr_to_stdout: true) do
@@ -247,6 +251,92 @@ defmodule CodingAdventures.ZstdTest do
       end
     else
       IO.puts(:stderr, "zstd CLI not found on PATH — skipping TC-9 interop test")
+    end
+  end
+
+  # ── Repeat-Offset (R1/R2/R3) interoperability (lessons.md Lesson 98) ───────
+  #
+  # RFC 8878 §3.1.1.3.2.1.1 defines a Repeated-Offset mechanism: Offset_Value
+  # <= 3 is not a literal distance but a reference into a 3-slot history of
+  # recently-used offsets (R1/R2/R3, default 1/4/8), letting the real `zstd`
+  # encoder spend ~2 bits instead of a full offset code whenever a match
+  # reuses a recent distance. Real `zstd` encoders use this CONSTANTLY —
+  # it's one of their principal entropy wins, especially for periodic or
+  # highly repetitive data (exactly what a compression test suite tends to
+  # contain).
+  #
+  # This package's OWN encoder never emits repeat-offset codes (an
+  # intentional educational simplification — see encode_sequences_section's
+  # module doc), so this codec's own compress()/decompress() round trip
+  # (`rt/1`, and TC-1..TC-8 above) NEVER exercises the decode-side
+  # Repeated-Offset path — nor did TC-9's original fixed corpus, which
+  # apparently never produced a real-`zstd`-encoded sequence with
+  # Offset_Value <= 3. That gap was invisible to every test in this suite
+  # until audited in via lessons.md Lesson 98 (the same audit that first
+  # found and fixed it in `code/packages/c/zstd`, PR #9941): a decoder that
+  # only understood the explicit-offset path would either crash (an
+  # out-of-bounds binary access from a negative `offset = of_raw - 3` when
+  # of_raw is 1..3) or emit wrong bytes, on any real-world `.zst` frame that
+  # happens to use repeat offsets.
+  #
+  # These inputs deliberately target that path: a fixed pattern recurring at
+  # a CONSTANT distance (spec CMP07-zstd.md's own TC-8 shape) and a long
+  # constant-byte run (the Lesson-98 minimal repro: real `zstd` compresses
+  # 4713 bytes of `'Z'` as a Compressed block with one sequence whose
+  # Offset_Value is 1 — "reuse Repeated_Offset1" — rather than the RLE block
+  # type this port's own encoder would choose for the same input).
+  @tag :cli_interop
+  test "repeat-offset: real `zstd`-compressed repeat-offset frames decode correctly" do
+    if zstd_cli_available?() do
+      pattern = "ABCDEFGH"
+      fixed_distance_repeat = pattern <> String.duplicate(String.duplicate("X", 128) <> pattern, 10)
+
+      for {name, input} <- [
+            {"constant-byte run (Lesson 98 minimal repro)", String.duplicate("Z", 4713)},
+            {"pattern at fixed distance (spec TC-8 shape)", fixed_distance_repeat},
+            {"short constant run", String.duplicate("q", 50)},
+            {"periodic 3-byte cycle", String.duplicate("xyz", 4000)}
+          ] do
+        unique = unique_tmp_name("ex-zstd-repoff")
+        tmp_txt = Path.join(System.tmp_dir!(), "#{unique}.txt")
+        tmp_zst = Path.join(System.tmp_dir!(), "#{unique}.zst")
+        File.write!(tmp_txt, input)
+
+        try do
+          {_output, exit_code} = System.cmd("zstd", ["-q", "-f", "-o", tmp_zst, tmp_txt], stderr_to_stdout: true)
+          assert exit_code == 0, "real `zstd` CLI failed to compress #{name}"
+
+          cli_compressed = File.read!(tmp_zst)
+          assert {:ok, ^input} = Zstd.decompress(cli_compressed),
+            "our decompress/1 failed to decode real `zstd`'s repeat-offset output for #{name} (#{byte_size(input)} bytes)"
+        after
+          File.rm(tmp_txt)
+          File.rm(tmp_zst)
+        end
+      end
+    else
+      IO.puts(:stderr, "zstd CLI not found on PATH — skipping repeat-offset interop test")
+    end
+  end
+
+  # Same set of inputs, but round-tripped purely through THIS package's own
+  # compress/1 followed by decompress/1. This package's encoder never emits
+  # repeat-offset codes, so this direction alone would never have caught
+  # Lesson 98 — it's included for completeness/regression coverage of the
+  # ordinary explicit-offset path on the same inputs, not as evidence the
+  # repeat-offset decode path works (the CLI-interop test above is the one
+  # that actually proves that).
+  test "repeat-offset-shaped inputs still round-trip through our own encoder" do
+    pattern = "ABCDEFGH"
+    fixed_distance_repeat = pattern <> String.duplicate(String.duplicate("X", 128) <> pattern, 10)
+
+    for input <- [
+          String.duplicate("Z", 4713),
+          fixed_distance_repeat,
+          String.duplicate("q", 50),
+          String.duplicate("xyz", 4000)
+        ] do
+      assert rt(input) == input
     end
   end
 


### PR DESCRIPTION
## Summary

- Audits `code/packages/elixir/zstd` for the same decode-side Repeated-Offset (R1/R2/R3) gap first found and fixed in `code/packages/c/zstd` (PR #9941, lessons.md Lesson 98), and fixes it here.
- The decoder never implemented RFC 8878 §3.1.1.3.2.1.1: it computed `offset = of_raw - 3` unconditionally for every sequence, treating offset codes 1-3 as literal (and, for `of_raw` in `{1,2,3}`, *negative*) distances instead of references into a 3-slot history of recently-used offsets (R1/R2/R3, default `1`/`4`/`8`). Real `zstd` encoders use repeat offsets constantly (one of their principal entropy wins), so a real-world `.zst` frame using this mechanism would crash — the negative offset slipped past the existing `offset == 0 or offset > out_len` bounds check straight into `:binary.at/2`, raising an uncaught `ArgumentError` — or decode wrong bytes if it somehow didn't crash.
- This package's own encoder never emits repeat-offset codes by design (minimum LZ77 match offset is 1, so `raw_off = offset + 3 >= 4` always), so no existing round-trip test in this package's history ever exercised the decode path.

## Fix

Threaded three frame-scoped Repeated-Offset registers (`rep1`/`rep2`/`rep3`, defaulting to `1`/`4`/`8`) through `decompress_blocks/6` → `decompress_block/5` → `decompress_block_seqs/8` → `apply_sequences/14`. Raw/RLE blocks pass the registers through unchanged; Compressed blocks' sequences both consume and update them, per RFC 8878's selector logic (`selector = ll_is_zero + of_raw - 1`, including the "Literals_Length == 0 shifts the interpretation" special case).

Cross-checked against three independent sources before implementing, per the Lesson-96 playbook of not trusting any one alone:
1. RFC 8878 §3.1.1.3.2.1.1's prose (fetched directly)
2. The real `ZSTD_decodeSequence` reference C source (`zstd_decompress_block.c`, fetched directly from github.com/facebook/zstd)
3. PR #9941's already-reviewed `code/packages/c/zstd` fix

All three agree exactly on the selector mapping and register-rotation shape used here.

## Test plan

- [x] Added a CLI-interop test (`test/zstd_test.exs`) that compresses several repeat-offset-prone inputs (a constant-byte run — the Lesson-98 minimal repro; a fixed-distance repeating pattern per this package's own spec `CMP07-zstd.md` TC-8 shape; two more shapes) with the **real `zstd` CLI**, then decodes with `decompress/1`.
- [x] Confirmed this new test genuinely proves the gap: reverted just the source fix (via patch, not `git stash` — see note below) and re-ran the test — it failed with an `ArgumentError` crash, matching the crash class described above. Reapplied the fix and reran — passes.
- [x] Added a companion same-encoder round-trip test for regression coverage of the ordinary explicit-offset path on the same input shapes.
- [x] Full existing suite: `mix test` → 29 tests, 0 failures (27 pre-existing + 2 new).
- [x] Fixed a stale comment in the TC-9 test group that had incorrectly claimed repeat-offset inputs were "a pre-existing, spec-documented limitation" per `code/specs/CMP07-zstd.md` — that spec's "Educational Simplification" table lists no such carve-out; it was an undocumented decoder gap.
- [x] `CHANGELOG.md` updated (0.1.3 → 0.1.4), `mix.exs` version bumped.
- [x] Security review (sub-agent) passed — traced every branch that can produce a register/offset value and confirmed negative offsets are now structurally impossible (not just filtered), and that the new `System.cmd`/temp-file test code uses list-form arguments (no shell) and CSPRNG-randomized temp paths.

Note: while investigating this, a `git stash` I ran raced with a concurrent agent's stash push in this same repo (the shared-across-worktrees stash list) and briefly pulled an unrelated in-progress `java/zstd` change into this worktree. Recovered by pushing it back onto the stash with a clearly tagged message (and a backup patch) before redoing my own edits from scratch — no `java/zstd` changes are included in this PR.

References: PR #9941 (`c/zstd`, the original fix), `lessons.md` Lesson 98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)