### PR TITLE
feat(human-languages): author the Hindi chapter capability ledger

### DIFF
--- a/code/learning/human-languages/hindi/CHANGELOG.md
+++ b/code/learning/human-languages/hindi/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## Chapter capability ledger (HL05)
+
+- Added `chapters.json`, the hand-authored capability ledger: one entry per
+  chapter carrying a first-person `canDo`, the shared-spine nodes the chapter
+  realises, and a `payoff` naming the lesson that proves the claim.
+- Thirty of the thirty-three chapters are authored — Chapters 1, 2, and 6
+  through 33. Titles and labels for Chapters 6–33 are copied exactly from
+  `core/book-generation.json`; Chapters 1 and 2 have no generator target and
+  take their names from the hand-authored `book/chapters/ch01`–`ch02` sources.
+- Chapters 3, 4, and 5 are deliberately **absent**. Every lesson in them is
+  still schema v1 with no `practises.knowledge`, so no payoff could name a real
+  knowledge atom. The gap is recorded as debt in the file's own note rather
+  than filled with a stub, because a stub would satisfy the gate while
+  destroying the signal it exists to carry.
+- Chapters 1 and 2 have no schema-v2 terminal consolidation lesson either:
+  their `HI-C01-practice` and `HI-C02-practice` lessons are schema v1. Their
+  payoffs therefore fall back to the chapter's last lesson by `sequence`, which
+  in both cases is a Devanagari writing lesson — `HI-W02-ka-ta-mouth-order`
+  and `HI-W05-write-namaste`. Both are recorded as `kind: task` and described
+  as hand-writing work, not as spoken dialogue they are not.
+- Every `payoff.assesses` list is exactly the payoff lesson's own declared
+  `practises.knowledge`, so no chapter claims an atom its lesson never
+  exercises.
+- Four chapters will sit below the 0.5 representativeness threshold when the
+  HL05 gates land: Chapter 1 (3/9), Chapter 2 (2/12), Chapter 6 (1/4), and
+  Chapter 32 (1/3). Each is a chapter whose terminal lesson is narrower than
+  the chapter as a whole; the fix is a real consolidation lesson, not a wider
+  claim in this ledger.
+
 ## Warning-free 33-chapter book
 
 - Devanagari, Arabic, and Cyrillic use explicit static bold and italic faces;

--- a/code/learning/human-languages/hindi/README.md
+++ b/code/learning/human-languages/hindi/README.md
@@ -58,6 +58,31 @@ Two things shape this track.
   words. They remain inline in the opening chapters rather than becoming a
   prerequisite alphabet drill.
 
+## Chapter capabilities (`chapters.json`)
+
+[`chapters.json`](./chapters.json) is the track's
+[`HL05`](../../../specs/HL05-chapter-capability-and-step-by-step-shape.md)
+capability ledger: for each chapter, one first-person `canDo` promise, the
+shared-spine nodes it realises, and the **payoff** lesson that proves the
+promise, with the exact knowledge atoms that lesson practises. It is authored
+intent, not a derived cache — no validator may rewrite it.
+
+Thirty of the thirty-three chapters are authored. Three are honestly missing:
+
+- **Chapters 3, 4, and 5 have no entry.** Every lesson in them is still schema
+  v1 with no `practises.knowledge`, so a payoff there could not name a single
+  real atom. The absence is measurable debt; a placeholder would hide it.
+- **Chapters 1 and 2 pay off in a writing lesson.** Their `HI-C0*-practice`
+  lessons are also schema v1, so the payoff falls back to the last lesson by
+  `sequence` — `HI-W02-ka-ta-mouth-order` and `HI-W05-write-namaste`. Both are
+  recorded as `kind: task`, because forming क, त, and नमस्ते by hand is a
+  writing task and calling it a dialogue would be a lie about the chapter.
+
+Four chapters (1, 2, 6, and 32) currently assess less than half the atoms their
+chapter introduces and will be reported under the 0.5 representativeness
+threshold once the HL05 gates land. The cure is a real terminal consolidation
+lesson in each, not a broader claim here.
+
 ## Book / fonts
 
 The 33-chapter book compiles with XeLaTeX using **vendored** Noto Sans
@@ -70,7 +95,9 @@ warning-free, and every intentionally blank open-right verso is truly empty.
 
 ## Files
 
-- [`lessons/`](./lessons/) · [`pronunciation-reference.md`](./pronunciation-reference.md)
+- [`lessons/`](./lessons/) · [`chapters.json`](./chapters.json)
+  · [`curriculum.json`](./curriculum.json)
+  · [`pronunciation-reference.md`](./pronunciation-reference.md)
   · [`roadmap.md`](./roadmap.md) · [`session-map.md`](./session-map.md)
   · [`book/`](./book/)
 

--- a/code/learning/human-languages/hindi/chapters.json
+++ b/code/learning/human-languages/hindi/chapters.json
@@ -1,0 +1,551 @@
+{
+  "version": 1,
+  "language": "hindi",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapters 3, 4 and 5 are deliberately absent — every lesson in them is still schema v1 with no practises.knowledge, so no payoff could name a real atom, and a stub would destroy the very signal the gap report exists to carry. Chapters 1 and 2 have no schema-v2 terminal consolidation lesson either: their HI-C01/HI-C02 practice lessons are schema v1, so the payoff falls back to the chapter's last lesson by sequence, which in both cases is a Devanagari writing lesson. Those are recorded as kind 'task' and described as hand-writing work rather than dressed up as spoken dialogue.",
+  "chapters": [
+    {
+      "chapter": 1,
+      "title": "Greetings",
+      "label": "ch:greetings",
+      "canDo": "I can greet, thank, and take my leave in Hindi, and write by hand the first Devanagari letters those words are built from.",
+      "spineNodes": [
+        "SPINE-MEET-GREET",
+        "SPINE-COURTESY-THANK",
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "HI-W02-ka-ta-mouth-order",
+        "kind": "task",
+        "summary": "Write क and त in stroke order — loop or curl, spine, bar last — then say the stop series back to front along the mouth.",
+        "assesses": [
+          "HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-01",
+          "HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-02",
+          "HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-03"
+        ]
+      }
+    },
+    {
+      "chapter": 2,
+      "title": "Introducing Yourself",
+      "label": "ch:introductions",
+      "canDo": "I can give my name and ask for someone else's in Hindi, and write मेरा नाम and नमस्ते by hand.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "HI-W05-write-namaste",
+        "kind": "task",
+        "summary": "Assemble नमस्ते from न, म, स् and ते under a single head-line, then say the bow the word literally names.",
+        "assesses": [
+          "HI-CONCEPT-W05-WRITE-NAMASTE-01",
+          "HI-CONCEPT-W05-WRITE-NAMASTE-02"
+        ]
+      }
+    },
+    {
+      "chapter": 6,
+      "title": "Numbers One to Five",
+      "label": "ch:hi-numbers-1-5",
+      "canDo": "I can count from one to five in Hindi and hear the older Sanskrit shapes still sitting inside तीन, चार and पाँच.",
+      "spineNodes": [
+        "SPINE-COUNT-ONE-TO-FIVE"
+      ],
+      "payoff": {
+        "lesson": "HI-C06-paanch-nasal",
+        "kind": "task",
+        "summary": "Say पाँच beside Sanskrit pañca and point to the moon-dot that is all that survives of the lost nasal consonant.",
+        "assesses": [
+          "HI-CONCEPT-C06-PAANCH-NASAL-01"
+        ]
+      }
+    },
+    {
+      "chapter": 7,
+      "title": "Yes and No",
+      "label": "ch:hi-yes-and-no",
+      "canDo": "I can say yes and no in Hindi and use नहीं to negate a whole sentence.",
+      "spineNodes": [
+        "SPINE-RESPOND-BASIC"
+      ],
+      "payoff": {
+        "lesson": "HI-C07-nahin",
+        "kind": "production",
+        "summary": "Say नहीं, put it in front of a verb — मैं नहीं जानता — and hear the single PIE *ne behind no, non and nein.",
+        "assesses": [
+          "HI-CONCEPT-C07-NAHIN-01",
+          "HI-CONCEPT-C07-NAHIN-02",
+          "HI-CONCEPT-C07-NAHIN-03"
+        ]
+      }
+    },
+    {
+      "chapter": 8,
+      "title": "Please",
+      "label": "ch:hi-please",
+      "canDo": "I can say please in Hindi, both with कृपया and with the polite verb ending everyday speech actually prefers.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "HI-C08-kripaya",
+        "kind": "production",
+        "summary": "Say कृपया with its vocalic ऋ, unpack it as 'of your compassion', then switch to the everyday बैठिए, 'please sit'.",
+        "assesses": [
+          "HI-CONCEPT-C08-KRIPAYA-01",
+          "HI-CONCEPT-C08-KRIPAYA-02"
+        ]
+      }
+    },
+    {
+      "chapter": 9,
+      "title": "Sorry",
+      "label": "ch:hi-sorry",
+      "canDo": "I can apologise in Hindi with माफ़ कीजिए and reach for its more formal cousin when the moment calls for it.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "HI-C09-maaf-kijiye",
+        "kind": "production",
+        "summary": "Say माफ़ कीजिए as 'please do forgiveness', then क्षमा करें when the setting is formal.",
+        "assesses": [
+          "HI-CONCEPT-C09-MAAF-KIJIYE-01",
+          "HI-CONCEPT-C09-MAAF-KIJIYE-02"
+        ]
+      }
+    },
+    {
+      "chapter": 10,
+      "title": "Days of the Week",
+      "label": "ch:hi-days-of-the-week",
+      "canDo": "I can name all seven days of the week in Hindi and say which planet each day is named for.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "HI-C10-shanivaar-ravivaar",
+        "kind": "production",
+        "summary": "Recite सोमवार through रविवार end to end, naming Saturn's day and the Sun's day to close the planet-week.",
+        "assesses": [
+          "HI-CONCEPT-C10-SHANIVAAR-RAVIVAAR-01",
+          "HI-CONCEPT-C10-SHANIVAAR-RAVIVAAR-02"
+        ]
+      }
+    },
+    {
+      "chapter": 11,
+      "title": "Four Core Colours",
+      "label": "ch:hi-core-colours",
+      "canDo": "I can name black, white, red and blue in Hindi and say which of them came from Sanskrit and which from Persian.",
+      "spineNodes": [
+        "SPINE-DEFINITE-REFERENCE"
+      ],
+      "payoff": {
+        "lesson": "HI-C11-laal-niila",
+        "kind": "production",
+        "summary": "Say लाल and नीला beside काला and सफ़ेद, keeping nīla and 'indigo' honestly linked by trade rather than by sound.",
+        "assesses": [
+          "HI-CONCEPT-C11-LAAL-NIILA-01",
+          "HI-CONCEPT-C11-LAAL-NIILA-02"
+        ]
+      }
+    },
+    {
+      "chapter": 12,
+      "title": "Family",
+      "label": "ch:hi-family",
+      "canDo": "I can name my father, mother, brother and sister in Hindi.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "HI-C12-bhaai-bahin",
+        "kind": "production",
+        "summary": "Say भाई and बहन beside पिता and माता, and name which one is a true cousin of English 'brother' and which is not.",
+        "assesses": [
+          "HI-CONCEPT-C12-BHAAI-BAHIN-01",
+          "HI-CONCEPT-C12-BHAAI-BAHIN-02"
+        ]
+      }
+    },
+    {
+      "chapter": 13,
+      "title": "Head and Hand",
+      "label": "ch:hi-head-and-hand",
+      "canDo": "I can name the head and the hand in Hindi and trace both back to the Sanskrit words they wore down from.",
+      "spineNodes": [
+        "SPINE-CHECK-WELLBEING"
+      ],
+      "payoff": {
+        "lesson": "HI-C13-haath",
+        "kind": "production",
+        "summary": "Say हाथ, then हस्त, then the shape of the change between them: the -st- cluster simplifies and the vowel lengthens.",
+        "assesses": [
+          "HI-CONCEPT-C13-HAATH-01",
+          "HI-CONCEPT-C13-HAATH-02"
+        ]
+      }
+    },
+    {
+      "chapter": 14,
+      "title": "Seasons",
+      "label": "ch:hi-seasons",
+      "canDo": "I can name all six traditional Indian seasons in Hindi, including the one the four-season frame has no word for.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "HI-C14-ritu",
+        "kind": "production",
+        "summary": "Say all six ऋतु in order and point to वर्षा, the monsoon season no Western four-season label maps onto.",
+        "assesses": [
+          "HI-CONCEPT-C14-RITU-01",
+          "HI-CONCEPT-C14-RITU-02"
+        ]
+      }
+    },
+    {
+      "chapter": 15,
+      "title": "Water and Bread",
+      "label": "ch:hi-water-and-bread",
+      "canDo": "I can ask for water and bread in Hindi and say what पानी literally means.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "HI-C15-paani-roti",
+        "kind": "production",
+        "summary": "Ask for पानी and रोटी, then unpack पानी as 'the drinkable one' — pā, to drink, plus -nīya, fit for.",
+        "assesses": [
+          "HI-CONCEPT-C15-PAANI-ROTI-01",
+          "HI-CONCEPT-C15-PAANI-ROTI-02"
+        ]
+      }
+    },
+    {
+      "chapter": 16,
+      "title": "Months",
+      "label": "ch:hi-months",
+      "canDo": "I can name the twelve months in Hindi and explain why the festivals move against the Gregorian calendar.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "HI-C16-mahine",
+        "kind": "production",
+        "summary": "Say जनवरी through दिसंबर, then name Chaitra and Vaiśākh and explain that the festivals are dated by Vikram Samvat instead.",
+        "assesses": [
+          "HI-CONCEPT-C16-MAHINE-01",
+          "HI-CONCEPT-C16-MAHINE-02"
+        ]
+      }
+    },
+    {
+      "chapter": 17,
+      "title": "Noon and Midnight",
+      "label": "ch:hi-noon-and-midnight",
+      "canDo": "I can say noon and midnight in Hindi and explain the old three-hour pahar hidden inside दोपहर.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "HI-C17-dopahar-aadhi-raat",
+        "kind": "production",
+        "summary": "Say दोपहर as 'two pahars' and आधी रात as 'half night', contrasting one built on an old time-unit with one built plainly.",
+        "assesses": [
+          "HI-CONCEPT-C17-DOPAHAR-AADHI-RAAT-01",
+          "HI-CONCEPT-C17-DOPAHAR-AADHI-RAAT-02"
+        ]
+      }
+    },
+    {
+      "chapter": 18,
+      "title": "Telling Time",
+      "label": "ch:hi-telling-time",
+      "canDo": "I can tell someone what o'clock it is in Hindi.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "HI-C18-ghanta",
+        "kind": "production",
+        "summary": "Say एक बज रहा है and दो बज रहे हैं — the hour striking, exactly as the ghaṇṭā bell once did.",
+        "assesses": [
+          "HI-CONCEPT-C18-GHANTA-01",
+          "HI-CONCEPT-C18-GHANTA-02"
+        ]
+      }
+    },
+    {
+      "chapter": 19,
+      "title": "Asking Someone's Age",
+      "label": "ch:hi-asking-age",
+      "canDo": "I can ask someone's age in Hindi and give my own in the belonging-to-years shape Hindi uses.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "HI-C19-age-grammar",
+        "kind": "dialogue",
+        "summary": "Ask तुम कितने साल के हो? and answer मैं बीस साल का हूँ, with के/का carrying the 'belonging to' work.",
+        "assesses": [
+          "HI-CONCEPT-C19-AGE-GRAMMAR-01"
+        ]
+      }
+    },
+    {
+      "chapter": 20,
+      "title": "Weather",
+      "label": "ch:hi-weather",
+      "canDo": "I can say what the weather is doing in Hindi and stay out of the बारिश / वर्षा false-friend trap.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "HI-C20-mausam",
+        "kind": "production",
+        "summary": "Say मौसम, then गर्मी है and ठंड है, and keep everyday बारिश apart from formal वर्षा despite the resemblance.",
+        "assesses": [
+          "HI-CONCEPT-C20-MAUSAM-01",
+          "HI-CONCEPT-C20-MAUSAM-02",
+          "HI-CONCEPT-C20-MAUSAM-03"
+        ]
+      }
+    },
+    {
+      "chapter": 21,
+      "title": "Numbers Six to Ten",
+      "label": "ch:hi-numbers-six-to-ten",
+      "canDo": "I can count from six to ten in Hindi and hear the sound changes that wore the Sanskrit numerals down.",
+      "spineNodes": [
+        "SPINE-COUNT-ONE-TO-FIVE"
+      ],
+      "payoff": {
+        "lesson": "HI-C21-six-nine-ten-history",
+        "kind": "task",
+        "summary": "Trace ṣaṣ → chhah, nava → nau and daśa → das, naming the one change each numeral underwent.",
+        "assesses": [
+          "HI-CONCEPT-C21-SIX-NINE-TEN-HISTORY-01",
+          "HI-CONCEPT-C21-SIX-NINE-TEN-HISTORY-02",
+          "HI-CONCEPT-C21-SIX-NINE-TEN-HISTORY-03"
+        ]
+      }
+    },
+    {
+      "chapter": 22,
+      "title": "Numbers Eleven to Twenty",
+      "label": "ch:hi-numbers-eleven-to-twenty",
+      "canDo": "I can count from eleven to twenty in Hindi and spot the subtractive nineteen sitting inside the list.",
+      "spineNodes": [
+        "SPINE-COUNT-ONE-TO-FIVE"
+      ],
+      "payoff": {
+        "lesson": "HI-C22-gyarah-bees",
+        "kind": "production",
+        "summary": "Count ग्यारह to बीस, then read उन्नीस as 'one less than twenty', the same logic as Latin's ūndēvīgintī.",
+        "assesses": [
+          "HI-CONCEPT-C22-GYARAH-BEES-01",
+          "HI-CONCEPT-C22-GYARAH-BEES-02",
+          "HI-CONCEPT-C22-GYARAH-BEES-03",
+          "HI-CONCEPT-C22-GYARAH-BEES-04"
+        ]
+      }
+    },
+    {
+      "chapter": 23,
+      "title": "Dog and Cat",
+      "label": "ch:hi-dog-and-cat",
+      "canDo": "I can name a dog and a cat in Hindi and say honestly how far back each word can actually be traced.",
+      "spineNodes": [
+        "SPINE-DEFINITE-REFERENCE"
+      ],
+      "payoff": {
+        "lesson": "HI-C23-billi-history",
+        "kind": "task",
+        "summary": "Trace बिल्ली back through biḍālikā to biḍāla, then say out loud where the evidence stops being solid.",
+        "assesses": [
+          "HI-CONCEPT-C23-BILLI-HISTORY-01"
+        ]
+      }
+    },
+    {
+      "chapter": 24,
+      "title": "Green and Yellow",
+      "label": "ch:hi-green-and-yellow",
+      "canDo": "I can name green and yellow in Hindi and trace पीला step by step back to Sanskrit.",
+      "spineNodes": [
+        "SPINE-DEFINITE-REFERENCE"
+      ],
+      "payoff": {
+        "lesson": "HI-C24-pila-history",
+        "kind": "task",
+        "summary": "Trace pīta · pītala · pīala · pīlā in order, and flag the drink-to-yellow link as uncertain rather than settled.",
+        "assesses": [
+          "HI-CONCEPT-C24-PILA-HISTORY-01"
+        ]
+      }
+    },
+    {
+      "chapter": 25,
+      "title": "Day",
+      "label": "ch:hi-day",
+      "canDo": "I can say day in Hindi and explain how दिन both is and is not related to Latin's diēs.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "HI-C25-din",
+        "kind": "task",
+        "summary": "Say दिन, put it and diēs on the same PIE *dyew- root but different branches, then name द्यु/दिव् as the closer cousins.",
+        "assesses": [
+          "HI-CONCEPT-C25-DIN-01",
+          "HI-CONCEPT-C25-DIN-02"
+        ]
+      }
+    },
+    {
+      "chapter": 26,
+      "title": "Night",
+      "label": "ch:hi-night",
+      "canDo": "I can say night in Hindi and explain why रात and Latin's nox are not cousins at all.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "HI-C26-raat",
+        "kind": "task",
+        "summary": "Trace rātri → ratti → raat, then state the honest twist: unlike दिन and diēs, रात and nox share no root.",
+        "assesses": [
+          "HI-CONCEPT-C26-RAAT-01",
+          "HI-CONCEPT-C26-RAAT-02"
+        ]
+      }
+    },
+    {
+      "chapter": 27,
+      "title": "Good Night",
+      "label": "ch:hi-good-night",
+      "canDo": "I can wish someone good night in Hindi and say why the phrase uses literary रात्रि rather than everyday रात.",
+      "spineNodes": [
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "HI-C27-shubh-raatri",
+        "kind": "production",
+        "summary": "Say शुभ रात्रि at parting, name the raat / rātri register pair, and trace śubh from 'to shine' to 'auspicious'.",
+        "assesses": [
+          "HI-CONCEPT-C27-SHUBH-RAATRI-01",
+          "HI-CONCEPT-C27-SHUBH-RAATRI-02"
+        ]
+      }
+    },
+    {
+      "chapter": 28,
+      "title": "Morning",
+      "label": "ch:hi-morning",
+      "canDo": "I can say morning in Hindi and recognise सुबह as a Persian-Arabic loan rather than a Sanskrit word.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "HI-C28-subah",
+        "kind": "production",
+        "summary": "Say सुबह, find the ṣ-b-ḥ root it shares with Arabic ṣabāḥ, and name the break from Sanskrit दिन and रात.",
+        "assesses": [
+          "HI-CONCEPT-C28-SUBAH-01",
+          "HI-CONCEPT-C28-SUBAH-02",
+          "HI-CONCEPT-C28-SUBAH-03"
+        ]
+      }
+    },
+    {
+      "chapter": 29,
+      "title": "Evening",
+      "label": "ch:hi-evening",
+      "canDo": "I can say evening in Hindi and refuse the tempting but false link between शाम and Sanskrit śyāmā.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "HI-C29-shaam",
+        "kind": "production",
+        "summary": "Say शाम, reject the śyāmā resemblance as a false cognate, and pair it with सुबह as two loans from the same source.",
+        "assesses": [
+          "HI-CONCEPT-C29-SHAAM-01",
+          "HI-CONCEPT-C29-SHAAM-02"
+        ]
+      }
+    },
+    {
+      "chapter": 30,
+      "title": "Afternoon",
+      "label": "ch:hi-afternoon",
+      "canDo": "I can say afternoon in Hindi using दोपहर in its modern, widened sense.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "HI-C30-dopahar-widened",
+        "kind": "production",
+        "summary": "Say दोपहर में for 'in the afternoon' — the Chapter 17 word doing a wider job than its etymology promises.",
+        "assesses": [
+          "HI-CONCEPT-C30-DOPAHAR-WIDENED-01",
+          "HI-CONCEPT-C30-DOPAHAR-WIDENED-02"
+        ]
+      }
+    },
+    {
+      "chapter": 31,
+      "title": "Good Morning",
+      "label": "ch:hi-good-morning",
+      "canDo": "I can wish someone good morning in Hindi and judge when सुप्रभात fits and when नमस्ते is the better choice.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "HI-C31-suprabhat",
+        "kind": "production",
+        "summary": "Say सुप्रभात, split it into su + prabhāt, and set that native Sanskrit dawn against the Persian loan सुबह.",
+        "assesses": [
+          "HI-CONCEPT-C31-SUPRABHAT-01",
+          "HI-CONCEPT-C31-SUPRABHAT-02"
+        ]
+      }
+    },
+    {
+      "chapter": 32,
+      "title": "Good Evening",
+      "label": "ch:hi-good-evening",
+      "canDo": "I can wish someone good evening in Hindi and choose between शुभ संध्या and नमस्ते by register.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "HI-C32-evening-register",
+        "kind": "task",
+        "summary": "Pick शुभ संध्या for a written evening card and नमस्ते for a casual 7 p.m. hello, treating the split as a tendency, not a ban.",
+        "assesses": [
+          "HI-CONCEPT-C32-EVENING-REGISTER-01"
+        ]
+      }
+    },
+    {
+      "chapter": 33,
+      "title": "Good Afternoon",
+      "label": "ch:hi-good-afternoon",
+      "canDo": "I can wish someone good afternoon in Hindi and say honestly how rarely शुभ दोपहर is actually used.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "HI-C33-shubh-dopahar",
+        "kind": "production",
+        "summary": "Say शुभ दोपहर with दोपहर in its widened sense, then rank it honestly below नमस्ते/नमस्कार for everyday afternoons.",
+        "assesses": [
+          "HI-CONCEPT-C33-SHUBH-DOPAHAR-01",
+          "HI-CONCEPT-C33-SHUBH-DOPAHAR-02"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds `code/learning/human-languages/hindi/chapters.json`, the HL05 capability layer for the Hindi track: one entry per chapter carrying a first-person `canDo`, the shared-spine nodes it realises, and a `payoff` naming the lesson that proves the promise plus the exact knowledge atoms that lesson exercises.

**30 of the 33 chapters are authored** — Chapters 1, 2, and 6 through 33.

## How each field was derived

Read off the data, not guessed:

| Field | Source |
|---|---|
| `title` / `label` (ch. 6–33) | Copied verbatim from the `hindi` targets in `core/book-generation.json`, so `chapter-title-drift` holds through the HL-C04 inversion. |
| `title` / `label` (ch. 1–2) | No generator target exists for these. Taken from the hand-authored `book/chapters/ch01-greetings.tex` and `ch02-introductions.tex`: `Greetings` / `ch:greetings` and `Introducing Yourself` / `ch:introductions`. |
| `canDo` | One first-person sentence per chapter, written from that chapter's actual lessons — what the reader can *do*, in their terms. |
| `spineNodes` | Mapped from `hindi/curriculum.json` path segments: each segment's `spine_node`, resolved through its lesson ids to the chapters those lessons belong to. Every id is present in `core/spine.json`. No authored chapter falls outside the eleven-node spine, so none needed an empty list. |
| `payoff.assesses` | Exactly the payoff lesson's own declared `practises.knowledge`. No atom is invented, and none is claimed that its lesson does not exercise. |

## Skipped — 3 chapters, no stubs left behind

**Chapters 3 (How Are You), 4 (Farewells), and 5 (First Verbs)** have no entry.

Every lesson in all three is still schema v1 with no `practises.knowledge` at all, so a payoff there could not name a single real knowledge atom. An absent entry is honest, measurable debt; a stub would satisfy the gate while destroying the signal the gap report exists to carry. The omission and its reason are recorded in the file's own `note`, in the README, and in the CHANGELOG.

## Payoff-lesson fallbacks, noted explicitly

Chapters 1 and 2 *do* have a terminal consolidation lesson — `HI-C01-practice` (practice-mix) and `HI-C02-practice` (practice) — but both are schema v1 with no `practises.knowledge`, and neither appears in the curriculum path. Their payoffs therefore fall back to the chapter's **last lesson by `sequence`**:

- Chapter 1 → `HI-W02-ka-ta-mouth-order` (seq 130)
- Chapter 2 → `HI-W05-write-namaste` (seq 200)

Both are Devanagari `type: writing` lessons, which are legitimate members of these chapters — Hindi teaches script inline rather than as a detached alphabet course. They are recorded as `kind: task`, and their summaries describe hand-forming क, त, and नमस्ते. A script-formation exercise is not dressed up as a spoken dialogue.

Every other authored chapter's payoff is likewise that chapter's last lesson by `sequence`: the Hindi track has no schema-v2 `practice` or `practice-mix` lesson anywhere in Chapters 6–33.

## Known representativeness debt

Four chapters will be reported below the 0.5 threshold when the HL05 gates land:

| Chapter | Payoff | Assessed / introduced | Share |
|---|---|---|---|
| 1 — Greetings | `HI-W02-ka-ta-mouth-order` | 3 / 9 | 0.33 |
| 2 — Introducing Yourself | `HI-W05-write-namaste` | 2 / 12 | 0.17 |
| 6 — Numbers One to Five | `HI-C06-paanch-nasal` | 1 / 4 | 0.25 |
| 32 — Good Evening | `HI-C32-evening-register` | 1 / 3 | 0.33 |

Each is a chapter whose terminal lesson is narrower than the chapter as a whole. The cure is a real consolidation lesson in each, not a wider claim in this ledger, so the shortfall is reported rather than papered over. The remaining twenty-six authored chapters sit at or above 0.5.

## Spec

`HL05-chapter-capability-and-step-by-step-shape.md` needed no revision. The ledger matches the specified field contracts exactly, and the spec already permits an empty `spineNodes` and a payoff that is not a `practice` lesson.

## Verification

```
cd code/packages/typescript/human-language-data
npm ci --silent && npx tsc --noEmit && npx vitest run
```

14 test files, **123 tests passing** — including the `canDo` first-person assertion, payoff-lesson resolution and chapter match, the `assesses ⊆ practises.knowledge` subset assertion, and title/label agreement with `book-generation.json`. No `package-lock.json` diff.

Security review: passed on round 1, no findings. The change is data and documentation only — no executable code, no dependencies, no secrets or URLs, valid JSON with no prototype-pollution keys (`JSON.parse` is the one real vector) and no control characters that could break the downstream LaTeX renderer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw3PKmLS2yEnDmhck3fM1z)_