### PR TITLE
docs(task-app): add a working backlog for the super-app roadmap

### DIFF
--- a/code/programs/mosaic/task-app/BACKLOG.md
+++ b/code/programs/mosaic/task-app/BACKLOG.md
@@ -1,0 +1,63 @@
+# task-app backlog
+
+Working backlog for the [super-app roadmap](../../../specs/task-app-super-app.md). Ordered
+by priority — top item is next up. Re-prioritized whenever a new item is discovered mid-flight.
+Each item, once picked up, follows: spec-sync → tests → implementation → CHANGELOG → README →
+`/security-review` → PR → `/babysit-pr` → auto-merge.
+
+## Next up (priority order)
+
+1. **Phase 5 — Sheet component.** `mosaic-pkg-sheet` on top of `mosaic-pkg-grid` (v0.2, reuse),
+   wired to the engine's `table(view)` projection (already shipped, [#8626](https://github.com/adhithyan15/coding-adventures/pull/8626)/[#9110](https://github.com/adhithyan15/coding-adventures/pull/9110)-era). Needs: editable cells,
+   engine-driven sort/filter/group (the view-selection pipeline already exists at the engine
+   layer — this is wiring, not new engine work), column show/hide. `mosaic-pkg-grid` gap noted
+   in the spec: no sort/filter/multi-select/frozen-cols/row-DnD yet — check whether the sheet
+   needs any of those or can lean on the engine's own filter/sort instead of grid-native ones.
+   Reordered ahead of where the roadmap originally placed it relative to the board (Phase 6
+   shipped first in practice) — no dependency runs the other way, so doing it now just catches
+   the roadmap up.
+
+2. **Phase 7 — Calendar component.** `mosaic-pkg-calendar`, wired to the engine's `calendar(range,
+   view)` projection (already shipped, [#8726](https://github.com/adhithyan15/coding-adventures/pull/8726)) + the UI35 drag kernel for
+   drag-to-reschedule/resize. Month/week/day views, time-blocking, auto-schedule placement around
+   fixed commitments. The drag kernel is proven end-to-end now (board PR found and fixed three
+   real bugs in it), so this should be smoother than the board was.
+
+3. **Phase 8 — Notes component + entity.** The engine has **no notes entity at all** yet — this
+   needs a `task-core` model addition (standalone notes + attachable to any task/project) before
+   the `mosaic-pkg-notes` UI (adapted from `mosaic-pkg-note-editor`, which was built for a
+   different domain — Anki notes — and needs re-pointing at generic entities).
+
+4. **Phase 9 — App-shell assembly + progressive disclosure.** Partially done already via ad hoc
+   UI-design passes ([#8970](https://github.com/adhithyan15/coding-adventures/pull/8970), [#8983](https://github.com/adhithyan15/coding-adventures/pull/8983), [#9112](https://github.com/adhithyan15/coding-adventures/pull/9112), [#8994](https://github.com/adhithyan15/coding-adventures/pull/8994), [#9110](https://github.com/adhithyan15/coding-adventures/pull/9110), [#9127](https://github.com/adhithyan15/coding-adventures/pull/9127), [#9136](https://github.com/adhithyan15/coding-adventures/pull/9136))
+   — theming, project switching, nested-project hierarchy, shell/groups/status/cards all landed.
+   Remaining: package it as a reusable `mosaic-pkg-project-nav` (nested-project tree + view
+   switcher), and the per-project/task **complexity config** (board-only ↔ full CPM) that the
+   spec calls "the single most important product rule" (§2.3) — currently every project exposes
+   the same surface regardless of how simple it is.
+
+## Backlog (lower priority — Phase 10+, spec explicitly defers these)
+
+- **Native drag support for HostDraggable/HostDropTarget.** Every non-web backend (SwiftUI,
+  Compose, Qt, Flutter, WinUI/XAML, webcomponent) currently degrades the drag family to a plain
+  static container — see `code/specs/UI35-host-drag-drop.md`. This means the board (and, once
+  built, the calendar) is fully interactive on web but inert on every native shell. Spec-deferred
+  intentionally (native shells are Phase 10+), but tracked as a spawned task:
+  [background task](task_239f7f69) "Wire HostDraggable/HostDropTarget into mosaic-emit-xaml" — do
+  XAML first since it's the most-built-out native backend, then fan out the same pattern to the
+  rest.
+- Recurring tasks / reminders UX.
+- Automation rules (Butler-style).
+- Resource-leveling UI (the engine's `constraint-*` leveling exists; no UI surfaces it).
+- Portfolio dashboards / cross-project rollup views.
+- `IndexedDBStorage.query()`/`transaction()` are unimplemented (spec §9) — revisit if a view
+  needs SQL-over-IndexedDB rather than load-all.
+
+## Resolved (kept for traceability, not actionable)
+
+- **Phase 6 — Board (kanban) view.** [#9897](https://github.com/adhithyan15/coding-adventures/pull/9897),
+  merged. Drag-and-drop columns wired to the UI35 kernel.
+- Dark-mode "Add task" pressed-color regression (copy-pasted from light theme) — fixed alongside
+  the board PR's CI failure.
+- Stale XAML hover-count acceptance-test assertion (12/9 → 16/13 after the board added 4 new
+  segmented-control hover surfaces) — fixed alongside the board PR's CI failure.

--- a/code/programs/mosaic/task-app/CHANGELOG.md
+++ b/code/programs/mosaic/task-app/CHANGELOG.md
@@ -35,6 +35,12 @@ Also from security review: a drop's `targetKey` is validated against the known c
 `HostDropTarget` is given a flex direction so its `gap` isn't inert — it lowers to a
 bare `<div>`, unlike `Column`, so cards were stacking flush.
 
+### Added - working backlog
+
+`BACKLOG.md` tracks the remaining super-app roadmap phases (sheet, calendar, notes,
+app-shell assembly) in priority order, plus lower-priority items the spec explicitly
+defers (native drag support, recurring/reminders, automation, resource leveling,
+portfolio dashboards). Kept current as phases ship and new gaps are discovered.
 
 ### Added - native pressed feedback through Mosaic
 

--- a/lessons.md
+++ b/lessons.md
@@ -39,6 +39,7 @@ A condensed quick-reference of mistakes made during development, grouped by cate
 - **Add `.gitattributes` `* text=auto eol=lf`** to force LF line endings everywhere. Otherwise Elixir heredoc tests, Python doctests, Ruby tests fail on Windows checkouts because `\r\n` ≠ `\n`.
 - **Use body files for `gh pr` text containing Markdown backticks.** Inline backticks in `--body "..."` get evaluated by zsh as command substitution. Write to a tempfile with single-quoted heredoc and pass via `--body-file`.
 - **`git worktree add` inherits HEAD unless you pin the base.** Always `git worktree add <path> -b <branch> origin/main`. Whenever the source checkout is shared or noisy, default to a fresh worktree from `origin/main` to avoid accidentally committing other agents' files or shared-manifest pollution.
+- **`git worktree add` on this repo can exceed a 2-minute Bash timeout** (tens of thousands of tracked files across 4800+ packages) and gets killed mid-checkout, leaving 60k+ files showing as deleted in `git status` and a stale `.git/worktrees/<name>/index.lock`. Fix: confirm no real git process is running (`ps aux | grep git`), `rm -f` the stale `index.lock`, then re-run the checkout with a long timeout: `git checkout HEAD -- .` (pass `timeout: 480000` or similar to the Bash tool). Better: pass a generous timeout to the original `git worktree add` call itself rather than letting it hit the default.
 
 ## Workspace & package metadata
 


### PR DESCRIPTION
## Summary
- Adds `code/programs/mosaic/task-app/BACKLOG.md`: a priority-ordered working backlog for the remaining super-app roadmap phases (sheet, calendar, notes, app-shell assembly), plus the lower-priority items the spec explicitly defers to Phase 10+.
- Documents a `git worktree add` gotcha in `lessons.md`: on this repo the checkout can exceed a 2-minute default timeout and get killed mid-flight, leaving a stale `index.lock` and a worktree full of phantom deletions.

## Why
Driving the roadmap forward as a loop (pick top item → implement → PR → babysit → merge → reprioritize → repeat) needs a durable, git-tracked artifact rather than only in-conversation state, so priority and status survive across sessions.

## Test plan
- [x] Docs-only change, no code paths affected
- [x] `/security-review` — passed clean