### PR TITLE
feat(human-languages): author Persian and Urdu chapter capability ledgers

### DIFF
--- a/code/learning/human-languages/persian/CHANGELOG.md
+++ b/code/learning/human-languages/persian/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.7.0 — 2026-08-06
+
+- Added `chapters.json`, the HL05 chapter capability ledger, for Chapters 2–5:
+  each declares a first-person `canDo`, the spine nodes it realises, and the
+  payoff lesson that proves the claim.
+- Every `payoff.assesses` list is the payoff lesson's own
+  `practises.knowledge` set verbatim — nothing is claimed that the lesson does
+  not already practise, and nothing is padded to clear a threshold.
+- Chapter 1 is deliberately omitted. Its four lessons are still schema v1 and
+  declare no knowledge atoms, so any payoff written for it would be invented
+  rather than derived. The gap is left visible as debt.
+- Measured payoff representativeness (assessed ÷ chapter-introduced atoms)
+  against the 0.5 policy threshold: ch2 3/3 = 1.00, ch3 7/14 = 0.50,
+  ch4 6/16 = 0.375, ch5 4/11 = 0.364. Chapters 4 and 5 sit below threshold
+  because their word lessons introduce script and etymon atoms that the
+  consolidating dialogue does not re-exercise; that is a content gap for a
+  later revision, not something to paper over here.
+
 ## 0.6.0 — 2026-08-04
 
 - Added four schema-v2 Chapter 5 micro-lessons for **خدا**, **حافظ**, joined

--- a/code/learning/human-languages/persian/README.md
+++ b/code/learning/human-languages/persian/README.md
@@ -23,6 +23,10 @@ materials. Romanization is a learning aid, not a substitute for reading Persian.
   exact session-count review ledger through S35.
 - [`pronunciation-reference.md`](./pronunciation-reference.md) collects the
   script and sound facts for lookup; it is never a prerequisite chapter.
+- [`chapters.json`](./chapters.json) is the HL05 capability ledger: for each
+  authored chapter, one first-person "I can …" promise and the payoff lesson
+  that proves it. Chapters 2–5 are authored; Chapter 1 is not, because its
+  lessons are still schema v1 and declare no knowledge atoms to assess.
 - [`lessons/`](./lessons/) contains the twenty canonical short practice lessons.
 - [`book/book.tex`](./book/book.tex) builds the free five-chapter starter edition
   with XeLaTeX; merged editions appear in the public human-languages book catalog.

--- a/code/learning/human-languages/persian/chapters.json
+++ b/code/learning/human-languages/persian/chapters.json
@@ -1,0 +1,87 @@
+{
+  "version": 1,
+  "language": "persian",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapter 1 is deliberately absent — all four of its lessons are still schema v1 with no declared knowledge atoms, so any payoff written for it would be invented rather than derived. That absence is real, measurable debt and must not be papered over with a placeholder.",
+  "chapters": [
+    {
+      "chapter": 2,
+      "title": "Give your name",
+      "label": "ch:persian-name",
+      "canDo": "I can say my name in Persian in one careful sentence, and I can hear the small linking -e that ties the name to its owner.",
+      "spineNodes": ["SPINE-EXCHANGE-NAMES"],
+      "payoff": {
+        "lesson": "FA-C02-esm-e-man",
+        "kind": "production",
+        "summary": "One careful sentence with a slot for your own name: esm-e man ... ast, with the spoken ezafe doing the linking.",
+        "assesses": [
+          "FA-LEX-ESM-E-MAN-AST",
+          "FA-SCRIPT-ESM-MAN-AST",
+          "FA-GRAMMAR-EZAFE-OWNER"
+        ]
+      }
+    },
+    {
+      "chapter": 3,
+      "title": "Ask and Answer Names",
+      "label": "ch:fa-ask-and-answer-names",
+      "canDo": "I can ask someone's name respectfully with shomâ, answer with my own, and tell them I am pleased to meet them.",
+      "spineNodes": ["SPINE-EXCHANGE-NAMES"],
+      "payoff": {
+        "lesson": "FA-C03-practice",
+        "kind": "dialogue",
+        "summary": "A six-line first meeting: greet, ask the name with respectful shomâ, answer with your own, and acknowledge with khoshvaghtam.",
+        "assesses": [
+          "FA-LEX-ESM-E-MAN-AST",
+          "FA-GRAMMAR-EZAFE-OWNER",
+          "FA-LEX-SHOMA-TO",
+          "FA-PRAGMATICS-SHOMA-REGISTER",
+          "FA-LEX-CHIST",
+          "FA-LEX-NAME-QUESTION",
+          "FA-SCRIPT-PERSIAN-QUESTION-MARK",
+          "FA-LEX-KHOSHVAGHTAM",
+          "FA-DIALOGUE-NAME-EXCHANGE"
+        ]
+      }
+    },
+    {
+      "chapter": 4,
+      "title": "How Are You?",
+      "label": "ch:fa-how-are-you",
+      "canDo": "I can ask how someone is in careful respectful Persian and answer that I am well, thank you.",
+      "spineNodes": ["SPINE-CHECK-WELLBEING"],
+      "payoff": {
+        "lesson": "FA-C04-practice",
+        "kind": "dialogue",
+        "summary": "The careful wellbeing exchange in two moves: hâl-e shomâ chetor ast? answered khubam, mamnun.",
+        "assesses": [
+          "FA-LEX-WELLBEING-QUESTION",
+          "FA-GRAMMAR-HAL-E-SHOMA",
+          "FA-PRAGMATICS-WELLBEING-FORMAL",
+          "FA-LEX-KHUBAM-REPLY",
+          "FA-GRAMMAR-PERSONAL-COPULA-AM",
+          "FA-DIALOGUE-NAME-EXCHANGE",
+          "FA-DIALOGUE-WELLBEING"
+        ]
+      }
+    },
+    {
+      "chapter": 5,
+      "title": "Take Leave",
+      "label": "ch:fa-take-leave",
+      "canDo": "I can open a short Persian conversation, check how the other person is, and close it with khodâ hâfez.",
+      "spineNodes": ["SPINE-TAKE-LEAVE"],
+      "payoff": {
+        "lesson": "FA-C05-practice",
+        "kind": "dialogue",
+        "summary": "A four-line interaction with a beginning and an end: salâm, the wellbeing check, then khodâ hâfez from both voices.",
+        "assesses": [
+          "FA-DIALOGUE-WELLBEING",
+          "FA-LEX-KHODAHAFEZ",
+          "FA-SCRIPT-KHODAHAFEZ-JOINED",
+          "FA-PRAGMATICS-STANDARD-FAREWELL",
+          "FA-DIALOGUE-TAKE-LEAVE"
+        ]
+      }
+    }
+  ]
+}

--- a/code/learning/human-languages/urdu/CHANGELOG.md
+++ b/code/learning/human-languages/urdu/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.7.0 — 2026-08-06
+
+- Added `chapters.json`, the HL05 chapter capability ledger, for Chapters 2–5:
+  each declares a first-person `canDo`, the spine nodes it realises, and the
+  payoff lesson that proves the claim.
+- Every `payoff.assesses` list is the payoff lesson's own
+  `practises.knowledge` set verbatim — nothing is claimed that the lesson does
+  not already practise, and nothing is padded to clear a threshold.
+- Chapter 1 is deliberately omitted. Its four lessons are still schema v1 and
+  declare no knowledge atoms, so any payoff written for it would be invented
+  rather than derived. The gap is left visible as debt.
+- Measured payoff representativeness (assessed ÷ chapter-introduced atoms)
+  against the 0.5 policy threshold: ch2 3/3 = 1.00, ch3 8/14 = 0.571,
+  ch4 6/16 = 0.375, ch5 4/12 = 0.333. Chapters 4 and 5 sit below threshold
+  because their word lessons introduce script, cross-lingual, and etymon atoms
+  that the consolidating dialogue does not re-exercise; that is a content gap
+  for a later revision, not something to paper over here.
+- Chapter capability text describes what the shipped book actually renders. The
+  Naskh fallback recorded in HL-U01 remains unfixed, so no chapter claims to
+  teach Nastaliq letterforms.
+
 ## 0.6.0 — 2026-08-04
 
 - Added four schema-v2 Chapter 5 micro-lessons for **خدا**, **حافظ**, spaced

--- a/code/learning/human-languages/urdu/README.md
+++ b/code/learning/human-languages/urdu/README.md
@@ -26,6 +26,12 @@ Script conventions are grounded in Northwestern University's *Zero Zabar*.
   exact session-count review ledger through S35.
 - [`pronunciation-reference.md`](./pronunciation-reference.md) gathers Urdu
   script and sound facts on demand and labels the current Naskh fallback.
+- [`chapters.json`](./chapters.json) is the HL05 capability ledger: for each
+  authored chapter, one first-person "I can …" promise and the payoff lesson
+  that proves it. Chapters 2–5 are authored; Chapter 1 is not, because its
+  lessons are still schema v1 and declare no knowledge atoms to assess. The
+  capability text describes the shipped Naskh-fallback rendering, not the
+  intended Nastaliq letterforms.
 - [`lessons/`](./lessons/) contains the twenty canonical short practice lessons.
 - [`book/book.tex`](./book/book.tex) builds the free five-chapter starter edition
   with XeLaTeX; merged editions appear in the public human-languages book catalog.

--- a/code/learning/human-languages/urdu/chapters.json
+++ b/code/learning/human-languages/urdu/chapters.json
@@ -1,0 +1,87 @@
+{
+  "version": 1,
+  "language": "urdu",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapter 1 is deliberately absent — all four of its lessons are still schema v1 with no declared knowledge atoms, so any payoff written for it would be invented rather than derived. That absence is real, measurable debt and must not be papered over with a placeholder.",
+  "chapters": [
+    {
+      "chapter": 2,
+      "title": "Give your name",
+      "label": "ch:urdu-name",
+      "canDo": "I can say my name in Urdu in one sentence, keeping hai at the end where Urdu puts it.",
+      "spineNodes": ["SPINE-EXCHANGE-NAMES"],
+      "payoff": {
+        "lesson": "UR-C02-mera-naam",
+        "kind": "production",
+        "summary": "One sentence with a slot for your own name: merā nām ... hai, with the copula held to the end of the line.",
+        "assesses": [
+          "UR-LEX-MERA-NAAM-HAI",
+          "UR-SCRIPT-MERA-NAAM-HAI",
+          "UR-GRAMMAR-COPULA-FINAL"
+        ]
+      }
+    },
+    {
+      "chapter": 3,
+      "title": "Ask and Answer Names",
+      "label": "ch:ur-ask-and-answer-names",
+      "canDo": "I can ask someone's name with respectful āp, answer with my own, and close the introduction politely.",
+      "spineNodes": ["SPINE-EXCHANGE-NAMES"],
+      "payoff": {
+        "lesson": "UR-C03-practice",
+        "kind": "dialogue",
+        "summary": "A six-line first meeting: greet, ask āp kā nām kyā hai?, answer with your own name, and close with āp se mil kar khushī huī.",
+        "assesses": [
+          "UR-LEX-MERA-NAAM-HAI",
+          "UR-GRAMMAR-COPULA-FINAL",
+          "UR-LEX-AAP-TUM-TU",
+          "UR-PRAGMATICS-YOU-REGISTER",
+          "UR-LEX-KYA",
+          "UR-LEX-NAME-QUESTION",
+          "UR-GRAMMAR-AAP-KA",
+          "UR-SCRIPT-URDU-QUESTION-MARK",
+          "UR-LEX-NICE-TO-MEET",
+          "UR-DIALOGUE-NAME-EXCHANGE"
+        ]
+      }
+    },
+    {
+      "chapter": 4,
+      "title": "How Are You?",
+      "label": "ch:ur-how-are-you",
+      "canDo": "I can ask how someone is with respectful āp, choose kaise or kaisī for the person I am addressing, and reply that I am fine, thank you.",
+      "spineNodes": ["SPINE-CHECK-WELLBEING"],
+      "payoff": {
+        "lesson": "UR-C04-practice",
+        "kind": "dialogue",
+        "summary": "The wellbeing exchange run both ways — āp kaise haiṅ? and āp kaisī haiṅ? — answered with the unchanging maiṅ ṭhīk hūṅ, shukriyā.",
+        "assesses": [
+          "UR-LEX-WELLBEING-QUESTION",
+          "UR-GRAMMAR-AAP-HAIN",
+          "UR-PRAGMATICS-RESPECTFUL-GENDER-CHOICE",
+          "UR-LEX-WELLBEING-REPLY",
+          "UR-GRAMMAR-WELLBEING-WORD-ORDER",
+          "UR-DIALOGUE-WELLBEING"
+        ]
+      }
+    },
+    {
+      "chapter": 5,
+      "title": "Take Leave",
+      "label": "ch:ur-take-leave",
+      "canDo": "I can open a short Urdu conversation, ask how the other person is, and close it with khudā hāfiz.",
+      "spineNodes": ["SPINE-TAKE-LEAVE"],
+      "payoff": {
+        "lesson": "UR-C05-practice",
+        "kind": "dialogue",
+        "summary": "A four-line interaction with a beginning and an end: salām, the wellbeing check, then khudā hāfiz from both voices.",
+        "assesses": [
+          "UR-DIALOGUE-WELLBEING",
+          "UR-LEX-KHUDA-HAFIZ",
+          "UR-SCRIPT-KHUDA-HAFIZ-SPACED",
+          "UR-PRAGMATICS-STANDARD-FAREWELL",
+          "UR-DIALOGUE-TAKE-LEAVE"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
HL-C11 for the two newest and cleanest tracks. Both Persian and Urdu now carry `chapters.json`, the HL05 capability layer: per chapter one first-person "I can …" promise, the shared spine nodes it realises, and the payoff lesson that proves the claim.

## What is authored

| Track | Authored | Omitted |
|---|---|---|
| persian | chapters 2, 3, 4, 5 | chapter 1 |
| urdu | chapters 2, 3, 4, 5 | chapter 1 |

Chapter 1 is deliberately omitted from both tracks. Its four lessons are still schema v1 and declare no `introduces` / `practises` knowledge atoms, so a payoff written for it would be invented rather than derived from the corpus. Leaving it absent keeps the gap measurable instead of papering over it with a placeholder.

## Everything is derived, not guessed

- **`title` / `label`** for chapters 3–5 are copied verbatim from the `core/book-generation.json` targets, so `chapter-title-drift` holds. Chapters 2 are **targetless**, so their printed names come from `book/chapters/ch02-give-your-name.tex`: title `Give your name`, labels `ch:persian-name` and `ch:urdu-name`. Worth flagging — those two labels use the older per-language prefix rather than the `ch:fa-` / `ch:ur-` convention the `book-generation.json` targets use. HL-C04 will have to reconcile that when it inverts title ownership.
- **`canDo`** restates each track's real spine extension `canDo` statements in the reader's voice rather than copying them verbatim.
- **`spineNodes`** come from each track's `curriculum.json` path segments; every id is present in `core/spine.json`.
- **`payoff.lesson`** is the chapter's `practice-mix` lesson for chapters 3–5. Chapter 2 has no practice lesson, so its payoff is the single `phrase` lesson (`FA-C02-esm-e-man` / `UR-C02-mera-naam`) with `kind: "production"` — the reader fills the name slot themselves.
- **`payoff.assesses`** is exactly the payoff lesson's own `practises.knowledge` set. No atom is invented, and no list is padded to clear a threshold.

## Payoff representativeness

Assessed ÷ chapter-introduced atoms, against the 0.5 threshold in `core/chapter-policy.json`:

| Chapter | persian | urdu |
|---|---|---|
| 2 | 3/3 = **1.000** | 3/3 = **1.000** |
| 3 | 7/14 = **0.500** | 8/14 = **0.571** |
| 4 | 6/16 = **0.375** ⚠️ | 6/16 = **0.375** ⚠️ |
| 5 | 4/11 = **0.364** ⚠️ | 4/12 = **0.333** ⚠️ |

Chapters 4 and 5 in both tracks fall below threshold, for the same reason in each case: the word lessons introduce script and etymon atoms that the consolidating dialogue never re-exercises — `FA-SCRIPT-KHUB`, `FA-ETYMON-HAFEZ`, `FA-LEX-KHODA`, `UR-SCRIPT-THIK`, `UR-GRAMMAR-MAIN-HUN-FRAME`, `UR-CROSSLINGUAL-KHUDA-HAFIZ-SPELLING`, and friends. That is a genuine content gap in those practice lessons, to be fixed by widening what the practice actually assesses. It is reported here rather than hidden by padding `assesses`.

## Track-specific notes

Both tracks are RTL. Urdu capability text describes what the shipped book actually renders: the Naskh fallback recorded in HL-U01 is still unfixed, so no Urdu chapter claims to teach Nastaliq letterforms. Persian and Urdu are derived independently from their own `curriculum.json`, lessons, and book targets — neither is treated as a variant of Arabic or Hindi.

## Verification

```
cd code/packages/typescript/human-language-data
npm ci && npx tsc --noEmit && npx vitest run
```

Clean typecheck; **14 test files, 123 tests passing**. That includes the `chapters.test.ts` assertions on first-person `canDo`, payoff lesson resolution into the same chapter and language, the `assesses` ⊆ `practises.knowledge` subset rule, and title/label agreement with `book-generation.json`. No `package-lock.json` diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw3PKmLS2yEnDmhck3fM1z)_