### PR TITLE
feat(human-languages): author Arabic and Malayalam chapter capability ledgers

### DIFF
--- a/code/learning/human-languages/arabic/CHANGELOG.md
+++ b/code/learning/human-languages/arabic/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Chapter capability ledger for Chapters 3–27 (2026-08-06)
+
+- Added [`chapters.json`](./chapters.json), the track's HL05 chapter capability
+  ledger: one `canDo` promise and one validated payoff for each of Chapters
+  3–27. Titles and labels are copied from `core/book-generation.json` so the
+  two agree until HL-C04 inverts that dependency; `spineNodes` are derived from
+  `curriculum.json`'s path segments; every `payoff.assesses` atom is taken from
+  the payoff lesson's own `practises.knowledge`, never invented.
+- **Chapters 1–2 are deliberately absent.** Their terminal practice lessons
+  (`AR-C01-practice`, `AR-C02-practice`) are still schema v1 and declare no
+  `practises.knowledge`, so no payoff can name an atom without fabricating one.
+  Those two chapters also have no `book-generation.json` target to copy a title
+  from. The gap is recorded in the file's own `note` and stays visible to the
+  HL05 gap report rather than being filled with a placeholder.
+- Only Chapters 3 and 4 end in a `practice` lesson; every later chapter's payoff
+  is its last lesson by `sequence`, which is what the corpus actually offers.
+  All sixteen inline `writing` steps fall inside Chapters 1–4, so no chapter's
+  payoff is a script-formation exercise — Chapter 3's payoff does include
+  writing **بخير** by hand, and its summary says so.
+
 ## Warning-free complete book (2026-08-03)
 
 - Added explicit static bold and italic faces for Arabic and Hebrew, plus

--- a/code/learning/human-languages/arabic/README.md
+++ b/code/learning/human-languages/arabic/README.md
@@ -72,9 +72,32 @@ duplicate-destination, bookmark, LaTeX, or font-shape warnings. Open-right blank
 versos are intentionally retained for print and contain no running header or
 page number.
 
+## Chapter capabilities
+
+[`chapters.json`](./chapters.json) is the track's
+[`HL05`](../../../specs/HL05-chapter-capability-and-step-by-step-shape.md)
+capability ledger. Each entry says, in the reader's own first-person words, what
+finishing that chapter lets them do, and names the lesson that proves it:
+
+```json
+{
+  "chapter": 17,
+  "title": "Asking Someone's Age",
+  "canDo": "I can ask how old someone is in Arabic and give my own age without using a verb.",
+  "payoff": { "lesson": "AR-C17-kam-umruka", "kind": "dialogue", "assesses": ["…"] }
+}
+```
+
+The file is **authored intent**, not a derived cache — no validator may rewrite
+it. Chapters 3–27 are covered. Chapters 1 and 2 are deliberately left out: their
+recap lessons are still schema v1 with no declared knowledge atoms, so a payoff
+there could only be invented. That absence is honest, measurable debt and is
+reported as such.
+
 ## Files
 
-- [`lessons/`](./lessons/) · [`pronunciation-reference.md`](./pronunciation-reference.md)
+- [`lessons/`](./lessons/) · [`chapters.json`](./chapters.json)
+  · [`pronunciation-reference.md`](./pronunciation-reference.md)
   · [`roadmap.md`](./roadmap.md) · [`session-map.md`](./session-map.md)
   · [`book/`](./book/)
 

--- a/code/learning/human-languages/arabic/chapters.json
+++ b/code/learning/human-languages/arabic/chapters.json
@@ -1,0 +1,457 @@
+{
+  "version": 1,
+  "language": "arabic",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapters 1-2 are deliberately absent -- their terminal practice lessons (AR-C01-practice, AR-C02-practice) are still schema v1 with no practises.knowledge, so no payoff can name atoms without inventing them. That absence is real, measurable debt and must not be papered over with placeholders.",
+  "chapters": [
+    {
+      "chapter": 3,
+      "title": "How Are You?",
+      "label": "ch:ar-how-are-you",
+      "canDo": "I can ask an Arabic speaker how they are, answer that I am well, and change the ending of the question to match a man or a woman.",
+      "spineNodes": [
+        "SPINE-CHECK-WELLBEING"
+      ],
+      "payoff": {
+        "lesson": "AR-C03-practice",
+        "kind": "dialogue",
+        "summary": "The whole how-are-you exchange, run once to a man and once to a woman, with bi-khayr written out by hand.",
+        "assesses": [
+          "AR-CONCEPT-C03-PRACTICE-01",
+          "AR-CONCEPT-C03-PRACTICE-02"
+        ]
+      }
+    },
+    {
+      "chapter": 4,
+      "title": "Farewells",
+      "label": "ch:ar-farewells",
+      "canDo": "I can close a conversation in Arabic, choosing between maʿa s-salāma and ilā l-liqāʾ.",
+      "spineNodes": [
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "AR-C04-practice",
+        "kind": "dialogue",
+        "summary": "The four-chapter conversation end to end -- greet, name, how-are-you, farewell -- with every -ka swapped to -ki on the second run.",
+        "assesses": [
+          "AR-CONCEPT-C04-PRACTICE-01",
+          "AR-CONCEPT-C04-PRACTICE-02"
+        ]
+      }
+    },
+    {
+      "chapter": 5,
+      "title": "Yes and No",
+      "label": "ch:ar-yes-and-no",
+      "canDo": "I can answer a question in Arabic with naʿam or lā, and write lā as the single joined lām-alif shape.",
+      "spineNodes": [
+        "SPINE-RESPOND-BASIC"
+      ],
+      "payoff": {
+        "lesson": "AR-C05-la",
+        "kind": "production",
+        "summary": "Say the yes/no pair and form lā as one lām-alif ligature rather than two separate letters.",
+        "assesses": [
+          "AR-CONCEPT-C05-LA-01",
+          "AR-CONCEPT-C05-LA-02"
+        ]
+      }
+    },
+    {
+      "chapter": 6,
+      "title": "Please",
+      "label": "ch:ar-please",
+      "canDo": "I can attach min faḍlik to a request in Arabic and change its ending for a man or a woman.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "AR-C06-min-fadlik",
+        "kind": "production",
+        "summary": "Say min faḍlik with the heavy ḍād, take it apart as 'from your grace', and offer law samaḥt as the alternative.",
+        "assesses": [
+          "AR-CONCEPT-C06-MIN-FADLIK-01",
+          "AR-CONCEPT-C06-MIN-FADLIK-02"
+        ]
+      }
+    },
+    {
+      "chapter": 7,
+      "title": "Sorry",
+      "label": "ch:ar-sorry",
+      "canDo": "I can apologise in Arabic with āsif or āsifa, choosing the form that matches who is speaking.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "AR-C07-asif",
+        "kind": "production",
+        "summary": "Say the apology twice -- āsif for a man, āsifa for a woman -- then the ungendered maʿdhira.",
+        "assesses": [
+          "AR-CONCEPT-C07-ASIF-01",
+          "AR-CONCEPT-C07-ASIF-02"
+        ]
+      }
+    },
+    {
+      "chapter": 8,
+      "title": "Days of the Week",
+      "label": "ch:ar-days-of-the-week",
+      "canDo": "I can name any day of the Arabic week and say which two days break the counting pattern.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "AR-C08-al-jumua-as-sabt",
+        "kind": "production",
+        "summary": "Name al-jumʿa and as-sabt beside the counted days, and place as-sabt next to Hebrew shabbāt.",
+        "assesses": [
+          "AR-CONCEPT-C08-AL-JUMUA-AS-SABT-01",
+          "AR-CONCEPT-C08-AL-JUMUA-AS-SABT-02"
+        ]
+      }
+    },
+    {
+      "chapter": 9,
+      "title": "Four Core Colours",
+      "label": "ch:ar-core-colours",
+      "canDo": "I can name black, white, red and blue in Arabic and give each colour's feminine form.",
+      "spineNodes": [
+        "SPINE-DEFINITE-REFERENCE"
+      ],
+      "payoff": {
+        "lesson": "AR-C09-ahmar-azraq",
+        "kind": "production",
+        "summary": "Run the four colours in the masculine, then again in the feminine -- ḥamrāʾ, zarqāʾ -- on the same template.",
+        "assesses": [
+          "AR-CONCEPT-C09-AHMAR-AZRAQ-01",
+          "AR-CONCEPT-C09-AHMAR-AZRAQ-02"
+        ]
+      }
+    },
+    {
+      "chapter": 10,
+      "title": "Family",
+      "label": "ch:ar-family",
+      "canDo": "I can name my father, mother, brother and sister in Arabic.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "AR-C10-akh-ukht",
+        "kind": "production",
+        "summary": "Say akh and ukht, show how ukht is built from the same root plus a feminine -t, and place both beside their Hebrew cousins.",
+        "assesses": [
+          "AR-CONCEPT-C10-AKH-UKHT-01",
+          "AR-CONCEPT-C10-AKH-UKHT-02"
+        ]
+      }
+    },
+    {
+      "chapter": 11,
+      "title": "Head and Hand",
+      "label": "ch:ar-head-and-hand",
+      "canDo": "I can name the head and the hand in Arabic.",
+      "spineNodes": [
+        "SPINE-CHECK-WELLBEING"
+      ],
+      "payoff": {
+        "lesson": "AR-C11-yad",
+        "kind": "production",
+        "summary": "Say yad, set it against its near-identical Hebrew twin, and contrast how much further raʾs drifted.",
+        "assesses": [
+          "AR-CONCEPT-C11-YAD-01",
+          "AR-CONCEPT-C11-YAD-02"
+        ]
+      }
+    },
+    {
+      "chapter": 12,
+      "title": "Seasons",
+      "label": "ch:ar-seasons",
+      "canDo": "I can name the four seasons in Arabic and say why the Islamic months do not stay inside them.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "AR-C12-al-fusul",
+        "kind": "production",
+        "summary": "Say rabīʿ, ṣayf, kharīf, shitāʾ, then explain the lunar calendar's drift against the solar seasons.",
+        "assesses": [
+          "AR-CONCEPT-C12-AL-FUSUL-01",
+          "AR-CONCEPT-C12-AL-FUSUL-02"
+        ]
+      }
+    },
+    {
+      "chapter": 13,
+      "title": "Water and Bread",
+      "label": "ch:ar-water-and-bread",
+      "canDo": "I can name water and bread in Arabic and say which of the two sits on a regular root.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "AR-C13-maa-khubz",
+        "kind": "production",
+        "summary": "Say māʾ with its irregular plural miyāh, then khubz from the clean root kh-b-z.",
+        "assesses": [
+          "AR-CONCEPT-C13-MAA-KHUBZ-01",
+          "AR-CONCEPT-C13-MAA-KHUBZ-02"
+        ]
+      }
+    },
+    {
+      "chapter": 14,
+      "title": "Months",
+      "label": "ch:ar-months",
+      "canDo": "I can name the months in Arabic and tell the borrowed civil calendar apart from the Islamic one.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "AR-C14-ashhur",
+        "kind": "production",
+        "summary": "Say the Latin-sounding civil months, then the first Hijri months, and state what each calendar is used for.",
+        "assesses": [
+          "AR-CONCEPT-C14-ASHHUR-01",
+          "AR-CONCEPT-C14-ASHHUR-02"
+        ]
+      }
+    },
+    {
+      "chapter": 15,
+      "title": "Noon and Midnight",
+      "label": "ch:ar-noon-and-midnight",
+      "canDo": "I can say noon and midnight in Arabic and recognise aẓ-ẓuhr as the name of the midday prayer.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "AR-C15-ad-duhr-muntasaf-al-layl",
+        "kind": "production",
+        "summary": "Say aẓ-ẓuhr and muntaṣaf al-layl, and name the religious sense Arabic's noon carries.",
+        "assesses": [
+          "AR-CONCEPT-C15-AD-DUHR-MUNTASAF-AL-LAYL-01",
+          "AR-CONCEPT-C15-AD-DUHR-MUNTASAF-AL-LAYL-02"
+        ]
+      }
+    },
+    {
+      "chapter": 16,
+      "title": "Telling Time",
+      "label": "ch:ar-telling-time",
+      "canDo": "I can ask what time it is in Arabic and answer with the hour.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "AR-C16-al-saa",
+        "kind": "dialogue",
+        "summary": "Ask kam as-sāʿa? and answer with the ordinal hour, including the one-o'clock exception.",
+        "assesses": [
+          "AR-CONCEPT-C16-AL-SAA-01",
+          "AR-CONCEPT-C16-AL-SAA-02"
+        ]
+      }
+    },
+    {
+      "chapter": 17,
+      "title": "Asking Someone's Age",
+      "label": "ch:ar-asking-age",
+      "canDo": "I can ask how old someone is in Arabic and give my own age without using a verb.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "AR-C17-kam-umruka",
+        "kind": "dialogue",
+        "summary": "Ask kam ʿumruka? and answer 'ʿumrī ʿishrūna sana' -- age as a noun you possess, no verb anywhere.",
+        "assesses": [
+          "AR-CONCEPT-C17-KAM-UMRUKA-01",
+          "AR-CONCEPT-C17-KAM-UMRUKA-02"
+        ]
+      }
+    },
+    {
+      "chapter": 18,
+      "title": "Weather",
+      "label": "ch:ar-weather",
+      "canDo": "I can say what the weather is doing in Arabic -- hot, cold, or raining.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "AR-C18-al-taqs",
+        "kind": "production",
+        "summary": "Say aṭ-ṭaqs, then the verbless al-jaw ḥārr / al-jaw bārid, then innahā tumṭir, which does take a verb.",
+        "assesses": [
+          "AR-CONCEPT-C18-AL-TAQS-01",
+          "AR-CONCEPT-C18-AL-TAQS-02"
+        ]
+      }
+    },
+    {
+      "chapter": 19,
+      "title": "Numbers One to Five",
+      "label": "ch:ar-numbers-one-to-five",
+      "canDo": "I can count from one to five in Arabic.",
+      "spineNodes": [
+        "SPINE-COUNT-ONE-TO-FIVE"
+      ],
+      "payoff": {
+        "lesson": "AR-C19-wahid-khamsa",
+        "kind": "production",
+        "summary": "Count wāḥid to khamsa, then separate the Arabic number WORDS from the Indian-origin digit shapes.",
+        "assesses": [
+          "AR-CONCEPT-C19-WAHID-KHAMSA-01",
+          "AR-CONCEPT-C19-WAHID-KHAMSA-02"
+        ]
+      }
+    },
+    {
+      "chapter": 20,
+      "title": "Numbers Eleven to Twenty",
+      "label": "ch:ar-numbers-eleven-to-twenty",
+      "canDo": "I can count from eleven to twenty in Arabic and build the teens as 'X and ten'.",
+      "spineNodes": [
+        "SPINE-COUNT-ONE-TO-FIVE"
+      ],
+      "payoff": {
+        "lesson": "AR-C20-ahada-ashar-ishrun",
+        "kind": "production",
+        "summary": "Build the teens as additive X-ʿashar compounds, then say ʿishrūn, which is not built that way at all.",
+        "assesses": [
+          "AR-CONCEPT-C20-AHADA-ASHAR-ISHRUN-01",
+          "AR-CONCEPT-C20-AHADA-ASHAR-ISHRUN-02"
+        ]
+      }
+    },
+    {
+      "chapter": 21,
+      "title": "Dog and Cat",
+      "label": "ch:ar-dog-and-cat",
+      "canDo": "I can name a dog and a cat in Arabic.",
+      "spineNodes": [
+        "SPINE-DEFINITE-REFERENCE"
+      ],
+      "payoff": {
+        "lesson": "AR-C21-kalb-qitt",
+        "kind": "production",
+        "summary": "Say kalb beside Hebrew kelev, then qiṭṭ beside Latin cattus, flagging that the cat link is still debated.",
+        "assesses": [
+          "AR-CONCEPT-C21-KALB-QITT-01",
+          "AR-CONCEPT-C21-KALB-QITT-02"
+        ]
+      }
+    },
+    {
+      "chapter": 22,
+      "title": "Green and Yellow",
+      "label": "ch:ar-green-and-yellow",
+      "canDo": "I can name green and yellow in Arabic and trace aṣfar to the same root as ṣifr, 'zero'.",
+      "spineNodes": [
+        "SPINE-DEFINITE-REFERENCE"
+      ],
+      "payoff": {
+        "lesson": "AR-C22-akhdar-asfar",
+        "kind": "production",
+        "summary": "Say akhḍar beside khuḍār, 'vegetables', then aṣfar beside ṣifr, and follow ṣifr into English zero and cipher.",
+        "assesses": [
+          "AR-CONCEPT-C22-AKHDAR-ASFAR-01",
+          "AR-CONCEPT-C22-AKHDAR-ASFAR-02"
+        ]
+      }
+    },
+    {
+      "chapter": 23,
+      "title": "You're Welcome",
+      "label": "ch:ar-youre-welcome",
+      "canDo": "I can reply to shukran with ʿafwan, and use the same word to say excuse me.",
+      "spineNodes": [
+        "SPINE-COURTESY-THANK"
+      ],
+      "payoff": {
+        "lesson": "AR-C23-afwan",
+        "kind": "production",
+        "summary": "Say ʿafwan as the reply to thanks, unpack the root 'to erase' behind it, and hear the same -an ending it shares with shukran.",
+        "assesses": [
+          "AR-CONCEPT-C23-AFWAN-01",
+          "AR-CONCEPT-C23-AFWAN-02"
+        ]
+      }
+    },
+    {
+      "chapter": 24,
+      "title": "See You Tomorrow",
+      "label": "ch:ar-see-you-tomorrow",
+      "canDo": "I can part from someone in Arabic with ilā l-ghad, 'until tomorrow'.",
+      "spineNodes": [
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "AR-C24-ila-al-ghad",
+        "kind": "production",
+        "summary": "Say ilā l-ghad, point to the ilā already known from ilā l-liqāʾ, and follow gh-d-w from 'dawn' to 'tomorrow'.",
+        "assesses": [
+          "AR-CONCEPT-C24-ILA-AL-GHAD-01",
+          "AR-CONCEPT-C24-ILA-AL-GHAD-02"
+        ]
+      }
+    },
+    {
+      "chapter": 25,
+      "title": "Day",
+      "label": "ch:ar-day",
+      "canDo": "I can say 'day' in Arabic and recognise its cognate in Hebrew's Yom Kippur.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "AR-C25-yawm",
+        "kind": "production",
+        "summary": "Say yawm, run it across the Semitic family, and mark the Egyptian sun-word origin as unsettled.",
+        "assesses": [
+          "AR-CONCEPT-C25-YAWM-01",
+          "AR-CONCEPT-C25-YAWM-02"
+        ]
+      }
+    },
+    {
+      "chapter": 26,
+      "title": "Night",
+      "label": "ch:ar-night",
+      "canDo": "I can say 'night' in Arabic and point to layl inside the midnight phrase I already know.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "AR-C26-layl",
+        "kind": "production",
+        "summary": "Say layl, find it inside muntaṣaf al-layl, and pair it with yawm as the other pan-Semitic half of the day.",
+        "assesses": [
+          "AR-CONCEPT-C26-LAYL-01",
+          "AR-CONCEPT-C26-LAYL-02"
+        ]
+      }
+    },
+    {
+      "chapter": 27,
+      "title": "Good Night",
+      "label": "ch:ar-good-night",
+      "canDo": "I can wish someone good night in Arabic and explain why the phrase actually talks about the morning.",
+      "spineNodes": [
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "AR-C27-tusbih-ala-khayr",
+        "kind": "production",
+        "summary": "Say tuṣbiḥ ʿalā khayr, translate it as 'may you wake into goodness', and trace tuṣbiḥ back to ṣabāḥ al-khayr's own root.",
+        "assesses": [
+          "AR-CONCEPT-C27-TUSBIH-ALA-KHAYR-01",
+          "AR-CONCEPT-C27-TUSBIH-ALA-KHAYR-02"
+        ]
+      }
+    }
+  ]
+}

--- a/code/learning/human-languages/malayalam/CHANGELOG.md
+++ b/code/learning/human-languages/malayalam/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Chapter capability ledger for Chapters 6–31 (2026-08-06)
+
+- Added [`chapters.json`](./chapters.json), the track's HL05 chapter capability
+  ledger: one `canDo` promise and one validated payoff for each of Chapters
+  6–31. Titles and labels are copied from `core/book-generation.json` so the two
+  agree until HL-C04 inverts that dependency; `spineNodes` are derived from
+  `curriculum.json`'s path segments; every `payoff.assesses` atom is taken from
+  the payoff lesson's own `practises.knowledge`, never invented.
+- Derived from the lessons and `curriculum.json` rather than from
+  [`roadmap.md`](./roadmap.md) or [`session-map.md`](./session-map.md), which
+  still lag the canonical Chapters 6–31 (known debt, HL-M04).
+- **Chapters 1–5 are deliberately absent.** Their terminal practice lessons
+  (`ML-C01-practice` … `ML-C05-practice`) are still schema v1 and declare no
+  `practises.knowledge`, so no payoff can name an atom without fabricating one.
+  Those five chapters also have no `book-generation.json` target to copy a title
+  from. The gap is recorded in the file's own `note` and stays visible to the
+  HL05 gap report rather than being filled with a placeholder.
+- No chapter from 6 on ends in a `practice` lesson, so every payoff is that
+  chapter's last lesson by `sequence`. Where that terminal lesson is an
+  `etymology` lesson (Chapters 23, 24, 31) the payoff is typed `task` and its
+  summary describes the sorting the reader actually does.
+
 ## Warning-free complete book (2026-08-03)
 
 - Added explicit static bold and italic faces for Malayalam and every

--- a/code/learning/human-languages/malayalam/README.md
+++ b/code/learning/human-languages/malayalam/README.md
@@ -69,9 +69,33 @@ The book compiles with XeLaTeX using the **vendored** Noto Sans Malayalam font
 (`../../_fonts/`), loaded by relative path — so it builds identically locally
 and in CI, no system-font dependency. `latexmk -xelatex book.tex`.
 
+## Chapter capabilities
+
+[`chapters.json`](./chapters.json) is the track's
+[`HL05`](../../../specs/HL05-chapter-capability-and-step-by-step-shape.md)
+capability ledger. Each entry says, in the reader's own first-person words, what
+finishing that chapter lets them do, and names the lesson that proves it:
+
+```json
+{
+  "chapter": 19,
+  "title": "Asking Someone's Age",
+  "canDo": "I can ask how old someone is in Malayalam and answer with a dative subject.",
+  "payoff": { "lesson": "ML-C19-vayassu", "kind": "dialogue", "assesses": ["…"] }
+}
+```
+
+The file is **authored intent**, not a derived cache — no validator may rewrite
+it, and it is derived from the lessons themselves rather than from `roadmap.md`,
+which still lags Chapters 6–31. Chapters 6–31 are covered. Chapters 1–5 are
+deliberately left out: their recap lessons are still schema v1 with no declared
+knowledge atoms, so a payoff there could only be invented. That absence is
+honest, measurable debt and is reported as such.
+
 ## Files
 
-- [`lessons/`](./lessons/) · [`pronunciation-reference.md`](./pronunciation-reference.md)
+- [`lessons/`](./lessons/) · [`chapters.json`](./chapters.json)
+  · [`pronunciation-reference.md`](./pronunciation-reference.md)
   · [`roadmap.md`](./roadmap.md) · [`session-map.md`](./session-map.md)
   · [`book/`](./book/)
 

--- a/code/learning/human-languages/malayalam/chapters.json
+++ b/code/learning/human-languages/malayalam/chapters.json
@@ -1,0 +1,476 @@
+{
+  "version": 1,
+  "language": "malayalam",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapters 1-5 are deliberately absent -- their terminal practice lessons (ML-C01-practice through ML-C05-practice) are still schema v1 with no practises.knowledge, so no payoff can name atoms without inventing them. That absence is real, measurable debt and must not be papered over with placeholders.",
+  "chapters": [
+    {
+      "chapter": 6,
+      "title": "Case Endings and Dative Subjects",
+      "label": "ch:ml-dative-case",
+      "canDo": "I can say that I know Malayalam the way Malayalam itself builds it -- with no subject at all, marking myself with the dative -ikku.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "ML-C06-dative-subject",
+        "kind": "production",
+        "summary": "Say enikku malayāḷam aṟiyām, set it against ñān malayāḷam saṁsārikkunnu, and stack the dative's four Dravidian cousins.",
+        "assesses": [
+          "ML-CONCEPT-C06-DATIVE-SUBJECT-01",
+          "ML-CONCEPT-C06-DATIVE-SUBJECT-02",
+          "ML-CONCEPT-C06-DATIVE-SUBJECT-03"
+        ]
+      }
+    },
+    {
+      "chapter": 7,
+      "title": "Numbers One to Ten",
+      "label": "ch:ml-numbers-one-to-ten",
+      "canDo": "I can count from one to ten in Malayalam.",
+      "spineNodes": [
+        "SPINE-COUNT-ONE-TO-FIVE"
+      ],
+      "payoff": {
+        "lesson": "ML-C07-numbers-6-10",
+        "kind": "production",
+        "summary": "Count āṟu to pattu, keep the rare ḻ of ēḻu, and take ompatu apart as 'one short of ten'.",
+        "assesses": [
+          "ML-CONCEPT-C07-NUMBERS-6-10-01",
+          "ML-CONCEPT-C07-NUMBERS-6-10-02",
+          "ML-CONCEPT-C07-NUMBERS-6-10-03"
+        ]
+      }
+    },
+    {
+      "chapter": 8,
+      "title": "Please",
+      "label": "ch:ml-please",
+      "canDo": "I can say please in Malayalam, and soften a request with the everyday verb ending instead.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "ML-C08-dayavayi",
+        "kind": "production",
+        "summary": "Say dayavāyi, split it into daya 'compassion' plus -vāyi, then use the plainer -u verb ending as the everyday alternative.",
+        "assesses": [
+          "ML-CONCEPT-C08-DAYAVAYI-01",
+          "ML-CONCEPT-C08-DAYAVAYI-02",
+          "ML-CONCEPT-C08-DAYAVAYI-03",
+          "ML-CONCEPT-C08-DAYAVAYI-04"
+        ]
+      }
+    },
+    {
+      "chapter": 9,
+      "title": "Sorry",
+      "label": "ch:ml-sorry",
+      "canDo": "I can apologise in Malayalam with kṣamikkaṇaṁ, and use the plainer kṣamikkū when it suits.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "ML-C09-kshamikkanam",
+        "kind": "production",
+        "summary": "Say kṣamikkaṇaṁ, hear the necessitative -aṇaṁ softening it into politeness, then drop to the plain kṣamikkū.",
+        "assesses": [
+          "ML-CONCEPT-C09-KSHAMIKKANAM-01",
+          "ML-CONCEPT-C09-KSHAMIKKANAM-02",
+          "ML-CONCEPT-C09-KSHAMIKKANAM-03"
+        ]
+      }
+    },
+    {
+      "chapter": 10,
+      "title": "Days of the Week",
+      "label": "ch:ml-days-of-the-week",
+      "canDo": "I can name the seven days of the Malayalam week and say which planet each one is named for.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "ML-C10-azhcha",
+        "kind": "production",
+        "summary": "Name the seven planet-days, separate the native ones from the Sanskrit ones, and explain their near-identity with Tamil's.",
+        "assesses": [
+          "ML-CONCEPT-C10-AZHCHA-01",
+          "ML-CONCEPT-C10-AZHCHA-02"
+        ]
+      }
+    },
+    {
+      "chapter": 11,
+      "title": "Four Core Colours",
+      "label": "ch:ml-core-colours",
+      "canDo": "I can name black, white, red and blue in Malayalam.",
+      "spineNodes": [
+        "SPINE-DEFINITE-REFERENCE"
+      ],
+      "payoff": {
+        "lesson": "ML-C11-nirangal",
+        "kind": "production",
+        "summary": "Say karuppŭ, veḷḷa, cuvappŭ and nīla, and mark which three are native Dravidian and which one is a shared Sanskrit loan.",
+        "assesses": [
+          "ML-CONCEPT-C11-NIRANGAL-01",
+          "ML-CONCEPT-C11-NIRANGAL-02"
+        ]
+      }
+    },
+    {
+      "chapter": 12,
+      "title": "Family",
+      "label": "ch:ml-family",
+      "canDo": "I can name my father, mother, and my older and younger brothers and sisters in Malayalam.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "ML-C12-kudumbam",
+        "kind": "production",
+        "summary": "Say the six family words in age-graded pairs, and note that Malayalam built its own sibling set rather than tracking Tamil's.",
+        "assesses": [
+          "ML-CONCEPT-C12-KUDUMBAM-01",
+          "ML-CONCEPT-C12-KUDUMBAM-02"
+        ]
+      }
+    },
+    {
+      "chapter": 13,
+      "title": "Head and Hand",
+      "label": "ch:ml-head-and-hand",
+      "canDo": "I can name the head and the hand in Malayalam.",
+      "spineNodes": [
+        "SPINE-CHECK-WELLBEING"
+      ],
+      "payoff": {
+        "lesson": "ML-C13-shareera-bhaagangal",
+        "kind": "production",
+        "summary": "Say thala and kai, and match them against Tamil's talai and kai.",
+        "assesses": [
+          "ML-CONCEPT-C13-SHAREERA-BHAAGANGAL-01"
+        ]
+      }
+    },
+    {
+      "chapter": 14,
+      "title": "Seasons",
+      "label": "ch:ml-seasons",
+      "canDo": "I can name Malayalam's four seasons, including the monsoon that sits at the centre of the year.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "ML-C14-kaalangal",
+        "kind": "production",
+        "summary": "Say vēnalkkālam, mazhakkālam and śaithyakālam as native compounds, then vasanthakālam as the shared Sanskrit loan.",
+        "assesses": [
+          "ML-CONCEPT-C14-KAALANGAL-01",
+          "ML-CONCEPT-C14-KAALANGAL-02"
+        ]
+      }
+    },
+    {
+      "chapter": 15,
+      "title": "Water and Rice",
+      "label": "ch:ml-water-and-rice",
+      "canDo": "I can name water and rice in Malayalam, keeping raw ari apart from cooked cōṟu.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "ML-C15-vellam-ari",
+        "kind": "production",
+        "summary": "Say veḷḷam and explain why it does not match Tamil's nīr, then split ari from cōṟu.",
+        "assesses": [
+          "ML-CONCEPT-C15-VELLAM-ARI-01",
+          "ML-CONCEPT-C15-VELLAM-ARI-02"
+        ]
+      }
+    },
+    {
+      "chapter": 16,
+      "title": "The Traditional Months",
+      "label": "ch:ml-traditional-months",
+      "canDo": "I can name the twelve months of the Malayalam Kollam-era calendar and say which zodiac sign each one carries.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "ML-C16-kollavarsham-maasangal",
+        "kind": "production",
+        "summary": "Recite the twelve months from Chiṅṅam, tie Chiṅṅam to Leo, and contrast Malayalam's zodiac naming with Tamil's nakshatras.",
+        "assesses": [
+          "ML-CONCEPT-C16-KOLLAVARSHAM-MAASANGAL-01",
+          "ML-CONCEPT-C16-KOLLAVARSHAM-MAASANGAL-02"
+        ]
+      }
+    },
+    {
+      "chapter": 17,
+      "title": "Noon and Midnight",
+      "label": "ch:ml-noon-and-midnight",
+      "canDo": "I can say noon and midnight in Malayalam and hear paathi, 'half', inside paathira.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "ML-C17-paathira",
+        "kind": "production",
+        "summary": "Say pāthira, pull pāthi out of it, and show it is a native half-word rather than Sanskrit ardha.",
+        "assesses": [
+          "ML-CONCEPT-C17-PAATHIRA-01"
+        ]
+      }
+    },
+    {
+      "chapter": 18,
+      "title": "Telling Time",
+      "label": "ch:ml-telling-time",
+      "canDo": "I can say the hour in Malayalam with maṇi, as in oru maṇi, one o'clock.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "ML-C18-mani",
+        "kind": "production",
+        "summary": "Say maṇi for hour, bell and gem, then oru maṇi, and state where Malayalam's and Tamil's dictionaries disagree about it.",
+        "assesses": [
+          "ML-CONCEPT-C18-MANI-01",
+          "ML-CONCEPT-C18-MANI-02"
+        ]
+      }
+    },
+    {
+      "chapter": 19,
+      "title": "Asking Someone's Age",
+      "label": "ch:ml-asking-age",
+      "canDo": "I can ask how old someone is in Malayalam and answer with a dative subject.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "ML-C19-vayassu",
+        "kind": "dialogue",
+        "summary": "Ask ningaḷkku ethra vayassuṇṭŭ? and answer enikku irupatu vayassuṇṭŭ -- 'to me twenty age exists'.",
+        "assesses": [
+          "ML-CONCEPT-C19-VAYASSU-01"
+        ]
+      }
+    },
+    {
+      "chapter": 20,
+      "title": "Numbers 11–20 and Weather",
+      "label": "ch:ml-numbers-and-weather",
+      "canDo": "I can count from eleven to twenty in Malayalam and say what the weather is doing.",
+      "spineNodes": [
+        "SPINE-COUNT-ONE-TO-FIVE",
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "ML-C20-kalavastha",
+        "kind": "production",
+        "summary": "Say kālāvastha as 'the state of time', split it into kālam and avastha, and add mazha peyyunnu for rain.",
+        "assesses": [
+          "ML-CONCEPT-C20-KALAVASTHA-01",
+          "ML-CONCEPT-C20-KALAVASTHA-02"
+        ]
+      }
+    },
+    {
+      "chapter": 21,
+      "title": "Dog and Cat",
+      "label": "ch:ml-dog-and-cat",
+      "canDo": "I can name a dog and a cat in Malayalam.",
+      "spineNodes": [
+        "SPINE-DEFINITE-REFERENCE"
+      ],
+      "payoff": {
+        "lesson": "ML-C21-naaya-poocha",
+        "kind": "production",
+        "summary": "Say nāya on the shared Dravidian dog-root, then pūcha, which follows Tamil's cat-word rather than Kannada's.",
+        "assesses": [
+          "ML-CONCEPT-C21-NAAYA-POOCHA-01",
+          "ML-CONCEPT-C21-NAAYA-POOCHA-02"
+        ]
+      }
+    },
+    {
+      "chapter": 22,
+      "title": "Green and Yellow",
+      "label": "ch:ml-green-and-yellow",
+      "canDo": "I can name green and yellow in Malayalam and say why the two come from unrelated roots.",
+      "spineNodes": [
+        "SPINE-DEFINITE-REFERENCE"
+      ],
+      "payoff": {
+        "lesson": "ML-C22-paccha-manja",
+        "kind": "production",
+        "summary": "Say paccha beside Tamil paccai and mañña beside mañcaḷ, and show they are not doublets of each other.",
+        "assesses": [
+          "ML-CONCEPT-C22-PACCHA-MANJA-01",
+          "ML-CONCEPT-C22-PACCHA-MANJA-02"
+        ]
+      }
+    },
+    {
+      "chapter": 23,
+      "title": "Day",
+      "label": "ch:ml-day",
+      "canDo": "I can use divasam for an everyday day in Malayalam and still recognise native nāḷ where it survives.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "ML-C23-naal",
+        "kind": "task",
+        "summary": "Find nāḷ alive inside nāḷe, oru nāḷ and piṟannāḷ, and answer whether Sanskrit divasam erased it.",
+        "assesses": [
+          "ML-CONCEPT-C23-NAAL-01"
+        ]
+      }
+    },
+    {
+      "chapter": 24,
+      "title": "Night",
+      "label": "ch:ml-night",
+      "canDo": "I can say night in Malayalam with rāthri and tell literary iravŭ apart from everyday iruḷ, 'darkness'.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "ML-C24-native-night-words",
+        "kind": "task",
+        "summary": "Sort iravŭ from iruḷ by the job each one still does in the modern language.",
+        "assesses": [
+          "ML-CONCEPT-C24-NATIVE-NIGHT-WORDS-01"
+        ]
+      }
+    },
+    {
+      "chapter": 25,
+      "title": "Good Night",
+      "label": "ch:ml-good-night",
+      "canDo": "I can wish someone good night in Malayalam with śubha rāthri.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "ML-C25-shubha-rathri",
+        "kind": "production",
+        "summary": "Say śubha rāthri as 'auspicious night', and mark the English code-switching claim as thinly sourced and not unique to Malayalam.",
+        "assesses": [
+          "ML-CONCEPT-C25-SHUBHA-RATHRI-01",
+          "ML-CONCEPT-C25-SHUBHA-RATHRI-02"
+        ]
+      }
+    },
+    {
+      "chapter": 26,
+      "title": "Morning",
+      "label": "ch:ml-morning",
+      "canDo": "I can say morning in Malayalam with rāvile and hear the night-word hidden inside it.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "ML-C26-raavile",
+        "kind": "production",
+        "summary": "Say rāvile, pull rāvŭ 'night' out of it, and place prabhātaṁ beside it as the Sanskrit alternative.",
+        "assesses": [
+          "ML-CONCEPT-C26-RAAVILE-01",
+          "ML-CONCEPT-C26-RAAVILE-02",
+          "ML-CONCEPT-C26-RAAVILE-03"
+        ]
+      }
+    },
+    {
+      "chapter": 27,
+      "title": "Evening",
+      "label": "ch:ml-evening",
+      "canDo": "I can say evening in Malayalam with vaikunnēraṁ, 'latening time'.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "ML-C27-vaikunneram",
+        "kind": "production",
+        "summary": "Say vaikunnēraṁ, trace it to vaikuka 'to get late', and flag that sources disagree on whether it also covers afternoon.",
+        "assesses": [
+          "ML-CONCEPT-C27-VAIKUNNERAM-01",
+          "ML-CONCEPT-C27-VAIKUNNERAM-02"
+        ]
+      }
+    },
+    {
+      "chapter": 28,
+      "title": "Afternoon",
+      "label": "ch:ml-afternoon",
+      "canDo": "I can say afternoon in Malayalam as uchakaḻiññ -- literally 'noon having passed'.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "ML-C28-uchakazhinju",
+        "kind": "production",
+        "summary": "Build uchakaḻiññ from ucha plus kaḻiyuka, and contrast it with Telugu, which widened its noon-word instead.",
+        "assesses": [
+          "ML-CONCEPT-C28-UCHAKAZHINJU-01",
+          "ML-CONCEPT-C28-UCHAKAZHINJU-02"
+        ]
+      }
+    },
+    {
+      "chapter": 29,
+      "title": "Good Morning",
+      "label": "ch:ml-good-morning",
+      "canDo": "I can greet someone in the morning in Malayalam with suprabhātaṁ.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "ML-C29-suprabhaatham",
+        "kind": "production",
+        "summary": "Say suprabhātaṁ, split su- from prabhātaṁ, and show it is NOT built on śubha the way good night is.",
+        "assesses": [
+          "ML-CONCEPT-C29-SUPRABHAATHAM-01",
+          "ML-CONCEPT-C29-SUPRABHAATHAM-02"
+        ]
+      }
+    },
+    {
+      "chapter": 30,
+      "title": "Good Evening",
+      "label": "ch:ml-good-evening",
+      "canDo": "I can greet someone in the evening in Malayalam with śubha sāyāhnaṁ.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "ML-C30-shubha-sayaahnam",
+        "kind": "production",
+        "summary": "Say śubha sāyāhnaṁ, note it is built on the poetic sāyāhnaṁ rather than native vaikunnēraṁ, and follow sāya back to PIE.",
+        "assesses": [
+          "ML-CONCEPT-C30-SHUBHA-SAYAAHNAM-01",
+          "ML-CONCEPT-C30-SHUBHA-SAYAAHNAM-02"
+        ]
+      }
+    },
+    {
+      "chapter": 31,
+      "title": "Good Afternoon",
+      "label": "ch:ml-good-afternoon",
+      "canDo": "I can greet someone in the afternoon in Malayalam with śubha madhyāhnaṁ, and say how it differs from the everyday afternoon word.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "ML-C31-afternoon-convergence",
+        "kind": "task",
+        "summary": "Line up the three sister languages' everyday afternoon words and show where all three converge on śubha + madhyāhna.",
+        "assesses": [
+          "ML-CONCEPT-C31-AFTERNOON-CONVERGENCE-01"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
HL-C11 for two unrelated tracks. Each chapter now declares, in the reader's own first-person words, what finishing it lets them do, and names the lesson that proves the claim (HL05).

| Track | Chapters | Authored | Skipped |
|---|---|---|---|
| Arabic | 27 | **25** (3–27) | 2 (1, 2) |
| Malayalam | 31 | **26** (6–31) | 5 (1–5) |

## How this was derived

Everything mechanical comes off disk, not out of the air:

- **`title` / `label`** — copied verbatim from `core/book-generation.json`, so `chapter-title-drift` holds until HL-C04 inverts that dependency.
- **`spineNodes`** — derived from each track's `curriculum.json` path segments, mapping each segment's lessons back to their chapter. Every id used is one of the 11 nodes in `core/spine.json`; no chapter needed an empty list.
- **`payoff.lesson`** — the chapter's terminal `practice` lesson where one exists, otherwise its last lesson by `sequence`.
- **`payoff.assesses`** — that lesson's own `practises.knowledge`, in full. No atom is invented.
- **`canDo` / `payoff.summary`** — written after reading each chapter's lessons.

### Chapters whose payoff is the last lesson by `sequence`, not a practice lesson

Only Arabic 3 and 4 have a terminal `practice` lesson at all. **Arabic 5–27** and **Malayalam 6–31** therefore take their chapter's last lesson by `sequence` as the payoff — that is what the corpus offers, and it is stated here rather than hidden.

## Skipped, deliberately

Recorded in each file's own `note`. In every case the chapter's terminal recap lesson is still **schema v1 with no `practises.knowledge`**, so a payoff there could only name fabricated atoms — and none of these chapters has a `book-generation.json` target to copy a title from either.

- **Arabic ch. 1 (Greetings)** — `AR-C01-practice`
- **Arabic ch. 2 (Introducing Yourself)** — `AR-C02-practice`
- **Malayalam ch. 1–5** — `ML-C01-practice` … `ML-C05-practice`

An absent entry is honest, measurable debt the HL05 gap report can carry. A stubbed one would destroy exactly the signal that report exists to give.

## Track-specific notes

**Arabic (RTL, 16 inline `writing` steps).** All sixteen abjad/joining/hamza steps fall inside Chapters 1–4, and in Chapters 3 and 4 the terminal lesson is the spoken practice — so no chapter's payoff is a script-formation exercise, and nothing is typed `task` on that basis. Chapter 3's payoff *does* include writing **بخير** by hand, and its summary says so instead of presenting it as pure dialogue.

**Malayalam (abugida, generated Chapters 6–31).** Derived from the lessons and `curriculum.json` directly, **not** from `roadmap.md` or `session-map.md`, which still lag the canonical chapters (known debt, HL-M04). Chapters 23, 24 and 31 end in an `etymology` lesson, so their payoffs are typed `task` and describe the sorting the reader actually does.

**`payoff.kind` rule**, applied uniformly across both tracks: `dialogue` where the payoff lesson lays out a question and its reply; `task` where the payoff is non-spoken sorting or script work; `production` where the reader produces forms aloud from a set or template.

## Known representativeness risk (HL05 gate, threshold 0.5)

The gate is not built yet (HL-C03), but computing `|assesses ∩ chapter-introduced| / |chapter-introduced|` today flags five chapters that will fail it. All five are structural — `assesses` may only draw on the payoff lesson's own `practises.knowledge`, so no honest authoring choice raises them:

| Chapter | Introduced | Assessed | Share |
|---|---|---|---|
| Arabic 3 — How Are You? | 18 | 2 | 0.11 |
| Arabic 4 — Farewells | 16 | 2 | 0.12 |
| Malayalam 17 — Noon and Midnight | 3 | 1 | 0.33 |
| Malayalam 23 — Day | 3 | 1 | 0.33 |
| Malayalam 24 — Night | 3 | 1 | 0.33 |

Arabic 3 and 4 are the two largest chapters in the track (nine and eight lessons, including the writing companions), yet their practice lessons declare only two atoms each. Malayalam 17/23/24 each end in a one-atom lesson behind a two-atom one. Fixing these means adding atoms to the payoff lessons themselves, which is lesson work, not ledger work.

Malayalam 31 sits exactly at 0.50 and passes only if the gate is `>=`.

## Verification

```
cd code/packages/typescript/human-language-data
npm ci --silent && npx tsc --noEmit && npx vitest run
```

14 files, **123 tests green** — including `chapters.test.ts`'s assertions on the `"I can "` prefix, `assesses ⊆ practises.knowledge`, payoff-lesson/chapter agreement, and title/label agreement with `book-generation.json`. No `package-lock.json` change. Both track `CHANGELOG.md` and `README.md` updated.

Security review performed on the diff: data and prose only, no executable code, no URLs or secrets, valid JSON, and — checked specifically because Arabic is RTL — zero Unicode control or format characters, so no bidirectional-override (Trojan Source) content.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw3PKmLS2yEnDmhck3fM1z)_