### PR TITLE
feat(task-app): notes (list + editor) view — UI half of Phase 8

### DIFF
--- a/code/packages/mosaic/mosaic-pkg-notes/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-pkg-notes/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to `mosaic-pkg-notes` are documented in this file.
+The format follows [Keep a Changelog](https://keepachangelog.com/) and
+the package follows semantic versioning.
+
+## 0.1.0 — 2026-08-06 — initial release
+
+### Added
+
+- `Notes` component: a list-plus-editor view, adapted from
+  `mosaic-pkg-note-editor` (built for a different domain — Anki-style
+  flashcard notes — with none of its note-type/deck/focused-field
+  machinery carried over). Create, edit, and delete a note (title + plain
+  text body) via `upsertNote`/`deleteNote`.
+- Deliberate, disclosed use of the legacy `Input` primitive with
+  `multiline: true` for the body field — UI29's kernel `HostInput` is
+  single-line only, and no userland `MultilineInput` exists yet. See the
+  package README's "A deliberate legacy-primitive use" section.
+- Both themes, styled to match the rest of TaskApp's existing tokens (no
+  design-mock reference exists for this component).
+
+### Fixed (found live-testing, before first ship)
+
+- **A slot referenced by its kebab-case name inside an expression
+  silently miscompiled.** `( n[0] == selected-note-id )` compiles cleanly
+  at every static layer (mosmodel/moslayout/mosstyle all accept it) but
+  is wrong at runtime: the emitted JS parses `selected-note-id` as
+  subtraction of three undefined identifiers (`selected - note - id`),
+  not a reference to the `selected-note-id` slot. Fixed to the correct
+  camelCase form (`selectedNoteId`), matching the convention
+  `mosaic-pkg-grid`'s `Grid.mll` already established (`editRow`/`editCol`
+  inside `is-editing`/`is-selected` expressions). Caught by live-testing
+  in a browser — clicking Save threw `ReferenceError: selected is not
+  defined` and blanked the page — not by the package's own compile-layer
+  tests, which is exactly why a regression test pinning the camelCase
+  form was added alongside the fix.
+
+See [task-app-notes-ui-v1.md](../../../specs/task-app-notes-ui-v1.md) for
+the full scope and what's deliberately deferred (attachment picker, tags,
+rich text, search).

--- a/code/packages/mosaic/mosaic-pkg-notes/Cargo.toml
+++ b/code/packages/mosaic/mosaic-pkg-notes/Cargo.toml
@@ -1,0 +1,33 @@
+# Cargo.toml — smoke-test harness for mosaic-pkg-notes.
+#
+# Same shape as mosaic-pkg-sheet's Cargo.toml: this package's actual
+# deliverables are .mil / .mll / .msl source files, not a Rust crate.
+# This Cargo.toml exists only to host an integration smoke test.
+#
+# `[workspace]` is empty so this Cargo project does NOT join the main
+# code/packages/rust workspace — it's a standalone Cargo project run
+# via `cargo test`, same as every other mosaic-pkg-*.
+
+[workspace]
+# Intentionally empty: opt out of the parent workspace.
+
+[package]
+name        = "mosaic-pkg-notes"
+version     = "0.1.0"
+edition     = "2021"
+description = "Smoke-test harness for the mosaic-pkg-notes component package"
+publish     = false
+
+# The crate has no library code — it exists for the integration test below.
+[lib]
+path       = "src/lib.rs"
+
+[dev-dependencies]
+mosmodel-compiler   = { path = "../../rust/mosmodel-compiler" }
+moslayout-compiler  = { path = "../../rust/moslayout-compiler" }
+mosstyle-compiler   = { path = "../../rust/mosstyle-compiler" }
+toml                = "0.8"
+
+[[test]]
+name = "package_compiles"
+path = "tests/package_compiles.rs"

--- a/code/packages/mosaic/mosaic-pkg-notes/README.md
+++ b/code/packages/mosaic/mosaic-pkg-notes/README.md
@@ -1,0 +1,98 @@
+# mosaic-pkg-notes
+
+> List-plus-editor view over task-core's `Note` entity (create/edit/delete).
+
+A two-column shell adapted from `mosaic-pkg-note-editor` — built for a
+different domain (Anki-style flashcard notes: note types, decks, focused-
+field editing) — re-pointed at a plain title+body note. See
+[task-app-notes-ui-v1.md](../../../specs/task-app-notes-ui-v1.md) for the
+full scope and design rationale.
+
+## What this package exports
+
+One component, per `mosaic-package.toml`'s `[components].exports`:
+
+| Component | Role | File trio |
+|---|---|---|
+| `Notes` | note list + editor | `Notes.mil` / `Notes.mll` / `Notes.{light,dark}.msl` |
+
+## How it fits in the stack
+
+```
+          ┌──────────────────────────────────────────┐
+          │  Host application (task-app's Notes view) │
+          └─────────────────────┬──────────────────────┘
+                                │ component reference
+                                ▼
+          ┌──────────────────────────────────────────┐
+          │  mosaic-pkg-notes (this package)          │
+          │  Notes → Column/Row/Text/HostButton/      │
+          │          HostInput/Input(multiline)       │
+          └──────────────────────────────────────────┘
+```
+
+## Fat engine, dumb UI
+
+Notes does no persistence, filtering, or id-minting of its own. The host
+builds `note-rows` from task-core's `Note` entities (read via
+`workspace()` — no dedicated query needed, the whole-project dump already
+includes `notes`), owns the in-progress edit buffer
+(`title-value`/`body-value`), and decides what Save/Delete/Cancel mean as
+engine ops (`upsertNote`/`deleteNote`).
+
+## A deliberate legacy-primitive use
+
+UI29's kernel `HostInput` is single-line only — multiline support lives
+only on the legacy `Input` (UI25) primitive, and was never carried
+forward into a userland `MultilineInput` component (which doesn't exist
+yet). The note body genuinely needs multiple lines, so
+`notes-body-input` uses `Input ( multiline: true )` — the one such use in
+this package, disclosed rather than hidden. See the spec's "A real kernel
+gap found while designing this" section.
+
+## Usage
+
+```moslayout
+// In a host component's .mll:
+pkg::mosaic-pkg-notes::Notes (
+  notes-title:      slot: notes-title ,
+  note-rows:        slot: note-rows ,
+  selected-note-id: slot: selected-note-id ,
+  title-value:      slot: note-title-value ,
+  body-value:       slot: note-body-value ,
+  onSelectNote:  emit: onSelectNote ,
+  onNewNote:     emit: onNewNote ,
+  onTitleChange: emit: onNoteTitleChange ,
+  onBodyChange:  emit: onNoteBodyChange ,
+  onSave:        emit: onSaveNote ,
+  onDelete:      emit: onDeleteNote ,
+  onCancel:      emit: onCancelNote
+)
+```
+
+The host mints a new note's id up front (on "+ New note", not on Save —
+see `selectedNoteId`'s own comment in `main.tsx`), builds `note-rows` from
+`engine.workspace()`, and calls `upsertNote`/`deleteNote` in response to
+Save/Delete — see `code/programs/mosaic/task-app/host/web/src/main.tsx`
+(`noteRows()` and the `saveNote`/`deleteNote`/`selectNote` dispatch cases)
+for the reference host consumer.
+
+## Smoke test
+
+```bash
+cd code/packages/mosaic/mosaic-pkg-notes
+cargo test
+```
+
+Mirrors `mosaic-pkg-calendar`'s own smoke test: manifest parses and
+declares the expected export; `Notes.mil` compiles via `mosmodel-compiler`;
+`Notes.mll` compiles against that interface via `moslayout-compiler`
+(with explicit pins that it actually uses a multiline body field, and
+that the selected-note-id slot is referenced by its camelCase identifier
+inside expressions — a real bug found live-testing this package, not a
+hypothetical, see the test's own comment); both themes' `.msl` compile
+against the resulting part map.
+
+## License
+
+MIT OR Apache-2.0.

--- a/code/packages/mosaic/mosaic-pkg-notes/mosaic-package.toml
+++ b/code/packages/mosaic/mosaic-pkg-notes/mosaic-package.toml
@@ -1,0 +1,27 @@
+# mosaic-package.toml — manifest for mosaic-pkg-notes.
+#
+# A list-plus-editor view over task-core's Note entity (upsert_note/
+# delete_note). Adapted from mosaic-pkg-note-editor (built for a different
+# domain — Anki-style flashcard notes: note types, decks, focused-field
+# editing — none of which apply to a plain title+body note). Built entirely
+# from kernel primitives, plus one deliberate use of the legacy `Input`
+# primitive for its `multiline` textarea support (UI29's kernel HostInput
+# is single-line only — see code/specs/task-app-notes-ui-v1.md).
+#
+# v0.1.0 scope — see code/specs/task-app-notes-ui-v1.md for the full
+# rationale. Create/edit/delete a note (title + plain-text body), standalone
+# only (no attachment picker yet), no tags, no rich text, no search.
+
+[package]
+name = "mosaic-pkg-notes"
+version = "0.1.0"
+description = "List-plus-editor view over task-core's Note entity (create/edit/delete)"
+license = "MIT OR Apache-2.0"
+
+[components]
+exports = ["Notes"]
+
+[dependencies]
+
+[kernel]
+version = "1"

--- a/code/packages/mosaic/mosaic-pkg-notes/src/Notes.dark.msl
+++ b/code/packages/mosaic/mosaic-pkg-notes/src/Notes.dark.msl
@@ -1,0 +1,172 @@
+// Notes.dark.msl — default dark theme style for the Notes component.
+//
+// Same structure as Notes.light.msl, dark-theme token values matching the
+// rest of TaskApp (--surface:#252019 --ink:#f1ebe1 --ink-soft:#b3a99c
+// --ink-faint:#867c70 --line:#352e25 --line-soft:#2c2620 --honey:#eaa63f
+// --red:#e26a52 --red-tint:#3a221c).
+
+style Notes {
+  part notes-root {
+    gap : 12 ;
+  }
+
+  part notes-heading {
+    font-size   : 16 ;
+    font-weight : bold ;
+    color       : "#f1ebe1" ;
+  }
+
+  part notes-body {
+    gap : 16 ;
+  }
+
+  part notes-list {
+    width          : 220 ;
+    flex-shrink    : 0 ;
+    gap            : 4 ;
+    padding-right  : 12 ;
+    border-right-width : 1 ;
+    border-right-color : "#352e25" ;
+    border-right-style : "solid" ;
+  }
+
+  part notes-new {
+    width         : 100% ;
+    padding-top    : 8 ;
+    padding-right  : 12 ;
+    padding-bottom : 8 ;
+    padding-left   : 12 ;
+    border-radius : 8 ;
+    border-width  : 0 ;
+    background    : "#eaa63f" ;
+    color         : "#1a1714" ;
+    font-size     : 13 ;
+    font-weight   : bold ;
+    state hover {
+      background: "#d4922f" ;
+    }
+  }
+
+  part notes-row-on {
+    width          : 100% ;
+    text-align     : "left" ;
+    padding-top    : 8 ;
+    padding-right  : 12 ;
+    padding-bottom : 8 ;
+    padding-left   : 12 ;
+    border-radius  : 8 ;
+    border-width   : 0 ;
+    background     : "#252019" ;
+    color          : "#f1ebe1" ;
+    font-size      : 13 ;
+    font-weight    : bold ;
+    box-shadow     : "0 1px 2px rgba(0,0,0,.3), 0 4px 14px rgba(0,0,0,.28)" ;
+  }
+
+  part notes-row-off {
+    width          : 100% ;
+    text-align     : "left" ;
+    padding-top    : 8 ;
+    padding-right  : 12 ;
+    padding-bottom : 8 ;
+    padding-left   : 12 ;
+    border-radius  : 8 ;
+    border-width   : 0 ;
+    background     : "transparent" ;
+    color          : "#b3a99c" ;
+    font-size      : 13 ;
+    state hover {
+      background: "#2c2620" ;
+      color: "#f1ebe1" ;
+    }
+  }
+
+  part notes-editor {
+    flex-grow : 1 ;
+    gap       : 10 ;
+  }
+
+  part notes-title-input {
+    padding       : 10 ;
+    border-radius : 6 ;
+    background    : "#1a1714" ;
+    color         : "#f1ebe1" ;
+    border-width  : 1 ;
+    border-color  : "#352e25" ;
+    font-size     : 14 ;
+    font-weight   : bold ;
+  }
+
+  part notes-body-input {
+    width         : 100% ;
+    min-height    : 200 ;
+    padding       : 10 ;
+    border-radius : 6 ;
+    background    : "#1a1714" ;
+    color         : "#f1ebe1" ;
+    border-width  : 1 ;
+    border-color  : "#352e25" ;
+    font-size     : 13 ;
+  }
+
+  part notes-actions {
+    gap : 8 ;
+  }
+
+  part notes-save {
+    padding-top    : 8 ;
+    padding-right  : 16 ;
+    padding-bottom : 8 ;
+    padding-left   : 16 ;
+    border-radius  : 8 ;
+    border-width   : 0 ;
+    background     : "#eaa63f" ;
+    color          : "#1a1714" ;
+    font-size      : 13 ;
+    font-weight    : bold ;
+    state hover {
+      background: "#d4922f" ;
+    }
+  }
+
+  part notes-delete {
+    padding-top    : 8 ;
+    padding-right  : 16 ;
+    padding-bottom : 8 ;
+    padding-left   : 16 ;
+    border-radius  : 8 ;
+    border-width   : 0 ;
+    background     : "#3a221c" ;
+    color          : "#e26a52" ;
+    font-size      : 13 ;
+    font-weight    : bold ;
+    state hover {
+      background: "#472a22" ;
+    }
+  }
+
+  part notes-cancel {
+    padding-top    : 8 ;
+    padding-right  : 16 ;
+    padding-bottom : 8 ;
+    padding-left   : 16 ;
+    border-radius  : 8 ;
+    border-width   : 0 ;
+    background     : "transparent" ;
+    color          : "#b3a99c" ;
+    font-size      : 13 ;
+    state hover {
+      color: "#f1ebe1" ;
+    }
+  }
+
+  part notes-empty {
+    flex-grow  : 1 ;
+    align      : center ;
+  }
+
+  part notes-empty-hint {
+    font-size : 13 ;
+    color     : "#867c70" ;
+  }
+}

--- a/code/packages/mosaic/mosaic-pkg-notes/src/Notes.light.msl
+++ b/code/packages/mosaic/mosaic-pkg-notes/src/Notes.light.msl
@@ -1,0 +1,174 @@
+// Notes.light.msl — default light theme style for the Notes component.
+//
+// No design-mock reference exists for this component (design/ui-prototype.html
+// predates the notes entity — see task-app-notes-ui-v1.md), so the palette
+// matches the tokens the rest of TaskApp already uses (light theme:
+// --surface:#fffdfa --surface-2:#f7f2ea --ink:#2b2723 --ink-soft:#6a625a
+// --ink-faint:#9b9289 --line:#e6ded3 --line-soft:#efe8dd --honey:#e0942a
+// --red:#cf4b34 --red-tint:#f8e4df).
+
+style Notes {
+  part notes-root {
+    gap : 12 ;
+  }
+
+  part notes-heading {
+    font-size   : 16 ;
+    font-weight : bold ;
+    color       : "#2b2723" ;
+  }
+
+  part notes-body {
+    gap : 16 ;
+  }
+
+  part notes-list {
+    width          : 220 ;
+    flex-shrink    : 0 ;
+    gap            : 4 ;
+    padding-right  : 12 ;
+    border-right-width : 1 ;
+    border-right-color : "#e6ded3" ;
+    border-right-style : "solid" ;
+  }
+
+  part notes-new {
+    width         : 100% ;
+    padding-top    : 8 ;
+    padding-right  : 12 ;
+    padding-bottom : 8 ;
+    padding-left   : 12 ;
+    border-radius : 8 ;
+    border-width  : 0 ;
+    background    : "#e0942a" ;
+    color         : "#ffffff" ;
+    font-size     : 13 ;
+    font-weight   : bold ;
+    state hover {
+      background: "#c67f1e" ;
+    }
+  }
+
+  part notes-row-on {
+    width          : 100% ;
+    text-align     : "left" ;
+    padding-top    : 8 ;
+    padding-right  : 12 ;
+    padding-bottom : 8 ;
+    padding-left   : 12 ;
+    border-radius  : 8 ;
+    border-width   : 0 ;
+    background     : "#fffdfa" ;
+    color          : "#2b2723" ;
+    font-size      : 13 ;
+    font-weight    : bold ;
+    box-shadow     : "0 1px 2px rgba(60,45,25,.05), 0 4px 14px rgba(60,45,25,.05)" ;
+  }
+
+  part notes-row-off {
+    width          : 100% ;
+    text-align     : "left" ;
+    padding-top    : 8 ;
+    padding-right  : 12 ;
+    padding-bottom : 8 ;
+    padding-left   : 12 ;
+    border-radius  : 8 ;
+    border-width   : 0 ;
+    background     : "transparent" ;
+    color          : "#6a625a" ;
+    font-size      : 13 ;
+    state hover {
+      background: "#efe8dd" ;
+      color: "#2b2723" ;
+    }
+  }
+
+  part notes-editor {
+    flex-grow : 1 ;
+    gap       : 10 ;
+  }
+
+  part notes-title-input {
+    padding       : 10 ;
+    border-radius : 6 ;
+    background    : "#ffffff" ;
+    color         : "#2b2723" ;
+    border-width  : 1 ;
+    border-color  : "#e6ded3" ;
+    font-size     : 14 ;
+    font-weight   : bold ;
+  }
+
+  part notes-body-input {
+    width         : 100% ;
+    min-height    : 200 ;
+    padding       : 10 ;
+    border-radius : 6 ;
+    background    : "#ffffff" ;
+    color         : "#2b2723" ;
+    border-width  : 1 ;
+    border-color  : "#e6ded3" ;
+    font-size     : 13 ;
+  }
+
+  part notes-actions {
+    gap : 8 ;
+  }
+
+  part notes-save {
+    padding-top    : 8 ;
+    padding-right  : 16 ;
+    padding-bottom : 8 ;
+    padding-left   : 16 ;
+    border-radius  : 8 ;
+    border-width   : 0 ;
+    background     : "#e0942a" ;
+    color          : "#ffffff" ;
+    font-size      : 13 ;
+    font-weight    : bold ;
+    state hover {
+      background: "#c67f1e" ;
+    }
+  }
+
+  part notes-delete {
+    padding-top    : 8 ;
+    padding-right  : 16 ;
+    padding-bottom : 8 ;
+    padding-left   : 16 ;
+    border-radius  : 8 ;
+    border-width   : 0 ;
+    background     : "#f8e4df" ;
+    color          : "#cf4b34" ;
+    font-size      : 13 ;
+    font-weight    : bold ;
+    state hover {
+      background: "#f3d3ca" ;
+    }
+  }
+
+  part notes-cancel {
+    padding-top    : 8 ;
+    padding-right  : 16 ;
+    padding-bottom : 8 ;
+    padding-left   : 16 ;
+    border-radius  : 8 ;
+    border-width   : 0 ;
+    background     : "transparent" ;
+    color          : "#6a625a" ;
+    font-size      : 13 ;
+    state hover {
+      color: "#2b2723" ;
+    }
+  }
+
+  part notes-empty {
+    flex-grow  : 1 ;
+    align      : center ;
+  }
+
+  part notes-empty-hint {
+    font-size : 13 ;
+    color     : "#9b9289" ;
+  }
+}

--- a/code/packages/mosaic/mosaic-pkg-notes/src/Notes.mil
+++ b/code/packages/mosaic/mosaic-pkg-notes/src/Notes.mil
@@ -1,0 +1,71 @@
+// Notes.mil — interface for the list-plus-editor notes view.
+//
+// Notes renders a two-column shell: a list of every note on the left, an
+// editor for whichever one is selected on the right. See
+// code/specs/task-app-notes-ui-v1.md for the full scope and what's
+// deliberately deferred (attachment picker, tags, rich text, search).
+//
+// Fat engine, dumb UI: the host builds `note-rows` from task-core's
+// `Note` entities (via `workspace()` — no dedicated query needed, see the
+// spec), owns the in-progress edit buffer (`title-value`/`body-value`),
+// and decides what Save/Delete/Cancel mean as engine ops
+// (`upsertNote`/`deleteNote`). Notes does no persistence, filtering, or
+// id-minting of its own.
+//
+// Slot vocabulary
+// ---------------
+//
+//   notes-title       the panel's heading (e.g. "Notes").
+//
+//   note-rows         one row per note, in host display order:
+//                        [ 0 ] id     the note's id — a KEY, not an index
+//                                     (see TaskApp.mil's board-columns note
+//                                     on why: an inner render's index can
+//                                     drift from a stale click).
+//                        [ 1 ] title  display title (host substitutes a
+//                                     placeholder like "Untitled" for an
+//                                     empty title — Notes doesn't decide
+//                                     that).
+//
+//   selected-note-id   the currently open note's id, or empty for none
+//                       selected (the editor panel is hidden).
+//
+//   title-value        the editor's in-progress title text.
+//   body-value         the editor's in-progress body text.
+//
+// Emit vocabulary
+// ---------------
+//
+//   onSelectNote ( index )   a list row was clicked. Payload is the
+//                            CLICKED ROW'S INDEX (HostButton's own
+//                            dedicated-primitive payload synthesis — the
+//                            same mechanism onSelectProject/onExpandTask
+//                            already use for plain list clicks, distinct
+//                            from the drag kernel's key-based payloads).
+//                            The host resolves index → id through the
+//                            SAME ordered list note-rows was built from.
+//   onNewNote                start a blank, unsaved note (host clears its
+//                            edit buffer and sets no id — the note is
+//                            minted on first Save, the same pattern
+//                            addTask/addProject already use).
+//   onTitleChange ( value )   the title field's content changed.
+//   onBodyChange ( value )    the body field's content changed.
+//   onSave                    commit the edit buffer via upsertNote.
+//   onDelete                  delete the open note via deleteNote.
+//   onCancel                  discard the edit buffer without saving.
+
+component Notes {
+  slot notes-title      : text ;
+  slot note-rows        : list<list<text>> ;
+  slot selected-note-id : text ;
+  slot title-value      : text ;
+  slot body-value       : text ;
+
+  emit onSelectNote ( index : number ) ;
+  emit onNewNote ;
+  emit onTitleChange ( value : text ) ;
+  emit onBodyChange ( value : text ) ;
+  emit onSave ;
+  emit onDelete ;
+  emit onCancel ;
+}

--- a/code/packages/mosaic/mosaic-pkg-notes/src/Notes.mll
+++ b/code/packages/mosaic/mosaic-pkg-notes/src/Notes.mll
@@ -1,0 +1,77 @@
+// Notes.mll — layout for the list-plus-editor notes view.
+//
+// Composition:
+//
+//   Column [ notes-root ]
+//     Text [ notes-heading ]
+//     Row [ notes-body ]
+//       Column [ notes-list ]           (+ New note, one row per note)
+//       If ( a note is selected )
+//         Column [ notes-editor ]        (title, body, actions)
+//       Else
+//         Column [ notes-empty ]         ("select or start a note" hint)
+//
+// Selecting a row: keys, not indices — same reasoning as TaskApp's Board
+// section (see TaskApp.mil's board-columns note). `If ( when: ( n[0] ==
+// selectedNoteId ) )` compares the row's own id against the host-owned
+// selected-note-id slot, the same cross-loop-variable-vs-slot comparison
+// Grid.mll's `is-editing: ( r == editRow && c == editCol )` already
+// proved works — but note the CAMELCASE form: inside a parenthesized
+// expression a slot is referenced by its camelCase identifier
+// (`selectedNoteId`), not the kebab-case `slot: selected-note-id` form
+// used everywhere else. Writing the kebab-case name bare here compiles
+// (nothing rejects it) but is silently wrong: the emitted JS parses
+// `selected-note-id` as subtraction (`selected - note - id`), three
+// undefined identifiers, not one — a real bug found live-testing this
+// package, not a hypothetical.
+//
+// The legacy `Input` primitive, once, deliberately: UI29's kernel
+// `HostInput` is single-line only (no `multiline` support was carried
+// forward from `Input`/UI25 — see code/specs/task-app-notes-ui-v1.md).
+// The note body genuinely needs multiple lines, so `notes-body-input`
+// uses `Input ( multiline: true )` rather than a single-line `HostInput`.
+// This is the only such use in this package.
+
+layout Notes {
+  Column [ notes-root ] {
+    Text [ notes-heading ] ( content : slot: notes-title )
+    Row [ notes-body ] {
+      Column [ notes-list ] {
+        HostButton [ notes-new ] ( label : "+ New note" , onClick : emit: onNewNote )
+        For ( each: slot: note-rows , as: n , index: ni ) {
+          If ( when: ( n[0] == selectedNoteId ) ) {
+            HostButton [ notes-row-on ] ( label : ( n[1] ) , onClick : emit: onSelectNote )
+          }
+          Else {
+            HostButton [ notes-row-off ] ( label : ( n[1] ) , onClick : emit: onSelectNote )
+          }
+        }
+      }
+      If ( when: slot: selected-note-id ) {
+        Column [ notes-editor ] {
+          HostInput [ notes-title-input ] (
+            value : slot: title-value ,
+            placeholder : "Title" ,
+            onChange : emit: onTitleChange
+          )
+          Input [ notes-body-input ] (
+            value : slot: body-value ,
+            placeholder : "Write something…" ,
+            multiline : true ,
+            onChange : emit: onBodyChange
+          )
+          Row [ notes-actions ] {
+            HostButton [ notes-save ] ( label : "Save" , onClick : emit: onSave )
+            HostButton [ notes-delete ] ( label : "Delete" , onClick : emit: onDelete )
+            HostButton [ notes-cancel ] ( label : "Cancel" , onClick : emit: onCancel )
+          }
+        }
+      }
+      Else {
+        Column [ notes-empty ] {
+          Text [ notes-empty-hint ] ( content : "Select a note, or start a new one." )
+        }
+      }
+    }
+  }
+}

--- a/code/packages/mosaic/mosaic-pkg-notes/src/lib.rs
+++ b/code/packages/mosaic/mosaic-pkg-notes/src/lib.rs
@@ -1,0 +1,13 @@
+//! mosaic-pkg-notes — userland Mosaic component package.
+//!
+//! This crate is intentionally empty. The package's real deliverables are
+//! `Notes.mil` / `Notes.mll` / `Notes.dark.msl` / `Notes.light.msl` under
+//! `src/` and the `mosaic-package.toml` manifest at the package root — they
+//! describe one component (Notes) built from UI29 kernel primitives plus one
+//! deliberate use of the legacy `Input` primitive (for its `multiline`
+//! textarea support — see the package's README).
+//!
+//! The Rust crate exists only so a smoke-test integration test can run the
+//! source files through the mosmodel / moslayout / mosstyle compilers and
+//! assert the package round-trips at the language-frontend layer. See
+//! `tests/package_compiles.rs`.

--- a/code/packages/mosaic/mosaic-pkg-notes/tests/package_compiles.rs
+++ b/code/packages/mosaic/mosaic-pkg-notes/tests/package_compiles.rs
@@ -1,0 +1,186 @@
+//! package_compiles — smoke test for the mosaic-pkg-notes package.
+//!
+//! Mirrors mosaic-pkg-calendar's own `package_compiles.rs`: manifest parses
+//! and declares the expected export; Notes.mil compiles via mosmodel;
+//! Notes.mll compiles against that interface via moslayout; Notes.dark.msl /
+//! Notes.light.msl each compile against the resulting part map via mosstyle.
+//! No cross-package dependency to pin (built entirely from kernel
+//! primitives, like mosaic-pkg-grid and mosaic-pkg-calendar).
+
+use std::fs;
+use std::path::PathBuf;
+
+fn package_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn src_path(name: &str) -> PathBuf {
+    package_root().join("src").join(name)
+}
+
+fn read_source(name: &str) -> String {
+    let path = src_path(name);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e))
+}
+
+// ---------------------------------------------------------------------------
+// 1. Manifest
+// ---------------------------------------------------------------------------
+
+#[test]
+fn manifest_declares_expected_exports() {
+    let manifest_src = fs::read_to_string(package_root().join("mosaic-package.toml"))
+        .expect("manifest mosaic-package.toml must exist at the package root");
+
+    let value: toml::Value =
+        toml::from_str(&manifest_src).expect("mosaic-package.toml must parse as valid TOML");
+
+    let name = value
+        .get("package")
+        .and_then(|p| p.get("name"))
+        .and_then(|n| n.as_str())
+        .expect("[package].name must be set");
+    assert_eq!(name, "mosaic-pkg-notes", "[package].name mismatch");
+
+    let exports = value
+        .get("components")
+        .and_then(|c| c.get("exports"))
+        .and_then(|e| e.as_array())
+        .expect("[components].exports must be an array");
+    let export_names: Vec<&str> = exports.iter().filter_map(|v| v.as_str()).collect();
+    assert_eq!(
+        export_names,
+        vec!["Notes"],
+        "[components].exports must list exactly Notes"
+    );
+
+    let kernel_version = value
+        .get("kernel")
+        .and_then(|k| k.get("version"))
+        .and_then(|v| v.as_str())
+        .expect("[kernel].version must be set");
+    assert_eq!(kernel_version, "1", "[kernel].version must target UI29 kernel v1");
+}
+
+// ---------------------------------------------------------------------------
+// 2. mosmodel — .mil compilation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn notes_mil_compiles() {
+    let src = read_source("Notes.mil");
+    let out = mosmodel_compiler::compile(&src)
+        .unwrap_or_else(|e| panic!("Notes.mil failed to compile via mosmodel_compiler:\n{:#?}", e));
+    assert_eq!(out.component.component, "Notes");
+
+    let slot_names: Vec<&str> = out.component.slots.iter().map(|s| s.name.as_str()).collect();
+    for expected in [
+        "notes-title",
+        "note-rows",
+        "selected-note-id",
+        "title-value",
+        "body-value",
+    ] {
+        assert!(
+            slot_names.contains(&expected),
+            "Notes.mil must declare slot `{}`, got: {:?}",
+            expected,
+            slot_names
+        );
+    }
+
+    let emit_names: Vec<&str> = out.component.emits.iter().map(|e| e.name.as_str()).collect();
+    for expected in [
+        "onSelectNote",
+        "onNewNote",
+        "onTitleChange",
+        "onBodyChange",
+        "onSave",
+        "onDelete",
+        "onCancel",
+    ] {
+        assert!(
+            emit_names.contains(&expected),
+            "Notes.mil must declare emit `{}`, got: {:?}",
+            expected,
+            emit_names
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. moslayout — .mll compilation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn notes_mll_compiles_against_its_interface() {
+    let mil_src = read_source("Notes.mil");
+    let mil_out = mosmodel_compiler::compile(&mil_src)
+        .unwrap_or_else(|e| panic!("Notes.mil precompile failed: {:#?}", e));
+
+    let mll_src = read_source("Notes.mll");
+    moslayout_compiler::compile(&mll_src, Some(&mil_out.descriptor_json))
+        .unwrap_or_else(|e| panic!("Notes.mll failed to compile via moslayout_compiler:\n{:#?}", e));
+}
+
+#[test]
+fn notes_mll_references_selected_note_id_in_camel_case() {
+    // Regression guard: found live-testing this package. A slot referenced
+    // bare inside a parenthesized expression must use its camelCase
+    // identifier (`selectedNoteId`) — the kebab-case `slot:` spelling
+    // (`selected-note-id`) compiles at every static layer (mosmodel/
+    // moslayout/mosstyle all accept it) but is silently wrong at runtime:
+    // the emitted JS parses `selected-note-id` as subtraction of three
+    // undefined identifiers, not one reference to the slot.
+    let src = read_source("Notes.mll");
+    assert!(
+        src.contains("selectedNoteId"),
+        "Notes.mll must reference the selected-note-id slot as `selectedNoteId` inside expressions"
+    );
+    assert!(
+        !src.contains("== selected-note-id"),
+        "Notes.mll must not reference the slot by its kebab-case name inside an expression"
+    );
+}
+
+#[test]
+fn notes_mll_uses_a_multiline_body_field() {
+    // Pins the deliberate legacy-`Input` use for the body's textarea — a
+    // regression guard against silently regressing to a single-line
+    // HostInput, which would be a real UX loss for a note body. See
+    // task-app-notes-ui-v1.md for why HostInput alone isn't enough.
+    let src = read_source("Notes.mll");
+    assert!(src.contains("multiline : true"), "Notes.mll must use a multiline body field");
+}
+
+// ---------------------------------------------------------------------------
+// 4. mosstyle — .msl compilation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn each_msl_theme_compiles_against_the_part_map() {
+    let mll_src = read_source("Notes.mll");
+    let mll_out = moslayout_compiler::compile(&mll_src, None)
+        .unwrap_or_else(|e| panic!("Notes.mll precompile failed: {:#?}", e));
+
+    for theme in ["Notes.dark.msl", "Notes.light.msl"] {
+        let msl_path = src_path(theme);
+        assert!(msl_path.exists(), "{} must exist", msl_path.display());
+
+        let msl_src = read_source(theme);
+        mosstyle_compiler::compile(&msl_src, Some(&mll_out.part_map_json))
+            .unwrap_or_else(|e| panic!("{} failed to compile via mosstyle_compiler:\n{:#?}", theme, e));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Source-tree sanity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn source_tree_has_expected_shape() {
+    for name in ["Notes.mil", "Notes.mll", "Notes.dark.msl", "Notes.light.msl"] {
+        let path = src_path(name);
+        assert!(path.exists(), "expected package source file missing: {}", path.display());
+    }
+}

--- a/code/programs/mosaic/task-app/BACKLOG.md
+++ b/code/programs/mosaic/task-app/BACKLOG.md
@@ -34,19 +34,7 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
    - Calendar view — shipped since (Phase 7, see Resolved below); the mock's calendar
      was corroborating evidence for that roadmap phase, not a separate design-fidelity task.
 
-3. **Phase 8 — `mosaic-pkg-notes` UI component.** The engine half shipped (see Resolved
-   below): `Note { id, title, body, attached_task }`, `upsert_note`/`delete_note`, wired
-   through to `task-engine.mjs`. What's left is the UI — adapted from
-   `mosaic-pkg-note-editor`, which was built for a different domain (Anki notes: note
-   types, decks, focused-field editing) and needs re-pointing at a plain title+body note.
-   Per `code/specs/task-app-notes-entity-v1.md`'s research, roughly a third of
-   `NoteEditor`'s 25 slots are Anki-specific dead weight and the focused-field-editing
-   cluster (6 slots) collapses to a single body textarea — this is closer to "a new
-   component inspired by NoteEditor's shell" than a mechanical port. Then wire it into
-   `TaskApp` as a 6th tab (List/Board/Sheet/Calendar/Timeline/Notes) the same way Sheet
-   and Calendar were.
-
-4. **Phase 9 — App-shell assembly + progressive disclosure.** Partially done already via ad hoc
+3. **Phase 9 — App-shell assembly + progressive disclosure.** Partially done already via ad hoc
    UI-design passes ([#8970](https://github.com/adhithyan15/coding-adventures/pull/8970), [#8983](https://github.com/adhithyan15/coding-adventures/pull/8983), [#9112](https://github.com/adhithyan15/coding-adventures/pull/9112), [#8994](https://github.com/adhithyan15/coding-adventures/pull/8994), [#9110](https://github.com/adhithyan15/coding-adventures/pull/9110), [#9127](https://github.com/adhithyan15/coding-adventures/pull/9127), [#9136](https://github.com/adhithyan15/coding-adventures/pull/9136))
    — theming, project switching, nested-project hierarchy, shell/groups/status/cards all landed.
    Remaining: package it as a reusable `mosaic-pkg-project-nav` (nested-project tree + view
@@ -73,6 +61,11 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
   a 4-way branch duplicating the whole drop-target + event-loop wasn't judged worth it for a
   colour difference. Today's badge shipped (it only needed a small conditional child, the
   same trick Board's `card-crit` chip already uses).
+- **Notes: attachment picker, tags, rich text, search.** Deferred from the Phase 8 UI
+  ship — see `code/specs/task-app-notes-ui-v1.md`. v1's notes are always standalone (no
+  UI to set `attached_task`); tags are generic and reusable in `mosaic-pkg-notes` but
+  nothing drives them; `Note.body` is plain text, matching every other free-text field
+  in the engine; no search box (mirrors Sheet's own v1 scope cut).
 - Recurring tasks / reminders UX.
 - Automation rules (Butler-style).
 - Resource-leveling UI (the engine's `constraint-*` leveling exists; no UI surfaces it).
@@ -82,7 +75,7 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
 
 ## Resolved (kept for traceability, not actionable)
 
-- **Phase 8 — Notes entity (engine half).** `task-core` gained `Note { id, title,
+- **Phase 8 — Notes, both halves.** Engine: `task-core` gained `Note { id, title,
   body, attached_task }`, stored per-project (`ProjectState.notes`, serde-defaulted
   so already-persisted workspaces keep loading), `upsert_note`/`delete_note` ops,
   `delete_task` orphans (not deletes) a task's attached notes, and both ops are
@@ -93,9 +86,21 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
   the delete-orphans-not-deletes behavior through the actual ABI, not just the pure
   Rust layer. Found and fixed a pre-existing gap while here: `set_notes` (a task's
   plain-text field, unrelated to this new entity) had a working WASM export but was
-  never wired into `task-engine.mjs` — fixed alongside the new bindings. The UI
-  (`mosaic-pkg-notes`) is the remaining "Next up" item above — deliberately split
-  into its own PR, see `code/specs/task-app-notes-entity-v1.md` for why.
+  never wired into `task-engine.mjs` — fixed alongside the new bindings.
+  UI: `mosaic-pkg-notes` (adapted from `mosaic-pkg-note-editor` — roughly a third of
+  its 25 slots were Anki-domain-specific dead weight, and the focused-field-editing
+  cluster collapsed to a single multiline body field), wired into `TaskApp` as a
+  sixth tab. Found and fixed one real bug live-testing it, before first ship: a slot
+  referenced by its kebab-case name inside an expression (`selected-note-id` instead
+  of the correct camelCase `selectedNoteId`) compiled cleanly at every static layer
+  but silently miscompiled to JS (`selected - note - id`, subtraction of undefined
+  identifiers) — clicking Save threw and blanked the page. Verified live end-to-end
+  after the fix: create → type (single-line title + multiline body) → Save → appears
+  in the list → persists across view navigation → Delete removes it → Cancel
+  discards an unsaved draft without touching the engine; both themes; zero console
+  errors. Deliberately split into two PRs — see `code/specs/task-app-notes-ui-v1.md`
+  for why — with the UI's own deferred scope (attachment picker, tags, rich text,
+  search) tracked above.
 - **Phase 7 — Calendar component.** `mosaic-pkg-calendar` — month grid + drag-to-move,
   see `code/specs/task-app-calendar-v1.md` for the full scope. The engine's
   `calendar(range, view)` projection needed zero new work (shipped in #8726); this PR was

--- a/code/programs/mosaic/task-app/CHANGELOG.md
+++ b/code/programs/mosaic/task-app/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to the `task-app` web program are documented here.
 
 ## [0.1.0] - Unreleased
 
+### Added - notes (list + editor) view
+
+Phase 8's UI half: a new `mosaic-pkg-notes` package (adapted from
+`mosaic-pkg-note-editor`), wired into `TaskApp` as a sixth view
+(List/Board/Sheet/Calendar/Notes/Timeline). The engine half — `task-core`'s
+`Note` entity and `upsertNote`/`deleteNote` — shipped separately; see
+`code/specs/task-app-notes-ui-v1.md` for why the two were split.
+
+- A list of every note (title, standalone or task-attached — v1 shows
+  them in one flat list, no separate browse split) with "+ New note", and
+  an editor for whichever one is open (title, multiline body, Save/
+  Delete/Cancel).
+- Save always calls `upsertNote` — a new note's id is minted the moment
+  "+ New note" is clicked (the same host-mints-ids-upfront pattern
+  `addTask`/`addProject` already use), not deferred to first Save, so the
+  editor stays open the whole time regardless of whether the note has
+  been persisted yet.
+- Deferred: an attachment picker (v1's notes are always standalone),
+  tags, rich text, search — see `BACKLOG.md`.
+
 ### Added - calendar (month grid) view
 
 Phase 7 of the roadmap: a new `mosaic-pkg-calendar` package, wired to

--- a/code/programs/mosaic/task-app/host/web/src/main.tsx
+++ b/code/programs/mosaic/task-app/host/web/src/main.tsx
@@ -254,14 +254,25 @@ function makeController(engine: any, init: ControllerInit = {}) {
   let newName = "";
   let newDue = "";
   let newProject = "";
-  // Which view is showing. A string rather than a set of booleans, so the five
+  // Which view is showing. A string rather than a set of booleans, so the six
   // states can't contradict each other.
-  let view: "list" | "board" | "timeline" | "sheet" | "calendar" = "list";
+  let view: "list" | "board" | "timeline" | "sheet" | "calendar" | "notes" = "list";
   // Sheet toolbar state.
   let sheetFilterText = "";
   let sheetSortField = ""; // a SHEET_FIELDS label, or "" for unsorted
   let sheetSortAscending = true;
   let sheetSortOpen = false;
+  // Notes editor state. `selectedNoteId` is the open note's id, or "" for
+  // none — including while composing a brand-new, not-yet-saved note: its id
+  // is minted the moment "+ New note" is clicked (the same host-mints-ids-
+  // upfront pattern addTask/addProject already use), NOT deferred to Save.
+  // That keeps `selected-note-id` a reliable non-empty "editor is open"
+  // marker throughout — Notes.mll shows the editor purely off its
+  // truthiness. Cancelling (or navigating away) before ever saving simply
+  // discards the draft; the engine never heard about it.
+  let selectedNoteId = "";
+  let noteTitleDraft = "";
+  let noteBodyDraft = "";
   // Grid's edit-cursor slots. -1/"" means "none", matching Grid's own contract
   // (see Grid.mil).
   let sheetSelectedRow = -1;
@@ -477,6 +488,25 @@ function makeController(engine: any, init: ControllerInit = {}) {
     return { cells, events };
   };
 
+  // The notes list — read straight off `workspace()` (no dedicated query
+  // exists, or is needed: see task-app-notes-entity-v1.md, the whole-project
+  // dump already includes `notes` for free once the field exists). Sorted
+  // alphabetically by title, the same "read the way a person would expect"
+  // call `projects()` already makes for sibling project names — raw
+  // BTreeMap/id order is just creation order, which reads worse for a list
+  // meant to be scanned.
+  const noteRows = (): { ids: string[]; rows: string[][] } => {
+    const ws = engine.workspace().data;
+    const activeId = engine.activeProject().data as string;
+    const notesMap = (ws.projects?.[activeId]?.notes ?? {}) as Record<string, any>;
+    const entries = Object.values(notesMap) as any[];
+    entries.sort((a, b) => String(a.title ?? "").localeCompare(String(b.title ?? "")));
+    return {
+      ids: entries.map((n) => n.id as string),
+      rows: entries.map((n) => [n.id as string, String(n.title ?? "").trim() || "Untitled"]),
+    };
+  };
+
   return {
     getProps() {
       // Ask the ENGINE for render-ready cells. The host no longer formats dates,
@@ -571,6 +601,8 @@ function makeController(engine: any, init: ControllerInit = {}) {
       // Computed only while the calendar is showing — same "don't run a query
       // the current view doesn't need" discipline as `sheet`/`boardCards`.
       const cal = view === "calendar" ? calendarData() : { cells: [], events: [] };
+      // Computed only while the notes view is showing — same discipline.
+      const notes = view === "notes" ? noteRows() : { ids: [], rows: [] };
       const boardCards: string[][] = (() => {
         if (view !== "board") return [];
         const pct = progress();
@@ -620,6 +652,12 @@ function makeController(engine: any, init: ControllerInit = {}) {
         calendarTitle: view === "calendar" ? monthLabel(calendarMonthStart) : "",
         calendarCells: cal.cells,
         calendarEvents: cal.events,
+        notesMode: view === "notes" ? "notes" : "",
+        notesTitle: "Notes",
+        noteRows: notes.rows,
+        selectedNoteId,
+        noteTitleValue: noteTitleDraft,
+        noteBodyValue: noteBodyDraft,
         timelineScale: tl.scale,
         timelineRows: tl.rows,
         newTaskName: newName,
@@ -662,6 +700,9 @@ function makeController(engine: any, init: ControllerInit = {}) {
           break;
         case "showCalendar":
           view = "calendar";
+          break;
+        case "showNotes":
+          view = "notes";
           break;
         case "cardDropped": {
           // A drop is a PROPOSAL. The engine owns what a status change means; the host
@@ -734,6 +775,73 @@ function makeController(engine: any, init: ControllerInit = {}) {
           persist();
           break;
         }
+        case "selectNote": {
+          // Resolve through the SAME ordered id list the rows were drawn
+          // from — same discipline as expandTask/selectProject, so a click
+          // can't land on the wrong note.
+          const { ids } = noteRows();
+          const id = ids[event.index];
+          if (!id) break;
+          const ws = engine.workspace().data;
+          const activeId = engine.activeProject().data as string;
+          const note = ws.projects?.[activeId]?.notes?.[id];
+          if (!note) break;
+          selectedNoteId = id;
+          noteTitleDraft = String(note.title ?? "");
+          noteBodyDraft = String(note.body ?? "");
+          break;
+        }
+        case "newNote":
+          // Mint the id now, not on Save — see selectedNoteId's own comment
+          // on why the editor needs a non-empty id to stay open at all.
+          selectedNoteId = `n${++counter}`;
+          noteTitleDraft = "";
+          noteBodyDraft = "";
+          break;
+        case "noteTitleChange":
+          noteTitleDraft = event.value;
+          break;
+        case "noteBodyChange":
+          noteBodyDraft = event.value;
+          break;
+        case "saveNote": {
+          if (!selectedNoteId) break;
+          // upsertNote is create-or-replace by id either way — whether this
+          // is a brand-new note (first Save) or an edit to an existing one
+          // makes no difference to the op itself.
+          const res = engine.upsertNote({
+            id: selectedNoteId,
+            title: noteTitleDraft,
+            body: noteBodyDraft,
+            attachedTask: null,
+          });
+          if (res?.ok === false) {
+            console.error("Note save failed:", res.error ?? res);
+            break;
+          }
+          persist();
+          break;
+        }
+        case "deleteNote": {
+          if (!selectedNoteId) break;
+          // Harmless (a no-op, per task-core's own contract) if the note was
+          // never actually saved — Delete works uniformly either way.
+          const res = engine.deleteNote({ id: selectedNoteId });
+          if (res?.ok === false) {
+            console.error("Note delete failed:", res.error ?? res);
+            break;
+          }
+          selectedNoteId = "";
+          noteTitleDraft = "";
+          noteBodyDraft = "";
+          persist();
+          break;
+        }
+        case "cancelNote":
+          selectedNoteId = "";
+          noteTitleDraft = "";
+          noteBodyDraft = "";
+          break;
         case "sheetNavigate": {
           sheetSelectedRow = event.row;
           sheetSelectedCol = event.col;

--- a/code/programs/mosaic/task-app/mosaic-package.toml
+++ b/code/programs/mosaic/task-app/mosaic-package.toml
@@ -10,6 +10,7 @@ exports = ["TaskApp"]
 [dependencies]
 mosaic-pkg-sheet = "0.1.0"
 mosaic-pkg-calendar = "0.1.0"
+mosaic-pkg-notes = "0.1.0"
 
 [kernel]
 version = "1"

--- a/code/programs/mosaic/task-app/src/TaskApp.dark.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.dark.msl
@@ -512,6 +512,136 @@ style TaskApp {
     }
   }
 
+  // Notes tab. "on" mirrors seg-cal-on's raised-card treatment; every "off"
+  // variant mirrors seg-cal-off's plain transparent-with-hover treatment.
+  part seg-notes-on {
+    background : "#252019" ;
+    color : "#f1ebe1" ;
+    font-size : 13 ;
+    font-weight : bold ;
+    padding-top : 6 ;
+    padding-right : 14 ;
+    padding-bottom : 6 ;
+    padding-left : 14 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    box-shadow : "0 1px 2px rgba(0,0,0,.3), 0 4px 14px rgba(0,0,0,.28)" ;
+  }
+  part seg-notes-off {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+  part seg-notes-off2 {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+  part seg-notes-off3 {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+  part seg-notes-off4 {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+  part seg-notes-off5 {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+
+  // The new notes-mode branch also needs an "off" instance of every OTHER
+  // family (list/board/sheet/calendar/timeline) — next unused numeric
+  // suffix per family (see TaskApp.mll's seg block for the mapping).
+  part seg-list-off5 {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+  part seg-board-off6 {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+  part seg-sheet-off5 {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+  part seg-cal-off5 {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+  part seg-tl-off5 {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+
   // ── board (kanban) ──────────────────────────────────────────────────────
   part board {
     gap : 14 ;

--- a/code/programs/mosaic/task-app/src/TaskApp.light.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.light.msl
@@ -512,6 +512,136 @@ style TaskApp {
     }
   }
 
+  // Notes tab. "on" mirrors seg-cal-on's raised-card treatment; every "off"
+  // variant mirrors seg-cal-off's plain transparent-with-hover treatment.
+  part seg-notes-on {
+    background : "#fffdfa" ;
+    color : "#2b2723" ;
+    font-size : 13 ;
+    font-weight : bold ;
+    padding-top : 6 ;
+    padding-right : 14 ;
+    padding-bottom : 6 ;
+    padding-left : 14 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    box-shadow : "0 1px 2px rgba(60,45,25,.05), 0 4px 14px rgba(60,45,25,.05)" ;
+  }
+  part seg-notes-off {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+  part seg-notes-off2 {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+  part seg-notes-off3 {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+  part seg-notes-off4 {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+  part seg-notes-off5 {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+
+  // The new notes-mode branch also needs an "off" instance of every OTHER
+  // family (list/board/sheet/calendar/timeline) — next unused numeric
+  // suffix per family (see TaskApp.mll's seg block for the mapping).
+  part seg-list-off5 {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+  part seg-board-off6 {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+  part seg-sheet-off5 {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+  part seg-cal-off5 {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+  part seg-tl-off5 {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+
   // ── board (kanban) ──────────────────────────────────────────────────────
   part board {
     gap : 14 ;

--- a/code/programs/mosaic/task-app/src/TaskApp.mil
+++ b/code/programs/mosaic/task-app/src/TaskApp.mil
@@ -89,6 +89,19 @@ component TaskApp {
   slot calendar-cells  : list<list<text>> ;
   slot calendar-events : list<list<text>> ;
 
+  // Notes (list + editor). `notes-mode` is non-empty when the notes view is
+  // showing. Every `notes-*` slot is a straight pass-through to
+  // `pkg::mosaic-pkg-notes::Notes` — see Notes.mil for the full contract
+  // and code/specs/task-app-notes-ui-v1.md for the scope. The host builds
+  // note-rows from task-core's Note entities (via `workspace()`) and owns
+  // the in-progress edit buffer.
+  slot notes-mode          : text ;
+  slot notes-title         : text ;
+  slot note-rows           : list<list<text>> ;
+  slot selected-note-id    : text ;
+  slot note-title-value    : text ;
+  slot note-body-value     : text ;
+
   // One row per task, in schedule order. Each row is a list of pre-formatted cells:
   //
   //   [ 0 ] done-glyph      [ 5 ] expanded-marker  — non-empty for the ONE open row
@@ -123,6 +136,7 @@ component TaskApp {
   emit onShowTimeline ;
   emit onShowSheet ;
   emit onShowCalendar ;
+  emit onShowNotes ;
 
   // A drop is a PROPOSAL: the engine decides whether the move is legal and performs
   // it. The payload is the UI35 contract — what moved, of what kind, onto which
@@ -143,6 +157,15 @@ component TaskApp {
   emit onCalendarPrev ;
   emit onCalendarNext ;
   emit onCalendarEventDropped ( key : text , kind : text , targetKey : text , position : text ) ;
+
+  // Notes emits — straight pass-through to/from pkg::mosaic-pkg-notes::Notes.
+  emit onSelectNote ( index : number ) ;
+  emit onNewNote ;
+  emit onNoteTitleChange ( value : text ) ;
+  emit onNoteBodyChange ( value : text ) ;
+  emit onSaveNote ;
+  emit onDeleteNote ;
+  emit onCancelNote ;
 
   // Expand (or collapse) a task row to reveal its scheduling detail.
   emit onExpandTask ( index : number ) ;

--- a/code/programs/mosaic/task-app/src/TaskApp.mll
+++ b/code/programs/mosaic/task-app/src/TaskApp.mll
@@ -68,13 +68,14 @@ layout TaskApp {
         // clicking the view you are already on is a no-op instead of a swap.
         Row [ seg ] {
           // Part names are unique layout-wide, even across mutually-exclusive
-          // branches, so each of the five buttons gets its own name in each of
-          // the five branches (one "on" + four "off" variants per button).
+          // branches, so each of the six buttons gets its own name in each of
+          // the six branches (one "on" + five "off" variants per button).
           If ( when: slot: timeline-mode ) {
             HostButton [ seg-list-off ] ( label : "List" , onClick : emit: onShowList )
             HostButton [ seg-board-off ] ( label : "Board" , onClick : emit: onShowBoard )
             HostButton [ seg-sheet-off ] ( label : "Sheet" , onClick : emit: onShowSheet )
             HostButton [ seg-cal-off ] ( label : "Calendar" , onClick : emit: onShowCalendar )
+            HostButton [ seg-notes-off ] ( label : "Notes" , onClick : emit: onShowNotes )
             HostButton [ seg-tl-on ] ( label : "Timeline" , onClick : emit: onShowTimeline )
           }
           Else {
@@ -83,6 +84,7 @@ layout TaskApp {
               HostButton [ seg-board-on ] ( label : "Board" , onClick : emit: onShowBoard )
               HostButton [ seg-sheet-off2 ] ( label : "Sheet" , onClick : emit: onShowSheet )
               HostButton [ seg-cal-off2 ] ( label : "Calendar" , onClick : emit: onShowCalendar )
+              HostButton [ seg-notes-off2 ] ( label : "Notes" , onClick : emit: onShowNotes )
               HostButton [ seg-tl-off2 ] ( label : "Timeline" , onClick : emit: onShowTimeline )
             }
             Else {
@@ -91,6 +93,7 @@ layout TaskApp {
                 HostButton [ seg-board-off3 ] ( label : "Board" , onClick : emit: onShowBoard )
                 HostButton [ seg-sheet-on ] ( label : "Sheet" , onClick : emit: onShowSheet )
                 HostButton [ seg-cal-off3 ] ( label : "Calendar" , onClick : emit: onShowCalendar )
+                HostButton [ seg-notes-off3 ] ( label : "Notes" , onClick : emit: onShowNotes )
                 HostButton [ seg-tl-off3 ] ( label : "Timeline" , onClick : emit: onShowTimeline )
               }
               Else {
@@ -99,14 +102,26 @@ layout TaskApp {
                   HostButton [ seg-board-off5 ] ( label : "Board" , onClick : emit: onShowBoard )
                   HostButton [ seg-sheet-off4 ] ( label : "Sheet" , onClick : emit: onShowSheet )
                   HostButton [ seg-cal-on ] ( label : "Calendar" , onClick : emit: onShowCalendar )
+                  HostButton [ seg-notes-off4 ] ( label : "Notes" , onClick : emit: onShowNotes )
                   HostButton [ seg-tl-off4 ] ( label : "Timeline" , onClick : emit: onShowTimeline )
                 }
                 Else {
-                  HostButton [ seg-list-on ] ( label : "List" , onClick : emit: onShowList )
-                  HostButton [ seg-board-off4 ] ( label : "Board" , onClick : emit: onShowBoard )
-                  HostButton [ seg-sheet-off3 ] ( label : "Sheet" , onClick : emit: onShowSheet )
-                  HostButton [ seg-cal-off4 ] ( label : "Calendar" , onClick : emit: onShowCalendar )
-                  HostButton [ seg-tl-off ] ( label : "Timeline" , onClick : emit: onShowTimeline )
+                  If ( when: slot: notes-mode ) {
+                    HostButton [ seg-list-off5 ] ( label : "List" , onClick : emit: onShowList )
+                    HostButton [ seg-board-off6 ] ( label : "Board" , onClick : emit: onShowBoard )
+                    HostButton [ seg-sheet-off5 ] ( label : "Sheet" , onClick : emit: onShowSheet )
+                    HostButton [ seg-cal-off5 ] ( label : "Calendar" , onClick : emit: onShowCalendar )
+                    HostButton [ seg-notes-on ] ( label : "Notes" , onClick : emit: onShowNotes )
+                    HostButton [ seg-tl-off5 ] ( label : "Timeline" , onClick : emit: onShowTimeline )
+                  }
+                  Else {
+                    HostButton [ seg-list-on ] ( label : "List" , onClick : emit: onShowList )
+                    HostButton [ seg-board-off4 ] ( label : "Board" , onClick : emit: onShowBoard )
+                    HostButton [ seg-sheet-off3 ] ( label : "Sheet" , onClick : emit: onShowSheet )
+                    HostButton [ seg-cal-off4 ] ( label : "Calendar" , onClick : emit: onShowCalendar )
+                    HostButton [ seg-notes-off5 ] ( label : "Notes" , onClick : emit: onShowNotes )
+                    HostButton [ seg-tl-off ] ( label : "Timeline" , onClick : emit: onShowTimeline )
+                  }
                 }
               }
             }
@@ -217,6 +232,26 @@ layout TaskApp {
           )
         }
         Else {
+        If ( when: slot: notes-mode ) {
+          // Every notes-* slot/emit is a straight pass-through to the
+          // package — TaskApp adds no shaping of its own, see Notes.mil
+          // for the contract and task-app-notes-ui-v1.md for the scope.
+          pkg::mosaic-pkg-notes::Notes (
+            notes-title : slot: notes-title ,
+            note-rows : slot: note-rows ,
+            selected-note-id : slot: selected-note-id ,
+            title-value : slot: note-title-value ,
+            body-value : slot: note-body-value ,
+            onSelectNote : emit: onSelectNote ,
+            onNewNote : emit: onNewNote ,
+            onTitleChange : emit: onNoteTitleChange ,
+            onBodyChange : emit: onNoteBodyChange ,
+            onSave : emit: onSaveNote ,
+            onDelete : emit: onDeleteNote ,
+            onCancel : emit: onCancelNote
+          )
+        }
+        Else {
           Column [ list-wrap ] {
             Row [ composer ] {
               HostInput [ name-input ] (
@@ -275,6 +310,7 @@ layout TaskApp {
               }
             }
           }
+        }
         }
         }
         }

--- a/code/specs/task-app-notes-ui-v1.md
+++ b/code/specs/task-app-notes-ui-v1.md
@@ -1,0 +1,84 @@
+# task-app Notes — v1 UI scope
+
+Second half of Phase 8, following on from the engine entity
+([task-app-notes-entity-v1.md](task-app-notes-entity-v1.md)). Scopes
+`mosaic-pkg-notes` — a list-plus-editor component adapted from
+`mosaic-pkg-note-editor`, wired into `TaskApp` as a sixth view.
+
+## What v1 ships
+
+- **A list + editor shell**: a left column listing every note (standalone
+  and task-attached, in one flat list — task-app has no separate "browse
+  standalone vs. per-task" UI in v1; a note's attachment is just data, not
+  a navigation split) with a "+ New note" button, and a right column
+  editing whichever note is selected (title, body, Save/Delete/Cancel).
+- **Create, edit, delete** — the full CRUD the engine already supports
+  (`upsert_note`/`delete_note`, shipped in the entity PR). Save always
+  calls `upsertNote` (create-or-replace by id — the same op whether it's a
+  brand-new note or an edit, matching the engine's own whole-entity-upsert
+  shape); a new note gets a freshly-minted id on first Save, the same
+  pattern `addTask`/`addProject` already use for `main.tsx`-minted ids.
+- **Both themes**, palette matching the rest of TaskApp's tokens (this
+  component has no design-mock reference — `design/ui-prototype.html`
+  predates the notes entity — so it's styled to match the existing
+  Sheet/Board/Calendar treatments rather than a specific mock).
+
+## What's explicitly deferred
+
+- **Per-task attachment picker.** v1's editor has no UI to set/change
+  `attached_task` — a note created from the Notes tab is always standalone.
+  Attaching a note to a specific task (e.g. from the task detail panel) is
+  real UI work belonging to the "richer task rows" design-fidelity item
+  already tracked in `BACKLOG.md`, not this PR.
+- **Tags.** `NoteEditor`'s `tags-value`/`onTagsChange` is generic and
+  reusable, but nothing in task-app's data model or UI has a notion of
+  note-tagging yet — deferred with no engine-side blocker, purely a
+  "nobody asked for it yet" scope cut.
+- **Rich text.** Per the entity spec, `Note.body` is plain text; v1's
+  editor is a plain multi-line text field, not a rich-text editor.
+- **Search/filter over notes.** The list renders every note; no search box
+  in v1 (mirrors how Sheet shipped without a saved-search picker in v1).
+
+## A real kernel gap found while designing this
+
+UI29's kernel `HostInput` is **single-line only** — the legacy `Input`
+(UI25) primitive is what supports `multiline: true` (lowering to
+`<textarea>` in the React backend), and that support was **not** carried
+forward into `HostInput`; per `mosaic-emit-react`'s own doc comment, a
+`multiline` toggle is meant to live in "a userland `MultilineInput`
+component," which doesn't exist yet. A note body genuinely needs multiple
+lines — a single-line body field would be a real UX regression, not just
+an aesthetic gap.
+
+**Decision**: use the legacy `Input` primitive directly for the body
+field, with `multiline: true`. This is a disclosed, deliberate use of an
+existing, still-functioning, still-emitter-supported primitive for a real
+need — not a new pattern to spread, and not blocking on building a new
+`MultilineInput` kernel-adjacent component as a detour from shipping
+Notes. If/when a userland `MultilineInput` lands, this is the one call
+site in the whole task-app codebase that would need updating.
+
+## Package structure
+
+`code/packages/mosaic/mosaic-pkg-notes/`, mirroring `mosaic-pkg-sheet`'s
+file trio: `Cargo.toml`, `mosaic-package.toml`, `src/lib.rs` (doc-only),
+`src/Notes.mil`, `src/Notes.mll`, `src/Notes.{light,dark}.msl`,
+`tests/package_compiles.rs`. No dependency on another package — built
+from kernel primitives plus the one legacy `Input` use above.
+
+## TaskApp wiring
+
+Same shape as Sheet/Calendar's integration: `slot notes-mode : text ;`,
+`emit onShowNotes ;` added to the "choose a view" group, a sixth branch in
+the segmented switcher (six uniquely-named buttons per branch — the
+pattern is now List/Board/Sheet/Calendar/Notes/Timeline, six families ×
+six branches = 36 button declarations, following the exact precedent
+Calendar's own addition already established), a sixth `If`/`Else` content
+branch, and `pkg::mosaic-pkg-notes::Notes ( ... )` embedded with every
+slot/emit forwarded explicitly. `main.tsx` gains `notes-mode`, a selected-
+note-id + title/body draft state (mirroring the composer's `newName`/
+`newDue` pattern), a `noteRows()` derivation from `engine.workspace()`'s
+`projects[activeProject].notes` (no dedicated query needed — the entity
+spec already noted `workspace()` includes it for free), and
+`showNotes`/`selectNote`/`newNote`/`noteTitleChange`/`noteBodyChange`/
+`saveNote`/`deleteNote`/`cancelNote` dispatch cases.


### PR DESCRIPTION
## Summary

Adds `mosaic-pkg-notes`, a list-plus-editor component adapted from
`mosaic-pkg-note-editor` (built for a different domain — Anki-style
flashcard notes: note types, decks, focused-field editing — none of which
apply to a plain title+body note). Roughly a third of `NoteEditor`'s 25
slots were Anki-specific dead weight; the focused-field-editing cluster
collapses to a single multiline body field. Wired into `TaskApp` as a
sixth tab (List/Board/Sheet/Calendar/Notes/Timeline), the same pattern
Sheet and Calendar already used.

Depends on the engine half (`Note` entity, `upsertNote`/`deleteNote`)
shipped separately in #10004 (now merged). Deliberately split into two
PRs per [task-app-notes-ui-v1.md](code/specs/task-app-notes-ui-v1.md).

- A list of every note with "+ New note", and an editor for whichever one
  is open (title, multiline body, Save/Delete/Cancel).
- Save always calls `upsertNote` — a new note's id is minted the moment
  "+ New note" is clicked (the same host-mints-ids-upfront pattern
  `addTask`/`addProject` already use), not deferred to first Save, so the
  editor stays open regardless of whether the note has been persisted yet.
- **A real kernel gap found while designing this**: UI29's kernel
  `HostInput` is single-line only — multiline support lives only on the
  legacy `Input` (UI25) primitive, and no userland `MultilineInput`
  exists yet. Used `Input(multiline: true)` for the body field, once,
  deliberately — a disclosed use of an existing, still-emitter-supported
  primitive for a real UX need, not a new pattern to spread.
- **Deferred**: attachment picker (v1 notes are always standalone), tags,
  rich text, search — see `BACKLOG.md`.

**Found and fixed one real bug live-testing this, before first ship**: a
slot referenced by its kebab-case name inside an expression
(`selected-note-id` instead of the correct camelCase `selectedNoteId`)
compiled cleanly at every static layer (mosmodel/moslayout/mosstyle all
accepted it) but silently miscompiled to JS — `selected-note-id` parses as
subtraction of three undefined identifiers, not a slot reference.
Clicking Save threw `ReferenceError` and blanked the page. Fixed to match
the camelCase convention `mosaic-pkg-grid`'s `Grid.mll` already
established (`editRow`/`editCol` inside `is-editing`/`is-selected`
expressions), and added a regression test pinning it — the package's own
compile-layer tests did **not** catch this; only live browser testing did.

## Test plan

- [x] 7 `mosaic-pkg-notes` tests pass (including the regression test),
      `task-app` compile tests pass, `cargo clippy` clean on both
- [x] Live browser end-to-end: create → type (title + multiline body) →
      Save → appears in list → persists across view navigation → Delete
      removes it → Cancel discards an unsaved draft without touching the
      engine; both themes; zero console errors on a fresh tab
- [x] `/security-review` — passed, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)