### PR TITLE
docs(semantic-ir-to-{c,go,rust,javascript}): cite SIR25 §2 as dispatch authority, not "matches Ruby"

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.36.5 — doc-comment reframing: SIR25 §2 is the dispatch authority, not "matches Ruby"
+
+Documentation-only, no behavior change. Per `SIR25-language-agnostic-
+object-model.md`'s §6 (which explicitly tracks this as its own follow-up),
+this backend's OOP-dispatch-mechanism doc-comments — method-resolution
+precedence (`_sir_resolve_method`) and default no-op construction
+(`_sir_call_new`) — now cite SIR25 §2.1/§2.2 as the authority, keeping
+"matching Ruby's ..." as a parenthetical (still true, still useful context:
+this dispatch model happens to coincide with Ruby's today, it just isn't
+*defined as* "whatever Ruby does"). Per-method Collections-catalog
+doc-comments ("matching Ruby's `Array#fetch`", etc.) are deliberately left
+untouched — SIR25 §3 explicitly designates that framing as legitimate
+naming provenance, not structural coupling.
+
 ## 0.36.4 — string interpolation (`"a#{x}b"`)
 
 Filed as its own backlog item ("C backend: support string interpolation").

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.36.4"
+version = "0.36.5"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -1360,7 +1360,8 @@ void _sir_register_extend(const char *cls, const char *module) {
 
 /* Resolve `method` for an INSTANCE of `cls`: walk the ancestry, and at each class
  * check the class's own methods THEN its included modules' methods (most-recently
- * included first, matching Ruby's precedence).  Bounded by SIR_ANCESTRY_MAX. */
+ * included first, per SIR25 §2.2/§2.4's precedence — matching Ruby's).
+ * Bounded by SIR_ANCESTRY_MAX. */
 static SirValue _sir_resolve_method(const char *cls, const char *method) {
     const char *cur = cls;
     int steps = 0;
@@ -1425,7 +1426,8 @@ SirValue _sir_call_method(SirValue recv, const char *method, int argc, ...) {
  * the Go/Rust/Ruby backends, which have always run `initialize` here).  Self
  * is restored afterward, same save/restore as `_sir_call_method`.  The object
  * is always returned, even with no `initialize` registered — a plain
- * allocation, matching Ruby's default no-op `Object#initialize`. */
+ * allocation, per SIR25 §2.1's no-op-default construction (matching Ruby's
+ * default `Object#initialize`). */
 SirValue _sir_call_new(const char *cls, int argc, ...) {
     va_list ap;
     SirValue *args, obj, fn;

--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.37.2 — doc-comment reframing: SIR25 §2 is the dispatch authority, not "matches Ruby"
+
+Documentation-only, no behavior change. Per `SIR25-language-agnostic-
+object-model.md`'s §6 (which explicitly tracks this as its own follow-up),
+this backend's OOP-dispatch-mechanism doc-comments — the `Feature::Modules`
+manifest note, mixin/ancestry transitivity, and `extend`'s singleton-first
+precedence — now cite SIR25 §2.2/§2.4 as the authority, keeping "matching
+Ruby's ..." as a parenthetical (still true, still useful context: this
+dispatch model happens to coincide with Ruby's today, it just isn't
+*defined as* "whatever Ruby does"). Per-method Collections-catalog
+doc-comments are deliberately left untouched — SIR25 §3 explicitly
+designates that framing as legitimate naming provenance, not structural
+coupling.
+
 ## 0.37.1 — `<<` (Ruby's shift operator) as a top-level builtin
 
 Part of "Python/JS/Go/Rust/Ruby backends: implement `<<` runtime

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.37.1"
+version = "0.37.2"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/lib.rs
@@ -164,8 +164,10 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // module name); `include M` / `extend M` lower to the `__include__` /
     // `__extend__` builtins, whose owner/module NAMES ride in as `StrLit`s
     // (never a `Const`), so the runtime side stays a pure NAME-keyed map
-    // operation — NEVER reflection.  Method resolution follows Ruby's MRO
-    // (class → its included modules in reverse → superclass → …), cycle-guarded
+    // operation — NEVER reflection.  Method resolution follows SIR25 §2.2/§2.4's
+    // MRO-based order (class → its included modules in reverse → superclass →
+    // …, SIR's own dispatch semantics — happens to match Ruby's, not defined
+    // as "whatever Ruby does"), cycle-guarded
     // (see `runtime::RUNTIME` — `_sir_included_modules`,
     // `_sir_resolve_instance_method`, `_sir_extend`, `_sir_call_class_method`).
     // A `ModuleDef` body reaching emit is now hosted (not rejected); the

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -4286,8 +4286,9 @@ func _sir_value_is_a(recv Value, actual string, target string) bool {
 }
 
 // Does `owner` reach `target` through the modules mixed into it or into any of
-// its ancestors?  Ruby's MRO is TRANSITIVE — `class C; include M; end` where
-// `module M; include N; end` makes `c.is_a?(N)` true.
+// its ancestors?  SIR25 §2.4's mixin resolution is TRANSITIVE (matching
+// Ruby's MRO) — `class C; include M; end` where `module M; include N; end`
+// makes `c.is_a?(N)` true.
 //
 // Deliberately ITERATIVE (an explicit worklist, not recursion): include-graph
 // depth is shaped by the source, so a recursive walk could exhaust the stack on
@@ -4454,12 +4455,13 @@ func _sir_include(owner string, module string) Value {
 // SNAPSHOT `M`'s registered instance methods (including those `M` itself
 // includes, via the same MRO walk used for instances) and copy each into
 // `Owner`'s class-method table.  An entry `Owner` already defines is NOT
-// overwritten (a class/own method shadows an extended module method), matching
-// Ruby's singleton-first precedence.  Copy-at-extend-time is the v0 model:
-// methods defined on `M` AFTER the `extend` are not retroactively added, which
-// is sufficient because the frontend emits every `__def_method__` for `M`
-// before any `__extend__` that names it (registrations run in source order,
-// module def before the including class).
+// overwritten (a class/own method shadows an extended module method), per
+// SIR25 §2.4's singleton-first precedence (matching Ruby's).
+// Copy-at-extend-time is the v0 model: methods defined on `M` AFTER the
+// `extend` are not retroactively added, which is sufficient because the
+// frontend emits every `__def_method__` for `M` before any `__extend__`
+// that names it (registrations run in source order, module def before the
+// including class).
 func _sir_extend(owner string, module string) Value {
 	for _, name := range _sir_module_method_names(module) {
 		key := _sir_method_key(owner, name)
@@ -4508,7 +4510,8 @@ func _sir_module_method_names(module string) []string {
 	return names
 }
 
-// Resolve `method` on `cls` following Ruby's MRO (Method Resolution Order):
+// Resolve `method` on `cls` following SIR25 §2.2's MRO (Method Resolution
+// Order — matching Ruby's, SIR's own dispatch semantics per SIR25):
 //
 //	cls  →  cls's included modules (REVERSE / most-recent-first)  →
 //	cls's superclass  →  its included modules  →  …  →  Object

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.51.8 — doc-comment reframing: SIR25 §2 is the dispatch authority, not "matches Ruby"
+
+Documentation-only, no behavior change. Per `SIR25-language-agnostic-
+object-model.md`'s §6 (which explicitly tracks this as its own follow-up),
+this backend's OOP-dispatch-mechanism doc-comments — the `Feature::Modules`
+manifest note, mixin/ancestry transitivity, and `super`'s live-receiver
+resolution — now cite SIR25 §2.2/§2.3/§2.4 as the authority, keeping
+"matching Ruby's ..." as a parenthetical (still true, still useful context:
+this dispatch model happens to coincide with Ruby's today, it just isn't
+*defined as* "whatever Ruby does"). Per-method Collections-catalog
+doc-comments are deliberately left untouched — SIR25 §3 explicitly
+designates that framing as legitimate naming provenance, not structural
+coupling.
+
 ## 0.51.7 — `<<` (Ruby's shift operator) as a top-level builtin
 
 Part of "JS/TS backend: implement shift-operator runtime dispatch".

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.51.7"
+version = "0.51.8"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
@@ -189,8 +189,9 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // (keyed by the module name via `__def_method__`), and `include M` /
     // `extend M` lower to `__include__("Owner","M")` / `__extend__(…)` — the
     // frontend triggers `Feature::Modules` for all three.  The inlined OOP
-    // runtime's method-resolution walk now follows Ruby's MRO (class →
-    // included modules, most-recent-first → superclass → …), and `extend`
+    // runtime's method-resolution walk now follows SIR25 §2.2/§2.4's
+    // MRO-based order (matching Ruby's — class → included modules,
+    // most-recent-first → superclass → …), and `extend`
     // registers a module's methods as class ("singleton") methods, so a
     // mixed-in method is found on an including class's instances (`include`)
     // or on the class itself (`extend`).  See `emit`'s `__include__` /

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -2312,9 +2312,10 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     return false;
   }
   // Does `owner` (a class) reach `target` through the modules mixed into it
-  // or into any of its ancestors?  Ruby's MRO is TRANSITIVE — `class C;
-  // include M; end` where `module M; include N; end` makes `c.is_a?(N)` true
-  // — so the module graph must be searched, not just scanned one level.
+  // or into any of its ancestors?  SIR25 §2.4's mixin resolution is
+  // TRANSITIVE (matching Ruby's MRO) — `class C; include M; end` where
+  // `module M; include N; end` makes `c.is_a?(N)` true — so the module graph
+  // must be searched, not just scanned one level.
   //
   // Deliberately ITERATIVE (an explicit worklist, not recursion): the graph's
   // depth is attacker-shaped by the source, and a recursive walk over a long
@@ -2943,7 +2944,8 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
   // `callSuper("method", "cls", args…)`.  Resolve `method` starting from
   // the SUPERCLASS of `cls` (skipping the current definition) and apply
   // it with the CURRENT `self` still bound — `super` reuses the live
-  // receiver.  A missing super method is a NoMethodError, matching Ruby.
+  // receiver (SIR25 §2.3).  A missing super method is a NoMethodError,
+  // matching Ruby.
   function callSuper(method, cls, ...args) {
     const fn = resolveMethod(methodTable, ancestry[cls], method, includedModules);
     if (fn === undefined) {

--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.39.4 — doc-comment reframing: SIR25 §2 is the dispatch authority, not "matches Ruby"
+
+Documentation-only, no behavior change. Per `SIR25-language-agnostic-
+object-model.md`'s §6 (which explicitly tracks this as its own follow-up),
+this backend's OOP-dispatch-mechanism doc-comments — mixin/ancestry
+transitivity, `extend`'s singleton-first precedence, `resolve_class_method`/
+`resolve_instance_method`'s MRO walk, and the built-in-vs-user-defined
+`send`/`tap` precedence rule — now cite SIR25 §2.2/§2.4 as the authority,
+keeping "matching Ruby's ..." as a parenthetical (still true, still useful
+context: this dispatch model happens to coincide with Ruby's today, it just
+isn't *defined as* "whatever Ruby does"). Per-method Collections-catalog
+doc-comments are deliberately left untouched — SIR25 §3 explicitly
+designates that framing as legitimate naming provenance, not structural
+coupling.
+
 ## 0.39.3 — `<<` (Ruby's shift operator) as a top-level builtin
 
 Part of "Python/JS/Rust/Ruby backends: implement shift-operator runtime

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.39.3"
+version = "0.39.4"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -1518,7 +1518,8 @@ pub const RUNTIME: &str = r##"mod __sir {
         // is inert data that can only ever select an ARM we spelled out.
         //
         // A user-defined `send`/`tap`/etc. must win over the universal one
-        // (Ruby's resolution order), so for a `Value::Instance` receiver we
+        // (SIR25 §2.2's resolution order, matching Ruby's), so for a
+        // `Value::Instance` receiver we
         // check the user method table FIRST (below); only a genuine miss
         // reaches these universal Kernel methods, via `object_method`.
         //
@@ -1724,8 +1725,9 @@ pub const RUNTIME: &str = r##"mod __sir {
     }
 
     // Does `owner` reach `target` through the modules mixed into it or into any
-    // of its ancestors?  Ruby's MRO is TRANSITIVE — `class C; include M; end`
-    // where `module M; include N; end` makes `c.is_a?(N)` true.
+    // of its ancestors?  SIR25 §2.4's mixin resolution is TRANSITIVE (matching
+    // Ruby's MRO) — `class C; include M; end` where `module M; include N; end`
+    // makes `c.is_a?(N)` true.
     //
     // Deliberately ITERATIVE (an explicit worklist, not recursion): include-graph
     // depth is shaped by the source, so a recursive walk could exhaust the stack
@@ -4359,13 +4361,15 @@ pub const RUNTIME: &str = r##"mod __sir {
         // ── MX6 mixins: per-owner included-module list ────────────────
         //
         // `include M` (in class/module `Owner`) records `M` on `Owner`'s
-        // list, in SOURCE (include) order.  Ruby's MRO searches the
-        // MOST-RECENTLY-included module first, so the resolution walk
-        // iterates this list in REVERSE (see `resolve_instance_method`).
+        // list, in SOURCE (include) order.  SIR25 §2.4's MRO (matching
+        // Ruby's) searches the MOST-RECENTLY-included module first, so the
+        // resolution walk iterates this list in REVERSE (see
+        // `resolve_instance_method`).
         //
         // An owner is a class OR a module NAME — a module that itself
         // `include`s another module has its own entry here, so the MRO walk
-        // recursing into it honours Ruby's transitive mixin inclusion.
+        // recursing into it honours the transitive mixin inclusion SIR25
+        // §2.4 specifies (matching Ruby's).
         //
         // SECURITY: a plain `HashMap<String, Vec<String>>` keyed by
         // source-derived NAMES — no reflection (the C3 RCE discipline).  The
@@ -4450,7 +4454,8 @@ pub const RUNTIME: &str = r##"mod __sir {
     /// itself includes, via the same MRO walk instances use) and copy each
     /// into `Owner`'s class-method table.  An entry `Owner` ALREADY defines
     /// is NOT overwritten — a class's own `def self.m` shadows an extended
-    /// module method, matching Ruby's singleton-first precedence.
+    /// module method, per SIR25 §2.4's singleton-first precedence (matching
+    /// Ruby's).
     ///
     /// Copy-at-extend-time is the v0 model: methods defined on `M` AFTER the
     /// `extend` are not retroactively added, which is sufficient because the
@@ -4505,7 +4510,8 @@ pub const RUNTIME: &str = r##"mod __sir {
         names
     }
 
-    /// Resolve instance method `name` on `cls` following Ruby's MRO:
+    /// Resolve instance method `name` on `cls` following SIR25 §2.2's MRO
+    /// (matching Ruby's, SIR's own dispatch semantics per SIR25):
     ///
     /// ```text
     ///   cls  →  cls's included modules (REVERSE / most-recent-first)  →


### PR DESCRIPTION
## Summary
- Slice 5 of the SIR25 arc (making SIR's OOP surface genuinely language-agnostic, not Ruby-shaped) — the final planned slice.
- Mechanical, comment-only pass: OOP dispatch-mechanism doc-comments ("Method resolution follows Ruby's MRO", mixin/ancestry transitivity, singleton-first `extend` precedence, `super`'s live-receiver resolution) in `semantic-ir-to-{c,go,rust,javascript}` now cite `SIR25 §2.2/§2.3/§2.4` as the authority, keeping "matching Ruby's ..." as parenthetical context rather than the stated source of correctness.
- `python-to-semantic-ir` and `semantic-ir-to-typescript` had no matching doc-comments needing change.
- Deliberately leaves the Collections built-in method catalog's per-method "matching Ruby" comments (`Array#fetch`, `Hash#select`, `gsub`, etc.) untouched — SIR25 §3 explicitly designates that framing as legitimate naming provenance, not structural coupling.
- No behavior change — every edit is inside a comment (including comment lines within embedded runtime-template raw strings).

## Test plan
- [x] `cargo test -p semantic-ir-to-c -p semantic-ir-to-go -p semantic-ir-to-rust -p semantic-ir-to-javascript` — full suite green
- [x] `cargo clippy ... --all-targets` — clean
- [x] Security review — passed (confirmed every changed line is a comment, no executable code touched)
- [x] CHANGELOG + version bump per crate (all patch bumps: doc-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)