### PR TITLE
fix(human-languages): make the Russian track drivable and its payoff representative (HL-C32)

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -69,8 +69,9 @@ direction, and no gate may penalise page, lesson, or chapter count.
 | HL-C14 | Queued | Derive modality (`voice`/`sight`/`pen`) for every lesson and each chapter's drivable prefix. | The gap report publishes per-track modality counts and the corpus-wide drivable percentage; overrides without a recorded reason are reported. |
 | HL-C15 | Queued | Print modality signs and the drivable prefix at every chapter opening. | The book shows 🚗/👁/✍ beside the HL05 capability, so a reader knows before starting whether a chapter needs eyes or a pen. |
 | HL-C16 | Queued | Build the narration export (`narration-cli`) with `--write`/`--check`. | Plain-text and structured-JSON scripts emit from the canonical AST with `[PAUSE]`/`[REPEAT]`/`[YOU SAY]` preserved as directives and hash-gated against the lesson AST. This implements the audio-script output HL04 named and nothing ever built. |
-| HL-C17 | Queued | Linearise or reclassify the 322 table-bearing lessons. | Every table either reads correctly aloud or its lesson is honestly marked `sight`; the export never silently drops content. |
+| HL-C17 | Queued — 308 remaining after HL-C32 | Linearise or reclassify the 308 table-bearing lessons. | Every table either reads correctly aloud or its lesson is honestly marked `sight`; the export never silently drops content. |
 | HL-C18 | Queued | Burn down the 52 lessons that exceed the gentle-ramp budget. | No lesson introduces more than `maxNewAtomsPerLesson`; over-budget lessons are split into prerequisite-ordered micro-lessons, longest first, starting with `ES-C31-numeros-11-20` at seven. |
+| HL-C32 | Complete in this PR | Diagnose and repair the Russian track, worst in the corpus on two independent measurements: 9% drivable with **zero** lessons reachable by ear in either chapter, and payoff representativeness of 0.20. | Russian measures 73% drivable (16 `voice`, 1 `sight`, 5 `pen`) with 15 lessons reachable in chapter-prefix order, and Chapter 2's payoff representativeness is 0.67 against the 0.5 floor. Zero new validation errors, zero duration violations. |
 | HL-C27 | Complete in this PR | Run the book catalog builder's tests in CI. `test_build_human_language_book_catalog.py` existed but was executed by no workflow, so the script that writes the published `index.html` and `catalog.json` shipped with its tests never running. | `human-languages-books.yml` runs the suite in its own named step before the expensive XeLaTeX build, and both the workflow's `paths:` trigger and the `detect` job's `git diff` list include the test file so a change to it re-runs the job. |
 
 The illustration licensing question HL06 raised is **settled**. The project owner
@@ -1863,6 +1864,52 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - The audit found 117 authored links across the wider lesson corpus. The 62 not
   yet represented in generated targets remain canonical app content and will
   become live automatically when those chapters migrate to book generation.
+
+## Findings from HL-C32
+
+The Russian repair is worth reading as a diagnosis, because the diagnosis
+generalises and the fix does not.
+
+- **Russian's 9% was one rule firing fifteen times out of fifteen.** Every
+  `sight` lesson in the track tripped `wide-table`. Not one carried a `script`
+  block. Twelve tripped nothing else. It was never a script-heavy track; it was a
+  table-heavy one.
+- **Two of the three sight cues that did match were false positives.** The cue
+  list is literal substring matching, so `"the course's first look at case"`
+  matched `look at`, and a sentence describing a comparison as `"the most extreme
+  change in the table"` matched `the table` only because the table existed. Only
+  `RU-C02-practice-cases` — *"cover the right column"* — points at anything real.
+- **The tables were carrying prose.** Almost every one was a cross-language
+  word→gloss list: `| Language | "yes" | built from |`. `RU-C01-privet` and
+  `RU-C01-zdravstvuyte` carry exactly that section as sentences, and they were
+  the track's only two `voice` lessons. The same content, set two ways, produced
+  two different modalities — which is the whole finding.
+- **One table was genuinely visual and stayed.** `RU-C02-practice-cases` is a
+  cover-the-column retrieval drill; the table *is* the exercise. It remains
+  `sight`, and Chapter 2's drivable prefix correctly stops there at 8 of 10.
+- **The pattern is corpus-wide, and Russian was only its most extreme case.**
+  Of 337 `sight` lessons remaining, 271 trip `wide-table` and nothing else.
+  Grouped by track, `onlyTable` counts run: spanish 57, german 33, portuguese 32,
+  french 29, italian 29, arabic 14, tamil 14, and so on. Those five European
+  tracks sit at 43–47% drivable for the same reason Russian sat at 9%. HL-C17 is
+  therefore not a Russian problem that leaked; it is the corpus's single largest
+  modality lever, and this pass is a worked example of how to pull it —
+  distinguishing a two- or three-column word→gloss list, which linearises, from a
+  real multi-column paradigm, which does not.
+- **Representativeness was a migration symptom, not an authoring failure.**
+  Chapter 2's payoff pointed at a cross-language etymology lesson because that was
+  the last schema-v2 lesson by sequence; the chapter's actual consolidation
+  lesson was schema v1 and declared no atoms. Migrating that one lesson took
+  representativeness from 0.20 to 0.67 without inventing content. The same
+  substitution is visible in the remaining sub-floor chapters (arabic ch3/ch4 at
+  0.11/0.13, spanish ch3 at 0.25, hindi ch2 at 0.17), and the same one-lesson fix
+  should work wherever the chapter's consolidation lesson is the schema-v1 one.
+- **Two artefacts remain and only a full migration closes them.** Fifteen Russian
+  lessons are still schema v1. Because `sequence` is a schema-v2 field, Chapter 1
+  is still ordered alphabetically rather than pedagogically for modality
+  purposes, and `RU-C02-practice` now sorts ahead of its own schema-v1
+  prerequisite. Neither affects validation or the drivable prefix, and neither is
+  worth a cosmetic patch.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/russian/CHANGELOG.md
+++ b/code/learning/human-languages/russian/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog — Russian track
 
+## 0.7.0 — 2026-08-06
+
+HL-C32. Russian was the worst-performing track in the corpus on two independent
+measurements — 9% drivable (2 `voice`, 15 `sight`, 5 `pen`, and **zero** lessons
+reachable by ear in either chapter) and payoff representativeness of 0.20. Both
+are now fixed, and the diagnosis matters more than the fix.
+
+**The root cause was formatting, not content.** All fifteen `sight` lessons
+tripped the same rule: `wide-table`. Not one carried a `script` block. Twelve
+tripped nothing else at all; the three that also matched a sight cue matched
+phrases like "the course's first **look at** case", which point at nothing on the
+page. And the tables themselves were almost entirely cross-language
+word→gloss lists — *"Language | 'yes' | built from"* — the exact material
+`RU-C01-privet` and `RU-C01-zdravstvuyte` already carry as prose, which is why
+those two were the track's only `voice` lessons. The same section, set two
+different ways, produced two different modalities.
+
+- Rewrote fourteen table-driven lessons so their word→gloss and letter→sound
+  lists are speakable prose or bullets. No content was dropped, no comparison
+  was shortened, and every lesson stayed under the duration budget.
+- Left `RU-C02-practice-cases` as `sight`, deliberately. Its table is a
+  cover-the-column retrieval drill: the table *is* the exercise, and linearising
+  it would delete the lesson. An immovable `sight` lesson is a correct finding,
+  not a failure.
+- Left `RU-W02-false-friends-s-n`'s four-column table alone. It is a `writing`
+  lesson, so it is `pen` regardless, and reformatting would buy nothing.
+- Result: 16 `voice`, 1 `sight`, 5 `pen` — **9% → 73% drivable**, and **0 → 15
+  lessons reachable in chapter-prefix order**. Chapter 1's first seven lessons
+  and Chapter 2's first eight are now doable in the car. Corpus-wide drivable
+  lessons rose from 694 (63%) to 708 (65%); Russian alone accounts for all of it.
+- Migrated `RU-C02-practice` — one lesson, not the remaining fifteen — to schema
+  v2 so the chapter payoff can point at the chapter's actual consolidation
+  lesson instead of `RU-C02-kak-cross-language`, a cross-language etymology
+  lesson that was standing in only because it was the last schema-v2 lesson by
+  sequence. The migrated lesson runs the full introduction formally, switches it
+  informally, and assesses ten of Chapter 2's fifteen introduced atoms:
+  **representativeness 0.20 → 0.67**, above the 0.5 policy floor. Closure is
+  strict — every line uses only already-taught material, and the lesson
+  introduces nothing new.
+- Added `RU-EXT-006-CONSOLIDATION` to `curriculum.json` and placed
+  `RU-C02-practice` in `RU-PATH-006`, because every schema-v2 lesson naming a
+  spine node must appear in the local realization map.
+
+**Still open, and honestly so.** Fifteen Russian lessons remain schema v1 — all
+twelve of Chapter 1, plus `RU-C02-ochen-priyatno`, `RU-C02-practice-cases` and
+`RU-C02-practice-zero-copula`. That is why Chapter 1 still has no `chapters.json`
+entry: it introduces no knowledge atoms, so no payoff can assess anything. And
+because `sequence` is a schema-v2 field, Chapter 1's modality ordering is still
+alphabetical rather than pedagogical, and `RU-C02-practice` now sorts ahead of
+its own prerequisite `RU-C02-ochen-priyatno` in that ordering. Neither affects
+validation or the drivable prefix; both close only with the full migration.
+
 ## 0.6.0 — 2026-08-06
 
 - Added `chapters.json`, the HL05 chapter capability ledger, covering Chapter 2:

--- a/code/learning/human-languages/russian/README.md
+++ b/code/learning/human-languages/russian/README.md
@@ -28,6 +28,12 @@ grammar introduced only when a word needs it.
 - **Objective Chapter 2 progression**: the closed chain from *я* through
   *как вас зовут* uses typed knowledge boundaries, and Language Ladder checks
   polite *вы* plus the cross-language *how/what* contrast before advancing.
+- **Drivable by ear.** 16 of the track's 22 lessons need only your ears; the
+  other 6 are the five handwriting lessons and one cover-the-column retrieval
+  drill. Russian used to be the corpus's least drivable track at 9%, entirely
+  because its cross-language comparisons were set as Markdown tables rather than
+  said as sentences. They are sentences now. See the 0.7.0 entry in
+  [`CHANGELOG.md`](./CHANGELOG.md) for the measurement.
 
 ## Progress
 
@@ -53,17 +59,14 @@ first-person can-do sentence and the lesson that pays it off.
 
 - **Chapter 2** — *"I can give my name in Russian, ask for someone else's, and
   pick ты or вы to match how well I know them."* Payoff:
-  [`RU-C02-kak-cross-language`](./lessons/RU-C02-kak-cross-language.md), a task —
-  ask *Как вас зовут?* and account for its shape.
+  [`RU-C02-practice`](./lessons/RU-C02-practice.md), a dialogue — run the whole
+  introduction with a stranger, then switch it for one friend by changing only
+  the greeting and *вас → тебя*. It assesses ten of the chapter's fifteen
+  introduced atoms, for a representativeness of **0.67** against the 0.5 floor.
 
-  Two honest caveats. Russian has no `core/book-generation.json` targets, so the
-  chapter title and label come from
+  One honest caveat remains: Russian has no `core/book-generation.json` targets,
+  so the chapter title and label come from
   [`book/chapters/ch02-introducing-yourself.tex`](./book/chapters/ch02-introducing-yourself.tex).
-  And the payoff is not the chapter's `practice-mix` consolidation, because those
-  three lessons are still schema v1 and declare no knowledge atoms; the last
-  schema-v2 lesson by sequence stands in. Representativeness is therefore 3/15
-  (0.20), well under the 0.5 floor — recorded rather than padded, and it closes
-  when the practice lessons migrate.
 
 **Chapter 1 is not in the ledger**, and that gap is deliberate: all twelve of its
 lessons are schema v1, so it has no assessable payoff to point at. A placeholder

--- a/code/learning/human-languages/russian/chapters.json
+++ b/code/learning/human-languages/russian/chapters.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "language": "russian",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Only chapter 2 is authorable today. Chapter 1 is entirely schema-v1 (no introduces/practises knowledge atoms), so it has no assessable payoff to point at and is deliberately absent rather than stubbed — its absence is real, measurable debt. Chapter 2 has no core/book-generation.json target either; its title and label are taken from russian/book/chapters/ch02-introducing-yourself.tex, the only other place they are written down.",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Only chapter 2 is authorable today. Chapter 1 is entirely schema-v1 (no introduces/practises knowledge atoms), so it has no assessable payoff to point at and is deliberately absent rather than stubbed — its absence is real, measurable debt. Chapter 2 has no core/book-generation.json target either; its title and label are taken from russian/book/chapters/ch02-introducing-yourself.tex, the only other place they are written down. The payoff points at RU-C02-practice, the chapter's consolidation lesson, which HL-C32 migrated to schema v2 for exactly this reason; before that migration the only schema-v2 candidate was the cross-language etymology lesson RU-C02-kak-cross-language, whose three atoms gave a representativeness of 0.20 against a 0.50 floor.",
   "chapters": [
     {
       "chapter": 2,
@@ -10,13 +10,20 @@
       "canDo": "I can give my name in Russian, ask for someone else's, and pick ты or вы to match how well I know them.",
       "spineNodes": ["SPINE-EXCHANGE-NAMES"],
       "payoff": {
-        "lesson": "RU-C02-kak-cross-language",
-        "kind": "task",
-        "summary": "Ask Как вас зовут? and account for its shape: Russian, like French and Spanish, asks how people call you, where English asks what your name is.",
+        "lesson": "RU-C02-practice",
+        "kind": "dialogue",
+        "summary": "Run the whole introduction with a stranger — greet, ask Как вас зовут?, answer Меня зовут…, close with Очень приятно — then switch it for one friend by changing only the greeting and вас → тебя.",
         "assesses": [
+          "RU-LEX-YA",
+          "RU-LEX-TY-VY",
+          "RU-GRAMMAR-TY-VY-REGISTER",
+          "RU-PRAGMATICS-VY-POLITENESS",
+          "RU-LEX-MENYA-ZOVUT",
+          "RU-GRAMMAR-INDEFINITE-PERSONAL-PLURAL",
+          "RU-GRAMMAR-MENYA-OBJECT-CASE",
           "RU-LEX-KAK-VAS-ZOVUT",
-          "RU-GRAMMAR-NAMING-HOW-FRAME",
-          "RU-COMPARISON-NAMING-QUESTION-FRAMES"
+          "RU-GRAMMAR-OBJECT-PRONOUNS",
+          "RU-GRAMMAR-NAMING-HOW-FRAME"
         ]
       }
     }

--- a/code/learning/human-languages/russian/curriculum.json
+++ b/code/learning/human-languages/russian/curriculum.json
@@ -65,14 +65,17 @@
         "RU-C02-menya-zovut",
         "RU-C02-kak-vas-zovut",
         "RU-C02-kak-cross-language",
-        "RU-C02-ochen-priyatno"
+        "RU-C02-ochen-priyatno",
+        "RU-C02-practice"
       ],
       "before": [],
       "inline": [
         "RU-EXT-006-REGISTER",
         "RU-EXT-006-GRAMMAR"
       ],
-      "after": []
+      "after": [
+        "RU-EXT-006-CONSOLIDATION"
+      ]
     }
   ],
   "spine": {
@@ -210,6 +213,17 @@
       "prerequisites": [],
       "lessons": [
         "RU-C02-kak-cross-language"
+      ]
+    },
+    {
+      "id": "RU-EXT-006-CONSOLIDATION",
+      "stage": "pre-A1",
+      "kind": "supporting",
+      "category": "consolidation",
+      "canDo": "I can retrieve and combine the Russian material introduced in this part of the path.",
+      "prerequisites": [],
+      "lessons": [
+        "RU-C02-practice"
       ]
     },
     {

--- a/code/learning/human-languages/russian/lessons/RU-C01-da.md
+++ b/code/learning/human-languages/russian/lessons/RU-C01-da.md
@@ -38,13 +38,14 @@ in the language.
 
 ## Across the family — the shapes of "yes"
 
-| Language | "yes" | built from |
-|---|---|---|
-| **Russian** | *da* (да) | old Slavic affirmative |
-| Spanish | *sí* | Latin *sic*, "thus, so" |
-| French | *oui* | Latin *hoc ille*, "that's it" |
-| German | *ja* | old Germanic *ja* |
-| Latin | *ita / sic* | "thus, so" |
+Every language improvised its own "yes," and you can hear where each one came
+from:
+
+- Russian **да** — an old Slavic affirmative.
+- Spanish **sí** — Latin *sic*, "thus, so."
+- French **oui** — Latin *hoc ille*, "that's it."
+- German **ja** — old Germanic *ja*.
+- Latin **ita** or **sic** — "thus, so."
 
 Notice how many languages say "yes" with a word that means **"so / thus"**
 (*sí*, *sic*, *ita*). Russian's *да* is its own thing — but its side-job as a

--- a/code/learning/human-languages/russian/lessons/RU-C01-net.md
+++ b/code/learning/human-languages/russian/lessons/RU-C01-net.md
@@ -59,17 +59,11 @@ for six thousand years.
 
 ## Across the family — one ancient "no"
 
-| Language | "no" | from PIE **\*ne** |
-|---|---|---|
-| **Russian** | *nyet* (нет) | ✓ (не = "not") |
-| English | *no / not* | ✓ |
-| Latin | *nōn* | ✓ |
-| French | *non* | ✓ |
-| Sanskrit | *na* | ✓ |
-
 Unlike "yes" — where every language improvised — the world's "no" is
-astonishingly **one word**, stretched across the whole family. *нет* is Russia's
-share of it.
+astonishingly **one word**, stretched across the whole family. Russian **нет**
+carries *не*; English says **no** and **not**; Latin said *nōn*, French says
+*non*, Sanskrit said *na*. All of them are the same ancient \**ne*, and *нет* is
+Russia's share of it.
 
 ## Guided Practice
 

--- a/code/learning/human-languages/russian/lessons/RU-C01-pozhaluysta.md
+++ b/code/learning/human-languages/russian/lessons/RU-C01-pozhaluysta.md
@@ -56,13 +56,11 @@ English needs a separate "you're welcome," Russian just answers *спасибо*
 
 ## Across the family — "please" is a favour, everywhere
 
-| Language | "please" | literally |
-|---|---|---|
-| **Russian** | *pozhálusta* (пожалуйста) | "grant [me] a favour" |
-| French | *s'il vous plaît* | "if it pleases you" |
-| Spanish | *por favor* | "for a favour" |
-| English | *please* | "[if it] please [you]" |
-| German | *bitte* | "I request" (and, like Russian, also "you're welcome") |
+- Russian **пожалуйста** — "grant [me] a favour."
+- French **s'il vous plaît** — "if it pleases you."
+- Spanish **por favor** — "for a favour."
+- English **please** — "[if it] please [you]."
+- German **bitte** — "I request," and also "you're welcome."
 
 German *bitte* pulls the exact same double shift as *пожалуйста* — one word for
 both "please" and "you're welcome."

--- a/code/learning/human-languages/russian/lessons/RU-C01-practice.md
+++ b/code/learning/human-languages/russian/lessons/RU-C01-practice.md
@@ -23,12 +23,10 @@ well enough to sound them all out. Let's prove it.
 
 These are the letters that look Latin and lie. Say each sound aloud:
 
-| looks like | actually says | in the word |
-|---|---|---|
-| **в** (Latin B) | **v** | при**в**ет |
-| **р** (Latin P) | **r** | п**р**ивет |
-| **с** (Latin C) | **s** | **с**пасибо |
-| **н** (Latin H) | **n** | **н**ет |
+- **в** wears the shape of a Latin B and says **v** — as in при**в**ет.
+- **р** wears the shape of a Latin P and says **r** — as in п**р**ивет.
+- **с** wears the shape of a Latin C and says **s** — as in **с**пасибо.
+- **н** wears the shape of a Latin H and says **n** — as in **н**ет.
 
 And the two easy vowel traps: **у** = "oo" (not y), **е** = "ye."
 

--- a/code/learning/human-languages/russian/lessons/RU-C01-spasibo.md
+++ b/code/learning/human-languages/russian/lessons/RU-C01-spasibo.md
@@ -60,13 +60,11 @@ prayer wore invisible.
 
 ## Across the family — thanks, and where it comes from
 
-| Language | "thank you" | its root idea |
-|---|---|---|
-| **Russian** | *spasíbo* (спасибо) | **"God save you"** |
-| Spanish | *gracias* | Latin *gratia*, "grace" |
-| French | *merci* | Latin *merces*, "reward, mercy" |
-| German | *danke* | "think of / be mindful" |
-| English | *thank you* | "think" — I'll hold you in thought |
+- Russian **спасибо** — **"God save you."**
+- Spanish **gracias** — Latin *gratia*, "grace."
+- French **merci** — Latin *merces*, "reward, mercy."
+- German **danke** — "think of, be mindful."
+- English **thank you** — "think": I'll hold you in thought.
 
 Every culture built "thanks" from a different metaphor — grace, reward, mindful
 thought — and Russian built it from a **blessing**.

--- a/code/learning/human-languages/russian/lessons/RU-C02-kak-cross-language.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-kak-cross-language.md
@@ -43,12 +43,10 @@ Russian asks **how** people call you, treating naming as something people do.
 
 English is the odd one out in this small comparison:
 
-| Language | question frame |
-|---|---|
-| Russian | *Как вас зовут?* — **how** |
-| French | *Comment vous appelez-vous ?* — **how** |
-| Spanish | *¿Cómo se llama?* — **how** |
-| English | ***What*** is your name? — **what** |
+- Russian asks *Как вас зовут?* — **how**.
+- French asks *Comment vous appelez-vous ?* — **how**.
+- Spanish asks *¿Cómo se llama?* — **how**.
+- English asks ***What*** is your name? — **what**.
 
 Three languages organize the question around an **action**; English organizes
 it around a **possession**. The answer is the same social fact, but the route to

--- a/code/learning/human-languages/russian/lessons/RU-C02-kak-vas-zovut.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-kak-vas-zovut.md
@@ -45,11 +45,8 @@ that Russian asks a different question from English.
 
 Taken apart:
 
-| | | |
-|---|---|---|
-| **как** | *kak* | **how** |
-| **вас** / **тебя** | *vas* / *tebya* | **you** (object form) |
-| **зовут** | *zovut* | they call |
+**как** — *kak* — **how**. **вас** or **тебя** — *vas* / *tebya* — **you**, in
+the object form. **зовут** — *zovut* — they call.
 
 So: **"How do they call you?"**
 
@@ -59,11 +56,9 @@ So: **"How do they call you?"**
 Last lesson's *меня* has partners, and they follow the same logic — the person
 being called is the **object**, so the word changes shape:
 
-| subject | object | |
-|---|---|---|
-| я | **меня** | me |
-| ты | **тебя** | you (informal) |
-| вы | **вас** | you (formal/plural) |
+- **я** becomes **меня** — me.
+- **ты** becomes **тебя** — you, informal.
+- **вы** becomes **вас** — you, formal or plural.
 
 You now have a matched pair: **Как вас зовут?** — **Меня зовут…**
 

--- a/code/learning/human-languages/russian/lessons/RU-C02-menya-zovut.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-menya-zovut.md
@@ -45,10 +45,8 @@ worth taking apart slowly.
 
 Now the literal reading:
 
-| | | |
-|---|---|---|
-| **меня** | *menya* | **me** (object form) |
-| **зовут** | *zovut* | **they call** |
+**меня** — *menya* — **me**, the object form. **зовут** — *zovut* —
+**they call**.
 
 So: **"[they] call me Anna."**
 
@@ -70,16 +68,13 @@ English has the same trick and doesn't notice it:
 ## Grammar Lens: меня is not я
 <!-- hl-knowledge: introduces=[RU-GRAMMAR-MENYA-OBJECT-CASE]; assesses=[] -->
 
-This is the important part, and the course's first look at **case**.
+This is the important part, and the course's first taste of **case**.
 
 You learned **я** for "I" last lesson. But here it is **меня** — because *I* is
 now the **object** of the calling, not the one doing it. Russian changes the
 **shape of the word** to mark that job:
 
-| | |
-|---|---|
-| **я** | I — the one acting |
-| **меня** | me — the one acted on |
+**я** is *I*, the one acting; **меня** is *me*, the one acted on.
 
 English does this with about six **pairs** — *I/me*, *he/him*, *she/her*,
 *we/us*, *they/them*, *who/whom*, plus the archaic *thou/thee*. Russian does it with **every noun and

--- a/code/learning/human-languages/russian/lessons/RU-C02-ochen-priyatno.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-ochen-priyatno.md
@@ -27,10 +27,7 @@ chapter.
 
 Literally: **"very pleasant."**
 
-| | | |
-|---|---|---|
-| **очень** | *ochen* | very |
-| **приятно** | *priyatno* | pleasant, agreeable |
+**очень** — *ochen* — very. **приятно** — *priyatno* — pleasant, agreeable.
 
 There is no "to meet you" and no "I am." Russian states the **quality of the
 moment** and leaves the rest understood — the same economy as *меня зовут*, which
@@ -47,11 +44,10 @@ toward" — which gives Russian **приятель** (*priyátel'*), a friend.
 That root goes back to PIE \**preyH-*, "to love, to please." And it went into
 Germanic too:
 
-| | |
-|---|---|
-| Russian | **приятно** — pleasant · **приятель** — friend |
-| English | **friend** — literally "one who is loving," an old participle of a verb meaning *to love* |
-| German | *Freund* |
+- Russian **приятно**, pleasant, and **приятель**, a friend.
+- English **friend** — literally "one who is loving," an old participle of a
+  verb meaning *to love*.
+- German *Freund*.
 
 So *приятно* and *friend* are the same root, arriving from opposite ends of
 Europe.

--- a/code/learning/human-languages/russian/lessons/RU-C02-practice-zero-copula.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-practice-zero-copula.md
@@ -20,11 +20,12 @@ words that are genuinely absent; do not erase a verb that is really there.
 
 ## Three phrases, three English expansions
 
-| Russian | literal reading | English adds |
-|---|---|---|
-| **Меня зовут Анна** | "they call me Anna" | *my*, *name* |
-| **Очень приятно** | "very pleasant" | *it is*, *to meet you* |
-| **Как вас зовут?** | "how do they call you?" | *what*, *your* |
+- **Меня зовут Анна** reads literally "they call me Anna"; English adds *my*
+  and *name*.
+- **Очень приятно** reads literally "very pleasant"; English adds *it is* and
+  *to meet you*.
+- **Как вас зовут?** reads literally "how do they call you?"; English adds
+  *what* and *your*.
 
 Only the middle sentence has **no verb at all**. In present-tense descriptions,
 Russian normally drops the linking verb: *Очень приятно* needs no spoken "is."

--- a/code/learning/human-languages/russian/lessons/RU-C02-practice.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-practice.md
@@ -1,57 +1,93 @@
 ---
+schema_version: 2
 id: RU-C02-practice
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 130
 chapter: 2
 type: practice-mix
 headword: "Chapter 2 practice: the exchange"
-gloss: "run the introduction formally and informally"
+gloss: "run the whole introduction formally, then make the two changes that turn it informal"
 concept_tag: CH2-PRACTICE
+romanization: "zdravstvuyte / kak vas zovut / menya zovut"
 prerequisites: [RU-C02-ochen-priyatno, RU-C02-kak-cross-language]
 sounds: [cyrillic-false-friends, stress-unmarked]
-roots: []
-est_minutes: 3
+roots: [slavic-zvati]
+etymology_hook: "the chapter's payoff is one exchange: зовут never moves, and only the greeting and the object pronoun change when вы becomes ты"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [RU-LEX-YA, RU-LEX-TY-VY, RU-GRAMMAR-TY-VY-REGISTER, RU-PRAGMATICS-VY-POLITENESS, RU-LEX-MENYA-ZOVUT, RU-GRAMMAR-INDEFINITE-PERSONAL-PLURAL, RU-GRAMMAR-MENYA-OBJECT-CASE, RU-LEX-KAK-VAS-ZOVUT, RU-GRAMMAR-OBJECT-PRONOUNS, RU-GRAMMAR-NAMING-HOW-FRAME]
+introduces:
+  knowledge: []
+practises:
+  knowledge: [RU-LEX-YA, RU-LEX-TY-VY, RU-GRAMMAR-TY-VY-REGISTER, RU-PRAGMATICS-VY-POLITENESS, RU-LEX-MENYA-ZOVUT, RU-GRAMMAR-INDEFINITE-PERSONAL-PLURAL, RU-GRAMMAR-MENYA-OBJECT-CASE, RU-LEX-KAK-VAS-ZOVUT, RU-GRAMMAR-OBJECT-PRONOUNS, RU-GRAMMAR-NAMING-HOW-FRAME]
+skills: [listening, speaking, reading]
+modes: [interpersonal, presentational, interpretive]
+strands: [meaning-input, meaning-output, fluency]
+register: formal-informal-contrast
+variety: standard-contemporary
 reviews_of: [RU-C02-ya, RU-C02-ty-vy, RU-C02-vy-formality, RU-C02-menya-zovut, RU-C02-kak-vas-zovut, RU-C02-ochen-priyatno]
 ---
 
 # Chapter 2 practice — run the exchange
 
 ## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[RU-LEX-YA, RU-LEX-TY-VY] -->
 
-[PAUSE 2s] The chapter's words now add up to a real conversation. Run it first
-with a stranger, then make the two changes that turn it informal.
+[PAUSE 2s] Give the three words the chapter opened with: *I*, familiar *you*,
+formal *you*. (*Я*, *ты*, *вы*.) Everything below is built from those.
 
-## Formal exchange
+## The exchange
+<!-- hl-knowledge: introduces=[]; assesses=[RU-LEX-KAK-VAS-ZOVUT, RU-LEX-MENYA-ZOVUT, RU-PRAGMATICS-VY-POLITENESS] -->
 
-Say both halves aloud:
+Two strangers meet. Say both voices aloud, one after the other:
 
-| | |
-|---|---|
-| — **Здравствуйте!** | Hello. |
-| — **Как вас зовут?** | What's your name? |
-| — **Меня зовут** Анна. **А вас?** | My name is Anna. And you? |
-| — Меня зовут Иван. **Очень приятно.** | My name is Ivan. Pleased to meet you. |
+> — **Здравствуйте!**
+> — **Как вас зовут?**
+> — **Меня зовут Анна. А вас?**
+> — **Меня зовут Иван. Очень приятно.**
 
-## Informal switch
+Everything in it is formal, because *вы* is the safe opening with an adult you
+do not know.
 
-With one friend, change only two pieces:
+## Grammar Lens: what moves when the exchange goes informal
+<!-- hl-knowledge: introduces=[]; assesses=[RU-LEX-TY-VY, RU-GRAMMAR-TY-VY-REGISTER, RU-GRAMMAR-OBJECT-PRONOUNS] -->
 
-| formal | informal |
-|---|---|
-| **Здравствуйте!** | **Привет!** |
-| **Как вас зовут?** | **Как тебя зовут?** |
+With one friend, exactly two pieces change:
 
-The greeting and object pronoun change. The verb **зовут** stays exactly where
-it was.
+- the greeting — **Здравствуйте** becomes **Привет**;
+- the object pronoun — **вас** becomes **тебя**.
+
+So *Как вас зовут?* becomes *Как тебя зовут?* The verb **зовут** does not move,
+and **меня** in the answer does not move either — you are still the one being
+called, whoever is asking.
+
+## Grammar Lens: why the shapes change at all
+<!-- hl-knowledge: introduces=[]; assesses=[RU-GRAMMAR-MENYA-OBJECT-CASE, RU-GRAMMAR-INDEFINITE-PERSONAL-PLURAL, RU-GRAMMAR-NAMING-HOW-FRAME] -->
+
+*Я* becomes *меня* because the calling lands **on** you rather than coming
+**from** you; *ты* and *вы* become *тебя* and *вас* for the same reason.
+
+And *зовут* is a plural verb with nobody behind it — "**they** call me," where
+*they* is no one in particular. That is why the Russian question asks **how**
+people call you, not **what** your name is: naming is something people do, not
+something you own.
 
 ## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[RU-LEX-KAK-VAS-ZOVUT, RU-LEX-MENYA-ZOVUT, RU-GRAMMAR-OBJECT-PRONOUNS, RU-GRAMMAR-TY-VY-REGISTER, RU-PRAGMATICS-VY-POLITENESS, RU-GRAMMAR-NAMING-HOW-FRAME] -->
+<!-- hl-activity: {"id":"RU-C02-practice-informal-question","kind":"text","assesses":["RU-GRAMMAR-OBJECT-PRONOUNS"],"prompt":"Turn Как вас зовут? into the form you use with one friend.","answer":"Как тебя зовут?","accepted":["Kak tebya zovut?","Как тебя зовут","Kak tebya zovut"],"feedback":{"correct":"Correct: вас becomes тебя, and зовут stays exactly where it was.","incorrect":"Only the object pronoun changes: вас becomes тебя, giving Как тебя зовут?"},"response_seconds":10} -->
 
 [PAUSE 1s]
 - [YOU SAY: the full formal exchange, both voices]
-- [YOU SAY: the same exchange informally]
-- [YOU SAY: the two pieces that change — greeting and pronoun]
-- [YOU SAY: *как*, not *что* — naming is framed as an action]
+- [YOU SAY: the same exchange to one friend]
+- [YOU SAY: your own answer — "Меня зовут…" and your name]
 
 ## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[RU-LEX-YA, RU-LEX-TY-VY, RU-GRAMMAR-TY-VY-REGISTER, RU-PRAGMATICS-VY-POLITENESS, RU-LEX-MENYA-ZOVUT, RU-GRAMMAR-INDEFINITE-PERSONAL-PLURAL, RU-GRAMMAR-MENYA-OBJECT-CASE, RU-LEX-KAK-VAS-ZOVUT, RU-GRAMMAR-OBJECT-PRONOUNS, RU-GRAMMAR-NAMING-HOW-FRAME] -->
 
-[PAUSE 3s] Run the formal exchange without looking. Then switch it for one
-friend. What changed? (The greeting and *вас → тебя*.) What stayed fixed?
-(*Зовут*.)
+[PAUSE 3s] Run the formal exchange from memory, then switch it for one friend.
+Which two pieces changed? (The greeting, and *вас → тебя*.) Which word never
+moved? (*Зовут*.) Which form do you choose for an adult you have just met, and
+why? (*Вы* — a plural used as respect, and the safer default.) Who is doing the
+calling in *меня зовут*? (Nobody in particular — a bare plural verb.) And why is
+the question *как* rather than *что*? (Russian asks **how** people call you.)

--- a/code/learning/human-languages/russian/lessons/RU-C02-ty-vy.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-ty-vy.md
@@ -41,10 +41,8 @@ Russian has **two words for "you."**
 ## The two words
 <!-- hl-knowledge: introduces=[RU-LEX-TY-VY, RU-GRAMMAR-TY-VY-REGISTER]; assesses=[] -->
 
-| | | |
-|---|---|---|
-| **ты** | *ty* | you — one person you're familiar with |
-| **вы** | *vy* | you — formal, **or** more than one person |
+> **ты** — *ty* — you, one person you're familiar with.
+> **вы** — *vy* — you, formal, **or** more than one person.
 
 Both turn on **ы**, which is the hardest vowel in Russian for an English speaker:
 not the *ee* of *ты*'s look-alike, but a tighter, further-back sound made with
@@ -57,13 +55,11 @@ your tongue drawn back. The writing track hasn't reached **ы** either.
 Pronouns are the **least borrowable** part of a language. Nouns come and go;
 *I* and *you* stay. So the first two line up almost too neatly:
 
-| Russian | Latin | English | German |
-|---|---|---|---|
-| **я** (last lesson) | *ego* | **I** | *ich* |
-| **ты** | *tū* | **thou** | *du* |
-| **вы** | *vōs* | — | — |
+- **я** (last lesson) — Latin *ego*, English **I**, German *ich*.
+- **ты** — Latin *tū*, English **thou**, German *du*.
+- **вы** — Latin *vōs*, with no English or German survivor to set beside it.
 
-The first two rows are the same word four times over. **The third row is only
+The first two lines are the same word four times over. **The third is only
 half a set**: *вы* and *vōs* both continue PIE \**wos*, but English *you* and
 German *ihr* come from the **other** stem in that paradigm, \**yūs*. Cousins,
 not twins — worth marking rather than smoothing over.

--- a/code/learning/human-languages/russian/lessons/RU-C02-vy-formality.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-vy-formality.md
@@ -45,12 +45,10 @@ does the same job with second-person plural **vous**. Chapter 1's
 
 Other languages reached respect differently:
 
-| Language | respectful form | route |
-|---|---|---|
-| Russian | *вы* | second-person plural |
-| French | *vous* | second-person plural |
-| German | *Sie* | third-person plural, not ordinary *ihr* |
-| Spanish | *usted* | title *vuestra merced*, "your grace" |
+- Russian **вы** — the second-person plural.
+- French **vous** — the second-person plural, the very same route.
+- German **Sie** — the *third*-person plural, not the ordinary *ihr*.
+- Spanish **usted** — a worn-down title, *vuestra merced*, "your grace."
 
 Russian's polite *вы* is generally treated as an eighteenth-century import
 from French and German social usage, not a pattern Russian invented alone.

--- a/code/learning/human-languages/russian/lessons/RU-C02-ya.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-ya.md
@@ -64,18 +64,12 @@ the thousand — *sputnik*, *pizza*, *computer* — but nobody borrows a word fo
 *I*. So *я* has simply been inherited, without interruption, for as long as
 there has been an Indo-European family:
 
-| | |
-|---|---|
-| Russian | **я** |
-| Latin | *ego* |
-| German | *ich* |
-| English | **I** |
-| Greek | *egṓ* |
+Russian **я**, Latin *ego*, German *ich*, English **I**, Greek *egṓ*.
 
 All from PIE \**eǵh₂(om)*. Russian's route ran through Proto-Slavic \**azъ*,
 which East Slavic reshaped — a *j-* was added at the front (\**azъ* → *язъ*) and
 the ending fell away — leaving the **one letter** you now say. It is the most
-extreme change in the table, and the reason *я* looks nothing like *ego* while
+extreme change in the family, and the reason *я* sounds nothing like *ego* while
 being the same word.
 
 Latin *ego* is the one English borrowed back, whole and untranslated, for the

--- a/code/packages/typescript/human-language-data/tests/integration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/integration.test.ts
@@ -128,6 +128,7 @@ describe("real curriculum", () => {
       "PA-C06-panj-convergence-borrowing",
       "PT-C02-practice-neutral-question",
       "RU-C02-kak-cross-language-what-language",
+      "RU-C02-practice-informal-question",
       "RU-C02-vy-formality-safe-default",
       "SA-C06-number-cognates-inheritance",
       "TA-W01-curves-va-ka-writing-surface",

--- a/code/packages/typescript/human-language-data/tests/modality.test.ts
+++ b/code/packages/typescript/human-language-data/tests/modality.test.ts
@@ -519,20 +519,29 @@ describe("corpus regression", () => {
   // dangerously, a block field rename that makes every lesson look clean — moves it
   // and fails here instead of shipping a curriculum falsely advertised as drivable.
   //
-  // Reproduces the HL08 baseline: 51 `pen`, 7 script-block lessons, and 322
-  // table-bearing lessons among the remaining 1,038. HL08 records 695 drivable from
-  // 56 cue-bearing lessons; this implementation's published cue list matches 61 and
-  // therefore lands on 694. The spec's exact cue list was never recorded, and the
-  // detector is deliberately NOT tuned to close a one-lesson gap.
+  // The HL08 baseline was 51 `pen`, 7 script-block lessons and 322 table-bearing
+  // lessons among the remaining 1,038, giving 694 drivable at 63%. HL-C32 then
+  // remediated the Russian track: fourteen of its lessons were `sight` only because
+  // a cross-language word→gloss list had been set as a Markdown table, so the tables
+  // became speakable prose and the lessons became `voice`. That moved the corpus to
+  // 708 drivable (65%) and left 308 table-bearing lessons. The numbers below are
+  // re-pinned to that measurement, not relaxed — they still fail on any silent change
+  // to the parser, the table detector or the cue list, most dangerously a block field
+  // rename that would make every lesson look clean.
+  //
+  // HL08 itself recorded 695 drivable from 56 cue-bearing lessons; this
+  // implementation's published cue list matches 61 and therefore started one lesson
+  // lower. The spec's exact cue list was never recorded, and the detector is
+  // deliberately NOT tuned to close a one-lesson gap.
   it("pins the corpus-wide drivable count", () => {
     const { lessons } = loadEverything();
     const summary = summarizeModality(lessons);
     expect(summary.totalLessons).toBe(1096);
     expect(summary.pen).toBe(51);
-    expect(summary.voice).toBe(694);
-    expect(summary.sight).toBe(351);
+    expect(summary.voice).toBe(708);
+    expect(summary.sight).toBe(337);
     expect(summary.voice + summary.sight + summary.pen).toBe(summary.totalLessons);
-    expect(summary.drivablePercent).toBe(63);
+    expect(summary.drivablePercent).toBe(65);
   });
 
   it("pins the structural counts the derivation is built on", () => {
@@ -548,7 +557,7 @@ describe("corpus regression", () => {
     expect(remaining).toHaveLength(1038);
     expect(
       remaining.filter((entry) => widestTableColumns(lessonText(entry)) > 0),
-    ).toHaveLength(322);
+    ).toHaveLength(308);
   });
 
   it("keeps the corpus free of unexplained overrides", () => {


### PR DESCRIPTION
Russian was the worst-performing track in the corpus on **two independent** measurements: **9% drivable** (2 `voice`, 15 `sight`, 5 `pen`, and **zero** lessons reachable by ear in either chapter, against 43–90% everywhere else) and **payoff representativeness 0.20** on its single authorable chapter.

## Root cause — one rule, fifteen times out of fifteen

Modality derives `sight` from three triggers: a `script` block, a sight cue, or a table wider than the configured linearisable width (currently 0, so *any* table). The diagnosis was run before anything was changed:

| Trigger | Russian `sight` lessons |
|---|---|
| `script-block` | **0** |
| `wide-table` only | **12** |
| `wide-table` + `sight-cue` | **3** |
| **Total** | **15 of 15** |

Not one Russian lesson carried a script block. And two of the three cue matches were **false positives** of literal-substring cue matching: `"the course's first **look at** case"` matched `look at`, and a sentence calling something `"the most extreme change in **the table**"` matched `the table` only because the table existed.

**The tables were carrying prose.** Almost every one was a cross-language word→gloss list — `| Language | "yes" | built from |`. `RU-C01-privet` and `RU-C01-zdravstvuyte` already carry that exact section as *sentences*, and they were the track's only two `voice` lessons. The same content, set two ways, produced two different modalities. Russian was never script-heavy; it was table-heavy.

## What changed

Fourteen lessons had their word→gloss and letter→sound tables rewritten as speakable prose or bullets. Nothing was dropped or shortened, and every lesson stayed under the duration budget (the tightest, `RU-C01-pozhaluysta`, moved 290s → 287s).

Two tables were **left alone on purpose**:

- `RU-C02-practice-cases` keeps its table and stays `sight`. It is a *cover-the-column* retrieval drill — the table **is** the exercise, and linearising it would delete the lesson. Chapter 2's drivable prefix correctly stops there at 8 of 10. An immovable `sight` lesson is a correct finding, not a failure.
- `RU-W02-false-friends-s-n` keeps its four-column table. It is a `writing` lesson, so it is `pen` regardless.

## The payoff

The chapter payoff pointed at `RU-C02-kak-cross-language`, a cross-language etymology lesson, only because it was the last schema-v2 lesson by sequence — the chapter's *real* consolidation lesson was schema v1 and declared no atoms.

`RU-C02-practice` is migrated to schema v2 (sequence 130) with typed blocks, per-block `hl-knowledge` directives, coverage metadata, `register`/`variety`, and one objective activity. It runs the full introduction formally, then switches it informally, and assesses **ten of Chapter 2's fifteen** introduced atoms without inventing content. It introduces nothing new and every line sits inside closure.

`curriculum.json` gains `RU-EXT-006-CONSOLIDATION` and places `RU-C02-practice` in `RU-PATH-006`, because every schema-v2 lesson naming a spine node must appear in the local realization map.

## Before / after

| Measurement | Before | After |
|---|---|---|
| Russian drivable | 2 `voice`, 15 `sight`, 5 `pen` — **9%** | 16 `voice`, 1 `sight`, 5 `pen` — **73%** |
| Russian lessons reachable in chapter-prefix order | **0** (ch1 0/12, ch2 0/10) | **15** (ch1 7/12, ch2 8/10) |
| Ch2 payoff representativeness | **0.20** (3/15) | **0.67** (10/15), floor 0.5 |
| Corpus drivable | 694 (63%) | **708 (65%)** |

All of the corpus-wide gain comes from this one track.

## This is one migration, not sixteen

Fifteen Russian lessons remain schema v1. That is why Chapter 1 still has no `chapters.json` entry — it introduces no knowledge atoms, so no payoff can assess anything. Because `sequence` is a schema-v2 field, Chapter 1's modality ordering is still alphabetical rather than pedagogical, and `RU-C02-practice` now sorts ahead of its own schema-v1 prerequisite. Neither affects validation nor the drivable prefix, and neither is worth a cosmetic patch. Both close only with the full migration.

## The pattern is corpus-wide

Of the 337 `sight` lessons remaining, **271 trip `wide-table` and nothing else**: spanish 57, german 33, portuguese 32, french 29, italian 29, arabic 14, tamil 14. Those European tracks sit at 43–47% drivable for exactly the reason Russian sat at 9%. **HL-C17 is the corpus's single largest modality lever**, and this pass is a worked example of how to pull it — distinguishing a two- or three-column word→gloss list, which linearises, from a real multi-column paradigm, which does not. HL-C17's remaining count is re-pinned 322 → 308.

The same substitution shows up in representativeness: the remaining sub-floor chapters (arabic ch3/ch4 at 0.11/0.13, spanish ch3 at 0.25, hindi ch2 at 0.17) all point their payoff at a schema-v2 stand-in because the chapter's real consolidation lesson is the schema-v1 one. The same one-lesson fix should work there.

## Verification

- `npx tsc --noEmit` clean
- `npx vitest run` — **166/166 pass**
- validator: **0 errors**, unchanged warning count
- gap report: **0 lessons at or above 300 effective seconds**
- `book-cli --check` clean (Russian has no generated book target, so no hash-gate impact)

The two modality corpus regressions and the integration activity list are **re-pinned to the new measurement, not relaxed** — they still fail on any silent change to the parser, the table detector, or the cue list.

`russian/CHANGELOG.md`, `russian/README.md`, and `BACKLOG.md` (HL-C32, plus a "Findings from HL-C32" section) are updated. No `package-lock.json` diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw3PKmLS2yEnDmhck3fM1z)_