### PR TITLE
feat(task-app): minimal notes attach-to-task control + task-detail notes paragraph

### DIFF
--- a/code/packages/mosaic/mosaic-pkg-notes/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-pkg-notes/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to `mosaic-pkg-notes` are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/) and
 the package follows semantic versioning.
 
+## 0.2.0 — 2026-08-06 — minimal attach-to-task control
+
+### Added
+
+- `slot task-name-value : text ;` and `emit onTaskNameChange ( value :
+  text ) ;` — a single-line "Attach to task" input in the editor, next
+  to title/body. Notes has no notion of task ids; the field holds a
+  task NAME and the host resolves it to an id on Save (mirroring the
+  Sheet Labels column's discipline in `task-app`). Empty means "no
+  attachment." See
+  [task-app-notes-ui-v1.md](../../../specs/task-app-notes-ui-v1.md)'s
+  addendum for the full scope decision — this is deliberately not a
+  dropdown/autocomplete picker, just the minimal write path that makes
+  `Note.attached_task` usable at all.
+
 ## 0.1.0 — 2026-08-06 — initial release
 
 ### Added

--- a/code/packages/mosaic/mosaic-pkg-notes/README.md
+++ b/code/packages/mosaic/mosaic-pkg-notes/README.md
@@ -60,15 +60,24 @@ pkg::mosaic-pkg-notes::Notes (
   selected-note-id: slot: selected-note-id ,
   title-value:      slot: note-title-value ,
   body-value:       slot: note-body-value ,
-  onSelectNote:  emit: onSelectNote ,
-  onNewNote:     emit: onNewNote ,
-  onTitleChange: emit: onNoteTitleChange ,
-  onBodyChange:  emit: onNoteBodyChange ,
-  onSave:        emit: onSaveNote ,
-  onDelete:      emit: onDeleteNote ,
-  onCancel:      emit: onCancelNote
+  task-name-value:  slot: note-task-value ,
+  onSelectNote:     emit: onSelectNote ,
+  onNewNote:        emit: onNewNote ,
+  onTitleChange:    emit: onNoteTitleChange ,
+  onBodyChange:     emit: onNoteBodyChange ,
+  onTaskNameChange: emit: onNoteTaskNameChange ,
+  onSave:           emit: onSaveNote ,
+  onDelete:         emit: onDeleteNote ,
+  onCancel:         emit: onCancelNote
 )
 ```
+
+`task-name-value`/`onTaskNameChange` are the v0.2.0 "attach to task"
+field — a task NAME (not id), resolved by the host to `upsertNote`'s
+`attachedTask` on Save. An unrecognised name rejects the whole save,
+mirroring the Sheet Labels column's discipline. See
+[task-app-notes-ui-v1.md](../../../specs/task-app-notes-ui-v1.md)'s
+addendum.
 
 The host mints a new note's id up front (on "+ New note", not on Save —
 see `selectedNoteId`'s own comment in `main.tsx`), builds `note-rows` from

--- a/code/packages/mosaic/mosaic-pkg-notes/mosaic-package.toml
+++ b/code/packages/mosaic/mosaic-pkg-notes/mosaic-package.toml
@@ -11,10 +11,14 @@
 # v0.1.0 scope — see code/specs/task-app-notes-ui-v1.md for the full
 # rationale. Create/edit/delete a note (title + plain-text body), standalone
 # only (no attachment picker yet), no tags, no rich text, no search.
+#
+# v0.2.0 — the spec's addendum adds a minimal "attach to task" text field
+# (task-name-value/onTaskNameChange), resolved by the host to a task id on
+# Save. Still not a real picker (no dropdown/search) — see the addendum.
 
 [package]
 name = "mosaic-pkg-notes"
-version = "0.1.0"
+version = "0.2.0"
 description = "List-plus-editor view over task-core's Note entity (create/edit/delete)"
 license = "MIT OR Apache-2.0"
 

--- a/code/packages/mosaic/mosaic-pkg-notes/src/Notes.dark.msl
+++ b/code/packages/mosaic/mosaic-pkg-notes/src/Notes.dark.msl
@@ -109,6 +109,16 @@ style Notes {
     font-size     : 13 ;
   }
 
+  part notes-task-input {
+    padding       : 10 ;
+    border-radius : 6 ;
+    background    : "#1a1714" ;
+    color         : "#b3a99c" ;
+    border-width  : 1 ;
+    border-color  : "#352e25" ;
+    font-size     : 13 ;
+  }
+
   part notes-actions {
     gap : 8 ;
   }

--- a/code/packages/mosaic/mosaic-pkg-notes/src/Notes.light.msl
+++ b/code/packages/mosaic/mosaic-pkg-notes/src/Notes.light.msl
@@ -111,6 +111,16 @@ style Notes {
     font-size     : 13 ;
   }
 
+  part notes-task-input {
+    padding       : 10 ;
+    border-radius : 6 ;
+    background    : "#ffffff" ;
+    color         : "#6a625a" ;
+    border-width  : 1 ;
+    border-color  : "#e6ded3" ;
+    font-size     : 13 ;
+  }
+
   part notes-actions {
     gap : 8 ;
   }

--- a/code/packages/mosaic/mosaic-pkg-notes/src/Notes.mil
+++ b/code/packages/mosaic/mosaic-pkg-notes/src/Notes.mil
@@ -32,6 +32,13 @@
 //
 //   title-value        the editor's in-progress title text.
 //   body-value         the editor's in-progress body text.
+//   task-name-value    the editor's in-progress "attach to task" text —
+//                       a task NAME, not an id (Notes has no notion of
+//                       task ids; the host resolves name → id on Save,
+//                       the same discipline the Sheet Labels column
+//                       already uses — see
+//                       code/specs/task-app-notes-ui-v1.md's addendum).
+//                       Empty means "no attachment."
 //
 // Emit vocabulary
 // ---------------
@@ -50,6 +57,7 @@
 //                            addTask/addProject already use).
 //   onTitleChange ( value )   the title field's content changed.
 //   onBodyChange ( value )    the body field's content changed.
+//   onTaskNameChange ( value )  the attach-to-task field's content changed.
 //   onSave                    commit the edit buffer via upsertNote.
 //   onDelete                  delete the open note via deleteNote.
 //   onCancel                  discard the edit buffer without saving.
@@ -60,11 +68,13 @@ component Notes {
   slot selected-note-id : text ;
   slot title-value      : text ;
   slot body-value       : text ;
+  slot task-name-value  : text ;
 
   emit onSelectNote ( index : number ) ;
   emit onNewNote ;
   emit onTitleChange ( value : text ) ;
   emit onBodyChange ( value : text ) ;
+  emit onTaskNameChange ( value : text ) ;
   emit onSave ;
   emit onDelete ;
   emit onCancel ;

--- a/code/packages/mosaic/mosaic-pkg-notes/src/Notes.mll
+++ b/code/packages/mosaic/mosaic-pkg-notes/src/Notes.mll
@@ -60,6 +60,11 @@ layout Notes {
             multiline : true ,
             onChange : emit: onBodyChange
           )
+          HostInput [ notes-task-input ] (
+            value : slot: task-name-value ,
+            placeholder : "Attach to task (optional)" ,
+            onChange : emit: onTaskNameChange
+          )
           Row [ notes-actions ] {
             HostButton [ notes-save ] ( label : "Save" , onClick : emit: onSave )
             HostButton [ notes-delete ] ( label : "Delete" , onClick : emit: onDelete )

--- a/code/programs/mosaic/task-app/BACKLOG.md
+++ b/code/programs/mosaic/task-app/BACKLOG.md
@@ -27,18 +27,11 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
    - Richer Gantt: day-grid columns, weekend/today shading, milestone diamonds,
      dependency arrows, hover tooltips, a legend. Current timeline is a simple
      proportional-bar-per-row view.
-   - Richer task rows: labels/priority chips and the dependency list shipped (see
-     Resolved below). Still missing: critical/slack *chips* (today the detail panel's
-     scheduling prose already says "on the critical path" / states slack in prose —
-     a dedicated chip would be a value-only restyle, low priority) and a notes
-     paragraph in the detail panel. The notes paragraph turned out to be
-     **blocked on the "Notes: attachment picker" item below**, not just an engine
-     lookup as previously written here: `Note.attached_task` exists and a
-     `detail-notes` cell would be trivial to wire, but there is no UI anywhere to
-     ever set `attached_task` — v1's notes are permanently standalone. Ship both
-     together: the attach control (however it ends up scoped — a name-matching
-     text field mirroring the Labels column's discipline is the obvious minimal
-     shape) and the detail-panel cell that reads it, in the same PR.
+   - Richer task rows: labels/priority chips, the dependency list, and the notes
+     paragraph all shipped (see Resolved below). Still missing: critical/slack
+     *chips* — today the detail panel's scheduling prose already says "on the
+     critical path" / states slack in prose, so a dedicated chip would be a
+     value-only restyle, low priority.
    - Calendar view — shipped since (Phase 7, see Resolved below); the mock's calendar
      was corroborating evidence for that roadmap phase, not a separate design-fidelity task.
 
@@ -74,13 +67,13 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
   a 4-way branch duplicating the whole drop-target + event-loop wasn't judged worth it for a
   colour difference. Today's badge shipped (it only needed a small conditional child, the
   same trick Board's `card-crit` chip already uses).
-- **Notes: attachment picker, tags, rich text, search.** Deferred from the Phase 8 UI
-  ship — see `code/specs/task-app-notes-ui-v1.md`. v1's notes are always standalone (no
-  UI to set `attached_task`); tags are generic and reusable in `mosaic-pkg-notes` but
-  nothing drives them; `Note.body` is plain text, matching every other free-text field
-  in the engine; no search box (mirrors Sheet's own v1 scope cut). The attach picker
-  specifically is now also the blocker for the "Next up" design-fidelity item's
-  task-detail notes paragraph above — ship them together.
+- **Notes: a real attachment picker, tags, rich text, search.** Deferred from the
+  Phase 8 UI ship — see `code/specs/task-app-notes-ui-v1.md`. A minimal name-matching
+  attach-to-task *text field* shipped (see Resolved below); this item is what's still
+  missing: a real dropdown/autocomplete/search picker, not just the write path. Tags
+  are generic and reusable in `mosaic-pkg-notes` but nothing drives them; `Note.body`
+  is plain text, matching every other free-text field in the engine; no search box
+  (mirrors Sheet's own v1 scope cut).
 - **Label colour picker + duplicate-name prevention + per-label removal.** Deferred
   from the label-management ship (see Resolved below) — `Label.color` is set (always
   `""` in v1) but nothing renders it; two labels can share a name (mirrors project
@@ -95,14 +88,28 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
 
 ## Resolved (kept for traceability, not actionable)
 
+- **Notes attach-to-task + task-detail notes paragraph.** Closes the gap the
+  dependency-list entry below disclosed. `mosaic-pkg-notes` 0.2.0 gained a
+  minimal "Attach to task" text field (task NAME, resolved to
+  `attachedTask` on Save, unrecognised name **rejects the whole save** —
+  same discipline as the Sheet Labels column). `TaskApp`'s task-detail
+  panel gained `detail-notes` (`row[13]`), reading the open task's
+  attached note body. Found and fixed one real bug before shipping:
+  `Note` is `#[serde(rename_all = "camelCase")]`, so the JSON field is
+  `attachedTask` — the first draft used the wrong snake_case key in both
+  the detail-panel filter and the editor's name-display lookup, silently
+  matching nothing. Caught live-testing by reading the persisted
+  IndexedDB record directly (the UI alone wouldn't have shown *why* it
+  was empty). Verified live end-to-end, both themes: attach by typing a
+  task name case-insensitively, detail panel shows the note body,
+  reopening the note shows the resolved display name, an unrecognised
+  name is rejected without corrupting the existing attachment (checked
+  the persisted snapshot, not just the UI). A real picker (dropdown/
+  autocomplete/search) is still deferred — see the Backlog item above.
 - **Task-detail dependency list.** The open task's detail panel shows its CPM
   dependencies (`→ Build the prototype (FS)` / `← Design the wireframes (FS)`),
   read from `task-core`'s existing `flowchart()` projection — zero new engine
-  work. A matching notes paragraph was drafted alongside this but pulled back
-  out before shipping: it would have read `Note.attached_task`, but no UI
-  anywhere sets that field yet (see the "Notes: attachment picker" backlog item
-  above, now updated to note it blocks this too). Verified live in both themes,
-  zero console errors.
+  work. Verified live in both themes, zero console errors.
 - **Phase 9 — nested-project tree extracted to `mosaic-pkg-project-nav`.** The
   add/add-subproject composer + nested-project list, extracted verbatim from
   `TaskApp`'s own rail block — same part names, same styling (both themes), same

--- a/code/programs/mosaic/task-app/CHANGELOG.md
+++ b/code/programs/mosaic/task-app/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to the `task-app` web program are documented here.
 
 ## [0.1.0] - Unreleased
 
+### Added - minimal notes attachment + notes paragraph in the task-detail panel
+
+Closes the gap the dependency-list entry below disclosed: `Note.attached_task`
+existed since Phase 8, but no UI anywhere could ever set it, so a
+task-detail "notes paragraph" cell was drafted and pulled back out as
+dead plumbing. `mosaic-pkg-notes` 0.2.0 adds a single-line "Attach to
+task" field to the Notes editor — a task NAME, not id, resolved to
+`attachedTask` on Save. An unrecognised name **rejects the whole save**,
+the same discipline the Sheet Labels column already uses (verified
+live: typing a nonexistent task name and hitting Save logs a console
+error and leaves the note's real attachment untouched — checked the
+persisted IndexedDB record directly, not just the UI). The task-detail
+panel gains `detail-notes` (`row[13]`, appended after the dependency
+list's `row[12]`), reading the attached note's body for the one open
+task.
+
+Found and fixed one real bug before shipping: `Note` is
+`#[serde(rename_all = "camelCase")]` in `task-core`, so the JSON field
+is `attachedTask`, not `attached_task` — the first draft of both the
+detail-panel filter and the editor's "show the currently attached task
+name" lookup used the wrong (snake_case) key and silently matched
+nothing. Caught live-testing (the notes paragraph rendered empty
+despite a real attachment existing) by reading the persisted
+IndexedDB snapshot directly, not by inspection.
+
+Verified live end-to-end, both themes, zero unexpected console errors:
+created a task, created a note, attached it by typing the task's name
+in lowercase (case-insensitive match), confirmed the detail panel's
+notes paragraph renders the body text; reopened the note and confirmed
+the attach field shows the resolved display name (not the raw id);
+typed an unrecognised name and confirmed Save is rejected with a
+console error while the note's real attachment is left untouched in
+the persisted snapshot.
+
+See `code/specs/task-app-notes-ui-v1.md`'s addendum for the full scope
+decision (why a name-matching text field, not a picker).
+
 ### Added - dependency list in the task-detail panel
 
 The open task's detail panel now shows its CPM dependencies alongside the

--- a/code/programs/mosaic/task-app/host/web/src/main.tsx
+++ b/code/programs/mosaic/task-app/host/web/src/main.tsx
@@ -301,6 +301,11 @@ function makeController(engine: any, init: ControllerInit = {}) {
   let selectedNoteId = "";
   let noteTitleDraft = "";
   let noteBodyDraft = "";
+  // A task NAME (not id) — resolved to attachedTask on Save via
+  // tasksByName(), same "reject the whole save on an unmatched name"
+  // discipline the Sheet Labels column already uses. Empty means "no
+  // attachment." See code/specs/task-app-notes-ui-v1.md's addendum.
+  let noteTaskDraft = "";
   // Grid's edit-cursor slots. -1/"" means "none", matching Grid's own contract
   // (see Grid.mil).
   let sheetSelectedRow = -1;
@@ -550,6 +555,31 @@ function makeController(engine: any, init: ControllerInit = {}) {
     return out;
   };
 
+  // Same shape as labelsByName() — the Notes editor's "attach to task" field
+  // resolves a typed task NAME back to the id upsertNote's attachedTask
+  // needs. Scoped to the active project only, same boundary labelsByName()
+  // uses (task names, like project/label names, aren't unique
+  // workspace-wide — see code/specs/task-app-notes-ui-v1.md's addendum).
+  const tasksByName = (): Map<string, string> => {
+    const ws = engine.workspace().data;
+    const activeId = engine.activeProject().data as string;
+    const map = (ws.projects?.[activeId]?.tasks ?? {}) as Record<string, any>;
+    const out = new Map<string, string>();
+    for (const t of Object.values(map) as any[]) {
+      out.set(String(t.name ?? "").toLowerCase(), t.id as string);
+    }
+    return out;
+  };
+
+  // Reverse of tasksByName() — the editor needs to SHOW the attached task's
+  // name (not its id) when a note is selected.
+  const taskNameById = (id: string): string => {
+    const ws = engine.workspace().data;
+    const activeId = engine.activeProject().data as string;
+    const map = (ws.projects?.[activeId]?.tasks ?? {}) as Record<string, any>;
+    return String(map[id]?.name ?? "");
+  };
+
   return {
     getProps() {
       // Ask the ENGINE for render-ready cells. The host no longer formats dates,
@@ -609,6 +639,24 @@ function makeController(engine: any, init: ControllerInit = {}) {
         return parts.join(" · ");
       };
 
+      // Attached-notes paragraph for the ONE open row — read from the same
+      // whole-project `workspace()` dump `noteRows()`/`tasksByName()` already
+      // use (no dedicated query exists or is needed for this either). Reachable
+      // now that the Notes editor has a real write side — see the "attach to
+      // task" field wired above and code/specs/task-app-notes-ui-v1.md's
+      // addendum for why this was previously dead plumbing.
+      const notesFor = (id: string): string => {
+        if (expanded === null) return "";
+        const ws = engine.workspace().data;
+        const activeId = engine.activeProject().data as string;
+        const notesMap = (ws.projects?.[activeId]?.notes ?? {}) as Record<string, any>;
+        return (Object.values(notesMap) as any[])
+          .filter((n) => n.attachedTask === id)
+          .map((n) => String(n.body ?? "").trim())
+          .filter(Boolean)
+          .join(" · ");
+      };
+
       // Group the list the way the design does: what's underway, what's next, and
       // what's finished. The heading rides on the row that OPENS each group, so the
       // layout can print it without knowing anything about grouping.
@@ -655,6 +703,7 @@ function makeController(engine: any, init: ControllerInit = {}) {
           // Same "appended, not inserted" discipline as priority/labels above —
           // and same progressive-disclosure gating as d1-d3: empty unless open.
           isOpen ? depsFor(id) : "",
+          isOpen ? notesFor(id) : "",
         ];
       });
       const doneCount = ids.filter((id) => byTask.get(id)!.value[DONE]?.value === true).length;
@@ -735,6 +784,7 @@ function makeController(engine: any, init: ControllerInit = {}) {
         selectedNoteId,
         noteTitleValue: noteTitleDraft,
         noteBodyValue: noteBodyDraft,
+        noteTaskValue: noteTaskDraft,
         timelineScale: tl.scale,
         timelineRows: tl.rows,
         newTaskName: newName,
@@ -866,6 +916,7 @@ function makeController(engine: any, init: ControllerInit = {}) {
           selectedNoteId = id;
           noteTitleDraft = String(note.title ?? "");
           noteBodyDraft = String(note.body ?? "");
+          noteTaskDraft = note.attachedTask ? taskNameById(note.attachedTask) : "";
           break;
         }
         case "newNote":
@@ -874,6 +925,7 @@ function makeController(engine: any, init: ControllerInit = {}) {
           selectedNoteId = `n${++counter}`;
           noteTitleDraft = "";
           noteBodyDraft = "";
+          noteTaskDraft = "";
           break;
         case "noteTitleChange":
           noteTitleDraft = event.value;
@@ -881,8 +933,26 @@ function makeController(engine: any, init: ControllerInit = {}) {
         case "noteBodyChange":
           noteBodyDraft = event.value;
           break;
+        case "noteTaskNameChange":
+          noteTaskDraft = event.value;
+          break;
         case "saveNote": {
           if (!selectedNoteId) break;
+          // Empty field → no attachment. A non-empty field must resolve
+          // against the active project's tasks or the WHOLE save is
+          // rejected — same discipline as the Sheet Labels column's
+          // write(), so a typo can't silently attach to nothing or drop an
+          // existing attachment.
+          const typedName = noteTaskDraft.trim();
+          let attachedTask: string | null = null;
+          if (typedName) {
+            const taskId = tasksByName().get(typedName.toLowerCase());
+            if (!taskId) {
+              console.error("Note save failed: no task named", JSON.stringify(typedName));
+              break;
+            }
+            attachedTask = taskId;
+          }
           // upsertNote is create-or-replace by id either way — whether this
           // is a brand-new note (first Save) or an edit to an existing one
           // makes no difference to the op itself.
@@ -890,7 +960,7 @@ function makeController(engine: any, init: ControllerInit = {}) {
             id: selectedNoteId,
             title: noteTitleDraft,
             body: noteBodyDraft,
-            attachedTask: null,
+            attachedTask,
           });
           if (res?.ok === false) {
             console.error("Note save failed:", res.error ?? res);
@@ -911,6 +981,7 @@ function makeController(engine: any, init: ControllerInit = {}) {
           selectedNoteId = "";
           noteTitleDraft = "";
           noteBodyDraft = "";
+          noteTaskDraft = "";
           persist();
           break;
         }
@@ -918,6 +989,7 @@ function makeController(engine: any, init: ControllerInit = {}) {
           selectedNoteId = "";
           noteTitleDraft = "";
           noteBodyDraft = "";
+          noteTaskDraft = "";
           break;
         case "sheetNavigate": {
           sheetSelectedRow = event.row;

--- a/code/programs/mosaic/task-app/mosaic-package.toml
+++ b/code/programs/mosaic/task-app/mosaic-package.toml
@@ -10,7 +10,7 @@ exports = ["TaskApp"]
 [dependencies]
 mosaic-pkg-sheet = "0.1.0"
 mosaic-pkg-calendar = "0.1.0"
-mosaic-pkg-notes = "0.1.0"
+mosaic-pkg-notes = "0.2.0"
 mosaic-pkg-project-nav = "0.1.0"
 
 [kernel]

--- a/code/programs/mosaic/task-app/src/TaskApp.dark.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.dark.msl
@@ -837,6 +837,10 @@ style TaskApp {
     color : "#b3a99c" ;
     font-size : 12 ;
   }
+  part detail-notes {
+    color : "#867c70" ;
+    font-size : 12 ;
+  }
 
   // ── timeline ────────────────────────────────────────────────────────────
   part timeline-card {

--- a/code/programs/mosaic/task-app/src/TaskApp.light.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.light.msl
@@ -837,6 +837,10 @@ style TaskApp {
     color : "#6a625a" ;
     font-size : 12 ;
   }
+  part detail-notes {
+    color : "#9b9289" ;
+    font-size : 12 ;
+  }
 
   // ── timeline ────────────────────────────────────────────────────────────
   part timeline-card {

--- a/code/programs/mosaic/task-app/src/TaskApp.mil
+++ b/code/programs/mosaic/task-app/src/TaskApp.mil
@@ -115,6 +115,7 @@ component TaskApp {
   slot selected-note-id    : text ;
   slot note-title-value    : text ;
   slot note-body-value     : text ;
+  slot note-task-value     : text ;
 
   // One row per task, in schedule order. Each row is a list of pre-formatted cells:
   //
@@ -128,19 +129,19 @@ component TaskApp {
   //                         [ 11 ] labels, comma-joined display names, or empty
   //                         [ 12 ] detail: dependency list (predecessors/successors,
   //                                each labelled FS/SS/FF/SF), or empty
+  //                         [ 13 ] detail: attached notes' body text, or empty
   //
   // Every cell is optional: an empty one (no due date, not overdue, nothing to add)
-  // is the empty string and the layout hides it. Cells 6-8 and 12 are the
+  // is the empty string and the layout hides it. Cells 6-8 and 12-13 are the
   // progressive-disclosure payload, filled ONLY for the expanded row — so a collapsed
   // list stays a plain to-do list, and the host skips the CPM recompute (and the
-  // dependency lookup) entirely when nothing is open. 10-12 are appended
+  // dependency/notes lookups) entirely when nothing is open. 10-13 are appended
   // rather than inserted between 9 and the old end, so no existing row[n] reference
-  // anywhere shifts meaning. A notes-paragraph cell was considered here too (Note
-  // entities already carry an `attached_task` link) but dropped: there is no UI
-  // anywhere yet to actually attach a note to a task (the Notes v1 spec deliberately
-  // deferred that as its own "attachment picker" item), so the cell would only ever
-  // render empty — dead plumbing nothing could reach. Add it alongside that picker,
-  // not before it.
+  // anywhere shifts meaning. Cell 13 was drafted once before and pulled back out
+  // because nothing could populate `Note.attached_task` — now that
+  // `pkg::mosaic-pkg-notes::Notes` has the attach-to-task field (see its own
+  // Notes.mil and code/specs/task-app-notes-ui-v1.md's addendum), the read side
+  // is reachable and ships here.
   slot task-rows : list<list<text>> ;
 
   // Typing in the inputs.
@@ -192,6 +193,7 @@ component TaskApp {
   emit onNewNote ;
   emit onNoteTitleChange ( value : text ) ;
   emit onNoteBodyChange ( value : text ) ;
+  emit onNoteTaskNameChange ( value : text ) ;
   emit onSaveNote ;
   emit onDeleteNote ;
   emit onCancelNote ;

--- a/code/programs/mosaic/task-app/src/TaskApp.mll
+++ b/code/programs/mosaic/task-app/src/TaskApp.mll
@@ -239,10 +239,12 @@ layout TaskApp {
             selected-note-id : slot: selected-note-id ,
             title-value : slot: note-title-value ,
             body-value : slot: note-body-value ,
+            task-name-value : slot: note-task-value ,
             onSelectNote : emit: onSelectNote ,
             onNewNote : emit: onNewNote ,
             onTitleChange : emit: onNoteTitleChange ,
             onBodyChange : emit: onNoteBodyChange ,
+            onTaskNameChange : emit: onNoteTaskNameChange ,
             onSave : emit: onSaveNote ,
             onDelete : emit: onDeleteNote ,
             onCancel : emit: onCancelNote
@@ -309,6 +311,9 @@ layout TaskApp {
                       }
                       If ( when: ( row[12] ) ) {
                         Text [ detail-deps ] ( content : ( row[12] ) )
+                      }
+                      If ( when: ( row[13] ) ) {
+                        Text [ detail-notes ] ( content : ( row[13] ) )
                       }
                     }
                   }

--- a/code/specs/task-app-notes-ui-v1.md
+++ b/code/specs/task-app-notes-ui-v1.md
@@ -82,3 +82,51 @@ note-id + title/body draft state (mirroring the composer's `newName`/
 spec already noted `workspace()` includes it for free), and
 `showNotes`/`selectNote`/`newNote`/`noteTitleChange`/`noteBodyChange`/
 `saveNote`/`deleteNote`/`cancelNote` dispatch cases.
+
+## Addendum (v1.1): minimal attach-to-task control
+
+Discovered while shipping the task-detail dependency list (a small,
+spec-free PR — see `task-app`'s `CHANGELOG.md`): a task-detail "notes
+paragraph" cell was drafted, reading
+`Note.attached_task`, then pulled back out — `attached_task` exists on
+every `Note` since the entity PR, but v1's editor (this doc, above)
+never gave the user a way to *set* it. A read-only cell for a field
+nothing can write is dead plumbing, not a shippable slice. This
+addendum closes that gap with the smallest control that does, ship
+together with the detail-panel cell it unblocks in the same PR.
+
+**Scope decision**: a single-line "Attach to task" text field in the
+Notes editor, next to title/body, resolving a typed *task name* to a
+task id on Save — the exact same discipline the Sheet Labels column
+(`code/programs/mosaic/task-app/CHANGELOG.md`'s label-management entry)
+already established: case-insensitive exact-name match, and an
+**unrecognised name rejects the whole Save** rather than silently
+dropping the attachment or (worse) fuzzy-matching to the wrong task.
+An empty field means "no attachment" — clearing the field and saving
+detaches the note (`attachedTask: null`).
+
+**What this deliberately is NOT**: not a dropdown/autocomplete picker,
+not a multi-select, not editable from the task-detail side (attaching
+happens only from the Notes tab — the detail panel is read-only,
+matching every other detail-panel cell in `TaskApp.mll`). A real
+picker UI (search-as-you-type, browse-by-project) is still the
+"Notes: attachment picker" backlog item's fuller scope — this addendum
+ships the minimal write path that makes the entity field usable at
+all, not the final UX. Two task names colliding case-insensitively
+across different projects is a pre-existing, undeduped condition (task
+names, like project and label names, aren't unique workspace-wide) —
+matching resolves within the *active* project's task list only, same
+scope boundary `labelsByName()` already uses for labels.
+
+**Wiring**: `Notes.mil` gains `slot task-name-value : text ;` and
+`emit onTaskNameChange ( value : text ) ;`, rendered as one more
+`HostInput` in the editor column. `TaskApp` passes both through
+unchanged (same pattern as `title-value`/`body-value`) and owns a
+`noteTaskName` draft string alongside the existing title/body draft.
+On Save, the host resolves the typed name against the active
+project's tasks (case-insensitive exact match); a miss aborts the
+whole save with a console error, mirroring the Sheet Labels column's
+`write()` contract. The task-detail panel's `detail-notes` cell
+(`row[13]`, appended after the dependency list's `row[12]`) then reads
+`Note.attached_task` for the open task — the read side this addendum
+was blocked on.


### PR DESCRIPTION
## Summary

- `mosaic-pkg-notes` 0.2.0 gains a single-line "Attach to task" field in the Notes editor. Notes has no notion of task ids, so the field holds a task **name**; the host resolves it to `attachedTask` on Save. An unrecognised name **rejects the whole save** — same discipline the Sheet Labels column already uses. Empty means no attachment.
- Closes the gap [#10009](https://github.com/adhithyan15/coding-adventures/pull/10009) disclosed: `Note.attached_task` has existed since Phase 8, but nothing could ever set it, so a task-detail "notes paragraph" cell was drafted once and pulled back out as dead plumbing. With the write side now shipped, `TaskApp` gains `detail-notes` (`row[13]`, appended after the dependency list's `row[12]`), reading the open task's attached note body.
- `code/specs/task-app-notes-ui-v1.md` gains an addendum documenting the scope decision (a name-matching text field, not a full picker — a real dropdown/autocomplete picker remains a separate, deferred backlog item).

**Bug found and fixed before shipping**: `Note` is `#[serde(rename_all = "camelCase")]` in `task-core`, so the JSON field is `attachedTask`, not `attached_task`. The first draft of both the detail-panel filter and the editor's name-display lookup used the wrong snake_case key and silently matched nothing — caught by reading the persisted IndexedDB snapshot directly (the UI alone just rendered empty with no error), not by inspection.

Stacked on the not-yet-merged [#10009](https://github.com/adhithyan15/coding-adventures/pull/10009) (task-detail dependency list) — this diff will shrink once that merges and this rebases.

## Test plan

- [x] `cargo test` in `code/packages/mosaic/mosaic-pkg-notes` — 7/7 pass
- [x] `cargo test` in `code/programs/mosaic/task-app` — 2/2 pass
- [x] `npx vitest run` in `host/web` — 28/28 pass (the actual CI gate for this package)
- [x] Live browser verification, both themes, zero unexpected console errors:
  - Attach a note to a task by typing its name case-insensitively, confirm the detail panel's notes paragraph renders the body
  - Reopen the note and confirm the attach field shows the resolved display name (not the raw task id)
  - Type an unrecognised task name and confirm Save is rejected with a console error, while checking the *persisted IndexedDB snapshot directly* to confirm the note's real attachment stays untouched (not just checking the UI)
- [x] `/security-review` — passed, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)