### PR TITLE
feat(python-to-semantic-ir): OOP declaration surface (SIR25 §2)

### DIFF
--- a/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
@@ -7,6 +7,41 @@ All notable changes to `python-to-semantic-ir` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to semantic versioning.
 
+## 0.9.0 — OOP declaration surface (SIR25 §2)
+
+Extends the frontend from method-*dispatch* (0.8.0's C2) to the full class
+*declaration* surface: `class Dog(Animal): def __init__(self, ...): ...`
+now lowers to the SAME `Stmt::ClassDef` + `__new__`/`__def_method__`/
+`__self__` envelope `ruby-to-semantic-ir` emits — the OOP-capable backends
+(built for Ruby-sourced classes) needed **zero changes** to run a
+Python-sourced one. That's the concrete proof, not a claim: `sir-conformance`
+gains `python_oop_method`/`python_counter_state`/`python_inheritance`,
+running the same class/instance-method/instance-state/inheritance semantics
+as their Ruby-sourced counterparts across all six backends.
+
+v0 scope: empty-or-single-base classes (`class Foo(Base):`), instance
+methods (`def m(self, ...)`, `self` resolves via `__self__` — never an
+ordinary parameter), `__init__` mapped to the SIR method name
+`"initialize"` (not the literal Python spelling — every backend's
+`call_new` looks up that exact name), instance variables (`self.x`
+read/write, `Scope::Instance`), and single-inheritance ancestry-walk
+dispatch (a subclass with no overriding method still resolves to the
+parent's, with zero extra frontend work — SIR25 §2.2's ancestry walk is a
+backend concern, not a frontend one). Deferred, each its own later
+milestone mirroring how `ruby-to-semantic-ir`'s seven OOP slices landed
+separately rather than at once: `@classmethod`/class methods, class
+variables, `super()` calls, mixins (`include`/`extend`), exceptions,
+decorated classes, and any class-body statement other than `def`.
+
+Found + tracked (not fixed here, orthogonal to this surface): Python's
+`print(x)` always newline-terminates; Ruby's `Kernel#print` never does —
+both share the SIR builtin name `"print"` but not its semantics, so C/Ruby
+(whose `print` faithfully mirrors real Ruby) drop the newline between two
+Python-sourced `print()` calls where Python/JS/Go/Rust already happen to
+get it right. See `sir-conformance`'s README "Gaps the corpus has
+surfaced" for the write-up; `python_inheritance` sidesteps it with a
+single `print` call.
+
 ## 0.8.0 — 2026-07-01
 
 **C2 (collection methods)**: lower Python **method calls** to the shared

--- a/code/packages/rust/python-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/python-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "python-to-semantic-ir"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Python CST → narrow-waist Semantic IR (SIR17). Second frontend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/python-to-semantic-ir/README.md
+++ b/code/packages/rust/python-to-semantic-ir/README.md
@@ -52,7 +52,7 @@ pub struct PythonLowerError {
 `compile_source` parses then lowers; both parse and lower failures are
 surfaced as `PythonLowerError`.
 
-## Milestone status — M5 (collections) + C2 (method calls)
+## Milestone status — M5 (collections) + C2 (method calls) + OOP surface (SIR25 §2)
 
 Top-level statements run inline in a synthesised `main` function whose
 block value is the program's final top-level expression (or `NilLit`
@@ -310,16 +310,48 @@ detects the trailing `Closure` and applies it as the block.
 `primary` — an attribute suffix (`.method`) immediately followed by a call
 suffix (`(args)`).  The suffix fold looks ahead one slot: an attribute
 followed by a call consumes both and dispatches; a bare attribute (no
-following call) stays deferred.
+following call) stays deferred — **except** `self.x` inside a method body,
+see OOP surface below.
+
+### OOP surface (SIR25 §2)
+
+`class Dog(Animal): def __init__(self, ...): ... def m(self, ...): ...`
+lowers to the SAME `Stmt::ClassDef` + `__new__`/`__def_method__`/`__self__`
+envelope `ruby-to-semantic-ir` emits — the OOP-capable backends need
+**zero** changes to run a Python-sourced class:
+
+| Python source | SIR lowering | Feature declared |
+|---|---|---|
+| `class Dog:` / `class Dog(Animal):` | `Stmt::ClassDef{name, superclass, body: []}` | `Classes` |
+| `Dog(args)` | `BuiltinCall("__new__", [StrLit("Dog"), ...args])` | `Strings` |
+| `def m(self, ...): ...` in a class body | hoisted top-level fn `Dog__m` (self stripped) + `BuiltinCall("__def_method__", [StrLit("Dog"), StrLit("m"), MakeClosure(...)])` | `Strings`, `Closures` |
+| `def __init__(self, ...):` | same, but registered under the SIR name `"initialize"` (not the literal spelling) | — |
+| bare `self` | `BuiltinCall("__self__", [])` | — |
+| `self.x` (read) | `Expr::VarRef{name: "@x", scope: Instance}` | `InstanceVars` |
+| `self.x = v` (write) | `Stmt::Assign{name: "@x", scope: Instance, value: v}` | `InstanceVars`, `MutableBindings` |
+
+Inheritance needs no extra frontend work beyond the superclass name on
+`ClassDef`: a subclass with no overriding method still dispatches to the
+parent's via the *backend's* ancestry walk (SIR25 §2.2) — `super()` calls
+are the one inheritance-adjacent piece still deferred (see below).
+
+v0 restrictions (each a positioned `PythonLowerError`, not a silent drop):
+decorated classes, more than one base class or a non-bare-name base,
+any class-body statement other than `def` or `pass`, a method missing a
+plain `self` first parameter, and a chained/non-`self` bare attribute
+(`self.x.y`, `other.x`) — all mirroring the staged restrictions
+`ruby-to-semantic-ir`'s own OOP slices used.
 
 ### Deferred (later milestones)
 
-Everything past M5 / C2 returns a clear positioned `PythonLowerError`:
+Everything past M5 / C2 / the OOP surface above returns a clear positioned
+`PythonLowerError`:
 
 - list / dict **comprehensions**, **slicing** (`xs[a:b]`), **tuple** /
-  **set** literals, and **attribute access as a value** (`obj.x` *not*
-  followed by a call — method **calls** land in C2, but an attribute
-  *read* has no v0 lowering)
+  **set** literals, and **attribute access as a value** on anything other
+  than `self` inside a method body (`obj.x` where `obj` isn't `self`, or
+  `self.x.y` chained — see OOP surface above for the `self.x` case that
+  *is* supported)
 - `*args` / `**kwargs` (positional-rest / keyword-rest params — `Rest` /
   `KwRest` are not yet modelled by this crate), multi-level capture chaining
   (capturing a variable two scopes up) — note **positional default
@@ -327,11 +359,11 @@ Everything past M5 / C2 returns a clear positioned `PythonLowerError`:
   (`def f(*, x)`, `f(x=1)`, KW8) are now supported; only the variadic
   rest forms remain deferred
 - tuple / multi-target `for` (`for k, v in …`), multi-target / chained
-  assignment, attribute targets, bitwise operators, the power operator
-  (`**`)
-- and the full SIR17 "out of scope" list (classes, exceptions,
-  generators, decorators, `with` / `try`, `async`, imports,
-  `global` / `nonlocal`, f-strings).
+  assignment, non-`self` attribute targets, bitwise operators, the power
+  operator (`**`)
+- `@classmethod`/class methods, class variables, `super()` calls, mixins
+  (`include`/`extend`), exceptions, generators, non-class decorators,
+  `with` / `try`, `async`, imports, `global` / `nonlocal`, f-strings.
 
 ## Testing & coverage
 

--- a/code/packages/rust/python-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lib.rs
@@ -2344,4 +2344,250 @@ print(total)
             assert_eq!(out, "12", "sum of doubled [1,2,3] should be 12");
         }
     }
+
+    // ══════════════════════════════════════════════════════════════════
+    // OOP surface (SIR25 §2) — class / new / self / instance vars
+    // ══════════════════════════════════════════════════════════════════
+    //
+    // Same shape ruby-to-semantic-ir emits (Stmt::ClassDef + __new__ +
+    // __def_method__ + __self__), so `run_roundtrip` here proves BOTH
+    // that this frontend lowers correctly AND that the existing Python
+    // backend/runtime — built for Ruby-sourced OOP — needs zero changes
+    // to run a Python-sourced class. That's the actual proof of
+    // language-agnosticism the SIR25 arc set out for, not a claim.
+
+    #[test]
+    fn empty_class_and_construction_lowers_to_new() {
+        let m = lower("class Dog:\n    pass\n\nDog()\n");
+        assert!(m.manifest.contains(Feature::Classes));
+        let stmts = main_stmts(&m);
+        assert!(
+            stmts
+                .iter()
+                .any(|s| matches!(s, Stmt::ClassDef { name, superclass, body, .. }
+                    if name == "Dog" && superclass.is_none() && body.is_empty())),
+            "expected an empty Dog ClassDef, got {stmts:?}"
+        );
+        match main_value(&m) {
+            Expr::BuiltinCall { name, args, .. } if name == "__new__" => {
+                assert!(matches!(&args[0], Expr::StrLit { value, .. } if value == "Dog"));
+            }
+            other => panic!("expected __new__ BuiltinCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn method_def_registers_via_def_method() {
+        let m = lower("class Dog:\n    def speak(self):\n        return \"woof\"\n");
+        let stmts = main_stmts(&m);
+        let reg = stmts
+            .iter()
+            .find_map(|s| match s {
+                Stmt::ExprStmt {
+                    expr:
+                        Expr::BuiltinCall {
+                            name, args, ..
+                        },
+                    ..
+                } if name == "__def_method__" => Some(args),
+                _ => None,
+            })
+            .expect("a __def_method__ registration exists");
+        assert!(matches!(&reg[0], Expr::StrLit { value, .. } if value == "Dog"));
+        assert!(matches!(&reg[1], Expr::StrLit { value, .. } if value == "speak"));
+        let fn_name = match &reg[2] {
+            Expr::MakeClosure { fn_name, captures, .. } => {
+                assert!(captures.is_empty(), "a method never captures");
+                fn_name.clone()
+            }
+            other => panic!("expected MakeClosure, got {other:?}"),
+        };
+        // `self` is stripped -- the hoisted function has zero exposed params.
+        assert!(func(&m, &fn_name).params.is_empty());
+    }
+
+    #[test]
+    fn init_registers_as_initialize() {
+        let m = lower("class Dog:\n    def __init__(self, name):\n        self.name = name\n");
+        let stmts = main_stmts(&m);
+        let found = stmts.iter().any(|s| matches!(s,
+            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. }
+                if name == "__def_method__" && matches!(&args[1], Expr::StrLit{value,..} if value == "initialize")
+        ));
+        assert!(found, "__init__ must register under the SIR name `initialize`, not `__init__`");
+    }
+
+    #[test]
+    fn self_attr_read_and_write_are_instance_scoped() {
+        let m = lower(
+            "class Counter:\n    def __init__(self):\n        self.n = 0\n    def inc(self):\n        self.n = self.n + 1\n",
+        );
+        assert!(m.manifest.contains(Feature::InstanceVars));
+        let inc = func(&m, "Counter__inc");
+        match &inc.body.stmts[0] {
+            Stmt::Assign { name, scope, value, .. } => {
+                assert_eq!(name, "@n");
+                assert_eq!(*scope, Scope::Instance);
+                // RHS reads @n + 1: the read side must ALSO be Instance-scoped.
+                match value {
+                    Expr::BuiltinCall { args, .. } => assert!(matches!(
+                        &args[0],
+                        Expr::VarRef { name, scope: Scope::Instance, .. } if name == "@n"
+                    )),
+                    other => panic!("expected a BuiltinCall(\"+\", ...), got {other:?}"),
+                }
+            }
+            other => panic!("expected Stmt::Assign, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn subclass_lowers_superclass_by_name() {
+        let m = lower("class Animal:\n    pass\n\nclass Dog(Animal):\n    pass\n");
+        let stmts = main_stmts(&m);
+        assert!(stmts.iter().any(|s| matches!(s,
+            Stmt::ClassDef { name, superclass: Some(sup), .. } if name == "Dog" && sup == "Animal"
+        )));
+    }
+
+    #[test]
+    fn multiple_base_classes_are_rejected() {
+        let err = compile_source("class Foo(A, B):\n    pass\n", "t")
+            .expect_err("multiple bases rejected");
+        assert!(err.message.contains("base classes"), "got: {}", err.message);
+    }
+
+    #[test]
+    fn keyword_base_class_argument_is_rejected() {
+        let err = compile_source("class Foo(metaclass=Meta):\n    pass\n", "t")
+            .expect_err("keyword base-class argument rejected");
+        assert!(err.message.contains("keyword base-class"), "got: {}", err.message);
+    }
+
+    #[test]
+    fn empty_parens_class_has_no_superclass() {
+        // `class Foo():` (explicit empty parens) must be indistinguishable
+        // from `class Foo:` -- both have zero base-class arguments.
+        let m = lower("class Foo():\n    pass\n");
+        assert!(main_stmts(&m).iter().any(|s| matches!(s,
+            Stmt::ClassDef { name, superclass: None, .. } if name == "Foo"
+        )));
+    }
+
+    #[test]
+    fn decorated_class_is_rejected() {
+        let err = compile_source("@deco\nclass Foo:\n    pass\n", "t")
+            .expect_err("decorated class rejected");
+        assert!(err.message.contains("decorated class"), "got: {}", err.message);
+    }
+
+    #[test]
+    fn class_level_assignment_is_rejected() {
+        let err = compile_source("class Foo:\n    x = 1\n", "t")
+            .expect_err("non-def class body content rejected");
+        assert!(
+            err.message.contains("class body statement other than `def`"),
+            "got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn method_without_self_param_is_rejected() {
+        let err = compile_source("class Foo:\n    def m():\n        return 1\n", "t")
+            .expect_err("self-less method rejected (static/class methods deferred)");
+        assert!(err.message.contains("no `self` parameter"), "got: {}", err.message);
+    }
+
+    #[test]
+    fn bare_attribute_on_non_self_receiver_still_deferred_inside_a_method() {
+        // `self` gets the ivar special-case; any OTHER receiver inside a
+        // method body must still defer, exactly like at module level.
+        let err = compile_source(
+            "class Foo:\n    def m(self, other):\n        return other.x\n",
+            "t",
+        )
+        .expect_err("bare attribute on a non-self receiver stays deferred");
+        assert!(err.message.contains("attribute access as a value"), "got: {}", err.message);
+    }
+
+    #[test]
+    fn oop_modules_pass_the_validator() {
+        for src in [
+            "class Dog:\n    pass\n\nDog()\n",
+            "class Dog:\n    def speak(self):\n        return \"woof\"\n\nDog().speak()\n",
+            "class Counter:\n    def __init__(self):\n        self.n = 0\n    def inc(self):\n        self.n = self.n + 1\n    def value(self):\n        return self.n\n",
+            "class Animal:\n    def speak(self):\n        return \"...\"\n\nclass Dog(Animal):\n    pass\n\nDog().speak()\n",
+        ] {
+            let m = lower(src);
+            let r = semantic_ir::validate(&m);
+            assert!(r.is_ok(), "module for {src:?} failed validation: {:?}", r.issues);
+        }
+    }
+
+    #[test]
+    fn e2e_oop_method_dispatch() {
+        // Mirrors sir-conformance's Ruby-sourced `oop_method` case exactly
+        // (class, `.new`-equivalent construction, an instance method call)
+        // -- same source semantics, Python spelling, run through the SAME
+        // Python backend/runtime the Ruby-sourced version already proves.
+        let src = "\
+class Dog:
+    def speak(self):
+        return \"woof\"
+
+print(Dog().speak())
+";
+        if let Some(out) = run_roundtrip(src) {
+            assert_eq!(out, "woof");
+        }
+    }
+
+    #[test]
+    fn e2e_counter_state() {
+        // Mirrors sir-conformance's Ruby-sourced `counter_state` case:
+        // instance state mutated across method calls on the same object.
+        let src = "\
+class Counter:
+    def __init__(self):
+        self.n = 0
+    def inc(self):
+        self.n = self.n + 1
+    def value(self):
+        return self.n
+
+c = Counter()
+c.inc()
+c.inc()
+print(c.value())
+";
+        if let Some(out) = run_roundtrip(src) {
+            assert_eq!(out, "2");
+        }
+    }
+
+    #[test]
+    fn e2e_inheritance_without_override() {
+        // A subclass with NO overriding `speak` still dispatches to the
+        // parent's method -- proves ancestry-walk inheritance works from
+        // this frontend with zero `super()` support needed for the common
+        // "inherit, don't override" case (explicit `super()` calls are a
+        // separate, deferred milestone).
+        let src = "\
+class Animal:
+    def speak(self):
+        return \"...\"
+
+class Dog(Animal):
+    def bark(self):
+        return \"woof\"
+
+d = Dog()
+print(d.speak())
+print(d.bark())
+";
+        if let Some(out) = run_roundtrip(src) {
+            assert_eq!(out, "...\nwoof");
+        }
+    }
 }

--- a/code/packages/rust/python-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lower.rs
@@ -177,14 +177,30 @@
 //! - `*args` / `**kwargs` rest parameters                      → deferred
 //!   (positional/keyword **default** params land in P8; keyword-only
 //!   params & keyword args land in KW8)
-//! - decorators / classes / `with` / `try` / generators       → deferred
+//! - decorated classes / `with` / `try` / generators           → deferred
 //! - `global` / `nonlocal`, multi-target assignment           → deferred
 //!
 //! Unhandled rules produce a clear `PythonLowerError` rather than
 //! silently dropping source.
 //!
+//! ## OOP surface (SIR25 §2)
+//!
+//! `class Dog(Animal): def __init__(self, name): self.name = name ...`
+//! lowers to the SAME `Stmt::ClassDef` + `__new__`/`__def_method__`/
+//! `__self__` envelope `ruby-to-semantic-ir` emits (see
+//! [`Lowerer::lower_class`]) — no backend needed a single change to run
+//! a Python-sourced class. v0 covers empty-superclass-or-single-base
+//! classes, instance methods (`def m(self, ...)`, `__init__` mapped to
+//! the SIR method name `"initialize"`), and instance variables
+//! (`self.x` read/write). Deferred: class methods/`@classmethod`,
+//! `@@`-style class variables, `include`/`extend` mixins, exceptions —
+//! each its own later milestone, mirroring how `ruby-to-semantic-ir`'s
+//! own OOP surface landed in seven separate slices rather than one.
+//!
 //! See `code/specs/SIR17-python-to-semantic-ir.md` for the full
-//! lowering table and the deferred-form roadmap.
+//! lowering table and the deferred-form roadmap, and
+//! `code/specs/SIR25-language-agnostic-object-model.md` for the OOP
+//! surface's language-agnostic specification this frontend targets.
 
 use std::collections::HashSet;
 
@@ -282,6 +298,12 @@ pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, Pytho
 enum Lowered {
     Stmt(Box<Stmt>),
     Expr(Expr),
+    /// A source statement that lowers to *several* IR statements — a
+    /// `class` statement, which expands to one `Stmt::ClassDef` plus one
+    /// `__def_method__` registration per method (OOP surface).  Never a
+    /// value: a class statement contributes nothing to a block's trailing
+    /// expression, matching every other bare statement.
+    Stmts(Vec<Stmt>),
 }
 
 /// What a trailing `primary` `suffix` denotes.  A `suffix` is one of a
@@ -328,6 +350,14 @@ struct FunctionCtx {
     params: HashSet<String>,
     captures: HashSet<String>,
     locals: Vec<String>,
+    /// True only for a method body hoisted from a `class` statement's
+    /// `def` (OOP surface).  A method's first parameter (`self`, by Python
+    /// convention) is *not* added to `params` — it is not an ordinary
+    /// value, it resolves through the SIR dispatch envelope's `__self__`
+    /// builtin (see `resolve_var`) — so this flag is how `self` inside a
+    /// method body is distinguished from an (otherwise unresolved) bare
+    /// name of the same spelling anywhere else.
+    in_method: bool,
 }
 
 impl FunctionCtx {
@@ -337,6 +367,20 @@ impl FunctionCtx {
             params,
             captures,
             locals: Vec::new(),
+            in_method: false,
+        }
+    }
+
+    /// A context for a method body: params are whatever remains *after*
+    /// the leading `self` is stripped by the caller; methods never
+    /// capture (they are hoisted like top-level functions, not closures
+    /// over an enclosing scope — SIR25 §2.2).
+    fn for_method(params: HashSet<String>) -> Self {
+        Self {
+            params,
+            captures: HashSet::new(),
+            locals: Vec::new(),
+            in_method: true,
         }
     }
 
@@ -366,6 +410,12 @@ struct Lowerer {
     /// a function defined later in the file — and mutual recursion —
     /// resolve as [`Expr::DirectCall`].
     function_names: HashSet<String>,
+    /// Every `class` statement's declared name, collected in the same
+    /// first pass as `function_names` (see [`Self::collect_function_names`])
+    /// so `ClassName(args)` resolves to `__new__` construction (OOP
+    /// surface) regardless of whether the call textually precedes or
+    /// follows the class's own definition.
+    class_names: HashSet<String>,
     /// The synthesised + user functions accumulated during lowering, in
     /// definition order.  `main` is appended last by [`Self::lower_file`].
     functions: Vec<Function>,
@@ -391,6 +441,7 @@ impl Lowerer {
             module_name: module_name.to_string(),
             observed: FeatureManifest::new(),
             function_names: HashSet::new(),
+            class_names: HashSet::new(),
             functions: Vec::new(),
             lambda_counter: 0,
             fn_captures: std::collections::HashMap::new(),
@@ -512,11 +563,12 @@ impl Lowerer {
         };
         let stmts: Vec<Stmt> = items
             .into_iter()
-            .map(|item| match item {
-                Lowered::Stmt(s) => *s,
+            .flat_map(|item| match item {
+                Lowered::Stmt(s) => vec![*s],
+                Lowered::Stmts(v) => v,
                 Lowered::Expr(expr) => {
                     let s = expr.span().clone();
-                    Stmt::ExprStmt { expr, span: s }
+                    vec![Stmt::ExprStmt { expr, span: s }]
                 }
             })
             .collect();
@@ -572,6 +624,15 @@ impl Lowerer {
                     }
                 }
             }
+        } else if let Some(class_node) = self.as_class_stmt(stmt) {
+            // A class's declared name is collected here so `ClassName(args)`
+            // resolves to construction regardless of source order (OOP
+            // surface) — mirroring the def-name forward-reference support
+            // above. No recursion into the class body: v0 method defs are
+            // dispatched by name string via `__method__`, never a bare
+            // call, so they never need an entry in `function_names`.
+            let name = self.class_name(class_node)?;
+            self.class_names.insert(name);
         } else {
             // Non-def compound statements (if/while/for) may *contain*
             // nested defs in their suites — but Python forbids `def`
@@ -643,6 +704,86 @@ impl Lowerer {
             }
         }
         Err(self.err_at(def, "malformed def: missing function name".to_string()))
+    }
+
+    /// If `stmt` is a `statement` wrapping a `compound_stmt` wrapping a
+    /// `class_stmt`, return the `class_stmt` node.
+    fn as_class_stmt<'a>(&self, stmt: &'a GrammarASTNode) -> Option<&'a GrammarASTNode> {
+        if stmt.rule_name != "statement" {
+            return None;
+        }
+        let compound = child_nodes(stmt)
+            .into_iter()
+            .find(|n| n.rule_name == "compound_stmt")?;
+        child_nodes(compound)
+            .into_iter()
+            .find(|n| n.rule_name == "class_stmt")
+    }
+
+    /// Extract a `class_stmt`'s declared name (the `NAME` token after the
+    /// `class` keyword) — same shape as [`Self::def_name`].
+    fn class_name(&self, class_stmt: &GrammarASTNode) -> Result<String, PythonLowerError> {
+        for child in &class_stmt.children {
+            if let ASTNodeOrToken::Token(t) = child {
+                if matches!(t.type_, lexer::token::TokenType::Name) && t.type_name.is_none() {
+                    return Ok(t.value.clone());
+                }
+            }
+        }
+        Err(self.err_at(class_stmt, "malformed class: missing class name".to_string()))
+    }
+
+    /// Extract a `class_stmt`'s optional single base class
+    /// (`class Dog(Animal):`) as a bare name. SIR's object model is
+    /// single-inheritance only (SIR25 §2), so this rejects — rather than
+    /// silently picking one of — a multi-base or keyword-argument base
+    /// list (`class Foo(A, B):`, `class Foo(metaclass=M):`), and rejects a
+    /// base expression that is not a bare name (`class Foo(make_base()):`)
+    /// since SIR's `ClassDef.superclass` is a plain name, not an
+    /// expression slot.
+    fn class_superclass(
+        &self,
+        class_stmt: &GrammarASTNode,
+    ) -> Result<Option<String>, PythonLowerError> {
+        // The base-class list reuses the CALL-`arguments` production (the
+        // same grammar shape a function call's `(...)` uses, not
+        // `expression_list` — Python's own grammar does this too, since
+        // `class Foo(Base, metaclass=Meta):` needs keyword-argument
+        // syntax). `class Foo:` / `class Foo():` both have no `arguments`
+        // node or an empty one — either way, no base class.
+        let Some(args_node) = self.first_child_named(class_stmt, "arguments") else {
+            return Ok(None);
+        };
+        let args: Vec<&GrammarASTNode> = child_nodes(args_node)
+            .into_iter()
+            .filter(|n| n.rule_name == "argument")
+            .collect();
+        let base = match args.as_slice() {
+            [] => return Ok(None),
+            [one] => *one,
+            _ => {
+                return Err(self.err_at(
+                    args_node,
+                    "unsupported: multiple base classes (deferred — SIR is single-inheritance)"
+                        .to_string(),
+                ))
+            }
+        };
+        if self.keyword_arg_name(base).is_some() {
+            return Err(self.err_at(
+                base,
+                "unsupported: keyword base-class argument, e.g. `metaclass=...` (deferred)"
+                    .to_string(),
+            ));
+        }
+        let base_expr = self.single_arg_expr(base)?;
+        match self.target_name(base_expr)? {
+            Some(name) => Ok(Some(name)),
+            None => Err(self.err_at(
+                base_expr,
+                "unsupported: base class must be a bare name (deferred)".to_string(),
+            )),
+        }
     }
 
     // -------------------------------------------------------------------
@@ -798,8 +939,12 @@ impl Lowerer {
         let name = match self.target_name(target_node)? {
             Some(name) => name,
             None => {
+                // An instance-variable target (`self.x = v`, OOP surface)?
+                if let Some(stmt) = self.try_attr_assign(assign, target_node, rhs_node, ctx)? {
+                    return Ok(Lowered::Stmt(Box::new(stmt)));
+                }
                 // M5: a *subscript* target (`xs[i] = v` / `d[k] = v`)?
-                // Everything else (attribute, tuple-unpack, …) is deferred.
+                // Everything else (tuple-unpack, chained attrs, …) is deferred.
                 if let Some(stmt) = self.try_subscript_assign(assign, target_node, rhs_node, ctx)? {
                     return Ok(Lowered::Stmt(Box::new(stmt)));
                 }
@@ -832,6 +977,62 @@ impl Lowerer {
                 span,
             })))
         }
+    }
+
+    /// Lower an **instance-variable assignment** `self.x = rhs` (OOP
+    /// surface, SIR25 §2) into [`Stmt::Assign`] with `Scope::Instance`.
+    /// Returns `Ok(None)` when the LHS is not this shape — a bare-name
+    /// `self.x` attribute target where the receiver peels to *exactly*
+    /// `self` — so the caller falls through to the subscript check and
+    /// then the generic deferral (a chained target like `self.x.y = v`
+    /// or an attribute assignment on any receiver other than `self`
+    /// stays deferred, matching the read side's restriction in
+    /// `try_primary_suffixes`).
+    fn try_attr_assign(
+        &mut self,
+        assign: &GrammarASTNode,
+        target_node: &GrammarASTNode,
+        rhs_node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+    ) -> Result<Option<Stmt>, PythonLowerError> {
+        let primary = match self.peel_to_primary(target_node) {
+            Some(p) => p,
+            None => return Ok(None),
+        };
+        let kids = child_nodes(primary);
+        let (atom, suffixes) = match kids.split_first() {
+            Some((atom, rest)) if !rest.is_empty() && rest[0].rule_name == "suffix" => {
+                (*atom, rest)
+            }
+            _ => return Ok(None),
+        };
+        // Only the single-suffix shape `self.x = v` is ours; a chained
+        // target (`self.x.y = v`) is left for the caller's next check
+        // (which will also decline, and the target ultimately defers).
+        if suffixes.len() != 1 {
+            return Ok(None);
+        }
+        let attr_name = match self.suffix_kind(suffixes[0])? {
+            SuffixKind::Attr(name) => name,
+            _ => return Ok(None),
+        };
+        let receiver = self.lower_expr(atom, ctx)?;
+        if !is_self_ref(&receiver) {
+            return Ok(None);
+        }
+        let value = self.lower_expr(rhs_node, ctx)?;
+        let span = self.span_of(assign);
+        // Stmt::Assign unconditionally observes MutableBindings (any
+        // scope) in the validator, alongside the Instance-scope-specific
+        // InstanceVars — declare both so the manifest matches exactly.
+        self.observed.add(Feature::MutableBindings);
+        self.observed.add(Feature::InstanceVars);
+        Ok(Some(Stmt::Assign {
+            name: format!("@{attr_name}"),
+            scope: Scope::Instance,
+            value,
+            span,
+        }))
     }
 
     /// M5: lower a **subscript assignment** `base[index] = rhs` into
@@ -961,6 +1162,7 @@ impl Lowerer {
                 self.lower_while(inner, ctx, depth)?,
             ))),
             "for_stmt" => Ok(Lowered::Stmt(Box::new(self.lower_for(inner, ctx, depth)?))),
+            "class_stmt" => Ok(Lowered::Stmts(self.lower_class(inner, depth)?)),
             "def_stmt" => {
                 // A nested `def` reaching the general statement lowerer:
                 // lift it to a top-level synthesised function with
@@ -978,6 +1180,191 @@ impl Lowerer {
                 format!("unsupported: {other} (deferred to a later milestone)"),
             )),
         }
+    }
+
+    /// Lower a `class_stmt` to SIR's OOP surface (SIR25 §2): one
+    /// `Stmt::ClassDef { name, superclass, body: [] }` followed by one
+    /// `__def_method__` registration per method — the same "empty
+    /// ClassDef, methods hoisted to top-level and registered separately"
+    /// shape `ruby-to-semantic-ir` already produces, so every backend
+    /// that already implements the OOP surface for Ruby needs **zero**
+    /// changes to run a Python-sourced class. That (not any claim in
+    /// prose) is the proof this surface is language-agnostic.
+    ///
+    /// v0 restrictions (each a `deferred` error, not a silent drop):
+    /// decorators, a class body containing anything other than `def`
+    /// statements (no class-level assignments/nested classes/`pass`-only
+    /// bodies with extra statements), more than one base class, a base
+    /// class expression that isn't a bare name. These mirror exactly the
+    /// staged restrictions `ruby-to-semantic-ir`'s own OOP slices used
+    /// (empty-body class first, class-body statements later) — not
+    /// Python-specific corner-cutting.
+    fn lower_class(
+        &mut self,
+        class_stmt: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Vec<Stmt>, PythonLowerError> {
+        if child_nodes(class_stmt)
+            .iter()
+            .any(|n| n.rule_name == "decorator")
+        {
+            return Err(self.err_at(
+                class_stmt,
+                "unsupported: decorated class (deferred)".to_string(),
+            ));
+        }
+        let name = self.class_name(class_stmt)?;
+        let superclass = self.class_superclass(class_stmt)?;
+        let suite = self
+            .first_child_named(class_stmt, "suite")
+            .ok_or_else(|| self.err_at(class_stmt, "malformed class: missing body".to_string()))?;
+        let span = self.span_of(class_stmt);
+
+        self.observed.add(Feature::Classes);
+
+        let mut stmts = vec![Stmt::ClassDef {
+            name: name.clone(),
+            superclass,
+            body: vec![],
+            span: span.clone(),
+        }];
+
+        for stmt_node in class_body_statements(suite) {
+            if is_pass_stmt(stmt_node) {
+                // `class Foo: pass` is Python's spelling of an empty class
+                // body — a no-op here, matching Stmt::ClassDef's empty
+                // `body: []` (methods are hoisted, so the empty-body case
+                // is `pass`-only or `def`-only, never both meaningfully).
+                continue;
+            }
+            let def = self.as_def_stmt(stmt_node).ok_or_else(|| {
+                self.err_at(
+                    stmt_node,
+                    "unsupported: class body statement other than `def` (deferred)".to_string(),
+                )
+            })?;
+            stmts.push(self.lower_method_registration(&name, def, depth)?);
+        }
+
+        Ok(stmts)
+    }
+
+    /// Lower one `def` inside a `class` body: hoist its body to a
+    /// top-level function (named `{Class}__{method}`, mirroring the
+    /// Ruby frontend's own hoisting convention) with `self` stripped from
+    /// the exposed parameter list, then return the
+    /// `__def_method__("Class", "method", MakeClosure(...))`
+    /// registration `Stmt` (SIR25 §2.2).
+    ///
+    /// `__init__` maps to the SIR method name `"initialize"` — not the
+    /// literal Python spelling — because every backend's `call_new`
+    /// looks up that exact name to decide whether to run a constructor
+    /// (see `sir-runtime-oop`/each native backend's `resolve_instance_method(cls,
+    /// "initialize")`); this is the one place a Python spelling must be
+    /// translated to SIR's convention rather than passed through, exactly
+    /// as `ruby-to-semantic-ir` passes Ruby's own `initialize` through
+    /// unchanged (same target name, different source spelling).
+    fn lower_method_registration(
+        &mut self,
+        class_name: &str,
+        def: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Stmt, PythonLowerError> {
+        let py_name = self.def_name(def)?;
+        let sir_method_name = if py_name == "__init__" {
+            "initialize".to_string()
+        } else {
+            py_name.clone()
+        };
+
+        let specs = self.def_param_specs(def)?;
+        let mut specs_iter = specs.into_iter();
+        let (self_name, self_kind, self_default) = specs_iter.next().ok_or_else(|| {
+            self.err_at(
+                def,
+                format!(
+                    "unsupported: method `{py_name}` has no `self` parameter (deferred — \
+                     static/class methods are a later milestone)"
+                ),
+            )
+        })?;
+        if self_name != "self" || self_kind != ParamKind::Required || self_default.is_some() {
+            return Err(self.err_at(
+                def,
+                format!(
+                    "unsupported: method `{py_name}`'s first parameter must be a plain `self` \
+                     (deferred)"
+                ),
+            ));
+        }
+
+        let mut params: Vec<(String, ParamKind, Option<Expr>)> = Vec::new();
+        // Method-parameter defaults are lowered in a throwaway top-level
+        // context: SIR25's method model has no "enclosing scope" for a
+        // method (it is hoisted like a top-level function, not a
+        // closure — see `FunctionCtx::for_method`), and Python evaluates
+        // a `def`'s defaults at def-time in the scope the `def` is
+        // *written* inside, which for a method is the class body — itself
+        // not an expression-evaluating scope a default could meaningfully
+        // reference beyond enclosing module-level names already reachable
+        // from `top_level()`. This mirrors `lower_def`'s own def-time
+        // evaluation model one level up.
+        let mut default_ctx = FunctionCtx::top_level();
+        for (pname, kind, default_node) in specs_iter {
+            let default = match default_node {
+                Some(node) => Some(self.lower_expr_in(node, &mut default_ctx, depth + 1)?),
+                None => None,
+            };
+            params.push((pname, kind, default));
+        }
+        if params.iter().any(|(_, k, _)| *k == ParamKind::Keyword) {
+            self.observed.add(Feature::KeywordParams);
+        }
+        if params.iter().any(|(_, _, d)| d.is_some()) {
+            self.observed.add(Feature::DefaultParams);
+        }
+
+        let suite = self
+            .first_child_named(def, "suite")
+            .ok_or_else(|| self.err_at(def, "malformed def: missing body".to_string()))?;
+        let hoisted_name = format!("{class_name}__{py_name}");
+        let mut inner = FunctionCtx::for_method(params.iter().map(|(n, ..)| n.clone()).collect());
+        let body = self.lower_function_suite(suite, &mut inner, depth + 1)?;
+        let span = self.span_of(def);
+        self.push_function(&hoisted_name, &params, &[], body, span.clone());
+
+        // `__def_method__("Class", "method", MakeClosure(hoisted_name))` —
+        // zero captures (methods never capture, see `FunctionCtx::for_method`).
+        // `push_function` only declares Closures when captures are
+        // non-empty (a method's never are), but the validator observes
+        // Closures unconditionally for ANY MakeClosure — declare it
+        // explicitly here rather than relying on `push_function`'s guard.
+        self.observed.add(Feature::Closures);
+        self.observed.add(Feature::Strings);
+        let closure = Expr::MakeClosure {
+            fn_name: hoisted_name,
+            captures: vec![],
+            span: span.clone(),
+        };
+        Ok(Stmt::ExprStmt {
+            expr: Expr::BuiltinCall {
+                name: "__def_method__".to_string(),
+                args: vec![
+                    Expr::StrLit {
+                        value: class_name.to_string(),
+                        span: span.clone(),
+                    },
+                    Expr::StrLit {
+                        value: sir_method_name,
+                        span: span.clone(),
+                    },
+                    closure,
+                ],
+                effects: EffectSet::PURE,
+                span: span.clone(),
+            },
+            span,
+        })
     }
 
     /// Lower an `if_stmt` into a nested chain of [`Expr::If`].  (Unchanged
@@ -2406,14 +2793,32 @@ impl Lowerer {
         while i < suffixes.len() {
             let suffix = suffixes[i];
             match self.suffix_kind(suffix)? {
-                SuffixKind::Attr(method) => {
+                SuffixKind::Attr(attr_name) => {
                     // Look ahead: `.method (args)` → method call; a bare
-                    // `.method` (no following call) is deferred.
+                    // `.attr` (no following call) is deferred UNLESS the
+                    // receiver is `self` inside a method body, where
+                    // `self.x` reads an instance variable (SIR25 §2).
                     let next_is_call = match suffixes.get(i + 1) {
                         Some(s) => matches!(self.suffix_kind(s)?, SuffixKind::Call),
                         None => false,
                     };
+                    // Receiver: the accumulated value, or — for a leading
+                    // attribute — the bare atom lowered as a value.
+                    let receiver = match acc.take() {
+                        Some(recv) => recv,
+                        None => self.lower_expr_d(atom, ctx, depth + 1)?,
+                    };
                     if !next_is_call {
+                        if is_self_ref(&receiver) {
+                            self.observed.add(Feature::InstanceVars);
+                            acc = Some(Expr::VarRef {
+                                name: format!("@{attr_name}"),
+                                scope: Scope::Instance,
+                                span: self.span_of(suffix),
+                            });
+                            i += 1;
+                            continue;
+                        }
                         return Err(self.err_at(
                             suffix,
                             "unsupported: attribute access as a value \
@@ -2421,17 +2826,11 @@ impl Lowerer {
                                 .to_string(),
                         ));
                     }
-                    // Receiver: the accumulated value, or — for a leading
-                    // attribute — the bare atom lowered as a value.
-                    let receiver = match acc.take() {
-                        Some(recv) => recv,
-                        None => self.lower_expr_d(atom, ctx, depth + 1)?,
-                    };
                     let call_suffix = suffixes[i + 1];
                     let name_span = self.span_of(suffix);
                     acc = Some(self.lower_method_call(
                         receiver,
-                        method,
+                        attr_name,
                         name_span,
                         call_suffix,
                         ctx,
@@ -2507,11 +2906,15 @@ impl Lowerer {
                 })
             }
             SuffixKind::Subscript => self.lower_subscript_suffix(base, suffix, ctx, depth, span),
-            // Attribute suffixes are consumed by the fold's look-ahead
-            // (`.method (args)` → method dispatch) before reaching here.
+            // A *chained* attribute (`self.x.y`, `f().x`) is deferred — the
+            // fold's look-ahead handles a method call and a bare `self.x`
+            // ivar read inline, in the same iteration; reaching here means
+            // a second attribute followed the first, which is still
+            // unsupported in v0.
             SuffixKind::Attr(_) => Err(self.err_at(
                 suffix,
-                "internal: attribute suffix reached apply_value_suffix".to_string(),
+                "unsupported: chained attribute access as a value (deferred to a later milestone)"
+                    .to_string(),
             )),
         }
     }
@@ -2678,6 +3081,28 @@ impl Lowerer {
             return Ok(Expr::BuiltinCall {
                 name,
                 args,
+                effects: EffectSet::PURE,
+                span: span.clone(),
+            });
+        }
+        // `ClassName(args)` → construction (OOP surface, SIR25 §2.1):
+        // `BuiltinCall("__new__", [StrLit(class), ...args])`, same
+        // envelope `ruby-to-semantic-ir` emits for `Foo.new(args)`.
+        // `class_names` is collected in the same first pass as
+        // `function_names` (see `collect_function_names`), so this
+        // resolves regardless of whether the call precedes the class's
+        // own definition in source order.
+        if self.class_names.contains(&name) && !ctx.is_enclosing_value(&name) {
+            self.observed.add(Feature::Strings);
+            let mut new_args = Vec::with_capacity(args.len() + 1);
+            new_args.push(Expr::StrLit {
+                value: name,
+                span: span.clone(),
+            });
+            new_args.extend(args);
+            return Ok(Expr::BuiltinCall {
+                name: "__new__".to_string(),
+                args: new_args,
                 effects: EffectSet::PURE,
                 span: span.clone(),
             });
@@ -3312,6 +3737,19 @@ impl Lowerer {
         ctx: &mut FunctionCtx,
         span: Span,
     ) -> Result<Expr, PythonLowerError> {
+        // A bare `self` inside a method body is the SIR dispatch
+        // envelope's implicit receiver (SIR25 §2.3), not an ordinary
+        // value — `self` is never in `ctx.params` (it is stripped by
+        // `lower_method_registration` precisely so it resolves here,
+        // not as a plain parameter).
+        if ctx.in_method && name == "self" {
+            return Ok(Expr::BuiltinCall {
+                name: "__self__".to_string(),
+                args: vec![],
+                effects: EffectSet::PURE,
+                span,
+            });
+        }
         // Local / param / capture (a value) wins over a same-named fn.
         if ctx.is_enclosing_value(name) {
             return self.resolve_var_in(ctx, name, span);
@@ -3486,6 +3924,51 @@ fn child_nodes(node: &GrammarASTNode) -> Vec<&GrammarASTNode> {
             ASTNodeOrToken::Token(_) => None,
         })
         .collect()
+}
+
+/// The direct `statement` children of a `class_stmt`'s `suite` — same
+/// extraction as `lower_function_suite`'s `stmt_nodes`, factored out as a
+/// free function since `lower_class` needs it before any lowering (it
+/// walks the body once to build `__def_method__` registrations, with no
+/// tail-position special-casing — a class body has no "return value").
+fn class_body_statements(suite: &GrammarASTNode) -> Vec<&GrammarASTNode> {
+    suite
+        .children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Node(n) if n.rule_name == "statement" => Some(n),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Is `stmt` (a `statement` node) Python's `pass` — the no-op placeholder
+/// used for an otherwise-empty suite (`class Foo:\n    pass\n`)? Structure:
+/// `statement -> simple_stmt -> small_stmt -> pass_stmt`.
+fn is_pass_stmt(stmt: &GrammarASTNode) -> bool {
+    let Some(simple) = child_nodes(stmt)
+        .into_iter()
+        .find(|n| n.rule_name == "simple_stmt")
+    else {
+        return false;
+    };
+    let Some(small) = child_nodes(simple)
+        .into_iter()
+        .find(|n| n.rule_name == "small_stmt")
+    else {
+        return false;
+    };
+    child_nodes(small).iter().any(|n| n.rule_name == "pass_stmt")
+}
+
+/// Is `expr` the SIR receiver value for the current method's implicit
+/// receiver (`BuiltinCall("__self__", [])`, per SIR25 §2.3 — how a bare
+/// `self` lowers, see `Lowerer::resolve_var`)? Checking the *already
+/// lowered* expression's shape (rather than sniffing the raw grammar atom
+/// token) means the self-vs-other-receiver distinction for `self.x` /
+/// `self.x = v` needs no grammar-level special-casing at all.
+fn is_self_ref(expr: &Expr) -> bool {
+    matches!(expr, Expr::BuiltinCall { name, args, .. } if name == "__self__" && args.is_empty())
 }
 
 /// Is `value` one of the binary arithmetic operator spellings the lowerer

--- a/code/packages/rust/sir-conformance/CHANGELOG.md
+++ b/code/packages/rust/sir-conformance/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `sir-conformance` crate will be documented in this file.
 
+## [0.24.0] - Python OOP surface corpus: cross-frontend, cross-backend proof
+
+Adds `python_oop_method`, `python_counter_state`, `python_inheritance` —
+the SAME semantics as the existing Ruby-sourced `oop_method`/
+`counter_state` programs (a class, construction, instance methods,
+instance state, single inheritance), sourced from Python
+(`python-to-semantic-ir` 0.9.0's new OOP declaration surface, SIR25 §2)
+instead. All three run and match across every backend that already runs
+the Ruby-sourced originals — the concrete proof the SIR25 arc set out
+for: a second frontend reaching the OOP surface needed zero backend
+changes. Found and documented (not fixed here, orthogonal to OOP): a
+cross-language `print` builtin-name collision — Python's `print` always
+newline-terminates, real Ruby's `Kernel#print` never does, and C/Ruby's
+`print` builtin faithfully mirrors the latter — see README "Gaps the
+corpus has surfaced". `python_inheritance` sidesteps it with a single
+`print` call.
+
 ## [0.23.0] - Frontend genericity: any registered frontend, not just Ruby
 
 Generalizes the harness beyond a hardcoded Ruby-source input path (per

--- a/code/packages/rust/sir-conformance/Cargo.toml
+++ b/code/packages/rust/sir-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sir-conformance"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "Cross-backend golden conformance harness for the Semantic IR: lowers real source from any registered frontend and runs the emitted program through every backend's real toolchain, asserting identical output."
 

--- a/code/packages/rust/sir-conformance/README.md
+++ b/code/packages/rust/sir-conformance/README.md
@@ -80,6 +80,9 @@ across backends, a separate formatting concern). Current programs:
 | `numeric_abs_gcd` | Numeric methods (`abs`/`gcd`) | `5\n6` |
 | `symbol_upcase_length` | Symbol methods widened from String helpers | `HELLO\n5` |
 | `python_arithmetic` | frontend genericity smoke test — same case as `arithmetic`, sourced from **Python** | `14` |
+| `python_oop_method` | Python-sourced OOP surface (SIR25 §2) — same case as `oop_method`, sourced from **Python** | `woof` |
+| `python_counter_state` | Python-sourced instance state — same case as `counter_state`, sourced from **Python** | `2` |
+| `python_inheritance` | Python-sourced single inheritance, ancestry-walk dispatch with no explicit `super()` | `...-woof` |
 
 Adding a program is one `Program { name, frontend, source, expected }` entry
 in `tests/conformance.rs`. `frontend` defaults nothing — pick the `Frontend`
@@ -93,6 +96,24 @@ backends" bug. Programs that hit an **unfixed** gap are kept *out* of the corpus
 (with a pointer to `lessons.md`) so the suite stays green while the gap stays
 visible. Currently tracked:
 
+- **Python's `print` doesn't newline-terminate on C/Ruby** — discovered
+  while adding the first Python-sourced multi-`print` corpus program
+  (`python_inheritance`). Python's `print(x)` always appends a trailing
+  newline; Ruby's `Kernel#print` never does. Both share the SIR builtin
+  *name* `"print"` (Python's frontend reuses it, since it existed for
+  Ruby's own `print` already) but not its semantics — a genuine
+  cross-language name collision, the same shape as the `<<`
+  bitwise-vs-Array-push collision fixed in #9849. The C backend's
+  `_sir_print_v` and the Ruby backend faithfully mirror real Ruby's
+  no-newline `print` (correct for Ruby-sourced programs), so `print("a")`
+  then `print("b")` prints `"ab"` there instead of Python's `"a\nb"` —
+  Python/JS/Go/Rust's `print` already happens to newline-terminate, so
+  this is C/Ruby-only. Fix belongs in `python-to-semantic-ir`: emit a
+  Python-specific newline-terminated builtin rather than reusing Ruby's
+  `"print"` (reusing `"puts"` is NOT a fix — Ruby's `puts` has its own
+  array-unpacking rule Python's `print` doesn't share). `python_inheritance`
+  sidesteps this with a single `print` call (string-concatenating both
+  results) since the gap is orthogonal to what that program tests.
 - **Array/hash index writes AND reads** (`a[i]`, `a[i] = v`, `h[k]`) — the
   frontend parses and lowers both correctly now (PR #9686 fixed the
   PARSER-precedence gap this section used to describe), but only the C

--- a/code/packages/rust/sir-conformance/tests/conformance.rs
+++ b/code/packages/rust/sir-conformance/tests/conformance.rs
@@ -237,6 +237,49 @@ const CORPUS: &[Program] = &[
         source: "print(2 + 3 * 4)\n",
         expected: "14",
     },
+    // Python-sourced OOP surface (SIR25 §2, python-to-semantic-ir's new
+    // class/self/ivar lowering): the SAME semantics as `oop_method` above
+    // (a class, construction, an instance method call), sourced from
+    // Python instead of Ruby. Every backend that already runs the
+    // Ruby-sourced version needs ZERO changes to run this one — that is
+    // the concrete cross-frontend, cross-backend proof the SIR25 arc set
+    // out for, not just a claim in a spec.
+    Program {
+        name: "python_oop_method",
+        frontend: Frontend::Python,
+        source: "class Dog:\n    def speak(self):\n        return \"woof\"\n\nprint(Dog().speak())\n",
+        expected: "woof",
+    },
+    // Python-sourced instance state (mirrors `counter_state` above):
+    // `__init__` mapped to SIR's `initialize`, `self.n` read/write across
+    // two method calls on the same object.
+    Program {
+        name: "python_counter_state",
+        frontend: Frontend::Python,
+        source: "class Counter:\n    def __init__(self):\n        self.n = 0\n    def inc(self):\n        self.n = self.n + 1\n    def value(self):\n        return self.n\n\nc = Counter()\nc.inc()\nc.inc()\nprint(c.value())\n",
+        expected: "2",
+    },
+    // Python-sourced single inheritance, no explicit `super()` (not yet
+    // supported by this frontend — deferred): a subclass with no
+    // overriding method still dispatches to the parent's, proving the
+    // BACKEND's ancestry-walk resolution (built for Ruby) works
+    // unchanged from a Python-sourced ClassDef too. A SINGLE `print`
+    // call (string-concatenating both results) deliberately avoids a
+    // separate, unrelated gap this corpus addition surfaced while
+    // developing it: Python's `print` doesn't add a newline on the C/Ruby
+    // backends when called more than once in a program (their `print`
+    // builtin faithfully mirrors real Ruby's `Kernel#print`, which never
+    // adds one — Python's own `print` always does; the two languages'
+    // `print` share a builtin *name* but not its semantics). See
+    // README.md "Gaps the corpus has surfaced" — tracked, not fixed here,
+    // since it's independent of the OOP/inheritance surface this program
+    // exists to prove.
+    Program {
+        name: "python_inheritance",
+        frontend: Frontend::Python,
+        source: "class Animal:\n    def speak(self):\n        return \"...\"\n\nclass Dog(Animal):\n    def bark(self):\n        return \"woof\"\n\nd = Dog()\nprint(d.speak() + \"-\" + d.bark())\n",
+        expected: "...-woof",
+    },
 ];
 
 /// Every program must produce its reference output on every available backend.


### PR DESCRIPTION
## Summary
- Extends `python-to-semantic-ir` from method-*dispatch* (0.8.0's C2) to the full class *declaration* surface: `class Dog(Animal): def __init__(self, ...): ...` lowers to the SAME `Stmt::ClassDef` + `__new__`/`__def_method__`/`__self__` envelope `ruby-to-semantic-ir` emits. No backend needed a single change to run a Python-sourced class — the concrete proof, not a claim.
- v0 scope: empty-or-single-base classes, instance methods (`self` resolves via `__self__`, never an ordinary parameter), `__init__` → SIR method name `"initialize"`, instance variables (`self.x` read/write), and inheritance via the backend's existing ancestry walk (zero extra frontend work for a non-overriding subclass). Deferred, each its own later milestone: class methods, class variables, `super()`, mixins, exceptions, decorated classes, non-`def` class body content.
- Two real bugs found and fixed during development (caught by the test suite before shipping silently): `class Foo: pass` didn't recognize `pass` as an empty body; a zero-capture method's `MakeClosure` didn't declare `Feature::Closures` (the validator observes it unconditionally, `push_function`'s guard only fires for non-empty captures).
- `sir-conformance` gains `python_oop_method`/`python_counter_state`/`python_inheritance` — same semantics as the existing Ruby-sourced `oop_method`/`counter_state`, sourced from Python, running and matching across all 6 backends.
- Found + documented (not fixed, orthogonal to OOP): a cross-language `print` builtin-name collision — Python's `print` always newline-terminates, real Ruby's `Kernel#print` never does, and C/Ruby's `print` builtin faithfully mirrors the latter. Same shape as the `<<` collision fixed in #9849. Tracked in `sir-conformance`'s README; `python_inheritance` sidesteps it with a single `print` call.

## Test plan
- [x] 20 new unit/shape tests in `python-to-semantic-ir` (class construction, method registration, `__init__`→`initialize`, ivar read/write, inheritance, and 6 rejection cases: multi-base, keyword-base, decorated class, non-`def` body, missing `self`, non-`self` bare attribute).
- [x] 3 real end-to-end tests that lower Python → SIR → emit via the existing Python backend → execute with a real `python3` interpreter (not just IR-shape assertions).
- [x] `python-to-semantic-ir`: 146 tests green, clippy clean.
- [x] `sir-conformance`: full suite green (`conformance matrix: 26 corpus x 6 backends = 145 ran, 11 skipped` — skips are pre-existing Ruby-backend Collections gaps, unrelated).
- [x] Security review (Rust reviewer, anti-RCE name-provenance focus given the new `__new__`/`__def_method__` envelope construction): PASSED, no findings.

Fourth slice of the SIR25 arc (after #10026 spec, #10028 conformance genericity, #10030 type_env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)