### PR TITLE
ci(human-languages): run the book catalog builder's tests in CI (HL-C27)

### DIFF
--- a/.github/workflows/human-languages-books.yml
+++ b/.github/workflows/human-languages-books.yml
@@ -22,6 +22,7 @@ on:
       - "code/packages/typescript/human-language-data/**"
       - "code/scripts/build_human_language_book_catalog.py"
       - "code/scripts/scan_latex_log_warnings.py"
+      - "code/scripts/tests/test_build_human_language_book_catalog.py"
       - "code/scripts/tests/test_scan_latex_log_warnings.py"
       - ".github/workflows/human-languages-books.yml"
   pull_request:
@@ -75,6 +76,7 @@ jobs:
             code/packages/typescript/human-language-data \
             code/scripts/build_human_language_book_catalog.py \
             code/scripts/scan_latex_log_warnings.py \
+            code/scripts/tests/test_build_human_language_book_catalog.py \
             code/scripts/tests/test_scan_latex_log_warnings.py \
             .github/workflows/human-languages-books.yml
           diff_status=$?
@@ -115,6 +117,23 @@ jobs:
           set -euo pipefail
           python3 -m unittest discover -s code/scripts/tests \
             -p 'test_scan_latex_log_warnings.py' -v
+
+      # The catalog builder writes the index.html and catalog.json that main
+      # pushes publish to GitHub Pages, so it is the other piece of this
+      # workflow whose breakage reaches readers. Same reasoning as above: test
+      # it before the 20-book build, not after.
+      #
+      # This is a second step rather than a widened `-p` on the step above
+      # because `unittest discover` takes exactly ONE pattern, and no glob
+      # matches these two files without also sweeping in the unrelated
+      # test_build_tool_conformance_* and test_build_adj_* suites. Separate
+      # named steps also keep the failure legible — the red step name says
+      # which suite broke without anyone opening the log.
+      - name: Test the book catalog builder
+        run: |
+          set -euo pipefail
+          python3 -m unittest discover -s code/scripts/tests \
+            -p 'test_build_human_language_book_catalog.py' -v
 
       - name: Build curriculum gap report
         working-directory: code/packages/typescript/human-language-data

--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -71,6 +71,7 @@ direction, and no gate may penalise page, lesson, or chapter count.
 | HL-C16 | Queued | Build the narration export (`narration-cli`) with `--write`/`--check`. | Plain-text and structured-JSON scripts emit from the canonical AST with `[PAUSE]`/`[REPEAT]`/`[YOU SAY]` preserved as directives and hash-gated against the lesson AST. This implements the audio-script output HL04 named and nothing ever built. |
 | HL-C17 | Queued | Linearise or reclassify the 322 table-bearing lessons. | Every table either reads correctly aloud or its lesson is honestly marked `sight`; the export never silently drops content. |
 | HL-C18 | Queued | Burn down the 52 lessons that exceed the gentle-ramp budget. | No lesson introduces more than `maxNewAtomsPerLesson`; over-budget lessons are split into prerequisite-ordered micro-lessons, longest first, starting with `ES-C31-numeros-11-20` at seven. |
+| HL-C27 | Complete in this PR | Run the book catalog builder's tests in CI. `test_build_human_language_book_catalog.py` existed but was executed by no workflow, so the script that writes the published `index.html` and `catalog.json` shipped with its tests never running. | `human-languages-books.yml` runs the suite in its own named step before the expensive XeLaTeX build, and both the workflow's `paths:` trigger and the `detect` job's `git diff` list include the test file so a change to it re-runs the job. |
 
 The illustration licensing question HL06 raised is **settled**. The project owner
 decided on 2026-08-06 that the books stay CC BY-SA 4.0 and that generated


### PR DESCRIPTION
## The gap

`code/scripts/tests/test_build_human_language_book_catalog.py` existed in the tree but was executed by **no workflow**.

The script it covers, `code/scripts/build_human_language_book_catalog.py`, writes the `index.html` and `catalog.json` that every push to `main` publishes to GitHub Pages. The public book catalog was shipping with its tests never running.

## The fix

Wires that suite into `.github/workflows/human-languages-books.yml` as its own named step, immediately after the existing **Test the LaTeX warning scanner** step and deliberately **before** the expensive 20-book XeLaTeX build — the same reasoning that step already records: a silently broken gate is worse than no gate, and finding out after twenty minutes of TeX wastes the build. The suite is stdlib-only, so it needs nothing beyond the runner's stock `python3`.

## Why a second step and not a widened `-p`

The task asked me to prefer widening the existing scanner step's `-p` pattern over adding a near-duplicate step, *provided* that keeps the failure output legible. It does not, for two independent reasons:

1. **`unittest discover` accepts exactly one `-p` pattern.** It is a single-valued argparse option — passing `-p` twice means the last one silently wins, which would be worse than not wiring the tests at all. So covering both files requires one glob that matches both.
2. **No such glob is clean.** The two filenames are `test_scan_latex_log_warnings.py` and `test_build_human_language_book_catalog.py`. Any pattern loose enough to match both also matches `test_build_tool_conformance_*` (nine suites) and `test_build_adj_proportion_provenance.py` — all already run by `ci.yml`, none of which belong in a books job. Widening would have this workflow redundantly re-run unrelated suites and fail on their breakage.

Even setting both aside, a single merged step reports one red step name covering two unrelated concerns. Two named steps mean the GitHub Actions UI says **which** suite broke before anyone opens a log — which is the whole point of testing early here.

## Trigger plumbing

The scanner PR added both `code/scripts/scan_latex_log_warnings.py` and its test to the workflow's `paths:` trigger *and* the `detect` job's `git diff` pathspec list. This does the same for `code/scripts/tests/test_build_human_language_book_catalog.py`, so editing the test actually re-runs the job instead of silently skipping it. The builder script itself was already in both lists.

## Verification

- **The tests pass as found** — confirmed before wiring, not after: `python3 -m unittest discover -s code/scripts/tests -p 'test_build_human_language_book_catalog.py' -v` → `Ran 2 tests ... OK`. Nothing red was wired in.
- **The workflow parses** — `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/human-languages-books.yml'))"` succeeds; step list and job structure confirmed intact.
- No `${{ }}` interpolation was added to any `run:` block.
- `permissions:` unchanged, top-level and job-level.
- The `books-gate` job's PR-vs-push name expression and its pass/fail contract are **untouched** — it is a required status check.

## The wider picture in `code/scripts/tests/`

Task item 3 asked whether other test files are similarly orphaned. Surveyed all of them by matching each filename against every file under `.github/workflows/`:

- **60 test files total**
- **21 referenced by a workflow** (`ci.yml` names most explicitly; `build-ocaml.yml` and this workflow name one each)
- **39 referenced by none** — 38 remaining after this PR

The other 38 are not "similarly orphaned" in a way this PR can responsibly fix. They are overwhelmingly the neural-learning `validate_*_labs` suites (`test_attention_qkv_labs.py`, `test_multi_head_attention_labs.py`, `test_variational_autoencoder_labs.py`, and ~30 more) plus a handful of unrelated fixture and report checks (`test_reference_fixture_catalog.py`, `test_cross_language_fixture_consumers.py`, `test_websocket_core_fixtures.py`, `test_learning_coverage_report.py`, `test_typescript_sir_windows_prerequisites.py`, `test_build_adj_proportion_provenance.py`).

None of them have anything to do with human-language books. Wiring them into `human-languages-books.yml` would mean they only run when a `.tex` file changes and never when their own subjects change — worse than useless, because it would look like coverage while providing none. They belong in `ci.yml` or their own workflow, with their own `paths:` triggers, which is a separate and considerably larger piece of work. Flagging it here rather than smuggling it into a human-languages PR.

Only `test_scan_latex_log_warnings.py` and `test_build_human_language_book_catalog.py` are in this workflow's domain, and after this PR both run.

## Also

- `code/learning/human-languages/BACKLOG.md` gains an **HL-C27** row marked complete in this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw3PKmLS2yEnDmhck3fM1z)_