### PR TITLE
feat(human-languages): give Hindi its own present-habitual paradigm lesson

### DIFF
--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -1506,20 +1506,21 @@
     {
       "language": "hindi",
       "chapter": 5,
-      "sourceHash": "fnv1a64:ee145d9341fbff22",
+      "sourceHash": "fnv1a64:43c5f48914f2f1ba",
       "lessonIds": [
         "HI-C05-bolna",
+        "HI-C05-bolta-hun",
         "HI-C05-karna",
         "HI-C05-main-hindi-bolta-hun",
         "HI-C05-practice",
         "HI-C05-rahna"
       ],
-      "voiceLessons": 4,
-      "drivablePrefix": 4,
+      "voiceLessons": 5,
+      "drivablePrefix": 5,
       "text": "hindi/narration/ch05.txt",
       "json": "hindi/narration/ch05.json",
-      "textHash": "fnv1a64:df3186a36c7d7eea",
-      "jsonHash": "fnv1a64:162a0310e99c37f9"
+      "textHash": "fnv1a64:5447bb8d3c10ea73",
+      "jsonHash": "fnv1a64:96c472975a3314c9"
     },
     {
       "language": "hindi",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,17 +7,17 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:ec285ffdf2590cc0",
+  "sourceHash": "fnv1a64:c79bbb8df3d255e8",
   "summary": {
-    "totalLessons": 1133,
-    "voice": 956,
+    "totalLessons": 1134,
+    "voice": 957,
     "sight": 124,
     "pen": 53,
-    "drivableLessons": 956,
+    "drivableLessons": 957,
     "drivablePercent": 84,
     "trackCount": 22,
     "chapterCount": 377,
-    "drivablePrefixTotal": 824,
+    "drivablePrefixTotal": 825,
     "fullyDrivableChapters": 284,
     "unstartableChapters": 44,
     "overriddenLessons": 0,
@@ -1626,12 +1626,12 @@
     },
     {
       "language": "hindi",
-      "lessonCount": 84,
-      "voice": 70,
+      "lessonCount": 85,
+      "voice": 71,
       "sight": 3,
       "pen": 11,
-      "drivablePercent": 83,
-      "drivablePrefixTotal": 54,
+      "drivablePercent": 84,
+      "drivablePrefixTotal": 55,
       "modalities": [
         "voice",
         "sight",
@@ -1715,19 +1715,20 @@
         },
         {
           "chapter": 5,
-          "lessonCount": 5,
-          "voice": 4,
+          "lessonCount": 6,
+          "voice": 5,
           "sight": 1,
           "pen": 0,
           "modalities": [
             "voice",
             "sight"
           ],
-          "drivablePrefix": 4,
+          "drivablePrefix": 5,
           "firstNonVoiceLesson": "HI-C05-rahna",
           "drivable": false,
           "drivableLessonIds": [
             "HI-C05-bolna",
+            "HI-C05-bolta-hun",
             "HI-C05-karna",
             "HI-C05-main-hindi-bolta-hun",
             "HI-C05-practice"
@@ -11203,6 +11204,19 @@
       "sourceHash": "fnv1a64:96d065e73903a163"
     },
     {
+      "id": "HI-C05-bolta-hun",
+      "language": "hindi",
+      "chapter": 5,
+      "sequence": null,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:6aed02a1964d754d"
+    },
+    {
       "id": "HI-C05-karna",
       "language": "hindi",
       "chapter": 5,
@@ -11226,7 +11240,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:6a7eb469a4013d3f"
+      "sourceHash": "fnv1a64:5316fa9dbfd1dad1"
     },
     {
       "id": "HI-C05-practice",

--- a/code/learning/human-languages/hindi/lessons/HI-C05-bolta-hun.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C05-bolta-hun.md
@@ -1,0 +1,75 @@
+---
+id: HI-C05-bolta-hun
+chapter: 5
+type: word
+headword: बोलता हूँ, बोलती हूँ, बोलते हैं
+gloss: the present-habitual template — stem + -tā/-tī/-te + honā
+concept_tag: HI-GRAMMAR-PRESENT-HABITUAL
+prerequisites: [HI-C05-bolna, HI-C03-hun]
+sounds: [matra-a, matra-i, chandrabindu-nasal]
+roots: [bol-speak]
+est_minutes: 4
+reviews_of: [HI-C05-bolna, HI-C03-hun]
+---
+
+# बोलता हूँ (boltā hūṁ) — one stem, and the two things Hindi makes it agree with
+
+## Warm-up
+
+[PAUSE 2s] You have the stem *bol-*. This lesson is the machine that turns any
+stem into a sentence about what someone *does* — and it is the single biggest
+piece of leverage in the course so far, because it fits every verb you will
+ever meet.
+
+## You'll want to know first
+
+- [बोलना](./HI-C05-bolna.md) — the infinitive, and how to strip *-nā* to get the stem.
+- [हूँ](./HI-C03-hun.md) — "I am," the verb this template leans on.
+
+## Grammar Lens: stem + -tā/-tī/-te + honā
+
+To say what someone does *in general*, Hindi builds three pieces in a row:
+the **stem**, a **participle ending**, and the **"to be" verb**.
+
+| who | the pieces | the whole thing |
+|---|---|---|
+| I (a man) | **-ता** *-tā* + **हूँ** *hūṁ* | **बोलता हूँ** *boltā hūṁ* |
+| I (a woman) | **-ती** *-tī* + **हूँ** *hūṁ* | **बोलती हूँ** *boltī hūṁ* |
+| आप *āp* (you, respectful) | **-ते** *-te* + **हैं** *haiṁ* | **बोलते हैं** *bolte haiṁ* |
+
+Strip *-nā*, add the ending, add *honā*. That is the whole rule, and it does
+not change from verb to verb.
+
+## Grammar Lens: the two agreements, and why they are two
+
+This is the part worth slowing down for, because Hindi is doing **two separate
+jobs at once** and a beginner naturally expects one.
+
+- **-ता / -ती / -ते** agrees with **gender and number**. It does not care who is
+  speaking. A woman says *boltī* whether she is talking about herself or being
+  addressed.
+- **हूँ / है / हैं** agrees with **person**. It does not care about gender. *Hūṁ*
+  is "I am" for a man and a woman alike.
+
+So *boltī hūṁ* is not one ending chosen from a list of six. It is two choices made
+independently and then set side by side — feminine on the participle, first-person
+on the verb. Once you treat them as two dials rather than one, the whole present
+tense stops needing to be memorised.
+
+English does this too, and hides it: *"I am speaking"* is also participle plus
+*to be*. Hindi simply puts the *to be* last, where Hindi always puts its verbs.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY (m.): "I speak" — *boltā hūṁ*]
+- [YOU SAY (f.): "I speak" — *boltī hūṁ*]
+- [YOU SAY: "you (respectful) speak" — *āp bolte haiṁ*]
+- [YOU SAY: which of the two endings changed when you switched from a man to a
+  woman, and which one did not (*-tā*→*-tī* changed; *hūṁ* did not)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Hindi's present habitual makes two agreements at once. Name what each
+of the two pieces agrees with. (*-tā/-tī/-te* agrees with gender and number;
+*hūṁ/hai/haiṁ* agrees with person.)

--- a/code/learning/human-languages/hindi/lessons/HI-C05-main-hindi-bolta-hun.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C05-main-hindi-bolta-hun.md
@@ -5,11 +5,11 @@ type: phrase
 headword: मैं हिंदी बोलता हूँ
 gloss: I speak Hindi (gendered)
 concept_tag: HI-WORD-HINDI
-prerequisites: [HI-C05-bolna, HI-C03-main, HI-C03-hun]
+prerequisites: [HI-C05-bolta-hun, HI-C03-main, HI-C03-hun]
 sounds: [anusvara, matra-i]
 roots: [sindhu-river]
 est_minutes: 4
-reviews_of: [HI-C05-bolna, HI-C03-main, HI-C03-hun]
+reviews_of: [HI-C05-bolta-hun, HI-C03-main, HI-C03-hun]
 ---
 
 # मैं हिंदी बोलता हूँ (maiṁ hindī boltā hūṁ) — "I speak Hindi"
@@ -36,17 +36,14 @@ Indus) → Persian *hind* (the land past that river) → *hindī* ("of Hind"). T
 same *sindhu* gave Greek *Indos* → English **India**, **Indus**, **Hindu**. The
 language is named, at two removes, after a river.
 
-## Grammar Lens: the present habitual = stem + -tā/-tī + honā
+## Grammar Lens: the frame you already have
 
-To say "I do X" in general, Hindi uses **stem + -tā/-tī (+ -e for plural) + the
-"to be" verb**:
+The verb here is the present habitual — **stem + -tā/-tī/-te + honā** — which
+[बोलता हूँ](./HI-C05-bolta-hun.md) built one lesson ago. Nothing about it is new;
+this sentence is the first place you get to *use* it on a real object.
 
-- a man: **मैं हिंदी बोलता हूँ** (*boltā hūṁ*)
-- a woman: **मैं हिंदी बोलती हूँ** (*boltī hūṁ*)
-- respectful "you": **आप हिंदी बोलते हैं** (*bolte haiṁ*)
-
-The *-tā/-tī/-te* agrees in gender and number; *hūṁ/hai/haiṁ* agrees in person.
-Two agreements, one small sentence — this is the engine of Hindi's present tense.
+What is new is the word order: **मैं हिंदी बोलता हूँ** puts the object *before*
+the verb frame, so the sentence ends on *hūṁ*. Hindi's verb goes last, always.
 
 ## Guided Practice
 

--- a/code/learning/human-languages/hindi/narration/ch05.json
+++ b/code/learning/human-languages/hindi/narration/ch05.json
@@ -3,8 +3,8 @@
   "language": "hindi",
   "chapter": 5,
   "title": "Chapter 5",
-  "drivablePrefix": 4,
-  "sourceHash": "fnv1a64:ee145d9341fbff22",
+  "drivablePrefix": 5,
+  "sourceHash": "fnv1a64:43c5f48914f2f1ba",
   "lessons": [
     {
       "id": "HI-C05-bolna",
@@ -126,6 +126,169 @@
             {
               "kind": "speech",
               "text": "What ending does every Hindi infinitive carry, and what is bolnā's stem? (-nā; the stem is bol-.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C05-bolta-hun",
+      "sequence": null,
+      "title": "बोलता हूँ (boltā hūṁ) — one stem, and the two things Hindi makes it agree with",
+      "headword": "बोलता हूँ, बोलती हूँ, बोलते हैं",
+      "romanization": "",
+      "gloss": "the present-habitual template — stem + -tā/-tī/-te + honā",
+      "script": "devanagari",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:6aed02a1964d754d",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You have the stem bol-. This lesson is the machine that turns any stem into a sentence about what someone does — and it is the single biggest piece of leverage in the course so far, because it fits every verb you will ever meet."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know first",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "बोलना — the infinitive, and how to strip -nā to get the stem."
+            },
+            {
+              "kind": "speech",
+              "text": "हूँ — \"I am,\" the verb this template leans on."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: stem + -tā/-tī/-te + honā",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "To say what someone does in general, Hindi builds three pieces in a row: the stem, a participle ending, and the \"to be\" verb."
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "who",
+                "the pieces",
+                "the whole thing"
+              ],
+              "columns": 3,
+              "rowCount": 3,
+              "utterances": [
+                "who: I (a man). the pieces: -ता -tā + हूँ hūṁ. the whole thing: बोलता हूँ boltā hūṁ.",
+                "who: I (a woman). the pieces: -ती -tī + हूँ hūṁ. the whole thing: बोलती हूँ boltī hūṁ.",
+                "who: आप āp (you, respectful). the pieces: -ते -te + हैं haiṁ. the whole thing: बोलते हैं bolte haiṁ."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Strip -nā, add the ending, add honā. That is the whole rule, and it does not change from verb to verb."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: the two agreements, and why they are two",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "This is the part worth slowing down for, because Hindi is doing two separate jobs at once and a beginner naturally expects one."
+            },
+            {
+              "kind": "speech",
+              "text": "-ता / -ती / -ते agrees with gender and number. It does not care who is speaking. A woman says boltī whether she is talking about herself or being addressed."
+            },
+            {
+              "kind": "speech",
+              "text": "हूँ / है / हैं agrees with person. It does not care about gender. Hūṁ is \"I am\" for a man and a woman alike."
+            },
+            {
+              "kind": "speech",
+              "text": "So boltī hūṁ is not one ending chosen from a list of six. It is two choices made independently and then set side by side — feminine on the participle, first-person on the verb. Once you treat them as two dials rather than one, the whole present tense stops needing to be memorised."
+            },
+            {
+              "kind": "speech",
+              "text": "English does this too, and hides it: \"I am speaking\" is also participle plus to be. Hindi simply puts the to be last, where Hindi always puts its verbs."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "speech",
+              "text": "[YOU SAY (m.): \"I speak\" — boltā hūṁ]."
+            },
+            {
+              "kind": "speech",
+              "text": "[YOU SAY (f.): \"I speak\" — boltī hūṁ]."
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"you (respectful) speak\" — āp bolte haiṁ",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"you (respectful) speak\" — *āp bolte haiṁ*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "which of the two endings changed when you switched from a man to a woman, and which one did not (-tā becomes -tī changed; hūṁ did not)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: which of the two endings changed when you switched from a man to a woman, and which one did not (*-tā*→*-tī* changed; *hūṁ* did not)]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Hindi's present habitual makes two agreements at once. Name what each of the two pieces agrees with. (-tā/-tī/-te agrees with gender and number; hūṁ/hai/haiṁ agrees with person.)"
             }
           ]
         }
@@ -301,7 +464,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:6a7eb469a4013d3f",
+      "sourceHash": "fnv1a64:5316fa9dbfd1dad1",
       "notice": null,
       "blocks": [
         {
@@ -350,27 +513,15 @@
         {
           "index": 3,
           "type": "grammar",
-          "title": "Grammar Lens: the present habitual = stem + -tā/-tī + honā",
+          "title": "Grammar Lens: the frame you already have",
           "segments": [
             {
               "kind": "speech",
-              "text": "To say \"I do X\" in general, Hindi uses stem + -tā/-tī (+ -e for plural) + the \"to be\" verb:"
+              "text": "The verb here is the present habitual — stem + -tā/-tī/-te + honā — which बोलता हूँ built one lesson ago. Nothing about it is new; this sentence is the first place you get to use it on a real object."
             },
             {
               "kind": "speech",
-              "text": "a man: मैं हिंदी बोलता हूँ (boltā hūṁ)."
-            },
-            {
-              "kind": "speech",
-              "text": "a woman: मैं हिंदी बोलती हूँ (boltī hūṁ)."
-            },
-            {
-              "kind": "speech",
-              "text": "respectful \"you\": आप हिंदी बोलते हैं (bolte haiṁ)."
-            },
-            {
-              "kind": "speech",
-              "text": "The -tā/-tī/-te agrees in gender and number; hūṁ/hai/haiṁ agrees in person. Two agreements, one small sentence — this is the engine of Hindi's present tense."
+              "text": "What is new is the word order: मैं हिंदी बोलता हूँ puts the object before the verb frame, so the sentence ends on hūṁ. Hindi's verb goes last, always."
             }
           ]
         },

--- a/code/learning/human-languages/hindi/narration/ch05.txt
+++ b/code/learning/human-languages/hindi/narration/ch05.txt
@@ -1,8 +1,8 @@
 Hindi, chapter 5: Chapter 5.
-5 lessons. You can do the first 4 of them in the car; after that you will want to have stopped.
+6 lessons. You can do the first 5 of them in the car; after that you will want to have stopped.
 
 
-Lesson 1 of 5.
+Lesson 1 of 6.
 बोलना (bolnā) — "to speak," your first full verb.
 
 Warm-up.
@@ -32,7 +32,47 @@ Wrap-up Recall.
 What ending does every Hindi infinitive carry, and what is bolnā's stem? (-nā; the stem is bol-.)
 
 
-Lesson 2 of 5.
+Lesson 2 of 6.
+बोलता हूँ (boltā hūṁ) — one stem, and the two things Hindi makes it agree with.
+
+Warm-up.
+[pause 2 seconds]
+You have the stem bol-. This lesson is the machine that turns any stem into a sentence about what someone does — and it is the single biggest piece of leverage in the course so far, because it fits every verb you will ever meet.
+
+You'll want to know first.
+बोलना — the infinitive, and how to strip -nā to get the stem.
+हूँ — "I am," the verb this template leans on.
+
+Grammar Lens: stem + -tā/-tī/-te + honā.
+To say what someone does in general, Hindi builds three pieces in a row: the stem, a participle ending, and the "to be" verb.
+[a table of 3 rows, read aloud]
+who: I (a man). the pieces: -ता -tā + हूँ hūṁ. the whole thing: बोलता हूँ boltā hūṁ.
+who: I (a woman). the pieces: -ती -tī + हूँ hūṁ. the whole thing: बोलती हूँ boltī hūṁ.
+who: आप āp (you, respectful). the pieces: -ते -te + हैं haiṁ. the whole thing: बोलते हैं bolte haiṁ.
+Strip -nā, add the ending, add honā. That is the whole rule, and it does not change from verb to verb.
+
+Grammar Lens: the two agreements, and why they are two.
+This is the part worth slowing down for, because Hindi is doing two separate jobs at once and a beginner naturally expects one.
+-ता / -ती / -ते agrees with gender and number. It does not care who is speaking. A woman says boltī whether she is talking about herself or being addressed.
+हूँ / है / हैं agrees with person. It does not care about gender. Hūṁ is "I am" for a man and a woman alike.
+So boltī hūṁ is not one ending chosen from a list of six. It is two choices made independently and then set side by side — feminine on the participle, first-person on the verb. Once you treat them as two dials rather than one, the whole present tense stops needing to be memorised.
+English does this too, and hides it: "I am speaking" is also participle plus to be. Hindi simply puts the to be last, where Hindi always puts its verbs.
+
+Guided Practice.
+[pause 1 second]
+[YOU SAY (m.): "I speak" — boltā hūṁ].
+[YOU SAY (f.): "I speak" — boltī hūṁ].
+[your turn — say: "you (respectful) speak" — āp bolte haiṁ]
+[pause 8 seconds for the answer]
+[your turn — say: which of the two endings changed when you switched from a man to a woman, and which one did not (-tā becomes -tī changed; hūṁ did not)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Hindi's present habitual makes two agreements at once. Name what each of the two pieces agrees with. (-tā/-tī/-te agrees with gender and number; hūṁ/hai/haiṁ agrees with person.)
+
+
+Lesson 3 of 6.
 करना (karnā) — "to do," the most useful verb in Hindi.
 
 Warm-up.
@@ -70,7 +110,7 @@ Wrap-up Recall.
 What Sanskrit root is karnā from, and name two words in this course built on it. (√kṛ "to do"; any two of karma, namaskār, Sanskrit.)
 
 
-Lesson 3 of 5.
+Lesson 4 of 6.
 मैं हिंदी बोलता हूँ (maiṁ hindī boltā hūṁ) — "I speak Hindi".
 
 Warm-up.
@@ -84,12 +124,9 @@ The sentence, taken apart.
 मैं हिंदी बोलता हूँ = मैं (maiṁ, "I") + हिंदी (hindī, "Hindi," the object) + बोलता (boltā, "speak," m.) + हूँ (hūṁ, "am") becomes literally "I Hindi speaking am." Verb-frame last, exactly as always.
 The name हिंदी itself is a traveller: from सिन्धु (sindhu, the river Indus) becomes Persian hind (the land past that river) becomes hindī ("of Hind"). The same sindhu gave Greek Indos becomes English India, Indus, Hindu. The language is named, at two removes, after a river.
 
-Grammar Lens: the present habitual = stem + -tā/-tī + honā.
-To say "I do X" in general, Hindi uses stem + -tā/-tī (+ -e for plural) + the "to be" verb:
-a man: मैं हिंदी बोलता हूँ (boltā hūṁ).
-a woman: मैं हिंदी बोलती हूँ (boltī hūṁ).
-respectful "you": आप हिंदी बोलते हैं (bolte haiṁ).
-The -tā/-tī/-te agrees in gender and number; hūṁ/hai/haiṁ agrees in person. Two agreements, one small sentence — this is the engine of Hindi's present tense.
+Grammar Lens: the frame you already have.
+The verb here is the present habitual — stem + -tā/-tī/-te + honā — which बोलता हूँ built one lesson ago. Nothing about it is new; this sentence is the first place you get to use it on a real object.
+What is new is the word order: मैं हिंदी बोलता हूँ puts the object before the verb frame, so the sentence ends on hūṁ. Hindi's verb goes last, always.
 
 Guided Practice.
 [pause 1 second]
@@ -104,7 +141,7 @@ Wrap-up Recall.
 Build "I speak Hindi" as a woman, and name the river behind hindī. (Maiṁ hindī boltī hūṁ; the Sindhu/Indus.)
 
 
-Lesson 4 of 5.
+Lesson 5 of 6.
 Chapter 5 — The first verbs.
 
 Warm-up.
@@ -143,7 +180,7 @@ Wrap-up Recall.
 In one breath, tell me your language, your city, and your work in Hindi (as a woman). (Maiṁ hindī boltī hūṁ. Maiṁ … meṁ rahtī hūṁ. Maiṁ kām kartī hūṁ.)
 
 
-Lesson 5 of 5.
+Lesson 6 of 6.
 रहना (rahnā) — "to live, to stay".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped.

--- a/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
+++ b/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
@@ -654,6 +654,13 @@ describe("corpus regression", () => {
   // all and `unstartableChapters` gains one. Routing that content through `input` blocks
   // would have held the drivable share flat by mislabelling it; the honest classification
   // is the one that costs the metric.
+  //
+  // HL-C05-bolta-hun (the Hindi present-habitual paradigm, split out of the assembly
+  // lesson) then added one `voice` lesson: 1133 -> 1134, voice 956 -> 957. It is `voice`
+  // deliberately — its paradigm grid was narrowed from four columns to three so the
+  // narration lineariser can read it, and a \"once you see them as\" aside was reworded,
+  // because a lesson teaching the engine of the present tense is exactly the kind a
+  // commuter should not be locked out of.
   // HL-C16 then built the narration lineariser and moved the shipped table width from
   // 0 to 3. This is the largest single move the corpus has ever taken, and none of it
   // is new content — it is the same 1,133 lessons, re-judged by a detector that can now
@@ -677,18 +684,18 @@ describe("corpus regression", () => {
     const { lessons } = loadEverything();
     const manifest = buildModalityManifest(lessons);
     expect(manifest.summary).toEqual({
-      totalLessons: 1133,
-      voice: 956,
+      totalLessons: 1134,
+      voice: 957,
       sight: 124,
       pen: 53,
-      drivableLessons: 956,
+      drivableLessons: 957,
       drivablePercent: 84,
       trackCount: 22,
       chapterCount: 377,
-      // Prerequisite order still costs a commuter 132 of the 956 ear-only lessons:
+      // Prerequisite order still costs a commuter 132 of the 957 ear-only lessons:
       // they sit behind a blocker in their own chapter and stay unreachable in the car
       // until HL-C17 reshapes the remaining wide tables.
-      drivablePrefixTotal: 824,
+      drivablePrefixTotal: 825,
       fullyDrivableChapters: 284,
       unstartableChapters: 44,
       overriddenLessons: 0,


### PR DESCRIPTION
Spanish teaches its present tense in a **dedicated paradigm lesson** (`ES-C06-ar-presente`) and then assembles a sentence from it. Hindi folded the same material *inside* its assembly lesson `HI-C05-main-hindi-bolta-hun`, so the engine of the entire Hindi present tense arrived as a sub-section of a lesson about one sentence.

That is the opposite of atom-first, and it is why **Hindi ch5 carries 5 lessons where Spanish ch6 carries 9**.

## What this adds

`HI-C05-bolta-hun` teaches **stem + -tā/-tī/-te + honā** on its own, and the assembly lesson is slimmed to point at it. The dedicated lesson makes the point the folded version could not afford:

> Hindi runs **two agreements at once** — the participle agrees with gender and number, the copula agrees with person — and a beginner naturally expects one. Two dials, not one ending chosen from a list of six.

## Deliberately drivable

The paradigm grid is **three columns rather than four**, so the HL-C16 lineariser can read it aloud, and one "once you see them as" aside was reworded. A lesson teaching the engine of the present tense is exactly the kind a commuter should not be locked out of. Verified: `modality: voice`, `reasons: [no-visual-dependency]`.

## Why schema v1, not v2

It cannot be v2 yet, and the reason is worth recording: **v2 requires a canonical `spine_node`, and the shared spine's 11 nodes are all A1 social functions** (`SPINE-MEET-GREET`, `SPINE-TAKE-LEAVE`, `SPINE-COUNT-ONE-TO-FIVE`, …) with nothing covering verbs or tense. Hindi's ch5 verbs belong to no node at all.

**That blocks the schema-v2 grammar arc for every track, not just Hindi** — it is HL-C10, and it is now the critical path to the Easy→Advanced progression.

## Corpus effect

| | before | after |
|---|---|---|
| lessons | 1,133 | 1,134 |
| voice | 956 | 957 |
| drivable share | 84% | 84% |

## Verification

300 tests across 18 files pass; `check:books`, `check:modality`, `check:narration` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)