### PR TITLE
feat(gc-core): adaptive safepoint scheduling for generational GC (AOT00-T8)

### DIFF
--- a/code/packages/rust/gc-core-capi/CHANGELOG.md
+++ b/code/packages/rust/gc-core-capi/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this crate are documented here.
 
+## 0.24.0 - 2026-08-06 — `__gc_safepoint` gains an (opt-in) automatic generational path (AOT00-T8)
+
+- **`__gc_collect_minor_precise()`** — new C ABI entry, the minor-generation analogue of
+  `__gc_collect_precise`: same frame-pointer walk (precise slots for stack-mapped frames,
+  conservative regions for the rest), but drives `gc_core::FlatHeap::collect_minor_mixed`
+  instead of `collect_mixed`, so it never scans or frees the old generation. Degrades to
+  exactly `__gc_collect_minor` with no stack maps registered. Always directly callable.
+- **`__gc_safepoint`** now also checks `gc_core::FlatHeap::should_collect_minor` — the
+  `Generational` half of `AdaptivePolicy`'s recommendations, previously advisory-only at
+  every automatic collection site. Priority (matching `AdaptivePolicy`'s own): minor, then
+  compacting (`should_compact`, unchanged), then a plain precise collect.
+- **`__gc_set_auto_minor(on)` / `__gc_is_auto_minor()`** — C ABI for `gc-core`'s new
+  barrier-coverage attestation gate. **Off by default**, and this default is load-bearing:
+  a security review of the first draft found that `__gc_safepoint`'s automatic callers —
+  the native-AOT/LLVM backends emit `safepoint` at every loop back-edge and function
+  entry — do not emit `__gc_write_barrier` on their `field_store` lowering (only
+  `vm-core`'s interpreter does), so an unconditional minor path would have been a real
+  use-after-free for ordinary AOT-compiled programs. `__gc_safepoint` is therefore
+  byte-for-byte unchanged from 0.23.0's behavior — precise + compacting only — until an
+  embedder calls `__gc_set_auto_minor(1)` after confirming its own barrier coverage. No
+  producer does yet (tracked as follow-up work in the spec).
+- **`__gc_set_max_minor_streak(cap)` / `__gc_max_minor_streak()`** — C ABI for
+  `gc-core`'s minor-streak cap (bounds consecutive automatic minor collections, once
+  attested, so a sustained low-survival-ratio workload can't starve the old generation of
+  collection forever — a leak, orthogonal to the use-after-free above). Clamped to
+  `1..=u32::MAX`; default `8`. Mirrors `__gc_set_tenure_age`/`__gc_tenure_age`.
+- No change to any existing symbol's ABI or default behavior below the collection
+  threshold, or above it while unattested — `__gc_safepoint` is still a no-op until
+  `should_collect` fires, and every other entry point is untouched.
+- See `code/specs/AOT00-T8-adaptive-safepoint-scheduling.md`, especially §2b.
+
 ## 0.23.0 - 2026-08-02 — `__gc_safepoint` upgrades to precise + automatic compaction
 
 - **`__gc_safepoint`** no longer runs the fully-conservative `__gc_collect`

--- a/code/packages/rust/gc-core-capi/Cargo.toml
+++ b/code/packages/rust/gc-core-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core-capi"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "C ABI for gc-core's flat-native heap — the gc_runtime_<target> archive linked into native-AOT output (LANG16 / AOT00 T1)."
 license = "MIT"

--- a/code/packages/rust/gc-core-capi/README.md
+++ b/code/packages/rust/gc-core-capi/README.md
@@ -40,9 +40,12 @@ The interpreters use `gc-core`'s managed-object collector; native output uses
 | `int64_t __gc_collect_roots(const int64_t *roots, int64_t count)` | mark from `count` root words, sweep; returns objects freed |
 | `int64_t __gc_collect_region(const uint8_t *base, int64_t len)` | mark from every candidate pointer in a raw region, sweep; returns objects freed |
 | `int64_t __gc_collect(void)` | conservative collection rooted at this thread's live stack + callee-saved registers (no caller roots); returns objects freed |
-| `int64_t __gc_safepoint(void)` | paced collect — once the live set reaches the adaptive threshold, runs `__gc_collect_precise` (or `__gc_collect_compacting` when `FlatHeap::should_compact` says fragmentation warrants it); returns objects freed (0 if throttled) |
+| `int64_t __gc_safepoint(void)` | paced collect — once the live set reaches the adaptive threshold, runs `__gc_collect_minor_precise` (only if `__gc_set_auto_minor(1)` attested barrier coverage) or `__gc_collect_compacting`/`__gc_collect_precise`, per `FlatHeap::should_collect_minor`/`should_compact`'s priority order; returns objects freed (0 if throttled) |
 | `void __gc_write_barrier(int64_t parent, int64_t child)` | generational write barrier — records an old `parent` so a minor cycle finds its young children (O(1); `child` not dereferenced) |
 | `int64_t __gc_collect_minor(void)` | minor (young-only) collection rooted at this thread's stack + registers; reclaims young garbage without scanning the old generation; returns objects freed |
+| `int64_t __gc_collect_minor_precise(void)` | minor collection rooted precisely at this thread's stack (AOT00-T8) — the generational analogue of `__gc_collect_precise`; returns objects freed |
+| `void __gc_set_max_minor_streak(int64_t cap)` / `int64_t __gc_max_minor_streak(void)` | tune/read the cap on consecutive automatic minor collections before one is forced to be full (default `8`; clamped `1..=UINT32_MAX`) |
+| `void __gc_set_auto_minor(int64_t on)` / `int64_t __gc_is_auto_minor(void)` | attest every reference store this embedder emits is `__gc_write_barrier`-covered, enabling `__gc_safepoint`'s automatic minor path — **off by default**; enabling it without real barrier coverage is a use-after-free, not a leak |
 | `int64_t __gc_live_bytes(void)` | live payload bytes |
 | `int64_t __gc_collection_count(void)` | collections run so far |
 | `void __gc_reset(void)` | drop the whole heap; free everything |

--- a/code/packages/rust/gc-core-capi/include/gc_core.h
+++ b/code/packages/rust/gc-core-capi/include/gc_core.h
@@ -92,12 +92,20 @@ int64_t __gc_collect_region(const uint8_t *base, int64_t len);
  * whatever the machine is holding. Returns objects freed. Single-threaded. */
 int64_t __gc_collect(void);
 
-/* Paced collect: run __gc_collect ONLY if the live set has reached the heap's
+/* Paced collect: run a collection ONLY if the live set has reached the heap's
  * adaptive threshold; otherwise do nothing. Returns objects freed (0 if no
  * collection ran). Drop-in for twig_gc.c's __twig_gc_safepoint — the native
  * backend calls it at loop back-edges and function entries, and it collects
  * only under memory pressure so a tight allocation loop can't starve the GC.
- * __gc_alloc also runs this same paced collect before allocating. */
+ * __gc_alloc also runs this same paced collect before allocating.
+ *
+ * Which collection kind runs is the adaptive policy's call (AOT00-T8): minor
+ * (__gc_collect_minor_precise) when __gc_set_auto_minor(1) has attested barrier
+ * coverage AND the survival-ratio signal recommends it AND the minor-streak cap
+ * hasn't been hit; else compacting (__gc_collect_compacting) when the fragmentation
+ * signal recommends it; else a plain precise collect (__gc_collect_precise). Always
+ * safe to call regardless of which kind runs — with no attestation (the default),
+ * this behaves exactly as it did before AOT00-T8. */
 int64_t __gc_safepoint(void);
 
 /* Generational write barrier: call whenever the mutator stores a heap reference
@@ -128,6 +136,29 @@ void __gc_set_tenure_age(int64_t threshold);
 
 /* The current generational tenuring age (see __gc_set_tenure_age). */
 int64_t __gc_tenure_age(void);
+
+/* Set the cap on consecutive paced minor collections (AOT00-T8) — how many
+ * __gc_safepoint calls in a row may run a minor collection before one is forced to
+ * be full, bounding how stale old-generation garbage can get under a sustained
+ * low-survival-ratio workload. Clamped to 1..=UINT32_MAX (0/negative -> 1). Default
+ * 8. Safe at any time. */
+void __gc_set_max_minor_streak(int64_t cap);
+
+/* The current minor-streak cap (see __gc_set_max_minor_streak). */
+int64_t __gc_max_minor_streak(void);
+
+/* Attest that EVERY reference store this embedder's compiled output performs is
+ * covered by __gc_write_barrier, and thereby allow __gc_safepoint to run automatic
+ * minor collections. OFF BY DEFAULT. A minor collection's correctness depends
+ * entirely on the remembered set being complete: if the code generator does not call
+ * __gc_write_barrier on every old->young reference store, calling this with a
+ * nonzero `on` lets __gc_safepoint free a still-referenced young object — a real
+ * use-after-free, not a leak. Do not call this without verifying that. */
+void __gc_set_auto_minor(int64_t on);
+
+/* Whether automatic minor scheduling is attested-safe (see __gc_set_auto_minor).
+ * Returns 0/1. */
+int64_t __gc_is_auto_minor(void);
 
 /* Drop the whole heap (frees everything) and reset counters. */
 void __gc_reset(void);
@@ -169,6 +200,21 @@ int64_t __gc_register_stackmap(uint64_t func_start, uint64_t func_len,
  * scan, never a missed root. Returns objects freed. Same threading contract as
  * __gc_collect. (For precision the image must be built with frame pointers.) */
 int64_t __gc_collect_precise(void);
+
+/* Minor (young-generation-only) collection rooted PRECISELY at this thread's stack
+ * (AOT00-T8) — the generational analogue of __gc_collect_precise, using the SAME
+ * frame-pointer walk (precise slots for stack-mapped frames, conservative regions for
+ * the rest). Reclaims only young garbage; old objects are never scanned or freed (see
+ * __gc_collect_minor). With no maps registered it degrades to exactly
+ * __gc_collect_minor. Returns objects freed. Same threading contract as
+ * __gc_collect_precise.
+ *
+ * UNLIKE __gc_safepoint, this is always directly callable regardless of
+ * __gc_set_auto_minor — the attestation gate applies only to __gc_safepoint's
+ * AUTOMATIC choice to run a minor cycle, not to this explicit entry. Calling this
+ * directly still requires every old->young reference store to have gone through
+ * __gc_write_barrier; the caller (not gc-core) is responsible for that. */
+int64_t __gc_collect_minor_precise(void);
 
 /* Full **moving/compacting** collection rooted PRECISELY at this thread's stack — the
  * relocating analogue of __gc_collect_precise (spec AOT00-T3-moving-collector.md §5). The

--- a/code/packages/rust/gc-core-capi/src/lib.rs
+++ b/code/packages/rust/gc-core-capi/src/lib.rs
@@ -25,7 +25,7 @@
 //! | `__gc_collect_roots(roots, count)` | mark from `count` root words at `roots`, sweep; returns objects freed |
 //! | `__gc_collect_region(base, len)` | mark from every candidate pointer in a raw region, sweep; returns objects freed |
 //! | `__gc_collect()` | conservative collect rooted at this thread's live stack + callee-saved registers; returns objects freed |
-//! | `__gc_safepoint()` | paced collect — when live bytes reach the adaptive threshold, runs `__gc_collect_precise` (or `__gc_collect_compacting` when `FlatHeap::should_compact` says so); returns objects freed |
+//! | `__gc_safepoint()` | paced collect — when live bytes reach the adaptive threshold, runs `__gc_collect_minor_precise` (only if `__gc_set_auto_minor(1)` attested barrier coverage), or `__gc_collect_compacting`/`__gc_collect_precise`, per `FlatHeap::should_collect_minor`/`should_compact`; returns objects freed |
 //! | `__gc_live_bytes()` | live payload bytes |
 //! | `__gc_collection_count()` | collections run so far |
 //! | `__gc_reset()` | drop the whole heap (frees everything); mainly for tests / process teardown |
@@ -300,6 +300,48 @@ pub extern "C" fn __gc_set_tenure_age(threshold: i64) {
 #[no_mangle]
 pub extern "C" fn __gc_tenure_age() -> i64 {
     with_heap(|h| h.tenure_age() as i64)
+}
+
+/// Set the cap on **consecutive paced minor collections** (AOT00-T8; see
+/// [`gc_core::FlatHeap::should_collect_minor`]) — how many `__gc_safepoint` calls in a
+/// row may run a minor collection before one is forced to be full, bounding how stale
+/// old-generation garbage can get under a sustained low-survival-ratio workload.
+/// `cap` is clamped to `1..=u32::MAX` (`0` and negatives → `1`; a `0` cap would silently
+/// disable automatic minor scheduling rather than just tune it). Idempotent; safe at
+/// any time.
+#[no_mangle]
+pub extern "C" fn __gc_set_max_minor_streak(cap: i64) {
+    let c = cap.clamp(1, u32::MAX as i64) as u32;
+    with_heap(|h| h.set_max_minor_streak(c));
+}
+
+/// The current minor-streak cap (see [`__gc_set_max_minor_streak`]).
+#[no_mangle]
+pub extern "C" fn __gc_max_minor_streak() -> i64 {
+    with_heap(|h| h.max_minor_streak() as i64)
+}
+
+/// **Attest that every reference store this embedder's compiled output performs is
+/// covered by [`__gc_write_barrier`]**, and thereby allow `__gc_safepoint` to run
+/// automatic minor collections (see [`gc_core::FlatHeap::auto_minor`]'s doc comment for
+/// the full soundness argument this attests to).
+///
+/// **Off by default.** A minor collection's correctness depends entirely on the
+/// remembered set being complete; if this embedder's compiled field-store lowering does
+/// not call `__gc_write_barrier` on every old→young reference store, calling this with
+/// a nonzero `on` makes `__gc_safepoint` capable of freeing a still-referenced young
+/// object — a real use-after-free, not a leak or an imprecision. Do not call this unless
+/// you have verified every heap-reference store your compiler emits is barrier-covered.
+#[no_mangle]
+pub extern "C" fn __gc_set_auto_minor(on: i64) {
+    with_heap(|h| h.set_auto_minor(on != 0));
+}
+
+/// Whether automatic minor scheduling is attested-safe (see [`__gc_set_auto_minor`]).
+/// Returns `0`/`1`.
+#[no_mangle]
+pub extern "C" fn __gc_is_auto_minor() -> i64 {
+    with_heap(|h| h.auto_minor() as i64)
 }
 
 /// Drop the entire heap, freeing every outstanding block, and reset counters.
@@ -626,6 +668,47 @@ mod tests {
         // `__gc_reset` drops the heap but a fresh heap re-defaults to 1.
         __gc_reset();
         assert_eq!(__gc_tenure_age(), 1, "reset restores the default threshold");
+    }
+
+    /// The minor-streak cap (AOT00-T8) is settable + gettable through the C ABI and
+    /// clamps to `1..=u32::MAX` — mirrors `c_abi_set_and_get_tenure_age_clamps`.
+    #[test]
+    fn c_abi_set_and_get_max_minor_streak_clamps() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        __gc_reset();
+
+        assert_eq!(__gc_max_minor_streak(), 8, "default cap is 8");
+
+        __gc_set_max_minor_streak(3);
+        assert_eq!(__gc_max_minor_streak(), 3);
+
+        __gc_set_max_minor_streak(0);
+        assert_eq!(__gc_max_minor_streak(), 1, "0 clamps to 1");
+        __gc_set_max_minor_streak(-9);
+        assert_eq!(__gc_max_minor_streak(), 1, "negative clamps to 1");
+
+        __gc_reset();
+        assert_eq!(__gc_max_minor_streak(), 8, "reset restores the default cap");
+    }
+
+    /// `__gc_is_auto_minor`/`__gc_set_auto_minor` forward to `FlatHeap::auto_minor`/
+    /// `set_auto_minor`, off by default — the security-review fix that keeps
+    /// `__gc_safepoint` from running an automatic minor collection until the embedder
+    /// attests barrier coverage.
+    #[test]
+    fn c_abi_auto_minor_defaults_off_and_is_settable() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        __gc_reset();
+
+        assert_eq!(__gc_is_auto_minor(), 0, "off by default");
+        __gc_set_auto_minor(1);
+        assert_eq!(__gc_is_auto_minor(), 1);
+        __gc_set_auto_minor(0);
+        assert_eq!(__gc_is_auto_minor(), 0);
+
+        __gc_set_auto_minor(1);
+        __gc_reset();
+        assert_eq!(__gc_is_auto_minor(), 0, "reset restores the default (off)");
     }
 
     /// `__gc_register_kind` + `__gc_alloc_kind` give **precise** interior tracing

--- a/code/packages/rust/gc-core-capi/src/stack_scan.rs
+++ b/code/packages/rust/gc-core-capi/src/stack_scan.rs
@@ -375,10 +375,13 @@ pub unsafe extern "C" fn __gc_collect_minor() -> i64 {
 
 /// A **paced** collect: if the heap has reached its adaptive threshold
 /// ([`gc_core::FlatHeap::should_collect`]), run a collection — **precise**
-/// roots when [`__gc_collect_precise`] can provide them, upgraded further to
-/// a **compacting** cycle ([`__gc_collect_compacting`]) when
-/// [`gc_core::FlatHeap::should_compact`] says fragmentation warrants it.
-/// Otherwise does nothing. Returns objects freed (`0` if no collection ran).
+/// roots when [`__gc_collect_precise`] can provide them, upgraded to a **minor**
+/// cycle ([`__gc_collect_minor_precise`]) when
+/// [`gc_core::FlatHeap::should_collect_minor`] says the survival-ratio signal
+/// warrants it (AOT00-T8), or to a **compacting** cycle
+/// ([`__gc_collect_compacting`]) when [`gc_core::FlatHeap::should_compact`] says
+/// fragmentation warrants it. Otherwise does nothing. Returns objects freed (`0`
+/// if no collection ran).
 ///
 /// This is the drop-in for `twig_gc.c`'s `__twig_gc_safepoint`. The native
 /// backend emits a `safepoint` op at loop back-edges and function entries — cheap,
@@ -387,16 +390,36 @@ pub unsafe extern "C" fn __gc_collect_minor() -> i64 {
 /// cost stays proportional to allocation, and a tight allocation loop can never
 /// starve the collector (the twig_gc.c comment's original motivation).
 ///
-/// **Always calling the precise/compacting entry points is sound, not just an
-/// optimisation opportunity:** both degrade *exactly* to this function's old
+/// **The minor branch requires an explicit attestation** ([`__gc_set_auto_minor`]) —
+/// unlike every other branch here, it is *not* on by default. A minor collection's
+/// soundness depends entirely on the remembered set being complete (every old→young
+/// reference store must have called [`__gc_write_barrier`]), which this crate cannot
+/// verify a given embedder's compiled output actually does; [`gc_core::FlatHeap::
+/// should_collect_minor`] hardcodes `false` until [`gc_core::FlatHeap::set_auto_minor`]
+/// is called, so this branch is unreachable — and `__gc_safepoint`'s behavior is
+/// byte-for-byte what it was before AOT00-T8 — until an embedder opts in.
+///
+/// **Priority order** (minor, then compacting, then plain precise) mirrors
+/// [`gc_core::policy::AdaptivePolicy`]'s own stated priority: `should_collect_minor`
+/// only answers `true` when Generational is the policy's single top-priority
+/// recommendation (Incremental — the only higher-priority signal — isn't
+/// auto-enactable at a single safepoint call, see `AOT00-T8-adaptive-safepoint-
+/// scheduling.md` §1), and `should_collect_minor`/`should_compact` are mutually
+/// exclusive by the same construction, so checking minor first never masks a
+/// legitimate compacting signal — it only defers to a higher-priority one, exactly
+/// as `should_compact`'s own doc comment already describes for pause-time.
+///
+/// **Always calling the precise/minor/compacting entry points is sound, not just an
+/// optimisation opportunity:** all three degrade *exactly* to this function's old
 /// fully-conservative behaviour when no stack maps are registered yet (see
 /// their own doc comments — an unmapped frame becomes a conservative region
 /// tiling its span, so nothing is missed and nothing unsound is moved). A
 /// program with zero maps registered pays a small extra bookkeeping cost
 /// (walking the frame-pointer chain into per-frame regions instead of one
-/// bulk `[sp, base)` scan) for identical coverage; as backends register
-/// maps, this safepoint gets more precise — and, once `should_compact` fires
-/// — starts relocating objects — automatically, with no separate opt-in.
+/// bulk `[sp, base)` scan) for identical coverage; as backends register maps, this
+/// safepoint gets more precise — and, once attested-safe and `should_collect_minor`
+/// or `should_compact` fires, starts running cheaper/relocating cycles —
+/// automatically, with no *further* opt-in beyond the one-time attestation above.
 ///
 /// # Safety
 ///
@@ -407,7 +430,9 @@ pub unsafe extern "C" fn __gc_safepoint() -> i64 {
     if !with_heap(|h| h.should_collect()) {
         return 0;
     }
-    if with_heap(|h| h.should_compact()) {
+    if with_heap(|h| h.should_collect_minor()) {
+        __gc_collect_minor_precise()
+    } else if with_heap(|h| h.should_compact()) {
         __gc_collect_compacting()
     } else {
         __gc_collect_precise()
@@ -480,6 +505,52 @@ pub unsafe extern "C" fn __gc_collect_precise() -> i64 {
 
     // Keep `regs` materialised across the collect: its address is what makes the
     // spilled registers part of the scanned roots.
+    core::hint::black_box(&regs);
+    freed
+}
+
+/// A **minor** (young-generation-only) collection rooted PRECISELY at this thread's
+/// stack (AOT00-T8) — the generational analogue of [`__gc_collect_precise`], sharing
+/// the exact same frame-pointer walk (precise slots for stack-mapped frames,
+/// conservative regions for the rest, plus the spilled callee-saved registers) but
+/// handing the result to [`gc_core::FlatHeap::collect_minor_mixed`] instead of
+/// `collect_mixed` — so it never scans or frees the old generation (see
+/// [`gc_core::FlatHeap::collect_minor`]'s own doc comment for why).
+///
+/// With no stack maps registered this degrades to exactly [`__gc_collect_minor`] (every
+/// frame becomes one conservative region tiling `[sp, base)`), the same safe
+/// degradation `__gc_collect_precise` has relative to `__gc_collect`. A failed
+/// stack-base detection collects nothing this cycle — bias-to-leak, identical to every
+/// other collect entry here.
+///
+/// # Safety
+///
+/// Same contract as [`__gc_collect_precise`]: sound to call from any thread that owns
+/// its stack; it must not run while another thread mutates the same heap.
+#[no_mangle]
+#[inline(never)]
+pub unsafe extern "C" fn __gc_collect_minor_precise() -> i64 {
+    // Spill callee-saved registers into a stack buffer (in this frame), then SP.
+    let mut regs = [0usize; SPILL_SLOTS];
+    let sp = spill_and_sp(regs.as_mut_ptr());
+    // Capture this frame's frame pointer — the walk's unwind anchor.
+    let fp = current_fp();
+    let base = stack_base();
+
+    // Same trustworthy-range gate as every other precise entry (bias-to-leak).
+    let freed = if base != 0 && sp < base && base - sp <= MAX_STACK_SCAN {
+        let mut slots: Vec<usize> = Vec::new();
+        let mut regions: Vec<(*const u8, usize)> = Vec::new();
+        crate::precise_walk::build_precise_roots(fp, sp, base, &mut slots, &mut regions);
+        regions.push((
+            regs.as_ptr() as *const u8,
+            SPILL_SLOTS * core::mem::size_of::<usize>(),
+        ));
+        with_heap(|h| h.collect_minor_mixed(&slots, &regions).freed as i64)
+    } else {
+        0
+    };
+
     core::hint::black_box(&regs);
     freed
 }
@@ -820,6 +891,63 @@ mod tests {
         );
         assert!(__gc_live_bytes() >= 16);
         assert_eq!(__gc_collection_count(), 1);
+        core::hint::black_box(kept);
+    }
+
+    /// End-to-end smoke test for the argument-less **minor** entry
+    /// `__gc_collect_minor_precise` (AOT00-T8): the same asm-capture → frame-pointer-walk
+    /// path, now driving `collect_minor_mixed`. A stack-rooted young local survives — and,
+    /// the property that actually distinguishes this from `__gc_collect_precise`, a
+    /// genuinely unreachable **old**-generation object survives too, because a minor
+    /// cycle never scans or frees the old generation.
+    ///
+    /// This deliberately does **not** assert on the *count* of young objects freed: a raw
+    /// conservative stack scan can retain an extra object if a stray, stale stack word
+    /// happens to look like its address (the same caveat `run_stack_scan_case` documents),
+    /// and that noise is orthogonal to what this test is proving. `__gc_kind_of` gives an
+    /// exact, non-conservative answer for the one property that matters here — the old
+    /// object's survival is unconditional (never touched, stray garbage or not), not a
+    /// "happened to be found live" — so it is safe to assert on exactly.
+    #[test]
+    fn minor_precise_collect_keeps_live_local_and_retains_old() {
+        let _guard = crate::TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        __gc_reset();
+        run_minor_precise_collect_case();
+        __gc_reset();
+    }
+
+    #[inline(never)]
+    fn run_minor_precise_collect_case() {
+        // A kind with no ref fields, registered only so `__gc_kind_of` can distinguish
+        // "still a live block" (returns the kind id) from "reclaimed" (returns 0) — a
+        // kind-0 object is ambiguous between the two (opaque/unregistered is also `0`).
+        let probe_kind = unsafe { crate::__gc_register_kind(core::ptr::null(), 0) } as u16;
+
+        // Tenure an object to the old generation, then orphan it: no root keeps it
+        // alive from here on, so only a cycle that skips the old generation entirely
+        // (a minor cycle) can leave it standing.
+        let old = crate::__gc_alloc_kind(16, probe_kind);
+        assert!(old != 0);
+        let _ = unsafe { __gc_collect() }; // stack-rooted at this call -> tenured
+        assert_eq!(__gc_collection_count(), 1);
+
+        let kept = __gc_alloc(16); // young, rooted through the collect below
+        assert!(kept != 0);
+        unsafe { *(kept as *mut i64) = 0x0ff1ce };
+
+        let _freed = unsafe { __gc_collect_minor_precise() };
+
+        assert_eq!(
+            unsafe { *(kept as *const i64) },
+            0x0ff1ce,
+            "the stack-rooted young object survives the minor collect"
+        );
+        assert_eq!(
+            unsafe { crate::__gc_kind_of(old) },
+            probe_kind as i64,
+            "the unrooted OLD object survives — a minor cycle never scans/frees the old generation"
+        );
+        assert_eq!(__gc_collection_count(), 2, "minor collections count too");
         core::hint::black_box(kept);
     }
 

--- a/code/packages/rust/gc-core/CHANGELOG.md
+++ b/code/packages/rust/gc-core/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog — gc-core
 
+## 0.28.0 — 2026-08-06 — `FlatHeap::should_collect_minor` — automatic generational enactment, gated (AOT00-T8)
+
+- **`FlatHeap::should_collect_minor(&self) -> bool`** — the generational sibling of
+  `should_compact`: whether the *next* paced collection should be a **minor**
+  (young-generation-only) cycle instead of a full one, per `AdaptivePolicy`'s
+  survival-ratio signal. Until now `AdaptivePolicy`'s `Generational`
+  recommendation was purely advisory — nothing ever auto-selected a minor
+  collection at an automatic collection site; only an explicit direct caller
+  (`vm-core`) ever ran one.
+- **`auto_minor: bool` (default `false`) + `set_auto_minor`/`auto_minor`** —
+  `should_collect_minor` hardcodes `false` unless this is set. A minor
+  collection's correctness depends entirely on the remembered set being
+  *complete* (every old→young reference store must have called
+  `write_barrier`), which `gc-core` cannot verify a given embedder's compiled
+  output actually does. **Security-review finding, fixed before merge:**
+  `vm-core`'s interpreter loop calls the barrier on every store, but the
+  native-AOT/LLVM code generators' `field_store` lowering does not — enabling
+  automatic minor collection unconditionally would have been a real
+  use-after-free for every AOT-compiled program, not a corner case (immediate
+  tenuring + a churny allocation loop is the *common* profile
+  `AdaptivePolicy` reads as "recommend Generational"). Default `false` keeps
+  every existing call site's behavior byte-for-byte unchanged; an embedder
+  opts in only after confirming its own barrier coverage.
+- **`minor_streak` + `max_minor_streak` (default `8`, `DEFAULT_MAX_MINOR_STREAK`)** —
+  bounds how many consecutive paced minor collections may run before one is
+  forced to be full, once `auto_minor` is on. A minor cycle never scans or
+  frees the old generation, and the EMA survival-ratio signal driving
+  `should_collect_minor` can stay low indefinitely, so without this cap a
+  sustained low-survival workload would starve the old generation of
+  collection forever (a leak, orthogonal to the UAF above).
+  `set_max_minor_streak`/`max_minor_streak` (clamped to a minimum of `1`)
+  mirror `set_tenure_age`/`tenure_age`. Every full-collect entry (`collect`,
+  `collect_region`, `collect_precise`, `collect_mixed`, `collect_compacting`,
+  `incremental_finish`) resets the streak; every minor entry increments it.
+- **`FlatHeap::collect_minor_mixed(root_slots, regions)`** — the young-generation
+  analogue of `collect_mixed`: traces exact root slots *and* conservative
+  regions in one pass, young-only. Needed because a real precise stack walk
+  produces exactly that mix (some frames stack-mapped, some not), and neither
+  existing minor entry (`collect_minor` takes root *values*; `collect_minor_region`
+  takes one raw span) matches that shape. Always directly callable (the
+  `auto_minor` gate applies only to `should_collect_minor`'s automatic
+  recommendation, not to this or any other explicit minor entry).
+- **`minor_finish` now calls `adapt_threshold`**, mirroring every full-collect
+  entry — a review-caught gap: without it, pacing state didn't re-tune after a
+  minor cycle, so a heap sitting over threshold could stay `should_collect()
+  == true` (re-walking the stack at every safepoint) until a full collect
+  eventually ran.
+- See `code/specs/AOT00-T8-adaptive-safepoint-scheduling.md` for the full design,
+  the starvation-hazard analysis (§2), and the barrier-coverage hazard (§2b).
+  `gc-core-capi` 0.24.0 wires this into `__gc_safepoint`.
+
 ## 0.27.1 — 2026-08-03 — regression test: array elements need a ref-array kind, not a no-ref one
 
 No production code change — adds

--- a/code/packages/rust/gc-core/Cargo.toml
+++ b/code/packages/rust/gc-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core"
-version = "0.27.1"
+version = "0.28.0"
 edition = "2021"
 description = "The shared GC engine (FlatHeap) for the LANG pipeline: linked directly by native-AOT backends (via gc-core-capi) and by vm-core."
 license = "MIT"

--- a/code/packages/rust/gc-core/README.md
+++ b/code/packages/rust/gc-core/README.md
@@ -14,7 +14,7 @@ against — native or interpreted alike — instead of each carrying its own.
 | `GcProfile` / `GcCycleStats` | Per-cycle metrics: allocation rate, survival ratio, pause time, fragmentation |
 | `GcPolicy` | Trait for algorithm-switch / tuning strategies |
 | `DefaultPolicy` | Never recommends a switch; for tests and short programs |
-| `AdaptivePolicy` | Recommends a switch based on profiling heuristics; backs `FlatHeap::should_compact` |
+| `AdaptivePolicy` | Recommends a switch based on profiling heuristics; backs `FlatHeap::should_compact`/`should_collect_minor` |
 | `GcAlgorithm` | Enum of GC algorithms `AdaptivePolicy` can recommend |
 | `StackMapBuilder` | Producer side of the precise-root stack-map format for native code generators |
 
@@ -46,10 +46,23 @@ strictly additive over conservative fallback. **All rungs are implemented:**
    object for one cycle.
 2. **Precise interior tracing** — a registered `kind`'s ref-field map
    (`register_kind`) is followed exactly; non-ref fields pin nothing.
-3. **Generational** (`collect_minor_region`) — young/old split, a
-   remembered-set write barrier, young-only minor collections, tenuring
-   after N survivals with an immediate promotion-barrier rebuild (closing a
-   reviewer-caught use-after-free window on the promoted edge).
+3. **Generational** (`collect_minor` / `collect_minor_region` /
+   `collect_minor_mixed`) — young/old split, a remembered-set write barrier,
+   young-only minor collections, tenuring after N survivals with an
+   immediate promotion-barrier rebuild (closing a reviewer-caught
+   use-after-free window on the promoted edge). Reachable automatically via
+   `FlatHeap::should_collect_minor` (backed by `AdaptivePolicy`'s
+   survival-ratio signal, capped by `max_minor_streak` so a sustained
+   low-survival workload can't starve the old generation of collection
+   forever — `AOT00-T8-adaptive-safepoint-scheduling.md`) — **gated behind
+   `FlatHeap::set_auto_minor(true)`, off by default.** A minor collection's
+   soundness rests entirely on the remembered set being complete, which
+   requires *every* old→young reference store to go through `write_barrier`;
+   `gc-core` can't verify that a given embedder's compiled output actually
+   does (a security-review finding: the native-AOT/LLVM code generators
+   don't emit it on `field_store` today, only `vm-core`'s interpreter loop
+   does). Enabling `auto_minor` without real barrier coverage is a real
+   use-after-free, not an imprecision — see the field's own doc comment.
 4. **Precise roots** (`collect_precise` / `collect_mixed`) —
    `StackMapRecord`/`StackMapTable` describe exactly which slots hold
    references at each safepoint, so stack-integer false roots disappear for

--- a/code/packages/rust/gc-core/src/flat_heap.rs
+++ b/code/packages/rust/gc-core/src/flat_heap.rs
@@ -257,6 +257,36 @@ pub struct FlatHeap {
     /// sweep pause is bounded exactly like the mark. `None` unless a stepped sweep is under
     /// way. [`Self::incremental_finish`] drains any remainder and consumes it.
     sweep_state: Option<SweepState>,
+    /// Consecutive **minor** collections run since the last full collection (AOT00-T8).
+    /// Incremented by [`Self::minor_finish`]; reset to `0` by every full-collect entry
+    /// (`collect_region`/`collect_precise`/`collect_mixed`/`collect_compacting`). Consulted by
+    /// [`Self::should_collect_minor`] to bound how long old-generation garbage can go
+    /// unreclaimed: a minor collection never scans or frees the old generation, so if the
+    /// adaptive policy's survival-ratio signal stayed low forever, always honoring it would
+    /// starve the old generation of collection entirely.
+    minor_streak: u32,
+    /// Cap on [`Self::minor_streak`] before [`Self::should_collect_minor`] forces a full
+    /// collection regardless of the policy signal. Default [`DEFAULT_MAX_MINOR_STREAK`];
+    /// tunable via [`Self::set_max_minor_streak`], mirroring [`Self::set_tenure_age`].
+    max_minor_streak: u32,
+    /// **Barrier-coverage attestation** (AOT00-T8): whether [`Self::should_collect_minor`]
+    /// is allowed to recommend a minor collection at all. Default **`false`**.
+    ///
+    /// A minor collection's soundness rests entirely on the remembered set being
+    /// *complete* — every old→young reference store must have gone through
+    /// [`Self::write_barrier`], or a minor cycle can free a young object that is only
+    /// reachable through an unrecorded old→young edge (a real use-after-free, not a
+    /// leak). `gc-core` cannot verify that a given embedder's compiled field-store
+    /// lowering actually calls the barrier — the two are enforced in entirely separate
+    /// crates (a code generator vs. this one). Defaulting to `false` means
+    /// `should_collect_minor` never fires, and every existing automatic collection site
+    /// (`gc-core-capi`'s `__gc_safepoint`) keeps its exact pre-AOT00-T8 behavior, until
+    /// the embedder calls [`Self::set_auto_minor`] to attest that every reference store
+    /// its compiled output performs is barrier-covered. (`vm-core`'s interpreter loop is
+    /// barrier-covered — see `handle_gc_field_store` — and can safely opt in; the
+    /// native-AOT/LLVM code generators do not emit the barrier on `field_store` today,
+    /// so they must not.)
+    auto_minor: bool,
 }
 
 /// The resumable state of an incremental sweep — the sweep-phase analogue of the mark's
@@ -296,6 +326,13 @@ enum SweepVisit {
 /// (existing consumers and tests are unchanged); aging is opt-in via
 /// [`FlatHeap::set_tenure_age`] and can become the default in a later tuning pass.
 pub const DEFAULT_TENURE_AGE: u8 = 1;
+
+/// Default [`FlatHeap::max_minor_streak`] (AOT00-T8): how many consecutive paced minor
+/// collections `should_collect_minor` allows before forcing a full collect. `8` is a
+/// starting heuristic (analogous to [`INITIAL_THRESHOLD`]'s doubling/halving constant) —
+/// generous enough that a genuinely young-heavy workload gets real minor-GC throughput,
+/// small enough that old-generation garbage is never more than 8 paced cycles stale.
+pub const DEFAULT_MAX_MINOR_STREAK: u32 = 8;
 
 /// Debug-assert message for the four stop-the-world `collect*` entries: none may run
 /// *between* an [`FlatHeap::incremental_start`] and its [`FlatHeap::incremental_finish`].
@@ -415,6 +452,9 @@ impl FlatHeap {
             mark_roots: Vec::new(),
             mark_regions: Vec::new(),
             sweep_state: None,
+            minor_streak: 0,
+            max_minor_streak: DEFAULT_MAX_MINOR_STREAK,
+            auto_minor: false,
         }
     }
 
@@ -432,6 +472,34 @@ impl FlatHeap {
     /// The current tenuring threshold (see [`Self::set_tenure_age`]).
     pub fn tenure_age(&self) -> u8 {
         self.tenure_age
+    }
+
+    /// Set the cap on consecutive paced minor collections (AOT00-T8; see
+    /// [`Self::should_collect_minor`]). Clamped to a minimum of `1` — `0` would make
+    /// `should_collect_minor` never fire, silently disabling automatic generational
+    /// scheduling rather than just tuning it.
+    pub fn set_max_minor_streak(&mut self, cap: u32) {
+        self.max_minor_streak = cap.max(1);
+    }
+
+    /// The current minor-streak cap (see [`Self::set_max_minor_streak`]).
+    pub fn max_minor_streak(&self) -> u32 {
+        self.max_minor_streak
+    }
+
+    /// **Attest that every reference store this embedder's compiled output performs is
+    /// covered by [`Self::write_barrier`]**, and thereby allow [`Self::should_collect_minor`]
+    /// to recommend automatic minor collections (see the field's own doc comment for the
+    /// full soundness argument). Off by default. Call this only after confirming your
+    /// code generator's field-store lowering calls the barrier on every old→young store —
+    /// getting this wrong is a real use-after-free, not a leak or a perf regression.
+    pub fn set_auto_minor(&mut self, on: bool) {
+        self.auto_minor = on;
+    }
+
+    /// Whether automatic minor scheduling is attested-safe (see [`Self::set_auto_minor`]).
+    pub fn auto_minor(&self) -> bool {
+        self.auto_minor
     }
 
     /// Allocate `n` zeroed bytes and return a **real pointer** to the payload.
@@ -670,6 +738,39 @@ impl FlatHeap {
         )
     }
 
+    /// Whether the *next* paced collection should be a **minor** (young-generation-only)
+    /// collection instead of a full one, per [`AdaptivePolicy`]'s survival-ratio signal —
+    /// the generational analogue of [`Self::should_compact`], and the other half of the
+    /// same "one place this decision lives" contract (AOT00-T8).
+    ///
+    /// Three conditions must all hold:
+    /// 0. [`Self::auto_minor`] is `true` — the embedder has attested every reference store
+    ///    its compiled output performs is barrier-covered (see that field's doc comment
+    ///    for why this gate exists: an unattested caller enabling minor collections here
+    ///    would be a real use-after-free, not just an imprecision). **Off by default**, so
+    ///    this method — and therefore every automatic collection site that consults it —
+    ///    is a no-op until an embedder opts in.
+    /// 1. `AdaptivePolicy` recommends [`GcAlgorithm::Generational`] as its single top-priority
+    ///    decision (so, like `should_compact`, this correctly answers `false` when a
+    ///    higher-priority Incremental signal fired instead — the same deferral, one rung up).
+    /// 2. [`Self::minor_streak`] hasn't reached [`Self::max_minor_streak`]. A minor collection
+    ///    never scans or frees the old generation (see [`Self::collect_minor`]), and the EMA
+    ///    survival ratio driving condition 1 can stay low indefinitely — so without this cap,
+    ///    sustained low survival would recommend `Generational` forever and a caller that
+    ///    always honored it would never run a full collection again, leaking the old
+    ///    generation without bound. The cap forces a full collect at least every
+    ///    `max_minor_streak` paced cycles, exactly bounding how stale old-generation garbage
+    ///    can get. Pure policy, like its sibling: names no roots, runs no collection.
+    pub fn should_collect_minor(&self) -> bool {
+        if !self.auto_minor || self.minor_streak >= self.max_minor_streak {
+            return false;
+        }
+        matches!(
+            AdaptivePolicy::default().evaluate(&self.profile),
+            PolicyDecision::SuggestSwitch(GcAlgorithm::Generational, _)
+        )
+    }
+
     /// Re-tune the threshold after a cycle, given the live bytes *before* it.
     ///
     /// The heuristic (ported verbatim from `twig_gc.c`): if **more than half** the
@@ -742,6 +843,7 @@ impl FlatHeap {
     /// extra cycle; it never frees a live one.
     pub fn collect(&mut self, roots: &[usize]) -> GcCycleStats {
         debug_assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
+        self.minor_streak = 0; // full collect: bound on consecutive minors is satisfied (AOT00-T8)
         let before = self.object_count();
         let prev_live = self.live_bytes;
 
@@ -808,6 +910,7 @@ impl FlatHeap {
     /// scanning starts at `base` and a sub-8-byte tail is ignored.
     pub unsafe fn collect_region(&mut self, base: *const u8, len: usize) -> GcCycleStats {
         debug_assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
+        self.minor_streak = 0; // full collect: bound on consecutive minors is satisfied (AOT00-T8)
         let before = self.object_count();
         let prev_live = self.live_bytes;
 
@@ -929,12 +1032,13 @@ impl FlatHeap {
     pub fn collect_minor(&mut self, roots: &[usize]) -> GcCycleStats {
         debug_assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
         let before = self.object_count();
+        let prev_live = self.live_bytes;
         let mut work: Vec<*mut FlatHeader> = Vec::new();
         // Roots — mark only the young objects they reach (old are live).
         for &r in roots {
             self.mark_word(r, &mut work, true);
         }
-        self.minor_finish(before, work)
+        self.minor_finish(before, prev_live, work)
     }
 
     /// A **minor** collection rooted at a **raw memory region** — the stack-scan
@@ -949,17 +1053,71 @@ impl FlatHeap {
     pub unsafe fn collect_minor_region(&mut self, base: *const u8, len: usize) -> GcCycleStats {
         debug_assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
         let before = self.object_count();
+        let prev_live = self.live_bytes;
         let mut work: Vec<*mut FlatHeader> = Vec::new();
         // SAFETY: caller guarantees `[base, base+len)` is readable.
         self.mark_region(base, len, &mut work, true);
-        self.minor_finish(before, work)
+        self.minor_finish(before, prev_live, work)
+    }
+
+    /// A **minor** collection rooted from **both** exact root slots *and* raw
+    /// conservative regions in one cycle (AOT00-T8) — the young-generation analogue of
+    /// [`Self::collect_mixed`], for exactly the same reason `collect_mixed` exists
+    /// alongside `collect_precise`/`collect_region`: a real precise stack walk
+    /// (`crate::frame_root_slots` via `gc-core-capi`'s `build_precise_roots`) produces a
+    /// *mix* of exact slots (stack-mapped frames) and whole conservative spans (unmapped
+    /// frames), and both must be marked in the same pass and reclaimed by the same sweep.
+    /// Neither existing minor entry matches that shape: [`Self::collect_minor`] takes
+    /// root *values* (a plain slice a caller like `vm-core` already assembled, not
+    /// addresses to dereference), and [`Self::collect_minor_region`] takes one raw span
+    /// only. This is the strict generalisation of both, exactly as `collect_mixed` is of
+    /// `collect_precise`/`collect_region`: `collect_minor_mixed(slots, &[])` traces the
+    /// same set as looping `mark_word` over `slots` values would if they were pre-read,
+    /// and `collect_minor_mixed(&[], &[(base, len)])` is `collect_minor_region(base, len)`.
+    ///
+    /// # Safety
+    /// Every address in `root_slots` must be readable (each names a live stack /
+    /// register-spill slot; read `unaligned`), and every `(base, len)` region must be
+    /// readable — the same contract as [`Self::collect_mixed`].
+    pub unsafe fn collect_minor_mixed(
+        &mut self,
+        root_slots: &[usize],
+        regions: &[(*const u8, usize)],
+    ) -> GcCycleStats {
+        debug_assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
+        let before = self.object_count();
+        let prev_live = self.live_bytes;
+        let mut work: Vec<*mut FlatHeader> = Vec::new();
+        // Exact slots first (precise frames): read the one word at each address.
+        for &slot in root_slots {
+            // SAFETY: caller guarantees each `slot` address is readable; the word
+            // there is a candidate root. `read_unaligned` tolerates sub-alignment.
+            let word = unsafe { ptr::read_unaligned(slot as *const usize) };
+            self.mark_word(word, &mut work, true);
+        }
+        // Then whole regions (unmapped frames): every aligned word is a candidate.
+        for &(base, len) in regions {
+            // SAFETY: caller guarantees `[base, base+len)` is readable.
+            self.mark_region(base, len, &mut work, true);
+        }
+        self.minor_finish(before, prev_live, work)
     }
 
     /// Shared tail of a minor cycle: scan the remembered old→young parents, drain
-    /// the young worklist, sweep the young generation, and build the stats. Both
-    /// [`Self::collect_minor`] and [`Self::collect_minor_region`] call this after
-    /// their (slice- vs region-sourced) root mark.
-    fn minor_finish(&mut self, before: usize, mut work: Vec<*mut FlatHeader>) -> GcCycleStats {
+    /// the young worklist, sweep the young generation, re-tune the pacing threshold, and
+    /// build the stats. [`Self::collect_minor`], [`Self::collect_minor_region`], and
+    /// [`Self::collect_minor_mixed`] all call this after their (value-, region-, or
+    /// mixed-sourced) root mark. `prev_live` is `self.live_bytes` as it stood *before* the
+    /// mark (captured by the caller, mirroring every full-collect entry) — needed by
+    /// [`Self::adapt_threshold`] so a minor cycle re-tunes pacing exactly like a full one
+    /// does, instead of leaving `should_collect` pinned true (and re-walking the stack on
+    /// every subsequent safepoint) until a full collect finally happens to run.
+    fn minor_finish(
+        &mut self,
+        before: usize,
+        prev_live: usize,
+        mut work: Vec<*mut FlatHeader>,
+    ) -> GcCycleStats {
         // Remembered old parents — scan each for the young children it holds.
         // Snapshot the addresses first so the immutable scan can't alias the set.
         // Each entry is a live old object (a full collect clears the set; a minor
@@ -977,6 +1135,11 @@ impl FlatHeap {
         // Sweep the young generation only; age/promote survivors.
         let (freed, survived, live, promoted) = self.sweep(true);
         self.live_bytes = live;
+        // Re-tune pacing exactly as a full collect does (AOT00-T8): without this, a
+        // heap sitting over threshold after a minor cycle would stay `should_collect()
+        // == true`, re-walking the stack at every subsequent safepoint until a full
+        // collect eventually runs and adapts it — this keeps that in step.
+        self.adapt_threshold(prev_live);
         // The remembered set is intentionally *kept*: a minor cycle frees no old
         // object, so no entry dangles. Entries whose young child was promoted are
         // now old→old — stale but harmless (the next minor scan finds no young
@@ -995,6 +1158,9 @@ impl FlatHeap {
         };
         self.profile.record_cycle(&stats);
         self.collection_count += 1;
+        // A minor cycle never scans/frees the old generation — see should_collect_minor's
+        // doc for why this is bounded, not left to grow unchecked (AOT00-T8).
+        self.minor_streak = self.minor_streak.saturating_add(1);
         stats
     }
 
@@ -1050,6 +1216,7 @@ impl FlatHeap {
     /// [`Self::collect_region`] places on its `[base, base + len)` span.
     pub unsafe fn collect_precise(&mut self, root_slots: &[usize]) -> GcCycleStats {
         debug_assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
+        self.minor_streak = 0; // full collect: bound on consecutive minors is satisfied (AOT00-T8)
         let before = self.object_count();
         let prev_live = self.live_bytes;
 
@@ -1129,6 +1296,7 @@ impl FlatHeap {
         regions: &[(*const u8, usize)],
     ) -> GcCycleStats {
         debug_assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
+        self.minor_streak = 0; // full collect: bound on consecutive minors is satisfied (AOT00-T8)
         let before = self.object_count();
         let prev_live = self.live_bytes;
 
@@ -1358,6 +1526,7 @@ impl FlatHeap {
     pub unsafe fn incremental_finish(&mut self) -> GcCycleStats {
         debug_assert!(self.mark_in_progress, "incremental_finish outside a mark phase");
         debug_assert!(self.mark_worklist.is_empty(), "marking not complete — step to done first");
+        self.minor_streak = 0; // full collect: bound on consecutive minors is satisfied (AOT00-T8)
 
         let (freed, survived, before, prev_live) = if let Some(mut st) = self.sweep_state.take() {
             // A stepped sweep is under way. Drain any remaining blocks monolithically so finish
@@ -1981,6 +2150,7 @@ impl FlatHeap {
         regions: &[(*const u8, usize)],
     ) -> GcCycleStats {
         debug_assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
+        self.minor_streak = 0; // full collect: bound on consecutive minors is satisfied (AOT00-T8)
         let before = self.object_count();
         let prev_live = self.live_bytes;
 
@@ -2695,6 +2865,153 @@ mod tests {
         // deferral `should_compact`'s doc comment describes.
         heap.profile.max_pause_ns = 20_000_000;
         assert!(!heap.should_compact(), "pause-time signal outranks fragmentation");
+    }
+
+    // ── Adaptive safepoint scheduling — generational enactment (AOT00-T8) ─────
+
+    /// `should_collect_minor` is a hard `false` until the embedder attests barrier
+    /// coverage via `set_auto_minor(true)` — even with every other condition (enough
+    /// cycles, low survival ratio) satisfied. This is the fix for the security-review
+    /// finding that automatic minor scheduling is unsound for a producer (native-AOT/LLVM)
+    /// that doesn't emit `write_barrier` on its heap stores; see `auto_minor`'s own doc
+    /// comment on the `FlatHeap` struct.
+    #[test]
+    fn should_collect_minor_is_false_until_auto_minor_is_attested() {
+        let mut heap = FlatHeap::new();
+        assert!(!heap.auto_minor(), "off by default");
+
+        heap.profile.total_collections = 10;
+        heap.profile.ema_survival_ratio = 0.01; // otherwise a clean Generational recommendation
+        assert!(!heap.should_collect_minor(), "unattested: false regardless of the policy signal");
+
+        heap.set_auto_minor(true);
+        assert!(heap.auto_minor());
+        assert!(heap.should_collect_minor(), "attested: the policy signal is now honored");
+    }
+
+    #[test]
+    fn should_collect_minor_follows_adaptive_policy_survival_signal() {
+        let mut heap = FlatHeap::new();
+        heap.set_auto_minor(true); // attest barrier coverage — see the gate test above
+
+        // Too few cycles: gated exactly like should_compact.
+        heap.profile.total_collections = 4;
+        heap.profile.ema_survival_ratio = 0.01;
+        assert!(!heap.should_collect_minor(), "too few cycles to advise yet");
+
+        // Enough cycles, but survival ratio above the 0.15 threshold.
+        heap.profile.total_collections = 10;
+        heap.profile.ema_survival_ratio = 0.50;
+        assert!(!heap.should_collect_minor(), "survival ratio too high to warrant generational");
+
+        // Enough cycles, survival ratio below threshold, no higher-priority
+        // (pause-time) signal preempting it.
+        heap.profile.ema_survival_ratio = 0.01;
+        assert!(heap.should_collect_minor(), "low survival ratio with no higher-priority signal");
+
+        // A higher-priority signal (max pause > 10ms) takes precedence over
+        // the survival-ratio signal, per AdaptivePolicy's own priority order —
+        // mirrors should_compact's own pause-outranks-fragmentation case.
+        heap.profile.max_pause_ns = 20_000_000;
+        assert!(!heap.should_collect_minor(), "pause-time signal outranks generational");
+    }
+
+    /// When both the generational (low survival) and compacting (high fragmentation)
+    /// signals would fire, `should_collect_minor` wins — Generational outranks
+    /// Compacting in `AdaptivePolicy`'s own priority order, and `AdaptivePolicy::evaluate`
+    /// returns only its single top recommendation, so the two predicates are naturally
+    /// mutually exclusive.
+    #[test]
+    fn should_collect_minor_outranks_should_compact() {
+        let mut heap = FlatHeap::new();
+        heap.set_auto_minor(true);
+        heap.profile.total_collections = 10;
+        heap.profile.ema_survival_ratio = 0.01; // generational signal
+        heap.profile.last_fragmentation = 0.90; // compacting signal, also firing
+        assert!(heap.should_collect_minor(), "generational outranks compacting");
+        assert!(!heap.should_compact(), "should_compact defers to the higher-priority signal");
+    }
+
+    /// A sustained low-survival profile would recommend `Generational` forever — the
+    /// starvation hazard AOT00-T8 §2 describes. `minor_streak` bounds it: once it reaches
+    /// `max_minor_streak`, `should_collect_minor` forces a full collect regardless of the
+    /// policy signal.
+    #[test]
+    fn should_collect_minor_streak_cap_forces_full_collect() {
+        let mut heap = FlatHeap::new();
+        heap.set_auto_minor(true);
+        assert_eq!(heap.max_minor_streak(), DEFAULT_MAX_MINOR_STREAK);
+        heap.profile.total_collections = 10;
+        heap.profile.ema_survival_ratio = 0.01; // sustained low survival
+
+        heap.set_max_minor_streak(3);
+        assert_eq!(heap.max_minor_streak(), 3);
+
+        heap.minor_streak = 2;
+        assert!(heap.should_collect_minor(), "under the cap: policy signal still honored");
+        heap.minor_streak = 3;
+        assert!(!heap.should_collect_minor(), "at the cap: forced to a full collect");
+        heap.minor_streak = 4;
+        assert!(!heap.should_collect_minor(), "past the cap: still forced");
+    }
+
+    /// `set_max_minor_streak` clamps to a minimum of 1 — a `0` cap would make
+    /// `should_collect_minor` never fire, silently disabling the feature rather than
+    /// just tuning it (mirrors `set_tenure_age`'s `0` → `1` clamp).
+    #[test]
+    fn set_max_minor_streak_clamps_to_one() {
+        let mut heap = FlatHeap::new();
+        heap.set_max_minor_streak(0);
+        assert_eq!(heap.max_minor_streak(), 1);
+    }
+
+    /// Real collections (not just direct field pokes) drive the streak correctly: a
+    /// minor collection increments it, and any full collection resets it to 0 — proven
+    /// against `collect_minor` and `collect` (`collect_precise`/`collect_mixed`/
+    /// `collect_compacting`/`collect_region`/`incremental_finish` share the same reset,
+    /// added at each of their entry points).
+    #[test]
+    fn minor_streak_increments_on_minor_and_resets_on_full_collect() {
+        let mut heap = FlatHeap::new();
+        let _ = heap.collect_minor(&[]);
+        let _ = heap.collect_minor(&[]);
+        assert_eq!(heap.minor_streak, 2);
+
+        let _ = heap.collect(&[]);
+        assert_eq!(heap.minor_streak, 0, "a full collect resets the streak");
+    }
+
+    /// `collect_minor_mixed` is the young-only analogue of `collect_mixed`: it traces
+    /// exact root slots plus conservative regions in one pass, but — unlike
+    /// `collect_mixed` — never reaps the old generation. An old object unreachable from
+    /// anything survives (old objects are never swept by a minor cycle); a young
+    /// look-alike-free object not named by any root/region is reclaimed.
+    #[test]
+    fn collect_minor_mixed_traces_slots_and_regions_young_only() {
+        let mut heap = FlatHeap::new();
+        let old_garbage = heap.alloc(16, 0) as usize;
+        let _ = heap.collect(&[old_garbage]); // promote to old; unrooted from here on
+
+        let a = heap.alloc(16, 0) as usize; // rooted via a slot
+        let b = heap.alloc(16, 0) as usize; // rooted via a region
+        let garbage = heap.alloc(16, 0) as usize; // young, unrooted
+
+        let frame_a: [usize; 1] = [a];
+        let rec = StackMapRecord::new(0, vec![0]);
+        let mut slots = Vec::new();
+        frame_root_slots(frame_a.as_ptr() as usize, &rec, &mut slots);
+        let frame_b: [usize; 1] = [b];
+        let region = (frame_b.as_ptr() as *const u8, std::mem::size_of_val(&frame_b));
+
+        let stats = unsafe { heap.collect_minor_mixed(&slots, &[region]) };
+        assert_eq!(stats.freed, 1, "only the unrooted young object is freed");
+        assert!(!heap.find_header(a).is_null(), "slot-rooted young survivor kept");
+        assert!(!heap.find_header(b).is_null(), "region-rooted young survivor kept");
+        assert!(heap.find_header(garbage).is_null(), "unrooted young garbage reclaimed");
+        assert!(
+            !heap.find_header(old_garbage).is_null(),
+            "old garbage untouched — a minor cycle never sweeps the old generation"
+        );
     }
 
     /// Retention-heavy cycle (> half survived) doubles the threshold.

--- a/code/specs/AOT00-T8-adaptive-safepoint-scheduling.md
+++ b/code/specs/AOT00-T8-adaptive-safepoint-scheduling.md
@@ -1,0 +1,285 @@
+# AOT00-T8 — adaptive safepoint scheduling (generational auto-enactment) (design)
+
+> Status: **design, pre-implementation.**
+>
+> The precision-ladder **algorithms** are complete
+> (`mark-and-sweep ✓ → interior-precise ✓ → generational ✓ → precise-roots ✓ → compacting ✓ → incremental ✓`),
+> and [`AOT00-T5`](AOT00-T5-variable-length-ref-arrays.md) closed the object-model gap (arrays are
+> precise + movable). What remains is **policy**: `AdaptivePolicy` (`gc-core/src/policy.rs`)
+> evaluates a `GcProfile` and recommends an algorithm switch, but today only *one* of its three
+> recommendations is actually carried out automatically. This rung closes that gap for the
+> **Generational** recommendation.
+
+---
+
+## 1. The problem — only `Compacting` is enacted at the safepoint
+
+`AdaptivePolicy::evaluate` returns the single highest-priority recommendation, in this order
+(`policy.rs` doc comment):
+
+1. **Incremental** — max pause time exceeds budget.
+2. **Generational** — EMA survival ratio is low (most objects die young).
+3. **Compacting** — fragmentation is high.
+
+`gc-core-capi`'s `__gc_safepoint` — the paced, auto-collect entry every native-AOT program's
+`safepoint` op calls — consults exactly one of these signals: `FlatHeap::should_compact()`. If
+fragmentation is high *and nothing higher-priority fired*, the safepoint runs a compacting
+collection instead of a plain precise one. That wiring is real end-to-end automation (`should_compact`
+→ `__gc_collect_compacting`).
+
+The **Generational** recommendation has no equivalent. `FlatHeap::collect_minor` /
+`collect_minor_region` exist and are correct (proven by the write-barrier + promotion-barrier
+differentials in the generational arc), but nothing ever calls them automatically — a minor
+collection only happens if some *specific* consumer (`vm-core`, today) chooses to call it
+directly. A native-AOT program compiled purely through `twig-aot` never runs a minor GC no matter
+how low its survival ratio is; every automatic collection is a full scan of the whole live set,
+old generation included. The generational collector — the highest-value payoff for
+high-allocation-rate, short-lived-object workloads (exactly the JS/Ruby/Python shape T5 targeted)
+— sits unused at the one call site that matters for AOT binaries.
+
+**Incremental** is intentionally out of scope here: unlike a compacting or minor collection, it
+is not a single call — `incremental_start`/`_step`/`_finish` is a stateful three-call protocol
+that must interleave with the mutator across many safepoints. Auto-driving it needs a persistent
+per-heap "am I mid-cycle" state machine at the capi layer, a materially different (and separately
+reviewable) feature. This spec's fix keeps that decision advisory, unchanged from today.
+
+---
+
+## 2. The starvation hazard — why "always honor Generational" is unsound
+
+The naive fix — `if should_collect_minor() { collect_minor } else { ... }` — has a real bug. The
+EMA survival ratio is *sticky*: a workload that keeps the ratio below threshold keeps
+`AdaptivePolicy` recommending `Generational` every single time it's asked, cycle after cycle. If
+the safepoint always honors that recommendation, **no full collection ever runs again**. A minor
+collection *by definition* never scans or frees the old generation (`collect_minor`'s own doc
+comment: "Old objects are never scanned or freed"). So old-generation garbage — objects that
+died after being tenured — would accumulate forever: not a use-after-free, but an unbounded,
+policy-driven memory leak, which for an always-on adaptive heuristic is exactly the kind of
+"switched on and never noticed" bug worth designing out rather than documenting around.
+
+**Fix: bound consecutive minors.** Track how many minor collections have run *in a row* since the
+last full collection (`collect_region`/`collect_precise`/`collect_mixed`/`collect_compacting` —
+any of them resets the streak; only a minor collection increments it). Once the streak reaches a
+cap, `should_collect_minor()` returns `false` regardless of what the policy says, forcing the next
+paced collection to be full and reclaim whatever accumulated in the old generation. This is the
+same shape as a real generational collector's "major GC every N minors" trigger, chosen over
+tracking old-generation bytes directly (which would need new accounting threaded through every
+sweep/compact/tenure path) because it is a strictly simpler, still-sound bound: it does not need
+to know *how much* old garbage exists, only that a full sweep runs often enough that it can never
+be starved out.
+
+The cap is tunable (mirroring the existing `tenure_age` getter/setter pattern) rather than a bare
+constant, since the right value trades off "how much old churn a workload can tolerate before its
+next full pause" against "how much minor-GC throughput a workload gives up for early full
+collects" — a workload-specific choice, not a universal one.
+
+---
+
+## 2b. The barrier-coverage hazard — why automatic enactment needs an explicit attestation
+
+A second, more severe hazard surfaced by adversarial security review of the first draft: minor
+collection's correctness — not just its pacing — depends on the remembered set being *complete*.
+`collect_minor`'s own doc comment says it plainly: "every old→young store must have called
+`write_barrier`; a missed old→young pointer whose only path to a young object is through that
+old parent would let the young object be wrongly freed." That is a **use-after-free**, not the
+§2 leak.
+
+`gc-core` cannot verify this on its own — the barrier is a *producer* obligation, enforced (or
+not) in an entirely different crate than the collector. Auditing every current producer of the
+shared `field_store` IIR op:
+
+- `vm-core`'s `handle_gc_field_store` (`dispatch.rs`) calls `ctx.heap.write_barrier(...)` on every
+  store. **Barrier-correct.**
+- `aarch64-backend`, `x86_64-backend`, and `iir-to-llvm`'s `field_store` lowering each emit a bare
+  store (`str`/`mov`/`store` respectively) with **no barrier call** — confirmed by grep: `write_barrier`
+  appears nowhere in any of the three crates. **Not barrier-correct.**
+
+Those three backends are exactly the ones that emit `safepoint` at loop back-edges and function
+entries (forwarded to `__gc_safepoint` via the `__twig_gc_safepoint` alias) — i.e. exactly the
+automatic call site this spec's §3.2 wires up. With `DEFAULT_TENURE_AGE = 1` (immediate tenuring)
+and `AdaptivePolicy`'s generational threshold (`ema_survival_ratio < 0.15`) describing an ordinary
+allocation-heavy loop rather than a corner case, an unconditional `should_collect_minor` wired into
+`__gc_safepoint` would make every AOT-compiled program that stores a reference into an
+already-tenured object a live UAF, not a latent one — the missing barriers exist today, but no
+automatic collection site could ever reach a minor cycle before this spec, so they were harmless.
+
+**Fix: an explicit, off-by-default attestation.** `FlatHeap::should_collect_minor` gains a new
+precondition, checked *before* the streak cap: `self.auto_minor` (default `false`), set only via
+`FlatHeap::set_auto_minor(true)` / the capi `__gc_set_auto_minor(1)`. This is not a correctness
+mechanism gc-core can enforce (it's an attestation, not a proof) — it is a deliberate, documented
+"you must know what you are doing" gate, the same shape as `unsafe` itself: the default keeps
+`__gc_safepoint`'s behavior byte-for-byte what it was before this spec (safe, matches every
+existing producer's actual guarantees), and turning it on is a one-line, loudly-documented opt-in
+a future producer takes only after it emits the barrier on every store. `vm-core` does not need
+it (it doesn't call `__gc_safepoint`/`gc-core-capi` at all — its own `handle_safepoint` calls
+`should_collect`/`should_compact` directly and could, in a follow-up, opt into
+`should_collect_minor` too, since it *is* barrier-correct). Closing the gap for the native/LLVM
+backends — emitting `__gc_write_barrier` from their `field_store` lowering — is future work,
+tracked separately; it is what would let an embedder responsibly call `__gc_set_auto_minor(1)`.
+
+---
+
+## 3. Design
+
+### 3.1 `gc-core` (`flat_heap.rs`)
+
+- `minor_streak: u32` field on `FlatHeap` (init `0`).
+- `max_minor_streak: u32` field (default `DEFAULT_MAX_MINOR_STREAK = 8`), with
+  `set_max_minor_streak(u32)` (clamped to a minimum of `1` — `0` would forbid every minor
+  collection, defeating the feature) / `max_minor_streak() -> u32` accessors, mirroring
+  `set_tenure_age`/`tenure_age`.
+- Every **full**-collect method (`collect_region`, `collect_precise`, `collect_mixed`,
+  `collect_compacting`) resets `self.minor_streak = 0` in its finishing tail, alongside the
+  existing stats bookkeeping.
+- `minor_finish` (the shared tail of `collect_minor`/`collect_minor_region`, and the new
+  `collect_minor_mixed` below) increments `self.minor_streak = self.minor_streak.saturating_add(1)`.
+- `auto_minor: bool` field (init `false`), with `set_auto_minor(bool)` / `auto_minor() -> bool`
+  accessors — the barrier-coverage attestation gate from §2b.
+- `pub fn should_collect_minor(&self) -> bool` — mirrors `should_compact`, gated by §2b's
+  attestation:
+  ```rust
+  pub fn should_collect_minor(&self) -> bool {
+      if !self.auto_minor || self.minor_streak >= self.max_minor_streak {
+          return false; // unattested, or bound old-generation growth — force a full collect
+      }
+      matches!(
+          AdaptivePolicy::default().evaluate(&self.profile),
+          PolicyDecision::SuggestSwitch(GcAlgorithm::Generational, _)
+      )
+  }
+  ```
+  Same policy-priority deference `should_compact` already documents: `AdaptivePolicy::evaluate`
+  returns exactly one recommendation, so `should_collect_minor` only fires when Generational is
+  the *top* signal (Incremental didn't fire) — no separate ordering logic needed here.
+- `pub unsafe fn collect_minor_mixed(&mut self, root_slots: &[usize], regions: &[(*const u8, usize)]) -> GcCycleStats`
+  — the young-generation analogue of `collect_mixed`: mark every `root_slots` word and every
+  `regions` candidate with `young_only = true`, then delegate to the existing `minor_finish`.
+  Needed because the only minor entry points today take *either* explicit root values
+  (`collect_minor`) *or* one conservative region (`collect_minor_region`) — neither matches the
+  precise-slots-plus-conservative-regions shape `build_precise_roots` produces, which
+  `collect_precise`/`collect_mixed`/`collect_compacting` already consume. Same safety contract as
+  `collect_mixed` (every slot address and region span must be readable).
+- `minor_finish` (the shared tail all three minor entries call) now also calls
+  `adapt_threshold(prev_live)`, threaded in from each caller's pre-mark `self.live_bytes` — a
+  review-caught gap: without it, a heap sitting over threshold after a minor cycle stayed
+  `should_collect() == true`, re-walking the stack at *every* subsequent safepoint until a full
+  collect eventually happened to run and adapt it. Every full-collect entry already does this;
+  minor cycles now match.
+
+### 3.2 `gc-core-capi`
+
+- `__gc_collect_minor_precise() -> i64` — new `#[no_mangle]` entry, byte-for-byte the same
+  spill/frame-walk/gate structure as `__gc_collect_precise`, calling
+  `h.collect_minor_mixed(&slots, &regions)` instead of `h.collect_mixed(...)`. Always directly
+  callable — the attestation gate (§2b) applies only to `__gc_safepoint`'s *automatic* choice to
+  run a minor cycle, not to this explicit entry (an explicit caller is presumed to know its own
+  barrier coverage, the same trust level `__gc_collect_minor`/`collect_minor` already carry).
+- `__gc_set_auto_minor(on: i64)` / `__gc_is_auto_minor() -> i64` — thin C ABI wrapper over
+  `FlatHeap::set_auto_minor`/`auto_minor` (§2b).
+- `__gc_safepoint` priority, extended:
+  ```rust
+  pub unsafe extern "C" fn __gc_safepoint() -> i64 {
+      if !with_heap(|h| h.should_collect()) { return 0; }
+      if with_heap(|h| h.should_collect_minor()) {
+          __gc_collect_minor_precise()
+      } else if with_heap(|h| h.should_compact()) {
+          __gc_collect_compacting()
+      } else {
+          __gc_collect_precise()
+      }
+  }
+  ```
+  Minor is checked *before* compacting, matching `AdaptivePolicy`'s own stated priority
+  (Generational outranks Compacting) — consistent with `should_compact`'s doc comment, which
+  already describes deferring to a higher-priority signal. `should_collect_minor` folds in the
+  §2b attestation check, so this dispatch needs no separate gate of its own.
+- No new `twig_compat` alias: the automatic enactment flows entirely through the already-aliased
+  `__twig_gc_safepoint` → `__gc_safepoint`. (`collect_minor`/`collect_minor_region` themselves
+  were never twig-aliased either — there is no existing native builtin that calls them directly,
+  unlike `gc_collect_precise`/`gc_collect_compacting`, so there is no parity gap to close here.)
+
+### 3.3 What does *not* change
+
+- `vm-core`'s own `safepoint` opcode and any direct `collect_minor`/`collect_minor_region` caller
+  are unaffected — this only changes what the *paced, automatic* `__gc_safepoint` entry does.
+- The Incremental recommendation stays advisory (§1).
+- Nothing about `collect_minor`, the write barrier, or tenuring changes; this spec adds a
+  *scheduling* decision on top of already-proven mechanism.
+
+---
+
+## 4. Safety argument
+
+- **Soundness of the minor collection itself** is unchanged — this spec adds no new collection
+  algorithm, only a new call site for the existing, already-reviewed `collect_minor`/write-barrier
+  machinery (generational arc, PR #8526 and follow-ups).
+- **The attestation gate (§2b) is the load-bearing correctness piece for the automatic path.**
+  `should_collect_minor` hardcodes `false` while `auto_minor` is `false` (the default), so
+  `__gc_safepoint`'s minor branch is unreachable, and its behavior is byte-for-byte identical to
+  before this spec, for every existing producer. Enabling it is a one-line, explicitly-documented
+  action an embedder takes only after confirming its own barrier coverage — `gc-core` cannot
+  verify this itself (the barrier is emitted, or not, in a different crate entirely), so this is
+  an attestation contract, not a provable invariant; the risk of getting it wrong (a real UAF) is
+  stated plainly on every touchpoint (the field, both setters, both doc-comment call sites).
+- **The streak cap is the second correctness-relevant piece**, orthogonal to the gate above (a
+  leak, not a UAF, and only reachable once `auto_minor` is already true). It is a
+  monotonically-increasing counter reset only by an actual full collection, so old-generation
+  garbage can accumulate for at most `max_minor_streak` consecutive paced collections before a
+  full collect is forced — a hard, easily-tested bound, not a heuristic that can silently regress.
+- **Degenerate inputs are safe by construction:** `set_max_minor_streak(0)` clamps to `1`
+  (mirroring `set_tenure_age`'s `0`→`1` clamp), so `should_collect_minor` can be made to always
+  defer to a full collect but never to lock in an infinite minor-only regime. `set_auto_minor`
+  takes a plain `bool` (Rust) / any nonzero `i64` (capi) — no clamp needed, no invalid state
+  representable.
+- **`collect_minor_mixed` carries the identical safety contract** as `collect_mixed` (every slot
+  address and region span readable) — no new unsafe reasoning, just the existing precise/region
+  mark logic with `young_only = true` and the existing `minor_finish` tail.
+- **Pacing correctness:** `minor_finish`'s new `adapt_threshold` call uses the same `prev_live`
+  captured before the mark phase that every full-collect entry already uses — same formula, same
+  caller-supplied input, no new safety-relevant logic.
+
+---
+
+## 5. Testing plan
+
+- `gc-core` unit tests, mirroring `should_compact_follows_adaptive_policy_fragmentation_signal`:
+  - **the attestation gate itself**: `should_collect_minor() == false` with every other condition
+    (enough cycles, low survival ratio) satisfied but `auto_minor` still at its default `false`;
+    `true` once `set_auto_minor(true)` is called — this is the direct regression test for the §2b
+    security-review fix.
+  - low survival ratio + attested → `should_collect_minor() == true`.
+  - the streak cap: force `max_minor_streak` consecutive minor collections under a sustained
+    low-survival, attested profile, assert the *next* `should_collect_minor()` call is `false`
+    even though the policy would still recommend Generational; assert a full collect resets the
+    streak.
+  - priority: an attested profile where both Generational and Compacting signals would fire —
+    Generational wins (mirrors the existing pause-outranks-fragmentation test for `should_compact`).
+- `gc-core-capi`: `__gc_set_max_minor_streak`/`__gc_max_minor_streak` clamp test (mirrors
+  `c_abi_set_and_get_tenure_age_clamps`); `__gc_set_auto_minor`/`__gc_is_auto_minor` default-off +
+  round-trip test; plus an end-to-end smoke test for `__gc_collect_minor_precise` itself (called
+  directly, not gated by `auto_minor` — see §3.2) — mirroring `__gc_collect_precise`'s own smoke
+  test, plus the property that actually distinguishes it: a genuinely-unrooted OLD object survives
+  (checked via `__gc_kind_of`, not a conservative-scan-dependent `freed` count — see lessons.md,
+  the `freed` count from a raw stack scan is not deterministic in a debug build and is the wrong
+  signal to assert a *specific* new behavior on). `__gc_safepoint`'s three-way dispatch itself is
+  exercised by inspection plus the already-thorough `should_collect_minor`/`should_compact`
+  gc-core unit tests it calls — matching the existing precedent that `should_compact`'s wiring
+  into `__gc_safepoint` also has no dedicated capi-level dispatch-integration test.
+- `cargo miri test -p gc-core -p gc-core-capi` (mandatory for this crate per repo convention —
+  every prior GC-ladder PR was Miri-clean).
+
+---
+
+## 6. Follow-up (not in this PR)
+
+The mechanism this spec ships (`should_collect_minor`, `collect_minor_mixed`,
+`__gc_collect_minor_precise`, the streak cap, the attestation gate) is complete and tested, but
+**no producer can turn it on yet**: `vm-core` is barrier-correct but doesn't call
+`__gc_safepoint`; the native/LLVM backends call `__gc_safepoint` but aren't barrier-correct. The
+actual payoff — a real AOT-compiled program running cheaper minor collections automatically —
+needs a follow-up that emits `__gc_write_barrier` from `field_store` lowering in
+`aarch64-backend`, `x86_64-backend`, and `iir-to-llvm`, then calls `__gc_set_auto_minor(1)` once
+per process (e.g. from the same `__gc_init_stackmaps`-style startup hook the precise-roots rung
+uses) with a differential proving an old→young store survives a minor collection end-to-end on
+real hardware. `vm-core`'s own `handle_safepoint` opting into `should_collect_minor` too (it is
+barrier-correct today) is a smaller, independent follow-up.

--- a/code/specs/AOT00-T8-adaptive-safepoint-scheduling.md
+++ b/code/specs/AOT00-T8-adaptive-safepoint-scheduling.md
@@ -265,8 +265,11 @@ tracked separately; it is what would let an embedder responsibly call `__gc_set_
   exercised by inspection plus the already-thorough `should_collect_minor`/`should_compact`
   gc-core unit tests it calls — matching the existing precedent that `should_compact`'s wiring
   into `__gc_safepoint` also has no dedicated capi-level dispatch-integration test.
-- `cargo miri test -p gc-core -p gc-core-capi` (mandatory for this crate per repo convention —
-  every prior GC-ladder PR was Miri-clean).
+- `cargo miri test -p gc-core` — clean, 116/116 (the crate this PR substantively changes).
+  `cargo miri test -p gc-core-capi` fails independently of this PR: reproduced identically on
+  unmodified `origin/main` in `precise_walk::tests::all_unmapped_frames_become_conservative_regions`
+  (a Stacked-Borrows violation in a pre-existing synthetic-stack-walk test, `precise_walk.rs:176` —
+  a file this PR does not touch). Flagged as a separate follow-up rather than fixed here.
 
 ---
 

--- a/lessons.md
+++ b/lessons.md
@@ -2611,3 +2611,40 @@ Lessons:
    (Rust's default per-test-thread stack is ~2 MiB unless `RUST_MIN_STACK` or
    an explicit `Builder::stack_size` overrides it) is the same failure class as
    Windows' `0xC00000FD` — a real stack overflow, not a flaky/cancelled CI job.
+
+## A conservative-stack-scan GC test's "freed" count is not deterministic in a debug build — assert on a non-conservative signal instead (gc-core-capi, AOT00-T8)
+
+Writing a capi-level test for the new `__gc_collect_minor_precise` entry (AOT00-T8,
+adaptive safepoint scheduling), I copied the exact pattern every other stack-scan
+smoke test in `gc-core-capi/src/stack_scan.rs` already uses: allocate a `kept` object,
+root it in a local; allocate a second object and immediately discard the pointer
+(`let _ = __gc_alloc(16);`); call the collect entry; `assert!(freed >= 1, ...)`. It
+failed **deterministically** (not flaky-sometimes — every run, `freed == 0`) even
+though the underlying algorithm was already proven correct by a controlled
+gc-core-only unit test with exact root slots. Swapping in the pre-existing,
+already-shipped `__gc_collect_precise()` in the *exact same test function* reproduced
+the identical `freed == 0` failure — proving the bug was not in my new code at all,
+but in the test's own shape.
+
+Root cause is the sibling of the "same-shaped `if` block" lesson directly above, one
+layer down: in an unoptimized debug build, a discarded temporary's value (the dead
+object's return value from `__gc_alloc`) is not guaranteed to be scrubbed from the
+stack slot/register it transiently occupied — it can keep sitting there, byte-for-byte
+identical to a real heap address, for the rest of the function's lifetime. A
+conservative stack scan (`__gc_collect`/`__gc_collect_precise`/`__gc_collect_minor_precise`
+with no stack maps registered — the exact case every existing unit test exercises)
+reads *every* word in the scanned region as a *candidate* root, so that stale word
+retains the "dead" object regardless of whether any live Rust binding still names it.
+Whether a given test happens to dodge this is pure happenstance of that function's
+specific local-variable layout and register allocation, not a property of the GC
+algorithm — mine tripped it, several pre-existing tests apparently do not (this time).
+
+**Fix:** don't assert `freed >= N` (or any positive lower bound) as the *sole* signal
+in a new stack-scan integration test — it's inherently non-deterministic and doing so
+just adds a coin-flip to CI without telling you anything actionable. If the property
+under test has a **non-conservative, exact** way to check it (here: `__gc_kind_of`,
+which does a real `find_header` lookup — no stack scanning involved — so it reports
+"still live" vs "reclaimed" precisely), assert on that instead. Reserve the
+`freed >= 1` pattern (as the *existing* precise/compacting smoke tests already do) for
+cases with no better signal available, and don't add new tests that rely on it as the
+primary proof of a specific new behavior.


### PR DESCRIPTION
## Summary

- Wires `AdaptivePolicy`'s **Generational** recommendation into `gc-core-capi`'s automatic `__gc_safepoint` — previously only the Compacting recommendation was ever auto-enacted; Generational sat advisory-only, so no AOT-compiled program ever ran a cheap minor collection automatically no matter how young-heavy its allocation pattern.
- Adds `FlatHeap::should_collect_minor`, a `minor_streak`/`max_minor_streak` cap (bounds consecutive automatic minors so a sustained low-survival workload can't starve the old generation of collection forever), and `FlatHeap::collect_minor_mixed` + `__gc_collect_minor_precise` (the precise-slots-plus-conservative-regions minor entry a real stack walk needs).
- **Security review (round 1) caught a real HIGH-severity issue**: enacting minor collections automatically would be a use-after-free for native-AOT/LLVM-compiled programs, because those backends' `field_store` lowering never calls `__gc_write_barrier` (only `vm-core`'s interpreter does) — the remembered set a minor collection depends on would be incomplete. Fixed by gating `should_collect_minor` behind a new `auto_minor` attestation flag, off by default, so `__gc_safepoint`'s behavior is byte-for-byte unchanged for every current producer until an embedder explicitly attests its own barrier coverage. Round 2 review passed clean.
- Also fixes a review-caught pacing gap: minor cycles weren't calling `adapt_threshold`, so a heap sitting over the collection threshold after a minor cycle could re-walk the stack at every subsequent safepoint until a full collect happened to run.
- Spec: `code/specs/AOT00-T8-adaptive-safepoint-scheduling.md` (§2b covers the barrier-coverage hazard; §6 tracks the follow-up work — emitting write barriers from the native/LLVM backends — needed before any producer can safely call `__gc_set_auto_minor(1)`).

## Test plan

- [x] `cargo test -p gc-core` — 116 passed (was 115; +unit tests for the attestation gate, streak cap, priority ordering, `collect_minor_mixed`)
- [x] `cargo test -p gc-core-capi` — 40 passed (+ smoke test for `__gc_collect_minor_precise`, C ABI clamp/round-trip tests for the new setters)
- [x] `cargo test -p vm-core` — 106 passed (downstream consumer of `gc-core`, unaffected)
- [x] `cargo clippy -p gc-core -p gc-core-capi --all-targets -- -D warnings` — clean
- [x] `cargo miri test -p gc-core` — clean, 116/116 (gc-core-capi's Miri suite has a pre-existing, unrelated Stacked-Borrows failure in `precise_walk.rs`, reproduced on unmodified `origin/main`, flagged separately)
- [x] Two-round adversarial security review (round 1 found the HIGH finding above and a LOW pacing finding; round 2, on the fix, passed clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)