### PR TITLE
feat(human-languages): grow the shared spine above A1 with an A2 verb tranche (HL-C10)

### DIFF
--- a/code/learning/human-languages/arabic/curriculum.json
+++ b/code/learning/human-languages/arabic/curriculum.json
@@ -467,6 +467,43 @@
         "NUMBER-ONE-TO-FIVE"
       ],
       "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-DO": {
+      "segments": [],
+      "omits": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-NEGATE-AND-ASK": {
+      "segments": [],
+      "omits": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-WANT": {
+      "segments": [],
+      "omits": [
+        "VERB-WANT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-PAST": {
+      "segments": [],
+      "omits": [
+        "VERB-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-FUTURE": {
+      "segments": [],
+      "omits": [
+        "VERB-FUTURE"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/bengali/curriculum.json
+++ b/code/learning/human-languages/bengali/curriculum.json
@@ -231,6 +231,43 @@
         "NUMBER-ONE-TO-FIVE"
       ],
       "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-DO": {
+      "segments": [],
+      "omits": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-NEGATE-AND-ASK": {
+      "segments": [],
+      "omits": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-WANT": {
+      "segments": [],
+      "omits": [
+        "VERB-WANT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-PAST": {
+      "segments": [],
+      "omits": [
+        "VERB-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-FUTURE": {
+      "segments": [],
+      "omits": [
+        "VERB-FUTURE"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/chinese/curriculum.json
+++ b/code/learning/human-languages/chinese/curriculum.json
@@ -140,6 +140,43 @@
         "NUMBER-ONE-TO-FIVE"
       ],
       "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-DO": {
+      "segments": [],
+      "omits": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-NEGATE-AND-ASK": {
+      "segments": [],
+      "omits": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-WANT": {
+      "segments": [],
+      "omits": [
+        "VERB-WANT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-PAST": {
+      "segments": [],
+      "omits": [
+        "VERB-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-FUTURE": {
+      "segments": [],
+      "omits": [
+        "VERB-FUTURE"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -15,14 +15,28 @@
       "core": false,
       "notes": "bonjour / Guten Tag / buongiorno / bom dia. Distinct from GREETING-MORNING and from the noun TIME-DAY."
     },
-    "GREETING-MORNING": { "family": "GREETING", "gloss": "good morning", "core": false },
-    "GREETING-AFTERNOON": { "family": "GREETING", "gloss": "good afternoon", "core": false },
-    "GREETING-EVENING": { "family": "GREETING", "gloss": "good evening (said on meeting)", "core": false },
+    "GREETING-MORNING": {
+      "family": "GREETING",
+      "gloss": "good morning",
+      "core": false
+    },
+    "GREETING-AFTERNOON": {
+      "family": "GREETING",
+      "gloss": "good afternoon",
+      "core": false
+    },
+    "GREETING-EVENING": {
+      "family": "GREETING",
+      "gloss": "good evening (said on meeting)",
+      "core": false
+    },
     "GREETING-GOODNIGHT": {
       "family": "GREETING",
       "gloss": "good night (said on parting / before sleep)",
       "core": false,
-      "retires": ["GREETING-NIGHT"],
+      "retires": [
+        "GREETING-NIGHT"
+      ],
       "notes": "Parting greeting, distinct from the meeting greeting GREETING-EVENING. Retires Spanish/Italian's older GREETING-NIGHT tag; where a track's 'noches/notte' word doubles as the evening noun, the noun is TIME-NIGHT."
     },
     "GREETING-FORMAL": {
@@ -45,7 +59,9 @@
       "family": "GREETING",
       "gloss": "goodbye / parting word",
       "core": true,
-      "retires": ["GREETING-GOODBYE"],
+      "retires": [
+        "GREETING-GOODBYE"
+      ],
       "notes": "Unifies the parting word across tracks (valē, āshi, alvidā, येतो/येते). The plain goodbye (adiós, au revoir, auf Wiedersehen); the time-specific 'see you …' partings are FAREWELL-LATER/TOMORROW/SOON."
     },
     "FAREWELL-LATER": {
@@ -72,19 +88,24 @@
       "core": false,
       "notes": "The informal parting distinct from the neutral FAREWELL: German tschüss, French salut/tchao, Italian ciao, Portuguese tchau."
     },
-
     "COURTESY-THANKS": {
       "family": "COURTESY",
       "gloss": "thank you (neutral / default register)",
       "core": true,
-      "retires": ["THANKS", "GRATITUDE-THANKS", "THANKS-FORMAL"],
+      "retires": [
+        "THANKS",
+        "GRATITUDE-THANKS",
+        "THANKS-FORMAL"
+      ],
       "notes": "The default 'thank you'. Where a track teaches a second, more colloquial word (often Perso-Arabic), that one is COURTESY-THANKS-CASUAL."
     },
     "COURTESY-THANKS-CASUAL": {
       "family": "COURTESY",
       "gloss": "thanks (casual / colloquial register)",
       "core": false,
-      "retires": ["THANKS-CASUAL"],
+      "retires": [
+        "THANKS-CASUAL"
+      ],
       "notes": "e.g. Hindi shukriyā, Punjabi shukrīā — the everyday, often Perso-Arabic-derived alternative to the Sanskritic COURTESY-THANKS."
     },
     "COURTESY-PLEASE": {
@@ -99,107 +120,270 @@
       "core": false,
       "notes": "Apology/attention formula: Spanish lo siento (regret) vs. perdón (fault/attention), German Entschuldigung vs. es tut mir leid, Arabic āsif, Hindi māf kījiye. Many languages split this into two words — one for regret/sympathy, one for fault/forgiveness or getting someone's attention — track both where a language has the split."
     },
-
     "RESPONSE-YES": {
       "family": "RESPONSE",
       "gloss": "yes",
       "core": true,
       "notes": "Tracks that teach yes and no in a single lesson use RESPONSE-YESNO until that lesson is split during the parity pass."
     },
-    "RESPONSE-NO": { "family": "RESPONSE", "gloss": "no", "core": true },
+    "RESPONSE-NO": {
+      "family": "RESPONSE",
+      "gloss": "no",
+      "core": true
+    },
     "RESPONSE-YESNO": {
       "family": "RESPONSE",
       "gloss": "yes / no (taught together in one lesson)",
       "core": false,
-      "retires": ["FUNCTION-YESNO"],
+      "retires": [
+        "FUNCTION-YESNO"
+      ],
       "notes": "A single lesson realizing both yes and no (ita/nōn, hāṇ/nahīṇ, hyã/nā, ām/na). Split into RESPONSE-YES + RESPONSE-NO when the track reaches parity."
     },
     "RESPONSE-OKAY": {
       "family": "RESPONSE",
       "gloss": "okay / alright",
       "core": false,
-      "retires": ["OKAY", "FUNCTION-OKAY"]
+      "retires": [
+        "OKAY",
+        "FUNCTION-OKAY"
+      ]
     },
-
-    "QUESTION-WHAT": { "family": "QUESTION", "gloss": "what", "core": true, "retires": ["WHAT"] },
-    "QUESTION-HOW": { "family": "QUESTION", "gloss": "how", "core": false, "retires": ["HOW"] },
-    "QUESTION-WHERE": { "family": "QUESTION", "gloss": "where", "core": false, "retires": ["WHERE"] },
-
+    "QUESTION-WHAT": {
+      "family": "QUESTION",
+      "gloss": "what",
+      "core": true,
+      "retires": [
+        "WHAT"
+      ]
+    },
+    "QUESTION-HOW": {
+      "family": "QUESTION",
+      "gloss": "how",
+      "core": false,
+      "retires": [
+        "HOW"
+      ]
+    },
+    "QUESTION-WHERE": {
+      "family": "QUESTION",
+      "gloss": "where",
+      "core": false,
+      "retires": [
+        "WHERE"
+      ]
+    },
     "INTRO-MY-NAME-IS": {
       "family": "INTRO",
       "gloss": "\"my name is …\"",
       "core": true,
-      "retires": ["MY-NAME-IS"]
+      "retires": [
+        "MY-NAME-IS"
+      ]
     },
     "INTRO-WHATS-YOUR-NAME": {
       "family": "INTRO",
       "gloss": "\"what's your name?\"",
       "core": true,
-      "retires": ["WHATS-YOUR-NAME"]
+      "retires": [
+        "WHATS-YOUR-NAME"
+      ]
     },
     "INTRO-NICE-TO-MEET-YOU": {
       "family": "INTRO",
       "gloss": "pleased to meet you",
       "core": true,
-      "retires": ["PLEASED-TO-MEET"],
+      "retires": [
+        "PLEASED-TO-MEET"
+      ],
       "notes": "Some tracks realize this with a bare 'joy/happiness' noun (khushī, magizhchi, santōṣa); that word is the realization."
     },
-
-    "PRONOUN-I": { "family": "PRONOUN", "gloss": "I (first-person subject)", "core": false },
-    "PRONOUN-ME": { "family": "PRONOUN", "gloss": "me / myself (object / reflexive)", "core": false },
+    "PRONOUN-I": {
+      "family": "PRONOUN",
+      "gloss": "I (first-person subject)",
+      "core": false
+    },
+    "PRONOUN-ME": {
+      "family": "PRONOUN",
+      "gloss": "me / myself (object / reflexive)",
+      "core": false
+    },
     "PRONOUN-YOU": {
       "family": "PRONOUN",
       "gloss": "you (with informal / formal forms)",
       "core": true
     },
-    "PRONOUN-MY": { "family": "PRONOUN", "gloss": "my (first-person possessive)", "core": false, "retires": ["MY"] },
-
-    "TIME-DAY": { "family": "TIME", "gloss": "day (noun)", "core": false, "retires": ["DIA", "JOUR", "TAG", "DAY"] },
-    "TIME-NIGHT": { "family": "TIME", "gloss": "night (noun)", "core": false, "retires": ["NOCHE", "NUIT", "NACHT"] },
-    "TIME-MORNING": { "family": "TIME", "gloss": "morning (noun)", "core": false, "retires": ["MORGEN"] },
-    "TIME-AFTERNOON": { "family": "TIME", "gloss": "afternoon (noun)", "core": false, "retires": ["TARDE"] },
-    "TIME-EVENING": { "family": "TIME", "gloss": "evening (noun)", "core": false, "retires": ["ABEND", "SOIR"] },
-
+    "PRONOUN-MY": {
+      "family": "PRONOUN",
+      "gloss": "my (first-person possessive)",
+      "core": false,
+      "retires": [
+        "MY"
+      ]
+    },
+    "TIME-DAY": {
+      "family": "TIME",
+      "gloss": "day (noun)",
+      "core": false,
+      "retires": [
+        "DIA",
+        "JOUR",
+        "TAG",
+        "DAY"
+      ]
+    },
+    "TIME-NIGHT": {
+      "family": "TIME",
+      "gloss": "night (noun)",
+      "core": false,
+      "retires": [
+        "NOCHE",
+        "NUIT",
+        "NACHT"
+      ]
+    },
+    "TIME-MORNING": {
+      "family": "TIME",
+      "gloss": "morning (noun)",
+      "core": false,
+      "retires": [
+        "MORGEN"
+      ]
+    },
+    "TIME-AFTERNOON": {
+      "family": "TIME",
+      "gloss": "afternoon (noun)",
+      "core": false,
+      "retires": [
+        "TARDE"
+      ]
+    },
+    "TIME-EVENING": {
+      "family": "TIME",
+      "gloss": "evening (noun)",
+      "core": false,
+      "retires": [
+        "ABEND",
+        "SOIR"
+      ]
+    },
     "NUMBER-ONE-TO-FIVE": {
       "family": "NUMBER",
       "gloss": "the cardinal numbers one through five",
       "core": false,
       "notes": "A shared retrieval ability whose language-specific realizations may add script, sound-change, agreement, classifier, or etymology extensions."
     },
-
-    "WORD-GOOD": { "family": "WORD", "gloss": "good (adjective)", "core": false, "retires": ["BON", "GOOD", "GUT"] },
-    "WORD-WELL": { "family": "WORD", "gloss": "well / fine (adverb)", "core": false, "retires": ["BIEN"] },
-    "WORD-NAME": { "family": "WORD", "gloss": "name (noun)", "core": false, "retires": ["NAME"] },
-    "WORD-IS": { "family": "WORD", "gloss": "is (copula, third person)", "core": false, "retires": ["IS"] },
-
+    "WORD-GOOD": {
+      "family": "WORD",
+      "gloss": "good (adjective)",
+      "core": false,
+      "retires": [
+        "BON",
+        "GOOD",
+        "GUT"
+      ]
+    },
+    "WORD-WELL": {
+      "family": "WORD",
+      "gloss": "well / fine (adverb)",
+      "core": false,
+      "retires": [
+        "BIEN"
+      ]
+    },
+    "WORD-NAME": {
+      "family": "WORD",
+      "gloss": "name (noun)",
+      "core": false,
+      "retires": [
+        "NAME"
+      ]
+    },
+    "WORD-IS": {
+      "family": "WORD",
+      "gloss": "is (copula, third person)",
+      "core": false,
+      "retires": [
+        "IS"
+      ]
+    },
     "GRAMMAR-THE": {
       "family": "GRAMMAR",
       "gloss": "the (definite article / gender marker)",
       "core": false,
-      "retires": ["ARTICLES-EL-LA", "ARTICLES-LE-LA", "ARTICLES-DER-DIE-DAS", "ARTICLE-GENDER", "ARTICLE"],
+      "retires": [
+        "ARTICLES-EL-LA",
+        "ARTICLES-LE-LA",
+        "ARTICLES-DER-DIE-DAS",
+        "ARTICLE-GENDER",
+        "ARTICLE"
+      ],
       "notes": "One join key for 'the'; the realization holds each language's specific forms (el/la, der/die/das, il/la/lo, o/a, al-)."
     },
-
     "COURTESY-YOUREWELCOME": {
       "family": "COURTESY",
       "gloss": "you're welcome (the standard reply to thanks)",
       "core": false,
-      "retires": ["YOURE-WELCOME", "WELCOME-REPLY"],
+      "retires": [
+        "YOURE-WELCOME",
+        "WELCOME-REPLY"
+      ],
       "notes": "The reply that closes a thanks exchange (de nada, prego, bitte, не за что). Distinct from GREETING-WELCOME (svāgatam), which welcomes an arrival."
     },
     "STATE-HOW-ARE-YOU": {
       "family": "STATE",
       "gloss": "how are you? (asking after someone's state)",
       "core": false,
-      "retires": ["HOW-ARE-YOU", "HOWAREYOU"],
+      "retires": [
+        "HOW-ARE-YOU",
+        "HOWAREYOU"
+      ],
       "notes": "The realization holds each language's phrasing and register split (¿cómo está usted? / ¿cómo estás?). Builds on QUESTION-HOW plus the state verb."
     },
     "WORD-SOSO": {
       "family": "WORD",
       "gloss": "so-so / not bad (a middling answer to 'how are you?')",
       "core": false,
-      "retires": ["SO-SO", "SOSO"],
+      "retires": [
+        "SO-SO",
+        "SOSO"
+      ],
       "notes": "The neither-good-nor-bad reply (regular / más o menos, così così, comme ci comme ça)."
+    },
+    "VERB-INFINITIVE": {
+      "family": "VERB",
+      "gloss": "the dictionary form of a verb, and the stem inside it",
+      "core": true
+    },
+    "VERB-PRESENT-HABITUAL": {
+      "family": "VERB",
+      "gloss": "saying what someone does, in general",
+      "core": true
+    },
+    "VERB-NEGATE": {
+      "family": "VERB",
+      "gloss": "saying that something is not so",
+      "core": true
+    },
+    "QUESTION-POLAR": {
+      "family": "QUESTION",
+      "gloss": "a question answerable yes or no",
+      "core": true
+    },
+    "VERB-PAST": {
+      "family": "VERB",
+      "gloss": "saying what happened before now",
+      "core": true
+    },
+    "VERB-FUTURE": {
+      "family": "VERB",
+      "gloss": "saying what will happen, or what one intends",
+      "core": true
+    },
+    "VERB-WANT": {
+      "family": "VERB",
+      "gloss": "saying what one wants or needs",
+      "core": true
     }
   },
   "namespaced": {

--- a/code/learning/human-languages/core/spine.json
+++ b/code/learning/human-languages/core/spine.json
@@ -1,6 +1,11 @@
 {
   "version": 1,
-  "stages": ["pre-A1", "A1", "A2", "B1"],
+  "stages": [
+    "pre-A1",
+    "A1",
+    "A2",
+    "B1"
+  ],
   "nodes": [
     {
       "id": "SPINE-MEET-GREET",
@@ -8,87 +13,229 @@
       "canDo": "I can recognize and use an appropriate greeting when I meet someone.",
       "prerequisites": [],
       "core": true,
-      "concepts": ["GREETING-HELLO", "GREETING-FORMAL", "GREETING-PEACE", "GREETING-WELCOME"]
+      "concepts": [
+        "GREETING-HELLO",
+        "GREETING-FORMAL",
+        "GREETING-PEACE",
+        "GREETING-WELCOME"
+      ]
     },
     {
       "id": "SPINE-COURTESY-THANK",
       "stage": "pre-A1",
       "canDo": "I can thank someone and respond appropriately to thanks.",
-      "prerequisites": ["SPINE-MEET-GREET"],
+      "prerequisites": [
+        "SPINE-MEET-GREET"
+      ],
       "core": true,
-      "concepts": ["COURTESY-THANKS", "COURTESY-THANKS-CASUAL", "COURTESY-YOUREWELCOME"]
+      "concepts": [
+        "COURTESY-THANKS",
+        "COURTESY-THANKS-CASUAL",
+        "COURTESY-YOUREWELCOME"
+      ]
     },
     {
       "id": "SPINE-RESPOND-BASIC",
       "stage": "pre-A1",
       "canDo": "I can give a basic yes, no, or okay response.",
-      "prerequisites": ["SPINE-MEET-GREET"],
+      "prerequisites": [
+        "SPINE-MEET-GREET"
+      ],
       "core": true,
-      "concepts": ["RESPONSE-YES", "RESPONSE-NO", "RESPONSE-YESNO", "RESPONSE-OKAY"]
+      "concepts": [
+        "RESPONSE-YES",
+        "RESPONSE-NO",
+        "RESPONSE-YESNO",
+        "RESPONSE-OKAY"
+      ]
     },
     {
       "id": "SPINE-EXCHANGE-NAMES",
       "stage": "pre-A1",
       "canDo": "I can ask someone's name, give my own, and acknowledge the introduction.",
-      "prerequisites": ["SPINE-MEET-GREET", "SPINE-RESPOND-BASIC"],
+      "prerequisites": [
+        "SPINE-MEET-GREET",
+        "SPINE-RESPOND-BASIC"
+      ],
       "core": true,
-      "concepts": ["QUESTION-WHAT", "PRONOUN-I", "PRONOUN-ME", "PRONOUN-YOU", "PRONOUN-MY", "WORD-NAME", "WORD-IS", "INTRO-MY-NAME-IS", "INTRO-WHATS-YOUR-NAME", "INTRO-NICE-TO-MEET-YOU"]
+      "concepts": [
+        "QUESTION-WHAT",
+        "PRONOUN-I",
+        "PRONOUN-ME",
+        "PRONOUN-YOU",
+        "PRONOUN-MY",
+        "WORD-NAME",
+        "WORD-IS",
+        "INTRO-MY-NAME-IS",
+        "INTRO-WHATS-YOUR-NAME",
+        "INTRO-NICE-TO-MEET-YOU"
+      ]
     },
     {
       "id": "SPINE-CHECK-WELLBEING",
       "stage": "pre-A1",
       "canDo": "I can ask how someone is and give a simple answer.",
-      "prerequisites": ["SPINE-EXCHANGE-NAMES"],
+      "prerequisites": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
       "core": true,
-      "concepts": ["QUESTION-HOW", "STATE-HOW-ARE-YOU", "WORD-GOOD", "WORD-WELL", "WORD-SOSO"]
+      "concepts": [
+        "QUESTION-HOW",
+        "STATE-HOW-ARE-YOU",
+        "WORD-GOOD",
+        "WORD-WELL",
+        "WORD-SOSO"
+      ]
     },
     {
       "id": "SPINE-POLITE-REQUEST-REPAIR",
       "stage": "pre-A1",
       "canDo": "I can make a request politely and repair a small social mistake.",
-      "prerequisites": ["SPINE-COURTESY-THANK"],
+      "prerequisites": [
+        "SPINE-COURTESY-THANK"
+      ],
       "core": true,
-      "concepts": ["COURTESY-PLEASE", "COURTESY-SORRY"]
+      "concepts": [
+        "COURTESY-PLEASE",
+        "COURTESY-SORRY"
+      ]
     },
     {
       "id": "SPINE-TAKE-LEAVE",
       "stage": "pre-A1",
       "canDo": "I can end a short interaction and choose a suitable parting expression.",
-      "prerequisites": ["SPINE-CHECK-WELLBEING"],
+      "prerequisites": [
+        "SPINE-CHECK-WELLBEING"
+      ],
       "core": true,
-      "concepts": ["FAREWELL", "FAREWELL-CASUAL", "FAREWELL-LATER", "FAREWELL-SOON", "FAREWELL-TOMORROW", "GREETING-GOODNIGHT"]
+      "concepts": [
+        "FAREWELL",
+        "FAREWELL-CASUAL",
+        "FAREWELL-LATER",
+        "FAREWELL-SOON",
+        "FAREWELL-TOMORROW",
+        "GREETING-GOODNIGHT"
+      ]
     },
     {
       "id": "SPINE-TIME-OF-DAY",
       "stage": "A1",
       "canDo": "I can recognize basic times of day and choose a time-appropriate greeting.",
-      "prerequisites": ["SPINE-MEET-GREET"],
+      "prerequisites": [
+        "SPINE-MEET-GREET"
+      ],
       "core": true,
-      "concepts": ["TIME-DAY", "TIME-MORNING", "TIME-AFTERNOON", "TIME-EVENING", "TIME-NIGHT", "GREETING-DAY", "GREETING-MORNING", "GREETING-AFTERNOON", "GREETING-EVENING"]
+      "concepts": [
+        "TIME-DAY",
+        "TIME-MORNING",
+        "TIME-AFTERNOON",
+        "TIME-EVENING",
+        "TIME-NIGHT",
+        "GREETING-DAY",
+        "GREETING-MORNING",
+        "GREETING-AFTERNOON",
+        "GREETING-EVENING"
+      ]
     },
     {
       "id": "SPINE-ASK-LOCATION",
       "stage": "A1",
       "canDo": "I can ask where a familiar person, place, or object is.",
-      "prerequisites": ["SPINE-EXCHANGE-NAMES"],
+      "prerequisites": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
       "core": true,
-      "concepts": ["QUESTION-WHERE"]
+      "concepts": [
+        "QUESTION-WHERE"
+      ]
     },
     {
       "id": "SPINE-DEFINITE-REFERENCE",
       "stage": "A1",
       "canDo": "I can recognize how this language marks a specific known person or thing when it does so.",
-      "prerequisites": ["SPINE-EXCHANGE-NAMES"],
+      "prerequisites": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
       "core": false,
-      "concepts": ["GRAMMAR-THE"]
+      "concepts": [
+        "GRAMMAR-THE"
+      ]
     },
     {
       "id": "SPINE-COUNT-ONE-TO-FIVE",
       "stage": "A1",
       "canDo": "I can understand and produce the cardinal numbers one through five.",
-      "prerequisites": ["SPINE-RESPOND-BASIC"],
+      "prerequisites": [
+        "SPINE-RESPOND-BASIC"
+      ],
       "core": false,
-      "concepts": ["NUMBER-ONE-TO-FIVE"]
+      "concepts": [
+        "NUMBER-ONE-TO-FIVE"
+      ]
+    },
+    {
+      "id": "SPINE-SAY-WHAT-I-DO",
+      "stage": "A2",
+      "canDo": "I can say what I do — name a verb, find its stem, and put it in the present.",
+      "prerequisites": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "core": true,
+      "concepts": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ]
+    },
+    {
+      "id": "SPINE-NEGATE-AND-ASK",
+      "stage": "A2",
+      "canDo": "I can say that something is not so, and ask a question that can be answered yes or no.",
+      "prerequisites": [
+        "SPINE-SAY-WHAT-I-DO",
+        "SPINE-RESPOND-BASIC"
+      ],
+      "core": true,
+      "concepts": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ]
+    },
+    {
+      "id": "SPINE-SAY-WHAT-I-WANT",
+      "stage": "A2",
+      "canDo": "I can say what I want or need, and ask for it.",
+      "prerequisites": [
+        "SPINE-SAY-WHAT-I-DO",
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "core": true,
+      "concepts": [
+        "VERB-WANT"
+      ]
+    },
+    {
+      "id": "SPINE-TALK-ABOUT-PAST",
+      "stage": "A2",
+      "canDo": "I can say what happened before now.",
+      "prerequisites": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "core": true,
+      "concepts": [
+        "VERB-PAST"
+      ]
+    },
+    {
+      "id": "SPINE-TALK-ABOUT-FUTURE",
+      "stage": "A2",
+      "canDo": "I can say what will happen, or what I mean to do.",
+      "prerequisites": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "core": true,
+      "concepts": [
+        "VERB-FUTURE"
+      ]
     }
   ]
 }

--- a/code/learning/human-languages/french/curriculum.json
+++ b/code/learning/human-languages/french/curriculum.json
@@ -337,6 +337,43 @@
         "NUMBER-ONE-TO-FIVE"
       ],
       "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-DO": {
+      "segments": [],
+      "omits": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-NEGATE-AND-ASK": {
+      "segments": [],
+      "omits": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-WANT": {
+      "segments": [],
+      "omits": [
+        "VERB-WANT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-PAST": {
+      "segments": [],
+      "omits": [
+        "VERB-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-FUTURE": {
+      "segments": [],
+      "omits": [
+        "VERB-FUTURE"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/german/curriculum.json
+++ b/code/learning/human-languages/german/curriculum.json
@@ -363,6 +363,43 @@
         "NUMBER-ONE-TO-FIVE"
       ],
       "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-DO": {
+      "segments": [],
+      "omits": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-NEGATE-AND-ASK": {
+      "segments": [],
+      "omits": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-WANT": {
+      "segments": [],
+      "omits": [
+        "VERB-WANT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-PAST": {
+      "segments": [],
+      "omits": [
+        "VERB-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-FUTURE": {
+      "segments": [],
+      "omits": [
+        "VERB-FUTURE"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/gujarati/curriculum.json
+++ b/code/learning/human-languages/gujarati/curriculum.json
@@ -223,6 +223,43 @@
         "NUMBER-ONE-TO-FIVE"
       ],
       "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-DO": {
+      "segments": [],
+      "omits": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-NEGATE-AND-ASK": {
+      "segments": [],
+      "omits": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-WANT": {
+      "segments": [],
+      "omits": [
+        "VERB-WANT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-PAST": {
+      "segments": [],
+      "omits": [
+        "VERB-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-FUTURE": {
+      "segments": [],
+      "omits": [
+        "VERB-FUTURE"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/hindi/curriculum.json
+++ b/code/learning/human-languages/hindi/curriculum.json
@@ -462,6 +462,43 @@
         "NUMBER-ONE-TO-FIVE"
       ],
       "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-DO": {
+      "segments": [],
+      "omits": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-NEGATE-AND-ASK": {
+      "segments": [],
+      "omits": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-WANT": {
+      "segments": [],
+      "omits": [
+        "VERB-WANT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-PAST": {
+      "segments": [],
+      "omits": [
+        "VERB-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-FUTURE": {
+      "segments": [],
+      "omits": [
+        "VERB-FUTURE"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/italian/curriculum.json
+++ b/code/learning/human-languages/italian/curriculum.json
@@ -391,6 +391,43 @@
         "NUMBER-ONE-TO-FIVE"
       ],
       "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-DO": {
+      "segments": [],
+      "omits": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-NEGATE-AND-ASK": {
+      "segments": [],
+      "omits": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-WANT": {
+      "segments": [],
+      "omits": [
+        "VERB-WANT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-PAST": {
+      "segments": [],
+      "omits": [
+        "VERB-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-FUTURE": {
+      "segments": [],
+      "omits": [
+        "VERB-FUTURE"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/japanese/curriculum.json
+++ b/code/learning/human-languages/japanese/curriculum.json
@@ -162,6 +162,43 @@
         "NUMBER-ONE-TO-FIVE"
       ],
       "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-DO": {
+      "segments": [],
+      "omits": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-NEGATE-AND-ASK": {
+      "segments": [],
+      "omits": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-WANT": {
+      "segments": [],
+      "omits": [
+        "VERB-WANT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-PAST": {
+      "segments": [],
+      "omits": [
+        "VERB-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-FUTURE": {
+      "segments": [],
+      "omits": [
+        "VERB-FUTURE"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/kannada/curriculum.json
+++ b/code/learning/human-languages/kannada/curriculum.json
@@ -425,6 +425,43 @@
         "NUMBER-ONE-TO-FIVE"
       ],
       "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-DO": {
+      "segments": [],
+      "omits": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-NEGATE-AND-ASK": {
+      "segments": [],
+      "omits": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-WANT": {
+      "segments": [],
+      "omits": [
+        "VERB-WANT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-PAST": {
+      "segments": [],
+      "omits": [
+        "VERB-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-FUTURE": {
+      "segments": [],
+      "omits": [
+        "VERB-FUTURE"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/latin/curriculum.json
+++ b/code/learning/human-languages/latin/curriculum.json
@@ -439,6 +439,43 @@
         "NUMBER-ONE-TO-FIVE"
       ],
       "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-DO": {
+      "segments": [],
+      "omits": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-NEGATE-AND-ASK": {
+      "segments": [],
+      "omits": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-WANT": {
+      "segments": [],
+      "omits": [
+        "VERB-WANT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-PAST": {
+      "segments": [],
+      "omits": [
+        "VERB-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-FUTURE": {
+      "segments": [],
+      "omits": [
+        "VERB-FUTURE"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/malayalam/curriculum.json
+++ b/code/learning/human-languages/malayalam/curriculum.json
@@ -438,6 +438,43 @@
         "NUMBER-ONE-TO-FIVE"
       ],
       "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-DO": {
+      "segments": [],
+      "omits": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-NEGATE-AND-ASK": {
+      "segments": [],
+      "omits": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-WANT": {
+      "segments": [],
+      "omits": [
+        "VERB-WANT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-PAST": {
+      "segments": [],
+      "omits": [
+        "VERB-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-FUTURE": {
+      "segments": [],
+      "omits": [
+        "VERB-FUTURE"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/marathi/curriculum.json
+++ b/code/learning/human-languages/marathi/curriculum.json
@@ -243,6 +243,43 @@
         "NUMBER-ONE-TO-FIVE"
       ],
       "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-DO": {
+      "segments": [],
+      "omits": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-NEGATE-AND-ASK": {
+      "segments": [],
+      "omits": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-WANT": {
+      "segments": [],
+      "omits": [
+        "VERB-WANT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-PAST": {
+      "segments": [],
+      "omits": [
+        "VERB-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-FUTURE": {
+      "segments": [],
+      "omits": [
+        "VERB-FUTURE"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/persian/curriculum.json
+++ b/code/learning/human-languages/persian/curriculum.json
@@ -208,6 +208,43 @@
         "NUMBER-ONE-TO-FIVE"
       ],
       "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-DO": {
+      "segments": [],
+      "omits": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-NEGATE-AND-ASK": {
+      "segments": [],
+      "omits": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-WANT": {
+      "segments": [],
+      "omits": [
+        "VERB-WANT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-PAST": {
+      "segments": [],
+      "omits": [
+        "VERB-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-FUTURE": {
+      "segments": [],
+      "omits": [
+        "VERB-FUTURE"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/portuguese/curriculum.json
+++ b/code/learning/human-languages/portuguese/curriculum.json
@@ -405,6 +405,43 @@
         "NUMBER-ONE-TO-FIVE"
       ],
       "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-DO": {
+      "segments": [],
+      "omits": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-NEGATE-AND-ASK": {
+      "segments": [],
+      "omits": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-WANT": {
+      "segments": [],
+      "omits": [
+        "VERB-WANT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-PAST": {
+      "segments": [],
+      "omits": [
+        "VERB-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-FUTURE": {
+      "segments": [],
+      "omits": [
+        "VERB-FUTURE"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/punjabi/curriculum.json
+++ b/code/learning/human-languages/punjabi/curriculum.json
@@ -234,6 +234,43 @@
         "NUMBER-ONE-TO-FIVE"
       ],
       "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-DO": {
+      "segments": [],
+      "omits": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-NEGATE-AND-ASK": {
+      "segments": [],
+      "omits": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-WANT": {
+      "segments": [],
+      "omits": [
+        "VERB-WANT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-PAST": {
+      "segments": [],
+      "omits": [
+        "VERB-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-FUTURE": {
+      "segments": [],
+      "omits": [
+        "VERB-FUTURE"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/russian/curriculum.json
+++ b/code/learning/human-languages/russian/curriculum.json
@@ -190,6 +190,43 @@
         "NUMBER-ONE-TO-FIVE"
       ],
       "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-DO": {
+      "segments": [],
+      "omits": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-NEGATE-AND-ASK": {
+      "segments": [],
+      "omits": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-WANT": {
+      "segments": [],
+      "omits": [
+        "VERB-WANT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-PAST": {
+      "segments": [],
+      "omits": [
+        "VERB-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-FUTURE": {
+      "segments": [],
+      "omits": [
+        "VERB-FUTURE"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/sanskrit/curriculum.json
+++ b/code/learning/human-languages/sanskrit/curriculum.json
@@ -223,6 +223,43 @@
         "NUMBER-ONE-TO-FIVE"
       ],
       "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-DO": {
+      "segments": [],
+      "omits": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-NEGATE-AND-ASK": {
+      "segments": [],
+      "omits": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-WANT": {
+      "segments": [],
+      "omits": [
+        "VERB-WANT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-PAST": {
+      "segments": [],
+      "omits": [
+        "VERB-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-FUTURE": {
+      "segments": [],
+      "omits": [
+        "VERB-FUTURE"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/spanish/curriculum.json
+++ b/code/learning/human-languages/spanish/curriculum.json
@@ -526,6 +526,43 @@
         "NUMBER-ONE-TO-FIVE"
       ],
       "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-DO": {
+      "segments": [],
+      "omits": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-NEGATE-AND-ASK": {
+      "segments": [],
+      "omits": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-WANT": {
+      "segments": [],
+      "omits": [
+        "VERB-WANT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-PAST": {
+      "segments": [],
+      "omits": [
+        "VERB-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-FUTURE": {
+      "segments": [],
+      "omits": [
+        "VERB-FUTURE"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/tamil/curriculum.json
+++ b/code/learning/human-languages/tamil/curriculum.json
@@ -491,6 +491,43 @@
         "NUMBER-ONE-TO-FIVE"
       ],
       "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-DO": {
+      "segments": [],
+      "omits": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-NEGATE-AND-ASK": {
+      "segments": [],
+      "omits": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-WANT": {
+      "segments": [],
+      "omits": [
+        "VERB-WANT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-PAST": {
+      "segments": [],
+      "omits": [
+        "VERB-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-FUTURE": {
+      "segments": [],
+      "omits": [
+        "VERB-FUTURE"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/telugu/curriculum.json
+++ b/code/learning/human-languages/telugu/curriculum.json
@@ -436,6 +436,43 @@
         "NUMBER-ONE-TO-FIVE"
       ],
       "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-DO": {
+      "segments": [],
+      "omits": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-NEGATE-AND-ASK": {
+      "segments": [],
+      "omits": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-WANT": {
+      "segments": [],
+      "omits": [
+        "VERB-WANT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-PAST": {
+      "segments": [],
+      "omits": [
+        "VERB-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-FUTURE": {
+      "segments": [],
+      "omits": [
+        "VERB-FUTURE"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/urdu/curriculum.json
+++ b/code/learning/human-languages/urdu/curriculum.json
@@ -208,6 +208,43 @@
         "NUMBER-ONE-TO-FIVE"
       ],
       "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-DO": {
+      "segments": [],
+      "omits": [
+        "VERB-INFINITIVE",
+        "VERB-PRESENT-HABITUAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-NEGATE-AND-ASK": {
+      "segments": [],
+      "omits": [
+        "VERB-NEGATE",
+        "QUESTION-POLAR"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SAY-WHAT-I-WANT": {
+      "segments": [],
+      "omits": [
+        "VERB-WANT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-PAST": {
+      "segments": [],
+      "omits": [
+        "VERB-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-TALK-ABOUT-FUTURE": {
+      "segments": [],
+      "omits": [
+        "VERB-FUTURE"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added — HL-C10: the shared spine reaches above A1
+
+- Add an **A2 tranche** of five spine nodes — `SPINE-SAY-WHAT-I-DO`,
+  `SPINE-NEGATE-AND-ASK`, `SPINE-SAY-WHAT-I-WANT`, `SPINE-TALK-ABOUT-PAST`,
+  `SPINE-TALK-ABOUT-FUTURE` — and the seven canonical concepts they own
+  (`VERB-INFINITIVE`, `VERB-PRESENT-HABITUAL`, `VERB-NEGATE`, `QUESTION-POLAR`,
+  `VERB-WANT`, `VERB-PAST`, `VERB-FUTURE`).
+- **This unblocks the entire Easy-to-Advanced grammar arc, and nothing else could.**
+  Schema v2 requires a canonical `spine_node`. Every one of the previous eleven nodes was
+  an A1 social function — greeting, taking leave, counting to five — with nothing covering
+  verbs or tense, so a lesson teaching a present tense had no node it could legally
+  declare. The arc was unauthorable in v2 for all 22 tracks. It was found the hard way,
+  by trying to migrate a Hindi verb lesson and discovering its chapter belongs to no node.
+- All 22 realization ledgers declare where they stand on each new node. An unrealized node
+  is recorded as `segments: []` **with `omits` naming every concept it is not yet
+  delivering** — the validator requires this, and rightly: "we have not built this yet" is
+  a recorded position, so the debt stays countable instead of being an absent key nobody
+  can see. Today that is all 22 tracks on all five nodes; those numbers are the burn-down.
+- The taxonomy grows 46 → 53 concepts. Each concept is owned by exactly one node, which
+  the validator enforces, so a later tranche cannot quietly re-file a concept it wants.
+
 ### Added — HL-C03: the nine HL05 chapter gates, as measurement rather than judgement
 
 - Add `src/chapters.ts` with all nine HL05 gates — `chapter-missing-capability`,

--- a/code/packages/typescript/human-language-data/tests/integration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/integration.test.ts
@@ -37,6 +37,37 @@ describe("real curriculum", () => {
     }));
   });
 
+  // HL-C10: the spine reaches above A1.
+  //
+  // This is not bookkeeping. Schema v2 REQUIRES a canonical `spine_node`, and until this
+  // tranche existed every node was an A1 social function — greeting, taking leave,
+  // counting to five — with nothing covering verbs or tense. A lesson teaching the present
+  // tense had no node it could legally declare, so the entire Easy-to-Advanced grammar arc
+  // was unauthorable in v2 for all 22 tracks. These five nodes are what unblock it.
+  it("carries an A2 tranche, and every track declares where it stands on it", () => {
+    const a2 = spine.nodes.filter((node) => node.stage === "A2");
+    expect(a2.map((node) => node.id).sort()).toEqual([
+      "SPINE-NEGATE-AND-ASK",
+      "SPINE-SAY-WHAT-I-DO",
+      "SPINE-SAY-WHAT-I-WANT",
+      "SPINE-TALK-ABOUT-FUTURE",
+      "SPINE-TALK-ABOUT-PAST",
+    ]);
+
+    // Every track answers for every A2 node. An unrealized node is declared as such and
+    // must name the concepts it is omitting — "we have not built this yet" is a recorded
+    // position, never an absent key, so the debt is countable rather than invisible.
+    for (const curriculum of curricula) {
+      for (const node of a2) {
+        const entry = curriculum.spine[node.id];
+        expect(entry, `${curriculum.language} omits ${node.id}`).toBeDefined();
+        if (entry!.segments.length === 0) {
+          expect([...entry!.omits].sort()).toEqual([...node.concepts].sort());
+        }
+      }
+    }
+  });
+
   it("loads one prerequisite-safe realization map for every language", () => {
     expect(curricula.map((curriculum) => curriculum.language).sort())
       .toEqual(registry.languages.map((language) => language.id).sort());


### PR DESCRIPTION
Adds five **A2 spine nodes** — `SPINE-SAY-WHAT-I-DO`, `SPINE-NEGATE-AND-ASK`, `SPINE-SAY-WHAT-I-WANT`, `SPINE-TALK-ABOUT-PAST`, `SPINE-TALK-ABOUT-FUTURE` — and the seven canonical concepts they own.

## This unblocks the Easy→Advanced arc, and nothing else could

Schema v2 requires a canonical `spine_node`. **All eleven existing nodes were A1 social functions** — greeting, taking leave, counting to five — with nothing covering verbs or tense. A lesson teaching a present tense had no node it could legally declare, so the grammar arc was **unauthorable in v2 for all 22 tracks**.

Found the hard way: by trying to migrate a Hindi verb lesson to v2 and discovering its chapter belongs to no node at all.

## Debt stays countable

All 22 realization ledgers declare where they stand. An unrealized node is recorded as `segments: []` **with `omits` naming every concept it is not yet delivering** — the validator requires this, and rightly: "not built yet" is a recorded position, so the debt is countable rather than an absent key nobody can see.

Today that is all 22 tracks on all five nodes. Those numbers are the burn-down list, and the new test asserts the shape so a track cannot quietly drop a node instead of realizing it.

## Scope

| | before | after |
|---|---|---|
| spine nodes | 11 | 16 |
| nodes above A1 | **0** | **5** |
| taxonomy concepts | 46 | 53 |

Each concept is owned by exactly one node, which the validator enforces, so a later tranche cannot re-file a concept it wants.

## Verification

301 tests across 18 files pass; `check:books`, `check:modality`, `check:narration` all clean. Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)