### PR TITLE
fix(human-languages): classify the inline-letters section as the script block it is

### DIFF
--- a/code/learning/human-languages/arabic/narration/ch01.json
+++ b/code/learning/human-languages/arabic/narration/ch01.json
@@ -3,8 +3,8 @@
   "language": "arabic",
   "chapter": 1,
   "title": "Chapter 1",
-  "drivablePrefix": 8,
-  "sourceHash": "fnv1a64:ee98228661f8a87c",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:644087df44cb504a",
   "lessons": [
     {
       "id": "AR-C01-al",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "the (al- — the attached article)",
       "script": "arabic",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:04f0de193ab68eb4",
-      "notice": null,
+      "sourceHash": "fnv1a64:5c3401b074a9ed4b",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -151,13 +160,22 @@
       "romanization": "",
       "gloss": "peace be upon you (as-salāmu ʿalaykum)",
       "script": "arabic",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:19ad9e308a103f91",
-      "notice": null,
+      "sourceHash": "fnv1a64:4cecaf9d8aad4700",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -178,7 +196,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -292,13 +310,22 @@
       "romanization": "",
       "gloss": "hello / welcome (marḥaban — \"there's room for you\")",
       "script": "arabic",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8b542fd3708bb15d",
-      "notice": null,
+      "sourceHash": "fnv1a64:5d9f80c6fec8c304",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -319,7 +346,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -437,13 +464,22 @@
       "romanization": "",
       "gloss": "good evening (masāʾ al-khayr — \"evening of goodness\")",
       "script": "arabic",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:aa1efa6fd080b7b6",
-      "notice": null,
+      "sourceHash": "fnv1a64:12cfed97a5c22789",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -464,7 +500,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -723,13 +759,22 @@
       "romanization": "",
       "gloss": "good morning (ṣabāḥ al-khayr — \"morning of goodness\")",
       "script": "arabic",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:a5540f4bb2aab0b9",
-      "notice": null,
+      "sourceHash": "fnv1a64:cb050b6fcf90da8c",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -750,7 +795,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -860,13 +905,22 @@
       "romanization": "",
       "gloss": "peace / hello (salām)",
       "script": "arabic",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:a8978a2326b4dfd8",
-      "notice": null,
+      "sourceHash": "fnv1a64:44f0446378253c51",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -887,7 +941,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -1001,13 +1055,22 @@
       "romanization": "",
       "gloss": "thank you (shukran)",
       "script": "arabic",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:85350b005d3129ef",
-      "notice": null,
+      "sourceHash": "fnv1a64:e4e8e7fe129d4df8",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -1028,7 +1091,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/arabic/narration/ch01.txt
+++ b/code/learning/human-languages/arabic/narration/ch01.txt
@@ -1,9 +1,11 @@
 Arabic, chapter 1: Chapter 1.
-14 lessons. You can do the first 8 of them in the car; after that you will want to have stopped.
+14 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 14.
 ال (al-) — "the," hiding in English algebra.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -37,6 +39,8 @@ What does ال mean, and how does it attach? ("The," glued to the front of its n
 
 Lesson 2 of 14.
 السلام عليكم (as-salāmu ʿalaykum) — "peace be upon you".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -72,6 +76,8 @@ Read السلام عليكم. What are its two pieces, and why is the s doubled?
 Lesson 3 of 14.
 مرحبا (marḥaban) — "hello," i.e. "there's room for you".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 The casual, everyday "hi" — and, like the last word, a little sentence hiding inside a greeting.
@@ -106,6 +112,8 @@ Read مرحبا. What does it literally say, and from what root? ("There's room 
 
 Lesson 4 of 14.
 مساء الخير (masāʾ al-khayr) — "evening of goodness".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -180,6 +188,8 @@ Next chapter: introducing yourself — ismī… ("my name is…") — and how Ar
 Lesson 6 of 14.
 صباح الخير (ṣabāḥ al-khayr) — "morning of goodness".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 Time-of-day greetings — built, like everything, from roots and the attached al-. And a chance to hear two sounds English doesn't have.
@@ -212,6 +222,8 @@ Read صباح الخير. What are the two roots? (ṣ–b–ḥ "morning," kh�
 
 Lesson 7 of 14.
 سلام (salām) — "peace," the most famous root.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -246,6 +258,8 @@ Read سلام (salām) right to left. What is its three-consonant root, and what
 
 Lesson 8 of 14.
 شكرا (shukran) — "thank you".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/arabic/narration/ch02.json
+++ b/code/learning/human-languages/arabic/narration/ch02.json
@@ -3,8 +3,8 @@
   "language": "arabic",
   "chapter": 2,
   "title": "Chapter 2",
-  "drivablePrefix": 8,
-  "sourceHash": "fnv1a64:9f60986d19f205ad",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:1078ff046e54595b",
   "lessons": [
     {
       "id": "AR-C02-anta-anti",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "you (anta m. / anti f.)",
       "script": "arabic",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b676153f2dd8b0fb",
-      "notice": null,
+      "sourceHash": "fnv1a64:2d97705045b6d7b0",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -130,13 +139,22 @@
       "romanization": "",
       "gloss": "my (possessive suffix -ī)",
       "script": "arabic",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:49ad7a1e47602997",
-      "notice": null,
+      "sourceHash": "fnv1a64:c938ceadba398f9e",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -157,7 +175,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -235,13 +253,22 @@
       "romanization": "",
       "gloss": "name",
       "script": "arabic",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:cef1c8e7a1f20ed0",
-      "notice": null,
+      "sourceHash": "fnv1a64:7f07aaa91a92ea81",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -262,7 +289,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -453,13 +480,22 @@
       "romanization": "",
       "gloss": "what",
       "script": "arabic",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:e668571f5c4412b4",
-      "notice": null,
+      "sourceHash": "fnv1a64:dbd1e0cf51386345",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -480,7 +516,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -796,13 +832,22 @@
       "romanization": "",
       "gloss": "pleased to meet you (literally \"we have been honoured\")",
       "script": "arabic",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b46fd5c36a18ef44",
-      "notice": null,
+      "sourceHash": "fnv1a64:3e43ab7585f164eb",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -823,7 +868,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/arabic/narration/ch02.txt
+++ b/code/learning/human-languages/arabic/narration/ch02.txt
@@ -1,9 +1,11 @@
 Arabic, chapter 2: Chapter 2.
-12 lessons. You can do the first 8 of them in the car; after that you will want to have stopped.
+12 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 12.
 أنت (anta / anti) — "you," marked by gender.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -33,6 +35,8 @@ How does Arabic split "you," and how is that different from French or Tamil? (By
 Lesson 2 of 12.
 ي (yāʾ) (-ī) — "my," a letter stuck on the end.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 Arabic has no separate word for "my" — it glues one letter onto the noun.
@@ -57,6 +61,8 @@ How does Arabic say "my," and what is "my name"? (A suffix ي (yāʾ) (-ī) glue
 
 Lesson 3 of 12.
 اسم (ism) — "name".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -109,6 +115,8 @@ Give your name in Arabic. (Ismī ….) What does Arabic leave out, and which oth
 
 Lesson 5 of 12.
 ما (mā) — "what".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -192,6 +200,8 @@ Next chapter: kayfa ḥāluka? ("how are you?") and al-ḥamdu lillāh — the r
 
 Lesson 8 of 12.
 تشرفنا (tasharrafnā) — "pleased to meet you".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/bengali/narration/ch01.json
+++ b/code/learning/human-languages/bengali/narration/ch01.json
@@ -3,8 +3,8 @@
   "language": "bengali",
   "chapter": 1,
   "title": "Chapter 1",
-  "drivablePrefix": 6,
-  "sourceHash": "fnv1a64:c3d4e5c6853b3e4c",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:4d5d139533791964",
   "lessons": [
     {
       "id": "BN-C01-achchha",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "okay / alright / I see (āchchhā)",
       "script": "bengali",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:ecfb5931ae70005b",
-      "notice": null,
+      "sourceHash": "fnv1a64:84972988a9ab9cfe",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -130,13 +139,22 @@
       "romanization": "",
       "gloss": "goodbye, lit. \"I'll come [again]\" (āshi)",
       "script": "bengali",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:a4b3b567bfc563a3",
-      "notice": null,
+      "sourceHash": "fnv1a64:3548b8e1e6d8b786",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -157,7 +175,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -246,13 +264,22 @@
       "romanization": "",
       "gloss": "thank you (dhônyobad)",
       "script": "bengali",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:d63acf8d4947753b",
-      "notice": null,
+      "sourceHash": "fnv1a64:b6dedebbef9e9c4a",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -273,7 +300,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -362,13 +389,22 @@
       "romanization": "",
       "gloss": "yes / no (hyã / nā)",
       "script": "bengali",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c6bb5b7ea2744dd0",
-      "notice": null,
+      "sourceHash": "fnv1a64:d86583f11bfbb6a7",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -389,7 +425,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -478,13 +514,22 @@
       "romanization": "",
       "gloss": "hello / goodbye (nômoshkar)",
       "script": "bengali",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c7b6ee200a99c053",
-      "notice": null,
+      "sourceHash": "fnv1a64:63149e08a09fd266",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -505,7 +550,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/bengali/narration/ch01.txt
+++ b/code/learning/human-languages/bengali/narration/ch01.txt
@@ -1,9 +1,11 @@
 Bengali, chapter 1: Chapter 1.
-6 lessons. All 6 can be done entirely by ear.
+6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 6.
 আচ্ছা (āchchhā) — "okay / I see".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -33,6 +35,8 @@ What does āchchhā do in conversation, and why is its first vowel a full letter
 Lesson 2 of 6.
 আসি (āshi) — "I'll be going" (goodbye).
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 Bengalis do not say "I'm leaving." They say "I'll come again." Here is why.
@@ -60,6 +64,8 @@ Why does "I come" mean goodbye in Bengali, and what does Bengali not mark on thi
 
 Lesson 3 of 6.
 ধন্যবাদ (dhônyobad) — "thank you".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -89,6 +95,8 @@ Dhônyobad comes from which two Sanskrit parts, and why is the "v" gone? (Dhanya
 Lesson 4 of 6.
 হ্যাঁ / না (hyã / nā) — "yes" and "no".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 Two words no conversation survives without — and one is an old cousin of English.
@@ -116,6 +124,8 @@ What does the chandrabindu do, and what links Bengali nā to English no? (It nas
 
 Lesson 5 of 6.
 নমস্কার (nômoshkar) — "hello".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/bengali/narration/ch02.json
+++ b/code/learning/human-languages/bengali/narration/ch02.json
@@ -3,8 +3,8 @@
   "language": "bengali",
   "chapter": 2,
   "title": "Chapter 2",
-  "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:c031b298420c4285",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:ab1e761f11bffcf6",
   "lessons": [
     {
       "id": "BN-C02-alaap",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "pleased to meet you (lit. \"having made acquaintance, [it] felt good\")",
       "script": "bengali",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8918532be0f2580d",
-      "notice": null,
+      "sourceHash": "fnv1a64:4b0fda4f32ec3fd6",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -119,13 +128,22 @@
       "romanization": "",
       "gloss": "my",
       "script": "bengali",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8a4102c395c018b4",
-      "notice": null,
+      "sourceHash": "fnv1a64:a2568d0190f56ea9",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -146,7 +164,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -356,13 +374,22 @@
       "romanization": "",
       "gloss": "what",
       "script": "bengali",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:12674305ac867360",
-      "notice": null,
+      "sourceHash": "fnv1a64:9742adfbc75528a3",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -383,7 +410,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -461,13 +488,22 @@
       "romanization": "",
       "gloss": "name",
       "script": "bengali",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8e6497290c9feddf",
-      "notice": null,
+      "sourceHash": "fnv1a64:ff4b24b412c6f334",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -488,7 +524,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -850,13 +886,22 @@
       "romanization": "",
       "gloss": "you (familiar / respectful; also তুই intimate)",
       "script": "bengali",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:62c593d00a4d25ce",
-      "notice": null,
+      "sourceHash": "fnv1a64:7ced4161be7a9daf",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -877,7 +922,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/bengali/narration/ch02.txt
+++ b/code/learning/human-languages/bengali/narration/ch02.txt
@@ -1,9 +1,11 @@
 Bengali, chapter 2: Chapter 2.
-8 lessons. You can do the first 2 of them in the car; after that you will want to have stopped.
+8 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 8.
 আলাপ করে ভালো লাগলো (ālāp kore bhālo lāglo) — "pleased to meet you".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -29,6 +31,8 @@ What does the phrase literally say, and what is ālāp? ("Having made [your] acq
 
 Lesson 2 of 8.
 আমার (āmār) — "my".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -87,6 +91,8 @@ Give your name in Bengali, and say what it leaves out that English requires. (Ā
 Lesson 4 of 8.
 কি (ki) — "what".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 The question-word — and it starts with the k- that heads nearly every Bengali question.
@@ -111,6 +117,8 @@ What root do Bengali's question-words share, and its English family? (The interr
 
 Lesson 5 of 8.
 নাম (nām) — "name," a word older than Europe.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -202,6 +210,8 @@ Ask "what's your name?" respectfully, and note what's still missing. (Āpnār n�
 
 Lesson 8 of 8.
 তুমি / আপনি (tumi / āpni) — "you," three ways.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/bengali/narration/ch03.json
+++ b/code/learning/human-languages/bengali/narration/ch03.json
@@ -3,8 +3,8 @@
   "language": "bengali",
   "chapter": 3,
   "title": "Chapter 3",
-  "drivablePrefix": 6,
-  "sourceHash": "fnv1a64:64ff8d9dc7b8c795",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:c879efbcfdf4fccb",
   "lessons": [
     {
       "id": "BN-C03-ami",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "I",
       "script": "bengali",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c60c0e7f18648b68",
-      "notice": null,
+      "sourceHash": "fnv1a64:8e68eb4530d5434b",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -139,13 +148,22 @@
       "romanization": "",
       "gloss": "well, good — and the reply \"আমি ভালো আছি\"",
       "script": "bengali",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:7c11ba61ef52c299",
-      "notice": null,
+      "sourceHash": "fnv1a64:77f8059fd4601afa",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -166,7 +184,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -268,13 +286,22 @@
       "romanization": "",
       "gloss": "how",
       "script": "bengali",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:0d33f4c886dc4534",
-      "notice": null,
+      "sourceHash": "fnv1a64:62bb3e5d57aa6659",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -295,7 +322,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -373,13 +400,22 @@
       "romanization": "",
       "gloss": "it's no matter / no problem / you're welcome",
       "script": "bengali",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:e99dccdd9a2f1f4f",
-      "notice": null,
+      "sourceHash": "fnv1a64:2620bde01fad47a8",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -400,7 +436,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -657,13 +693,22 @@
       "romanization": "",
       "gloss": "how are you? (familiar)",
       "script": "bengali",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8d16bc56471a30c1",
-      "notice": null,
+      "sourceHash": "fnv1a64:dc0e1d8dda6194ec",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -684,7 +729,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/bengali/narration/ch03.txt
+++ b/code/learning/human-languages/bengali/narration/ch03.txt
@@ -1,9 +1,11 @@
 Bengali, chapter 3: Chapter 3.
-6 lessons. All 6 can be done entirely by ear.
+6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 6.
 আমি (āmi) — "I," cousin of English am.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -34,6 +36,8 @@ What Sanskrit word is āmi from, and its English cousin? (Asmi, "I am"; English 
 
 Lesson 2 of 6.
 ভালো (bhālo) — "well," and how to answer.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -66,6 +70,8 @@ Give the full reply to tumi kēmon āchho?, and name bhālo's likely Sanskrit so
 Lesson 3 of 6.
 কেমন (kēmon) — "how," another of the k- questions.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 You met কি (ki, "what") in Chapter 2. Here is its sibling.
@@ -90,6 +96,8 @@ What root do Bengali's question-words share, and its English family? (The interr
 
 Lesson 4 of 6.
 কোনো ব্যাপার না (kono bæpār nā) — "no matter".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -156,6 +164,8 @@ A stranger asks āpni kēmon āchhen? — give a full, polite reply, and answer 
 
 Lesson 6 of 6.
 তুমি কেমন আছো? (tumi kēmon āchho?) — "how are you?"
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/bengali/narration/ch04.json
+++ b/code/learning/human-languages/bengali/narration/ch04.json
@@ -3,8 +3,8 @@
   "language": "bengali",
   "chapter": 4,
   "title": "Chapter 4",
-  "drivablePrefix": 4,
-  "sourceHash": "fnv1a64:51da02ace09da6eb",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:28db9f1b151935e5",
   "lessons": [
     {
       "id": "BN-C04-abar",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "again",
       "script": "bengali",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:cbc94e2b280a6364",
-      "notice": null,
+      "sourceHash": "fnv1a64:bdbcded841cd4265",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -222,13 +231,22 @@
       "romanization": "",
       "gloss": "(we) will meet (lit. \"seeing will happen\")",
       "script": "bengali",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b7ade652cd8841c6",
-      "notice": null,
+      "sourceHash": "fnv1a64:b8f661e6e0594a07",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -249,7 +267,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -347,13 +365,22 @@
       "romanization": "",
       "gloss": "see you tomorrow (and the কাল puzzle)",
       "script": "bengali",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:5c4378bb2d018701",
-      "notice": null,
+      "sourceHash": "fnv1a64:5a5040768b99964e",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -374,7 +401,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/bengali/narration/ch04.txt
+++ b/code/learning/human-languages/bengali/narration/ch04.txt
@@ -1,9 +1,11 @@
 Bengali, chapter 4: Chapter 4.
-5 lessons. You can do the first 4 of them in the car; after that you will want to have stopped.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 5.
 আবার (ābār) — "again," the seed of "see you again".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -54,6 +56,8 @@ What does ābār dækhā hôbe literally say, and how does it relate to āshi? (
 Lesson 3 of 5.
 দেখা হবে (dækhā hôbe) — "(we) will meet".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 A future-tense phrase — the other half of "see you again," built in a way English never would.
@@ -83,6 +87,8 @@ What does dækhā hôbe literally say, and what is odd (to English ears) about i
 
 Lesson 4 of 5.
 কাল দেখা হবে (kāl dækhā hôbe) — "see you tomorrow".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/bengali/narration/ch05.json
+++ b/code/learning/human-languages/bengali/narration/ch05.json
@@ -3,8 +3,8 @@
   "language": "bengali",
   "chapter": 5,
   "title": "Chapter 5",
-  "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:0c2fa04e39eeca0a",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:79852e715c7e5696",
   "lessons": [
     {
       "id": "BN-C05-ami-bangla-boli",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "I speak Bengali",
       "script": "bengali",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:367535d790b3ba1a",
-      "notice": null,
+      "sourceHash": "fnv1a64:71f11d270c7b77e9",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -139,13 +148,22 @@
       "romanization": "",
       "gloss": "to speak, to say",
       "script": "bengali",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:f9670d529ffafee9",
-      "notice": null,
+      "sourceHash": "fnv1a64:03bcf22359a87d4e",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -166,7 +184,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -264,13 +282,22 @@
       "romanization": "",
       "gloss": "to work (lit. \"work-do\")",
       "script": "bengali",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:6b733c44565c2435",
-      "notice": null,
+      "sourceHash": "fnv1a64:88ae3d7246caf29a",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -291,7 +318,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -560,13 +587,22 @@
       "romanization": "",
       "gloss": "to live, to stay, to remain",
       "script": "bengali",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:d3fd0e8a3ed59a29",
-      "notice": null,
+      "sourceHash": "fnv1a64:f1a739ff51404a22",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -587,7 +623,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/bengali/narration/ch05.txt
+++ b/code/learning/human-languages/bengali/narration/ch05.txt
@@ -1,9 +1,11 @@
 Bengali, chapter 5: Chapter 5.
-5 lessons. All 5 can be done entirely by ear.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 5.
 আমি বাংলা বলি (āmi bānglā bôli) — "I speak Bengali".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -35,6 +37,8 @@ Say "I speak Bengali," and give the origin of the name bānglā. (Āmi bānglā 
 Lesson 2 of 5.
 বলা (bôlā) — "to speak," your first full verb.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 So far, "to be." Here is a verb that does something — and it reveals how gloriously simple Bengali verbs are.
@@ -64,6 +68,8 @@ What does the Bengali verb change for, and what does it never change for? (For p
 
 Lesson 3 of 5.
 কাজ করা (kāj kôrā) — "to work".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -133,6 +139,8 @@ In one breath, say your language, your city, and your work in Bengali — and no
 
 Lesson 5 of 5.
 থাকা (thākā) — "to live, to stay".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -6,7 +6,7 @@
     {
       "language": "arabic",
       "chapter": 1,
-      "sourceHash": "fnv1a64:ee98228661f8a87c",
+      "sourceHash": "fnv1a64:644087df44cb504a",
       "lessonIds": [
         "AR-C01-al",
         "AR-C01-as-salamu-alaykum",
@@ -23,17 +23,17 @@
         "AR-W03-dots-mim-ba-salam",
         "AR-W03-write-salam"
       ],
-      "voiceLessons": 8,
-      "drivablePrefix": 8,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "arabic/narration/ch01.txt",
       "json": "arabic/narration/ch01.json",
-      "textHash": "fnv1a64:0a8fc9cb80a9eb33",
-      "jsonHash": "fnv1a64:f41fe1883ab0a7f9"
+      "textHash": "fnv1a64:37835c10448c2a89",
+      "jsonHash": "fnv1a64:cb3b1950ed04bfa5"
     },
     {
       "language": "arabic",
       "chapter": 2,
-      "sourceHash": "fnv1a64:9f60986d19f205ad",
+      "sourceHash": "fnv1a64:1078ff046e54595b",
       "lessonIds": [
         "AR-C02-anta-anti",
         "AR-C02-ii-my",
@@ -48,12 +48,12 @@
         "AR-W06-hamza",
         "AR-W06-harakat-and-hamza"
       ],
-      "voiceLessons": 8,
-      "drivablePrefix": 8,
+      "voiceLessons": 3,
+      "drivablePrefix": 0,
       "text": "arabic/narration/ch02.txt",
       "json": "arabic/narration/ch02.json",
-      "textHash": "fnv1a64:a630bd1f378aa880",
-      "jsonHash": "fnv1a64:8ef9c00d9c5a7d51"
+      "textHash": "fnv1a64:eee465a78e2aa46e",
+      "jsonHash": "fnv1a64:0710899da140f119"
     },
     {
       "language": "arabic",
@@ -428,7 +428,7 @@
     {
       "language": "bengali",
       "chapter": 1,
-      "sourceHash": "fnv1a64:c3d4e5c6853b3e4c",
+      "sourceHash": "fnv1a64:4d5d139533791964",
       "lessonIds": [
         "BN-C01-achchha",
         "BN-C01-ashi",
@@ -437,17 +437,17 @@
         "BN-C01-nomoshkar",
         "BN-C01-practice"
       ],
-      "voiceLessons": 6,
-      "drivablePrefix": 6,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "bengali/narration/ch01.txt",
       "json": "bengali/narration/ch01.json",
-      "textHash": "fnv1a64:b9dc6975cda4d36e",
-      "jsonHash": "fnv1a64:3d3ffc75271ce713"
+      "textHash": "fnv1a64:2472dd143fa15866",
+      "jsonHash": "fnv1a64:99a679bf9016530b"
     },
     {
       "language": "bengali",
       "chapter": 2,
-      "sourceHash": "fnv1a64:c031b298420c4285",
+      "sourceHash": "fnv1a64:ab1e761f11bffcf6",
       "lessonIds": [
         "BN-C02-alaap",
         "BN-C02-amar",
@@ -458,17 +458,17 @@
         "BN-C02-tomar-naam-ki",
         "BN-C02-tumi-apni"
       ],
-      "voiceLessons": 7,
-      "drivablePrefix": 2,
+      "voiceLessons": 2,
+      "drivablePrefix": 0,
       "text": "bengali/narration/ch02.txt",
       "json": "bengali/narration/ch02.json",
-      "textHash": "fnv1a64:b53a4b7600db0b8d",
-      "jsonHash": "fnv1a64:deebe598f57672e2"
+      "textHash": "fnv1a64:ee185c67cd51a9e1",
+      "jsonHash": "fnv1a64:2c784f9a13106aba"
     },
     {
       "language": "bengali",
       "chapter": 3,
-      "sourceHash": "fnv1a64:64ff8d9dc7b8c795",
+      "sourceHash": "fnv1a64:c879efbcfdf4fccb",
       "lessonIds": [
         "BN-C03-ami",
         "BN-C03-bhalo",
@@ -477,17 +477,17 @@
         "BN-C03-practice",
         "BN-C03-tumi-kemon-achho"
       ],
-      "voiceLessons": 6,
-      "drivablePrefix": 6,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "bengali/narration/ch03.txt",
       "json": "bengali/narration/ch03.json",
-      "textHash": "fnv1a64:4da390689161efc4",
-      "jsonHash": "fnv1a64:a6c03f161205be7a"
+      "textHash": "fnv1a64:1c9e27f3a7145dc4",
+      "jsonHash": "fnv1a64:4e3b7141ca534b73"
     },
     {
       "language": "bengali",
       "chapter": 4,
-      "sourceHash": "fnv1a64:51da02ace09da6eb",
+      "sourceHash": "fnv1a64:28db9f1b151935e5",
       "lessonIds": [
         "BN-C04-abar",
         "BN-C04-abar-dekha-hobe",
@@ -495,17 +495,17 @@
         "BN-C04-kal-dekha-hobe",
         "BN-C04-practice"
       ],
-      "voiceLessons": 4,
-      "drivablePrefix": 4,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "bengali/narration/ch04.txt",
       "json": "bengali/narration/ch04.json",
-      "textHash": "fnv1a64:84099b6582eba2be",
-      "jsonHash": "fnv1a64:8b615a938ad28935"
+      "textHash": "fnv1a64:6afdd39262eac838",
+      "jsonHash": "fnv1a64:3561507d2e0fdf0f"
     },
     {
       "language": "bengali",
       "chapter": 5,
-      "sourceHash": "fnv1a64:0c2fa04e39eeca0a",
+      "sourceHash": "fnv1a64:79852e715c7e5696",
       "lessonIds": [
         "BN-C05-ami-bangla-boli",
         "BN-C05-bola",
@@ -513,12 +513,12 @@
         "BN-C05-practice",
         "BN-C05-thaka"
       ],
-      "voiceLessons": 5,
-      "drivablePrefix": 5,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "bengali/narration/ch05.txt",
       "json": "bengali/narration/ch05.json",
-      "textHash": "fnv1a64:e048a107978f5b3c",
-      "jsonHash": "fnv1a64:9fdf8f702d0bd7b3"
+      "textHash": "fnv1a64:6c63213edab024f5",
+      "jsonHash": "fnv1a64:4bf4c1e5b386d26c"
     },
     {
       "language": "bengali",
@@ -1304,7 +1304,7 @@
     {
       "language": "gujarati",
       "chapter": 1,
-      "sourceHash": "fnv1a64:57ef8bb46075c230",
+      "sourceHash": "fnv1a64:85602192fd87c52f",
       "lessonIds": [
         "GU-C01-aabhaar",
         "GU-C01-aavjo",
@@ -1313,17 +1313,17 @@
         "GU-C01-practice",
         "GU-C01-saarun"
       ],
-      "voiceLessons": 4,
-      "drivablePrefix": 3,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "gujarati/narration/ch01.txt",
       "json": "gujarati/narration/ch01.json",
-      "textHash": "fnv1a64:b8defc730a923232",
-      "jsonHash": "fnv1a64:9a42b670e7d0d476"
+      "textHash": "fnv1a64:0686ef65a8cb5ed7",
+      "jsonHash": "fnv1a64:0e7d26b0bcbcdfe6"
     },
     {
       "language": "gujarati",
       "chapter": 2,
-      "sourceHash": "fnv1a64:9465a57f929995ae",
+      "sourceHash": "fnv1a64:84eae05a789c7889",
       "lessonIds": [
         "GU-C02-anand",
         "GU-C02-chhe",
@@ -1335,17 +1335,17 @@
         "GU-C02-tamarun-naam-shun-chhe",
         "GU-C02-tu-tame"
       ],
-      "voiceLessons": 9,
-      "drivablePrefix": 9,
+      "voiceLessons": 3,
+      "drivablePrefix": 0,
       "text": "gujarati/narration/ch02.txt",
       "json": "gujarati/narration/ch02.json",
-      "textHash": "fnv1a64:072f2795f85aa63c",
-      "jsonHash": "fnv1a64:ec94517d169e16c5"
+      "textHash": "fnv1a64:7e44531359f0154f",
+      "jsonHash": "fnv1a64:e7d07b6f7e5ebd43"
     },
     {
       "language": "gujarati",
       "chapter": 3,
-      "sourceHash": "fnv1a64:94c6c7cb92e26b0e",
+      "sourceHash": "fnv1a64:519a94fefb3cc1fb",
       "lessonIds": [
         "GU-C03-hun",
         "GU-C03-kem",
@@ -1354,17 +1354,17 @@
         "GU-C03-tame-kem-chho",
         "GU-C03-vandho-nahi"
       ],
-      "voiceLessons": 6,
-      "drivablePrefix": 6,
+      "voiceLessons": 2,
+      "drivablePrefix": 0,
       "text": "gujarati/narration/ch03.txt",
       "json": "gujarati/narration/ch03.json",
-      "textHash": "fnv1a64:01eb4d010a7e7f57",
-      "jsonHash": "fnv1a64:b636f280f8e4d633"
+      "textHash": "fnv1a64:f8d37af0dc391627",
+      "jsonHash": "fnv1a64:549a398fad87fdd6"
     },
     {
       "language": "gujarati",
       "chapter": 4,
-      "sourceHash": "fnv1a64:b1d4dbc86a587681",
+      "sourceHash": "fnv1a64:9d5823ce6f705cb4",
       "lessonIds": [
         "GU-C04-kaale",
         "GU-C04-malishun",
@@ -1372,17 +1372,17 @@
         "GU-C04-pachha-malishun",
         "GU-C04-practice"
       ],
-      "voiceLessons": 4,
-      "drivablePrefix": 4,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "gujarati/narration/ch04.txt",
       "json": "gujarati/narration/ch04.json",
-      "textHash": "fnv1a64:90b602d09ed64b35",
-      "jsonHash": "fnv1a64:ce036ce19db49001"
+      "textHash": "fnv1a64:1491cf91c9d18b29",
+      "jsonHash": "fnv1a64:412be3d3ee8d1f67"
     },
     {
       "language": "gujarati",
       "chapter": 5,
-      "sourceHash": "fnv1a64:b17755f75edda7b3",
+      "sourceHash": "fnv1a64:8012e9dfcbaeaad7",
       "lessonIds": [
         "GU-C05-bolvun",
         "GU-C05-hun-gujarati-bolun-chhun",
@@ -1390,12 +1390,12 @@
         "GU-C05-practice",
         "GU-C05-rahevun"
       ],
-      "voiceLessons": 5,
-      "drivablePrefix": 5,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "gujarati/narration/ch05.txt",
       "json": "gujarati/narration/ch05.json",
-      "textHash": "fnv1a64:c3ed621da85c4189",
-      "jsonHash": "fnv1a64:44837bd5628a8f0e"
+      "textHash": "fnv1a64:cc87d04fdb1f32f0",
+      "jsonHash": "fnv1a64:4ed582bc2b5f5699"
     },
     {
       "language": "gujarati",
@@ -1415,7 +1415,7 @@
     {
       "language": "hindi",
       "chapter": 1,
-      "sourceHash": "fnv1a64:03002547302f8900",
+      "sourceHash": "fnv1a64:f6301764a50979e5",
       "lessonIds": [
         "HI-W01-shirorekha-na-ma",
         "HI-W01-na-ma",
@@ -1428,17 +1428,17 @@
         "HI-C01-practice",
         "HI-C01-shukriya"
       ],
-      "voiceLessons": 6,
+      "voiceLessons": 1,
       "drivablePrefix": 0,
       "text": "hindi/narration/ch01.txt",
       "json": "hindi/narration/ch01.json",
-      "textHash": "fnv1a64:610bf1577829cde0",
-      "jsonHash": "fnv1a64:6d85f7aa5893680e"
+      "textHash": "fnv1a64:f6c9f60962c60faa",
+      "jsonHash": "fnv1a64:424e17ed7ace0aa3"
     },
     {
       "language": "hindi",
       "chapter": 2,
-      "sourceHash": "fnv1a64:74dec42edfdc489b",
+      "sourceHash": "fnv1a64:15417887e8a232d7",
       "lessonIds": [
         "HI-W03-matras-naam",
         "HI-W03-preposed-i",
@@ -1457,17 +1457,17 @@
         "HI-C02-naam",
         "HI-C02-practice"
       ],
-      "voiceLessons": 9,
+      "voiceLessons": 4,
       "drivablePrefix": 0,
       "text": "hindi/narration/ch02.txt",
       "json": "hindi/narration/ch02.json",
-      "textHash": "fnv1a64:820a9217a628a5bc",
-      "jsonHash": "fnv1a64:ca233eb320731ee9"
+      "textHash": "fnv1a64:748accad9ac4c728",
+      "jsonHash": "fnv1a64:1ea61b80965173af"
     },
     {
       "language": "hindi",
       "chapter": 3,
-      "sourceHash": "fnv1a64:271040af036cfc26",
+      "sourceHash": "fnv1a64:5daa0e43b0e9f05d",
       "lessonIds": [
         "HI-C03-aap-kaise-hain",
         "HI-C03-aapka-swagat-hai",
@@ -1477,17 +1477,17 @@
         "HI-C03-practice",
         "HI-C03-thik"
       ],
-      "voiceLessons": 7,
-      "drivablePrefix": 7,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "hindi/narration/ch03.txt",
       "json": "hindi/narration/ch03.json",
-      "textHash": "fnv1a64:ba406690dfb15987",
-      "jsonHash": "fnv1a64:63b73b0077eab2af"
+      "textHash": "fnv1a64:eee65256308004a8",
+      "jsonHash": "fnv1a64:ef21ec8d03c96649"
     },
     {
       "language": "hindi",
       "chapter": 4,
-      "sourceHash": "fnv1a64:bbe49907699889b7",
+      "sourceHash": "fnv1a64:cf7b02944e8671f2",
       "lessonIds": [
         "HI-C04-chalta-hun",
         "HI-C04-kal-milte-hain",
@@ -1496,17 +1496,17 @@
         "HI-C04-phir-milenge",
         "HI-C04-practice"
       ],
-      "voiceLessons": 5,
-      "drivablePrefix": 5,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "hindi/narration/ch04.txt",
       "json": "hindi/narration/ch04.json",
-      "textHash": "fnv1a64:ebcc3391d0551dbd",
-      "jsonHash": "fnv1a64:fe2a230a88e76301"
+      "textHash": "fnv1a64:9e36baed450159ea",
+      "jsonHash": "fnv1a64:0cd095ec31d26341"
     },
     {
       "language": "hindi",
       "chapter": 5,
-      "sourceHash": "fnv1a64:43c5f48914f2f1ba",
+      "sourceHash": "fnv1a64:12bcb2ada8e71c1f",
       "lessonIds": [
         "HI-C05-bolna",
         "HI-C05-bolta-hun",
@@ -1515,12 +1515,12 @@
         "HI-C05-practice",
         "HI-C05-rahna"
       ],
-      "voiceLessons": 5,
-      "drivablePrefix": 5,
+      "voiceLessons": 2,
+      "drivablePrefix": 0,
       "text": "hindi/narration/ch05.txt",
       "json": "hindi/narration/ch05.json",
-      "textHash": "fnv1a64:5447bb8d3c10ea73",
-      "jsonHash": "fnv1a64:96c472975a3314c9"
+      "textHash": "fnv1a64:ddf43e013d62d725",
+      "jsonHash": "fnv1a64:d710e8d1e314eef1"
     },
     {
       "language": "hindi",
@@ -2229,7 +2229,7 @@
     {
       "language": "kannada",
       "chapter": 1,
-      "sourceHash": "fnv1a64:5ee7903d3c87a162",
+      "sourceHash": "fnv1a64:f51419731435c437",
       "lessonIds": [
         "KA-C01-dhanyavada",
         "KA-C01-haudu",
@@ -2238,17 +2238,17 @@
         "KA-C01-practice",
         "KA-C01-sari"
       ],
-      "voiceLessons": 4,
+      "voiceLessons": 0,
       "drivablePrefix": 0,
       "text": "kannada/narration/ch01.txt",
       "json": "kannada/narration/ch01.json",
-      "textHash": "fnv1a64:1baccdcd96b45911",
-      "jsonHash": "fnv1a64:99a5ccafdeb5a37a"
+      "textHash": "fnv1a64:4419d6f761c33a60",
+      "jsonHash": "fnv1a64:0de82d9848ea2b5f"
     },
     {
       "language": "kannada",
       "chapter": 2,
-      "sourceHash": "fnv1a64:b70e666895d0cb49",
+      "sourceHash": "fnv1a64:ebb799b08b06b8f8",
       "lessonIds": [
         "KA-C02-enu",
         "KA-C02-hesaru",
@@ -2259,17 +2259,17 @@
         "KA-C02-practice",
         "KA-C02-santosha"
       ],
-      "voiceLessons": 8,
-      "drivablePrefix": 8,
+      "voiceLessons": 4,
+      "drivablePrefix": 0,
       "text": "kannada/narration/ch02.txt",
       "json": "kannada/narration/ch02.json",
-      "textHash": "fnv1a64:be40f04939051eff",
-      "jsonHash": "fnv1a64:ffe94e729c84caed"
+      "textHash": "fnv1a64:7a269a9597177b7b",
+      "jsonHash": "fnv1a64:ceb9a56ef9b33c90"
     },
     {
       "language": "kannada",
       "chapter": 3,
-      "sourceHash": "fnv1a64:9b0a242f0d26de2b",
+      "sourceHash": "fnv1a64:cd9c763fa849439d",
       "lessonIds": [
         "KA-C03-cennaagi",
         "KA-C03-hege",
@@ -2278,17 +2278,17 @@
         "KA-C03-paravaagilla",
         "KA-C03-practice"
       ],
-      "voiceLessons": 6,
-      "drivablePrefix": 6,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "kannada/narration/ch03.txt",
       "json": "kannada/narration/ch03.json",
-      "textHash": "fnv1a64:d333e3a4c1fe83c0",
-      "jsonHash": "fnv1a64:b3ff0c3052a611cd"
+      "textHash": "fnv1a64:5325f64d955b958e",
+      "jsonHash": "fnv1a64:c51c8e63e746d68a"
     },
     {
       "language": "kannada",
       "chapter": 4,
-      "sourceHash": "fnv1a64:c0b0bab89cb795bd",
+      "sourceHash": "fnv1a64:e08a7fd2e7d9d6f8",
       "lessonIds": [
         "KA-C04-hoogi-baruttene",
         "KA-C04-hoogu",
@@ -2296,17 +2296,17 @@
         "KA-C04-naale-sigona",
         "KA-C04-practice"
       ],
-      "voiceLessons": 5,
-      "drivablePrefix": 5,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "kannada/narration/ch04.txt",
       "json": "kannada/narration/ch04.json",
-      "textHash": "fnv1a64:6dcc8c1e0d79ed65",
-      "jsonHash": "fnv1a64:275bd43ae11c4aa6"
+      "textHash": "fnv1a64:ecfeb15eabc11fea",
+      "jsonHash": "fnv1a64:ea56172059a2e047"
     },
     {
       "language": "kannada",
       "chapter": 5,
-      "sourceHash": "fnv1a64:e7c2f3c3c510af9b",
+      "sourceHash": "fnv1a64:c43a92e2750d8991",
       "lessonIds": [
         "KA-C05-iru",
         "KA-C05-kelasa-maadu",
@@ -2314,12 +2314,12 @@
         "KA-C05-naanu-kannada-maatanaaduttene",
         "KA-C05-practice"
       ],
-      "voiceLessons": 5,
-      "drivablePrefix": 5,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "kannada/narration/ch05.txt",
       "json": "kannada/narration/ch05.json",
-      "textHash": "fnv1a64:d3a31d21b8f4550d",
-      "jsonHash": "fnv1a64:f8152939df8b0258"
+      "textHash": "fnv1a64:31c113e0e09b6d34",
+      "jsonHash": "fnv1a64:74346b3f73558e04"
     },
     {
       "language": "kannada",
@@ -3217,7 +3217,7 @@
     {
       "language": "malayalam",
       "chapter": 1,
-      "sourceHash": "fnv1a64:466190a4496f5073",
+      "sourceHash": "fnv1a64:bfb1a1a7a0f1d6f8",
       "lessonIds": [
         "ML-C01-athe",
         "ML-C01-illa",
@@ -3226,17 +3226,17 @@
         "ML-C01-practice",
         "ML-C01-sari"
       ],
-      "voiceLessons": 5,
-      "drivablePrefix": 4,
+      "voiceLessons": 0,
+      "drivablePrefix": 0,
       "text": "malayalam/narration/ch01.txt",
       "json": "malayalam/narration/ch01.json",
-      "textHash": "fnv1a64:4a09e870362d31c2",
-      "jsonHash": "fnv1a64:758f5b08a58ef887"
+      "textHash": "fnv1a64:9a33e8b6a5db1814",
+      "jsonHash": "fnv1a64:0e9d2ab3e5d65269"
     },
     {
       "language": "malayalam",
       "chapter": 2,
-      "sourceHash": "fnv1a64:59770356ce4edd60",
+      "sourceHash": "fnv1a64:ac6aa6db065a34b3",
       "lessonIds": [
         "ML-C02-aanu",
         "ML-C02-enre",
@@ -3248,17 +3248,17 @@
         "ML-C02-practice",
         "ML-C02-santosham"
       ],
-      "voiceLessons": 9,
-      "drivablePrefix": 9,
+      "voiceLessons": 4,
+      "drivablePrefix": 0,
       "text": "malayalam/narration/ch02.txt",
       "json": "malayalam/narration/ch02.json",
-      "textHash": "fnv1a64:56ac8b8d10679593",
-      "jsonHash": "fnv1a64:3266821d8f006684"
+      "textHash": "fnv1a64:a763fd2681c81ae2",
+      "jsonHash": "fnv1a64:b7b021556ead3fda"
     },
     {
       "language": "malayalam",
       "chapter": 3,
-      "sourceHash": "fnv1a64:fe0a2d758903636a",
+      "sourceHash": "fnv1a64:6e4c284aceda5c95",
       "lessonIds": [
         "ML-C03-engane",
         "ML-C03-njaan",
@@ -3267,17 +3267,17 @@
         "ML-C03-sukham",
         "ML-C03-sukhamaano"
       ],
-      "voiceLessons": 6,
-      "drivablePrefix": 6,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "malayalam/narration/ch03.txt",
       "json": "malayalam/narration/ch03.json",
-      "textHash": "fnv1a64:19036c1fdccc785c",
-      "jsonHash": "fnv1a64:b05eb04de1695f32"
+      "textHash": "fnv1a64:324cd383814e8838",
+      "jsonHash": "fnv1a64:129aa23a47ed2cae"
     },
     {
       "language": "malayalam",
       "chapter": 4,
-      "sourceHash": "fnv1a64:1f30deae0c4c4e8b",
+      "sourceHash": "fnv1a64:f1c85116657207db",
       "lessonIds": [
         "ML-C04-naale-kaanaam",
         "ML-C04-pokuka",
@@ -3285,17 +3285,17 @@
         "ML-C04-practice",
         "ML-C04-veendum-kaanaam"
       ],
-      "voiceLessons": 5,
-      "drivablePrefix": 5,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "malayalam/narration/ch04.txt",
       "json": "malayalam/narration/ch04.json",
-      "textHash": "fnv1a64:dcb81c48a78c5c4b",
-      "jsonHash": "fnv1a64:a2946d6bb6b86d20"
+      "textHash": "fnv1a64:72dd8f6f768ab094",
+      "jsonHash": "fnv1a64:1c024b5b6534e475"
     },
     {
       "language": "malayalam",
       "chapter": 5,
-      "sourceHash": "fnv1a64:bcf5594822945cec",
+      "sourceHash": "fnv1a64:0bd13d76a6d2d33f",
       "lessonIds": [
         "ML-C05-joli-ceyyuka",
         "ML-C05-njaan-malayalam-samsaarikkunnu",
@@ -3303,12 +3303,12 @@
         "ML-C05-samsaarikkuka",
         "ML-C05-taamasikkuka"
       ],
-      "voiceLessons": 5,
-      "drivablePrefix": 5,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "malayalam/narration/ch05.txt",
       "json": "malayalam/narration/ch05.json",
-      "textHash": "fnv1a64:9f637443bad502d8",
-      "jsonHash": "fnv1a64:4683f6c0528af61f"
+      "textHash": "fnv1a64:b5872e69e79d7819",
+      "jsonHash": "fnv1a64:1fd09d83af2da8ac"
     },
     {
       "language": "malayalam",
@@ -3684,7 +3684,7 @@
     {
       "language": "marathi",
       "chapter": 1,
-      "sourceHash": "fnv1a64:f996ecda0ad9f9a1",
+      "sourceHash": "fnv1a64:07798362d454a9f2",
       "lessonIds": [
         "MR-C01-baram",
         "MR-C01-dhanyavad",
@@ -3694,17 +3694,17 @@
         "MR-C01-practice",
         "MR-C01-yeto"
       ],
-      "voiceLessons": 7,
-      "drivablePrefix": 7,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "marathi/narration/ch01.txt",
       "json": "marathi/narration/ch01.json",
-      "textHash": "fnv1a64:45f02deba153ea98",
-      "jsonHash": "fnv1a64:dcccc1acd4b1459e"
+      "textHash": "fnv1a64:49f0cb079d15c5b1",
+      "jsonHash": "fnv1a64:70ba4fd397e7104b"
     },
     {
       "language": "marathi",
       "chapter": 2,
-      "sourceHash": "fnv1a64:a5335a4a839d6f4a",
+      "sourceHash": "fnv1a64:d7d34ac586baf0bb",
       "lessonIds": [
         "MR-C02-aahe",
         "MR-C02-anand",
@@ -3716,17 +3716,17 @@
         "MR-C02-tu-tumhi",
         "MR-C02-tumche-naav-kaay-aahe"
       ],
-      "voiceLessons": 9,
-      "drivablePrefix": 9,
+      "voiceLessons": 4,
+      "drivablePrefix": 0,
       "text": "marathi/narration/ch02.txt",
       "json": "marathi/narration/ch02.json",
-      "textHash": "fnv1a64:b024eae5d69a8d27",
-      "jsonHash": "fnv1a64:fd9e415e54d28e98"
+      "textHash": "fnv1a64:997f52a3ec21ea1e",
+      "jsonHash": "fnv1a64:f3c421e9870c7e9d"
     },
     {
       "language": "marathi",
       "chapter": 3,
-      "sourceHash": "fnv1a64:c164fc7244c4ec14",
+      "sourceHash": "fnv1a64:4698352cdd6ad6ca",
       "lessonIds": [
         "MR-C03-kaahi-harkat-nahi",
         "MR-C03-kasa",
@@ -3735,17 +3735,17 @@
         "MR-C03-practice",
         "MR-C03-tumhi-kase-aahat"
       ],
-      "voiceLessons": 6,
-      "drivablePrefix": 6,
+      "voiceLessons": 4,
+      "drivablePrefix": 1,
       "text": "marathi/narration/ch03.txt",
       "json": "marathi/narration/ch03.json",
-      "textHash": "fnv1a64:200572dbaa109cf8",
-      "jsonHash": "fnv1a64:01bcf5b759f58989"
+      "textHash": "fnv1a64:b3924db40016bddf",
+      "jsonHash": "fnv1a64:dd3baa3f168ccbab"
     },
     {
       "language": "marathi",
       "chapter": 4,
-      "sourceHash": "fnv1a64:909c1ade8961cad1",
+      "sourceHash": "fnv1a64:698a7e2e82e9ad58",
       "lessonIds": [
         "MR-C04-bhetu",
         "MR-C04-kalji-ghya",
@@ -3754,17 +3754,17 @@
         "MR-C04-punha-bhetu",
         "MR-C04-udya-bhetu"
       ],
-      "voiceLessons": 6,
-      "drivablePrefix": 6,
+      "voiceLessons": 2,
+      "drivablePrefix": 0,
       "text": "marathi/narration/ch04.txt",
       "json": "marathi/narration/ch04.json",
-      "textHash": "fnv1a64:00ad3b4f927f3e7d",
-      "jsonHash": "fnv1a64:d1d52344b7856b6a"
+      "textHash": "fnv1a64:aa70c216d026b9c3",
+      "jsonHash": "fnv1a64:9039a6a2b6096a25"
     },
     {
       "language": "marathi",
       "chapter": 5,
-      "sourceHash": "fnv1a64:8fddef5ce8ffce13",
+      "sourceHash": "fnv1a64:03f79a98594f4da1",
       "lessonIds": [
         "MR-C05-bolne",
         "MR-C05-kaam-karne",
@@ -3772,12 +3772,12 @@
         "MR-C05-practice",
         "MR-C05-rahne"
       ],
-      "voiceLessons": 4,
-      "drivablePrefix": 4,
+      "voiceLessons": 2,
+      "drivablePrefix": 0,
       "text": "marathi/narration/ch05.txt",
       "json": "marathi/narration/ch05.json",
-      "textHash": "fnv1a64:3fb5b239769985ca",
-      "jsonHash": "fnv1a64:ace9e8abbc2b68e0"
+      "textHash": "fnv1a64:02fa10401fbe1fbb",
+      "jsonHash": "fnv1a64:7f0704071b792bb0"
     },
     {
       "language": "marathi",
@@ -4162,7 +4162,7 @@
     {
       "language": "punjabi",
       "chapter": 1,
-      "sourceHash": "fnv1a64:01fd22edaff3d7c7",
+      "sourceHash": "fnv1a64:03685e752baf67fe",
       "lessonIds": [
         "PA-C01-dhanvaad",
         "PA-C01-han-nahin",
@@ -4171,17 +4171,17 @@
         "PA-C01-sat-sri-akal",
         "PA-C01-shukriya"
       ],
-      "voiceLessons": 6,
-      "drivablePrefix": 6,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "punjabi/narration/ch01.txt",
       "json": "punjabi/narration/ch01.json",
-      "textHash": "fnv1a64:b3bc9ea17aa66d9f",
-      "jsonHash": "fnv1a64:6709e998adc2ce77"
+      "textHash": "fnv1a64:ca04bdb476231635",
+      "jsonHash": "fnv1a64:06bec4dc9f7d757a"
     },
     {
       "language": "punjabi",
       "chapter": 2,
-      "sourceHash": "fnv1a64:e643cd66d39cebf5",
+      "sourceHash": "fnv1a64:3fcfc2e95caa5978",
       "lessonIds": [
         "PA-C02-hai",
         "PA-C02-khushi",
@@ -4193,17 +4193,17 @@
         "PA-C02-tu-tusi",
         "PA-C02-tuhada-naam-ki-hai"
       ],
-      "voiceLessons": 9,
-      "drivablePrefix": 9,
+      "voiceLessons": 3,
+      "drivablePrefix": 0,
       "text": "punjabi/narration/ch02.txt",
       "json": "punjabi/narration/ch02.json",
-      "textHash": "fnv1a64:fa70961739f936cd",
-      "jsonHash": "fnv1a64:cceb2258dad183de"
+      "textHash": "fnv1a64:9ca222c6683223de",
+      "jsonHash": "fnv1a64:775483b872a02354"
     },
     {
       "language": "punjabi",
       "chapter": 3,
-      "sourceHash": "fnv1a64:dd2fc76c2ba1f219",
+      "sourceHash": "fnv1a64:653a3e23669dcad9",
       "lessonIds": [
         "PA-C03-kivein",
         "PA-C03-koi-gall-nahin",
@@ -4212,17 +4212,17 @@
         "PA-C03-thik",
         "PA-C03-tusi-kivein-ho"
       ],
-      "voiceLessons": 6,
-      "drivablePrefix": 6,
+      "voiceLessons": 2,
+      "drivablePrefix": 0,
       "text": "punjabi/narration/ch03.txt",
       "json": "punjabi/narration/ch03.json",
-      "textHash": "fnv1a64:c278ab425b7a9954",
-      "jsonHash": "fnv1a64:028901f65af12368"
+      "textHash": "fnv1a64:e7f2a6e1df2ff084",
+      "jsonHash": "fnv1a64:6d4f79d9202f6d79"
     },
     {
       "language": "punjabi",
       "chapter": 4,
-      "sourceHash": "fnv1a64:cd853793437ea4bb",
+      "sourceHash": "fnv1a64:9d2ba0448ca47532",
       "lessonIds": [
         "PA-C04-milaange",
         "PA-C04-phir",
@@ -4230,17 +4230,17 @@
         "PA-C04-practice",
         "PA-C04-rab-raakha"
       ],
-      "voiceLessons": 4,
-      "drivablePrefix": 3,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "punjabi/narration/ch04.txt",
       "json": "punjabi/narration/ch04.json",
-      "textHash": "fnv1a64:a7a53b2c9ebc4584",
-      "jsonHash": "fnv1a64:bf62e1dcb01f31ea"
+      "textHash": "fnv1a64:2e16f7953cb93fb3",
+      "jsonHash": "fnv1a64:62fc5791f68bba82"
     },
     {
       "language": "punjabi",
       "chapter": 5,
-      "sourceHash": "fnv1a64:b725380704b3457e",
+      "sourceHash": "fnv1a64:25a70d4ed764c8eb",
       "lessonIds": [
         "PA-C05-bolna",
         "PA-C05-kamm-karna",
@@ -4248,12 +4248,12 @@
         "PA-C05-practice",
         "PA-C05-rahna"
       ],
-      "voiceLessons": 4,
-      "drivablePrefix": 4,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "punjabi/narration/ch05.txt",
       "json": "punjabi/narration/ch05.json",
-      "textHash": "fnv1a64:44512a9d05773e13",
-      "jsonHash": "fnv1a64:d3f662668264810f"
+      "textHash": "fnv1a64:879875ffd9f259ce",
+      "jsonHash": "fnv1a64:00f7fb68488dd023"
     },
     {
       "language": "punjabi",
@@ -4273,7 +4273,7 @@
     {
       "language": "russian",
       "chapter": 1,
-      "sourceHash": "fnv1a64:945bc040fc4ba72c",
+      "sourceHash": "fnv1a64:666276e1d698f4d5",
       "lessonIds": [
         "RU-C01-da",
         "RU-C01-net",
@@ -4288,12 +4288,12 @@
         "RU-W04-privet-letters-p-i",
         "RU-W05-privet-letters-e-t"
       ],
-      "voiceLessons": 7,
-      "drivablePrefix": 7,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "russian/narration/ch01.txt",
       "json": "russian/narration/ch01.json",
-      "textHash": "fnv1a64:c37c1b6044d3058d",
-      "jsonHash": "fnv1a64:303e4c5d261bc03e"
+      "textHash": "fnv1a64:48b836859ea2b1c0",
+      "jsonHash": "fnv1a64:c186e34a4c1dcac4"
     },
     {
       "language": "russian",
@@ -4321,7 +4321,7 @@
     {
       "language": "sanskrit",
       "chapter": 1,
-      "sourceHash": "fnv1a64:d7cbcfae685a6ecc",
+      "sourceHash": "fnv1a64:aad0ad5150f2038b",
       "lessonIds": [
         "SA-C01-am-na",
         "SA-C01-dhanyavada",
@@ -4330,17 +4330,17 @@
         "SA-C01-practice",
         "SA-C01-svagatam"
       ],
-      "voiceLessons": 5,
-      "drivablePrefix": 2,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "sanskrit/narration/ch01.txt",
       "json": "sanskrit/narration/ch01.json",
-      "textHash": "fnv1a64:4d28c7fe42ee774b",
-      "jsonHash": "fnv1a64:09412dc7c43b245a"
+      "textHash": "fnv1a64:639e8e93536db3ca",
+      "jsonHash": "fnv1a64:55d1bbde1012dc89"
     },
     {
       "language": "sanskrit",
       "chapter": 2,
-      "sourceHash": "fnv1a64:874f4d8be76423e5",
+      "sourceHash": "fnv1a64:bb5a242c96a6f6d0",
       "lessonIds": [
         "SA-C02-anandah",
         "SA-C02-asti",
@@ -4351,17 +4351,17 @@
         "SA-C02-nama",
         "SA-C02-tava-nama-kim"
       ],
-      "voiceLessons": 8,
-      "drivablePrefix": 8,
+      "voiceLessons": 2,
+      "drivablePrefix": 0,
       "text": "sanskrit/narration/ch02.txt",
       "json": "sanskrit/narration/ch02.json",
-      "textHash": "fnv1a64:1a882709e9deb7db",
-      "jsonHash": "fnv1a64:82520570bf865a4a"
+      "textHash": "fnv1a64:e2a1835d5ba8f515",
+      "jsonHash": "fnv1a64:a10b16c718be4dfe"
     },
     {
       "language": "sanskrit",
       "chapter": 3,
-      "sourceHash": "fnv1a64:0294567d2aa4f6ee",
+      "sourceHash": "fnv1a64:dcf6cb6bc6f91b5c",
       "lessonIds": [
         "SA-C03-aham",
         "SA-C03-bhavan-katham-asti",
@@ -4370,17 +4370,17 @@
         "SA-C03-na-cinta",
         "SA-C03-practice"
       ],
-      "voiceLessons": 6,
-      "drivablePrefix": 6,
+      "voiceLessons": 2,
+      "drivablePrefix": 0,
       "text": "sanskrit/narration/ch03.txt",
       "json": "sanskrit/narration/ch03.json",
-      "textHash": "fnv1a64:3a49b17e8da11476",
-      "jsonHash": "fnv1a64:70b32f94e928b322"
+      "textHash": "fnv1a64:4da71758ebc41fd6",
+      "jsonHash": "fnv1a64:f8f50ab61a926054"
     },
     {
       "language": "sanskrit",
       "chapter": 4,
-      "sourceHash": "fnv1a64:0d47b72b02c0839e",
+      "sourceHash": "fnv1a64:f28a789d74943117",
       "lessonIds": [
         "SA-C04-gacchami",
         "SA-C04-practice",
@@ -4388,17 +4388,17 @@
         "SA-C04-punar-darshanaya",
         "SA-C04-shvah"
       ],
-      "voiceLessons": 5,
-      "drivablePrefix": 5,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "sanskrit/narration/ch04.txt",
       "json": "sanskrit/narration/ch04.json",
-      "textHash": "fnv1a64:6a00cd6c015afbf4",
-      "jsonHash": "fnv1a64:e44102a223077b13"
+      "textHash": "fnv1a64:cb447311705e58b3",
+      "jsonHash": "fnv1a64:cbaf16911820298c"
     },
     {
       "language": "sanskrit",
       "chapter": 5,
-      "sourceHash": "fnv1a64:847f27ccd51242f5",
+      "sourceHash": "fnv1a64:45070b3634ab6b25",
       "lessonIds": [
         "SA-C05-aham-samskritam-vadami",
         "SA-C05-karomi",
@@ -4406,12 +4406,12 @@
         "SA-C05-vadami",
         "SA-C05-vasami"
       ],
-      "voiceLessons": 5,
-      "drivablePrefix": 5,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "sanskrit/narration/ch05.txt",
       "json": "sanskrit/narration/ch05.json",
-      "textHash": "fnv1a64:dd7748d16ad5f055",
-      "jsonHash": "fnv1a64:abb7d8af15182722"
+      "textHash": "fnv1a64:d872a0719de56684",
+      "jsonHash": "fnv1a64:85fa13617e23c7d8"
     },
     {
       "language": "sanskrit",
@@ -5007,7 +5007,7 @@
     {
       "language": "tamil",
       "chapter": 1,
-      "sourceHash": "fnv1a64:84f0b9839e6e01b9",
+      "sourceHash": "fnv1a64:b80adea0055c5306",
       "lessonIds": [
         "TA-W01-curves-va-ka",
         "TA-W01-abugida-va-ka",
@@ -5026,17 +5026,17 @@
         "TA-C01-vanakkam",
         "TA-C01-vanakkam-family-register"
       ],
-      "voiceLessons": 7,
+      "voiceLessons": 3,
       "drivablePrefix": 0,
       "text": "tamil/narration/ch01.txt",
       "json": "tamil/narration/ch01.json",
-      "textHash": "fnv1a64:4bdee24048b74aa0",
-      "jsonHash": "fnv1a64:0575e4d9ef572cce"
+      "textHash": "fnv1a64:48d5d883f2ea52c9",
+      "jsonHash": "fnv1a64:243dc9ef125be921"
     },
     {
       "language": "tamil",
       "chapter": 2,
-      "sourceHash": "fnv1a64:ff99e97b090b9e65",
+      "sourceHash": "fnv1a64:4a88253cf308c812",
       "lessonIds": [
         "TA-C02-en",
         "TA-C02-en-peyar",
@@ -5047,17 +5047,17 @@
         "TA-C02-practice",
         "TA-C02-ungal-peyar-enna"
       ],
-      "voiceLessons": 7,
-      "drivablePrefix": 1,
+      "voiceLessons": 3,
+      "drivablePrefix": 0,
       "text": "tamil/narration/ch02.txt",
       "json": "tamil/narration/ch02.json",
-      "textHash": "fnv1a64:868b4827041900e5",
-      "jsonHash": "fnv1a64:f3663d5df2d0edee"
+      "textHash": "fnv1a64:0093e1e0a5686f58",
+      "jsonHash": "fnv1a64:98647cd4b9623dac"
     },
     {
       "language": "tamil",
       "chapter": 3,
-      "sourceHash": "fnv1a64:f8cfd6742c9fe44b",
+      "sourceHash": "fnv1a64:8ccf2dad23d346e7",
       "lessonIds": [
         "TA-C03-eppadi",
         "TA-C03-eppadi-irukkirirgal",
@@ -5066,17 +5066,17 @@
         "TA-C03-paravayillai",
         "TA-C03-practice"
       ],
-      "voiceLessons": 6,
-      "drivablePrefix": 6,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "tamil/narration/ch03.txt",
       "json": "tamil/narration/ch03.json",
-      "textHash": "fnv1a64:ddec0569b5fec53c",
-      "jsonHash": "fnv1a64:4ecf25f51ea567df"
+      "textHash": "fnv1a64:ea7853c6d4277b9a",
+      "jsonHash": "fnv1a64:4f015ef82391247e"
     },
     {
       "language": "tamil",
       "chapter": 4,
-      "sourceHash": "fnv1a64:c8db7d90878a9d80",
+      "sourceHash": "fnv1a64:e6cc92ef0275935e",
       "lessonIds": [
         "TA-C04-mindum-sandippom",
         "TA-C04-naalai",
@@ -5084,17 +5084,17 @@
         "TA-C04-poy-varugiren",
         "TA-C04-practice"
       ],
-      "voiceLessons": 5,
-      "drivablePrefix": 5,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "tamil/narration/ch04.txt",
       "json": "tamil/narration/ch04.json",
-      "textHash": "fnv1a64:e876af9992acdcba",
-      "jsonHash": "fnv1a64:a369b68dfc5a3faf"
+      "textHash": "fnv1a64:ae9e25d9c47018af",
+      "jsonHash": "fnv1a64:3f9ef050ea8e704f"
     },
     {
       "language": "tamil",
       "chapter": 5,
-      "sourceHash": "fnv1a64:3f17bc39874c53ae",
+      "sourceHash": "fnv1a64:6e46aaef34f9ba78",
       "lessonIds": [
         "TA-C05-naan-tamizh-pesugiren",
         "TA-C05-pesu",
@@ -5102,12 +5102,12 @@
         "TA-C05-vaazh",
         "TA-C05-velai-sey"
       ],
-      "voiceLessons": 5,
-      "drivablePrefix": 5,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "tamil/narration/ch05.txt",
       "json": "tamil/narration/ch05.json",
-      "textHash": "fnv1a64:e72fd2bfbbb05a60",
-      "jsonHash": "fnv1a64:2145b4af5025c94a"
+      "textHash": "fnv1a64:2dd4162f93a7fc45",
+      "jsonHash": "fnv1a64:4027d382a2e05e1f"
     },
     {
       "language": "tamil",
@@ -5493,7 +5493,7 @@
     {
       "language": "telugu",
       "chapter": 1,
-      "sourceHash": "fnv1a64:3459acb100727861",
+      "sourceHash": "fnv1a64:3fd3f66959fa87bf",
       "lessonIds": [
         "TE-C01-avunu",
         "TE-C01-dhanyavadamulu",
@@ -5502,17 +5502,17 @@
         "TE-C01-practice",
         "TE-C01-sare"
       ],
-      "voiceLessons": 4,
-      "drivablePrefix": 1,
+      "voiceLessons": 0,
+      "drivablePrefix": 0,
       "text": "telugu/narration/ch01.txt",
       "json": "telugu/narration/ch01.json",
-      "textHash": "fnv1a64:f1ebed22230c3d35",
-      "jsonHash": "fnv1a64:be04b9fdfdb7a663"
+      "textHash": "fnv1a64:81cf6989fed88a39",
+      "jsonHash": "fnv1a64:880ee06fc086ebcf"
     },
     {
       "language": "telugu",
       "chapter": 2,
-      "sourceHash": "fnv1a64:acd01dd37ac9c774",
+      "sourceHash": "fnv1a64:1cf5973cc83511a8",
       "lessonIds": [
         "TE-C02-emiti",
         "TE-C02-mii-peru-emiti",
@@ -5523,17 +5523,17 @@
         "TE-C02-practice",
         "TE-C02-santosham"
       ],
-      "voiceLessons": 8,
-      "drivablePrefix": 8,
+      "voiceLessons": 4,
+      "drivablePrefix": 0,
       "text": "telugu/narration/ch02.txt",
       "json": "telugu/narration/ch02.json",
-      "textHash": "fnv1a64:0e8b8eabf1470052",
-      "jsonHash": "fnv1a64:1fae43f7eb4f839d"
+      "textHash": "fnv1a64:4047544b5bf36dc6",
+      "jsonHash": "fnv1a64:dc1a241df86c0bc5"
     },
     {
       "language": "telugu",
       "chapter": 3,
-      "sourceHash": "fnv1a64:0b37bc1d7a4651d2",
+      "sourceHash": "fnv1a64:4ce874054fee9743",
       "lessonIds": [
         "TE-C03-baagaa",
         "TE-C03-elaa",
@@ -5542,17 +5542,17 @@
         "TE-C03-paravaaledu",
         "TE-C03-practice"
       ],
-      "voiceLessons": 6,
-      "drivablePrefix": 6,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "telugu/narration/ch03.txt",
       "json": "telugu/narration/ch03.json",
-      "textHash": "fnv1a64:3ceb6f9bd44f055c",
-      "jsonHash": "fnv1a64:3f49e57cb2df708b"
+      "textHash": "fnv1a64:19d5b8b6c39cbb04",
+      "jsonHash": "fnv1a64:1ac00673abdf1166"
     },
     {
       "language": "telugu",
       "chapter": 4,
-      "sourceHash": "fnv1a64:149edab58bdc1eec",
+      "sourceHash": "fnv1a64:e4153a7d2fa6af5d",
       "lessonIds": [
         "TE-C04-malli-kaluddaam",
         "TE-C04-practice",
@@ -5560,17 +5560,17 @@
         "TE-C04-velli-vastaanu",
         "TE-C04-vellu"
       ],
-      "voiceLessons": 5,
-      "drivablePrefix": 5,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "telugu/narration/ch04.txt",
       "json": "telugu/narration/ch04.json",
-      "textHash": "fnv1a64:e96095ef0ca8c0aa",
-      "jsonHash": "fnv1a64:3816b185c0fa6bb1"
+      "textHash": "fnv1a64:bf3dfbc4ec5455af",
+      "jsonHash": "fnv1a64:a6377b88277ba168"
     },
     {
       "language": "telugu",
       "chapter": 5,
-      "sourceHash": "fnv1a64:28ad5f45ddc17ec5",
+      "sourceHash": "fnv1a64:e585e84796aea7f4",
       "lessonIds": [
         "TE-C05-maatlaadu",
         "TE-C05-nenu-telugu-maatlaadataanu",
@@ -5578,12 +5578,12 @@
         "TE-C05-practice",
         "TE-C05-undu"
       ],
-      "voiceLessons": 5,
-      "drivablePrefix": 5,
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
       "text": "telugu/narration/ch05.txt",
       "json": "telugu/narration/ch05.json",
-      "textHash": "fnv1a64:7858f4b89e3efa0e",
-      "jsonHash": "fnv1a64:ebb54fe92cfb5d46"
+      "textHash": "fnv1a64:832b54fc12af5997",
+      "jsonHash": "fnv1a64:42cc5d3cd8309241"
     },
     {
       "language": "telugu",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,19 +7,19 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:c79bbb8df3d255e8",
+  "sourceHash": "fnv1a64:6aa6fcf5b3634832",
   "summary": {
     "totalLessons": 1134,
-    "voice": 957,
-    "sight": 124,
+    "voice": 726,
+    "sight": 355,
     "pen": 53,
-    "drivableLessons": 957,
-    "drivablePercent": 84,
+    "drivableLessons": 726,
+    "drivablePercent": 64,
     "trackCount": 22,
     "chapterCount": 377,
-    "drivablePrefixTotal": 825,
-    "fullyDrivableChapters": 284,
-    "unstartableChapters": 44,
+    "drivablePrefixTotal": 555,
+    "fullyDrivableChapters": 251,
+    "unstartableChapters": 92,
     "overriddenLessons": 0,
     "lessonsWithoutChapter": 0
   },
@@ -27,11 +27,11 @@
     {
       "language": "arabic",
       "lessonCount": 71,
-      "voice": 50,
-      "sight": 5,
+      "voice": 38,
+      "sight": 17,
       "pen": 16,
-      "drivablePercent": 70,
-      "drivablePrefixTotal": 42,
+      "drivablePercent": 54,
+      "drivablePrefixTotal": 26,
       "modalities": [
         "voice",
         "sight",
@@ -41,52 +41,34 @@
         {
           "chapter": 1,
           "lessonCount": 14,
-          "voice": 8,
-          "sight": 0,
+          "voice": 1,
+          "sight": 7,
           "pen": 6,
           "modalities": [
             "voice",
             "sight",
             "pen"
           ],
-          "drivablePrefix": 8,
-          "firstNonVoiceLesson": "AR-W01-abjad-short-vowels",
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "AR-C01-al",
           "drivable": false,
-          "drivableLessonIds": [
-            "AR-C01-al",
-            "AR-C01-as-salamu-alaykum",
-            "AR-C01-marhaba",
-            "AR-C01-masa-al-khayr",
-            "AR-C01-practice",
-            "AR-C01-sabah-al-khayr",
-            "AR-C01-salam",
-            "AR-C01-shukran"
-          ]
+          "drivableLessonIds": []
         },
         {
           "chapter": 2,
           "lessonCount": 12,
-          "voice": 8,
-          "sight": 0,
+          "voice": 3,
+          "sight": 5,
           "pen": 4,
           "modalities": [
             "voice",
             "sight",
             "pen"
           ],
-          "drivablePrefix": 8,
-          "firstNonVoiceLesson": "AR-W04-dots-family-nun-ta",
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "AR-C02-anta-anti",
           "drivable": false,
-          "drivableLessonIds": [
-            "AR-C02-anta-anti",
-            "AR-C02-ii-my",
-            "AR-C02-ism",
-            "AR-C02-ismii",
-            "AR-C02-maa",
-            "AR-C02-maa-ismuka",
-            "AR-C02-practice",
-            "AR-C02-tasharrafna"
-          ]
+          "drivableLessonIds": []
         },
         {
           "chapter": 3,
@@ -496,11 +478,11 @@
     {
       "language": "bengali",
       "lessonCount": 31,
-      "voice": 29,
-      "sight": 2,
+      "voice": 7,
+      "sight": 24,
       "pen": 0,
-      "drivablePercent": 94,
-      "drivablePrefixTotal": 24,
+      "drivablePercent": 23,
+      "drivablePrefixTotal": 1,
       "modalities": [
         "voice",
         "sight"
@@ -509,102 +491,77 @@
         {
           "chapter": 1,
           "lessonCount": 6,
-          "voice": 6,
-          "sight": 0,
+          "voice": 1,
+          "sight": 5,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 6,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "BN-C01-achchha",
-            "BN-C01-ashi",
-            "BN-C01-dhonnobad",
-            "BN-C01-hyan-na",
-            "BN-C01-nomoshkar",
-            "BN-C01-practice"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "BN-C01-achchha",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 2,
           "lessonCount": 8,
-          "voice": 7,
-          "sight": 1,
+          "voice": 2,
+          "sight": 6,
           "pen": 0,
           "modalities": [
             "voice",
             "sight"
           ],
-          "drivablePrefix": 2,
-          "firstNonVoiceLesson": "BN-C02-amar-naam",
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "BN-C02-alaap",
           "drivable": false,
-          "drivableLessonIds": [
-            "BN-C02-alaap",
-            "BN-C02-amar"
-          ]
+          "drivableLessonIds": []
         },
         {
           "chapter": 3,
           "lessonCount": 6,
-          "voice": 6,
-          "sight": 0,
-          "pen": 0,
-          "modalities": [
-            "voice"
-          ],
-          "drivablePrefix": 6,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "BN-C03-ami",
-            "BN-C03-bhalo",
-            "BN-C03-kemon",
-            "BN-C03-kono-bepar-na",
-            "BN-C03-practice",
-            "BN-C03-tumi-kemon-achho"
-          ]
-        },
-        {
-          "chapter": 4,
-          "lessonCount": 5,
-          "voice": 4,
-          "sight": 1,
+          "voice": 1,
+          "sight": 5,
           "pen": 0,
           "modalities": [
             "voice",
             "sight"
           ],
-          "drivablePrefix": 4,
-          "firstNonVoiceLesson": "BN-C04-practice",
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "BN-C03-ami",
           "drivable": false,
-          "drivableLessonIds": [
-            "BN-C04-abar",
-            "BN-C04-abar-dekha-hobe",
-            "BN-C04-dekha-hobe",
-            "BN-C04-kal-dekha-hobe"
-          ]
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 4,
+          "lessonCount": 5,
+          "voice": 1,
+          "sight": 4,
+          "pen": 0,
+          "modalities": [
+            "voice",
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "BN-C04-abar",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 5,
           "lessonCount": 5,
-          "voice": 5,
-          "sight": 0,
+          "voice": 1,
+          "sight": 4,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 5,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "BN-C05-ami-bangla-boli",
-            "BN-C05-bola",
-            "BN-C05-kaj-kora",
-            "BN-C05-practice",
-            "BN-C05-thaka"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "BN-C05-ami-bangla-boli",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 6,
@@ -1491,11 +1448,11 @@
     {
       "language": "gujarati",
       "lessonCount": 33,
-      "voice": 30,
-      "sight": 3,
+      "voice": 10,
+      "sight": 23,
       "pen": 0,
-      "drivablePercent": 91,
-      "drivablePrefixTotal": 29,
+      "drivablePercent": 30,
+      "drivablePrefixTotal": 2,
       "modalities": [
         "voice",
         "sight"
@@ -1504,106 +1461,77 @@
         {
           "chapter": 1,
           "lessonCount": 6,
-          "voice": 4,
-          "sight": 2,
+          "voice": 1,
+          "sight": 5,
           "pen": 0,
           "modalities": [
             "voice",
             "sight"
           ],
-          "drivablePrefix": 3,
-          "firstNonVoiceLesson": "GU-C01-namaste",
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "GU-C01-aabhaar",
           "drivable": false,
-          "drivableLessonIds": [
-            "GU-C01-aabhaar",
-            "GU-C01-aavjo",
-            "GU-C01-haa-naa"
-          ]
+          "drivableLessonIds": []
         },
         {
           "chapter": 2,
           "lessonCount": 9,
-          "voice": 9,
-          "sight": 0,
-          "pen": 0,
-          "modalities": [
-            "voice"
-          ],
-          "drivablePrefix": 9,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "GU-C02-anand",
-            "GU-C02-chhe",
-            "GU-C02-maarun",
-            "GU-C02-maarun-naam-chhe",
-            "GU-C02-naam",
-            "GU-C02-practice",
-            "GU-C02-shun",
-            "GU-C02-tamarun-naam-shun-chhe",
-            "GU-C02-tu-tame"
-          ]
-        },
-        {
-          "chapter": 3,
-          "lessonCount": 6,
-          "voice": 6,
-          "sight": 0,
-          "pen": 0,
-          "modalities": [
-            "voice"
-          ],
-          "drivablePrefix": 6,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "GU-C03-hun",
-            "GU-C03-kem",
-            "GU-C03-majaa",
-            "GU-C03-practice",
-            "GU-C03-tame-kem-chho",
-            "GU-C03-vandho-nahi"
-          ]
-        },
-        {
-          "chapter": 4,
-          "lessonCount": 5,
-          "voice": 4,
-          "sight": 1,
+          "voice": 3,
+          "sight": 6,
           "pen": 0,
           "modalities": [
             "voice",
             "sight"
           ],
-          "drivablePrefix": 4,
-          "firstNonVoiceLesson": "GU-C04-practice",
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "GU-C02-anand",
           "drivable": false,
-          "drivableLessonIds": [
-            "GU-C04-kaale",
-            "GU-C04-malishun",
-            "GU-C04-pachha",
-            "GU-C04-pachha-malishun"
-          ]
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 3,
+          "lessonCount": 6,
+          "voice": 2,
+          "sight": 4,
+          "pen": 0,
+          "modalities": [
+            "voice",
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "GU-C03-hun",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 4,
+          "lessonCount": 5,
+          "voice": 1,
+          "sight": 4,
+          "pen": 0,
+          "modalities": [
+            "voice",
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "GU-C04-kaale",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 5,
           "lessonCount": 5,
-          "voice": 5,
-          "sight": 0,
+          "voice": 1,
+          "sight": 4,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 5,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "GU-C05-bolvun",
-            "GU-C05-hun-gujarati-bolun-chhun",
-            "GU-C05-kaam-karvun",
-            "GU-C05-practice",
-            "GU-C05-rahevun"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "GU-C05-bolvun",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 6,
@@ -1627,11 +1555,11 @@
     {
       "language": "hindi",
       "lessonCount": 85,
-      "voice": 71,
-      "sight": 3,
+      "voice": 48,
+      "sight": 26,
       "pen": 11,
-      "drivablePercent": 84,
-      "drivablePrefixTotal": 55,
+      "drivablePercent": 56,
+      "drivablePrefixTotal": 38,
       "modalities": [
         "voice",
         "sight",
@@ -1641,8 +1569,8 @@
         {
           "chapter": 1,
           "lessonCount": 10,
-          "voice": 6,
-          "sight": 0,
+          "voice": 1,
+          "sight": 5,
           "pen": 4,
           "modalities": [
             "voice",
@@ -1657,8 +1585,8 @@
         {
           "chapter": 2,
           "lessonCount": 16,
-          "voice": 9,
-          "sight": 0,
+          "voice": 4,
+          "sight": 5,
           "pen": 7,
           "modalities": [
             "voice",
@@ -1673,66 +1601,47 @@
         {
           "chapter": 3,
           "lessonCount": 7,
-          "voice": 7,
-          "sight": 0,
+          "voice": 1,
+          "sight": 6,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 7,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "HI-C03-aap-kaise-hain",
-            "HI-C03-aapka-swagat-hai",
-            "HI-C03-hun",
-            "HI-C03-kaise",
-            "HI-C03-main",
-            "HI-C03-practice",
-            "HI-C03-thik"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "HI-C03-aap-kaise-hain",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 4,
           "lessonCount": 6,
-          "voice": 5,
-          "sight": 1,
+          "voice": 1,
+          "sight": 5,
           "pen": 0,
           "modalities": [
             "voice",
             "sight"
           ],
-          "drivablePrefix": 5,
-          "firstNonVoiceLesson": "HI-C04-practice",
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "HI-C04-chalta-hun",
           "drivable": false,
-          "drivableLessonIds": [
-            "HI-C04-chalta-hun",
-            "HI-C04-kal-milte-hain",
-            "HI-C04-milenge",
-            "HI-C04-phir",
-            "HI-C04-phir-milenge"
-          ]
+          "drivableLessonIds": []
         },
         {
           "chapter": 5,
           "lessonCount": 6,
-          "voice": 5,
-          "sight": 1,
+          "voice": 2,
+          "sight": 4,
           "pen": 0,
           "modalities": [
             "voice",
             "sight"
           ],
-          "drivablePrefix": 5,
-          "firstNonVoiceLesson": "HI-C05-rahna",
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "HI-C05-bolna",
           "drivable": false,
-          "drivableLessonIds": [
-            "HI-C05-bolna",
-            "HI-C05-bolta-hun",
-            "HI-C05-karna",
-            "HI-C05-main-hindi-bolta-hun",
-            "HI-C05-practice"
-          ]
+          "drivableLessonIds": []
         },
         {
           "chapter": 6,
@@ -2536,11 +2445,11 @@
     {
       "language": "kannada",
       "lessonCount": 60,
-      "voice": 53,
-      "sight": 7,
+      "voice": 32,
+      "sight": 28,
       "pen": 0,
-      "drivablePercent": 88,
-      "drivablePrefixTotal": 48,
+      "drivablePercent": 53,
+      "drivablePrefixTotal": 24,
       "modalities": [
         "voice",
         "sight"
@@ -2549,11 +2458,10 @@
         {
           "chapter": 1,
           "lessonCount": 6,
-          "voice": 4,
-          "sight": 2,
+          "voice": 0,
+          "sight": 6,
           "pen": 0,
           "modalities": [
-            "voice",
             "sight"
           ],
           "drivablePrefix": 0,
@@ -2564,86 +2472,62 @@
         {
           "chapter": 2,
           "lessonCount": 8,
-          "voice": 8,
-          "sight": 0,
+          "voice": 4,
+          "sight": 4,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 8,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "KA-C02-enu",
-            "KA-C02-hesaru",
-            "KA-C02-nanna",
-            "KA-C02-nanna-hesaru",
-            "KA-C02-niinu-niivu",
-            "KA-C02-nimma-hesaru-enu",
-            "KA-C02-practice",
-            "KA-C02-santosha"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "KA-C02-enu",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 3,
           "lessonCount": 6,
-          "voice": 6,
-          "sight": 0,
+          "voice": 1,
+          "sight": 5,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 6,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "KA-C03-cennaagi",
-            "KA-C03-hege",
-            "KA-C03-naanu",
-            "KA-C03-niivu-hegiddiira",
-            "KA-C03-paravaagilla",
-            "KA-C03-practice"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "KA-C03-cennaagi",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 4,
           "lessonCount": 5,
-          "voice": 5,
-          "sight": 0,
+          "voice": 1,
+          "sight": 4,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 5,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "KA-C04-hoogi-baruttene",
-            "KA-C04-hoogu",
-            "KA-C04-matte-sigona",
-            "KA-C04-naale-sigona",
-            "KA-C04-practice"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "KA-C04-hoogi-baruttene",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 5,
           "lessonCount": 5,
-          "voice": 5,
-          "sight": 0,
+          "voice": 1,
+          "sight": 4,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 5,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "KA-C05-iru",
-            "KA-C05-kelasa-maadu",
-            "KA-C05-maatanaadu",
-            "KA-C05-naanu-kannada-maatanaaduttene",
-            "KA-C05-practice"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "KA-C05-iru",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 6,
@@ -3669,11 +3553,11 @@
     {
       "language": "malayalam",
       "lessonCount": 64,
-      "voice": 58,
-      "sight": 6,
+      "voice": 35,
+      "sight": 29,
       "pen": 0,
-      "drivablePercent": 91,
-      "drivablePrefixTotal": 57,
+      "drivablePercent": 55,
+      "drivablePrefixTotal": 28,
       "modalities": [
         "voice",
         "sight"
@@ -3682,107 +3566,76 @@
         {
           "chapter": 1,
           "lessonCount": 6,
-          "voice": 5,
-          "sight": 1,
+          "voice": 0,
+          "sight": 6,
+          "pen": 0,
+          "modalities": [
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "ML-C01-athe",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 2,
+          "lessonCount": 9,
+          "voice": 4,
+          "sight": 5,
           "pen": 0,
           "modalities": [
             "voice",
             "sight"
           ],
-          "drivablePrefix": 4,
-          "firstNonVoiceLesson": "ML-C01-practice",
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "ML-C02-aanu",
           "drivable": false,
-          "drivableLessonIds": [
-            "ML-C01-athe",
-            "ML-C01-illa",
-            "ML-C01-namaskaram",
-            "ML-C01-nandi"
-          ]
-        },
-        {
-          "chapter": 2,
-          "lessonCount": 9,
-          "voice": 9,
-          "sight": 0,
-          "pen": 0,
-          "modalities": [
-            "voice"
-          ],
-          "drivablePrefix": 9,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "ML-C02-aanu",
-            "ML-C02-enre",
-            "ML-C02-enre-peru-aanu",
-            "ML-C02-entu",
-            "ML-C02-nii-ningal",
-            "ML-C02-ninre-peru-entaanu",
-            "ML-C02-peru",
-            "ML-C02-practice",
-            "ML-C02-santosham"
-          ]
+          "drivableLessonIds": []
         },
         {
           "chapter": 3,
           "lessonCount": 6,
-          "voice": 6,
-          "sight": 0,
+          "voice": 1,
+          "sight": 5,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 6,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "ML-C03-engane",
-            "ML-C03-njaan",
-            "ML-C03-practice",
-            "ML-C03-saaramilla",
-            "ML-C03-sukham",
-            "ML-C03-sukhamaano"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "ML-C03-engane",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 4,
           "lessonCount": 5,
-          "voice": 5,
-          "sight": 0,
+          "voice": 1,
+          "sight": 4,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 5,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "ML-C04-naale-kaanaam",
-            "ML-C04-pokuka",
-            "ML-C04-poyi-varaam",
-            "ML-C04-practice",
-            "ML-C04-veendum-kaanaam"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "ML-C04-naale-kaanaam",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 5,
           "lessonCount": 5,
-          "voice": 5,
-          "sight": 0,
+          "voice": 1,
+          "sight": 4,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 5,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "ML-C05-joli-ceyyuka",
-            "ML-C05-njaan-malayalam-samsaarikkunnu",
-            "ML-C05-practice",
-            "ML-C05-samsaarikkuka",
-            "ML-C05-taamasikkuka"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "ML-C05-joli-ceyyuka",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 6,
@@ -4204,11 +4057,11 @@
     {
       "language": "marathi",
       "lessonCount": 35,
-      "voice": 34,
-      "sight": 1,
+      "voice": 15,
+      "sight": 20,
       "pen": 0,
-      "drivablePercent": 97,
-      "drivablePrefixTotal": 34,
+      "drivablePercent": 43,
+      "drivablePrefixTotal": 3,
       "modalities": [
         "voice",
         "sight"
@@ -4217,110 +4070,79 @@
         {
           "chapter": 1,
           "lessonCount": 7,
-          "voice": 7,
-          "sight": 0,
-          "pen": 0,
-          "modalities": [
-            "voice"
-          ],
-          "drivablePrefix": 7,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "MR-C01-baram",
-            "MR-C01-dhanyavad",
-            "MR-C01-ho",
-            "MR-C01-nahi",
-            "MR-C01-namaskar",
-            "MR-C01-practice",
-            "MR-C01-yeto"
-          ]
-        },
-        {
-          "chapter": 2,
-          "lessonCount": 9,
-          "voice": 9,
-          "sight": 0,
-          "pen": 0,
-          "modalities": [
-            "voice"
-          ],
-          "drivablePrefix": 9,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "MR-C02-aahe",
-            "MR-C02-anand",
-            "MR-C02-kaay",
-            "MR-C02-majhe",
-            "MR-C02-majhe-naav-aahe",
-            "MR-C02-naav",
-            "MR-C02-practice",
-            "MR-C02-tu-tumhi",
-            "MR-C02-tumche-naav-kaay-aahe"
-          ]
-        },
-        {
-          "chapter": 3,
-          "lessonCount": 6,
-          "voice": 6,
-          "sight": 0,
-          "pen": 0,
-          "modalities": [
-            "voice"
-          ],
-          "drivablePrefix": 6,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "MR-C03-kaahi-harkat-nahi",
-            "MR-C03-kasa",
-            "MR-C03-mi",
-            "MR-C03-mi-bara-aahe",
-            "MR-C03-practice",
-            "MR-C03-tumhi-kase-aahat"
-          ]
-        },
-        {
-          "chapter": 4,
-          "lessonCount": 6,
-          "voice": 6,
-          "sight": 0,
-          "pen": 0,
-          "modalities": [
-            "voice"
-          ],
-          "drivablePrefix": 6,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "MR-C04-bhetu",
-            "MR-C04-kalji-ghya",
-            "MR-C04-practice",
-            "MR-C04-punha",
-            "MR-C04-punha-bhetu",
-            "MR-C04-udya-bhetu"
-          ]
-        },
-        {
-          "chapter": 5,
-          "lessonCount": 5,
-          "voice": 4,
-          "sight": 1,
+          "voice": 1,
+          "sight": 6,
           "pen": 0,
           "modalities": [
             "voice",
             "sight"
           ],
-          "drivablePrefix": 4,
-          "firstNonVoiceLesson": "MR-C05-rahne",
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "MR-C01-baram",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 2,
+          "lessonCount": 9,
+          "voice": 4,
+          "sight": 5,
+          "pen": 0,
+          "modalities": [
+            "voice",
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "MR-C02-aahe",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 3,
+          "lessonCount": 6,
+          "voice": 4,
+          "sight": 2,
+          "pen": 0,
+          "modalities": [
+            "voice",
+            "sight"
+          ],
+          "drivablePrefix": 1,
+          "firstNonVoiceLesson": "MR-C03-kasa",
           "drivable": false,
           "drivableLessonIds": [
-            "MR-C05-bolne",
-            "MR-C05-kaam-karne",
-            "MR-C05-mi-marathi-bolto",
-            "MR-C05-practice"
+            "MR-C03-kaahi-harkat-nahi"
           ]
+        },
+        {
+          "chapter": 4,
+          "lessonCount": 6,
+          "voice": 2,
+          "sight": 4,
+          "pen": 0,
+          "modalities": [
+            "voice",
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "MR-C04-bhetu",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 5,
+          "lessonCount": 5,
+          "voice": 2,
+          "sight": 3,
+          "pen": 0,
+          "modalities": [
+            "voice",
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "MR-C05-bolne",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 6,
@@ -4765,11 +4587,11 @@
     {
       "language": "punjabi",
       "lessonCount": 33,
-      "voice": 31,
-      "sight": 2,
+      "voice": 10,
+      "sight": 23,
       "pen": 0,
-      "drivablePercent": 94,
-      "drivablePrefixTotal": 30,
+      "drivablePercent": 30,
+      "drivablePrefixTotal": 2,
       "modalities": [
         "voice",
         "sight"
@@ -4778,107 +4600,77 @@
         {
           "chapter": 1,
           "lessonCount": 6,
-          "voice": 6,
-          "sight": 0,
+          "voice": 1,
+          "sight": 5,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 6,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "PA-C01-dhanvaad",
-            "PA-C01-han-nahin",
-            "PA-C01-namaste",
-            "PA-C01-practice",
-            "PA-C01-sat-sri-akal",
-            "PA-C01-shukriya"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "PA-C01-dhanvaad",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 2,
           "lessonCount": 9,
-          "voice": 9,
-          "sight": 0,
+          "voice": 3,
+          "sight": 6,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 9,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "PA-C02-hai",
-            "PA-C02-khushi",
-            "PA-C02-ki",
-            "PA-C02-mera",
-            "PA-C02-mera-naam-hai",
-            "PA-C02-naam",
-            "PA-C02-practice",
-            "PA-C02-tu-tusi",
-            "PA-C02-tuhada-naam-ki-hai"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "PA-C02-hai",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 3,
           "lessonCount": 6,
-          "voice": 6,
-          "sight": 0,
+          "voice": 2,
+          "sight": 4,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 6,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "PA-C03-kivein",
-            "PA-C03-koi-gall-nahin",
-            "PA-C03-main",
-            "PA-C03-practice",
-            "PA-C03-thik",
-            "PA-C03-tusi-kivein-ho"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "PA-C03-kivein",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 4,
           "lessonCount": 5,
-          "voice": 4,
-          "sight": 1,
+          "voice": 1,
+          "sight": 4,
           "pen": 0,
           "modalities": [
             "voice",
             "sight"
           ],
-          "drivablePrefix": 3,
-          "firstNonVoiceLesson": "PA-C04-practice",
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "PA-C04-milaange",
           "drivable": false,
-          "drivableLessonIds": [
-            "PA-C04-milaange",
-            "PA-C04-phir",
-            "PA-C04-phir-milaange"
-          ]
+          "drivableLessonIds": []
         },
         {
           "chapter": 5,
           "lessonCount": 5,
-          "voice": 4,
-          "sight": 1,
+          "voice": 1,
+          "sight": 4,
           "pen": 0,
           "modalities": [
             "voice",
             "sight"
           ],
-          "drivablePrefix": 4,
-          "firstNonVoiceLesson": "PA-C05-rahna",
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "PA-C05-bolna",
           "drivable": false,
-          "drivableLessonIds": [
-            "PA-C05-bolna",
-            "PA-C05-kamm-karna",
-            "PA-C05-main-punjabi-bolda-han",
-            "PA-C05-practice"
-          ]
+          "drivableLessonIds": []
         },
         {
           "chapter": 6,
@@ -4902,11 +4694,11 @@
     {
       "language": "russian",
       "lessonCount": 22,
-      "voice": 16,
-      "sight": 1,
+      "voice": 10,
+      "sight": 7,
       "pen": 5,
-      "drivablePercent": 73,
-      "drivablePrefixTotal": 15,
+      "drivablePercent": 45,
+      "drivablePrefixTotal": 8,
       "modalities": [
         "voice",
         "sight",
@@ -4916,26 +4708,18 @@
         {
           "chapter": 1,
           "lessonCount": 12,
-          "voice": 7,
-          "sight": 0,
+          "voice": 1,
+          "sight": 6,
           "pen": 5,
           "modalities": [
             "voice",
             "sight",
             "pen"
           ],
-          "drivablePrefix": 7,
-          "firstNonVoiceLesson": "RU-W01-false-friends-v-r",
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "RU-C01-da",
           "drivable": false,
-          "drivableLessonIds": [
-            "RU-C01-da",
-            "RU-C01-net",
-            "RU-C01-pozhaluysta",
-            "RU-C01-practice",
-            "RU-C01-privet",
-            "RU-C01-spasibo",
-            "RU-C01-zdravstvuyte"
-          ]
+          "drivableLessonIds": []
         },
         {
           "chapter": 2,
@@ -4966,11 +4750,11 @@
     {
       "language": "sanskrit",
       "lessonCount": 33,
-      "voice": 31,
-      "sight": 2,
+      "voice": 9,
+      "sight": 24,
       "pen": 0,
-      "drivablePercent": 94,
-      "drivablePrefixTotal": 26,
+      "drivablePercent": 27,
+      "drivablePrefixTotal": 0,
       "modalities": [
         "voice",
         "sight"
@@ -4979,104 +4763,77 @@
         {
           "chapter": 1,
           "lessonCount": 6,
-          "voice": 5,
-          "sight": 1,
+          "voice": 1,
+          "sight": 5,
           "pen": 0,
           "modalities": [
             "voice",
             "sight"
           ],
-          "drivablePrefix": 2,
-          "firstNonVoiceLesson": "SA-C01-namaskara",
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "SA-C01-am-na",
           "drivable": false,
-          "drivableLessonIds": [
-            "SA-C01-am-na",
-            "SA-C01-dhanyavada"
-          ]
+          "drivableLessonIds": []
         },
         {
           "chapter": 2,
           "lessonCount": 8,
-          "voice": 8,
-          "sight": 0,
+          "voice": 2,
+          "sight": 6,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 8,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "SA-C02-anandah",
-            "SA-C02-asti",
-            "SA-C02-bhavan-tvam",
-            "SA-C02-kim",
-            "SA-C02-mama",
-            "SA-C02-mama-nama-asti",
-            "SA-C02-nama",
-            "SA-C02-tava-nama-kim"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "SA-C02-anandah",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 3,
           "lessonCount": 6,
-          "voice": 6,
-          "sight": 0,
+          "voice": 2,
+          "sight": 4,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 6,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "SA-C03-aham",
-            "SA-C03-bhavan-katham-asti",
-            "SA-C03-katham",
-            "SA-C03-kushalam",
-            "SA-C03-na-cinta",
-            "SA-C03-practice"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "SA-C03-aham",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 4,
           "lessonCount": 5,
-          "voice": 5,
-          "sight": 0,
+          "voice": 1,
+          "sight": 4,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 5,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "SA-C04-gacchami",
-            "SA-C04-practice",
-            "SA-C04-punah",
-            "SA-C04-punar-darshanaya",
-            "SA-C04-shvah"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "SA-C04-gacchami",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 5,
           "lessonCount": 5,
-          "voice": 5,
-          "sight": 0,
+          "voice": 1,
+          "sight": 4,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 5,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "SA-C05-aham-samskritam-vadami",
-            "SA-C05-karomi",
-            "SA-C05-practice",
-            "SA-C05-vadami",
-            "SA-C05-vasami"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "SA-C05-aham-samskritam-vadami",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 6,
@@ -5711,11 +5468,11 @@
     {
       "language": "tamil",
       "lessonCount": 83,
-      "voice": 67,
-      "sight": 8,
+      "voice": 46,
+      "sight": 29,
       "pen": 8,
-      "drivablePercent": 81,
-      "drivablePrefixTotal": 53,
+      "drivablePercent": 55,
+      "drivablePrefixTotal": 36,
       "modalities": [
         "voice",
         "sight",
@@ -5725,8 +5482,8 @@
         {
           "chapter": 1,
           "lessonCount": 16,
-          "voice": 7,
-          "sight": 1,
+          "voice": 3,
+          "sight": 5,
           "pen": 8,
           "modalities": [
             "voice",
@@ -5741,80 +5498,62 @@
         {
           "chapter": 2,
           "lessonCount": 8,
-          "voice": 7,
-          "sight": 1,
+          "voice": 3,
+          "sight": 5,
           "pen": 0,
           "modalities": [
             "voice",
             "sight"
           ],
-          "drivablePrefix": 1,
-          "firstNonVoiceLesson": "TA-C02-en-peyar",
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "TA-C02-en",
           "drivable": false,
-          "drivableLessonIds": [
-            "TA-C02-en"
-          ]
+          "drivableLessonIds": []
         },
         {
           "chapter": 3,
           "lessonCount": 6,
-          "voice": 6,
-          "sight": 0,
+          "voice": 1,
+          "sight": 5,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 6,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "TA-C03-eppadi",
-            "TA-C03-eppadi-irukkirirgal",
-            "TA-C03-naan",
-            "TA-C03-nalam",
-            "TA-C03-paravayillai",
-            "TA-C03-practice"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "TA-C03-eppadi",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 4,
           "lessonCount": 5,
-          "voice": 5,
-          "sight": 0,
+          "voice": 1,
+          "sight": 4,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 5,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "TA-C04-mindum-sandippom",
-            "TA-C04-naalai",
-            "TA-C04-po",
-            "TA-C04-poy-varugiren",
-            "TA-C04-practice"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "TA-C04-mindum-sandippom",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 5,
           "lessonCount": 5,
-          "voice": 5,
-          "sight": 0,
+          "voice": 1,
+          "sight": 4,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 5,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "TA-C05-naan-tamizh-pesugiren",
-            "TA-C05-pesu",
-            "TA-C05-practice",
-            "TA-C05-vaazh",
-            "TA-C05-velai-sey"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "TA-C05-naan-tamizh-pesugiren",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 6,
@@ -6248,11 +5987,11 @@
     {
       "language": "telugu",
       "lessonCount": 60,
-      "voice": 54,
-      "sight": 6,
+      "voice": 33,
+      "sight": 27,
       "pen": 0,
-      "drivablePercent": 90,
-      "drivablePrefixTotal": 50,
+      "drivablePercent": 55,
+      "drivablePrefixTotal": 25,
       "modalities": [
         "voice",
         "sight"
@@ -6261,103 +6000,76 @@
         {
           "chapter": 1,
           "lessonCount": 6,
+          "voice": 0,
+          "sight": 6,
+          "pen": 0,
+          "modalities": [
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "TE-C01-avunu",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 2,
+          "lessonCount": 8,
           "voice": 4,
-          "sight": 2,
+          "sight": 4,
           "pen": 0,
           "modalities": [
             "voice",
             "sight"
           ],
-          "drivablePrefix": 1,
-          "firstNonVoiceLesson": "TE-C01-dhanyavadamulu",
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "TE-C02-emiti",
           "drivable": false,
-          "drivableLessonIds": [
-            "TE-C01-avunu"
-          ]
-        },
-        {
-          "chapter": 2,
-          "lessonCount": 8,
-          "voice": 8,
-          "sight": 0,
-          "pen": 0,
-          "modalities": [
-            "voice"
-          ],
-          "drivablePrefix": 8,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "TE-C02-emiti",
-            "TE-C02-mii-peru-emiti",
-            "TE-C02-naa",
-            "TE-C02-naa-peru",
-            "TE-C02-nuvvu-miiru",
-            "TE-C02-peru",
-            "TE-C02-practice",
-            "TE-C02-santosham"
-          ]
+          "drivableLessonIds": []
         },
         {
           "chapter": 3,
           "lessonCount": 6,
-          "voice": 6,
-          "sight": 0,
+          "voice": 1,
+          "sight": 5,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 6,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "TE-C03-baagaa",
-            "TE-C03-elaa",
-            "TE-C03-miiru-elaa-unnaaru",
-            "TE-C03-nenu",
-            "TE-C03-paravaaledu",
-            "TE-C03-practice"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "TE-C03-baagaa",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 4,
           "lessonCount": 5,
-          "voice": 5,
-          "sight": 0,
+          "voice": 1,
+          "sight": 4,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 5,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "TE-C04-malli-kaluddaam",
-            "TE-C04-practice",
-            "TE-C04-reepu-kaluddaam",
-            "TE-C04-velli-vastaanu",
-            "TE-C04-vellu"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "TE-C04-malli-kaluddaam",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 5,
           "lessonCount": 5,
-          "voice": 5,
-          "sight": 0,
+          "voice": 1,
+          "sight": 4,
           "pen": 0,
           "modalities": [
-            "voice"
+            "voice",
+            "sight"
           ],
-          "drivablePrefix": 5,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
-          "drivableLessonIds": [
-            "TE-C05-maatlaadu",
-            "TE-C05-nenu-telugu-maatlaadataanu",
-            "TE-C05-pani-ceyu",
-            "TE-C05-practice",
-            "TE-C05-undu"
-          ]
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "TE-C05-maatlaadu",
+          "drivable": false,
+          "drivableLessonIds": []
         },
         {
           "chapter": 6,
@@ -6888,52 +6600,52 @@
       "language": "arabic",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:04f0de193ab68eb4"
+      "sourceHash": "fnv1a64:5c3401b074a9ed4b"
     },
     {
       "id": "AR-C01-as-salamu-alaykum",
       "language": "arabic",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:19ad9e308a103f91"
+      "sourceHash": "fnv1a64:4cecaf9d8aad4700"
     },
     {
       "id": "AR-C01-marhaba",
       "language": "arabic",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8b542fd3708bb15d"
+      "sourceHash": "fnv1a64:5d9f80c6fec8c304"
     },
     {
       "id": "AR-C01-masa-al-khayr",
       "language": "arabic",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:aa1efa6fd080b7b6"
+      "sourceHash": "fnv1a64:12cfed97a5c22789"
     },
     {
       "id": "AR-C01-practice",
@@ -6953,39 +6665,39 @@
       "language": "arabic",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:a5540f4bb2aab0b9"
+      "sourceHash": "fnv1a64:cb050b6fcf90da8c"
     },
     {
       "id": "AR-C01-salam",
       "language": "arabic",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:a8978a2326b4dfd8"
+      "sourceHash": "fnv1a64:44f0446378253c51"
     },
     {
       "id": "AR-C01-shukran",
       "language": "arabic",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:85350b005d3129ef"
+      "sourceHash": "fnv1a64:e4e8e7fe129d4df8"
     },
     {
       "id": "AR-W01-abjad-short-vowels",
@@ -7071,39 +6783,39 @@
       "language": "arabic",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b676153f2dd8b0fb"
+      "sourceHash": "fnv1a64:2d97705045b6d7b0"
     },
     {
       "id": "AR-C02-ii-my",
       "language": "arabic",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:49ad7a1e47602997"
+      "sourceHash": "fnv1a64:c938ceadba398f9e"
     },
     {
       "id": "AR-C02-ism",
       "language": "arabic",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:cef1c8e7a1f20ed0"
+      "sourceHash": "fnv1a64:7f07aaa91a92ea81"
     },
     {
       "id": "AR-C02-ismii",
@@ -7123,13 +6835,13 @@
       "language": "arabic",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:e668571f5c4412b4"
+      "sourceHash": "fnv1a64:dbd1e0cf51386345"
     },
     {
       "id": "AR-C02-maa-ismuka",
@@ -7162,13 +6874,13 @@
       "language": "arabic",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b46fd5c36a18ef44"
+      "sourceHash": "fnv1a64:3e43ab7585f164eb"
     },
     {
       "id": "AR-W04-dots-family-nun-ta",
@@ -7820,65 +7532,65 @@
       "language": "bengali",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:ecfb5931ae70005b"
+      "sourceHash": "fnv1a64:84972988a9ab9cfe"
     },
     {
       "id": "BN-C01-ashi",
       "language": "bengali",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:a4b3b567bfc563a3"
+      "sourceHash": "fnv1a64:3548b8e1e6d8b786"
     },
     {
       "id": "BN-C01-dhonnobad",
       "language": "bengali",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:d63acf8d4947753b"
+      "sourceHash": "fnv1a64:b6dedebbef9e9c4a"
     },
     {
       "id": "BN-C01-hyan-na",
       "language": "bengali",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c6bb5b7ea2744dd0"
+      "sourceHash": "fnv1a64:d86583f11bfbb6a7"
     },
     {
       "id": "BN-C01-nomoshkar",
       "language": "bengali",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c7b6ee200a99c053"
+      "sourceHash": "fnv1a64:63149e08a09fd266"
     },
     {
       "id": "BN-C01-practice",
@@ -7898,26 +7610,26 @@
       "language": "bengali",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8918532be0f2580d"
+      "sourceHash": "fnv1a64:4b0fda4f32ec3fd6"
     },
     {
       "id": "BN-C02-amar",
       "language": "bengali",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8a4102c395c018b4"
+      "sourceHash": "fnv1a64:a2568d0190f56ea9"
     },
     {
       "id": "BN-C02-amar-naam",
@@ -7937,26 +7649,26 @@
       "language": "bengali",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:12674305ac867360"
+      "sourceHash": "fnv1a64:9742adfbc75528a3"
     },
     {
       "id": "BN-C02-naam",
       "language": "bengali",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8e6497290c9feddf"
+      "sourceHash": "fnv1a64:ff4b24b412c6f334"
     },
     {
       "id": "BN-C02-practice",
@@ -7989,65 +7701,65 @@
       "language": "bengali",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:62c593d00a4d25ce"
+      "sourceHash": "fnv1a64:7ced4161be7a9daf"
     },
     {
       "id": "BN-C03-ami",
       "language": "bengali",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c60c0e7f18648b68"
+      "sourceHash": "fnv1a64:8e68eb4530d5434b"
     },
     {
       "id": "BN-C03-bhalo",
       "language": "bengali",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:7c11ba61ef52c299"
+      "sourceHash": "fnv1a64:77f8059fd4601afa"
     },
     {
       "id": "BN-C03-kemon",
       "language": "bengali",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:0d33f4c886dc4534"
+      "sourceHash": "fnv1a64:62bb3e5d57aa6659"
     },
     {
       "id": "BN-C03-kono-bepar-na",
       "language": "bengali",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:e99dccdd9a2f1f4f"
+      "sourceHash": "fnv1a64:2620bde01fad47a8"
     },
     {
       "id": "BN-C03-practice",
@@ -8067,26 +7779,26 @@
       "language": "bengali",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8d16bc56471a30c1"
+      "sourceHash": "fnv1a64:dc0e1d8dda6194ec"
     },
     {
       "id": "BN-C04-abar",
       "language": "bengali",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:cbc94e2b280a6364"
+      "sourceHash": "fnv1a64:bdbcded841cd4265"
     },
     {
       "id": "BN-C04-abar-dekha-hobe",
@@ -8106,26 +7818,26 @@
       "language": "bengali",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b7ade652cd8841c6"
+      "sourceHash": "fnv1a64:b8f661e6e0594a07"
     },
     {
       "id": "BN-C04-kal-dekha-hobe",
       "language": "bengali",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:5c4378bb2d018701"
+      "sourceHash": "fnv1a64:5a5040768b99964e"
     },
     {
       "id": "BN-C04-practice",
@@ -8145,39 +7857,39 @@
       "language": "bengali",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:367535d790b3ba1a"
+      "sourceHash": "fnv1a64:71f11d270c7b77e9"
     },
     {
       "id": "BN-C05-bola",
       "language": "bengali",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:f9670d529ffafee9"
+      "sourceHash": "fnv1a64:03bcf22359a87d4e"
     },
     {
       "id": "BN-C05-kaj-kora",
       "language": "bengali",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:6b733c44565c2435"
+      "sourceHash": "fnv1a64:88ae3d7246caf29a"
     },
     {
       "id": "BN-C05-practice",
@@ -8197,13 +7909,13 @@
       "language": "bengali",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:d3fd0e8a3ed59a29"
+      "sourceHash": "fnv1a64:f1a739ff51404a22"
     },
     {
       "id": "BN-C06-numbers-1-5",
@@ -10257,39 +9969,39 @@
       "language": "gujarati",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:d03a1a725e3f3adf"
+      "sourceHash": "fnv1a64:69ea2a54aec07b1c"
     },
     {
       "id": "GU-C01-aavjo",
       "language": "gujarati",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c97664a9d71a07a2"
+      "sourceHash": "fnv1a64:ce0ea8a630586fd1"
     },
     {
       "id": "GU-C01-haa-naa",
       "language": "gujarati",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:d689ac91b0bb3e55"
+      "sourceHash": "fnv1a64:a4560b58e96e7406"
     },
     {
       "id": "GU-C01-namaste",
@@ -10300,9 +10012,10 @@
       "derived": "sight",
       "drivable": false,
       "reasons": [
+        "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:13fa1be3b0302b28"
+      "sourceHash": "fnv1a64:ea2d04a685deb837"
     },
     {
       "id": "GU-C01-practice",
@@ -10326,48 +10039,49 @@
       "derived": "sight",
       "drivable": false,
       "reasons": [
+        "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:55a442f7072f7692"
+      "sourceHash": "fnv1a64:f4d2ea530bbfb36b"
     },
     {
       "id": "GU-C02-anand",
       "language": "gujarati",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:bea070887443df96"
+      "sourceHash": "fnv1a64:d464ae8af941057d"
     },
     {
       "id": "GU-C02-chhe",
       "language": "gujarati",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:2d64c3d248109066"
+      "sourceHash": "fnv1a64:602b01069582a487"
     },
     {
       "id": "GU-C02-maarun",
       "language": "gujarati",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:6f4a483780a3f30d"
+      "sourceHash": "fnv1a64:d67b8ebaba84b5c4"
     },
     {
       "id": "GU-C02-maarun-naam-chhe",
@@ -10387,13 +10101,13 @@
       "language": "gujarati",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:ee2f6efb959d5c01"
+      "sourceHash": "fnv1a64:3af8f4bb9a8cc066"
     },
     {
       "id": "GU-C02-practice",
@@ -10413,13 +10127,13 @@
       "language": "gujarati",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:fa0e42cc0983783c"
+      "sourceHash": "fnv1a64:4f579e4f44a6b2af"
     },
     {
       "id": "GU-C02-tamarun-naam-shun-chhe",
@@ -10439,52 +10153,52 @@
       "language": "gujarati",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8a4a31923090f2f1"
+      "sourceHash": "fnv1a64:243b1dd19af26cfa"
     },
     {
       "id": "GU-C03-hun",
       "language": "gujarati",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:742510bdf7b7d0cc"
+      "sourceHash": "fnv1a64:806b44e166aa90b1"
     },
     {
       "id": "GU-C03-kem",
       "language": "gujarati",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:6f6abb0e8b5db845"
+      "sourceHash": "fnv1a64:6d24d1ed458a9ebc"
     },
     {
       "id": "GU-C03-majaa",
       "language": "gujarati",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b9eb03fd125860cd"
+      "sourceHash": "fnv1a64:303cb39547727116"
     },
     {
       "id": "GU-C03-practice",
@@ -10517,52 +10231,52 @@
       "language": "gujarati",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:538e577793d6ad11"
+      "sourceHash": "fnv1a64:b56e87993b078b6e"
     },
     {
       "id": "GU-C04-kaale",
       "language": "gujarati",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:fa76d9878f1ccbe8"
+      "sourceHash": "fnv1a64:f3ae78bb775a679b"
     },
     {
       "id": "GU-C04-malishun",
       "language": "gujarati",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:a3491b7e9a70d68d"
+      "sourceHash": "fnv1a64:29a3baacaa084aec"
     },
     {
       "id": "GU-C04-pachha",
       "language": "gujarati",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b18fb50e72610777"
+      "sourceHash": "fnv1a64:6f60f2bede52fd1e"
     },
     {
       "id": "GU-C04-pachha-malishun",
@@ -10595,39 +10309,39 @@
       "language": "gujarati",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:86781c9b005bbb2d"
+      "sourceHash": "fnv1a64:a6494186f38b1670"
     },
     {
       "id": "GU-C05-hun-gujarati-bolun-chhun",
       "language": "gujarati",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:9bb2a4e1414e5731"
+      "sourceHash": "fnv1a64:becb16ef892b890c"
     },
     {
       "id": "GU-C05-kaam-karvun",
       "language": "gujarati",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:6533fb9b5296dad7"
+      "sourceHash": "fnv1a64:c2bb56f4b0ce16c2"
     },
     {
       "id": "GU-C05-practice",
@@ -10647,13 +10361,13 @@
       "language": "gujarati",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:0ff6f0e088b688fc"
+      "sourceHash": "fnv1a64:38ff136f2541f6f9"
     },
     {
       "id": "GU-C06-numbers-1-5",
@@ -10739,52 +10453,52 @@
       "language": "hindi",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:a8d3fa187e31ebfb"
+      "sourceHash": "fnv1a64:89abbff53db9e06c"
     },
     {
       "id": "HI-C01-dhanyavad",
       "language": "hindi",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:f1a27c8f161dcc3d"
+      "sourceHash": "fnv1a64:1ef2eb843b696428"
     },
     {
       "id": "HI-C01-namaskar",
       "language": "hindi",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:734f8d4854a077f2"
+      "sourceHash": "fnv1a64:dd0f0aa5fdb9b145"
     },
     {
       "id": "HI-C01-namaste",
       "language": "hindi",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:235b281987e84524"
+      "sourceHash": "fnv1a64:d41848618c702321"
     },
     {
       "id": "HI-C01-practice",
@@ -10804,13 +10518,13 @@
       "language": "hindi",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:798016f633e45631"
+      "sourceHash": "fnv1a64:49b311784186967c"
     },
     {
       "id": "HI-W03-matras-naam",
@@ -10909,13 +10623,13 @@
       "language": "hindi",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:1cc61290d3f8d83e"
+      "sourceHash": "fnv1a64:7bf9dd1fbfeaa979"
     },
     {
       "id": "HI-C02-aapka-naam-kya-hai",
@@ -10935,13 +10649,13 @@
       "language": "hindi",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:83eeb386ed32542a"
+      "sourceHash": "fnv1a64:373276fb279897f5"
     },
     {
       "id": "HI-C02-khushi",
@@ -10961,13 +10675,13 @@
       "language": "hindi",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:512da90f41bdc281"
+      "sourceHash": "fnv1a64:98b5bd2e8efd62f6"
     },
     {
       "id": "HI-C02-mera-naam-hai",
@@ -10987,26 +10701,26 @@
       "language": "hindi",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:022b143283444ab6"
+      "sourceHash": "fnv1a64:eeaa065b35da7455"
     },
     {
       "id": "HI-C02-naam",
       "language": "hindi",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:a0071583c7d72281"
+      "sourceHash": "fnv1a64:a0371fc3206c766e"
     },
     {
       "id": "HI-C02-practice",
@@ -11026,65 +10740,65 @@
       "language": "hindi",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:dfd0d574989f31ed"
+      "sourceHash": "fnv1a64:91c389645b62af66"
     },
     {
       "id": "HI-C03-aapka-swagat-hai",
       "language": "hindi",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b4622c6526e290a1"
+      "sourceHash": "fnv1a64:2f6fac68a084606c"
     },
     {
       "id": "HI-C03-hun",
       "language": "hindi",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c26366136afb3ac1"
+      "sourceHash": "fnv1a64:23b02573179317a8"
     },
     {
       "id": "HI-C03-kaise",
       "language": "hindi",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:9a784fb6eeaa2b1c"
+      "sourceHash": "fnv1a64:5a680be90e0f885f"
     },
     {
       "id": "HI-C03-main",
       "language": "hindi",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:1bf6f1505972d988"
+      "sourceHash": "fnv1a64:aea62ee6b7a4034b"
     },
     {
       "id": "HI-C03-practice",
@@ -11104,65 +10818,65 @@
       "language": "hindi",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:f48936c9aa07fdbf"
+      "sourceHash": "fnv1a64:bff42bea4150f974"
     },
     {
       "id": "HI-C04-chalta-hun",
       "language": "hindi",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:95fd29897ea2d068"
+      "sourceHash": "fnv1a64:1bfbb5b02a0d294f"
     },
     {
       "id": "HI-C04-kal-milte-hain",
       "language": "hindi",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c9d6c61b248661e9"
+      "sourceHash": "fnv1a64:ee0eb7d8e9024f10"
     },
     {
       "id": "HI-C04-milenge",
       "language": "hindi",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:653171cf1029e28b"
+      "sourceHash": "fnv1a64:a70a0ef65533891a"
     },
     {
       "id": "HI-C04-phir",
       "language": "hindi",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:3ef3fc411f6197f4"
+      "sourceHash": "fnv1a64:aedfba61a69ddd3b"
     },
     {
       "id": "HI-C04-phir-milenge",
@@ -11195,13 +10909,13 @@
       "language": "hindi",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:96d065e73903a163"
+      "sourceHash": "fnv1a64:72e329b599f1e7c0"
     },
     {
       "id": "HI-C05-bolta-hun",
@@ -11221,26 +10935,26 @@
       "language": "hindi",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:f4bf9d5e3ccdf49c"
+      "sourceHash": "fnv1a64:f237aa47182dc171"
     },
     {
       "id": "HI-C05-main-hindi-bolta-hun",
       "language": "hindi",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:5316fa9dbfd1dad1"
+      "sourceHash": "fnv1a64:195fea9e56a29808"
     },
     {
       "id": "HI-C05-practice",
@@ -11264,9 +10978,10 @@
       "derived": "sight",
       "drivable": false,
       "reasons": [
+        "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:b25f452653f1ace0"
+      "sourceHash": "fnv1a64:0cbfce468a3484eb"
     },
     {
       "id": "HI-C06-numbers-1-5",
@@ -12656,48 +12371,49 @@
       "derived": "sight",
       "drivable": false,
       "reasons": [
+        "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:d72a74c1246439e5"
+      "sourceHash": "fnv1a64:035084b4558bdd72"
     },
     {
       "id": "KA-C01-haudu",
       "language": "kannada",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:90811f2aa90b3f6d"
+      "sourceHash": "fnv1a64:762cd4edbe26fc8e"
     },
     {
       "id": "KA-C01-illa",
       "language": "kannada",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:868a70d2e36aaae3"
+      "sourceHash": "fnv1a64:5d8cbb19876741f0"
     },
     {
       "id": "KA-C01-namaskara",
       "language": "kannada",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:5f6a90778892b506"
+      "sourceHash": "fnv1a64:3466dc173743e691"
     },
     {
       "id": "KA-C01-practice",
@@ -12717,52 +12433,52 @@
       "language": "kannada",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:e0f9ccaac4250b7c"
+      "sourceHash": "fnv1a64:9aa5a310f9bc828b"
     },
     {
       "id": "KA-C02-enu",
       "language": "kannada",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b9d4879e03664154"
+      "sourceHash": "fnv1a64:1be9909948d15d65"
     },
     {
       "id": "KA-C02-hesaru",
       "language": "kannada",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:2e55e2b9599e2e3d"
+      "sourceHash": "fnv1a64:31cbf4d18c055096"
     },
     {
       "id": "KA-C02-nanna",
       "language": "kannada",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:25ce7bc99a448aa3"
+      "sourceHash": "fnv1a64:acd0ca42626d82bc"
     },
     {
       "id": "KA-C02-nanna-hesaru",
@@ -12782,13 +12498,13 @@
       "language": "kannada",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8d2a0f5bd8c72e49"
+      "sourceHash": "fnv1a64:d50a8710b4d9aea6"
     },
     {
       "id": "KA-C02-nimma-hesaru-enu",
@@ -12834,65 +12550,65 @@
       "language": "kannada",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:79c93c37febcd5e1"
+      "sourceHash": "fnv1a64:93437e98f663cb1c"
     },
     {
       "id": "KA-C03-hege",
       "language": "kannada",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b65b5d9b2253dba7"
+      "sourceHash": "fnv1a64:8b830f9a970ffdec"
     },
     {
       "id": "KA-C03-naanu",
       "language": "kannada",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:ea38eab32e5096de"
+      "sourceHash": "fnv1a64:58de706b080bec57"
     },
     {
       "id": "KA-C03-niivu-hegiddiira",
       "language": "kannada",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:15049175dc65d0c3"
+      "sourceHash": "fnv1a64:b4afa9f62df6a322"
     },
     {
       "id": "KA-C03-paravaagilla",
       "language": "kannada",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:757783589299b144"
+      "sourceHash": "fnv1a64:a41e1b1c079f7f0b"
     },
     {
       "id": "KA-C03-practice",
@@ -12912,52 +12628,52 @@
       "language": "kannada",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:f223e4feb429dfae"
+      "sourceHash": "fnv1a64:5424de3b9e5d6cef"
     },
     {
       "id": "KA-C04-hoogu",
       "language": "kannada",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:a6558fd264dce624"
+      "sourceHash": "fnv1a64:30e99c8aa7d1463b"
     },
     {
       "id": "KA-C04-matte-sigona",
       "language": "kannada",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8146489205fffb28"
+      "sourceHash": "fnv1a64:4340dca3b939a451"
     },
     {
       "id": "KA-C04-naale-sigona",
       "language": "kannada",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:5f57de1f51f81b2e"
+      "sourceHash": "fnv1a64:9c7fce2e8376967d"
     },
     {
       "id": "KA-C04-practice",
@@ -12977,52 +12693,52 @@
       "language": "kannada",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:96ce3a7baf526cb9"
+      "sourceHash": "fnv1a64:6f539f1993b90d24"
     },
     {
       "id": "KA-C05-kelasa-maadu",
       "language": "kannada",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:115616cc46b6a9c3"
+      "sourceHash": "fnv1a64:9f1823451187ac5a"
     },
     {
       "id": "KA-C05-maatanaadu",
       "language": "kannada",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:1ab08538385fa1b1"
+      "sourceHash": "fnv1a64:ea6df29016abfee2"
     },
     {
       "id": "KA-C05-naanu-kannada-maatanaaduttene",
       "language": "kannada",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:fe8afc670a6c6758"
+      "sourceHash": "fnv1a64:c58b743e977f94c7"
     },
     {
       "id": "KA-C05-practice",
@@ -14174,52 +13890,52 @@
       "language": "malayalam",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:f9774d8c3e4314d9"
+      "sourceHash": "fnv1a64:b5428b9487e2b5ca"
     },
     {
       "id": "ML-C01-illa",
       "language": "malayalam",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:80ad38e397f1e428"
+      "sourceHash": "fnv1a64:a386c9616c67b3e7"
     },
     {
       "id": "ML-C01-namaskaram",
       "language": "malayalam",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c43845351f531425"
+      "sourceHash": "fnv1a64:bd41bd8573b9cfb8"
     },
     {
       "id": "ML-C01-nandi",
       "language": "malayalam",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:71619d799967562e"
+      "sourceHash": "fnv1a64:77fae88f5176850b"
     },
     {
       "id": "ML-C01-practice",
@@ -14239,39 +13955,39 @@
       "language": "malayalam",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:11736a060797bc74"
+      "sourceHash": "fnv1a64:2cdf31bc9b98e609"
     },
     {
       "id": "ML-C02-aanu",
       "language": "malayalam",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:ca846f2149ba8954"
+      "sourceHash": "fnv1a64:ff571c00f6d40e5d"
     },
     {
       "id": "ML-C02-enre",
       "language": "malayalam",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:4eb8dd06d741b871"
+      "sourceHash": "fnv1a64:fdf49546f6b2b6ee"
     },
     {
       "id": "ML-C02-enre-peru-aanu",
@@ -14291,26 +14007,26 @@
       "language": "malayalam",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:bf3c2300dc6c14d6"
+      "sourceHash": "fnv1a64:cd1b34c3574c0c15"
     },
     {
       "id": "ML-C02-nii-ningal",
       "language": "malayalam",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:395430ab6f3c9043"
+      "sourceHash": "fnv1a64:8df6cc5e645d2578"
     },
     {
       "id": "ML-C02-ninre-peru-entaanu",
@@ -14330,13 +14046,13 @@
       "language": "malayalam",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:100f6d116c58b4b2"
+      "sourceHash": "fnv1a64:fce78214aef0ef35"
     },
     {
       "id": "ML-C02-practice",
@@ -14369,26 +14085,26 @@
       "language": "malayalam",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:5a66b4614d4b7092"
+      "sourceHash": "fnv1a64:64cd69a9348bd1f5"
     },
     {
       "id": "ML-C03-njaan",
       "language": "malayalam",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8da33b7e9fed0b0b"
+      "sourceHash": "fnv1a64:1c8c8f8f5981e1da"
     },
     {
       "id": "ML-C03-practice",
@@ -14408,78 +14124,78 @@
       "language": "malayalam",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:35a3b3272ff193c6"
+      "sourceHash": "fnv1a64:9eae0087a7a99e4f"
     },
     {
       "id": "ML-C03-sukham",
       "language": "malayalam",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:2d474cea454b6dfe"
+      "sourceHash": "fnv1a64:5e0de3df6b96aec1"
     },
     {
       "id": "ML-C03-sukhamaano",
       "language": "malayalam",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:449aa5c6628bf79f"
+      "sourceHash": "fnv1a64:5c17999601548f76"
     },
     {
       "id": "ML-C04-naale-kaanaam",
       "language": "malayalam",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:842529b6bc3d8bec"
+      "sourceHash": "fnv1a64:7f5e2b7fe9218475"
     },
     {
       "id": "ML-C04-pokuka",
       "language": "malayalam",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:10c9632ed9ac0ad6"
+      "sourceHash": "fnv1a64:bd9c0c56fa2d2c9d"
     },
     {
       "id": "ML-C04-poyi-varaam",
       "language": "malayalam",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8bda01a873c3b6df"
+      "sourceHash": "fnv1a64:887651ed8d638d32"
     },
     {
       "id": "ML-C04-practice",
@@ -14499,39 +14215,39 @@
       "language": "malayalam",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:777e27f1f2ba69c5"
+      "sourceHash": "fnv1a64:e9a77070f795c048"
     },
     {
       "id": "ML-C05-joli-ceyyuka",
       "language": "malayalam",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b5ecaf2fe0bba6f8"
+      "sourceHash": "fnv1a64:31d528a76c0bd599"
     },
     {
       "id": "ML-C05-njaan-malayalam-samsaarikkunnu",
       "language": "malayalam",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:34084bab8c366974"
+      "sourceHash": "fnv1a64:b14fc6b48cd6b91d"
     },
     {
       "id": "ML-C05-practice",
@@ -14551,26 +14267,26 @@
       "language": "malayalam",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:77bdc5ceae8db3cf"
+      "sourceHash": "fnv1a64:1bdbc87303276fc6"
     },
     {
       "id": "ML-C05-taamasikkuka",
       "language": "malayalam",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:130ecb3a14fa1f8c"
+      "sourceHash": "fnv1a64:8af0e0a180efa543"
     },
     {
       "id": "ML-C06-dative-ikku",
@@ -15007,65 +14723,65 @@
       "language": "marathi",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:470e64794fe70d13"
+      "sourceHash": "fnv1a64:e8acc6d28293a532"
     },
     {
       "id": "MR-C01-dhanyavad",
       "language": "marathi",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:e2f0461be05fa928"
+      "sourceHash": "fnv1a64:dff856539c02590f"
     },
     {
       "id": "MR-C01-ho",
       "language": "marathi",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:9c62989dc4fd723f"
+      "sourceHash": "fnv1a64:1870ccc311c6214e"
     },
     {
       "id": "MR-C01-nahi",
       "language": "marathi",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:efb26c1b9b2eb060"
+      "sourceHash": "fnv1a64:014b65433ef4192f"
     },
     {
       "id": "MR-C01-namaskar",
       "language": "marathi",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b39b9c3ee91f7d7d"
+      "sourceHash": "fnv1a64:ac1642934e61a0cc"
     },
     {
       "id": "MR-C01-practice",
@@ -15085,26 +14801,26 @@
       "language": "marathi",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:ebb2971ad7d6de75"
+      "sourceHash": "fnv1a64:9860ee3897f812f0"
     },
     {
       "id": "MR-C02-aahe",
       "language": "marathi",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:9705b53376844118"
+      "sourceHash": "fnv1a64:6d76204e5a92182f"
     },
     {
       "id": "MR-C02-anand",
@@ -15124,26 +14840,26 @@
       "language": "marathi",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:9860595f8229c2bb"
+      "sourceHash": "fnv1a64:a3a3199a2f631da2"
     },
     {
       "id": "MR-C02-majhe",
       "language": "marathi",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:11d3798fdcb2fa3b"
+      "sourceHash": "fnv1a64:12147a7db0bc628e"
     },
     {
       "id": "MR-C02-majhe-naav-aahe",
@@ -15163,13 +14879,13 @@
       "language": "marathi",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:57b479b322914a69"
+      "sourceHash": "fnv1a64:5c6ccd43c11eba92"
     },
     {
       "id": "MR-C02-practice",
@@ -15189,13 +14905,13 @@
       "language": "marathi",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:950c37e604cfe300"
+      "sourceHash": "fnv1a64:8cd11b308e6ab1df"
     },
     {
       "id": "MR-C02-tumche-naav-kaay-aahe",
@@ -15228,26 +14944,26 @@
       "language": "marathi",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:39fd627bef914f90"
+      "sourceHash": "fnv1a64:e695d0daa0640a61"
     },
     {
       "id": "MR-C03-mi",
       "language": "marathi",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:bde9cf33ad91e0d8"
+      "sourceHash": "fnv1a64:22844eecb06db04d"
     },
     {
       "id": "MR-C03-mi-bara-aahe",
@@ -15293,26 +15009,26 @@
       "language": "marathi",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:221e44ca948216d3"
+      "sourceHash": "fnv1a64:d2a93e1d9ba5feca"
     },
     {
       "id": "MR-C04-kalji-ghya",
       "language": "marathi",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:cdd2a126f3d44bb1"
+      "sourceHash": "fnv1a64:2262fbdb932d7780"
     },
     {
       "id": "MR-C04-practice",
@@ -15332,13 +15048,13 @@
       "language": "marathi",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:7bd17775906f558d"
+      "sourceHash": "fnv1a64:8fee2b0b32a934c4"
     },
     {
       "id": "MR-C04-punha-bhetu",
@@ -15358,39 +15074,39 @@
       "language": "marathi",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:9cf0d36c0711c94c"
+      "sourceHash": "fnv1a64:97e1110a9c571d0b"
     },
     {
       "id": "MR-C05-bolne",
       "language": "marathi",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:33d723877a8f5454"
+      "sourceHash": "fnv1a64:8e3878fbe5f91411"
     },
     {
       "id": "MR-C05-kaam-karne",
       "language": "marathi",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:0d0e22db168d221b"
+      "sourceHash": "fnv1a64:77068cc88a0a5570"
     },
     {
       "id": "MR-C05-mi-marathi-bolto",
@@ -15427,9 +15143,10 @@
       "derived": "sight",
       "drivable": false,
       "reasons": [
+        "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:f756499e45e3ad01"
+      "sourceHash": "fnv1a64:a5aee5a710cf9dc8"
     },
     {
       "id": "MR-C06-numbers-1-5",
@@ -16490,39 +16207,39 @@
       "language": "punjabi",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:e02b9f6b81ed66fd"
+      "sourceHash": "fnv1a64:a89b857d7542da98"
     },
     {
       "id": "PA-C01-han-nahin",
       "language": "punjabi",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:3f13af405d691e05"
+      "sourceHash": "fnv1a64:711c263e7b6de012"
     },
     {
       "id": "PA-C01-namaste",
       "language": "punjabi",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:857d62e029440681"
+      "sourceHash": "fnv1a64:2e52f78d315f8fba"
     },
     {
       "id": "PA-C01-practice",
@@ -16542,78 +16259,78 @@
       "language": "punjabi",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:79c517eb855a8656"
+      "sourceHash": "fnv1a64:093c9a80c31e6643"
     },
     {
       "id": "PA-C01-shukriya",
       "language": "punjabi",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b9d7c0fda6bd2c48"
+      "sourceHash": "fnv1a64:9d7714fe70dee67b"
     },
     {
       "id": "PA-C02-hai",
       "language": "punjabi",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:94a70273d5e0a297"
+      "sourceHash": "fnv1a64:922e7239562cb946"
     },
     {
       "id": "PA-C02-khushi",
       "language": "punjabi",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:a9a4604f1fddeb5b"
+      "sourceHash": "fnv1a64:2d68323af6b51fd6"
     },
     {
       "id": "PA-C02-ki",
       "language": "punjabi",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:99569178c1456ae2"
+      "sourceHash": "fnv1a64:6fde17101437fdf7"
     },
     {
       "id": "PA-C02-mera",
       "language": "punjabi",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:9ef4c2bf734d4a52"
+      "sourceHash": "fnv1a64:1750d6e42b415d7f"
     },
     {
       "id": "PA-C02-mera-naam-hai",
@@ -16633,13 +16350,13 @@
       "language": "punjabi",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8f5abaece205dd36"
+      "sourceHash": "fnv1a64:6e4f130bce7c66bd"
     },
     {
       "id": "PA-C02-practice",
@@ -16659,13 +16376,13 @@
       "language": "punjabi",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:583e3d8151cfcefc"
+      "sourceHash": "fnv1a64:af3a545579ee1871"
     },
     {
       "id": "PA-C02-tuhada-naam-ki-hai",
@@ -16685,39 +16402,39 @@
       "language": "punjabi",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:4547db8d4b611a69"
+      "sourceHash": "fnv1a64:fb0615eb3dc5a6d0"
     },
     {
       "id": "PA-C03-koi-gall-nahin",
       "language": "punjabi",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:9291a33bd7cea41e"
+      "sourceHash": "fnv1a64:0ffbdb425dfe11b1"
     },
     {
       "id": "PA-C03-main",
       "language": "punjabi",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:d4ab64d6e65f4aed"
+      "sourceHash": "fnv1a64:0ab088277790b4ee"
     },
     {
       "id": "PA-C03-practice",
@@ -16737,13 +16454,13 @@
       "language": "punjabi",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:0f8400c16874910a"
+      "sourceHash": "fnv1a64:aeae745d883bd1c5"
     },
     {
       "id": "PA-C03-tusi-kivein-ho",
@@ -16763,26 +16480,26 @@
       "language": "punjabi",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:200d62f97be544c5"
+      "sourceHash": "fnv1a64:f84a739655088280"
     },
     {
       "id": "PA-C04-phir",
       "language": "punjabi",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:6722c4e1f0152c37"
+      "sourceHash": "fnv1a64:c5e8584e9954c824"
     },
     {
       "id": "PA-C04-phir-milaange",
@@ -16815,52 +16532,52 @@
       "language": "punjabi",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:e5c05a7f3f239a7e"
+      "sourceHash": "fnv1a64:ee53d2792100e157"
     },
     {
       "id": "PA-C05-bolna",
       "language": "punjabi",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:f646adc390acda0f"
+      "sourceHash": "fnv1a64:307dfe45fa3042e4"
     },
     {
       "id": "PA-C05-kamm-karna",
       "language": "punjabi",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:f0b27b4137063cd5"
+      "sourceHash": "fnv1a64:f9467160d95bc6b0"
     },
     {
       "id": "PA-C05-main-punjabi-bolda-han",
       "language": "punjabi",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:d794001d662e05af"
+      "sourceHash": "fnv1a64:f4f87d3d34970a4c"
     },
     {
       "id": "PA-C05-practice",
@@ -16884,9 +16601,10 @@
       "derived": "sight",
       "drivable": false,
       "reasons": [
+        "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:084fbd009af99704"
+      "sourceHash": "fnv1a64:78cb36385d3494ad"
     },
     {
       "id": "PA-C06-numbers-1-5",
@@ -16919,39 +16637,39 @@
       "language": "russian",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:ad76bd6ec3c7ff35"
+      "sourceHash": "fnv1a64:fcaf3fa3908abd78"
     },
     {
       "id": "RU-C01-net",
       "language": "russian",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:9be8d98be29726be"
+      "sourceHash": "fnv1a64:1bb4f36be79471f9"
     },
     {
       "id": "RU-C01-pozhaluysta",
       "language": "russian",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:ca51aaccb8210809"
+      "sourceHash": "fnv1a64:7022b561af758fe6"
     },
     {
       "id": "RU-C01-practice",
@@ -16971,39 +16689,39 @@
       "language": "russian",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:1d62d9b457dff8fb"
+      "sourceHash": "fnv1a64:8258d0d87859c9ea"
     },
     {
       "id": "RU-C01-spasibo",
       "language": "russian",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8d9039e851a00c86"
+      "sourceHash": "fnv1a64:007b0e31e887f8eb"
     },
     {
       "id": "RU-C01-zdravstvuyte",
       "language": "russian",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:695f02ad0b38c149"
+      "sourceHash": "fnv1a64:1129d225cc1a7f6e"
     },
     {
       "id": "RU-W01-false-friends-v-r",
@@ -17206,26 +16924,26 @@
       "language": "sanskrit",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:f4a152c82fb187c0"
+      "sourceHash": "fnv1a64:487c7a73e21f5983"
     },
     {
       "id": "SA-C01-dhanyavada",
       "language": "sanskrit",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:2c0c2b15ff204ffd"
+      "sourceHash": "fnv1a64:ea7c7dc97c584b3a"
     },
     {
       "id": "SA-C01-namaskara",
@@ -17236,22 +16954,23 @@
       "derived": "sight",
       "drivable": false,
       "reasons": [
+        "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:c198ab8f8bcbd456"
+      "sourceHash": "fnv1a64:a0eb563a777d2f13"
     },
     {
       "id": "SA-C01-namaste",
       "language": "sanskrit",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:924cb760b6a2268d"
+      "sourceHash": "fnv1a64:727560286d972f72"
     },
     {
       "id": "SA-C01-practice",
@@ -17271,78 +16990,78 @@
       "language": "sanskrit",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:e7db6ac32473eeec"
+      "sourceHash": "fnv1a64:cbf7ca601bf00a4f"
     },
     {
       "id": "SA-C02-anandah",
       "language": "sanskrit",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:4635ee97b52ef681"
+      "sourceHash": "fnv1a64:e8e0fd6673d824d6"
     },
     {
       "id": "SA-C02-asti",
       "language": "sanskrit",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:89c0326f11abfda3"
+      "sourceHash": "fnv1a64:9088728915fcc1e6"
     },
     {
       "id": "SA-C02-bhavan-tvam",
       "language": "sanskrit",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:aef0f87d889406aa"
+      "sourceHash": "fnv1a64:5f68b66f9b279a71"
     },
     {
       "id": "SA-C02-kim",
       "language": "sanskrit",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:677c26e53142f872"
+      "sourceHash": "fnv1a64:4e40385ad96c7c3b"
     },
     {
       "id": "SA-C02-mama",
       "language": "sanskrit",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:e012f4f4c7b19e80"
+      "sourceHash": "fnv1a64:19cf8b63960c764f"
     },
     {
       "id": "SA-C02-mama-nama-asti",
@@ -17362,13 +17081,13 @@
       "language": "sanskrit",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c682947246b38ec9"
+      "sourceHash": "fnv1a64:dd8f39ca044c965c"
     },
     {
       "id": "SA-C02-tava-nama-kim",
@@ -17388,13 +17107,13 @@
       "language": "sanskrit",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:d5ac8458c8c04d4b"
+      "sourceHash": "fnv1a64:45944c82838832c8"
     },
     {
       "id": "SA-C03-bhavan-katham-asti",
@@ -17414,39 +17133,39 @@
       "language": "sanskrit",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:9f33ba19199bd217"
+      "sourceHash": "fnv1a64:656fec3705a363e8"
     },
     {
       "id": "SA-C03-kushalam",
       "language": "sanskrit",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8b8e0008fd9fc833"
+      "sourceHash": "fnv1a64:3fe117d8b3a2e1c0"
     },
     {
       "id": "SA-C03-na-cinta",
       "language": "sanskrit",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:d9502af13d3fdfe7"
+      "sourceHash": "fnv1a64:3b49148c41bacfa4"
     },
     {
       "id": "SA-C03-practice",
@@ -17466,13 +17185,13 @@
       "language": "sanskrit",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:fa1664721e8e4a99"
+      "sourceHash": "fnv1a64:b682dedfea2ec53e"
     },
     {
       "id": "SA-C04-practice",
@@ -17492,65 +17211,65 @@
       "language": "sanskrit",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:0c76a9a313171c2a"
+      "sourceHash": "fnv1a64:ca5312471924cfcf"
     },
     {
       "id": "SA-C04-punar-darshanaya",
       "language": "sanskrit",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:6ba524c037c5a6dd"
+      "sourceHash": "fnv1a64:c01517255bb7ee88"
     },
     {
       "id": "SA-C04-shvah",
       "language": "sanskrit",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:db019743f5cfaf71"
+      "sourceHash": "fnv1a64:4ded4e8244e80298"
     },
     {
       "id": "SA-C05-aham-samskritam-vadami",
       "language": "sanskrit",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:d79162bbb5b45307"
+      "sourceHash": "fnv1a64:6ce6fe49bf237194"
     },
     {
       "id": "SA-C05-karomi",
       "language": "sanskrit",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c3654ce94d03fb8b"
+      "sourceHash": "fnv1a64:06c187eb35a64186"
     },
     {
       "id": "SA-C05-practice",
@@ -17570,26 +17289,26 @@
       "language": "sanskrit",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:0b6ba48b6a53454a"
+      "sourceHash": "fnv1a64:dab4cb61ca2e0775"
     },
     {
       "id": "SA-C05-vasami",
       "language": "sanskrit",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:89ebfed68ce2c42e"
+      "sourceHash": "fnv1a64:d03f17265b4a3ef7"
     },
     {
       "id": "SA-C06-numbers-1-5",
@@ -19659,35 +19378,36 @@
       "derived": "sight",
       "drivable": false,
       "reasons": [
+        "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:2d5faca18cc1086b"
+      "sourceHash": "fnv1a64:5971b60f9445ebba"
     },
     {
       "id": "TA-C01-illai",
       "language": "tamil",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8ba581d5f20e88ef"
+      "sourceHash": "fnv1a64:eb7d4be5afd2b4a8"
     },
     {
       "id": "TA-C01-nandri",
       "language": "tamil",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8ea833da2a696d9e"
+      "sourceHash": "fnv1a64:e3b598578abbeee7"
     },
     {
       "id": "TA-C01-nandri-family-register",
@@ -19720,26 +19440,26 @@
       "language": "tamil",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:aad4a63947d1d3ef"
+      "sourceHash": "fnv1a64:8abff912866c6ae0"
     },
     {
       "id": "TA-C01-vanakkam",
       "language": "tamil",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:0d3f5255c32d643c"
+      "sourceHash": "fnv1a64:4c4fa4af1fcb85dd"
     },
     {
       "id": "TA-C01-vanakkam-family-register",
@@ -19759,13 +19479,13 @@
       "language": "tamil",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:4002a4a576358ffd"
+      "sourceHash": "fnv1a64:a21db6ae59748a32"
     },
     {
       "id": "TA-C02-en-peyar",
@@ -19785,13 +19505,13 @@
       "language": "tamil",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:2f95aecc89663aa8"
+      "sourceHash": "fnv1a64:25fcc38dc3c7e5ad"
     },
     {
       "id": "TA-C02-magizhcci",
@@ -19811,26 +19531,26 @@
       "language": "tamil",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c88dc2f79e9b71c7"
+      "sourceHash": "fnv1a64:777a927ff6b68192"
     },
     {
       "id": "TA-C02-peyar",
       "language": "tamil",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:1afc0f924cfcdc99"
+      "sourceHash": "fnv1a64:f21262c05a8174ac"
     },
     {
       "id": "TA-C02-practice",
@@ -19863,65 +19583,65 @@
       "language": "tamil",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:9a6acf5b5ed9ca1e"
+      "sourceHash": "fnv1a64:115a665d0b5ae3db"
     },
     {
       "id": "TA-C03-eppadi-irukkirirgal",
       "language": "tamil",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:f599daa3f8cf668f"
+      "sourceHash": "fnv1a64:54b96e84af48f100"
     },
     {
       "id": "TA-C03-naan",
       "language": "tamil",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:7e2890d9f38c9587"
+      "sourceHash": "fnv1a64:bf125d1e56b58ba0"
     },
     {
       "id": "TA-C03-nalam",
       "language": "tamil",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:28b2f4ba162bdadf"
+      "sourceHash": "fnv1a64:7085a36204532448"
     },
     {
       "id": "TA-C03-paravayillai",
       "language": "tamil",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:2c5f0520a471a9e2"
+      "sourceHash": "fnv1a64:706b526524e2e1ab"
     },
     {
       "id": "TA-C03-practice",
@@ -19941,52 +19661,52 @@
       "language": "tamil",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:21967926008e7f2a"
+      "sourceHash": "fnv1a64:2bd30145a8a3485b"
     },
     {
       "id": "TA-C04-naalai",
       "language": "tamil",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c0d1729df2afa26a"
+      "sourceHash": "fnv1a64:46d7d64986982553"
     },
     {
       "id": "TA-C04-po",
       "language": "tamil",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:5f85b3ab22d90337"
+      "sourceHash": "fnv1a64:99257b30e11fb454"
     },
     {
       "id": "TA-C04-poy-varugiren",
       "language": "tamil",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:fbad061f7ef31b3f"
+      "sourceHash": "fnv1a64:f14e5eedd7053032"
     },
     {
       "id": "TA-C04-practice",
@@ -20006,26 +19726,26 @@
       "language": "tamil",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:bb4a6dcbe90b230e"
+      "sourceHash": "fnv1a64:42a739df1441cc91"
     },
     {
       "id": "TA-C05-pesu",
       "language": "tamil",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8266db30a57599fa"
+      "sourceHash": "fnv1a64:5667a5594c84050d"
     },
     {
       "id": "TA-C05-practice",
@@ -20045,26 +19765,26 @@
       "language": "tamil",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:ba6c5ec62fe20952"
+      "sourceHash": "fnv1a64:9853bbbff15ebc67"
     },
     {
       "id": "TA-C05-velai-sey",
       "language": "tamil",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:4ed45cec7b747617"
+      "sourceHash": "fnv1a64:ca5c5c9223f2aab4"
     },
     {
       "id": "TA-C06-dative-ukku",
@@ -20631,13 +20351,13 @@
       "language": "telugu",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:deb4137d4926d7d8"
+      "sourceHash": "fnv1a64:02c7e53b73ee6c0f"
     },
     {
       "id": "TE-C01-dhanyavadamulu",
@@ -20648,35 +20368,36 @@
       "derived": "sight",
       "drivable": false,
       "reasons": [
+        "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:52e6a170d8e806ef"
+      "sourceHash": "fnv1a64:00aabcd9866ae9f2"
     },
     {
       "id": "TE-C01-ledu",
       "language": "telugu",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:63631ea67c7cecc0"
+      "sourceHash": "fnv1a64:fa3ba3d6439ce271"
     },
     {
       "id": "TE-C01-namaskaram",
       "language": "telugu",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:78ac9a59aa88d832"
+      "sourceHash": "fnv1a64:86c4ca28846a9629"
     },
     {
       "id": "TE-C01-practice",
@@ -20696,26 +20417,26 @@
       "language": "telugu",
       "chapter": 1,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:a1fbc47062cc2b95"
+      "sourceHash": "fnv1a64:563edf856ad232b4"
     },
     {
       "id": "TE-C02-emiti",
       "language": "telugu",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:343e25a5e5a68aa0"
+      "sourceHash": "fnv1a64:c24865d86c900c57"
     },
     {
       "id": "TE-C02-mii-peru-emiti",
@@ -20735,13 +20456,13 @@
       "language": "telugu",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:00072d563ff13309"
+      "sourceHash": "fnv1a64:66506069a92e1306"
     },
     {
       "id": "TE-C02-naa-peru",
@@ -20761,26 +20482,26 @@
       "language": "telugu",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:448c39a65d3d4f86"
+      "sourceHash": "fnv1a64:354cf9f77192856b"
     },
     {
       "id": "TE-C02-peru",
       "language": "telugu",
       "chapter": 2,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c916ce68f6de5518"
+      "sourceHash": "fnv1a64:282c8e00b4bab667"
     },
     {
       "id": "TE-C02-practice",
@@ -20813,65 +20534,65 @@
       "language": "telugu",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:4a89e9d8e5793aee"
+      "sourceHash": "fnv1a64:921926f70cd68931"
     },
     {
       "id": "TE-C03-elaa",
       "language": "telugu",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:d1c1f582da47b682"
+      "sourceHash": "fnv1a64:290d6f92cdec1fa7"
     },
     {
       "id": "TE-C03-miiru-elaa-unnaaru",
       "language": "telugu",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:d5d6317720c976df"
+      "sourceHash": "fnv1a64:cdaadb9998d4dc78"
     },
     {
       "id": "TE-C03-nenu",
       "language": "telugu",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:48438bd695432100"
+      "sourceHash": "fnv1a64:c9f149c5d962518f"
     },
     {
       "id": "TE-C03-paravaaledu",
       "language": "telugu",
       "chapter": 3,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b49c08e7ae42ca6e"
+      "sourceHash": "fnv1a64:4f0cfb3134d69cfb"
     },
     {
       "id": "TE-C03-practice",
@@ -20891,13 +20612,13 @@
       "language": "telugu",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:44e8adcad4eea9bb"
+      "sourceHash": "fnv1a64:515fec85b9e97e7c"
     },
     {
       "id": "TE-C04-practice",
@@ -20917,78 +20638,78 @@
       "language": "telugu",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:4399e54f55c7d582"
+      "sourceHash": "fnv1a64:f241961853fa1fdd"
     },
     {
       "id": "TE-C04-velli-vastaanu",
       "language": "telugu",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:bd4810e5f26ab33e"
+      "sourceHash": "fnv1a64:7a4b023ba6421195"
     },
     {
       "id": "TE-C04-vellu",
       "language": "telugu",
       "chapter": 4,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:57415cf23840ee92"
+      "sourceHash": "fnv1a64:662e875342cd06a1"
     },
     {
       "id": "TE-C05-maatlaadu",
       "language": "telugu",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:07af09d6a3e88ad0"
+      "sourceHash": "fnv1a64:8d053f228fb6653b"
     },
     {
       "id": "TE-C05-nenu-telugu-maatlaadataanu",
       "language": "telugu",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:959c4e28573052f3"
+      "sourceHash": "fnv1a64:b49ca03d60180860"
     },
     {
       "id": "TE-C05-pani-ceyu",
       "language": "telugu",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:098e7100a3d5e2d6"
+      "sourceHash": "fnv1a64:eaa29c2ebacac405"
     },
     {
       "id": "TE-C05-practice",
@@ -21008,13 +20729,13 @@
       "language": "telugu",
       "chapter": 5,
       "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:55ea402e2b7eabe2"
+      "sourceHash": "fnv1a64:26e4f178d9a9f193"
     },
     {
       "id": "TE-C06-dative-ku",

--- a/code/learning/human-languages/gujarati/narration/ch01.json
+++ b/code/learning/human-languages/gujarati/narration/ch01.json
@@ -3,8 +3,8 @@
   "language": "gujarati",
   "chapter": 1,
   "title": "Chapter 1",
-  "drivablePrefix": 3,
-  "sourceHash": "fnv1a64:57ef8bb46075c230",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:85602192fd87c52f",
   "lessons": [
     {
       "id": "GU-C01-aabhaar",
@@ -14,13 +14,22 @@
       "romanization": "આભાર",
       "gloss": "thank you (ābhār)",
       "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:d03a1a725e3f3adf",
-      "notice": null,
+      "sourceHash": "fnv1a64:69ea2a54aec07b1c",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -128,13 +137,22 @@
       "romanization": "આવજો",
       "gloss": "goodbye (lit. \"[please] come [again]\")",
       "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c97664a9d71a07a2",
-      "notice": null,
+      "sourceHash": "fnv1a64:ce0ea8a630586fd1",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -155,7 +173,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -242,13 +260,22 @@
       "romanization": "હા / ના",
       "gloss": "yes / no (hā / nā)",
       "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:d689ac91b0bb3e55",
-      "notice": null,
+      "sourceHash": "fnv1a64:a4560b58e96e7406",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -269,7 +296,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -350,16 +377,20 @@
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
+        "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:13fa1be3b0302b28",
+      "sourceHash": "fnv1a64:ea2d04a685deb837",
       "notice": {
         "modality": "sight",
         "needs": [
+          "your eyes, for letter shapes on the page",
           "your eyes, because the lesson points at something written down"
         ],
-        "waitUntilStopped": [],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped."
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
       },
       "blocks": [
         {
@@ -381,7 +412,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -641,16 +672,20 @@
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
+        "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:55a442f7072f7692",
+      "sourceHash": "fnv1a64:f4d2ea530bbfb36b",
       "notice": {
         "modality": "sight",
         "needs": [
+          "your eyes, for letter shapes on the page",
           "your eyes, because the lesson points at something written down"
         ],
-        "waitUntilStopped": [],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped."
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
       },
       "blocks": [
         {
@@ -672,7 +707,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/gujarati/narration/ch01.txt
+++ b/code/learning/human-languages/gujarati/narration/ch01.txt
@@ -1,9 +1,11 @@
 Gujarati, chapter 1: Chapter 1.
-6 lessons. You can do the first 3 of them in the car; after that you will want to have stopped.
+6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 6.
 આભાર (ābhār) — "thank you," an obligation gladly owed.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -32,6 +34,8 @@ What does ābhār literally mean, and what English word shares its root? ("An ob
 Lesson 2 of 6.
 આવજો (āvjo) — "goodbye" (come again).
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 The everyday Gujarati goodbye — and, like the goodbyes across all of India, it is really an invitation to return.
@@ -59,6 +63,8 @@ What does the Gujarati goodbye literally say, and what verb is it from? ("Come [
 Lesson 3 of 6.
 હા / ના (hā / nā) — "yes" and "no".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 Two tiny words no conversation survives without — and one is a cousin of English.
@@ -84,7 +90,7 @@ What ancient root links Gujarati nā to English no? (Proto-Indo- European ne, "n
 Lesson 4 of 6.
 નમસ્તે (namaste) — "hello," and a script with no ceiling.
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped.
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -152,7 +158,7 @@ Someone thanks you and turns to leave. Answer their thanks and send them off the
 Lesson 6 of 6.
 સારું (sārũ) — "good," "okay".
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped.
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/gujarati/narration/ch02.json
+++ b/code/learning/human-languages/gujarati/narration/ch02.json
@@ -3,8 +3,8 @@
   "language": "gujarati",
   "chapter": 2,
   "title": "Chapter 2",
-  "drivablePrefix": 9,
-  "sourceHash": "fnv1a64:9465a57f929995ae",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:84eae05a789c7889",
   "lessons": [
     {
       "id": "GU-C02-anand",
@@ -14,13 +14,22 @@
       "romanization": "તમને મળીને આનંદ થયો",
       "gloss": "pleased to meet you (lit. \"meeting you, joy happened\")",
       "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:bea070887443df96",
-      "notice": null,
+      "sourceHash": "fnv1a64:d464ae8af941057d",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -128,13 +137,22 @@
       "romanization": "છે",
       "gloss": "is (the copula)",
       "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:2d64c3d248109066",
-      "notice": null,
+      "sourceHash": "fnv1a64:602b01069582a487",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -155,7 +173,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -253,13 +271,22 @@
       "romanization": "મારું",
       "gloss": "my (neuter; also મારો m. / મારી f.)",
       "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:6f4a483780a3f30d",
-      "notice": null,
+      "sourceHash": "fnv1a64:d67b8ebaba84b5c4",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -280,7 +307,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -499,13 +526,22 @@
       "romanization": "નામ",
       "gloss": "name",
       "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:ee2f6efb959d5c01",
-      "notice": null,
+      "sourceHash": "fnv1a64:3af8f4bb9a8cc066",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -526,7 +562,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -774,13 +810,22 @@
       "romanization": "શું",
       "gloss": "what",
       "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:fa0e42cc0983783c",
-      "notice": null,
+      "sourceHash": "fnv1a64:4f579e4f44a6b2af",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -801,7 +846,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -1002,13 +1047,22 @@
       "romanization": "તું / તમે",
       "gloss": "you (familiar / respectful)",
       "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8a4a31923090f2f1",
-      "notice": null,
+      "sourceHash": "fnv1a64:243b1dd19af26cfa",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -1029,7 +1083,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/gujarati/narration/ch02.txt
+++ b/code/learning/human-languages/gujarati/narration/ch02.txt
@@ -1,9 +1,11 @@
 Gujarati, chapter 2: Chapter 2.
-9 lessons. All 9 can be done entirely by ear.
+9 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 9.
 તમને મળીને આનંદ થયો (tamne maḷīne ānand thayo) — "pleased to meet you".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -31,6 +33,8 @@ What does the phrase literally say, and what is ānand? ("Having met you, joy ha
 
 Lesson 2 of 9.
 છે (chhe) — "is," a copula all Gujarati's own.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -61,6 +65,8 @@ What is chhe, and how does it differ from Hindi? (Gujarati's copula, "is"; it is
 
 Lesson 3 of 9.
 મારું (mārũ) — "my," and gender again.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -120,6 +126,8 @@ Give your name in Gujarati, and say where the verb goes. (Mārũ nām … chhe; 
 
 Lesson 5 of 9.
 નામ (nām) — "name," a word older than Europe.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -185,6 +193,8 @@ Introduce yourself and ask a stranger's name in Gujarati. (Mārũ nām … chhe.
 Lesson 7 of 9.
 શું (shũ) — "what".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 The question-word — and the one Gujarati question that does not start with k-.
@@ -238,6 +248,8 @@ Ask "what's your name?" respectfully. (Tamārũ nām shũ chhe?; the verb chhe i
 
 Lesson 9 of 9.
 તું / તમે (tũ / tame) — "you," familiar and respectful.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/gujarati/narration/ch03.json
+++ b/code/learning/human-languages/gujarati/narration/ch03.json
@@ -3,8 +3,8 @@
   "language": "gujarati",
   "chapter": 3,
   "title": "Chapter 3",
-  "drivablePrefix": 6,
-  "sourceHash": "fnv1a64:94c6c7cb92e26b0e",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:519a94fefb3cc1fb",
   "lessons": [
     {
       "id": "GU-C03-hun",
@@ -14,13 +14,22 @@
       "romanization": "હું",
       "gloss": "I",
       "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:742510bdf7b7d0cc",
-      "notice": null,
+      "sourceHash": "fnv1a64:806b44e166aa90b1",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -139,13 +148,22 @@
       "romanization": "કેમ",
       "gloss": "how (also \"why\")",
       "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:6f6abb0e8b5db845",
-      "notice": null,
+      "sourceHash": "fnv1a64:6d24d1ed458a9ebc",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -166,7 +184,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -244,13 +262,22 @@
       "romanization": "મજા",
       "gloss": "enjoyment, fun — and the reply \"હું મજામાં છું\"",
       "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b9eb03fd125860cd",
-      "notice": null,
+      "sourceHash": "fnv1a64:303cb39547727116",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -271,7 +298,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -661,13 +688,22 @@
       "romanization": "વાંધો નહીં",
       "gloss": "no problem / it's okay / you're welcome",
       "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:538e577793d6ad11",
-      "notice": null,
+      "sourceHash": "fnv1a64:b56e87993b078b6e",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -688,7 +724,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/gujarati/narration/ch03.txt
+++ b/code/learning/human-languages/gujarati/narration/ch03.txt
@@ -1,9 +1,11 @@
 Gujarati, chapter 3: Chapter 3.
-6 lessons. All 6 can be done entirely by ear.
+6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 6.
 હું (hũ) — "I".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -35,6 +37,8 @@ What Sanskrit word is hũ from, and its cousins? (Aham; Latin ego, English I.)
 Lesson 2 of 6.
 કેમ (kem) — "how," a proper k- question.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 Where shũ ("what") hid its k-, this one wears it plainly — and it opens the most Gujarati of greetings.
@@ -59,6 +63,8 @@ What root does kem share with English how/what? (The interrogative ka-, PIE kʷo
 
 Lesson 3 of 6.
 મજા (majā) — "enjoyment," and how to answer.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -157,6 +163,8 @@ Give the everyday Gujarati "how are you?", and its copula form. (Tame kem chho?;
 
 Lesson 6 of 6.
 વાંધો નહીં (vāndho nahĩ) — "no problem".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/gujarati/narration/ch04.json
+++ b/code/learning/human-languages/gujarati/narration/ch04.json
@@ -3,8 +3,8 @@
   "language": "gujarati",
   "chapter": 4,
   "title": "Chapter 4",
-  "drivablePrefix": 4,
-  "sourceHash": "fnv1a64:b1d4dbc86a587681",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:9d5823ce6f705cb4",
   "lessons": [
     {
       "id": "GU-C04-kaale",
@@ -14,13 +14,22 @@
       "romanization": "કાલે મળીશું",
       "gloss": "see you tomorrow (and the કાલ puzzle)",
       "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:fa76d9878f1ccbe8",
-      "notice": null,
+      "sourceHash": "fnv1a64:f3ae78bb775a679b",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -128,13 +137,22 @@
       "romanization": "મળીશું",
       "gloss": "(we) will meet",
       "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:a3491b7e9a70d68d",
-      "notice": null,
+      "sourceHash": "fnv1a64:29a3baacaa084aec",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -155,7 +173,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -253,13 +271,22 @@
       "romanization": "પાછા",
       "gloss": "again, back",
       "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b18fb50e72610777",
-      "notice": null,
+      "sourceHash": "fnv1a64:6f60f2bede52fd1e",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -280,7 +307,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/gujarati/narration/ch04.txt
+++ b/code/learning/human-languages/gujarati/narration/ch04.txt
@@ -1,9 +1,11 @@
 Gujarati, chapter 4: Chapter 4.
-5 lessons. You can do the first 4 of them in the car; after that you will want to have stopped.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 5.
 કાલે મળીશું (kāle maḷīshũ) — "see you tomorrow".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -31,6 +33,8 @@ What two opposite days does kāl mean, and what tells them apart? (Both tomorrow
 
 Lesson 2 of 5.
 મળીશું (maḷīshũ) — "(we) will meet".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -61,6 +65,8 @@ What verb is maḷīshũ from, and what special letter does it use? (Maḷvũ "t
 
 Lesson 3 of 5.
 પાછા (pāchhā) — "again, back".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/gujarati/narration/ch05.json
+++ b/code/learning/human-languages/gujarati/narration/ch05.json
@@ -3,8 +3,8 @@
   "language": "gujarati",
   "chapter": 5,
   "title": "Chapter 5",
-  "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:b17755f75edda7b3",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:8012e9dfcbaeaad7",
   "lessons": [
     {
       "id": "GU-C05-bolvun",
@@ -14,13 +14,22 @@
       "romanization": "બોલવું",
       "gloss": "to speak",
       "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:86781c9b005bbb2d",
-      "notice": null,
+      "sourceHash": "fnv1a64:a6494186f38b1670",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -159,13 +168,22 @@
       "romanization": "હું ગુજરાતી બોલું છું",
       "gloss": "I speak Gujarati",
       "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:9bb2a4e1414e5731",
-      "notice": null,
+      "sourceHash": "fnv1a64:becb16ef892b890c",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -186,7 +204,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -284,13 +302,22 @@
       "romanization": "કામ કરવું",
       "gloss": "to work (lit. \"work-do\")",
       "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:6533fb9b5296dad7",
-      "notice": null,
+      "sourceHash": "fnv1a64:c2bb56f4b0ce16c2",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -311,7 +338,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -580,13 +607,22 @@
       "romanization": "રહેવું",
       "gloss": "to live, to stay",
       "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:0ff6f0e088b688fc",
-      "notice": null,
+      "sourceHash": "fnv1a64:38ff136f2541f6f9",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -607,7 +643,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/gujarati/narration/ch05.txt
+++ b/code/learning/human-languages/gujarati/narration/ch05.txt
@@ -1,9 +1,11 @@
 Gujarati, chapter 5: Chapter 5.
-5 lessons. All 5 can be done entirely by ear.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 5.
 બોલવું (bolvũ) — "to speak," your first full verb.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -40,6 +42,8 @@ What ending marks a Gujarati infinitive, and how do you say "I speak"? (-vũ; h�
 Lesson 2 of 5.
 હું ગુજરાતી બોલું છું (hũ gujarātī bolũ chhũ) — "I speak Gujarati".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 Your first complete, moving sentence — and the language names itself after a people who arrived on horseback.
@@ -69,6 +73,8 @@ Say "I speak Gujarati," and give the origin of the name. (Hũ gujarātī bolũ c
 
 Lesson 3 of 5.
 કામ કરવું (kām karvũ) — "to work".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -138,6 +144,8 @@ In one breath, tell me your language, your city, and your work in Gujarati. (Hũ
 
 Lesson 5 of 5.
 રહેવું (rahevũ) — "to live, to stay".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/hindi/narration/ch01.json
+++ b/code/learning/human-languages/hindi/narration/ch01.json
@@ -4,7 +4,7 @@
   "chapter": 1,
   "title": "Greetings",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:03002547302f8900",
+  "sourceHash": "fnv1a64:f6301764a50979e5",
   "lessons": [
     {
       "id": "HI-W01-shirorekha-na-ma",
@@ -686,13 +686,22 @@
       "romanization": "",
       "gloss": "goodbye (alvidā — a final farewell, Persian/Arabic-derived)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:a8d3fa187e31ebfb",
-      "notice": null,
+      "sourceHash": "fnv1a64:89abbff53db9e06c",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -724,7 +733,7 @@
         },
         {
           "index": 2,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -834,13 +843,22 @@
       "romanization": "",
       "gloss": "thank you (dhanyavād — formal, Sanskritic)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:f1a27c8f161dcc3d",
-      "notice": null,
+      "sourceHash": "fnv1a64:1ef2eb843b696428",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -872,7 +890,7 @@
         },
         {
           "index": 2,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -986,13 +1004,22 @@
       "romanization": "",
       "gloss": "hello (namaskār — more formal)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:734f8d4854a077f2",
-      "notice": null,
+      "sourceHash": "fnv1a64:dd0f0aa5fdb9b145",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -1024,7 +1051,7 @@
         },
         {
           "index": 2,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -1142,13 +1169,22 @@
       "romanization": "",
       "gloss": "hello / goodbye (namaste — \"I bow to you\")",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:235b281987e84524",
-      "notice": null,
+      "sourceHash": "fnv1a64:d41848618c702321",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -1169,7 +1205,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -1414,13 +1450,22 @@
       "romanization": "",
       "gloss": "thanks (shukriyā — everyday, Persian/Arabic-derived)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:798016f633e45631",
-      "notice": null,
+      "sourceHash": "fnv1a64:49b311784186967c",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -1452,7 +1497,7 @@
         },
         {
           "index": 2,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/hindi/narration/ch01.txt
+++ b/code/learning/human-languages/hindi/narration/ch01.txt
@@ -156,6 +156,8 @@ What do क and त say alone? (Ka, ta — each has an inherent vowel.) What ord
 Lesson 5 of 10.
 अलविदा (alvidā) — "farewell," and the Arabic al- again.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 A goodbye — and another Perso-Arabic word, carrying a piece of Arabic grammar you may have met from the other side.
@@ -191,6 +193,8 @@ alvidā literally means what, and what's the little al- doing there? ("The farew
 
 Lesson 6 of 10.
 धन्यवाद (dhanyavād) — "thank you," the Sanskrit way.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -229,6 +233,8 @@ Read धन्यवाद. What are its two parts? (dhanya "worthy" + vāda "sa
 Lesson 7 of 10.
 नमस्कार (namaskār) — the more formal bow.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 The dressier sibling of namaste — same root, one new piece, and two new letters.
@@ -266,6 +272,8 @@ What does the piece कार (-kāra) mean? ("The making/doing of.") So namask�
 
 Lesson 8 of 10.
 नमस्ते (namaste) — "I bow to you".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -331,6 +339,8 @@ Which "thanks" is Sanskrit and which is Persian? (dhanyavād / shukriyā.) What 
 
 Lesson 10 of 10.
 शुक्रिया (shukriyā) — "thanks," Hindi's other heritage.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/hindi/narration/ch02.json
+++ b/code/learning/human-languages/hindi/narration/ch02.json
@@ -4,7 +4,7 @@
   "chapter": 2,
   "title": "Introducing Yourself",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:74dec42edfdc489b",
+  "sourceHash": "fnv1a64:15417887e8a232d7",
   "lessons": [
     {
       "id": "HI-W03-matras-naam",
@@ -1066,13 +1066,22 @@
       "romanization": "",
       "gloss": "you (respectful / familiar)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:1cc61290d3f8d83e",
-      "notice": null,
+      "sourceHash": "fnv1a64:7bf9dd1fbfeaa979",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -1093,7 +1102,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -1317,13 +1326,22 @@
       "romanization": "",
       "gloss": "is",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:83eeb386ed32542a",
-      "notice": null,
+      "sourceHash": "fnv1a64:373276fb279897f5",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -1344,7 +1362,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -1564,13 +1582,22 @@
       "romanization": "",
       "gloss": "what",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:512da90f41bdc281",
-      "notice": null,
+      "sourceHash": "fnv1a64:98b5bd2e8efd62f6",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -1591,7 +1618,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -1791,13 +1818,22 @@
       "romanization": "",
       "gloss": "my",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:022b143283444ab6",
-      "notice": null,
+      "sourceHash": "fnv1a64:eeaa065b35da7455",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -1818,7 +1854,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -1916,13 +1952,22 @@
       "romanization": "",
       "gloss": "name",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:a0071583c7d72281",
-      "notice": null,
+      "sourceHash": "fnv1a64:a0371fc3206c766e",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -1943,7 +1988,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/hindi/narration/ch02.txt
+++ b/code/learning/human-languages/hindi/narration/ch02.txt
@@ -239,6 +239,8 @@ Write नमस्ते (namaste). How many bars? (One — it is one word.) Wha
 Lesson 8 of 16.
 आप / तुम (āp / tum) — "you," respectful and familiar.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 To ask someone's name, you need "you" — and Hindi grades it in three levels of respect.
@@ -299,6 +301,8 @@ What does आपका नाम क्या है? literally say, and where's
 Lesson 10 of 16.
 है (hai) — "is," cousin of English is.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 The little verb "is" — and it's the same "is" spoken from Ireland to India.
@@ -358,6 +362,8 @@ What does the Hindi "pleased to meet you" literally mean, and where is khushī f
 Lesson 12 of 16.
 क्या (kyā) — "what".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 German asks a name with "how"; Hindi uses "what" — so here's kyā.
@@ -412,6 +418,8 @@ Give your name in Hindi. (Merā nām … hai.) What's different about where "is"
 Lesson 14 of 16.
 मेरा (merā) — "my".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 The word for "my" — and, like name, a first-person word English shares to the root.
@@ -441,6 +449,8 @@ What root is मेरा built on, and its English cousins? (ma- — me, my, mi
 
 Lesson 15 of 16.
 नाम (nām) — "name," a word older than Europe.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/hindi/narration/ch03.json
+++ b/code/learning/human-languages/hindi/narration/ch03.json
@@ -3,8 +3,8 @@
   "language": "hindi",
   "chapter": 3,
   "title": "Chapter 3",
-  "drivablePrefix": 7,
-  "sourceHash": "fnv1a64:271040af036cfc26",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:5daa0e43b0e9f05d",
   "lessons": [
     {
       "id": "HI-C03-aap-kaise-hain",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "how are you? (respectful)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:dfd0d574989f31ed",
-      "notice": null,
+      "sourceHash": "fnv1a64:91c389645b62af66",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -139,13 +148,22 @@
       "romanization": "",
       "gloss": "you're welcome (also \"welcome!\")",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b4622c6526e290a1",
-      "notice": null,
+      "sourceHash": "fnv1a64:2f6fac68a084606c",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -166,7 +184,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -265,13 +283,22 @@
       "romanization": "",
       "gloss": "am (1st-person of होना, \"to be\")",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c26366136afb3ac1",
-      "notice": null,
+      "sourceHash": "fnv1a64:23b02573179317a8",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -292,7 +319,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -405,13 +432,22 @@
       "romanization": "",
       "gloss": "how (also कैसा/कैसी, agreeing)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:9a784fb6eeaa2b1c",
-      "notice": null,
+      "sourceHash": "fnv1a64:5a680be90e0f885f",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -432,7 +468,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -530,13 +566,22 @@
       "romanization": "",
       "gloss": "I",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:1bf6f1505972d988",
-      "notice": null,
+      "sourceHash": "fnv1a64:aea62ee6b7a4034b",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -557,7 +602,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -816,13 +861,22 @@
       "romanization": "",
       "gloss": "fine, well, correct — and the reply \"मैं ठीक हूँ\"",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:f48936c9aa07fdbf",
-      "notice": null,
+      "sourceHash": "fnv1a64:bff42bea4150f974",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -843,7 +897,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/hindi/narration/ch03.txt
+++ b/code/learning/human-languages/hindi/narration/ch03.txt
@@ -1,9 +1,11 @@
 Hindi, chapter 3: Chapter 3.
-7 lessons. All 7 can be done entirely by ear.
+7 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 7.
 आप कैसे हैं? (āp kaise haiṁ?) — "how are you?"
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -35,6 +37,8 @@ Why is it haiṁ (plural) and not hai with āp? (Because respect in Hindi is gra
 Lesson 2 of 7.
 आपका स्वागत है (āpkā svāgat hai) — "you're welcome".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 When someone thanks you, this is what you say back — and it hides a word you may meet again in Sanskrit.
@@ -64,6 +68,8 @@ What does svāgat literally mean, and what English word matches it piece for pie
 
 Lesson 3 of 7.
 हूँ (hūṁ) — "am," cousin of English am.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -99,6 +105,8 @@ What Sanskrit word is hūṁ from, and its English cousin? (Asmi, "I am"; Englis
 Lesson 4 of 7.
 कैसे (kaise) — "how," another of the k- questions.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 You already met क्या (kyā, "what"). Here is its sibling — and, like all of Hindi's question-words, it starts with k-.
@@ -128,6 +136,8 @@ What root do all of Hindi's question-words share, and what English family is it 
 
 Lesson 5 of 7.
 मैं (maiṁ) — "I," the m- of the first person.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -195,6 +205,8 @@ A stranger asks āp kaise haiṁ? — give a complete, polite reply, then thank-
 
 Lesson 7 of 7.
 ठीक (ṭhīk) — "fine," and how to answer.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/hindi/narration/ch04.json
+++ b/code/learning/human-languages/hindi/narration/ch04.json
@@ -3,8 +3,8 @@
   "language": "hindi",
   "chapter": 4,
   "title": "Chapter 4",
-  "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:bbe49907699889b7",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:cf7b02944e8671f2",
   "lessons": [
     {
       "id": "HI-C04-chalta-hun",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "I'll be off (lit. \"I go\"), gendered",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:95fd29897ea2d068",
-      "notice": null,
+      "sourceHash": "fnv1a64:1bfbb5b02a0d294f",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -142,13 +151,22 @@
       "romanization": "",
       "gloss": "see you tomorrow (and the कल puzzle)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c9d6c61b248661e9",
-      "notice": null,
+      "sourceHash": "fnv1a64:ee0eb7d8e9024f10",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -169,7 +187,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -271,13 +289,22 @@
       "romanization": "",
       "gloss": "(we) will meet",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:653171cf1029e28b",
-      "notice": null,
+      "sourceHash": "fnv1a64:a70a0ef65533891a",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -298,7 +325,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -396,13 +423,22 @@
       "romanization": "",
       "gloss": "again, then",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:3ef3fc411f6197f4",
-      "notice": null,
+      "sourceHash": "fnv1a64:aedfba61a69ddd3b",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -423,7 +459,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/hindi/narration/ch04.txt
+++ b/code/learning/human-languages/hindi/narration/ch04.txt
@@ -1,9 +1,11 @@
 Hindi, chapter 4: Chapter 4.
-6 lessons. You can do the first 5 of them in the car; after that you will want to have stopped.
+6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 6.
 चलता हूँ (chaltā hūṁ) — "I'll be off".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -36,6 +38,8 @@ What does chaltā hūṁ literally mean, and how does a woman say it? ("I go/mov
 Lesson 2 of 6.
 कल मिलते हैं (kal milte haiṁ) — "see you tomorrow".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 A goodbye for tomorrow — built on a word that means both tomorrow and yesterday.
@@ -67,6 +71,8 @@ What two opposite days does kal mean, and what tells them apart? (Both tomorrow 
 Lesson 3 of 6.
 मिलेंगे (milenge) — "(we) will meet".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 Your first future-tense verb — and the other half of "see you again."
@@ -96,6 +102,8 @@ What verb is milenge from, and how does Hindi show "will"? (Milnā "to meet," fr
 
 Lesson 4 of 6.
 फिर (phir) — "again," the seed of "see you again".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/hindi/narration/ch05.json
+++ b/code/learning/human-languages/hindi/narration/ch05.json
@@ -3,8 +3,8 @@
   "language": "hindi",
   "chapter": 5,
   "title": "Chapter 5",
-  "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:43c5f48914f2f1ba",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:12bcb2ada8e71c1f",
   "lessons": [
     {
       "id": "HI-C05-bolna",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "to speak",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:96d065e73903a163",
-      "notice": null,
+      "sourceHash": "fnv1a64:72e329b599f1e7c0",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -302,13 +311,22 @@
       "romanization": "",
       "gloss": "to do, to make (and काम करना, \"to work\")",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:f4bf9d5e3ccdf49c",
-      "notice": null,
+      "sourceHash": "fnv1a64:f237aa47182dc171",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -329,7 +347,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -459,13 +477,22 @@
       "romanization": "",
       "gloss": "I speak Hindi (gendered)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:5316fa9dbfd1dad1",
-      "notice": null,
+      "sourceHash": "fnv1a64:195fea9e56a29808",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -486,7 +513,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -760,16 +787,20 @@
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
+        "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:b25f452653f1ace0",
+      "sourceHash": "fnv1a64:0cbfce468a3484eb",
       "notice": {
         "modality": "sight",
         "needs": [
+          "your eyes, for letter shapes on the page",
           "your eyes, because the lesson points at something written down"
         ],
-        "waitUntilStopped": [],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped."
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
       },
       "blocks": [
         {
@@ -791,7 +822,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/hindi/narration/ch05.txt
+++ b/code/learning/human-languages/hindi/narration/ch05.txt
@@ -1,9 +1,11 @@
 Hindi, chapter 5: Chapter 5.
-6 lessons. You can do the first 5 of them in the car; after that you will want to have stopped.
+6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 6.
 बोलना (bolnā) — "to speak," your first full verb.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -75,6 +77,8 @@ Hindi's present habitual makes two agreements at once. Name what each of the two
 Lesson 3 of 6.
 करना (karnā) — "to do," the most useful verb in Hindi.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 One verb powers a thousand phrases — and its root already sits inside a word you learned back in Chapter 1.
@@ -112,6 +116,8 @@ What Sanskrit root is karnā from, and name two words in this course built on it
 
 Lesson 4 of 6.
 मैं हिंदी बोलता हूँ (maiṁ hindī boltā hūṁ) — "I speak Hindi".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -183,7 +189,7 @@ In one breath, tell me your language, your city, and your work in Hindi (as a wo
 Lesson 6 of 6.
 रहना (rahnā) — "to live, to stay".
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped.
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/kannada/narration/ch01.json
+++ b/code/learning/human-languages/kannada/narration/ch01.json
@@ -4,7 +4,7 @@
   "chapter": 1,
   "title": "Chapter 1",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:5ee7903d3c87a162",
+  "sourceHash": "fnv1a64:f51419731435c437",
   "lessons": [
     {
       "id": "KA-C01-dhanyavada",
@@ -17,16 +17,20 @@
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
+        "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:d72a74c1246439e5",
+      "sourceHash": "fnv1a64:035084b4558bdd72",
       "notice": {
         "modality": "sight",
         "needs": [
+          "your eyes, for letter shapes on the page",
           "your eyes, because the lesson points at something written down"
         ],
-        "waitUntilStopped": [],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped."
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
       },
       "blocks": [
         {
@@ -48,7 +52,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -198,13 +202,22 @@
       "romanization": "",
       "gloss": "yes (haudu)",
       "script": "kannada",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:90811f2aa90b3f6d",
-      "notice": null,
+      "sourceHash": "fnv1a64:762cd4edbe26fc8e",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -225,7 +238,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -339,13 +352,22 @@
       "romanization": "",
       "gloss": "no / there isn't (illa — the negative)",
       "script": "kannada",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:868a70d2e36aaae3",
-      "notice": null,
+      "sourceHash": "fnv1a64:5d8cbb19876741f0",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -366,7 +388,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -520,13 +542,22 @@
       "romanization": "",
       "gloss": "hello / greetings (namaskāra — \"a making of a bow\")",
       "script": "kannada",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:5f6a90778892b506",
-      "notice": null,
+      "sourceHash": "fnv1a64:3466dc173743e691",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -547,7 +578,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -858,13 +889,22 @@
       "romanization": "",
       "gloss": "okay / alright / correct (sari)",
       "script": "kannada",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:e0f9ccaac4250b7c",
-      "notice": null,
+      "sourceHash": "fnv1a64:9aa5a310f9bc828b",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -885,7 +925,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/kannada/narration/ch01.txt
+++ b/code/learning/human-languages/kannada/narration/ch01.txt
@@ -5,7 +5,7 @@ Kannada, chapter 1: Chapter 1.
 Lesson 1 of 6.
 ಧನ್ಯವಾದ (dhanyavāda) — "thank you," an utterance of "worthy".
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped.
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -52,6 +52,8 @@ Read ಧನ್ಯವಾದ. What are its two Sanskrit pieces? (dhanya "worthy" +
 Lesson 2 of 6.
 ಹೌದು (haudu) — "yes".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 After two Sanskrit loans, a native Kannada word — the plain "yes."
@@ -85,6 +87,8 @@ Read ಹೌದು. Is it native Kannada or a Sanskrit loan? (Native.) Besides ha
 
 Lesson 3 of 6.
 ಇಲ್ಲ (illa) — "no," and a word Tamil shares almost exactly.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -131,6 +135,8 @@ Read ಇಲ್ಲ. Literally, is it closer to "no" or "is not"? ("Is not / there
 
 Lesson 4 of 6.
 ನಮಸ್ಕಾರ (namaskāra) — "greetings," a making of a bow.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -213,6 +219,8 @@ Next chapter: introducing yourself — nanna hesaru… ("my name…") — and Ka
 
 Lesson 6 of 6.
 ಸರಿ (sari) — "okay," the word that oils every conversation.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/kannada/narration/ch02.json
+++ b/code/learning/human-languages/kannada/narration/ch02.json
@@ -3,8 +3,8 @@
   "language": "kannada",
   "chapter": 2,
   "title": "Chapter 2",
-  "drivablePrefix": 8,
-  "sourceHash": "fnv1a64:b70e666895d0cb49",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:ebb799b08b06b8f8",
   "lessons": [
     {
       "id": "KA-C02-enu",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "what",
       "script": "kannada",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b9d4879e03664154",
-      "notice": null,
+      "sourceHash": "fnv1a64:1be9909948d15d65",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -119,13 +128,22 @@
       "romanization": "",
       "gloss": "name",
       "script": "kannada",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:2e55e2b9599e2e3d",
-      "notice": null,
+      "sourceHash": "fnv1a64:31cbf4d18c055096",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -146,7 +164,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -237,13 +255,22 @@
       "romanization": "",
       "gloss": "my",
       "script": "kannada",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:25ce7bc99a448aa3",
-      "notice": null,
+      "sourceHash": "fnv1a64:acd0ca42626d82bc",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -264,7 +291,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -455,13 +482,22 @@
       "romanization": "",
       "gloss": "you (familiar / respectful)",
       "script": "kannada",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8d2a0f5bd8c72e49",
-      "notice": null,
+      "sourceHash": "fnv1a64:d50a8710b4d9aea6",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -482,7 +518,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/kannada/narration/ch02.txt
+++ b/code/learning/human-languages/kannada/narration/ch02.txt
@@ -1,9 +1,11 @@
 Kannada, chapter 2: Chapter 2.
-8 lessons. All 8 can be done entirely by ear.
+8 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 8.
 ಏನು (ēnu) — "what".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -29,6 +31,8 @@ What Dravidian stem heads ಏನು and Kannada's other question-words? (yā-/e-
 
 Lesson 2 of 8.
 ಹೆಸರು (hesaru) — "name," and the p becomes h shift.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -57,6 +61,8 @@ What sound-law turned pesar into hesaru, and what Tamil word is its cousin? (p b
 
 Lesson 3 of 8.
 ನನ್ನ (nanna) — "my".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -109,6 +115,8 @@ Give your name in Kannada. (Nanna hesaru ….) What does Kannada leave out that 
 
 Lesson 5 of 8.
 ನೀನು / ನೀವು (nīnu / nīvu) — "you," familiar and respectful.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/kannada/narration/ch03.json
+++ b/code/learning/human-languages/kannada/narration/ch03.json
@@ -3,8 +3,8 @@
   "language": "kannada",
   "chapter": 3,
   "title": "Chapter 3",
-  "drivablePrefix": 6,
-  "sourceHash": "fnv1a64:9b0a242f0d26de2b",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:cd9c763fa849439d",
   "lessons": [
     {
       "id": "KA-C03-cennaagi",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "well, nicely — and the reply \"ನಾನು ಚೆನ್ನಾಗಿದ್ದೇನೆ\"",
       "script": "kannada",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:79c93c37febcd5e1",
-      "notice": null,
+      "sourceHash": "fnv1a64:93437e98f663cb1c",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -143,13 +152,22 @@
       "romanization": "",
       "gloss": "how",
       "script": "kannada",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b65b5d9b2253dba7",
-      "notice": null,
+      "sourceHash": "fnv1a64:8b830f9a970ffdec",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -170,7 +188,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -248,13 +266,22 @@
       "romanization": "",
       "gloss": "I",
       "script": "kannada",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:ea38eab32e5096de",
-      "notice": null,
+      "sourceHash": "fnv1a64:58de706b080bec57",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -275,7 +302,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -373,13 +400,22 @@
       "romanization": "",
       "gloss": "how are you? (respectful)",
       "script": "kannada",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:15049175dc65d0c3",
-      "notice": null,
+      "sourceHash": "fnv1a64:b4afa9f62df6a322",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -400,7 +436,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -498,13 +534,22 @@
       "romanization": "",
       "gloss": "it's okay / no problem / you're welcome",
       "script": "kannada",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:757783589299b144",
-      "notice": null,
+      "sourceHash": "fnv1a64:a41e1b1c079f7f0b",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -525,7 +570,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/kannada/narration/ch03.txt
+++ b/code/learning/human-languages/kannada/narration/ch03.txt
@@ -1,9 +1,11 @@
 Kannada, chapter 3: Chapter 3.
-6 lessons. All 6 can be done entirely by ear.
+6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 6.
 ಚೆನ್ನಾಗಿ (cennāgi) — "well," and how to answer.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -36,6 +38,8 @@ Give the full reply to nīvu hēgiddīrā?, and say what cennāgi literally mean
 Lesson 2 of 6.
 ಹೇಗೆ (hēge) — "how," another of the ē- questions.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 You met ಏನು (ēnu, "what") in Chapter 2. Here is its sibling in Kannada's question family.
@@ -60,6 +64,8 @@ What base do Kannada's question-words share, and which cousins head their own? (
 
 Lesson 3 of 6.
 ನಾನು (nānu) — "I," the Dravidian first person.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -91,6 +97,8 @@ What is nānu's possessive, and is Kannada's "I" cousin to English me? (Nanna, "
 Lesson 4 of 6.
 ನೀವು ಹೇಗಿದ್ದೀರಾ? (nīvu hēgiddīrā?) — how are you? (respectful).
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 The everyday "how are you?" — and the verb "to be" that carries it.
@@ -120,6 +128,8 @@ What verb powers "how are you?", and which Dravidian sister uses the same one? (
 
 Lesson 5 of 6.
 ಪರವಾಗಿಲ್ಲ (paravāgilla) — "no problem".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/kannada/narration/ch04.json
+++ b/code/learning/human-languages/kannada/narration/ch04.json
@@ -3,8 +3,8 @@
   "language": "kannada",
   "chapter": 4,
   "title": "Chapter 4",
-  "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:c0b0bab89cb795bd",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:e08a7fd2e7d9d6f8",
   "lessons": [
     {
       "id": "KA-C04-hoogi-baruttene",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "goodbye (lit. \"I'll go and come back\")",
       "script": "kannada",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:f223e4feb429dfae",
-      "notice": null,
+      "sourceHash": "fnv1a64:5424de3b9e5d6cef",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -139,13 +148,22 @@
       "romanization": "",
       "gloss": "to go (and ಬಾ, come)",
       "script": "kannada",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:a6558fd264dce624",
-      "notice": null,
+      "sourceHash": "fnv1a64:30e99c8aa7d1463b",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -166,7 +184,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -244,13 +262,22 @@
       "romanization": "",
       "gloss": "we'll meet again",
       "script": "kannada",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8146489205fffb28",
-      "notice": null,
+      "sourceHash": "fnv1a64:4340dca3b939a451",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -271,7 +298,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -349,13 +376,22 @@
       "romanization": "",
       "gloss": "see you tomorrow",
       "script": "kannada",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:5f57de1f51f81b2e",
-      "notice": null,
+      "sourceHash": "fnv1a64:9c7fce2e8376967d",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -376,7 +412,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/kannada/narration/ch04.txt
+++ b/code/learning/human-languages/kannada/narration/ch04.txt
@@ -1,9 +1,11 @@
 Kannada, chapter 4: Chapter 4.
-5 lessons. All 5 can be done entirely by ear.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 5.
 ಹೋಗಿ ಬರುತ್ತೇನೆ (hōgi baruttēne) — "I'll go and come back".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -35,6 +37,8 @@ What does the Kannada goodbye literally promise, and how do you answer? ("I'll g
 Lesson 2 of 5.
 ಹೋಗು (hōgu) — "go," and ಬಾ (come).
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 Two everyday verbs — and together they make the Kannada goodbye.
@@ -60,6 +64,8 @@ What do hōgu and bā mean, and why will you need both to part? ("Go" and "come"
 Lesson 3 of 5.
 ಮತ್ತೆ ಸಿಗೋಣ (matte sigōṇa) — "we'll meet again".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 The open-ended, warm goodbye — no date, just a promise.
@@ -84,6 +90,8 @@ What does the phrase mean, and which native verb does Kannada use for "meet"? ("
 
 Lesson 4 of 5.
 ನಾಳೆ ಸಿಗೋಣ (nāḷe sigōṇa) — "see you tomorrow".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/kannada/narration/ch05.json
+++ b/code/learning/human-languages/kannada/narration/ch05.json
@@ -3,8 +3,8 @@
   "language": "kannada",
   "chapter": 5,
   "title": "Chapter 5",
-  "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:e7c2f3c3c510af9b",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:c43a92e2750d8991",
   "lessons": [
     {
       "id": "KA-C05-iru",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "to be, to stay, to live",
       "script": "kannada",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:96ce3a7baf526cb9",
-      "notice": null,
+      "sourceHash": "fnv1a64:6f539f1993b90d24",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -139,13 +148,22 @@
       "romanization": "",
       "gloss": "to work (lit. \"work-do\")",
       "script": "kannada",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:115616cc46b6a9c3",
-      "notice": null,
+      "sourceHash": "fnv1a64:9f1823451187ac5a",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -166,7 +184,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -280,13 +298,22 @@
       "romanization": "",
       "gloss": "to speak",
       "script": "kannada",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:1ab08538385fa1b1",
-      "notice": null,
+      "sourceHash": "fnv1a64:ea6df29016abfee2",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -307,7 +334,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -413,13 +440,22 @@
       "romanization": "",
       "gloss": "I speak Kannada",
       "script": "kannada",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:fe8afc670a6c6758",
-      "notice": null,
+      "sourceHash": "fnv1a64:c58b743e977f94c7",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -440,7 +476,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/kannada/narration/ch05.txt
+++ b/code/learning/human-languages/kannada/narration/ch05.txt
@@ -1,9 +1,11 @@
 Kannada, chapter 5: Chapter 5.
-5 lessons. All 5 can be done entirely by ear.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 5.
 ಇರು (iru) — "to be, to stay, to live".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -34,6 +36,8 @@ Name three things the one verb iru can mean, and say where "in" goes. ("To be / 
 
 Lesson 2 of 5.
 ಕೆಲಸ ಮಾಡು (kelasa māḍu) — "to work".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -69,6 +73,8 @@ How does Kannada turn "work" into "to work," and what verbs work the same way in
 Lesson 3 of 5.
 ಮಾತನಾಡು (mātanāḍu) — "to speak," your first full verb.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 So far, "to be." Here is a verb that does something — and it shows how Kannada builds "I do X."
@@ -100,6 +106,8 @@ Build "I speak" from mātanāḍu, and name the noun it's built on. (Mātanāḍ
 
 Lesson 4 of 5.
 ನಾನು ಕನ್ನಡ ಮಾತನಾಡುತ್ತೇನೆ (nānu kannaḍa mātanāḍuttēne) — "I speak Kannada".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/malayalam/narration/ch01.json
+++ b/code/learning/human-languages/malayalam/narration/ch01.json
@@ -3,8 +3,8 @@
   "language": "malayalam",
   "chapter": 1,
   "title": "Chapter 1",
-  "drivablePrefix": 4,
-  "sourceHash": "fnv1a64:466190a4496f5073",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:bfb1a1a7a0f1d6f8",
   "lessons": [
     {
       "id": "ML-C01-athe",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "yes (athe — \"that [is so]\")",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:f9774d8c3e4314d9",
-      "notice": null,
+      "sourceHash": "fnv1a64:b5428b9487e2b5ca",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -155,13 +164,22 @@
       "romanization": "",
       "gloss": "no / there isn't (illa — the negative)",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:80ad38e397f1e428",
-      "notice": null,
+      "sourceHash": "fnv1a64:a386c9616c67b3e7",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -182,7 +200,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -332,13 +350,22 @@
       "romanization": "",
       "gloss": "hello / greetings (namaskāram — \"a making of a bow\")",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c43845351f531425",
-      "notice": null,
+      "sourceHash": "fnv1a64:bd41bd8573b9cfb8",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -359,7 +386,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -514,13 +541,22 @@
       "romanization": "",
       "gloss": "thank you (nandi — the native Dravidian word, Tamil's cousin)",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:71619d799967562e",
-      "notice": null,
+      "sourceHash": "fnv1a64:77fae88f5176850b",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -541,7 +577,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -839,13 +875,22 @@
       "romanization": "",
       "gloss": "okay / alright / correct (śari)",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:11736a060797bc74",
-      "notice": null,
+      "sourceHash": "fnv1a64:2cdf31bc9b98e609",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -866,7 +911,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/malayalam/narration/ch01.txt
+++ b/code/learning/human-languages/malayalam/narration/ch01.txt
@@ -1,9 +1,11 @@
 Malayalam, chapter 1: Chapter 1.
-6 lessons. You can do the first 4 of them in the car; after that you will want to have stopped.
+6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 6.
 അതെ (athe) — "yes," literally "that [is so]".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -38,6 +40,8 @@ Read അതെ. What everyday word is it built from, and so what does "yes" lite
 
 Lesson 2 of 6.
 ഇല്ല (illa) — "no," the word Malayalam and Tamil share almost exactly.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -83,6 +87,8 @@ Read ഇല്ല. Literally, is it closer to "no" or "is not"? ("Is not / there
 
 Lesson 3 of 6.
 നമസ്കാരം (namaskāram) — "greetings," a making of a bow.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -130,6 +136,8 @@ Read നമസ്കാരം. Native Malayalam or a borrowing, and what does it
 
 Lesson 4 of 6.
 നന്ദി (nandi) — "thank you," and the Tamil kinship made visible.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -208,6 +216,8 @@ That completes the four Dravidian first chapters — Tamil, Kannada, Telugu, Mal
 
 Lesson 6 of 6.
 ശരി (śari) — "okay," the whole-family word once more.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/malayalam/narration/ch02.json
+++ b/code/learning/human-languages/malayalam/narration/ch02.json
@@ -3,8 +3,8 @@
   "language": "malayalam",
   "chapter": 2,
   "title": "Chapter 2",
-  "drivablePrefix": 9,
-  "sourceHash": "fnv1a64:59770356ce4edd60",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:ac6aa6db065a34b3",
   "lessons": [
     {
       "id": "ML-C02-aanu",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "is (the copula)",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:ca846f2149ba8954",
-      "notice": null,
+      "sourceHash": "fnv1a64:ff571c00f6d40e5d",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -134,13 +143,22 @@
       "romanization": "",
       "gloss": "my",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:4eb8dd06d741b871",
-      "notice": null,
+      "sourceHash": "fnv1a64:fdf49546f6b2b6ee",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -161,7 +179,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -352,13 +370,22 @@
       "romanization": "",
       "gloss": "what",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:bf3c2300dc6c14d6",
-      "notice": null,
+      "sourceHash": "fnv1a64:cd1b34c3574c0c15",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -379,7 +406,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -457,13 +484,22 @@
       "romanization": "",
       "gloss": "you (familiar / respectful)",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:395430ab6f3c9043",
-      "notice": null,
+      "sourceHash": "fnv1a64:8df6cc5e645d2578",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -484,7 +520,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -681,13 +717,22 @@
       "romanization": "",
       "gloss": "name",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:100f6d116c58b4b2",
-      "notice": null,
+      "sourceHash": "fnv1a64:fce78214aef0ef35",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -708,7 +753,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/malayalam/narration/ch02.txt
+++ b/code/learning/human-languages/malayalam/narration/ch02.txt
@@ -1,9 +1,11 @@
 Malayalam, chapter 2: Chapter 2.
-9 lessons. All 9 can be done entirely by ear.
+9 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 9.
 ആണ് (āṇŭ) — "is," where Malayalam breaks with its sisters.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -33,6 +35,8 @@ What is ആണ്, and how does Malayalam differ from Tamil here? (The copula "i
 
 Lesson 2 of 9.
 എന്റെ (enṟe) — "my".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -86,6 +90,8 @@ Give your name in Malayalam. (Enṟe pēru … āṇŭ.) What word does Malayala
 Lesson 4 of 9.
 എന്ത് (entŭ) — "what".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 The last piece of the question: "what."
@@ -110,6 +116,8 @@ What Dravidian stem heads എന്ത്? (yā-/e-, same as Tamil eṉṉa, Tel
 
 Lesson 5 of 9.
 നീ / നിങ്ങൾ (nī / niṅṅaḷ) — "you," familiar and respectful.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -164,6 +172,8 @@ What two words fuse into എന്താണ്, and how does this differ from th
 
 Lesson 7 of 9.
 പേര് (pēru) — "name," the native Dravidian word.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/malayalam/narration/ch03.json
+++ b/code/learning/human-languages/malayalam/narration/ch03.json
@@ -3,8 +3,8 @@
   "language": "malayalam",
   "chapter": 3,
   "title": "Chapter 3",
-  "drivablePrefix": 6,
-  "sourceHash": "fnv1a64:fe0a2d758903636a",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:6e4c284aceda5c95",
   "lessons": [
     {
       "id": "ML-C03-engane",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "how",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:5a66b4614d4b7092",
-      "notice": null,
+      "sourceHash": "fnv1a64:64cd69a9348bd1f5",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -119,13 +128,22 @@
       "romanization": "",
       "gloss": "I",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8da33b7e9fed0b0b",
-      "notice": null,
+      "sourceHash": "fnv1a64:1c8c8f8f5981e1da",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -146,7 +164,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -409,13 +427,22 @@
       "romanization": "",
       "gloss": "it doesn't matter / no problem / you're welcome",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:35a3b3272ff193c6",
-      "notice": null,
+      "sourceHash": "fnv1a64:9eae0087a7a99e4f",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -436,7 +463,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -534,13 +561,22 @@
       "romanization": "",
       "gloss": "well-being — and the reply \"സുഖമാണ്\"",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:2d474cea454b6dfe",
-      "notice": null,
+      "sourceHash": "fnv1a64:5e0de3df6b96aec1",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -561,7 +597,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -667,13 +703,22 @@
       "romanization": "",
       "gloss": "how are you? (lit. \"are you well?\")",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:449aa5c6628bf79f",
-      "notice": null,
+      "sourceHash": "fnv1a64:5c17999601548f76",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -694,7 +739,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/malayalam/narration/ch03.txt
+++ b/code/learning/human-languages/malayalam/narration/ch03.txt
@@ -1,9 +1,11 @@
 Malayalam, chapter 3: Chapter 3.
-6 lessons. All 6 can be done entirely by ear.
+6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 6.
 എങ്ങനെ (eṅṅane) — "how," another of the e- questions.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -29,6 +31,8 @@ What base do Malayalam's question-words share, and which Tamil cousin heads its 
 
 Lesson 2 of 6.
 ഞാൻ (ñān) — "I," the Dravidian first person.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -98,6 +102,8 @@ A friend asks sukhamāṇō? — give a full, polite reply, and answer their tha
 Lesson 4 of 6.
 സാരമില്ല (sāramilla) — "it doesn't matter".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 When someone thanks you — or apologises — this is the easy, gracious reply, and it fuses Malayalam's two heritages in one word.
@@ -127,6 +133,8 @@ What does sāramilla literally say, and which of its two words is Sanskrit? ("Th
 
 Lesson 5 of 6.
 സുഖം (sukhaṁ) — "well-being," and how to answer.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -159,6 +167,8 @@ Give the reply to sukhamāṇō?, and say where sukham comes from. (Sukhamāṇ�
 
 Lesson 6 of 6.
 സുഖമാണോ? (sukhamāṇō?) — "how are you?"
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/malayalam/narration/ch04.json
+++ b/code/learning/human-languages/malayalam/narration/ch04.json
@@ -3,8 +3,8 @@
   "language": "malayalam",
   "chapter": 4,
   "title": "Chapter 4",
-  "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:1f30deae0c4c4e8b",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:f1c85116657207db",
   "lessons": [
     {
       "id": "ML-C04-naale-kaanaam",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "see you tomorrow",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:842529b6bc3d8bec",
-      "notice": null,
+      "sourceHash": "fnv1a64:7f5e2b7fe9218475",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -128,13 +137,22 @@
       "romanization": "",
       "gloss": "to go (and വരിക, to come)",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:10c9632ed9ac0ad6",
-      "notice": null,
+      "sourceHash": "fnv1a64:bd9c0c56fa2d2c9d",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -155,7 +173,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -233,13 +251,22 @@
       "romanization": "",
       "gloss": "goodbye (lit. \"I'll go and come back\")",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8bda01a873c3b6df",
-      "notice": null,
+      "sourceHash": "fnv1a64:887651ed8d638d32",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -260,7 +287,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -524,13 +551,22 @@
       "romanization": "",
       "gloss": "we'll meet again",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:777e27f1f2ba69c5",
-      "notice": null,
+      "sourceHash": "fnv1a64:e9a77070f795c048",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -551,7 +587,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/malayalam/narration/ch04.txt
+++ b/code/learning/human-languages/malayalam/narration/ch04.txt
@@ -1,9 +1,11 @@
 Malayalam, chapter 4: Chapter 4.
-5 lessons. All 5 can be done entirely by ear.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 5.
 നാളെ കാണാം (nāḷe kāṇāṁ) — "see you tomorrow".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -32,6 +34,8 @@ What are the two pieces of nāḷe kāṇāṁ, and what Dravidian sisters share
 Lesson 2 of 5.
 പോകുക (pōkuka) — "to go," and വരിക (to come).
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 Two everyday verbs — and together they make the Malayalam goodbye.
@@ -56,6 +60,8 @@ What ending marks a Malayalam infinitive, and why do you need both "go" and "com
 
 Lesson 3 of 5.
 പോയി വരാം (pōyi varāṁ) — "I'll go and come back".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -124,6 +130,8 @@ Why does Malayalam never say a plain "I'm leaving," and what does its everyday g
 
 Lesson 5 of 5.
 വീണ്ടും കാണാം (vīṇḍuṁ kāṇāṁ) — "we'll meet again".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/malayalam/narration/ch05.json
+++ b/code/learning/human-languages/malayalam/narration/ch05.json
@@ -3,8 +3,8 @@
   "language": "malayalam",
   "chapter": 5,
   "title": "Chapter 5",
-  "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:bcf5594822945cec",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:0bd13d76a6d2d33f",
   "lessons": [
     {
       "id": "ML-C05-joli-ceyyuka",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "to work (lit. \"work-do\")",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b5ecaf2fe0bba6f8",
-      "notice": null,
+      "sourceHash": "fnv1a64:31d528a76c0bd599",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -151,13 +160,22 @@
       "romanization": "",
       "gloss": "I speak Malayalam",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:34084bab8c366974",
-      "notice": null,
+      "sourceHash": "fnv1a64:b14fc6b48cd6b91d",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -178,7 +196,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -446,13 +464,22 @@
       "romanization": "",
       "gloss": "to speak, to converse",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:77bdc5ceae8db3cf",
-      "notice": null,
+      "sourceHash": "fnv1a64:1bdbc87303276fc6",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -473,7 +500,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -595,13 +622,22 @@
       "romanization": "",
       "gloss": "to live, to stay",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:130ecb3a14fa1f8c",
-      "notice": null,
+      "sourceHash": "fnv1a64:8af0e0a180efa543",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -622,7 +658,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/malayalam/narration/ch05.txt
+++ b/code/learning/human-languages/malayalam/narration/ch05.txt
@@ -1,9 +1,11 @@
 Malayalam, chapter 5: Chapter 5.
-5 lessons. All 5 can be done entirely by ear.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 5.
 ജോലി ചെയ്യുക (jōli ceyyuka) — "to work".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -37,6 +39,8 @@ How does Malayalam turn "work" into "to work," and which Tamil verb is its twin?
 
 Lesson 2 of 5.
 ഞാൻ മലയാളം സംസാരിക്കുന്നു (ñān malayāḷaṁ saṁsārikkunnu) — "I speak Malayalam".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -107,6 +111,8 @@ In one breath, say your language, your city, and your work in Malayalam — and 
 Lesson 4 of 5.
 സംസാരിക്കുക (saṁsārikkuka) — "to speak," your first full verb.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 So far, "to be." Here is a verb that does something — and it reveals the single strangest, simplest thing about Malayalam grammar.
@@ -142,6 +148,8 @@ How does the Malayalam verb change between "I speak" and "he speaks," and what d
 
 Lesson 5 of 5.
 താമസിക്കുക (tāmasikkuka) — "to live, to stay".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/marathi/narration/ch01.json
+++ b/code/learning/human-languages/marathi/narration/ch01.json
@@ -3,8 +3,8 @@
   "language": "marathi",
   "chapter": 1,
   "title": "Chapter 1",
-  "drivablePrefix": 7,
-  "sourceHash": "fnv1a64:f996ecda0ad9f9a1",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:07798362d454a9f2",
   "lessons": [
     {
       "id": "MR-C01-baram",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "okay / fine (baraṃ)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:470e64794fe70d13",
-      "notice": null,
+      "sourceHash": "fnv1a64:e8acc6d28293a532",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -119,13 +128,22 @@
       "romanization": "",
       "gloss": "thank you (dhanyavād)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:e2f0461be05fa928",
-      "notice": null,
+      "sourceHash": "fnv1a64:dff856539c02590f",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -146,7 +164,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -224,13 +242,22 @@
       "romanization": "",
       "gloss": "yes (ho)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:9c62989dc4fd723f",
-      "notice": null,
+      "sourceHash": "fnv1a64:1870ccc311c6214e",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -251,7 +278,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -329,13 +356,22 @@
       "romanization": "",
       "gloss": "no / is not (nāhī)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:efb26c1b9b2eb060",
-      "notice": null,
+      "sourceHash": "fnv1a64:014b65433ef4192f",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -356,7 +392,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -434,13 +470,22 @@
       "romanization": "",
       "gloss": "hello / goodbye (namaskār)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b39b9c3ee91f7d7d",
-      "notice": null,
+      "sourceHash": "fnv1a64:ac1642934e61a0cc",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -461,7 +506,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -681,13 +726,22 @@
       "romanization": "",
       "gloss": "\"I'll be going\" (yeto m. / yete f.)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:ebb2971ad7d6de75",
-      "notice": null,
+      "sourceHash": "fnv1a64:9860ee3897f812f0",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -708,7 +762,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/marathi/narration/ch01.txt
+++ b/code/learning/human-languages/marathi/narration/ch01.txt
@@ -1,9 +1,11 @@
 Marathi, chapter 1: Chapter 1.
-7 lessons. All 7 can be done entirely by ear.
+7 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 7.
 बरं (baraṃ) — "okay, fine".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -30,6 +32,8 @@ What does बरं mean, and what does the dot ं do? ("Okay/fine"; the anusv�
 Lesson 2 of 7.
 धन्यवाद (dhanyavād) — "thank you".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 The formal "thanks" — Sanskrit, shared across the Indian languages.
@@ -54,6 +58,8 @@ What are the two Sanskrit pieces of धन्यवाद, and a warmer Marathi 
 
 Lesson 3 of 7.
 हो (ho) — "yes".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -80,6 +86,8 @@ What is Marathi's "yes," and how does it differ from Hindi's? (ho; Hindi says h�
 Lesson 4 of 7.
 नाही (nāhī) — "no," a word older than English.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 The partner of ho — built on one of the oldest words in the whole Indo-European family.
@@ -104,6 +112,8 @@ What ancient root is नाही built on, and what English words share it? (PI
 
 Lesson 5 of 7.
 नमस्कार (namaskār) — "greetings".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -166,6 +176,8 @@ Next chapter: introducing yourself — mājhe nāv… ("my name…") — and Mar
 
 Lesson 7 of 7.
 येतो / येते (yeto / yete) — "I'll take my leave".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/marathi/narration/ch02.json
+++ b/code/learning/human-languages/marathi/narration/ch02.json
@@ -3,8 +3,8 @@
   "language": "marathi",
   "chapter": 2,
   "title": "Chapter 2",
-  "drivablePrefix": 9,
-  "sourceHash": "fnv1a64:a5335a4a839d6f4a",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:d7d34ac586baf0bb",
   "lessons": [
     {
       "id": "MR-C02-aahe",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "is (āhe)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:9705b53376844118",
-      "notice": null,
+      "sourceHash": "fnv1a64:6d76204e5a92182f",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -246,13 +255,22 @@
       "romanization": "",
       "gloss": "what (kāy)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:9860595f8229c2bb",
-      "notice": null,
+      "sourceHash": "fnv1a64:a3a3199a2f631da2",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -273,7 +291,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -362,13 +380,22 @@
       "romanization": "",
       "gloss": "my (mājhaṁ, neuter)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:11d3798fdcb2fa3b",
-      "notice": null,
+      "sourceHash": "fnv1a64:12147a7db0bc628e",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -389,7 +416,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -599,13 +626,22 @@
       "romanization": "",
       "gloss": "name (nāv)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:57b479b322914a69",
-      "notice": null,
+      "sourceHash": "fnv1a64:5c6ccd43c11eba92",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -626,7 +662,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -851,13 +887,22 @@
       "romanization": "",
       "gloss": "you (tū familiar / tumhī respectful)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:950c37e604cfe300",
-      "notice": null,
+      "sourceHash": "fnv1a64:8cd11b308e6ab1df",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -878,7 +923,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/marathi/narration/ch02.txt
+++ b/code/learning/human-languages/marathi/narration/ch02.txt
@@ -1,9 +1,11 @@
 Marathi, chapter 2: Chapter 2.
-9 lessons. All 9 can be done entirely by ear.
+9 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 9.
 आहे (āhe) — "is".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -61,6 +63,8 @@ Literally, what does a Marathi speaker say when meeting you? ("Having met you, j
 Lesson 3 of 9.
 काय (kāy) — "what".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 One more atom before the question "what's your name?" — the word what itself.
@@ -88,6 +92,8 @@ What do Marathi kāy, English what, and Latin quid share? (One PIE question-root
 
 Lesson 4 of 9.
 माझं (mājhaṁ) — "my".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -145,6 +151,8 @@ Put "my name is Arun" into Marathi. (mājhaṁ nāv Arun āhe.)
 
 Lesson 6 of 9.
 नाव (nāv) — "name".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -207,6 +215,8 @@ What two Marathi distinctives showed up again this chapter? (Three genders on m�
 
 Lesson 8 of 9.
 तू / तुम्ही (tū / tumhī) — "you".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/marathi/narration/ch03.json
+++ b/code/learning/human-languages/marathi/narration/ch03.json
@@ -3,8 +3,8 @@
   "language": "marathi",
   "chapter": 3,
   "title": "Chapter 3",
-  "drivablePrefix": 6,
-  "sourceHash": "fnv1a64:c164fc7244c4ec14",
+  "drivablePrefix": 1,
+  "sourceHash": "fnv1a64:4698352cdd6ad6ca",
   "lessons": [
     {
       "id": "MR-C03-kaahi-harkat-nahi",
@@ -142,13 +142,22 @@
       "romanization": "",
       "gloss": "how (kasā m. / kaśī f. / kasaṁ n.)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:39fd627bef914f90",
-      "notice": null,
+      "sourceHash": "fnv1a64:e695d0daa0640a61",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -169,7 +178,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -274,13 +283,22 @@
       "romanization": "",
       "gloss": "I (mī)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:bde9cf33ad91e0d8",
-      "notice": null,
+      "sourceHash": "fnv1a64:22844eecb06db04d",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -301,7 +319,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/marathi/narration/ch03.txt
+++ b/code/learning/human-languages/marathi/narration/ch03.txt
@@ -1,5 +1,5 @@
 Marathi, chapter 3: Chapter 3.
-6 lessons. All 6 can be done entirely by ear.
+6 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
 
 
 Lesson 1 of 6.
@@ -36,6 +36,8 @@ What two language families meet in kāhī harkat nāhī? (Indo-European nāhī f
 Lesson 2 of 6.
 कसा / कशी / कसं (kasā / kaśī / kasaṁ) — "how".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 The everyday "how are you?" needs one more k- question word — how. And, being an adjective-like word, it too carries gender.
@@ -67,6 +69,8 @@ Which "how" do you use asking a woman? (kaśī — feminine.)
 
 Lesson 3 of 6.
 मी (mī) — "I".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/marathi/narration/ch04.json
+++ b/code/learning/human-languages/marathi/narration/ch04.json
@@ -3,8 +3,8 @@
   "language": "marathi",
   "chapter": 4,
   "title": "Chapter 4",
-  "drivablePrefix": 6,
-  "sourceHash": "fnv1a64:909c1ade8961cad1",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:698a7e2e82e9ad58",
   "lessons": [
     {
       "id": "MR-C04-bhetu",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "(we'll) meet (bheṭū)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:221e44ca948216d3",
-      "notice": null,
+      "sourceHash": "fnv1a64:d2a93e1d9ba5feca",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -130,13 +139,22 @@
       "romanization": "",
       "gloss": "take care (kāḷjī ghyā)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:cdd2a126f3d44bb1",
-      "notice": null,
+      "sourceHash": "fnv1a64:2262fbdb932d7780",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -157,7 +175,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -378,13 +396,22 @@
       "romanization": "",
       "gloss": "again (punhā)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:7bd17775906f558d",
-      "notice": null,
+      "sourceHash": "fnv1a64:8fee2b0b32a934c4",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -405,7 +432,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -603,13 +630,22 @@
       "romanization": "",
       "gloss": "see you tomorrow (udyā bheṭū)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:9cf0d36c0711c94c",
-      "notice": null,
+      "sourceHash": "fnv1a64:97e1110a9c571d0b",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -630,7 +666,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/marathi/narration/ch04.txt
+++ b/code/learning/human-languages/marathi/narration/ch04.txt
@@ -1,9 +1,11 @@
 Marathi, chapter 4: Chapter 4.
-6 lessons. All 6 can be done entirely by ear.
+6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 6.
 भेटू (bheṭū) — "(let's / we'll) meet".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -32,6 +34,8 @@ What does bheṭū pack into one word? ("(we/let's) will meet" — the "we" live
 
 Lesson 2 of 6.
 काळजी घ्या (kāḷjī ghyā) — "take care".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -94,6 +98,8 @@ What do every Marathi goodbye have in common? (None says "farewell" — each is 
 Lesson 4 of 6.
 पुन्हा (punhā) — "again".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 Chapter 1 gave you the goodbye yeto ("I'll come [again]"). Now the explicit word for again, to build the warm "see you again."
@@ -147,6 +153,8 @@ What does punhā bheṭū literally promise? ("We'll meet again" — return, not
 
 Lesson 6 of 6.
 उद्या भेटू (udyā bheṭū) — "see you tomorrow".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/marathi/narration/ch05.json
+++ b/code/learning/human-languages/marathi/narration/ch05.json
@@ -3,8 +3,8 @@
   "language": "marathi",
   "chapter": 5,
   "title": "Chapter 5",
-  "drivablePrefix": 4,
-  "sourceHash": "fnv1a64:8fddef5ce8ffce13",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:03f79a98594f4da1",
   "lessons": [
     {
       "id": "MR-C05-bolne",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "to speak (bolṇe)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:33d723877a8f5454",
-      "notice": null,
+      "sourceHash": "fnv1a64:8e3878fbe5f91411",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -146,13 +155,22 @@
       "romanization": "",
       "gloss": "to work (kām karṇe)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:0d0e22db168d221b",
-      "notice": null,
+      "sourceHash": "fnv1a64:77068cc88a0a5570",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -173,7 +191,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -531,16 +549,20 @@
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
+        "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:f756499e45e3ad01",
+      "sourceHash": "fnv1a64:a5aee5a710cf9dc8",
       "notice": {
         "modality": "sight",
         "needs": [
+          "your eyes, for letter shapes on the page",
           "your eyes, because the lesson points at something written down"
         ],
-        "waitUntilStopped": [],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped."
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
       },
       "blocks": [
         {
@@ -562,7 +584,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/marathi/narration/ch05.txt
+++ b/code/learning/human-languages/marathi/narration/ch05.txt
@@ -1,9 +1,11 @@
 Marathi, chapter 5: Chapter 5.
-5 lessons. You can do the first 4 of them in the car; after that you will want to have stopped.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 5.
 बोलणे (bolṇe) — "to speak".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -36,6 +38,8 @@ What is the Marathi infinitive ending, and how does the present split? (-ṇe; t
 
 Lesson 2 of 5.
 काम करणे (kām karṇe) — "to work".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -130,7 +134,7 @@ What three things does the Marathi present tense fold into one word? (The action
 Lesson 5 of 5.
 राहणे (rāhṇe) — "to live, to stay".
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped.
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/punjabi/narration/ch01.json
+++ b/code/learning/human-languages/punjabi/narration/ch01.json
@@ -3,8 +3,8 @@
   "language": "punjabi",
   "chapter": 1,
   "title": "Chapter 1",
-  "drivablePrefix": 6,
-  "sourceHash": "fnv1a64:01fd22edaff3d7c7",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:03685e752baf67fe",
   "lessons": [
     {
       "id": "PA-C01-dhanvaad",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "thank you (Sanskritic) (dhannavād)",
       "script": "gurmukhi",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:e02b9f6b81ed66fd",
-      "notice": null,
+      "sourceHash": "fnv1a64:a89b857d7542da98",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -130,13 +139,22 @@
       "romanization": "",
       "gloss": "yes / no (hāṇ / nahīṇ)",
       "script": "gurmukhi",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:3f13af405d691e05",
-      "notice": null,
+      "sourceHash": "fnv1a64:711c263e7b6de012",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -157,7 +175,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -246,13 +264,22 @@
       "romanization": "",
       "gloss": "hello (general, pan-Indian) (namaste)",
       "script": "gurmukhi",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:857d62e029440681",
-      "notice": null,
+      "sourceHash": "fnv1a64:2e52f78d315f8fba",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -273,7 +300,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -541,13 +568,22 @@
       "romanization": "",
       "gloss": "hello / goodbye, the Sikh greeting (sat srī akāl)",
       "script": "gurmukhi",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:79c517eb855a8656",
-      "notice": null,
+      "sourceHash": "fnv1a64:093c9a80c31e6643",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -568,7 +604,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -673,13 +709,22 @@
       "romanization": "",
       "gloss": "thank you (Perso-Arabic) (shukrīā)",
       "script": "gurmukhi",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b9d7c0fda6bd2c48",
-      "notice": null,
+      "sourceHash": "fnv1a64:9d7714fe70dee67b",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -700,7 +745,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/punjabi/narration/ch01.txt
+++ b/code/learning/human-languages/punjabi/narration/ch01.txt
@@ -1,9 +1,11 @@
 Punjabi, chapter 1: Chapter 1.
-6 lessons. All 6 can be done entirely by ear.
+6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 6.
 ਧੰਨਵਾਦ (dhannavād) — "thank you," the Sanskrit way.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -33,6 +35,8 @@ What are the two Sanskrit parts of dhannavād, and which north-Indian languages 
 Lesson 2 of 6.
 ਹਾਂ / ਨਹੀਂ (hāṇ / nahīṇ) — "yes" and "no".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 Two tiny words you cannot hold a conversation without — and one of them is a cousin of English.
@@ -60,6 +64,8 @@ What ancient root links Punjabi nahīṇ to English no, and what does the bindi 
 
 Lesson 3 of 6.
 ਨਮਸਤੇ (namaste) — the shared greeting.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -130,6 +136,8 @@ Two speakers greet you: one folds their hands and says sat srī akāl, another s
 Lesson 5 of 6.
 ਸਤਿ ਸ੍ਰੀ ਅਕਾਲ (sat srī akāl) — the Sikh greeting.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 The first Punjabi words — and a greeting that is a small statement of faith.
@@ -161,6 +169,8 @@ What does the greeting literally declare, and what English word shares a root wi
 
 Lesson 6 of 6.
 ਸ਼ੁਕਰੀਆ (shukrīā) — "thank you," the Persian way.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/punjabi/narration/ch02.json
+++ b/code/learning/human-languages/punjabi/narration/ch02.json
@@ -3,8 +3,8 @@
   "language": "punjabi",
   "chapter": 2,
   "title": "Chapter 2",
-  "drivablePrefix": 9,
-  "sourceHash": "fnv1a64:e643cd66d39cebf5",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:3fcfc2e95caa5978",
   "lessons": [
     {
       "id": "PA-C02-hai",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "is",
       "script": "gurmukhi",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:94a70273d5e0a297",
-      "notice": null,
+      "sourceHash": "fnv1a64:922e7239562cb946",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -139,13 +148,22 @@
       "romanization": "",
       "gloss": "pleased to meet you (lit. \"happiness happened\")",
       "script": "gurmukhi",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:a9a4604f1fddeb5b",
-      "notice": null,
+      "sourceHash": "fnv1a64:2d68323af6b51fd6",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -166,7 +184,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -253,13 +271,22 @@
       "romanization": "",
       "gloss": "what",
       "script": "gurmukhi",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:99569178c1456ae2",
-      "notice": null,
+      "sourceHash": "fnv1a64:6fde17101437fdf7",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -280,7 +307,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -367,13 +394,22 @@
       "romanization": "",
       "gloss": "my",
       "script": "gurmukhi",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:9ef4c2bf734d4a52",
-      "notice": null,
+      "sourceHash": "fnv1a64:1750d6e42b415d7f",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -394,7 +430,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -597,13 +633,22 @@
       "romanization": "",
       "gloss": "name",
       "script": "gurmukhi",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8f5abaece205dd36",
-      "notice": null,
+      "sourceHash": "fnv1a64:6e4f130bce7c66bd",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -624,7 +669,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -872,13 +917,22 @@
       "romanization": "",
       "gloss": "you (familiar / respectful)",
       "script": "gurmukhi",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:583e3d8151cfcefc",
-      "notice": null,
+      "sourceHash": "fnv1a64:af3a545579ee1871",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -899,7 +953,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/punjabi/narration/ch02.txt
+++ b/code/learning/human-languages/punjabi/narration/ch02.txt
@@ -1,9 +1,11 @@
 Punjabi, chapter 2: Chapter 2.
-9 lessons. All 9 can be done entirely by ear.
+9 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 9.
 ਹੈ (hai) — "is," cousin of English is.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -35,6 +37,8 @@ What root is hai from, and where does the verb sit in a Punjabi sentence? (Sansk
 Lesson 2 of 9.
 ਖ਼ੁਸ਼ੀ ਹੋਈ (khushī hoī) — "pleased to meet you".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 The warm close of an introduction — and, like shukrīā, it comes from Persian, not Sanskrit.
@@ -62,6 +66,8 @@ What does the phrase literally mean, and where does khushī come from? ("Having 
 Lesson 3 of 9.
 ਕੀ (kī) — "what".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 The question-word — and it starts with the k- that heads nearly every Punjabi question.
@@ -88,6 +94,8 @@ What root do Punjabi's question-words share, and its English family? (The interr
 
 Lesson 4 of 9.
 ਮੇਰਾ (merā) — "my".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -143,6 +151,8 @@ Give your name in Punjabi, and say where the verb sits. (Merā nāṁ … hai; t
 
 Lesson 6 of 9.
 ਨਾਂ (nāṁ) — "name," a word older than Europe.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -207,6 +217,8 @@ Introduce yourself and ask a stranger's name in Punjabi. (Merā nāṁ … hai. 
 
 Lesson 8 of 9.
 ਤੂੰ / ਤੁਸੀਂ (tū̃ / tusī̃) — "you," familiar and respectful.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/punjabi/narration/ch03.json
+++ b/code/learning/human-languages/punjabi/narration/ch03.json
@@ -3,8 +3,8 @@
   "language": "punjabi",
   "chapter": 3,
   "title": "Chapter 3",
-  "drivablePrefix": 6,
-  "sourceHash": "fnv1a64:dd2fc76c2ba1f219",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:653a3e23669dcad9",
   "lessons": [
     {
       "id": "PA-C03-kivein",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "how",
       "script": "gurmukhi",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:4547db8d4b611a69",
-      "notice": null,
+      "sourceHash": "fnv1a64:fb0615eb3dc5a6d0",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -119,13 +128,22 @@
       "romanization": "",
       "gloss": "it's nothing / no problem / you're welcome",
       "script": "gurmukhi",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:9291a33bd7cea41e",
-      "notice": null,
+      "sourceHash": "fnv1a64:0ffbdb425dfe11b1",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -146,7 +164,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -233,13 +251,22 @@
       "romanization": "",
       "gloss": "I",
       "script": "gurmukhi",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:d4ab64d6e65f4aed",
-      "notice": null,
+      "sourceHash": "fnv1a64:0ab088277790b4ee",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -260,7 +287,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -528,13 +555,22 @@
       "romanization": "",
       "gloss": "fine, well — and the reply \"ਮੈਂ ਠੀਕ ਹਾਂ\"",
       "script": "gurmukhi",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:0f8400c16874910a",
-      "notice": null,
+      "sourceHash": "fnv1a64:aeae745d883bd1c5",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -555,7 +591,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/punjabi/narration/ch03.txt
+++ b/code/learning/human-languages/punjabi/narration/ch03.txt
@@ -1,9 +1,11 @@
 Punjabi, chapter 3: Chapter 3.
-6 lessons. All 6 can be done entirely by ear.
+6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 6.
 ਕਿਵੇਂ (kivēṁ) — "how," another of the k- questions.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -29,6 +31,8 @@ What root do Punjabi's question-words share, and its English family? (The interr
 
 Lesson 2 of 6.
 ਕੋਈ ਗੱਲ ਨਹੀਂ (koī gall nahīṁ) — "it's nothing".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -56,6 +60,8 @@ What does koī gall nahīṁ literally say, and which Chapter-1 word does it reu
 
 Lesson 3 of 6.
 ਮੈਂ (maiṁ) — "I," the m- of the first person.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -125,6 +131,8 @@ A stranger asks tusī̃ kivēṁ ho? — give a full, polite reply, and answer t
 
 Lesson 5 of 6.
 ਠੀਕ (ṭhīk) — "fine," and how to answer.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/punjabi/narration/ch04.json
+++ b/code/learning/human-languages/punjabi/narration/ch04.json
@@ -3,8 +3,8 @@
   "language": "punjabi",
   "chapter": 4,
   "title": "Chapter 4",
-  "drivablePrefix": 3,
-  "sourceHash": "fnv1a64:cd853793437ea4bb",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:9d2ba0448ca47532",
   "lessons": [
     {
       "id": "PA-C04-milaange",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "(we) will meet",
       "script": "gurmukhi",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:200d62f97be544c5",
-      "notice": null,
+      "sourceHash": "fnv1a64:f84a739655088280",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -130,13 +139,22 @@
       "romanization": "",
       "gloss": "again, then",
       "script": "gurmukhi",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:6722c4e1f0152c37",
-      "notice": null,
+      "sourceHash": "fnv1a64:c5e8584e9954c824",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -157,7 +175,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -502,13 +520,22 @@
       "romanization": "",
       "gloss": "goodbye (lit. \"God [be your] keeper\")",
       "script": "gurmukhi",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:e5c05a7f3f239a7e",
-      "notice": null,
+      "sourceHash": "fnv1a64:ee53d2792100e157",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -529,7 +556,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/punjabi/narration/ch04.txt
+++ b/code/learning/human-languages/punjabi/narration/ch04.txt
@@ -1,9 +1,11 @@
 Punjabi, chapter 4: Chapter 4.
-5 lessons. You can do the first 3 of them in the car; after that you will want to have stopped.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 5.
 ਮਿਲਾਂਗੇ (milāṁge) — "(we) will meet".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -32,6 +34,8 @@ What verb is milāṁge from, and how does Punjabi mark "will"? (Milṇā "to me
 
 Lesson 2 of 5.
 ਫਿਰ (phir) — "again," the seed of "see you again".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -119,6 +123,8 @@ You're leaving a friend and expect to see them soon. Give the warm goodbye, then
 
 Lesson 5 of 5.
 ਰੱਬ ਰਾਖਾ (rabb rākhā) — "God keep you".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/punjabi/narration/ch05.json
+++ b/code/learning/human-languages/punjabi/narration/ch05.json
@@ -3,8 +3,8 @@
   "language": "punjabi",
   "chapter": 5,
   "title": "Chapter 5",
-  "drivablePrefix": 4,
-  "sourceHash": "fnv1a64:b725380704b3457e",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:25a70d4ed764c8eb",
   "lessons": [
     {
       "id": "PA-C05-bolna",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "to speak",
       "script": "gurmukhi",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:f646adc390acda0f",
-      "notice": null,
+      "sourceHash": "fnv1a64:307dfe45fa3042e4",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -139,13 +148,22 @@
       "romanization": "",
       "gloss": "to work (lit. \"work-do\")",
       "script": "gurmukhi",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:f0b27b4137063cd5",
-      "notice": null,
+      "sourceHash": "fnv1a64:f9467160d95bc6b0",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -166,7 +184,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -265,13 +283,22 @@
       "romanization": "",
       "gloss": "I speak Punjabi (gendered)",
       "script": "gurmukhi",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:d794001d662e05af",
-      "notice": null,
+      "sourceHash": "fnv1a64:f4f87d3d34970a4c",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -292,7 +319,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -565,16 +592,20 @@
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
+        "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:084fbd009af99704",
+      "sourceHash": "fnv1a64:78cb36385d3494ad",
       "notice": {
         "modality": "sight",
         "needs": [
+          "your eyes, for letter shapes on the page",
           "your eyes, because the lesson points at something written down"
         ],
-        "waitUntilStopped": [],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped."
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
       },
       "blocks": [
         {
@@ -596,7 +627,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/punjabi/narration/ch05.txt
+++ b/code/learning/human-languages/punjabi/narration/ch05.txt
@@ -1,9 +1,11 @@
 Punjabi, chapter 5: Chapter 5.
-5 lessons. You can do the first 4 of them in the car; after that you will want to have stopped.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 5.
 ਬੋਲਣਾ (bolṇā) — "to speak," your first full verb.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -35,6 +37,8 @@ What ending does a Punjabi infinitive carry, and what is bolṇā's stem? (-ṇ�
 Lesson 2 of 5.
 ਕੰਮ ਕਰਨਾ (kamm karnā) — "to work".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 The last verb of the chapter — and its root already sits inside a Chapter-1 word.
@@ -64,6 +68,8 @@ What Sanskrit root is karnā from, and name a Chapter-1 word built on it. (√k�
 
 Lesson 3 of 5.
 ਮੈਂ ਪੰਜਾਬੀ ਬੋਲਦਾ ਹਾਂ (maiṁ panjābī boldā hāṁ) — "I speak Punjabi".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -135,7 +141,7 @@ In one breath, tell me your language, your city, and your work in Punjabi (as a 
 Lesson 5 of 5.
 ਰਹਿਣਾ (rahiṇā) — "to live, to stay".
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped.
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/russian/narration/ch01.json
+++ b/code/learning/human-languages/russian/narration/ch01.json
@@ -3,8 +3,8 @@
   "language": "russian",
   "chapter": 1,
   "title": "Chapter 1",
-  "drivablePrefix": 7,
-  "sourceHash": "fnv1a64:945bc040fc4ba72c",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:666276e1d698f4d5",
   "lessons": [
     {
       "id": "RU-C01-da",
@@ -14,17 +14,26 @@
       "romanization": "da",
       "gloss": "yes (da)",
       "script": "cyrillic",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:ad76bd6ec3c7ff35",
-      "notice": null,
+      "sourceHash": "fnv1a64:fcaf3fa3908abd78",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -162,13 +171,22 @@
       "romanization": "nyet",
       "gloss": "no (nyet)",
       "script": "cyrillic",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:9be8d98be29726be",
-      "notice": null,
+      "sourceHash": "fnv1a64:1bb4f36be79471f9",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -183,7 +201,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -325,13 +343,22 @@
       "romanization": "pozhálusta",
       "gloss": "please / you're welcome (pozhálusta)",
       "script": "cyrillic",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:ca51aaccb8210809",
-      "notice": null,
+      "sourceHash": "fnv1a64:7022b561af758fe6",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -346,7 +373,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -683,13 +710,22 @@
       "romanization": "privét",
       "gloss": "hi / hello (privét — informal)",
       "script": "cyrillic",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:1d62d9b457dff8fb",
-      "notice": null,
+      "sourceHash": "fnv1a64:8258d0d87859c9ea",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -710,7 +746,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -875,13 +911,22 @@
       "romanization": "spasíbo",
       "gloss": "thank you (spasíbo)",
       "script": "cyrillic",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8d9039e851a00c86",
-      "notice": null,
+      "sourceHash": "fnv1a64:007b0e31e887f8eb",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -896,7 +941,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -1073,13 +1118,22 @@
       "romanization": "zdrávstvuyte",
       "gloss": "hello (zdrávstvuyte — formal / polite)",
       "script": "cyrillic",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:695f02ad0b38c149",
-      "notice": null,
+      "sourceHash": "fnv1a64:1129d225cc1a7f6e",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -1094,7 +1148,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/russian/narration/ch01.txt
+++ b/code/learning/human-languages/russian/narration/ch01.txt
@@ -1,9 +1,11 @@
 Russian, chapter 1: Chapter 1.
-12 lessons. You can do the first 7 of them in the car; after that you will want to have stopped.
+12 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 12.
 да (da) — "yes".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 The letters in this word.
 (Skim if you read Cyrillic.) Just two, both already familiar from здравствуйте (zdrávstvuyte): д (d, from Greek delta Δ) + а (a, as in father).
@@ -40,6 +42,8 @@ Read да (da). Two letters — name their sounds (d, a). Besides "yes," what el
 
 Lesson 2 of 12.
 нет (nyet) — "no," literally "there-is-not".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 You'll want to know first.
 да (da) — its opposite, learned together as a pair.
@@ -80,6 +84,8 @@ Read нет (nyet). What clause is it worn down from? (не + есть, "not is.
 
 Lesson 3 of 12.
 пожалуйста (pozhálusta) — "please," and also "you're welcome".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 You'll want to know first.
 спасибо (spasíbo) — this is its natural partner: спасибо (spasíbo) becomes пожалуйста (pozhálusta) is Russia's "thank you" becomes "you're welcome."
@@ -169,6 +175,8 @@ Without looking: which greeting is formal and which is informal? (здравст
 Lesson 5 of 12.
 привет (privét) — "hi," the everyday hello.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 Your first Russian word and Cyrillic letters. Several shapes are false friends that look Latin but sound different; meet them head-on.
@@ -215,6 +223,8 @@ Read привет (privét). What do в and р each sound like (v and r — the 
 
 Lesson 6 of 12.
 спасибо (spasíbo) — "God save you," now just "thanks".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 You'll want to know first.
 привет (privét) for с=s (false friend), and to contrast б (b) with the в (v) you met there.
@@ -264,6 +274,8 @@ Read спасибо (spasíbo). What two words is it worn down from, and what do
 
 Lesson 7 of 12.
 здравствуйте (zdrávstvuyte) — "be healthy," the formal hello.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 You'll want to know first.
 the привет (privét) lesson — this is its formal opposite, and it reuses в=v, е=ye, т=t, р=r from there.

--- a/code/learning/human-languages/sanskrit/narration/ch01.json
+++ b/code/learning/human-languages/sanskrit/narration/ch01.json
@@ -3,8 +3,8 @@
   "language": "sanskrit",
   "chapter": 1,
   "title": "Chapter 1",
-  "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:d7cbcfae685a6ecc",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:aad0ad5150f2038b",
   "lessons": [
     {
       "id": "SA-C01-am-na",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "yes / no (ām / na)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:f4a152c82fb187c0",
-      "notice": null,
+      "sourceHash": "fnv1a64:487c7a73e21f5983",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -139,13 +148,22 @@
       "romanization": "",
       "gloss": "thank you (dhanyavādaḥ)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:2c0c2b15ff204ffd",
-      "notice": null,
+      "sourceHash": "fnv1a64:ea7c7dc97c584b3a",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -166,7 +184,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -271,16 +289,20 @@
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
+        "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:c198ab8f8bcbd456",
+      "sourceHash": "fnv1a64:a0eb563a777d2f13",
       "notice": {
         "modality": "sight",
         "needs": [
+          "your eyes, for letter shapes on the page",
           "your eyes, because the lesson points at something written down"
         ],
-        "waitUntilStopped": [],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped."
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
       },
       "blocks": [
         {
@@ -302,7 +324,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -400,13 +422,22 @@
       "romanization": "",
       "gloss": "hello (lit. \"a bow to you\") (namaste)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:924cb760b6a2268d",
-      "notice": null,
+      "sourceHash": "fnv1a64:727560286d972f72",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -427,7 +458,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -721,13 +752,22 @@
       "romanization": "",
       "gloss": "welcome (lit. \"well come\") (svāgatam)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:e7db6ac32473eeec",
-      "notice": null,
+      "sourceHash": "fnv1a64:cbf7ca601bf00a4f",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -748,7 +788,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/sanskrit/narration/ch01.txt
+++ b/code/learning/human-languages/sanskrit/narration/ch01.txt
@@ -1,9 +1,11 @@
 Sanskrit, chapter 1: Chapter 1.
-6 lessons. You can do the first 2 of them in the car; after that you will want to have stopped.
+6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 6.
 आम् / न (ām / na) — "yes" and "no".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -34,6 +36,8 @@ What is the ancient root of na, and name three of its living cousins. (PIE ne "n
 
 Lesson 2 of 6.
 धन्यवादः (dhanyavādaḥ) — "thank you".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -66,7 +70,7 @@ Dhanyavāda is built from which two parts, and what modern greeting descends fro
 Lesson 3 of 6.
 नमस्कारः (namaskāraḥ) — the fuller form.
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped.
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -97,6 +101,8 @@ Namaskāra is built from which two parts, and what does its visarga ending tell 
 
 Lesson 4 of 6.
 नमस्ते (namaste) — "I bow to you".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -172,6 +178,8 @@ In 1786 Sir William Jones said Sanskrit, Latin, and Greek shared "a stronger aff
 
 Lesson 6 of 6.
 स्वागतम् (svāgatam) — "welcome".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/sanskrit/narration/ch02.json
+++ b/code/learning/human-languages/sanskrit/narration/ch02.json
@@ -3,8 +3,8 @@
   "language": "sanskrit",
   "chapter": 2,
   "title": "Chapter 2",
-  "drivablePrefix": 8,
-  "sourceHash": "fnv1a64:874f4d8be76423e5",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:bb5a242c96a6f6d0",
   "lessons": [
     {
       "id": "SA-C02-anandah",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "joy — and \"meeting you is a joy\"",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:4635ee97b52ef681",
-      "notice": null,
+      "sourceHash": "fnv1a64:e8e0fd6673d824d6",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -128,13 +137,22 @@
       "romanization": "",
       "gloss": "is",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:89c0326f11abfda3",
-      "notice": null,
+      "sourceHash": "fnv1a64:9088728915fcc1e6",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -155,7 +173,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -233,13 +251,22 @@
       "romanization": "",
       "gloss": "you (respectful / familiar)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:aef0f87d889406aa",
-      "notice": null,
+      "sourceHash": "fnv1a64:5f68b66f9b279a71",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -260,7 +287,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -358,13 +385,22 @@
       "romanization": "",
       "gloss": "what",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:677c26e53142f872",
-      "notice": null,
+      "sourceHash": "fnv1a64:4e40385ad96c7c3b",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -385,7 +421,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -472,13 +508,22 @@
       "romanization": "",
       "gloss": "my",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:e012f4f4c7b19e80",
-      "notice": null,
+      "sourceHash": "fnv1a64:19cf8b63960c764f",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -499,7 +544,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -682,13 +727,22 @@
       "romanization": "",
       "gloss": "name",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c682947246b38ec9",
-      "notice": null,
+      "sourceHash": "fnv1a64:dd8f39ca044c965c",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -709,7 +763,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/sanskrit/narration/ch02.txt
+++ b/code/learning/human-languages/sanskrit/narration/ch02.txt
@@ -1,9 +1,11 @@
 Sanskrit, chapter 2: Chapter 2.
-8 lessons. All 8 can be done entirely by ear.
+8 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 8.
 आनन्दः (ānandaḥ) — "joy," and "a joy to meet you".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -32,6 +34,8 @@ What does ānandaḥ mean, and what is it built from? ("Joy, bliss"; ā- "fully"
 Lesson 2 of 8.
 अस्ति (asti) — "is," the ancestor of is and est.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 The little verb "is" — and here you meet it in the form that fathered half the "to be" words on earth.
@@ -56,6 +60,8 @@ What root is asti from, and its cousins across the family? (As- / PIE h₁es-; E
 
 Lesson 3 of 8.
 भवान् / त्वम् (bhavān / tvam) — "you," respectful and familiar.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -87,6 +93,8 @@ Which "you" is respectful, and what English word is tvam cousin to? (Bhavān —
 Lesson 4 of 8.
 किम् (kim) — "what," the source of the question-words.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 The question-word — and the fountainhead of a whole family of "wh-" words, east and west.
@@ -113,6 +121,8 @@ What PIE root is kim from, and its cousins? (kʷo-; English what, Latin quis, Hi
 
 Lesson 5 of 8.
 मम (mama) — "my," the ancestor of me and my.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -163,6 +173,8 @@ Give your name in Sanskrit, and say what it keeps that Tamil and Bengali drop. (
 
 Lesson 7 of 8.
 नाम (nāma) — "name," the source of a word half the world shares.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/sanskrit/narration/ch03.json
+++ b/code/learning/human-languages/sanskrit/narration/ch03.json
@@ -3,8 +3,8 @@
   "language": "sanskrit",
   "chapter": 3,
   "title": "Chapter 3",
-  "drivablePrefix": 6,
-  "sourceHash": "fnv1a64:0294567d2aa4f6ee",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:dcf6cb6bc6f91b5c",
   "lessons": [
     {
       "id": "SA-C03-aham",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "I",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:d5ac8458c8c04d4b",
-      "notice": null,
+      "sourceHash": "fnv1a64:45944c82838832c8",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -253,13 +262,22 @@
       "romanization": "",
       "gloss": "how",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:9f33ba19199bd217",
-      "notice": null,
+      "sourceHash": "fnv1a64:656fec3705a363e8",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -280,7 +298,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -358,13 +376,22 @@
       "romanization": "",
       "gloss": "well-being — and the reply \"अहं कुशली अस्मि\"",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8b8e0008fd9fc833",
-      "notice": null,
+      "sourceHash": "fnv1a64:3fe117d8b3a2e1c0",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -385,7 +412,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -487,13 +514,22 @@
       "romanization": "",
       "gloss": "no worry / it's nothing / you're welcome",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:d9502af13d3fdfe7",
-      "notice": null,
+      "sourceHash": "fnv1a64:3b49148c41bacfa4",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -514,7 +550,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/sanskrit/narration/ch03.txt
+++ b/code/learning/human-languages/sanskrit/narration/ch03.txt
@@ -1,9 +1,11 @@
 Sanskrit, chapter 3: Chapter 3.
-6 lessons. All 6 can be done entirely by ear.
+6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 6.
 अहम् (aham) — "I," the ancestor of ego and I.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -62,6 +64,8 @@ Why is it asti ("is") with bhavān, and what are the three copula forms? (Bhavā
 Lesson 3 of 6.
 कथम् (katham) — "how," another of the ka- questions.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 You met किम् (kim, "what") in Chapter 2. Here is its sibling in the question-family.
@@ -86,6 +90,8 @@ What root do Sanskrit's question-words share, and its western cousins? (The inte
 
 Lesson 4 of 6.
 कुशलम् (kuśalam) — "well-being," and how to answer.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -117,6 +123,8 @@ Give the reply to bhavān katham asti?, and kuśalam's surprising origin. (Aha�
 
 Lesson 5 of 6.
 न चिन्ता (na cintā) — "no worry".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/sanskrit/narration/ch04.json
+++ b/code/learning/human-languages/sanskrit/narration/ch04.json
@@ -3,8 +3,8 @@
   "language": "sanskrit",
   "chapter": 4,
   "title": "Chapter 4",
-  "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:0d47b72b02c0839e",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:f28a789d74943117",
   "lessons": [
     {
       "id": "SA-C04-gacchami",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "I go (a way to take leave)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:fa1664721e8e4a99",
-      "notice": null,
+      "sourceHash": "fnv1a64:b682dedfea2ec53e",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -289,13 +298,22 @@
       "romanization": "",
       "gloss": "again",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:0c76a9a313171c2a",
-      "notice": null,
+      "sourceHash": "fnv1a64:ca5312471924cfcf",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -316,7 +334,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -394,13 +412,22 @@
       "romanization": "",
       "gloss": "until we meet again (lit. \"for seeing again\")",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:6ba524c037c5a6dd",
-      "notice": null,
+      "sourceHash": "fnv1a64:c01517255bb7ee88",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -421,7 +448,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -519,13 +546,22 @@
       "romanization": "",
       "gloss": "tomorrow — and \"see you tomorrow\"",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:db019743f5cfaf71",
-      "notice": null,
+      "sourceHash": "fnv1a64:4ded4e8244e80298",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -546,7 +582,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/sanskrit/narration/ch04.txt
+++ b/code/learning/human-languages/sanskrit/narration/ch04.txt
@@ -1,9 +1,11 @@
 Sanskrit, chapter 4: Chapter 4.
-5 lessons. All 5 can be done entirely by ear.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 5.
 गच्छामि (gacchāmi) — "I go" (taking leave).
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -69,6 +71,8 @@ You're taking leave and expect to see someone tomorrow. Give the graceful goodby
 Lesson 3 of 5.
 पुनः (punaḥ) — "again," the seed of "till we meet again".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 One small word turns a leave-taking into a promise of return.
@@ -93,6 +97,8 @@ What does punaḥ mean, and what is its combining form? ("Again"; punar-, as in 
 
 Lesson 4 of 5.
 पुनर्दर्शनाय (punar-darśanāya) — "until we meet again".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -123,6 +129,8 @@ What does punar-darśanāya literally mean, and what case gives the "for"? ("For
 
 Lesson 5 of 5.
 श्वः (śvaḥ) — "tomorrow".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/sanskrit/narration/ch05.json
+++ b/code/learning/human-languages/sanskrit/narration/ch05.json
@@ -3,8 +3,8 @@
   "language": "sanskrit",
   "chapter": 5,
   "title": "Chapter 5",
-  "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:847f27ccd51242f5",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:45070b3634ab6b25",
   "lessons": [
     {
       "id": "SA-C05-aham-samskritam-vadami",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "I speak Sanskrit",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:d79162bbb5b45307",
-      "notice": null,
+      "sourceHash": "fnv1a64:6ce6fe49bf237194",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -139,13 +148,22 @@
       "romanization": "",
       "gloss": "I do, I make (कार्यं करोमि, \"I work\")",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c3654ce94d03fb8b",
-      "notice": null,
+      "sourceHash": "fnv1a64:06c187eb35a64186",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -166,7 +184,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -439,13 +457,22 @@
       "romanization": "",
       "gloss": "I speak (from वद्, to speak)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:0b6ba48b6a53454a",
-      "notice": null,
+      "sourceHash": "fnv1a64:dab4cb61ca2e0775",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -466,7 +493,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -583,13 +610,22 @@
       "romanization": "",
       "gloss": "I live, I dwell (from वस्, to dwell)",
       "script": "devanagari",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:89ebfed68ce2c42e",
-      "notice": null,
+      "sourceHash": "fnv1a64:d03f17265b4a3ef7",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -610,7 +646,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/sanskrit/narration/ch05.txt
+++ b/code/learning/human-languages/sanskrit/narration/ch05.txt
@@ -1,9 +1,11 @@
 Sanskrit, chapter 5: Chapter 5.
-5 lessons. All 5 can be done entirely by ear.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 5.
 अहं संस्कृतं वदामि (ahaṁ saṁskṛtaṁ vadāmi) — "I speak Sanskrit".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -34,6 +36,8 @@ Say "I speak Sanskrit," and unpack the name. (Ahaṁ saṁskṛtaṁ vadāmi; sa
 
 Lesson 2 of 5.
 करोमि (karomi) — "I do," from the root behind karma and namaskāra.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -105,6 +109,8 @@ In one breath, say your language, your city, and your work in Sanskrit — then 
 Lesson 4 of 5.
 वदामि (vadāmi) — "I speak," and the Sanskrit verb.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 So far, "to be." Here is a verb that acts — and it reveals the most famous feature of the Sanskrit verb: it counts to three.
@@ -139,6 +145,8 @@ What root is vadāmi from, and what third "number" does Sanskrit have that Engli
 
 Lesson 5 of 5.
 वसामि (vasāmi) — "I live, I dwell".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/tamil/narration/ch01.json
+++ b/code/learning/human-languages/tamil/narration/ch01.json
@@ -4,7 +4,7 @@
   "chapter": 1,
   "title": "Greetings",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:84f0b9839e6e01b9",
+  "sourceHash": "fnv1a64:b80adea0055c5306",
   "lessons": [
     {
       "id": "TA-W01-curves-va-ka",
@@ -1350,16 +1350,20 @@
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
+        "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:2d5faca18cc1086b",
+      "sourceHash": "fnv1a64:5971b60f9445ebba",
       "notice": {
         "modality": "sight",
         "needs": [
+          "your eyes, for letter shapes on the page",
           "your eyes, because the lesson points at something written down"
         ],
-        "waitUntilStopped": [],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped."
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
       },
       "blocks": [
         {
@@ -1381,7 +1385,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -1495,13 +1499,22 @@
       "romanization": "",
       "gloss": "no / there isn't (illai — the negative)",
       "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8ba581d5f20e88ef",
-      "notice": null,
+      "sourceHash": "fnv1a64:eb7d4be5afd2b4a8",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -1522,7 +1535,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -1656,13 +1669,22 @@
       "romanization": "",
       "gloss": "thank you (naṉṟi — \"goodness, gratitude\")",
       "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8ea833da2a696d9e",
-      "notice": null,
+      "sourceHash": "fnv1a64:e3b598578abbeee7",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -1683,7 +1705,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -2106,13 +2128,22 @@
       "romanization": "",
       "gloss": "okay / alright / correct (sari)",
       "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:aad4a63947d1d3ef",
-      "notice": null,
+      "sourceHash": "fnv1a64:8abff912866c6ae0",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -2133,7 +2164,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -2247,13 +2278,22 @@
       "romanization": "",
       "gloss": "hello / greetings (vaṇakkam — \"reverence, homage\")",
       "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:0d3f5255c32d643c",
-      "notice": null,
+      "sourceHash": "fnv1a64:4c4fa4af1fcb85dd",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -2274,7 +2314,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/tamil/narration/ch01.txt
+++ b/code/learning/human-languages/tamil/narration/ch01.txt
@@ -299,7 +299,7 @@ What are a consonant's three vowel choices? (Keep inherent a, remove it with pu�
 Lesson 9 of 16.
 ஆம் (ām) — "yes".
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped.
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -334,6 +334,8 @@ Read ஆம். Why is ஆ a full vowel letter rather than a vowel sign? (The wo
 
 Lesson 10 of 16.
 இல்லை (illai) — "no," and how Tamil says a thing is not.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -373,6 +375,8 @@ Read இல்லை. Literally, is it closer to "no" or to "is not"? ("Is not /
 
 Lesson 11 of 16.
 நன்றி (naṉṟi) — "thank you," literally "goodness".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -486,6 +490,8 @@ Next chapter: introducing yourself — en peyar… ("my name…"), and Tamil's n
 Lesson 14 of 16.
 சரி (sari) — "okay," the word that oils every conversation.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 If ām is "yes" and illai is "no," sari is the easy middle: "okay, alright, fine, agreed." You'll hear it constantly — and it hides a neat fact about the Tamil alphabet.
@@ -519,6 +525,8 @@ Read சரி. What does it literally mean, and what does it do in conversation
 
 Lesson 15 of 16.
 வணக்கம் (vaṇakkam) — "greetings," a small act of respect.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/tamil/narration/ch02.json
+++ b/code/learning/human-languages/tamil/narration/ch02.json
@@ -3,8 +3,8 @@
   "language": "tamil",
   "chapter": 2,
   "title": "Chapter 2",
-  "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:ff99e97b090b9e65",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:4a88253cf308c812",
   "lessons": [
     {
       "id": "TA-C02-en",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "my",
       "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:4002a4a576358ffd",
-      "notice": null,
+      "sourceHash": "fnv1a64:a21db6ae59748a32",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -239,13 +248,22 @@
       "romanization": "",
       "gloss": "what",
       "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:2f95aecc89663aa8",
-      "notice": null,
+      "sourceHash": "fnv1a64:25fcc38dc3c7e5ad",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -266,7 +284,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -449,13 +467,22 @@
       "romanization": "",
       "gloss": "you (familiar / respectful)",
       "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c88dc2f79e9b71c7",
-      "notice": null,
+      "sourceHash": "fnv1a64:777a927ff6b68192",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -476,7 +503,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -565,13 +592,22 @@
       "romanization": "",
       "gloss": "name",
       "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:1afc0f924cfcdc99",
-      "notice": null,
+      "sourceHash": "fnv1a64:f21262c05a8174ac",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -592,7 +628,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/tamil/narration/ch02.txt
+++ b/code/learning/human-languages/tamil/narration/ch02.txt
@@ -1,9 +1,11 @@
 Tamil, chapter 2: Chapter 2.
-8 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
+8 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 8.
 என் (eṉ) — "my".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -59,6 +61,8 @@ Give your name in Tamil. (Eṉ peyar ….) What does Tamil leave out that Englis
 Lesson 3 of 8.
 என்ன (eṉṉa) — "what".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 The last piece of the question: "what."
@@ -109,6 +113,8 @@ What does மகிழ்ச்சி mean and from what verb? ("Joy," from magi
 Lesson 5 of 8.
 நீ / நீங்கள் (nī / nīṅgaḷ) — "you," familiar and respectful.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 To ask a name you need "you" — and Tamil makes respect the same way French does.
@@ -136,6 +142,8 @@ How does Tamil make "you" respectful, and which European language uses the same 
 
 Lesson 6 of 8.
 பெயர் (peyar) — "name," where the family is not Indo-European.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/tamil/narration/ch03.json
+++ b/code/learning/human-languages/tamil/narration/ch03.json
@@ -3,8 +3,8 @@
   "language": "tamil",
   "chapter": 3,
   "title": "Chapter 3",
-  "drivablePrefix": 6,
-  "sourceHash": "fnv1a64:f8cfd6742c9fe44b",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:8ccf2dad23d346e7",
   "lessons": [
     {
       "id": "TA-C03-eppadi",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "how",
       "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:9a6acf5b5ed9ca1e",
-      "notice": null,
+      "sourceHash": "fnv1a64:115a665d0b5ae3db",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -128,13 +137,22 @@
       "romanization": "",
       "gloss": "how are you? (respectful)",
       "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:f599daa3f8cf668f",
-      "notice": null,
+      "sourceHash": "fnv1a64:54b96e84af48f100",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -155,7 +173,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -261,13 +279,22 @@
       "romanization": "",
       "gloss": "I",
       "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:7e2890d9f38c9587",
-      "notice": null,
+      "sourceHash": "fnv1a64:bf125d1e56b58ba0",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -288,7 +315,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -386,13 +413,22 @@
       "romanization": "",
       "gloss": "well, wellness, good — and the reply \"நான் நலமாக இருக்கிறேன்\"",
       "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:28b2f4ba162bdadf",
-      "notice": null,
+      "sourceHash": "fnv1a64:7085a36204532448",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -413,7 +449,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -519,13 +555,22 @@
       "romanization": "",
       "gloss": "it's okay / no problem / you're welcome",
       "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:2c5f0520a471a9e2",
-      "notice": null,
+      "sourceHash": "fnv1a64:706b526524e2e1ab",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -546,7 +591,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/tamil/narration/ch03.txt
+++ b/code/learning/human-languages/tamil/narration/ch03.txt
@@ -1,9 +1,11 @@
 Tamil, chapter 3: Chapter 3.
-6 lessons. All 6 can be done entirely by ear.
+6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 6.
 எப்படி (eppaḍi) — "how," another of the e- questions.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -31,6 +33,8 @@ What base do Tamil's question-words share, and how is it different from Hindi's?
 
 Lesson 2 of 6.
 நீங்கள் எப்படி இருக்கிறீர்கள்? (nīṅgaḷ eppaḍi irukkiṟīrgaḷ?) — how are you? (respectful).
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -64,6 +68,8 @@ What verb does "how are you?" use, and why does this sentence need one when "my 
 Lesson 3 of 6.
 நான் (nāṉ) — "I," the Dravidian first person.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 To answer "how are you?" you first need "I." In Chapter 2 you learned eṉ ("my"); here is its owner.
@@ -93,6 +99,8 @@ What is nāṉ's possessive, and is it cousin to English me? (Eṉ, "my"; no —
 
 Lesson 4 of 6.
 நலம் (nalam) — "well," and how to answer.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -125,6 +133,8 @@ Give the full reply to "how are you?", and name the Chapter-1 word that shares n
 
 Lesson 5 of 6.
 பரவாயில்லை (paravāyillai) — "no problem".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/tamil/narration/ch04.json
+++ b/code/learning/human-languages/tamil/narration/ch04.json
@@ -3,8 +3,8 @@
   "language": "tamil",
   "chapter": 4,
   "title": "Chapter 4",
-  "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:c8db7d90878a9d80",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:e6cc92ef0275935e",
   "lessons": [
     {
       "id": "TA-C04-mindum-sandippom",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "we'll meet again",
       "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:21967926008e7f2a",
-      "notice": null,
+      "sourceHash": "fnv1a64:2bd30145a8a3485b",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -131,13 +140,22 @@
       "romanization": "",
       "gloss": "see you tomorrow",
       "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c0d1729df2afa26a",
-      "notice": null,
+      "sourceHash": "fnv1a64:46d7d64986982553",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -158,7 +176,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -245,13 +263,22 @@
       "romanization": "",
       "gloss": "to go (and வா, to come)",
       "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:5f85b3ab22d90337",
-      "notice": null,
+      "sourceHash": "fnv1a64:99257b30e11fb454",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -272,7 +299,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -350,13 +377,22 @@
       "romanization": "",
       "gloss": "goodbye (lit. \"I'll go and come back\")",
       "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:fbad061f7ef31b3f",
-      "notice": null,
+      "sourceHash": "fnv1a64:f14e5eedd7053032",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -377,7 +413,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/tamil/narration/ch04.txt
+++ b/code/learning/human-languages/tamil/narration/ch04.txt
@@ -1,9 +1,11 @@
 Tamil, chapter 4: Chapter 4.
-5 lessons. All 5 can be done entirely by ear.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 5.
 மீண்டும் சந்திப்போம் (mīṇḍum sandippōm) — "we'll meet again".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -33,6 +35,8 @@ What does the phrase mean, and which of its two words is the Sanskrit loan? ("We
 Lesson 2 of 5.
 நாளை பார்க்கலாம் (nāḷai pārkkalām) — "see you tomorrow".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 A goodbye with a date on it — built on the Tamil word for "day."
@@ -60,6 +64,8 @@ What does nāḷai come from, and what does pārkkalām add? (Nāḷ, "day"; "le
 Lesson 3 of 5.
 போ (pō) — "go," and வா (come).
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 Two of the shortest, oldest verbs in Tamil — and together they make the Tamil goodbye.
@@ -84,6 +90,8 @@ What do pō and vā mean, and why will you need them both to say goodbye? ("Go" 
 
 Lesson 4 of 5.
 போய் வருகிறேன் (pōy varugiṟēṉ) — "I'll go and come back".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/tamil/narration/ch05.json
+++ b/code/learning/human-languages/tamil/narration/ch05.json
@@ -3,8 +3,8 @@
   "language": "tamil",
   "chapter": 5,
   "title": "Chapter 5",
-  "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:3f17bc39874c53ae",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:6e46aaef34f9ba78",
   "lessons": [
     {
       "id": "TA-C05-naan-tamizh-pesugiren",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "I speak Tamil",
       "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:bb4a6dcbe90b230e",
-      "notice": null,
+      "sourceHash": "fnv1a64:42a739df1441cc91",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -139,13 +148,22 @@
       "romanization": "",
       "gloss": "to speak",
       "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:8266db30a57599fa",
-      "notice": null,
+      "sourceHash": "fnv1a64:5667a5594c84050d",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -166,7 +184,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -442,13 +460,22 @@
       "romanization": "",
       "gloss": "to live, to flourish",
       "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:ba6c5ec62fe20952",
-      "notice": null,
+      "sourceHash": "fnv1a64:9853bbbff15ebc67",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -469,7 +496,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -571,13 +598,22 @@
       "romanization": "",
       "gloss": "to work (lit. \"work-do\")",
       "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:4ed45cec7b747617",
-      "notice": null,
+      "sourceHash": "fnv1a64:ca5c5c9223f2aab4",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -598,7 +634,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/tamil/narration/ch05.txt
+++ b/code/learning/human-languages/tamil/narration/ch05.txt
@@ -1,9 +1,11 @@
 Tamil, chapter 5: Chapter 5.
-5 lessons. All 5 can be done entirely by ear.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 5.
 நான் தமிழ் பேசுகிறேன் (nāṉ tamiḻ pēsugiṟēṉ) — "I speak Tamil".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -34,6 +36,8 @@ Say "I speak Tamil," and name the rare sound in the word tamiḻ. (Nāṉ tami�
 
 Lesson 2 of 5.
 பேசு (pēsu) — "to speak," your first full verb.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -106,6 +110,8 @@ In one breath, say your language and your work in Tamil, then bless someone with
 Lesson 4 of 5.
 வாழ் (vāḻ) — "to live, to flourish".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 A second verb — and one of the most beloved words in the language, the one Tamils use to bless.
@@ -136,6 +142,8 @@ Build "I live" from vāḻ, and give the blessing made from it. (Vāḻgiṟē�
 
 Lesson 5 of 5.
 வேலை செய் (vēlai sey) — "to work".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/telugu/narration/ch01.json
+++ b/code/learning/human-languages/telugu/narration/ch01.json
@@ -3,8 +3,8 @@
   "language": "telugu",
   "chapter": 1,
   "title": "Chapter 1",
-  "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:3459acb100727861",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:3fd3f66959fa87bf",
   "lessons": [
     {
       "id": "TE-C01-avunu",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "yes (avunu)",
       "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:deb4137d4926d7d8",
-      "notice": null,
+      "sourceHash": "fnv1a64:02c7e53b73ee6c0f",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -162,16 +171,20 @@
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
+        "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:52e6a170d8e806ef",
+      "sourceHash": "fnv1a64:00aabcd9866ae9f2",
       "notice": {
         "modality": "sight",
         "needs": [
+          "your eyes, for letter shapes on the page",
           "your eyes, because the lesson points at something written down"
         ],
-        "waitUntilStopped": [],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped."
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
       },
       "blocks": [
         {
@@ -193,7 +206,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -339,13 +352,22 @@
       "romanization": "",
       "gloss": "no / there isn't (lēdu)",
       "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:63631ea67c7cecc0",
-      "notice": null,
+      "sourceHash": "fnv1a64:fa3ba3d6439ce271",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -366,7 +388,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -516,13 +538,22 @@
       "romanization": "",
       "gloss": "hello / greetings (namaskāram — \"a making of a bow\")",
       "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:78ac9a59aa88d832",
-      "notice": null,
+      "sourceHash": "fnv1a64:86c4ca28846a9629",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -543,7 +574,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -854,13 +885,22 @@
       "romanization": "",
       "gloss": "okay / alright (sarē)",
       "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:a1fbc47062cc2b95",
-      "notice": null,
+      "sourceHash": "fnv1a64:563edf856ad232b4",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -881,7 +921,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/telugu/narration/ch01.txt
+++ b/code/learning/human-languages/telugu/narration/ch01.txt
@@ -1,9 +1,11 @@
 Telugu, chapter 1: Chapter 1.
-6 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
+6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 6.
 అవును (avunu) — "yes".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -40,7 +42,7 @@ Read అవును. Native Telugu or Sanskrit loan? (Native.) At root, what ki
 Lesson 2 of 6.
 ధన్యవాదములు (dhanyavādamulu) — "thank you," utterances of "worthy".
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped.
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -86,6 +88,8 @@ Read ధన్యవాదములు. What is Sanskrit in it, and what is Telu
 Lesson 3 of 6.
 లేదు (lēdu) — "no," where Telugu parts ways with its sisters.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 The partner of avunu — and a small surprise. Tamil, Kannada, and Malayalam all say "no" with a word built on il- (illai / illa). Telugu does not: it goes its own way with lēdu.
@@ -130,6 +134,8 @@ Read లేదు. What does it deny — existence or identity? (Existence — "
 
 Lesson 4 of 6.
 నమస్కారం (namaskāram) — "greetings," a making of a bow.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -212,6 +218,8 @@ Next chapter: introducing yourself — nā pēru… ("my name…") — and Telug
 
 Lesson 6 of 6.
 సరే (sarē) — "okay," the family word in Telugu dress.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/telugu/narration/ch02.json
+++ b/code/learning/human-languages/telugu/narration/ch02.json
@@ -3,8 +3,8 @@
   "language": "telugu",
   "chapter": 2,
   "title": "Chapter 2",
-  "drivablePrefix": 8,
-  "sourceHash": "fnv1a64:acd01dd37ac9c774",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:1cf5973cc83511a8",
   "lessons": [
     {
       "id": "TE-C02-emiti",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "what",
       "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:343e25a5e5a68aa0",
-      "notice": null,
+      "sourceHash": "fnv1a64:c24865d86c900c57",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -232,13 +241,22 @@
       "romanization": "",
       "gloss": "my",
       "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:00072d563ff13309",
-      "notice": null,
+      "sourceHash": "fnv1a64:66506069a92e1306",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -259,7 +277,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -450,13 +468,22 @@
       "romanization": "",
       "gloss": "you (familiar / respectful)",
       "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:448c39a65d3d4f86",
-      "notice": null,
+      "sourceHash": "fnv1a64:354cf9f77192856b",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -477,7 +504,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -561,13 +588,22 @@
       "romanization": "",
       "gloss": "name",
       "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:c916ce68f6de5518",
-      "notice": null,
+      "sourceHash": "fnv1a64:282c8e00b4bab667",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -588,7 +624,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/telugu/narration/ch02.txt
+++ b/code/learning/human-languages/telugu/narration/ch02.txt
@@ -1,9 +1,11 @@
 Telugu, chapter 2: Chapter 2.
-8 lessons. All 8 can be done entirely by ear.
+8 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 8.
 ఏమిటి (ēmiṭi) — "what".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -57,6 +59,8 @@ What does మీ పేరు ఏమిటి? literally say, and what's missing
 Lesson 3 of 8.
 నా (nā) — "my".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 "My" — native Dravidian, no European cousin.
@@ -109,6 +113,8 @@ Give your name in Telugu. (Nā pēru ….) What does Telugu leave out that Engli
 Lesson 5 of 8.
 నువ్వు / మీరు (nuvvu / mīru) — "you," familiar and respectful.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 "You" — respect made the same way as Tamil, Kannada, and French.
@@ -135,6 +141,8 @@ How does Telugu make "you" respectful, and which languages share the trick? (By 
 
 Lesson 6 of 8.
 పేరు (pēru) — "name," the native Dravidian word.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/telugu/narration/ch03.json
+++ b/code/learning/human-languages/telugu/narration/ch03.json
@@ -3,8 +3,8 @@
   "language": "telugu",
   "chapter": 3,
   "title": "Chapter 3",
-  "drivablePrefix": 6,
-  "sourceHash": "fnv1a64:0b37bc1d7a4651d2",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:4ce874054fee9743",
   "lessons": [
     {
       "id": "TE-C03-baagaa",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "well, fine — and the reply \"నేను బాగున్నాను\"",
       "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:4a89e9d8e5793aee",
-      "notice": null,
+      "sourceHash": "fnv1a64:921926f70cd68931",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -140,13 +149,22 @@
       "romanization": "",
       "gloss": "how",
       "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:d1c1f582da47b682",
-      "notice": null,
+      "sourceHash": "fnv1a64:290d6f92cdec1fa7",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -167,7 +185,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -245,13 +263,22 @@
       "romanization": "",
       "gloss": "how are you? (respectful)",
       "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:d5d6317720c976df",
-      "notice": null,
+      "sourceHash": "fnv1a64:cdaadb9998d4dc78",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -272,7 +299,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -370,13 +397,22 @@
       "romanization": "",
       "gloss": "I",
       "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:48438bd695432100",
-      "notice": null,
+      "sourceHash": "fnv1a64:c9f149c5d962518f",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -397,7 +433,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -495,13 +531,22 @@
       "romanization": "",
       "gloss": "it's okay / no problem / you're welcome",
       "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:b49c08e7ae42ca6e",
-      "notice": null,
+      "sourceHash": "fnv1a64:4f0cfb3134d69cfb",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -522,7 +567,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/telugu/narration/ch03.txt
+++ b/code/learning/human-languages/telugu/narration/ch03.txt
@@ -1,9 +1,11 @@
 Telugu, chapter 3: Chapter 3.
-6 lessons. All 6 can be done entirely by ear.
+6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 6.
 బాగా (bāgā) — "well," and how to answer.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -35,6 +37,8 @@ Give the full reply to mīru elā unnāru?. (Nēnu bāgunnānu — bāgā "well"
 Lesson 2 of 6.
 ఎలా (elā) — "how," another of the e- questions.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 You met ఏమిటి (ēmiṭi, "what") in Chapter 2. Here is its sibling — and, like all of Telugu's question-words, it begins with e-.
@@ -59,6 +63,8 @@ What base do Telugu's question-words share, and which cousins head their own? (T
 
 Lesson 3 of 6.
 మీరు ఎలా ఉన్నారు? (mīru elā unnāru?) — how are you? (respectful).
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -90,6 +96,8 @@ What verb powers "how are you?", and how does the ending change for a friend? (U
 Lesson 4 of 6.
 నేను (nēnu) — "I," the Dravidian first person.
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 To answer "how are you?" you first need "I." In Chapter 2 you learned nā ("my"); here is its owner.
@@ -119,6 +127,8 @@ What is nēnu's possessive, and is Telugu's "I" cousin to English me? (Nā, "my"
 
 Lesson 5 of 6.
 పరవాలేదు (paravālēdu) — "no problem".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/telugu/narration/ch04.json
+++ b/code/learning/human-languages/telugu/narration/ch04.json
@@ -3,8 +3,8 @@
   "language": "telugu",
   "chapter": 4,
   "title": "Chapter 4",
-  "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:149edab58bdc1eec",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:e4153a7d2fa6af5d",
   "lessons": [
     {
       "id": "TE-C04-malli-kaluddaam",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "we'll meet again",
       "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:44e8adcad4eea9bb",
-      "notice": null,
+      "sourceHash": "fnv1a64:515fec85b9e97e7c",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -285,13 +294,22 @@
       "romanization": "",
       "gloss": "see you tomorrow",
       "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:4399e54f55c7d582",
-      "notice": null,
+      "sourceHash": "fnv1a64:f241961853fa1fdd",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -312,7 +330,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -399,13 +417,22 @@
       "romanization": "",
       "gloss": "goodbye (lit. \"I'll go and come back\")",
       "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:bd4810e5f26ab33e",
-      "notice": null,
+      "sourceHash": "fnv1a64:7a4b023ba6421195",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -426,7 +453,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -524,13 +551,22 @@
       "romanization": "",
       "gloss": "to go (and వచ్చు, to come)",
       "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:57415cf23840ee92",
-      "notice": null,
+      "sourceHash": "fnv1a64:662e875342cd06a1",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -551,7 +587,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/telugu/narration/ch04.txt
+++ b/code/learning/human-languages/telugu/narration/ch04.txt
@@ -1,9 +1,11 @@
 Telugu, chapter 4: Chapter 4.
-5 lessons. All 5 can be done entirely by ear.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 5.
 మళ్ళీ కలుద్దాం (maḷḷī kaluddām) — "we'll meet again".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -68,6 +70,8 @@ Why does Telugu never say a plain "I'm leaving," and what does its everyday good
 Lesson 3 of 5.
 రేపు కలుద్దాం (rēpu kaluddām) — "see you tomorrow".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 A goodbye with a date on it.
@@ -94,6 +98,8 @@ What are the two pieces of rēpu kaluddām, and what does -ddām mean? (Rēpu "t
 
 Lesson 4 of 5.
 వెళ్ళి వస్తాను (veḷḷi vastānu) — "I'll go and come back".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -124,6 +130,8 @@ What does the Telugu goodbye literally promise, and how do you answer? ("I'll go
 
 Lesson 5 of 5.
 వెళ్ళు (veḷḷu) — "go," and వచ్చు (come).
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/learning/human-languages/telugu/narration/ch05.json
+++ b/code/learning/human-languages/telugu/narration/ch05.json
@@ -3,8 +3,8 @@
   "language": "telugu",
   "chapter": 5,
   "title": "Chapter 5",
-  "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:28ad5f45ddc17ec5",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:e585e84796aea7f4",
   "lessons": [
     {
       "id": "TE-C05-maatlaadu",
@@ -14,13 +14,22 @@
       "romanization": "",
       "gloss": "to speak",
       "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:07af09d6a3e88ad0",
-      "notice": null,
+      "sourceHash": "fnv1a64:8d053f228fb6653b",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -41,7 +50,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -147,13 +156,22 @@
       "romanization": "",
       "gloss": "I speak Telugu",
       "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:959c4e28573052f3",
-      "notice": null,
+      "sourceHash": "fnv1a64:b49ca03d60180860",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -174,7 +192,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -272,13 +290,22 @@
       "romanization": "",
       "gloss": "to work (lit. \"work-do\")",
       "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:098e7100a3d5e2d6",
-      "notice": null,
+      "sourceHash": "fnv1a64:eaa29c2ebacac405",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -299,7 +326,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {
@@ -583,13 +610,22 @@
       "romanization": "",
       "gloss": "to be, to stay, to live",
       "script": "telugu",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "sight",
+      "derivedModality": "sight",
       "modalityReasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
-      "sourceHash": "fnv1a64:55ea402e2b7eabe2",
-      "notice": null,
+      "sourceHash": "fnv1a64:26e4f178d9a9f193",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
       "blocks": [
         {
           "index": 0,
@@ -610,7 +646,7 @@
         },
         {
           "index": 1,
-          "type": "unknown",
+          "type": "script",
           "title": "The letters in this word",
           "segments": [
             {

--- a/code/learning/human-languages/telugu/narration/ch05.txt
+++ b/code/learning/human-languages/telugu/narration/ch05.txt
@@ -1,9 +1,11 @@
 Telugu, chapter 5: Chapter 5.
-5 lessons. All 5 can be done entirely by ear.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 5.
 మాట్లాడు (māṭlāḍu) — "to speak," your first full verb.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -37,6 +39,8 @@ Build "I speak" from māṭlāḍu, and name the noun it's built on. (Māṭlā�
 Lesson 2 of 5.
 నేను తెలుగు మాట్లాడతాను (nēnu telugu māṭlāḍatānu) — "I speak Telugu".
 
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
 Warm-up.
 [pause 2 seconds]
 Your first full, moving sentence — and it names one of India's most musical languages.
@@ -66,6 +70,8 @@ Say "I speak Telugu," and give Telugu's old nickname. (Nēnu telugu māṭlāḍ
 
 Lesson 3 of 5.
 పని చేయు (pani cēyu) — "to work".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -139,6 +145,8 @@ In one breath, say your language, your city, and your work in Telugu. (Nēnu tel
 
 Lesson 5 of 5.
 ఉండు (uṇḍu) — "to be, to stay, to live".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Changed — the inline-letters section is a `script` block, honestly
+
+- `## The letters in this word` — HL00's inline-letters section, used by **240 lessons
+  across 12 tracks** — parsed as `unknown`, which schema v2 rejects. That single gap
+  blocked the v2 migration for every Indic track at once. It now parses as `script`,
+  which is what it has always been: the place a word lesson teaches the glyphs that word
+  needs.
+- **This costs 20 points of drivable share (84% → 64%) and that is the point.** A glyph
+  shape cannot be read aloud, so the previous number advertised a driving edition that
+  would have narrated "ब plus the o-mātrā" at somebody on a motorway. Corpus moves
+  `voice` 957 → 726, `sight` 124 → 355, `pen` unchanged at 53, unstartable chapters
+  44 → 92.
+- **The loss is recoverable and the route is known.** HL-C41 gave `writing` blocks a
+  `coreModality` so a hands-free view can set them aside, and the inline-letters section
+  is detachable in exactly that sense — HL00 calls it optional scaffolding a fluent reader
+  skims. Adding `script` to `DETACHABLE_BLOCK_TYPES` was tried and reverted here: the
+  model currently conflates "detachable" with "is a writing segment", so script blocks
+  began claiming a lesson needs a **pen** to read letters (`pen` 53 → 309) and reported
+  276 writing segments that are nothing of the kind. Separating those two ideas returns
+  the core share to ~86% with the honest label intact, and is the natural next slice.
+
 ### Added — HL-C03: the nine HL05 chapter gates, as measurement rather than judgement
 
 - Add `src/chapters.ts` with all nine HL05 gates — `chapter-missing-capability`,

--- a/code/packages/typescript/human-language-data/src/parse.ts
+++ b/code/packages/typescript/human-language-data/src/parse.ts
@@ -51,6 +51,14 @@ function classifyBlock(title: string): LessonBlockType {
   if (normalized.startsWith("you'll want to know")) return "input";
   if (normalized.startsWith("sounds you'll need")) return "pronunciation";
   if (normalized.startsWith("script")) return "script";
+  // "The letters in this word" is HL00's inline-letters section: the place a word lesson
+  // teaches the glyphs that word needs. It is a `script` block in everything but name —
+  // 240 lessons across 12 tracks use this exact heading — and it mapped to `unknown`,
+  // which schema v2 rejects. That single gap blocked the v2 migration for every Indic
+  // track at once. Classifying it honestly costs drivability (a letter shape cannot be
+  // read aloud) and buys a migration path; the driving edition is a filter over the
+  // modality flag, not a quality bar, so the honest label is the right one.
+  if (normalized.includes("letters in this word")) return "script";
   // "Writing:" opens a hand-formation section — the one detachable block type.
   // Checked before the looser prefixes below because a writing section's title
   // normally names the letter it teaches ("Writing: మ — the tick on top").

--- a/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
+++ b/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
@@ -653,7 +653,25 @@ describe("corpus regression", () => {
   // chapter's drivable prefix is 0 — which is why `drivablePrefixTotal` does not move at
   // all and `unstartableChapters` gains one. Routing that content through `input` blocks
   // would have held the drivable share flat by mislabelling it; the honest classification
-  // is the one that costs the metric.
+  // is the one that costs the metric.  //
+  // HL00's inline-letters section ("the letters in this word") is now classified as the
+  // `script` block it has always been, which moves 240 lessons across 12 tracks:
+  //
+  //   voice 957 -> 726      sight 124 -> 355      pen 53 (unchanged)
+  //   drivablePercent 84 -> 64      unstartableChapters 44 -> 92
+  //
+  // THIS IS A DELIBERATE LOSS, AND THE SAFE DIRECTION TO BE WRONG IN. Those sections teach
+  // glyph shapes, which cannot be read aloud, so the previous 84% was advertising a
+  // driving edition that would have narrated "ब plus the o-matra" at somebody on a
+  // motorway. The whole point of the flag is to be honest about what needs eyes.
+  //
+  // It is also recoverable, and the route is known. HL-C41 gave `writing` blocks a
+  // `coreModality` so a hands-free view can set them aside; the inline-letters section is
+  // detachable in exactly the same sense (HL00 calls it optional scaffolding a fluent
+  // reader skims). Adding `script` to DETACHABLE_BLOCK_TYPES was tried here and reverted:
+  // that model currently conflates "detachable" with "is a writing segment", so script
+  // blocks started claiming a lesson needs a PEN (pen 53 -> 309) to read letters. Split
+  // those two ideas and the core share returns to ~86% with the honest label intact.
   //
   // HL-C05-bolta-hun (the Hindi present-habitual paradigm, split out of the assembly
   // lesson) then added one `voice` lesson: 1133 -> 1134, voice 956 -> 957. It is `voice`
@@ -685,19 +703,19 @@ describe("corpus regression", () => {
     const manifest = buildModalityManifest(lessons);
     expect(manifest.summary).toEqual({
       totalLessons: 1134,
-      voice: 957,
-      sight: 124,
+      voice: 726,
+      sight: 355,
       pen: 53,
-      drivableLessons: 957,
-      drivablePercent: 84,
+      drivableLessons: 726,
+      drivablePercent: 64,
       trackCount: 22,
       chapterCount: 377,
       // Prerequisite order still costs a commuter 132 of the 957 ear-only lessons:
       // they sit behind a blocker in their own chapter and stay unreachable in the car
       // until HL-C17 reshapes the remaining wide tables.
-      drivablePrefixTotal: 825,
-      fullyDrivableChapters: 284,
-      unstartableChapters: 44,
+      drivablePrefixTotal: 555,
+      fullyDrivableChapters: 251,
+      unstartableChapters: 92,
       overriddenLessons: 0,
       lessonsWithoutChapter: 0,
     });


### PR DESCRIPTION
`## The letters in this word` — HL00's inline-letters section, used by **240 lessons across 12 tracks** — parsed as `unknown`, which schema v2 rejects. **That single gap blocked the v2 migration for every Indic track at once.** It now parses as `script`, which is what it has always been.

## This costs 20 points of drivable share, and that is the point

| | before | after |
|---|---|---|
| voice | 957 | **726** |
| sight | 124 | **355** |
| pen | 53 | 53 |
| drivable | 84% | **64%** |
| unstartable chapters | 44 | 92 |

A glyph shape cannot be read aloud. The previous 84% advertised a driving edition that would have narrated *"ब plus the o-mātrā"* at somebody on a motorway. The whole purpose of the modality flag is to be honest about what needs eyes, and HL-C44's own design note names this the safe direction to be wrong in: a pessimistic driving edition is correct, an optimistic one is dangerous.

## The loss is recoverable, and I found the exact blocker

HL-C41 gave `writing` blocks a `coreModality` so a hands-free view can set them aside. The inline-letters section is detachable in precisely that sense — HL00 calls it *optional scaffolding a fluent reader skims*.

I tried adding `script` to `DETACHABLE_BLOCK_TYPES` and **reverted it**: the model currently conflates *"detachable"* with *"is a writing segment"*, so script blocks started claiming a lesson needs a **pen** to read letters (`pen` 53 → 309) and reported 276 "writing segments" that are nothing of the kind.

Separating those two ideas returns the core share to **~86%** with the honest label intact. That's the natural next slice, and it's now a known one-file change rather than a mystery.

## Verification

300 tests across 18 files; `check:books`, `check:modality`, `check:narration` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)