### PR TITLE
fix(ci): raise the gap-report test timeout, which HL09 pushed past 5s

### DIFF
--- a/code/packages/typescript/human-language-data/tests/cli.test.ts
+++ b/code/packages/typescript/human-language-data/tests/cli.test.ts
@@ -17,7 +17,12 @@ describe("runValidate", () => {
 });
 
 describe("runCurriculumGapReport", () => {
-  it("prints JSON or text reports for the real curriculum", () => {
+  // 20s, not the 5s default: this builds the WHOLE gap report twice, and since
+  // HL09 that includes the continuity walk (~900ms per build on the real corpus,
+  // more on a cold runner). The cost is real and deliberate — order, reinforcement
+  // and forward references are properties of every lesson, so the walk cannot be
+  // input-gated the way `ramp` and `levels` are.
+  it("prints JSON or text reports for the real curriculum", { timeout: 20_000 }, () => {
     const out = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     try {
       expect(runCurriculumGapReport(["--format", "json"])).toBe(0);


### PR DESCRIPTION
One-line fix for a latent flake I merged in #10042.

## What happened

`buildCurriculumGapReport` calls `measureContinuity` **unconditionally**, unlike `ramp`, `levels` and `chapterGates` which are input-gated. That's deliberate — order, reinforcement and forward references are properties of every lesson, not of a policy the caller may omit — but it adds **~900ms per report build**, and this test builds the whole report twice (JSON, then text).

It timed out at the 5s default on #10042's **push-context** run. That run is *not* a required check, so auto-merge fired on the pull_request-context `CI gate`, which had passed on a faster runner — and the fix I pushed **raced the squash-merge and missed it**.

So main currently carries a test that passes or fails on runner speed. This fixes that.

## The optimisation I did not ship

I tried to buy the time back rather than raise the limit: replacing the `O(lessons × headwords)` regex scan in `continuity.ts` with a tokenise-once hash lookup. It ran **760ms against 911ms** — and changed the answer: **507 forward references against 509**.

Two findings vanished with no explanation I could give. A 150ms saving is not worth an unexplained change to a number the report exists to publish, so it is not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)