### PR TITLE
feat(task-app): calendar (month grid) view with drag-to-move rescheduling

### DIFF
--- a/code/packages/mosaic/mosaic-pkg-calendar/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-pkg-calendar/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to `mosaic-pkg-calendar` are documented in this file.
+The format follows [Keep a Changelog](https://keepachangelog.com/) and
+the package follows semantic versioning.
+
+## 0.1.0 — 2026-08-06 — initial release
+
+### Added
+
+- `Calendar` component: a 6×7 (42-cell) month grid, Sunday-first, built
+  entirely from UI29 kernel primitives (no wrapped package). Wired to
+  task-core's `calendar(range, view)` projection (host-driven — Calendar
+  does no date arithmetic or filtering itself).
+- Drag-to-move rescheduling via the UI35 `HostDraggable`/`HostDropTarget`
+  kernel: dragging an event onto a different day fires `onEventDropped`
+  as a proposal, exactly matching Board's already-shipped drop contract.
+- Multi-day events render on every day they span, not just their start
+  day — the engine already computes the real span; collapsing to the
+  start day (as `design/ui-prototype.html`'s demo JS does) would discard
+  data the engine computed.
+- Today gets a filled badge; critical/completed/overdue events get a
+  conditional text chip (the same "one draggable part, conditional child
+  chips for state" trade-off Board's `card-crit` already established, not
+  a per-state container restyle — see Calendar.mll's doc comment).
+- Both themes (`Calendar.light.msl` / `Calendar.dark.msl`), palette taken
+  directly from `design/ui-prototype.html`'s `.cal-*` classes.
+
+See [task-app-calendar-v1.md](../../../specs/task-app-calendar-v1.md) for
+the full scope and what's deliberately deferred (week/day views, resize,
+time-blocking, weekend/out-of-month cell tinting).

--- a/code/packages/mosaic/mosaic-pkg-calendar/Cargo.toml
+++ b/code/packages/mosaic/mosaic-pkg-calendar/Cargo.toml
@@ -1,0 +1,33 @@
+# Cargo.toml — smoke-test harness for mosaic-pkg-calendar.
+#
+# Same shape as mosaic-pkg-sheet's Cargo.toml: this package's actual
+# deliverables are .mil / .mll / .msl source files, not a Rust crate.
+# This Cargo.toml exists only to host an integration smoke test.
+#
+# `[workspace]` is empty so this Cargo project does NOT join the main
+# code/packages/rust workspace — it's a standalone Cargo project run
+# via `cargo test`, same as every other mosaic-pkg-*.
+
+[workspace]
+# Intentionally empty: opt out of the parent workspace.
+
+[package]
+name        = "mosaic-pkg-calendar"
+version     = "0.1.0"
+edition     = "2021"
+description = "Smoke-test harness for the mosaic-pkg-calendar component package"
+publish     = false
+
+# The crate has no library code — it exists for the integration test below.
+[lib]
+path       = "src/lib.rs"
+
+[dev-dependencies]
+mosmodel-compiler   = { path = "../../rust/mosmodel-compiler" }
+moslayout-compiler  = { path = "../../rust/moslayout-compiler" }
+mosstyle-compiler   = { path = "../../rust/mosstyle-compiler" }
+toml                = "0.8"
+
+[[test]]
+name = "package_compiles"
+path = "tests/package_compiles.rs"

--- a/code/packages/mosaic/mosaic-pkg-calendar/README.md
+++ b/code/packages/mosaic/mosaic-pkg-calendar/README.md
@@ -1,0 +1,94 @@
+# mosaic-pkg-calendar
+
+> Month-grid calendar view wired to task-core's `calendar(range, view)`
+> projection, with drag-to-move rescheduling via the UI35 drag kernel.
+
+A 6×7 month grid built entirely from UI29 kernel primitives — no wrapped
+package, the same shape as `mosaic-pkg-grid`. See
+[task-app-calendar-v1.md](../../../specs/task-app-calendar-v1.md) for the
+full scope and what's deliberately deferred.
+
+## What this package exports
+
+One component, per `mosaic-package.toml`'s `[components].exports`:
+
+| Component  | Role                                   | File trio |
+|---|---|---|
+| `Calendar` | month grid + nav + drag-to-move events | `Calendar.mil` / `Calendar.mll` / `Calendar.{dark,light}.msl` |
+
+## How it fits in the stack
+
+```
+          ┌──────────────────────────────────────────┐
+          │  Host application (task-app's Calendar view) │
+          └─────────────────────┬──────────────────────┘
+                                │ component reference
+                                ▼
+          ┌──────────────────────────────────────────┐
+          │  mosaic-pkg-calendar (this package)       │
+          │  Calendar → Column/Row/Text/HostButton/   │
+          │             HostDropTarget/HostDraggable  │
+          └────────────────────┬─────────────────────┘
+                                │ kernel primitives only
+                                ▼
+                     UI29 kernel + UI35 drag kernel
+```
+
+## Fat engine, dumb UI
+
+Calendar does no date arithmetic, filtering, or scheduling of its own. The
+host computes the visible month's grid range, calls task-core's
+`calendar(range, view)` projection, and hands this component pre-shaped
+cell/event rows — see `calendarData()` in
+`code/programs/mosaic/task-app/host/web/src/main.tsx` for the reference host
+consumer.
+
+## Drag-to-move, not drag-to-resize
+
+Dropping an event on a different day fires `onEventDropped` — a PROPOSAL,
+exactly like `mosaic-pkg-grid`/task-app's Board section: the UI35 contract
+(`key`, `kind`, `targetKey`, `position`). The host decides what it means; for
+task-app that's `engine.setConstraint({ id, constraint: { mustStartOn } })`,
+**not** a deadline change (see task-app-calendar-v1.md for why the
+calendar's own display precedence makes that distinction load-bearing, not
+cosmetic). Resize is out of scope — the UI35 kernel doesn't support it
+today (see [UI35-host-drag-drop.md](../../../specs/UI35-host-drag-drop.md)
+§7).
+
+## Usage
+
+```moslayout
+// In a host component's .mll:
+pkg::mosaic-pkg-calendar::Calendar (
+  calendar-title:  slot: calendar-title ,
+  calendar-cells:  slot: calendar-cells ,
+  calendar-events: slot: calendar-events ,
+  onPrev:          emit: onCalendarPrev ,
+  onNext:          emit: onCalendarNext ,
+  onEventDropped:  emit: onCalendarEventDropped
+)
+```
+
+The host builds `calendar-cells` (42 rows: `[day-number, day-key, is-today]`)
+and `calendar-events` (one row per event **per day it spans**: `[task-id,
+label, day-key, critical, completed, overdue]`) from a `calendar(range,
+view)` call whose range covers the visible 6×7 grid — see `calendarData()`
+in `main.tsx` for a worked example.
+
+## Smoke test
+
+```bash
+cd code/packages/mosaic/mosaic-pkg-calendar
+cargo test
+```
+
+Mirrors `mosaic-pkg-sheet`'s own smoke test: manifest parses and declares
+the expected export; `Calendar.mil` compiles via `mosmodel-compiler`;
+`Calendar.mll` compiles against that interface via `moslayout-compiler`
+(with an explicit pin that it actually uses `HostDropTarget`/
+`HostDraggable`, not a degraded static container); both themes' `.msl`
+compile against the resulting part map.
+
+## License
+
+MIT OR Apache-2.0.

--- a/code/packages/mosaic/mosaic-pkg-calendar/mosaic-package.toml
+++ b/code/packages/mosaic/mosaic-pkg-calendar/mosaic-package.toml
@@ -1,0 +1,27 @@
+# mosaic-package.toml — manifest for mosaic-pkg-calendar.
+#
+# A month-grid calendar view over task-core's calendar(range, view) projection,
+# with drag-to-move rescheduling via the UI35 drag kernel. Built entirely from
+# kernel primitives (Box/Row/Column/Text/HostButton/HostDraggable/HostDropTarget/
+# For/If) — no dependency on another mosaic-pkg-*, same as mosaic-pkg-grid.
+# Conforms to the UI29 §4.2 package-manifest shape.
+#
+# v0.1.0 scope — see code/specs/task-app-calendar-v1.md for the full rationale.
+# Month view only; drag-to-move (not resize); events render on every day they
+# span; today gets a badge. Weekend/out-of-month cell tinting, week/day views,
+# resize, and time-blocking are deferred — see the spec's "explicitly deferred"
+# section.
+
+[package]
+name = "mosaic-pkg-calendar"
+version = "0.1.0"
+description = "Month-grid calendar view wired to task-core's calendar(range, view) projection, with drag-to-move rescheduling"
+license = "MIT OR Apache-2.0"
+
+[components]
+exports = ["Calendar"]
+
+[dependencies]
+
+[kernel]
+version = "1"

--- a/code/packages/mosaic/mosaic-pkg-calendar/src/Calendar.dark.msl
+++ b/code/packages/mosaic/mosaic-pkg-calendar/src/Calendar.dark.msl
@@ -1,0 +1,229 @@
+// Calendar.dark.msl — default dark theme style for the Calendar component.
+//
+// Same structure as Calendar.light.msl, dark-theme token values from
+// design/ui-prototype.html's `:root[data-theme="dark"]` (see
+// task-app-calendar-v1.md).
+
+style Calendar {
+  part calendar-root {
+    background     : "#252019" ;
+    border-width   : 1 ;
+    border-color   : "#352e25" ;
+    border-style   : "solid" ;
+    border-radius  : 10 ;
+    box-shadow     : "0 1px 2px rgba(0,0,0,.3), 0 4px 14px rgba(0,0,0,.28)" ;
+  }
+
+  part calendar-head {
+    align          : center-vertical ;
+    padding-top    : 14 ;
+    padding-right  : 18 ;
+    padding-bottom : 14 ;
+    padding-left   : 18 ;
+    border-bottom-width : 1 ;
+    border-bottom-color : "#2c2620" ;
+    border-bottom-style : "solid" ;
+  }
+
+  part calendar-title {
+    width      : 100% ;
+    font-size  : 16 ;
+    font-weight: bold ;
+    color      : "#f1ebe1" ;
+  }
+
+  part calendar-nav {
+    gap: 6 ;
+  }
+
+  part calendar-prev {
+    padding       : 6 ;
+    border-radius : 6 ;
+    border-width  : 0 ;
+    background    : "transparent" ;
+    color         : "#f1ebe1" ;
+    font-size     : 14 ;
+    state hover {
+      background: "#2c2620" ;
+    }
+  }
+
+  part calendar-next {
+    padding       : 6 ;
+    border-radius : 6 ;
+    border-width  : 0 ;
+    background    : "transparent" ;
+    color         : "#f1ebe1" ;
+    font-size     : 14 ;
+    state hover {
+      background: "#2c2620" ;
+    }
+  }
+
+  part calendar-dow {
+    border-bottom-width : 1 ;
+    border-bottom-color : "#2c2620" ;
+    border-bottom-style : "solid" ;
+  }
+
+  // Sun..Sat: identical bodies, one part name each (moslayout requires a
+  // distinct part name per literal instance — see Calendar.mll's comment).
+  part calendar-dow-sun {
+    width          : "14.2857%" ;
+    text-align     : "center" ;
+    padding-top    : 8 ;
+    padding-bottom : 8 ;
+    font-size      : 10.5 ;
+    font-weight    : bold ;
+    letter-spacing : "0.06em" ;
+    text-transform : "uppercase" ;
+    color          : "#867c70" ;
+  }
+  part calendar-dow-mon {
+    width          : "14.2857%" ;
+    text-align     : "center" ;
+    padding-top    : 8 ;
+    padding-bottom : 8 ;
+    font-size      : 10.5 ;
+    font-weight    : bold ;
+    letter-spacing : "0.06em" ;
+    text-transform : "uppercase" ;
+    color          : "#867c70" ;
+  }
+  part calendar-dow-tue {
+    width          : "14.2857%" ;
+    text-align     : "center" ;
+    padding-top    : 8 ;
+    padding-bottom : 8 ;
+    font-size      : 10.5 ;
+    font-weight    : bold ;
+    letter-spacing : "0.06em" ;
+    text-transform : "uppercase" ;
+    color          : "#867c70" ;
+  }
+  part calendar-dow-wed {
+    width          : "14.2857%" ;
+    text-align     : "center" ;
+    padding-top    : 8 ;
+    padding-bottom : 8 ;
+    font-size      : 10.5 ;
+    font-weight    : bold ;
+    letter-spacing : "0.06em" ;
+    text-transform : "uppercase" ;
+    color          : "#867c70" ;
+  }
+  part calendar-dow-thu {
+    width          : "14.2857%" ;
+    text-align     : "center" ;
+    padding-top    : 8 ;
+    padding-bottom : 8 ;
+    font-size      : 10.5 ;
+    font-weight    : bold ;
+    letter-spacing : "0.06em" ;
+    text-transform : "uppercase" ;
+    color          : "#867c70" ;
+  }
+  part calendar-dow-fri {
+    width          : "14.2857%" ;
+    text-align     : "center" ;
+    padding-top    : 8 ;
+    padding-bottom : 8 ;
+    font-size      : 10.5 ;
+    font-weight    : bold ;
+    letter-spacing : "0.06em" ;
+    text-transform : "uppercase" ;
+    color          : "#867c70" ;
+  }
+  part calendar-dow-sat {
+    width          : "14.2857%" ;
+    text-align     : "center" ;
+    padding-top    : 8 ;
+    padding-bottom : 8 ;
+    font-size      : 10.5 ;
+    font-weight    : bold ;
+    letter-spacing : "0.06em" ;
+    text-transform : "uppercase" ;
+    color          : "#867c70" ;
+  }
+
+  part calendar-grid {
+    flex-wrap: "wrap" ;
+  }
+
+  part calendar-cell {
+    width          : "14.2857%" ;
+    min-height     : 96 ;
+    padding        : 6 ;
+    gap            : 3 ;
+    border-right-width  : 1 ;
+    border-right-color  : "#2c2620" ;
+    border-right-style  : "solid" ;
+    border-bottom-width : 1 ;
+    border-bottom-color : "#2c2620" ;
+    border-bottom-style : "solid" ;
+  }
+
+  part calendar-daynum {
+    font-size : 12 ;
+    color     : "#b3a99c" ;
+  }
+
+  part calendar-daynum-today {
+    width         : 21 ;
+    height        : 21 ;
+    border-radius : 20 ;
+    text-align    : "center" ;
+    font-size     : 11 ;
+    font-weight   : bold ;
+    background    : "#eaa63f" ;
+    color         : "#1a1714" ;
+  }
+
+  // flex-grow fills the remaining height of calendar-cell's 96px min-height —
+  // without it, an empty day (no events, no intrinsic content height) leaves
+  // a zero-height drop target, so a real pointer drag has nothing to land on.
+  part calendar-cell-drop {
+    width      : 100% ;
+    flex-grow  : 1 ;
+    gap        : 3 ;
+  }
+
+  part calendar-event {
+    width          : 100% ;
+    padding-top    : 2 ;
+    padding-right  : 7 ;
+    padding-bottom : 2 ;
+    padding-left   : 7 ;
+    border-radius  : 5 ;
+    border-left-width : 3 ;
+    border-left-color : "#eaa63f" ;
+    border-left-style : "solid" ;
+    background     : "#3a2c17" ;
+    color          : "#eaa63f" ;
+    font-size      : 11 ;
+    overflow       : "hidden" ;
+    white-space    : "nowrap" ;
+    text-overflow  : "ellipsis" ;
+  }
+
+  part calendar-event-label {
+    font-size : 11 ;
+  }
+
+  part calendar-event-crit {
+    font-size  : 10 ;
+    font-weight: bold ;
+    color      : "#e26a52" ;
+  }
+
+  part calendar-event-done {
+    font-size  : 10 ;
+    color      : "#6fb489" ;
+  }
+
+  part calendar-event-over {
+    font-size  : 10 ;
+    font-weight: bold ;
+    color      : "#e26a52" ;
+  }
+}

--- a/code/packages/mosaic/mosaic-pkg-calendar/src/Calendar.light.msl
+++ b/code/packages/mosaic/mosaic-pkg-calendar/src/Calendar.light.msl
@@ -1,0 +1,228 @@
+// Calendar.light.msl — default light theme style for the Calendar component.
+//
+// Palette lifted straight from design/ui-prototype.html's `:root` tokens and
+// its `.cal-*` classes (see task-app-calendar-v1.md) — not invented values.
+
+style Calendar {
+  part calendar-root {
+    background     : "#fffdfa" ;
+    border-width   : 1 ;
+    border-color   : "#e6ded3" ;
+    border-style   : "solid" ;
+    border-radius  : 10 ;
+    box-shadow     : "0 1px 2px rgba(60,45,25,.05), 0 4px 14px rgba(60,45,25,.05)" ;
+  }
+
+  part calendar-head {
+    align          : center-vertical ;
+    padding-top    : 14 ;
+    padding-right  : 18 ;
+    padding-bottom : 14 ;
+    padding-left   : 18 ;
+    border-bottom-width : 1 ;
+    border-bottom-color : "#efe8dd" ;
+    border-bottom-style : "solid" ;
+  }
+
+  part calendar-title {
+    width      : 100% ;
+    font-size  : 16 ;
+    font-weight: bold ;
+    color      : "#2b2723" ;
+  }
+
+  part calendar-nav {
+    gap: 6 ;
+  }
+
+  part calendar-prev {
+    padding       : 6 ;
+    border-radius : 6 ;
+    border-width  : 0 ;
+    background    : "transparent" ;
+    color         : "#2b2723" ;
+    font-size     : 14 ;
+    state hover {
+      background: "#efe8dd" ;
+    }
+  }
+
+  part calendar-next {
+    padding       : 6 ;
+    border-radius : 6 ;
+    border-width  : 0 ;
+    background    : "transparent" ;
+    color         : "#2b2723" ;
+    font-size     : 14 ;
+    state hover {
+      background: "#efe8dd" ;
+    }
+  }
+
+  part calendar-dow {
+    border-bottom-width : 1 ;
+    border-bottom-color : "#efe8dd" ;
+    border-bottom-style : "solid" ;
+  }
+
+  // Sun..Sat: identical bodies, one part name each (moslayout requires a
+  // distinct part name per literal instance — see Calendar.mll's comment).
+  part calendar-dow-sun {
+    width          : "14.2857%" ;
+    text-align     : "center" ;
+    padding-top    : 8 ;
+    padding-bottom : 8 ;
+    font-size      : 10.5 ;
+    font-weight    : bold ;
+    letter-spacing : "0.06em" ;
+    text-transform : "uppercase" ;
+    color          : "#9b9289" ;
+  }
+  part calendar-dow-mon {
+    width          : "14.2857%" ;
+    text-align     : "center" ;
+    padding-top    : 8 ;
+    padding-bottom : 8 ;
+    font-size      : 10.5 ;
+    font-weight    : bold ;
+    letter-spacing : "0.06em" ;
+    text-transform : "uppercase" ;
+    color          : "#9b9289" ;
+  }
+  part calendar-dow-tue {
+    width          : "14.2857%" ;
+    text-align     : "center" ;
+    padding-top    : 8 ;
+    padding-bottom : 8 ;
+    font-size      : 10.5 ;
+    font-weight    : bold ;
+    letter-spacing : "0.06em" ;
+    text-transform : "uppercase" ;
+    color          : "#9b9289" ;
+  }
+  part calendar-dow-wed {
+    width          : "14.2857%" ;
+    text-align     : "center" ;
+    padding-top    : 8 ;
+    padding-bottom : 8 ;
+    font-size      : 10.5 ;
+    font-weight    : bold ;
+    letter-spacing : "0.06em" ;
+    text-transform : "uppercase" ;
+    color          : "#9b9289" ;
+  }
+  part calendar-dow-thu {
+    width          : "14.2857%" ;
+    text-align     : "center" ;
+    padding-top    : 8 ;
+    padding-bottom : 8 ;
+    font-size      : 10.5 ;
+    font-weight    : bold ;
+    letter-spacing : "0.06em" ;
+    text-transform : "uppercase" ;
+    color          : "#9b9289" ;
+  }
+  part calendar-dow-fri {
+    width          : "14.2857%" ;
+    text-align     : "center" ;
+    padding-top    : 8 ;
+    padding-bottom : 8 ;
+    font-size      : 10.5 ;
+    font-weight    : bold ;
+    letter-spacing : "0.06em" ;
+    text-transform : "uppercase" ;
+    color          : "#9b9289" ;
+  }
+  part calendar-dow-sat {
+    width          : "14.2857%" ;
+    text-align     : "center" ;
+    padding-top    : 8 ;
+    padding-bottom : 8 ;
+    font-size      : 10.5 ;
+    font-weight    : bold ;
+    letter-spacing : "0.06em" ;
+    text-transform : "uppercase" ;
+    color          : "#9b9289" ;
+  }
+
+  part calendar-grid {
+    flex-wrap: "wrap" ;
+  }
+
+  part calendar-cell {
+    width          : "14.2857%" ;
+    min-height     : 96 ;
+    padding        : 6 ;
+    gap            : 3 ;
+    border-right-width  : 1 ;
+    border-right-color  : "#efe8dd" ;
+    border-right-style  : "solid" ;
+    border-bottom-width : 1 ;
+    border-bottom-color : "#efe8dd" ;
+    border-bottom-style : "solid" ;
+  }
+
+  part calendar-daynum {
+    font-size : 12 ;
+    color     : "#6a625a" ;
+  }
+
+  part calendar-daynum-today {
+    width         : 21 ;
+    height        : 21 ;
+    border-radius : 20 ;
+    text-align    : "center" ;
+    font-size     : 11 ;
+    font-weight   : bold ;
+    background    : "#e0942a" ;
+    color         : "#ffffff" ;
+  }
+
+  // flex-grow fills the remaining height of calendar-cell's 96px min-height —
+  // without it, an empty day (no events, no intrinsic content height) leaves
+  // a zero-height drop target, so a real pointer drag has nothing to land on.
+  part calendar-cell-drop {
+    width      : 100% ;
+    flex-grow  : 1 ;
+    gap        : 3 ;
+  }
+
+  part calendar-event {
+    width          : 100% ;
+    padding-top    : 2 ;
+    padding-right  : 7 ;
+    padding-bottom : 2 ;
+    padding-left   : 7 ;
+    border-radius  : 5 ;
+    border-left-width : 3 ;
+    border-left-color : "#e0942a" ;
+    border-left-style : "solid" ;
+    background     : "#faedd6" ;
+    color          : "#b6741a" ;
+    font-size      : 11 ;
+    overflow       : "hidden" ;
+    white-space    : "nowrap" ;
+    text-overflow  : "ellipsis" ;
+  }
+
+  part calendar-event-label {
+    font-size : 11 ;
+  }
+
+  part calendar-event-crit {
+    font-size  : 10 ;
+    font-weight: bold ;
+    color      : "#cf4b34" ;
+  }
+
+  part calendar-event-done {
+    font-size  : 10 ;
+    color      : "#4f8e6a" ;
+  }
+
+  part calendar-event-over {
+    font-size  : 10 ;
+    font-weight: bold ;
+    color      : "#cf4b34" ;
+  }
+}

--- a/code/packages/mosaic/mosaic-pkg-calendar/src/Calendar.mil
+++ b/code/packages/mosaic/mosaic-pkg-calendar/src/Calendar.mil
@@ -1,0 +1,67 @@
+// Calendar.mil — interface for the month-grid calendar view.
+//
+// Calendar renders a 6×7 month grid over task-core's `calendar(range, view)`
+// projection (task-app-super-app.md Phase 7). See
+// code/specs/task-app-calendar-v1.md for the full scope and what's
+// deliberately deferred (week/day views, resize, time-blocking).
+//
+// Fat engine, dumb UI: the host computes the visible month's date range, calls
+// `calendar(range, view)`, and hands this component pre-shaped rows — Calendar
+// does no date arithmetic, filtering, or scheduling of its own. It only places
+// cells and events, and reports drag/nav gestures back as proposals.
+//
+// Slot vocabulary
+// ---------------
+//
+//   calendar-title   the visible month's display label (e.g. "August 2026").
+//
+//   calendar-cells    one row per grid cell (always 42 = 6 weeks × 7 days,
+//                     Sunday-first, the same shape design/ui-prototype.html's
+//                     renderCalendar() builds):
+//                       [ 0 ] day-number   e.g. "14"
+//                       [ 1 ] day-key      the cell's ISO date, e.g. "2026-08-14" —
+//                                          a KEY, not an index (see TaskApp.mil's
+//                                          board-columns note on why: an inner
+//                                          loop's index would otherwise shadow the
+//                                          outer one, and a re-render can reorder
+//                                          cells out from under a stale index).
+//                       [ 2 ] is-today     non-empty when this cell is today.
+//
+//   calendar-events   one row per (event, day-it-covers) pair — a task spanning
+//                     three days contributes three rows, one per day-key, so a
+//                     multi-day event renders on every day it spans rather than
+//                     only its start day (the engine already computed the full
+//                     span; discarding it to match the day-only mock would throw
+//                     away real data):
+//                       [ 0 ] task-id    the drag key.
+//                       [ 1 ] label      the task's name.
+//                       [ 2 ] day-key    which cell this row belongs in — compared
+//                                        against calendar-cells[n][1], never an index.
+//                       [ 3 ] critical   non-empty when on the critical path.
+//                       [ 4 ] completed  non-empty when done.
+//                       [ 5 ] overdue    non-empty when late and not done.
+//
+// Emit vocabulary
+// ---------------
+//
+//   onPrev / onNext   month navigation. No payload — the host owns which month
+//                     is showing and recomputes the range.
+//
+//   onEventDropped    a drop is a PROPOSAL, exactly like TaskApp's own
+//                     onCardDropped: the UI35 contract (what moved, of what
+//                     kind, onto which target, and where within it). The host
+//                     decides what "moved to this day" means (task-app-calendar-v1.md:
+//                     a MustStartOn constraint, not a deadline change — the
+//                     calendar's own display precedence favours a computed
+//                     schedule over the deadline fallback, so only a constraint
+//                     that feeds the CPM pass actually moves the event on screen).
+
+component Calendar {
+  slot calendar-title  : text ;
+  slot calendar-cells  : list<list<text>> ;
+  slot calendar-events : list<list<text>> ;
+
+  emit onPrev ;
+  emit onNext ;
+  emit onEventDropped ( key : text , kind : text , targetKey : text , position : text ) ;
+}

--- a/code/packages/mosaic/mosaic-pkg-calendar/src/Calendar.mll
+++ b/code/packages/mosaic/mosaic-pkg-calendar/src/Calendar.mll
@@ -1,0 +1,114 @@
+// Calendar.mll — layout for the month-grid calendar view.
+//
+// Composition (kernel primitives only — no wrapped package, same as
+// mosaic-pkg-grid's own Grid.mll):
+//
+//   Column [ calendar-root ]
+//     Row [ calendar-head ]              (title + prev/next nav)
+//     Row [ calendar-dow ]                (Sun..Sat labels, static — they never
+//                                          change, so no slot for them. Each gets
+//                                          its own part name — moslayout rejects a
+//                                          literal part name reused across static
+//                                          siblings, the same "duplicate part per
+//                                          instance" constraint the segmented
+//                                          switch's off/off2/off3/off4 already
+//                                          works around.)
+//     Row [ calendar-grid ]                (flex-wrap: wrap — see below)
+//       For over calendar-cells
+//         Column [ calendar-cell ]
+//           day number (today gets its own part, badge-styled)
+//           HostDropTarget [ calendar-cell-drop ]
+//             For over calendar-events, filtered to this cell's day-key
+//               HostDraggable [ calendar-event ]
+//
+// A flex-wrap grid, not CSS grid
+// -------------------------------
+// Mosaic's layout primitives are Box/Row/Column/Stack — there is no grid
+// primitive. `calendar-grid` is a Row with `flex-wrap: "wrap"` and each
+// `calendar-cell` is `width: "14.2857%"` (100÷7): seven same-width cells per
+// row, wrapping every 7, produces the 6-row month grid without a new
+// primitive. `flex-wrap` is just another kebab-case CSS property — mosstyle's
+// per-property system passes any of them through generically (the same
+// mechanism the design-fidelity pass already exercised for directional
+// padding).
+//
+// Placing an event in its cell: keys, not indices — same reasoning as
+// TaskApp's Board section (see TaskApp.mil's board-columns/board-cards note).
+// `If ( when: ( ev[2] == cell[1] ) )` compares the event's day-key against
+// the cell's day-key, nested inside the cell loop, exactly like Board's
+// `If ( when: ( card[1] == col[1] ) )` compares a card's column-key against
+// the column's.
+//
+// One draggable part, conditional CHILD chips for state — not four branches
+// -------------------------------------------------------------------------
+// TaskApp's Board section renders exactly one `board-card` HostDraggable part
+// always, and adds a small conditional `card-crit` text child for the
+// critical marker, rather than branching the whole card into differently
+// -styled variants per state (mosstyle can't express a per-data-value style
+// on one part; only per-branch part names can differ, and duplicating the
+// entire draggable+drop-target+event-loop across a 3-or-4-way branch was
+// judged not worth the resulting file size for what is ultimately a colour
+// difference). Calendar follows the identical, already-accepted trade-off:
+// one `calendar-event` part, with independent (non-exclusive — a task can be
+// both critical AND overdue) conditional chips for critical/completed/
+// overdue. This is the same reason Board's own critical treatment is a text
+// chip rather than the mock's coloured left border — tracked as a known,
+// deferred gap in BACKLOG.md, not something Calendar re-litigates here.
+
+layout Calendar {
+  Column [ calendar-root ] {
+    Row [ calendar-head ] {
+      Text [ calendar-title ] ( content : slot: calendar-title )
+      Row [ calendar-nav ] {
+        HostButton [ calendar-prev ] ( label : "‹" , onClick : emit: onPrev )
+        HostButton [ calendar-next ] ( label : "›" , onClick : emit: onNext )
+      }
+    }
+    Row [ calendar-dow ] {
+      Text [ calendar-dow-sun ] ( content : "Sun" )
+      Text [ calendar-dow-mon ] ( content : "Mon" )
+      Text [ calendar-dow-tue ] ( content : "Tue" )
+      Text [ calendar-dow-wed ] ( content : "Wed" )
+      Text [ calendar-dow-thu ] ( content : "Thu" )
+      Text [ calendar-dow-fri ] ( content : "Fri" )
+      Text [ calendar-dow-sat ] ( content : "Sat" )
+    }
+    Row [ calendar-grid ] {
+      For ( each: slot: calendar-cells , as: cell , index: ci ) {
+        Column [ calendar-cell ] {
+          If ( when: ( cell[2] ) ) {
+            Text [ calendar-daynum-today ] ( content : ( cell[0] ) )
+          }
+          Else {
+            Text [ calendar-daynum ] ( content : ( cell[0] ) )
+          }
+          HostDropTarget [ calendar-cell-drop ] (
+            drop-key : ( cell[1] ) ,
+            onDrop : emit: onEventDropped
+          ) {
+            For ( each: slot: calendar-events , as: ev , index: ei ) {
+              If ( when: ( ev[2] == cell[1] ) ) {
+                HostDraggable [ calendar-event ] (
+                  drag-key : ( ev[0] ) ,
+                  drag-kind : "task" ,
+                  drag-label : ( ev[1] )
+                ) {
+                  Text [ calendar-event-label ] ( content : ( ev[1] ) )
+                  If ( when: ( ev[3] ) ) {
+                    Text [ calendar-event-crit ] ( content : "Critical" )
+                  }
+                  If ( when: ( ev[4] ) ) {
+                    Text [ calendar-event-done ] ( content : "Done" )
+                  }
+                  If ( when: ( ev[5] ) ) {
+                    Text [ calendar-event-over ] ( content : "Overdue" )
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/code/packages/mosaic/mosaic-pkg-calendar/src/lib.rs
+++ b/code/packages/mosaic/mosaic-pkg-calendar/src/lib.rs
@@ -1,0 +1,12 @@
+//! mosaic-pkg-calendar — userland Mosaic component package.
+//!
+//! This crate is intentionally empty. The package's real deliverables are
+//! `Calendar.mil` / `Calendar.mll` / `Calendar.dark.msl` / `Calendar.light.msl`
+//! under `src/` and the `mosaic-package.toml` manifest at the package root —
+//! they describe one component (Calendar) built entirely from UI29 kernel
+//! primitives, no other userland package.
+//!
+//! The Rust crate exists only so a smoke-test integration test can run the
+//! source files through the mosmodel / moslayout / mosstyle compilers and
+//! assert the package round-trips at the language-frontend layer. See
+//! `tests/package_compiles.rs`.

--- a/code/packages/mosaic/mosaic-pkg-calendar/tests/package_compiles.rs
+++ b/code/packages/mosaic/mosaic-pkg-calendar/tests/package_compiles.rs
@@ -1,0 +1,159 @@
+//! package_compiles — smoke test for the mosaic-pkg-calendar package.
+//!
+//! Mirrors mosaic-pkg-sheet's own `package_compiles.rs`: manifest parses and
+//! declares the expected export; Calendar.mil compiles via mosmodel;
+//! Calendar.mll compiles against that interface via moslayout;
+//! Calendar.dark.msl / Calendar.light.msl each compile against the resulting
+//! part map via mosstyle. Unlike Sheet, Calendar has no cross-package
+//! dependency to pin (it's built entirely from kernel primitives, like
+//! mosaic-pkg-grid), so there's no `pkg::` qualified-reference regression
+//! test here.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn package_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn src_path(name: &str) -> PathBuf {
+    package_root().join("src").join(name)
+}
+
+fn read_source(name: &str) -> String {
+    let path = src_path(name);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e))
+}
+
+// ---------------------------------------------------------------------------
+// 1. Manifest
+// ---------------------------------------------------------------------------
+
+#[test]
+fn manifest_declares_expected_exports() {
+    let manifest_src = fs::read_to_string(package_root().join("mosaic-package.toml"))
+        .expect("manifest mosaic-package.toml must exist at the package root");
+
+    let value: toml::Value =
+        toml::from_str(&manifest_src).expect("mosaic-package.toml must parse as valid TOML");
+
+    let name = value
+        .get("package")
+        .and_then(|p| p.get("name"))
+        .and_then(|n| n.as_str())
+        .expect("[package].name must be set");
+    assert_eq!(name, "mosaic-pkg-calendar", "[package].name mismatch");
+
+    let exports = value
+        .get("components")
+        .and_then(|c| c.get("exports"))
+        .and_then(|e| e.as_array())
+        .expect("[components].exports must be an array");
+    let export_names: Vec<&str> = exports.iter().filter_map(|v| v.as_str()).collect();
+    assert_eq!(
+        export_names,
+        vec!["Calendar"],
+        "[components].exports must list exactly Calendar"
+    );
+
+    let kernel_version = value
+        .get("kernel")
+        .and_then(|k| k.get("version"))
+        .and_then(|v| v.as_str())
+        .expect("[kernel].version must be set");
+    assert_eq!(kernel_version, "1", "[kernel].version must target UI29 kernel v1");
+}
+
+// ---------------------------------------------------------------------------
+// 2. mosmodel — .mil compilation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn calendar_mil_compiles() {
+    let src = read_source("Calendar.mil");
+    let out = mosmodel_compiler::compile(&src)
+        .unwrap_or_else(|e| panic!("Calendar.mil failed to compile via mosmodel_compiler:\n{:#?}", e));
+    assert_eq!(out.component.component, "Calendar");
+
+    let slot_names: Vec<&str> = out.component.slots.iter().map(|s| s.name.as_str()).collect();
+    for expected in ["calendar-title", "calendar-cells", "calendar-events"] {
+        assert!(
+            slot_names.contains(&expected),
+            "Calendar.mil must declare slot `{}`, got: {:?}",
+            expected,
+            slot_names
+        );
+    }
+
+    let emit_names: Vec<&str> = out.component.emits.iter().map(|e| e.name.as_str()).collect();
+    for expected in ["onPrev", "onNext", "onEventDropped"] {
+        assert!(
+            emit_names.contains(&expected),
+            "Calendar.mil must declare emit `{}`, got: {:?}",
+            expected,
+            emit_names
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. moslayout — .mll compilation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn calendar_mll_compiles_against_its_interface() {
+    let mil_src = read_source("Calendar.mil");
+    let mil_out = mosmodel_compiler::compile(&mil_src)
+        .unwrap_or_else(|e| panic!("Calendar.mil precompile failed: {:#?}", e));
+
+    let mll_src = read_source("Calendar.mll");
+    moslayout_compiler::compile(&mll_src, Some(&mil_out.descriptor_json))
+        .unwrap_or_else(|e| panic!("Calendar.mll failed to compile via moslayout_compiler:\n{:#?}", e));
+}
+
+#[test]
+fn calendar_mll_uses_the_drag_kernel() {
+    // Pins the UI35 drag-kernel usage this package depends on — a regression
+    // guard against accidentally degrading drag-to-move into a plain static
+    // container.
+    let src = read_source("Calendar.mll");
+    assert!(src.contains("HostDropTarget"), "Calendar.mll must use HostDropTarget");
+    assert!(src.contains("HostDraggable"), "Calendar.mll must use HostDraggable");
+}
+
+// ---------------------------------------------------------------------------
+// 4. mosstyle — .msl compilation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn each_msl_theme_compiles_against_the_part_map() {
+    let mll_src = read_source("Calendar.mll");
+    let mll_out = moslayout_compiler::compile(&mll_src, None)
+        .unwrap_or_else(|e| panic!("Calendar.mll precompile failed: {:#?}", e));
+
+    for theme in ["Calendar.dark.msl", "Calendar.light.msl"] {
+        let msl_path = src_path(theme);
+        assert!(msl_path.exists(), "{} must exist", msl_path.display());
+
+        let msl_src = read_source(theme);
+        mosstyle_compiler::compile(&msl_src, Some(&mll_out.part_map_json))
+            .unwrap_or_else(|e| panic!("{} failed to compile via mosstyle_compiler:\n{:#?}", theme, e));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Source-tree sanity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn source_tree_has_expected_shape() {
+    for name in [
+        "Calendar.mil",
+        "Calendar.mll",
+        "Calendar.dark.msl",
+        "Calendar.light.msl",
+    ] {
+        let path = src_path(name);
+        assert!(path.exists(), "expected package source file missing: {}", path.display());
+    }
+}

--- a/code/programs/mosaic/task-app/BACKLOG.md
+++ b/code/programs/mosaic/task-app/BACKLOG.md
@@ -31,21 +31,15 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
      paragraph in the detail panel. `task-core` already has labels/priority as
      first-class fields (shipped) — this is wiring them into `main.tsx`'s row-building
      and `TaskApp.mil`/`.mll`'s row-cell layout, not new engine work.
-   - Calendar view — this IS the existing Phase 7 item below, not a separate task; the
-     mock having one is corroborating evidence for that roadmap phase, not new scope.
+   - Calendar view — shipped since (Phase 7, see Resolved below); the mock's calendar
+     was corroborating evidence for that roadmap phase, not a separate design-fidelity task.
 
-3. **Phase 7 — Calendar component.** `mosaic-pkg-calendar`, wired to the engine's `calendar(range,
-   view)` projection (already shipped, [#8726](https://github.com/adhithyan15/coding-adventures/pull/8726)) + the UI35 drag kernel for
-   drag-to-reschedule/resize. Month/week/day views, time-blocking, auto-schedule placement around
-   fixed commitments. The drag kernel is proven end-to-end now (board PR found and fixed three
-   real bugs in it), so this should be smoother than the board was.
-
-4. **Phase 8 — Notes component + entity.** The engine has **no notes entity at all** yet — this
+3. **Phase 8 — Notes component + entity.** The engine has **no notes entity at all** yet — this
    needs a `task-core` model addition (standalone notes + attachable to any task/project) before
    the `mosaic-pkg-notes` UI (adapted from `mosaic-pkg-note-editor`, which was built for a
    different domain — Anki notes — and needs re-pointing at generic entities).
 
-5. **Phase 9 — App-shell assembly + progressive disclosure.** Partially done already via ad hoc
+4. **Phase 9 — App-shell assembly + progressive disclosure.** Partially done already via ad hoc
    UI-design passes ([#8970](https://github.com/adhithyan15/coding-adventures/pull/8970), [#8983](https://github.com/adhithyan15/coding-adventures/pull/8983), [#9112](https://github.com/adhithyan15/coding-adventures/pull/9112), [#8994](https://github.com/adhithyan15/coding-adventures/pull/8994), [#9110](https://github.com/adhithyan15/coding-adventures/pull/9110), [#9127](https://github.com/adhithyan15/coding-adventures/pull/9127), [#9136](https://github.com/adhithyan15/coding-adventures/pull/9136))
    — theming, project switching, nested-project hierarchy, shell/groups/status/cards all landed.
    Remaining: package it as a reusable `mosaic-pkg-project-nav` (nested-project tree + view
@@ -57,12 +51,21 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
 
 - **Native drag support for HostDraggable/HostDropTarget.** Every non-web backend (SwiftUI,
   Compose, Qt, Flutter, WinUI/XAML, webcomponent) currently degrades the drag family to a plain
-  static container — see `code/specs/UI35-host-drag-drop.md`. This means the board (and, once
-  built, the calendar) is fully interactive on web but inert on every native shell. Spec-deferred
+  static container — see `code/specs/UI35-host-drag-drop.md`. This means the board and the
+  calendar are both fully interactive on web but inert on every native shell. Spec-deferred
   intentionally (native shells are Phase 10+), but tracked as a spawned task:
   [background task](task_239f7f69) "Wire HostDraggable/HostDropTarget into mosaic-emit-xaml" — do
   XAML first since it's the most-built-out native backend, then fan out the same pattern to the
   rest.
+- **Calendar week/day views, resize, and time-blocking.** Deferred from the Phase 7 ship —
+  see `code/specs/task-app-calendar-v1.md` for the full rationale (resize isn't supported by
+  the UI35 kernel today; time-blocking needs a time-of-day field on `TaskSchedule` that
+  doesn't exist yet, an engine-side gap, not a UI one).
+- **Calendar weekend/out-of-month cell tinting.** Deferred alongside the critical-card border
+  gap below — mosstyle can't vary one part's background per data value, only per branch, and
+  a 4-way branch duplicating the whole drop-target + event-loop wasn't judged worth it for a
+  colour difference. Today's badge shipped (it only needed a small conditional child, the
+  same trick Board's `card-crit` chip already uses).
 - Recurring tasks / reminders UX.
 - Automation rules (Butler-style).
 - Resource-leveling UI (the engine's `constraint-*` leveling exists; no UI surfaces it).
@@ -72,6 +75,17 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
 
 ## Resolved (kept for traceability, not actionable)
 
+- **Phase 7 — Calendar component.** `mosaic-pkg-calendar` — month grid + drag-to-move,
+  see `code/specs/task-app-calendar-v1.md` for the full scope. The engine's
+  `calendar(range, view)` projection needed zero new work (shipped in #8726); this PR was
+  pure UI. Verified live: month grid renders correctly (42-cell Sunday-first, both themes),
+  prev/next navigation, and dragging an event onto a new day calls `setConstraint` with a
+  `mustStartOn` date — confirmed the project's own projected-finish date recomputed after
+  the drop, proving it's a real CPM reschedule, not a UI-only move. Found and fixed one real
+  bug before shipping: an empty day's `HostDropTarget` had zero intrinsic height (no events,
+  no explicit sizing), leaving nothing for a pointer to land on — fixed with `flex-grow: 1`
+  so it fills the cell's `min-height`. Week/day views, resize, time-blocking, and cell
+  weekend/out-of-month tinting deferred — see the two Backlog items above.
 - **Phase 5 — Sheet component, now fully editable.** `mosaic-pkg-sheet` shipped
   read-only first, then editing landed as a fast-follow once the emitter gap was
   fixed properly ([UI37](../../../specs/UI37-generic-payload-dispatch.md) +

--- a/code/programs/mosaic/task-app/CHANGELOG.md
+++ b/code/programs/mosaic/task-app/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to the `task-app` web program are documented here.
 
 ## [0.1.0] - Unreleased
 
+### Added - calendar (month grid) view
+
+Phase 7 of the roadmap: a new `mosaic-pkg-calendar` package, wired to
+task-core's `calendar(range, view)` projection (no new engine work needed —
+that projection shipped in #8726) plus the UI35 drag kernel for drag-to-move
+rescheduling. See `code/specs/task-app-calendar-v1.md` for the full scope.
+
+- Month grid: 42 cells (6×7, Sunday-first), today gets a filled badge,
+  multi-day events render on every day they span (not just their start
+  day — the engine already computes the real span).
+- Drag an event onto a different day and it reschedules for real: the host
+  calls `engine.setConstraint({ id, constraint: { mustStartOn } })`, which
+  feeds the CPM pass — not `setDeadline`, which the calendar's own display
+  precedence (computed schedule beats the deadline fallback) would have
+  silently ignored for any already-scheduled task. Verified live: the
+  project's own projected-finish date recomputed after a drop.
+- Critical/completed/overdue events get a conditional text chip, the same
+  "one draggable part, conditional child chips for state" trade-off Board's
+  `card-crit` already established (not a per-state container restyle).
+- Both themes, palette taken directly from `design/ui-prototype.html`'s
+  `.cal-*` classes.
+
+Deferred to a follow-up (tracked in `BACKLOG.md`): week/day views, resize
+(the UI35 kernel doesn't support it), time-blocking (needs a time-of-day
+field on `TaskSchedule` that doesn't exist yet — an engine gap), and
+weekend/out-of-month cell tinting (would need a 4-way branch duplicating
+the whole drop-target + event-loop for a colour difference — not judged
+worth it, matching Board's own deferred critical-border-vs-chip gap).
+
+Found and fixed one real bug before shipping, not after: an empty day's
+`HostDropTarget` had zero intrinsic height (no events inside it, no
+explicit sizing), leaving nothing for a pointer to actually land on —
+fixed with `flex-grow: 1` so it fills the cell's 96px `min-height`.
+
 ### Changed - re-closed the design-fidelity gap (partial pass)
 
 A prior pass (`### Changed - the app now looks like the design`, below) brought the app

--- a/code/programs/mosaic/task-app/host/web/src/main.tsx
+++ b/code/programs/mosaic/task-app/host/web/src/main.tsx
@@ -186,6 +186,52 @@ const isoToDays = (iso: string): number | null => {
 const daysToIso = (days: number): string =>
   new Date(days * DAY_MS).toISOString().slice(0, 10);
 
+// The calendar view — the engine's calendar(range, view) projection, built with
+// the same "no filter, whole workspace" View every other view starts from.
+// `shape: "calendar"` matches task-core's ViewShape::Calendar; the engine
+// itself only reads filter/sort from this (calendar() doesn't group or show
+// columns), but the View type requires the field to be present regardless.
+const CALENDAR_VIEW = (projectStart: number, start: number, end: number) => ({
+  view: {
+    id: "calendar",
+    name: "Calendar",
+    shape: "calendar",
+    filter: { statuses: [], completed: null, search: null },
+    groupBy: null,
+    sort: [{ field: { builtin: "name" }, ascending: true }],
+    visibleFields: [{ builtin: "name" }],
+  },
+  projectStart,
+  start,
+  end,
+});
+
+// Calendar month arithmetic. All UTC — `days` is already a UTC day-count (see
+// DAY_MS above), so mixing in local-timezone Date methods here would skew the
+// grid by a day near a DST boundary or a non-UTC system clock.
+const daysToDateUtc = (days: number): Date => new Date(days * DAY_MS);
+// The first day (UTC) of the month containing `days`.
+const monthStartDays = (days: number): number => {
+  const d = daysToDateUtc(days);
+  return Math.floor(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1) / DAY_MS);
+};
+// `monthStart` shifted by `delta` whole months, landing on that month's 1st.
+const shiftMonth = (monthStart: number, delta: number): number => {
+  const d = daysToDateUtc(monthStart);
+  return Math.floor(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + delta, 1) / DAY_MS);
+};
+const monthLabel = (monthStart: number): string =>
+  daysToDateUtc(monthStart).toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+// The Sunday on/before `monthStart` — the grid's top-left cell. A fixed 42-cell
+// (6×7) grid from here always covers the whole month, the same shape
+// design/ui-prototype.html's own renderCalendar() builds.
+const gridStartDays = (monthStart: number): number =>
+  monthStart - daysToDateUtc(monthStart).getUTCDay();
+
 // State the controller can be seeded with on boot (restored from storage).
 interface ControllerInit {
   initialOrder?: string[];
@@ -208,9 +254,9 @@ function makeController(engine: any, init: ControllerInit = {}) {
   let newName = "";
   let newDue = "";
   let newProject = "";
-  // Which view is showing. A string rather than a set of booleans, so the four
+  // Which view is showing. A string rather than a set of booleans, so the five
   // states can't contradict each other.
-  let view: "list" | "board" | "timeline" | "sheet" = "list";
+  let view: "list" | "board" | "timeline" | "sheet" | "calendar" = "list";
   // Sheet toolbar state.
   let sheetFilterText = "";
   let sheetSortField = ""; // a SHEET_FIELDS label, or "" for unsorted
@@ -232,6 +278,9 @@ function makeController(engine: any, init: ControllerInit = {}) {
   const order: string[] = [...initialOrder]; // task ids in creation order
   let counter = initialCounter;
   const today = Math.floor(Date.now() / DAY_MS);
+  // Calendar nav state: the first day (UTC) of the currently shown month,
+  // seeded to the current month.
+  let calendarMonthStart = monthStartDays(today);
 
   // Every project, flattened depth-first so a sub-project immediately follows its
   // parent, carrying the depth so the bar can show the hierarchy. The engine stores
@@ -394,6 +443,40 @@ function makeController(engine: any, init: ControllerInit = {}) {
     };
   };
 
+  // The calendar's own cell/event derivation — analogous to sheetRows(), keyed
+  // to whichever month `calendarMonthStart` currently names rather than a
+  // fixed range. Cell/event row shapes match Calendar.mil exactly.
+  const calendarData = (): { cells: string[][]; events: string[][] } => {
+    const gridStart = gridStartDays(calendarMonthStart);
+    const gridEnd = gridStart + 41; // 42 cells, inclusive
+    const cells: string[][] = [];
+    for (let i = 0; i < 42; i += 1) {
+      const day = gridStart + i;
+      cells.push([String(daysToDateUtc(day).getUTCDate()), daysToIso(day), day === today ? "today" : ""]);
+    }
+    const raw = engine.calendar(CALENDAR_VIEW(today, gridStart, gridEnd)).data;
+    const events: string[][] = [];
+    for (const ev of (raw?.events ?? []) as any[]) {
+      // One row PER DAY the event spans, clipped to the visible grid — a
+      // multi-day event renders on every day it covers rather than only its
+      // start day (see task-app-calendar-v1.md: the engine already computed
+      // the real span; collapsing to the start day would discard it).
+      const from = Math.max(ev.start as number, gridStart);
+      const to = Math.min(ev.finish as number, gridEnd);
+      for (let day = from; day <= to; day += 1) {
+        events.push([
+          ev.task as string,
+          ev.label as string,
+          daysToIso(day),
+          ev.critical ? "critical" : "",
+          ev.completed ? "done" : "",
+          ev.overdue ? "overdue" : "",
+        ]);
+      }
+    }
+    return { cells, events };
+  };
+
   return {
     getProps() {
       // Ask the ENGINE for render-ready cells. The host no longer formats dates,
@@ -485,6 +568,9 @@ function makeController(engine: any, init: ControllerInit = {}) {
       // below: an engine query the current view doesn't need shouldn't run on every
       // keystroke elsewhere in the app.
       const sheet = view === "sheet" ? sheetRows() : { ids: [], cells: [] };
+      // Computed only while the calendar is showing — same "don't run a query
+      // the current view doesn't need" discipline as `sheet`/`boardCards`.
+      const cal = view === "calendar" ? calendarData() : { cells: [], events: [] };
       const boardCards: string[][] = (() => {
         if (view !== "board") return [];
         const pct = progress();
@@ -530,6 +616,10 @@ function makeController(engine: any, init: ControllerInit = {}) {
         sheetSortOptions: SHEET_FIELDS.filter((f) => f.sortable).map((f) => f.label),
         sheetSortOpen,
         sheetSortAscending,
+        calendarMode: view === "calendar" ? "calendar" : "",
+        calendarTitle: view === "calendar" ? monthLabel(calendarMonthStart) : "",
+        calendarCells: cal.cells,
+        calendarEvents: cal.events,
         timelineScale: tl.scale,
         timelineRows: tl.rows,
         newTaskName: newName,
@@ -569,6 +659,9 @@ function makeController(engine: any, init: ControllerInit = {}) {
           break;
         case "showSheet":
           view = "sheet";
+          break;
+        case "showCalendar":
+          view = "calendar";
           break;
         case "cardDropped": {
           // A drop is a PROPOSAL. The engine owns what a status change means; the host
@@ -612,6 +705,32 @@ function makeController(engine: any, init: ControllerInit = {}) {
             ok = ran("un-start", engine.setPercentComplete({ id: event.key, percent: 0 }));
           }
           if (!ok) break;
+          persist();
+          break;
+        }
+        case "calendarPrev":
+          calendarMonthStart = shiftMonth(calendarMonthStart, -1);
+          break;
+        case "calendarNext":
+          calendarMonthStart = shiftMonth(calendarMonthStart, 1);
+          break;
+        case "calendarEventDropped": {
+          // A drop is a PROPOSAL — same reasoning as cardDropped above. The
+          // calendar's own display precedence favours a computed schedule
+          // over the deadline fallback (see task-app-calendar-v1.md), so a
+          // MustStartOn constraint is what actually moves the event on
+          // screen — setDeadline alone would silently no-op for any task the
+          // CPM pass already dated.
+          const targetDay = isoToDays(event.targetKey);
+          if (targetDay == null) break; // not a valid day-key
+          const res = engine.setConstraint({
+            id: event.key,
+            constraint: { mustStartOn: targetDay },
+          });
+          if (res?.ok === false) {
+            console.error("Calendar reschedule failed:", res.error ?? res);
+            break;
+          }
           persist();
           break;
         }

--- a/code/programs/mosaic/task-app/mosaic-package.toml
+++ b/code/programs/mosaic/task-app/mosaic-package.toml
@@ -9,6 +9,7 @@ exports = ["TaskApp"]
 
 [dependencies]
 mosaic-pkg-sheet = "0.1.0"
+mosaic-pkg-calendar = "0.1.0"
 
 [kernel]
 version = "1"

--- a/code/programs/mosaic/task-app/src/TaskApp.dark.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.dark.msl
@@ -402,6 +402,116 @@ style TaskApp {
     }
   }
 
+  // Calendar tab. "on" mirrors seg-sheet-on's raised-card treatment; every
+  // "off" variant (one per other branch) mirrors seg-sheet-off's plain
+  // transparent-with-hover treatment — see TaskApp.mll's seg comment for why
+  // each mutually-exclusive branch needs its own part name.
+  part seg-cal-on {
+    background : "#252019" ;
+    color : "#f1ebe1" ;
+    font-size : 13 ;
+    font-weight : bold ;
+    padding-top : 6 ;
+    padding-right : 14 ;
+    padding-bottom : 6 ;
+    padding-left : 14 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    box-shadow : "0 1px 2px rgba(0,0,0,.3), 0 4px 14px rgba(0,0,0,.28)" ;
+  }
+  part seg-cal-off {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+  part seg-cal-off2 {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+  part seg-cal-off3 {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+  part seg-cal-off4 {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+
+  // The new calendar-mode branch also needs an "off" instance of every OTHER
+  // family (list/board/sheet/timeline) — same plain treatment, next unused
+  // numeric suffix per family (see TaskApp.mll's seg block for the mapping).
+  part seg-list-off4 {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+  part seg-board-off5 {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+  part seg-sheet-off4 {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+  part seg-tl-off4 {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+
   // ── board (kanban) ──────────────────────────────────────────────────────
   part board {
     gap : 14 ;

--- a/code/programs/mosaic/task-app/src/TaskApp.light.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.light.msl
@@ -402,6 +402,116 @@ style TaskApp {
     }
   }
 
+  // Calendar tab. "on" mirrors seg-sheet-on's raised-card treatment; every
+  // "off" variant (one per other branch) mirrors seg-sheet-off's plain
+  // transparent-with-hover treatment — see TaskApp.mll's seg comment for why
+  // each mutually-exclusive branch needs its own part name.
+  part seg-cal-on {
+    background : "#fffdfa" ;
+    color : "#2b2723" ;
+    font-size : 13 ;
+    font-weight : bold ;
+    padding-top : 6 ;
+    padding-right : 14 ;
+    padding-bottom : 6 ;
+    padding-left : 14 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    box-shadow : "0 1px 2px rgba(60,45,25,.05), 0 4px 14px rgba(60,45,25,.05)" ;
+  }
+  part seg-cal-off {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+  part seg-cal-off2 {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+  part seg-cal-off3 {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+  part seg-cal-off4 {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+
+  // The new calendar-mode branch also needs an "off" instance of every OTHER
+  // family (list/board/sheet/timeline) — same plain treatment, next unused
+  // numeric suffix per family (see TaskApp.mll's seg block for the mapping).
+  part seg-list-off4 {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+  part seg-board-off5 {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+  part seg-sheet-off4 {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+  part seg-tl-off4 {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+
   // ── board (kanban) ──────────────────────────────────────────────────────
   part board {
     gap : 14 ;

--- a/code/programs/mosaic/task-app/src/TaskApp.mil
+++ b/code/programs/mosaic/task-app/src/TaskApp.mil
@@ -78,6 +78,17 @@ component TaskApp {
   slot sheet-sort-open        : bool ;
   slot sheet-sort-ascending   : bool ;
 
+  // Calendar (month grid). `calendar-mode` is non-empty when the calendar is
+  // showing. Every `calendar-*` slot is a straight pass-through to
+  // `pkg::mosaic-pkg-calendar::Calendar` — see Calendar.mil for the full
+  // contract and code/specs/task-app-calendar-v1.md for the scope. The host
+  // builds calendar-cells/calendar-events from the SAME `calendar(range,
+  // view)` engine call each time the visible month changes.
+  slot calendar-mode   : text ;
+  slot calendar-title  : text ;
+  slot calendar-cells  : list<list<text>> ;
+  slot calendar-events : list<list<text>> ;
+
   // One row per task, in schedule order. Each row is a list of pre-formatted cells:
   //
   //   [ 0 ] done-glyph      [ 5 ] expanded-marker  — non-empty for the ONE open row
@@ -111,6 +122,7 @@ component TaskApp {
   emit onShowBoard ;
   emit onShowTimeline ;
   emit onShowSheet ;
+  emit onShowCalendar ;
 
   // A drop is a PROPOSAL: the engine decides whether the move is legal and performs
   // it. The payload is the UI35 contract — what moved, of what kind, onto which
@@ -126,6 +138,11 @@ component TaskApp {
   emit onSheetSortFieldChange     ( value : text ) ;
   emit onSheetToggleSortOpen ;
   emit onSheetToggleSortDirection ;
+
+  // Calendar emits — straight pass-through to/from pkg::mosaic-pkg-calendar::Calendar.
+  emit onCalendarPrev ;
+  emit onCalendarNext ;
+  emit onCalendarEventDropped ( key : text , kind : text , targetKey : text , position : text ) ;
 
   // Expand (or collapse) a task row to reveal its scheduling detail.
   emit onExpandTask ( index : number ) ;

--- a/code/programs/mosaic/task-app/src/TaskApp.mll
+++ b/code/programs/mosaic/task-app/src/TaskApp.mll
@@ -68,12 +68,13 @@ layout TaskApp {
         // clicking the view you are already on is a no-op instead of a swap.
         Row [ seg ] {
           // Part names are unique layout-wide, even across mutually-exclusive
-          // branches, so each of the four buttons gets its own name in each of
-          // the four branches (one "on" + three "off" variants per button).
+          // branches, so each of the five buttons gets its own name in each of
+          // the five branches (one "on" + four "off" variants per button).
           If ( when: slot: timeline-mode ) {
             HostButton [ seg-list-off ] ( label : "List" , onClick : emit: onShowList )
             HostButton [ seg-board-off ] ( label : "Board" , onClick : emit: onShowBoard )
             HostButton [ seg-sheet-off ] ( label : "Sheet" , onClick : emit: onShowSheet )
+            HostButton [ seg-cal-off ] ( label : "Calendar" , onClick : emit: onShowCalendar )
             HostButton [ seg-tl-on ] ( label : "Timeline" , onClick : emit: onShowTimeline )
           }
           Else {
@@ -81,6 +82,7 @@ layout TaskApp {
               HostButton [ seg-list-off2 ] ( label : "List" , onClick : emit: onShowList )
               HostButton [ seg-board-on ] ( label : "Board" , onClick : emit: onShowBoard )
               HostButton [ seg-sheet-off2 ] ( label : "Sheet" , onClick : emit: onShowSheet )
+              HostButton [ seg-cal-off2 ] ( label : "Calendar" , onClick : emit: onShowCalendar )
               HostButton [ seg-tl-off2 ] ( label : "Timeline" , onClick : emit: onShowTimeline )
             }
             Else {
@@ -88,13 +90,24 @@ layout TaskApp {
                 HostButton [ seg-list-off3 ] ( label : "List" , onClick : emit: onShowList )
                 HostButton [ seg-board-off3 ] ( label : "Board" , onClick : emit: onShowBoard )
                 HostButton [ seg-sheet-on ] ( label : "Sheet" , onClick : emit: onShowSheet )
+                HostButton [ seg-cal-off3 ] ( label : "Calendar" , onClick : emit: onShowCalendar )
                 HostButton [ seg-tl-off3 ] ( label : "Timeline" , onClick : emit: onShowTimeline )
               }
               Else {
-                HostButton [ seg-list-on ] ( label : "List" , onClick : emit: onShowList )
-                HostButton [ seg-board-off4 ] ( label : "Board" , onClick : emit: onShowBoard )
-                HostButton [ seg-sheet-off3 ] ( label : "Sheet" , onClick : emit: onShowSheet )
-                HostButton [ seg-tl-off ] ( label : "Timeline" , onClick : emit: onShowTimeline )
+                If ( when: slot: calendar-mode ) {
+                  HostButton [ seg-list-off4 ] ( label : "List" , onClick : emit: onShowList )
+                  HostButton [ seg-board-off5 ] ( label : "Board" , onClick : emit: onShowBoard )
+                  HostButton [ seg-sheet-off4 ] ( label : "Sheet" , onClick : emit: onShowSheet )
+                  HostButton [ seg-cal-on ] ( label : "Calendar" , onClick : emit: onShowCalendar )
+                  HostButton [ seg-tl-off4 ] ( label : "Timeline" , onClick : emit: onShowTimeline )
+                }
+                Else {
+                  HostButton [ seg-list-on ] ( label : "List" , onClick : emit: onShowList )
+                  HostButton [ seg-board-off4 ] ( label : "Board" , onClick : emit: onShowBoard )
+                  HostButton [ seg-sheet-off3 ] ( label : "Sheet" , onClick : emit: onShowSheet )
+                  HostButton [ seg-cal-off4 ] ( label : "Calendar" , onClick : emit: onShowCalendar )
+                  HostButton [ seg-tl-off ] ( label : "Timeline" , onClick : emit: onShowTimeline )
+                }
               }
             }
           }
@@ -190,6 +203,20 @@ layout TaskApp {
           )
         }
         Else {
+        If ( when: slot: calendar-mode ) {
+          // Every calendar-* slot/emit is a straight pass-through to the
+          // package — TaskApp adds no shaping of its own, see Calendar.mil
+          // for the contract and task-app-calendar-v1.md for the scope.
+          pkg::mosaic-pkg-calendar::Calendar (
+            calendar-title : slot: calendar-title ,
+            calendar-cells : slot: calendar-cells ,
+            calendar-events : slot: calendar-events ,
+            onPrev : emit: onCalendarPrev ,
+            onNext : emit: onCalendarNext ,
+            onEventDropped : emit: onCalendarEventDropped
+          )
+        }
+        Else {
           Column [ list-wrap ] {
             Row [ composer ] {
               HostInput [ name-input ] (
@@ -248,6 +275,7 @@ layout TaskApp {
               }
             }
           }
+        }
         }
         }
         }

--- a/code/specs/task-app-calendar-v1.md
+++ b/code/specs/task-app-calendar-v1.md
@@ -1,0 +1,122 @@
+# task-app Calendar — v1 scope
+
+Phase 7 of [task-app-super-app.md](task-app-super-app.md) calls for `mosaic-pkg-calendar`:
+"month/week/day, events, drag-to-reschedule, resize, time-blocking, auto-schedule
+placement." This spec narrows that to a first shippable slice, and says explicitly what's
+deferred and why — the same "ship narrower, iterate" sequencing Sheet and Board already
+used in this codebase (Sheet shipped read-only before cell editing; Board shipped three
+columns with no accent bar before richer treatment).
+
+## What v1 ships
+
+- **Month view only.** The engine's `calendar(range, view)` projection
+  ([task-core/src/view.rs](../packages/rust/task-core/src/view.rs)) and its WASM/JS
+  binding are already shipped (#8726) — this PR is pure UI, no engine work. A 6×7
+  (42-cell) grid, Sunday-first, covering the shown month plus the leading/trailing days
+  needed to fill whole weeks — matching `design/ui-prototype.html`'s `renderCalendar()`.
+- **Drag-to-move**, using the UI35 `HostDraggable`/`HostDropTarget` kernel, the same
+  kernel Board already proved end-to-end. Dragging an event onto a different day cell
+  reschedules that task to start on the dropped day.
+- **Prev/next month navigation.**
+- **Event styling**: critical (red-tinted, left border), completed (struck through,
+  dimmed), overdue (amber-tinted, left border — the mock has no overdue treatment for
+  the calendar specifically; this reuses the list view's overdue vocabulary rather than
+  inventing a new one), plain (honey-tinted, left border) — mirrors
+  `design/ui-prototype.html`'s `.cal-ev` classes.
+- **Today** gets a filled date-number badge; **weekend** and **out-of-month** days get a
+  quiet background tint — matching the mock's `.cal-cell.today`/`.wknd`/`.out`.
+- **Multi-day events render on every day they span**, not just their start day. The mock
+  only renders a single cell per event (it has no span logic in its demo JS), but the
+  engine's `CalendarEvent` already carries a real `start`/`finish` span — rendering only
+  the start day would silently discard data the engine computed. Fat engine, dumb UI: if
+  the engine says a task spans five days, the UI shows it on all five.
+
+## What's explicitly deferred (and why)
+
+- **Week/day views.** The mock only implements a month grid (no rendered week/day
+  toggle). Month view alone already exercises the projection, the grid layout, and the
+  drag kernel end-to-end; week/day are a straightforward follow-up once this lands, not
+  a blocker to shipping *a* calendar.
+- **Resize** (dragging an event's edge to change its duration). UI35's own spec says
+  this explicitly: "Drag-to-resize (calendar event edges, Gantt bar ends). That is a
+  distinct gesture — worth its own primitive later; the calendar ships drag-to-move
+  first." ([UI35-host-drag-drop.md](UI35-host-drag-drop.md), §7 Out of scope). The
+  kernel does not support it today; building it would mean inventing a second drag
+  primitive as a side effect of a calendar PR, which is out of scope here.
+- **Time-blocking / intraday placement.** `CalendarEvent.all_day` is hardcoded `true` —
+  "reserved for timed events (time-blocking) in a later phase" per the engine's own
+  doc comment. There is no time-of-day field on `TaskSchedule` at all yet. This is an
+  engine gap, not a UI gap, and belongs to a future engine-side phase.
+- **Auto-schedule placement around fixed commitments.** Depends on time-blocking
+  existing first (auto-placement needs a notion of "busy" intervals within a day, which
+  requires the time-of-day model above).
+
+## How drag-to-move reaches the engine
+
+A day cell is a `HostDropTarget` with `drop-key` set to that cell's ISO date string
+(`"2026-08-14"`, not an index — an index would break the moment the visible month
+changes, and it wouldn't survive a re-render reordering). An event is a `HostDraggable`
+inside its day cell(s), with `drag-key` set to the task's id (mirroring Board's card
+`drag-key`).
+
+On drop, the host validates the dragged task id still exists and the target key parses
+as a valid date, computes it, then calls `engine.setConstraint({ id, constraint: {
+mustStartOn: <day> } })` — **not** `setDeadline`. The calendar's own precedence rule
+(`schedule.dates.get(&id)` wins over the deadline fallback) means a CPM-scheduled task's
+displayed position comes from the computed schedule, not its deadline; changing the
+deadline alone would silently fail to move it on screen. `MustStartOn` is a real,
+inflexible date constraint the CPM pass honours, so the dropped position is what the
+engine actually schedules going forward — not a fake optimistic move the next
+recompute would revert.
+
+## Data shape (mosmodel slots)
+
+Two flat `list<list<text>>` slots, matching the shape Board's `board-columns`/
+`board-cards` already established for this kind of loop-rendered grid data — no nested
+list-of-list type is needed or (per the existing type grammar) supported:
+
+```
+slot calendar-cells  : list<list<text>> ;
+// [ dayNumber, dayKey(ISO date), isOutOfMonth, isWeekend, isToday ]  — one per grid cell, 42 rows
+
+slot calendar-events : list<list<text>> ;
+// [ taskId, label, dayKey, critical, completed, overdue ]  — one row per (event, spanned day) pair;
+// a 3-day event contributes 3 rows, one per day it covers, each with a different dayKey
+```
+
+Placing an event in its cell is a nested `For`+`If` exactly like Board's card placement
+(`If (when: (event[2] == cell[1]))` inside the cell loop) — comparing the event's day
+key against the cell's day key, not indices.
+
+## Layout: a flex-wrap grid, not CSS grid
+
+Mosaic's layout primitives are `Box`/`Row`/`Column`/`Stack` — no grid primitive. Rather
+than introduce one, `calendar-grid` is a `Row` with `flex-wrap: "wrap"` (already proven:
+mosstyle's per-property system passes through any kebab-case CSS property generically —
+`padding-top`/`-right`/`-bottom`/`-left` already exercised this for the design-fidelity
+pass) and each `calendar-cell` is `width: "14.2857%"` (100 ÷ 7). Seven same-width cells
+per row, wrapping every 7, produces the 6-row month grid without a new primitive.
+
+## Package structure
+
+`code/packages/mosaic/mosaic-pkg-calendar/`, mirroring `mosaic-pkg-sheet`'s file trio
+exactly (the sanctioned pattern for a real reusable package — unlike Board, which
+shipped inline in `TaskApp.mll` and was flagged in `BACKLOG.md` as a spec deviation):
+`Cargo.toml`, `mosaic-package.toml`, `src/lib.rs` (doc-only), `src/Calendar.mil`,
+`src/Calendar.mll`, `src/Calendar.light.msl`, `src/Calendar.dark.msl`,
+`tests/package_compiles.rs`. No dependency on another package — built from kernel
+primitives only, same as `mosaic-pkg-grid`.
+
+## TaskApp wiring
+
+Same shape as Sheet's integration: a `slot calendar-mode : text ;` view flag, an
+`emit onShowCalendar ;` added to TaskApp's "choose a view" group, a fifth branch in the
+segmented switcher (five uniquely-named buttons per branch, following the existing
+`seg-*-on`/`seg-*-off{2,3,4}` pattern so mosstyle can scope each button's hover/pressed
+state), a fifth `If`/`Else` content branch inserted before the final `Else` (list), and
+`pkg::mosaic-pkg-calendar::Calendar ( ... )` embedded with every slot/emit forwarded
+explicitly. `main.tsx` gains a `"calendar"` view state, a `CALENDAR_VIEW` builder
+calling `engine.calendar({...})`, a `calendarCells()`/`calendarEvents()` derivation
+(computed only when `view === "calendar"`, matching the existing "don't compute what
+the current view doesn't need" discipline), and a `calendarEventDropped` dispatch case
+mirroring `cardDropped`'s validate-then-op-then-persist shape.


### PR DESCRIPTION
## Summary

Phase 7 of the roadmap: a new `mosaic-pkg-calendar` package wired to
task-core's `calendar(range, view)` projection (no new engine work needed —
that projection shipped in #8726) plus the UI35 drag kernel for
drag-to-move rescheduling. Scoped per
[task-app-calendar-v1.md](code/specs/task-app-calendar-v1.md): month view +
drag-to-move only, matching what the kernel and engine actually support
today (resize and time-blocking aren't there yet — see the spec for why).

- **Month grid**: 42 cells (6×7, Sunday-first), today gets a filled badge,
  multi-day events render on every day they span (the engine already
  computes the real span; collapsing to the start day would discard it).
- **Drag an event onto a different day and it reschedules for real**: the
  host calls `engine.setConstraint({ id, constraint: { mustStartOn } })`,
  which feeds the CPM pass — not `setDeadline`, which the calendar's own
  display precedence (computed schedule beats the deadline fallback) would
  have silently ignored for any already-scheduled task. Verified live: the
  project's own projected-finish date recomputed after a drop.
- Critical/completed/overdue events get a conditional text chip — the same
  "one draggable part, conditional child chips for state" trade-off
  Board's `card-crit` already established, not a per-state container
  restyle (mosstyle can't express that).
- Both themes, palette taken directly from `design/ui-prototype.html`'s
  `.cal-*` classes.

**Deliberately deferred** (tracked in `BACKLOG.md`): week/day views,
resize (the UI35 kernel doesn't support it —
[UI35-host-drag-drop.md](code/specs/UI35-host-drag-drop.md) §7 says so
explicitly), time-blocking (needs a time-of-day field on `TaskSchedule`
that doesn't exist yet — an engine gap, not a UI one), and weekend/
out-of-month cell tinting (would need a 4-way branch duplicating the whole
drop-target + event-loop for a colour difference — not judged worth it).

**Found and fixed one real bug before shipping**: an empty day's
`HostDropTarget` had zero intrinsic height (no events inside it, no
explicit sizing), leaving nothing for a pointer to actually land on —
fixed with `flex-grow: 1` so it fills the cell's 96px `min-height`.

## Test plan

- [x] `cargo test` + `cargo clippy --all-features --all-targets -- -D warnings`
      clean on `mosaic-pkg-calendar` and `task-app`
- [x] Live browser verification: month grid renders correctly (both
      themes), prev/next navigation works, drag-to-move works end-to-end
      including a real CPM recompute (project's projected-finish date
      changed after the drop), zero console errors on a fresh tab
- [x] `/security-review` — passed, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)