### PR TITLE
ci(human-languages): deploy language-ladder to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-language-ladder.yml
+++ b/.github/workflows/deploy-language-ladder.yml
@@ -72,8 +72,18 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
+      # persist-credentials: false — checkout otherwise writes an x-access-token
+      # carrying this job's `contents: write` scope into .git/config, and the npm
+      # steps below then execute lifecycle scripts from the whole transitive dep
+      # tree in that same workspace. One compromised transitive package could read
+      # the token and push to the repo. peaceiris/actions-gh-pages builds its own
+      # authenticated remote from the github_token input and never consults the
+      # persisted credential, so dropping it costs nothing here. Precedent:
+      # build-ocaml.yml lines 48, 80, 198.
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy-language-ladder.yml
+++ b/.github/workflows/deploy-language-ladder.yml
@@ -1,0 +1,111 @@
+# ================================================================
+# Deploy Language Ladder to GitHub Pages
+# ================================================================
+#
+# Builds the language-ladder Vite SPA (the HL03 unified curriculum app)
+# and deploys it to the gh-pages branch under human-languages/language-ladder/,
+# preserving everything else already published there (human-languages/books/,
+# engram/, logic-gates/, ...) via keep_files.
+#
+# Pages serves from the gh-pages branch (legacy mode), so the app lands at:
+#   https://adhithyan15.github.io/coding-adventures/human-languages/language-ladder/
+#
+# Why nested under human-languages/ rather than a flat top-level directory:
+# the Human Languages track already owns that namespace on gh-pages —
+# human-languages-books.yml publishes the book catalog to
+# human-languages/books/. The ladder is the interactive companion to those
+# books, drawn from the same curriculum, so it belongs beside them rather
+# than scattered among the unrelated visualizers at the root.
+#
+# NOTE — no VITE_BASE here, unlike deploy-engram.yml. That workflow has to
+# inject an absolute base because engram-app reads `process.env.VITE_BASE`.
+# language-ladder's vite.config.ts instead hardcodes `base: "./"`, so every
+# asset URL in the built index.html is already relative and resolves correctly
+# from any sub-path. Setting VITE_BASE here would do nothing — the app never
+# reads it — so the relative base is what we rely on.
+#
+# ---------------------------------------------------------------
+# Trigger paths: why they are broader than "just the app"
+# ---------------------------------------------------------------
+# The build inlines content from OUTSIDE the app directory:
+#
+#   code/packages/typescript/human-language-data  ← the one runtime `file:` dep
+#   code/learning/human-languages/**              ← imported directly by src/:
+#                                                   core/languages.json,
+#                                                   core/spine.json,
+#                                                   core/generated-book-hashes.json,
+#                                                   */curriculum.json (glob),
+#                                                   */lessons/*.md (glob),
+#                                                   data/scripts/*.json,
+#                                                   _fonts/*.ttf
+#
+# Because that curriculum content is bundled at build time, a new lesson or a
+# corrected glyph table only reaches readers when this workflow re-runs. Leaving
+# code/learning/human-languages out of the path filter would silently freeze the
+# published app at whatever the curriculum looked like on its last deploy.
+
+name: Deploy Language Ladder
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "code/programs/typescript/language-ladder/**"
+      - "code/packages/typescript/human-language-data/**"
+      - "code/learning/human-languages/**"
+      - ".github/workflows/deploy-language-ladder.yml"
+  workflow_dispatch:
+
+# The workflow only needs to push the built assets onto the gh-pages branch.
+# `contents: write` is the whole of it — no packages, no id-token, no pull
+# requests. Same minimum deploy-engram.yml uses.
+permissions:
+  contents: write
+
+# Two overlapping runs would both try to push to gh-pages and the loser fails
+# on a non-fast-forward. Serialize instead; only the newest content matters.
+concurrency:
+  group: deploy-language-ladder
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      # Per lessons.md ("Clean Vite deploys with source-level `file:`
+      # dependencies must install every local source package in dependency
+      # order"): human-language-data declares `main: src/index.ts`, so Vite
+      # follows the `file:` symlink back into the package's TypeScript SOURCE
+      # and compiles it as part of this app. Source needs the package's own
+      # node_modules present; a fresh runner has none until we install here.
+      # This mirrors the app's own BUILD file, which installs the dep first
+      # for exactly this reason. Do not collapse it into the app's install
+      # with --install-links.
+      - name: Install package dependencies
+        run: cd code/packages/typescript/human-language-data && npm install
+
+      - name: Install app dependencies
+        run: cd code/programs/typescript/language-ladder && npm install
+
+      - name: Build for GitHub Pages
+        run: cd code/programs/typescript/language-ladder && npm run build
+
+      # Fail loudly here rather than silently publishing an empty directory.
+      - name: Verify build output
+        run: test -s code/programs/typescript/language-ladder/dist/index.html
+
+      - name: Deploy to GitHub Pages (human-languages/language-ladder/)
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: code/programs/typescript/language-ladder/dist
+          destination_dir: human-languages/language-ladder
+          keep_files: true

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## Unreleased — continuous deployment to GitHub Pages
+
+### Added — the app is published for the first time
+
+- Add `.github/workflows/deploy-language-ladder.yml`. Until now the app had
+  481 passing tests and no way for anyone to actually use it: no workflow
+  referenced it, so it had never been published. It now builds on every push
+  to `main` that touches its inputs and deploys to the `gh-pages` branch at
+  <https://adhithyan15.github.io/coding-adventures/human-languages/language-ladder/>.
+- Publish under `human-languages/language-ladder` rather than a flat top-level
+  directory, joining the book catalog already at `human-languages/books`, and
+  set `keep_files: true` so other published apps on `gh-pages` survive.
+- Trigger on `code/learning/human-languages/**` as well as this app and the
+  `human-language-data` package. `src/` imports the curriculum content
+  directly, so lessons, `spine.json`, script data, and fonts are bundled at
+  build time — without that trigger the published app would freeze at the
+  curriculum's state on its last deploy.
+- Install `human-language-data` before this app in CI, mirroring the `BUILD`
+  file, because the package resolves to TypeScript source and needs its own
+  `node_modules` on a clean runner.
+
+### Notes
+
+- No `VITE_BASE` handling was added. `vite.config.ts` already sets
+  `base: "./"`, so built asset URLs are relative and work from the Pages
+  sub-path as-is; an absolute base like `engram-app`'s would be redundant.
+
 ## Unreleased — schema-v2 lesson compatibility
 
 ### Changed — Persian and Urdu Chapter 5 frontiers

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -233,6 +233,32 @@ npm run build      # production build to dist/
 npm run preview    # serve the production build
 ```
 
+## Deployed
+
+**Live:** <https://adhithyan15.github.io/coding-adventures/human-languages/language-ladder/>
+
+`.github/workflows/deploy-language-ladder.yml` builds the app and pushes
+`dist/` to the `gh-pages` branch under `human-languages/language-ladder/`,
+beside the book catalog at `human-languages/books/` that the same curriculum
+feeds. `keep_files: true`, so publishing the ladder never disturbs the other
+apps already on that branch.
+
+No deploy-specific base path is needed: `vite.config.ts` sets `base: "./"`, so
+every asset URL in the built `index.html` is relative and the bundle works
+unchanged from a Pages sub-path, a local `file://` open, or `npm run preview`.
+
+The workflow re-runs on pushes to `main` that touch this app, the
+`human-language-data` package, or **`code/learning/human-languages/**`**. That
+last path matters: `src/` imports the curriculum itself — `languages.json`,
+`spine.json`, every `*/curriculum.json`, every `*/lessons/*.md`, the script
+tables, and the Arabic font — so lesson content is *baked into the bundle at
+build time*. A new lesson only reaches readers once this workflow runs again.
+
+Build order is load-bearing, and CI mirrors this app's `BUILD` file: install
+`code/packages/typescript/human-language-data` **first**, then this app. That
+package ships TypeScript source (`main: src/index.ts`), so Vite compiles it in
+place and it needs its own `node_modules` on a clean runner.
+
 ## Practice mode (recall drill)
 
 Toggle **Practice** to drill *recall*: the app shows a **sound** and you pick the


### PR DESCRIPTION
## Why

The HL03 unified curriculum app (`language-ladder`) has **481 passing tests and has never been published**. No workflow referenced it, so the only way to use it was to clone the repo and start a dev server — all the curriculum work behind it was effectively unreachable by readers. This publishes it.

**Live URL (once merged):**
https://adhithyan15.github.io/coding-adventures/human-languages/language-ladder/

## What

Adds `.github/workflows/deploy-language-ladder.yml`, modeled on `deploy-engram.yml`, plus README/CHANGELOG updates.

Three deliberate differences from the engram workflow, each justified:

**1. Published under `human-languages/language-ladder`, not a flat top-level dir.**
Most app deploys use a flat directory (`engram/`, `logic-gates/`), but the Human Languages track already owns a namespace on `gh-pages` — `human-languages-books.yml` publishes the book catalog to `human-languages/books/`. The ladder is the interactive companion to those books, built from the same curriculum, so it belongs beside them rather than scattered among the unrelated root visualizers. `keep_files: true` so every other published app survives.

**2. No `VITE_BASE`.**
I checked: `engram-app/vite.config.ts` reads `process.env.VITE_BASE ?? "./"`, which is why its workflow injects an absolute base. **`language-ladder/vite.config.ts` does not — it hardcodes `base: "./"`.** Asset URLs in the built `index.html` are therefore already relative and resolve correctly from a Pages sub-path. Setting `VITE_BASE` here would be inert, so no env var was invented for it; the deploy relies on the existing relative base.

**3. Triggers include `code/learning/human-languages/**`.**
Beyond the app and the `human-language-data` package, `src/` imports the curriculum *directly*: `core/languages.json`, `core/spine.json`, `core/generated-book-hashes.json`, every `*/curriculum.json`, every `*/lessons/*.md` (glob), `data/scripts/*.json`, and `_fonts/NotoNaskhArabic-Static.ttf`. That content is bundled at build time, so **omitting this path would mean a newly authored lesson never reaches the published app**, silently freezing it at the curriculum's state on its last deploy.

## Dependency install order

Per `lessons.md` — *"Clean Vite deploys with source-level `file:` dependencies must install every local source package in dependency order"* — CI installs `human-language-data` **first**, then the app, mirroring the app's own `BUILD` file. That package declares `main: src/index.ts`, so Vite follows the `file:` symlink into its TypeScript source and compiles it in place; it needs its own `node_modules` on a clean runner. `npm install --install-links` is deliberately not used.

## Verification (run locally exactly as CI will)

```
cd code/packages/typescript/human-language-data && npm install   # dep first
cd code/programs/typescript/language-ladder     && npm install
npm run build   # ✅ dist/index.html + assets produced
npx vitest run  # ✅ 30 files, 481 tests passing
```

`dist/` contains `index.html`, the JS/CSS bundles, and the vendored Arabic font. The workflow also asserts `test -s dist/index.html` before deploying, so a broken build fails loudly instead of publishing an empty directory.

No `node_modules`, `dist`, or lockfile churn is committed — `npm install` rewrote `libc` fields in both `package-lock.json` files (an npm-version artifact); those were reverted and only three files are staged.

## Security review

- **No injection surface** — the only `${{ }}` expression is `secrets.GITHUB_TOKEN` passed as an *action input*, never into a `run:` block. No `github.event.*` value (PR title, branch name, commit message) reaches any shell.
- **No fork-PR exposure** — triggers are `push` to `main` and `workflow_dispatch` (no inputs). Deliberately *not* `pull_request_target`, so the `contents: write` token is never handed to unreviewed fork code.
- **Minimal permissions** — `contents: write` and nothing else, matching engram. No `id-token`, `packages`, or `pull-requests`.
- **Bounded blast radius** — `destination_dir` is a static literal and `keep_files: true`, so the job cannot clobber sibling published apps.
- **Token never logged** — it flows only into the deploy action's input.
- A `concurrency` group was added (engram has none) so two overlapping runs can't both push to `gh-pages` and lose on a non-fast-forward.

## Notes for the backlog

- **Landing page** — `code/programs/static/landing-page` (deployed by `deploy-root.yml`) may need a link to the ladder; not touched here.
- **Bundle size** — the app builds to a single **3.9 MB** JS chunk (992 KB gzipped), because the entire multi-language curriculum is inlined. Worth code-splitting per language track.
- **Supply chain, repo-wide** — every deploy workflow (this one included) runs `npm install`, executing dependency lifecycle scripts in a job holding `contents: write`. Splitting build and deploy into separate jobs, or pinning actions to SHAs rather than mutable `@v4` tags, would harden all of them together; doing it for one workflow alone would just be inconsistent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw3PKmLS2yEnDmhck3fM1z)_