### PR TITLE
feat(task-app): label management -- create and assign

### DIFF
--- a/code/programs/mosaic/task-app/BACKLOG.md
+++ b/code/programs/mosaic/task-app/BACKLOG.md
@@ -66,12 +66,11 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
   UI to set `attached_task`); tags are generic and reusable in `mosaic-pkg-notes` but
   nothing drives them; `Note.body` is plain text, matching every other free-text field
   in the engine; no search box (mirrors Sheet's own v1 scope cut).
-- **Label management UI (create, colour-pick, assign to a task).** `upsertLabel`/
-  `setTaskLabels` exist on the engine; nothing in `main.tsx` calls either yet, and the
-  Sheet's column catalogue has no Labels column. The task-row labels chip shipped
-  (see Resolved below) and is fully wired — it just has no data to show until this
-  lands, the same "engine ready, no create UI yet" shape Notes' attachment picker is
-  in.
+- **Label colour picker + duplicate-name prevention + per-label removal.** Deferred
+  from the label-management ship (see Resolved below) — `Label.color` is set (always
+  `""` in v1) but nothing renders it; two labels can share a name (mirrors project
+  names, also undeduped); removing one label from a multi-label task means retyping
+  the whole comma-separated Sheet cell.
 - Recurring tasks / reminders UX.
 - Automation rules (Butler-style).
 - Resource-leveling UI (the engine's `constraint-*` leveling exists; no UI surfaces it).
@@ -81,16 +80,28 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
 
 ## Resolved (kept for traceability, not actionable)
 
+- **Label management (create + assign).** Closes the gap the task-row-chips ship
+  below disclosed. A "+ Label" composer wraps the Sheet tab in `TaskApp.mll`
+  (deliberately TaskApp's own concern, not a `mosaic-pkg-sheet` slot — Sheet has no
+  business knowing about labels), calling the engine's existing `upsertLabel`. A new
+  Sheet "Labels" column accepts comma-separated *existing* label names, matched
+  case-insensitively, and **rejects the whole edit** on an unrecognised name rather
+  than creating a throwaway label or silently dropping it (the same discipline the
+  Priority column already uses). Verified live end-to-end: created a label named
+  "Urgent", assigned it by typing "urgent" (matched case-insensitively), confirmed
+  the chip renders on the List tab; confirmed an unknown name leaves the existing
+  assignment untouched rather than corrupting it. Both themes, zero console errors.
+  Colour picker, duplicate-name prevention, and per-label removal deferred — see the
+  Backlog item above.
 - **Task-row priority + labels chips.** Pure display wiring — `task-core` already had
   both fields shipped; `TASK_VIEW`'s `visibleFields` gained `priority`/`labels`,
   `taskRows()` appends them as trailing cells (`row[10]`/`row[11]`, not inserted, so no
   existing index shifts), `TaskApp.mil`/`.mll` gained `chip-priority`/`chip-labels`
   following the exact `chip-due`/`chip-sched`/`chip-over` pattern. Verified live: set a
   task's priority to "High" via the Sheet tab's already-editable Priority column,
-  confirmed the chip renders on the List tab in both themes. The labels chip uses the
-  identical mechanism but has no way to actually populate yet — no UI assigns a label
-  to a task anywhere in the app — tracked as its own item above (label management UI),
-  not silently glossed over.
+  confirmed the chip renders on the List tab in both themes. The labels chip shipped
+  with no way to populate it yet — closed immediately after by the label-management
+  item above, not left hanging.
 - **Phase 8 — Notes, both halves.** Engine: `task-core` gained `Note { id, title,
   body, attached_task }`, stored per-project (`ProjectState.notes`, serde-defaulted
   so already-persisted workspaces keep loading), `upsert_note`/`delete_note` ops,

--- a/code/programs/mosaic/task-app/CHANGELOG.md
+++ b/code/programs/mosaic/task-app/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to the `task-app` web program are documented here.
 
 ## [0.1.0] - Unreleased
 
+### Added - label management (create + assign)
+
+Closes the gap the previous entry disclosed: labels can now actually be
+created and assigned, not just displayed.
+
+- **Creation**: a small composer ("+ Label") wrapping the Sheet tab in
+  `TaskApp.mll` — deliberately TaskApp's own concern, not a
+  `mosaic-pkg-sheet` slot, since Sheet is a generic grid+toolbar wrapper
+  with no business knowing about labels specifically. Calls the engine's
+  existing `upsertLabel({ id, name, color: "" })`; no colour picker in v1
+  (a fixed empty string — nothing reads the field yet).
+- **Assignment**: a new "Labels" column on the Sheet, editable like every
+  other column. Accepts comma-separated *existing* label names, matched
+  case-insensitively (`"urgent"` resolves to a label named "Urgent").
+  An unrecognised name **rejects the whole edit** rather than creating a
+  throwaway label or silently dropping it — the same "reject an
+  unrecognised value rather than sending it through" discipline the
+  Priority column already uses.
+
+Verified live end-to-end: created a label named "Urgent", assigned it to
+a task by typing "urgent" (lowercase) into its Sheet Labels cell — matched
+case-insensitively — confirmed the chip renders on the List tab; then
+confirmed typing an unknown name leaves the existing assignment untouched
+rather than corrupting it. Both themes. Zero console errors.
+
+**Still deferred**: colour picker (the `Label.color` field is set but
+inert — nothing renders it yet), duplicate-name prevention (creating two
+labels with the same name is allowed, mirroring how project names aren't
+deduped either), and a way to *remove* a single label from a task without
+retyping the whole comma-separated list.
+
 ### Added - priority and labels shown on task rows
 
 The list view now shows a task's priority (e.g. "High") and labels (comma-

--- a/code/programs/mosaic/task-app/host/web/src/main.tsx
+++ b/code/programs/mosaic/task-app/host/web/src/main.tsx
@@ -71,7 +71,9 @@ interface SheetField {
   width: number;
   editable: boolean;
   sortable: boolean;
-  write?: (id: string, value: string) => any;
+  // `ctx` is optional and only the Labels column reads it (name→id lookup) — every
+  // other column's `write` ignores the third argument entirely.
+  write?: (id: string, value: string, ctx?: { labelsByName: Map<string, string> }) => any;
 }
 const PRIORITY_VALUES = ["low", "normal", "high", "urgent"];
 const SHEET_FIELDS: SheetField[] = [
@@ -156,6 +158,29 @@ const SHEET_FIELDS: SheetField[] = [
   { field: { builtin: "overdue" }, label: "Overdue", width: 90, editable: false, sortable: false },
   { field: { builtin: "start" }, label: "Start", width: 100, editable: false, sortable: false },
   { field: { builtin: "finish" }, label: "Finish", width: 100, editable: false, sortable: false },
+  {
+    field: { builtin: "labels" },
+    label: "Labels",
+    width: 160,
+    editable: true,
+    sortable: false,
+    // Comma-separated EXISTING label names, matched case-insensitively — the same
+    // "reject an unrecognised value rather than sending it through" discipline the
+    // Priority column above already uses. This deliberately does NOT create a label
+    // on an unmatched name: a typo would otherwise mint a throwaway label silently.
+    // Label *creation* is its own composer (see the label-composer row wrapping the
+    // Sheet in TaskApp.mll) — assignment here only ever references what already exists.
+    write: (id, value, ctx) => {
+      const names = value.split(",").map((s) => s.trim()).filter(Boolean);
+      const ids: string[] = [];
+      for (const name of names) {
+        const labelId = ctx?.labelsByName.get(name.toLowerCase());
+        if (!labelId) return null; // unknown name — reject the whole edit, not a partial one
+        ids.push(labelId);
+      }
+      return { op: "setTaskLabels", args: { id, labels: ids } };
+    },
+  },
 ];
 
 // Sheet toolbar/state → the View the engine actually evaluates. Rebuilt every
@@ -256,6 +281,7 @@ function makeController(engine: any, init: ControllerInit = {}) {
   let newName = "";
   let newDue = "";
   let newProject = "";
+  let newLabel = "";
   // Which view is showing. A string rather than a set of booleans, so the six
   // states can't contradict each other.
   let view: "list" | "board" | "timeline" | "sheet" | "calendar" | "notes" = "list";
@@ -509,6 +535,21 @@ function makeController(engine: any, init: ControllerInit = {}) {
     };
   };
 
+  // Existing labels, keyed by lowercased name — read straight off `workspace()`
+  // (no dedicated query needed, same reasoning as `noteRows()`). The Sheet's Labels
+  // column uses this to resolve a typed name back to the id `setTaskLabels` needs;
+  // an unmatched name is rejected there, not created here.
+  const labelsByName = (): Map<string, string> => {
+    const ws = engine.workspace().data;
+    const activeId = engine.activeProject().data as string;
+    const map = (ws.projects?.[activeId]?.labels ?? {}) as Record<string, any>;
+    const out = new Map<string, string>();
+    for (const l of Object.values(map) as any[]) {
+      out.set(String(l.name ?? "").toLowerCase(), l.id as string);
+    }
+    return out;
+  };
+
   return {
     getProps() {
       // Ask the ENGINE for render-ready cells. The host no longer formats dates,
@@ -658,6 +699,7 @@ function makeController(engine: any, init: ControllerInit = {}) {
         sheetSortOptions: SHEET_FIELDS.filter((f) => f.sortable).map((f) => f.label),
         sheetSortOpen,
         sheetSortAscending,
+        newLabelName: newLabel,
         calendarMode: view === "calendar" ? "calendar" : "",
         calendarTitle: view === "calendar" ? monthLabel(calendarMonthStart) : "",
         calendarCells: cal.cells,
@@ -886,7 +928,7 @@ function makeController(engine: any, init: ControllerInit = {}) {
           sheetEditCol = -1;
           sheetEditContent = "";
           if (!id || !col?.write) break;
-          const change = col.write(id, event.value);
+          const change = col.write(id, event.value, { labelsByName: labelsByName() });
           if (!change) break; // the column rejected the value (e.g. an unknown priority)
           const res = (engine as any)[change.op](change.args);
           if (res?.ok === false) {
@@ -909,6 +951,27 @@ function makeController(engine: any, init: ControllerInit = {}) {
         case "sheetToggleSortDirection":
           sheetSortAscending = !sheetSortAscending;
           break;
+        case "newLabelNameChange":
+          newLabel = event.value;
+          break;
+        case "addLabel": {
+          const name = newLabel.trim();
+          if (!name) break;
+          // Label ids share the same monotonic counter tasks/notes already mint from
+          // (`t${n}`/`n${n}`) — the "l" prefix keeps the namespace distinct, so no
+          // collision is possible across entity kinds.
+          const id = `l${++counter}`;
+          // No colour picker in v1 (see BACKLOG.md) — a fixed empty string. The
+          // engine only ever round-trips this field verbatim; nothing reads it yet.
+          const res = engine.upsertLabel({ id, name, color: "" });
+          if (res?.ok === false) {
+            console.error("Could not create the label:", res.error ?? res);
+            break;
+          }
+          newLabel = "";
+          persist();
+          break;
+        }
         case "newProjectNameChange":
           newProject = event.value;
           break;

--- a/code/programs/mosaic/task-app/src/TaskApp.dark.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.dark.msl
@@ -751,6 +751,48 @@ style TaskApp {
     }
   }
 
+  // ── sheet: label composer ──────────────────────────────────────────────
+  part sheet-view-wrap {
+    gap : 14 ;
+  }
+  part label-composer {
+    gap : 8 ;
+    align : center-vertical ;
+    background : "#252019" ;
+    padding : 8 ;
+    border-width : 1 ;
+    border-color : "#352e25" ;
+    border-radius : 13 ;
+    box-shadow : "0 1px 2px rgba(0,0,0,.35), 0 4px 14px rgba(0,0,0,.35)" ;
+  }
+  part label-name-input {
+    width : 220 ;
+    background : "transparent" ;
+    color : "#f1ebe1" ;
+    font-size : 14 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 8 ;
+  }
+  part label-add-btn {
+    background : "#eaa63f" ;
+    color : "#1a1714" ;
+    font-size : 13 ;
+    font-weight : bold ;
+    padding-top : 8 ;
+    padding-right : 16 ;
+    padding-bottom : 8 ;
+    padding-left : 16 ;
+    border-width : 0 ;
+    border-radius : 8 ;
+    state hover {
+      background : "#d4922f" ;
+    }
+    state pressed {
+      background : "#b87822" ;
+    }
+  }
+
   part task-list {
     gap : 7 ;
   }

--- a/code/programs/mosaic/task-app/src/TaskApp.light.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.light.msl
@@ -751,6 +751,48 @@ style TaskApp {
     }
   }
 
+  // ── sheet: label composer ──────────────────────────────────────────────
+  part sheet-view-wrap {
+    gap : 14 ;
+  }
+  part label-composer {
+    gap : 8 ;
+    align : center-vertical ;
+    background : "#fffdfa" ;
+    padding : 8 ;
+    border-width : 1 ;
+    border-color : "#e6ded3" ;
+    border-radius : 13 ;
+    box-shadow : "0 1px 2px rgba(60,45,25,.05), 0 4px 14px rgba(60,45,25,.05)" ;
+  }
+  part label-name-input {
+    width : 220 ;
+    background : "transparent" ;
+    color : "#2b2723" ;
+    font-size : 14 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 8 ;
+  }
+  part label-add-btn {
+    background : "#e0942a" ;
+    color : "#ffffff" ;
+    font-size : 13 ;
+    font-weight : bold ;
+    padding-top : 8 ;
+    padding-right : 16 ;
+    padding-bottom : 8 ;
+    padding-left : 16 ;
+    border-width : 0 ;
+    border-radius : 8 ;
+    state hover {
+      background : "#c67f1e" ;
+    }
+    state pressed {
+      background : "#a96816" ;
+    }
+  }
+
   part task-list {
     gap : 7 ;
   }

--- a/code/programs/mosaic/task-app/src/TaskApp.mil
+++ b/code/programs/mosaic/task-app/src/TaskApp.mil
@@ -78,6 +78,14 @@ component TaskApp {
   slot sheet-sort-open        : bool ;
   slot sheet-sort-ascending   : bool ;
 
+  // The label composer wrapping the Sheet (see TaskApp.mll's sheet-mode branch).
+  // Deliberately TaskApp's own concern, not a mosaic-pkg-sheet slot — Sheet is a
+  // generic grid+toolbar wrapper and has no business knowing about labels
+  // specifically. Assignment (typing an existing label's name into a task's Labels
+  // cell) goes through the Sheet's own editable-cell mechanism instead; this
+  // composer is creation only.
+  slot new-label-name : text ;
+
   // Calendar (month grid). `calendar-mode` is non-empty when the calendar is
   // showing. Every `calendar-*` slot is a straight pass-through to
   // `pkg::mosaic-pkg-calendar::Calendar` — see Calendar.mil for the full
@@ -155,6 +163,10 @@ component TaskApp {
   emit onSheetSortFieldChange     ( value : text ) ;
   emit onSheetToggleSortOpen ;
   emit onSheetToggleSortDirection ;
+
+  // Label composer (TaskApp's own — see the new-label-name slot's note).
+  emit onNewLabelNameChange ( value : text ) ;
+  emit onAddLabel ;
 
   // Calendar emits — straight pass-through to/from pkg::mosaic-pkg-calendar::Calendar.
   emit onCalendarPrev ;

--- a/code/programs/mosaic/task-app/src/TaskApp.mll
+++ b/code/programs/mosaic/task-app/src/TaskApp.mll
@@ -191,31 +191,43 @@ layout TaskApp {
         }
         Else {
         If ( when: slot: sheet-mode ) {
-          // Every sheet-* slot/emit is a straight pass-through to the package —
-          // TaskApp adds no shaping of its own, see Sheet.mil for the contract.
-          pkg::mosaic-pkg-sheet::Sheet (
-            viewport-rows : slot: sheet-viewport-rows ,
-            column-headers : slot: sheet-column-headers ,
-            column-widths : slot: sheet-column-widths ,
-            selected-row : slot: sheet-selected-row ,
-            selected-col : slot: sheet-selected-col ,
-            edit-row : slot: sheet-edit-row ,
-            edit-col : slot: sheet-edit-col ,
-            edit-content : slot: sheet-edit-content ,
-            filter-text : slot: sheet-filter-text ,
-            sort-field : slot: sheet-sort-field ,
-            sort-options : slot: sheet-sort-options ,
-            sort-open : slot: sheet-sort-open ,
-            sort-ascending : slot: sheet-sort-ascending ,
-            onNavigate : emit: onSheetNavigate ,
-            onFormulaChange : emit: onSheetFormulaChange ,
-            onEditCommit : emit: onSheetEditCommit ,
-            onEditCancel : emit: onSheetEditCancel ,
-            onFilterChange : emit: onSheetFilterChange ,
-            onSortFieldChange : emit: onSheetSortFieldChange ,
-            onToggleSortOpen : emit: onSheetToggleSortOpen ,
-            onToggleSortDirection : emit: onSheetToggleSortDirection
-          )
+          // TaskApp wraps the Sheet with its own label composer, above the grid —
+          // deliberately NOT inside mosaic-pkg-sheet (see new-label-name's slot
+          // comment on TaskApp.mil for why). Every sheet-* slot/emit below is still
+          // a straight pass-through to the package itself.
+          Column [ sheet-view-wrap ] {
+            Row [ label-composer ] {
+              HostInput [ label-name-input ] (
+                value : slot: new-label-name ,
+                placeholder : "New label" ,
+                onChange : emit: onNewLabelNameChange
+              )
+              HostButton [ label-add-btn ] ( label : "+ Label" , onClick : emit: onAddLabel )
+            }
+            pkg::mosaic-pkg-sheet::Sheet (
+              viewport-rows : slot: sheet-viewport-rows ,
+              column-headers : slot: sheet-column-headers ,
+              column-widths : slot: sheet-column-widths ,
+              selected-row : slot: sheet-selected-row ,
+              selected-col : slot: sheet-selected-col ,
+              edit-row : slot: sheet-edit-row ,
+              edit-col : slot: sheet-edit-col ,
+              edit-content : slot: sheet-edit-content ,
+              filter-text : slot: sheet-filter-text ,
+              sort-field : slot: sheet-sort-field ,
+              sort-options : slot: sheet-sort-options ,
+              sort-open : slot: sheet-sort-open ,
+              sort-ascending : slot: sheet-sort-ascending ,
+              onNavigate : emit: onSheetNavigate ,
+              onFormulaChange : emit: onSheetFormulaChange ,
+              onEditCommit : emit: onSheetEditCommit ,
+              onEditCancel : emit: onSheetEditCancel ,
+              onFilterChange : emit: onSheetFilterChange ,
+              onSortFieldChange : emit: onSheetSortFieldChange ,
+              onToggleSortOpen : emit: onSheetToggleSortOpen ,
+              onToggleSortDirection : emit: onSheetToggleSortDirection
+            )
+          }
         }
         Else {
         If ( when: slot: calendar-mode ) {


### PR DESCRIPTION
## Summary

Closes the gap the previous PR (#10006) disclosed: the labels chip shipped
fully wired but with no way to actually populate it. Labels can now be
created and assigned.

- **Creation**: a small "+ Label" composer wraps the Sheet tab in
  `TaskApp.mll` — deliberately TaskApp's own concern, not a
  `mosaic-pkg-sheet` slot, since Sheet is a generic grid+toolbar wrapper
  with no business knowing about labels specifically. Calls the engine's
  existing `upsertLabel({ id, name, color: "" })`; no colour picker in
  v1 — a fixed empty string, nothing reads the field yet.
- **Assignment**: a new "Labels" column on the Sheet, editable like
  every other column. Accepts comma-separated *existing* label names,
  matched case-insensitively. An unrecognised name **rejects the whole
  edit** rather than creating a throwaway label or silently dropping
  it — the same "reject an unrecognised value rather than sending it
  through" discipline the Priority column already uses.

## Test plan

- [x] Verified live end-to-end: created a label named "Urgent", assigned
      it by typing "urgent" (lowercase) into a task's Sheet Labels
      cell — matched case-insensitively, resolved to the label's
      canonical name — confirmed the chip renders on the List tab; then
      confirmed typing an unknown name leaves the existing assignment
      untouched rather than corrupting it. Both themes. Zero console
      errors.
- [x] `task-app` compile tests pass, `cargo clippy` clean
- [x] `/security-review` — passed, no findings

## Still deferred (disclosed in `BACKLOG.md`)

Colour picker (`Label.color` is set but inert), duplicate-name
prevention, per-label removal without retyping the whole comma-separated
list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)