### PR TITLE
feat(human-languages): measure whether the course remembers itself (HL09 step 1)

### DIFF
--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,60 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added — does the course have a memory of itself? (HL09 step 1)
+
+- Add `src/continuity.ts`: `measureContinuity` measures the three things a
+  per-lesson budget cannot see, published in the gap report's new `continuity`
+  section. The ramp budgets measure how big each *step* is; this measures whether
+  the steps hold together.
+
+      order: 565 lessons with no declared sequence across 19 tracks;
+             271 prerequisites and 331 reviews pointing forward
+      reinforcement: 746 of 1469 atoms never revisited (51%);
+             missed windows R1 745, R2 1068, R3 649, R4 132
+      forward references: 509 uses of material a later lesson teaches
+
+- **You cannot review a lesson that has not happened yet**, and **331** do. A
+  forward `reviews_of` cannot close a reinforcement window — it names lessons, not
+  atoms — but it is still an authored claim about order, and a claim pointing
+  forward is wrong on its own terms. `ES-C07-beber` reviews `ES-C07-vivir`, which
+  `curriculum.json` places *after* it.
+- **Order comes first because everything else depends on it.** 565 lessons carry
+  no `sequence`, so their reading order exists only inside hand-typed LaTeX —
+  Spanish 56 of 146, French **64 of 73**. A ramp whose order is unknown cannot be
+  verified at all, so every other number here is provisional until this is zero.
+- **51% of taught atoms are never practised again.** HL00 specified the schedule
+  (N+1, N+3, N+7, N+15), defined a `review` lesson type to carry it, and named
+  `session-map.md` as the artifact that verifies it. The corpus has **zero**
+  `review` lessons and a session map covering 3 chapters of 33. The schedule was
+  specified and never built.
+- The measurement reads `practises.knowledge`, **never `reviews_of`** — which 144
+  of Spanish's 146 lessons set, and which cannot close a window because it names
+  *lesson ids* while atoms live in another namespace. Measuring that field would
+  report a corpus that reinforces beautifully and teaches nothing twice.
+- Windows are judged **only where the track is long enough to contain them**. A
+  25-lesson track missing R4 has not failed; it has not got there yet.
+- **Forward references are proved, not guessed.** A word is reported only when a
+  *later lesson's own headword* teaches it, so the finding carries its own
+  evidence and cannot false-positive on ordinary English prose. It reproduces
+  what a human reviewer found by reading: `ES-C07-beber` rewards the learner with
+  *"Como pan y bebo agua"* while **`pan` and `agua` are chapter 26**, and
+  `ES-C08-practice` drills `diecinueve` in a chapter that taught 1–10.
+- Three false-positive classes were found by censusing the output rather than
+  guessing, and each is excluded on principle: **single-character headwords** from
+  `writing` lessons (a Cyrillic `е` or a Devanagari mātrā matched in every lesson
+  of its script — five scripts' worth), **pattern notation** like `e→ie`, and
+  English collisions like `once` (18 hits) — only lessons whose type is `word` or
+  `phrase` create a matcher at all.
+- Honest limit, stated because it changes how the number reads: a word the course
+  **never** teaches anywhere is invisible here. Chapter 7's `¿Algo más?` and the
+  untaught `un`/`una` do not appear, because nothing in the data says they are
+  target language. 509 is a floor.
+- Report-only, per the HL05 precedent: the debt predates the measurement.
+- `readingOrder`, `frontmatterList` and `introducedAtoms` are now exported from
+  `ramp.ts` and shared. Two independent orderings that drifted apart would make
+  the two reports disagree about which lesson comes first, silently.
+
 ### Added — the ramp now includes the script (HL-C18C)
 
 - Add `measureScriptRamp` to `src/ramp.ts`, and two budgets to `core/chapter-policy.json`:

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -105,6 +105,36 @@ modality.tracks[0].chapters[0];        // { drivablePrefix: 5, firstNonVoiceLess
 deriveLessonModality(lessons[0]).reasons; // ["wide-table"] — why it needs eyes
 ```
 
+### Continuity — does the course have a memory of itself? (HL09)
+
+The ramp budgets measure how big each **step** is. This measures whether the steps
+hold together.
+
+```ts
+import { measureContinuity, loadEverything } from "@coding-adventures/human-language-data";
+
+const { lessons } = loadEverything();
+const c = measureContinuity(lessons);
+
+c.summary.lessonsWithoutSequence;   // 565 — no declared reading order at all
+c.summary.atomsNeverRevisited;      // 746 of 1469 (51%) taught once, never again
+c.summary.missedByWindow;           // { R1: 745, R2: 1068, R3: 649, R4: 132 }
+c.summary.forwardReferences;        // 509 uses of material a later lesson teaches
+```
+
+Order comes first: 565 lessons carry no `sequence`, so their order exists only in
+hand-typed LaTeX (French: **64 of 73**). A ramp whose order is unknown cannot be
+verified, so every other number is provisional until that reaches zero.
+
+Reinforcement reads `practises.knowledge`, **never `reviews_of`** — which 144 of
+Spanish's 146 lessons set and which cannot close a window, because it names lesson
+ids while atoms live in another namespace.
+
+Forward references carry their own evidence: a word is reported only when a *later
+lesson's headword* teaches it. That reproduces what a human reviewer found by
+reading — `ES-C07-beber` says *"Como pan y bebo agua"* while `pan` and `agua` are
+chapter 26.
+
 ### The two ramps (HL08)
 
 Gentleness has **two** curves, and until HL-C18C only one of them was counted.

--- a/code/packages/typescript/human-language-data/src/continuity.ts
+++ b/code/packages/typescript/human-language-data/src/continuity.ts
@@ -1,0 +1,488 @@
+// Does the course have a memory of itself? — HL09 step 1.
+//
+// The ramp budgets (HL08, HL-C18C) measure how big each STEP is. They cannot see
+// whether the steps hold together, and reading Spanish chapters 1-8 showed that
+// is where the course actually fails:
+//
+//   "A gentle ramp is not made of small steps; it's made of steps you can still
+//    stand on."
+//
+// Three things go wrong, and each is invisible to a per-lesson budget.
+//
+// 1. ORDER. 56 of Spanish's 146 lessons carry no `sequence`, so their reading
+//    order exists only inside hand-typed LaTeX. French is worse: 64 of 73. A ramp
+//    whose order is unknown cannot be verified at all — every other measurement in
+//    this file is conditional on knowing what comes first.
+//
+// 2. REINFORCEMENT. 93 of Spanish's 182 taught atoms (51%) are never practised
+//    again; the median atom is revisited ZERO times. HL00 specified the schedule
+//    (N+1, N+3, N+7, N+15), defined a `review` lesson type to carry it, and named
+//    session-map.md as the artifact that verifies it. The corpus has zero `review`
+//    lessons and a session map covering 3 chapters of 33. The schedule was
+//    specified and never built.
+//
+// 3. FORWARD REFERENCES. Starved of anything to review, later chapters reach
+//    sideways for whatever they need: chapter 7 rewards the learner with
+//    "Como pan y bebo agua" — and `pan` and `agua` are taught in chapter 26.
+//
+// The third is a SYMPTOM of the second, which is why they are measured together.
+// Fix the scheduler and the forward references lose their cause.
+//
+// WHAT THIS UNDERCOUNTS, stated because it changes how the number reads. A word the
+// course never teaches ANYWHERE is invisible: chapter 7's untaught "¿Algo más?" and
+// its `un`/`una` never appear, because nothing in the data marks them as target
+// language. Hyphenated headwords are split on the hyphen (right for a range like
+// "once — quince", wrong for "dix-sept"), so a hyphenated compound never becomes a
+// matcher. And the plain-prose floor counts UTF-16 units, so two-character CJK words
+// are reachable only through emphasis — part of why Chinese and Japanese report zero.
+// Every one of these makes the published figure a FLOOR, never an overstatement.
+//
+// Report-only, per the HL05 precedent: the debt predates the measurement.
+
+import type { ParsedLesson } from "./parse.js";
+import { readingOrder, frontmatterList } from "./ramp.js";
+import { CONTENT_TYPES } from "./constants.js";
+
+/**
+ * The spaced-retrieval windows from HL09 §7.
+ *
+ * Expanding, because that is how retrieval practice works: consolidate before
+ * decay, then retrieve at growing distances. An atom must reappear in some later
+ * lesson's `practises.knowledge` inside each window.
+ */
+export const REINFORCEMENT_WINDOWS = [
+  { name: "R1", from: 1, to: 3, purpose: "consolidate before it decays" },
+  { name: "R2", from: 5, to: 15, purpose: "first real retrieval" },
+  { name: "R3", from: 20, to: 60, purpose: "durable" },
+  { name: "R4", from: 80, to: 250, purpose: "recognition at distance" },
+] as const;
+
+export type WindowName = (typeof REINFORCEMENT_WINDOWS)[number]["name"];
+
+/** A lesson whose declared order is missing or collides with another's. */
+export interface OrderDefect {
+  lessonId: string;
+  language: string;
+  chapter: number | null;
+  kind: "no-sequence" | "duplicate-sequence" | "forward-prerequisite" | "forward-review";
+  /** For a duplicate, the other lesson; for a forward prerequisite, the one needed. */
+  other?: string;
+  detail: string;
+}
+
+/** One atom that misses a reinforcement window it was long enough to have. */
+export interface ReinforcementDefect {
+  atom: string;
+  language: string;
+  introducedBy: string;
+  /** Zero-based position in the track's reading order. */
+  introducedAt: number;
+  /** Windows the track was long enough to contain, and the atom missed. */
+  missed: WindowName[];
+  /** Total later lessons practising this atom, at any distance. */
+  revisits: number;
+}
+
+/** A lesson using target-language material that only a LATER lesson teaches. */
+export interface ForwardReference {
+  lessonId: string;
+  language: string;
+  /** Position of the lesson doing the borrowing. */
+  position: number;
+  /** The word it used. */
+  word: string;
+  /** The lesson that actually teaches that word. */
+  taughtBy: string;
+  /** How many lessons later the learner will meet it properly. */
+  lessonsEarly: number;
+}
+
+export interface TrackContinuity {
+  language: string;
+  lessonCount: number;
+  lessonsWithoutSequence: number;
+  forwardPrerequisites: number;
+  /** Lessons whose `reviews_of` names a lesson the learner has not reached. */
+  forwardReviews: number;
+  /** Atoms introduced in this track that any window measurement could see. */
+  atomsTaught: number;
+  /** Atoms never practised again at any distance. */
+  atomsNeverRevisited: number;
+  forwardReferences: number;
+}
+
+export interface ContinuityReport {
+  windows: typeof REINFORCEMENT_WINDOWS;
+  order: OrderDefect[];
+  reinforcement: ReinforcementDefect[];
+  forwardReferences: ForwardReference[];
+  tracks: TrackContinuity[];
+  summary: {
+    /** Lessons with no `sequence`. Until this is zero, the rest is provisional. */
+    lessonsWithoutSequence: number;
+    /** Tracks where at least one lesson has no declared order. */
+    tracksWithUnorderedLessons: number;
+    forwardPrerequisites: number;
+    /** You cannot review a lesson that has not happened yet. */
+    forwardReviews: number;
+    atomsTaught: number;
+    /** Atoms never practised again at ANY distance — the headline number. */
+    atomsNeverRevisited: number;
+    /** Share of taught atoms that are never revisited. */
+    neverRevisitedPercent: number;
+    /** Per-window miss counts, over atoms whose track was long enough to have it. */
+    missedByWindow: Record<WindowName, number>;
+    forwardReferences: number;
+  };
+}
+
+/**
+ * Atoms a lesson PRACTISES — the reinforcement signal.
+ *
+ * Deliberately NOT `reviews_of`, which 144 of Spanish's 146 lessons set and which
+ * cannot close a window: it names LESSON ids while atoms live in another
+ * namespace, so it has never reinforced anything. Measuring it would report a
+ * corpus that reinforces beautifully and teaches nothing twice.
+ */
+function practisedAtoms(lesson: ParsedLesson): string[] {
+  const atoms = new Set(frontmatterList(lesson, "practises.knowledge"));
+  for (const block of lesson.blocks ?? []) {
+    for (const atom of block.knowledge?.assesses ?? []) atoms.add(atom);
+  }
+  return [...atoms];
+}
+
+function declaredSequence(lesson: ParsedLesson): number | null {
+  const raw = lesson.frontmatter.sequence;
+  const value = typeof raw === "number" ? raw : Number(raw);
+  return typeof raw !== "undefined" && String(raw).trim() !== "" && Number.isFinite(value)
+    ? value
+    : null;
+}
+
+/**
+ * Headwords, normalised for matching, that a lesson teaches.
+ *
+ * A multi-word headword ("buenos días") is kept whole: matching its parts
+ * separately would report `días` as a forward reference from any lesson that
+ * mentions the phrase.
+ */
+function taughtWords(lesson: ParsedLesson): string[] {
+  const headword = lesson.realization.headword ?? "";
+  // A headword may hold alternatives — "hola / buenas", "sí, no" — or a RANGE,
+  // written with a dash: "dieciséis — diecinueve", "once — quince".
+  const parts = headword
+    .split(/[/,]|\s+y\s+|\s*[—–-]\s*/)
+    .map((part) => part.trim().toLowerCase())
+    .filter((part) => part.length > 0);
+
+  const out = new Set(parts);
+  for (const part of parts) {
+    // Headwords carry their article: "el pan", "el agua", "la casa". A body that
+    // says "bebo agua" is using the same word, so the bare noun must match too.
+    // Only a SHORT leading function word is stripped, which leaves "buenos días"
+    // whole — splitting that would report `días` from every lesson mentioning it.
+    const match = /^(\S{1,3})\s+(.+)$/.exec(part);
+    if (match) out.add(match[2]!.trim());
+  }
+  return [...out].filter((word) => word.length > 0);
+}
+
+/**
+ * English words that are also common target-language headwords.
+ *
+ * Without this, every English sentence in a Spanish lesson reports `a`, `no`,
+ * `son` and `me` as forward references. The list is small and deliberately so:
+ * the length rule below does most of the work, and a denylist that grows without
+ * bound is a sign the matching rule is wrong.
+ */
+const ENGLISH_COLLISIONS = new Set([
+  "a", "an", "as", "at", "be", "but", "can", "do", "eat", "el", "en", "es", "fin",
+  "for", "go", "he", "in", "is", "it", "la", "led", "me", "no", "of", "on", "once",
+  "or", "past", "pie", "roman", "san", "sea", "sin", "so", "son", "some", "tag",
+  "tan", "the", "three", "to", "us", "van", "was", "we", "y", "you",
+]);
+
+/**
+ * Is this headword usable as a forward-reference matcher at all?
+ *
+ * Two classes are excluded on principle rather than by list, because a denylist
+ * that has to name them is a sign the rule is wrong:
+ *
+ * - **Single characters.** A writing lesson teaching the Cyrillic letter `е` or a
+ *   Devanagari mātrā `ा` would otherwise match in every lesson of that script.
+ *   That was the worst false positive in the first census — five scripts' worth.
+ * - **Pattern notation.** `e→ie` and `o→ue` are how the corpus writes a stem
+ *   change. They are descriptions of a rule, not words a learner meets.
+ */
+function usableAsMatcher(word: string): boolean {
+  return [...word].length >= 2 && !/[→?()[\]]/u.test(word);
+}
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Emphasised or code-spanned runs, where the corpus marks target language. */
+function emphasisedRuns(body: string): string {
+  const runs: string[] = [];
+  for (const match of body.matchAll(/\*\*([^*]+)\*\*|\*([^*]+)\*|`([^`]+)`/g)) {
+    runs.push(match[1] ?? match[2] ?? match[3] ?? "");
+  }
+  return runs.join("   ").toLowerCase();
+}
+
+/** Measure order integrity, reinforcement windows, and forward references. */
+export function measureContinuity(lessons: ParsedLesson[]): ContinuityReport {
+  const order: OrderDefect[] = [];
+  const reinforcement: ReinforcementDefect[] = [];
+  const forwardReferences: ForwardReference[] = [];
+  const tracks: TrackContinuity[] = [];
+  // Seeded FROM the window list, not hand-written: a hand-written literal compiles
+  // fine when a window is added and then silently drops that column from the
+  // rendered report whenever it happens to have zero misses.
+  const missedByWindow = Object.fromEntries(
+    REINFORCEMENT_WINDOWS.map((window) => [window.name, 0]),
+  ) as Record<WindowName, number>;
+
+  const byTrack = new Map<string, ParsedLesson[]>();
+  for (const lesson of lessons) {
+    let group = byTrack.get(lesson.language);
+    if (!group) byTrack.set(lesson.language, (group = []));
+    group.push(lesson);
+  }
+
+  for (const [language, group] of [...byTrack].sort((a, b) => a[0].localeCompare(b[0]))) {
+    const ordered = [...group].sort(readingOrder);
+    const last = ordered.length - 1;
+    const positionOf = new Map<string, number>();
+    ordered.forEach((lesson, index) => positionOf.set(lesson.realization.lessonId, index));
+
+    const track: TrackContinuity = {
+      language,
+      lessonCount: ordered.length,
+      lessonsWithoutSequence: 0,
+      forwardPrerequisites: 0,
+      forwardReviews: 0,
+      atomsTaught: 0,
+      atomsNeverRevisited: 0,
+      forwardReferences: 0,
+    };
+
+    // ---- (a) order integrity ----
+    const seenSequence = new Map<number, string>();
+    ordered.forEach((lesson, index) => {
+      const id = lesson.realization.lessonId;
+      const chapter =
+        typeof lesson.realization.chapter === "number" && Number.isFinite(lesson.realization.chapter)
+          ? lesson.realization.chapter
+          : null;
+      const sequence = declaredSequence(lesson);
+
+      if (sequence === null) {
+        track.lessonsWithoutSequence += 1;
+        order.push({
+          lessonId: id,
+          language,
+          chapter,
+          kind: "no-sequence",
+          detail: "no declared reading order; position is a fallback, not a fact",
+        });
+      } else {
+        const clash = seenSequence.get(sequence);
+        if (clash !== undefined) {
+          order.push({
+            lessonId: id,
+            language,
+            chapter,
+            kind: "duplicate-sequence",
+            other: clash,
+            detail: `sequence ${sequence} is also claimed by ${clash}`,
+          });
+        } else {
+          seenSequence.set(sequence, id);
+        }
+      }
+
+      // You cannot review a lesson that has not happened yet. `reviews_of` cannot
+      // close a reinforcement window (it names lessons, not atoms), but it is still
+      // an authored claim about order, and a claim pointing forward is wrong on its
+      // own terms: ES-C07-beber reviews ES-C07-vivir, which curriculum.json places
+      // AFTER it.
+      for (const reviewed of frontmatterList(lesson, "reviews_of")) {
+        const at = positionOf.get(reviewed);
+        if (at !== undefined && at > index) {
+          track.forwardReviews += 1;
+          order.push({
+            lessonId: id,
+            language,
+            chapter,
+            kind: "forward-review",
+            other: reviewed,
+            detail: `reviews ${reviewed}, which the learner does not reach for another ${at - index} lesson(s)`,
+          });
+        }
+      }
+
+      for (const prerequisite of frontmatterList(lesson, "prerequisites")) {
+        const at = positionOf.get(prerequisite);
+        if (at !== undefined && at > index) {
+          track.forwardPrerequisites += 1;
+          order.push({
+            lessonId: id,
+            language,
+            chapter,
+            kind: "forward-prerequisite",
+            other: prerequisite,
+            detail: `requires ${prerequisite}, which comes ${at - index} lesson(s) later`,
+          });
+        }
+      }
+    });
+
+    // ---- (b) reinforcement windows ----
+    const firstTaught = new Map<string, { by: string; at: number }>();
+    ordered.forEach((lesson, index) => {
+      for (const atom of frontmatterList(lesson, "introduces.knowledge")) {
+        if (!firstTaught.has(atom)) {
+          firstTaught.set(atom, { by: lesson.realization.lessonId, at: index });
+        }
+      }
+      for (const block of lesson.blocks ?? []) {
+        for (const atom of block.knowledge?.introduces ?? []) {
+          if (!firstTaught.has(atom)) {
+            firstTaught.set(atom, { by: lesson.realization.lessonId, at: index });
+          }
+        }
+      }
+    });
+
+    const practisedAt = new Map<string, number[]>();
+    ordered.forEach((lesson, index) => {
+      for (const atom of practisedAtoms(lesson)) {
+        let positions = practisedAt.get(atom);
+        if (!positions) practisedAt.set(atom, (positions = []));
+        positions.push(index);
+      }
+    });
+
+    track.atomsTaught = firstTaught.size;
+    for (const [atom, { by, at }] of [...firstTaught].sort((a, b) => a[0].localeCompare(b[0]))) {
+      const later = (practisedAt.get(atom) ?? []).filter((position) => position > at);
+      if (later.length === 0) track.atomsNeverRevisited += 1;
+
+      const missed: WindowName[] = [];
+      for (const window of REINFORCEMENT_WINDOWS) {
+        // Only judge a window the track was long enough to contain. A 25-lesson
+        // track missing R4 has not failed; it has not got there yet.
+        if (at + window.from > last) continue;
+        if (!later.some((position) => position - at >= window.from && position - at <= window.to)) {
+          missed.push(window.name);
+          missedByWindow[window.name] = (missedByWindow[window.name] ?? 0) + 1;
+        }
+      }
+      if (missed.length > 0) {
+        reinforcement.push({
+          atom,
+          language,
+          introducedBy: by,
+          introducedAt: at,
+          missed,
+          revisits: later.length,
+        });
+      }
+    }
+
+    // ---- (c) forward references ----
+    // Only words the course ITSELF teaches later are reported. That is provable
+    // — the later lesson's own headword is the evidence — and it never
+    // false-positives on ordinary English prose. The honest blind spot: a word
+    // the course never teaches anywhere (chapter 7's "¿Algo más?") is invisible
+    // here, because nothing in the data says it is target language at all.
+    const earliestTeaching = new Map<string, { by: string; at: number }>();
+    ordered.forEach((lesson, index) => {
+      // Only lessons that teach a WORD or PHRASE create a matcher. A `writing`
+      // lesson teaching one letter, or a `grammar` lesson whose headword is a
+      // rule, is not vocabulary the learner "meets too early" — and treating it
+      // as such produced the single-character false positives above.
+      if (!CONTENT_TYPES.has(lesson.realization.type)) return;
+      for (const word of taughtWords(lesson).filter(usableAsMatcher)) {
+        const existing = earliestTeaching.get(word);
+        if (!existing || index < existing.at) {
+          earliestTeaching.set(word, { by: lesson.realization.lessonId, at: index });
+        }
+      }
+    });
+
+    ordered.forEach((lesson, index) => {
+      const body = lesson.body.toLowerCase();
+      const emphasised = emphasisedRuns(lesson.body);
+      const own = new Set(taughtWords(lesson));
+      const reported = new Set<string>();
+
+      for (const [word, teaching] of earliestTeaching) {
+        if (teaching.at <= index || own.has(word) || reported.has(word)) continue;
+        // The English-collision guard applies on BOTH paths, and BEFORE the regex is
+        // built — otherwise every collision word costs a construction in every
+        // lesson of the track for a value thrown away on the next line. Applying it
+        // only to plain prose let "**no** glide, no drift" — ordinary emphasised
+        // English — report `no` as a forward reference from 7 different lessons.
+        if (ENGLISH_COLLISIONS.has(word)) continue;
+        // A trailing hyphen means a compound like "pan-Hispanic" — English, not a
+        // borrowed headword.
+        const pattern = new RegExp(
+          `(?<![\\p{L}\\p{M}-])${escapeRegExp(word)}(?![\\p{L}\\p{M}-])`,
+          "u",
+        );
+        const inPlain = word.length >= 4 && pattern.test(body);
+        const inEmphasis = pattern.test(emphasised);
+        if (!inPlain && !inEmphasis) continue;
+
+        reported.add(word);
+        track.forwardReferences += 1;
+        forwardReferences.push({
+          lessonId: lesson.realization.lessonId,
+          language,
+          position: index,
+          word,
+          taughtBy: teaching.by,
+          lessonsEarly: teaching.at - index,
+        });
+      }
+    });
+
+    tracks.push(track);
+  }
+
+  // Worst first, so each list is a work queue rather than a set.
+  order.sort((a, b) => a.language.localeCompare(b.language) || a.lessonId.localeCompare(b.lessonId));
+  reinforcement.sort(
+    (a, b) => b.missed.length - a.missed.length || a.atom.localeCompare(b.atom),
+  );
+  forwardReferences.sort(
+    (a, b) => b.lessonsEarly - a.lessonsEarly || a.lessonId.localeCompare(b.lessonId),
+  );
+
+  const atomsTaught = tracks.reduce((sum, track) => sum + track.atomsTaught, 0);
+  const atomsNeverRevisited = tracks.reduce((sum, track) => sum + track.atomsNeverRevisited, 0);
+
+  return {
+    windows: REINFORCEMENT_WINDOWS,
+    order,
+    reinforcement,
+    forwardReferences,
+    tracks,
+    summary: {
+      lessonsWithoutSequence: tracks.reduce((sum, t) => sum + t.lessonsWithoutSequence, 0),
+      tracksWithUnorderedLessons: tracks.filter((t) => t.lessonsWithoutSequence > 0).length,
+      forwardPrerequisites: tracks.reduce((sum, t) => sum + t.forwardPrerequisites, 0),
+      forwardReviews: tracks.reduce((sum, t) => sum + t.forwardReviews, 0),
+      atomsTaught,
+      atomsNeverRevisited,
+      neverRevisitedPercent:
+        atomsTaught === 0 ? 0 : Math.round((atomsNeverRevisited / atomsTaught) * 100),
+      missedByWindow,
+      forwardReferences: tracks.reduce((sum, t) => sum + t.forwardReferences, 0),
+    },
+  };
+}

--- a/code/packages/typescript/human-language-data/src/index.ts
+++ b/code/packages/typescript/human-language-data/src/index.ts
@@ -209,6 +209,16 @@ export {
   type ScriptSystemViolation,
   type TrackScriptRamp,
 } from "./ramp.js";
+export {
+  measureContinuity,
+  REINFORCEMENT_WINDOWS,
+  type ContinuityReport,
+  type OrderDefect,
+  type ReinforcementDefect,
+  type ForwardReference,
+  type TrackContinuity,
+  type WindowName,
+} from "./continuity.js";
 export { runValidate } from "./cli.js";
 export { runCurriculumGapReport } from "./report-cli.js";
 export { generatedBookOutputs, runBookGeneration } from "./book-cli.js";

--- a/code/packages/typescript/human-language-data/src/ramp.ts
+++ b/code/packages/typescript/human-language-data/src/ramp.ts
@@ -139,8 +139,14 @@ function systemOf(ch: string): string | null {
   return null;
 }
 
-/** Reading order within a track: chapter, then sequence, then id for stability. */
-function readingOrder(a: ParsedLesson, b: ParsedLesson): number {
+/**
+ * Reading order within a track: chapter, then sequence, then id for stability.
+ *
+ * Exported because `continuity.ts` measures the same walk. Two independent
+ * orderings that drift apart would make the two reports disagree about which
+ * lesson comes first, and the disagreement would be silent.
+ */
+export function readingOrder(a: ParsedLesson, b: ParsedLesson): number {
   const chapter = (lesson: ParsedLesson) =>
     typeof lesson.realization.chapter === "number" && Number.isFinite(lesson.realization.chapter)
       ? lesson.realization.chapter
@@ -267,7 +273,7 @@ export interface RampReport {
   };
 }
 
-function frontmatterList(lesson: ParsedLesson, key: string): string[] {
+export function frontmatterList(lesson: ParsedLesson, key: string): string[] {
   const value = lesson.frontmatter[key];
   if (Array.isArray(value)) return value.filter((item): item is string => typeof item === "string");
   return typeof value === "string" && value.trim() ? [value.trim()] : [];
@@ -281,7 +287,7 @@ function frontmatterList(lesson: ParsedLesson, key: string): string[] {
  * chapter gates report all 279 authored chapters as broken, so it is worth restating
  * wherever atoms are counted.
  */
-function introducedAtoms(lesson: ParsedLesson): string[] {
+export function introducedAtoms(lesson: ParsedLesson): string[] {
   const atoms = new Set(frontmatterList(lesson, "introduces.knowledge"));
   for (const block of lesson.blocks ?? []) {
     for (const atom of block.knowledge?.introduces ?? []) atoms.add(atom);

--- a/code/packages/typescript/human-language-data/src/report.ts
+++ b/code/packages/typescript/human-language-data/src/report.ts
@@ -2,6 +2,7 @@ import type { ParsedLesson } from "./parse.js";
 import { runChapterGates, type ChapterGateReport } from "./chapters.js";
 import { CEFR_LEVELS, summarizeLevels, type LevelSummary } from "./levels.js";
 import { measureRamp, type RampReport } from "./ramp.js";
+import { measureContinuity, type ContinuityReport } from "./continuity.js";
 import type {
   BookCorpus,
   ChapterPolicy,
@@ -111,6 +112,14 @@ export interface CurriculumGapReport {
     scriptRampOverBudgetLessons: number | null;
     /** HL08: lessons opening more than one writing system at once. */
     lessonsOpeningMultipleScripts: number | null;
+    /** HL09: lessons with no declared reading order. Until zero, the rest is provisional. */
+    lessonsWithoutSequence: number;
+    /** HL09: lessons reviewing a lesson the learner has not reached yet. */
+    forwardReviews: number;
+    /** HL09: atoms taught once and never practised again — the headline gap. */
+    atomsNeverRevisited: number;
+    /** HL09: uses of target-language material a later lesson teaches. */
+    forwardReferences: number;
     chaptersWithoutCapability: number | null;
     chapterPayoffsNotRepresentative: number | null;
     chapterGateCleanTracks: number | null;
@@ -161,6 +170,14 @@ export interface CurriculumGapReport {
    * nobody chose.
    */
   ramp?: RampReport;
+  /**
+   * HL09 step 1 — whether the course has a memory of itself.
+   *
+   * The ramp budgets measure how big each step is; this measures whether the
+   * steps hold together. Always present: unlike `ramp` it needs no policy, since
+   * order, reinforcement and forward references are all properties of the lessons.
+   */
+  continuity: ContinuityReport;
   modality: ModalitySummary;
 }
 
@@ -471,6 +488,7 @@ export function buildCurriculumGapReport(input: CurriculumGapReportInput): Curri
   // HL08 ramp budgets. Needs only the policy — every lesson carries its own atoms and
   // its own script, so unlike the chapter gates this does not wait on the ledgers.
   const ramp = input.chapterPolicy ? measureRamp(lessons, input.chapterPolicy) : undefined;
+  const continuity = measureContinuity(lessons);
 
   const chapterGates =
     input.trackChapters && input.chapterPolicy
@@ -510,6 +528,10 @@ export function buildCurriculumGapReport(input: CurriculumGapReportInput): Curri
       rampOverBudgetLessons: ramp?.summary.lessonViolations ?? null,
       scriptRampOverBudgetLessons: ramp?.script.summary.lessonViolations ?? null,
       lessonsOpeningMultipleScripts: ramp?.script.summary.systemViolations ?? null,
+      lessonsWithoutSequence: continuity.summary.lessonsWithoutSequence,
+      forwardReviews: continuity.summary.forwardReviews,
+      atomsNeverRevisited: continuity.summary.atomsNeverRevisited,
+      forwardReferences: continuity.summary.forwardReferences,
       chaptersWithoutCapability: chapterGates?.summary.chaptersWithoutCapability ?? null,
       chapterPayoffsNotRepresentative: chapterGates?.summary.payoffsNotRepresentative ?? null,
       chapterGateCleanTracks: chapterGates?.summary.cleanTracks ?? null,
@@ -527,6 +549,7 @@ export function buildCurriculumGapReport(input: CurriculumGapReportInput): Curri
     chapters: chapterGates,
     levels,
     ramp,
+    continuity,
     modality,
   };
 }
@@ -566,6 +589,16 @@ export function renderCurriculumGapReport(report: CurriculumGapReport): string {
             `(max ${report.ramp.script.summary.maxForeignGlyphsInALesson} glyphs) — context, never charged to the budget`,
         ]
       : []),
+    `order: ${report.continuity.summary.lessonsWithoutSequence} lessons with no declared sequence ` +
+      `across ${report.continuity.summary.tracksWithUnorderedLessons} tracks; ` +
+      `${report.continuity.summary.forwardPrerequisites} prerequisites and ` +
+      `${report.continuity.summary.forwardReviews} reviews pointing forward`,
+    `reinforcement: ${report.continuity.summary.atomsNeverRevisited} of ${report.continuity.summary.atomsTaught} ` +
+      `atoms never revisited (${report.continuity.summary.neverRevisitedPercent}%); missed windows ` +
+      Object.entries(report.continuity.summary.missedByWindow)
+        .map(([name, count]) => `${name} ${count}`)
+        .join(", "),
+    `forward references: ${report.continuity.summary.forwardReferences} uses of material a later lesson teaches`,
     ...(report.chapters
       ? [
           `${report.chapters.summary.chaptersWithoutCapability} of ${report.chapters.summary.bookChapters} book chapters without an HL05 capability; ` +

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -1,0 +1,287 @@
+// HL09 step 1 — does the course have a memory of itself? See src/continuity.ts.
+
+import { describe, expect, it } from "vitest";
+import { loadEverything } from "../src/loader.js";
+import { measureContinuity, REINFORCEMENT_WINDOWS } from "../src/continuity.js";
+import { parseLesson } from "../src/parse.js";
+
+/** A lesson with a declared order, an optional headword, and atom directives. */
+function lesson(opts: {
+  id: string;
+  chapter: number;
+  sequence?: number | "";
+  headword?: string;
+  type?: string;
+  introduces?: string[];
+  practises?: string[];
+  prerequisites?: string[];
+  body?: string;
+}) {
+  const seq = opts.sequence === undefined ? 10 : opts.sequence;
+  const fm = [
+    "schema_version: 2",
+    `id: ${opts.id}`,
+    `chapter: ${opts.chapter}`,
+    ...(seq === "" ? [] : [`sequence: ${seq}`]),
+    `type: ${opts.type ?? "word"}`,
+    `headword: "${opts.headword ?? "x"}"`,
+    "gloss: x",
+    "concept_tag: GREETING-HELLO",
+    ...(opts.introduces ? [`introduces.knowledge: [${opts.introduces.join(", ")}]`] : []),
+    ...(opts.practises ? [`practises.knowledge: [${opts.practises.join(", ")}]`] : []),
+    ...(opts.prerequisites ? [`prerequisites: [${opts.prerequisites.join(", ")}]`] : []),
+  ].join("\n");
+  return parseLesson(
+    `---\n${fm}\n---\n\n# ${opts.id}\n\n## Warm-up\n\n${opts.body ?? "Say it."}\n`,
+    "spanish",
+  );
+}
+
+/** Filler so a track is long enough for a window to be judged. */
+function filler(from: number, count: number) {
+  return Array.from({ length: count }, (_, i) =>
+    lesson({ id: `ES-F${from + i}`, chapter: 1, sequence: (from + i) * 10 }),
+  );
+}
+
+describe("order integrity", () => {
+  it("names a lesson with no declared reading order", () => {
+    const report = measureContinuity([
+      lesson({ id: "ES-1", chapter: 1, sequence: 10 }),
+      lesson({ id: "ES-2", chapter: 1, sequence: "" }),
+    ]);
+    expect(report.summary.lessonsWithoutSequence).toBe(1);
+    expect(report.order.find((d) => d.kind === "no-sequence")?.lessonId).toBe("ES-2");
+  });
+
+  it("catches two lessons claiming the same slot", () => {
+    const report = measureContinuity([
+      lesson({ id: "ES-1", chapter: 1, sequence: 10 }),
+      lesson({ id: "ES-2", chapter: 1, sequence: 10 }),
+    ]);
+    expect(report.order.some((d) => d.kind === "duplicate-sequence")).toBe(true);
+  });
+
+  it("catches a lesson reviewing one that has not happened yet", () => {
+    // You cannot review a lesson the learner has not reached. reviews_of cannot
+    // close a reinforcement window (it names lessons, not atoms) but it is still an
+    // authored claim about order, and a forward claim is wrong on its own terms.
+    const reviewer = parseLesson(
+      `---\nschema_version: 2\nid: ES-1\nchapter: 1\nsequence: 10\ntype: word\n` +
+        `headword: "x"\ngloss: x\nconcept_tag: GREETING-HELLO\nreviews_of: [ES-2]\n---\n\n` +
+        `# ES-1\n\n## Warm-up\n\nSay it.\n`,
+      "spanish",
+    );
+    const report = measureContinuity([reviewer, lesson({ id: "ES-2", chapter: 1, sequence: 20 })]);
+    expect(report.summary.forwardReviews).toBe(1);
+    expect(report.order.find((d) => d.kind === "forward-review")).toMatchObject({
+      lessonId: "ES-1",
+      other: "ES-2",
+    });
+  });
+
+  it("catches a prerequisite that comes later in reading order", () => {
+    const report = measureContinuity([
+      lesson({ id: "ES-1", chapter: 1, sequence: 10, prerequisites: ["ES-2"] }),
+      lesson({ id: "ES-2", chapter: 1, sequence: 20 }),
+    ]);
+    expect(report.summary.forwardPrerequisites).toBe(1);
+    expect(report.order.find((d) => d.kind === "forward-prerequisite")).toMatchObject({
+      lessonId: "ES-1",
+      other: "ES-2",
+    });
+  });
+});
+
+describe("reinforcement windows", () => {
+  it("flags an atom that is never practised again", () => {
+    const report = measureContinuity([
+      lesson({ id: "ES-1", chapter: 1, sequence: 10, introduces: ["A"] }),
+      ...filler(2, 5),
+    ]);
+    expect(report.summary.atomsNeverRevisited).toBe(1);
+    expect(report.summary.neverRevisitedPercent).toBe(100);
+    expect(report.reinforcement[0]?.missed).toContain("R1");
+  });
+
+  it("counts an atom practised inside R1 as closing R1", () => {
+    const report = measureContinuity([
+      lesson({ id: "ES-1", chapter: 1, sequence: 10, introduces: ["A"] }),
+      lesson({ id: "ES-2", chapter: 1, sequence: 20, practises: ["A"] }),
+      ...filler(3, 4),
+    ]);
+    expect(report.summary.atomsNeverRevisited).toBe(0);
+    expect(report.reinforcement[0]?.missed ?? []).not.toContain("R1");
+  });
+
+  it("does not judge a window the track is too short to contain", () => {
+    // Three lessons cannot possibly satisfy R2 (n+5). Reporting it would blame a
+    // track for not having got there yet.
+    const report = measureContinuity([
+      lesson({ id: "ES-1", chapter: 1, sequence: 10, introduces: ["A"] }),
+      lesson({ id: "ES-2", chapter: 1, sequence: 20, practises: ["A"] }),
+      lesson({ id: "ES-3", chapter: 1, sequence: 30 }),
+    ]);
+    expect(report.summary.missedByWindow.R2).toBe(0);
+    expect(report.summary.missedByWindow.R3).toBe(0);
+    expect(report.summary.missedByWindow.R4).toBe(0);
+  });
+
+  it("uses practises, not reviews_of, because reviews_of names lessons", () => {
+    // 144 of Spanish's 146 lessons set reviews_of. If this measured that field the
+    // corpus would look perfectly reinforced while teaching nothing twice.
+    const withReviewsOnly = parseLesson(
+      `---\nschema_version: 2\nid: ES-2\nchapter: 1\nsequence: 20\ntype: word\n` +
+        `headword: "x"\ngloss: x\nconcept_tag: GREETING-HELLO\nreviews_of: [ES-1]\n---\n\n` +
+        `# ES-2\n\n## Warm-up\n\nSay it.\n`,
+      "spanish",
+    );
+    const report = measureContinuity([
+      lesson({ id: "ES-1", chapter: 1, sequence: 10, introduces: ["A"] }),
+      withReviewsOnly,
+      ...filler(3, 4),
+    ]);
+    expect(report.summary.atomsNeverRevisited).toBe(1);
+  });
+});
+
+describe("forward references", () => {
+  it("catches a lesson using a word only a later lesson teaches", () => {
+    // A short word is trusted only inside emphasis, where the corpus marks target
+    // language. In plain English prose a three-letter match is as likely to be
+    // English as Spanish, so the length rule guards it — see the `once` test below.
+    const report = measureContinuity([
+      lesson({ id: "ES-1", chapter: 1, sequence: 10, headword: "beber", body: "Como **pan** y bebo." }),
+      lesson({ id: "ES-26-pan", chapter: 26, sequence: 20, headword: "el pan" }),
+    ]);
+    expect(report.forwardReferences).toHaveLength(1);
+    expect(report.forwardReferences[0]).toMatchObject({
+      lessonId: "ES-1",
+      word: "pan",
+      taughtBy: "ES-26-pan",
+    });
+  });
+
+  it("leaves a short word in plain English prose alone", () => {
+    // The other half of the same rule, stated as a test so it cannot drift: `pan`
+    // unmarked in an English sentence is not evidence of anything.
+    const report = measureContinuity([
+      lesson({ id: "ES-1", chapter: 1, sequence: 10, body: "Heat the pan on the stove." }),
+      lesson({ id: "ES-26-pan", chapter: 26, sequence: 20, headword: "el pan" }),
+    ]);
+    expect(report.forwardReferences).toHaveLength(0);
+  });
+
+  it("strips a leading article so 'el pan' matches bare 'pan'", () => {
+    // Headwords carry their article; bodies do not. Without this the corpus's real
+    // forward references — pan and agua, borrowed 74 lessons early — were invisible.
+    const report = measureContinuity([
+      lesson({ id: "ES-1", chapter: 1, sequence: 10, body: "bebo agua." }),
+      lesson({ id: "ES-26-agua", chapter: 26, sequence: 20, headword: "el agua" }),
+    ]);
+    expect(report.forwardReferences[0]?.word).toBe("agua");
+  });
+
+  it("splits a range headword on its dash", () => {
+    const report = measureContinuity([
+      lesson({ id: "ES-1", chapter: 1, sequence: 10, body: "Tengo diecinueve." }),
+      lesson({ id: "ES-31", chapter: 31, sequence: 20, headword: "dieciséis — diecinueve" }),
+    ]);
+    expect(report.forwardReferences[0]?.word).toBe("diecinueve");
+  });
+
+  it("does not report a word the lesson itself teaches", () => {
+    const report = measureContinuity([
+      lesson({ id: "ES-1", chapter: 1, sequence: 10, headword: "pan", body: "El pan." }),
+      lesson({ id: "ES-2", chapter: 2, sequence: 20, headword: "pan" }),
+    ]);
+    expect(report.forwardReferences).toHaveLength(0);
+  });
+
+  it("ignores English words that collide with target vocabulary", () => {
+    // Spanish `once` is eleven; English `once` is an adverb that appears constantly.
+    // It was the single worst false positive in the first census, at 18 hits.
+    const report = measureContinuity([
+      lesson({ id: "ES-1", chapter: 1, sequence: 10, body: "Say it once, then again." }),
+      lesson({ id: "ES-31", chapter: 31, sequence: 20, headword: "once" }),
+    ]);
+    expect(report.forwardReferences).toHaveLength(0);
+  });
+
+  it("ignores a single-character headword from a writing lesson", () => {
+    // A writing lesson teaching one letter would otherwise match in every lesson of
+    // that script — five scripts' worth of false positives in the first census.
+    const report = measureContinuity([
+      lesson({ id: "ES-1", chapter: 1, sequence: 10, body: "The letter е appears here." }),
+      lesson({ id: "ES-W", chapter: 2, sequence: 20, headword: "е", type: "writing" }),
+    ]);
+    expect(report.forwardReferences).toHaveLength(0);
+  });
+
+  it("ignores pattern notation like e→ie", () => {
+    const report = measureContinuity([
+      lesson({ id: "ES-1", chapter: 1, sequence: 10, body: "The e→ie change." }),
+      lesson({ id: "ES-2", chapter: 2, sequence: 20, headword: "e→ie", type: "grammar" }),
+    ]);
+    expect(report.forwardReferences).toHaveLength(0);
+  });
+});
+
+describe("the real corpus", () => {
+  it("pins what nothing had measured", () => {
+    const { lessons } = loadEverything();
+    const report = measureContinuity(lessons);
+
+    // ORDER. Until this reaches zero every other number here is provisional: a ramp
+    // whose reading order is unknown cannot be verified at all.
+    expect(report.summary.lessonsWithoutSequence).toBe(565);
+    expect(report.summary.tracksWithUnorderedLessons).toBe(19);
+    expect(report.summary.forwardPrerequisites).toBe(271);
+
+    // 331 lessons claim to review material the learner has not reached yet.
+    expect(report.summary.forwardReviews).toBe(331);
+
+    // REINFORCEMENT. The founding promise is that the course "constantly
+    // re-emphasizes what was learnt previously". Half of it is taught once.
+    expect(report.summary.atomsTaught).toBe(1469);
+    expect(report.summary.atomsNeverRevisited).toBe(746);
+    expect(report.summary.neverRevisitedPercent).toBe(51);
+
+    expect(report.summary.forwardReferences).toBe(509);
+  });
+
+  it("reproduces the Spanish audit exactly", () => {
+    // These four numbers were measured independently in Python before this module
+    // existed. They agreeing is the evidence that the walk is the right one.
+    const { lessons } = loadEverything();
+    const spanish = measureContinuity(lessons).tracks.find((t) => t.language === "spanish");
+    expect(spanish).toMatchObject({
+      lessonCount: 146,
+      lessonsWithoutSequence: 56,
+      forwardPrerequisites: 31,
+      atomsTaught: 182,
+      atomsNeverRevisited: 93,
+    });
+  });
+
+  it("finds the forward references a human reviewer found by reading", () => {
+    const { lessons } = loadEverything();
+    const found = measureContinuity(lessons).forwardReferences;
+    const of = (word: string) => found.find((f) => f.language === "spanish" && f.word === word);
+
+    // "Como pan y bebo agua" — in chapter 7. Both words are chapter 26.
+    expect(of("pan")).toMatchObject({ lessonId: "ES-C07-beber", taughtBy: "ES-C26-pan" });
+    expect(of("agua")).toMatchObject({ lessonId: "ES-C07-beber", taughtBy: "ES-C26-agua" });
+    // A chapter that taught 1-10 drilling a chapter-31 number.
+    expect(of("diecinueve")?.lessonId).toBe("ES-C08-practice");
+  });
+
+  it("keeps the windows expanding, which is the whole point", () => {
+    let previous = 0;
+    for (const window of REINFORCEMENT_WINDOWS) {
+      expect(window.from).toBeGreaterThan(previous);
+      expect(window.to).toBeGreaterThan(window.from);
+      previous = window.to;
+    }
+  });
+});


### PR DESCRIPTION
The ramp budgets measure how big each **step** is. Nothing measured whether the steps hold together — and reading Spanish chapters 1–8 showed that's where the course actually fails.

> A gentle ramp is not made of small steps; it's made of steps you can still stand on.

## What it publishes

```
order: 565 lessons with no declared sequence across 19 tracks;
       271 prerequisites and 331 reviews pointing forward
reinforcement: 746 of 1469 atoms never revisited (51%);
       missed windows R1 745, R2 1068, R3 649, R4 132
forward references: 509 uses of material a later lesson teaches
```

## Order comes first — everything else is conditional on it

**565 lessons carry no `sequence`**, so their reading order exists only inside hand-typed LaTeX (Spanish 56/146, French **64/73**). A ramp whose order is unknown cannot be verified at all.

**You cannot review a lesson that has not happened yet — and 331 do.** A forward `reviews_of` can't close a reinforcement window (it names lessons, not atoms), but it's still an authored claim about order, and a forward claim is wrong on its own terms. `ES-C07-beber` reviews `ES-C07-vivir`, which `curriculum.json` places *after* it.

## Reinforcement: the founding promise, measured

The course claims to "constantly re-emphasize what was learnt previously." **Half of it is taught once.**

HL00 specified the schedule (N+1, N+3, N+7, N+15), defined a `review` lesson type to carry it, and named `session-map.md` as the artifact that verifies it. The corpus has **zero** `review` lessons and a session map covering **3 chapters of 33**. The schedule was specified and never built.

The measurement reads `practises.knowledge`, **never `reviews_of`** — which 144 of Spanish's 146 lessons set, and which cannot close a window because it names *lesson ids* while atoms live in another namespace. Measuring that field would report a corpus that reinforces beautifully and teaches nothing twice.

Windows are judged **only where the track is long enough to contain them** — a 25-lesson track missing R4 hasn't failed, it hasn't got there yet.

## Forward references are proved, not guessed

A word is reported only when a **later lesson's own headword** teaches it, so each finding carries its own evidence and cannot false-positive on English prose. It reproduces what a human reviewer found by reading:

- `ES-C07-beber` rewards the learner with *"Como pan y bebo agua"* — **`pan` and `agua` are chapter 26**
- `ES-C08-practice` drills `diecinueve` in a chapter that taught 1–10

### Three false-positive classes, found by censusing rather than guessing

Each is excluded **on principle**, not by list:

| class | example | why it broke |
|---|---|---|
| single-character headwords from `writing` lessons | Cyrillic `е`, Devanagari `ा` | matched in **every** lesson of its script — five scripts' worth |
| pattern notation | `e→ie`, `o→ue` | a description of a rule, not a word |
| English collisions | `once` | 18 hits from the English adverb |

Only `word`/`phrase` lessons create a matcher at all. An earlier *guess* that `pan` was English cookware killed a real finding — which is why the list is now censused.

### Blind spots, named

A word the course **never** teaches anywhere is invisible (chapter 7's `¿Algo más?`, its untaught `un`/`una`). Hyphenated headwords split on the hyphen. The plain-prose floor counts UTF-16 units, so 2-char CJK is emphasis-only. **Every one makes 509 a floor, never an overstatement.**

Report-only, per the HL05 precedent: the debt predates the measurement.

## Security review

No blocking issues — regex construction is fully literal (no ReDoS from a crafted headword), every data-controlled key is a `Map`, `declaredSequence` handles `sequence: 0` correctly, and the window gate is not off-by-one. Three cheap improvements found and applied:

1. the collision guard now runs **before** the regex is built (it was constructing then discarding)
2. `missedByWindow` is seeded **from** the window list, so adding an R5 can't silently drop a column from the rendered table
3. blind spots documented in the module header

## Verification

- **368 tests pass**; coverage **94.7%** overall, `continuity.ts` at **99%**.
- The corpus pins reproduce an **independent Python audit exactly** — Spanish 56 unordered, 31 forward prerequisites, 182 atoms, 93 never revisited. That agreement is the evidence the walk is the right one.
- `readingOrder`/`frontmatterList`/`introducedAtoms` are now shared from `ramp.ts`: two orderings that drifted apart would make the two reports disagree about which lesson comes first, silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)