### PR TITLE
feat(human-languages): author French and German chapter capability ledgers

### DIFF
--- a/code/learning/human-languages/french/CHANGELOG.md
+++ b/code/learning/human-languages/french/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Chapter capability ledger — Chapters 17–23 — 2026-08-06
+
+- Added [`chapters.json`](./chapters.json), the track's HL05 capability ledger:
+  a first-person `canDo`, the shared-spine nodes realised, and a validated
+  payoff for each of the **seven** chapters that carry schema-v2 lessons.
+- Deliberately authored **only Chapters 17–23**. Chapters 1–16 are still schema
+  v1 and declare no `practises.knowledge`, so every payoff written for them
+  would have to assess atoms that do not exist. They are omitted rather than
+  stubbed: an absent entry is honest debt the gap report can count, a
+  placeholder is destroyed signal.
+- Every `payoff.assesses` list is a strict subset of the payoff lesson's own
+  `practises.knowledge`; no atom is invented, and none is padded to clear a
+  threshold.
+- Chapters 19–23 are single-lesson chapters, so their payoff assesses
+  everything the chapter introduces (representativeness 1.00). Chapters 17 and
+  18 have **no terminal consolidation lesson**, so their payoff is the last
+  lesson by `sequence`: Chapter 18 still reaches 4/7 = 0.57 because *non*
+  reassesses *oui*, and Chapter 17 sits exactly on the 0.50 floor at 4/8. Both
+  facts are recorded in the ledger's per-chapter `summary`.
+- Titles and labels are copied verbatim from `core/book-generation.json`, so the
+  `chapter-title-drift` gate holds through the HL-C04 inversion.
+
 ## Warning-free 98-page book — 2026-08-03
 
 - Added natural page bottoms for intentionally short micro-lessons and concise

--- a/code/learning/human-languages/french/README.md
+++ b/code/learning/human-languages/french/README.md
@@ -62,9 +62,41 @@ Language Ladder verifies independently. A forced XeLaTeX build is free of
 missing glyphs, layout boxes, duplicate destinations, Hyperref warnings, and
 LaTeX warnings.
 
+## Chapter capabilities (HL05)
+
+[`chapters.json`](./chapters.json) states what a reader can *do* when they
+finish a chapter, and names the lesson that proves it. It is authored intent —
+no validator may rewrite it.
+
+**Seven of twenty-three chapters are authored: 17–23.** Those are exactly the
+chapters whose lessons have been migrated to schema version 2 and so declare
+real knowledge atoms. Chapters 1–16 are still schema v1 and carry no
+`practises.knowledge`, so a payoff written for them could only assess invented
+atoms. They are left out on purpose: an absent entry is debt the gap report can
+measure, a stub is a chapter falsely claiming a capability it never delivered.
+
+Representativeness — the share of a chapter's introduced atoms its payoff
+actually assesses, floored at 0.5 by `core/chapter-policy.json`:
+
+| Chapter | Payoff lesson | Assessed / introduced |
+|---|---|---|
+| 17 Head and Hand | `FR-C17-main` | 4 / 8 = 0.50 (on the floor) |
+| 18 Yes and No | `FR-C18-non` | 4 / 7 = 0.57 |
+| 19 Please | `FR-C19-sil-vous-plait` | 3 / 3 = 1.00 |
+| 20 Sorry | `FR-C20-je-suis-desole` | 3 / 3 = 1.00 |
+| 21 Weather | `FR-C21-le-temps` | 4 / 4 = 1.00 |
+| 22 Dog and Cat | `FR-C22-chien-chat` | 4 / 4 = 1.00 |
+| 23 Green and Yellow | `FR-C23-vert-jaune` | 5 / 5 = 1.00 |
+
+Chapters 17 and 18 have **no terminal consolidation lesson**, so their payoff is
+the last lesson by `sequence`. Chapter 18 still clears the floor because *non*
+reassesses *oui*; Chapter 17 sits exactly on it. Neither `assesses` list is
+padded — a shortfall is a signal that the chapter needs a real practice lesson.
+
 ## Files
 
 - [`lessons/`](./lessons/) — the deep one-word practice lessons.
+- [`chapters.json`](./chapters.json) — the HL05 chapter capability ledger.
 - [`pronunciation-reference.md`](./pronunciation-reference.md) — French sounds,
   to look up on demand.
 - [`roadmap.md`](./roadmap.md) · [`session-map.md`](./session-map.md)

--- a/code/learning/human-languages/french/chapters.json
+++ b/code/learning/human-languages/french/chapters.json
@@ -1,0 +1,132 @@
+{
+  "version": 1,
+  "language": "french",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Only Chapters 17-23 are authored — they are the seven French chapters whose lessons have been migrated to schema version 2 and therefore declare real knowledge atoms. Chapters 1-16 are still schema v1: their lessons carry no practises.knowledge, so any payoff written for them would assess invented atoms. Their absence here is real, measurable debt and must not be papered over with placeholders. Chapter 17's payoff sits exactly at the 0.5 representativeness floor and Chapters 17-18 have no terminal practice lesson at all; both facts are recorded per chapter below rather than hidden by padding assesses.",
+  "chapters": [
+    {
+      "chapter": 17,
+      "title": "Head and Hand",
+      "label": "ch:fr-head-and-hand",
+      "canDo": "I can name the head and the hand in French with the right article, and point out the Latin manus hiding inside English manual, manufacture and maintain.",
+      "spineNodes": ["SPINE-CHECK-WELLBEING"],
+      "payoff": {
+        "lesson": "FR-C17-main",
+        "kind": "production",
+        "summary": "Say la main with its nasal -ain, then run the manus family out loud — manual, manuscript, maintenir — and land on manufacture, 'made by hand', now the name for the opposite. Chapter 17 has no terminal practice lesson, so the payoff is the last lesson by sequence; it exercises the main half of the chapter but not the tête half.",
+        "assesses": [
+          "FR-LEX-MAIN-02",
+          "FR-SOUND-MAIN-03",
+          "FR-ETYMON-MAIN-04",
+          "FR-ETYMON-MAINTENIR-05"
+        ]
+      }
+    },
+    {
+      "chapter": 18,
+      "title": "Yes and No",
+      "label": "ch:fr-yes-and-no",
+      "canDo": "I can answer yes or no in French, send non through my nose as a nasal vowel, and recognise the ne … pas pair that carries negation inside a sentence.",
+      "spineNodes": ["SPINE-RESPOND-BASIC"],
+      "payoff": {
+        "lesson": "FR-C18-non",
+        "kind": "production",
+        "summary": "The oui / non pair said back to back, non's -on nasal placed against bon and bonjour, and the ne … pas frame named as the sentence-level negation to come. Chapter 18 has no terminal practice lesson, so the payoff is the last lesson by sequence; it reaches back to reassess oui.",
+        "assesses": [
+          "FR-LEX-OUI-02",
+          "FR-LEX-NON-02",
+          "FR-SOUND-NON-03",
+          "FR-GRAMMAR-NEGATION-04"
+        ]
+      }
+    },
+    {
+      "chapter": 19,
+      "title": "Please",
+      "label": "ch:fr-please",
+      "canDo": "I can say please in French and choose between s'il vous plaît and s'il te plaît depending on who I am speaking to.",
+      "spineNodes": ["SPINE-POLITE-REQUEST-REPAIR"],
+      "payoff": {
+        "lesson": "FR-C19-sil-vous-plait",
+        "kind": "production",
+        "summary": "Say s'il vous plaît with its silent final -t, take it apart into 'if it pleases you', then switch to s'il te plaît for a friend. The chapter's only lesson, so the payoff covers everything it introduces.",
+        "assesses": [
+          "FR-LEX-PLEASE-02",
+          "FR-ETYMON-PLAIRE-03",
+          "FR-GRAMMAR-PLEASE-REGISTER-04"
+        ]
+      }
+    },
+    {
+      "chapter": 20,
+      "title": "Sorry",
+      "label": "ch:fr-sorry",
+      "canDo": "I can apologise in French and pick between je suis désolé(e), pardon and excusez-moi for the situation I am actually in.",
+      "spineNodes": ["SPINE-POLITE-REQUEST-REPAIR"],
+      "payoff": {
+        "lesson": "FR-C20-je-suis-desole",
+        "kind": "production",
+        "summary": "Say je suis désolé(e) knowing it literally means 'I am desolate', then place pardon as the quick reflex and excusez-moi as the attention-getter. The chapter's only lesson, so the payoff covers everything it introduces.",
+        "assesses": [
+          "FR-LEX-DESOLE-02",
+          "FR-ETYMON-DESOLE-03",
+          "FR-PRAGMATICS-SORRY-04"
+        ]
+      }
+    },
+    {
+      "chapter": 21,
+      "title": "Weather",
+      "label": "ch:fr-weather",
+      "canDo": "I can talk about the weather in French — quel temps fait-il, il fait chaud, il fait froid, il pleut.",
+      "spineNodes": ["SPINE-TIME-OF-DAY"],
+      "payoff": {
+        "lesson": "FR-C21-le-temps",
+        "kind": "production",
+        "summary": "Use le temps in both its senses, build the weather with faire (il fait chaud / il fait froid), and say il pleut with the Latin pl- cluster French kept intact. The chapter's only lesson, so the payoff covers everything it introduces.",
+        "assesses": [
+          "FR-LEX-TEMPS-02",
+          "FR-GRAMMAR-IL-FAIT-03",
+          "FR-LEX-IL-PLEUT-04",
+          "FR-ETYMON-PLEUVOIR-05"
+        ]
+      }
+    },
+    {
+      "chapter": 22,
+      "title": "Dog and Cat",
+      "label": "ch:fr-dog-and-cat",
+      "canDo": "I can name a dog and a cat in French and say why chien is the regular descendant of canis while chat is a word that travelled out of Egypt.",
+      "spineNodes": ["SPINE-DEFINITE-REFERENCE"],
+      "payoff": {
+        "lesson": "FR-C22-chien-chat",
+        "kind": "production",
+        "summary": "Say chien and check its ca- → cha- shift against champ and chanter, then say chat and place it beside Spanish gato and Italian gatto as one inherited cattus. The chapter's only lesson, so the payoff covers everything it introduces.",
+        "assesses": [
+          "FR-LEX-CHIEN-02",
+          "FR-ETYMON-CHIEN-03",
+          "FR-LEX-CHAT-04",
+          "FR-ETYMON-CHAT-05"
+        ]
+      }
+    },
+    {
+      "chapter": 23,
+      "title": "Green and Yellow",
+      "label": "ch:fr-green-and-yellow",
+      "canDo": "I can name green and yellow in French, and say how solid the claimed link between jaune and German gelb actually is.",
+      "spineNodes": ["SPINE-DEFINITE-REFERENCE"],
+      "payoff": {
+        "lesson": "FR-C23-vert-jaune",
+        "kind": "production",
+        "summary": "Say vert as the ordinary Romance inheritance from viridis, say jaune as galbinus 'yellow-green', and state the jaune / gelb cousinhood as probable rather than certain. The chapter's only lesson, so the payoff covers everything it introduces.",
+        "assesses": [
+          "FR-LEX-VERT-02",
+          "FR-ETYMON-VERT-03",
+          "FR-LEX-JAUNE-04",
+          "FR-ETYMON-JAUNE-05",
+          "FR-EVIDENCE-JAUNE-GELB-06"
+        ]
+      }
+    }
+  ]
+}

--- a/code/learning/human-languages/german/CHANGELOG.md
+++ b/code/learning/human-languages/german/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## Chapter capability ledger — Chapters 17–23 (2026-08-06)
+
+- Added [`chapters.json`](./chapters.json), the track's HL05 capability ledger:
+  a first-person `canDo`, the shared-spine nodes realised, and a validated
+  payoff for each of the **seven** chapters that carry schema-v2 lessons.
+- Deliberately authored **only Chapters 17–23**. Chapters 1–16 are still schema
+  v1 and declare no `practises.knowledge`, so every payoff written for them
+  would have to assess atoms that do not exist. They are omitted rather than
+  stubbed: an absent entry is honest debt the gap report can count, a
+  placeholder is destroyed signal.
+- Every `payoff.assesses` list is a strict subset of the payoff lesson's own
+  `practises.knowledge`; no atom is invented, and none is padded to clear a
+  threshold.
+- **Chapter 17 fails the 0.5 representativeness floor at 4/12 = 0.33.** It runs
+  three word lessons deep — *Kopf*, *Kopf/Haupt*, *Hand* — with no terminal
+  consolidation lesson, so the payoff can only be the last lesson by
+  `sequence` and reaches just its own third of the chapter. The shortfall is
+  recorded in the ledger rather than hidden; the fix is a real
+  Kopf/Haupt/Hand practice lesson, not a longer `assesses` list.
+- Chapter 18 also lacks a terminal practice lesson but still reaches 5/8 = 0.63
+  because *nein* reassesses *ja*. Chapters 19–23 are single-lesson chapters and
+  assess everything they introduce (1.00).
+- Titles and labels are copied verbatim from `core/book-generation.json`, so the
+  `chapter-title-drift` gate holds through the HL-C04 inversion.
+
 ## Warning-free 104-page book (2026-08-03)
 
 - Made intentionally short micro-lesson pages explicit with `\raggedbottom`,

--- a/code/learning/human-languages/german/README.md
+++ b/code/learning/human-languages/german/README.md
@@ -62,8 +62,42 @@ Language Ladder verifies independently. The forced XeLaTeX build is warning-free
 zero missing glyphs, overfull or underfull boxes, duplicate destinations,
 Hyperref warnings, or LaTeX warnings.
 
+## Chapter capabilities (HL05)
+
+[`chapters.json`](./chapters.json) states what a reader can *do* when they
+finish a chapter, and names the lesson that proves it. It is authored intent —
+no validator may rewrite it.
+
+**Seven of twenty-three chapters are authored: 17–23.** Those are exactly the
+chapters whose lessons have been migrated to schema version 2 and so declare
+real knowledge atoms. Chapters 1–16 are still schema v1 and carry no
+`practises.knowledge`, so a payoff written for them could only assess invented
+atoms. They are left out on purpose: an absent entry is debt the gap report can
+measure, a stub is a chapter falsely claiming a capability it never delivered.
+
+Representativeness — the share of a chapter's introduced atoms its payoff
+actually assesses, floored at 0.5 by `core/chapter-policy.json`:
+
+| Chapter | Payoff lesson | Assessed / introduced |
+|---|---|---|
+| 17 Head and Hand | `GE-C17-hand` | 4 / 12 = 0.33 — **below the floor** |
+| 18 Yes and No | `GE-C18-nein` | 5 / 8 = 0.63 |
+| 19 Please | `GE-C19-bitte-requests` | 3 / 3 = 1.00 |
+| 20 Sorry | `GE-C20-entschuldigung` | 3 / 3 = 1.00 |
+| 21 Weather | `GE-C21-das-wetter` | 5 / 5 = 1.00 |
+| 22 Dog and Cat | `GE-C22-hund-katze` | 5 / 5 = 1.00 |
+| 23 Green and Yellow | `GE-C23-gruen-gelb` | 5 / 5 = 1.00 |
+
+Chapter 17 is the one authored chapter that fails. It runs three word lessons
+deep — *Kopf*, *Kopf/Haupt*, *Hand* — with no terminal consolidation lesson, so
+its payoff can only be the last lesson by `sequence` and reaches a third of the
+chapter. The `assesses` list is **not** padded to hide that: the honest fix is a
+real Kopf/Haupt/Hand practice lesson. Chapter 18 has the same missing-practice
+shape but clears the floor because *nein* reassesses *ja*.
+
 ## Files
 
+- [`chapters.json`](./chapters.json) — the HL05 chapter capability ledger.
 - [`lessons/`](./lessons/) · [`pronunciation-reference.md`](./pronunciation-reference.md)
   · [`roadmap.md`](./roadmap.md) · [`session-map.md`](./session-map.md)
   · [`book/`](./book/) (`latexmk -xelatex book.tex`)

--- a/code/learning/human-languages/german/chapters.json
+++ b/code/learning/human-languages/german/chapters.json
@@ -1,0 +1,135 @@
+{
+  "version": 1,
+  "language": "german",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Only Chapters 17-23 are authored — they are the seven German chapters whose lessons have been migrated to schema version 2 and therefore declare real knowledge atoms. Chapters 1-16 are still schema v1: their lessons carry no practises.knowledge, so any payoff written for them would assess invented atoms. Their absence here is real, measurable debt and must not be papered over with placeholders. Chapter 17 is the one authored chapter that FAILS the 0.5 representativeness floor (4 of 12 introduced atoms, 0.33): it is three word lessons deep with no terminal consolidation lesson, so its payoff can only reach the last of the three. That is recorded here rather than hidden by padding assesses — the fix is a real Kopf/Haupt/Hand practice lesson, not a longer list.",
+  "chapters": [
+    {
+      "chapter": 17,
+      "title": "Head and Hand",
+      "label": "ch:ge-head-and-hand",
+      "canDo": "I can name the head and the hand in German, devoice the final d of Hand, and say where the Germanic and Latin families stop matching.",
+      "spineNodes": ["SPINE-CHECK-WELLBEING"],
+      "payoff": {
+        "lesson": "GE-C17-hand",
+        "kind": "production",
+        "summary": "Say die Hand with its final d spoken as t, bring the d back in die Hände, run the Germanic body set Hand/Arm/Finger/Fuß/Herz, and name the gap: main, mano, mão — but Hand. Chapter 17 has no terminal practice lesson, so the payoff is the last lesson by sequence and reaches only its own third of the chapter (4 of 12 atoms, below the 0.5 floor).",
+        "assesses": [
+          "GE-LEX-HAND-02",
+          "GE-SOUND-HAND-03",
+          "GE-ETYMON-HAND-04",
+          "GE-ETYMON-HAND-MANUS-05"
+        ]
+      }
+    },
+    {
+      "chapter": 18,
+      "title": "Yes and No",
+      "label": "ch:ge-yes-and-no",
+      "canDo": "I can answer yes or no in German and take nein apart into ni + ein, the same 'not one' English froze into none.",
+      "spineNodes": ["SPINE-RESPOND-BASIC"],
+      "payoff": {
+        "lesson": "GE-C18-nein",
+        "kind": "production",
+        "summary": "Say nein to rhyme with nine, split it into ni + ein and match it to English none, then run the PIE *ne chain — nōn, non, nein, nahīṃ. Chapter 18 has no terminal practice lesson, so the payoff is the last lesson by sequence; it reaches back to reassess ja.",
+        "assesses": [
+          "GE-LEX-JA-02",
+          "GE-LEX-NEIN-02",
+          "GE-SOUND-NEIN-03",
+          "GE-ETYMON-NEIN-04",
+          "GE-ETYMON-NEGATION-05"
+        ]
+      }
+    },
+    {
+      "chapter": 19,
+      "title": "Please",
+      "label": "ch:ge-please",
+      "canDo": "I can ask politely for something in German by putting bitte after the thing I want — Wasser, bitte.",
+      "spineNodes": ["SPINE-POLITE-REQUEST-REPAIR"],
+      "payoff": {
+        "lesson": "GE-C19-bitte-requests",
+        "kind": "task",
+        "summary": "Assemble a complete polite request out of two words already learned — Wasser, bitte — and hear the request still living inside bitte via bitten, English bid and bead. The chapter's only lesson, so the payoff covers everything it introduces.",
+        "assesses": [
+          "GE-LEX-BITTE-PLEASE-02",
+          "GE-PHRASE-WASSER-BITTE-03",
+          "GE-ETYMON-BITTE-04"
+        ]
+      }
+    },
+    {
+      "chapter": 20,
+      "title": "Sorry",
+      "label": "ch:ge-sorry",
+      "canDo": "I can apologise or excuse myself in German with Entschuldigung, and reach for es tut mir leid when I mean it more.",
+      "spineNodes": ["SPINE-POLITE-REQUEST-REPAIR"],
+      "payoff": {
+        "lesson": "GE-C20-entschuldigung",
+        "kind": "production",
+        "summary": "Say Schuld, then Entschuldigung as the 'un-guilting' built on it, and switch to es tut mir leid for real regret rather than a bump in the hallway. The chapter's only lesson, so the payoff covers everything it introduces.",
+        "assesses": [
+          "GE-LEX-ENTSCHULDIGUNG-02",
+          "GE-ETYMON-ENTSCHULDIGUNG-03",
+          "GE-PRAGMATICS-SORRY-04"
+        ]
+      }
+    },
+    {
+      "chapter": 21,
+      "title": "Weather",
+      "label": "ch:ge-weather",
+      "canDo": "I can talk about the weather in German — das Wetter, es ist heiß, es ist kalt, es regnet.",
+      "spineNodes": ["SPINE-TIME-OF-DAY"],
+      "payoff": {
+        "lesson": "GE-C21-das-wetter",
+        "kind": "production",
+        "summary": "Say das Wetter as English weather's own cousin, build hot and cold with sein rather than a Romance 'make', and say es regnet on the same root as English rain. The chapter's only lesson, so the payoff covers everything it introduces.",
+        "assesses": [
+          "GE-LEX-WETTER-02",
+          "GE-ETYMON-WETTER-03",
+          "GE-GRAMMAR-WEATHER-SEIN-04",
+          "GE-LEX-REGNET-05",
+          "GE-ETYMON-REGNET-06"
+        ]
+      }
+    },
+    {
+      "chapter": 22,
+      "title": "Dog and Cat",
+      "label": "ch:ge-dog-and-cat",
+      "canDo": "I can name a dog and a cat in German and say which of the two words German inherited and which one it borrowed.",
+      "spineNodes": ["SPINE-DEFINITE-REFERENCE"],
+      "payoff": {
+        "lesson": "GE-C22-hund-katze",
+        "kind": "production",
+        "summary": "Say Hund beside English hound and the unexplained dog that displaced it, then say Katze and admit it is the borrowed Late Latin cattus — widespread, but not universal: Romanian pisică and Serbian mačka went their own way. The chapter's only lesson, so the payoff covers everything it introduces.",
+        "assesses": [
+          "GE-LEX-HUND-02",
+          "GE-ETYMON-HUND-03",
+          "GE-LEX-KATZE-04",
+          "GE-ETYMON-KATZE-05",
+          "GE-EVIDENCE-CAT-WORDS-06"
+        ]
+      }
+    },
+    {
+      "chapter": 23,
+      "title": "Green and Yellow",
+      "label": "ch:ge-green-and-yellow",
+      "canDo": "I can name green and yellow in German, and say why grün is English green's own cousin while gelb's link to French jaune is only probable.",
+      "spineNodes": ["SPINE-DEFINITE-REFERENCE"],
+      "payoff": {
+        "lesson": "GE-C23-gruen-gelb",
+        "kind": "production",
+        "summary": "Say grün as the direct cousin of English green from a root unrelated to Latin viridis, say gelb, and state the gelb / jaune cousinhood as probable rather than airtight. The chapter's only lesson, so the payoff covers everything it introduces.",
+        "assesses": [
+          "GE-LEX-GRUEN-02",
+          "GE-ETYMON-GRUEN-03",
+          "GE-LEX-GELB-04",
+          "GE-ETYMON-GELB-05",
+          "GE-EVIDENCE-GELB-JAUNE-06"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds `chapters.json` to the **French** and **German** tracks — the HL05 capability layer that states, per chapter, what the reader can do when they finish it and which lesson proves the claim.

**7 chapters authored per track (17–23 in both). 16 per track deliberately omitted.**

## Why only seven

Chapters 17–23 are exactly the chapters in each track whose lessons have been migrated to **schema version 2** and therefore declare real `practises.knowledge` atoms. Chapters 1–16 in both tracks are still schema v1 and declare nothing, so any payoff written for them could only assess atoms that do not exist.

They are **omitted rather than stubbed**. An absent entry is debt the HL05 gap report can count; a placeholder is a chapter falsely claiming a capability it never delivered.

Skipped, per track:

| Track | Skipped chapters |
|---|---|
| French | 1–16 (`FR-C01`…`FR-C16`) — all schema v1 |
| German | 1–16 (`GE-C01`…`GE-C16`) — all schema v1 |

## Derived, not guessed

- **`title` / `label`** — copied verbatim from `core/book-generation.json`. Both tracks carry targets for exactly chapters 17–23, so no authored chapter is targetless and `chapter-title-drift` holds through the HL-C04 inversion.
- **`canDo`** — one first-person sentence per chapter, grounded in that chapter's actual lessons.
- **`spineNodes`** — taken from each track's own `curriculum.json` path segments (`FR-PATH-014`…`018`, `GE-PATH-016`…`020`); every id is present in `core/spine.json`.
- **`payoff.assesses`** — a strict subset of the payoff lesson's own `practises.knowledge`. No atom is invented.
- **`payoff.lesson`** — neither track has a terminal `practice` / `practice-mix` lesson anywhere in chapters 17–23, so **every payoff is the chapter's last lesson by `sequence`**. This is noted per chapter in the ledger's `summary`.

French and German were derived independently from their own lessons, atoms and etymologies. Nothing crosses between the two tracks.

## Representativeness

Assessed atoms ÷ chapter-introduced atoms, against the 0.5 floor in `core/chapter-policy.json`:

| Track | Ch | Payoff lesson | Ratio |
|---|---|---|---|
| French | 17 | `FR-C17-main` | 4/8 = **0.50** (exactly on the floor) |
| French | 18 | `FR-C18-non` | 4/7 = 0.57 |
| French | 19 | `FR-C19-sil-vous-plait` | 3/3 = 1.00 |
| French | 20 | `FR-C20-je-suis-desole` | 3/3 = 1.00 |
| French | 21 | `FR-C21-le-temps` | 4/4 = 1.00 |
| French | 22 | `FR-C22-chien-chat` | 4/4 = 1.00 |
| French | 23 | `FR-C23-vert-jaune` | 5/5 = 1.00 |
| German | 17 | `GE-C17-hand` | 4/12 = **0.33 — BELOW THE FLOOR** |
| German | 18 | `GE-C18-nein` | 5/8 = 0.63 |
| German | 19 | `GE-C19-bitte-requests` | 3/3 = 1.00 |
| German | 20 | `GE-C20-entschuldigung` | 3/3 = 1.00 |
| German | 21 | `GE-C21-das-wetter` | 5/5 = 1.00 |
| German | 22 | `GE-C22-hund-katze` | 5/5 = 1.00 |
| German | 23 | `GE-C23-gruen-gelb` | 5/5 = 1.00 |

**One failure: German chapter 17.** It runs three word lessons deep — *Kopf*, *Kopf/Haupt*, *Hand* — with no consolidation lesson, so its payoff can only be the last of the three and reaches just its own third of the chapter.

The `assesses` list is **deliberately not padded** to clear the threshold. The shortfall *is* the signal that the chapter needs a real Kopf/Haupt/Hand practice lesson; hiding it would defeat the gate. It is recorded in the ledger `note`, the German README table, and the CHANGELOG.

French chapters 17 and 18 have the same missing-practice shape. Chapter 18 still clears the floor because `FR-C18-non` reassesses *oui*; chapter 17 lands exactly on 0.50 and passes.

## Verification

```
cd code/packages/typescript/human-language-data && npm ci && npx tsc --noEmit && npx vitest run
```

- `tsc --noEmit` — clean.
- `vitest run` — **14 files, 123 tests passing**, including every `chapters.test.ts` assertion: first-person `canDo`, payoff-lesson resolution into the same chapter and language, `assesses ⊆ practises.knowledge`, unique chapter numbers, and title/label agreement with `book-generation.json`.
- `package-lock.json` is unchanged; only the six intended files are staged.

## Files

- `code/learning/human-languages/french/chapters.json` (new)
- `code/learning/human-languages/german/chapters.json` (new)
- both tracks' `README.md` — a Chapter capabilities section with the representativeness table and the omission rationale
- both tracks' `CHANGELOG.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw3PKmLS2yEnDmhck3fM1z)_