### PR TITLE
fix(human-languages): separate "detachable" from "is a writing segment"

### DIFF
--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Fixed — "detachable" and "is a writing segment" are two different things
+
+- `DETACHABLE_BLOCK_TYPES` gains `script`, so a hands-free renderer may set aside the
+  inline-letters section. HL00 makes it optional scaffolding by design — "a reader who
+  already knows the script skims that section" — and nothing later in the lesson depends
+  on having read it.
+- **This required separating two ideas the model had merged.** `writingSegments` was
+  computed as `blocks.filter((block) => block.detachable)` — named for writing, filtered on
+  detachability. That was harmless only while `writing` was the sole detachable type. The
+  moment a second type joined, every inline-letters section counted as a writing segment,
+  which set `hasWritingBlock` and dragged the lesson to `pen`: **`pen` 53 → 309, and 276
+  reported "writing segments" that teach no writing at all.** Detachability is about what a
+  renderer may skip; pen-ness is about what the learner's hand must do.
+- `writingSegments` now filters on `block.type === "writing"`, and a new
+  `detachableSegments` carries what a hands-free view sets aside — a superset.
+- **Result: the book stays honest and the driver gets more.** Whole-lesson modality is
+  unchanged (`voice` 726, `sight` 355, `pen` 53) because the printed book really does show
+  glyphs; the core — what the driving edition reads — is **972 lessons, 86%**, above even
+  the 84% that stood before the inline-letters section was classified honestly.
+- `drivablePercent` is derived from `coreVoice` and now legitimately differs from
+  `voice / totalLessons`. The invariant test was updated to assert the correct relationship
+  rather than the coincidence that held while core and whole were always equal, and gained
+  two more: the whole-lesson partition still closes, and `coreVoice >= voice` always
+  (detaching can only help).
+- A chapter whose only obstacle was a script section is no longer blocked; the gap
+  report's blocked-chapter fixture was moved to a four-column paradigm, which the
+  lineariser genuinely refuses, so the test still proves a real blocker gets named.
+- **Next slice:** the manifest still publishes the conservative whole-lesson figure (64%)
+  while the gap report publishes the core (86%). `coreModality` is the additive key HL-C44
+  reserved for exactly this; emitting it and flipping `features.blockModality` closes the
+  gap.
+
 ### Changed — the inline-letters section is a `script` block, honestly
 
 - `## The letters in this word` — HL00's inline-letters section, used by **240 lessons

--- a/code/packages/typescript/human-language-data/src/modality.ts
+++ b/code/packages/typescript/human-language-data/src/modality.ts
@@ -190,6 +190,11 @@ export type ModalityReasonCode =
  */
 export const DETACHABLE_BLOCK_TYPES: ReadonlySet<LessonBodyBlock["type"]> = new Set([
   "writing",
+  // The inline-letters section. HL00 makes it optional scaffolding by design — "a reader
+  // who already knows the script skims that section" — and nothing later in the lesson
+  // depends on having read it, so a hands-free renderer may set it aside and still teach
+  // the word. The book prints it in full; only the driving edition skips it.
+  "script",
 ]);
 
 /** Whether one parsed block may be set aside by a hands-free renderer. */
@@ -253,8 +258,16 @@ export interface LessonModality {
   coreReasons: ModalityReasonCode[];
   /** Per-block requirements, in body order. */
   blocks: BlockModality[];
-  /** Titles of the detachable writing segments, in body order. */
+  /** Titles of the sections that teach the hand, in body order. Drive `pen`. */
   writingSegments: string[];
+  /**
+   * Titles of every section a hands-free renderer may set aside, in body order.
+   *
+   * A superset of {@link writingSegments}: an inline-letters `script` section is
+   * detachable (HL00 calls it optional scaffolding a fluent reader skims) but teaches
+   * no writing, so it belongs here and NOT there.
+   */
+  detachableSegments: string[];
   /** Rules that fired, in derivation order. */
   reasons: ModalityReasonCode[];
   /** Raw authored `modality:` value; null when the author left it derived. */
@@ -543,7 +556,24 @@ export function deriveLessonModality(
   const reasons: ModalityReasonCode[] = [];
 
   const blocks = lesson.blocks.map((block, index) => deriveBlockModality(block, index, options));
-  const writingSegments = blocks.filter((block) => block.detachable).map((block) => block.title);
+
+  // TWO DIFFERENT QUESTIONS, AND THEY WERE ONE VARIABLE UNTIL NOW.
+  //
+  //   writingSegments      sections that teach the HAND. They make a lesson `pen`.
+  //   detachableSegments   sections a hands-free renderer may SET ASIDE. They make the
+  //                        core differ from the whole, and say nothing about pen.
+  //
+  // Every writing segment is detachable, so while `writing` was the only detachable type
+  // the two lists were identical and one variable served both. The moment a second type
+  // became detachable the conflation bit: filtering on `detachable` and calling the
+  // result `writingSegments` made every inline-letters section claim a lesson needs a pen
+  // to READ a letter (`pen` 53 -> 309 corpus-wide, and 276 reported "writing segments"
+  // that teach no writing at all). Detachability is about what a renderer may skip;
+  // pen-ness is about what the learner's hand must do. They are now separate.
+  const writingSegments = blocks
+    .filter((block) => block.type === "writing")
+    .map((block) => block.title);
+  const detachableSegments = blocks.filter((block) => block.detachable).map((block) => block.title);
 
   // Rule 1 — a writing lesson teaches the hand. Nothing else can override that
   // downward, so we do not even look at the body. Note this is the lesson TYPE:
@@ -626,6 +656,7 @@ export function deriveLessonModality(
     coreReasons,
     blocks,
     writingSegments,
+    detachableSegments,
     reasons,
     authored,
     authoredReason,

--- a/code/packages/typescript/human-language-data/tests/modality.test.ts
+++ b/code/packages/typescript/human-language-data/tests/modality.test.ts
@@ -394,13 +394,26 @@ describe("block-level modality", () => {
     expect(block.reasons).toEqual(expect.arrayContaining(["sight-cue", "wide-table"]));
   });
 
-  it("only the writing type is detachable — a script block is not", () => {
-    expect([...DETACHABLE_BLOCK_TYPES]).toEqual(["writing"]);
+  it("both writing and script are detachable — a table block is not", () => {
+    // `script` joined `writing`: HL00 makes the inline-letters section optional
+    // scaffolding, so a hands-free renderer may skip it. Detachable is about what a
+    // renderer may set aside, NOT about what the learner's hand must do — which is why
+    // adding it here no longer drags a lesson to `pen`.
+    expect([...DETACHABLE_BLOCK_TYPES]).toEqual(["writing", "script"]);
     const parsed = lesson({
       id: "HI-C01-s",
       body: "## Warm-up\n\nSay it.\n\n## Script — क\n\nA vertical bar.\n\n## Wrap-up Recall\n\nSay it.",
     });
-    expect(parsed.blocks.map(isDetachableBlock)).toEqual([false, false, false]);
+    // Warm-up and Wrap-up are load-bearing prose; the Script section is not.
+    expect(parsed.blocks.map(isDetachableBlock)).toEqual([false, true, false]);
+
+    // A table-bearing block is NOT detachable: the table is the content, so skipping it
+    // would silently drop what the lesson teaches rather than defer optional scaffolding.
+    const tabular = lesson({
+      id: "ES-C01-t",
+      body: "## Warm-up\n\nSay it.\n\n## Grammar Lens — forms\n\n| a | b |\n| - | - |\n| 1 | 2 |",
+    });
+    expect(tabular.blocks.map(isDetachableBlock)).toEqual([false, false]);
   });
 
   it("the full modality is pen and the core is voice — one lesson, two answers", () => {
@@ -602,8 +615,14 @@ describe("chapter and track rollups", () => {
     expect(track?.voice).toBe(2);
     expect(track?.sight).toBe(1);
     expect(track?.pen).toBe(1);
-    expect(track?.drivablePercent).toBe(50);
-    expect(track?.drivablePrefixTotal).toBe(2);
+    // 75, not 50. `drivablePercent` counts the CORE, and ES-C02-a's only obstacle is a
+    // detachable `## Script` section — so once that section is set aside the lesson is
+    // listenable, and three of the four lessons are. Only the `writing`-TYPE lesson
+    // (ES-C01-c) is genuinely lost to a driver: the whole lesson is the handwriting, so
+    // there is nothing separable to skip.
+    expect(track?.drivablePercent).toBe(75);
+    // ...and chapter 2 now starts by ear, which is the point of the split.
+    expect(track?.drivablePrefixTotal).toBe(3);
 
     const [first, second] = track?.chapters ?? [];
     expect(first).toMatchObject({
@@ -613,7 +632,9 @@ describe("chapter and track rollups", () => {
       firstNonVoiceLesson: "ES-C01-c",
       modalities: ["voice", "sight", "pen"],
     });
-    expect(second).toMatchObject({ chapter: 2, drivablePrefix: 0, firstNonVoiceLesson: "ES-C02-a" });
+    // Chapter 2 used to be prefix-0, blocked at its first lesson by the script section.
+    // That section detaches, so the chapter is startable and has no blocker at all.
+    expect(second).toMatchObject({ chapter: 2, drivablePrefix: 1, firstNonVoiceLesson: null });
   });
 
   it("leaves firstNonVoiceLesson null when a whole chapter is drivable", () => {
@@ -758,10 +779,11 @@ describe("the gap report", () => {
       ],
       books: { books: [] },
     });
-    // Chapter 3 is blocked by its script block. Chapter 4 is NOT: the override is
-    // unexplained and reported, but this PR gates nothing, so the authored `voice`
-    // still takes effect and the chapter stays drivable.
-    expect(report.summary.chaptersWithoutDrivablePrefix).toBe(1);
+    // NEITHER chapter is blocked now. Chapter 3's only obstacle is a `## Script`
+    // section, which detaches — a driver skips the glyphs and keeps the lesson — so it
+    // starts by ear. Chapter 4 was never blocked: its override is unexplained and
+    // reported, but nothing here gates, so the authored `voice` still takes effect.
+    expect(report.summary.chaptersWithoutDrivablePrefix).toBe(0);
     expect(report.summary.unexplainedModalityOverrides).toBe(1);
   });
 
@@ -783,7 +805,16 @@ describe("the gap report", () => {
       buildCurriculumGapReport({
         registry,
         lessons: [
-          lesson({ id: "ES-C05", chapter: 5, sequence: 10, body: "## Script — ñ\n\nA tilde." }),
+          // A four-column paradigm, NOT a script section: the lineariser refuses it and
+          // it is not detachable, so it genuinely blocks the chapter. The fixture used to
+          // be a `## Script` block, which stopped blocking once script became detachable —
+          // and this test is about whether a blocker gets NAMED, so it needs a real one.
+          lesson({
+            id: "ES-C05",
+            chapter: 5,
+            sequence: 10,
+            body: "## Warm-up\n\n| a | b | c | d |\n| - | - | - | - |\n| 1 | 2 | 3 | 4 |",
+          }),
           lesson({ id: "ES-C06", chapter: 6, sequence: 20, type: "writing", modality: "voice" }),
         ],
         books: { books: [] },
@@ -843,9 +874,19 @@ describe("corpus regression", () => {
     // than being a separately maintained number that could drift away from it.
     // (`drivableLessons` lives on the generated manifest's summary, not here --
     // ModalitySummary exposes the channel counts and the percentage.)
+    // The published percentage describes the DRIVING EDITION, which reads the core —
+    // the lesson minus the sections a hands-free renderer sets aside. It was equal to
+    // voice/total only while `writing` was the sole detachable type and no lesson had
+    // one; now that the inline-letters section detaches, core and whole legitimately
+    // differ and the percentage must follow the core or it would advertise the wrong
+    // book. Still derived, never separately maintained.
     expect(summary.drivablePercent).toBe(
-      Math.round((summary.voice / summary.totalLessons) * 100),
+      Math.round((summary.coreVoice / summary.totalLessons) * 100),
     );
+    // The whole-lesson partition still has to close.
+    expect(summary.voice + summary.sight + summary.pen).toBe(summary.totalLessons);
+    // And the core is never weaker than the whole: detaching can only help.
+    expect(summary.coreVoice).toBeGreaterThanOrEqual(summary.voice);
 
     // A corpus that derived as entirely one channel would mean the detector had
     // stopped detecting -- the failure mode a fixed number was really guarding.
@@ -891,11 +932,18 @@ describe("corpus regression", () => {
   //
   // When the first interspersed lesson lands, `lessonsWithWritingSegments` rises and
   // this equality breaks — which is the point. Record which track did it; never loosen.
-  it("pins the amendment as a no-op until the first writing segment is authored", () => {
+  it("pins the core as strictly better than the whole, with no writing segments yet", () => {
     const { lessons } = loadEverything();
     const summary = summarizeModality(lessons);
+    // Still zero: no track has authored a `## Writing:` section. This is the assertion
+    // that caught the conflation — while `writingSegments` filtered on `detachable`, this
+    // read 276 the moment a second type became detachable, reporting writing sections
+    // that teach no writing.
     expect(summary.lessonsWithWritingSegments).toBe(0);
-    expect(summary.coreVoice).toBe(summary.voice);
+    // coreVoice NO LONGER equals voice, and that is the whole point of the split: 240
+    // inline-letters sections detach, so the core of those lessons is listenable even
+    // though the lesson as printed needs eyes.
+    expect(summary.coreVoice).toBeGreaterThan(summary.voice);
     for (const entry of lessonModalities(lessons)) {
       // The invariant a hands-free view relies on: the core never asks for more
       // than the whole lesson does.


### PR DESCRIPTION
**Stacked on #10011** — its diff will collapse to a single commit once that merges.

`DETACHABLE_BLOCK_TYPES` gains `script`, so a hands-free renderer may set aside the inline-letters section. HL00 makes it optional scaffolding by design — *"a reader who already knows the script skims that section"* — and nothing later in a lesson depends on having read it.

## The bug this had to fix first

`writingSegments` was computed as `blocks.filter((block) => block.detachable)` — **named for writing, filtered on detachability**. Harmless while `writing` was the only detachable type. The moment a second type joined, every inline-letters section counted as a writing segment, set `hasWritingBlock`, and dragged the lesson to `pen`:

- `pen` **53 → 309** — lessons claiming you need a pen to *read* a letter
- **276** reported "writing segments" that teach no writing at all

Detachability is about what a renderer may **skip**. Pen-ness is about what the learner's **hand** must do. They are now separate: `writingSegments` filters on `block.type === "writing"`, and a new `detachableSegments` carries what a hands-free view sets aside.

## Result: the book stays honest, the driver gets more

| | value |
|---|---|
| whole-lesson (what the book prints) | voice 726 / sight 355 / **pen 53** |
| **core (what the driving edition reads)** | **972 = 86%** |

That is above even the **84%** that stood *before* the inline-letters section was classified honestly — the glyph sections are labelled truthfully **and** the commuter keeps the lesson minus its letters.

## Test changes, and why none of them are weakenings

- `drivablePercent` derives from `coreVoice` and now legitimately differs from `voice / totalLessons`. The invariant asserts the correct relationship instead of a coincidence that held only while core and whole were always equal — and **gained two**: the whole-lesson partition still closes, and `coreVoice >= voice` always.
- The blocked-chapter fixture moved from a `## Script` block to a four-column paradigm the lineariser genuinely refuses, so the test still proves a **real** blocker gets named.
- `lessonsWithWritingSegments === 0` still holds — that assertion is what caught the conflation.

## Next slice

The manifest still publishes the conservative whole-lesson figure (64%) while the gap report publishes the core (86%). `coreModality` is the additive key HL-C44 reserved for exactly this.

## Verification

300 tests across 18 files; `check:books`, `check:modality`, `check:narration` clean. Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)