### PR TITLE
feat(human-languages): Spanish, French and German join the cross-language corpus

### DIFF
--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -2190,7 +2190,7 @@
     {
       "language": "spanish",
       "chapter": 6,
-      "sourceHash": "fnv1a64:eac6f9bff395c7b3",
+      "sourceHash": "fnv1a64:4450428fd5374b11",
       "lessonIds": [
         "ES-C06-cafe",
         "ES-C06-por-favor",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -1039,7 +1039,7 @@
     {
       "language": "german",
       "chapter": 3,
-      "sourceHash": "fnv1a64:65dc0d28eed56e84",
+      "sourceHash": "fnv1a64:9c052e4af0dd40f4",
       "lessonIds": [
         "GE-C03-bitte",
         "GE-C03-danke",
@@ -1055,7 +1055,7 @@
       "text": "german/narration/ch03.txt",
       "json": "german/narration/ch03.json",
       "textHash": "fnv1a64:a42137aea498ce7f",
-      "jsonHash": "fnv1a64:926c509847e0b5f9"
+      "jsonHash": "fnv1a64:cf42b33ece08daa6"
     },
     {
       "language": "german",
@@ -1082,7 +1082,7 @@
     {
       "language": "german",
       "chapter": 5,
-      "sourceHash": "fnv1a64:226ff8e7967736a8",
+      "sourceHash": "fnv1a64:fa85693f7e833aff",
       "lessonIds": [
         "GE-C05-ich-lerne-deutsch",
         "GE-C05-lernen",
@@ -1095,7 +1095,7 @@
       "text": "german/narration/ch05.txt",
       "json": "german/narration/ch05.json",
       "textHash": "fnv1a64:ad10bc73a7f1fd68",
-      "jsonHash": "fnv1a64:d864d576994202db"
+      "jsonHash": "fnv1a64:6e97996fa3f9e4dc"
     },
     {
       "language": "german",
@@ -1220,7 +1220,7 @@
     {
       "language": "german",
       "chapter": 14,
-      "sourceHash": "fnv1a64:fb7d311ddf2d57e0",
+      "sourceHash": "fnv1a64:a9f6d19b7d1de599",
       "lessonIds": [
         "GE-C14-alter",
         "GE-C14-haben"
@@ -1230,7 +1230,7 @@
       "text": "german/narration/ch14.txt",
       "json": "german/narration/ch14.json",
       "textHash": "fnv1a64:d2386a8b05d32f27",
-      "jsonHash": "fnv1a64:cda1ed27287f023f"
+      "jsonHash": "fnv1a64:92d0a828316ae7a9"
     },
     {
       "language": "german",
@@ -1251,7 +1251,7 @@
     {
       "language": "german",
       "chapter": 16,
-      "sourceHash": "fnv1a64:b519f69c62cd5cd0",
+      "sourceHash": "fnv1a64:e0757a9507364a37",
       "lessonIds": [
         "GE-C16-perfekt-sein",
         "GE-C16-perfekt-sein-agreement",
@@ -1262,7 +1262,7 @@
       "text": "german/narration/ch16.txt",
       "json": "german/narration/ch16.json",
       "textHash": "fnv1a64:c4eeefbaf59636a0",
-      "jsonHash": "fnv1a64:dadb52a3a246b076"
+      "jsonHash": "fnv1a64:09aa4b8b422475e9"
     },
     {
       "language": "german",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -667,7 +667,7 @@
     {
       "language": "french",
       "chapter": 3,
-      "sourceHash": "fnv1a64:ed1a5f95e7f12a0c",
+      "sourceHash": "fnv1a64:7b6162d999488180",
       "lessonIds": [
         "FR-C03-aller",
         "FR-C03-comme-ci-comme-ca",
@@ -682,7 +682,7 @@
       "text": "french/narration/ch03.txt",
       "json": "french/narration/ch03.json",
       "textHash": "fnv1a64:14f9aa931a9ccc5c",
-      "jsonHash": "fnv1a64:d8142dfa04f0be8a"
+      "jsonHash": "fnv1a64:cf1ec701d3a195a5"
     },
     {
       "language": "french",
@@ -708,7 +708,7 @@
     {
       "language": "french",
       "chapter": 5,
-      "sourceHash": "fnv1a64:78949b91a1ec7467",
+      "sourceHash": "fnv1a64:1ac542fc6064f48f",
       "lessonIds": [
         "FR-C05-habiter",
         "FR-C05-je-parle-francais",
@@ -721,7 +721,7 @@
       "text": "french/narration/ch05.txt",
       "json": "french/narration/ch05.json",
       "textHash": "fnv1a64:1593c8b35c764439",
-      "jsonHash": "fnv1a64:f38001fd5fccbdf0"
+      "jsonHash": "fnv1a64:39a85f17fd2c0aee"
     },
     {
       "language": "french",
@@ -846,7 +846,7 @@
     {
       "language": "french",
       "chapter": 14,
-      "sourceHash": "fnv1a64:5d9fc699a891b8f4",
+      "sourceHash": "fnv1a64:a60c4c85228a0399",
       "lessonIds": [
         "FR-C14-age",
         "FR-C14-avoir"
@@ -856,7 +856,7 @@
       "text": "french/narration/ch14.txt",
       "json": "french/narration/ch14.json",
       "textHash": "fnv1a64:c9ff51f24ddbbef0",
-      "jsonHash": "fnv1a64:a63426ffabd68307"
+      "jsonHash": "fnv1a64:44af7bbdb01e0f60"
     },
     {
       "language": "french",
@@ -876,7 +876,7 @@
     {
       "language": "french",
       "chapter": 16,
-      "sourceHash": "fnv1a64:39265ac877f397ff",
+      "sourceHash": "fnv1a64:d8315d6d2e9e3429",
       "lessonIds": [
         "FR-C16-etre",
         "FR-C16-etre-roots",
@@ -888,7 +888,7 @@
       "text": "french/narration/ch16.txt",
       "json": "french/narration/ch16.json",
       "textHash": "fnv1a64:71ce25815506d603",
-      "jsonHash": "fnv1a64:ca55c72812f343c4"
+      "jsonHash": "fnv1a64:4be9f083d6aa429c"
     },
     {
       "language": "french",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -4801,7 +4801,7 @@
     {
       "language": "spanish",
       "chapter": 6,
-      "sourceHash": "fnv1a64:eac6f9bff395c7b3",
+      "sourceHash": "fnv1a64:4450428fd5374b11",
       "lessonIds": [
         "ES-C06-cafe",
         "ES-C06-por-favor",
@@ -4818,12 +4818,12 @@
       "text": "spanish/narration/ch06.txt",
       "json": "spanish/narration/ch06.json",
       "textHash": "fnv1a64:0fe1565dd6c60f60",
-      "jsonHash": "fnv1a64:c45a889170de99cc"
+      "jsonHash": "fnv1a64:ce7e670927dba398"
     },
     {
       "language": "spanish",
       "chapter": 7,
-      "sourceHash": "fnv1a64:4d7e644b06b4b607",
+      "sourceHash": "fnv1a64:38c0aead8768635a",
       "lessonIds": [
         "ES-C07-beber",
         "ES-C07-comer",
@@ -4837,12 +4837,12 @@
       "text": "spanish/narration/ch07.txt",
       "json": "spanish/narration/ch07.json",
       "textHash": "fnv1a64:78f249997579d1cf",
-      "jsonHash": "fnv1a64:3e38e8c2d69da6c7"
+      "jsonHash": "fnv1a64:c754fb62a238a09c"
     },
     {
       "language": "spanish",
       "chapter": 8,
-      "sourceHash": "fnv1a64:f8fd827c9e8e2e3f",
+      "sourceHash": "fnv1a64:aa8faca659cd6608",
       "lessonIds": [
         "ES-C08-cuantos-anos",
         "ES-C08-numeros-1-5",
@@ -4855,12 +4855,12 @@
       "text": "spanish/narration/ch08.txt",
       "json": "spanish/narration/ch08.json",
       "textHash": "fnv1a64:be7d633db66f8b7b",
-      "jsonHash": "fnv1a64:a740737106c32f05"
+      "jsonHash": "fnv1a64:db44f9bd66e0e88f"
     },
     {
       "language": "spanish",
       "chapter": 9,
-      "sourceHash": "fnv1a64:3f6b233c47e2ea13",
+      "sourceHash": "fnv1a64:0f128ec69fedf560",
       "lessonIds": [
         "ES-C09-esta-en",
         "ES-C09-practice",
@@ -4873,12 +4873,12 @@
       "text": "spanish/narration/ch09.txt",
       "json": "spanish/narration/ch09.json",
       "textHash": "fnv1a64:bae5d6bfbfc8ab11",
-      "jsonHash": "fnv1a64:482e374cd363bba8"
+      "jsonHash": "fnv1a64:91d70285361fc947"
     },
     {
       "language": "spanish",
       "chapter": 10,
-      "sourceHash": "fnv1a64:45eb64c530fd2523",
+      "sourceHash": "fnv1a64:60c303e5299f5fd7",
       "lessonIds": [
         "ES-C10-ir",
         "ES-C10-ir-a-futuro",
@@ -4890,12 +4890,12 @@
       "text": "spanish/narration/ch10.txt",
       "json": "spanish/narration/ch10.json",
       "textHash": "fnv1a64:ce35d1302b956038",
-      "jsonHash": "fnv1a64:d3d5289266422bc3"
+      "jsonHash": "fnv1a64:2397b740bf0e5019"
     },
     {
       "language": "spanish",
       "chapter": 11,
-      "sourceHash": "fnv1a64:da677dc4c1b0d05e",
+      "sourceHash": "fnv1a64:a4622dd6cae2c8a2",
       "lessonIds": [
         "ES-C11-nuestro",
         "ES-C11-poder",
@@ -4908,12 +4908,12 @@
       "text": "spanish/narration/ch11.txt",
       "json": "spanish/narration/ch11.json",
       "textHash": "fnv1a64:bebb54974da7c797",
-      "jsonHash": "fnv1a64:26adad335c1a61d5"
+      "jsonHash": "fnv1a64:3b2d9bbfe4d51fa7"
     },
     {
       "language": "spanish",
       "chapter": 12,
-      "sourceHash": "fnv1a64:d0e8994ddaf5883b",
+      "sourceHash": "fnv1a64:5f72f74488786bf2",
       "lessonIds": [
         "ES-C12-decir",
         "ES-C12-hacer",
@@ -4925,12 +4925,12 @@
       "text": "spanish/narration/ch12.txt",
       "json": "spanish/narration/ch12.json",
       "textHash": "fnv1a64:be5bb25c4cc3e165",
-      "jsonHash": "fnv1a64:500d2d86fa8357ae"
+      "jsonHash": "fnv1a64:1bc44c1620735de7"
     },
     {
       "language": "spanish",
       "chapter": 13,
-      "sourceHash": "fnv1a64:70b10e3c98a8e598",
+      "sourceHash": "fnv1a64:fd74e6b6faccb060",
       "lessonIds": [
         "ES-C13-poner",
         "ES-C13-practice",
@@ -4942,7 +4942,7 @@
       "text": "spanish/narration/ch13.txt",
       "json": "spanish/narration/ch13.json",
       "textHash": "fnv1a64:c8554fd2563bf43c",
-      "jsonHash": "fnv1a64:d4be39edabc6ac1a"
+      "jsonHash": "fnv1a64:f5505e86dabb2117"
     },
     {
       "language": "spanish",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:10aa628bb744043a",
+  "sourceHash": "fnv1a64:fe6960c3ff466de1",
   "summary": {
     "totalLessons": 1225,
     "voice": 824,
@@ -9810,7 +9810,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:2f5debf915f23ce0"
+      "sourceHash": "fnv1a64:2a5f813dc0845297"
     },
     {
       "id": "GE-C03-practice",
@@ -9992,7 +9992,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ff029ca03897854f"
+      "sourceHash": "fnv1a64:b692dc8bfe1e4b40"
     },
     {
       "id": "GE-C05-machen",
@@ -10005,7 +10005,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:6038f0a02649b609"
+      "sourceHash": "fnv1a64:92a8f484ee09fb92"
     },
     {
       "id": "GE-C05-practice",
@@ -10031,7 +10031,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e93089459bad42a0"
+      "sourceHash": "fnv1a64:03068b42d443b4fe"
     },
     {
       "id": "GE-C06-zahlen-1-5",
@@ -10266,7 +10266,7 @@
       "reasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:d1046ec3cd8b7d51"
+      "sourceHash": "fnv1a64:ac77aad8695d3ee6"
     },
     {
       "id": "GE-C15-perfekt",
@@ -10344,7 +10344,7 @@
       "reasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:cec3f047484e5bd8"
+      "sourceHash": "fnv1a64:d89aa6546b6499a7"
     },
     {
       "id": "GE-C17-kopf",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:fe6960c3ff466de1",
+  "sourceHash": "fnv1a64:4dd26c2a78c9472c",
   "summary": {
     "totalLessons": 1225,
     "voice": 824,
@@ -8805,7 +8805,7 @@
       "reasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:f90923bced4bff0b"
+      "sourceHash": "fnv1a64:4c4319e2d9dc8c2e"
     },
     {
       "id": "FR-C03-comme-ci-comme-ca",
@@ -9000,7 +9000,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:22b91db850c4a6bf"
+      "sourceHash": "fnv1a64:13b0ef183fb8ac0b"
     },
     {
       "id": "FR-C05-je-parle-francais",
@@ -9026,7 +9026,7 @@
       "reasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:1788b64ee60cd864"
+      "sourceHash": "fnv1a64:1b52b778db2ff0f7"
     },
     {
       "id": "FR-C05-practice",
@@ -9052,7 +9052,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:3a95b86575122ba2"
+      "sourceHash": "fnv1a64:aa49383efb48bb90"
     },
     {
       "id": "FR-C06-nombres-1-5",
@@ -9290,7 +9290,7 @@
       "reasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:e1fce68257fb1f71"
+      "sourceHash": "fnv1a64:8e9f481dabe6b8c4"
     },
     {
       "id": "FR-C15-passe-compose",
@@ -9329,7 +9329,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:76c03aabc76bc918"
+      "sourceHash": "fnv1a64:2ad8553705ea5e8f"
     },
     {
       "id": "FR-C16-etre-roots",
@@ -19334,7 +19334,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:9f0c8a41a736120d"
+      "sourceHash": "fnv1a64:ec974cf7795b5dea"
     },
     {
       "id": "ES-C06-ar-presente",
@@ -19361,7 +19361,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:37787818353f0baa"
+      "sourceHash": "fnv1a64:87e1da307dcee2f5"
     },
     {
       "id": "ES-C06-estudiar",
@@ -19426,7 +19426,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:0088dadb5fdf6331"
+      "sourceHash": "fnv1a64:1cc22b5309fcdd0c"
     },
     {
       "id": "ES-C07-comer",
@@ -19439,7 +19439,7 @@
       "reasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:ce6a687141938f2c"
+      "sourceHash": "fnv1a64:2c5c24910d6f4117"
     },
     {
       "id": "ES-C07-donde",
@@ -19491,7 +19491,7 @@
       "reasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:1857cec1eb24a351"
+      "sourceHash": "fnv1a64:1a9b0f692c3ce186"
     },
     {
       "id": "ES-C08-cuantos-anos",
@@ -19556,7 +19556,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:73eb2365c48ed0d8"
+      "sourceHash": "fnv1a64:25fe3250fd9cbc5b"
     },
     {
       "id": "ES-C09-esta-en",
@@ -19595,7 +19595,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ea5fdc59c0e2c713"
+      "sourceHash": "fnv1a64:a82cd4ab00b99923"
     },
     {
       "id": "ES-C09-ser-vs-estar",
@@ -19634,7 +19634,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:cfbc7b80522ef5b7"
+      "sourceHash": "fnv1a64:8625b52e5ef33af5"
     },
     {
       "id": "ES-C10-ir-a-futuro",
@@ -19699,7 +19699,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:142a93616e523eef"
+      "sourceHash": "fnv1a64:fc28c84739b62d76"
     },
     {
       "id": "ES-C11-practice",
@@ -19751,7 +19751,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ab045c322463a363"
+      "sourceHash": "fnv1a64:b70e553d669e1c90"
     },
     {
       "id": "ES-C12-hacer",
@@ -19764,7 +19764,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:babb115768b0f09b"
+      "sourceHash": "fnv1a64:8af16bd2e1a9ced7"
     },
     {
       "id": "ES-C12-practice",
@@ -19803,7 +19803,7 @@
       "reasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:3dece00044903fdb"
+      "sourceHash": "fnv1a64:853daae9f3657b07"
     },
     {
       "id": "ES-C13-practice",
@@ -19842,7 +19842,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:6ac43d9b03170b92"
+      "sourceHash": "fnv1a64:43d46c297f5ac8ef"
     },
     {
       "id": "ES-C14-hablar-preterite",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:10aa628bb744043a",
+  "sourceHash": "fnv1a64:a81390188116b364",
   "summary": {
     "totalLessons": 1225,
     "voice": 824,
@@ -19334,7 +19334,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:9f0c8a41a736120d"
+      "sourceHash": "fnv1a64:ec974cf7795b5dea"
     },
     {
       "id": "ES-C06-ar-presente",
@@ -19361,7 +19361,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:37787818353f0baa"
+      "sourceHash": "fnv1a64:87e1da307dcee2f5"
     },
     {
       "id": "ES-C06-estudiar",
@@ -19426,7 +19426,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:0088dadb5fdf6331"
+      "sourceHash": "fnv1a64:1cc22b5309fcdd0c"
     },
     {
       "id": "ES-C07-comer",
@@ -19439,7 +19439,7 @@
       "reasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:ce6a687141938f2c"
+      "sourceHash": "fnv1a64:2c5c24910d6f4117"
     },
     {
       "id": "ES-C07-donde",
@@ -19491,7 +19491,7 @@
       "reasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:1857cec1eb24a351"
+      "sourceHash": "fnv1a64:1a9b0f692c3ce186"
     },
     {
       "id": "ES-C08-cuantos-anos",
@@ -19556,7 +19556,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:73eb2365c48ed0d8"
+      "sourceHash": "fnv1a64:25fe3250fd9cbc5b"
     },
     {
       "id": "ES-C09-esta-en",
@@ -19595,7 +19595,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ea5fdc59c0e2c713"
+      "sourceHash": "fnv1a64:a82cd4ab00b99923"
     },
     {
       "id": "ES-C09-ser-vs-estar",
@@ -19634,7 +19634,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:cfbc7b80522ef5b7"
+      "sourceHash": "fnv1a64:8625b52e5ef33af5"
     },
     {
       "id": "ES-C10-ir-a-futuro",
@@ -19699,7 +19699,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:142a93616e523eef"
+      "sourceHash": "fnv1a64:fc28c84739b62d76"
     },
     {
       "id": "ES-C11-practice",
@@ -19751,7 +19751,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ab045c322463a363"
+      "sourceHash": "fnv1a64:b70e553d669e1c90"
     },
     {
       "id": "ES-C12-hacer",
@@ -19764,7 +19764,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:babb115768b0f09b"
+      "sourceHash": "fnv1a64:8af16bd2e1a9ced7"
     },
     {
       "id": "ES-C12-practice",
@@ -19803,7 +19803,7 @@
       "reasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:3dece00044903fdb"
+      "sourceHash": "fnv1a64:853daae9f3657b07"
     },
     {
       "id": "ES-C13-practice",
@@ -19842,7 +19842,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:6ac43d9b03170b92"
+      "sourceHash": "fnv1a64:43d46c297f5ac8ef"
     },
     {
       "id": "ES-C14-hablar-preterite",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:10aa628bb744043a",
+  "sourceHash": "fnv1a64:8c4d6f3e4903dcf9",
   "summary": {
     "totalLessons": 1225,
     "voice": 824,
@@ -8805,7 +8805,7 @@
       "reasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:f90923bced4bff0b"
+      "sourceHash": "fnv1a64:4c4319e2d9dc8c2e"
     },
     {
       "id": "FR-C03-comme-ci-comme-ca",
@@ -9000,7 +9000,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:22b91db850c4a6bf"
+      "sourceHash": "fnv1a64:13b0ef183fb8ac0b"
     },
     {
       "id": "FR-C05-je-parle-francais",
@@ -9026,7 +9026,7 @@
       "reasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:1788b64ee60cd864"
+      "sourceHash": "fnv1a64:1b52b778db2ff0f7"
     },
     {
       "id": "FR-C05-practice",
@@ -9052,7 +9052,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:3a95b86575122ba2"
+      "sourceHash": "fnv1a64:aa49383efb48bb90"
     },
     {
       "id": "FR-C06-nombres-1-5",
@@ -9290,7 +9290,7 @@
       "reasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:e1fce68257fb1f71"
+      "sourceHash": "fnv1a64:8e9f481dabe6b8c4"
     },
     {
       "id": "FR-C15-passe-compose",
@@ -9329,7 +9329,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:76c03aabc76bc918"
+      "sourceHash": "fnv1a64:2ad8553705ea5e8f"
     },
     {
       "id": "FR-C16-etre-roots",

--- a/code/learning/human-languages/french/CHANGELOG.md
+++ b/code/learning/human-languages/french/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## French joins the cross-language verb corpus — 2026-08-07
+
+- Retagged the track's six shared verbs from language-local `FR-VERB-*` ids to
+  the canonical concepts every other track already realises: *être* →
+  `VERB-BE`, *avoir* → `VERB-HAVE`, *aller* → `VERB-GO`, *parler* →
+  `VERB-SPEAK`, *habiter* → `VERB-LIVE`, *travailler* → `VERB-WORK`. French
+  contributed **zero** core verbs to the cross-language join before this and
+  now contributes **six**; it is the only track in the corpus that realises
+  `VERB-WORK`, which stops being universally missing.
+- Left `(s')appeler` on `FR-VERB-APPELER`. No core concept covers the
+  reflexive naming verb, and inventing one to make the number look better
+  would be a false realisation.
+- Rewired [`curriculum.json`](./curriculum.json) so the realisation path tells
+  the truth about those six lessons. A canonical `VERB-*` concept is owned by
+  `SPINE-SAY-WHAT-I-DO`, so each retagged lesson has to sit in a segment for
+  **that** node — the node French previously realised with nothing at all
+  (`segments: []`, all forty-two verb concepts in `omits`). Four new
+  `SPINE-SAY-WHAT-I-DO` segments now carry them, each spliced in at exactly
+  the point the lesson already occupied so no chapter moves and no lesson is
+  renumbered:
+  - `FR-PATH-010` — *aller*, lifted out of the head of the old Chapter 3
+    wellbeing segment and placed immediately before it, where it already sat.
+  - `FR-PATH-014` — *parler*, *habiter*, *travailler*, lifted off the front of
+    the long Chapter 5–13 support run.
+  - `FR-PATH-016` — *avoir*, with `FR-C14-age` following it as local support,
+    because *j'ai X ans* is built out of *avoir* and has to stay behind it.
+  - `FR-PATH-017` — *être*, preceded by the two Chapter 15 past-tense lessons
+    it declares as prerequisites.
+- Put **four lessons on the path that had never been on it**: *travailler* and
+  *être* (both now shared realisations, so the path must carry them) and, as
+  the prerequisite closure *être* pulls in, `FR-C15-passe-compose` and
+  `FR-C15-passe-simple`. The two past-tense lessons are French-local support,
+  so they are attached as an extension rather than pretending to realise a
+  shared concept.
+- Split the old Chapter 5–13 segment where *avoir* had to be extracted, and
+  split its language-specific extension to match, since an extension's lessons
+  must all live inside the single segment it attaches to. Segment and
+  extension ids are renumbered to stay ascending in path order, which is the
+  convention every other track follows; `FR-EXT-010` is gone because *aller*
+  was its only lesson and *aller* is no longer local support.
+- Dropped the six concepts from `SPINE-SAY-WHAT-I-DO`'s `omits` and refreshed
+  every node's `segments` ledger against the authored path.
+- Consequence worth naming: `SPINE-SAY-WHAT-I-DO` is an A2 node, so the nine
+  lessons now sitting under it are derived as A2 rather than A1. French's
+  reach moves from A1 to A2 — the same reach the other fifteen verb-realising
+  tracks already report — and five lessons leave the ramp-to-A1 edition.
+
 ## Chapter capability ledger — Chapters 17–23 — 2026-08-06
 
 - Added [`chapters.json`](./chapters.json), the track's HL05 capability ledger:

--- a/code/learning/human-languages/french/curriculum.json
+++ b/code/learning/human-languages/french/curriculum.json
@@ -105,20 +105,27 @@
     },
     {
       "id": "FR-PATH-010",
-      "spine_node": "SPINE-CHECK-WELLBEING",
+      "spine_node": "SPINE-SAY-WHAT-I-DO",
       "lessons": [
-        "FR-C03-aller",
-        "FR-C03-comment-ca-va",
-        "FR-C03-comme-ci-comme-ca"
+        "FR-C03-aller"
       ],
-      "before": [
-        "FR-EXT-010-LANGUAGE-SPECIFIC"
-      ],
+      "before": [],
       "inline": [],
       "after": []
     },
     {
       "id": "FR-PATH-011",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "FR-C03-comment-ca-va",
+        "FR-C03-comme-ci-comme-ca"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "FR-PATH-012",
       "spine_node": "SPINE-COURTESY-THANK",
       "lessons": [
         "FR-C03-merci",
@@ -129,7 +136,7 @@
       "after": []
     },
     {
-      "id": "FR-PATH-012",
+      "id": "FR-PATH-013",
       "spine_node": "SPINE-TAKE-LEAVE",
       "lessons": [
         "FR-C04-au-revoir",
@@ -142,11 +149,21 @@
       "after": []
     },
     {
-      "id": "FR-PATH-013",
-      "spine_node": "SPINE-TIME-OF-DAY",
+      "id": "FR-PATH-014",
+      "spine_node": "SPINE-SAY-WHAT-I-DO",
       "lessons": [
         "FR-C05-parler",
         "FR-C05-habiter",
+        "FR-C05-travailler"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "FR-PATH-015",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
         "FR-C06-nombres-1-5",
         "FR-C06-nombres-6-10",
         "FR-C07-jours-1",
@@ -159,18 +176,43 @@
         "FR-C12-nombres-11-16",
         "FR-C12-nombres-17-20",
         "FR-C13-noir-blanc",
-        "FR-C13-rouge-bleu",
-        "FR-C14-avoir",
-        "FR-C14-age"
+        "FR-C13-rouge-bleu"
       ],
       "before": [],
       "inline": [
-        "FR-EXT-013-LANGUAGE-SPECIFIC"
+        "FR-EXT-015-LANGUAGE-SPECIFIC"
       ],
       "after": []
     },
     {
-      "id": "FR-PATH-014",
+      "id": "FR-PATH-016",
+      "spine_node": "SPINE-SAY-WHAT-I-DO",
+      "lessons": [
+        "FR-C14-avoir",
+        "FR-C14-age"
+      ],
+      "before": [],
+      "inline": [],
+      "after": [
+        "FR-EXT-016-LANGUAGE-SPECIFIC"
+      ]
+    },
+    {
+      "id": "FR-PATH-017",
+      "spine_node": "SPINE-SAY-WHAT-I-DO",
+      "lessons": [
+        "FR-C15-passe-compose",
+        "FR-C15-passe-simple",
+        "FR-C16-etre"
+      ],
+      "before": [
+        "FR-EXT-017-LANGUAGE-SPECIFIC"
+      ],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "FR-PATH-018",
       "spine_node": "SPINE-CHECK-WELLBEING",
       "lessons": [
         "FR-C17-tete",
@@ -178,12 +220,12 @@
       ],
       "before": [],
       "inline": [
-        "FR-EXT-014-LANGUAGE-SPECIFIC"
+        "FR-EXT-018-LANGUAGE-SPECIFIC"
       ],
       "after": []
     },
     {
-      "id": "FR-PATH-015",
+      "id": "FR-PATH-019",
       "spine_node": "SPINE-RESPOND-BASIC",
       "lessons": [
         "FR-C18-oui",
@@ -194,7 +236,7 @@
       "after": []
     },
     {
-      "id": "FR-PATH-016",
+      "id": "FR-PATH-020",
       "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
       "lessons": [
         "FR-C19-sil-vous-plait",
@@ -205,19 +247,19 @@
       "after": []
     },
     {
-      "id": "FR-PATH-017",
+      "id": "FR-PATH-021",
       "spine_node": "SPINE-TIME-OF-DAY",
       "lessons": [
         "FR-C21-le-temps"
       ],
       "before": [],
       "inline": [
-        "FR-EXT-017-LANGUAGE-SPECIFIC"
+        "FR-EXT-021-LANGUAGE-SPECIFIC"
       ],
       "after": []
     },
     {
-      "id": "FR-PATH-018",
+      "id": "FR-PATH-022",
       "spine_node": "SPINE-DEFINITE-REFERENCE",
       "lessons": [
         "FR-C22-chien-chat",
@@ -225,7 +267,7 @@
       ],
       "before": [],
       "inline": [
-        "FR-EXT-018-LANGUAGE-SPECIFIC"
+        "FR-EXT-022-LANGUAGE-SPECIFIC"
       ],
       "after": []
     }
@@ -244,7 +286,7 @@
     },
     "SPINE-COURTESY-THANK": {
       "segments": [
-        "FR-PATH-011"
+        "FR-PATH-012"
       ],
       "omits": [
         "COURTESY-THANKS-CASUAL"
@@ -253,7 +295,7 @@
     },
     "SPINE-RESPOND-BASIC": {
       "segments": [
-        "FR-PATH-015"
+        "FR-PATH-019"
       ],
       "omits": [
         "RESPONSE-YESNO",
@@ -278,15 +320,15 @@
       "segments": [
         "FR-PATH-002",
         "FR-PATH-008",
-        "FR-PATH-010",
-        "FR-PATH-014"
+        "FR-PATH-011",
+        "FR-PATH-018"
       ],
       "omits": [],
       "relocates": {}
     },
     "SPINE-POLITE-REQUEST-REPAIR": {
       "segments": [
-        "FR-PATH-016"
+        "FR-PATH-020"
       ],
       "omits": [],
       "relocates": {}
@@ -294,7 +336,7 @@
     "SPINE-TAKE-LEAVE": {
       "segments": [
         "FR-PATH-005",
-        "FR-PATH-012"
+        "FR-PATH-013"
       ],
       "omits": [
         "FAREWELL-CASUAL"
@@ -305,8 +347,8 @@
       "segments": [
         "FR-PATH-004",
         "FR-PATH-006",
-        "FR-PATH-013",
-        "FR-PATH-017"
+        "FR-PATH-015",
+        "FR-PATH-021"
       ],
       "omits": [
         "TIME-MORNING",
@@ -326,7 +368,7 @@
     "SPINE-DEFINITE-REFERENCE": {
       "segments": [
         "FR-PATH-003",
-        "FR-PATH-018"
+        "FR-PATH-022"
       ],
       "omits": [],
       "relocates": {}
@@ -339,17 +381,18 @@
       "relocates": {}
     },
     "SPINE-SAY-WHAT-I-DO": {
-      "segments": [],
+      "segments": [
+        "FR-PATH-010",
+        "FR-PATH-014",
+        "FR-PATH-016",
+        "FR-PATH-017"
+      ],
       "omits": [
         "VERB-INFINITIVE",
         "VERB-PRESENT-HABITUAL",
-        "VERB-BE",
-        "VERB-HAVE",
         "VERB-DO-MAKE",
-        "VERB-GO",
         "VERB-COME",
         "VERB-SAY",
-        "VERB-SPEAK",
         "VERB-SEE",
         "VERB-HEAR",
         "VERB-KNOW",
@@ -367,8 +410,6 @@
         "VERB-EAT",
         "VERB-DRINK",
         "VERB-SLEEP",
-        "VERB-LIVE",
-        "VERB-WORK",
         "VERB-PLAY",
         "VERB-WALK",
         "VERB-RUN",
@@ -429,26 +470,13 @@
       ]
     },
     {
-      "id": "FR-EXT-010-LANGUAGE-SPECIFIC",
-      "stage": "pre-A1",
-      "kind": "required",
-      "category": "language-specific",
-      "canDo": "I can use the additional French material required at this point in the path.",
-      "prerequisites": [],
-      "lessons": [
-        "FR-C03-aller"
-      ]
-    },
-    {
-      "id": "FR-EXT-013-LANGUAGE-SPECIFIC",
+      "id": "FR-EXT-015-LANGUAGE-SPECIFIC",
       "stage": "A1",
       "kind": "required",
       "category": "language-specific",
       "canDo": "I can use the additional French material required at this point in the path.",
       "prerequisites": [],
       "lessons": [
-        "FR-C05-parler",
-        "FR-C05-habiter",
         "FR-C06-nombres-1-5",
         "FR-C06-nombres-6-10",
         "FR-C07-jours-1",
@@ -461,13 +489,34 @@
         "FR-C12-nombres-11-16",
         "FR-C12-nombres-17-20",
         "FR-C13-noir-blanc",
-        "FR-C13-rouge-bleu",
-        "FR-C14-avoir",
+        "FR-C13-rouge-bleu"
+      ]
+    },
+    {
+      "id": "FR-EXT-016-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional French material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
         "FR-C14-age"
       ]
     },
     {
-      "id": "FR-EXT-014-LANGUAGE-SPECIFIC",
+      "id": "FR-EXT-017-LANGUAGE-SPECIFIC",
+      "stage": "A2",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional French material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "FR-C15-passe-compose",
+        "FR-C15-passe-simple"
+      ]
+    },
+    {
+      "id": "FR-EXT-018-LANGUAGE-SPECIFIC",
       "stage": "pre-A1",
       "kind": "required",
       "category": "language-specific",
@@ -479,7 +528,7 @@
       ]
     },
     {
-      "id": "FR-EXT-017-LANGUAGE-SPECIFIC",
+      "id": "FR-EXT-021-LANGUAGE-SPECIFIC",
       "stage": "A1",
       "kind": "required",
       "category": "language-specific",
@@ -490,7 +539,7 @@
       ]
     },
     {
-      "id": "FR-EXT-018-LANGUAGE-SPECIFIC",
+      "id": "FR-EXT-022-LANGUAGE-SPECIFIC",
       "stage": "A1",
       "kind": "required",
       "category": "language-specific",

--- a/code/learning/human-languages/french/lessons/FR-C03-aller.md
+++ b/code/learning/human-languages/french/lessons/FR-C03-aller.md
@@ -4,7 +4,7 @@ chapter: 3
 type: word
 headword: aller
 gloss: to go (and, oddly, "to be" in "how are you?")
-concept_tag: FR-VERB-ALLER
+concept_tag: VERB-GO
 prerequisites: []
 sounds: [er-ending, r-uvular]
 roots: [ambulare-latin, vadere-latin, ire-latin]

--- a/code/learning/human-languages/french/lessons/FR-C05-habiter.md
+++ b/code/learning/human-languages/french/lessons/FR-C05-habiter.md
@@ -4,7 +4,7 @@ chapter: 5
 type: word
 headword: habiter
 gloss: to live / to dwell (a second -er verb — same pattern)
-concept_tag: FR-VERB-HABITER
+concept_tag: VERB-LIVE
 prerequisites: [FR-C05-parler]
 sounds: [silent-final, r-uvular]
 roots: [habitare-latin]

--- a/code/learning/human-languages/french/lessons/FR-C05-parler.md
+++ b/code/learning/human-languages/french/lessons/FR-C05-parler.md
@@ -4,7 +4,7 @@ chapter: 5
 type: word
 headword: parler
 gloss: to speak / to talk (your first regular -er verb)
-concept_tag: FR-VERB-PARLER
+concept_tag: VERB-SPEAK
 prerequisites: [FR-C02-je, FR-C02-tu-vous]
 sounds: [er-ending, r-uvular]
 roots: [parabolare-latin]

--- a/code/learning/human-languages/french/lessons/FR-C05-travailler.md
+++ b/code/learning/human-languages/french/lessons/FR-C05-travailler.md
@@ -4,7 +4,7 @@ chapter: 5
 type: word
 headword: travailler
 gloss: to work (a third -er verb — and the origin of "travel")
-concept_tag: FR-VERB-TRAVAILLER
+concept_tag: VERB-WORK
 prerequisites: [FR-C05-parler]
 sounds: [ai-y, r-uvular]
 roots: [tripalium-latin]

--- a/code/learning/human-languages/french/lessons/FR-C14-avoir.md
+++ b/code/learning/human-languages/french/lessons/FR-C14-avoir.md
@@ -4,7 +4,7 @@ chapter: 14
 type: word
 headword: avoir
 gloss: to have — the most worn-down verb in French, and a root you already met
-concept_tag: FR-VERB-HAVE
+concept_tag: VERB-HAVE
 prerequisites: [FR-C13-rouge-bleu, FR-C05-habiter]
 sounds: [elision-j-ai, liaison]
 roots: [latin-habere]

--- a/code/learning/human-languages/french/lessons/FR-C16-etre.md
+++ b/code/learning/human-languages/french/lessons/FR-C16-etre.md
@@ -4,7 +4,7 @@ chapter: 16
 type: word
 headword: être
 gloss: to be — the six present forms
-concept_tag: FR-VERB-BE
+concept_tag: VERB-BE
 prerequisites: [FR-C15-passe-simple, FR-C14-avoir]
 sounds: [nasal-on, circumflex]
 roots: [latin-esse]

--- a/code/learning/human-languages/french/narration/ch03.json
+++ b/code/learning/human-languages/french/narration/ch03.json
@@ -4,7 +4,7 @@
   "chapter": 3,
   "title": "Chapter 3",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:ed1a5f95e7f12a0c",
+  "sourceHash": "fnv1a64:7b6162d999488180",
   "lessons": [
     {
       "id": "FR-C03-aller",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:f90923bced4bff0b",
+      "sourceHash": "fnv1a64:4c4319e2d9dc8c2e",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/french/narration/ch05.json
+++ b/code/learning/human-languages/french/narration/ch05.json
@@ -4,7 +4,7 @@
   "chapter": 5,
   "title": "Chapter 5",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:78949b91a1ec7467",
+  "sourceHash": "fnv1a64:1ac542fc6064f48f",
   "lessons": [
     {
       "id": "FR-C05-habiter",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:22b91db850c4a6bf",
+      "sourceHash": "fnv1a64:13b0ef183fb8ac0b",
       "notice": null,
       "blocks": [
         {
@@ -316,7 +316,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:1788b64ee60cd864",
+      "sourceHash": "fnv1a64:1b52b778db2ff0f7",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -647,7 +647,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:3a95b86575122ba2",
+      "sourceHash": "fnv1a64:aa49383efb48bb90",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/french/narration/ch14.json
+++ b/code/learning/human-languages/french/narration/ch14.json
@@ -4,7 +4,7 @@
   "chapter": 14,
   "title": "Chapter 14",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:5d9fc699a891b8f4",
+  "sourceHash": "fnv1a64:a60c4c85228a0399",
   "lessons": [
     {
       "id": "FR-C14-age",
@@ -186,7 +186,7 @@
       "modalityReasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:e1fce68257fb1f71",
+      "sourceHash": "fnv1a64:8e9f481dabe6b8c4",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/french/narration/ch16.json
+++ b/code/learning/human-languages/french/narration/ch16.json
@@ -4,7 +4,7 @@
   "chapter": 16,
   "title": "Chapter 16",
   "drivablePrefix": 4,
-  "sourceHash": "fnv1a64:39265ac877f397ff",
+  "sourceHash": "fnv1a64:d8315d6d2e9e3429",
   "lessons": [
     {
       "id": "FR-C16-etre",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:76c03aabc76bc918",
+      "sourceHash": "fnv1a64:2ad8553705ea5e8f",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/german/CHANGELOG.md
+++ b/code/learning/human-languages/german/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## German joins the cross-language core verbs (2026-08-07)
+
+- Retagged **six** verb lessons from language-local ids to the canonical
+  concepts owned by `SPINE-SAY-WHAT-I-DO`, so German's verbs finally join the
+  cross-language corpus instead of being seven private ids no other track can
+  see: `GE-C16-sein` → `VERB-BE`, `GE-C14-haben` → `VERB-HAVE`,
+  `GE-C03-gehen` → `VERB-GO`, `GE-C05-machen` → `VERB-DO-MAKE`,
+  `GE-C05-lernen` → `VERB-LEARN`, `GE-C05-wohnen` → `VERB-LIVE`
+  (*wohnen* is taught as "to live / to dwell", which is exactly `VERB-LIVE`).
+  German's core-verb coverage goes **0/40 → 6/40**, and `VERB-DO-MAKE` and
+  `VERB-LEARN` leave the corpus-wide `universallyMissing` list (29 → 27) —
+  German is the first track anywhere to realize either.
+- `GE-C02-heissen` keeps its namespaced `DE-VERB-HEISSEN`. No core concept
+  means "to be called": *heißen* is not a translation of anything on the
+  shared list, and forcing it onto one would be a false join.
+- **Rewired `curriculum.json` so the realization path matches the retag.** A
+  canonical concept obliges its lesson to sit in the segment of the node that
+  owns it, so the four verb tranches moved into their own
+  `SPINE-SAY-WHAT-I-DO` segments — `GE-PATH-011` (*gehen*), `GE-PATH-014`
+  (*wohnen*, *machen*, *lernen*), `GE-PATH-018` (*haben*), `GE-PATH-021`
+  (*sein*) — and left `SPINE-CHECK-WELLBEING` and `SPINE-TIME-OF-DAY`, where
+  they had been sitting as language-specific extension material.
+- **Teaching order is untouched.** No chapter was reordered and no lesson
+  renumbered: each moved lesson holds the exact position it already had, and
+  the segments were split around it rather than resequenced. *gehen* still
+  lands immediately before *wie geht es*, which needs it.
+- Three orphan lessons entered the path because the retag required it.
+  `GE-C05-lernen` and `GE-C16-sein` realize canonical concepts and so cannot
+  be absent from it; *sein* in turn declares `GE-C15-praeteritum` as a
+  prerequisite (its *war/waren* forms are Präteritum), which pulled
+  `GE-C15-perfekt` and `GE-C15-praeteritum` in behind it. Those two are a
+  German-local past, not `VERB-PAST`, so they are recorded as a
+  `SPINE-TALK-ABOUT-PAST` segment (`GE-PATH-020`) whose omission ledger still
+  names `VERB-PAST` as undelivered. The node is now realized without the
+  debt being quietly written off.
+- Path segments were renumbered `GE-PATH-001..026` and extensions renamed to
+  match their host segment, keeping the ids monotonic in path order as every
+  other track has them. `GE-EXT-011-LANGUAGE-SPECIFIC` was deleted outright:
+  it existed only to classify *gehen* as local support, and *gehen* is now
+  shared content.
+- Derived levels move accordingly: German reaches **A2** for the first time,
+  corpus `A2` 91 → 99, `A1` 307 → 304, `pre-A1` 657 → 656, unmapped 170 → 166.
+
 ## Chapter capability ledger — Chapters 17–23 (2026-08-06)
 
 - Added [`chapters.json`](./chapters.json), the track's HL05 capability ledger:

--- a/code/learning/human-languages/german/curriculum.json
+++ b/code/learning/human-languages/german/curriculum.json
@@ -116,20 +116,27 @@
     },
     {
       "id": "GE-PATH-011",
-      "spine_node": "SPINE-CHECK-WELLBEING",
+      "spine_node": "SPINE-SAY-WHAT-I-DO",
       "lessons": [
-        "GE-C03-gehen",
-        "GE-C03-wie-geht-es",
-        "GE-C03-es-geht"
+        "GE-C03-gehen"
       ],
-      "before": [
-        "GE-EXT-011-LANGUAGE-SPECIFIC"
-      ],
+      "before": [],
       "inline": [],
       "after": []
     },
     {
       "id": "GE-PATH-012",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "GE-C03-wie-geht-es",
+        "GE-C03-es-geht"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-013",
       "spine_node": "SPINE-TAKE-LEAVE",
       "lessons": [
         "GE-C04-auf-wiedersehen",
@@ -143,22 +150,32 @@
       "after": []
     },
     {
-      "id": "GE-PATH-013",
-      "spine_node": "SPINE-TIME-OF-DAY",
+      "id": "GE-PATH-014",
+      "spine_node": "SPINE-SAY-WHAT-I-DO",
       "lessons": [
         "GE-C05-wohnen",
         "GE-C05-machen",
+        "GE-C05-lernen"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-015",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
         "GE-C06-zahlen-1-5",
         "GE-C06-zahlen-6-10"
       ],
       "before": [],
       "inline": [
-        "GE-EXT-013-LANGUAGE-SPECIFIC"
+        "GE-EXT-015-LANGUAGE-SPECIFIC"
       ],
       "after": []
     },
     {
-      "id": "GE-PATH-014",
+      "id": "GE-PATH-016",
       "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
       "lessons": [
         "GE-C08-uhr",
@@ -171,29 +188,72 @@
       ],
       "before": [],
       "inline": [
-        "GE-EXT-014-LANGUAGE-SPECIFIC"
+        "GE-EXT-016-LANGUAGE-SPECIFIC"
       ],
       "after": []
     },
     {
-      "id": "GE-PATH-015",
+      "id": "GE-PATH-017",
       "spine_node": "SPINE-TIME-OF-DAY",
       "lessons": [
         "GE-C12-elf-zwoelf",
         "GE-C12-zahlen-13-20",
         "GE-C13-schwarz-weiss",
-        "GE-C13-rot-blau",
-        "GE-C14-haben",
-        "GE-C14-alter"
+        "GE-C13-rot-blau"
       ],
       "before": [],
       "inline": [
-        "GE-EXT-015-LANGUAGE-SPECIFIC"
+        "GE-EXT-017-LANGUAGE-SPECIFIC"
       ],
       "after": []
     },
     {
-      "id": "GE-PATH-016",
+      "id": "GE-PATH-018",
+      "spine_node": "SPINE-SAY-WHAT-I-DO",
+      "lessons": [
+        "GE-C14-haben"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-019",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "GE-C14-alter"
+      ],
+      "before": [],
+      "inline": [
+        "GE-EXT-019-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-020",
+      "spine_node": "SPINE-TALK-ABOUT-PAST",
+      "lessons": [
+        "GE-C15-perfekt",
+        "GE-C15-praeteritum"
+      ],
+      "before": [],
+      "inline": [
+        "GE-EXT-020-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-021",
+      "spine_node": "SPINE-SAY-WHAT-I-DO",
+      "lessons": [
+        "GE-C16-sein"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-022",
       "spine_node": "SPINE-CHECK-WELLBEING",
       "lessons": [
         "GE-C17-kopf",
@@ -202,13 +262,13 @@
       ],
       "before": [],
       "inline": [
-        "GE-EXT-016-LANGUAGE-SPECIFIC",
-        "GE-EXT-016-ETYMOLOGY"
+        "GE-EXT-022-LANGUAGE-SPECIFIC",
+        "GE-EXT-022-ETYMOLOGY"
       ],
       "after": []
     },
     {
-      "id": "GE-PATH-017",
+      "id": "GE-PATH-023",
       "spine_node": "SPINE-RESPOND-BASIC",
       "lessons": [
         "GE-C18-ja",
@@ -219,7 +279,7 @@
       "after": []
     },
     {
-      "id": "GE-PATH-018",
+      "id": "GE-PATH-024",
       "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
       "lessons": [
         "GE-C19-bitte-requests",
@@ -230,19 +290,19 @@
       "after": []
     },
     {
-      "id": "GE-PATH-019",
+      "id": "GE-PATH-025",
       "spine_node": "SPINE-TIME-OF-DAY",
       "lessons": [
         "GE-C21-das-wetter"
       ],
       "before": [],
       "inline": [
-        "GE-EXT-019-LANGUAGE-SPECIFIC"
+        "GE-EXT-025-LANGUAGE-SPECIFIC"
       ],
       "after": []
     },
     {
-      "id": "GE-PATH-020",
+      "id": "GE-PATH-026",
       "spine_node": "SPINE-DEFINITE-REFERENCE",
       "lessons": [
         "GE-C22-hund-katze",
@@ -250,7 +310,7 @@
       ],
       "before": [],
       "inline": [
-        "GE-EXT-020-LANGUAGE-SPECIFIC"
+        "GE-EXT-026-LANGUAGE-SPECIFIC"
       ],
       "after": []
     }
@@ -278,7 +338,7 @@
     },
     "SPINE-RESPOND-BASIC": {
       "segments": [
-        "GE-PATH-017"
+        "GE-PATH-023"
       ],
       "omits": [
         "RESPONSE-YESNO",
@@ -304,8 +364,8 @@
       "segments": [
         "GE-PATH-002",
         "GE-PATH-008",
-        "GE-PATH-011",
-        "GE-PATH-016"
+        "GE-PATH-012",
+        "GE-PATH-022"
       ],
       "omits": [
         "WORD-WELL"
@@ -314,8 +374,8 @@
     },
     "SPINE-POLITE-REQUEST-REPAIR": {
       "segments": [
-        "GE-PATH-014",
-        "GE-PATH-018"
+        "GE-PATH-016",
+        "GE-PATH-024"
       ],
       "omits": [],
       "relocates": {}
@@ -323,7 +383,7 @@
     "SPINE-TAKE-LEAVE": {
       "segments": [
         "GE-PATH-005",
-        "GE-PATH-012"
+        "GE-PATH-013"
       ],
       "omits": [],
       "relocates": {}
@@ -332,9 +392,10 @@
       "segments": [
         "GE-PATH-004",
         "GE-PATH-006",
-        "GE-PATH-013",
         "GE-PATH-015",
-        "GE-PATH-019"
+        "GE-PATH-017",
+        "GE-PATH-019",
+        "GE-PATH-025"
       ],
       "omits": [
         "TIME-AFTERNOON",
@@ -352,7 +413,7 @@
     "SPINE-DEFINITE-REFERENCE": {
       "segments": [
         "GE-PATH-003",
-        "GE-PATH-020"
+        "GE-PATH-026"
       ],
       "omits": [],
       "relocates": {}
@@ -365,14 +426,15 @@
       "relocates": {}
     },
     "SPINE-SAY-WHAT-I-DO": {
-      "segments": [],
+      "segments": [
+        "GE-PATH-011",
+        "GE-PATH-014",
+        "GE-PATH-018",
+        "GE-PATH-021"
+      ],
       "omits": [
         "VERB-INFINITIVE",
         "VERB-PRESENT-HABITUAL",
-        "VERB-BE",
-        "VERB-HAVE",
-        "VERB-DO-MAKE",
-        "VERB-GO",
         "VERB-COME",
         "VERB-SAY",
         "VERB-SPEAK",
@@ -381,7 +443,6 @@
         "VERB-KNOW",
         "VERB-THINK",
         "VERB-UNDERSTAND",
-        "VERB-LEARN",
         "VERB-READ",
         "VERB-WRITE",
         "VERB-CAN",
@@ -393,7 +454,6 @@
         "VERB-EAT",
         "VERB-DRINK",
         "VERB-SLEEP",
-        "VERB-LIVE",
         "VERB-WORK",
         "VERB-PLAY",
         "VERB-WALK",
@@ -428,7 +488,9 @@
       "relocates": {}
     },
     "SPINE-TALK-ABOUT-PAST": {
-      "segments": [],
+      "segments": [
+        "GE-PATH-020"
+      ],
       "omits": [
         "VERB-PAST"
       ],
@@ -455,32 +517,19 @@
       ]
     },
     {
-      "id": "GE-EXT-011-LANGUAGE-SPECIFIC",
-      "stage": "pre-A1",
-      "kind": "required",
-      "category": "language-specific",
-      "canDo": "I can use the additional German material required at this point in the path.",
-      "prerequisites": [],
-      "lessons": [
-        "GE-C03-gehen"
-      ]
-    },
-    {
-      "id": "GE-EXT-013-LANGUAGE-SPECIFIC",
+      "id": "GE-EXT-015-LANGUAGE-SPECIFIC",
       "stage": "A1",
       "kind": "required",
       "category": "language-specific",
       "canDo": "I can use the additional German material required at this point in the path.",
       "prerequisites": [],
       "lessons": [
-        "GE-C05-wohnen",
-        "GE-C05-machen",
         "GE-C06-zahlen-1-5",
         "GE-C06-zahlen-6-10"
       ]
     },
     {
-      "id": "GE-EXT-014-LANGUAGE-SPECIFIC",
+      "id": "GE-EXT-016-LANGUAGE-SPECIFIC",
       "stage": "pre-A1",
       "kind": "required",
       "category": "language-specific",
@@ -497,7 +546,7 @@
       ]
     },
     {
-      "id": "GE-EXT-015-LANGUAGE-SPECIFIC",
+      "id": "GE-EXT-017-LANGUAGE-SPECIFIC",
       "stage": "A1",
       "kind": "required",
       "category": "language-specific",
@@ -507,13 +556,34 @@
         "GE-C12-elf-zwoelf",
         "GE-C12-zahlen-13-20",
         "GE-C13-schwarz-weiss",
-        "GE-C13-rot-blau",
-        "GE-C14-haben",
+        "GE-C13-rot-blau"
+      ]
+    },
+    {
+      "id": "GE-EXT-019-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional German material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
         "GE-C14-alter"
       ]
     },
     {
-      "id": "GE-EXT-016-LANGUAGE-SPECIFIC",
+      "id": "GE-EXT-020-LANGUAGE-SPECIFIC",
+      "stage": "A2",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can form the German Perfekt that speech actually uses, and recognize the Präteritum the written language keeps — the two pasts sein draws its war/waren forms from.",
+      "prerequisites": [],
+      "lessons": [
+        "GE-C15-perfekt",
+        "GE-C15-praeteritum"
+      ]
+    },
+    {
+      "id": "GE-EXT-022-LANGUAGE-SPECIFIC",
       "stage": "pre-A1",
       "kind": "required",
       "category": "language-specific",
@@ -525,7 +595,7 @@
       ]
     },
     {
-      "id": "GE-EXT-016-ETYMOLOGY",
+      "id": "GE-EXT-022-ETYMOLOGY",
       "stage": "pre-A1",
       "kind": "supporting",
       "category": "etymology",
@@ -536,7 +606,7 @@
       ]
     },
     {
-      "id": "GE-EXT-019-LANGUAGE-SPECIFIC",
+      "id": "GE-EXT-025-LANGUAGE-SPECIFIC",
       "stage": "A1",
       "kind": "required",
       "category": "language-specific",
@@ -547,7 +617,7 @@
       ]
     },
     {
-      "id": "GE-EXT-020-LANGUAGE-SPECIFIC",
+      "id": "GE-EXT-026-LANGUAGE-SPECIFIC",
       "stage": "A1",
       "kind": "required",
       "category": "language-specific",

--- a/code/learning/human-languages/german/lessons/GE-C03-gehen.md
+++ b/code/learning/human-languages/german/lessons/GE-C03-gehen.md
@@ -4,7 +4,7 @@ chapter: 3
 type: word
 headword: gehen
 gloss: to go — and the verb German uses for "how are you?"
-concept_tag: DE-VERB-GEHEN
+concept_tag: VERB-GO
 prerequisites: []
 sounds: [h-pronounced]
 roots: [gehen-german]

--- a/code/learning/human-languages/german/lessons/GE-C05-lernen.md
+++ b/code/learning/human-languages/german/lessons/GE-C05-lernen.md
@@ -4,7 +4,7 @@ chapter: 5
 type: word
 headword: lernen
 gloss: to learn (a third weak verb — the pattern is yours)
-concept_tag: GE-VERB-LERNEN
+concept_tag: VERB-LEARN
 prerequisites: [GE-C05-wohnen]
 sounds: [r-uvular-german]
 roots: [liznojan-germanic]

--- a/code/learning/human-languages/german/lessons/GE-C05-machen.md
+++ b/code/learning/human-languages/german/lessons/GE-C05-machen.md
@@ -4,7 +4,7 @@ chapter: 5
 type: word
 headword: machen
 gloss: to make / to do (a second weak verb — same endings)
-concept_tag: GE-VERB-MACHEN
+concept_tag: VERB-DO-MAKE
 prerequisites: [GE-C05-wohnen]
 sounds: [ch-ach, vowel-a-german]
 roots: [makon-germanic]

--- a/code/learning/human-languages/german/lessons/GE-C05-wohnen.md
+++ b/code/learning/human-languages/german/lessons/GE-C05-wohnen.md
@@ -4,7 +4,7 @@ chapter: 5
 type: word
 headword: wohnen
 gloss: to live / to dwell (your first regular "weak" verb)
-concept_tag: GE-VERB-WOHNEN
+concept_tag: VERB-LIVE
 prerequisites: [GE-C02-ich, GE-C02-du-sie]
 sounds: [w-is-v, h-pronounced]
 roots: [wonen-ohg]

--- a/code/learning/human-languages/german/lessons/GE-C14-haben.md
+++ b/code/learning/human-languages/german/lessons/GE-C14-haben.md
@@ -4,7 +4,7 @@ chapter: 14
 type: word
 headword: haben
 gloss: to have — identical to Latin habēre in sound and sense, and unrelated to it
-concept_tag: GE-VERB-HAVE
+concept_tag: VERB-HAVE
 prerequisites: [GE-C13-rot-blau, GE-C05-machen]
 sounds: [long-a, final-t]
 roots: [germanic-habjana]

--- a/code/learning/human-languages/german/lessons/GE-C16-sein.md
+++ b/code/learning/human-languages/german/lessons/GE-C16-sein.md
@@ -4,7 +4,7 @@ chapter: 16
 type: word
 headword: sein
 gloss: to be — one verb assembled from three different ancient roots
-concept_tag: GE-VERB-BE
+concept_tag: VERB-BE
 prerequisites: [GE-C14-haben, GE-C15-praeteritum]
 sounds: [ich-laut, final-devoicing]
 roots: [pie-h1es, pie-bhuh, pie-wes]

--- a/code/learning/human-languages/german/narration/ch03.json
+++ b/code/learning/human-languages/german/narration/ch03.json
@@ -4,7 +4,7 @@
   "chapter": 3,
   "title": "Chapter 3",
   "drivablePrefix": 8,
-  "sourceHash": "fnv1a64:65dc0d28eed56e84",
+  "sourceHash": "fnv1a64:9c052e4af0dd40f4",
   "lessons": [
     {
       "id": "GE-C03-bitte",
@@ -581,7 +581,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:2f5debf915f23ce0",
+      "sourceHash": "fnv1a64:2a5f813dc0845297",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/german/narration/ch05.json
+++ b/code/learning/human-languages/german/narration/ch05.json
@@ -4,7 +4,7 @@
   "chapter": 5,
   "title": "Chapter 5",
   "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:226ff8e7967736a8",
+  "sourceHash": "fnv1a64:fa85693f7e833aff",
   "lessons": [
     {
       "id": "GE-C05-ich-lerne-deutsch",
@@ -169,7 +169,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ff029ca03897854f",
+      "sourceHash": "fnv1a64:b692dc8bfe1e4b40",
       "notice": null,
       "blocks": [
         {
@@ -316,7 +316,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:6038f0a02649b609",
+      "sourceHash": "fnv1a64:92a8f484ee09fb92",
       "notice": null,
       "blocks": [
         {
@@ -635,7 +635,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e93089459bad42a0",
+      "sourceHash": "fnv1a64:03068b42d443b4fe",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/german/narration/ch14.json
+++ b/code/learning/human-languages/german/narration/ch14.json
@@ -4,7 +4,7 @@
   "chapter": 14,
   "title": "Chapter 14",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:fb7d311ddf2d57e0",
+  "sourceHash": "fnv1a64:a9f6d19b7d1de599",
   "lessons": [
     {
       "id": "GE-C14-alter",
@@ -197,7 +197,7 @@
       "modalityReasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:d1046ec3cd8b7d51",
+      "sourceHash": "fnv1a64:ac77aad8695d3ee6",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/german/narration/ch16.json
+++ b/code/learning/human-languages/german/narration/ch16.json
@@ -4,7 +4,7 @@
   "chapter": 16,
   "title": "Chapter 16",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:b519f69c62cd5cd0",
+  "sourceHash": "fnv1a64:e0757a9507364a37",
   "lessons": [
     {
       "id": "GE-C16-perfekt-sein",
@@ -308,7 +308,7 @@
       "modalityReasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:cec3f047484e5bd8",
+      "sourceHash": "fnv1a64:d89aa6546b6499a7",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/spanish/book/chapters/ch06-first-verbs.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch06-first-verbs.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:eac6f9bff395c7b3
+% canonical-source-hash: fnv1a64:4450428fd5374b11
 % canonical-lessons: ES-C06-cafe, ES-C06-por-favor, ES-C06-hablar, ES-C06-ar-presente, ES-C06-trabajar, ES-C06-estudiar, ES-C06-espanol, ES-C06-hablo-espanol, ES-C06-practice
 
 \chapter{The First Verbs}

--- a/code/learning/human-languages/spanish/curriculum.json
+++ b/code/learning/human-languages/spanish/curriculum.json
@@ -213,15 +213,33 @@
       ]
     },
     {
+      "id": "ES-PATH-028",
+      "spine_node": "SPINE-SAY-WHAT-I-DO",
+      "lessons": [
+        "ES-C07-comer",
+        "ES-C07-beber"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
       "id": "ES-PATH-014",
       "spine_node": "SPINE-EXCHANGE-NAMES",
       "lessons": [
-        "ES-C07-comer",
         "ES-C07-que"
       ],
-      "before": [
-        "ES-EXT-014-LANGUAGE-SPECIFIC"
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-029",
+      "spine_node": "SPINE-SAY-WHAT-I-DO",
+      "lessons": [
+        "ES-C07-vivir"
       ],
+      "before": [],
       "inline": [],
       "after": []
     },
@@ -229,12 +247,9 @@
       "id": "ES-PATH-015",
       "spine_node": "SPINE-ASK-LOCATION",
       "lessons": [
-        "ES-C07-vivir",
         "ES-C07-donde"
       ],
-      "before": [
-        "ES-EXT-015-LANGUAGE-SPECIFIC"
-      ],
+      "before": [],
       "inline": [],
       "after": []
     },
@@ -243,13 +258,33 @@
       "spine_node": "SPINE-TIME-OF-DAY",
       "lessons": [
         "ES-C08-numeros-1-5",
-        "ES-C08-numeros-6-10",
-        "ES-C08-tener",
-        "ES-C12-hacer"
+        "ES-C08-numeros-6-10"
       ],
       "before": [],
       "inline": [
         "ES-EXT-016-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-030",
+      "spine_node": "SPINE-SAY-WHAT-I-DO",
+      "lessons": [
+        "ES-C08-tener",
+        "ES-C09-ser",
+        "ES-C10-ir",
+        "ES-C11-querer",
+        "ES-C11-poder",
+        "ES-C12-hacer",
+        "ES-C12-decir",
+        "ES-C12-yo-go",
+        "ES-C13-poner",
+        "ES-C13-salir",
+        "ES-C13-venir"
+      ],
+      "before": [],
+      "inline": [
+        "ES-EXT-030-LANGUAGE-SPECIFIC"
       ],
       "after": []
     },
@@ -528,17 +563,14 @@
       "relocates": {}
     },
     "SPINE-SAY-WHAT-I-DO": {
-      "segments": [],
+      "segments": [
+        "ES-PATH-028",
+        "ES-PATH-029",
+        "ES-PATH-030"
+      ],
       "omits": [
         "VERB-INFINITIVE",
         "VERB-PRESENT-HABITUAL",
-        "VERB-BE",
-        "VERB-HAVE",
-        "VERB-DO-MAKE",
-        "VERB-GO",
-        "VERB-COME",
-        "VERB-SAY",
-        "VERB-SPEAK",
         "VERB-SEE",
         "VERB-HEAR",
         "VERB-KNOW",
@@ -547,17 +579,11 @@
         "VERB-LEARN",
         "VERB-READ",
         "VERB-WRITE",
-        "VERB-CAN",
         "VERB-GIVE",
         "VERB-TAKE",
         "VERB-BRING",
         "VERB-GET",
-        "VERB-PUT",
-        "VERB-EAT",
-        "VERB-DRINK",
         "VERB-SLEEP",
-        "VERB-LIVE",
-        "VERB-WORK",
         "VERB-PLAY",
         "VERB-WALK",
         "VERB-RUN",
@@ -573,7 +599,10 @@
         "VERB-CLOSE",
         "VERB-LIKE-LOVE"
       ],
-      "relocates": {}
+      "relocates": {
+        "VERB-SPEAK": "SPINE-POLITE-REQUEST-REPAIR",
+        "VERB-WORK": "SPINE-POLITE-REQUEST-REPAIR"
+      }
     },
     "SPINE-NEGATE-AND-ASK": {
       "segments": [],
@@ -851,28 +880,6 @@
       ]
     },
     {
-      "id": "ES-EXT-014-LANGUAGE-SPECIFIC",
-      "stage": "pre-A1",
-      "kind": "required",
-      "category": "language-specific",
-      "canDo": "I can use the additional Spanish material required at this point in the path.",
-      "prerequisites": [],
-      "lessons": [
-        "ES-C07-comer"
-      ]
-    },
-    {
-      "id": "ES-EXT-015-LANGUAGE-SPECIFIC",
-      "stage": "A1",
-      "kind": "required",
-      "category": "language-specific",
-      "canDo": "I can use the additional Spanish material required at this point in the path.",
-      "prerequisites": [],
-      "lessons": [
-        "ES-C07-vivir"
-      ]
-    },
-    {
       "id": "ES-EXT-016-LANGUAGE-SPECIFIC",
       "stage": "A1",
       "kind": "required",
@@ -881,9 +888,7 @@
       "prerequisites": [],
       "lessons": [
         "ES-C08-numeros-1-5",
-        "ES-C08-numeros-6-10",
-        "ES-C08-tener",
-        "ES-C12-hacer"
+        "ES-C08-numeros-6-10"
       ]
     },
     {
@@ -1014,6 +1019,19 @@
         "ES-C32-perro",
         "ES-C33-verde",
         "ES-C33-amarillo"
+      ]
+    },
+    {
+      "id": "ES-EXT-030-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the additional Spanish material required at this point in the path.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C11-querer",
+        "ES-C12-yo-go",
+        "ES-C13-salir"
       ]
     }
   ]

--- a/code/learning/human-languages/spanish/lessons/ES-C06-hablar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-hablar.md
@@ -7,7 +7,7 @@ chapter: 6
 type: word
 headword: hablar
 gloss: to speak / to talk — at root, "to tell stories"
-concept_tag: ES-VERB-HABLAR
+concept_tag: VERB-SPEAK
 prerequisites: [ES-C06-por-favor]
 sounds: [silent-h, r-tap, v-b]
 roots: [fabulari-latin]

--- a/code/learning/human-languages/spanish/lessons/ES-C06-trabajar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-trabajar.md
@@ -7,7 +7,7 @@ chapter: 6
 type: word
 headword: trabajar
 gloss: to work (a second -ar verb — same pattern)
-concept_tag: ES-VERB-TRABAJAR
+concept_tag: VERB-WORK
 prerequisites: [ES-C06-hablar, ES-C06-ar-presente]
 sounds: [r-tap, j-jota, b-soft]
 roots: [tripalium-latin]

--- a/code/learning/human-languages/spanish/lessons/ES-C07-beber.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C07-beber.md
@@ -4,7 +4,7 @@ chapter: 7
 type: word
 headword: beber
 gloss: to drink (another -er verb — cementing the pattern)
-concept_tag: ES-VERB-BEBER
+concept_tag: VERB-DRINK
 prerequisites: [ES-C07-comer]
 sounds: [v-b, r-tap]
 roots: [bibere-latin]

--- a/code/learning/human-languages/spanish/lessons/ES-C07-comer.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C07-comer.md
@@ -4,7 +4,7 @@ chapter: 7
 type: word
 headword: comer
 gloss: to eat (your first -er verb)
-concept_tag: ES-VERB-COMER
+concept_tag: VERB-EAT
 prerequisites: [ES-C06-hablar]
 sounds: [r-tap, vowel-o]
 roots: [comedere-latin]

--- a/code/learning/human-languages/spanish/lessons/ES-C07-vivir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C07-vivir.md
@@ -4,7 +4,7 @@ chapter: 7
 type: word
 headword: vivir
 gloss: to live (your first -ir verb)
-concept_tag: ES-VERB-VIVIR
+concept_tag: VERB-LIVE
 prerequisites: [ES-C07-comer]
 sounds: [v-b, r-tap]
 roots: [vivere-latin]

--- a/code/learning/human-languages/spanish/lessons/ES-C08-tener.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C08-tener.md
@@ -4,7 +4,7 @@ chapter: 8
 type: word
 headword: tener
 gloss: to have (your first irregular / stem-changing verb)
-concept_tag: ES-VERB-TENER
+concept_tag: VERB-HAVE
 prerequisites: [ES-C06-hablar]
 sounds: [diphthong-ie, r-tap]
 roots: [tenere-latin]

--- a/code/learning/human-languages/spanish/lessons/ES-C09-ser.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C09-ser.md
@@ -4,7 +4,7 @@ chapter: 9
 type: word
 headword: ser
 gloss: to be (identity — permanent, essential)
-concept_tag: ES-VERB-SER
+concept_tag: VERB-BE
 prerequisites: [ES-C04-estar, ES-C08-tener]
 sounds: [vowel-e, r-tap]
 roots: [esse-latin, sedere-latin]

--- a/code/learning/human-languages/spanish/lessons/ES-C10-ir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C10-ir.md
@@ -4,7 +4,7 @@ chapter: 10
 type: word
 headword: ir
 gloss: to go (the most irregular Spanish verb — three Latin verbs in one)
-concept_tag: ES-VERB-IR
+concept_tag: VERB-GO
 prerequisites: [ES-C09-ser, ES-C04-estar]
 sounds: [vowel-i, diphthong-oy]
 roots: [ire-vadere-latin]

--- a/code/learning/human-languages/spanish/lessons/ES-C11-poder.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C11-poder.md
@@ -4,7 +4,7 @@ chapter: 11
 type: word
 headword: poder
 gloss: to be able / can — a stem-changing verb, o→ue
-concept_tag: ES-VERB-PODER
+concept_tag: VERB-CAN
 prerequisites: [ES-C11-querer, ES-C06-hablar]
 sounds: [diphthong-ue, r-tap]
 roots: [potere-latin]

--- a/code/learning/human-languages/spanish/lessons/ES-C12-decir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C12-decir.md
@@ -4,7 +4,7 @@ chapter: 12
 type: word
 headword: decir
 gloss: to say / to tell — doubly irregular, digo + e→i
-concept_tag: ES-VERB-DECIR
+concept_tag: VERB-SAY
 prerequisites: [ES-C12-hacer, ES-C11-querer]
 sounds: [diphthong-none-i, g-hard]
 roots: [dicere-latin]

--- a/code/learning/human-languages/spanish/lessons/ES-C12-hacer.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C12-hacer.md
@@ -4,7 +4,7 @@ chapter: 12
 type: word
 headword: hacer
 gloss: to do / to make — an irregular yo-form, hago
-concept_tag: ES-VERB-HACER
+concept_tag: VERB-DO-MAKE
 prerequisites: [ES-C08-tener, ES-C06-hablar]
 sounds: [jota-h-silent, g-hard]
 roots: [facere-latin]

--- a/code/learning/human-languages/spanish/lessons/ES-C13-poner.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C13-poner.md
@@ -4,7 +4,7 @@ chapter: 13
 type: word
 headword: poner
 gloss: to put / to place — a -go yo-form, pongo
-concept_tag: ES-VERB-PONER
+concept_tag: VERB-PUT
 prerequisites: [ES-C12-yo-go, ES-C12-hacer]
 sounds: [g-hard, r-tap]
 roots: [ponere-latin]

--- a/code/learning/human-languages/spanish/lessons/ES-C13-venir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C13-venir.md
@@ -4,7 +4,7 @@ chapter: 13
 type: word
 headword: venir
 gloss: to come — doubly irregular, vengo + e→ie, completing the -go club
-concept_tag: ES-VERB-VENIR
+concept_tag: VERB-COME
 prerequisites: [ES-C13-salir, ES-C11-querer]
 sounds: [g-hard, diphthong-ie]
 roots: [venire-latin]

--- a/code/learning/human-languages/spanish/narration/ch06.json
+++ b/code/learning/human-languages/spanish/narration/ch06.json
@@ -4,7 +4,7 @@
   "chapter": 6,
   "title": "The First Verbs",
   "drivablePrefix": 3,
-  "sourceHash": "fnv1a64:eac6f9bff395c7b3",
+  "sourceHash": "fnv1a64:4450428fd5374b11",
   "lessons": [
     {
       "id": "ES-C06-cafe",
@@ -286,7 +286,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:9f0c8a41a736120d",
+      "sourceHash": "fnv1a64:ec974cf7795b5dea",
       "notice": null,
       "blocks": [
         {
@@ -568,7 +568,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:37787818353f0baa",
+      "sourceHash": "fnv1a64:87e1da307dcee2f5",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch07.json
+++ b/code/learning/human-languages/spanish/narration/ch07.json
@@ -4,7 +4,7 @@
   "chapter": 7,
   "title": "Chapter 7",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:4d7e644b06b4b607",
+  "sourceHash": "fnv1a64:38c0aead8768635a",
   "lessons": [
     {
       "id": "ES-C07-beber",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:0088dadb5fdf6331",
+      "sourceHash": "fnv1a64:1cc22b5309fcdd0c",
       "notice": null,
       "blocks": [
         {
@@ -179,7 +179,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:ce6a687141938f2c",
+      "sourceHash": "fnv1a64:2c5c24910d6f4117",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -800,7 +800,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:1857cec1eb24a351",
+      "sourceHash": "fnv1a64:1a9b0f692c3ce186",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/spanish/narration/ch08.json
+++ b/code/learning/human-languages/spanish/narration/ch08.json
@@ -4,7 +4,7 @@
   "chapter": 8,
   "title": "Chapter 8",
   "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:f8fd827c9e8e2e3f",
+  "sourceHash": "fnv1a64:aa8faca659cd6608",
   "lessons": [
     {
       "id": "ES-C08-cuantos-anos",
@@ -611,7 +611,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:73eb2365c48ed0d8",
+      "sourceHash": "fnv1a64:25fe3250fd9cbc5b",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch09.json
+++ b/code/learning/human-languages/spanish/narration/ch09.json
@@ -4,7 +4,7 @@
   "chapter": 9,
   "title": "Chapter 9",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:3f6b233c47e2ea13",
+  "sourceHash": "fnv1a64:0f128ec69fedf560",
   "lessons": [
     {
       "id": "ES-C09-esta-en",
@@ -391,7 +391,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ea5fdc59c0e2c713",
+      "sourceHash": "fnv1a64:a82cd4ab00b99923",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch10.json
+++ b/code/learning/human-languages/spanish/narration/ch10.json
@@ -4,7 +4,7 @@
   "chapter": 10,
   "title": "Chapter 10",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:45eb64c530fd2523",
+  "sourceHash": "fnv1a64:60c303e5299f5fd7",
   "lessons": [
     {
       "id": "ES-C10-ir",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:cfbc7b80522ef5b7",
+      "sourceHash": "fnv1a64:8625b52e5ef33af5",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch11.json
+++ b/code/learning/human-languages/spanish/narration/ch11.json
@@ -4,7 +4,7 @@
   "chapter": 11,
   "title": "Chapter 11",
   "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:da677dc4c1b0d05e",
+  "sourceHash": "fnv1a64:a4622dd6cae2c8a2",
   "lessons": [
     {
       "id": "ES-C11-nuestro",
@@ -155,7 +155,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:142a93616e523eef",
+      "sourceHash": "fnv1a64:fc28c84739b62d76",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch12.json
+++ b/code/learning/human-languages/spanish/narration/ch12.json
@@ -4,7 +4,7 @@
   "chapter": 12,
   "title": "Chapter 12",
   "drivablePrefix": 3,
-  "sourceHash": "fnv1a64:d0e8994ddaf5883b",
+  "sourceHash": "fnv1a64:5f72f74488786bf2",
   "lessons": [
     {
       "id": "ES-C12-decir",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ab045c322463a363",
+      "sourceHash": "fnv1a64:b70e553d669e1c90",
       "notice": null,
       "blocks": [
         {
@@ -181,7 +181,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:babb115768b0f09b",
+      "sourceHash": "fnv1a64:8af16bd2e1a9ced7",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch13.json
+++ b/code/learning/human-languages/spanish/narration/ch13.json
@@ -4,7 +4,7 @@
   "chapter": 13,
   "title": "Chapter 13",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:70b10e3c98a8e598",
+  "sourceHash": "fnv1a64:fd74e6b6faccb060",
   "lessons": [
     {
       "id": "ES-C13-poner",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:3dece00044903fdb",
+      "sourceHash": "fnv1a64:853daae9f3657b07",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -537,7 +537,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:6ac43d9b03170b92",
+      "sourceHash": "fnv1a64:43d46c297f5ac8ef",
       "notice": null,
       "blocks": [
         {

--- a/code/packages/typescript/human-language-data/tests/levels.test.ts
+++ b/code/packages/typescript/human-language-data/tests/levels.test.ts
@@ -217,9 +217,9 @@ describe("corpus snapshot", () => {
     const { lessons, curricula: paths, spine } = loadEverything();
     const summary = summarizeLevels(lessons, paths, spine);
 
-    expect(summary.byLevel["pre-A1"]).toBe(657);
-    expect(summary.byLevel.A1).toBe(307);
-    expect(summary.byLevel.A2).toBe(91);
+    expect(summary.byLevel["pre-A1"]).toBe(654);
+    expect(summary.byLevel.A1).toBe(297);
+    expect(summary.byLevel.A2).toBe(122);
     expect(summary.byLevel.B1).toBe(0);
     expect(summary.byLevel.B2).toBe(0);
     expect(summary.byLevel.C1).toBe(0);
@@ -227,11 +227,11 @@ describe("corpus snapshot", () => {
 
     // 170 lessons sit in no realization-path segment, all of them schema-v1. They are the
     // reason `mappedPercent` is not 100, and mapping them is migration work, not a gate.
-    expect(summary.unmapped).toBe(170);
-    expect(summary.mappedPercent).toBe(86);
+    expect(summary.unmapped).toBe(152);
+    expect(summary.mappedPercent).toBe(88);
   });
 
-  it("shows fifteen tracks have reached A2, and only two have not reached A1", () => {
+  it("shows eighteen tracks have reached A2, and only two have not reached A1", () => {
     const { lessons, curricula: paths, spine } = loadEverything();
     const summary = summarizeLevels(lessons, paths, spine);
     // `reach` is the highest level a track has ANY lesson at, so this names the tracks
@@ -243,6 +243,8 @@ describe("corpus snapshot", () => {
     ).toEqual([
       "arabic",
       "bengali",
+      "french",
+      "german",
       "gujarati",
       "kannada",
       "latin",
@@ -253,6 +255,7 @@ describe("corpus snapshot", () => {
       "punjabi",
       "russian",
       "sanskrit",
+      "spanish",
       "tamil",
       "telugu",
       "urdu",
@@ -269,7 +272,7 @@ describe("corpus snapshot", () => {
     const { lessons, curricula: paths, spine } = loadEverything();
     const ramp = lessonsUpToLevel(lessons, paths, spine, "A1");
     // The whole point: this is a FILTER over the one corpus, not a second corpus.
-    expect(ramp).toHaveLength(964);
+    expect(ramp).toHaveLength(951);
     expect(ramp.length).toBeLessThan(lessons.length);
   });
 });

--- a/code/packages/typescript/human-language-data/tests/verbs.test.ts
+++ b/code/packages/typescript/human-language-data/tests/verbs.test.ts
@@ -89,15 +89,15 @@ describe("corpus snapshot", () => {
   // Each agent measured this alone and each wrote "the first track off zero". All three
   // were right in isolation and wrong together; the numbers here are re-measured against
   // the merged corpus.
-  it("pins the core verb baseline: three tracks realize twenty between them", () => {
+  it("pins the core verb baseline: eighteen tracks, and Spanish has joined", () => {
     const { lessons, taxonomy } = loadEverything();
     const report = verbCoverage(lessons, taxonomy);
 
     expect(report.summary.coreVerbCount).toBe(40);
 
-    expect(report.summary.tracksWithNoCoreVerb).toBe(7);
-    expect(report.summary.universallyMissing).toHaveLength(29);
-    expect(report.summary.meanCoveredPercent).toBe(10);
+    expect(report.summary.tracksWithNoCoreVerb).toBe(4);
+    expect(report.summary.universallyMissing).toHaveLength(23);
+    expect(report.summary.meanCoveredPercent).toBe(13);
 
     // The tracks that have joined the cross-language corpus, named explicitly so a
     // regression that silently unhooks these lessons cannot hide inside a total.
@@ -141,11 +141,21 @@ describe("corpus snapshot", () => {
       expect(report.summary.universallyMissing).not.toContain(verb);
     }
 
-    // The existing namespaced verbs are still counted, so the work already done is
-    // visible rather than erased.
+    // SPANISH IS THE POINT OF THE WHOLE EXERCISE, AND IT HAS TURNED OVER.
+    //
+    // This assertion used to read `covered: []` and `extras: 19` — a track teaching
+    // nineteen verbs and joining the cross-language corpus on not one of them, because
+    // every tag was namespaced. That was the finding the canonical verb layer existed to
+    // fix, and it is now fixed: thirteen were retagged to canonical concepts and the
+    // realization paths rewired to match, so Spanish is the largest verb contributor in
+    // the corpus.
+    //
+    // Six remain namespaced ON PURPOSE — estar, estar-forms, salir, estudiar, llamar,
+    // querer. `ser` takes VERB-BE (one lesson per concept), and the rest have no core
+    // concept that fits without stretching it.
     const spanish = report.tracks.find((track) => track.language === "spanish")!;
-    expect(spanish.extras.length).toBe(19);
-    expect(spanish.covered).toEqual([]);
+    expect(spanish.covered).toHaveLength(13);
+    expect(spanish.extras.length).toBe(6);
   });
 
   it("gives every track an explicit authoring list", () => {


### PR DESCRIPTION
Retags **25 existing verb lessons** from namespaced ids to canonical concepts, and does the realization-path rewiring that requires.

```
tracks with core verbs  15 -> 18 of 22
universallyMissing      29 -> 23
VERB-GO now taught by 18 tracks · VERB-BE by 17
```

**Spanish is the headline.** It taught **nineteen verbs and joined the corpus on none of them**, because every tag was language-local — *hablar* and *parler* were unrelated concepts to the system. Thirteen are now canonical, making Spanish the largest verb contributor. **German** is the first track anywhere to realize `VERB-DO-MAKE` and `VERB-LEARN`; **French** the first to realize `VERB-WORK`.

## Why this needed judgement, not a script

I tried the bulk retag earlier today and **reverted it at 33 validator errors**: a canonical concept owned by `SPINE-SAY-WHAT-I-DO` requires its lessons to sit in that node's path, and these lived under other nodes. The per-track work is where the value turned out to be:

- **German refused to force two past-tense lessons** under *"I can say what I do (present)"* to satisfy a prerequisite closure. That would have **validated while misrepresenting the curriculum**. They went to `SPINE-TALK-ABOUT-PAST`, with `VERB-PAST` still declared omitted, since they realize a German-local past rather than the canonical concept.
- **Spanish used `relocates`** for `hablar`/`trabajar` rather than editing their *authored* `spine_node` pin or shredding a coherent nine-lesson café stretch into fragments. That is exactly what the mechanism exists for.
- **German found two lessons using a `DE-` prefix** where my brief said `GE-`, and corrected rather than silently skipping them.

Teaching order is preserved in all three tracks — no chapter reordered, no lesson renumbered.

## Known consequence, surfaced by all three independently

Level derives from the spine node's stage, so retagged lessons move to **A2**. French's **chapter-3 `aller`** is now A2, and the ramp-to-A1 edition shrinks **964 → 951**.

Either `SPINE-SAY-WHAT-I-DO` is misplaced at A2 — *"I can say what I do"* arguably straddles A1/A2 — or early verb lessons genuinely are A2 material. **That is a curriculum decision, recorded rather than resolved**, because it moves every verb-realizing track's level profile.

## Verification

330 tests, 523 ladder tests, three drift gates, both Python suites, **all 22 XeLaTeX books**, warning scan — all local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)