### PR TITLE
feat(human-languages): the ramp now includes the script (HL-C18C)

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -30,6 +30,35 @@ discarding deep content.
 3. Finish a small vertical slice before starting the same migration everywhere.
 4. Keep the application, book, and canonical lesson content aligned.
 
+## The owner's direction, 2026-08-07
+
+Recorded here because the repository, not an agent session, is the source of truth.
+These restate and sharpen the program; where they conflict with an older item, these win.
+
+1. **One core JSON is the source.** Book *and* app derive from it. It already records
+   voice-vs-read modality (`core/lesson-modality.json`) so a voice assistant can teach
+   while the learner drives — that stays first-class.
+2. **The spine is shared across languages.** The same gentle ramp, in the same order, in
+   every track, so a reader can pattern-match across languages.
+3. **pre-A1 → C2 for every language.** Where a language has no CEFR exam, derive an
+   equivalent ladder rather than leaving it unmapped. `core/spine.json` today has 16
+   nodes and **zero above A2**, which is the binding ceiling (HL-C10).
+4. **The ramp includes the script**, not just vocabulary. Sometimes you cannot introduce
+   more than one script at a time. → HL-C18C, HL-C18D.
+5. **Length is free.** Books may run to thousands of pages. Never trade gentleness for
+   brevity; split rather than compress. The five-minute contract is per *lesson*, not per
+   book, and no gate may penalise page, lesson, or chapter count.
+6. **Re-emphasise constantly.** Keep resurfacing earlier material to build confidence.
+7. **English is the only requirement for each book.** Same-family cousin material is an
+   *additional* layer for readers who know a relative — a bonus, never a prerequisite, and
+   never something that gates comprehension or inflates the script ramp. → HL-C48.
+8. **Every chapter opens with a short, well-written intro.** Not "you learnt this in
+   Hindi" cross-track name-drops, which dangle in a standalone single-language PDF.
+   288 of 393 chapters currently have no intro at all. → HL-C49.
+9. **The book is a standalone artifact.** No repo paths (98 chapters print
+   `lessons/XX-CNN-*.md` at the reader today), no app assumptions, no dangling cross-track
+   references, and the front/back matter a book is expected to have. → HL-C50.
+
 ## P0 — Step-by-Step capability program (HL05–HL08)
 
 Specified in [HL05](../../specs/HL05-chapter-capability-and-step-by-step-shape.md),
@@ -81,6 +110,11 @@ direction, and no gate may penalise page, lesson, or chapter count.
 | HL-C18 | Queued — Spanish slice complete | Burn down the 52 lessons that exceed the gentle-ramp budget. | No lesson introduces more than `maxNewAtomsPerLesson`; over-budget lessons are split into prerequisite-ordered micro-lessons, longest first, starting with `ES-C31-numeros-11-20` at seven. |
 | HL-C18A | Complete | Split the fifteen over-budget Spanish lessons, including the corpus-worst `ES-C31-numeros-11-20` at seven. | Spanish measures zero over-budget lessons; the fifteen become thirty-three prerequisite-ordered micro-lessons and the corpus figure drops from 52 to 37. |
 | HL-C18B | Queued | Split the remaining 37 over-budget lessons across the other sixteen tracks. | Every track measures zero lessons above `maxNewAtomsPerLesson`; the corpus maximum drops from 6 to 3. |
+| HL-C18C | Complete in this PR | Measure the **script** ramp, which no gate had ever counted. The atom budget measures units of meaning and is blind to decoding load: `HI-W01-shirorekha-na-ma` declares **one** atom and shows **twelve** new Devanagari glyphs, and passed cleanly for a whole release. | `measureScriptRamp` counts new target-script glyphs per lesson in reading order, charged once; `maxNewGlyphsPerLesson: 3` (the corpus's own p90, not its max of 12) and `maxNewScriptSystemsPerLesson: 1` land in `core/chapter-policy.json` with measured provenance. First published figures: **61** lessons over the glyph budget (38 of which declare zero atoms), **5** opening more than one writing system at once — all Japanese Chapter 1. Cousin-script glyphs are counted separately and never charged: conflating them made a Kannada Chapter-1 lesson read as a 34-glyph cliff when its real Kannada load is 7. Report-only, per the HL05 precedent. Also fixes `measureRamp` being called by nothing but its own test — the atom budgets now reach the gap report — and three tracks (**gujarati**, **chinese**, **japanese**) that silently resolved to `latin`. |
+| HL-C18D | Queued | Burn down the 61 lessons over the script budget, steepest first, and split the 5 Japanese lessons that open two writing systems at once. | No lesson introduces more than `maxNewGlyphsPerLesson` new glyphs or opens more than one writing system; the corpus maximum drops from 12 to 3. Starts with `HI-W01-shirorekha-na-ma`, `MR-C01-dhanyavad` and `RU-C01-da` at twelve each. Follows HL-C18C, which produced the list. |
+| HL-C48 | Queued | Generate the cousin/cognate layer from `concept_tag` instead of hand-typing it, and make it visually skippable. | The cross-language comparison table exists in **18 hand-typed instances across 4 Dravidian tracks** (4.6% of chapters) while four prefaces promise it per-lesson; `parse.ts` has no block type for it, so an author cannot write one into a canonical lesson. `concept_tag` (1,131 lessons) is the join key that would generate them, and the book renderer ignores it — as it ignores 708 `etymology_hook` fields (~25,400 words) that the app already displays cross-language. Per the owner's rule, the layer is a bonus for readers who know a relative: it must never gate comprehension, and its foreign glyphs must stay out of the target-script ramp. |
+| HL-C49 | Queued | Give every chapter a short, well-written intro, generated from `chapters.json`. | **288 of 393 chapters open with no intro at all** — title straight into the first lesson section. The 105 handwritten ones have prose, several of it cross-track name-drops ("the same wearing-down the Hindi track shows") that dangle in a single-language PDF. Every chapter opens with a few sentences that stand on their own in English. |
+| HL-C50 | Queued | Make the book a standalone artifact. | **98 chapters print a repo path** (`lessons/XX-CNN-*.md`) at a reader holding a PDF; six make cross-track references to books that do not exist beside them; no track has a glossary, an index, or an answer key, and 5 of 22 lack even a pronunciation appendix. `book-cli.ts` already states the principle — "a reader holding the PDF cannot follow a link into a Git repository" — and the handwritten shell does not honour it. |
 | HL-C19 | Queued | Verify every prose `strokeOrder` against an authored ductus, so no letter's step list implies a pen lift nothing has checked. | All 190 prose stroke orders across the nine scripts (`arabic` 21, `chinese` 24, `cyrillic` 33, `devanagari` 28, `gujarati` 29, `hebrew` 22, `perso-arabic` 9, `tamil` 10, `urdu-nastaliq` 13) either carry a font-checked pen path with `penLifts` + `strokeOrderSource`, or are worded so they claim part order only. Today exactly one letter — Tamil ம — is verified; the audit that found it is written up in [`data/scripts/README.md`](data/scripts/README.md). Follows HL-C09, which authors the paths this check consumes. |
 | HL-C30 | Closed — no move is both legal and useful | Recover Arabic's drivable prefix by moving the writing lessons that open Chapters 3 and 4 later in their chapters. | Measured and answered: zero. Both chapters are prefix-0 under **every** legal ordering because neither has a `voice` lesson without an in-chapter prerequisite, and all 18 of Arabic's `sight` lessons are tables, not script. Corpus-wide only 2 chapters (`portuguese ch2`, `italian ch2`, +4 lessons) can be improved by reordering at all; 116 of the 123 zero-prefix chapters are table-blocked at the root and belong to HL-C17. See *Findings from HL-C30*. |
 | HL-C24 | Complete in this PR | Pilot real chapter payoff lessons on the weakest Latin chapters. | Latin chapters 19, 21, 33, and 36 each own a dedicated terminal consolidation lesson built only from already-taught material, and `chapters.json` points their `payoff.lesson` at it. |

--- a/code/learning/human-languages/core/chapter-policy.json
+++ b/code/learning/human-languages/core/chapter-policy.json
@@ -5,6 +5,8 @@
   "maxNewAtomsPerLesson": 3,
   "maxNewAtomsPerChapter": 12,
   "maxLinearisableTableColumns": 3,
+  "maxNewGlyphsPerLesson": 3,
+  "maxNewScriptSystemsPerLesson": 1,
   "provenance": {
     "measuredAt": "2026-08-06",
     "corpus": "1096 lessons, 531 schema-v2, 277 schema-v2 chapters",
@@ -12,5 +14,15 @@
     "atomsPerChapter": { "median": 3, "p75": 5, "p90": 10, "max": 31 },
     "tableColumns": { "2": 99, "3": 173, "4": 60, "5+": 8, "files": 340 },
     "rationale": "maxNewAtomsPerLesson sits at the existing p90, so the median lesson is already compliant and only genuine spikes are flagged (52 lessons). maxNewAtomsPerChapter sits just above the chapter p90 of 10, flagging 17 chapters. payoffRepresentativeness starts at half a chapter's introduced atoms; it is a floor to be raised, not a target. maxLinearisableTableColumns was 0 until the HL-C16 narration lineariser existed; 3 is where a table stops being a list of labelled facts a listener can hold ('Language: Telugu. Hello: namaskaram. Source: Sanskrit.') and starts being a grid whose meaning lives in comparison across rows — the corpus's own four-column tables have an unlabelled first column that only means something because of where it sits on the page. Three covers 272 of the 340 table-bearing lesson files."
+  },
+  "scriptRampProvenance": {
+    "measuredAt": "2026-08-07",
+    "corpus": "1225 lessons; 741 in the 16 non-Latin tracks, which are the only ones with a script-reading burden",
+    "newTargetGlyphsPerLesson": { "mean": 0.94, "median": 0, "p75": 1, "p90": 3, "p95": 5, "max": 12 },
+    "overBudget": { "gt3": 61, "gt4": 43, "gt5": 28, "gt6": 18, "gt8": 8 },
+    "steepest": "HI-W01-shirorekha-na-ma, MR-C01-dhanyavad, RU-C01-da — 12 new glyphs each",
+    "multiSystemLessons": 5,
+    "lessonsShowingForeignScript": 119,
+    "rationale": "maxNewGlyphsPerLesson sits at the corpus's own p90 of 3 — the same rule that justified maxNewAtomsPerLesson, applied to the burden nobody was counting. The median non-Latin lesson introduces ZERO new glyphs, so this flags 61 genuine spikes rather than taxing ordinary lessons. It is deliberately NOT set at the max (12): a budget at the worst case is not a budget. maxNewScriptSystemsPerLesson is 1 by the project owner's rule that you cannot introduce more than one script at a time; today it flags only Japanese, whose five Chapter-1 lessons open kanji alongside hiragana and then add katakana. Counted separately and NEVER charged against these budgets: glyphs from OTHER scripts, which appear in 119 lessons and reach 26 in one — those are cousin-table context for a reader who already knows a related language, not a reading obligation, and conflating the two made a Kannada Chapter-1 lesson look like a 34-glyph cliff when its real Kannada load is 7."
   }
 }

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -449,7 +449,7 @@
     {
       "language": "gujarati",
       "chapter": 6,
-      "sourceHash": "fnv1a64:952853fc84148cac",
+      "sourceHash": "fnv1a64:834feb5e4fa699a5",
       "lessonIds": [
         "GU-C06-numbers-1-5",
         "GU-C06-number-histories"
@@ -459,7 +459,7 @@
     {
       "language": "gujarati",
       "chapter": 7,
-      "sourceHash": "fnv1a64:cfdf1f54d8c2b941",
+      "sourceHash": "fnv1a64:0be661817755e933",
       "lessonIds": [
         "GU-C07-hovun",
         "GU-C07-javun",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -1368,7 +1368,7 @@
     {
       "language": "gujarati",
       "chapter": 1,
-      "sourceHash": "fnv1a64:85602192fd87c52f",
+      "sourceHash": "fnv1a64:08fb66dea407c28f",
       "lessonIds": [
         "GU-C01-aabhaar",
         "GU-C01-aavjo",
@@ -1382,12 +1382,12 @@
       "text": "gujarati/narration/ch01.txt",
       "json": "gujarati/narration/ch01.json",
       "textHash": "fnv1a64:0686ef65a8cb5ed7",
-      "jsonHash": "fnv1a64:0e7d26b0bcbcdfe6"
+      "jsonHash": "fnv1a64:c64fa78feceb63b4"
     },
     {
       "language": "gujarati",
       "chapter": 2,
-      "sourceHash": "fnv1a64:84eae05a789c7889",
+      "sourceHash": "fnv1a64:b40428346fb84ab2",
       "lessonIds": [
         "GU-C02-anand",
         "GU-C02-chhe",
@@ -1404,12 +1404,12 @@
       "text": "gujarati/narration/ch02.txt",
       "json": "gujarati/narration/ch02.json",
       "textHash": "fnv1a64:7e44531359f0154f",
-      "jsonHash": "fnv1a64:e7d07b6f7e5ebd43"
+      "jsonHash": "fnv1a64:5e97674043dc6a4b"
     },
     {
       "language": "gujarati",
       "chapter": 3,
-      "sourceHash": "fnv1a64:519a94fefb3cc1fb",
+      "sourceHash": "fnv1a64:abfa845dbcbdcdb7",
       "lessonIds": [
         "GU-C03-hun",
         "GU-C03-kem",
@@ -1423,12 +1423,12 @@
       "text": "gujarati/narration/ch03.txt",
       "json": "gujarati/narration/ch03.json",
       "textHash": "fnv1a64:f8d37af0dc391627",
-      "jsonHash": "fnv1a64:549a398fad87fdd6"
+      "jsonHash": "fnv1a64:3665369c829b462e"
     },
     {
       "language": "gujarati",
       "chapter": 4,
-      "sourceHash": "fnv1a64:9d5823ce6f705cb4",
+      "sourceHash": "fnv1a64:a7cb2a54ee279339",
       "lessonIds": [
         "GU-C04-kaale",
         "GU-C04-malishun",
@@ -1441,12 +1441,12 @@
       "text": "gujarati/narration/ch04.txt",
       "json": "gujarati/narration/ch04.json",
       "textHash": "fnv1a64:e9eaa5d1fbca8eb2",
-      "jsonHash": "fnv1a64:d393c811beb846bb"
+      "jsonHash": "fnv1a64:b4c1a5c208550fff"
     },
     {
       "language": "gujarati",
       "chapter": 5,
-      "sourceHash": "fnv1a64:8012e9dfcbaeaad7",
+      "sourceHash": "fnv1a64:21df006e01581a7f",
       "lessonIds": [
         "GU-C05-bolvun",
         "GU-C05-hun-gujarati-bolun-chhun",
@@ -1459,12 +1459,12 @@
       "text": "gujarati/narration/ch05.txt",
       "json": "gujarati/narration/ch05.json",
       "textHash": "fnv1a64:cc87d04fdb1f32f0",
-      "jsonHash": "fnv1a64:4ed582bc2b5f5699"
+      "jsonHash": "fnv1a64:b0592938137ca239"
     },
     {
       "language": "gujarati",
       "chapter": 6,
-      "sourceHash": "fnv1a64:952853fc84148cac",
+      "sourceHash": "fnv1a64:834feb5e4fa699a5",
       "lessonIds": [
         "GU-C06-numbers-1-5",
         "GU-C06-number-histories"
@@ -1474,12 +1474,12 @@
       "text": "gujarati/narration/ch06.txt",
       "json": "gujarati/narration/ch06.json",
       "textHash": "fnv1a64:a797b79b308e1814",
-      "jsonHash": "fnv1a64:bf9f816cc94f4abc"
+      "jsonHash": "fnv1a64:614e95aba4c962d5"
     },
     {
       "language": "gujarati",
       "chapter": 7,
-      "sourceHash": "fnv1a64:cfdf1f54d8c2b941",
+      "sourceHash": "fnv1a64:0be661817755e933",
       "lessonIds": [
         "GU-C07-hovun",
         "GU-C07-javun",
@@ -1493,7 +1493,7 @@
       "text": "gujarati/narration/ch07.txt",
       "json": "gujarati/narration/ch07.json",
       "textHash": "fnv1a64:94b27cb1c27b9eb6",
-      "jsonHash": "fnv1a64:371051d2e9dcf330"
+      "jsonHash": "fnv1a64:f9fee8f10c7c2515"
     },
     {
       "language": "hindi",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:d1604dc4f84e4287",
+  "sourceHash": "fnv1a64:10bf9af0e3ac3dd0",
   "summary": {
     "totalLessons": 1225,
     "voice": 824,
@@ -10487,7 +10487,7 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:69ea2a54aec07b1c"
+      "sourceHash": "fnv1a64:6c81ef39a7506b6f"
     },
     {
       "id": "GU-C01-aavjo",
@@ -10500,7 +10500,7 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ce0ea8a630586fd1"
+      "sourceHash": "fnv1a64:876b08b9d022898c"
     },
     {
       "id": "GU-C01-haa-naa",
@@ -10513,7 +10513,7 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a4560b58e96e7406"
+      "sourceHash": "fnv1a64:a2be660d94bf9647"
     },
     {
       "id": "GU-C01-namaste",
@@ -10527,7 +10527,7 @@
         "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:ea2d04a685deb837"
+      "sourceHash": "fnv1a64:90098ada701a7ec6"
     },
     {
       "id": "GU-C01-practice",
@@ -10540,7 +10540,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:f16410c38f67b542"
+      "sourceHash": "fnv1a64:d43324531cc9bef5"
     },
     {
       "id": "GU-C01-saarun",
@@ -10554,7 +10554,7 @@
         "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:f4d2ea530bbfb36b"
+      "sourceHash": "fnv1a64:8e36192d74166b6c"
     },
     {
       "id": "GU-C02-anand",
@@ -10567,7 +10567,7 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:d464ae8af941057d"
+      "sourceHash": "fnv1a64:0ec28b57e91bb066"
     },
     {
       "id": "GU-C02-chhe",
@@ -10580,7 +10580,7 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:602b01069582a487"
+      "sourceHash": "fnv1a64:9421ea8c1eed68ca"
     },
     {
       "id": "GU-C02-maarun",
@@ -10593,7 +10593,7 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:d67b8ebaba84b5c4"
+      "sourceHash": "fnv1a64:69923e316ee556fb"
     },
     {
       "id": "GU-C02-maarun-naam-chhe",
@@ -10606,7 +10606,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:30d99ef7cafd7f66"
+      "sourceHash": "fnv1a64:131deb18a89b3213"
     },
     {
       "id": "GU-C02-naam",
@@ -10619,7 +10619,7 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:3af8f4bb9a8cc066"
+      "sourceHash": "fnv1a64:45c0fba6f08e5ec3"
     },
     {
       "id": "GU-C02-practice",
@@ -10632,7 +10632,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:246937fe74368dde"
+      "sourceHash": "fnv1a64:46d495762ef4f25d"
     },
     {
       "id": "GU-C02-shun",
@@ -10645,7 +10645,7 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:4f579e4f44a6b2af"
+      "sourceHash": "fnv1a64:7b05173babb06dca"
     },
     {
       "id": "GU-C02-tamarun-naam-shun-chhe",
@@ -10658,7 +10658,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:6085acd1c0bd05de"
+      "sourceHash": "fnv1a64:05037cae388d1cb5"
     },
     {
       "id": "GU-C02-tu-tame",
@@ -10671,7 +10671,7 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:243b1dd19af26cfa"
+      "sourceHash": "fnv1a64:ddef50cd33aa95af"
     },
     {
       "id": "GU-C03-hun",
@@ -10684,7 +10684,7 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:806b44e166aa90b1"
+      "sourceHash": "fnv1a64:11e76b7f4b053d5c"
     },
     {
       "id": "GU-C03-kem",
@@ -10697,7 +10697,7 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:6d24d1ed458a9ebc"
+      "sourceHash": "fnv1a64:bf5b7526a590d3e1"
     },
     {
       "id": "GU-C03-majaa",
@@ -10710,7 +10710,7 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:303cb39547727116"
+      "sourceHash": "fnv1a64:a8f4832b1584963f"
     },
     {
       "id": "GU-C03-practice",
@@ -10723,7 +10723,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:59f00495c27cccb5"
+      "sourceHash": "fnv1a64:2cbc0c298d7b79c6"
     },
     {
       "id": "GU-C03-tame-kem-chho",
@@ -10736,7 +10736,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5b3f6d4232bf928d"
+      "sourceHash": "fnv1a64:e015921a087205c8"
     },
     {
       "id": "GU-C03-vandho-nahi",
@@ -10749,7 +10749,7 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:b56e87993b078b6e"
+      "sourceHash": "fnv1a64:4b281c51975b08c1"
     },
     {
       "id": "GU-C04-kaale",
@@ -10762,7 +10762,7 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f3ae78bb775a679b"
+      "sourceHash": "fnv1a64:1d688df2a4389d1a"
     },
     {
       "id": "GU-C04-malishun",
@@ -10775,7 +10775,7 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:29a3baacaa084aec"
+      "sourceHash": "fnv1a64:00667abc9913b227"
     },
     {
       "id": "GU-C04-pachha",
@@ -10788,7 +10788,7 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:6f60f2bede52fd1e"
+      "sourceHash": "fnv1a64:ed7b37cea503d5c3"
     },
     {
       "id": "GU-C04-pachha-malishun",
@@ -10801,7 +10801,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:f245151fd5538775"
+      "sourceHash": "fnv1a64:722ed898b16425d4"
     },
     {
       "id": "GU-C04-practice",
@@ -10814,7 +10814,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:0c080b0034a7e8c2"
+      "sourceHash": "fnv1a64:5f7441aa51718c15"
     },
     {
       "id": "GU-C05-bolvun",
@@ -10827,7 +10827,7 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a6494186f38b1670"
+      "sourceHash": "fnv1a64:a78b0a484e53552b"
     },
     {
       "id": "GU-C05-hun-gujarati-bolun-chhun",
@@ -10840,7 +10840,7 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:becb16ef892b890c"
+      "sourceHash": "fnv1a64:dc39a148e0c32c27"
     },
     {
       "id": "GU-C05-kaam-karvun",
@@ -10853,7 +10853,7 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:c2bb56f4b0ce16c2"
+      "sourceHash": "fnv1a64:bc64f6af5ca4e7a5"
     },
     {
       "id": "GU-C05-practice",
@@ -10866,7 +10866,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:449b435eb5c743b6"
+      "sourceHash": "fnv1a64:930baab2a86c682d"
     },
     {
       "id": "GU-C05-rahevun",
@@ -10879,7 +10879,7 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:38ff136f2541f6f9"
+      "sourceHash": "fnv1a64:0776c98caaa4da8c"
     },
     {
       "id": "GU-C06-numbers-1-5",
@@ -10892,7 +10892,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ce2aca277bb3c6ba"
+      "sourceHash": "fnv1a64:efa63868bdf27365"
     },
     {
       "id": "GU-C06-number-histories",
@@ -10905,7 +10905,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:775766c23caf743f"
+      "sourceHash": "fnv1a64:01b835a278e4ed28"
     },
     {
       "id": "GU-C07-hovun",
@@ -10918,7 +10918,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ef298f0a3ff2dd7d"
+      "sourceHash": "fnv1a64:074c898a263805b4"
     },
     {
       "id": "GU-C07-javun",
@@ -10931,7 +10931,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:528b94932b45e54c"
+      "sourceHash": "fnv1a64:ac22a70b3f014c43"
     },
     {
       "id": "GU-C07-aavvun",
@@ -10944,7 +10944,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:295013173e636454"
+      "sourceHash": "fnv1a64:0a598e9332487ff5"
     },
     {
       "id": "GU-C07-khaavun",
@@ -10957,7 +10957,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:bc5f4ec3252f1232"
+      "sourceHash": "fnv1a64:b4e5c4ae025d4ddb"
     },
     {
       "id": "GU-C07-jovun",
@@ -10970,7 +10970,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:b9479b5c8be53f39"
+      "sourceHash": "fnv1a64:123451e5d601e80a"
     },
     {
       "id": "GU-C07-jaanvun",
@@ -10983,7 +10983,7 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:983268fd3190a48d"
+      "sourceHash": "fnv1a64:0a53c84fae291b0a"
     },
     {
       "id": "HI-W01-shirorekha-na-ma",

--- a/code/learning/human-languages/gujarati/book/chapters/ch06-numbers-1-5.tex
+++ b/code/learning/human-languages/gujarati/book/chapters/ch06-numbers-1-5.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:952853fc84148cac
+% canonical-source-hash: fnv1a64:834feb5e4fa699a5
 % canonical-lessons: GU-C06-numbers-1-5, GU-C06-number-histories
 
 \chapter{Numbers One to Five}

--- a/code/learning/human-languages/gujarati/book/chapters/ch07-core-verbs.tex
+++ b/code/learning/human-languages/gujarati/book/chapters/ch07-core-verbs.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:cfdf1f54d8c2b941
+% canonical-source-hash: fnv1a64:0be661817755e933
 % canonical-lessons: GU-C07-hovun, GU-C07-javun, GU-C07-aavvun, GU-C07-khaavun, GU-C07-jovun, GU-C07-jaanvun
 
 \chapter{Six Verbs at the Core}

--- a/code/learning/human-languages/gujarati/narration/ch01.json
+++ b/code/learning/human-languages/gujarati/narration/ch01.json
@@ -4,22 +4,22 @@
   "chapter": 1,
   "title": "Chapter 1",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:85602192fd87c52f",
+  "sourceHash": "fnv1a64:08fb66dea407c28f",
   "lessons": [
     {
       "id": "GU-C01-aabhaar",
       "sequence": null,
       "title": "આભાર (ābhār) — \"thank you,\" an obligation gladly owed",
       "headword": "આભાર",
-      "romanization": "આભાર",
+      "romanization": "",
       "gloss": "thank you (ābhār)",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:69ea2a54aec07b1c",
+      "sourceHash": "fnv1a64:6c81ef39a7506b6f",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -134,15 +134,15 @@
       "sequence": null,
       "title": "આવજો (āvjo) — \"goodbye\" (come again)",
       "headword": "આવજો",
-      "romanization": "આવજો",
+      "romanization": "",
       "gloss": "goodbye (lit. \"[please] come [again]\")",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ce0ea8a630586fd1",
+      "sourceHash": "fnv1a64:876b08b9d022898c",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -257,15 +257,15 @@
       "sequence": null,
       "title": "હા / ના (hā / nā) — \"yes\" and \"no\"",
       "headword": "હા / ના",
-      "romanization": "હા / ના",
+      "romanization": "",
       "gloss": "yes / no (hā / nā)",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a4560b58e96e7406",
+      "sourceHash": "fnv1a64:a2be660d94bf9647",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -371,16 +371,16 @@
       "sequence": null,
       "title": "નમસ્તે (namaste) — \"hello,\" and a script with no ceiling",
       "headword": "નમસ્તે",
-      "romanization": "નમસ્તે",
+      "romanization": "",
       "gloss": "hello / goodbye (namaste)",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:ea2d04a685deb837",
+      "sourceHash": "fnv1a64:90098ada701a7ec6",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -496,15 +496,15 @@
       "sequence": null,
       "title": "Chapter 1 — The greetings",
       "headword": "(recap)",
-      "romanization": "(recap)",
+      "romanization": "",
       "gloss": "Chapter 1 recap — the greetings",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "voice",
       "derivedModality": "voice",
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:f16410c38f67b542",
+      "sourceHash": "fnv1a64:d43324531cc9bef5",
       "notice": null,
       "blocks": [
         {
@@ -666,16 +666,16 @@
       "sequence": null,
       "title": "સારું (sārũ) — \"good,\" \"okay\"",
       "headword": "સારું",
-      "romanization": "સારું",
+      "romanization": "",
       "gloss": "good, okay, fine (sārũ)",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:f4d2ea530bbfb36b",
+      "sourceHash": "fnv1a64:8e36192d74166b6c",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/gujarati/narration/ch02.json
+++ b/code/learning/human-languages/gujarati/narration/ch02.json
@@ -4,22 +4,22 @@
   "chapter": 2,
   "title": "Chapter 2",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:84eae05a789c7889",
+  "sourceHash": "fnv1a64:b40428346fb84ab2",
   "lessons": [
     {
       "id": "GU-C02-anand",
       "sequence": null,
       "title": "તમને મળીને આનંદ થયો (tamne maḷīne ānand thayo) — \"pleased to meet you\"",
       "headword": "તમને મળીને આનંદ થયો",
-      "romanization": "તમને મળીને આનંદ થયો",
+      "romanization": "",
       "gloss": "pleased to meet you (lit. \"meeting you, joy happened\")",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:d464ae8af941057d",
+      "sourceHash": "fnv1a64:0ec28b57e91bb066",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -134,15 +134,15 @@
       "sequence": null,
       "title": "છે (chhe) — \"is,\" a copula all Gujarati's own",
       "headword": "છે",
-      "romanization": "છે",
+      "romanization": "",
       "gloss": "is (the copula)",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:602b01069582a487",
+      "sourceHash": "fnv1a64:9421ea8c1eed68ca",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -268,15 +268,15 @@
       "sequence": null,
       "title": "મારું (mārũ) — \"my,\" and gender again",
       "headword": "મારું",
-      "romanization": "મારું",
+      "romanization": "",
       "gloss": "my (neuter; also મારો m. / મારી f.)",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:d67b8ebaba84b5c4",
+      "sourceHash": "fnv1a64:69923e316ee556fb",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -418,15 +418,15 @@
       "sequence": null,
       "title": "મારું નામ … છે (mārũ nām … chhe) — \"my name is…\"",
       "headword": "મારું નામ … છે",
-      "romanization": "મારું નામ … છે",
+      "romanization": "",
       "gloss": "my name is…",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "voice",
       "derivedModality": "voice",
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:30d99ef7cafd7f66",
+      "sourceHash": "fnv1a64:131deb18a89b3213",
       "notice": null,
       "blocks": [
         {
@@ -523,15 +523,15 @@
       "sequence": null,
       "title": "નામ (nām) — \"name,\" a word older than Europe",
       "headword": "નામ",
-      "romanization": "નામ",
+      "romanization": "",
       "gloss": "name",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:3af8f4bb9a8cc066",
+      "sourceHash": "fnv1a64:45c0fba6f08e5ec3",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -637,15 +637,15 @@
       "sequence": null,
       "title": "Chapter 2 — The introduction exchange",
       "headword": "(dialogue)",
-      "romanization": "(dialogue)",
+      "romanization": "",
       "gloss": "Chapter 2 recap — the introduction exchange",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "voice",
       "derivedModality": "voice",
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:246937fe74368dde",
+      "sourceHash": "fnv1a64:46d495762ef4f25d",
       "notice": null,
       "blocks": [
         {
@@ -807,15 +807,15 @@
       "sequence": null,
       "title": "શું (shũ) — \"what\"",
       "headword": "શું",
-      "romanization": "શું",
+      "romanization": "",
       "gloss": "what",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:4f579e4f44a6b2af",
+      "sourceHash": "fnv1a64:7b05173babb06dca",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -930,15 +930,15 @@
       "sequence": null,
       "title": "તમારું નામ શું છે? (tamārũ nām shũ chhe?) — \"what's your name?\"",
       "headword": "તમારું નામ શું છે?",
-      "romanization": "તમારું નામ શું છે?",
+      "romanization": "",
       "gloss": "what's your name?",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "voice",
       "derivedModality": "voice",
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:6085acd1c0bd05de",
+      "sourceHash": "fnv1a64:05037cae388d1cb5",
       "notice": null,
       "blocks": [
         {
@@ -1044,15 +1044,15 @@
       "sequence": null,
       "title": "તું / તમે (tũ / tame) — \"you,\" familiar and respectful",
       "headword": "તું / તમે",
-      "romanization": "તું / તમે",
+      "romanization": "",
       "gloss": "you (familiar / respectful)",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:243b1dd19af26cfa",
+      "sourceHash": "fnv1a64:ddef50cd33aa95af",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/gujarati/narration/ch03.json
+++ b/code/learning/human-languages/gujarati/narration/ch03.json
@@ -4,22 +4,22 @@
   "chapter": 3,
   "title": "Chapter 3",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:519a94fefb3cc1fb",
+  "sourceHash": "fnv1a64:abfa845dbcbdcdb7",
   "lessons": [
     {
       "id": "GU-C03-hun",
       "sequence": null,
       "title": "હું (hũ) — \"I\"",
       "headword": "હું",
-      "romanization": "હું",
+      "romanization": "",
       "gloss": "I",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:806b44e166aa90b1",
+      "sourceHash": "fnv1a64:11e76b7f4b053d5c",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -145,15 +145,15 @@
       "sequence": null,
       "title": "કેમ (kem) — \"how,\" a proper k- question",
       "headword": "કેમ",
-      "romanization": "કેમ",
+      "romanization": "",
       "gloss": "how (also \"why\")",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:6d24d1ed458a9ebc",
+      "sourceHash": "fnv1a64:bf5b7526a590d3e1",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -259,15 +259,15 @@
       "sequence": null,
       "title": "મજા (majā) — \"enjoyment,\" and how to answer",
       "headword": "મજા",
-      "romanization": "મજા",
+      "romanization": "",
       "gloss": "enjoyment, fun — and the reply \"હું મજામાં છું\"",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:303cb39547727116",
+      "sourceHash": "fnv1a64:a8f4832b1584963f",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -393,15 +393,15 @@
       "sequence": null,
       "title": "Chapter 3 — The how-are-you exchange",
       "headword": "(dialogue)",
-      "romanization": "(dialogue)",
+      "romanization": "",
       "gloss": "Chapter 3 recap — the how-are-you exchange",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "voice",
       "derivedModality": "voice",
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:59f00495c27cccb5",
+      "sourceHash": "fnv1a64:2cbc0c298d7b79c6",
       "notice": null,
       "blocks": [
         {
@@ -563,15 +563,15 @@
       "sequence": null,
       "title": "તમે કેમ છો? (tame kem chho?) — \"how are you?\"",
       "headword": "તમે કેમ છો?",
-      "romanization": "તમે કેમ છો?",
+      "romanization": "",
       "gloss": "how are you? (respectful)",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "voice",
       "derivedModality": "voice",
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5b3f6d4232bf928d",
+      "sourceHash": "fnv1a64:e015921a087205c8",
       "notice": null,
       "blocks": [
         {
@@ -685,15 +685,15 @@
       "sequence": null,
       "title": "વાંધો નહીં (vāndho nahĩ) — \"no problem\"",
       "headword": "વાંધો નહીં",
-      "romanization": "વાંધો નહીં",
+      "romanization": "",
       "gloss": "no problem / it's okay / you're welcome",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:b56e87993b078b6e",
+      "sourceHash": "fnv1a64:4b281c51975b08c1",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/gujarati/narration/ch04.json
+++ b/code/learning/human-languages/gujarati/narration/ch04.json
@@ -4,22 +4,22 @@
   "chapter": 4,
   "title": "Chapter 4",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:9d5823ce6f705cb4",
+  "sourceHash": "fnv1a64:a7cb2a54ee279339",
   "lessons": [
     {
       "id": "GU-C04-kaale",
       "sequence": null,
       "title": "કાલે મળીશું (kāle maḷīshũ) — \"see you tomorrow\"",
       "headword": "કાલે મળીશું",
-      "romanization": "કાલે મળીશું",
+      "romanization": "",
       "gloss": "see you tomorrow (and the કાલ puzzle)",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f3ae78bb775a679b",
+      "sourceHash": "fnv1a64:1d688df2a4389d1a",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -134,15 +134,15 @@
       "sequence": null,
       "title": "મળીશું (maḷīshũ) — \"(we) will meet\"",
       "headword": "મળીશું",
-      "romanization": "મળીશું",
+      "romanization": "",
       "gloss": "(we) will meet",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:29a3baacaa084aec",
+      "sourceHash": "fnv1a64:00667abc9913b227",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -268,15 +268,15 @@
       "sequence": null,
       "title": "પાછા (pāchhā) — \"again, back\"",
       "headword": "પાછા",
-      "romanization": "પાછા",
+      "romanization": "",
       "gloss": "again, back",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:6f60f2bede52fd1e",
+      "sourceHash": "fnv1a64:ed7b37cea503d5c3",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -382,15 +382,15 @@
       "sequence": null,
       "title": "પાછા મળીશું (pāchhā maḷīshũ) — \"we'll meet again\"",
       "headword": "પાછા મળીશું",
-      "romanization": "પાછા મળીશું",
+      "romanization": "",
       "gloss": "we'll meet again (goodbye)",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "voice",
       "derivedModality": "voice",
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:f245151fd5538775",
+      "sourceHash": "fnv1a64:722ed898b16425d4",
       "notice": null,
       "blocks": [
         {
@@ -485,15 +485,15 @@
       "sequence": null,
       "title": "Chapter 4 — The farewells",
       "headword": "(dialogue)",
-      "romanization": "(dialogue)",
+      "romanization": "",
       "gloss": "Chapter 4 recap — the farewells",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "voice",
       "derivedModality": "voice",
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:0c080b0034a7e8c2",
+      "sourceHash": "fnv1a64:5f7441aa51718c15",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/gujarati/narration/ch05.json
+++ b/code/learning/human-languages/gujarati/narration/ch05.json
@@ -4,22 +4,22 @@
   "chapter": 5,
   "title": "Chapter 5",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:8012e9dfcbaeaad7",
+  "sourceHash": "fnv1a64:21df006e01581a7f",
   "lessons": [
     {
       "id": "GU-C05-bolvun",
       "sequence": null,
       "title": "બોલવું (bolvũ) — \"to speak,\" your first full verb",
       "headword": "બોલવું",
-      "romanization": "બોલવું",
+      "romanization": "",
       "gloss": "to speak",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a6494186f38b1670",
+      "sourceHash": "fnv1a64:a78b0a484e53552b",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -165,15 +165,15 @@
       "sequence": null,
       "title": "હું ગુજરાતી બોલું છું (hũ gujarātī bolũ chhũ) — \"I speak Gujarati\"",
       "headword": "હું ગુજરાતી બોલું છું",
-      "romanization": "હું ગુજરાતી બોલું છું",
+      "romanization": "",
       "gloss": "I speak Gujarati",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:becb16ef892b890c",
+      "sourceHash": "fnv1a64:dc39a148e0c32c27",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -299,15 +299,15 @@
       "sequence": null,
       "title": "કામ કરવું (kām karvũ) — \"to work\"",
       "headword": "કામ કરવું",
-      "romanization": "કામ કરવું",
+      "romanization": "",
       "gloss": "to work (lit. \"work-do\")",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:c2bb56f4b0ce16c2",
+      "sourceHash": "fnv1a64:bc64f6af5ca4e7a5",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -434,15 +434,15 @@
       "sequence": null,
       "title": "Chapter 5 — The first verbs",
       "headword": "(dialogue)",
-      "romanization": "(dialogue)",
+      "romanization": "",
       "gloss": "Chapter 5 recap — the first verbs",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "voice",
       "derivedModality": "voice",
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:449b435eb5c743b6",
+      "sourceHash": "fnv1a64:930baab2a86c682d",
       "notice": null,
       "blocks": [
         {
@@ -604,15 +604,15 @@
       "sequence": null,
       "title": "રહેવું (rahevũ) — \"to live, to stay\"",
       "headword": "રહેવું",
-      "romanization": "રહેવું",
+      "romanization": "",
       "gloss": "to live, to stay",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:38ff136f2541f6f9",
+      "sourceHash": "fnv1a64:0776c98caaa4da8c",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/gujarati/narration/ch06.json
+++ b/code/learning/human-languages/gujarati/narration/ch06.json
@@ -4,7 +4,7 @@
   "chapter": 6,
   "title": "Numbers One to Five",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:952853fc84148cac",
+  "sourceHash": "fnv1a64:834feb5e4fa699a5",
   "lessons": [
     {
       "id": "GU-C06-numbers-1-5",
@@ -13,13 +13,13 @@
       "headword": "એક બે ત્રણ ચાર પાંચ",
       "romanization": "ek be traṇ chār pā̃ch",
       "gloss": "one to five — the two numbers that don't look like their neighbours'",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "voice",
       "derivedModality": "voice",
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ce2aca277bb3c6ba",
+      "sourceHash": "fnv1a64:efa63868bdf27365",
       "notice": null,
       "blocks": [
         {
@@ -148,13 +148,13 @@
       "headword": "બે · ત્રણ",
       "romanization": "be · traṇ",
       "gloss": "why Gujarati two begins with b and why three regained an r",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "voice",
       "derivedModality": "voice",
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:775766c23caf743f",
+      "sourceHash": "fnv1a64:01b835a278e4ed28",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/gujarati/narration/ch07.json
+++ b/code/learning/human-languages/gujarati/narration/ch07.json
@@ -4,7 +4,7 @@
   "chapter": 7,
   "title": "Six Verbs at the Core",
   "drivablePrefix": 6,
-  "sourceHash": "fnv1a64:cfdf1f54d8c2b941",
+  "sourceHash": "fnv1a64:0be661817755e933",
   "lessons": [
     {
       "id": "GU-C07-hovun",
@@ -13,13 +13,13 @@
       "headword": "હોવું",
       "romanization": "hovũ",
       "gloss": "to be — and the neuter ending that names every Gujarati verb",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "voice",
       "derivedModality": "voice",
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ef298f0a3ff2dd7d",
+      "sourceHash": "fnv1a64:074c898a263805b4",
       "notice": null,
       "blocks": [
         {
@@ -165,13 +165,13 @@
       "headword": "જવું",
       "romanization": "javũ",
       "gloss": "to go — and the Sanskrit y- that Prakrit turned into j-",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "voice",
       "derivedModality": "voice",
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:528b94932b45e54c",
+      "sourceHash": "fnv1a64:ac22a70b3f014c43",
       "notice": null,
       "blocks": [
         {
@@ -354,13 +354,13 @@
       "headword": "આવવું",
       "romanization": "āvvũ",
       "gloss": "to come — from a root meaning “reach,” and a cousin of the word copula",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "voice",
       "derivedModality": "voice",
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:295013173e636454",
+      "sourceHash": "fnv1a64:0a598e9332487ff5",
       "notice": null,
       "blocks": [
         {
@@ -527,13 +527,13 @@
       "headword": "ખાવું",
       "romanization": "khāvũ",
       "gloss": "to eat — the verb whose family reaches its Indian sisters and stops there",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "voice",
       "derivedModality": "voice",
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:bc5f4ec3252f1232",
+      "sourceHash": "fnv1a64:b4e5c4ae025d4ddb",
       "notice": null,
       "blocks": [
         {
@@ -673,13 +673,13 @@
       "headword": "જોવું",
       "romanization": "jovũ",
       "gloss": "to see — one vowel sign away from “to go,” and an origin still argued over",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "voice",
       "derivedModality": "voice",
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:b9479b5c8be53f39",
+      "sourceHash": "fnv1a64:123451e5d601e80a",
       "notice": null,
       "blocks": [
         {
@@ -838,13 +838,13 @@
       "headword": "જાણવું",
       "romanization": "jāṇvũ",
       "gloss": "to know — the word English has been carrying all along",
-      "script": "latin",
+      "script": "gujarati",
       "modality": "voice",
       "derivedModality": "voice",
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:983268fd3190a48d",
+      "sourceHash": "fnv1a64:0a53c84fae291b0a",
       "notice": null,
       "blocks": [
         {

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,61 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added — the ramp now includes the script (HL-C18C)
+
+- Add `measureScriptRamp` to `src/ramp.ts`, and two budgets to `core/chapter-policy.json`:
+  `maxNewGlyphsPerLesson` (**3**) and `maxNewScriptSystemsPerLesson` (**1**).
+- **The atom budget was measuring one of two burdens.** `maxNewAtomsPerLesson` counts
+  units of *meaning*. `HI-W01-shirorekha-na-ma` declares **one** atom and puts **twelve**
+  new Devanagari glyphs on the page, and passed cleanly for a whole release. It is not an
+  outlier: **61 lessons** exceed three new glyphs and **38 of them declare zero atoms**, so
+  they read as maximally gentle while teaching up to a dozen new shapes. Decoding is a
+  separate skill on a separate curve, and nothing was watching it.
+- **3 is the corpus's own p90**, the same rule that justified `maxNewAtomsPerLesson` — not
+  the observed max of 12, because a budget placed at the worst case is not a budget. The
+  median non-Latin lesson introduces **zero** new glyphs, so this flags genuine spikes
+  rather than taxing ordinary lessons.
+- **Target script and the cousin layer are counted separately, and only the first is
+  charged.** A Kannada Chapter 1 lesson showing the same word in Devanagari, Tamil, Telugu
+  and Malayalam looks like a **34-glyph cliff** when the two are conflated; its actual
+  Kannada load is **7**. Sister-script material is context for a reader who already knows a
+  relative, and English is the only requirement for each book — so it is reported (119
+  lessons, up to 26 foreign glyphs in one) and never penalised. What that footprint
+  justifies is keeping the layer visually skippable.
+- Counting rules, each load-bearing: charged **once**, in reading order, so revision is
+  free; **Latin excluded**, or romanization would swamp the signal; **combining marks
+  included**, because an abugida is mostly marks; **script digits included**, because ०१२
+  is not readable to someone born to ASCII; and **`Script_Extensions`, not `Script`**,
+  because ー is formally `Common` and the narrow property undercounts コーヒー by the
+  mark that makes it a long vowel.
+- `maxNewScriptSystemsPerLesson: 1` states the rule that you cannot introduce more than
+  one script at a time. It flags **5** lessons, all Japanese Chapter 1, which opens kanji
+  beside hiragana in its first lesson and adds katakana in its fifth.
+- Report-only, per the HL05 precedent: the debt predates the measurement.
+
+### Fixed — `measureRamp` was called by nothing but its own test
+
+- The gap report now carries a `ramp` section, so `maxNewAtomsPerLesson` and
+  `maxNewAtomsPerChapter` are finally read by something a human sees. They had been
+  declared in `core/chapter-policy.json` since HL08 and enforced by nobody — policy in the
+  sense that a sign is policy. The first published figures: **40** lessons over the atom
+  budget, **25** chapters, with **572 lessons (47%) unmeasurable** because schema-v1
+  declares no atoms.
+
+### Fixed — three tracks silently resolved to the Latin script
+
+- `LANGUAGE_SCRIPT` had no entry for **Gujarati** — which was the worked example in its
+  own doc comment — so all 39 Gujarati lessons resolved to `latin`. Glyph-coverage
+  validation looked Gujarati headwords up in the *Latin* inventory, and `romanization`
+  fell back to the Gujarati headword itself, so the narration export published
+  `"romanization": "આભાર"` — **Gujarati script in the field a speech engine reads as
+  Latin.** Regenerating `lesson-modality.json` and the seven Gujarati narration chapters
+  is the whole blast radius; no lesson content changed.
+- **Chinese** and **Japanese** were missing from the same map and were saved only by
+  shipping a `track.json` the loader prefers. A fallback that is wrong for some tracks
+  fails only in the paths that skip the loader — which is exactly where a unit test lives.
+  Completing the map removes the trap.
+
 ### Added — every lesson declares the level it builds toward (HL-C10)
 
 - Add `src/levels.ts`: `CEFR_LEVELS` (`pre-A1` … `C2`), `deriveLessonLevel`,

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -105,6 +105,35 @@ modality.tracks[0].chapters[0];        // { drivablePrefix: 5, firstNonVoiceLess
 deriveLessonModality(lessons[0]).reasons; // ["wide-table"] — why it needs eyes
 ```
 
+### The two ramps (HL08)
+
+Gentleness has **two** curves, and until HL-C18C only one of them was counted.
+
+```ts
+import { measureRamp, loadChapterPolicy, loadEverything } from "@coding-adventures/human-language-data";
+
+const { lessons } = loadEverything();
+const ramp = measureRamp(lessons, loadChapterPolicy());
+
+ramp.summary.lessonViolations;          // 40 — lessons above 3 new ATOMS (meaning)
+ramp.script.summary.lessonViolations;   // 61 — lessons above 3 new GLYPHS (decoding)
+ramp.script.summary.steepestLesson;     // HI-W01-shirorekha-na-ma: 1 atom, 12 glyphs
+ramp.script.summary.systemViolations;   // 5 — lessons opening >1 writing system at once
+```
+
+The two come apart badly. `HI-W01-shirorekha-na-ma` declares **one** knowledge atom and
+puts **twelve** new Devanagari glyphs in front of the reader; it passes the atom budget
+comfortably. 38 of the 61 over-budget lessons declare *zero* atoms, so they read as
+maximally gentle while teaching up to a dozen new shapes.
+
+**Target script and cousin script are counted separately, and only the first is charged.**
+A Kannada Chapter 1 lesson that shows the same word in Devanagari, Tamil, Telugu and
+Malayalam looks like a 34-glyph cliff if you add them together — its actual Kannada load is
+7. Sister-script material is context for a reader who already knows a relative; English is
+the only requirement for any book, so that layer is reported and never penalised.
+
+Both are **report-only**: the debt predates the measurement.
+
 Three channels, each naming what the learner must have available:
 
 | Value | Sign | Meaning |

--- a/code/packages/typescript/human-language-data/package-lock.json
+++ b/code/packages/typescript/human-language-data/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/human-language-data",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/human-language-data",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/code/packages/typescript/human-language-data/src/constants.ts
+++ b/code/packages/typescript/human-language-data/src/constants.ts
@@ -19,6 +19,23 @@ export const LANGUAGE_SCRIPT: Record<string, Script> = {
   sanskrit: "devanagari",
   punjabi: "gurmukhi",
   bengali: "bengali",
+  // The three tracks below were missing, and the fallback silently resolved them to
+  // `latin` — a wrong answer that looks like a right one.
+  //
+  // Gujarati was the worked example in the comment above and never actually got an
+  // entry, so all 39 of its lessons resolved to `latin`: glyph-coverage validation
+  // looked its headwords up in the Latin inventory, and `romanization` fell back to
+  // the Gujarati headword itself, handing a voice assistant Gujarati script in the
+  // field a speech engine reads as Latin. The script ramp surfaced it — a track whose
+  // script is unknown reads as having no script to learn.
+  //
+  // Chinese and Japanese never hit that in production because both ship a `track.json`
+  // that the loader prefers. But a fallback that is wrong for some tracks is worse than
+  // no fallback: it fails only in the paths that skip the loader, which is exactly where
+  // a unit test lives. Completing the map costs nothing and removes the trap.
+  gujarati: "gujarati",
+  chinese: "chinese",
+  japanese: "japanese",
   tamil: "tamil",
   kannada: "kannada",
   telugu: "telugu",

--- a/code/packages/typescript/human-language-data/src/index.ts
+++ b/code/packages/typescript/human-language-data/src/index.ts
@@ -199,10 +199,15 @@ export {
 } from "./verbs.js";
 export {
   measureRamp,
+  measureScriptRamp,
   type RampReport,
   type RampViolation,
   type ChapterRampViolation,
   type TrackRampCoverage,
+  type ScriptRampReport,
+  type ScriptRampViolation,
+  type ScriptSystemViolation,
+  type TrackScriptRamp,
 } from "./ramp.js";
 export { runValidate } from "./cli.js";
 export { runCurriculumGapReport } from "./report-cli.js";

--- a/code/packages/typescript/human-language-data/src/loader.ts
+++ b/code/packages/typescript/human-language-data/src/loader.ts
@@ -86,9 +86,41 @@ export function loadTrackChapters(root = defaultCurriculumRoot()): TrackChapters
  * quietly stops running is worse than one that fails loudly.
  */
 export function loadChapterPolicy(root = defaultCurriculumRoot()): ChapterPolicy {
-  return JSON.parse(
+  const policy = JSON.parse(
     readFileSync(join(root, "core", "chapter-policy.json"), "utf8"),
   ) as ChapterPolicy;
+
+  // Validate the budgets, because the alternative is a gate that reads zero and looks
+  // clean. `JSON.parse` turns `1e999` into `Infinity`, and `newTarget.size > Infinity`
+  // is false for every lesson in the corpus — so a single typo publishes "0 violations",
+  // which is indistinguishable in the report from "measured, found none". A string or an
+  // object budget fails the same way. That silent-disable is the exact failure this
+  // function's own docstring warns about, and it was unchecked.
+  //
+  // Required, not optional, for the atom budgets: `measureRamp` reads them with no
+  // default, so a policy file missing them yields `undefined` and the same silent zero.
+  const budgets: ReadonlyArray<readonly [keyof ChapterPolicy, boolean]> = [
+    ["maxNewAtomsPerLesson", true],
+    ["maxNewAtomsPerChapter", true],
+    ["maxLinearisableTableColumns", false],
+    ["maxNewGlyphsPerLesson", false],
+    ["maxNewScriptSystemsPerLesson", false],
+  ];
+  for (const [key, required] of budgets) {
+    const value = policy[key];
+    if (value === undefined) {
+      if (required) {
+        throw new Error(`chapter-policy.json: ${key} is required and missing`);
+      }
+      continue;
+    }
+    if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+      throw new Error(
+        `chapter-policy.json: ${key} must be a non-negative integer, got ${JSON.stringify(value)}`,
+      );
+    }
+  }
+  return policy;
 }
 
 /**

--- a/code/packages/typescript/human-language-data/src/ramp.ts
+++ b/code/packages/typescript/human-language-data/src/ramp.ts
@@ -21,8 +21,141 @@
 // with a low violation count and a high unmeasurable count has not proved it is gentle; it
 // has proved it is unmigrated.
 
-import type { ChapterPolicy } from "./types.js";
+// ─────────────────────────────────────────────────────────────────────────────
+// THE SECOND RAMP: script.
+//
+// Everything above counts *atoms* — units of meaning. That is one of the two
+// burdens a lesson imposes, and the corpus had no measurement of the other.
+// Before a learner can mean anything by नमस्ते they have to decode it, and
+// decoding is a separate skill on a separate curve.
+//
+// The gap was not subtle. `HI-W01-shirorekha-na-ma` declares exactly ONE atom
+// and puts TWELVE new Devanagari glyphs on the page. It passes
+// `maxNewAtomsPerLesson: 3` comfortably. Sixty-one lessons are in that position;
+// thirty-eight of them declare zero atoms and so read as maximally gentle while
+// teaching up to a dozen new shapes.
+//
+// TARGET vs FOREIGN — the distinction that makes the number honest.
+//
+// A Kannada learner must eventually read every Kannada glyph. The Devanagari,
+// Tamil, Telugu and Malayalam in a cousin table is *context* — it says "your
+// language's word for thanks is the same word Hindi uses" to a reader who
+// happens to know Hindi, and it is meant to be skippable by everyone else.
+// Charging both to one budget is what makes `KA-C01-dhanyavada` look like a
+// 34-glyph cliff in Chapter 1. Its actual Kannada load is 7.
+//
+// So foreign glyphs are counted, reported, and never charged against the
+// budget. They are the cousin layer's footprint, useful to see and wrong to
+// penalise. What they DO justify is keeping that layer visually separable, so a
+// reader who does not know Hindi can skip it without skipping the lesson.
+//
+// ORDER MATTERS, so this walks lessons in reading order (chapter, then
+// sequence) per track and counts only what is genuinely new at that point. A
+// glyph taught in Chapter 1 is free in Chapter 30. That is what makes it a ramp
+// measurement rather than a density measurement.
+
+import type { ChapterPolicy, Script } from "./types.js";
 import type { ParsedLesson } from "./parse.js";
+import { hasOwn } from "./constants.js";
+
+/**
+ * Which Unicode scripts make up each of the curriculum's script ids.
+ *
+ * Nearly all are one-to-one. `japanese` is the exception that motivates the
+ * whole `maxNewScriptSystemsPerLesson` rule: three writing systems behind one
+ * id, which is also why HL-C42 wants a track to be able to declare several.
+ * `perso-arabic` and `urdu-nastaliq` are Arabic script in different hands, so
+ * they resolve to the same Unicode script.
+ */
+const SCRIPT_SYSTEMS: Record<string, string[]> = {
+  latin: ["Latin"],
+  devanagari: ["Devanagari"],
+  bengali: ["Bengali"],
+  gurmukhi: ["Gurmukhi"],
+  gujarati: ["Gujarati"],
+  tamil: ["Tamil"],
+  telugu: ["Telugu"],
+  kannada: ["Kannada"],
+  malayalam: ["Malayalam"],
+  arabic: ["Arabic"],
+  "perso-arabic": ["Arabic"],
+  "urdu-nastaliq": ["Arabic"],
+  cyrillic: ["Cyrillic"],
+  hebrew: ["Hebrew"],
+  chinese: ["Han"],
+  japanese: ["Hiragana", "Katakana", "Han"],
+};
+
+/** Every Unicode script this curriculum can name, for classifying a stray glyph. */
+const ALL_SYSTEMS = [
+  ...new Set(Object.values(SCRIPT_SYSTEMS).flat()),
+].filter((system) => system !== "Latin");
+
+/**
+ * `Script_Extensions`, not `Script`, and the difference is load-bearing.
+ *
+ * Several characters a learner must decode are formally `Script=Common` because
+ * more than one script borrows them — Japanese's prolonged-sound mark ー
+ * (U+30FC) is the clearest case, shared by hiragana and katakana and therefore
+ * belonging to neither under the narrow property. `Script=Katakana` misses it;
+ * `Script_Extensions=Katakana` catches it. Matching on the narrow property
+ * undercounted コーヒー by exactly the mark that makes it a long vowel.
+ */
+const SYSTEM_MATCHERS: ReadonlyArray<readonly [string, RegExp]> = ALL_SYSTEMS.map((system) => {
+  try {
+    return [system, new RegExp(`\\p{Script_Extensions=${system}}`, "u")] as const;
+  } catch {
+    // These regexes are built at module load, and `index.ts` re-exports this file, so a
+    // bad name takes down every CLI in the package — book generation, narration,
+    // modality, validate — with a SyntaxError naming a regex rather than the map that
+    // caused it. The names that throw are exactly the plausible extensions: "Kanji",
+    // "Nastaliq", or a typo like "Devangari". Say which one and where.
+    throw new Error(
+      `SCRIPT_SYSTEMS names "${system}", which is not a Unicode script. ` +
+        `Use the script's Unicode name (e.g. "Han", not "Kanji"; "Arabic", not "Nastaliq").`,
+    );
+  }
+});
+
+/**
+ * The Unicode script a character belongs to, or null when it is not script at all.
+ *
+ * Punctuation, spaces, format characters and Latin are all "not script" here. Latin
+ * is excluded deliberately: romanization (`namaskāram`) rides alongside every
+ * non-Latin headword, and counting `ā` as a glyph to be learned would swamp the
+ * signal with the very thing that exists to make the script approachable.
+ *
+ * Two things are deliberately NOT excluded. Combining marks: a Devanagari mātrā is
+ * a shape the learner must read, and dropping it would undercount every abugida in
+ * the corpus. And digits: ०१२ and ۱۲۳ are `\p{N}`, but they are also glyphs nobody
+ * born to ASCII can already read, so a numbers lesson genuinely does teach script.
+ * Latin digits never reach the matchers, so no exclusion is needed for them.
+ */
+function systemOf(ch: string): string | null {
+  if (/[\s\p{P}\p{C}]/u.test(ch)) return null;
+  for (const [system, matcher] of SYSTEM_MATCHERS) {
+    if (matcher.test(ch)) return system;
+  }
+  return null;
+}
+
+/** Reading order within a track: chapter, then sequence, then id for stability. */
+function readingOrder(a: ParsedLesson, b: ParsedLesson): number {
+  const chapter = (lesson: ParsedLesson) =>
+    typeof lesson.realization.chapter === "number" && Number.isFinite(lesson.realization.chapter)
+      ? lesson.realization.chapter
+      : Number.MAX_SAFE_INTEGER;
+  const sequence = (lesson: ParsedLesson) => {
+    const raw = lesson.frontmatter.sequence;
+    const value = typeof raw === "number" ? raw : Number(raw);
+    return Number.isFinite(value) ? value : Number.MAX_SAFE_INTEGER;
+  };
+  return (
+    chapter(a) - chapter(b) ||
+    sequence(a) - sequence(b) ||
+    a.realization.lessonId.localeCompare(b.realization.lessonId)
+  );
+}
 
 /** One lesson that introduces more than the budget allows. */
 export interface RampViolation {
@@ -56,11 +189,70 @@ export interface TrackRampCoverage {
   chapterViolations: number;
 }
 
+/** One lesson putting more new target-script glyphs on the page than the budget allows. */
+export interface ScriptRampViolation {
+  lessonId: string;
+  language: string;
+  chapter: number | null;
+  /** New glyphs of the track's OWN script, first seen in this lesson. */
+  glyphs: number;
+  /** The glyphs themselves, so a splitter can see what it is dividing. */
+  sample: string;
+  /** Writing systems opened here — >1 is its own violation. */
+  systems: string[];
+  budget: number;
+}
+
+/** One lesson opening more writing systems at once than the budget allows. */
+export interface ScriptSystemViolation {
+  lessonId: string;
+  language: string;
+  chapter: number | null;
+  systems: string[];
+  budget: number;
+}
+
+export interface TrackScriptRamp {
+  language: string;
+  /** The track's declared script id. */
+  script: Script;
+  /** Latin-script tracks carry no decoding burden and are measured but never flagged. */
+  latinScript: boolean;
+  lessonCount: number;
+  /** Distinct target-script glyphs the whole track ever shows. */
+  totalGlyphs: number;
+  lessonViolations: number;
+  systemViolations: number;
+  /** Lessons showing at least one glyph from a DIFFERENT script (cousin tables). */
+  lessonsWithForeignScript: number;
+}
+
+export interface ScriptRampReport {
+  policy: { maxNewGlyphsPerLesson: number; maxNewScriptSystemsPerLesson: number };
+  lessons: ScriptRampViolation[];
+  systems: ScriptSystemViolation[];
+  tracks: TrackScriptRamp[];
+  summary: {
+    /** Lessons above `maxNewGlyphsPerLesson` — the script burn-down list. */
+    lessonViolations: number;
+    /** Lessons opening more than one writing system at once. */
+    systemViolations: number;
+    /** Lessons carrying cousin-table glyphs. Context, never a violation. */
+    lessonsWithForeignScript: number;
+    /** Most foreign glyphs any one lesson shows, so the cousin layer's cost is visible. */
+    maxForeignGlyphsInALesson: number;
+    /** The steepest single lesson, where a burn-down starts. */
+    steepestLesson: ScriptRampViolation | null;
+  };
+}
+
 export interface RampReport {
   policy: { maxNewAtomsPerLesson: number; maxNewAtomsPerChapter: number };
   lessons: RampViolation[];
   chapters: ChapterRampViolation[];
   tracks: TrackRampCoverage[];
+  /** The script ramp — a second, independent curve. See the note at the top of this file. */
+  script: ScriptRampReport;
   summary: {
     /** Lessons above `maxNewAtomsPerLesson`. The HL-C18 burn-down list. */
     lessonViolations: number;
@@ -95,6 +287,137 @@ function introducedAtoms(lesson: ParsedLesson): string[] {
     for (const atom of block.knowledge?.introduces ?? []) atoms.add(atom);
   }
   return [...atoms];
+}
+
+/**
+ * Measure the script ramp: new target-script glyphs per lesson, in reading order.
+ *
+ * Defaults mirror `chapter-policy.json` so a policy file written before this
+ * existed still measures something rather than silently reporting zero — the
+ * failure mode that let the atom budgets sit unread for a whole release.
+ */
+export function measureScriptRamp(
+  lessons: ParsedLesson[],
+  policy: ChapterPolicy,
+): ScriptRampReport {
+  const perLesson = policy.maxNewGlyphsPerLesson ?? 3;
+  const perSystems = policy.maxNewScriptSystemsPerLesson ?? 1;
+
+  const violations: ScriptRampViolation[] = [];
+  const systemViolations: ScriptSystemViolation[] = [];
+  const tracks: TrackScriptRamp[] = [];
+  let maxForeign = 0;
+  let foreignLessons = 0;
+
+  const byTrack = new Map<string, ParsedLesson[]>();
+  for (const lesson of lessons) {
+    let group = byTrack.get(lesson.language);
+    if (!group) byTrack.set(lesson.language, (group = []));
+    group.push(lesson);
+  }
+
+  for (const [language, group] of [...byTrack].sort((a, b) => a[0].localeCompare(b[0]))) {
+    const script = group[0]!.script;
+    // `hasOwn`, not `?? ["Latin"]`. A track.json may declare any string as its script,
+    // and `SCRIPT_SYSTEMS["__proto__"]` returns Object.prototype — which is not nullish,
+    // so `??` never fires and `new Set(Object.prototype)` throws, taking the whole gap
+    // report down with it. Same for `constructor`, `toString`, `valueOf`. The package
+    // already exports `hasOwn` for exactly this; this lookup is the one that skipped it.
+    const target = new Set(hasOwn(SCRIPT_SYSTEMS, script) ? SCRIPT_SYSTEMS[script]! : ["Latin"]);
+    const latinScript = target.has("Latin");
+
+    const seenTarget = new Set<string>();
+    const seenForeign = new Set<string>();
+    const track: TrackScriptRamp = {
+      language,
+      script,
+      latinScript,
+      lessonCount: group.length,
+      totalGlyphs: 0,
+      lessonViolations: 0,
+      systemViolations: 0,
+      lessonsWithForeignScript: 0,
+    };
+
+    for (const lesson of [...group].sort(readingOrder)) {
+      const newTarget = new Set<string>();
+      const newForeign = new Set<string>();
+      const systems = new Set<string>();
+
+      for (const ch of new Set(lesson.body)) {
+        const system = systemOf(ch);
+        if (system === null) continue;
+        if (target.has(system)) {
+          if (latinScript || seenTarget.has(ch)) continue;
+          seenTarget.add(ch);
+          newTarget.add(ch);
+          systems.add(system);
+        } else if (!seenForeign.has(ch)) {
+          seenForeign.add(ch);
+          newForeign.add(ch);
+        }
+      }
+
+      if (newForeign.size > 0) {
+        foreignLessons += 1;
+        track.lessonsWithForeignScript += 1;
+        maxForeign = Math.max(maxForeign, newForeign.size);
+      }
+      track.totalGlyphs += newTarget.size;
+
+      const chapter =
+        typeof lesson.realization.chapter === "number" && Number.isFinite(lesson.realization.chapter)
+          ? lesson.realization.chapter
+          : null;
+      const orderedSystems = [...systems].sort();
+
+      if (newTarget.size > perLesson) {
+        violations.push({
+          lessonId: lesson.realization.lessonId,
+          language,
+          chapter,
+          glyphs: newTarget.size,
+          sample: [...newTarget].sort().join(""),
+          systems: orderedSystems,
+          budget: perLesson,
+        });
+        track.lessonViolations += 1;
+      }
+
+      if (orderedSystems.length > perSystems) {
+        systemViolations.push({
+          lessonId: lesson.realization.lessonId,
+          language,
+          chapter,
+          systems: orderedSystems,
+          budget: perSystems,
+        });
+        track.systemViolations += 1;
+      }
+    }
+
+    tracks.push(track);
+  }
+
+  // Steepest first, then by id, so the list is a stable work queue rather than a set.
+  violations.sort((a, b) => b.glyphs - a.glyphs || a.lessonId.localeCompare(b.lessonId));
+  systemViolations.sort(
+    (a, b) => b.systems.length - a.systems.length || a.lessonId.localeCompare(b.lessonId),
+  );
+
+  return {
+    policy: { maxNewGlyphsPerLesson: perLesson, maxNewScriptSystemsPerLesson: perSystems },
+    lessons: violations,
+    systems: systemViolations,
+    tracks,
+    summary: {
+      lessonViolations: violations.length,
+      systemViolations: systemViolations.length,
+      lessonsWithForeignScript: foreignLessons,
+      maxForeignGlyphsInALesson: maxForeign,
+      steepestLesson: violations[0] ?? null,
+    },
+  };
 }
 
 /** Measure the gentle-ramp budgets across the corpus. */
@@ -175,6 +498,7 @@ export function measureRamp(lessons: ParsedLesson[], policy: ChapterPolicy): Ram
     lessons: violations,
     chapters,
     tracks: [...tracks.values()].sort((a, b) => a.language.localeCompare(b.language)),
+    script: measureScriptRamp(lessons, policy),
     summary: {
       lessonViolations: violations.length,
       chapterViolations: chapters.length,

--- a/code/packages/typescript/human-language-data/src/report.ts
+++ b/code/packages/typescript/human-language-data/src/report.ts
@@ -1,6 +1,7 @@
 import type { ParsedLesson } from "./parse.js";
 import { runChapterGates, type ChapterGateReport } from "./chapters.js";
 import { CEFR_LEVELS, summarizeLevels, type LevelSummary } from "./levels.js";
+import { measureRamp, type RampReport } from "./ramp.js";
 import type {
   BookCorpus,
   ChapterPolicy,
@@ -104,6 +105,12 @@ export interface CurriculumGapReport {
      */
     /** HL-C10: lessons no spine node claims, so no level could be derived. */
     lessonsWithoutLevel: number | null;
+    /** HL08: lessons above `maxNewAtomsPerLesson`. Null when no policy was supplied. */
+    rampOverBudgetLessons: number | null;
+    /** HL08: lessons above `maxNewGlyphsPerLesson` — the decoding burden, newly counted. */
+    scriptRampOverBudgetLessons: number | null;
+    /** HL08: lessons opening more than one writing system at once. */
+    lessonsOpeningMultipleScripts: number | null;
     chaptersWithoutCapability: number | null;
     chapterPayoffsNotRepresentative: number | null;
     chapterGateCleanTracks: number | null;
@@ -144,6 +151,16 @@ export interface CurriculumGapReport {
    * report shape rather than seeing an empty section it cannot tell from "measured none".
    */
   levels?: LevelSummary;
+  /**
+   * HL08 gentle-ramp budgets — vocabulary atoms AND target-script glyphs.
+   *
+   * `measureRamp` existed and was called by nothing but its own unit test, so the
+   * budgets in `chapter-policy.json` were policy in the sense that a sign is policy.
+   * Absent when the caller supplied no policy, so a consumer that never passes one
+   * keeps its report shape rather than seeing a section measured against defaults
+   * nobody chose.
+   */
+  ramp?: RampReport;
   modality: ModalitySummary;
 }
 
@@ -451,6 +468,10 @@ export function buildCurriculumGapReport(input: CurriculumGapReportInput): Curri
       ? summarizeLevels(lessons, input.curricula, input.spine)
       : undefined;
 
+  // HL08 ramp budgets. Needs only the policy — every lesson carries its own atoms and
+  // its own script, so unlike the chapter gates this does not wait on the ledgers.
+  const ramp = input.chapterPolicy ? measureRamp(lessons, input.chapterPolicy) : undefined;
+
   const chapterGates =
     input.trackChapters && input.chapterPolicy
       ? runChapterGates({
@@ -486,6 +507,9 @@ export function buildCurriculumGapReport(input: CurriculumGapReportInput): Curri
       mixedSchemaTracks: schemas.filter((track) => track.status === "mixed").length,
       version2SchemaTracks: schemas.filter((track) => track.status === "version-2").length,
       lessonsWithoutLevel: levels?.unmapped ?? null,
+      rampOverBudgetLessons: ramp?.summary.lessonViolations ?? null,
+      scriptRampOverBudgetLessons: ramp?.script.summary.lessonViolations ?? null,
+      lessonsOpeningMultipleScripts: ramp?.script.summary.systemViolations ?? null,
       chaptersWithoutCapability: chapterGates?.summary.chaptersWithoutCapability ?? null,
       chapterPayoffsNotRepresentative: chapterGates?.summary.payoffsNotRepresentative ?? null,
       chapterGateCleanTracks: chapterGates?.summary.cleanTracks ?? null,
@@ -502,6 +526,7 @@ export function buildCurriculumGapReport(input: CurriculumGapReportInput): Curri
     schemas: { tracks: schemas },
     chapters: chapterGates,
     levels,
+    ramp,
     modality,
   };
 }
@@ -523,6 +548,22 @@ export function renderCurriculumGapReport(report: CurriculumGapReport): string {
           `levels: ${CEFR_LEVELS.filter((l) => report.levels!.byLevel[l] > 0)
             .map((l) => `${report.levels!.byLevel[l]} ${l}`)
             .join(", ")}; ${report.levels!.unmapped} unmapped (${report.levels!.mappedPercent}% placed)`,
+        ]
+      : []),
+    ...(report.ramp
+      ? [
+          `ramp: ${report.ramp.summary.lessonViolations} lessons above ${report.ramp.policy.maxNewAtomsPerLesson} new atoms ` +
+            `(${report.ramp.summary.unmeasurableLessons} unmeasurable, ${report.ramp.summary.measurablePercent}% measurable); ` +
+            `${report.ramp.summary.chapterViolations} chapters above ${report.ramp.policy.maxNewAtomsPerChapter}`,
+          `script ramp: ${report.ramp.script.summary.lessonViolations} lessons above ` +
+            `${report.ramp.script.policy.maxNewGlyphsPerLesson} new glyphs; ` +
+            `${report.ramp.script.summary.systemViolations} opening more than ` +
+            `${report.ramp.script.policy.maxNewScriptSystemsPerLesson} writing system at once` +
+            (report.ramp.script.summary.steepestLesson
+              ? `; steepest ${report.ramp.script.summary.steepestLesson.lessonId} at ${report.ramp.script.summary.steepestLesson.glyphs}`
+              : ""),
+          `cousin layer: ${report.ramp.script.summary.lessonsWithForeignScript} lessons show another script ` +
+            `(max ${report.ramp.script.summary.maxForeignGlyphsInALesson} glyphs) — context, never charged to the budget`,
         ]
       : []),
     ...(report.chapters

--- a/code/packages/typescript/human-language-data/src/types.ts
+++ b/code/packages/typescript/human-language-data/src/types.ts
@@ -261,6 +261,25 @@ export interface ChapterPolicy {
    * lineariser's own measured default.
    */
   maxLinearisableTableColumns?: number;
+  /**
+   * HL08: most NEW target-script glyphs one lesson may put in front of the reader.
+   *
+   * Separate from `maxNewAtomsPerLesson` because the two measure different burdens and
+   * a lesson can pass one while failing the other badly: `HI-W01-shirorekha-na-ma`
+   * declares ONE atom and shows TWELVE new Devanagari glyphs. Vocabulary is what a
+   * learner must mean; script is what they must decode before meaning starts.
+   *
+   * Optional so a policy file written before the script ramp existed still loads.
+   */
+  maxNewGlyphsPerLesson?: number;
+  /**
+   * HL08: most distinct WRITING SYSTEMS one lesson may open at once.
+   *
+   * One, by the project owner's rule: "sometimes you can't introduce more than one
+   * script at a time." This only bites where a track's script is genuinely plural —
+   * Japanese, whose hiragana/katakana/kanji share one `script` id today.
+   */
+  maxNewScriptSystemsPerLesson?: number;
 }
 
 /** One authored chapter from an existing LaTeX book. */

--- a/code/packages/typescript/human-language-data/tests/ramp.test.ts
+++ b/code/packages/typescript/human-language-data/tests/ramp.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, it } from "vitest";
 import { loadChapterPolicy, loadEverything } from "../src/loader.js";
-import { measureRamp } from "../src/ramp.js";
+import { measureRamp, measureScriptRamp } from "../src/ramp.js";
 import { parseLesson } from "../src/parse.js";
 import type { ChapterPolicy } from "../src/types.js";
 
@@ -12,7 +12,25 @@ const POLICY = {
   maxNewAtomsPerLesson: 3,
   maxNewAtomsPerChapter: 12,
   maxLinearisableTableColumns: 3,
+  maxNewGlyphsPerLesson: 3,
+  maxNewScriptSystemsPerLesson: 1,
 } as ChapterPolicy;
+
+/** A lesson whose BODY carries `text`, for measuring what the reader must decode. */
+function scriptLesson(
+  id: string,
+  language: string,
+  chapter: number,
+  sequence: number,
+  text: string,
+) {
+  return parseLesson(
+    `---\nschema_version: 2\nid: ${id}\nchapter: ${chapter}\nsequence: ${sequence}\n` +
+      `type: word\nheadword: x\ngloss: x\nconcept_tag: GREETING-HELLO\n---\n\n# ${id}\n\n` +
+      `## Warm-up\n\n${text}\n`,
+    language,
+  );
+}
 
 function lesson(id: string, chapter: number, atoms: string[]) {
   const directive = `<!-- hl-knowledge: introduces=[${atoms.join(", ")}]; assesses=[] -->\n\n`;
@@ -95,5 +113,272 @@ describe("corpus snapshot", () => {
     const { lessons } = loadEverything();
     const report = measureRamp(lessons, loadChapterPolicy());
     expect(report.summary.steepestLesson).toMatchObject({ atoms: 6, budget: 3 });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE SCRIPT RAMP
+//
+// The second curve. Every test below exists because the atom budget could not
+// see the thing it measures: `HI-W01-shirorekha-na-ma` declares ONE atom and
+// shows TWELVE new Devanagari glyphs, and passed cleanly for a whole release.
+
+describe("the script budget", () => {
+  it("counts new target-script glyphs, which the atom budget cannot see", () => {
+    // One atom, four glyphs — the exact shape of the bug this was built for.
+    const report = measureScriptRamp(
+      [scriptLesson("HI-1", "hindi", 1, 10, "क ख ग घ")],
+      POLICY,
+    );
+    expect(report.summary.lessonViolations).toBe(1);
+    expect(report.lessons[0]).toMatchObject({ glyphs: 4, budget: 3, systems: ["Devanagari"] });
+  });
+
+  it("charges a glyph once, to the lesson that first shows it", () => {
+    // A ramp measurement, not a density measurement: what Chapter 1 taught is free
+    // in Chapter 30, or every later lesson would be punished for revision.
+    const report = measureScriptRamp(
+      [
+        scriptLesson("HI-1", "hindi", 1, 10, "क ख ग घ"),
+        scriptLesson("HI-2", "hindi", 30, 10, "क ख ग घ"),
+      ],
+      POLICY,
+    );
+    expect(report.lessons.map((v) => v.lessonId)).toEqual(["HI-1"]);
+  });
+
+  it("walks lessons in reading order, not file order", () => {
+    // Passed in back to front. Chapter 1 must still be the one charged.
+    const report = measureScriptRamp(
+      [
+        scriptLesson("HI-LATER", "hindi", 30, 10, "क ख ग घ"),
+        scriptLesson("HI-FIRST", "hindi", 1, 10, "क ख ग घ"),
+      ],
+      POLICY,
+    );
+    expect(report.lessons.map((v) => v.lessonId)).toEqual(["HI-FIRST"]);
+  });
+
+  it("ignores romanization, which exists to make the script approachable", () => {
+    // `namaskāram` is Latin. Counting ā as a glyph to learn would drown the signal.
+    const report = measureScriptRamp(
+      [scriptLesson("HI-1", "hindi", 1, 10, "namaskāram, dhanyavād — ā ē ī ō ū ṣ ṭ ḻ")],
+      POLICY,
+    );
+    expect(report.summary.lessonViolations).toBe(0);
+  });
+
+  it("counts combining marks, because an abugida is mostly marks", () => {
+    // ा ि ी ु are mātrās — shapes the reader must decode. Dropping them would
+    // undercount every Indic track in the corpus.
+    const report = measureScriptRamp([scriptLesson("HI-1", "hindi", 1, 10, "का कि की कु")], POLICY);
+    expect(report.lessons[0]?.glyphs).toBe(5); // क + four mātrās
+  });
+
+  it("counts script digits, which nobody born to ASCII can already read", () => {
+    const report = measureScriptRamp([scriptLesson("HI-1", "hindi", 1, 10, "१ २ ३ ४ ५")], POLICY);
+    expect(report.lessons[0]?.glyphs).toBe(5);
+  });
+
+  it("catches the prolonged-sound mark that Script= alone would miss", () => {
+    // ー is Script=Common, Script_Extensions={Hira,Kana}. Matching the narrow
+    // property undercounted コーヒー by the very mark that makes it a long vowel.
+    const report = measureScriptRamp(
+      [scriptLesson("JA-1", "japanese", 1, 10, "コーヒー アイスカフェ")],
+      POLICY,
+    );
+    expect(report.lessons[0]?.sample).toContain("ー");
+    // And it is only ever charged once, like any other glyph.
+    expect(report.lessons[0]?.glyphs).toBe(new Set("コーヒーアイスカフェ").size);
+  });
+});
+
+describe("the writing-system budget", () => {
+  it("flags a lesson opening two systems at once", () => {
+    // The owner's rule: sometimes you cannot introduce more than one script at a time.
+    const report = measureScriptRamp(
+      [scriptLesson("JA-1", "japanese", 1, 10, "こんにちは 今日")],
+      POLICY,
+    );
+    expect(report.systems[0]).toMatchObject({ lessonId: "JA-1", systems: ["Han", "Hiragana"] });
+  });
+
+  it("leaves a single-system lesson alone however many glyphs it shows", () => {
+    const report = measureScriptRamp(
+      [scriptLesson("JA-1", "japanese", 1, 10, "あいうえおかきくけこ")],
+      POLICY,
+    );
+    expect(report.summary.systemViolations).toBe(0);
+  });
+});
+
+describe("the cousin layer", () => {
+  it("counts foreign glyphs separately and never charges them to the budget", () => {
+    // A Kannada Chapter-1 lesson showing the same word in four sister scripts is
+    // context for a reader who knows one of them, not a reading obligation. Charging
+    // both to one budget made KA-C01-dhanyavada look like a 34-glyph cliff; its real
+    // Kannada load is 7.
+    const report = measureScriptRamp(
+      [scriptLesson("KA-1", "kannada", 1, 10, "ಧನ್ಯವಾದ — धन्यवाद நன்றி ధన్యవాదములు")],
+      POLICY,
+    );
+    expect(report.summary.lessonsWithForeignScript).toBe(1);
+    expect(report.summary.maxForeignGlyphsInALesson).toBeGreaterThan(3);
+    // Kannada's own glyphs are what the budget judges.
+    expect(report.lessons[0]?.systems ?? []).toEqual(["Kannada"]);
+  });
+
+  it("treats a Latin-script track as carrying no decoding burden", () => {
+    const report = measureScriptRamp(
+      [scriptLesson("ES-1", "spanish", 1, 10, "hola qué tal ñ")],
+      POLICY,
+    );
+    expect(report.summary.lessonViolations).toBe(0);
+    expect(report.tracks[0]).toMatchObject({ language: "spanish", latinScript: true, totalGlyphs: 0 });
+  });
+});
+
+describe("the script ramp against the real corpus", () => {
+  it("pins the script ramp, which no gate had ever measured", () => {
+    const { lessons } = loadEverything();
+    const report = measureRamp(lessons, loadChapterPolicy()).script;
+
+    expect(report.policy).toEqual({ maxNewGlyphsPerLesson: 3, maxNewScriptSystemsPerLesson: 1 });
+
+    // 61 lessons put more than three new shapes on the page at once. This is the
+    // HL-C18C burn-down list. It is REPORT-ONLY: the debt predates the measurement,
+    // so it is made visible rather than turned into a build failure.
+    expect(report.summary.lessonViolations).toBe(61);
+
+    // All five are Japanese Chapter 1, which opens kanji beside hiragana in its very
+    // first lesson and adds katakana in its fifth.
+    expect(report.summary.systemViolations).toBe(5);
+    expect(new Set(report.systems.map((v) => v.language))).toEqual(new Set(["japanese"]));
+
+    // The cousin layer's footprint. Not a violation — a reason to keep that layer
+    // visually skippable, so a reader who knows no sister language can pass it by.
+    expect(report.summary.lessonsWithForeignScript).toBe(119);
+    expect(report.summary.maxForeignGlyphsInALesson).toBe(26);
+  });
+
+  it("names the steepest lesson: one atom, twelve glyphs", () => {
+    const { lessons } = loadEverything();
+    const report = measureRamp(lessons, loadChapterPolicy()).script;
+    expect(report.summary.steepestLesson).toMatchObject({
+      lessonId: "HI-W01-shirorekha-na-ma",
+      glyphs: 12,
+      budget: 3,
+    });
+  });
+
+  it("resolves every non-Latin track to a real script", () => {
+    // Gujarati had no LANGUAGE_SCRIPT entry and silently resolved to `latin`, so its
+    // 39 lessons read as having no script to learn — and `romanization` fell back to
+    // the Gujarati headword, handing a voice assistant Gujarati in a Latin field.
+    const { lessons } = loadEverything();
+    const report = measureRamp(lessons, loadChapterPolicy()).script;
+    const gujarati = report.tracks.find((t) => t.language === "gujarati");
+    expect(gujarati).toMatchObject({ script: "gujarati", latinScript: false });
+    expect(gujarati!.totalGlyphs).toBeGreaterThan(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SECURITY REGRESSIONS
+//
+// All three came out of the pre-push security review of HL-C18C. Each was a way
+// for a measurement to stop measuring without anyone noticing — which is the
+// exact failure this module was written to end.
+
+describe("a hostile or fat-fingered script id", () => {
+  it("does not let a prototype key crash the whole report", () => {
+    // `track.json` may declare ANY string as its script. `SCRIPT_SYSTEMS["__proto__"]`
+    // returns Object.prototype, which is not nullish — so `?? ["Latin"]` never fires and
+    // `new Set(Object.prototype)` throws. measureScriptRamp is called unconditionally by
+    // measureRamp, so this took down the entire gap report, not just this section.
+    for (const key of ["__proto__", "constructor", "toString", "valueOf", "hasOwnProperty"]) {
+      const lesson = parseLesson(
+        `---\nschema_version: 2\nid: X-1\nchapter: 1\nsequence: 10\ntype: word\n` +
+          `headword: x\ngloss: x\nconcept_tag: GREETING-HELLO\n---\n\n# X\n\n## Warm-up\n\nक ख ग घ\n`,
+        "hostile",
+        key,
+      );
+      expect(() => measureScriptRamp([lesson], POLICY)).not.toThrow();
+      // Unknown script falls back to Latin, i.e. "no decoding burden we can name" —
+      // never a crash, and never a silent violation against the wrong inventory.
+      const report = measureScriptRamp([lesson], POLICY);
+      expect(report.tracks[0]).toMatchObject({ latinScript: true });
+    }
+  });
+});
+
+describe("chapter-policy.json validation", () => {
+  it("refuses a budget that would silently disable the gate", async () => {
+    // JSON.parse turns 1e999 into Infinity, and `size > Infinity` is false for every
+    // lesson alive — so one typo publishes "0 violations", which reads in the report
+    // exactly like "measured, found none".
+    const { mkdtempSync, mkdirSync, writeFileSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const { loadChapterPolicy } = await import("../src/loader.js");
+
+    const write = (policy: Record<string, unknown>) => {
+      const root = mkdtempSync(join(tmpdir(), "hl-policy-"));
+      mkdirSync(join(root, "core"), { recursive: true });
+      writeFileSync(join(root, "core", "chapter-policy.json"), JSON.stringify(policy));
+      return root;
+    };
+    const valid = {
+      version: 1,
+      payoffRepresentativeness: 0.5,
+      maxNewAtomsPerLesson: 3,
+      maxNewAtomsPerChapter: 12,
+    };
+
+    expect(() => loadChapterPolicy(write(valid))).not.toThrow();
+    expect(() => loadChapterPolicy(write({ ...valid, maxNewGlyphsPerLesson: 1e999 }))).toThrow(
+      /maxNewGlyphsPerLesson must be a non-negative integer/,
+    );
+    expect(() => loadChapterPolicy(write({ ...valid, maxNewGlyphsPerLesson: "banana" }))).toThrow();
+    expect(() => loadChapterPolicy(write({ ...valid, maxNewGlyphsPerLesson: {} }))).toThrow();
+    expect(() => loadChapterPolicy(write({ ...valid, maxNewGlyphsPerLesson: -1 }))).toThrow();
+    expect(() => loadChapterPolicy(write({ ...valid, maxNewGlyphsPerLesson: 2.5 }))).toThrow();
+
+    // The atom budgets are REQUIRED: measureRamp reads them with no default, so a policy
+    // file missing them yields undefined and the same silent zero.
+    const { maxNewAtomsPerLesson: _drop, ...missing } = valid;
+    expect(() => loadChapterPolicy(write(missing))).toThrow(
+      /maxNewAtomsPerLesson is required and missing/,
+    );
+  });
+});
+
+describe("the script-system map", () => {
+  // These regexes are built at MODULE LOAD, and index.ts re-exports this file, so a bad
+  // name takes down every CLI in the package — book generation, narration, modality,
+  // validate. Importing this test file at all proves the current map compiles; what is
+  // worth asserting is that each real track's matcher actually MATCHES its own script,
+  // since a name can be valid Unicode and still be the wrong script for the track.
+  it("gives every non-Latin track a matcher that finds its own glyphs", () => {
+    const { lessons } = loadEverything();
+    const report = measureRamp(lessons, loadChapterPolicy()).script;
+    const nonLatin = report.tracks.filter((t) => !t.latinScript);
+
+    expect(nonLatin.length).toBe(16);
+    for (const track of nonLatin) {
+      // A track whose matcher resolved to the wrong script would silently measure zero
+      // glyphs across its whole corpus — the failure that hid Gujarati for a release.
+      expect(track.totalGlyphs).toBeGreaterThan(0);
+    }
+  });
+
+  it("rejects a plausible-looking name that is not a Unicode script", () => {
+    // The names a future editor would reach for are exactly the ones that throw.
+    for (const wrong of ["Kanji", "Nastaliq", "Devangari"]) {
+      expect(() => new RegExp(`\\p{Script_Extensions=${wrong}}`, "u")).toThrow();
+    }
+    for (const right of ["Han", "Arabic", "Devanagari", "Hiragana", "Katakana"]) {
+      expect(() => new RegExp(`\\p{Script_Extensions=${right}}`, "u")).not.toThrow();
+    }
   });
 });

--- a/code/specs/HL08-modality-gentle-ramp-and-the-drivable-course.md
+++ b/code/specs/HL08-modality-gentle-ramp-and-the-drivable-course.md
@@ -369,6 +369,86 @@ A book of thousands of pages made of two-minute steps is a better outcome than a
 compact book that loses the reader in chapter three. No gate in this project may
 penalise page count, lesson count, or chapter count.
 
+## Amendment — the script ramp (HL-C18C)
+
+*Added 2026-08-07, on the project owner's direction that "the ramp should also include
+the script; sometimes you can't introduce more than one script at a time."*
+
+### Why the atom budget was not enough
+
+`maxNewAtomsPerLesson` counts **units of meaning**. It cannot see the other burden a
+lesson imposes, and the two come apart badly:
+
+> `HI-W01-shirorekha-na-ma` declares **one** atom and puts **twelve** new Devanagari
+> glyphs on the page. It passes the gentle-ramp budget comfortably.
+
+It is not an outlier. **61 lessons** exceed three new glyphs; **38 of them declare zero
+atoms**, so they read as maximally gentle while teaching up to a dozen new shapes.
+Before a learner can *mean* anything by नमस्ते they must decode it, and decoding is a
+separate skill on a separate curve. A curriculum that ramps meaning gently and script
+steeply is not gentle.
+
+### The two new budgets
+
+- `maxNewGlyphsPerLesson` — default **3**, at the corpus's own p90 for target-script
+  glyphs, the same rule that justified `maxNewAtomsPerLesson`. The median non-Latin
+  lesson introduces **zero** new glyphs, so this flags 61 genuine spikes rather than
+  taxing ordinary lessons. It is deliberately **not** set at the observed max of 12: a
+  budget placed at the worst case is not a budget.
+- `maxNewScriptSystemsPerLesson` — **1**, the owner's rule stated directly. Today it
+  flags five lessons, all Japanese Chapter 1, which opens kanji beside hiragana in its
+  very first lesson and adds katakana in its fifth.
+
+### Target script versus the cousin layer
+
+The measurement counts a lesson's **target-script** glyphs — the ones the learner is
+signing up to read. Glyphs from *other* scripts are counted, reported, and **never
+charged to the budget**.
+
+That distinction is what makes the number honest. A Kannada Chapter 1 lesson that shows
+the same word in Devanagari, Tamil, Telugu and Malayalam looks like a **34-glyph cliff**
+when the two are conflated. Its actual Kannada load is **7**. The sister-script material
+is *context* — it says "your word for thanks is Hindi's word too" to a reader who
+happens to know Hindi — and per the owner's rule that **English is the only requirement
+for each book**, it must be skippable by everyone else.
+
+So the cousin layer is not penalised. What its measured footprint justifies — 119
+lessons, up to 26 foreign glyphs in one — is keeping that layer **visually separable**,
+so a reader who knows no sister language can pass it by without passing by the lesson.
+
+### Counting rules, and why each one is deliberate
+
+- **In reading order, charged once.** A glyph taught in Chapter 1 is free in Chapter 30.
+  This is a ramp measurement, not a density measurement; charging revision would invert
+  the incentive the whole spec exists to create.
+- **Latin is not counted.** Romanization (`namaskāram`) rides alongside every non-Latin
+  headword. Counting `ā` as a glyph to learn would swamp the signal with the very thing
+  that exists to make the script approachable.
+- **Combining marks are counted.** A Devanagari mātrā is a shape the reader must decode;
+  dropping marks would undercount every abugida in the corpus.
+- **Script digits are counted.** ०१२ and ۱۲۳ are `\p{N}`, and also glyphs nobody born to
+  ASCII can already read. A numbers lesson genuinely does teach script.
+- **`Script_Extensions`, not `Script`.** Japanese's prolonged-sound mark ー is formally
+  `Script=Common` because hiragana and katakana share it. The narrow property undercounts
+  コーヒー by the mark that makes it a long vowel.
+- **Latin-script tracks carry no decoding burden** and are measured but never flagged.
+
+### Report-only, per the HL05 precedent
+
+The debt predates the measurement, so it is published and burnable rather than turned
+into a build failure on a corpus nobody regressed. Gates flip per track as debt clears.
+
+### A prerequisite this surfaced
+
+The ramp could not see Gujarati at all: `LANGUAGE_SCRIPT` never got a `gujarati` entry —
+Gujarati was the *worked example in its own doc comment* — so all 39 lessons resolved to
+`latin`. Glyph-coverage validation looked Gujarati headwords up in the Latin inventory,
+and `romanization` fell back to the Gujarati headword itself, handing the narration
+export **Gujarati script in the field a speech engine reads as Latin**. Chinese and
+Japanese were missing from the same map and were saved only by shipping a `track.json`.
+A track whose script is unknown reads as having no script to learn, so completing that
+map is part of this amendment, not a separate concern.
+
 ## Validation gates
 
 Added to `validateCurriculum()`, multi-pass, collecting every violation before


### PR DESCRIPTION
## Why

The gentle-ramp budget counted units of **meaning** and nothing counted units of **decoding**, so half of "gentle" was unmeasured. The two come apart badly:

> `HI-W01-shirorekha-na-ma` declares **one** knowledge atom and puts **twelve** new Devanagari glyphs on the page. It passes `maxNewAtomsPerLesson: 3` comfortably.

**61 lessons** are in that position, and **38 of them declare zero atoms** — so they read as maximally gentle while teaching up to a dozen new shapes. Before a learner can *mean* anything by नमस्ते they have to decode it, and decoding is a separate skill on a separate curve.

## What lands

Two budgets in `core/chapter-policy.json`, with measured provenance:

| | value | basis | flags today |
|---|---|---|---|
| `maxNewGlyphsPerLesson` | **3** | the corpus's own p90, the same rule that justified `maxNewAtomsPerLesson` — *not* the observed max of 12, because a budget at the worst case is not a budget | 61 lessons |
| `maxNewScriptSystemsPerLesson` | **1** | "you cannot introduce more than one script at a time" | 5 lessons, all Japanese Ch. 1 |

The median non-Latin lesson introduces **zero** new glyphs, so this flags genuine spikes rather than taxing ordinary lessons.

### Target script vs the cousin layer

This is what makes the number honest. A Kannada Chapter 1 lesson showing the same word in Devanagari, Tamil, Telugu and Malayalam reads as a **34-glyph cliff** when the two are added together. Its actual Kannada load is **7**.

Sister-script material is *context* for a reader who already knows a relative, and English is the only requirement for each book — so it is counted, reported (119 lessons, up to 26 foreign glyphs in one), and **never charged to the budget**. What its footprint justifies is keeping that layer visually skippable, which is HL-C48.

### Counting rules, each load-bearing

- **Charged once, in reading order** — a glyph taught in Ch. 1 is free in Ch. 30, or revision would be punished.
- **Latin excluded** — romanization rides alongside every non-Latin headword; counting `ā` would swamp the signal.
- **Combining marks included** — an abugida is mostly marks.
- **Script digits included** — ०१२ is not readable to someone born to ASCII.
- **`Script_Extensions`, not `Script`** — ー is formally `Common`, and the narrow property undercounts コーヒー by the mark that makes it a long vowel.

Report-only, per the HL05 precedent: the debt predates the measurement.

## Two bugs this surfaced

**`measureRamp` was called by nothing but its own unit test.** The atom budgets had been declared since HL08 and read by nobody — policy in the sense that a sign is policy. The gap report now carries them: **40** lessons and **25** chapters over budget, with **572 lessons (47%) unmeasurable** because schema-v1 declares no atoms.

**Three tracks silently resolved to the Latin script.** `LANGUAGE_SCRIPT` had no `gujarati` entry — Gujarati was the worked example *in its own doc comment* — so all 39 lessons resolved to `latin`. Glyph coverage was validated against the **Latin** inventory, and `romanization` fell back to the headword, so the narration export published:

```diff
-  "romanization": "આભાર"
+  "romanization": ""
```

…Gujarati script in the field a speech engine reads as Latin. `chinese` and `japanese` were missing from the same map and survived only by shipping a `track.json`. Regenerating the modality manifest and seven Gujarati narration chapters is the entire blast radius; **no lesson content changed**.

## Security review

Found three ways a measurement could stop measuring *silently* — the exact failure this PR exists to end. All fixed with regression tests:

1. **Prototype-chain read.** `SCRIPT_SYSTEMS[script]` with a `track.json` declaring `{"script": "__proto__"}` returned `Object.prototype`, which is not nullish, so the `??` fallback never fired and `new Set()` threw — taking down the **whole gap report**. Now guarded by the `hasOwn` helper the package already exports for exactly this.
2. **Unvalidated policy.** `chapter-policy.json` was cast, never checked. `JSON.parse` turns `1e999` into `Infinity`, and `size > Infinity` is false for every lesson alive, so one typo published "0 violations" — indistinguishable in the report from "measured, found none". The atom budgets are now **required**, since `measureRamp` reads them with no default and would go silently to zero the same way.
3. **Module-load crash.** A bad `SCRIPT_SYSTEMS` name threw a raw regex `SyntaxError` at import, killing every CLI in the package. The plausible edits are the ones that throw (`"Kanji"`, `"Nastaliq"`, a `"Devangari"` typo); the error now names the offender.

## Verification

- **348 tests pass**; coverage **94.5%** overall, `ramp.ts` at **99%**.
- `--check` clean for books, narration, modality; validator reports 0 errors.
- Spec amended (HL08) and committed **before** the implementation, per repo policy.

## Follow-ups opened in BACKLOG

`HL-C18D` burn down the 61 · `HL-C48` generate cousin tables from `concept_tag` · `HL-C49` chapter intros (288 of 393 chapters have none) · `HL-C50` make the book standalone (98 chapters print repo paths at the reader).

BACKLOG also now records the owner's 2026-08-07 direction in the repository rather than in a session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)