### PR TITLE
feat(mosaic): UI37 — generic-container payload dispatch; sheet cell editing

### DIFF
--- a/code/packages/mosaic/mosaic-pkg-grid/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-pkg-grid/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to `mosaic-pkg-grid` are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/) and
 the package follows semantic versioning.
 
+## 0.2.3 — 2026-08-06 — Cell's click now carries its coordinate
+
+### Fixed
+
+- **`onClick` fired (0.2.2) but never carried anything.** `Grid.mil` has always
+  declared `onNavigate(row: number, col: number)`, but `Cell`'s root is a `Box` — a
+  generic container — and `mosaic-emit-react`'s connects-wiring could only dispatch
+  a `Box`'s click void, no matter what the target emit declared. Fixed at the
+  emitter level: [UI37](../../../specs/UI37-generic-payload-dispatch.md) teaches the
+  React backend to resolve a payload-carrying target emit's declared params from
+  named props on the same node (the same mechanism UI35's `drag-key` already uses).
+  `Cell.mil` gains `row`/`col` slots and `onClick`'s declared payload; `Cell.mll`
+  threads them onto the `Box`; `Grid.mll` supplies them at the call site from its own
+  loop bindings (`row: ( r ), col: ( c )` — the same expression-in-slot-binding shape
+  already used for `is-editing`/`is-selected` two lines above). `onNavigate(row, col)`
+  now actually reaches a consumer for the first time since the emit was declared.
+
 ## 0.2.2 — 2026-08-06 — Cell's click was never wired to its own emit
 
 ### Fixed

--- a/code/packages/mosaic/mosaic-pkg-grid/Cargo.toml
+++ b/code/packages/mosaic/mosaic-pkg-grid/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name        = "mosaic-pkg-grid"
-version     = "0.2.2"
+version     = "0.2.3"
 edition     = "2021"
 description = "Smoke-test harness for the mosaic-pkg-grid component package"
 publish     = false

--- a/code/packages/mosaic/mosaic-pkg-grid/README.md
+++ b/code/packages/mosaic/mosaic-pkg-grid/README.md
@@ -105,14 +105,18 @@ consuming app, from v0.1.0 through v0.2.1. Found and fixed while building
 `mosaic-pkg-sheet` — the first real application to drive this package
 through an actual emitter pipeline. See CHANGELOG.md for the fix.
 
-**Known follow-on limitation, not fixed here:** the payload Grid.mil
-declares for `onNavigate` (`row: number, col: number`) still can't
-actually reach a consumer. `Cell`'s root is a `Box` (a generic container),
-and `mosaic-emit-react`'s connects-wiring only synthesizes an index/value
-payload for a small set of "dedicated" primitives (`HostButton`,
-`HostInput`, `HostLink`) — a generic `Box`'s `onClick` always dispatches
-void. So a click now correctly *fires*, but without row/col. Consumers
-that need to know which cell was clicked have no way to find out yet.
+## v0.2.3 — `onNavigate` actually carries `(row, col)` now
+
+The v0.2.2 gap above ("a click fires, but without row/col — `Cell`'s root
+is a `Box`, and `mosaic-emit-react`'s connects-wiring only synthesizes a
+payload for `HostButton`/`HostInput`/`HostLink`") is closed:
+[UI37](../../../specs/UI37-generic-payload-dispatch.md) extended the React
+backend so a payload-carrying target emit's declared params resolve from
+named props on the same node — the same mechanism UI35's `drag-key`
+already uses. `Cell.mil` gained `row`/`col` slots and `onClick`'s declared
+`(row, col)` payload; `Grid.mll` supplies them at the `Cell` call site from
+its own loop bindings. `Grid`'s `onNavigate(row, col)` contract — declared
+since v0.1.0 — reaches a consumer for the first time.
 
 ## What's still out of scope (deferred to UI28-2 / v0.3.0)
 

--- a/code/packages/mosaic/mosaic-pkg-grid/mosaic-package.toml
+++ b/code/packages/mosaic/mosaic-pkg-grid/mosaic-package.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "mosaic-pkg-grid"
-version = "0.2.2"
+version = "0.2.3"
 description = "Spreadsheet-style data grid built on UI29 kernel primitives (UI28-1 §3 composition)"
 license = "MIT OR Apache-2.0"
 

--- a/code/packages/mosaic/mosaic-pkg-grid/src/Cell.mil
+++ b/code/packages/mosaic/mosaic-pkg-grid/src/Cell.mil
@@ -32,6 +32,13 @@
 // ---------------
 //   value         the text currently displayed (and the seed for the
 //                 editor's initial value when editing begins)
+//   row, col      (v0.2.3, UI37) the cell's coordinate, opaque to Cell
+//                 itself — it never branches on these — but threaded onto
+//                 the root Box so onClick can carry them. Grid supplies
+//                 them via expression-in-slot-binding at the Cell call
+//                 site, the same mechanism it already uses for
+//                 is-editing/is-selected. See "Why row/col ride along on
+//                 click" below.
 //   editable      whether this cell may transition into edit mode at all
 //                 (advisory; the Grid host enforces the policy by setting
 //                 is-editing or not)
@@ -47,13 +54,35 @@
 //
 // Emit vocabulary
 // ---------------
-//   onClick       fired when the cell is activated (host promotes to edit)
+//   onClick       fired when the cell is activated (host promotes to edit).
+//                 Carries (row, col) — see below.
 //   onCommit      fired when an in-progress edit confirms; carries the
 //                 final string value the host should persist
 //   onCancel      fired when an in-progress edit is abandoned
+//
+// Why row/col ride along on click (v0.2.3, UI37)
+// ------------------------------------------------
+//
+//   Cell's root is a Box (a generic container, deliberately — a table
+//   cell is not semantically a button). Through v0.2.2, mosaic-emit-
+//   react's generic connects-wiring could only dispatch a Box's onClick
+//   void, no matter what the target emit declared — so a click FIRED
+//   (once 0.2.2 wired Box's onClick to Cell's own emit at all) but never
+//   carried anything, and Grid's documented onNavigate(row, col)
+//   contract could not actually be fulfilled by any consumer.
+//
+//   UI37 fixes the emitter: a payload-carrying target emit's declared
+//   params are now resolved from NAMED PROPS on the same node (literal /
+//   slot-ref / expression), the same mechanism UI35's drag-key already
+//   uses. Cell.mil declaring `row`/`col` slots and Cell.mll threading
+//   them onto the Box as `row: slot: row, col: slot: col` is what gives
+//   the emitter something to find. See
+//   code/specs/UI37-generic-payload-dispatch.md.
 
 component Cell {
   slot value        : text ;
+  slot row : number ;
+  slot col : number ;
   // edit-content — the host's live edit buffer (UI28-1 v0.3.0).  When
   // the cell is promoted to editing, the HostInput's `value=` is
   // wired to this slot rather than the underlying `value` so the
@@ -70,7 +99,7 @@ component Cell {
   slot alignment    : text ;
   slot cell-type    : text ;
 
-  emit onClick ;
+  emit onClick ( row : number , col : number ) ;
   // onChange fires every keystroke while editing.  Carries the new
   // input value so the host's reducer can update `edit-content`.
   // Paired with the `edit-content` slot to complete the

--- a/code/packages/mosaic/mosaic-pkg-grid/src/Cell.mll
+++ b/code/packages/mosaic/mosaic-pkg-grid/src/Cell.mll
@@ -49,14 +49,20 @@ layout Cell {
     // here verbatim.
     state-when-selected: slot: is-selected ,
     state-when-editing:  slot: is-editing ,
-    // v0.2.1 fix: Cell.mil declares `emit onClick`, and every call site
+    // v0.2.2 fix: Cell.mil declares `emit onClick`, and every call site
     // (Grid.mll's own `Cell(onClick: emit: onNavigate, ...)`) supplies a
     // handler for it — but nothing in this layout ever referenced
     // `emit: onClick`, so the resolver had nothing to substitute and a
     // click did NOTHING. Never caught because no real app exercised Grid
     // until the task-app sheet view did. Box takes a generic onClick
     // like any other node (UI24's connects-wiring is tag-agnostic).
-    onClick: emit: onClick
+    onClick: emit: onClick ,
+    // v0.2.3 / UI37: row/col ride along so the click can actually carry
+    // Cell's coordinate. Slot form (not expression), same reasoning as
+    // is-selected/is-editing above — the resolver's rewrite_bindings
+    // needs a SlotRef to substitute the call site's bound expression in.
+    row: slot: row ,
+    col: slot: col
   ) {
     If ( when: slot: is-editing ) {
       // value: slot: edit-content — the host's live edit buffer,

--- a/code/packages/mosaic/mosaic-pkg-grid/src/Grid.mll
+++ b/code/packages/mosaic/mosaic-pkg-grid/src/Grid.mll
@@ -138,6 +138,13 @@ layout Grid {
             // flow through after resolution.
             Cell (
               value:        ( v ) ,
+              // row/col (v0.2.3, UI37): ride along on onClick so the host
+              // can tell which cell was clicked. Same expression-in-slot-
+              // binding mechanism as is-editing/is-selected below — Cell
+              // never learns anything about Grid's internal loop, it just
+              // receives the two numbers.
+              row:          ( r ) ,
+              col:          ( c ) ,
               // edit-content forwards the host's live edit buffer
               // (the same buffer the FormulaBar drives) into every
               // cell.  Only the cell with `is-editing: true` will

--- a/code/packages/mosaic/mosaic-pkg-grid/tests/package_compiles.rs
+++ b/code/packages/mosaic/mosaic-pkg-grid/tests/package_compiles.rs
@@ -92,7 +92,7 @@ fn manifest_declares_expected_exports() {
         .and_then(|p| p.get("version"))
         .and_then(|v| v.as_str())
         .expect("[package].version must be set");
-    assert_eq!(version, "0.2.2", "[package].version must be 0.2.2 for the Cell onClick-wiring fix");
+    assert_eq!(version, "0.2.3", "[package].version must be 0.2.3 for the Cell onClick row/col payload (UI37)");
 
     // [components].exports
     let exports = value
@@ -275,6 +275,48 @@ fn ui28_1_cell_wires_its_own_onclick_emit() {
     let mil_out = mosmodel_compiler::compile(&mil_src).expect("Cell.mil compiles");
     moslayout_compiler::compile(&src, Some(&mil_out.descriptor_json))
         .expect("Cell.mll must validate against Cell.mil");
+}
+
+/// v0.2.3 / UI37 regression guard. onClick firing (v0.2.2) is necessary but
+/// not sufficient — Grid's documented `onNavigate(row, col)` contract needs
+/// Cell to actually carry a coordinate. Pins: Cell.mil declares onClick with
+/// a (row, col) payload and matching row/col slots; Cell.mll threads them
+/// onto the Box; Grid.mll supplies them at the call site via the same
+/// expression-in-slot-binding shape as is-editing/is-selected.
+#[test]
+fn ui37_cell_onclick_carries_row_and_col() {
+    let cell_mil_src = read_source("Cell.mil");
+    assert!(
+        cell_mil_src.contains("slot row") && cell_mil_src.contains("slot col"),
+        "Cell.mil must declare row/col slots:\n{cell_mil_src}"
+    );
+    let mil_out = mosmodel_compiler::compile(&cell_mil_src).expect("Cell.mil compiles");
+    let on_click = mil_out
+        .component
+        .emits
+        .iter()
+        .find(|e| e.name == "onClick")
+        .expect("Cell.mil must declare onClick");
+    let param_names: Vec<&str> = on_click.params.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(
+        param_names,
+        vec!["row", "col"],
+        "onClick must declare (row, col) in that order, got: {param_names:?}"
+    );
+
+    let cell_mll_src = read_source("Cell.mll");
+    let collapsed_cell: String = cell_mll_src.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        collapsed_cell.contains("row: slot: row") && collapsed_cell.contains("col: slot: col"),
+        "Cell.mll's Box must thread row/col onto itself:\n{cell_mll_src}"
+    );
+
+    let grid_mll_src = read_source("Grid.mll");
+    let collapsed_grid: String = grid_mll_src.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        collapsed_grid.contains("row: ( r )") && collapsed_grid.contains("col: ( c )"),
+        "Grid.mll must supply row/col at the Cell call site from its own loop bindings:\n{grid_mll_src}"
+    );
 }
 
 #[test]

--- a/code/packages/mosaic/mosaic-pkg-sheet/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-pkg-sheet/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to `mosaic-pkg-sheet` are documented in this file.
+The format follows [Keep a Changelog](https://keepachangelog.com/) and
+the package follows semantic versioning.
+
+## 0.1.1 — 2026-08-06 — editing is real
+
+### Fixed
+
+- **`onNavigate`/`onFormulaChange`/`onEditCommit` regain their real payloads.**
+  0.1.0 shipped these declared void, matching what `mosaic-emit-react` could
+  actually dispatch at the time — a `Box`-rooted `Cell` (see
+  `mosaic-pkg-grid`) couldn't carry a click payload through the emitter.
+  [UI37](../../../specs/UI37-generic-payload-dispatch.md) fixed that at the
+  emitter level; `mosaic-pkg-grid` 0.2.3 threads `row`/`col` through `Cell`
+  to use it. `onNavigate(row, col)` and `onEditCommit(value: text)` now
+  reach a consumer for the first time. Depends on `mosaic-pkg-grid` 0.2.3.
+
+## 0.1.0 — 2026-08-06 — initial release, read-only
+
+First release: filter box + sort-field `Select` + `mosaic-pkg-grid`'s
+`Grid`, wired to task-core's `table(view)` projection. Shipped in
+task-app's sheet view (v1 read-only — see task-app's own CHANGELOG for the
+two bugs found and fixed building it: `mosaic-pkg-grid`'s `Cell.onClick`
+never firing at all, and `mosaic-emit-react`'s `HostInput.onCommit` never
+carrying a declared payload).

--- a/code/packages/mosaic/mosaic-pkg-sheet/Cargo.toml
+++ b/code/packages/mosaic/mosaic-pkg-sheet/Cargo.toml
@@ -13,7 +13,7 @@
 
 [package]
 name        = "mosaic-pkg-sheet"
-version     = "0.1.0"
+version     = "0.1.1"
 edition     = "2021"
 description = "Smoke-test harness for the mosaic-pkg-sheet component package"
 publish     = false

--- a/code/packages/mosaic/mosaic-pkg-sheet/README.md
+++ b/code/packages/mosaic/mosaic-pkg-sheet/README.md
@@ -43,27 +43,15 @@ into the `View` it passes to task-core's `table(view)` projection on the
 next render. The rows Sheet receives back are already filtered, sorted,
 and formatted; Sheet only places them.
 
-## v1 scope: READ-ONLY
+## Editing (0.1.1+)
 
-Editing is declared in the interface (Grid requires its edit-cursor slots
-to be wired to something) but not functional yet. `onNavigate` /
-`onFormulaChange` / `onEditCommit` are declared **void** here, not with
-the payload `Grid.mil` itself declares — see `Sheet.mil`'s "Known
-limitation" doc-comment for the full explanation: `Grid`'s `Cell` is a
-`Box` (a generic container), and `mosaic-emit-react`'s connects-wiring
-only synthesizes an index/value payload for a small set of "dedicated"
-primitives (`HostButton`, `HostInput`, `HostLink`) — a generic `Box`'s
-`onClick` always dispatches void, in any consuming app, not just this
-one. Clicking a cell is a safe no-op today rather than silently wrong.
-
-Two ways to fix this properly, neither attempted in this package/UI-layer
-PR: (a) give `Cell` explicit `row`/`col` props read via expression — the
-same mechanism the UI35 drag family already uses for `drag-key` — so the
-payload comes from an authored expression rather than synthesized loop
-context; or (b) generalize the react emitter's loop-scope tracking from a
-single `Option<ForPayloadScope>` to a real stack, so index-payload
-synthesis works for `Box` at arbitrary nesting depth the way it already
-does for `HostButton`. Tracked in the task-app backlog.
+`onNavigate(row, col)` / `onFormulaChange(value)` / `onEditCommit(value)`
+carry their full payload — a click identifies the cell, and edits reach
+the host. This depends on `mosaic-pkg-grid` 0.2.3 +
+[UI37](../../../specs/UI37-generic-payload-dispatch.md); 0.1.0 shipped
+these void because `Grid`'s `Cell` (a `Box`, a generic container) couldn't
+carry a click payload through `mosaic-emit-react` at all yet. See
+CHANGELOG.md.
 
 ## Usage
 

--- a/code/packages/mosaic/mosaic-pkg-sheet/mosaic-package.toml
+++ b/code/packages/mosaic/mosaic-pkg-sheet/mosaic-package.toml
@@ -18,7 +18,7 @@
 
 [package]
 name = "mosaic-pkg-sheet"
-version = "0.1.0"
+version = "0.1.1"
 description = "Filterable, sortable, editable spreadsheet view wired to task-core's table(view) projection"
 license = "MIT OR Apache-2.0"
 
@@ -26,7 +26,7 @@ license = "MIT OR Apache-2.0"
 exports = ["Sheet"]
 
 [dependencies]
-mosaic-pkg-grid = "0.2.2"
+mosaic-pkg-grid = "0.2.3"
 mosaic-pkg-toolkit = "0.11.0"
 
 [kernel]

--- a/code/packages/mosaic/mosaic-pkg-sheet/src/Sheet.mil
+++ b/code/packages/mosaic/mosaic-pkg-sheet/src/Sheet.mil
@@ -11,43 +11,17 @@
 // two plain inputs the host collects and folds into the `View` it
 // passes to task-core's `table(view)` projection on the next render —
 // the returned rows are already filtered, sorted, and formatted.
+// Editing follows the same shape as Grid: the host owns edit-row /
+// edit-col / edit-content and decides what an `onEditCommit` means.
 //
-// v1 scope: READ-ONLY. Editing is deferred — see the note on the Grid
-// pass-through emits below.
-//
-// Known limitation: cell click carries no payload today
-// ------------------------------------------------------
-//
-// Grid's `Cell` is a `Box` (a generic container), not a `HostButton`.
-// mosaic-emit-react's connects-wiring only synthesizes an index/value
-// payload for a small set of "dedicated" primitives (HostButton,
-// HostInput, HostLink); a generic `Box`'s `onClick` always dispatches
-// void, no matter what the target emit declares. Grid's own row/col
-// selection (`onNavigate`) and its edit round-trip
-// (`onFormulaChange`/`onEditCommit`) all rely on Box carrying a
-// payload — so none of them can actually fire with useful data through
-// the current react emitter, in ANY app, not just this one. This was
-// invisible until now because no application had driven `Grid` through
-// a real emitter pipeline before the sheet view did.
-//
-// Two ways to fix it, neither attempted here (out of scope for a
-// package/UI PR): (a) give `Cell` explicit `row`/`col` props read via
-// expression, the same mechanism the UI35 drag family already uses for
-// `drag-key`, so the payload comes from an authored expression rather
-// than synthesized loop context; or (b) generalize the react emitter's
-// loop-scope tracking from a single `Option<ForPayloadScope>` to a
-// real stack, so index-payload synthesis works for `Box` at arbitrary
-// nesting depth the way it already (sort of) does for `HostButton`.
-// Tracked in the task-app backlog.
-//
-// Until then: `onNavigate`/`onFormulaChange`/`onEditCommit` are
-// declared VOID here (matching what the pipeline actually dispatches)
-// rather than with the payload Grid.mil itself still declares —
-// declaring a payload the wiring can never deliver would be a type a
-// host can never honestly satisfy. `selected-row`/`selected-col`/
-// `edit-row`/`edit-col`/`edit-content` stay in the interface (Grid
-// requires them to be wired to something) but the host has nothing
-// meaningful to drive them with in v1, so it just holds them at -1/"".
+// v1 shipped read-only: Grid's Cell is a Box (a generic container), and
+// mosaic-emit-react's connects-wiring could only dispatch a Box's onClick
+// void, no matter what the target emit declared — so onNavigate couldn't
+// actually carry (row, col) to any consumer. Fixed by
+// code/specs/UI37-generic-payload-dispatch.md (mosaic-emit-react resolves
+// a payload-carrying target emit's declared params from named props on the
+// same node) + mosaic-pkg-grid 0.2.3 (Cell.mil gains row/col slots,
+// Grid.mll supplies them at the call site). Editing is now real.
 //
 // Slot vocabulary
 // ---------------
@@ -77,9 +51,8 @@
 // Emit vocabulary
 // ---------------
 //
-//   Grid pass-through — fired verbatim from the wrapped Grid, but VOID
-//   here (see "Known limitation" above — this is not what Grid.mil
-//   itself declares):
+//   Grid pass-through — fired verbatim from the wrapped Grid, payload
+//   shapes unchanged:
 //
 //     onNavigate, onFormulaChange, onEditCommit, onEditCancel
 //
@@ -112,14 +85,9 @@ component Sheet {
   slot sort-open        : bool ;
   slot sort-ascending   : bool ;
 
-  emit onNavigate ;
-  // Unlike onNavigate/onEditCommit, this one IS reliable: it's wired via
-  // HostInput's onChange, which mosaic-emit-react always dispatches with a
-  // value payload unconditionally (not synthesized from loop/index context —
-  // see the "Known limitation" note above, which is specifically about Box's
-  // onClick and HostInput's onCommit, not onChange).
+  emit onNavigate ( row : number , col : number ) ;
   emit onFormulaChange ( value : text ) ;
-  emit onEditCommit ;
+  emit onEditCommit ( value : text ) ;
   emit onEditCancel ;
 
   emit onFilterChange        ( value : text ) ;

--- a/code/packages/rust/mosaic-emit-react/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-react/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added - UI37: generic-container payload dispatch
+
+`build_emit_handlers` (the generic connects-wiring path used by `Box`/`Row`/`Column`/
+`Stack` — everything that isn't a "dedicated" primitive like `HostButton`/`HostInput`/
+`HostLink`) previously always dispatched a void action, regardless of what the target
+emit declared. A payload-carrying target emit's declared params now resolve from
+**named props on the same node** — literal / slot-ref / expression, resolved via
+`drag_value_expr` (UI35's `drag-key` resolver; not drag-specific despite the name,
+this is its second caller). A declared param with no matching prop is a hard compile
+error, not a silent `undefined` — the same "accepted-but-ignored is the worst outcome"
+principle UI36 established for size props.
+
+This is what lets `mosaic-pkg-grid`'s `Cell` (a `Box`) actually deliver `Grid`'s
+`onNavigate(row, col)` — declared since that package's v0.1.0, never deliverable by
+any consumer until now. See `code/specs/UI37-generic-payload-dispatch.md`.
+
 ### Fixed - a payload-carrying `HostInput` `onCommit` now actually carries the payload
 
 `onCommit`'s merged `onKeyDown` handler always dispatched `{ type: "..." }` with no

--- a/code/packages/rust/mosaic-emit-react/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-react/src/pipeline.rs
@@ -1216,7 +1216,7 @@ fn emit_jsx_tree(
     // Append connects-wiring event handlers (UI24): for every prop on this
     // node whose value is an `EmitRef`, emit a JSX event handler attribute
     // that dispatches the corresponding event union variant.
-    open.push_str(&build_emit_handlers(node)?);
+    open.push_str(&build_emit_handlers(node, emits)?);
 
     if self_close {
         return Ok(format!("{pad}{open} />\n"));
@@ -4501,15 +4501,19 @@ fn escape_for_js_string_literal(s: &str) -> String {
 /// is derived from the emit name with the same UI24 §5 rule used for the
 /// union variants: strip a leading `on`, camelCase the rest.
 ///
-/// Only **void** emits are wired in this first cut. Payload-carrying emits
-/// require the moslayout `connects` syntax to declare how a JSX event's
-/// payload maps to the emit's parameters, which is grammar work tracked
-/// separately. For now, payload-carrying emit refs still produce a void
-/// dispatch (no payload fields), which is wrong for the host but at least
-/// fires the right event type — and the union shape still tells the
-/// TypeScript compiler that fields are missing, so the host sees a clear
-/// type error rather than a silent miscompilation.
-fn build_emit_handlers(node: &LayoutNode) -> Result<String, PipelineEmitError> {
+/// A **void** target emit (no declared params) dispatches exactly that —
+/// `{ type: "..." }`, nothing else.
+///
+/// A **payload-carrying** target emit (UI37) looks, for each declared
+/// param, for a prop **on the same node** named after that param —
+/// literal / slot-ref / expression, resolved the same way UI35's
+/// `drag-key` already is (`drag_value_expr` — not drag-specific despite
+/// the name; this is its second caller). A declared param with no
+/// matching prop is a hard compile error, not a silent `undefined`: an
+/// accepted-but-ignored payload is the exact failure mode UI36 rejected
+/// for size props, for the same reason — it teaches the author a feature
+/// works when it doesn't. See `code/specs/UI37-generic-payload-dispatch.md`.
+fn build_emit_handlers(node: &LayoutNode, emits: &[EmitDecl]) -> Result<String, PipelineEmitError> {
     let mut out = String::new();
     for prop in &node.props {
         let LayoutPropValue::EmitRef(emit_name) = &prop.value else {
@@ -4531,8 +4535,32 @@ fn build_emit_handlers(node: &LayoutNode) -> Result<String, PipelineEmitError> {
         let type_field = to_camel_case_first_lower(&lowered);
         validate_emit_name(&type_field)?;
 
+        let target = emits.iter().find(|e| &e.name == emit_name);
+        let params = target.map(|e| e.params.as_slice()).unwrap_or(&[]);
+
+        if params.is_empty() {
+            out.push_str(&format!(
+                " {attr_name}={{() => dispatch({{ type: \"{type_field}\" }})}}"
+            ));
+            continue;
+        }
+
+        let mut fields = String::new();
+        for param in params {
+            let Some(expr) = drag_value_expr(node, &param.name)? else {
+                return Err(PipelineEmitError::UnsafeSlotName(format!(
+                    "`{attr_name}: emit: {emit_name}` targets a payload-carrying emit \
+                     (param `{}`), but this node has no `{}:` prop to supply it — \
+                     add `{}: ( ... )` (literal, slot ref, or expression)",
+                    param.name, param.name, param.name
+                )));
+            };
+            let field_name = to_camel_case_first_lower(&param.name);
+            validate_payload_field_name(&field_name).map_err(PipelineEmitError::UnsafeSlotName)?;
+            fields.push_str(&format!(", {field_name}: {expr}"));
+        }
         out.push_str(&format!(
-            " {attr_name}={{() => dispatch({{ type: \"{type_field}\" }})}}"
+            " {attr_name}={{() => dispatch({{ type: \"{type_field}\"{fields} }})}}"
         ));
     }
     Ok(out)
@@ -4973,6 +5001,26 @@ fn validate_emit_name(s: &str) -> Result<(), PipelineEmitError> {
     }
     match s {
         "dispatch" | "children" | "key" => Err(PipelineEmitError::ReservedEmitName(s.to_string())),
+        _ => Ok(()),
+    }
+}
+
+/// Validate a UI37 payload field name — the JS object-literal key a
+/// payload-carrying emit's param becomes in `dispatch({ type: "...", <here>:
+/// expr })`. `validate_slot_or_field_name` alone is not enough here (unlike
+/// its other call sites): those only ever produce a JSX *attribute*, but this
+/// key sits in the SAME object literal as `type`, so a param named `type`
+/// would silently overwrite the dispatch discriminant with the payload
+/// value — an object literal permits a duplicate key with no compile error,
+/// so the union's exhaustive `switch (event.type)` in the host would
+/// silently dispatch as whatever the field happened to be, not what the
+/// author declared. `__proto__` is the same class of problem one level
+/// deeper: a non-computed `__proto__:` key sets the object's prototype
+/// instead of creating an own property.
+fn validate_payload_field_name(s: &str) -> Result<(), String> {
+    validate_slot_or_field_name(s)?;
+    match s {
+        "type" | "__proto__" | "constructor" | "prototype" => Err(s.to_string()),
         _ => Ok(()),
     }
 }
@@ -5577,6 +5625,175 @@ mod tests {
                 .contains("onClick={() => dispatch({ type: \"click\" })}"),
             "expected dispatch handler, got:\n{}",
             result.output
+        );
+    }
+
+    /// UI37 — a generic container (`Box`) whose `onClick` targets a
+    /// payload-carrying emit picks up the payload from named, author-supplied
+    /// props on the same node (literal / slot-ref / expression), the same
+    /// resolution `drag_value_expr` already does for UI35's `drag-key`. This
+    /// is what lets `mosaic-pkg-grid`'s `Cell` (a `Box`) actually deliver
+    /// `Grid`'s `onNavigate(row, col)` — previously always void regardless of
+    /// what the target emit declared.
+    #[test]
+    fn ui37_box_onclick_with_payload_reads_named_props() {
+        let m = component(
+            "Cell",
+            vec![],
+            vec![emit(
+                "onNavigate",
+                vec![
+                    param("row", EmitPayloadType::Number),
+                    param("col", EmitPayloadType::Number),
+                ],
+            )],
+        );
+        let l = LayoutDef {
+            component_name: "Cell".to_string(),
+            root: LayoutNode {
+                tag: "Box".to_string(),
+                part_name: None,
+                props: vec![
+                    LayoutProp {
+                        name: "onClick".to_string(),
+                        value: LayoutPropValue::EmitRef("onNavigate".to_string()),
+                    },
+                    LayoutProp {
+                        name: "row".to_string(),
+                        value: LayoutPropValue::Expr("r".to_string()),
+                    },
+                    LayoutProp {
+                        name: "col".to_string(),
+                        value: LayoutPropValue::Expr("c".to_string()),
+                    },
+                ],
+                children: Vec::new(),
+            },
+        };
+        let result = from_pipeline(&m, &l, &empty_style("Cell")).unwrap();
+        assert!(
+            result
+                .output
+                .contains("onClick={() => dispatch({ type: \"navigate\", row: r, col: c })}"),
+            "expected the payload synthesized from the row/col props, got:\n{}",
+            result.output
+        );
+    }
+
+    /// UI37 — a payload-carrying target emit with no matching prop on the
+    /// node is a hard compile error, not a silent void dispatch. Accepted-
+    /// but-ignored is the exact failure mode UI36 rejected for size props,
+    /// for the same reason: it teaches the author a feature works when it
+    /// doesn't.
+    #[test]
+    fn ui37_box_onclick_missing_payload_prop_errors_loudly() {
+        let m = component(
+            "Cell",
+            vec![],
+            vec![emit("onNavigate", vec![param("row", EmitPayloadType::Number)])],
+        );
+        let l = LayoutDef {
+            component_name: "Cell".to_string(),
+            root: node_with_emit_ref("Box", "onClick", "onNavigate"),
+        };
+        let err = from_pipeline(&m, &l, &empty_style("Cell")).unwrap_err();
+        assert!(
+            matches!(err, PipelineEmitError::UnsafeSlotName(ref msg) if msg.contains("row")),
+            "expected an error naming the missing `row` prop, got: {err:?}"
+        );
+    }
+
+    /// UI37 — a void target emit (no declared params) is unaffected: the
+    /// pre-existing generic dispatch stays exactly as it was.
+    #[test]
+    fn ui37_box_onclick_void_emit_still_dispatches_bare() {
+        let m = component("X", vec![], vec![emit("onActivate", vec![])]);
+        let l = LayoutDef {
+            component_name: "X".to_string(),
+            root: node_with_emit_ref("Box", "onClick", "onActivate"),
+        };
+        let result = from_pipeline(&m, &l, &empty_style("X")).unwrap();
+        assert!(
+            result
+                .output
+                .contains("onClick={() => dispatch({ type: \"activate\" })}"),
+            "a void emit must dispatch with no payload fields, got:\n{}",
+            result.output
+        );
+    }
+
+    /// UI37 — a payload param named `type` would silently overwrite the
+    /// dispatch discriminant (JS object literals allow a duplicate key with
+    /// no compile error), defeating the exhaustive `switch (event.type)` the
+    /// host relies on. Caught by security review; must be a hard error, not
+    /// a param that quietly wins.
+    #[test]
+    fn ui37_payload_param_named_type_is_rejected() {
+        let m = component(
+            "Cell",
+            vec![],
+            vec![emit("onNavigate", vec![param("type", EmitPayloadType::Text)])],
+        );
+        let l = LayoutDef {
+            component_name: "Cell".to_string(),
+            root: LayoutNode {
+                tag: "Box".to_string(),
+                part_name: None,
+                props: vec![
+                    LayoutProp {
+                        name: "onClick".to_string(),
+                        value: LayoutPropValue::EmitRef("onNavigate".to_string()),
+                    },
+                    LayoutProp {
+                        name: "type".to_string(),
+                        value: LayoutPropValue::Expr("t".to_string()),
+                    },
+                ],
+                children: Vec::new(),
+            },
+        };
+        let err = from_pipeline(&m, &l, &empty_style("Cell")).unwrap_err();
+        assert!(
+            matches!(err, PipelineEmitError::UnsafeSlotName(_)),
+            "expected a rejection of the reserved `type` payload field, got: {err:?}"
+        );
+    }
+
+    /// UI37 — same reasoning for `__proto__`: a non-computed `__proto__:` key
+    /// in an object literal sets the prototype rather than creating an own
+    /// property, silently dropping or corrupting the intended field.
+    #[test]
+    fn ui37_payload_param_named_proto_is_rejected() {
+        let m = component(
+            "Cell",
+            vec![],
+            vec![emit(
+                "onNavigate",
+                vec![param("__proto__", EmitPayloadType::Text)],
+            )],
+        );
+        let l = LayoutDef {
+            component_name: "Cell".to_string(),
+            root: LayoutNode {
+                tag: "Box".to_string(),
+                part_name: None,
+                props: vec![
+                    LayoutProp {
+                        name: "onClick".to_string(),
+                        value: LayoutPropValue::EmitRef("onNavigate".to_string()),
+                    },
+                    LayoutProp {
+                        name: "__proto__".to_string(),
+                        value: LayoutPropValue::Expr("p".to_string()),
+                    },
+                ],
+                children: Vec::new(),
+            },
+        };
+        let err = from_pipeline(&m, &l, &empty_style("Cell")).unwrap_err();
+        assert!(
+            matches!(err, PipelineEmitError::UnsafeSlotName(_)),
+            "expected a rejection of the reserved `__proto__` payload field, got: {err:?}"
         );
     }
 

--- a/code/programs/mosaic/task-app/BACKLOG.md
+++ b/code/programs/mosaic/task-app/BACKLOG.md
@@ -7,29 +7,7 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
 
 ## Next up (priority order)
 
-1. **Fix `Box`/generic-container payload dispatch in `mosaic-emit-react`.** (Discovered
-   2026-08-06 building Sheet.) `HostButton`/`HostInput`/`HostLink` get "dedicated" wiring
-   that can synthesize an index/value payload from loop context or the DOM event; a generic
-   `Box`'s `onClick` (and any other generic-container emit) always dispatches void, no matter
-   what the target emit declares. This is why `mosaic-pkg-grid`'s `Cell` (a `Box`) can't
-   deliver `onNavigate(row, col)` to anything — blocking sheet cell-editing (currently shipped
-   read-only, see `mosaic-pkg-sheet`'s CHANGELOG) and any future component that needs a
-   generic container to report *which* loop iteration was interacted with. Two candidate
-   fixes, either needs its own design pass: (a) narrow — give `Cell` explicit `row`/`col`
-   props read via expression, the same mechanism UI35's `drag-key` already uses (payload from
-   an authored expression, not synthesized loop context); (b) broad — generalize
-   `mosaic-emit-react`'s loop-scope tracking from `Option<ForPayloadScope>` (innermost scope
-   only) to a real stack, so index-payload synthesis works for `Box` at arbitrary nesting
-   depth the way it already does for `HostButton`. Prioritized above the next roadmap phase
-   because it's now a known correctness gap in a shipped, reused package, not speculative.
-
-2. **Finish sheet cell-editing**, once the above lands. `mosaic-pkg-sheet`'s `SheetField`
-   catalogue in `main.tsx` (`editable`/`write` per column, `SHEET_FIELDS`) and the
-   field-kind-aware write-back dispatcher were built and then stripped back to no-ops for the
-   v1 read-only ship — the design is already done, this is re-wiring once `Cell` can report
-   which cell was clicked.
-
-3. **Rename off "Planner" + close the design-fidelity gap.** (User decision, 2026-08-06.)
+1. **Rename off "Planner" + close the design-fidelity gap.** (User decision, 2026-08-06.)
    "Planner" collides with an existing trademark (Microsoft Planner et al.) — needs a new,
    trademark-safe name. User wants a **short list of alternatives proposed**, not "Travail"
    locked in unilaterally. Separately, the live app has drifted from `design/ui-prototype.html`
@@ -40,18 +18,18 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
    current app vs. `design/ui-prototype.html` and fix what's drifted. Queued deliberately behind
    Sheet — do not jump ahead of in-flight work.
 
-4. **Phase 7 — Calendar component.** `mosaic-pkg-calendar`, wired to the engine's `calendar(range,
+2. **Phase 7 — Calendar component.** `mosaic-pkg-calendar`, wired to the engine's `calendar(range,
    view)` projection (already shipped, [#8726](https://github.com/adhithyan15/coding-adventures/pull/8726)) + the UI35 drag kernel for
    drag-to-reschedule/resize. Month/week/day views, time-blocking, auto-schedule placement around
    fixed commitments. The drag kernel is proven end-to-end now (board PR found and fixed three
    real bugs in it), so this should be smoother than the board was.
 
-5. **Phase 8 — Notes component + entity.** The engine has **no notes entity at all** yet — this
+3. **Phase 8 — Notes component + entity.** The engine has **no notes entity at all** yet — this
    needs a `task-core` model addition (standalone notes + attachable to any task/project) before
    the `mosaic-pkg-notes` UI (adapted from `mosaic-pkg-note-editor`, which was built for a
    different domain — Anki notes — and needs re-pointing at generic entities).
 
-6. **Phase 9 — App-shell assembly + progressive disclosure.** Partially done already via ad hoc
+4. **Phase 9 — App-shell assembly + progressive disclosure.** Partially done already via ad hoc
    UI-design passes ([#8970](https://github.com/adhithyan15/coding-adventures/pull/8970), [#8983](https://github.com/adhithyan15/coding-adventures/pull/8983), [#9112](https://github.com/adhithyan15/coding-adventures/pull/9112), [#8994](https://github.com/adhithyan15/coding-adventures/pull/8994), [#9110](https://github.com/adhithyan15/coding-adventures/pull/9110), [#9127](https://github.com/adhithyan15/coding-adventures/pull/9127), [#9136](https://github.com/adhithyan15/coding-adventures/pull/9136))
    — theming, project switching, nested-project hierarchy, shell/groups/status/cards all landed.
    Remaining: package it as a reusable `mosaic-pkg-project-nav` (nested-project tree + view
@@ -78,11 +56,18 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
 
 ## Resolved (kept for traceability, not actionable)
 
-- **Phase 5 — Sheet component, read-only v1.** `mosaic-pkg-sheet` shipped: filter/sort
-  toolbar + 10-column `Grid` view over `table(view)`. Cell editing deferred — see items
-  1-2 above. Found + fixed two real bugs in packages nothing had driven through a real
-  app before: `mosaic-pkg-grid` 0.2.2 (`Cell`'s `onClick` never actually fired) and
-  `mosaic-emit-react` (`HostInput` `onCommit` never carried its declared payload).
+- **Phase 5 — Sheet component, now fully editable.** `mosaic-pkg-sheet` shipped
+  read-only first, then editing landed as a fast-follow once the emitter gap was
+  fixed properly ([UI37](../../../specs/UI37-generic-payload-dispatch.md) +
+  `mosaic-pkg-grid` 0.2.3): a payload-carrying target emit on a generic container
+  (`Box`) now resolves its params from named props on the node, the same mechanism
+  UI35's `drag-key` uses. `Grid`'s `onNavigate(row, col)` — declared since v0.1.0 —
+  reaches a consumer for the first time. Verified live: click a cell → edit → Enter
+  → commits through the real engine op → persists across reload → consistent with
+  the list view. Found + fixed three real bugs total in packages nothing had driven
+  through a real app before: `mosaic-pkg-grid` 0.2.2 (`Cell`'s `onClick` never fired
+  at all), `mosaic-emit-react` (`HostInput` `onCommit` never carried its declared
+  payload), and the `Box`-payload gap itself (0.2.3/UI37).
 - **Phase 6 — Board (kanban) view.** [#9897](https://github.com/adhithyan15/coding-adventures/pull/9897),
   merged. Drag-and-drop columns wired to the UI35 kernel.
 - Dark-mode "Add task" pressed-color regression (copy-pasted from light theme) — fixed alongside

--- a/code/programs/mosaic/task-app/CHANGELOG.md
+++ b/code/programs/mosaic/task-app/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to the `task-app` web program are documented here.
 
 ## [0.1.0] - Unreleased
 
+### Added - sheet cell editing
+
+The sheet view's cells are editable now. The fast-follow the read-only ship below
+promised: [UI37](../../../specs/UI37-generic-payload-dispatch.md) fixed the
+underlying gap at the `mosaic-emit-react` level (a payload-carrying target emit on
+a generic container now resolves its params from named props on the node, the same
+mechanism UI35's `drag-key` already uses), and `mosaic-pkg-grid` 0.2.3 threads
+`row`/`col` through `Cell` to use it. `Grid`'s `onNavigate(row, col)` contract —
+declared since v0.1.0 of that package — reaches a consumer for the first time.
+
+Click an editable cell (Done, Name, Deadline, % Complete, Priority, Status, Notes)
+to edit it in place; Overdue/Start/Finish stay read-only (they're computed). Enter
+commits through the matching engine op (`renameTask`, `setDeadline`,
+`setPercentComplete`, `setPriority`, `setStatus`, `setCompleted`, `setNotes`);
+Escape cancels. Verified live: edit → commit → persists across reload → consistent
+with the list view, zero console errors.
+
 ### Added - sheet (spreadsheet) view — read-only
 
 - **A fourth view: a sheet**, a filterable/sortable spreadsheet over 10 columns (Done,

--- a/code/programs/mosaic/task-app/host/web/src/main.tsx
+++ b/code/programs/mosaic/task-app/host/web/src/main.tsx
@@ -52,12 +52,12 @@ const TASK_VIEW = (projectStart: number) => ({
   projectStart,
 });
 // The sheet's column catalogue: one entry per column the sheet can show, in
-// display order. `sortable` controls whether the column appears as a Select
-// option in the sort toolbar. `editable`/`write` describe what SHOULD gate
-// edit-mode and turn a committed edit into an engine op — prepared for when
-// cell editing is fixed (see Sheet.mil's "Known limitation" note: Grid's
-// Cell can't carry a click payload through the current react emitter, so
-// v1 is read-only and neither field has a live consumer yet).
+// display order. `editable` gates whether clicking a cell in that column
+// enters edit mode at all (a computed column like Overdue never does — see
+// the "sheetNavigate" case below). `write` turns a committed cell edit into
+// the ONE engine op that expresses it; absent for non-editable columns.
+// `sortable` controls whether the column appears as a Select option in the
+// sort toolbar.
 //
 // This is a SECOND consumer of table(view) — same engine call the list view
 // already makes, just with a broader visibleFields and a different
@@ -216,16 +216,13 @@ function makeController(engine: any, init: ControllerInit = {}) {
   let sheetSortField = ""; // a SHEET_FIELDS label, or "" for unsorted
   let sheetSortAscending = true;
   let sheetSortOpen = false;
-  // Grid's edit-cursor slots. -1/"" ("none", matching Grid's own contract — see
-  // Grid.mil) permanently: v1 is read-only, since Grid's Cell can't carry a click
-  // payload through the current react emitter (see Sheet.mil's "Known limitation"
-  // note). Kept as real props rather than deleted — Grid requires them wired to
-  // something — and as `const` since nothing ever drives them yet.
-  const sheetSelectedRow = -1;
-  const sheetSelectedCol = -1;
-  const sheetEditRow = -1;
-  const sheetEditCol = -1;
-  const sheetEditContent = "";
+  // Grid's edit-cursor slots. -1/"" means "none", matching Grid's own contract
+  // (see Grid.mil).
+  let sheetSelectedRow = -1;
+  let sheetSelectedCol = -1;
+  let sheetEditRow = -1;
+  let sheetEditCol = -1;
+  let sheetEditContent = "";
   // Which row is expanded, by task id (not index — an index would follow the wrong
   // task the moment the list is re-sorted or something above it is deleted).
   let expanded: string | null = null;
@@ -618,20 +615,50 @@ function makeController(engine: any, init: ControllerInit = {}) {
           persist();
           break;
         }
-        // v1 sheet is READ-ONLY. Grid's Cell is a Box (a generic container), and
-        // mosaic-emit-react's connects-wiring only synthesizes an index/value payload
-        // for a small set of "dedicated" primitives (HostButton, HostInput, HostLink) —
-        // a generic Box's onClick always dispatches void, no matter what the target
-        // emit declares. That means Grid's row/col selection and edit round-trip can't
-        // actually carry data through the current emitter, in any app — not something
-        // fixable from this package/UI layer. These handlers stay as documented no-ops
-        // (rather than deleting the wiring, which the package resolver requires — see
-        // Sheet.mil's "Known limitation" note) until that's fixed at the emitter level.
-        case "sheetNavigate":
-        case "sheetFormulaChange":
-        case "sheetEditCancel":
-        case "sheetEditCommit":
+        case "sheetNavigate": {
+          sheetSelectedRow = event.row;
+          sheetSelectedCol = event.col;
+          const col = SHEET_FIELDS[event.col];
+          // Only an editable column enters edit mode at all — a computed column
+          // (Overdue, Start, Finish) just gets selected/highlighted, matching the
+          // Cell.mil doc's note that Grid/Cell don't enforce this policy themselves.
+          if (col?.editable) {
+            const { cells } = sheetRows();
+            sheetEditRow = event.row;
+            sheetEditCol = event.col;
+            sheetEditContent = cells[event.row]?.[event.col] ?? "";
+          } else {
+            sheetEditRow = -1;
+            sheetEditCol = -1;
+          }
           break;
+        }
+        case "sheetFormulaChange":
+          sheetEditContent = event.value;
+          break;
+        case "sheetEditCancel":
+          sheetEditRow = -1;
+          sheetEditCol = -1;
+          sheetEditContent = "";
+          break;
+        case "sheetEditCommit": {
+          const { ids } = sheetRows();
+          const id = ids[sheetEditRow];
+          const col = SHEET_FIELDS[sheetEditCol];
+          sheetEditRow = -1;
+          sheetEditCol = -1;
+          sheetEditContent = "";
+          if (!id || !col?.write) break;
+          const change = col.write(id, event.value);
+          if (!change) break; // the column rejected the value (e.g. an unknown priority)
+          const res = (engine as any)[change.op](change.args);
+          if (res?.ok === false) {
+            console.error(`Sheet edit failed (${col.label}):`, res.error ?? res);
+            break;
+          }
+          persist();
+          break;
+        }
         case "sheetFilterChange":
           sheetFilterText = event.value;
           break;

--- a/code/programs/mosaic/task-app/src/TaskApp.mil
+++ b/code/programs/mosaic/task-app/src/TaskApp.mil
@@ -118,16 +118,9 @@ component TaskApp {
   emit onCardDropped ( key : text , kind : text , targetKey : text , position : text ) ;
 
   // Sheet emits — straight pass-through to/from pkg::mosaic-pkg-sheet::Sheet.
-  // onNavigate/onFormulaChange/onEditCommit/onEditCancel are void, matching
-  // Sheet.mil (v1 is read-only — see Sheet.mil's "Known limitation" note:
-  // Grid's Cell is a Box, and mosaic-emit-react's connects-wiring can't
-  // synthesize an index/value payload for a generic container the way it
-  // does for HostButton/HostInput, so nothing meaningful would flow through
-  // a declared payload here anyway).
-  emit onSheetNavigate ;
-  // Reliable, unlike the others here — see Sheet.mil's matching onFormulaChange note.
+  emit onSheetNavigate ( row : number , col : number ) ;
   emit onSheetFormulaChange ( value : text ) ;
-  emit onSheetEditCommit ;
+  emit onSheetEditCommit ( value : text ) ;
   emit onSheetEditCancel ;
   emit onSheetFilterChange        ( value : text ) ;
   emit onSheetSortFieldChange     ( value : text ) ;

--- a/code/specs/UI37-generic-payload-dispatch.md
+++ b/code/specs/UI37-generic-payload-dispatch.md
@@ -1,0 +1,113 @@
+# UI37 — generic-container payload dispatch
+
+**Status:** design + React backend implementation.
+**Kernel surface:** any generic container (`Box`, `Row`, `Column`, `Stack`) that
+declares an `onClick`-shaped emit-ref prop, when the target emit has declared params.
+
+---
+
+## 1. The gap
+
+`mosaic-emit-react`'s connects-wiring (UI24) has two tiers:
+
+- **Dedicated primitives** (`HostButton`, `HostInput`, `HostLink`) get bespoke
+  handlers that can attach a payload — `HostButton` synthesizes an `index` field from
+  the nearest enclosing `For`'s index binding; `HostInput`'s `onChange` attaches
+  `e.target.value`; `onCommit` attaches `e.currentTarget.value` when the target emit
+  declares a param (fixed alongside this spec — see `mosaic-emit-react`'s CHANGELOG).
+- **Everything else** (`Box`, `Row`, `Column`, `Stack`, and any future generic
+  container) goes through `build_emit_handlers`, which dispatches `{ type: "..." }`
+  and nothing else — no matter what the target emit declares.
+
+This second tier is not a corner case. `mosaic-pkg-grid`'s `Cell` is a `Box` (chosen
+deliberately — a table cell is not semantically a button), and `Grid.mil` declares
+`onNavigate(row: number, col: number)`. Every consumer of `Grid` inherits a contract
+that **cannot be fulfilled**: a click fires (as of the `Cell.mll` wiring fix, also
+alongside this spec), but always void. `mosaic-pkg-sheet`'s v1 shipped read-only
+specifically because of this gap (see its CHANGELOG/README).
+
+The underlying reason dedicated primitives *can* attach a payload and `Box` can't is
+architectural, not incidental: `for_payload: Option<ForPayloadScope<'_>>` threaded
+through `emit_jsx_tree` tracks only the **single innermost** enclosing `For`'s
+`item`/`index` bindings. `HostButton`'s index synthesis reads that one scope. `Grid`'s
+`onNavigate` needs **two** nested scopes at once (`row` from the outer `For`, `col`
+from the inner) — which `ForPayloadScope` cannot represent even for the primitives
+that already get dedicated treatment. Generalizing loop-scope tracking into a real
+stack would fix this at the root, but is a substantially larger, higher-risk change
+(every `for_payload` call site in the recursive emit chain), deferred — see §5.
+
+## 2. The fix: payload from named, author-supplied props
+
+UI35's drag family already solved an equivalent problem a different way:
+`HostDropTarget`'s `drop-key` isn't synthesized from loop context at all — it's an
+**author-supplied prop**, resolved by `drag_value_expr` (literal / slot-ref /
+expression, the last being exactly `( col[1] )` from inside a `For`), and the
+resolved expression is embedded directly in the dispatch. No loop-scope tracking is
+needed because the author already named which loop-bound value to use.
+
+UI37 generalizes that pattern to any generic container's `onClick`:
+
+```mll
+Box [ cell ] (
+  onClick : emit: onClick ,
+  row      : ( r ) ,
+  col      : ( c ) ,
+)
+```
+
+When a generic container's emit-ref prop (`onClick`, or any future analog) targets an
+emit whose declared params are non-empty, the emitter looks for a **prop on the same
+node named after each declared param** (`row`, `col`, …). Each is resolved the same
+way `drag_value_expr` already resolves `drop-key` — literal, slot-ref, or expression —
+and included in the dispatch object under that param's camelCased name:
+
+```jsx
+onClick={() => dispatch({ type: "navigate", row: r, col: c })}
+```
+
+A declared param with **no matching prop on the node** is a hard compile error
+(`PipelineEmitError`), not a silent `undefined` — the same "accepted-but-ignored is
+the worst outcome" principle UI36 established for size props. A **void** emit (no
+declared params) is unaffected: `build_emit_handlers`'s existing behavior is exactly
+right for it already.
+
+## 3. Applying the fix to `Grid`/`Cell`
+
+- `Cell.mil`: add `slot row : number` and `slot col : number` alongside the existing
+  `is-editing`/`is-selected` coordinate-adjacent slots. `emit onClick` gains the
+  `(row: number, col: number)` payload it always should have had.
+- `Cell.mll`: thread the new slots onto `Box[cell]` as literal props (`row: slot:
+  row`, `col: slot: col`) alongside the existing `onClick: emit: onClick`.
+- `Grid.mll`: at the `Cell(...)` call site, supply `row: ( r )`, `col: ( c )` — the
+  exact same expression-in-slot-binding shape already used for `is-editing`/
+  `is-selected` two lines above.
+- `Sheet.mil`/`Sheet.mll`/`TaskApp.mil`/`TaskApp.mll`: `onNavigate` regains its
+  `(row, col)` payload the whole way up the forwarding chain; the "declared void
+  because nothing could deliver it" workaround is reverted.
+- `main.tsx`: the sheet's `onNavigate` handler is re-wired for real (enter edit mode
+  on an editable column, resolve the clicked task id via the ordered row list — the
+  design was already built and stripped back to a no-op for the v1 read-only ship,
+  see `SHEET_FIELDS`' `editable`/`write` fields).
+
+## 4. Backend status
+
+Implemented on **React** only, matching UI35's rollout shape (react + html
+implement the interaction; other backends degrade). Backends that don't implement
+this get the pre-existing behavior unchanged: `Box`'s generic `onClick` dispatches
+void there too today, so there is nothing to regress — this spec only adds
+capability, on the one backend task-app's web host actually uses.
+
+## 5. What this does NOT fix (deferred)
+
+- **The general N-level-nested-loop case for `HostButton`-style index synthesis.**
+  UI37's named-prop mechanism sidesteps needing a loop-scope stack for `Box`, but
+  `HostButton` inside doubly-nested `For`s still can't synthesize two index values —
+  only ever the innermost. If a future primitive needs that, the `Option<
+  ForPayloadScope>` → `Vec<ForPayloadScope>` generalization is still the real fix;
+  UI37 does not attempt it.
+- **Non-React backends.** HTML, SwiftUI, Qt, Flutter, Compose, WebComponent, XAML all
+  keep today's void-dispatch behavior for generic containers.
+- **A general `connects: onX(p) -> emit onY(p: p)` mapping syntax** in moslayout
+  (noted as a known limitation in `emit_input_jsx`'s own doc-comment, predating
+  this spec) — UI37's named-prop convention is narrower and purpose-built for the
+  loop-coordinate case, not a replacement for that broader idea.


### PR DESCRIPTION
## Summary

- **[UI37 spec](code/specs/UI37-generic-payload-dispatch.md)**: `mosaic-emit-react`'s generic connects-wiring (`Box`/`Row`/`Column`/`Stack`) always dispatched a void action on click, regardless of what the target emit declared — only "dedicated" primitives (`HostButton`/`HostInput`/`HostLink`) could attach a payload. A payload-carrying target emit's declared params now resolve from **named props on the same node**, the same mechanism UI35's `drag-key` already uses.
- This is what lets `mosaic-pkg-grid`'s `Cell` (a `Box`) actually deliver `Grid`'s `onNavigate(row, col)` — declared since that package's v0.1.0, never deliverable by any consumer until now. `mosaic-pkg-grid` 0.2.3 threads `row`/`col` through `Cell` to use it.
- **Sheet cell editing is real** (`mosaic-pkg-sheet` 0.1.1, task-app). Click an editable cell (Done, Name, Deadline, % Complete, Priority, Status, Notes) to edit it in place; Overdue/Start/Finish stay read-only (computed). Enter commits through the matching engine op; Escape cancels. This closes out the follow-up flagged in [#9993](https://github.com/adhithyan15/coding-adventures/pull/9993)'s read-only ship.

## Security review caught a real gap

A payload param literally named `type` would silently overwrite the dispatch discriminant (JS object literals allow a duplicate key with no compile error — the exhaustive `switch (event.type)` host code would silently misdispatch), and `__proto__` would set the object's prototype instead of creating an own property. Both are now hard compile errors via a new `validate_payload_field_name`, with regression tests (`ui37_payload_param_named_type_is_rejected`, `ui37_payload_param_named_proto_is_rejected`).

## Test plan

- [x] `cargo test` green: `mosaic-emit-react` (203, incl. 5 new UI37 tests), `mosaic-emit-xaml` (149+5 acceptance), `mosaic-emit-swiftui` (5+3 acceptance), `task-wasm` (19), `task-core` (89), `mosaic-pkg-grid` (14, incl. new row/col regression test), `mosaic-pkg-sheet` (6), `task-app` (2)
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean on every touched crate
- [x] `npx tsc --noEmit` clean in `host/web` (same pre-existing, unrelated gap in a sibling package noted in #9993, not introduced here)
- [x] `npx vitest run` green (28 tests)
- [x] Driven live in a browser: click a cell → edit → type → Enter → commits through the real engine op (`renameTask`) → persists across a full reload → consistent with the list view → zero console errors throughout
- [x] `/security-review` — found and fixed the `type`/`__proto__` payload-field gap above; clean on re-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)