### PR TITLE
feat(adj-formula-stdlib): base-ten place value (compose direction)

### DIFF
--- a/.claude/adj-curriculum-loop-state.json
+++ b/.claude/adj-curriculum-loop-state.json
@@ -17,7 +17,7 @@
     ],
     "excluded_scope_note": "Wave 1 (byte-provenance/CAS transactions/witnesses/process containment, ADJ-STDLIB-COVERAGE.md section 7 items 2 and 6-13i) is owned by a separate concurrent agent. This loop never edits adj-verify internals, CAS transaction/journal/registration code, or process-lifecycle/containment code, and never claims provenance beyond source_labeled on entries it adds."
   },
-  "active_pr": null,
+  "active_pr": 9999,
   "last_manifest_check": {
     "objectives": 66,
     "coverage_roots": 6,
@@ -76,7 +76,7 @@
       "status": "in_progress",
       "depends_on": [],
       "branch": "feat/adj-wave2-place-value",
-      "pr_number": null,
+      "pr_number": 9999,
       "notes": "Next Wave 2 K-8 gap per ADJ-STDLIB-COVERAGE.md 5.1's elementary row: 'base-ten procedures, word-problem schemas' are named Major Gaps with nothing shipped yet (unlike fractions/decimals/percent, which arithmetic/ already covers: fraction.adj, percent.adj, average.adj). Shipped mathematics/place-value.adj: tens_and_ones_to_number(tens, ones) = sum(product(tens, 10), ones), composing arithmetic.adj (CCSS 1.NBT.B.2), cited to mathsisfun.com's positional-notation definition (trust consensus), WebFetch-verified live before writing. Scoped as COMPOSE-direction only (digits -> number); DECOMPOSE (number -> digits) needs floor/modulo division, not reachable from the plain-arithmetic surface grammar today (only `latex \"...\"` reaches ComputeOp::Floor/Mod) - see the new wave2-place-value-decompose item this discovered. Added manifest objective adj.math.k2.place_value and a dedicated e2e test (formula_place_value_e2e.rs, 2 tests, both executed against the real CLI)."
     },
     {

--- a/.claude/adj-curriculum-loop-state.json
+++ b/.claude/adj-curriculum-loop-state.json
@@ -17,7 +17,7 @@
     ],
     "excluded_scope_note": "Wave 1 (byte-provenance/CAS transactions/witnesses/process containment, ADJ-STDLIB-COVERAGE.md section 7 items 2 and 6-13i) is owned by a separate concurrent agent. This loop never edits adj-verify internals, CAS transaction/journal/registration code, or process-lifecycle/containment code, and never claims provenance beyond source_labeled on entries it adds."
   },
-  "active_pr": 9998,
+  "active_pr": null,
   "last_manifest_check": {
     "objectives": 66,
     "coverage_roots": 6,
@@ -64,20 +64,29 @@
     {
       "id": "wave2-k2-math-cardinality-comparison",
       "title": "K-2 math: cardinality/sets, comparison, number lines",
-      "status": "in_progress",
+      "status": "done",
       "depends_on": [],
-      "branch": "feat/adj-wave2-k2-content",
+      "branch": null,
       "pr_number": 9998,
       "notes": "New content per ADJ-STDLIB-COVERAGE.md 5.1. Checked adj-ladder rung0 for harvestable material - none (rung0_arithmetic is generic MCQ word-problem benchmark items, not cardinality/comparison/number-line pedagogical content). Shipped 3 library pairs in code/specs/data/adj-formula-stdlib/mathematics/: number-sequence.adj (next/previous, composes arithmetic.adj's sum/difference, K.CC.A.1/A.2), comparison.adj (greater_than via FL-8, K.CC.C.6/C.7), cardinality.adj (total_cardinality composing sum, K.CC.B.4/B.5). All 3 citations WebFetch-verified live against MathWorld before writing (CountingNumber/Greater/CardinalNumber pages). Added 3 manifest.json objectives (adj.math.k2.*, band K-2, mathematics, ccss.math). Added a dedicated e2e test file (code/packages/rust/adj-lang-cli/tests/formula_k2_math_e2e.rs, 5 tests) actually executing each query file, not just structural checks. Also added the long-missing README.md/CHANGELOG.md at adj-formula-stdlib/ package root (flagged as a gap during Wave 0)."
     },
     {
       "id": "wave2-elementary-place-value",
       "title": "Elementary math: base-ten place value and word-problem schemas",
+      "status": "in_progress",
+      "depends_on": [],
+      "branch": "feat/adj-wave2-place-value",
+      "pr_number": null,
+      "notes": "Next Wave 2 K-8 gap per ADJ-STDLIB-COVERAGE.md 5.1's elementary row: 'base-ten procedures, word-problem schemas' are named Major Gaps with nothing shipped yet (unlike fractions/decimals/percent, which arithmetic/ already covers: fraction.adj, percent.adj, average.adj). Shipped mathematics/place-value.adj: tens_and_ones_to_number(tens, ones) = sum(product(tens, 10), ones), composing arithmetic.adj (CCSS 1.NBT.B.2), cited to mathsisfun.com's positional-notation definition (trust consensus), WebFetch-verified live before writing. Scoped as COMPOSE-direction only (digits -> number); DECOMPOSE (number -> digits) needs floor/modulo division, not reachable from the plain-arithmetic surface grammar today (only `latex \"...\"` reaches ComputeOp::Floor/Mod) - see the new wave2-place-value-decompose item this discovered. Added manifest objective adj.math.k2.place_value and a dedicated e2e test (formula_place_value_e2e.rs, 2 tests, both executed against the real CLI)."
+    },
+    {
+      "id": "wave2-place-value-decompose",
+      "title": "Wire floor/mod into the plain-arithmetic surface grammar to unblock place-value decomposition",
       "status": "pending",
-      "depends_on": ["wave2-k2-math-cardinality-comparison"],
+      "depends_on": ["wave2-elementary-place-value"],
       "branch": null,
       "pr_number": null,
-      "notes": "Next Wave 2 K-8 gap per ADJ-STDLIB-COVERAGE.md 5.1's elementary row: 'base-ten procedures, word-problem schemas' are named Major Gaps with nothing shipped yet (unlike fractions/decimals/percent, which arithmetic/ already covers: fraction.adj, percent.adj, average.adj). CCSS 1.NBT/2.NBT (place value: tens/ones decomposition) is the natural next K-8 math tranche per policy.selection_rule (Wave 2 before CAS-wiring/Wave 3/Wave 4). Needs its own scoping pass (relate/table for digit-place decomposition vs. a new formula) before implementation, same as wave2-k2 needed before this one landed."
+      "notes": "Discovered while shipping place-value.adj (COMPOSE direction: tens+ones -> number, via product/sum). DECOMPOSE (a two-digit number -> its tens/ones digits, the other half of CCSS 1.NBT.B.2) needs floor(n/10) and n mod 10, but ExprAst::Floor/ComputeOp::Mod are currently only reachable from the `latex \"...\"` frontend (e.g. `latex \"\\lfloor x \\rfloor\"`), not the plain arithmetic surface grammar's `factor` production. This is a small, well-scoped language rung (much smaller than FL-8): either add `floor(x)`/`mod(a, b)` as recognized built-in Apply names in the plain grammar (mirroring how round_to/round_sig/to_scientific are already recognized-by-name built-ins per ADJ-NUMERIC-SUBSTRATE 4.1, not a grammar change) or extend factor's surface directly. Research the exact mechanism (check lower.rs's expand_rec built-in-name dispatch, the same site round_to/to_percent/to_currency use) before implementing, same rigor as FL-8. Unblocks place-value decomposition and any other elementary-math content needing integer division/remainder (e.g. 'how many groups of 10' word problems)."
     }
   ]
 }

--- a/code/packages/rust/adj-lang-cli/tests/formula_place_value_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_place_value_e2e.rs
@@ -1,0 +1,106 @@
+//! End-to-end test for `mathematics/place-value.adj` — CCSS-M 1.NBT.B.2
+//! (a two-digit number is composed of tens and ones), driven through the
+//! built CLI binary against the SHIPPED stdlib. Composes `arithmetic.adj`'s
+//! `product`/`sum` (a cross-directory import, like `cockcroft_gault.adj` and
+//! `mathematics/number-sequence.adj`/`cardinality.adj`).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib")
+        .canonicalize()
+        .expect("shipped adj-formula-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_placeval_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy a shipped `.adj` file into `dir` at the given relative destination
+/// (creating parent dirs), preserving the directory layout so relative
+/// imports (`../arithmetic/…`) resolve from an entry program at the scratch
+/// root.
+fn place_at(dir: &Path, src_rel: &str, dst_rel: &str) {
+    let src = stdlib().join(src_rel);
+    let dst = dir.join(dst_rel);
+    std::fs::create_dir_all(dst.parent().unwrap()).unwrap();
+    std::fs::copy(&src, &dst).unwrap_or_else(|e| panic!("copy {src_rel} -> {dst_rel}: {e}"));
+}
+
+#[test]
+fn tens_and_ones_compose_a_two_digit_number_via_product_and_sum() {
+    let dir = scratch("compose");
+    place_at(&dir, "arithmetic/arithmetic.adj", "arithmetic/arithmetic.adj");
+    place_at(
+        &dir,
+        "mathematics/place-value.adj",
+        "mathematics/place-value.adj",
+    );
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"mathematics/place-value.adj\"\n\
+         observe tens(4)\n\
+         observe ones(7)\n\
+         ? tens_and_ones_to_number(tens, ones)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 4 tens (4 * 10 = 40) + 7 ones = 47.
+    assert!(
+        s.contains("\"name\":\"tens_and_ones_to_number\"") && s.contains("\"value\":47"),
+        "tens_and_ones_to_number(4, 7) = 47: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"consensus\"")
+            && s.contains("mathsisfun.com/definitions/positional-notation.html"),
+        "carries the positional-notation citation: {s}"
+    );
+    // Composed via the cited `product`/`sum` primitives, not bare arithmetic.
+    assert!(
+        s.contains("mathworld.wolfram.com/Product.html")
+            && s.contains("mathworld.wolfram.com/Sum.html"),
+        "corroborated by both composed arithmetic.adj primitives' citations: {s}"
+    );
+}
+
+#[test]
+fn zero_ones_is_a_clean_multiple_of_ten() {
+    let dir = scratch("zero_ones");
+    place_at(&dir, "arithmetic/arithmetic.adj", "arithmetic/arithmetic.adj");
+    place_at(
+        &dir,
+        "mathematics/place-value.adj",
+        "mathematics/place-value.adj",
+    );
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"mathematics/place-value.adj\"\n\
+         observe tens(3)\n\
+         observe ones(0)\n\
+         ? tens_and_ones_to_number(tens, ones)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(
+        s.contains("\"name\":\"tens_and_ones_to_number\"") && s.contains("\"value\":30"),
+        "tens_and_ones_to_number(3, 0) = 30: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-formula-stdlib/CHANGELOG.md
@@ -15,3 +15,8 @@ landed and why, not a semver-tracked API.
   (CCSS K.CC.C.6/C.7).
 - `mathematics/cardinality.adj` — `total_cardinality`, composing `arithmetic.adj`'s `sum` to
   find the count of a group made by combining two counted groups (CCSS K.CC.B.4/B.5).
+- `mathematics/place-value.adj` — `tens_and_ones_to_number`, composing `arithmetic.adj`'s
+  `product`/`sum` to compose a two-digit number from its tens and ones digits (CCSS 1.NBT.B.2).
+  Grounds the COMPOSE direction only; DECOMPOSE (a number's tens/ones) needs floor/modulo
+  division, not yet reachable from the plain-arithmetic surface grammar (only the `latex "…"`
+  frontend reaches `ComputeOp::Floor`/`Mod` today) — left for a follow-up.

--- a/code/specs/data/adj-formula-stdlib/mathematics/place-value.adj
+++ b/code/specs/data/adj-formula-stdlib/mathematics/place-value.adj
@@ -1,0 +1,59 @@
+% ============================================================================
+% place-value.adj — a two-digit number FROM its tens and ones (CCSS-M 1.NBT.B.2).
+% ============================================================================
+% "Understand that the two digits of a two-digit number represent amounts of
+% tens and ones" is the named "base-ten procedures" gap in
+% ADJ-STDLIB-COVERAGE.md 5.1's elementary row — the skill right after the K-2
+% counting/comparison/cardinality trio (`number-sequence.adj`, `comparison.adj`,
+% `cardinality.adj`): a two-digit number IS a composed quantity, tens
+% multiplied by their place value plus the ones. This library grounds the
+% COMPOSE direction (given the two digits, find the number); DECOMPOSE (given
+% the number, find the two digits) needs integer floor/modulo division, which
+% is out of scope for this rung (the plain-arithmetic surface grammar has no
+% built-in floor/mod application yet — only the `latex "…"` frontend reaches
+% `ComputeOp::Floor`/`Mod` today) and is left for a follow-up.
+%
+%     import "place-value.adj"              % transitively imports arithmetic.adj
+%     observe tens(4)                       % "…4 tens…"   (span cited)
+%     observe ones(7)                       % "…7 ones…"   (span cited)
+%     ? tens_and_ones_to_number(tens, ones) % engine → 47, MathWorld-cited
+%
+% Like `number-sequence.adj`/`cardinality.adj`, this states no bare arithmetic
+% of its own — it CALLS the cited `product`/`sum` primitives (RS-1
+% write-once-use-many): the tens digit is multiplied by its place value (10,
+% the definitional claim this library grounds), then the ones digit is added.
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Depends on the elementary primitives `product`/`sum`. The import is
+% RELATIVE to this file (same package, arithmetic/ sibling directory).
+% ----------------------------------------------------------------------------
+import "../arithmetic/arithmetic.adj"
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `tens`/`ones` are the two observed digit counts; the result is
+% the composed two-digit number. Rung-0 types each observable slot as
+% `finding`; the `surface` synonyms let a decomposer map everyday phrasing
+% ("tens place", "ones place", "units") onto the canonical terms.
+% ----------------------------------------------------------------------------
+dictionary place_value_vocab {
+    define tens                       : finding  surface "tens", "tens digit", "tens place"
+    define ones                       : finding  surface "ones", "ones digit", "ones place", "units"
+    define tens_and_ones_to_number    : finding  surface "the number", "two-digit number", "value"
+}
+
+% ----------------------------------------------------------------------------
+% The composed formula. `tens_and_ones_to_number(tens, ones) = sum(product(
+% tens, 10), ones)` CALLS the cited `product`/`sum` primitives rather than
+% restating `*`/`+` bare — the citable claim is specifically that each
+% digit's value is that digit multiplied by its place value (10 for the tens
+% place, one position left of the ones place), and the number is their sum.
+% ----------------------------------------------------------------------------
+formulabook place_value {
+    use place_value_vocab
+
+    formula tens_and_ones_to_number(tens, ones) = sum(product(tens, 10), ones)
+        source "Where each digit in a number is multiplied by its place value, and the place value is larger by \"base\" times for each position going left."
+        locator "https://www.mathsisfun.com/definitions/positional-notation.html"
+        trust consensus
+}

--- a/code/specs/data/adj-formula-stdlib/place-value.query.adj
+++ b/code/specs/data/adj-formula-stdlib/place-value.query.adj
@@ -1,0 +1,8 @@
+% This entry program stays at the stdlib root so the mathematics library's
+% cross-directory arithmetic import remains inside the import root.
+import "mathematics/place-value.adj"
+
+% 4 tens and 7 ones: 4 * 10 + 7 = 47.
+observe tens(4)
+observe ones(7)
+? tens_and_ones_to_number(tens, ones)   % expect 47

--- a/code/specs/data/adj-stdlib-coverage/manifest.json
+++ b/code/specs/data/adj-stdlib-coverage/manifest.json
@@ -1067,6 +1067,21 @@
       "source_cas_hashes": [],
       "benchmark_paths": [],
       "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
+    },
+    {
+      "id": "adj.math.k2.place_value",
+      "title": "Compose a two-digit number from its tens and ones digits",
+      "band": "K-2",
+      "domain": "mathematics",
+      "competency": "compute",
+      "coverage_roots": ["ccss.math"],
+      "standards": [],
+      "prerequisites": ["adj.math.arithmetic.primitives"],
+      "libraries": ["code/specs/data/adj-formula-stdlib/mathematics/place-value.adj"],
+      "modalities": ["text"],
+      "source_cas_hashes": [],
+      "benchmark_paths": [],
+      "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Next Wave 2 elementary gap per `ADJ-STDLIB-COVERAGE.md` §5.1: CCSS-M 1.NBT.B.2 ("understand that the two digits of a two-digit number represent amounts of tens and ones"), named a "base-ten procedures" Major Gap with nothing shipped yet.
- `mathematics/place-value.adj` — `tens_and_ones_to_number(tens, ones) = sum(product(tens, 10), ones)`, composing `arithmetic.adj`'s `product`/`sum` rather than restating bare `*`/`+`. Cited to mathsisfun.com's positional-notation definition (`trust consensus` — a secondary educational reference, same tier as `ordinal-numbers.adj`'s EF Education First citation), WebFetch-verified live immediately before writing.
- Scoped as **COMPOSE-direction only** (digits → number). DECOMPOSE (number → digits, 1.NBT.B.2's other half) needs `floor`/`mod`, which exist engine-side but aren't reachable from the plain-arithmetic surface grammar yet — tracked as its own follow-up item (`wave2-place-value-decompose`) rather than rushed into this PR, matching how FL-8 got its own dedicated scoping pass.
- New manifest objective `adj.math.k2.place_value` and a dedicated e2e test (`formula_place_value_e2e.rs`, 2 tests) that actually executes the query file through the real CLI.

Cites `code/specs/ADJ-STDLIB-COVERAGE.md#7-delivery-order`.

## Test plan
- [x] `adj_stdlib_manifest.py --validate-json-schema` — 67 objectives, 0 errors
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` — passes
- [x] Both Python unittest suites — 21/21 pass
- [x] `cargo test -p adj-lang-cli` — full suite including the 2 new e2e tests, all pass
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` — clean
- [x] Security review passed
- [ ] CI gate (3-OS matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)