### PR TITLE
fix(python/zstd): decode Repeated-Offset (R1/R2/R3) sequences per RFC 8878

### DIFF
--- a/code/packages/python/zstd/CHANGELOG.md
+++ b/code/packages/python/zstd/CHANGELOG.md
@@ -4,6 +4,84 @@ All notable changes to `coding-adventures-zstd` will be documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.1.2] — 2026-08-05
+
+### Fixed
+
+- **Repeated-Offset (R1/R2/R3) sequence decoding** (RFC 8878
+  §3.1.1.3.2.1.1): `decompress()` previously treated every Offset_Value as
+  an explicit back-reference distance (`offset = of_raw - 3`) and raised
+  `ValueError` whenever `of_raw < 3` — i.e. whenever an offset code
+  designated a repeat-offset reference rather than an explicit distance.
+  This package's own `compress()` never emits repeat-offset codes (every
+  LZSS match offset is coded explicitly), so its own round trip never
+  exercised this path — but the real `zstd` CLI's encoder uses repeat
+  offsets constantly (one of its main entropy wins, especially on
+  periodic/repetitive data), so a meaningful fraction of real-world `.zst`
+  files failed to decode. Found while auditing this package against
+  `c/zstd` (PR #9941), which independently discovered the same decode-only
+  gap in its own (freshly-transcribed, otherwise-conformant) FSE codec via
+  a 200-trial fuzz sweep against the real CLI. See lessons.md Lesson 98.
+
+  `_decompress_block` now maintains three Repeated_Offset registers
+  (`rep = [R1, R2, R3]`, seeded to `[1, 4, 8]` at the start of every frame
+  per RFC 8878, threaded — as the same list object — through every
+  Compressed block in `decompress()`'s block loop; Raw/RLE blocks don't
+  touch them). For `of_code >= 2` (Offset_Value >= 4), decoding is
+  unchanged: an explicit offset that rotates into R1, shifting R1->R2->R3.
+  For `of_code <= 1` (Offset_Value in {1, 2, 3}), the offset is resolved
+  via a selector `ll_is_zero + Offset_Value - 1` (the "when this
+  sequence's Literals_Length is 0, repeated offsets are shifted by 1" rule
+  from the RFC) into one of four cases: reuse R1 unchanged, swap in R2,
+  rotate in R3, or rotate in "R1 - 1" (a real pattern real encoders emit,
+  not degenerate). Algorithm cross-checked against both the RFC 8878 prose
+  and the literal `ZSTD_decodeSequence` reference C source (fetched
+  directly from `github.com/facebook/zstd`, not recalled from memory),
+  matching the already-verified fix transcribed into `c/zstd`.
+
+  This package's encoder is intentionally unchanged — it still never emits
+  repeat-offset codes; this is a decode-only conformance fix.
+
+### Added
+
+- `TestRepeatOffsetDecode` (`tests/test_zstd.py`): low-level unit tests
+  exercising all four repeat-offset selector cases and cross-block
+  register persistence directly against `_decompress_block`, independent
+  of the real `zstd` CLI. Since this package's own encoder can't produce a
+  repeat-offset code from a real match offset, these tests drive
+  `_Seq.off` values of `0`, `-1`, and `-2` — not real offsets, but a
+  documented trick exploiting the encoder's own `raw_off = seq.off + 3`
+  formula to land on a chosen Offset_Value — to reach the decoder's new
+  branches deterministically. Expected output bytes are computed via an
+  independent trivial LZ-apply helper (`_apply_seq_offsets`) fed
+  hand-derived, RFC/reference-cross-checked `(ll, ml, offset)` triples,
+  rather than re-deriving byte content by hand.
+- `TestCliInterop::test_real_compress_our_decompress_repeat_offset_rle`:
+  regression test compressing `b"A" * 500` with the real `zstd` CLI (which
+  reaches for a Repeat_Offset shortcut on this input rather than this
+  package's own RLE block type) and decompressing with `decompress()`,
+  asserting byte-exact output. This is the same input shape that, before
+  this fix, either raised `ValueError` (the explicit reject added in
+  0.1.1) or, before that guard existed, corrupted output.
+- `TestCliInterop::test_real_compress_our_decompress_repeat_offset_periodic`:
+  regression test using a 53-byte-period payload compressed by the real
+  `zstd` CLI, sized to make repeated back-to-back matches at the same
+  distance (the textbook repeat-offset-reuse case) very likely.
+- `TestCliInterop::test_real_compress_our_decompress_still_rejects_huffman_literals`:
+  confirms the unrelated, still-unsupported Huffman-literals limitation
+  (`code/specs/CMP07-zstd.md`'s "Educational Simplification" table) is
+  unaffected by this decode-only sequences-section fix — either a clean
+  `ValueError` or byte-exact output, never silent corruption.
+
+### Changed
+
+- `_decompress_block`'s signature gained a third parameter, `rep: list[int]`
+  (the frame-scoped Repeated_Offset registers), mutated in place. Its sole
+  caller, `decompress()`, now owns and threads this list across its block
+  loop. `_decompress_block` is a private (underscore-prefixed) helper, so
+  this is not a public API change — `compress()`/`decompress()` signatures
+  are unchanged.
+
 ## [0.1.1] — 2026-08-03
 
 ### Fixed

--- a/code/packages/python/zstd/pyproject.toml
+++ b/code/packages/python/zstd/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-zstd"
-version = "0.1.1"
+version = "0.1.2"
 description = "Zstandard (ZStd) compression algorithm (RFC 8878, CMP07) from scratch"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/code/packages/python/zstd/src/coding_adventures_zstd/__init__.py
+++ b/code/packages/python/zstd/src/coding_adventures_zstd/__init__.py
@@ -1178,7 +1178,63 @@ def _compress_block(block: bytes) -> bytes | None:
     return compressed
 
 
-def _decompress_block(data: bytes, out: bytearray) -> None:
+# =============================================================================
+# Repeated-Offset (R1/R2/R3) Decoding — RFC 8878 §3.1.1.3.2.1.1
+# =============================================================================
+#
+# An Offset_Value of 1, 2, or 3 does not encode an explicit back-reference
+# distance — it is a "repeat code" that reuses one of three offsets tracked
+# across the whole frame: Repeated_Offset1/2/3 (informally R1/R2/R3),
+# seeded to 1/4/8 at the start of every frame. Only Offset_Value >= 4 (i.e.
+# ``of_code >= 2``, since ``of_raw = (1 << of_code) | extra_bits`` and
+# ``of_code <= 1`` can only produce raw values in {1, 2, 3}) is an explicit
+# offset.
+#
+# THIS PORT'S ENCODER (``_encode_sequences_section`` above) never emits a
+# repeat code: every LZSS match offset is coded explicitly via
+# ``raw_off = seq.off + 3 >= 4``. That is a legitimate (if suboptimal)
+# encoder-side simplification — but it means this package's own
+# compress()/decompress() round trip, and any test built only from that
+# round trip, NEVER exercises the repeat-offset decode path. The real
+# `zstd` CLI's encoder uses repeat offsets constantly (one of its main
+# entropy wins, especially on periodic/repetitive data), so a decoder that
+# only understands explicit offsets will fail on a large fraction of
+# real-world `.zst` files — exactly the gap this section closes. See
+# lessons.md Lesson 98 (found first in `code/packages/c/zstd`, PR #9941).
+#
+# Selector derivation (cross-checked against RFC 8878 prose AND the literal
+# reference C source, `ZSTD_decodeSequence` in `zstd_decompress_block.c`
+# from github.com/facebook/zstd — not re-derived from memory):
+#
+#   of_code >= 2  → explicit offset. offset = of_raw - 3; the offset
+#                   history rotates unconditionally: R3=R2; R2=R1; R1=offset.
+#
+#   of_code <= 1  → repeat reference. Collapse to one selector in [0, 3]:
+#                       selector = ll_is_zero + of_raw - 1
+#                   where ``ll_is_zero`` is whether THIS sequence's literal
+#                   length is 0 — knowable from the peeked LL code alone
+#                   (code 0 is the only LL code with baseline 0 and 0 extra
+#                   bits) before any extra bits are read. RFC 8878: "when
+#                   the current sequence's Literals_Length is 0, repeated
+#                   offsets are shifted by 1" (so raw Offset_Value 1 means
+#                   "use R2", not "use R1", in that case).
+#
+#     selector 0 → offset = R1                          (no rotation)
+#     selector 1 → offset = R2;  R2 = R1;  R1 = offset   (R3 untouched)
+#     selector 2 → offset = R3;  R3 = R2;  R2 = R1;  R1 = offset  (full rotate)
+#     selector 3 → offset = R1 - 1 (or 0 if R1 == 0);  same full rotate as 2
+#
+# selector 3's "R1 - 1" case exists because Offset_Value 3 with
+# Literals_Length == 0 has no direct repeat-offset meaning (R1/R2/R3 only
+# cover 3 slots, and selectors 0/1/2 already claim of_raw in {1,2,3} for the
+# ll_is_zero=0 case) — the reference decoder repurposes it as "R1 minus
+# one", a real (if unusual) pattern real encoders emit. An R1 of 0 here
+# would be a malformed frame; producing 0 instead of underflowing lets the
+# existing ``offset == 0`` bounds check below reject it cleanly rather than
+# wrapping to a huge unsigned value.
+
+
+def _decompress_block(data: bytes, out: bytearray, rep: list[int]) -> None:
     """Decompress one ZStd compressed block, appending to ``out``.
 
     Parses the literals section, sequences section, and applies sequences
@@ -1187,6 +1243,14 @@ def _decompress_block(data: bytes, out: bytearray) -> None:
     Args:
         data: Compressed block data (without the 3-byte block header).
         out: Output buffer to append decompressed bytes to.
+        rep: The three Repeated_Offset registers ``[R1, R2, R3]`` (RFC 8878
+            §3.1.1.3.2.1.1), mutated in place. These are FRAME-scoped, not
+            block-scoped: the caller creates ``[1, 4, 8]`` once per frame
+            and threads the same list through every Compressed block, so a
+            later block's sequences can reuse offsets an earlier block's
+            sequences established. See the module comment above this
+            function for why this port's DECODER needs repeat-offset
+            support even though its own ENCODER never emits it.
 
     Raises:
         ValueError: On malformed data, unsupported modes, or bad back-references.
@@ -1270,30 +1334,57 @@ def _decompress_block(data: bytes, out: bytearray) -> None:
         ll_base, ll_extra_bits = LL_CODES[ll_code]
         ml_base, ml_extra_bits = ML_CODES[ml_code]
 
+        # ll_is_zero feeds the Repeat_Offset selector below (RFC 8878's
+        # "when Literals_Length is 0, repeated offsets are shifted by 1"
+        # rule) and is knowable right now, from the PEEKED ll_code alone —
+        # LL code 0 is the only code with baseline 0 and 0 extra bits, so
+        # ll_code == 0 iff the eventual decoded `ll` value is 0. No extra
+        # bits need to be read yet to know this.
+        ll_is_zero = ll_code == 0
+
         # ── Step 2: read extra bits, order OF, ML, LL ───────────────────────────
         # RFC 8878 §3.1.1.3.2.1.2: "Decoding starts by reading the
         # Number_of_Bits required to decode offset. It does the same for
         # Match_Length and then for Literals_Length."
-        # Offset: raw = (1 << of_code) | extra_bits; offset = raw - 3
-        # (inverse of the +3 applied during encoding).
+        # Offset: raw = (1 << of_code) | extra_bits. The number of bits read
+        # is always exactly `of_code`, regardless of whether the result
+        # turns out to be an explicit offset or a Repeat_Offset reference
+        # (RFC 8878 / the reference decoder never varies bit-consumption on
+        # ll_is_zero — only how the resulting value maps to an actual
+        # offset changes, immediately below).
         of_extra = br.read_bits(of_code)
         of_raw = (1 << of_code) | of_extra
-        # of_raw in {1, 2, 3} designates a Repeat_Offset (R1/R2/R3) shortcut
-        # rather than an explicit offset (RFC 8878 §3.1.1.3.2.1). This
-        # simplified codec's encoder never emits those codes (every offset
-        # is coded explicitly, raw = offset + 3 >= 4), so a frame that uses
-        # them came from another encoder (e.g. the real `zstd` CLI, which
-        # uses repeat offsets by default for compression efficiency) and
-        # exercises a feature outside our supported subset. Reject it with
-        # a clear error rather than computing a negative/zero "offset" that
-        # would silently read out of bounds or wrap to an unrelated slot.
-        if of_raw < 3:
-            raise ValueError(
-                f"decoded offset underflow: of_raw={of_raw} (Repeat_Offset "
-                "R1/R2/R3 shortcuts are not supported by this simplified "
-                "codec — every offset must be coded explicitly)"
-            )
-        offset = of_raw - 3
+
+        # Offset_Value -> actual offset (RFC 8878 §3.1.1.3.2.1.1), including
+        # the Repeated_Offset (R1/R2/R3) mechanism — see the module comment
+        # above this function for the full derivation and cross-checks
+        # (RFC prose + literal ZSTD_decodeSequence reference source).
+        # of_code >= 2 guarantees of_raw >= 4: an ordinary explicit offset.
+        # of_code <= 1 guarantees of_raw in {1, 2, 3}: a repeat reference.
+        if of_code >= 2:
+            offset = of_raw - 3
+            rep[2] = rep[1]
+            rep[1] = rep[0]
+            rep[0] = offset
+        else:
+            selector = ll_is_zero + of_raw - 1
+            if selector == 0:
+                offset = rep[0]
+            elif selector == 1:
+                offset = rep[1]
+                rep[1] = rep[0]
+                rep[0] = offset
+            elif selector == 2:
+                offset = rep[2]
+                rep[2] = rep[1]
+                rep[1] = rep[0]
+                rep[0] = offset
+            else:  # selector == 3
+                offset = rep[0] - 1 if rep[0] > 0 else 0
+                rep[2] = rep[1]
+                rep[1] = rep[0]
+                rep[0] = offset
+
         ml = ml_base + br.read_bits(ml_extra_bits)
         ll = ll_base + br.read_bits(ll_extra_bits)
 
@@ -1545,6 +1636,16 @@ def decompress(data: bytes) -> bytes:
     # ── Decode Blocks ─────────────────────────────────────────────────────────
     out = bytearray()
 
+    # Repeated_Offset registers (RFC 8878 §3.1.1.3.2.1.1): FRAME-scoped, not
+    # block-scoped. Seeded to [1, 4, 8] "for the first block", then threaded
+    # unmodified (as the SAME list object, mutated in place by
+    # _decompress_block) through every Compressed block for the rest of the
+    # frame. Raw and RLE blocks don't touch these registers — they simply
+    # don't advance them, which is correct: the next Compressed block picks
+    # up wherever the previous Compressed block's sequences left off. See
+    # lessons.md Lesson 98.
+    rep = [1, 4, 8]
+
     while True:
         # Each block has a 3-byte little-endian header.
         if pos + 3 > len(data):
@@ -1590,7 +1691,7 @@ def decompress(data: bytes) -> bytes:
                 )
             block_data = data[pos:pos + bsize]
             pos += bsize
-            _decompress_block(block_data, out)
+            _decompress_block(block_data, out, rep)
 
         else:
             # btype == 3: Reserved — must not appear in valid frames.

--- a/code/packages/python/zstd/tests/test_zstd.py
+++ b/code/packages/python/zstd/tests/test_zstd.py
@@ -29,6 +29,7 @@ from coding_adventures_zstd import (
     _build_decode_table,
     _decode_literals_section,
     _decode_seq_count,
+    _decompress_block,
     _encode_literals_section,
     _encode_seq_count,
     _encode_sequences_section,
@@ -625,6 +626,177 @@ class TestFSEEncodeDecode:
             assert off_dec == expected.off, f"seq {i} OFF"
 
 
+def _apply_seq_offsets(lits: bytes, seqs: list[tuple[int, int, int]]) -> bytes:
+    """Independently apply a list of ALREADY-RESOLVED (ll, ml, offset)
+    triples to ``lits``, mirroring the trivial "emit literals, then copy
+    ml bytes from offset positions back" step of ``_decompress_block``'s
+    main loop.
+
+    This is intentionally the ONLY piece of decode logic duplicated here —
+    it is not what TestRepeatOffsetDecode below is testing (that logic
+    predates this fix and is already covered by the FSE round-trip tests
+    above). What IS being tested is which `offset` value the decoder's new
+    Repeated_Offset (R1/R2/R3) selector logic computes for each sequence —
+    this helper just gives an independent way to turn "the offsets we
+    expect, by hand, per RFC 8878 / the reference decoder" into expected
+    OUTPUT BYTES, so the test can assert on `bytes(out)` instead of
+    re-deriving byte-for-byte content by hand (error-prone for 30+ bytes).
+    """
+    out = bytearray()
+    lit_pos = 0
+    for ll, ml, offset in seqs:
+        out.extend(lits[lit_pos:lit_pos + ll])
+        lit_pos += ll
+        copy_start = len(out) - offset
+        for i in range(ml):
+            out.append(out[copy_start + i])
+    return bytes(out)
+
+
+class TestRepeatOffsetDecode:
+    """Repeated-Offset (R1/R2/R3) sequence decoding — RFC 8878
+    §3.1.1.3.2.1.1 — lessons.md Lesson 98.
+
+    This package's own ENCODER never emits Offset_Value <= 3 (every LZSS
+    match offset is coded explicitly, ``raw_off = seq.off + 3 >= 4`` since
+    the minimum real match offset is 1), so the normal ``_Seq(off=...)``
+    API can't directly produce a repeat-offset code — a real back-reference
+    offset can never be small enough. To exercise the DECODER's
+    repeat-offset branch in isolation (independent of the real `zstd` CLI —
+    see TestCliInterop below for the end-to-end proof), these tests pass
+    ``_Seq.off`` values of 0, -1, and -2. Those are NOT real offsets (no
+    encoder would ever produce them from actual LZ77 matches) — they are a
+    deliberate trick that exploits `_encode_sequences_section`'s own
+    ``raw_off = seq.off + 3`` formula (the SAME formula the decoder inverts)
+    to land on a chosen (of_code, extra_bits) pair, i.e. a chosen
+    Offset_Value in {1, 2, 3}, letting the test drive the decoder's new
+    selector logic directly:
+
+        seq.off = -2  →  raw_off = 1  →  of_code=0, extra=0  →  Offset_Value=1
+        seq.off = -1  →  raw_off = 2  →  of_code=1, extra=0  →  Offset_Value=2
+        seq.off =  0  →  raw_off = 3  →  of_code=1, extra=1  →  Offset_Value=3
+
+    Combined with a chosen literal length (0 selects "ll_is_zero=True"; a
+    non-zero LL code 1..15 selects "ll_is_zero=False"), every one of the
+    four repeat-offset selectors (RFC 8878's "ll_is_zero + Offset_Value - 1"
+    shift, 0..3) is independently reachable and asserted below.
+    """
+
+    def test_all_four_selectors_and_frame_scoped_registers(self) -> None:
+        """Six sequences in one block: two explicit offsets seed R1/R2/R3
+        away from their frame-default [1, 4, 8], then four repeat-offset
+        sequences — one per selector (0, 1, 2, 3) — read and rotate them.
+
+        Expected offsets and register transitions below were derived BY
+        HAND from RFC 8878 §3.1.1.3.2.1.1 and cross-checked against the
+        literal `ZSTD_decodeSequence` reference C source (fetched from
+        github.com/facebook/zstd, not recalled from memory) before writing
+        this test — see the module comment above `_decompress_block` in
+        __init__.py for the full derivation. `_apply_seq_offsets` then
+        turns those hand-derived (ll, ml, offset) triples into expected
+        OUTPUT BYTES independently of `_decompress_block`, so this test
+        catches a wrong offset/register computation as either a byte
+        mismatch or (if the wrong offset is 0 or out of bounds) a
+        ValueError, not a silently-passing false positive.
+        """
+        lits = bytes(range(18))  # 18 arbitrary, distinct literal bytes
+
+        # (ll, ml, off) as fed to the ENCODER. `off` is a REAL offset for
+        # the two explicit sequences (A, B) and a repeat-offset "selector
+        # trick" value (see class docstring) for the other four.
+        seqs = [
+            _Seq(ll=5, ml=3, off=3),    # A: explicit -> offset 3
+            _Seq(ll=12, ml=3, off=20),  # B: explicit -> offset 20
+            _Seq(ll=0, ml=3, off=0),    # C: selector 3 (ll=0, Offset_Value=3)
+            _Seq(ll=1, ml=3, off=-2),   # D: selector 0 (ll>0, Offset_Value=1)
+            _Seq(ll=0, ml=3, off=-2),   # E: selector 1 (ll=0, Offset_Value=1)
+            _Seq(ll=0, ml=3, off=-1),   # F: selector 2 (ll=0, Offset_Value=2)
+        ]
+
+        block = bytearray()
+        block.extend(_encode_literals_section(lits))
+        block.extend(_encode_seq_count(len(seqs)))
+        block.append(0x00)  # symbol compression modes: all Predefined
+        block.extend(_encode_sequences_section(seqs))
+
+        out = bytearray()
+        rep = [1, 4, 8]  # frame defaults (RFC 8878 §3.1.1.3.2.1.1)
+        _decompress_block(bytes(block), out, rep)
+
+        # Hand-derived (ll, ml, resolved_offset) per sequence:
+        #   A explicit(3):    R=[1,4,8]  -> R=[3,1,4]
+        #   B explicit(20):   R=[3,1,4]  -> R=[20,3,1]
+        #   C selector3: offset=R1-1=19; full rotate -> R=[19,20,3]
+        #   D selector0: offset=R1=19;   no rotation  -> R=[19,20,3]
+        #   E selector1: offset=R2=20;   R1<->R2 swap -> R=[20,19,3]
+        #   F selector2: offset=R3=3;    full rotate  -> R=[3,20,19]
+        expected = _apply_seq_offsets(
+            lits,
+            [
+                (5, 3, 3),
+                (12, 3, 20),
+                (0, 3, 19),
+                (1, 3, 19),
+                (0, 3, 20),
+                (0, 3, 3),
+            ],
+        )
+        assert bytes(out) == expected
+        assert rep == [3, 20, 19]
+
+    def test_repeat_offset_persists_across_blocks_in_same_frame(self) -> None:
+        """The R1/R2/R3 registers are FRAME-scoped, not block-scoped: a
+        Compressed block's sequences must be able to reuse an offset an
+        EARLIER block in the same frame established, via the same `rep`
+        list threaded through both calls (mirroring what `decompress()`
+        does across the block loop).
+
+        Block 1's one explicit-offset(7) sequence rotates the frame
+        defaults [1, 4, 8] to [7, 1, 4] (R1=7, R2=1, R3=4 — note R2 is now
+        1, the OLD R1, not the original default 4; a naive "R2 is still
+        its startup default" assumption would be wrong here, which is
+        exactly why this test picks a selector-1 (R2) reference for block
+        2 rather than a selector-0 (R1) one). Block 2's sequence has
+        ll=0 and an Offset_Value of 1 (the ``off=-2`` selector trick, see
+        the class docstring) -> selector 1 -> "use R2" = 1.
+        """
+        lits1 = b"0123456789"
+        seqs1 = [_Seq(ll=10, ml=3, off=7)]  # explicit offset 7
+        block1 = bytearray()
+        block1.extend(_encode_literals_section(lits1))
+        block1.extend(_encode_seq_count(len(seqs1)))
+        block1.append(0x00)
+        block1.extend(_encode_sequences_section(seqs1))
+
+        lits2 = b""
+        seqs2 = [_Seq(ll=0, ml=3, off=-2)]  # selector 1 -> R2
+        block2 = bytearray()
+        block2.extend(_encode_literals_section(lits2))
+        block2.extend(_encode_seq_count(len(seqs2)))
+        block2.append(0x00)
+        block2.extend(_encode_sequences_section(seqs2))
+
+        out = bytearray()
+        rep = [1, 4, 8]
+        _decompress_block(bytes(block1), out, rep)
+        assert bytes(out) == _apply_seq_offsets(lits1, [(10, 3, 7)])
+        assert bytes(out) == b"0123456789345"
+        assert rep == [7, 1, 4]  # explicit offset 7 rotated in; R2 = old R1
+
+        _decompress_block(bytes(block2), out, rep)
+        # Block 2 has no literals of its own; its sequence copies 3 bytes
+        # at offset R2=1 from the TAIL of block 1's output (cross-block
+        # back-reference — only possible because `out` and `rep` both
+        # persist across the two _decompress_block calls, exactly as
+        # decompress() threads them across a frame's block loop).
+        # offset=1 with ml=3 self-overlaps: copy_start = 13-1 = 12, and
+        # each copied byte becomes readable by the next copy in the same
+        # loop, so it repeats out[12] ('5') three times, not a 3-byte slice.
+        assert bytes(out) == b"0123456789345" + b"555"
+        assert bytes(out) == b"0123456789345555"
+        assert rep == [1, 7, 4]  # selector 1: R1<->R2 swap, R3 untouched
+
+
 class TestWireFormat:
     """Test decompressor against manually constructed frames."""
 
@@ -839,19 +1011,66 @@ class TestCliInterop:
         compressed = _zstd_cli_compress(data, tmp_path)
         assert decompress(compressed) == data
 
-    def test_real_compress_our_decompress_rejects_unsupported_features(
+    def test_real_compress_our_decompress_repeat_offset_rle(
         self, tmp_path: Path
     ) -> None:
-        """Some real-`zstd`-compressed frames use features outside this
-        educational codec's supported subset — Repeat_Offset (R1/R2/R3)
-        shortcuts and Huffman-coded literals in particular (see the
-        'Educational simplification' note in the sibling java/zstd package
-        and code/specs/CMP07-zstd.md). Our decoder must REJECT these with a
-        clear ValueError, not crash or silently produce wrong output. This
-        was itself a real bug found via this same CLI-interop exercise: an
-        unchecked negative offset (from a Repeat_Offset code) caused an
-        uncaught IndexError instead of a clean error."""
-        data = b"A" * 500  # real zstd encodes this via a Repeat_Offset shortcut
+        """Regression test for lessons.md Lesson 98: `b"A" * 500` is exactly
+        the shape of input where the real `zstd` CLI's encoder reaches for a
+        Repeat_Offset (R1/R2/R3) shortcut — e.g. two literal bytes "AA"
+        followed by one long match with Offset_Value=1 ("reuse R1", whose
+        frame-default value is 1) — rather than this package's own RLE
+        block type. Before the Lesson 98 fix, this package's decoder didn't
+        understand Offset_Value <= 3 as a repeat reference and either raised
+        ValueError (an explicit reject, added as defence-in-depth after an
+        earlier revision crashed with an uncaught IndexError on the same
+        input) or, before that guard existed, corrupted output. It must now
+        decode to the exact original bytes.
+        """
+        data = b"A" * 500
         compressed = _zstd_cli_compress(data, tmp_path)
-        with pytest.raises(ValueError):
-            decompress(compressed)
+        assert decompress(compressed) == data
+
+    def test_real_compress_our_decompress_repeat_offset_periodic(
+        self, tmp_path: Path
+    ) -> None:
+        """Periodic data with a distinctive, non-trivial period gives the
+        real `zstd` CLI's encoder many back-to-back LZ77 matches at the
+        SAME distance (one full period apart) — the textbook case for
+        repeatedly reusing Repeated_Offset1 rather than re-encoding the
+        same explicit offset every time. Regression test for lessons.md
+        Lesson 98, using a period (53 bytes) chosen to avoid degenerating
+        into a single-byte RLE pattern (see test above) while still being
+        short enough, repeated enough times, to make repeat-offset reuse
+        very likely.
+        """
+        unit = bytes((i * 37 + 11) % 256 for i in range(53))
+        data = unit * 200  # 10,600 bytes; period 53 forces repeated matches
+        compressed = _zstd_cli_compress(data, tmp_path)
+        assert decompress(compressed) == data
+
+    def test_real_compress_our_decompress_still_rejects_huffman_literals(
+        self, tmp_path: Path
+    ) -> None:
+        """Huffman-coded literals remain outside this educational codec's
+        supported subset (see code/specs/CMP07-zstd.md's 'Educational
+        Simplification' table: 'Literals: Huffman or raw' -> 'Raw only').
+        This is UNCHANGED by the Lesson 98 repeat-offset fix — that fix is
+        decode-only support for a SEQUENCES-section feature (Offset_Value
+        <= 3), unrelated to the LITERALS-section encoding. High-entropy
+        data compressible enough for `zstd` to bother with Huffman, but
+        with enough symbol variety to make Huffman worthwhile over raw,
+        should still raise a clear ValueError rather than crash or silently
+        misdecode literals as if they were raw.
+        """
+        # A skewed-but-varied byte distribution: real zstd's heuristics
+        # reliably pick Huffman-coded literals for this shape over raw.
+        data = bytes((i * i) % 191 for i in range(20000))
+        compressed = _zstd_cli_compress(data, tmp_path)
+        try:
+            result = decompress(compressed)
+        except ValueError:
+            return  # expected: Huffman literals correctly rejected
+        # If the real CLI didn't actually choose Huffman literals for this
+        # input (heuristics can vary by zstd version), the least we require
+        # is that decode is still byte-exact — never silent corruption.
+        assert result == data


### PR DESCRIPTION
## Summary

- Fixes a real RFC 8878 conformance gap in `code/packages/python/zstd`: `decompress()` treated every sequence `Offset_Value` as an explicit back-reference distance and rejected `Offset_Value <= 3` with a `ValueError`. Real `zstd`-compressed data uses Repeated-Offset (R1/R2/R3, RFC 8878 §3.1.1.3.2.1.1) shortcuts constantly — especially on periodic/repetitive data — so a meaningful fraction of real-world `.zst` files failed to decode.
- This is the same decode-only gap independently found and fixed while implementing the first `c/zstd` port (#9941), documented as `lessons.md` Lesson 98. This PR audits and fixes the Python port against the same reference.
- `_decompress_block` now threads three frame-scoped Repeated_Offset registers (`rep = [R1, R2, R3]`, seeded `[1, 4, 8]` per RFC 8878, persisted across every Compressed block in a frame via `decompress()`'s block loop) and resolves `Offset_Value <= 3` via the RFC's `ll_is_zero`-shifted selector.
- Algorithm cross-checked against **both** the RFC 8878 prose and the literal `ZSTD_decodeSequence` reference C source (fetched directly from `github.com/facebook/zstd`, not recalled from memory), matching the already-verified `c/zstd` (#9941) fix. The encoder is intentionally unchanged — it still never emits repeat-offset codes; this is decode-only.

## Test plan

- [x] New `TestRepeatOffsetDecode` (2 tests): low-level unit tests exercising all four repeat-offset selector cases and cross-block register persistence directly against `_decompress_block`, independent of the real `zstd` CLI. Expected outputs are computed via an independent trivial LZ-apply helper fed hand-derived, RFC/reference-cross-checked `(ll, ml, offset)` triples — not re-derived from the implementation under test.
- [x] New `TestCliInterop::test_real_compress_our_decompress_repeat_offset_rle`: `b"A" * 500` compressed with the real `zstd` CLI (which reaches for a Repeat_Offset shortcut on this shape) now decodes byte-exact. Before this fix, this was the input shape that used to raise `ValueError` (via the pre-existing explicit reject) — confirmed by running the new tests against the pre-fix decoder first, which failed exactly as expected.
- [x] New `TestCliInterop::test_real_compress_our_decompress_repeat_offset_periodic`: a 53-byte-period, 10.6 KB payload compressed by the real CLI (forces many back-to-back matches at the same distance) decodes byte-exact.
- [x] Updated `TestCliInterop::test_real_compress_our_decompress_still_rejects_huffman_literals` (replaces the now-obsolete `..._rejects_unsupported_features`, which asserted the old, now-fixed repeat-offset rejection): confirms the still-unsupported, unrelated Huffman-literals limitation is unaffected by this decode-only sequences-section fix.
- [x] Full suite: 75/75 passing, 92.56% coverage (>90% required), `ruff check` clean.
- [x] `CHANGELOG.md` updated (0.1.1 -> 0.1.2), `pyproject.toml` version bumped to match.
- [x] Security review (sub-agent) passed — no findings. Specifically verified the new offset-resolution logic cannot produce a negative offset or bypass the existing `offset == 0 or offset > len(out)` bounds check on attacker-controlled compressed input.

Refs: #9941 (c/zstd, where this gap was first found), `lessons.md` Lesson 98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)