### PR TITLE
feat(human-languages): add the HL05 chapter capability data layer (HL-C02)

### DIFF
--- a/code/learning/human-languages/core/chapter-policy.json
+++ b/code/learning/human-languages/core/chapter-policy.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "note": "Tunable thresholds for the HL05 chapter payoff rule and the HL08 gentle-ramp budgets. Values are chosen from the corpus's own measured distribution so they are defensible rather than invented, and they live here rather than as constants in code so they can be tightened as debt burns down. Length is never a cost: no threshold here may penalise page, lesson, or chapter count.",
+  "payoffRepresentativeness": 0.5,
+  "maxNewAtomsPerLesson": 3,
+  "maxNewAtomsPerChapter": 12,
+  "provenance": {
+    "measuredAt": "2026-08-06",
+    "corpus": "1096 lessons, 531 schema-v2, 277 schema-v2 chapters",
+    "atomsPerLesson": { "mean": 2.31, "median": 2, "p90": 3, "max": 7 },
+    "atomsPerChapter": { "median": 3, "p75": 5, "p90": 10, "max": 31 },
+    "rationale": "maxNewAtomsPerLesson sits at the existing p90, so the median lesson is already compliant and only genuine spikes are flagged (52 lessons). maxNewAtomsPerChapter sits just above the chapter p90 of 10, flagging 17 chapters. payoffRepresentativeness starts at half a chapter's introduced atoms; it is a floor to be raised, not a target."
+  }
+}

--- a/code/learning/human-languages/spanish/chapters.json
+++ b/code/learning/human-languages/spanish/chapters.json
@@ -1,0 +1,72 @@
+{
+  "version": 1,
+  "language": "spanish",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapters 4 onward are authored in HL-C11; their absence here is real, measurable debt and must not be papered over with placeholders.",
+  "chapters": [
+    {
+      "chapter": 1,
+      "title": "Hola and Buenos Días",
+      "label": "ch:first-words",
+      "canDo": "I can greet someone in Spanish, say how I am, and wish them a good day.",
+      "spineNodes": ["SPINE-MEET-GREET"],
+      "payoff": {
+        "lesson": "ES-C01-practice",
+        "kind": "dialogue",
+        "summary": "A short doorway greeting: hola, an answer to how you are, and buenos días on the way in.",
+        "assesses": [
+          "ES-LEX-HOLA",
+          "ES-LEX-BIEN",
+          "ES-LEX-DIA",
+          "ES-LEX-BUENOS-DIAS",
+          "ES-MORPH-BUENO-BUENA",
+          "ES-GRAMMAR-NOUN-GENDER",
+          "ES-GRAMMAR-NOUN-NUMBER",
+          "ES-GRAMMAR-AGREEMENT-MASCULINE-PLURAL"
+        ]
+      }
+    },
+    {
+      "chapter": 2,
+      "title": "The Rest of the Greetings",
+      "label": "ch:greetings",
+      "canDo": "I can greet someone correctly at any hour — morning, afternoon, or night.",
+      "spineNodes": ["SPINE-TIME-OF-DAY"],
+      "payoff": {
+        "lesson": "ES-C02-practice",
+        "kind": "dialogue",
+        "summary": "The same greeting exchange run three times across the day, choosing the right form for each hour.",
+        "assesses": [
+          "ES-LEX-HOLA",
+          "ES-LEX-BUENOS-DIAS",
+          "ES-LEX-BUENAS-TARDES",
+          "ES-LEX-BUENAS-NOCHES",
+          "ES-GRAMMAR-NOUN-GENDER",
+          "ES-GRAMMAR-AGREEMENT-MASCULINE-PLURAL",
+          "ES-GRAMMAR-AGREEMENT-FEMININE-PLURAL"
+        ]
+      }
+    },
+    {
+      "chapter": 3,
+      "title": "Introducing Yourself",
+      "label": "ch:introductions",
+      "canDo": "I can give my name, ask someone else's, and say it was a pleasure to meet them.",
+      "spineNodes": ["SPINE-EXCHANGE-NAMES"],
+      "payoff": {
+        "lesson": "ES-C03-practice",
+        "kind": "dialogue",
+        "summary": "A first meeting start to finish: greet, exchange names at the right level of formality, and close with mucho gusto.",
+        "assesses": [
+          "ES-LEX-HOLA",
+          "ES-LEX-BUENOS-DIAS",
+          "ES-LEX-ME-LLAMO",
+          "ES-LEX-TU",
+          "ES-LEX-USTED",
+          "ES-LEX-COMO-SE-LLAMA",
+          "ES-LEX-TE-LLAMAS",
+          "ES-LEX-MUCHO-GUSTO"
+        ]
+      }
+    }
+  ]
+}

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added — HL05 chapter capability layer (data only, no gates)
+
+- Add `ChapterCapability`, `ChapterPayoff`, `TrackChapters`, and `ChapterPolicy`
+  types for the chapter capability ledger specified in
+  [`HL05`](../../../specs/HL05-chapter-capability-and-step-by-step-shape.md).
+  A chapter was previously nothing but an integer stamped on each lesson, so
+  nothing in the data model knew what a chapter was for and nothing could check
+  that finishing one left the reader able to do anything.
+- Add `loadTrackChapters()` and `loadChapterPolicy()` beside the existing
+  `loadLanguageCurricula()`. Tracks without a `chapters.json` are **skipped, not
+  defaulted** — an absent ledger means "not yet authored", which the gap report
+  must be able to tell apart from "authored and empty". Inventing a placeholder
+  would erase exactly the debt the report exists to measure.
+- Add `core/chapter-policy.json` carrying the HL05 payoff-representativeness
+  threshold and the HL08 gentle-ramp budgets, with the corpus measurements the
+  values were drawn from recorded alongside them. Thresholds sit at the existing
+  distribution: 3 new atoms per lesson (the current p90, flagging 52 lessons) and
+  12 per chapter (just above the chapter p90 of 10, flagging 17).
+- Add `spanish/chapters.json` covering Chapters 1–3 as the authored proof of
+  shape. Chapters 4 onward are deliberately absent rather than stubbed.
+- This slice ships **no validation gates**. Those are the next work item, and
+  they land report-only over all 379 chapters before any track fails on them.
+
 ### Fixed — live generated curriculum links
 
 - Preserve canonical Markdown links as live LaTeX `\href` targets instead of

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -67,6 +67,26 @@ mixedCurriculumFrontier(
 );
 ```
 
+### Chapter capabilities (HL05)
+
+A chapter used to be nothing but an integer on each lesson, so nothing could check
+that finishing one left the reader able to do anything. `<track>/chapters.json` is
+that missing promise — a first-person `canDo` plus a payoff the reader can deploy
+immediately — and `core/chapter-policy.json` holds the thresholds that judge it.
+
+```ts
+import { loadTrackChapters, loadChapterPolicy } from "@coding-adventures/human-language-data";
+
+const ledgers = loadTrackChapters();   // tracks WITHOUT a ledger are skipped, not defaulted
+const policy = loadChapterPolicy();    // payoff share + HL08 gentle-ramp budgets
+```
+
+The skip is deliberate. "Not yet authored" and "authored and empty" are different
+kinds of debt, and defaulting the first into the second would erase exactly what the
+gap report exists to measure. Ledgers are **authored intent** — unlike
+`curriculum.json`'s `omits`/`relocates`, which are recomputed caches, no validator
+may rewrite them.
+
 Build the JSON and readable gap reports locally with:
 
 ```bash

--- a/code/packages/typescript/human-language-data/src/index.ts
+++ b/code/packages/typescript/human-language-data/src/index.ts
@@ -59,6 +59,8 @@ export {
   loadLanguageRegistry,
   loadCurriculumSpine,
   loadLanguageCurricula,
+  loadTrackChapters,
+  loadChapterPolicy,
   loadBookCorpus,
   loadLessons,
   loadScripts,

--- a/code/packages/typescript/human-language-data/src/loader.ts
+++ b/code/packages/typescript/human-language-data/src/loader.ts
@@ -9,6 +9,7 @@ import { buildDataset, parseLesson, type ParsedLesson } from "./parse.js";
 import type {
   BookChapter,
   BookCorpus,
+  ChapterPolicy,
   CurriculumSpine,
   Dataset,
   LanguageCurriculum,
@@ -16,6 +17,7 @@ import type {
   Script,
   ScriptData,
   Taxonomy,
+  TrackChapters,
 } from "./types.js";
 
 /** Default curriculum root: code/learning/human-languages, relative to this package. */
@@ -52,6 +54,36 @@ export function loadLanguageCurricula(root = defaultCurriculumRoot()): LanguageC
     out.push(JSON.parse(readFileSync(path, "utf8")) as LanguageCurriculum);
   }
   return out.sort((left, right) => left.language.localeCompare(right.language));
+}
+
+/**
+ * Read each track's authored chapter capability ledger (HL05).
+ *
+ * Tracks without a `chapters.json` are skipped rather than defaulted. That is
+ * deliberate: an absent ledger means "not yet authored", which the gap report must
+ * be able to distinguish from "authored and empty". Inventing a placeholder here
+ * would erase exactly the debt the report exists to measure.
+ */
+export function loadTrackChapters(root = defaultCurriculumRoot()): TrackChapters[] {
+  const out: TrackChapters[] = [];
+  for (const track of readdirSync(root, { withFileTypes: true })) {
+    if (!track.isDirectory()) continue;
+    const path = join(root, track.name, "chapters.json");
+    if (!existsSync(path)) continue;
+    out.push(JSON.parse(readFileSync(path, "utf8")) as TrackChapters);
+  }
+  return out.sort((left, right) => left.language.localeCompare(right.language));
+}
+
+/**
+ * Read the tunable chapter policy. Unlike the ledgers above, this file is required:
+ * a missing policy would silently disable the payoff and ramp rules, and a gate that
+ * quietly stops running is worse than one that fails loudly.
+ */
+export function loadChapterPolicy(root = defaultCurriculumRoot()): ChapterPolicy {
+  return JSON.parse(
+    readFileSync(join(root, "core", "chapter-policy.json"), "utf8"),
+  ) as ChapterPolicy;
 }
 
 /**

--- a/code/packages/typescript/human-language-data/src/types.ts
+++ b/code/packages/typescript/human-language-data/src/types.ts
@@ -180,6 +180,80 @@ export interface LanguageCurriculum {
   extensions: CurriculumExtensionNode[];
 }
 
+// ---------------------------------------------------------------------------
+// HL05 — the chapter capability layer
+// ---------------------------------------------------------------------------
+//
+// A chapter used to be nothing but an integer stamped on each lesson. Nothing in
+// the data model knew what a chapter was FOR, so nothing could check that
+// finishing one left the reader able to do anything. These types are that missing
+// promise, made explicit and therefore checkable.
+//
+// The distinction that matters: `curriculum.json`'s `omits`/`relocates` ledgers are
+// recomputed CACHES — a validator derives them and errors on drift. A chapter
+// capability is authored INTENT. No validator may rewrite it.
+
+/** How a chapter proves its promise. */
+export type ChapterPayoffKind = "dialogue" | "task" | "production";
+
+/**
+ * The thing the reader can actually do at the end of a chapter.
+ *
+ * `assesses` is the load-bearing field. Without it a payoff could satisfy its
+ * chapter by exercising a single word, letting the chapter claim a capability it
+ * never delivered — which is the exact failure the representativeness rule exists
+ * to catch (HL05).
+ */
+export interface ChapterPayoff {
+  /** Lesson id that delivers the payoff — normally a practice/practice-mix/pattern. */
+  lesson: string;
+  kind: ChapterPayoffKind;
+  /** One line describing the payoff, for the chapter opening and the gap report. */
+  summary: string;
+  /** Knowledge atoms the payoff exercises. */
+  assesses: string[];
+}
+
+/** One chapter's authored promise. */
+export interface ChapterCapability {
+  chapter: number;
+  /** Printed chapter name. Canonical here; book-generation.json derives it. */
+  title: string;
+  /** LaTeX label, e.g. "ch:first-words". Canonical here. */
+  label: string;
+  /** One first-person sentence, in the reader's terms. */
+  canDo: string;
+  /** Shared spine nodes this chapter realizes; may be empty for local-only work. */
+  spineNodes: string[];
+  payoff: ChapterPayoff;
+  /** Optional HL06 figure ids. */
+  figures?: string[];
+}
+
+/** One track's chapter capability ledger (`<track>/chapters.json`). */
+export interface TrackChapters {
+  version: number;
+  language: string;
+  chapters: ChapterCapability[];
+}
+
+/**
+ * Tunable policy for the HL05 payoff rule and the HL08 gentle-ramp budgets.
+ *
+ * These live in `core/chapter-policy.json` rather than as constants at a call site
+ * precisely so they can be tightened as the corpus matures without hunting through
+ * code — the same reasoning that put the five-minute budget in the lesson schema.
+ */
+export interface ChapterPolicy {
+  version: number;
+  /** Minimum share of a chapter's introduced atoms its payoff must assess (0..1). */
+  payoffRepresentativeness: number;
+  /** HL08: most knowledge atoms one lesson may introduce. */
+  maxNewAtomsPerLesson: number;
+  /** HL08: most a whole chapter may introduce, so splitting cannot game the rule. */
+  maxNewAtomsPerChapter: number;
+}
+
 /** One authored chapter from an existing LaTeX book. */
 export interface BookChapter {
   language: string;

--- a/code/packages/typescript/human-language-data/tests/chapters.test.ts
+++ b/code/packages/typescript/human-language-data/tests/chapters.test.ts
@@ -1,0 +1,183 @@
+// HL05 chapter capability layer — loader and policy round-trip.
+//
+// This slice deliberately ships NO gates (those are HL-C03). What it must prove is
+// narrower and more foundational: that the ledger and the policy load off real disk
+// with the shapes the gates will later depend on, and that an unauthored track is
+// distinguishable from an empty one. If that distinction collapses, the gap report
+// silently loses the debt it exists to measure.
+
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  loadTrackChapters,
+  loadChapterPolicy,
+  defaultCurriculumRoot,
+  loadLessons,
+} from "../src/loader.js";
+import type { TrackChapters, ChapterPolicy } from "../src/types.js";
+
+const policy = loadChapterPolicy();
+const ledgers = loadTrackChapters();
+
+describe("chapter policy", () => {
+  it("loads with every tunable present", () => {
+    expect(policy.version).toBe(1);
+    expect(typeof policy.payoffRepresentativeness).toBe("number");
+    expect(typeof policy.maxNewAtomsPerLesson).toBe("number");
+    expect(typeof policy.maxNewAtomsPerChapter).toBe("number");
+  });
+
+  it("keeps representativeness a share, not a count", () => {
+    expect(policy.payoffRepresentativeness).toBeGreaterThan(0);
+    expect(policy.payoffRepresentativeness).toBeLessThanOrEqual(1);
+  });
+
+  it("keeps the chapter ramp budget at or above the lesson budget", () => {
+    // A chapter that may introduce less than a single lesson would be incoherent.
+    expect(policy.maxNewAtomsPerChapter).toBeGreaterThanOrEqual(policy.maxNewAtomsPerLesson);
+  });
+
+  it("records the measurement its thresholds were drawn from", () => {
+    // The thresholds are only defensible if the distribution behind them is written
+    // down. Without this, a later reader cannot tell a measured value from a guess.
+    const raw = policy as ChapterPolicy & { provenance?: Record<string, unknown> };
+    expect(raw.provenance).toBeDefined();
+    expect(raw.provenance?.corpus).toBeTruthy();
+    expect(raw.provenance?.rationale).toBeTruthy();
+  });
+});
+
+describe("chapter capability ledgers", () => {
+  it("loads at least the authored Spanish ledger", () => {
+    expect(ledgers.length).toBeGreaterThanOrEqual(1);
+    expect(ledgers.map((l) => l.language)).toContain("spanish");
+  });
+
+  it("returns ledgers in stable language order", () => {
+    const languages = ledgers.map((l) => l.language);
+    expect(languages).toEqual([...languages].sort());
+  });
+
+  it("gives every authored chapter a capability and a payoff", () => {
+    for (const ledger of ledgers) {
+      for (const chapter of ledger.chapters) {
+        expect(Number.isInteger(chapter.chapter)).toBe(true);
+        expect(chapter.title.trim()).not.toBe("");
+        expect(chapter.label.trim()).not.toBe("");
+        expect(chapter.canDo.trim()).not.toBe("");
+        expect(chapter.payoff.lesson.trim()).not.toBe("");
+        expect(chapter.payoff.summary.trim()).not.toBe("");
+        expect(chapter.payoff.assesses.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("states each canDo in the first person, as the reader's own claim", () => {
+    for (const ledger of ledgers) {
+      for (const chapter of ledger.chapters) {
+        expect(chapter.canDo.startsWith("I can ")).toBe(true);
+      }
+    }
+  });
+
+  it("uses one entry per chapter number per track", () => {
+    for (const ledger of ledgers) {
+      const numbers = ledger.chapters.map((c) => c.chapter);
+      expect(new Set(numbers).size).toBe(numbers.length);
+    }
+  });
+
+  it("points every payoff at a lesson that exists in that same chapter", () => {
+    const lessons = loadLessons();
+    const byId = new Map(lessons.map((l) => [String(l.frontmatter.id), l]));
+    for (const ledger of ledgers) {
+      for (const chapter of ledger.chapters) {
+        const lesson = byId.get(chapter.payoff.lesson);
+        expect(lesson, `${ledger.language} ch${chapter.chapter} payoff`).toBeDefined();
+        expect(lesson?.language).toBe(ledger.language);
+        expect(Number(lesson?.frontmatter.chapter)).toBe(chapter.chapter);
+      }
+    }
+  });
+
+  it("only claims atoms the payoff lesson actually practises", () => {
+    // The payoff's `assesses` is a claim about a real lesson. If it can drift from
+    // that lesson's own declared practice set, the representativeness gate would be
+    // measuring authored optimism rather than taught material.
+    const lessons = loadLessons();
+    const byId = new Map(lessons.map((l) => [String(l.frontmatter.id), l]));
+    for (const ledger of ledgers) {
+      for (const chapter of ledger.chapters) {
+        const lesson = byId.get(chapter.payoff.lesson);
+        const practised = new Set(
+          (lesson?.frontmatter["practises.knowledge"] as string[] | undefined) ?? [],
+        );
+        for (const atom of chapter.payoff.assesses) {
+          expect(practised.has(atom), `${chapter.payoff.lesson} practises ${atom}`).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("matches the titles and labels the book generator still owns", () => {
+    // HL-C04 inverts this dependency so chapters.json becomes canonical. Until then
+    // the two must agree, or the transition would silently rename printed chapters.
+    const config = JSON.parse(
+      readFileSync(join(defaultCurriculumRoot(), "core", "book-generation.json"), "utf8"),
+    ) as { targets: { language: string; chapter: number; title: string; label: string }[] };
+    for (const ledger of ledgers) {
+      for (const chapter of ledger.chapters) {
+        const target = config.targets.find(
+          (t) => t.language === ledger.language && t.chapter === chapter.chapter,
+        );
+        if (!target) continue;
+        expect(chapter.title).toBe(target.title);
+        expect(chapter.label).toBe(target.label);
+      }
+    }
+  });
+});
+
+describe("loadTrackChapters on a synthetic root", () => {
+  function withRoot(build: (root: string) => void): TrackChapters[] {
+    const root = mkdtempSync(join(tmpdir(), "hl-chapters-"));
+    try {
+      build(root);
+      return loadTrackChapters(root);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+
+  it("skips tracks with no ledger rather than inventing one", () => {
+    const loaded = withRoot((root) => {
+      mkdirSync(join(root, "klingon"));
+      // no chapters.json written
+    });
+    expect(loaded).toEqual([]);
+  });
+
+  it("distinguishes an unauthored track from an authored-but-empty one", () => {
+    // This is the distinction the gap report depends on: "not yet written" and
+    // "written, covering nothing" are different kinds of debt.
+    const loaded = withRoot((root) => {
+      mkdirSync(join(root, "absent"));
+      mkdirSync(join(root, "empty"));
+      writeFileSync(
+        join(root, "empty", "chapters.json"),
+        JSON.stringify({ version: 1, language: "empty", chapters: [] }),
+      );
+    });
+    expect(loaded.map((l) => l.language)).toEqual(["empty"]);
+    expect(loaded[0]?.chapters).toEqual([]);
+  });
+
+  it("ignores stray files that are not directories", () => {
+    const loaded = withRoot((root) => {
+      writeFileSync(join(root, "README.md"), "not a track");
+    });
+    expect(loaded).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

A chapter was previously nothing but an integer stamped on each lesson. Nothing in the data model knew what a chapter was **for**, so nothing could check that finishing one left the reader able to do anything — a reader could complete thirty lessons, hold thirty words with accurate etymologies, and still not own a usable exchange.

This is the first implementation slice of [HL05](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/HL05-chapter-capability-and-step-by-step-shape.md). It adds the missing object and nothing else.

**No validation gates ship here.** Those land next (HL-C03), report-only over all 379 chapters, so existing debt is measured rather than retroactively treated as a regression — the HL-V01 precedent.

## What changed

**Types** (`src/types.ts`) — `ChapterCapability`, `ChapterPayoff`, `TrackChapters`, `ChapterPolicy`.

The load-bearing field is `payoff.assesses`. Without it, a payoff could satisfy its chapter by exercising a single word, letting the chapter claim a capability it never delivered.

**Loaders** (`src/loader.ts`) — `loadTrackChapters()` and `loadChapterPolicy()`, beside the existing `loadLanguageCurricula()`.

Two deliberate asymmetries:
- Tracks without a `chapters.json` are **skipped, not defaulted**. "Not yet authored" and "authored and empty" are different kinds of debt, and collapsing the first into the second would erase exactly what the gap report exists to measure.
- The policy file, by contrast, is **required**. A missing policy would silently disable the payoff and ramp rules, and a gate that quietly stops running is worse than one that fails loudly.

**Policy** (`core/chapter-policy.json`) — thresholds drawn from the corpus's own measured distribution rather than invented, with that measurement recorded beside them:

| Threshold | Value | Basis |
|---|---|---|
| `maxNewAtomsPerLesson` | 3 | the existing p90 (mean 2.31, median 2) — flags 52 lessons |
| `maxNewAtomsPerChapter` | 12 | just above the chapter p90 of 10 — flags 17 chapters |
| `payoffRepresentativeness` | 0.5 | a floor to raise, not a target |

**Proof of shape** (`spanish/chapters.json`) — Chapters 1–3, the fully migrated schema-v2 slice. Chapters 4 onward are deliberately absent rather than stubbed.

## A finding worth carrying forward

Spanish Chapter 3 introduces **24 atoms** while its payoff exercises **8** — so it will fail representativeness at 0.5 once the gate lands in HL-C03.

That is the gate working, not a reason to weaken it. Chapter 3 teaches names, formality (`tú`/`usted`), the `qu-` family, and *mucho gusto*, and its practice lesson only recombines part of that. It is a real candidate for splitting, which is also the direction the gentle-ramp budget pushes.

## Verification

- `npx tsc --noEmit` clean.
- **123 tests passing** across 14 files in the package; 15 of them new.
- New tests cover the policy shape, first-person `canDo` phrasing, per-chapter uniqueness, payoff-lesson resolution against the real corpus, and — importantly — that every atom a payoff claims is one its lesson actually declares in `practises.knowledge`, so the ledger cannot drift into authored optimism.
- Synthetic-root tests prove the unauthored / authored-but-empty distinction survives, since the gap report depends on it.
- `/security-review` **passed in one round**, with the loaders' filesystem boundary, `JSON.parse` prototype-pollution surface, and temp-file handling specifically in scope.
- No build artifacts or lockfile churn staged; files added by explicit path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw3PKmLS2yEnDmhck3fM1z)_