### PR TITLE
feat(task-app): re-close the design-fidelity gap (partial pass)

### DIFF
--- a/code/programs/mosaic/task-app/BACKLOG.md
+++ b/code/programs/mosaic/task-app/BACKLOG.md
@@ -7,29 +7,45 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
 
 ## Next up (priority order)
 
-1. **Rename off "Planner" + close the design-fidelity gap.** (User decision, 2026-08-06.)
-   "Planner" collides with an existing trademark (Microsoft Planner et al.) — needs a new,
-   trademark-safe name. User wants a **short list of alternatives proposed**, not "Travail"
-   locked in unilaterally. Separately, the live app has drifted from `design/ui-prototype.html`
-   again — same gap a prior pass already closed once (`### Changed - the app now looks like the
-   design` in `CHANGELOG.md`), so it needs re-closing, not a new visual direction; the mock is
-   still the target. Two independent sub-tasks: (a) propose names, get one picked, sweep the
-   rename (brand text in `TaskApp.mll`, `README.md`, any package names that embed it), (b) audit
-   current app vs. `design/ui-prototype.html` and fix what's drifted. Queued deliberately behind
-   Sheet — do not jump ahead of in-flight work.
+1. **Rename off "Planner".** (User decision, 2026-08-06, still open — needs the user
+   awake to review.) "Planner" collides with an existing trademark (Microsoft Planner et
+   al.) — needs a new, trademark-safe name. User wants a **short list of alternatives
+   proposed**, not "Travail" locked in unilaterally. Not started: this needs the user's
+   input, not something to advance solo.
 
-2. **Phase 7 — Calendar component.** `mosaic-pkg-calendar`, wired to the engine's `calendar(range,
+2. **Design-fidelity gap, remaining items.** The clear value mismatches (colors that
+   didn't match a design token, collapsed-to-uniform spacing, drifted shadow alpha
+   values) are closed — see `CHANGELOG.md`'s "re-closed the design-fidelity gap" entry.
+   What's left needs either a product decision or real feature work, not a value fix:
+   - Icon/SVG assets: brand mark glyph, segmented-switch icons, a progress ring, a
+     stroked moon icon for the theme toggle (currently a floating unicode-glyph button
+     outside the topbar's flow — also worth moving into the topbar while touching it),
+     the pill status dot, group-count badge, composer "+" icon box.
+   - Board: a 4th column ("In review" — mock has 4, live has 3), colored top accent bar
+     + card-count badge on each column header, critical cards get a colored left border
+     instead of a text chip.
+   - Richer Gantt: day-grid columns, weekend/today shading, milestone diamonds,
+     dependency arrows, hover tooltips, a legend. Current timeline is a simple
+     proportional-bar-per-row view.
+   - Richer task rows: critical/slack chips, labels, priority, dependency list, notes
+     paragraph in the detail panel. `task-core` already has labels/priority as
+     first-class fields (shipped) — this is wiring them into `main.tsx`'s row-building
+     and `TaskApp.mil`/`.mll`'s row-cell layout, not new engine work.
+   - Calendar view — this IS the existing Phase 7 item below, not a separate task; the
+     mock having one is corroborating evidence for that roadmap phase, not new scope.
+
+3. **Phase 7 — Calendar component.** `mosaic-pkg-calendar`, wired to the engine's `calendar(range,
    view)` projection (already shipped, [#8726](https://github.com/adhithyan15/coding-adventures/pull/8726)) + the UI35 drag kernel for
    drag-to-reschedule/resize. Month/week/day views, time-blocking, auto-schedule placement around
    fixed commitments. The drag kernel is proven end-to-end now (board PR found and fixed three
    real bugs in it), so this should be smoother than the board was.
 
-3. **Phase 8 — Notes component + entity.** The engine has **no notes entity at all** yet — this
+4. **Phase 8 — Notes component + entity.** The engine has **no notes entity at all** yet — this
    needs a `task-core` model addition (standalone notes + attachable to any task/project) before
    the `mosaic-pkg-notes` UI (adapted from `mosaic-pkg-note-editor`, which was built for a
    different domain — Anki notes — and needs re-pointing at generic entities).
 
-4. **Phase 9 — App-shell assembly + progressive disclosure.** Partially done already via ad hoc
+5. **Phase 9 — App-shell assembly + progressive disclosure.** Partially done already via ad hoc
    UI-design passes ([#8970](https://github.com/adhithyan15/coding-adventures/pull/8970), [#8983](https://github.com/adhithyan15/coding-adventures/pull/8983), [#9112](https://github.com/adhithyan15/coding-adventures/pull/9112), [#8994](https://github.com/adhithyan15/coding-adventures/pull/8994), [#9110](https://github.com/adhithyan15/coding-adventures/pull/9110), [#9127](https://github.com/adhithyan15/coding-adventures/pull/9127), [#9136](https://github.com/adhithyan15/coding-adventures/pull/9136))
    — theming, project switching, nested-project hierarchy, shell/groups/status/cards all landed.
    Remaining: package it as a reusable `mosaic-pkg-project-nav` (nested-project tree + view

--- a/code/programs/mosaic/task-app/CHANGELOG.md
+++ b/code/programs/mosaic/task-app/CHANGELOG.md
@@ -4,6 +4,54 @@ All notable changes to the `task-app` web program are documented here.
 
 ## [0.1.0] - Unreleased
 
+### Changed - re-closed the design-fidelity gap (partial pass)
+
+A prior pass (`### Changed - the app now looks like the design`, below) brought the app
+up to `design/ui-prototype.html` once; it had drifted again. This pass closes the clear,
+unambiguous value mismatches — colors that didn't match a design token, spacing/padding
+that had collapsed to uniform values where the mock uses asymmetric ones, shadows that
+had drifted to ad hoc single-layer values instead of the shared two-layer `--shadow`
+token:
+
+- **Active-project highlight** no longer fills solid honey — it's a quiet raised card
+  (surface background + the shared shadow token), the same "on" treatment the segmented
+  switch already uses. This was the single most visible color mismatch in the app.
+- **Rail, topbar, and content padding** now match the mock's asymmetric values (e.g.
+  rail `20px 14px` not a uniform `20px`; topbar `20px 30px 14px`; content
+  `8px 30px 60px`) — mosstyle's per-property `padding-top`/`-right`/`-bottom`/`-left`
+  already supported this (confirmed via the react emitter's generic kebab→camelCase CSS
+  property translation), it just hadn't been used.
+- **Segmented-switch "on" buttons, pills, Add-task button** all gained their mock's
+  asymmetric padding and/or the shared shadow token instead of ad hoc single-layer
+  shadows with drifted alpha values.
+- **Task-row and task-detail padding** now match, including the mock's 47px left indent
+  on the detail panel (lines it up under the task name, past the checkbox).
+- **Checkbox border** and **project-off hover background** now use the mock's actual
+  design tokens (`--ink-faint`, `--line-soft`) instead of invented nearby colors.
+- **Font stack** gained the mock's `Helvetica Neue, Arial` fallbacks.
+
+Verified live in both themes: zero console errors, computed styles match the mock's
+values exactly (spot-checked via `getComputedStyle`).
+
+**Deliberately NOT done in this pass** — either because they're real feature work
+disguised as "drift" (the mock predates several now-shipped views) or because they need
+new markup/icon assets rather than a value fix, tracked in `BACKLOG.md`:
+
+- Calendar view (the mock has one; it's the existing Phase 7 roadmap item, not drift).
+- A richer Gantt (day-grid, weekend/today shading, milestones, dependency arrows,
+  legend) — the mock's timeline is considerably richer than the simple proportional-bar
+  view currently shipped.
+- Rich task-row data (critical/slack chips, labels, priority, dependency list, notes) —
+  `task-core` already has labels/priority as first-class fields; wiring them into the
+  row/detail layout is real feature work, not a style-file edit.
+- Everything needing a new icon/SVG asset: the brand mark's decorative glyph, segmented-
+  switch icons, the progress ring, a stroked moon icon (the theme toggle currently uses
+  a floating unicode-glyph button positioned outside the topbar's flow, not the mock's
+  inline icon button), the pill status dot, the group-count badge, the composer's "+"
+  icon box, and the "In review" board column (board is 3 columns; mock has 4, with a
+  colored top accent bar and card-count badge neither of which exist yet).
+- Board's critical-card treatment (colored left border in the mock vs. a text chip live).
+
 ### Added - sheet cell editing
 
 The sheet view's cells are editable now. The fast-follow the read-only ship below

--- a/code/programs/mosaic/task-app/src/TaskApp.dark.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.dark.msl
@@ -13,14 +13,17 @@ style TaskApp {
   part app-shell {
     background : "#1a1714" ;
     color : "#f1ebe1" ;
-    font-family : "-apple-system, Segoe UI, system-ui, sans-serif" ;
+    font-family : "-apple-system, Segoe UI, system-ui, Helvetica Neue, Arial, sans-serif" ;
     min-height : "100vh" ;
   }
   part rail {
     width : 236 ;
     flex-shrink : 0 ;
-    padding : 20 ;
-    gap : 18 ;
+    padding-top : 20 ;
+    padding-right : 14 ;
+    padding-bottom : 20 ;
+    padding-left : 14 ;
+    gap : 22 ;
     border-right-width : 1 ;
     border-right-color : "#352e25" ;
     border-right-style : "solid" ;
@@ -28,11 +31,14 @@ style TaskApp {
   part main {
     flex-grow : 1 ;
     min-width : 0 ;
-    padding : 20 ;
     gap : 14 ;
   }
   part content {
     gap : 14 ;
+    padding-top : 8 ;
+    padding-right : 30 ;
+    padding-bottom : 60 ;
+    padding-left : 30 ;
   }
 
   // ── brand ───────────────────────────────────────────────────────────────
@@ -46,7 +52,7 @@ style TaskApp {
     height : 28 ;
     border-radius : 8 ;
     background : "#eaa63f" ;
-    box-shadow : "0 1px 2px rgba(0,0,0,.35), 0 4px 14px rgba(0,0,0,.35)" ;
+    box-shadow : "0 1px 2px rgba(0,0,0,.3), 0 4px 14px rgba(0,0,0,.28)" ;
   }
   part brand-name {
     font-size : 15 ;
@@ -56,12 +62,15 @@ style TaskApp {
 
   // ── rail: projects ──────────────────────────────────────────────────────
   part rail-label {
-    font-size : 10 ;
+    font-size : 10.5 ;
     font-weight : bold ;
     color : "#867c70" ;
     letter-spacing : "0.08em" ;
     text-transform : "uppercase" ;
-    padding : 4 ;
+    padding-top : 0 ;
+    padding-right : 8 ;
+    padding-bottom : 6 ;
+    padding-left : 8 ;
   }
   part rail-projects {
     gap : 2 ;
@@ -74,19 +83,20 @@ style TaskApp {
     color : "#867c70" ;
     font-size : 13 ;
   }
-  // The project you are looking at. Honey fill, so "where am I" is answerable at a
-  // glance; the rest stay quiet until hovered.
+  // The project you are looking at. A quiet raised card — same "on" treatment the
+  // segmented switch uses — so "where am I" reads as a subtle lift, not a loud fill.
+  // (The honey accent is spent on the primary action / focus / *now*, not on this.)
   part project-on {
     width : 100% ;
-    background : "#eaa63f" ;
-    color : "#1a1714" ;
+    background : "#252019" ;
+    color : "#f1ebe1" ;
     font-size : 13 ;
     font-weight : bold ;
     text-align : "left" ;
     padding : 8 ;
     border-radius : 8 ;
     border-width : 0 ;
-    box-shadow : "0 1px 2px rgba(0,0,0,.35)" ;
+    box-shadow : "0 1px 2px rgba(0,0,0,.3), 0 4px 14px rgba(0,0,0,.28)" ;
   }
   part project-off {
     width : 100% ;
@@ -98,7 +108,7 @@ style TaskApp {
     border-radius : 8 ;
     border-width : 0 ;
     state hover {
-      background : "#332c23" ;
+      background : "#2c2620" ;
       color : "#f1ebe1" ;
     }
   }
@@ -148,9 +158,12 @@ style TaskApp {
 
   // ── topbar ──────────────────────────────────────────────────────────────
   part topbar {
-    gap : 16 ;
+    gap : 18 ;
     align : center-vertical ;
-    padding : 4 ;
+    padding-top : 20 ;
+    padding-right : 30 ;
+    padding-bottom : 14 ;
+    padding-left : 30 ;
   }
   part title-block {
     width : 100% ;
@@ -176,7 +189,10 @@ style TaskApp {
     color : "#6fb489" ;
     font-size : 12 ;
     font-weight : bold ;
-    padding : 3 ;
+    padding-top : 2 ;
+    padding-right : 9 ;
+    padding-bottom : 2 ;
+    padding-left : 9 ;
     border-radius : 20 ;
   }
   part pill-warn {
@@ -184,7 +200,10 @@ style TaskApp {
     color : "#e26a52" ;
     font-size : 12 ;
     font-weight : bold ;
-    padding : 3 ;
+    padding-top : 2 ;
+    padding-right : 9 ;
+    padding-bottom : 2 ;
+    padding-left : 9 ;
     border-radius : 20 ;
   }
 
@@ -203,30 +222,39 @@ style TaskApp {
     color : "#f1ebe1" ;
     font-size : 13 ;
     font-weight : bold ;
-    padding : 6 ;
+    padding-top : 6 ;
+    padding-right : 14 ;
+    padding-bottom : 6 ;
+    padding-left : 14 ;
     border-width : 0 ;
     border-radius : 7 ;
-    box-shadow : "0 1px 2px rgba(0,0,0,.4)" ;
+    box-shadow : "0 1px 2px rgba(0,0,0,.3), 0 4px 14px rgba(0,0,0,.28)" ;
   }
   part seg-tl-on {
     background : "#252019" ;
     color : "#f1ebe1" ;
     font-size : 13 ;
     font-weight : bold ;
-    padding : 6 ;
+    padding-top : 6 ;
+    padding-right : 14 ;
+    padding-bottom : 6 ;
+    padding-left : 14 ;
     border-width : 0 ;
     border-radius : 7 ;
-    box-shadow : "0 1px 2px rgba(0,0,0,.4)" ;
+    box-shadow : "0 1px 2px rgba(0,0,0,.3), 0 4px 14px rgba(0,0,0,.28)" ;
   }
   part seg-board-on {
     background : "#252019" ;
     color : "#f1ebe1" ;
     font-size : 13 ;
     font-weight : bold ;
-    padding : 6 ;
+    padding-top : 6 ;
+    padding-right : 14 ;
+    padding-bottom : 6 ;
+    padding-left : 14 ;
     border-width : 0 ;
     border-radius : 7 ;
-    box-shadow : "0 1px 2px rgba(0,0,0,.4)" ;
+    box-shadow : "0 1px 2px rgba(0,0,0,.3), 0 4px 14px rgba(0,0,0,.28)" ;
   }
   part seg-board-off {
     background : "transparent" ;
@@ -266,10 +294,13 @@ style TaskApp {
     color : "#f1ebe1" ;
     font-size : 13 ;
     font-weight : bold ;
-    padding : 6 ;
+    padding-top : 6 ;
+    padding-right : 14 ;
+    padding-bottom : 6 ;
+    padding-left : 14 ;
     border-width : 0 ;
     border-radius : 7 ;
-    box-shadow : "0 1px 2px rgba(0,0,0,.4)" ;
+    box-shadow : "0 1px 2px rgba(0,0,0,.3), 0 4px 14px rgba(0,0,0,.28)" ;
   }
   part seg-sheet-off {
     background : "transparent" ;
@@ -466,7 +497,10 @@ style TaskApp {
     color : "#1a1714" ;
     font-size : 13 ;
     font-weight : bold ;
-    padding : 8 ;
+    padding-top : 8 ;
+    padding-right : 16 ;
+    padding-bottom : 8 ;
+    padding-left : 16 ;
     border-width : 0 ;
     border-radius : 8 ;
     state hover {
@@ -499,7 +533,10 @@ style TaskApp {
   part task-row {
     gap : 10 ;
     align : center-vertical ;
-    padding : 12 ;
+    padding-top : 12 ;
+    padding-right : 14 ;
+    padding-bottom : 12 ;
+    padding-left : 14 ;
   }
   // The completion toggle — a round control whose label is the engine's glyph.
   part toggle {
@@ -508,7 +545,7 @@ style TaskApp {
     font-size : 14 ;
     padding : 3 ;
     border-width : 2 ;
-    border-color : "#4a4136" ;
+    border-color : "#867c70" ;
     border-radius : 20 ;
     state hover {
       border-color : "#eaa63f" ;
@@ -571,7 +608,12 @@ style TaskApp {
     border-top-width : 1 ;
     border-top-color : "#2c2620" ;
     border-top-style : "solid" ;
-    padding : 14 ;
+    // The 47px left indent lines the detail up under the task name (past the
+    // checkbox), matching the mock rather than sitting flush with the row edge.
+    padding-top : 15 ;
+    padding-right : 16 ;
+    padding-bottom : 16 ;
+    padding-left : 47 ;
     gap : 5 ;
   }
   part detail-sched {

--- a/code/programs/mosaic/task-app/src/TaskApp.light.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.light.msl
@@ -13,14 +13,17 @@ style TaskApp {
   part app-shell {
     background : "#f0ebe3" ;
     color : "#2b2723" ;
-    font-family : "-apple-system, Segoe UI, system-ui, sans-serif" ;
+    font-family : "-apple-system, Segoe UI, system-ui, Helvetica Neue, Arial, sans-serif" ;
     min-height : "100vh" ;
   }
   part rail {
     width : 236 ;
     flex-shrink : 0 ;
-    padding : 20 ;
-    gap : 18 ;
+    padding-top : 20 ;
+    padding-right : 14 ;
+    padding-bottom : 20 ;
+    padding-left : 14 ;
+    gap : 22 ;
     border-right-width : 1 ;
     border-right-color : "#e6ded3" ;
     border-right-style : "solid" ;
@@ -28,11 +31,14 @@ style TaskApp {
   part main {
     flex-grow : 1 ;
     min-width : 0 ;
-    padding : 20 ;
     gap : 14 ;
   }
   part content {
     gap : 14 ;
+    padding-top : 8 ;
+    padding-right : 30 ;
+    padding-bottom : 60 ;
+    padding-left : 30 ;
   }
 
   // ── brand ───────────────────────────────────────────────────────────────
@@ -46,7 +52,7 @@ style TaskApp {
     height : 28 ;
     border-radius : 8 ;
     background : "#e0942a" ;
-    box-shadow : "0 1px 2px rgba(60,45,25,.06), 0 4px 14px rgba(60,45,25,.06)" ;
+    box-shadow : "0 1px 2px rgba(60,45,25,.05), 0 4px 14px rgba(60,45,25,.05)" ;
   }
   part brand-name {
     font-size : 15 ;
@@ -56,12 +62,15 @@ style TaskApp {
 
   // ── rail: projects ──────────────────────────────────────────────────────
   part rail-label {
-    font-size : 10 ;
+    font-size : 10.5 ;
     font-weight : bold ;
     color : "#9b9289" ;
     letter-spacing : "0.08em" ;
     text-transform : "uppercase" ;
-    padding : 4 ;
+    padding-top : 0 ;
+    padding-right : 8 ;
+    padding-bottom : 6 ;
+    padding-left : 8 ;
   }
   part rail-projects {
     gap : 2 ;
@@ -74,19 +83,20 @@ style TaskApp {
     color : "#9b9289" ;
     font-size : 13 ;
   }
-  // The project you are looking at. Honey fill, so "where am I" is answerable at a
-  // glance; the rest stay quiet until hovered.
+  // The project you are looking at. A quiet raised card — same "on" treatment the
+  // segmented switch uses — so "where am I" reads as a subtle lift, not a loud fill.
+  // (The honey accent is spent on the primary action / focus / *now*, not on this.)
   part project-on {
     width : 100% ;
-    background : "#e0942a" ;
-    color : "#ffffff" ;
+    background : "#fffdfa" ;
+    color : "#2b2723" ;
     font-size : 13 ;
     font-weight : bold ;
     text-align : "left" ;
     padding : 8 ;
     border-radius : 8 ;
     border-width : 0 ;
-    box-shadow : "0 1px 2px rgba(60,45,25,.06)" ;
+    box-shadow : "0 1px 2px rgba(60,45,25,.05), 0 4px 14px rgba(60,45,25,.05)" ;
   }
   part project-off {
     width : 100% ;
@@ -98,7 +108,7 @@ style TaskApp {
     border-radius : 8 ;
     border-width : 0 ;
     state hover {
-      background : "#e8e0d4" ;
+      background : "#efe8dd" ;
       color : "#2b2723" ;
     }
   }
@@ -148,9 +158,12 @@ style TaskApp {
 
   // ── topbar ──────────────────────────────────────────────────────────────
   part topbar {
-    gap : 16 ;
+    gap : 18 ;
     align : center-vertical ;
-    padding : 4 ;
+    padding-top : 20 ;
+    padding-right : 30 ;
+    padding-bottom : 14 ;
+    padding-left : 30 ;
   }
   part title-block {
     width : 100% ;
@@ -176,7 +189,10 @@ style TaskApp {
     color : "#4f8e6a" ;
     font-size : 12 ;
     font-weight : bold ;
-    padding : 3 ;
+    padding-top : 2 ;
+    padding-right : 9 ;
+    padding-bottom : 2 ;
+    padding-left : 9 ;
     border-radius : 20 ;
   }
   part pill-warn {
@@ -184,7 +200,10 @@ style TaskApp {
     color : "#cf4b34" ;
     font-size : 12 ;
     font-weight : bold ;
-    padding : 3 ;
+    padding-top : 2 ;
+    padding-right : 9 ;
+    padding-bottom : 2 ;
+    padding-left : 9 ;
     border-radius : 20 ;
   }
 
@@ -203,30 +222,39 @@ style TaskApp {
     color : "#2b2723" ;
     font-size : 13 ;
     font-weight : bold ;
-    padding : 6 ;
+    padding-top : 6 ;
+    padding-right : 14 ;
+    padding-bottom : 6 ;
+    padding-left : 14 ;
     border-width : 0 ;
     border-radius : 7 ;
-    box-shadow : "0 1px 2px rgba(60,45,25,.07)" ;
+    box-shadow : "0 1px 2px rgba(60,45,25,.05), 0 4px 14px rgba(60,45,25,.05)" ;
   }
   part seg-tl-on {
     background : "#fffdfa" ;
     color : "#2b2723" ;
     font-size : 13 ;
     font-weight : bold ;
-    padding : 6 ;
+    padding-top : 6 ;
+    padding-right : 14 ;
+    padding-bottom : 6 ;
+    padding-left : 14 ;
     border-width : 0 ;
     border-radius : 7 ;
-    box-shadow : "0 1px 2px rgba(60,45,25,.07)" ;
+    box-shadow : "0 1px 2px rgba(60,45,25,.05), 0 4px 14px rgba(60,45,25,.05)" ;
   }
   part seg-board-on {
     background : "#fffdfa" ;
     color : "#2b2723" ;
     font-size : 13 ;
     font-weight : bold ;
-    padding : 6 ;
+    padding-top : 6 ;
+    padding-right : 14 ;
+    padding-bottom : 6 ;
+    padding-left : 14 ;
     border-width : 0 ;
     border-radius : 7 ;
-    box-shadow : "0 1px 2px rgba(60,45,25,.07)" ;
+    box-shadow : "0 1px 2px rgba(60,45,25,.05), 0 4px 14px rgba(60,45,25,.05)" ;
   }
   part seg-board-off {
     background : "transparent" ;
@@ -266,10 +294,13 @@ style TaskApp {
     color : "#2b2723" ;
     font-size : 13 ;
     font-weight : bold ;
-    padding : 6 ;
+    padding-top : 6 ;
+    padding-right : 14 ;
+    padding-bottom : 6 ;
+    padding-left : 14 ;
     border-width : 0 ;
     border-radius : 7 ;
-    box-shadow : "0 1px 2px rgba(60,45,25,.07)" ;
+    box-shadow : "0 1px 2px rgba(60,45,25,.05), 0 4px 14px rgba(60,45,25,.05)" ;
   }
   part seg-sheet-off {
     background : "transparent" ;
@@ -466,7 +497,10 @@ style TaskApp {
     color : "#ffffff" ;
     font-size : 13 ;
     font-weight : bold ;
-    padding : 8 ;
+    padding-top : 8 ;
+    padding-right : 16 ;
+    padding-bottom : 8 ;
+    padding-left : 16 ;
     border-width : 0 ;
     border-radius : 8 ;
     state hover {
@@ -499,7 +533,10 @@ style TaskApp {
   part task-row {
     gap : 10 ;
     align : center-vertical ;
-    padding : 12 ;
+    padding-top : 12 ;
+    padding-right : 14 ;
+    padding-bottom : 12 ;
+    padding-left : 14 ;
   }
   // The completion toggle — a round control whose label is the engine's glyph.
   part toggle {
@@ -508,7 +545,7 @@ style TaskApp {
     font-size : 14 ;
     padding : 3 ;
     border-width : 2 ;
-    border-color : "#c7bfb4" ;
+    border-color : "#9b9289" ;
     border-radius : 20 ;
     state hover {
       border-color : "#e0942a" ;
@@ -571,7 +608,12 @@ style TaskApp {
     border-top-width : 1 ;
     border-top-color : "#efe8dd" ;
     border-top-style : "solid" ;
-    padding : 14 ;
+    // The 47px left indent lines the detail up under the task name (past the
+    // checkbox), matching the mock rather than sitting flush with the row edge.
+    padding-top : 15 ;
+    padding-right : 16 ;
+    padding-bottom : 16 ;
+    padding-left : 47 ;
     gap : 5 ;
   }
   part detail-sched {


### PR DESCRIPTION
## Summary

The live task-app had drifted from `design/ui-prototype.html` again since the prior
fidelity pass (`### Changed - the app now looks like the design` in CHANGELOG.md).
This closes the clear, unambiguous value mismatches:

- **Active-project highlight**: solid honey fill -> quiet raised card (surface
  background + the shared shadow token) — the same "on" treatment the segmented
  switch already uses. This was the single most visible color mismatch.
- **Rail/topbar/content padding**: uniform values -> the mock's asymmetric ones
  (e.g. rail `20px 14px` not a uniform `20px`).
- **Segmented-switch "on" buttons, pills, add-task button**: asymmetric padding +
  the shared two-layer `--shadow` token instead of ad hoc single-layer shadows with
  drifted alpha values.
- **Task-row/task-detail padding**, including the mock's 47px left indent on the
  detail panel (lines up under the task name past the checkbox).
- **Checkbox border / project-off hover background**: the mock's actual design
  tokens (`--ink-faint`, `--line-soft`) instead of invented nearby colors.
- **Font stack**: added the mock's `Helvetica Neue, Arial` fallbacks.

Confirmed mosstyle's per-property `padding-top`/`-right`/`-bottom`/`-left` already
supported asymmetric padding (via the react emitter's generic kebab->camelCase CSS
property translation) — it just hadn't been used consistently.

**Deliberately deferred** (real feature work or new assets, not a value fix — now
tracked as its own BACKLOG.md item):
- Calendar view (mock has one; it's the existing Phase 7 roadmap item, not drift)
- A richer Gantt (day-grid, weekend/today shading, milestones, dependency arrows, legend)
- Rich task-row data (critical/slack chips, labels, priority, deps, notes paragraph)
- New icon/SVG assets (brand mark glyph, segmented-switch icons, progress ring,
  stroked moon icon, pill status dot, group-count badge, composer "+" icon box)
- Board's 4th column ("In review") + accent bar + card-count badge
- Board's critical-card border treatment (colored left border vs. current text chip)

Also splits BACKLOG.md's combined "rename + design-fidelity" item in two: the
rename is still open pending the user's review of proposed alternatives (not
started — needs the user), and the design-fidelity remainder above is its own item.

## Test plan

- [x] `cargo test` (task-app package) — passing
- [x] `cargo clippy --all-features --all-targets -- -D warnings` (task-app package) — clean
- [x] Verified live in both light/dark themes via `getComputedStyle` — rendered values
      match the mock's tokens exactly, zero console errors
- [x] `/security-review` — passed, no findings (diff is markdown + declarative
      stylesheet literals only, no code/logic changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)