### PR TITLE
feat(task-app): show a task's CPM dependency list in the detail panel

### DIFF
--- a/code/programs/mosaic/task-app/BACKLOG.md
+++ b/code/programs/mosaic/task-app/BACKLOG.md
@@ -27,10 +27,18 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
    - Richer Gantt: day-grid columns, weekend/today shading, milestone diamonds,
      dependency arrows, hover tooltips, a legend. Current timeline is a simple
      proportional-bar-per-row view.
-   - Richer task rows: labels/priority chips shipped (see Resolved below). Still
-     missing: critical/slack chips, dependency list, notes paragraph in the detail
-     panel — the notes-paragraph item can now pull from the real `Note` entity
-     (shipped in Phase 8) via an `attached_task` lookup, not just `Task.notes`.
+   - Richer task rows: labels/priority chips and the dependency list shipped (see
+     Resolved below). Still missing: critical/slack *chips* (today the detail panel's
+     scheduling prose already says "on the critical path" / states slack in prose —
+     a dedicated chip would be a value-only restyle, low priority) and a notes
+     paragraph in the detail panel. The notes paragraph turned out to be
+     **blocked on the "Notes: attachment picker" item below**, not just an engine
+     lookup as previously written here: `Note.attached_task` exists and a
+     `detail-notes` cell would be trivial to wire, but there is no UI anywhere to
+     ever set `attached_task` — v1's notes are permanently standalone. Ship both
+     together: the attach control (however it ends up scoped — a name-matching
+     text field mirroring the Labels column's discipline is the obvious minimal
+     shape) and the detail-panel cell that reads it, in the same PR.
    - Calendar view — shipped since (Phase 7, see Resolved below); the mock's calendar
      was corroborating evidence for that roadmap phase, not a separate design-fidelity task.
 
@@ -70,7 +78,9 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
   ship — see `code/specs/task-app-notes-ui-v1.md`. v1's notes are always standalone (no
   UI to set `attached_task`); tags are generic and reusable in `mosaic-pkg-notes` but
   nothing drives them; `Note.body` is plain text, matching every other free-text field
-  in the engine; no search box (mirrors Sheet's own v1 scope cut).
+  in the engine; no search box (mirrors Sheet's own v1 scope cut). The attach picker
+  specifically is now also the blocker for the "Next up" design-fidelity item's
+  task-detail notes paragraph above — ship them together.
 - **Label colour picker + duplicate-name prevention + per-label removal.** Deferred
   from the label-management ship (see Resolved below) — `Label.color` is set (always
   `""` in v1) but nothing renders it; two labels can share a name (mirrors project
@@ -85,6 +95,14 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
 
 ## Resolved (kept for traceability, not actionable)
 
+- **Task-detail dependency list.** The open task's detail panel shows its CPM
+  dependencies (`→ Build the prototype (FS)` / `← Design the wireframes (FS)`),
+  read from `task-core`'s existing `flowchart()` projection — zero new engine
+  work. A matching notes paragraph was drafted alongside this but pulled back
+  out before shipping: it would have read `Note.attached_task`, but no UI
+  anywhere sets that field yet (see the "Notes: attachment picker" backlog item
+  above, now updated to note it blocks this too). Verified live in both themes,
+  zero console errors.
 - **Phase 9 — nested-project tree extracted to `mosaic-pkg-project-nav`.** The
   add/add-subproject composer + nested-project list, extracted verbatim from
   `TaskApp`'s own rail block — same part names, same styling (both themes), same

--- a/code/programs/mosaic/task-app/CHANGELOG.md
+++ b/code/programs/mosaic/task-app/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to the `task-app` web program are documented here.
 
 ## [0.1.0] - Unreleased
 
+### Added - dependency list in the task-detail panel
+
+The open task's detail panel now shows its CPM dependencies alongside the
+existing scheduled/slack prose: `→ Build the prototype (FS)` for a
+predecessor edge, `← Design the wireframes (FS)` for a successor edge,
+each labelled FS/SS/FF/SF. Pure UI — `task-core`'s `flowchart()`
+projection (predecessor/successor task ids + kind label, already exported
+through `task-wasm`/`task-engine.mjs`) needed zero new engine work; only
+`scheduling` edges are shown (real CPM dependencies), not generic links.
+Follows the same "appended, not inserted" (`row[12]`) and
+progressive-disclosure (computed only for the one open row) conventions
+`row[6]`-`row[8]`/`row[10]`-`row[11]` already established.
+
+Verified live: added two tasks (every new task auto-links as a
+dependency successor of the previous one, so no dedicated dependency-UI
+was needed to exercise this), expanded each in turn, confirmed both edge
+directions and the FS label render correctly in both themes. Zero
+console errors.
+
+**Scope note**: a matching "notes paragraph" (attached `Note` entities'
+body text) was drafted alongside this but pulled back out before
+shipping — there is no UI anywhere yet to actually attach a note to a
+task (Notes v1 deliberately deferred that as its own "attachment picker"
+item), so the cell would only ever render empty. See `BACKLOG.md`: it
+now needs to ship together with that picker, not before it.
+
 ### Changed - project rail extracted to mosaic-pkg-project-nav
 
 Phase 9's first half: the nested-project tree + add/add-subproject

--- a/code/programs/mosaic/task-app/host/web/src/main.tsx
+++ b/code/programs/mosaic/task-app/host/web/src/main.tsx
@@ -587,6 +587,28 @@ function makeController(engine: any, init: ControllerInit = {}) {
         ];
       };
 
+      // Dependency list for the ONE open row — read from the same `flowchart()`
+      // projection the (currently unused-elsewhere) relation graph exposes:
+      // {nodes: [{task, name, kind}], edges: [{from, to, label, scheduling}]}.
+      // Only `scheduling` edges (real CPM dependencies, not generic links) belong
+      // in a task's dependency list. Computed only when a row is open, same
+      // "don't run a query the collapsed list doesn't need" discipline as `sched`.
+      const flow = expanded === null ? undefined : engine.flowchart().data;
+      const depsFor = (id: string): string => {
+        if (!flow) return "";
+        const names = new Map<string, string>();
+        for (const n of (flow.nodes ?? []) as any[]) {
+          names.set(n.task as string, n.name as string);
+        }
+        const parts: string[] = [];
+        for (const e of (flow.edges ?? []) as any[]) {
+          if (!e.scheduling) continue;
+          if (e.to === id) parts.push(`← ${names.get(e.from) ?? e.from} (${e.label})`);
+          if (e.from === id) parts.push(`→ ${names.get(e.to) ?? e.to} (${e.label})`);
+        }
+        return parts.join(" · ");
+      };
+
       // Group the list the way the design does: what's underway, what's next, and
       // what's finished. The heading rides on the row that OPENS each group, so the
       // layout can print it without knowing anything about grouping.
@@ -630,6 +652,9 @@ function makeController(engine: any, init: ControllerInit = {}) {
           // engine work.
           c.display[PRIORITY] ?? "",
           c.display[LABELS] ?? "",
+          // Same "appended, not inserted" discipline as priority/labels above —
+          // and same progressive-disclosure gating as d1-d3: empty unless open.
+          isOpen ? depsFor(id) : "",
         ];
       });
       const doneCount = ids.filter((id) => byTask.get(id)!.value[DONE]?.value === true).length;

--- a/code/programs/mosaic/task-app/src/TaskApp.dark.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.dark.msl
@@ -833,6 +833,10 @@ style TaskApp {
     color : "#867c70" ;
     font-size : 12 ;
   }
+  part detail-deps {
+    color : "#b3a99c" ;
+    font-size : 12 ;
+  }
 
   // ── timeline ────────────────────────────────────────────────────────────
   part timeline-card {

--- a/code/programs/mosaic/task-app/src/TaskApp.light.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.light.msl
@@ -833,6 +833,10 @@ style TaskApp {
     color : "#9b9289" ;
     font-size : 12 ;
   }
+  part detail-deps {
+    color : "#6a625a" ;
+    font-size : 12 ;
+  }
 
   // ── timeline ────────────────────────────────────────────────────────────
   part timeline-card {

--- a/code/programs/mosaic/task-app/src/TaskApp.mil
+++ b/code/programs/mosaic/task-app/src/TaskApp.mil
@@ -126,13 +126,21 @@ component TaskApp {
   //                                opens a group, so the list reads as sections
   //                         [ 10 ] priority display name (e.g. "High"), or empty
   //                         [ 11 ] labels, comma-joined display names, or empty
+  //                         [ 12 ] detail: dependency list (predecessors/successors,
+  //                                each labelled FS/SS/FF/SF), or empty
   //
   // Every cell is optional: an empty one (no due date, not overdue, nothing to add)
-  // is the empty string and the layout hides it. Cells 6-8 are the
+  // is the empty string and the layout hides it. Cells 6-8 and 12 are the
   // progressive-disclosure payload, filled ONLY for the expanded row — so a collapsed
-  // list stays a plain to-do list, and the host skips the CPM recompute entirely when
-  // nothing is open. 10-11 are appended rather than inserted between 9 and the old
-  // end, so no existing row[n] reference anywhere shifts meaning.
+  // list stays a plain to-do list, and the host skips the CPM recompute (and the
+  // dependency lookup) entirely when nothing is open. 10-12 are appended
+  // rather than inserted between 9 and the old end, so no existing row[n] reference
+  // anywhere shifts meaning. A notes-paragraph cell was considered here too (Note
+  // entities already carry an `attached_task` link) but dropped: there is no UI
+  // anywhere yet to actually attach a note to a task (the Notes v1 spec deliberately
+  // deferred that as its own "attachment picker" item), so the cell would only ever
+  // render empty — dead plumbing nothing could reach. Add it alongside that picker,
+  // not before it.
   slot task-rows : list<list<text>> ;
 
   // Typing in the inputs.

--- a/code/programs/mosaic/task-app/src/TaskApp.mll
+++ b/code/programs/mosaic/task-app/src/TaskApp.mll
@@ -307,6 +307,9 @@ layout TaskApp {
                       If ( when: ( row[8] ) ) {
                         Text [ detail-free ] ( content : ( row[8] ) )
                       }
+                      If ( when: ( row[12] ) ) {
+                        Text [ detail-deps ] ( content : ( row[12] ) )
+                      }
                     }
                   }
                 }


### PR DESCRIPTION
## Summary

- The open task's detail panel now shows its CPM dependencies alongside the existing scheduled/slack prose — e.g. `→ Build the prototype (FS)` for a predecessor edge, `← Design the wireframes (FS)` for a successor edge.
- Pure UI: `task-core`'s `flowchart()` projection (predecessor/successor task ids + FS/SS/FF/SF kind label) was already exported through `task-wasm`/`task-engine.mjs` — this needed **zero new engine work**. Only `scheduling` edges are shown (real CPM dependencies), not generic links.
- Follows the row-cell contract's existing conventions: appended as `row[12]` (not inserted, so no existing `row[n]` reference shifts), and progressive-disclosure gated (computed only for the one open row, same discipline as the existing schedule/slack cells).

**Scope note**: a matching "notes paragraph" (pulling a task's attached `Note.body` via `attached_task`) was drafted alongside this but pulled back out before shipping — there is no UI anywhere yet to actually attach a note to a task (Notes v1 deliberately deferred that as its own "attachment picker" item). Shipping the read side with no write side anywhere would just be dead plumbing. `BACKLOG.md` now correctly links the two so a future implementer ships them together.

Stacked on the not-yet-merged [#10008](https://github.com/adhithyan15/coding-adventures/pull/10008) (project-nav extraction) — this diff will shrink to just the dependency-list change once that merges and this rebases.

## Test plan

- [x] `cargo test` in `code/programs/mosaic/task-app` — 2/2 pass (manifest + `.mil`/`.mll`/`.msl` compile)
- [x] `npx vitest run` in `host/web` — 28/28 pass (the actual CI gate for this package)
- [x] Live browser verification: added two tasks (new tasks auto-link as a dependency successor of the previous one, so no dependency-UI was needed to exercise this), expanded each in turn, confirmed both edge directions and the FS label render correctly
- [x] Both themes (light/dark) verified — correct part colors picked up
- [x] Zero console errors
- [x] `/security-review` — passed, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)