### PR TITLE
feat(human-languages): add the Latin chapter capability ledger

### DIFF
--- a/code/learning/human-languages/latin/CHANGELOG.md
+++ b/code/learning/human-languages/latin/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## Chapter capability ledger — all 36 chapters
+
+- Adds [`chapters.json`](./chapters.json), the track's
+  [HL05](../../../specs/HL05-chapter-capability-and-step-by-step-shape.md)
+  capability ledger: one entry per chapter carrying a first-person `canDo`, the
+  shared spine nodes the chapter realises, and a `payoff` naming the lesson that
+  delivers the chapter's usable result.
+- Covers **all 36 chapters with no skips**. Every Latin chapter's terminal lesson
+  is already schema v2 with a non-empty `practises.knowledge`, so nothing here is
+  a placeholder and nothing was omitted as schema-v1 debt.
+- Copies each `payoff.assesses` verbatim from its payoff lesson's own
+  `practises.knowledge`, so the ledger cannot claim an atom the lesson does not
+  actually practise. Every chapter's payoff exercises **100%** of the atoms its
+  own chapter introduces, clearing the 0.5 representativeness threshold in
+  `core/chapter-policy.json` with room to spare.
+- Records two honest facts about the track rather than papering over them.
+  Chapter 1 is the only chapter with a terminal `practice` lesson
+  (`LA-C01-practice`); every other chapter's payoff is its last lesson by
+  `sequence`, which is where that chapter's recombination and wrap-up recall live.
+  Chapter 1 is also the only Latin chapter with no `core/book-generation.json`
+  target, so its `title` and `label` come from its hand-written
+  `book/chapters/ch01-greetings.tex`.
+- Leaves lessons, curriculum, spine, and book output untouched: this is a new
+  capability layer above the corpus, not a revision of it.
+
 ## Warning-free 36-chapter book
 
 - Supplies Latin Modern's matching small-caps face explicitly, keeps chapter

--- a/code/learning/human-languages/latin/README.md
+++ b/code/learning/human-languages/latin/README.md
@@ -31,6 +31,41 @@ book.
   hashes keep every later app/book chapter pair aligned.
 - Every lesson has a shared-spine placement, explicit knowledge boundaries, and
   an effective duration below five minutes.
+- **All 36 chapters carry a capability entry** in
+  [`chapters.json`](./chapters.json) — no chapter is skipped, and no entry is a
+  stub.
+
+## Chapter capability ledger
+
+[`chapters.json`](./chapters.json) is this track's
+[HL05](../../../specs/HL05-chapter-capability-and-step-by-step-shape.md) ledger.
+It answers, per chapter, the question the lesson corpus alone cannot: *what can I
+do when I finish this?*
+
+Each entry carries:
+
+- **`canDo`** — one first-person sentence, in the reader's own words. "I can wish
+  someone a good night in Latin, and say why the wish takes the accusative case."
+- **`spineNodes`** — the shared spine nodes this chapter realises, derived from
+  the `path` segments in [`curriculum.json`](./curriculum.json). Chapter 1 spans
+  four (`SPINE-MEET-GREET`, `SPINE-TAKE-LEAVE`, `SPINE-COURTESY-THANK`,
+  `SPINE-RESPOND-BASIC`); most later chapters realise exactly one.
+- **`payoff`** — the lesson that delivers the chapter's usable result, its kind
+  (`dialogue`, `task`, or `production`), a one-line summary of the actual
+  exchange, and the knowledge atoms it exercises.
+
+Two properties of this track are worth stating plainly, because the ledger is
+where they become visible:
+
+1. **Only Chapter 1 has a terminal practice lesson.** `LA-C01-practice` is the
+   track's single `type: practice` step. Every other chapter's payoff is its last
+   lesson by `sequence` — which is genuinely where that chapter's recombination
+   and wrap-up recall happen, but is not a dedicated consolidation step. A future
+   tranche that adds practice lessons should update the payoff pointers here.
+2. **`assesses` is copied from the payoff lesson, never invented.** Each list is
+   exactly that lesson's own `practises.knowledge`, so the ledger cannot overstate
+   what a chapter delivers. On that basis every Latin chapter's payoff exercises
+   100% of the atoms its chapter introduces.
 
 ## Book
 
@@ -39,7 +74,9 @@ Modern font — no vendored font needed): `latexmk -xelatex book.tex`.
 
 ## Files
 
-- [`lessons/`](./lessons/) · [`pronunciation-reference.md`](./pronunciation-reference.md)
+- [`lessons/`](./lessons/) · [`chapters.json`](./chapters.json)
+  · [`curriculum.json`](./curriculum.json)
+  · [`pronunciation-reference.md`](./pronunciation-reference.md)
   · [`roadmap.md`](./roadmap.md) · [`session-map.md`](./session-map.md)
   · [`book/`](./book/)
 

--- a/code/learning/human-languages/latin/chapters.json
+++ b/code/learning/human-languages/latin/chapters.json
@@ -1,0 +1,783 @@
+{
+  "version": 1,
+  "language": "latin",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. All 36 Latin chapters are authored here. Only Chapter 1 owns a terminal practice lesson; every other chapter's payoff is its last lesson by sequence, which is where that chapter's recombination and wrap-up recall actually live. Chapter 1's title and label come from its hand-written book/chapters/ch01-greetings.tex, the only Latin chapter with no core/book-generation.json target.",
+  "chapters": [
+    {
+      "chapter": 1,
+      "title": "Greetings",
+      "label": "ch:greetings",
+      "canDo": "I can greet someone in Latin, thank them, answer yes or no, and say goodbye.",
+      "spineNodes": [
+        "SPINE-MEET-GREET",
+        "SPINE-TAKE-LEAVE",
+        "SPINE-COURTESY-THANK",
+        "SPINE-RESPOND-BASIC"
+      ],
+      "payoff": {
+        "lesson": "LA-C01-practice",
+        "kind": "dialogue",
+        "summary": "The whole doorway sequence on cue: salvē or avē on arrival, grātiās tibi agō, ita or nōn, and valē on the way out.",
+        "assesses": [
+          "LA-PHONO-SALVE-01",
+          "LA-ETYMON-SALVE-02",
+          "LA-GRAMMAR-SALVE-03",
+          "LA-PHONO-AVE-01",
+          "LA-ETYMON-AVE-02",
+          "LA-LEX-AVE-03",
+          "LA-PHONO-VALE-01",
+          "LA-ETYMON-VALE-02",
+          "LA-GRAMMAR-VALE-03",
+          "LA-PHONO-GRATIAS-01",
+          "LA-ETYMON-GRATIAS-02",
+          "LA-GRAMMAR-GRATIAS-03",
+          "LA-PHONO-ITA-NON-01",
+          "LA-ETYMON-ITA-NON-02",
+          "LA-LEX-ITA-NON-03",
+          "LA-ETYMON-PRACTICE-01"
+        ]
+      }
+    },
+    {
+      "chapter": 2,
+      "title": "Numbers One to Ten",
+      "label": "ch:la-numbers-one-to-ten",
+      "canDo": "I can count from one to ten in Latin and say why September sits in the ninth month.",
+      "spineNodes": [
+        "SPINE-COUNT-ONE-TO-FIVE"
+      ],
+      "payoff": {
+        "lesson": "LA-C02-numbers-6-10",
+        "kind": "task",
+        "summary": "Count ūnus to decem aloud, then read the Roman tally VI-X and place September against Rome's March-start year.",
+        "assesses": [
+          "LA-LEX-NUMBERS-1-5-01",
+          "LA-ETYMON-NUMBERS-1-5-02",
+          "LA-GRAMMAR-NUMBERS-1-5-03",
+          "LA-LEX-NUMBERS-6-10-01",
+          "LA-LEX-NUMBERS-6-10-02",
+          "LA-ETYMON-NUMBERS-6-10-03"
+        ]
+      }
+    },
+    {
+      "chapter": 3,
+      "title": "Please",
+      "label": "ch:la-please",
+      "canDo": "I can soften a Latin request the way Romans did, with quaesō or sīs instead of a word for please.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "LA-C03-quaeso",
+        "kind": "dialogue",
+        "summary": "Attach quaesō to a real request — dā mihi aquam, quaesō — and swap in sīs for the if-you-wish version.",
+        "assesses": [
+          "LA-PHONO-SALVE-01",
+          "LA-ETYMON-SALVE-02",
+          "LA-GRAMMAR-SALVE-03",
+          "LA-ETYMON-QUAESO-01",
+          "LA-PRAGMATICS-QUAESO-02"
+        ]
+      }
+    },
+    {
+      "chapter": 4,
+      "title": "Sorry",
+      "label": "ch:la-sorry",
+      "canDo": "I can apologise in Latin with ignōsce mihi, and use paenitet mē when I want to name the regret instead.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "LA-C04-ignosce-mihi",
+        "kind": "dialogue",
+        "summary": "Apologise to someone's face with ignōsce mihi, then contrast it with paenitet mē, which names regret rather than asking pardon.",
+        "assesses": [
+          "LA-ETYMON-QUAESO-01",
+          "LA-PRAGMATICS-QUAESO-02",
+          "LA-ETYMON-IGNOSCE-MIHI-01",
+          "LA-PRAGMATICS-IGNOSCE-MIHI-02"
+        ]
+      }
+    },
+    {
+      "chapter": 5,
+      "title": "Days of the Week",
+      "label": "ch:la-days-of-the-week",
+      "canDo": "I can name all seven Roman weekdays and say which modern names kept Rome's gods and which were rewritten.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "LA-C05-saturni-solis",
+        "kind": "task",
+        "summary": "Name the full seven-day planetary week, then sort Saturday and Sunday by which languages kept Rome's gods and which renamed them.",
+        "assesses": [
+          "LA-LEX-DIES-LUNAE-VENERIS-01",
+          "LA-PRAGMATICS-DIES-LUNAE-VENERIS-02",
+          "LA-LEX-SATURNI-SOLIS-01",
+          "LA-PRAGMATICS-SATURNI-SOLIS-02"
+        ]
+      }
+    },
+    {
+      "chapter": 6,
+      "title": "Colours",
+      "label": "ch:la-colours",
+      "canDo": "I can say black, white, red, and blue in Latin, and explain why its blue was never as settled as its red.",
+      "spineNodes": [
+        "SPINE-DEFINITE-REFERENCE"
+      ],
+      "payoff": {
+        "lesson": "LA-C06-ruber-caeruleus",
+        "kind": "production",
+        "summary": "Say niger, albus, ruber, and caeruleus in turn, and split ruber's two children between French rouge and Spanish rojo.",
+        "assesses": [
+          "LA-LEX-NIGER-ALBUS-01",
+          "LA-PRAGMATICS-NIGER-ALBUS-02",
+          "LA-ETYMON-RUBER-CAERULEUS-01",
+          "LA-ETYMON-RUBER-CAERULEUS-02"
+        ]
+      }
+    },
+    {
+      "chapter": 7,
+      "title": "Family",
+      "label": "ch:la-family",
+      "canDo": "I can name my father, mother, brother, and sister in Latin, and say why Spanish stopped using frāter.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "LA-C07-frater-soror",
+        "kind": "production",
+        "summary": "Name the four household members aloud, then trace frāter germānus down to Spanish hermano.",
+        "assesses": [
+          "LA-ETYMON-PATER-MATER-01",
+          "LA-ETYMON-PATER-MATER-02",
+          "LA-ETYMON-FRATER-SOROR-01",
+          "LA-ETYMON-FRATER-SOROR-02",
+          "LA-PRAGMATICS-FRATER-SOROR-03"
+        ]
+      }
+    },
+    {
+      "chapter": 8,
+      "title": "Head and Hand",
+      "label": "ch:la-head-and-hand",
+      "canDo": "I can say head and hand in Latin, and explain why manus is feminine when its declension usually is not.",
+      "spineNodes": [
+        "SPINE-CHECK-WELLBEING"
+      ],
+      "payoff": {
+        "lesson": "LA-C08-manus",
+        "kind": "production",
+        "summary": "Say caput and manus with the correct gender, then list the manus words English still runs on.",
+        "assesses": [
+          "LA-ETYMON-CAPUT-01",
+          "LA-PRAGMATICS-CAPUT-02",
+          "LA-ETYMON-MANUS-01",
+          "LA-ETYMON-MANUS-02"
+        ]
+      }
+    },
+    {
+      "chapter": 9,
+      "title": "Seasons",
+      "label": "ch:la-seasons",
+      "canDo": "I can name the four seasons in Latin and say which ones Romance rebuilt out of a phrase instead.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "LA-C09-anni-tempora",
+        "kind": "production",
+        "summary": "Name vēr, aestās, autumnus, and hiems, then sort which survived plainly and which Romance rebuilt as prīma vēra and hībernum.",
+        "assesses": [
+          "LA-ETYMON-MANUS-01",
+          "LA-ETYMON-MANUS-02",
+          "LA-ETYMON-CAPUT-01",
+          "LA-PRAGMATICS-CAPUT-02",
+          "LA-LEX-ANNI-TEMPORA-01",
+          "LA-PRAGMATICS-ANNI-TEMPORA-02"
+        ]
+      }
+    },
+    {
+      "chapter": 10,
+      "title": "Water, Wine, and Bread",
+      "label": "ch:la-water-wine-bread",
+      "canDo": "I can name water, wine, and bread in Latin, and explain why a companion is someone you share bread with.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "LA-C10-panis",
+        "kind": "production",
+        "summary": "Ask for aqua, vīnum, and pānis, then unpack com- plus pānis into companion.",
+        "assesses": [
+          "LA-ETYMON-AQUA-VINUM-01",
+          "LA-LEX-AQUA-VINUM-02",
+          "LA-ETYMON-PANIS-01",
+          "LA-LEX-PANIS-02",
+          "LA-PRAGMATICS-PANIS-03"
+        ]
+      }
+    },
+    {
+      "chapter": 11,
+      "title": "Months",
+      "label": "ch:la-months",
+      "canDo": "I can name all twelve Roman months and say what July and August were called before they were renamed.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "LA-C11-menses",
+        "kind": "task",
+        "summary": "Recite the twelve months in order, then restore Quīntīlis and Sextīlis to July and August's slots.",
+        "assesses": [
+          "LA-ETYMON-PANIS-01",
+          "LA-LEX-PANIS-02",
+          "LA-PRAGMATICS-PANIS-03",
+          "LA-ETYMON-AQUA-VINUM-01",
+          "LA-LEX-AQUA-VINUM-02",
+          "LA-ETYMON-MENSES-01",
+          "LA-PRAGMATICS-MENSES-02"
+        ]
+      }
+    },
+    {
+      "chapter": 12,
+      "title": "Noon and Midnight",
+      "label": "ch:la-noon-and-midnight",
+      "canDo": "I can say noon and midnight in Latin, and explain why English's noon does not come from either.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "LA-C12-medius-dies-nox",
+        "kind": "task",
+        "summary": "Say medius diēs and media nox, then follow both halves into Spanish, French, and English's unrelated nōna hōra.",
+        "assesses": [
+          "LA-ETYMON-MENSES-01",
+          "LA-PRAGMATICS-MENSES-02",
+          "LA-LEX-MEDIUS-DIES-NOX-01",
+          "LA-PRAGMATICS-MEDIUS-DIES-NOX-02"
+        ]
+      }
+    },
+    {
+      "chapter": 13,
+      "title": "Telling Time",
+      "label": "ch:la-telling-time",
+      "canDo": "I can talk about the hour in Latin, and explain why a Roman hour was not a fixed sixty minutes.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "LA-C13-hora",
+        "kind": "task",
+        "summary": "Say hōra, then work out how long a Roman hour actually was on a winter day against a summer one.",
+        "assesses": [
+          "LA-LEX-MEDIUS-DIES-NOX-01",
+          "LA-PRAGMATICS-MEDIUS-DIES-NOX-02",
+          "LA-LEX-HORA-01",
+          "LA-PRAGMATICS-HORA-02",
+          "LA-ETYMON-HORA-03"
+        ]
+      }
+    },
+    {
+      "chapter": 14,
+      "title": "Asking Someone's Age",
+      "label": "ch:la-asking-age",
+      "canDo": "I can say how old I am in Latin, using the classical born-so-many-years construction.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "LA-C14-annos-natus",
+        "kind": "production",
+        "summary": "State your own age as vīgintī annōs nātus sum, and set that pattern against Romance's have-your-years and English's be-your-years.",
+        "assesses": [
+          "LA-LEX-HORA-01",
+          "LA-PRAGMATICS-HORA-02",
+          "LA-ETYMON-HORA-03",
+          "LA-LEX-ANNOS-NATUS-01",
+          "LA-PRAGMATICS-ANNOS-NATUS-02"
+        ]
+      }
+    },
+    {
+      "chapter": 15,
+      "title": "Weather",
+      "label": "ch:la-weather",
+      "canDo": "I can say it is raining, and name heat and sun in Latin, using its subjectless weather verbs.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "LA-C15-weather-verbs",
+        "kind": "task",
+        "summary": "Say pluit with no subject at all, then name calor and sol, and check the pl- to ll- path into llueve.",
+        "assesses": [
+          "LA-LEX-TEMPESTAS-PLUIT-01",
+          "LA-GRAMMAR-WEATHER-VERBS-01",
+          "LA-LEX-WEATHER-VERBS-02"
+        ]
+      }
+    },
+    {
+      "chapter": 16,
+      "title": "Numbers Eleven to Twenty",
+      "label": "ch:la-numbers-eleven-to-twenty",
+      "canDo": "I can count from eleven to twenty in Latin, including its backwards eighteen and nineteen.",
+      "spineNodes": [
+        "SPINE-COUNT-ONE-TO-FIVE"
+      ],
+      "payoff": {
+        "lesson": "LA-C16-undecim-viginti",
+        "kind": "task",
+        "summary": "Count ūndecim to vīgintī aloud, then say duodēvīgintī and ūndēvīgintī and explain what they are counting backwards from.",
+        "assesses": [
+          "LA-GRAMMAR-WEATHER-VERBS-01",
+          "LA-LEX-WEATHER-VERBS-02",
+          "LA-LEX-UNDECIM-VIGINTI-01",
+          "LA-LEX-UNDECIM-VIGINTI-02",
+          "LA-PRAGMATICS-UNDECIM-VIGINTI-03",
+          "LA-LEX-UNDECIM-VIGINTI-04"
+        ]
+      }
+    },
+    {
+      "chapter": 17,
+      "title": "Dog and Cat",
+      "label": "ch:la-dog-and-cat",
+      "canDo": "I can name a dog and a cat in Latin, and say which of its two cat-words came first.",
+      "spineNodes": [
+        "SPINE-DEFINITE-REFERENCE"
+      ],
+      "payoff": {
+        "lesson": "LA-C17-canis-feles-cattus",
+        "kind": "production",
+        "summary": "Name canis, fēlēs, and cattus, then say which cat-word is Classical Latin's own and where the newcomer arrived from.",
+        "assesses": [
+          "LA-LEX-UNDECIM-VIGINTI-01",
+          "LA-LEX-UNDECIM-VIGINTI-02",
+          "LA-PRAGMATICS-UNDECIM-VIGINTI-03",
+          "LA-LEX-UNDECIM-VIGINTI-04",
+          "LA-ETYMON-CANIS-FELES-CATTUS-01",
+          "LA-LEX-CANIS-FELES-CATTUS-02",
+          "LA-PRAGMATICS-CANIS-FELES-CATTUS-03"
+        ]
+      }
+    },
+    {
+      "chapter": 18,
+      "title": "Green and Yellow",
+      "label": "ch:la-green-and-yellow",
+      "canDo": "I can say green and yellow in Latin, and explain why almost no Romance language kept flāvus.",
+      "spineNodes": [
+        "SPINE-DEFINITE-REFERENCE"
+      ],
+      "payoff": {
+        "lesson": "LA-C18-viridis-flavus",
+        "kind": "production",
+        "summary": "Say viridis and flāvus, then follow verde one way and galbinus the other into jaune, giallo, and galben.",
+        "assesses": [
+          "LA-ETYMON-CANIS-FELES-CATTUS-01",
+          "LA-LEX-CANIS-FELES-CATTUS-02",
+          "LA-PRAGMATICS-CANIS-FELES-CATTUS-03",
+          "LA-ETYMON-VIRIDIS-FLAVUS-01",
+          "LA-ETYMON-VIRIDIS-FLAVUS-02"
+        ]
+      }
+    },
+    {
+      "chapter": 19,
+      "title": "How Are You?",
+      "label": "ch:la-how-are-you",
+      "canDo": "I can ask someone in Latin how they are, and answer that I am well.",
+      "spineNodes": [
+        "SPINE-CHECK-WELLBEING"
+      ],
+      "payoff": {
+        "lesson": "LA-C19-valeo-family",
+        "kind": "dialogue",
+        "summary": "Run the exchange both ways: ask ut valēs?, answer valeō, and close with valē — all three from one verb.",
+        "assesses": [
+          "LA-PRAGMATICS-QUID-AGIS-01",
+          "LA-LEX-VALEO-FAMILY-01"
+        ]
+      }
+    },
+    {
+      "chapter": 20,
+      "title": "Exchanging Names",
+      "label": "ch:la-exchanging-names",
+      "canDo": "I can ask someone's name in Latin and give my own, using the classical dative of possession.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "LA-C20-name-case-variation",
+        "kind": "dialogue",
+        "summary": "Ask quid tibi nōmen est? and answer mihi nōmen est, holding the possessor in the dative while the name itself may go either way.",
+        "assesses": [
+          "LA-LEX-QUID-TIBI-NOMEN-01",
+          "LA-LEX-QUID-TIBI-NOMEN-02",
+          "LA-GRAMMAR-NAME-CASE-VARIATION-01",
+          "LA-GRAMMAR-NAME-CASE-VARIATION-02"
+        ]
+      }
+    },
+    {
+      "chapter": 21,
+      "title": "Nice to Meet You",
+      "label": "ch:la-nice-to-meet-you",
+      "canDo": "I can say in Latin that it is a pleasure to have met someone, and say what that phrase really proves.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "LA-C21-meeting-phrase-context",
+        "kind": "dialogue",
+        "summary": "Say tē volup est convēnisse in its real scene — two acquaintances meeting by chance — and mark the modern alternative as modern.",
+        "assesses": [
+          "LA-PRAGMATICS-VOLUP-EST-CONVENISSE-01",
+          "LA-PRAGMATICS-MEETING-PHRASE-CONTEXT-01",
+          "LA-PRAGMATICS-MEETING-PHRASE-CONTEXT-02"
+        ]
+      }
+    },
+    {
+      "chapter": 22,
+      "title": "You, Singular and Plural",
+      "label": "ch:la-you-singular-plural",
+      "canDo": "I can choose tū or vōs correctly in Latin, knowing the choice is about number and not politeness.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "LA-C22-tu-vos",
+        "kind": "production",
+        "summary": "Address one person as tū and a group as vōs, then say why neither carries politeness the way German's Sie does.",
+        "assesses": [
+          "LA-GRAMMAR-NAME-CASE-VARIATION-01",
+          "LA-GRAMMAR-NAME-CASE-VARIATION-02",
+          "LA-LEX-TU-VOS-01",
+          "LA-LEX-TU-VOS-02",
+          "LA-PRAGMATICS-TU-VOS-03"
+        ]
+      }
+    },
+    {
+      "chapter": 23,
+      "title": "You're Welcome",
+      "label": "ch:la-youre-welcome",
+      "canDo": "I can reply to thanks in Latin with nihil est, and say honestly how classical that reply is.",
+      "spineNodes": [
+        "SPINE-COURTESY-THANK"
+      ],
+      "payoff": {
+        "lesson": "LA-C23-nihil-est",
+        "kind": "dialogue",
+        "summary": "Answer grātiās tibi agō with nihil est, and state plainly that the reply is modern convention built from real words.",
+        "assesses": [
+          "LA-PHONO-GRATIAS-01",
+          "LA-ETYMON-GRATIAS-02",
+          "LA-GRAMMAR-GRATIAS-03",
+          "LA-LEX-NIHIL-EST-01",
+          "LA-ETYMON-NIHIL-EST-02",
+          "LA-PRAGMATICS-NIHIL-EST-03"
+        ]
+      }
+    },
+    {
+      "chapter": 24,
+      "title": "See You Soon",
+      "label": "ch:la-see-you-soon",
+      "canDo": "I can tell someone in Latin that I will see them soon, using a phrase Cicero actually wrote.",
+      "spineNodes": [
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "LA-C24-propediem-te-videbo",
+        "kind": "dialogue",
+        "summary": "Say propediem tē vidēbō as a parting line, split propediem into prope and diem, and locate it in Cicero's letters.",
+        "assesses": [
+          "LA-LEX-DIES-LUNAE-VENERIS-01",
+          "LA-PRAGMATICS-DIES-LUNAE-VENERIS-02",
+          "LA-PHONO-VALE-01",
+          "LA-ETYMON-VALE-02",
+          "LA-GRAMMAR-VALE-03",
+          "LA-PHONO-GRATIAS-01",
+          "LA-ETYMON-GRATIAS-02",
+          "LA-GRAMMAR-GRATIAS-03",
+          "LA-LEX-PROPEDIEM-TE-VIDEBO-01",
+          "LA-ETYMON-PROPEDIEM-TE-VIDEBO-02",
+          "LA-GRAMMAR-PROPEDIEM-TE-VIDEBO-03"
+        ]
+      }
+    },
+    {
+      "chapter": 25,
+      "title": "See You Tomorrow",
+      "label": "ch:la-see-you-tomorrow",
+      "canDo": "I can say in Latin that I will see someone tomorrow, and say which piece of it Romance mostly abandoned.",
+      "spineNodes": [
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "LA-C25-cras-te-videbo",
+        "kind": "dialogue",
+        "summary": "Say crās tē vidēbō on the same pattern, and say honestly that this combination is not itself a surviving quotation.",
+        "assesses": [
+          "LA-LEX-PROPEDIEM-TE-VIDEBO-01",
+          "LA-ETYMON-PROPEDIEM-TE-VIDEBO-02",
+          "LA-GRAMMAR-PROPEDIEM-TE-VIDEBO-03",
+          "LA-LEX-CRAS-TE-VIDEBO-01",
+          "LA-ETYMON-CRAS-TE-VIDEBO-02",
+          "LA-PRAGMATICS-CRAS-TE-VIDEBO-03"
+        ]
+      }
+    },
+    {
+      "chapter": 26,
+      "title": "How",
+      "label": "ch:la-how",
+      "canDo": "I can ask how in Latin with quōmodo, and trace it into cómo, come, and comment.",
+      "spineNodes": [
+        "SPINE-CHECK-WELLBEING"
+      ],
+      "payoff": {
+        "lesson": "LA-C26-quomodo",
+        "kind": "production",
+        "summary": "Say quōmodo, split it into quō and modō, and show how comment double-marks the manner that come and cómo mark once.",
+        "assesses": [
+          "LA-LEX-VALEO-FAMILY-01",
+          "LA-LEX-QUOMODO-01",
+          "LA-ETYMON-QUOMODO-02",
+          "LA-ETYMON-QUOMODO-03"
+        ]
+      }
+    },
+    {
+      "chapter": 27,
+      "title": "Well",
+      "label": "ch:la-well",
+      "canDo": "I can answer well in Latin with bene, and show how one regular sound change turns it into bien.",
+      "spineNodes": [
+        "SPINE-CHECK-WELLBEING"
+      ],
+      "payoff": {
+        "lesson": "LA-C27-bene",
+        "kind": "dialogue",
+        "summary": "Answer bene when asked how you fare, then derive bien from it in one regular sound change.",
+        "assesses": [
+          "LA-LEX-VALEO-FAMILY-01",
+          "LA-LEX-BENE-01",
+          "LA-ETYMON-BENE-02",
+          "LA-PRAGMATICS-BENE-03"
+        ]
+      }
+    },
+    {
+      "chapter": 28,
+      "title": "Day",
+      "label": "ch:la-day",
+      "canDo": "I can use diēs on its own for day, after meeting it inside the weekday and noon phrases.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "LA-C28-dies",
+        "kind": "production",
+        "summary": "Say diēs alone, point to it inside diēs Lūnae and medius diēs, and separate journal and journey from diary.",
+        "assesses": [
+          "LA-LEX-DIES-LUNAE-VENERIS-01",
+          "LA-PRAGMATICS-DIES-LUNAE-VENERIS-02",
+          "LA-LEX-MEDIUS-DIES-NOX-01",
+          "LA-PRAGMATICS-MEDIUS-DIES-NOX-02",
+          "LA-LEX-DIES-01",
+          "LA-ETYMON-DIES-02"
+        ]
+      }
+    },
+    {
+      "chapter": 29,
+      "title": "Night",
+      "label": "ch:la-night",
+      "canDo": "I can say night in Latin as nox, noctis, and see English night sitting inside it.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "LA-C29-nox",
+        "kind": "production",
+        "summary": "Say nox and noctis, match it against English night, and build equinox out of aequus plus nox.",
+        "assesses": [
+          "LA-LEX-MEDIUS-DIES-NOX-01",
+          "LA-PRAGMATICS-MEDIUS-DIES-NOX-02",
+          "LA-LEX-DIES-01",
+          "LA-ETYMON-DIES-02",
+          "LA-LEX-NOX-01",
+          "LA-ETYMON-NOX-02",
+          "LA-GRAMMAR-NOX-03"
+        ]
+      }
+    },
+    {
+      "chapter": 30,
+      "title": "Good Night",
+      "label": "ch:la-good-night",
+      "canDo": "I can wish someone a good night in Latin, and say why the wish takes the accusative case.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "LA-C30-bonam-noctem",
+        "kind": "dialogue",
+        "summary": "Wish someone bonam noctem, and say why it is not bona nox — Latin wishes take the accusative.",
+        "assesses": [
+          "LA-LEX-NOX-01",
+          "LA-ETYMON-NOX-02",
+          "LA-GRAMMAR-NOX-03",
+          "LA-GRAMMAR-BONAM-NOCTEM-01",
+          "LA-GRAMMAR-BONAM-NOCTEM-02"
+        ]
+      }
+    },
+    {
+      "chapter": 31,
+      "title": "Morning",
+      "label": "ch:la-morning",
+      "canDo": "I can say morning in Latin with māne, and keep it apart from manus, the hand.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "LA-C31-mane",
+        "kind": "production",
+        "summary": "Say māne, recover it inside dē māne and mañana, and keep long-ā mānus apart from short-a manus, the hand.",
+        "assesses": [
+          "LA-LEX-CRAS-TE-VIDEBO-01",
+          "LA-ETYMON-CRAS-TE-VIDEBO-02",
+          "LA-PRAGMATICS-CRAS-TE-VIDEBO-03",
+          "LA-GRAMMAR-MANE-01",
+          "LA-ETYMON-MANE-02"
+        ]
+      }
+    },
+    {
+      "chapter": 32,
+      "title": "Good Morning",
+      "label": "ch:la-good-morning",
+      "canDo": "I can say good morning in Latin, and describe the salūtātiō Romans actually performed at dawn.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "LA-C32-bonum-mane",
+        "kind": "dialogue",
+        "summary": "Say bonum māne, note that its neuter case is invisible, and describe the dawn salūtātiō Romans really used.",
+        "assesses": [
+          "LA-GRAMMAR-MANE-01",
+          "LA-ETYMON-MANE-02",
+          "LA-PHONO-SALVE-01",
+          "LA-ETYMON-SALVE-02",
+          "LA-GRAMMAR-SALVE-03",
+          "LA-PRAGMATICS-BONUM-MANE-01",
+          "LA-PRAGMATICS-BONUM-MANE-02"
+        ]
+      }
+    },
+    {
+      "chapter": 33,
+      "title": "Evening",
+      "label": "ch:la-evening",
+      "canDo": "I can say evening in Latin, and follow the vesper root into Hesperia, víspera, and vespers.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "LA-C33-vesper-afterlives",
+        "kind": "production",
+        "summary": "Say vesper, then follow the evening root through Hesperia, víspera, and vespers, and set sērus aside as the source of soir.",
+        "assesses": [
+          "LA-ETYMON-VESPER-01",
+          "LA-LEX-VESPER-AFTERLIVES-01",
+          "LA-ETYMON-VESPER-AFTERLIVES-02"
+        ]
+      }
+    },
+    {
+      "chapter": 34,
+      "title": "Good Evening",
+      "label": "ch:la-good-evening",
+      "canDo": "I can wish someone a good evening in Latin, and point to the accusative that bonum māne could not show.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "LA-C34-bonum-vesperum",
+        "kind": "dialogue",
+        "summary": "Wish someone bonum vesperum, and use its masculine ending to show the accusative rule bonum māne could not.",
+        "assesses": [
+          "LA-LEX-VESPER-AFTERLIVES-01",
+          "LA-ETYMON-VESPER-AFTERLIVES-02",
+          "LA-GRAMMAR-BONAM-NOCTEM-01",
+          "LA-GRAMMAR-BONAM-NOCTEM-02",
+          "LA-PRAGMATICS-BONUM-MANE-01",
+          "LA-PRAGMATICS-BONUM-MANE-02",
+          "LA-GRAMMAR-BONUM-VESPERUM-01",
+          "LA-GRAMMAR-BONUM-VESPERUM-02"
+        ]
+      }
+    },
+    {
+      "chapter": 35,
+      "title": "Noon and Afternoon",
+      "label": "ch:la-noon-and-afternoon",
+      "canDo": "I can say midday in Latin, and use ante merīdiem and post merīdiem to place any hour of the day.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "LA-C35-meridies",
+        "kind": "task",
+        "summary": "Say merīdiēs, place an hour with ante merīdiem or post merīdiem, and say why Rome needed no separate afternoon noun.",
+        "assesses": [
+          "LA-LEX-MEDIUS-DIES-NOX-01",
+          "LA-PRAGMATICS-MEDIUS-DIES-NOX-02",
+          "LA-LEX-HORA-01",
+          "LA-PRAGMATICS-HORA-02",
+          "LA-ETYMON-HORA-03",
+          "LA-PHONO-MERIDIES-01",
+          "LA-PRAGMATICS-MERIDIES-02",
+          "LA-ETYMON-MERIDIES-03"
+        ]
+      }
+    },
+    {
+      "chapter": 36,
+      "title": "Good Afternoon",
+      "label": "ch:la-good-afternoon",
+      "canDo": "I can greet someone in Latin in the afternoon with salvē or salvēte, and explain why nothing more is needed.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "LA-C36-timeless-salve",
+        "kind": "dialogue",
+        "summary": "Greet one person with salvē and several with salvēte in the afternoon, and state that neither encodes a time of day.",
+        "assesses": [
+          "LA-PRAGMATICS-SALVE-POST-MERIDIEM-01",
+          "LA-PRAGMATICS-TIMELESS-SALVE-01"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What this adds

`code/learning/human-languages/latin/chapters.json` — the [HL05](../blob/main/code/specs/HL05-chapter-capability-and-step-by-step-shape.md) chapter capability layer for the Latin track, **all 36 chapters, no skips**.

Until now the only chapter-scoped record for Latin was a `targets[]` entry in `core/book-generation.json` — a LaTeX build manifest with no pedagogical content. Nothing in the data model knew what a Latin chapter was *for*, so nothing could check that finishing one left the reader able to do anything. This closes that gap for Latin.

Each entry carries:

| Field | Derived from |
|---|---|
| `title` / `label` | `core/book-generation.json` targets for `latin`, matched exactly (35 of 36 — see below) |
| `canDo` | one first-person sentence written from what the chapter's lessons actually teach |
| `spineNodes` | the `path` segments in `latin/curriculum.json`, via each segment's `spine_node` and lesson ids |
| `payoff.lesson` | the chapter's terminal consolidation lesson (see divergence 1) |
| `payoff.assesses` | copied **verbatim** from that lesson's own `practises.knowledge` |
| `payoff.kind` / `summary` | the lesson's actual guided-practice and wrap-up content |

## Chapters skipped: none

The hard rule was to omit any chapter whose payoff lesson is not `schema_version: 2` with a non-empty `practises.knowledge`, rather than stub it. That rule never fired. All 53 Latin lessons are schema v2 and every chapter's terminal lesson practises at least two atoms. **There is no Latin chapter debt to report.**

## Two divergences from the default shape

Both are recorded in the file's own `note` and in the track README rather than smoothed over.

**1. Only Chapter 1 has a terminal `practice` lesson.** `LA-C01-practice` is the track's single `type: practice` step; Latin has no `practice-mix` lesson anywhere. For chapters 2–36 the payoff is therefore **the chapter's last lesson by `sequence`** — genuinely where that chapter's recombination and wrap-up recall live, but not a dedicated consolidation step. A later tranche that adds practice lessons should repoint these.

**2. Chapter 1 has no `core/book-generation.json` target at all.** Its `.tex` is the hand-written opening that predates the generator manifest (latin targets run 2–36). Its `title` (`Greetings`) and `label` (`ch:greetings`) are taken from `book/chapters/ch01-greetings.tex` so the printed book and the ledger agree. The title/label-drift test skips chapters without a target, so this is consistent either way.

## Representativeness

`payoff.assesses` is generated from the payoff lesson's frontmatter rather than hand-transcribed, so the ledger cannot claim an atom the lesson does not practise. On that basis **every one of the 36 chapters exercises 100% of the atoms its own chapter introduces**, clearing the `payoffRepresentativeness: 0.5` threshold in `core/chapter-policy.json` with full margin. No chapter is at risk from the HL05 representativeness gate.

Worth flagging for a future gate on payoff *kind* rather than atom count: chapters 21, 33, and 36 have a `culture` or `etymology` lesson as their payoff, so what the reader "does" there is trace a root or place a phrase in its scene rather than perform an exchange. Those are the weakest payoffs in the track by shape, though not by coverage.

## Not touched

Lessons, `curriculum.json`, `core/spine.json`, and book output are unchanged. This is a new capability layer above the corpus, not a revision of it.

## Verification

```
cd code/packages/typescript/human-language-data
npx tsc --noEmit                      # clean
npx vitest run tests/chapters.test.ts # 15/15 passed
npx vitest run                        # 14 files, 123/123 passed
```

Includes the payoff-atom-subset assertion, the `canDo` first-person-prefix assertion, the payoff-lesson-in-same-chapter assertion, and the title/label-drift assertion against `book-generation.json`.

Security review: data and docs only — no executable code, no HTML/LaTeX metacharacters or template markers in the JSON, no URLs, credentials, dependencies, or lockfile change. Passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw3PKmLS2yEnDmhck3fM1z)_