### PR TITLE
feat(sir-conformance): accept any registered frontend, not just Ruby

### DIFF
--- a/code/packages/rust/sir-conformance/CHANGELOG.md
+++ b/code/packages/rust/sir-conformance/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the `sir-conformance` crate will be documented in this file.
 
+## [0.23.0] - Frontend genericity: any registered frontend, not just Ruby
+
+Generalizes the harness beyond a hardcoded Ruby-source input path (per
+[`SIR25` §5](../../../specs/SIR25-language-agnostic-object-model.md)):
+adds a `Frontend` enum (`Ruby`/`Python`/`JavaScript`, dispatching to each
+crate's own `compile_source`); `Program` gains a `frontend: Frontend`
+field alongside a renamed `source` field (was `ruby`); `lower_source`/
+`run_source` are now thin Ruby-only wrappers over new frontend-generic
+`lower_source_via`/`run_source_via` primitives, so every existing caller
+is unaffected. Adds `python_arithmetic` to the corpus — the first
+non-Ruby-sourced conformance program, proving the plumbing end-to-end:
+same arithmetic as `arithmetic` (Ruby-sourced), sourced from Python
+instead, runs and matches on all six backends. Fully additive/behavior-
+preserving for every existing test. New deps: `python-to-semantic-ir`,
+`javascript-to-semantic-ir`.
+
 ## [0.22.0] - `puts`-on-Array gap closed
 
 Adds `puts_array_unpack`, proving `puts [1, 2, 3]` / `puts [4, [5, 6], 7]`

--- a/code/packages/rust/sir-conformance/Cargo.toml
+++ b/code/packages/rust/sir-conformance/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "sir-conformance"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
-description = "Cross-backend golden conformance harness for the Semantic IR: lowers real Ruby source and runs the emitted program through every backend's real toolchain, asserting identical output."
+description = "Cross-backend golden conformance harness for the Semantic IR: lowers real source from any registered frontend and runs the emitted program through every backend's real toolchain, asserting identical output."
 
 [dependencies]
 ruby-to-semantic-ir = { path = "../ruby-to-semantic-ir" }
+python-to-semantic-ir = { path = "../python-to-semantic-ir" }
+javascript-to-semantic-ir = { path = "../javascript-to-semantic-ir" }
 semantic-ir = { path = "../semantic-ir" }
 semantic-ir-to-python = { path = "../semantic-ir-to-python" }
 semantic-ir-to-javascript = { path = "../semantic-ir-to-javascript" }

--- a/code/packages/rust/sir-conformance/README.md
+++ b/code/packages/rust/sir-conformance/README.md
@@ -2,17 +2,20 @@
 
 **Cross-backend golden conformance harness for the Semantic IR.**
 
-Lowers real Ruby *source* through the actual frontend and runs the emitted
-program through **every** backend's **real** toolchain, asserting the output is
-identical — byte for byte — on each.
+Lowers real *source*, through any registered [`Frontend`], and runs the
+emitted program through **every** backend's **real** toolchain, asserting the
+output is identical — byte for byte — on each.
 
 ## Why
 
-The Semantic IR (SIR) is a narrow waist: one Ruby frontend
-(`ruby-to-semantic-ir`) lowers to a language-agnostic IR, and several backends
-emit target source (`semantic-ir-to-{python,javascript,go,rust}`). The whole
-point is **behavioural equivalence** — a program's result must not depend on
-which backend emitted it.
+The Semantic IR (SIR) is a narrow waist: a [`Frontend`] (Ruby, Python, or
+JavaScript today) lowers source to a language-agnostic IR, and several
+backends emit target source (`semantic-ir-to-{python,javascript,go,rust,c,ruby}`).
+The whole point is **behavioural equivalence** — a program's result must not
+depend on which backend emitted it, *nor on which frontend produced the
+`Module`* (see [`SIR25` §5](../../../specs/SIR25-language-agnostic-object-model.md)
+— this harness used to hardcode Ruby as its only input, which is the
+structural gap SIR25 names and this crate now closes).
 
 Nothing enforced that end-to-end. Each backend's own `compile_and_run_*` test
 *hand-builds* an SIR module and checks one feature in isolation, so a construct
@@ -30,8 +33,8 @@ matrix specified in
 
 For every program in the corpus, and every backend:
 
-1. **Lower** the Ruby source through `ruby_to_semantic_ir::compile_source`
-   (the frontend runs once per program, as in production).
+1. **Lower** the source through `program.frontend`'s own `compile_source` (the
+   frontend runs once per program, as in production).
 2. **Emit** target source via the backend's `compile`.
 3. **Run** it through the real toolchain — `python3` (with the `sir-runtime-*`
    packages auto-discovered onto `PYTHONPATH`), `node`, `go run`, or
@@ -76,9 +79,12 @@ across backends, a separate formatting concern). Current programs:
 | `string_gsub_sub` | remaining String methods (`gsub`/`sub`) | `bbb\nbaa` |
 | `numeric_abs_gcd` | Numeric methods (`abs`/`gcd`) | `5\n6` |
 | `symbol_upcase_length` | Symbol methods widened from String helpers | `HELLO\n5` |
+| `python_arithmetic` | frontend genericity smoke test — same case as `arithmetic`, sourced from **Python** | `14` |
 
-Adding a program is one `Program { name, ruby, expected }` entry in
-`tests/conformance.rs`.
+Adding a program is one `Program { name, frontend, source, expected }` entry
+in `tests/conformance.rs`. `frontend` defaults nothing — pick the `Frontend`
+variant matching `source`'s language (`Frontend::Ruby` for every pre-existing
+entry).
 
 ### Gaps the corpus has surfaced (not yet in the suite)
 
@@ -181,8 +187,12 @@ implemented, and no test noticed" bug (the `case_eq` class). Two tests:
 ## Where it fits
 
 ```
-Ruby source ──► ruby-to-semantic-ir ──► SIR ──► semantic-ir-to-{py,js,go,rust} ──► run
+Ruby/Python/JS source ──► {ruby,python,javascript}-to-semantic-ir ──► SIR
+                                                                        │
+                                                                        ▼
+                                        semantic-ir-to-{py,js,go,rust,c,ruby} ──► run
                                                          ▲
-                              sir-conformance drives this whole path and
-                              checks all four outputs agree with the reference.
+                              sir-conformance drives this whole path — any
+                              registered frontend to every backend — and
+                              checks every output agrees with the reference.
 ```

--- a/code/packages/rust/sir-conformance/src/lib.rs
+++ b/code/packages/rust/sir-conformance/src/lib.rs
@@ -1,36 +1,49 @@
 //! # sir-conformance — cross-backend golden conformance harness
 //!
-//! This crate answers one question, by *running code*: **does the same Ruby
-//! program produce the same output on every backend?**
+//! This crate answers one question, by *running code*: **does the same
+//! program produce the same output on every backend, regardless of which
+//! frontend produced the SIR `Module` in the first place?**
 //!
-//! The Semantic IR (SIR) is a narrow waist — one Ruby frontend
-//! ([`ruby_to_semantic_ir`]) lowers to a language-agnostic IR, and several
-//! backends emit target source (Python, JavaScript, Go, Rust). The promise of
-//! that design is *behavioural equivalence*: a program's observable result must
-//! not depend on which backend emitted it. Nothing enforced that promise
-//! end-to-end — each backend's own `compile_and_run_*` test hand-builds an SIR
-//! module and checks one feature in isolation, so a construct the frontend
-//! emits but a backend never implemented could pass every unit test and still
-//! crash at runtime. (That is exactly what happened with the `case_eq` builtin,
-//! which was missing from three of five runtimes; see the repo's `lessons.md`.)
+//! The Semantic IR (SIR) is a narrow waist — a [`Frontend`] lowers source to a
+//! language-agnostic IR, and several backends emit target source (Python,
+//! JavaScript, Go, Rust, C, Ruby). The promise of that design is *behavioural
+//! equivalence*: a program's observable result must not depend on which
+//! backend emitted it, nor on which frontend produced the `Module`. Nothing
+//! enforced that promise end-to-end — each backend's own `compile_and_run_*`
+//! test hand-builds an SIR module and checks one feature in isolation, so a
+//! construct a frontend emits but a backend never implemented could pass every
+//! unit test and still crash at runtime. (That is exactly what happened with
+//! the `case_eq` builtin, which was missing from three of five runtimes; see
+//! the repo's `lessons.md`.)
 //!
-//! This harness closes that gap. It takes a corpus of **real Ruby source**
-//! programs, each paired with **one expected stdout** (the reference answer,
-//! written once), lowers each through the actual frontend, emits it through
-//! *every* backend, runs the emitted program through that backend's *real*
-//! toolchain (`python3`, `node`, `go`, `rustc`), and asserts the output equals
-//! the reference — **byte for byte, on every backend**. A disagreement is a
-//! faithfulness bug, localised to `(program, backend)`.
+//! This harness closes that gap. It takes a corpus of **real source**
+//! programs (originally Ruby-only; see [`Frontend`] for the full list), each
+//! paired with **one expected stdout** (the reference answer, written once),
+//! lowers each through its own frontend, emits it through *every* backend,
+//! runs the emitted program through that backend's *real* toolchain
+//! (`python3`, `node`, `go`, `rustc`), and asserts the output equals the
+//! reference — **byte for byte, on every backend**. A disagreement is a
+//! faithfulness bug, localised to `(program, backend)`; a case that only
+//! passes for one frontend but not another that reaches the same `Feature`
+//! surface is a genericity bug, localised to `(program, frontend)`.
 //!
 //! This is the first, concrete slice of the conformance matrix specified in
-//! [`SIR21` §Provability](../../../specs/SIR21-type-system-and-integer-semantics.md).
+//! [`SIR21` §Provability](../../../specs/SIR21-type-system-and-integer-semantics.md),
+//! and — for the OOP/dispatch/collection-method surface specifically — the
+//! multi-frontend discipline required by
+//! [`SIR25` §5](../../../specs/SIR25-language-agnostic-object-model.md).
 //!
 //! ## Reference-oracle discipline
 //!
 //! The expected output is compared against **the reference**, never against
-//! another backend — so two backends agreeing on a *wrong* answer cannot hide a
-//! bug. The reference is the value the Ruby program would print under a real
-//! Ruby interpreter; we encode it as a literal string in the corpus.
+//! another backend — so two backends agreeing on a *wrong* answer cannot hide
+//! a bug. For the original Ruby-sourced corpus, the reference is the value a
+//! real Ruby interpreter would print; a program's `expected` field is that
+//! value encoded once, as a literal string. A non-Ruby-sourced program's
+//! `expected` field is the same SIR-level answer — see SIR25 §5: the harness
+//! does not require a Ruby source to exist for a given case, only that
+//! *some* correct reference value was determined once, however it was
+//! determined.
 //!
 //! ## Graceful degradation
 //!
@@ -43,22 +56,68 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
-use ruby_to_semantic_ir::compile_source;
 use semantic_ir::{BackendErrorKind, Module};
 
 pub mod oracle;
 
-/// One conformance program: a name, its Ruby source, and the **reference**
-/// stdout it must produce on every backend.
+/// A source-language frontend the harness can lower a program through.
+///
+/// Deliberately a small, closed enum rather than a trait object: every
+/// variant's `compile_source(source, module_name) -> Result<Module, E>`
+/// signature is already uniform across the frontend crates (differing only in
+/// error type), so dispatch is a single match with no dynamic indirection.
+/// Not every frontend that exists in the repo needs a variant here — only the
+/// general-purpose ones this harness's OOP/Collections-flavoured corpus is
+/// relevant to (the math/CAS frontends have their own oracle-tested
+/// conformance under SIR22/SIR23, against their own native runtimes, which is
+/// a better fit than stdout-diffing against this corpus).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Frontend {
+    Ruby,
+    Python,
+    JavaScript,
+}
+
+impl Frontend {
+    /// Lower `source` (named `module_name`) through this frontend, collapsing
+    /// each frontend's distinct error type to a `String` — mirroring how
+    /// `RunOutcome::Failed` already carries error detail as a plain string.
+    fn compile_source(self, source: &str, module_name: &str) -> Result<Module, String> {
+        match self {
+            Frontend::Ruby => ruby_to_semantic_ir::compile_source(source, module_name)
+                .map_err(|e| format!("{e:?}")),
+            Frontend::Python => python_to_semantic_ir::compile_source(source, module_name)
+                .map_err(|e| format!("{e:?}")),
+            Frontend::JavaScript => {
+                javascript_to_semantic_ir::compile_source(source, module_name)
+                    .map_err(|e| format!("{e:?}"))
+            }
+        }
+    }
+
+    /// Human-readable tag for assertion messages.
+    pub fn tag(self) -> &'static str {
+        match self {
+            Frontend::Ruby => "ruby",
+            Frontend::Python => "python",
+            Frontend::JavaScript => "javascript",
+        }
+    }
+}
+
+/// One conformance program: a name, its source and the [`Frontend`] that
+/// lowers it, and the **reference** stdout it must produce on every backend.
 #[derive(Debug, Clone)]
 pub struct Program {
     /// Short identifier used in temp filenames and assertion messages.
     pub name: &'static str,
-    /// The Ruby source to lower and run.
-    pub ruby: &'static str,
-    /// The exact stdout a real Ruby interpreter would produce (trailing
-    /// whitespace is normalised away before comparison, so a single trailing
-    /// newline need not be encoded).
+    /// The source to lower and run, via `frontend`.
+    pub source: &'static str,
+    /// Which frontend lowers `source` to SIR.
+    pub frontend: Frontend,
+    /// The exact stdout a real interpreter for the source language would
+    /// produce (trailing whitespace is normalised away before comparison, so
+    /// a single trailing newline need not be encoded).
     pub expected: &'static str,
 }
 
@@ -171,30 +230,48 @@ pub enum RunOutcome {
     Failed(String),
 }
 
-/// Lower Ruby `source` (named `name`) to SIR. The source-level primitive used
-/// by both the static [`Program`] corpus and the oracle-derived arithmetic
-/// cases (whose source is generated at runtime, so it cannot be a `&'static`
-/// [`Program`]).
+/// Lower `source` (named `name`) to SIR via Ruby. Kept as the Ruby-only entry
+/// point since it's the one every existing caller uses; [`lower_source_via`]
+/// is the frontend-generic primitive this delegates to.
 pub fn lower_source(name: &str, source: &str) -> Result<Module, String> {
-    compile_source(source, name)
-        .map_err(|e| format!("frontend failed to lower `{name}`: {e:?}"))
+    lower_source_via(name, source, Frontend::Ruby)
 }
 
-/// Lower `program.ruby` to SIR (shared by every backend so the *frontend* runs
-/// exactly once per program, as it would in production).
+/// Lower `source` (named `name`) to SIR via `frontend`. The source-level
+/// primitive used by both the static [`Program`] corpus and the
+/// oracle-derived arithmetic cases (whose source is generated at runtime, so
+/// it cannot be a `&'static` [`Program`]).
+pub fn lower_source_via(name: &str, source: &str, frontend: Frontend) -> Result<Module, String> {
+    frontend
+        .compile_source(source, name)
+        .map_err(|e| format!("{} frontend failed to lower `{name}`: {e}", frontend.tag()))
+}
+
+/// Lower `program.source` to SIR via `program.frontend` (shared by every
+/// backend so the *frontend* runs exactly once per program, as it would in
+/// production).
 pub fn lower(program: &Program) -> Result<Module, String> {
-    lower_source(program.name, program.ruby)
+    lower_source_via(program.name, program.source, program.frontend)
 }
 
-/// Run Ruby `source` (named `name`) through one `target`: lower, emit, compile
-/// if needed, execute through the real toolchain, and return the normalised
-/// stdout. This is the source-level primitive [`run`] delegates to; it accepts
-/// a runtime-generated `&str` so oracle-derived programs can drive it.
+/// Run `source` (named `name`) through one `target`, lowering via Ruby. Kept
+/// as the Ruby-only entry point since it's the one every existing caller
+/// uses; [`run_source_via`] is the frontend-generic primitive this delegates
+/// to.
 pub fn run_source(name: &str, source: &str, target: Target) -> RunOutcome {
+    run_source_via(name, source, Frontend::Ruby, target)
+}
+
+/// Run `source` (named `name`) through one `target`, lowering via `frontend`:
+/// lower, emit, compile if needed, execute through the real toolchain, and
+/// return the normalised stdout. This is the source-level primitive [`run`]
+/// delegates to; it accepts a runtime-generated `&str` so oracle-derived
+/// programs can drive it.
+pub fn run_source_via(name: &str, source: &str, frontend: Frontend, target: Target) -> RunOutcome {
     if !target.available() {
         return RunOutcome::Skipped(format!("{} not on PATH", target.toolchain()));
     }
-    let module = match lower_source(name, source) {
+    let module = match lower_source_via(name, source, frontend) {
         Ok(m) => m,
         Err(e) => return RunOutcome::Failed(e),
     };
@@ -211,7 +288,7 @@ pub fn run_source(name: &str, source: &str, target: Target) -> RunOutcome {
 /// Run one `program` through one `target`: emit, compile if needed, execute
 /// through the real toolchain, and return the normalised stdout.
 pub fn run(program: &Program, target: Target) -> RunOutcome {
-    run_source(program.name, program.ruby, target)
+    run_source_via(program.name, program.source, program.frontend, target)
 }
 
 /// Normalise stdout for comparison: unify CRLF→LF and strip trailing newlines

--- a/code/packages/rust/sir-conformance/tests/conformance.rs
+++ b/code/packages/rust/sir-conformance/tests/conformance.rs
@@ -1,13 +1,14 @@
 //! The golden conformance matrix.
 //!
-//! Each [`Program`] in `CORPUS` is real Ruby source paired with the exact
-//! stdout a Ruby interpreter would produce. The matrix test lowers every
-//! program through the frontend and runs it through **every** backend's real
+//! Each [`Program`] in `CORPUS` is real source (mostly Ruby; see `frontend`
+//! on each entry) paired with the exact stdout a real interpreter for that
+//! source language would produce. The matrix test lowers every program
+//! through its own frontend and runs it through **every** backend's real
 //! toolchain, asserting the output equals the reference on each — the single
-//! test that drives Ruby *source* all the way to Python, JavaScript, Go, and
-//! Rust and proves they agree.
+//! test that drives real *source*, from any registered frontend, all the way
+//! to Python, JavaScript, Go, Rust, C, and Ruby and proves they agree.
 
-use sir_conformance::{run, Program, RunOutcome, Target};
+use sir_conformance::{run, Frontend, Program, RunOutcome, Target};
 
 /// The reference corpus. Outputs are intentionally strings and integers only —
 /// booleans render differently across backends (`#t` vs `true`), which is a
@@ -17,19 +18,22 @@ const CORPUS: &[Program] = &[
     // Operator precedence: `*` binds tighter than `+`.
     Program {
         name: "arithmetic",
-        ruby: "puts(2 + 3 * 4)\n",
+        frontend: Frontend::Ruby,
+        source: "puts(2 + 3 * 4)\n",
         expected: "14",
     },
     // A method with parameters, returning its last expression.
     Program {
         name: "def_params",
-        ruby: "def add(a, b)\n  a + b\nend\n\nputs add(2, 3)\n",
+        frontend: Frontend::Ruby,
+        source: "def add(a, b)\n  a + b\nend\n\nputs add(2, 3)\n",
         expected: "5",
     },
     // Implicit return of a trailing `if` (FC — shipped, proven here end-to-end).
     Program {
         name: "tail_if",
-        ruby: "def bigger(a, b)\n  if a > b\n    a\n  else\n    b\n  end\nend\n\nputs bigger(10, 7)\n",
+        frontend: Frontend::Ruby,
+        source: "def bigger(a, b)\n  if a > b\n    a\n  else\n    b\n  end\nend\n\nputs bigger(10, 7)\n",
         expected: "10",
     },
     // Implicit return of a trailing `case` (relies on the `case_eq` builtin
@@ -37,25 +41,29 @@ const CORPUS: &[Program] = &[
     // that whole class of bug).
     Program {
         name: "tail_case",
-        ruby: "def grade(n)\n  case n\n  when 90\n    \"A\"\n  when 80\n    \"B\"\n  else\n    \"C\"\n  end\nend\n\nputs grade(90)\nputs grade(80)\nputs grade(50)\n",
+        frontend: Frontend::Ruby,
+        source: "def grade(n)\n  case n\n  when 90\n    \"A\"\n  when 80\n    \"B\"\n  else\n    \"C\"\n  end\nend\n\nputs grade(90)\nputs grade(80)\nputs grade(50)\n",
         expected: "A\nB\nC",
     },
     // String concatenation (polymorphic `+`).
     Program {
         name: "string_concat",
-        ruby: "puts(\"ab\" + \"cd\")\n",
+        frontend: Frontend::Ruby,
+        source: "puts(\"ab\" + \"cd\")\n",
         expected: "abcd",
     },
     // A user-defined class, `.new`, and an instance method call.
     Program {
         name: "oop_method",
-        ruby: "class Dog\n  def speak\n    \"woof\"\n  end\nend\n\nputs Dog.new.speak\n",
+        frontend: Frontend::Ruby,
+        source: "class Dog\n  def speak\n    \"woof\"\n  end\nend\n\nputs Dog.new.speak\n",
         expected: "woof",
     },
     // A `while` loop with a mutable accumulator: 0+1+2+3+4.
     Program {
         name: "while_loop",
-        ruby: "i = 0\nsum = 0\nwhile i < 5\n  sum = sum + i\n  i = i + 1\nend\n\nputs sum\n",
+        frontend: Frontend::Ruby,
+        source: "i = 0\nsum = 0\nwhile i < 5\n  sum = sum + i\n  i = i + 1\nend\n\nputs sum\n",
         expected: "10",
     },
     // Array literal + `.length` (a method call, which lowers cleanly).
@@ -74,7 +82,8 @@ const CORPUS: &[Program] = &[
     // without tripping the index path.
     Program {
         name: "array_length",
-        ruby: "a = [10, 20, 30]\nputs a.length\n",
+        frontend: Frontend::Ruby,
+        source: "a = [10, 20, 30]\nputs a.length\n",
         expected: "3",
     },
     // `puts` on an Array UNPACKS it one element per line, recursively
@@ -86,7 +95,8 @@ const CORPUS: &[Program] = &[
     // delegating to a native array-aware `puts`); both fixed together.
     Program {
         name: "puts_array_unpack",
-        ruby: "puts [1, 2, 3]\nputs [4, [5, 6], 7]\n",
+        frontend: Frontend::Ruby,
+        source: "puts [1, 2, 3]\nputs [4, [5, 6], 7]\n",
         expected: "1\n2\n3\n4\n5\n6\n7",
     },
     // String `.length` (a method on a String receiver). NOTE: `.upcase` /
@@ -100,19 +110,22 @@ const CORPUS: &[Program] = &[
     // exercises string-method dispatch end-to-end without tripping the gap.
     Program {
         name: "string_length",
-        ruby: "puts \"hello\".length\n",
+        frontend: Frontend::Ruby,
+        source: "puts \"hello\".length\n",
         expected: "5",
     },
     // Instance state via `@ivar` mutated across method calls.
     Program {
         name: "counter_state",
-        ruby: "class Counter\n  def initialize\n    @n = 0\n  end\n  def inc\n    @n = @n + 1\n  end\n  def value\n    @n\n  end\nend\n\nc = Counter.new\nc.inc\nc.inc\nputs c.value\n",
+        frontend: Frontend::Ruby,
+        source: "class Counter\n  def initialize\n    @n = 0\n  end\n  def inc\n    @n = @n + 1\n  end\n  def value\n    @n\n  end\nend\n\nc = Counter.new\nc.inc\nc.inc\nputs c.value\n",
         expected: "2",
     },
     // A module mixed into a class with `include`.
     Program {
         name: "mixin_include",
-        ruby: "module Greet\n  def hi\n    \"hi\"\n  end\nend\n\nclass P\n  include Greet\nend\n\nputs P.new.hi\n",
+        frontend: Frontend::Ruby,
+        source: "module Greet\n  def hi\n    \"hi\"\n  end\nend\n\nclass P\n  include Greet\nend\n\nputs P.new.hi\n",
         expected: "hi",
     },
     // Short-circuit `||` / `&&` returning the deciding OPERAND (Ruby semantics),
@@ -122,14 +135,16 @@ const CORPUS: &[Program] = &[
     // `||`/`&&` threw `unknown builtin` at runtime on three of five backends.
     Program {
         name: "logical_ops",
-        ruby: "puts(\"a\" || \"b\")\nputs(nil || \"b\")\nputs(\"x\" && \"y\")\n",
+        frontend: Frontend::Ruby,
+        source: "puts(\"a\" || \"b\")\nputs(nil || \"b\")\nputs(\"x\" && \"y\")\n",
         expected: "a\nb\ny",
     },
     // A `case` with a multi-value `when` (`when 1, 2, 3`), which folds through
     // the same `or` builtin. Re-enabled now that `or`/`and` work on all backends.
     Program {
         name: "multi_when",
-        ruby: "def sz(n)\n  case n\n  when 1, 2, 3\n    \"small\"\n  else\n    \"big\"\n  end\nend\n\nputs sz(2)\nputs sz(9)\n",
+        frontend: Frontend::Ruby,
+        source: "def sz(n)\n  case n\n  when 1, 2, 3\n    \"small\"\n  else\n    \"big\"\n  end\nend\n\nputs sz(2)\nputs sz(9)\n",
         expected: "small\nbig",
     },
     // Ruby String methods whose names differ from JS natives (`upcase` →
@@ -139,7 +154,8 @@ const CORPUS: &[Program] = &[
     // raised `NoMethodError` on JS only.
     Program {
         name: "string_case",
-        ruby: "puts(\"hello\".upcase)\nputs(\"WORLD\".downcase)\nputs(\"  hi  \".strip)\n",
+        frontend: Frontend::Ruby,
+        source: "puts(\"hello\".upcase)\nputs(\"WORLD\".downcase)\nputs(\"  hi  \".strip)\n",
         expected: "HELLO\nworld\nhi",
     },
     // Sequential local assignments where a later binding READS an earlier one
@@ -149,7 +165,8 @@ const CORPUS: &[Program] = &[
     // existing_local` failed to compile on every backend. Now fixed.
     Program {
         name: "seq_assign",
-        ruby: "a = 5\nb = a + 1\nc = b + a\nputs a\nputs b\nputs c\n",
+        frontend: Frontend::Ruby,
+        source: "a = 5\nb = a + 1\nc = b + a\nputs a\nputs b\nputs c\n",
         expected: "5\n6\n11",
     },
     // ── Collections cascade (C-backend slices 3-10) ──────────────────────
@@ -167,39 +184,58 @@ const CORPUS: &[Program] = &[
     // through every backend's calling convention.
     Program {
         name: "array_reduce",
-        ruby: "puts [1, 2, 3, 4].reduce { |acc, x| acc + x }\n",
+        frontend: Frontend::Ruby,
+        source: "puts [1, 2, 3, 4].reduce { |acc, x| acc + x }\n",
         expected: "10",
     },
     // Two Array 0-arg query methods (slice 3).
     Program {
         name: "array_count_sum",
-        ruby: "puts [1, 2, 3, 4, 5].count\nputs [1, 2, 3].sum\n",
+        frontend: Frontend::Ruby,
+        source: "puts [1, 2, 3, 4, 5].count\nputs [1, 2, 3].sum\n",
         expected: "5\n6",
     },
     // Hash non-block methods (slice 6): `.length` and `.fetch`.
     Program {
         name: "hash_length_fetch",
-        ruby: "h = {\"a\" => 1, \"b\" => 2}\nputs h.length\nputs h.fetch(\"a\")\n",
+        frontend: Frontend::Ruby,
+        source: "h = {\"a\" => 1, \"b\" => 2}\nputs h.length\nputs h.fetch(\"a\")\n",
         expected: "2\n1",
     },
     // Remaining String methods (slice 8): literal `sub`/`gsub`.
     Program {
         name: "string_gsub_sub",
-        ruby: "puts \"aaa\".gsub(\"a\", \"b\")\nputs \"aaa\".sub(\"a\", \"b\")\n",
+        frontend: Frontend::Ruby,
+        source: "puts \"aaa\".gsub(\"a\", \"b\")\nputs \"aaa\".sub(\"a\", \"b\")\n",
         expected: "bbb\nbaa",
     },
     // Numeric methods (slice 9): `abs` and `gcd`.
     Program {
         name: "numeric_abs_gcd",
-        ruby: "puts((-5).abs)\nputs 12.gcd(18)\n",
+        frontend: Frontend::Ruby,
+        source: "puts((-5).abs)\nputs 12.gcd(18)\n",
         expected: "5\n6",
     },
     // Symbol methods (slice 10): `upcase` widened from the String helper,
     // `length` widened the same way.
     Program {
         name: "symbol_upcase_length",
-        ruby: "puts :hello.upcase\nputs :hello.length\n",
+        frontend: Frontend::Ruby,
+        source: "puts :hello.upcase\nputs :hello.length\n",
         expected: "HELLO\n5",
+    },
+    // Frontend genericity smoke test (SIR25 §5): the SAME arithmetic case as
+    // `arithmetic` above, sourced from PYTHON instead of Ruby, proving the
+    // harness — and every backend, since `run()` doesn't know or care which
+    // frontend produced the `Module` — is frontend-agnostic, not Ruby-only.
+    // Deliberately minimal (leaf arithmetic, not the OOP surface): proving the
+    // *plumbing* is this slice's job; extending python-to-semantic-ir to the
+    // OOP declaration surface and adding a matching corpus is the next slice.
+    Program {
+        name: "python_arithmetic",
+        frontend: Frontend::Python,
+        source: "print(2 + 3 * 4)\n",
+        expected: "14",
     },
 ];
 


### PR DESCRIPTION
## Summary
- `sir-conformance` hardcoded `ruby_to_semantic_ir::compile_source` as its only way to produce a `Module` — the single most structurally Ruby-privileged piece in the SIR stack, per [SIR25 §5](https://github.com/adhithyan15/coding-adventures/pull/10026).
- Adds a `Frontend` enum (`Ruby`/`Python`/`JavaScript`) dispatching to each frontend crate's own `compile_source`. `Program` gains a `frontend: Frontend` field; its `ruby` field is renamed `source`.
- `lower_source`/`run_source` stay as Ruby-only entry points (thin wrappers) — every existing caller (`arithmetic.rs`, `division.rs`, `comparisons.rs`, `reflection.rs`) is unaffected. `lower_source_via`/`run_source_via` are the new frontend-generic primitives `lower`/`run` delegate through.
- Adds `python_arithmetic` — the first non-Ruby-sourced conformance program — proving the plumbing end-to-end rather than just claiming it: same arithmetic as the existing `arithmetic` case, sourced from Python, runs and matches on all six backends.

## Test plan
- [x] `cargo build --tests` clean, `cargo clippy --all-targets -- -D warnings` clean.
- [x] Full existing suite green and unchanged: `cargo test` — 37 passed, 1 pre-existing `#[ignore]`d frontier test, 0 failed (conformance/arithmetic/division/comparisons/reflection).
- [x] New capability proven live: `python_arithmetic` (`Frontend::Python`) ran and matched on all 6 backends in the same test run (`conformance matrix: 23 corpus x 6 backends = 127 ran, 11 skipped` — the 11 skips are pre-existing Ruby-backend Collections gaps, unrelated to this change).
- [x] Security review passed (Rust reviewer): no new untrusted input, closed enum, no changes to the pre-existing toolchain shell-out/temp-file logic.

Second slice of the SIR25 arc (first was #10026, the spec itself). Next: wire the parameterized numeric layer (SIR21 T3b-2/T3c-3), then extend `python-to-semantic-ir` to the OOP declaration surface and use this harness to prove it end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)