### PR TITLE
feat(human-languages): author HL05 chapter capability ledgers for kannada and telugu

### DIFF
--- a/code/learning/human-languages/kannada/CHANGELOG.md
+++ b/code/learning/human-languages/kannada/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## Chapter capability ledger — HL05 (2026-08-06)
+
+- Added [`chapters.json`](./chapters.json), the track's HL05 chapter capability
+  ledger. Twenty-six chapters — 6 through 31 — each declare a first-person
+  `canDo`, the shared spine nodes they realise, and a `payoff` naming the lesson
+  that proves the claim.
+- Every `payoff.assesses` list is copied verbatim from its payoff lesson's own
+  `practises.knowledge`, so the ledger cannot claim an atom the lesson does not
+  actually practise.
+- No chapter from 6 on has a terminal `practice`/`practice-mix` lesson — the
+  Chapter 5 recap was the last one authored. Each payoff is therefore the
+  chapter's **last lesson by `sequence`**, which for these single- and
+  double-lesson chapters is also the lesson that recombines the chapter's
+  material in its Guided Practice block.
+- **Chapters 1–5 are deliberately absent.** Their lessons are still schema v1,
+  carry no `practises.knowledge`, and have no `core/book-generation.json`
+  target to derive a title from. A payoff written for them would be invented,
+  not derived; the gap is left visible as honest debt rather than stubbed.
+- Thinnest payoffs, for the representativeness gate that lands next: Chapter 20
+  covers 2 of the 4 atoms its two lessons introduce (exactly the 0.5 threshold,
+  because the weather lesson closes a chapter that also teaches 11–20), and
+  Chapter 6 covers 4 of 6.
+
 ## Warning-free complete book (2026-08-03)
 
 - Added explicit static-font faces for every comparison script and readable

--- a/code/learning/human-languages/kannada/README.md
+++ b/code/learning/human-languages/kannada/README.md
@@ -61,6 +61,24 @@ All thirty later lessons remain below five effective minutes. Their twenty-six
 generated chapters carry the same source hashes Language Ladder recomputes from
 the browser-loaded lesson AST, so app and book cannot drift silently.
 
+## Chapter capabilities
+
+[`chapters.json`](./chapters.json) is the track's
+[`HL05`](../../../specs/HL05-chapter-capability-and-step-by-step-shape.md)
+capability ledger: for each chapter, one first-person `canDo` ("I can tell
+someone the time on the hour in Kannada"), the shared spine nodes it realises,
+and the `payoff` lesson that proves the claim, with the exact knowledge atoms
+that payoff exercises.
+
+Chapters **6–31** are authored — twenty-six entries. Chapters **1–5 are absent
+on purpose**: their lessons are still schema v1 with no `practises.knowledge`
+and no `core/book-generation.json` target, so a payoff for them could only be
+invented. That absence is measurable debt, not a placeholder.
+
+Because no chapter after 5 has a terminal `practice` lesson, each payoff is the
+chapter's last lesson by `sequence` — in practice the lesson whose Guided
+Practice block recombines everything the chapter taught.
+
 ## Book / fonts
 
 The book compiles with XeLaTeX using the **vendored** Noto Sans Kannada font
@@ -69,7 +87,9 @@ and in CI, no system-font dependency. `latexmk -xelatex book.tex`.
 
 ## Files
 
-- [`lessons/`](./lessons/) · [`pronunciation-reference.md`](./pronunciation-reference.md)
+- [`lessons/`](./lessons/) · [`chapters.json`](./chapters.json)
+  · [`curriculum.json`](./curriculum.json)
+  · [`pronunciation-reference.md`](./pronunciation-reference.md)
   · [`roadmap.md`](./roadmap.md) · [`session-map.md`](./session-map.md)
   · [`book/`](./book/)
 

--- a/code/learning/human-languages/kannada/chapters.json
+++ b/code/learning/human-languages/kannada/chapters.json
@@ -1,0 +1,560 @@
+{
+  "version": 1,
+  "language": "kannada",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapters 1-5 are absent on purpose — their lessons are still schema v1, carry no practises.knowledge, and have no core/book-generation.json target, so any payoff written for them would be invented rather than derived. That absence is real, measurable debt and must not be papered over with placeholders. No chapter from 6 on has a terminal practice/practice-mix lesson, so each payoff is the chapter's last lesson by sequence.",
+  "chapters": [
+    {
+      "chapter": 6,
+      "title": "Case Endings and Dative Subjects",
+      "label": "ch:ka-dative-case",
+      "canDo": "I can say that I know Kannada the way Kannada itself says it — with no subject at all, marking myself with the dative -ge.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "KA-C06-dative-subject",
+        "kind": "production",
+        "summary": "Say ನನಗೆ ಕನ್ನಡ ಗೊತ್ತು — \"to-me Kannada known\" — set against ನಾನು ಕನ್ನಡ ಮಾತನಾಡುತ್ತೇನೆ, then line up the four Dravidian datives -ge · -ukku · -ku · -ikku.",
+        "assesses": [
+          "KA-GRAMMAR-C06-DATIVE-STACKING-01",
+          "KA-LEX-C06-DATIVE-SUBJECT-01",
+          "KA-GRAMMAR-C06-DATIVE-SUBJECT-02",
+          "KA-GRAMMAR-C06-DATIVE-SUBJECT-03"
+        ]
+      }
+    },
+    {
+      "chapter": 7,
+      "title": "Numbers One to Ten",
+      "label": "ch:ka-numbers-one-to-ten",
+      "canDo": "I can count from one to ten in Kannada and read the Kannada digits ೧–೧೦ off the page.",
+      "spineNodes": [
+        "SPINE-COUNT-ONE-TO-FIVE"
+      ],
+      "payoff": {
+        "lesson": "KA-C07-numbers-6-10",
+        "kind": "task",
+        "summary": "Count ಒಂದು through ಹತ್ತು aloud, read the digits ೬ ೭ ೮ ೯ ೧೦, and hear the p → h shift that turns Tamil pattu into Kannada hattu.",
+        "assesses": [
+          "KA-LEX-C07-NUMBERS-1-5-01",
+          "KA-ETYMON-C07-NUMBERS-1-5-02",
+          "KA-GRAMMAR-C07-NUMBERS-1-5-03",
+          "KA-LEX-C07-NUMBERS-6-10-01",
+          "KA-ETYMON-C07-NUMBERS-6-10-02",
+          "KA-ETYMON-C07-NUMBERS-6-10-03"
+        ]
+      }
+    },
+    {
+      "chapter": 8,
+      "title": "Please",
+      "label": "ch:ka-please",
+      "canDo": "I can say please in Kannada, and use the polite verb ending Kannada reaches for far more often than the word itself.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "KA-C08-dayavittu",
+        "kind": "production",
+        "summary": "Build ದಯವಿಟ್ಟು out of daya (\"compassion\") + iṭṭu (\"having placed\"), then make the everyday polite request instead: ಕುಳಿತುಕೊಳ್ಳಿ, \"please sit.\"",
+        "assesses": [
+          "KA-ETYMON-C08-DAYAVITTU-01",
+          "KA-ETYMON-C08-DAYAVITTU-02",
+          "KA-PRAGMATICS-C08-DAYAVITTU-03",
+          "KA-SCRIPT-C08-DAYAVITTU-04"
+        ]
+      }
+    },
+    {
+      "chapter": 9,
+      "title": "Sorry",
+      "label": "ch:ka-sorry",
+      "canDo": "I can apologise in Kannada and ask someone to forgive me.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "KA-C09-kshamisi",
+        "kind": "production",
+        "summary": "Say ಕ್ಷಮಿಸಿ, trace it back through kṣamisu to Sanskrit kṣamā, and contrast it with Tamil's unrelated maṉṉikkavum.",
+        "assesses": [
+          "KA-ETYMON-C08-DAYAVITTU-01",
+          "KA-ETYMON-C08-DAYAVITTU-02",
+          "KA-PRAGMATICS-C08-DAYAVITTU-03",
+          "KA-SCRIPT-C08-DAYAVITTU-04",
+          "KA-ETYMON-C09-KSHAMISI-01",
+          "KA-ETYMON-C09-KSHAMISI-02",
+          "KA-PRAGMATICS-C09-KSHAMISI-03"
+        ]
+      }
+    },
+    {
+      "chapter": 10,
+      "title": "Days of the Week",
+      "label": "ch:ka-days-of-the-week",
+      "canDo": "I can name any day of the week in Kannada, including the Sunday that uses a different sun-name from Hindi's.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "KA-C10-vaara",
+        "kind": "task",
+        "summary": "Run Somavāra through Śanivāra, then name Sunday ಭಾನುವಾರ and say why it is Bhānu here where Hindi says Ravi.",
+        "assesses": [
+          "KA-ETYMON-C09-KSHAMISI-01",
+          "KA-ETYMON-C09-KSHAMISI-02",
+          "KA-PRAGMATICS-C09-KSHAMISI-03",
+          "KA-LEX-C10-VAARA-01"
+        ]
+      }
+    },
+    {
+      "chapter": 11,
+      "title": "Four Core Colours",
+      "label": "ch:ka-core-colours",
+      "canDo": "I can name four basic colours in Kannada — black, white, red, and blue.",
+      "spineNodes": [
+        "SPINE-DEFINITE-REFERENCE"
+      ],
+      "payoff": {
+        "lesson": "KA-C11-bannagalu",
+        "kind": "production",
+        "summary": "Say ಕಪ್ಪು, ಬಿಳಿ, ಕೆಂಪು — the three native colours — then the borrowed ನೀಲಿ, and point out that the week is Sanskritic where the colours are not.",
+        "assesses": [
+          "KA-LEX-C10-VAARA-01",
+          "KA-LEX-C11-BANNAGALU-01",
+          "KA-LEX-C11-BANNAGALU-02"
+        ]
+      }
+    },
+    {
+      "chapter": 12,
+      "title": "Family",
+      "label": "ch:ka-family",
+      "canDo": "I can name my parents and my brothers and sisters in Kannada, choosing the right word for older or younger.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "KA-C12-kutumba",
+        "kind": "production",
+        "summary": "Name ಅಪ್ಪ and ಅಮ್ಮ, then the four age-graded siblings ಅಣ್ಣ · ತಮ್ಮ · ಅಕ್ಕ · ತಂಗಿ, where age is chosen before gender.",
+        "assesses": [
+          "KA-LEX-C11-BANNAGALU-01",
+          "KA-LEX-C11-BANNAGALU-02",
+          "KA-ETYMON-C12-KUTUMBA-01",
+          "KA-ETYMON-C12-KUTUMBA-02"
+        ]
+      }
+    },
+    {
+      "chapter": 13,
+      "title": "Head and Hand",
+      "label": "ch:ka-head-and-hand",
+      "canDo": "I can name the head and the hand in Kannada.",
+      "spineNodes": [
+        "SPINE-CHECK-WELLBEING"
+      ],
+      "payoff": {
+        "lesson": "KA-C13-dehada-bhagagalu",
+        "kind": "production",
+        "summary": "Say ತಲೆ and ಕೈ, and hear how nearly unchanged they are across Tamil, Malayalam and Kannada.",
+        "assesses": [
+          "KA-ETYMON-C12-KUTUMBA-01",
+          "KA-ETYMON-C12-KUTUMBA-02",
+          "KA-LEX-C13-DEHADA-BHAGAGALU-01"
+        ]
+      }
+    },
+    {
+      "chapter": 14,
+      "title": "Seasons",
+      "label": "ch:ka-seasons",
+      "canDo": "I can name the four seasons in Kannada, including the monsoon that actually shapes the Karnataka year.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "KA-C14-kaalagalu",
+        "kind": "production",
+        "summary": "Say ಬೇಸಿಗೆ, ಮಳೆಗಾಲ and ಚಳಿಗಾಲ from native roots, then the doubly-Sanskrit ವಸಂತ ಋತು for spring.",
+        "assesses": [
+          "KA-LEX-C13-DEHADA-BHAGAGALU-01",
+          "KA-LEX-C14-KAALAGALU-01",
+          "KA-PRAGMATICS-C14-KAALAGALU-02"
+        ]
+      }
+    },
+    {
+      "chapter": 15,
+      "title": "Water and Rice",
+      "label": "ch:ka-water-and-rice",
+      "canDo": "I can ask for water in Kannada and tell raw rice apart from cooked rice.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "KA-C15-niiru-akki",
+        "kind": "task",
+        "summary": "Say ನೀರು — matching Tamil's neer, not Malayalam's — then separate ಅಕ್ಕಿ, raw rice, from ಅನ್ನ, the cooked rice on the plate.",
+        "assesses": [
+          "KA-LEX-C14-KAALAGALU-01",
+          "KA-PRAGMATICS-C14-KAALAGALU-02",
+          "KA-ETYMON-C15-NIIRU-AKKI-01",
+          "KA-ETYMON-C15-NIIRU-AKKI-02"
+        ]
+      }
+    },
+    {
+      "chapter": 16,
+      "title": "The Traditional Months",
+      "label": "ch:ka-traditional-months",
+      "canDo": "I can name the twelve traditional Kannada months and say when the new year Ugadi falls.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "KA-C16-tingalugalu",
+        "kind": "task",
+        "summary": "Recite Caitra through Phālguṇa, place Ugadi at Chaitra Śukla Pratipada, and note that this calendar is shared with Hindi, not with Tamil or Malayalam.",
+        "assesses": [
+          "KA-ETYMON-C15-NIIRU-AKKI-01",
+          "KA-ETYMON-C15-NIIRU-AKKI-02",
+          "KA-LEX-C16-TINGALUGALU-01",
+          "KA-PRAGMATICS-C16-TINGALUGALU-02"
+        ]
+      }
+    },
+    {
+      "chapter": 17,
+      "title": "Noon and Midnight",
+      "label": "ch:ka-noon-and-midnight",
+      "canDo": "I can say noon and midnight in Kannada and point out the \"middle\" word they share.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "KA-C17-madhyaahna-madhyaraatri",
+        "kind": "production",
+        "summary": "Say ಮಧ್ಯಾಹ್ನ and ಮಧ್ಯರಾತ್ರಿ, then isolate the madhya sitting inside both.",
+        "assesses": [
+          "KA-LEX-C16-TINGALUGALU-01",
+          "KA-PRAGMATICS-C16-TINGALUGALU-02",
+          "KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01",
+          "KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02",
+          "KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03"
+        ]
+      }
+    },
+    {
+      "chapter": 18,
+      "title": "Telling Time",
+      "label": "ch:ka-telling-time",
+      "canDo": "I can tell someone the time on the hour in Kannada.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "KA-C18-gante",
+        "kind": "task",
+        "summary": "Say ಗಂಟೆ — hour, and also \"bell\" — then ಒಂದು ಗಂಟೆ and ಎರಡು ಗಂಟೆ for one and two o'clock.",
+        "assesses": [
+          "KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01",
+          "KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02",
+          "KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03",
+          "KA-ETYMON-C18-GANTE-01",
+          "KA-PRAGMATICS-C18-GANTE-02",
+          "KA-GRAMMAR-C18-GANTE-03"
+        ]
+      }
+    },
+    {
+      "chapter": 19,
+      "title": "Asking Someone's Age",
+      "label": "ch:ka-asking-age",
+      "canDo": "I can ask someone how old they are in Kannada and give my own age in return.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "KA-C19-vayassu",
+        "kind": "dialogue",
+        "summary": "Ask ನಿನ್ನ ವಯಸ್ಸು ಎಷ್ಟು? and answer ನನ್ನ ವಯಸ್ಸು ಇಪ್ಪತ್ತು — a complete verbless exchange about age.",
+        "assesses": [
+          "KA-ETYMON-C18-GANTE-01",
+          "KA-PRAGMATICS-C18-GANTE-02",
+          "KA-GRAMMAR-C18-GANTE-03",
+          "KA-ETYMON-C19-VAYASSU-01",
+          "KA-GRAMMAR-C19-VAYASSU-02"
+        ]
+      }
+    },
+    {
+      "chapter": 20,
+      "title": "Numbers 11–20 and Weather",
+      "label": "ch:ka-numbers-and-weather",
+      "canDo": "I can say what the weather is doing in Kannada and count past ten up to twenty.",
+      "spineNodes": [
+        "SPINE-COUNT-ONE-TO-FIVE",
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "KA-C20-havamana",
+        "kind": "task",
+        "summary": "Say ಹವಾಮಾನ — the Persian hava plus Sanskrit māna — and report the weather with ಮಳೆ ಬರುತ್ತಿದೆ, \"rain is coming.\"",
+        "assesses": [
+          "KA-ETYMON-C18-GANTE-01",
+          "KA-PRAGMATICS-C18-GANTE-02",
+          "KA-GRAMMAR-C18-GANTE-03",
+          "KA-ETYMON-C20-HAVAMANA-01",
+          "KA-LEX-C20-HAVAMANA-02"
+        ]
+      }
+    },
+    {
+      "chapter": 21,
+      "title": "Dog and Cat",
+      "label": "ch:ka-dog-and-cat",
+      "canDo": "I can name a dog and a cat in Kannada.",
+      "spineNodes": [
+        "SPINE-DEFINITE-REFERENCE"
+      ],
+      "payoff": {
+        "lesson": "KA-C21-naayi-bekku",
+        "kind": "production",
+        "summary": "Say ನಾಯಿ, an unambiguously native Dravidian root, and ಬೆಕ್ಕು, a different ancient root from Tamil's everyday cat word.",
+        "assesses": [
+          "KA-ETYMON-C20-HANNONDU-IPPATTU-01",
+          "KA-ETYMON-C20-HANNONDU-IPPATTU-02",
+          "KA-ETYMON-C21-NAAYI-BEKKU-01",
+          "KA-ETYMON-C21-NAAYI-BEKKU-02"
+        ]
+      }
+    },
+    {
+      "chapter": 22,
+      "title": "Green and Yellow",
+      "label": "ch:ka-green-and-yellow",
+      "canDo": "I can name green and yellow in Kannada, on top of the four colours I already had.",
+      "spineNodes": [
+        "SPINE-DEFINITE-REFERENCE"
+      ],
+      "payoff": {
+        "lesson": "KA-C22-hasiru-haladi",
+        "kind": "production",
+        "summary": "Say ಹಸಿರು, a true cousin of Tamil paccai and Telugu pacca, then ಹಳದಿ, the turmeric-borrowing that is secretly a cousin of German gelb.",
+        "assesses": [
+          "KA-LEX-C11-BANNAGALU-01",
+          "KA-LEX-C11-BANNAGALU-02",
+          "KA-ETYMON-C21-NAAYI-BEKKU-01",
+          "KA-ETYMON-C21-NAAYI-BEKKU-02",
+          "KA-ETYMON-C22-HASIRU-HALADI-01",
+          "KA-ETYMON-C22-HASIRU-HALADI-02"
+        ]
+      }
+    },
+    {
+      "chapter": 23,
+      "title": "Day",
+      "label": "ch:ka-day",
+      "canDo": "I can say \"day\" in Kannada and tell it apart from the native word for daytime.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "KA-C23-dina",
+        "kind": "production",
+        "summary": "Say ದಿನ, kept whole as a Sanskrit tatsama where Hindi's din eroded, and set it against native ಹಗಲು, which means daytime rather than a day.",
+        "assesses": [
+          "KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01",
+          "KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02",
+          "KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03",
+          "KA-ETYMON-C23-DINA-01",
+          "KA-ETYMON-C23-DINA-02",
+          "KA-ETYMON-C23-DINA-03"
+        ]
+      }
+    },
+    {
+      "chapter": 24,
+      "title": "Night",
+      "label": "ch:ka-night",
+      "canDo": "I can say \"night\" in Kannada and recognise it inside the midnight word I already knew.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "KA-C24-ratri",
+        "kind": "production",
+        "summary": "Say ರಾತ್ರಿ, find it again inside ಮಧ್ಯರಾತ್ರಿ, and note that native ಇರುಳು lost its job where ಹಗಲು kept a different one.",
+        "assesses": [
+          "KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01",
+          "KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02",
+          "KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03",
+          "KA-ETYMON-C23-DINA-01",
+          "KA-ETYMON-C23-DINA-02",
+          "KA-ETYMON-C23-DINA-03",
+          "KA-ETYMON-C24-RATRI-01",
+          "KA-ETYMON-C24-RATRI-02"
+        ]
+      }
+    },
+    {
+      "chapter": 25,
+      "title": "Good Night",
+      "label": "ch:ka-good-night",
+      "canDo": "I can wish someone good night in Kannada.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "KA-C25-shubha-ratri",
+        "kind": "dialogue",
+        "summary": "Say ಶುಭ ರಾತ್ರಿ — \"auspicious night\" — pairing the ರಾತ್ರಿ already learned with śubha, from a root meaning \"to be beautiful.\"",
+        "assesses": [
+          "KA-ETYMON-C24-RATRI-01",
+          "KA-ETYMON-C24-RATRI-02",
+          "KA-ETYMON-C25-SHUBHA-RATRI-01",
+          "KA-ETYMON-C25-SHUBHA-RATRI-02",
+          "KA-ETYMON-C25-SHUBHA-RATRI-03"
+        ]
+      }
+    },
+    {
+      "chapter": 26,
+      "title": "Morning",
+      "label": "ch:ka-morning",
+      "canDo": "I can say \"morning\" in Kannada using the language's own native word for it.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "KA-C26-belagge",
+        "kind": "production",
+        "summary": "Say ಬೆಳಗ್ಗೆ, trace it to beḷagu (\"to dawn\") and beḷaku (\"light\"), and contrast it with the Sanskrit dina, rātri and madhyāhna around it.",
+        "assesses": [
+          "KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01",
+          "KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02",
+          "KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03",
+          "KA-ETYMON-C23-DINA-01",
+          "KA-ETYMON-C23-DINA-02",
+          "KA-ETYMON-C23-DINA-03",
+          "KA-ETYMON-C24-RATRI-01",
+          "KA-ETYMON-C24-RATRI-02",
+          "KA-ETYMON-C26-BELAGGE-01",
+          "KA-PRAGMATICS-C26-BELAGGE-02"
+        ]
+      }
+    },
+    {
+      "chapter": 27,
+      "title": "Evening",
+      "label": "ch:ka-evening",
+      "canDo": "I can say \"evening\" in Kannada.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "KA-C27-sanje",
+        "kind": "production",
+        "summary": "Say ಸಂಜೆ, follow it back through Maharashtri Prakrit to Sanskrit saṃdhyā, and set it beside Hindi's साँझ, the same root down a different Prakrit road.",
+        "assesses": [
+          "KA-ETYMON-C24-RATRI-01",
+          "KA-ETYMON-C24-RATRI-02",
+          "KA-ETYMON-C26-BELAGGE-01",
+          "KA-PRAGMATICS-C26-BELAGGE-02",
+          "KA-ETYMON-C27-SANJE-01",
+          "KA-ETYMON-C27-SANJE-02"
+        ]
+      }
+    },
+    {
+      "chapter": 28,
+      "title": "Afternoon",
+      "label": "ch:ka-afternoon",
+      "canDo": "I can say \"afternoon\" in Kannada and keep it distinct from noon.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "KA-C28-aparahna",
+        "kind": "production",
+        "summary": "Say ಅಪರಾಹ್ನ, split it into apara (\"latter\") + ahna (\"day\"), and match that -ahna against the one in ಮಧ್ಯಾಹ್ನ.",
+        "assesses": [
+          "KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01",
+          "KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02",
+          "KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03",
+          "KA-ETYMON-C28-APARAHNA-01",
+          "KA-PRAGMATICS-C28-APARAHNA-02"
+        ]
+      }
+    },
+    {
+      "chapter": 29,
+      "title": "Good Morning",
+      "label": "ch:ka-good-morning",
+      "canDo": "I can wish someone good morning in Kannada and judge when it will sound too formal.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "KA-C29-shubhodaya",
+        "kind": "dialogue",
+        "summary": "Say ಶುಭೋದಯ — śubha + udaya, \"auspicious rising\" — and note the formal/written skew that makes ನಮಸ್ಕಾರ the safer casual morning greeting.",
+        "assesses": [
+          "KA-ETYMON-C26-BELAGGE-01",
+          "KA-PRAGMATICS-C26-BELAGGE-02",
+          "KA-ETYMON-C29-SHUBHODAYA-01",
+          "KA-PRAGMATICS-C29-SHUBHODAYA-02"
+        ]
+      }
+    },
+    {
+      "chapter": 30,
+      "title": "Good Evening",
+      "label": "ch:ka-good-evening",
+      "canDo": "I can wish someone good evening in Kannada.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "KA-C30-shubha-sanje",
+        "kind": "dialogue",
+        "summary": "Say ಶುಭ ಸಂಜೆ, correct the common claim that ಸಂಜೆ is native Dravidian, and keep ನಮಸ್ಕಾರ as the all-hours fallback.",
+        "assesses": [
+          "KA-ETYMON-C27-SANJE-01",
+          "KA-ETYMON-C27-SANJE-02",
+          "KA-ETYMON-C29-SHUBHODAYA-01",
+          "KA-PRAGMATICS-C29-SHUBHODAYA-02",
+          "KA-ETYMON-C30-SHUBHA-SANJE-01",
+          "KA-PRAGMATICS-C30-SHUBHA-SANJE-02"
+        ]
+      }
+    },
+    {
+      "chapter": 31,
+      "title": "Good Afternoon",
+      "label": "ch:ka-good-afternoon",
+      "canDo": "I can wish someone good afternoon in Kannada, and fall back on ನಮಸ್ಕಾರ when I want a greeting that fits any hour.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "KA-C31-shubha-madhyahna",
+        "kind": "dialogue",
+        "summary": "Say ಶುಭ ಮಧ್ಯಾಹ್ನ — built on the \"noon\" word rather than ಅಪರಾಹ್ನ — and reach instead for ನಮಸ್ಕಾರ, the greeting confirmed to work at any time of day.",
+        "assesses": [
+          "KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-01",
+          "KA-ETYMON-C17-MADHYAAHNA-MADHYARAATRI-02",
+          "KA-PRAGMATICS-C17-MADHYAAHNA-MADHYARAATRI-03",
+          "KA-ETYMON-C28-APARAHNA-01",
+          "KA-PRAGMATICS-C28-APARAHNA-02",
+          "KA-ETYMON-C30-SHUBHA-SANJE-01",
+          "KA-PRAGMATICS-C30-SHUBHA-SANJE-02",
+          "KA-ETYMON-C31-SHUBHA-MADHYAHNA-01",
+          "KA-PRAGMATICS-C31-SHUBHA-MADHYAHNA-02"
+        ]
+      }
+    }
+  ]
+}

--- a/code/learning/human-languages/telugu/CHANGELOG.md
+++ b/code/learning/human-languages/telugu/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Chapter capability ledger — HL05 (2026-08-06)
+
+- Added [`chapters.json`](./chapters.json), the track's HL05 chapter capability
+  ledger. Twenty-six chapters — 6 through 31 — each declare a first-person
+  `canDo`, the shared spine nodes they realise, and a `payoff` naming the lesson
+  that proves the claim.
+- Every `payoff.assesses` list is copied verbatim from its payoff lesson's own
+  `practises.knowledge`, so the ledger cannot claim an atom the lesson does not
+  actually practise.
+- No chapter from 6 on has a terminal `practice`/`practice-mix` lesson — the
+  Chapter 5 recap was the last one authored. Each payoff is therefore the
+  chapter's **last lesson by `sequence`**. For Chapter 31 that is the register
+  lesson `TE-C31-subha-madhyahnam-register`, which is the right payoff anyway:
+  the chapter's promise is knowing *when* the greeting fits, not just saying it.
+- **Chapters 1–5 are deliberately absent.** Their lessons are still schema v1,
+  carry no `practises.knowledge`, and have no `core/book-generation.json`
+  target to derive a title from. A payoff written for them would be invented,
+  not derived; the gap is left visible as honest debt rather than stubbed.
+- Thinnest payoff, for the representativeness gate that lands next: Chapter 20
+  covers 2 of the 4 atoms its two lessons introduce — exactly the 0.5 threshold,
+  because the weather lesson closes a chapter that also teaches 11–20.
+
 ## Warning-free 95-page book (2026-08-03)
 
 - Explicit static font faces and bookmark-safe script commands remove all font

--- a/code/learning/human-languages/telugu/README.md
+++ b/code/learning/human-languages/telugu/README.md
@@ -52,6 +52,25 @@ book.
   All are schema v2, stay below five minutes, and generate twenty-six book
   chapters from the exact canonical sources consumed by Language Ladder.
 
+## Chapter capabilities
+
+[`chapters.json`](./chapters.json) is the track's
+[`HL05`](../../../specs/HL05-chapter-capability-and-step-by-step-shape.md)
+capability ledger: for each chapter, one first-person `canDo` ("I can tell
+someone the time on the hour in Telugu, in the singular and the plural"), the
+shared spine nodes it realises, and the `payoff` lesson that proves the claim,
+with the exact knowledge atoms that payoff exercises.
+
+Chapters **6–31** are authored — twenty-six entries. Chapters **1–5 are absent
+on purpose**: their lessons are still schema v1 with no `practises.knowledge`
+and no `core/book-generation.json` target, so a payoff for them could only be
+invented. That absence is measurable debt, not a placeholder.
+
+Because no chapter after 5 has a terminal `practice` lesson, each payoff is the
+chapter's last lesson by `sequence`. Chapter 31 is the one place where that rule
+picks a `culture` lesson rather than a word or phrase lesson — and correctly so,
+since that chapter's promise is judging when శుభ మధ్యాహ్నం fits the setting.
+
 ## Book / fonts
 
 The book compiles with XeLaTeX using the **vendored** Noto Sans Telugu font
@@ -63,7 +82,9 @@ destinations, bookmark warnings, or font warnings.
 
 ## Files
 
-- [`lessons/`](./lessons/) · [`pronunciation-reference.md`](./pronunciation-reference.md)
+- [`lessons/`](./lessons/) · [`chapters.json`](./chapters.json)
+  · [`curriculum.json`](./curriculum.json)
+  · [`pronunciation-reference.md`](./pronunciation-reference.md)
   · [`roadmap.md`](./roadmap.md) · [`session-map.md`](./session-map.md)
   · [`book/`](./book/)
 

--- a/code/learning/human-languages/telugu/chapters.json
+++ b/code/learning/human-languages/telugu/chapters.json
@@ -1,0 +1,549 @@
+{
+  "version": 1,
+  "language": "telugu",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapters 1-5 are absent on purpose — their lessons are still schema v1, carry no practises.knowledge, and have no core/book-generation.json target, so any payoff written for them would be invented rather than derived. That absence is real, measurable debt and must not be papered over with placeholders. No chapter from 6 on has a terminal practice/practice-mix lesson, so each payoff is the chapter's last lesson by sequence.",
+  "chapters": [
+    {
+      "chapter": 6,
+      "title": "Case Endings and Dative Subjects",
+      "label": "ch:te-dative-case",
+      "canDo": "I can say that I know Telugu the way Telugu itself says it — \"to me Telugu comes,\" with no subject and the dative -ku.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "TE-C06-dative-subject",
+        "kind": "production",
+        "summary": "Say నాకు తెలుగు వచ్చు against నేను తెలుగు మాట్లాడతాను, then line up the four Dravidian datives -ku · -ukku · -ge · -ikku.",
+        "assesses": [
+          "TE-LEX-C06-DATIVE-KU-01",
+          "TE-GRAMMAR-C06-DATIVE-KU-02",
+          "TE-LEX-C06-DATIVE-SUBJECT-01",
+          "TE-GRAMMAR-C06-DATIVE-SUBJECT-02",
+          "TE-ETYMON-C06-DATIVE-SUBJECT-03"
+        ]
+      }
+    },
+    {
+      "chapter": 7,
+      "title": "Numbers One to Ten",
+      "label": "ch:te-numbers-one-to-ten",
+      "canDo": "I can count from one to ten in Telugu, including the numbers that wander furthest from their Dravidian cousins.",
+      "spineNodes": [
+        "SPINE-COUNT-ONE-TO-FIVE"
+      ],
+      "payoff": {
+        "lesson": "TE-C07-numbers-6-10",
+        "kind": "task",
+        "summary": "Count ఒకటి through పది, say the two Telugu builds fresh — enimidi and tommidi — and hear seven's three fates in ēḻu, ēḷu and ēḍu.",
+        "assesses": [
+          "TE-LEX-C07-NUMBERS-1-5-01",
+          "TE-ETYMON-C07-NUMBERS-1-5-02",
+          "TE-SCRIPT-C07-NUMBERS-1-5-03",
+          "TE-LEX-C07-NUMBERS-6-10-01",
+          "TE-ETYMON-C07-NUMBERS-6-10-02",
+          "TE-ETYMON-C07-NUMBERS-6-10-03"
+        ]
+      }
+    },
+    {
+      "chapter": 8,
+      "title": "Please",
+      "label": "ch:te-please",
+      "canDo": "I can say please in Telugu, and use the polite -aṇḍi verb ending speakers actually reach for.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "TE-C08-dayachesi",
+        "kind": "production",
+        "summary": "Build దయచేసి out of daya (\"compassion\") + cēsi (\"having done\"), then make the everyday polite request instead: కూర్చోండి, \"please sit.\"",
+        "assesses": [
+          "TE-LEX-C08-DAYACHESI-01",
+          "TE-ETYMON-C08-DAYACHESI-02",
+          "TE-PRAGMATICS-C08-DAYACHESI-03",
+          "TE-SCRIPT-C08-DAYACHESI-04"
+        ]
+      }
+    },
+    {
+      "chapter": 9,
+      "title": "Sorry",
+      "label": "ch:te-sorry",
+      "canDo": "I can apologise in Telugu and ask someone to forgive me, using the same respectful ending.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "TE-C09-kshaminchandi",
+        "kind": "production",
+        "summary": "Say క్షమించండి, unpack it as kṣamin̄cu plus the respectful -aṇḍi already met in kūrcōṇḍi, and trace it to Sanskrit kṣamā.",
+        "assesses": [
+          "TE-LEX-C08-DAYACHESI-01",
+          "TE-ETYMON-C08-DAYACHESI-02",
+          "TE-PRAGMATICS-C08-DAYACHESI-03",
+          "TE-SCRIPT-C08-DAYACHESI-04",
+          "TE-ETYMON-C09-KSHAMINCHANDI-01",
+          "TE-ETYMON-C09-KSHAMINCHANDI-02",
+          "TE-PRAGMATICS-C09-KSHAMINCHANDI-03"
+        ]
+      }
+    },
+    {
+      "chapter": 10,
+      "title": "Days of the Week",
+      "label": "ch:te-days-of-the-week",
+      "canDo": "I can name any day of the week in Telugu, including the Sunday that is counted rather than named for a planet.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "TE-C10-vaaram",
+        "kind": "task",
+        "summary": "Run Somavāram through Śanivāram, then name Sunday ఆదివారం, \"the first day\" — positional like Arabic's numbered days, not planetary.",
+        "assesses": [
+          "TE-ETYMON-C09-KSHAMINCHANDI-01",
+          "TE-ETYMON-C09-KSHAMINCHANDI-02",
+          "TE-PRAGMATICS-C09-KSHAMINCHANDI-03",
+          "TE-ETYMON-C10-VAARAM-01",
+          "TE-PRAGMATICS-C10-VAARAM-02"
+        ]
+      }
+    },
+    {
+      "chapter": 11,
+      "title": "Four Core Colours",
+      "label": "ch:te-core-colours",
+      "canDo": "I can name four basic colours in Telugu — black, white, red, and blue.",
+      "spineNodes": [
+        "SPINE-DEFINITE-REFERENCE"
+      ],
+      "payoff": {
+        "lesson": "TE-C11-rangulu",
+        "kind": "production",
+        "summary": "Say నలుపు, తెలుపు, ఎరుపు — Telugu's own three — then నీలం, the borrowed blue every language in this course now shares.",
+        "assesses": [
+          "TE-ETYMON-C10-VAARAM-01",
+          "TE-PRAGMATICS-C10-VAARAM-02",
+          "TE-LEX-C11-RANGULU-01",
+          "TE-ETYMON-C11-RANGULU-02"
+        ]
+      }
+    },
+    {
+      "chapter": 12,
+      "title": "Family",
+      "label": "ch:te-family",
+      "canDo": "I can name my parents and my brothers and sisters in Telugu, choosing the right word for older or younger.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "TE-C12-kutumbam",
+        "kind": "production",
+        "summary": "Name నాన్న and అమ్మ, then the four age-graded siblings అన్న · తమ్ముడు · అక్క · చెల్లి, with చెల్లి being Telugu's own.",
+        "assesses": [
+          "TE-LEX-C11-RANGULU-01",
+          "TE-ETYMON-C11-RANGULU-02",
+          "TE-LEX-C12-KUTUMBAM-01",
+          "TE-ETYMON-C12-KUTUMBAM-02"
+        ]
+      }
+    },
+    {
+      "chapter": 13,
+      "title": "Head and Hand",
+      "label": "ch:te-head-and-hand",
+      "canDo": "I can name the head and the hand in Telugu.",
+      "spineNodes": [
+        "SPINE-CHECK-WELLBEING"
+      ],
+      "payoff": {
+        "lesson": "TE-C13-sharira-bhagalu",
+        "kind": "production",
+        "summary": "Say తల, plainly matching its cousins, and చెయ్యి — the same Dravidian root as kai, reshaped by sound change past easy recognition.",
+        "assesses": [
+          "TE-LEX-C12-KUTUMBAM-01",
+          "TE-ETYMON-C12-KUTUMBAM-02",
+          "TE-LEX-C13-SHARIRA-BHAGALU-01"
+        ]
+      }
+    },
+    {
+      "chapter": 14,
+      "title": "Seasons",
+      "label": "ch:te-seasons",
+      "canDo": "I can name the four seasons in Telugu, including the rains that anchor the year.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "TE-C14-rutuvulu",
+        "kind": "production",
+        "summary": "Say వేసవి (cousin of Kannada's bēsige), వానాకాలం and శీతాకాలం from native roots, then the doubly-Sanskrit వసంత ఋతువు.",
+        "assesses": [
+          "TE-LEX-C13-SHARIRA-BHAGALU-01",
+          "TE-LEX-C14-RUTUVULU-01",
+          "TE-PRAGMATICS-C14-RUTUVULU-02"
+        ]
+      }
+    },
+    {
+      "chapter": 15,
+      "title": "Water and Rice",
+      "label": "ch:te-water-and-rice",
+      "canDo": "I can ask for water in Telugu and tell raw rice apart from cooked rice.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "TE-C15-neellu-biyyam",
+        "kind": "task",
+        "summary": "Say నీళ్ళు — matching Tamil and Kannada — then separate బియ్యం, Telugu's own word for raw rice, from అన్నం, the cooked rice on the plate.",
+        "assesses": [
+          "TE-LEX-C14-RUTUVULU-01",
+          "TE-PRAGMATICS-C14-RUTUVULU-02",
+          "TE-ETYMON-C15-NEELLU-BIYYAM-01",
+          "TE-ETYMON-C15-NEELLU-BIYYAM-02"
+        ]
+      }
+    },
+    {
+      "chapter": 16,
+      "title": "The Traditional Months",
+      "label": "ch:te-traditional-months",
+      "canDo": "I can name the twelve traditional Telugu months and say when Ugadi, the new year, falls.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "TE-C16-nelalu",
+        "kind": "task",
+        "summary": "Recite Caitraṁ through Phālguṇaṁ, place Ugadi at Chaitra Śuddha Pādyami, and note the family split: Telugu and Kannada share Hindi's calendar, Tamil and Malayalam do not.",
+        "assesses": [
+          "TE-ETYMON-C15-NEELLU-BIYYAM-01",
+          "TE-ETYMON-C15-NEELLU-BIYYAM-02",
+          "TE-LEX-C16-NELALU-01",
+          "TE-ETYMON-C16-NELALU-02"
+        ]
+      }
+    },
+    {
+      "chapter": 17,
+      "title": "Noon and Midnight",
+      "label": "ch:te-noon-and-midnight",
+      "canDo": "I can say noon and midnight in Telugu and explain why one is \"middle\" and the other \"half.\"",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "TE-C17-madhyaahnam-ardharaatri",
+        "kind": "production",
+        "summary": "Say మధ్యాహ్నం and అర్ధరాత్రి, then separate madhya (\"middle\") from ardha (\"half\") — two different Sanskrit roots where Kannada uses one.",
+        "assesses": [
+          "TE-LEX-C16-NELALU-01",
+          "TE-ETYMON-C16-NELALU-02",
+          "TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01",
+          "TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02",
+          "TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03"
+        ]
+      }
+    },
+    {
+      "chapter": 18,
+      "title": "Telling Time",
+      "label": "ch:te-telling-time",
+      "canDo": "I can tell someone the time on the hour in Telugu, in the singular and the plural.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "TE-C18-ganta",
+        "kind": "task",
+        "summary": "Say గంట — hour, and also \"bell\" — then ఒక గంట for one o'clock and రెండు గంటలు for two, taking the plural -lu.",
+        "assesses": [
+          "TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01",
+          "TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02",
+          "TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03",
+          "TE-LEX-C18-GANTA-01",
+          "TE-PRAGMATICS-C18-GANTA-02",
+          "TE-GRAMMAR-C18-GANTA-03"
+        ]
+      }
+    },
+    {
+      "chapter": 19,
+      "title": "Asking Someone's Age",
+      "label": "ch:te-asking-age",
+      "canDo": "I can ask someone how old they are in Telugu and give my own age in return.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "TE-C19-vayasu",
+        "kind": "dialogue",
+        "summary": "Ask నీ వయసెంత? and answer నా వయసు ఇరవై — a complete verbless exchange about age.",
+        "assesses": [
+          "TE-LEX-C18-GANTA-01",
+          "TE-PRAGMATICS-C18-GANTA-02",
+          "TE-GRAMMAR-C18-GANTA-03",
+          "TE-ETYMON-C19-VAYASU-01",
+          "TE-GRAMMAR-C19-VAYASU-02"
+        ]
+      }
+    },
+    {
+      "chapter": 20,
+      "title": "Numbers 11–20 and Weather",
+      "label": "ch:te-numbers-and-weather",
+      "canDo": "I can say what the weather is doing in Telugu and count past ten up to twenty.",
+      "spineNodes": [
+        "SPINE-COUNT-ONE-TO-FIVE",
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "TE-C20-vatavaranam",
+        "kind": "task",
+        "summary": "Say వాతావరణం — a pure Sanskrit vāta + āvaraṇa, \"the covering of air\" — and report the weather with వర్షం పడుతోంది, \"rain is falling.\"",
+        "assesses": [
+          "TE-LEX-C18-GANTA-01",
+          "TE-PRAGMATICS-C18-GANTA-02",
+          "TE-GRAMMAR-C18-GANTA-03",
+          "TE-ETYMON-C20-VATAVARANAM-01",
+          "TE-GRAMMAR-C20-VATAVARANAM-02"
+        ]
+      }
+    },
+    {
+      "chapter": 21,
+      "title": "Dog and Cat",
+      "label": "ch:te-dog-and-cat",
+      "canDo": "I can name a dog and a cat in Telugu.",
+      "spineNodes": [
+        "SPINE-DEFINITE-REFERENCE"
+      ],
+      "payoff": {
+        "lesson": "TE-C21-kukka-pilli",
+        "kind": "production",
+        "summary": "Say కుక్క, which genuinely breaks from the family's shared naayi root, and పిల్లి, most likely the Dravidian source behind Hindi's billī.",
+        "assesses": [
+          "TE-ETYMON-C20-PADAKONDU-IRAVAI-01",
+          "TE-ETYMON-C20-PADAKONDU-IRAVAI-02",
+          "TE-ETYMON-C21-KUKKA-PILLI-01",
+          "TE-ETYMON-C21-KUKKA-PILLI-02"
+        ]
+      }
+    },
+    {
+      "chapter": 22,
+      "title": "Green and Yellow",
+      "label": "ch:te-green-and-yellow",
+      "canDo": "I can name green and yellow in Telugu, on top of the four colours I already had.",
+      "spineNodes": [
+        "SPINE-DEFINITE-REFERENCE"
+      ],
+      "payoff": {
+        "lesson": "TE-C22-pacha-pasupu",
+        "kind": "production",
+        "summary": "Say పచ్చ and పసుపు and show they are doublets of one Proto-Dravidian *pac- root — where Kannada's yellow broke away as a Sanskrit loan.",
+        "assesses": [
+          "TE-LEX-C11-RANGULU-01",
+          "TE-ETYMON-C11-RANGULU-02",
+          "TE-ETYMON-C21-KUKKA-PILLI-01",
+          "TE-ETYMON-C21-KUKKA-PILLI-02",
+          "TE-ETYMON-C22-PACHA-PASUPU-01",
+          "TE-ETYMON-C22-PACHA-PASUPU-02"
+        ]
+      }
+    },
+    {
+      "chapter": 23,
+      "title": "Day",
+      "label": "ch:te-day",
+      "canDo": "I can say \"day\" in Telugu and choose between the everyday Persian loan and its formal Sanskrit alternate.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "TE-C23-roju",
+        "kind": "production",
+        "summary": "Say రోజు, a genuine Persian loan from rōz, and set it against the formal దినము — the mirror image of Kannada's plain dina.",
+        "assesses": [
+          "TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01",
+          "TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02",
+          "TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03",
+          "TE-ETYMON-C23-ROJU-01",
+          "TE-PRAGMATICS-C23-ROJU-02"
+        ]
+      }
+    },
+    {
+      "chapter": 24,
+      "title": "Night",
+      "label": "ch:te-night",
+      "canDo": "I can say \"night\" in Telugu and recognise it inside the midnight word I already knew.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "TE-C24-ratri",
+        "kind": "production",
+        "summary": "Say రాత్రి, find it again inside అర్ధరాత్రి, and note the three native words — rēyi, māpu, irulu — it pushed aside.",
+        "assesses": [
+          "TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01",
+          "TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02",
+          "TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03",
+          "TE-ETYMON-C23-ROJU-01",
+          "TE-PRAGMATICS-C23-ROJU-02",
+          "TE-ETYMON-C24-RATRI-01",
+          "TE-ETYMON-C24-RATRI-02"
+        ]
+      }
+    },
+    {
+      "chapter": 25,
+      "title": "Good Night",
+      "label": "ch:te-good-night",
+      "canDo": "I can wish someone good night in Telugu.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "TE-C25-shubha-ratri",
+        "kind": "dialogue",
+        "summary": "Say శుభ రాత్రి — \"auspicious night\" — pairing the రాత్రి already learned with śubha, while knowing many speakers code-switch to English here.",
+        "assesses": [
+          "TE-ETYMON-C24-RATRI-01",
+          "TE-ETYMON-C24-RATRI-02",
+          "TE-ETYMON-C25-SHUBHA-RATRI-01",
+          "TE-PRAGMATICS-C25-SHUBHA-RATRI-02"
+        ]
+      }
+    },
+    {
+      "chapter": 26,
+      "title": "Morning",
+      "label": "ch:te-morning",
+      "canDo": "I can say \"morning\" in Telugu with the same word that sits inside the morning greeting.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "TE-C26-udayam",
+        "kind": "production",
+        "summary": "Say ఉదయం, Telugu's broadest morning word, note the real native competitors poddu and vēkuva, and see that Kannada splits this job across two unrelated words.",
+        "assesses": [
+          "TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01",
+          "TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02",
+          "TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03",
+          "TE-ETYMON-C23-ROJU-01",
+          "TE-PRAGMATICS-C23-ROJU-02",
+          "TE-ETYMON-C26-UDAYAM-01",
+          "TE-PRAGMATICS-C26-UDAYAM-02"
+        ]
+      }
+    },
+    {
+      "chapter": 27,
+      "title": "Evening",
+      "label": "ch:te-evening",
+      "canDo": "I can say \"evening\" in Telugu.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "TE-C27-sayantram",
+        "kind": "production",
+        "summary": "Say సాయంత్రం, from sāyam plus a time-suffix, and follow its PIE *seh₁- root across to Latin sērus, French soir and Italian sera.",
+        "assesses": [
+          "TE-ETYMON-C26-UDAYAM-01",
+          "TE-PRAGMATICS-C26-UDAYAM-02",
+          "TE-ETYMON-C27-SAYANTRAM-01",
+          "TE-ETYMON-C27-SAYANTRAM-02"
+        ]
+      }
+    },
+    {
+      "chapter": 28,
+      "title": "Afternoon",
+      "label": "ch:te-afternoon",
+      "canDo": "I can use Telugu's noon word to talk about the afternoon, and reach for the classical term when I need to be precise.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "TE-C28-madhyahnam-widened",
+        "kind": "production",
+        "summary": "Reuse మధ్యాహ్నం for the stretch between noon and evening, then contrast it with అపరాహ్నం, the more formal, more precise later-afternoon word.",
+        "assesses": [
+          "TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-01",
+          "TE-ETYMON-C17-MADHYAAHNAM-ARDHARAATRI-02",
+          "TE-GRAMMAR-C17-MADHYAAHNAM-ARDHARAATRI-03",
+          "TE-ETYMON-C27-SAYANTRAM-01",
+          "TE-ETYMON-C27-SAYANTRAM-02",
+          "TE-PRAGMATICS-C28-MADHYAHNAM-WIDENED-01",
+          "TE-ETYMON-C28-MADHYAHNAM-WIDENED-02"
+        ]
+      }
+    },
+    {
+      "chapter": 29,
+      "title": "Good Morning",
+      "label": "ch:te-good-morning",
+      "canDo": "I can wish someone good morning in Telugu.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "TE-C29-subhodayam",
+        "kind": "dialogue",
+        "summary": "Say శుభోదయం — śubha + ఉదయం — and weigh the single low-authority claim that it is out of trend against నమస్కారం, the safer everyday bet.",
+        "assesses": [
+          "TE-ETYMON-C26-UDAYAM-01",
+          "TE-PRAGMATICS-C26-UDAYAM-02",
+          "TE-ETYMON-C29-SUBHODAYAM-01",
+          "TE-PRAGMATICS-C29-SUBHODAYAM-02"
+        ]
+      }
+    },
+    {
+      "chapter": 30,
+      "title": "Good Evening",
+      "label": "ch:te-good-evening",
+      "canDo": "I can wish someone good evening in Telugu.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "TE-C30-subha-sayantram",
+        "kind": "dialogue",
+        "summary": "Say శుభ సాయంత్రం, backed by two independent sources as genuinely common in both formal and casual speech, with నమస్కారం as an alternative rather than a replacement.",
+        "assesses": [
+          "TE-ETYMON-C27-SAYANTRAM-01",
+          "TE-ETYMON-C27-SAYANTRAM-02",
+          "TE-ETYMON-C30-SUBHA-SAYANTRAM-01",
+          "TE-PRAGMATICS-C30-SUBHA-SAYANTRAM-02"
+        ]
+      }
+    },
+    {
+      "chapter": 31,
+      "title": "Good Afternoon",
+      "label": "ch:te-good-afternoon",
+      "canDo": "I can wish someone good afternoon in Telugu and judge whether it fits the setting I am in.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "TE-C31-subha-madhyahnam-register",
+        "kind": "dialogue",
+        "summary": "Say శుభ మధ్యాహ్నం where the setting is formal or workplace-timed, and fall back on నమస్కారం, the time-independent everyday greeting.",
+        "assesses": [
+          "TE-LEX-C31-SUBHA-MADHYAHNAM-01",
+          "TE-PRAGMATICS-C31-SUBHA-MADHYAHNAM-REGISTER-01",
+          "TE-PRAGMATICS-C31-SUBHA-MADHYAHNAM-REGISTER-02"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds `chapters.json` to both Dravidian sister tracks — the [HL05](../blob/main/code/specs/HL05-chapter-capability-and-step-by-step-shape.md) capability layer above the existing lessons. Each entry declares what the reader can do when they finish the chapter, and names the lesson that proves it.

Kannada and Telugu are done in one PR because they share a chapter skeleton (31 chapters, 26 with book targets, same spine mapping). They share **no content**: different lesson ids, different atoms, different headwords, different etymologies. Every `canDo` and `summary` was written from that track's own lesson bodies. Neither ledger was copied from the other.

## Counts

| track | authored | skipped |
|---|---|---|
| kannada | 26 (ch 6–31) | 5 (ch 1–5) |
| telugu | 26 (ch 6–31) | 5 (ch 1–5) |

### Skipped, and why — absent, not stubbed

Chapters **1, 2, 3, 4, 5** in both tracks. Three independent reasons, all pointing the same way:

- their lessons are still **schema v1** — no `practises.knowledge` at all, so `payoff.assesses` could only be invented;
- they have **no `core/book-generation.json` target**, so there is no canonical `title`/`label` to derive;
- their `practice` recaps predate the knowledge-atom model entirely.

A stub here would satisfy the loader while destroying exactly the signal the HL05 gap report exists to measure. The absence is recorded in each file's `note`, in both CHANGELOGs, and in both READMEs.

## How each field was derived — from the data, not guessed

- **`title` / `label`** — copied from that language's `core/book-generation.json` target. Asserted by the `chapter-title-drift` check in `tests/chapters.test.ts`.
- **`spineNodes`** — taken from each track's own `curriculum.json` path segments for that chapter's lessons. Every id is one of the eleven in `core/spine.json`; no chapter needed the empty-list escape.
- **`payoff.assesses`** — copied **verbatim** from the payoff lesson's own `practises.knowledge`. Generated programmatically from the frontmatter so no atom can be invented.
- **`canDo`** — one first-person sentence per chapter, describing what the reader can *do*: "I can tell someone the time on the hour in Kannada", "I can ask for water in Telugu and tell raw rice apart from cooked rice."
- **`payoff.summary`** — one concrete line drawn from that lesson's Guided Practice block.

## Payoff lesson selection — noted as requested

**No chapter from 6 on has a terminal `practice`/`practice-mix` lesson in either track.** The Chapter 5 recap was the last consolidation lesson authored; chapters 6–31 are single- or double-lesson chapters. Each payoff is therefore the chapter's **last lesson by `sequence`**, which in every case is the lesson whose Guided Practice block recombines the chapter's material.

One case worth calling out: **Telugu chapter 31** resolves to `TE-C31-subha-madhyahnam-register`, a `culture` lesson rather than a word or phrase lesson. That is the right payoff regardless of the rule — the chapter's promise is judging *when* శుభ మధ్యాహ్నం fits, not just saying it.

## Representativeness — thinnest payoffs, ahead of the gate

Threshold in `core/chapter-policy.json` is **0.5**.

| chapter | share | note |
|---|---|---|
| kannada ch20 | **0.50** (2/4) | exactly at threshold |
| telugu ch20 | **0.50** (2/4) | exactly at threshold |
| kannada ch06 | 0.67 (4/6) | |
| all others | 1.00 | |

Both ch20 entries sit exactly on the line because that chapter teaches two unrelated things — numbers 11–20 *and* weather — and the weather lesson is the one that closes it. If the gate is ever tightened above 0.5, or implemented as strictly greater-than, these are the two chapters that will flag first. They are the only ones at risk in either track.

## Verification

```
cd code/packages/typescript/human-language-data
npm ci --silent && npx tsc --noEmit && npx vitest run
```

**14 test files, 123 tests, all passing** — including the loader assertions that every payoff resolves to a lesson in the same chapter of the same language, that every claimed atom appears in that lesson's `practises.knowledge`, that every `canDo` starts with "I can ", and that titles/labels agree with `book-generation.json`.

No `package-lock.json` diff. Files staged by explicit path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw3PKmLS2yEnDmhck3fM1z)_