### PR TITLE
feat(human-languages): author HL05 chapter ledgers for the six small tracks

### DIFF
--- a/code/learning/human-languages/bengali/CHANGELOG.md
+++ b/code/learning/human-languages/bengali/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Chapter capability ledger — 2026-08-06
+
+- Added `chapters.json`, the HL05 chapter capability ledger, covering Chapter 6:
+  the reader can count *ek, dui, tin, chār, pā̃ch* in Bengali script and say what
+  **দুই** kept that Hindi *do* and Marathi *don* flattened away.
+- Made `BN-C06-numbers-1-5` the chapter payoff — the chapter's only lesson, and
+  its only schema-v2 one. It is typed `production`: the payoff is counting the
+  five aloud, then placing *dui* in its family.
+- Recorded `SPINE-COUNT-ONE-TO-FIVE` as the chapter's spine node, matching
+  `BN-PATH-010` in `curriculum.json`.
+- Omitted Chapters 1–5 rather than stubbing them: all 30 of their lessons are
+  schema v1 and declare no `practises.knowledge`, so no payoff there could name
+  atoms a lesson actually exercises. Their absence is the debt the HL05 gap
+  report exists to measure.
+- Measured payoff representativeness for Chapter 6 at 6/6 introduced atoms
+  (1.00), comfortably above the 0.5 policy floor.
+
 ## Book warning cleanup — 2026-08-03
 
 - Kept punctuation outside the Bengali-only font and replaced five duplicate

--- a/code/learning/human-languages/bengali/README.md
+++ b/code/learning/human-languages/bengali/README.md
@@ -44,6 +44,22 @@ book.
   book from the same canonical schema-v2 lesson AST and source hash that
   Language Ladder loads.
 
+## What each chapter lets you do
+
+[`chapters.json`](./chapters.json) is the HL05 capability ledger: per chapter, one
+first-person can-do sentence and the lesson that pays it off.
+
+- **Chapter 6** — *"I can count from one to five in Bengali script and say what
+  দুই kept that Hindi and Marathi flattened away."* Payoff:
+  [`BN-C06-numbers-1-5`](./lessons/BN-C06-numbers-1-5.md), a spoken production —
+  count the five, name the chandrabindu on **পাঁচ**, place *dui* against *do* and
+  *don*.
+
+Chapters 1–5 are **not in the ledger yet**, and that gap is deliberate. They are
+still schema v1, so their lessons declare no knowledge atoms and no payoff there
+could honestly claim to assess anything. A placeholder would hide debt the HL05
+gap report is meant to surface; the entries land as those chapters migrate.
+
 ## Book / fonts
 
 Compiles with XeLaTeX using the **vendored** Noto Sans Bengali font

--- a/code/learning/human-languages/bengali/chapters.json
+++ b/code/learning/human-languages/bengali/chapters.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "language": "bengali",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Only chapter 6 is authorable today. Chapters 1-5 are entirely schema-v1 (no introduces/practises knowledge atoms), so no payoff there can name atoms a lesson actually practises; they are deliberately absent rather than stubbed, and that absence is real, measurable debt.",
+  "chapters": [
+    {
+      "chapter": 6,
+      "title": "Numbers One to Five",
+      "label": "ch:numbers-one-to-five",
+      "canDo": "I can count from one to five in Bengali script and say what দুই kept that Hindi and Marathi flattened away.",
+      "spineNodes": ["SPINE-COUNT-ONE-TO-FIVE"],
+      "payoff": {
+        "lesson": "BN-C06-numbers-1-5",
+        "kind": "production",
+        "summary": "Count ek, dui, tin, chār, pā̃ch aloud, name the chandrabindu riding পাঁচ, and set দুই beside Hindi do and Marathi don to show the -i it preserved.",
+        "assesses": [
+          "BN-LEX-NUMBERS-ONE-TO-FIVE",
+          "BN-SCRIPT-CHANDRABINDU-NASAL",
+          "BN-ETYMON-DUI-COMPARISON",
+          "BN-HISTORY-DV-NUMERAL-SIMPLIFICATION",
+          "BN-HISTORY-DUI-AREAL-COMPANY",
+          "BN-SOUND-INHERENT-O-NOT-IN-NUMBERS"
+        ]
+      }
+    }
+  ]
+}

--- a/code/learning/human-languages/gujarati/CHANGELOG.md
+++ b/code/learning/human-languages/gujarati/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Chapter capability ledger — 2026-08-06
+
+- Added `chapters.json`, the HL05 chapter capability ledger, covering Chapter 6:
+  the reader can count *ek, be, traṇ, chār, pā̃ch* in headless Gujarati script
+  and explain the track's two odd numerals.
+- Made `GU-C06-number-histories` the chapter payoff — the chapter's last
+  schema-v2 lesson by sequence (350), and the one that pays the chapter's
+  promise: **બે** from feminine/neuter *dvé* through *dv → bb → b*, and **ત્રણ**'s
+  *r* as a learned restoration after Prakrit *tiṇṇi* had already lost it.
+- Recorded `SPINE-COUNT-ONE-TO-FIVE` as the chapter's spine node, matching
+  `GU-PATH-009` in `curriculum.json`.
+- Omitted Chapters 1–5 rather than stubbing them: all 31 of their lessons are
+  schema v1 and declare no `practises.knowledge`, so no payoff there could name
+  atoms a lesson actually exercises. Their absence is the debt the HL05 gap
+  report exists to measure.
+- Measured payoff representativeness for Chapter 6 at 7/8 introduced atoms
+  (0.88). The one atom outside the payoff is `GU-SCRIPT-HEADLESS-CLUE`, which
+  the histories lesson does not re-exercise; it was not padded in.
+
 ## Warning-clean six-chapter book — 2026-08-03
 
 - Replaced the five duplicate recap labels with canonical lesson ids and moved

--- a/code/learning/human-languages/gujarati/README.md
+++ b/code/learning/human-languages/gujarati/README.md
@@ -44,6 +44,23 @@ Chapters 1–6 are in the book. Chapter 6 is generated from the same canonical
 schema-v2 lesson AST and source hashes that Language Ladder loads, while the
 first five chapters retain their authored long-form narrative during migration.
 
+## What each chapter lets you do
+
+[`chapters.json`](./chapters.json) is the HL05 capability ledger: per chapter, one
+first-person can-do sentence and the lesson that pays it off.
+
+- **Chapter 6** — *"I can count from one to five in headless Gujarati script and
+  explain why બે starts with b where its neighbours start with d, and why ત્રણ has
+  an r that Hindi tīn does not."* Payoff:
+  [`GU-C06-number-histories`](./lessons/GU-C06-number-histories.md), a task —
+  take **બે** back to feminine/neuter *dvé* via *dv → bb → b*, and **ત્રણ**'s *r*
+  back to a learned restoration from Sanskrit.
+
+Chapters 1–5 are **not in the ledger yet**, and that gap is deliberate. They are
+still schema v1, so their lessons declare no knowledge atoms and no payoff there
+could honestly claim to assess anything. A placeholder would hide debt the HL05
+gap report is meant to surface; the entries land as those chapters migrate.
+
 ## Book / fonts
 
 Compiles with XeLaTeX using the **vendored** Noto Sans Gujarati font

--- a/code/learning/human-languages/gujarati/chapters.json
+++ b/code/learning/human-languages/gujarati/chapters.json
@@ -1,0 +1,28 @@
+{
+  "version": 1,
+  "language": "gujarati",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Only chapter 6 is authorable today. Chapters 1-5 are entirely schema-v1 (no introduces/practises knowledge atoms), so no payoff there can name atoms a lesson actually practises; they are deliberately absent rather than stubbed, and that absence is real, measurable debt.",
+  "chapters": [
+    {
+      "chapter": 6,
+      "title": "Numbers One to Five",
+      "label": "ch:numbers-one-to-five",
+      "canDo": "I can count from one to five in headless Gujarati script and explain why બે starts with b where its neighbours start with d, and why ત્રણ has an r that Hindi tīn does not.",
+      "spineNodes": ["SPINE-COUNT-ONE-TO-FIVE"],
+      "payoff": {
+        "lesson": "GU-C06-number-histories",
+        "kind": "task",
+        "summary": "Take the two odd numerals apart: બે descends from the feminine/neuter dvé by dv → bb → b, while ત્રણ's r is a learned restoration from Sanskrit, put back after Prakrit tiṇṇi had already dropped it.",
+        "assesses": [
+          "GU-LEX-NUMBERS-ONE-TO-FIVE",
+          "GU-FORM-BE-INITIAL-B",
+          "GU-FORM-TRAN-R",
+          "GU-ETYMON-BE-DVE-SELECTION",
+          "GU-SOUND-DV-BB-B",
+          "GU-ETYMON-TRAN-R-RESTORATION",
+          "GU-HISTORY-LEARNED-RESTORATION"
+        ]
+      }
+    }
+  ]
+}

--- a/code/learning/human-languages/marathi/CHANGELOG.md
+++ b/code/learning/human-languages/marathi/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Chapter capability ledger — 2026-08-06
+
+- Added `chapters.json`, the HL05 chapter capability ledger, covering Chapter 6:
+  the reader can count *ek, don, tīn, tsār, pāch*, say **चार** with its Marathi
+  *ts*, and separate a Marathi innovation from a Hindi retention.
+- Made `MR-C06-number-differences` the chapter payoff — the chapter's last
+  schema-v2 lesson by sequence (350). It carries the whole argument: **दोन**'s
+  final *n* borrowed from the rhyme of *tiṇṇi/doṇṇi*, **पाच** dropping the nasal
+  Hindi **पाँच** still writes, and the sound behind an unchanged spelling.
+- Recorded `SPINE-COUNT-ONE-TO-FIVE` as the chapter's spine node, matching
+  `MR-PATH-011` in `curriculum.json`.
+- Omitted Chapters 1–5 rather than stubbing them: all 33 of their lessons are
+  schema v1 and declare no `practises.knowledge`, so no payoff there could name
+  atoms a lesson actually exercises. Their absence is the debt the HL05 gap
+  report exists to measure.
+- Measured payoff representativeness for Chapter 6 at 7/7 introduced atoms
+  (1.00), comfortably above the 0.5 policy floor.
+
 ## Warning-clean six-chapter book — 2026-08-03
 
 - Gave the five handwritten recap sections stable canonical lesson labels rather

--- a/code/learning/human-languages/marathi/README.md
+++ b/code/learning/human-languages/marathi/README.md
@@ -39,6 +39,23 @@ Chapters 1–6 are in the book. Chapter 6 is generated from the same canonical
 schema-v2 lesson AST and source hashes that Language Ladder loads, while the
 first five chapters retain their authored long-form narrative during migration.
 
+## What each chapter lets you do
+
+[`chapters.json`](./chapters.json) is the HL05 capability ledger: per chapter, one
+first-person can-do sentence and the lesson that pays it off.
+
+- **Chapter 6** — *"I can count from one to five in Marathi, say चार as tsār
+  rather than chār, and tell which of Marathi's differences from Hindi is an
+  innovation and which is Hindi holding on to something older."* Payoff:
+  [`MR-C06-number-differences`](./lessons/MR-C06-number-differences.md), a task —
+  **दोन**'s borrowed *-n*, **पाच**'s missing nasal, and the *ts* hiding behind an
+  unchanged spelling.
+
+Chapters 1–5 are **not in the ledger yet**, and that gap is deliberate. They are
+still schema v1, so their lessons declare no knowledge atoms and no payoff there
+could honestly claim to assess anything. A placeholder would hide debt the HL05
+gap report is meant to surface; the entries land as those chapters migrate.
+
 ## Book / fonts
 
 Compiles with XeLaTeX using the **vendored** Noto Sans Devanagari font

--- a/code/learning/human-languages/marathi/chapters.json
+++ b/code/learning/human-languages/marathi/chapters.json
@@ -1,0 +1,28 @@
+{
+  "version": 1,
+  "language": "marathi",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Only chapter 6 is authorable today. Chapters 1-5 are entirely schema-v1 (no introduces/practises knowledge atoms), so no payoff there can name atoms a lesson actually practises; they are deliberately absent rather than stubbed, and that absence is real, measurable debt.",
+  "chapters": [
+    {
+      "chapter": 6,
+      "title": "Numbers One to Five",
+      "label": "ch:numbers-one-to-five",
+      "canDo": "I can count from one to five in Marathi, say चार as tsār rather than chār, and tell which of Marathi's differences from Hindi is an innovation and which is Hindi holding on to something older.",
+      "spineNodes": ["SPINE-COUNT-ONE-TO-FIVE"],
+      "payoff": {
+        "lesson": "MR-C06-number-differences",
+        "kind": "task",
+        "summary": "Account for all three tells: दोन's final n copied from the rhyme of tiṇṇi/doṇṇi, पाच dropping the nasal Hindi पाँच still writes, and चार spelled as everywhere else but pronounced with a ts.",
+        "assesses": [
+          "MR-LEX-NUMBERS-ONE-TO-FIVE",
+          "MR-SCRIPT-DON-FINAL-N",
+          "MR-SCRIPT-PAACH-NONNASAL",
+          "MR-SOUND-CHA-TSAA",
+          "MR-ETYMON-DON-ANALOGY",
+          "MR-ETYMON-PAACH-NASAL-RETENTION",
+          "MR-HISTORY-SELECTIVE-RETENTION"
+        ]
+      }
+    }
+  ]
+}

--- a/code/learning/human-languages/punjabi/CHANGELOG.md
+++ b/code/learning/human-languages/punjabi/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Chapter capability ledger — 2026-08-06
+
+- Added `chapters.json`, the HL05 chapter capability ledger, covering Chapter 6:
+  the reader can count *ikk, do, tinn, chār, panj* in Gurmukhi, tell the addak
+  from the tippi, and argue **ਪੰਜ**'s origin.
+- Made `PA-C06-panj-convergence` the chapter payoff — the chapter's last
+  schema-v2 lesson by sequence (350). Its task is the convergence argument:
+  Sanskrit *pañca* voiced after a nasal to *-nj-*, evidenced by *panjāh* against
+  Hindi *pacās*, while Iranian *panč* reached the same shape independently.
+- Recorded `SPINE-COUNT-ONE-TO-FIVE` as the chapter's spine node, matching
+  `PA-PATH-010` in `curriculum.json`.
+- Omitted Chapters 1–5 rather than stubbing them: all 31 of their lessons are
+  schema v1 and declare no `practises.knowledge`, so no payoff there could name
+  atoms a lesson actually exercises. Their absence is the debt the HL05 gap
+  report exists to measure.
+- Measured payoff representativeness for Chapter 6 at 8/11 introduced atoms
+  (0.73). The three outside the payoff are the Gurmukhi script atoms, which the
+  convergence lesson does not re-exercise; they were not padded in.
+
 ## Warning-clean six-chapter book — 2026-08-03
 
 - Gave each handwritten recap its stable canonical lesson label.

--- a/code/learning/human-languages/punjabi/README.md
+++ b/code/learning/human-languages/punjabi/README.md
@@ -45,6 +45,22 @@ Chapters 1–6 are in the book. Chapter 6 is generated from the same canonical
 schema-v2 lesson AST and source hashes that Language Ladder loads, while the
 first five chapters retain their authored long-form narrative during migration.
 
+## What each chapter lets you do
+
+[`chapters.json`](./chapters.json) is the HL05 capability ledger: per chapter, one
+first-person can-do sentence and the lesson that pays it off.
+
+- **Chapter 6** — *"I can count from one to five in Gurmukhi, tell the addak
+  apart from the tippi, and show that ਪੰਜ is inherited from Sanskrit rather than
+  borrowed from the Persian panj in Punjab."* Payoff:
+  [`PA-C06-panj-convergence`](./lessons/PA-C06-panj-convergence.md), a task — run
+  the convergence argument, with *panjāh* against Hindi *pacās* as the evidence.
+
+Chapters 1–5 are **not in the ledger yet**, and that gap is deliberate. They are
+still schema v1, so their lessons declare no knowledge atoms and no payoff there
+could honestly claim to assess anything. A placeholder would hide debt the HL05
+gap report is meant to surface; the entries land as those chapters migrate.
+
 ## Book / fonts
 
 Compiles with XeLaTeX using the **vendored** Noto Sans Gurmukhi font

--- a/code/learning/human-languages/punjabi/chapters.json
+++ b/code/learning/human-languages/punjabi/chapters.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "language": "punjabi",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Only chapter 6 is authorable today. Chapters 1-5 are entirely schema-v1 (no introduces/practises knowledge atoms), so no payoff there can name atoms a lesson actually practises; they are deliberately absent rather than stubbed, and that absence is real, measurable debt.",
+  "chapters": [
+    {
+      "chapter": 6,
+      "title": "Numbers One to Five",
+      "label": "ch:numbers-one-to-five",
+      "canDo": "I can count from one to five in Gurmukhi, tell the addak apart from the tippi, and show that ਪੰਜ is inherited from Sanskrit rather than borrowed from the Persian panj in Punjab.",
+      "spineNodes": ["SPINE-COUNT-ONE-TO-FIVE"],
+      "payoff": {
+        "lesson": "PA-C06-panj-convergence",
+        "kind": "task",
+        "summary": "Set Punjabi ਪੰਜ beside Persian panj and argue the match is convergence, not borrowing: post-nasal voicing carried pañca to panj on the Indo-Aryan side, with panjāh against Hindi pacās as the evidence, while Iranian panč voiced separately.",
+        "assesses": [
+          "PA-LEX-NUMBERS-ONE-TO-FIVE",
+          "PA-HISTORY-PANJABI-FIVE-RIVERS",
+          "PA-COMPARISON-PANJ-MATCH",
+          "PA-ETYMON-PANJ-PANCA-INHERITANCE",
+          "PA-SOUND-NASAL-STOP-VOICING",
+          "PA-EVIDENCE-PANJAH-PACAS",
+          "PA-ETYMON-PERSIAN-PANJ-INDEPENDENT",
+          "PA-HISTORY-PANJ-CONVERGENCE"
+        ]
+      }
+    }
+  ]
+}

--- a/code/learning/human-languages/russian/CHANGELOG.md
+++ b/code/learning/human-languages/russian/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog — Russian track
 
+## 0.6.0 — 2026-08-06
+
+- Added `chapters.json`, the HL05 chapter capability ledger, covering Chapter 2:
+  the reader can give a name, ask for one, and choose *ты* or *вы* to match the
+  relationship.
+- Pointed the Chapter 2 payoff at `RU-C02-kak-cross-language`, the chapter's
+  last schema-v2 lesson by sequence. The chapter's own `practice-mix` lessons
+  are still schema v1, so they declare no `practises.knowledge` and cannot carry
+  an honest `assesses` list yet.
+- Took the chapter title and label from `book/chapters/ch02-introducing-yourself.tex`.
+  Russian has no `core/book-generation.json` targets, so the LaTeX source is the
+  only other place the printed name is written down.
+- Omitted Chapter 1 rather than stubbing it: all twelve of its lessons are
+  schema v1, so it has no assessable payoff. Its absence is the debt the HL05
+  gap report exists to measure.
+- Measured payoff representativeness for Chapter 2 at 3/15 introduced atoms
+  (0.20), below the 0.5 policy floor. Recorded, not padded — the shortfall is
+  the schema-v1 practice lessons, and it closes when they migrate.
+
 ## 0.5.0 — 2026-08-03
 
 - Migrated the closed Chapter 2 chain from *я* through the cross-language

--- a/code/learning/human-languages/russian/README.md
+++ b/code/learning/human-languages/russian/README.md
@@ -46,6 +46,29 @@ See [`roadmap.md`](./roadmap.md) for the plan toward B1 and
 [`session-map.md`](./session-map.md) for how the lessons compose into commute
 sessions.
 
+## What each chapter lets you do
+
+[`chapters.json`](./chapters.json) is the HL05 capability ledger: per chapter, one
+first-person can-do sentence and the lesson that pays it off.
+
+- **Chapter 2** — *"I can give my name in Russian, ask for someone else's, and
+  pick ты or вы to match how well I know them."* Payoff:
+  [`RU-C02-kak-cross-language`](./lessons/RU-C02-kak-cross-language.md), a task —
+  ask *Как вас зовут?* and account for its shape.
+
+  Two honest caveats. Russian has no `core/book-generation.json` targets, so the
+  chapter title and label come from
+  [`book/chapters/ch02-introducing-yourself.tex`](./book/chapters/ch02-introducing-yourself.tex).
+  And the payoff is not the chapter's `practice-mix` consolidation, because those
+  three lessons are still schema v1 and declare no knowledge atoms; the last
+  schema-v2 lesson by sequence stands in. Representativeness is therefore 3/15
+  (0.20), well under the 0.5 floor — recorded rather than padded, and it closes
+  when the practice lessons migrate.
+
+**Chapter 1 is not in the ledger**, and that gap is deliberate: all twelve of its
+lessons are schema v1, so it has no assessable payoff to point at. A placeholder
+would hide debt the HL05 gap report is meant to surface.
+
 ## Read and practise
 
 - [`book/book.tex`](./book/book.tex) builds the free two-chapter starter edition

--- a/code/learning/human-languages/russian/chapters.json
+++ b/code/learning/human-languages/russian/chapters.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "language": "russian",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Only chapter 2 is authorable today. Chapter 1 is entirely schema-v1 (no introduces/practises knowledge atoms), so it has no assessable payoff to point at and is deliberately absent rather than stubbed — its absence is real, measurable debt. Chapter 2 has no core/book-generation.json target either; its title and label are taken from russian/book/chapters/ch02-introducing-yourself.tex, the only other place they are written down.",
+  "chapters": [
+    {
+      "chapter": 2,
+      "title": "Introducing yourself",
+      "label": "ch:russian-introductions",
+      "canDo": "I can give my name in Russian, ask for someone else's, and pick ты or вы to match how well I know them.",
+      "spineNodes": ["SPINE-EXCHANGE-NAMES"],
+      "payoff": {
+        "lesson": "RU-C02-kak-cross-language",
+        "kind": "task",
+        "summary": "Ask Как вас зовут? and account for its shape: Russian, like French and Spanish, asks how people call you, where English asks what your name is.",
+        "assesses": [
+          "RU-LEX-KAK-VAS-ZOVUT",
+          "RU-GRAMMAR-NAMING-HOW-FRAME",
+          "RU-COMPARISON-NAMING-QUESTION-FRAMES"
+        ]
+      }
+    }
+  ]
+}

--- a/code/learning/human-languages/sanskrit/CHANGELOG.md
+++ b/code/learning/human-languages/sanskrit/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Chapter capability ledger — 2026-08-06
+
+- Added `chapters.json`, the HL05 chapter capability ledger, covering Chapter 6:
+  the reader can say *eka, dva, tri, catur, pañca* with their dual and gendered
+  forms and follow **पञ्च** outward into other languages.
+- Made `SA-C06-pancha-travels` the chapter payoff — the chapter's last schema-v2
+  lesson by sequence (360). It tracks *pañca* into Persian *panj-āb*, Greek
+  *pente* in *pentagon* and *pentathlon*, and the qualified five-ingredients
+  account of *punch*.
+- Recorded `SPINE-COUNT-ONE-TO-FIVE` as the chapter's spine node, matching
+  `SA-PATH-009` in `curriculum.json`.
+- Omitted Chapters 1–5 rather than stubbing them: all 30 of their lessons are
+  schema v1 and declare no `practises.knowledge`, so no payoff there could name
+  atoms a lesson actually exercises. Their absence is the debt the HL05 gap
+  report exists to measure.
+- Measured payoff representativeness for Chapter 6 at 7/15 introduced atoms
+  (0.47), just below the 0.5 policy floor. Sanskrit's chapter is the widest of
+  the six — three lessons, fifteen atoms — and the terminal lesson exercises the
+  *pañca* thread rather than the dual, the gendered paradigm, or the Grimm's-law
+  material. Recorded, not padded.
+
 ## Book warning cleanup — 2026-08-03
 
 - Replaced five duplicate recap anchors with stable chapter-qualified labels.

--- a/code/learning/human-languages/sanskrit/README.md
+++ b/code/learning/human-languages/sanskrit/README.md
@@ -45,6 +45,26 @@ Chapters 1–6 are in the book. Chapter 6 is generated from the same canonical
 schema-v2 lesson AST and source hashes that Language Ladder loads, while the
 first five chapters retain their authored long-form narrative during migration.
 
+## What each chapter lets you do
+
+[`chapters.json`](./chapters.json) is the HL05 capability ledger: per chapter, one
+first-person can-do sentence and the lesson that pays it off.
+
+- **Chapter 6** — *"I can say the Sanskrit numerals एक to पञ्च with their dual and
+  gendered forms, and follow पञ्च outward into Punjab, pentagon, and the disputed
+  history of punch."* Payoff:
+  [`SA-C06-pancha-travels`](./lessons/SA-C06-pancha-travels.md), a task.
+
+  Its representativeness is 7/15 introduced atoms (0.47), just under the 0.5
+  policy floor. This chapter is the widest of the Indic six, and its terminal
+  lesson follows the *pañca* thread rather than the dual, the gendered paradigm,
+  or the Grimm's-law material. The shortfall is recorded rather than padded away.
+
+Chapters 1–5 are **not in the ledger yet**, and that gap is deliberate. They are
+still schema v1, so their lessons declare no knowledge atoms and no payoff there
+could honestly claim to assess anything. A placeholder would hide debt the HL05
+gap report is meant to surface; the entries land as those chapters migrate.
+
 ## Book / fonts
 
 Compiles with XeLaTeX using the **vendored** Noto Sans Devanagari font

--- a/code/learning/human-languages/sanskrit/chapters.json
+++ b/code/learning/human-languages/sanskrit/chapters.json
@@ -1,0 +1,28 @@
+{
+  "version": 1,
+  "language": "sanskrit",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Only chapter 6 is authorable today. Chapters 1-5 are entirely schema-v1 (no introduces/practises knowledge atoms), so no payoff there can name atoms a lesson actually practises; they are deliberately absent rather than stubbed, and that absence is real, measurable debt.",
+  "chapters": [
+    {
+      "chapter": 6,
+      "title": "Numbers One to Five",
+      "label": "ch:numbers-one-to-five",
+      "canDo": "I can say the Sanskrit numerals एक to पञ्च with their dual and gendered forms, and follow पञ्च outward into Punjab, pentagon, and the disputed history of punch.",
+      "spineNodes": ["SPINE-COUNT-ONE-TO-FIVE"],
+      "payoff": {
+        "lesson": "SA-C06-pancha-travels",
+        "kind": "task",
+        "summary": "Trace pañca out of Sanskrit: into Persian panj-āb, the five waters behind Punjab; into Greek pente in pentagon and pentathlon; and into punch, with the five-ingredients account labelled as common rather than settled.",
+        "assesses": [
+          "SA-LEX-NUMBERS-ONE-TO-FIVE",
+          "SA-COMPARISON-NUMERAL-FAMILY",
+          "SA-HISTORY-NUMERAL-INHERITANCE",
+          "SA-HISTORY-PUNJAB-FIVE-WATERS",
+          "SA-ETYMON-PANJ-PANCA-COGNATE",
+          "SA-ETYMON-PENTE-DESCENDANTS",
+          "SA-ETYMON-PUNCH-DISPUTED"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Completes the 20-track HL05 fan-out with `chapters.json` for **russian, bengali, gujarati, marathi, punjabi and sanskrit**.

Each of these tracks has exactly one authorable chapter, so each file carries a single entry. That is the expected shape, not a shortfall in the authoring: these tracks are barely migrated (bengali 1/31 lessons on schema v2, gujarati/punjabi 2/33, marathi 2/35, sanskrit 3/33, russian 6/22).

## Authored

| track | chapter | title | payoff lesson | kind |
|---|---|---|---|---|
| russian | 2 | Introducing yourself | `RU-C02-kak-cross-language` | task |
| bengali | 6 | Numbers One to Five | `BN-C06-numbers-1-5` | production |
| gujarati | 6 | Numbers One to Five | `GU-C06-number-histories` | task |
| marathi | 6 | Numbers One to Five | `MR-C06-number-differences` | task |
| punjabi | 6 | Numbers One to Five | `PA-C06-panj-convergence` | task |
| sanskrit | 6 | Numbers One to Five | `SA-C06-pancha-travels` | task |

Every field is derived from that track's own data — lesson frontmatter for atoms and sequence, `curriculum.json` path segments for `spineNodes`, `core/book-generation.json` for `title`/`label`. The five Indo-Aryan chapter 6s are parallel by design, and their shared printed title is forced by the drift test, but underneath they sit in four different scripts with disjoint lesson ids and atom namespaces, and each `canDo` and payoff summary describes only its own track's material: Bengali's conservative *dui*, Gujarati's **બે** from feminine/neuter *dvé*, Marathi's analogical **दोन** and its *ts*, Punjabi's Gurmukhi marks and the *panj* convergence argument, Sanskrit's dual and the travels of *pañca*. Russian is unrelated to all five.

## Skipped, and why

Every omitted chapter below is **entirely schema v1**: its lessons carry no `introduces.knowledge` or `practises.knowledge`, so no payoff there can name atoms a lesson actually exercises and the HL05 `assesses` subset rule cannot be satisfied honestly. Per the spec these are left absent rather than stubbed — an absent entry is the debt the gap report exists to measure, and a placeholder would erase it.

| track | skipped chapters | schema-v1 lessons behind them |
|---|---|---|
| russian | 1 | 12 |
| bengali | 1, 2, 3, 4, 5 | 30 |
| gujarati | 1, 2, 3, 4, 5 | 31 |
| marathi | 1, 2, 3, 4, 5 | 33 |
| punjabi | 1, 2, 3, 4, 5 | 31 |
| sanskrit | 1, 2, 3, 4, 5 | 30 |

## Two deviations, recorded rather than worked around

**Russian.** Chapter 2's own `practice-mix` consolidation lessons are also schema v1, so the payoff is the chapter's last schema-v2 lesson by sequence instead. Russian has no `book-generation.json` targets at all, so the title and label come from `book/chapters/ch02-introducing-yourself.tex`, the only other place they are written down; the title-drift test skips targetless chapters.

**Representativeness** (assessed / chapter-introduced atoms, floor 0.5 from `core/chapter-policy.json`):

| track | chapter | assessed / introduced | share |
|---|---|---|---|
| bengali | 6 | 6/6 | 1.00 |
| marathi | 6 | 7/7 | 1.00 |
| gujarati | 6 | 7/8 | 0.88 |
| punjabi | 6 | 8/11 | 0.73 |
| **sanskrit** | 6 | 7/15 | **0.47** |
| **russian** | 2 | 3/15 | **0.20** |

Sanskrit and Russian fall below the floor. Neither `assesses` list was padded: both are exactly their payoff lesson's declared `practises.knowledge`. Inflating them would make the representativeness gate measure authored optimism rather than taught material, which is the failure the rule exists to catch. Sanskrit's chapter is the widest of the six (three lessons, fifteen atoms) and its terminal lesson follows the *pañca* thread rather than the dual, the gendered paradigm, or the Grimm's-law material. Russian's shortfall closes when its practice lessons migrate.

## Verification

`npx tsc --noEmit` and `npx vitest run` in `code/packages/typescript/human-language-data` — 14 files, 123 tests passing. That covers the first-person `canDo` assertion, payoff-lesson resolution and chapter match, the `assesses` ⊆ `practises.knowledge` rule, and the title/label drift check against `book-generation.json`. No `package-lock.json` diff. Track CHANGELOGs and READMEs updated with the per-chapter can-do, the payoff lesson, and the skipped-chapter reasoning.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw3PKmLS2yEnDmhck3fM1z)_