### PR TITLE
feat(human-languages): give Spanish a declared reading order (HL09 step 2)

### DIFF
--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -4842,43 +4842,43 @@
     {
       "language": "spanish",
       "chapter": 8,
-      "sourceHash": "fnv1a64:aa8faca659cd6608",
+      "sourceHash": "fnv1a64:f96b7bbd0ab4daba",
       "lessonIds": [
-        "ES-C08-cuantos-anos",
         "ES-C08-numeros-1-5",
         "ES-C08-numeros-6-10",
-        "ES-C08-practice",
-        "ES-C08-tener"
+        "ES-C08-tener",
+        "ES-C08-cuantos-anos",
+        "ES-C08-practice"
       ],
       "voiceLessons": 5,
       "drivablePrefix": 5,
       "text": "spanish/narration/ch08.txt",
       "json": "spanish/narration/ch08.json",
-      "textHash": "fnv1a64:be7d633db66f8b7b",
-      "jsonHash": "fnv1a64:db44f9bd66e0e88f"
+      "textHash": "fnv1a64:ece3418c7e272d33",
+      "jsonHash": "fnv1a64:e40b9465d8e7e51a"
     },
     {
       "language": "spanish",
       "chapter": 9,
-      "sourceHash": "fnv1a64:0f128ec69fedf560",
+      "sourceHash": "fnv1a64:a145296a95911d1d",
       "lessonIds": [
-        "ES-C09-esta-en",
-        "ES-C09-practice",
         "ES-C09-ser",
         "ES-C09-ser-vs-estar",
-        "ES-C09-soy-de"
+        "ES-C09-soy-de",
+        "ES-C09-esta-en",
+        "ES-C09-practice"
       ],
       "voiceLessons": 2,
-      "drivablePrefix": 0,
+      "drivablePrefix": 1,
       "text": "spanish/narration/ch09.txt",
       "json": "spanish/narration/ch09.json",
-      "textHash": "fnv1a64:bae5d6bfbfc8ab11",
-      "jsonHash": "fnv1a64:91d70285361fc947"
+      "textHash": "fnv1a64:04f0dba79a2d6484",
+      "jsonHash": "fnv1a64:9a960078fc7671da"
     },
     {
       "language": "spanish",
       "chapter": 10,
-      "sourceHash": "fnv1a64:60c303e5299f5fd7",
+      "sourceHash": "fnv1a64:3341e73c1c7419bf",
       "lessonIds": [
         "ES-C10-ir",
         "ES-C10-ir-a-futuro",
@@ -4890,147 +4890,147 @@
       "text": "spanish/narration/ch10.txt",
       "json": "spanish/narration/ch10.json",
       "textHash": "fnv1a64:ce35d1302b956038",
-      "jsonHash": "fnv1a64:2397b740bf0e5019"
+      "jsonHash": "fnv1a64:2bd9acfb02103a58"
     },
     {
       "language": "spanish",
       "chapter": 11,
-      "sourceHash": "fnv1a64:a4622dd6cae2c8a2",
+      "sourceHash": "fnv1a64:1845998478b152fa",
       "lessonIds": [
-        "ES-C11-nuestro",
-        "ES-C11-poder",
-        "ES-C11-practice",
         "ES-C11-querer",
-        "ES-C11-stem-changes"
+        "ES-C11-poder",
+        "ES-C11-stem-changes",
+        "ES-C11-nuestro",
+        "ES-C11-practice"
       ],
       "voiceLessons": 5,
       "drivablePrefix": 5,
       "text": "spanish/narration/ch11.txt",
       "json": "spanish/narration/ch11.json",
-      "textHash": "fnv1a64:bebb54974da7c797",
-      "jsonHash": "fnv1a64:3b2d9bbfe4d51fa7"
+      "textHash": "fnv1a64:75272d4b7e853a6d",
+      "jsonHash": "fnv1a64:363daed3a2daef7f"
     },
     {
       "language": "spanish",
       "chapter": 12,
-      "sourceHash": "fnv1a64:5f72f74488786bf2",
+      "sourceHash": "fnv1a64:1e748551bb813072",
       "lessonIds": [
-        "ES-C12-decir",
         "ES-C12-hacer",
-        "ES-C12-practice",
-        "ES-C12-yo-go"
+        "ES-C12-decir",
+        "ES-C12-yo-go",
+        "ES-C12-practice"
       ],
       "voiceLessons": 3,
-      "drivablePrefix": 3,
+      "drivablePrefix": 2,
       "text": "spanish/narration/ch12.txt",
       "json": "spanish/narration/ch12.json",
-      "textHash": "fnv1a64:be5bb25c4cc3e165",
-      "jsonHash": "fnv1a64:1bc44c1620735de7"
+      "textHash": "fnv1a64:a5d51f2b6d65e588",
+      "jsonHash": "fnv1a64:08762128a4a2f721"
     },
     {
       "language": "spanish",
       "chapter": 13,
-      "sourceHash": "fnv1a64:fd74e6b6faccb060",
+      "sourceHash": "fnv1a64:a4e20b412d6537ba",
       "lessonIds": [
         "ES-C13-poner",
-        "ES-C13-practice",
         "ES-C13-salir",
-        "ES-C13-venir"
+        "ES-C13-venir",
+        "ES-C13-practice"
       ],
       "voiceLessons": 2,
       "drivablePrefix": 0,
       "text": "spanish/narration/ch13.txt",
       "json": "spanish/narration/ch13.json",
-      "textHash": "fnv1a64:c8554fd2563bf43c",
-      "jsonHash": "fnv1a64:f5505e86dabb2117"
+      "textHash": "fnv1a64:06cdf215fd3994c6",
+      "jsonHash": "fnv1a64:0f3fd7134e6b7b0d"
     },
     {
       "language": "spanish",
       "chapter": 14,
-      "sourceHash": "fnv1a64:6bfd206207773458",
+      "sourceHash": "fnv1a64:7b5d1287654f2e62",
       "lessonIds": [
+        "ES-C14-ser-ir-preterite",
         "ES-C14-hablar-preterite",
-        "ES-C14-practice",
-        "ES-C14-ser-ir-preterite"
+        "ES-C14-practice"
       ],
       "voiceLessons": 3,
       "drivablePrefix": 3,
       "text": "spanish/narration/ch14.txt",
       "json": "spanish/narration/ch14.json",
-      "textHash": "fnv1a64:a0479bd837260365",
-      "jsonHash": "fnv1a64:fb7a7285f303d359"
+      "textHash": "fnv1a64:fb0503a6309245f7",
+      "jsonHash": "fnv1a64:776aab14f68423ae"
     },
     {
       "language": "spanish",
       "chapter": 15,
-      "sourceHash": "fnv1a64:8749ab0a4a2c672b",
+      "sourceHash": "fnv1a64:bf95b4776eb920c1",
       "lessonIds": [
         "ES-C15-comer-vivir-preterite",
-        "ES-C15-practice",
-        "ES-C15-preterite-fuertes"
+        "ES-C15-preterite-fuertes",
+        "ES-C15-practice"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 1,
       "text": "spanish/narration/ch15.txt",
       "json": "spanish/narration/ch15.json",
-      "textHash": "fnv1a64:7e966494ead5a7d7",
-      "jsonHash": "fnv1a64:07ee2619f00286f0"
+      "textHash": "fnv1a64:5cb5f5dcfab199e1",
+      "jsonHash": "fnv1a64:323b69f022616375"
     },
     {
       "language": "spanish",
       "chapter": 16,
-      "sourceHash": "fnv1a64:afadfe166aa49a8a",
+      "sourceHash": "fnv1a64:30eaac9352ed3655",
       "lessonIds": [
         "ES-C16-imperfecto",
-        "ES-C16-practice",
-        "ES-C16-tres-irregulares"
+        "ES-C16-tres-irregulares",
+        "ES-C16-practice"
       ],
       "voiceLessons": 2,
-      "drivablePrefix": 2,
+      "drivablePrefix": 1,
       "text": "spanish/narration/ch16.txt",
       "json": "spanish/narration/ch16.json",
-      "textHash": "fnv1a64:b058287fa32b5343",
-      "jsonHash": "fnv1a64:9859048070e1aac3"
+      "textHash": "fnv1a64:1aff743d44d8e988",
+      "jsonHash": "fnv1a64:8dc5202beae56582"
     },
     {
       "language": "spanish",
       "chapter": 17,
-      "sourceHash": "fnv1a64:f2cd4347daa28b7a",
+      "sourceHash": "fnv1a64:e4705d94e1f467da",
       "lessonIds": [
-        "ES-C17-condicional",
-        "ES-C17-future-guessing",
         "ES-C17-futuro",
-        "ES-C17-practice"
+        "ES-C17-condicional",
+        "ES-C17-practice",
+        "ES-C17-future-guessing"
       ],
       "voiceLessons": 3,
-      "drivablePrefix": 3,
+      "drivablePrefix": 2,
       "text": "spanish/narration/ch17.txt",
       "json": "spanish/narration/ch17.json",
-      "textHash": "fnv1a64:674619165aa34aac",
-      "jsonHash": "fnv1a64:7b49fb2301376418"
+      "textHash": "fnv1a64:892ec53d74d0c99f",
+      "jsonHash": "fnv1a64:b59af381ba6f993c"
     },
     {
       "language": "spanish",
       "chapter": 18,
-      "sourceHash": "fnv1a64:4a7227413ea2a976",
+      "sourceHash": "fnv1a64:056b353dce315e5a",
       "lessonIds": [
+        "ES-C18-subjuntivo",
         "ES-C18-inherited-subjunctive-stems",
+        "ES-C18-subjunctive-outliers",
+        "ES-C18-subjunctive-name",
+        "ES-C18-quiero-que",
+        "ES-C18-wanting-clause-trap",
         "ES-C18-ojala",
         "ES-C18-practice",
-        "ES-C18-practice-mood",
         "ES-C18-practice-subjects",
-        "ES-C18-quiero-que",
-        "ES-C18-subjunctive-name",
-        "ES-C18-subjunctive-outliers",
-        "ES-C18-subjuntivo",
-        "ES-C18-wanting-clause-trap"
+        "ES-C18-practice-mood"
       ],
       "voiceLessons": 9,
-      "drivablePrefix": 8,
+      "drivablePrefix": 0,
       "text": "spanish/narration/ch18.txt",
       "json": "spanish/narration/ch18.json",
-      "textHash": "fnv1a64:26d9db5d53b50ec8",
-      "jsonHash": "fnv1a64:22d6e0003f2bc843"
+      "textHash": "fnv1a64:03ab81aeb4513484",
+      "jsonHash": "fnv1a64:487e60f44c9bb0fd"
     },
     {
       "language": "spanish",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:10bf9af0e3ac3dd0",
+  "sourceHash": "fnv1a64:e020e2e7328a86c1",
   "summary": {
     "totalLessons": 1225,
     "voice": 824,
@@ -17,7 +17,7 @@
     "drivablePercent": 67,
     "trackCount": 22,
     "chapterCount": 394,
-    "drivablePrefixTotal": 655,
+    "drivablePrefixTotal": 645,
     "fullyDrivableChapters": 270,
     "unstartableChapters": 90,
     "overriddenLessons": 0,
@@ -5143,7 +5143,7 @@
       "sight": 18,
       "pen": 7,
       "drivablePercent": 83,
-      "drivablePrefixTotal": 101,
+      "drivablePrefixTotal": 91,
       "modalities": [
         "voice",
         "sight",
@@ -5312,11 +5312,11 @@
           "firstNonVoiceLesson": null,
           "drivable": true,
           "drivableLessonIds": [
-            "ES-C08-cuantos-anos",
             "ES-C08-numeros-1-5",
             "ES-C08-numeros-6-10",
-            "ES-C08-practice",
-            "ES-C08-tener"
+            "ES-C08-tener",
+            "ES-C08-cuantos-anos",
+            "ES-C08-practice"
           ]
         },
         {
@@ -5329,10 +5329,12 @@
             "voice",
             "sight"
           ],
-          "drivablePrefix": 0,
-          "firstNonVoiceLesson": "ES-C09-esta-en",
+          "drivablePrefix": 1,
+          "firstNonVoiceLesson": "ES-C09-ser-vs-estar",
           "drivable": false,
-          "drivableLessonIds": []
+          "drivableLessonIds": [
+            "ES-C09-ser"
+          ]
         },
         {
           "chapter": 10,
@@ -5365,11 +5367,11 @@
           "firstNonVoiceLesson": null,
           "drivable": true,
           "drivableLessonIds": [
-            "ES-C11-nuestro",
-            "ES-C11-poder",
-            "ES-C11-practice",
             "ES-C11-querer",
-            "ES-C11-stem-changes"
+            "ES-C11-poder",
+            "ES-C11-stem-changes",
+            "ES-C11-nuestro",
+            "ES-C11-practice"
           ]
         },
         {
@@ -5382,13 +5384,12 @@
             "voice",
             "sight"
           ],
-          "drivablePrefix": 3,
+          "drivablePrefix": 2,
           "firstNonVoiceLesson": "ES-C12-yo-go",
           "drivable": false,
           "drivableLessonIds": [
-            "ES-C12-decir",
             "ES-C12-hacer",
-            "ES-C12-practice"
+            "ES-C12-decir"
           ]
         },
         {
@@ -5419,9 +5420,9 @@
           "firstNonVoiceLesson": null,
           "drivable": true,
           "drivableLessonIds": [
+            "ES-C14-ser-ir-preterite",
             "ES-C14-hablar-preterite",
-            "ES-C14-practice",
-            "ES-C14-ser-ir-preterite"
+            "ES-C14-practice"
           ]
         },
         {
@@ -5435,7 +5436,7 @@
             "sight"
           ],
           "drivablePrefix": 1,
-          "firstNonVoiceLesson": "ES-C15-practice",
+          "firstNonVoiceLesson": "ES-C15-preterite-fuertes",
           "drivable": false,
           "drivableLessonIds": [
             "ES-C15-comer-vivir-preterite"
@@ -5451,12 +5452,11 @@
             "voice",
             "sight"
           ],
-          "drivablePrefix": 2,
+          "drivablePrefix": 1,
           "firstNonVoiceLesson": "ES-C16-tres-irregulares",
           "drivable": false,
           "drivableLessonIds": [
-            "ES-C16-imperfecto",
-            "ES-C16-practice"
+            "ES-C16-imperfecto"
           ]
         },
         {
@@ -5469,13 +5469,12 @@
             "voice",
             "sight"
           ],
-          "drivablePrefix": 3,
+          "drivablePrefix": 2,
           "firstNonVoiceLesson": "ES-C17-practice",
           "drivable": false,
           "drivableLessonIds": [
-            "ES-C17-condicional",
-            "ES-C17-future-guessing",
-            "ES-C17-futuro"
+            "ES-C17-futuro",
+            "ES-C17-condicional"
           ]
         },
         {
@@ -5488,19 +5487,10 @@
             "voice",
             "sight"
           ],
-          "drivablePrefix": 8,
+          "drivablePrefix": 0,
           "firstNonVoiceLesson": "ES-C18-subjuntivo",
           "drivable": false,
-          "drivableLessonIds": [
-            "ES-C18-inherited-subjunctive-stems",
-            "ES-C18-ojala",
-            "ES-C18-practice",
-            "ES-C18-practice-mood",
-            "ES-C18-practice-subjects",
-            "ES-C18-quiero-que",
-            "ES-C18-subjunctive-name",
-            "ES-C18-subjunctive-outliers"
-          ]
+          "drivableLessonIds": []
         },
         {
           "chapter": 19,
@@ -19494,654 +19484,654 @@
       "sourceHash": "fnv1a64:1a9b0f692c3ce186"
     },
     {
-      "id": "ES-C08-cuantos-anos",
-      "language": "spanish",
-      "chapter": 8,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:66597346c145929f"
-    },
-    {
       "id": "ES-C08-numeros-1-5",
       "language": "spanish",
       "chapter": 8,
-      "sequence": null,
+      "sequence": 524,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:4aa6da54f52285e5"
+      "sourceHash": "fnv1a64:d0ad0f4bf00e9dd5"
     },
     {
       "id": "ES-C08-numeros-6-10",
       "language": "spanish",
       "chapter": 8,
-      "sequence": null,
+      "sequence": 526,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e992fae36b1dfcbf"
-    },
-    {
-      "id": "ES-C08-practice",
-      "language": "spanish",
-      "chapter": 8,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:f877552a7e8bd113"
+      "sourceHash": "fnv1a64:31bbfdae30ea5829"
     },
     {
       "id": "ES-C08-tener",
       "language": "spanish",
       "chapter": 8,
-      "sequence": null,
+      "sequence": 528,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:25fe3250fd9cbc5b"
+      "sourceHash": "fnv1a64:d7ac3ca77bc32f7f"
     },
     {
-      "id": "ES-C09-esta-en",
+      "id": "ES-C08-cuantos-anos",
       "language": "spanish",
-      "chapter": 9,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "chapter": 8,
+      "sequence": 530,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "sight-cue"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:4ef4d041e2fb8044"
+      "sourceHash": "fnv1a64:fcb5f16ab501160a"
     },
     {
-      "id": "ES-C09-practice",
+      "id": "ES-C08-practice",
       "language": "spanish",
-      "chapter": 9,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "chapter": 8,
+      "sequence": 532,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "sight-cue"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:8670e97fe19667a6"
+      "sourceHash": "fnv1a64:6c650d67ce5cb460"
     },
     {
       "id": "ES-C09-ser",
       "language": "spanish",
       "chapter": 9,
-      "sequence": null,
+      "sequence": 534,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:a82cd4ab00b99923"
+      "sourceHash": "fnv1a64:06810f2823517346"
     },
     {
       "id": "ES-C09-ser-vs-estar",
       "language": "spanish",
       "chapter": 9,
-      "sequence": null,
+      "sequence": 536,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
       "reasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:0b147a09ef97b4b9"
+      "sourceHash": "fnv1a64:2e697cd43b1008d8"
     },
     {
       "id": "ES-C09-soy-de",
       "language": "spanish",
       "chapter": 9,
-      "sequence": null,
+      "sequence": 538,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e104e762179e9172"
+      "sourceHash": "fnv1a64:9d827a379647bb01"
+    },
+    {
+      "id": "ES-C09-esta-en",
+      "language": "spanish",
+      "chapter": 9,
+      "sequence": 540,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "sight-cue"
+      ],
+      "sourceHash": "fnv1a64:c4741a1391c9dd4e"
+    },
+    {
+      "id": "ES-C09-practice",
+      "language": "spanish",
+      "chapter": 9,
+      "sequence": 542,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "sight-cue"
+      ],
+      "sourceHash": "fnv1a64:bb563dc466711e9c"
     },
     {
       "id": "ES-C10-ir",
       "language": "spanish",
       "chapter": 10,
-      "sequence": null,
+      "sequence": 544,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:8625b52e5ef33af5"
+      "sourceHash": "fnv1a64:a112992448d98155"
     },
     {
       "id": "ES-C10-ir-a-futuro",
       "language": "spanish",
       "chapter": 10,
-      "sequence": null,
+      "sequence": 546,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e4484f041a323695"
+      "sourceHash": "fnv1a64:593eb56d09a903d9"
     },
     {
       "id": "ES-C10-mi-tu-su",
       "language": "spanish",
       "chapter": 10,
-      "sequence": null,
+      "sequence": 548,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
       "reasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:6331a08eb76e60e3"
+      "sourceHash": "fnv1a64:9e0132e713e2e689"
     },
     {
       "id": "ES-C10-practice",
       "language": "spanish",
       "chapter": 10,
-      "sequence": null,
+      "sequence": 550,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:a9c77a572314fc48"
-    },
-    {
-      "id": "ES-C11-nuestro",
-      "language": "spanish",
-      "chapter": 11,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:e999d3414412ed9e"
-    },
-    {
-      "id": "ES-C11-poder",
-      "language": "spanish",
-      "chapter": 11,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:fc28c84739b62d76"
-    },
-    {
-      "id": "ES-C11-practice",
-      "language": "spanish",
-      "chapter": 11,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:7036de4d6ec16687"
+      "sourceHash": "fnv1a64:6e9314985eb5ba8d"
     },
     {
       "id": "ES-C11-querer",
       "language": "spanish",
       "chapter": 11,
-      "sequence": null,
+      "sequence": 552,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:36fd4b2201539f9f"
+      "sourceHash": "fnv1a64:5431d0644d171e4a"
+    },
+    {
+      "id": "ES-C11-poder",
+      "language": "spanish",
+      "chapter": 11,
+      "sequence": 554,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:2d66abfcc957b70d"
     },
     {
       "id": "ES-C11-stem-changes",
       "language": "spanish",
       "chapter": 11,
-      "sequence": null,
+      "sequence": 556,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5d977c3e12affbb0"
+      "sourceHash": "fnv1a64:c7b9e4b8437c58d5"
     },
     {
-      "id": "ES-C12-decir",
+      "id": "ES-C11-nuestro",
       "language": "spanish",
-      "chapter": 12,
-      "sequence": null,
+      "chapter": 11,
+      "sequence": 558,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:b70e553d669e1c90"
+      "sourceHash": "fnv1a64:7a0ac7c6de92c18d"
+    },
+    {
+      "id": "ES-C11-practice",
+      "language": "spanish",
+      "chapter": 11,
+      "sequence": 560,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:76a65b2d1bd68da7"
     },
     {
       "id": "ES-C12-hacer",
       "language": "spanish",
       "chapter": 12,
-      "sequence": null,
+      "sequence": 562,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:8af16bd2e1a9ced7"
+      "sourceHash": "fnv1a64:4eaa4375ddf5ddc9"
     },
     {
-      "id": "ES-C12-practice",
+      "id": "ES-C12-decir",
       "language": "spanish",
       "chapter": 12,
-      "sequence": null,
+      "sequence": 564,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:1004de0cf5190d97"
+      "sourceHash": "fnv1a64:72edb388d5667454"
     },
     {
       "id": "ES-C12-yo-go",
       "language": "spanish",
       "chapter": 12,
-      "sequence": null,
+      "sequence": 566,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
       "reasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:ca7f98d41616fea8"
+      "sourceHash": "fnv1a64:676f366bba630168"
+    },
+    {
+      "id": "ES-C12-practice",
+      "language": "spanish",
+      "chapter": 12,
+      "sequence": 568,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:5cd89031d88c7419"
     },
     {
       "id": "ES-C13-poner",
       "language": "spanish",
       "chapter": 13,
-      "sequence": null,
+      "sequence": 570,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
       "reasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:853daae9f3657b07"
-    },
-    {
-      "id": "ES-C13-practice",
-      "language": "spanish",
-      "chapter": 13,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "sight-cue"
-      ],
-      "sourceHash": "fnv1a64:d957576393e1d909"
+      "sourceHash": "fnv1a64:4a6d21b6e5842518"
     },
     {
       "id": "ES-C13-salir",
       "language": "spanish",
       "chapter": 13,
-      "sequence": null,
+      "sequence": 572,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:a12d1080b1f174d9"
+      "sourceHash": "fnv1a64:6e1368dae4cebfe2"
     },
     {
       "id": "ES-C13-venir",
       "language": "spanish",
       "chapter": 13,
-      "sequence": null,
+      "sequence": 574,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:43d46c297f5ac8ef"
+      "sourceHash": "fnv1a64:aabd87fb7c1c7eae"
     },
     {
-      "id": "ES-C14-hablar-preterite",
+      "id": "ES-C13-practice",
       "language": "spanish",
-      "chapter": 14,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "chapter": 13,
+      "sequence": 576,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "sight-cue"
       ],
-      "sourceHash": "fnv1a64:6b93bb30072baaa4"
-    },
-    {
-      "id": "ES-C14-practice",
-      "language": "spanish",
-      "chapter": 14,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:528631b16e43cd5c"
+      "sourceHash": "fnv1a64:c38441962b855240"
     },
     {
       "id": "ES-C14-ser-ir-preterite",
       "language": "spanish",
       "chapter": 14,
-      "sequence": null,
+      "sequence": 578,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e940d842f1a80dd8"
+      "sourceHash": "fnv1a64:5cb98853f54215d7"
+    },
+    {
+      "id": "ES-C14-hablar-preterite",
+      "language": "spanish",
+      "chapter": 14,
+      "sequence": 580,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:99d2ac9cf71ade02"
+    },
+    {
+      "id": "ES-C14-practice",
+      "language": "spanish",
+      "chapter": 14,
+      "sequence": 582,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:eefb1d965f836b28"
     },
     {
       "id": "ES-C15-comer-vivir-preterite",
       "language": "spanish",
       "chapter": 15,
-      "sequence": null,
+      "sequence": 584,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:16ca99df1a1c073e"
-    },
-    {
-      "id": "ES-C15-practice",
-      "language": "spanish",
-      "chapter": 15,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "wide-table"
-      ],
-      "sourceHash": "fnv1a64:f60f008428500914"
+      "sourceHash": "fnv1a64:c4492b031d93a760"
     },
     {
       "id": "ES-C15-preterite-fuertes",
       "language": "spanish",
       "chapter": 15,
-      "sequence": null,
+      "sequence": 586,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
       "reasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:51b0f34d77b634bd"
+      "sourceHash": "fnv1a64:1bf08f09f5512a0b"
+    },
+    {
+      "id": "ES-C15-practice",
+      "language": "spanish",
+      "chapter": 15,
+      "sequence": 588,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "wide-table"
+      ],
+      "sourceHash": "fnv1a64:84f421ddf990bd02"
     },
     {
       "id": "ES-C16-imperfecto",
       "language": "spanish",
       "chapter": 16,
-      "sequence": null,
+      "sequence": 590,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:b01d70df596dd3f8"
-    },
-    {
-      "id": "ES-C16-practice",
-      "language": "spanish",
-      "chapter": 16,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:f2d5ad9eb96e32c1"
+      "sourceHash": "fnv1a64:a7934411170c064f"
     },
     {
       "id": "ES-C16-tres-irregulares",
       "language": "spanish",
       "chapter": 16,
-      "sequence": null,
+      "sequence": 592,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
       "reasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:02ca95b17070bfad"
+      "sourceHash": "fnv1a64:f0aeca46b35f7ba0"
     },
     {
-      "id": "ES-C17-condicional",
+      "id": "ES-C16-practice",
       "language": "spanish",
-      "chapter": 17,
-      "sequence": null,
+      "chapter": 16,
+      "sequence": 594,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:42b4d39476b7e46c"
-    },
-    {
-      "id": "ES-C17-future-guessing",
-      "language": "spanish",
-      "chapter": 17,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:8ad1c9c2cc752b7f"
+      "sourceHash": "fnv1a64:8ea9920b4d1ad6c4"
     },
     {
       "id": "ES-C17-futuro",
       "language": "spanish",
       "chapter": 17,
-      "sequence": null,
+      "sequence": 596,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c666ac55ceac5ba0"
+      "sourceHash": "fnv1a64:2a1bea9375fca1f7"
+    },
+    {
+      "id": "ES-C17-condicional",
+      "language": "spanish",
+      "chapter": 17,
+      "sequence": 598,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:b700b8e082384c9b"
     },
     {
       "id": "ES-C17-practice",
       "language": "spanish",
       "chapter": 17,
-      "sequence": null,
+      "sequence": 600,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
       "reasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:4dd06dd0cdb60b2a"
+      "sourceHash": "fnv1a64:2b4102bf168727e5"
     },
     {
-      "id": "ES-C18-inherited-subjunctive-stems",
+      "id": "ES-C17-future-guessing",
       "language": "spanish",
-      "chapter": 18,
-      "sequence": null,
+      "chapter": 17,
+      "sequence": 602,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:f9f520e222f1fcf5"
-    },
-    {
-      "id": "ES-C18-ojala",
-      "language": "spanish",
-      "chapter": 18,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:6cf6dfd274eb1199"
-    },
-    {
-      "id": "ES-C18-practice",
-      "language": "spanish",
-      "chapter": 18,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:0b4796f64dd3be91"
-    },
-    {
-      "id": "ES-C18-practice-mood",
-      "language": "spanish",
-      "chapter": 18,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:f384b514f5543593"
-    },
-    {
-      "id": "ES-C18-practice-subjects",
-      "language": "spanish",
-      "chapter": 18,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:f996e725c8d0a48e"
-    },
-    {
-      "id": "ES-C18-quiero-que",
-      "language": "spanish",
-      "chapter": 18,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:d3d46f22a51c12bc"
-    },
-    {
-      "id": "ES-C18-subjunctive-name",
-      "language": "spanish",
-      "chapter": 18,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:f781972d2354b9c4"
-    },
-    {
-      "id": "ES-C18-subjunctive-outliers",
-      "language": "spanish",
-      "chapter": 18,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:291d73d20167b954"
+      "sourceHash": "fnv1a64:5527b162c3ab4fe8"
     },
     {
       "id": "ES-C18-subjuntivo",
       "language": "spanish",
       "chapter": 18,
-      "sequence": null,
+      "sequence": 604,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
       "reasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:834a8361455e9a07"
+      "sourceHash": "fnv1a64:256303072a07e4d8"
     },
     {
-      "id": "ES-C18-wanting-clause-trap",
+      "id": "ES-C18-inherited-subjunctive-stems",
       "language": "spanish",
       "chapter": 18,
-      "sequence": null,
+      "sequence": 606,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:56bb68cc8d8dff47"
+      "sourceHash": "fnv1a64:9406fc796546d74a"
+    },
+    {
+      "id": "ES-C18-subjunctive-outliers",
+      "language": "spanish",
+      "chapter": 18,
+      "sequence": 608,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:87910704c052914f"
+    },
+    {
+      "id": "ES-C18-subjunctive-name",
+      "language": "spanish",
+      "chapter": 18,
+      "sequence": 610,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:40f17ef5d07b402a"
+    },
+    {
+      "id": "ES-C18-quiero-que",
+      "language": "spanish",
+      "chapter": 18,
+      "sequence": 612,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:5a5c6b962d384dee"
+    },
+    {
+      "id": "ES-C18-wanting-clause-trap",
+      "language": "spanish",
+      "chapter": 18,
+      "sequence": 614,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:2eedce6d8fb2c565"
+    },
+    {
+      "id": "ES-C18-ojala",
+      "language": "spanish",
+      "chapter": 18,
+      "sequence": 616,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:7a5cbefcd831a467"
+    },
+    {
+      "id": "ES-C18-practice",
+      "language": "spanish",
+      "chapter": 18,
+      "sequence": 618,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:d42894546917da8b"
+    },
+    {
+      "id": "ES-C18-practice-subjects",
+      "language": "spanish",
+      "chapter": 18,
+      "sequence": 620,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:e009f00a2d88fe2f"
+    },
+    {
+      "id": "ES-C18-practice-mood",
+      "language": "spanish",
+      "chapter": 18,
+      "sequence": 622,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:2bdbd831a0781532"
     },
     {
       "id": "ES-C19-si",

--- a/code/learning/human-languages/spanish/lessons/ES-C08-cuantos-anos.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C08-cuantos-anos.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C08-cuantos-anos
 chapter: 8
+sequence: 530
 type: phrase
 headword: ¿Cuántos años tienes?
 gloss: how old are you? (literally "how many years do you have?")

--- a/code/learning/human-languages/spanish/lessons/ES-C08-numeros-1-5.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C08-numeros-1-5.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C08-numeros-1-5
 chapter: 8
+sequence: 524
 type: word
 headword: uno, dos, tres, cuatro, cinco
 gloss: the numbers 1–5

--- a/code/learning/human-languages/spanish/lessons/ES-C08-numeros-6-10.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C08-numeros-6-10.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C08-numeros-6-10
 chapter: 8
+sequence: 526
 type: word
 headword: seis, siete, ocho, nueve, diez
 gloss: the numbers 6–10 (and the months hidden in them)

--- a/code/learning/human-languages/spanish/lessons/ES-C08-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C08-practice.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C08-practice
 chapter: 8
+sequence: 532
 type: practice-mix
 headword: (practice)
 gloss: counting, having, and telling your age

--- a/code/learning/human-languages/spanish/lessons/ES-C08-tener.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C08-tener.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C08-tener
 chapter: 8
+sequence: 528
 type: word
 headword: tener
 gloss: to have (your first irregular / stem-changing verb)

--- a/code/learning/human-languages/spanish/lessons/ES-C09-esta-en.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C09-esta-en.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C09-esta-en
 chapter: 9
+sequence: 540
 type: phrase
 headword: está en…
 gloss: "is in/at…" — location always takes estar

--- a/code/learning/human-languages/spanish/lessons/ES-C09-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C09-practice.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C09-practice
 chapter: 9
+sequence: 542
 type: practice-mix
 headword: (practice)
 gloss: drilling the ser / estar split

--- a/code/learning/human-languages/spanish/lessons/ES-C09-ser-vs-estar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C09-ser-vs-estar.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C09-ser-vs-estar
 chapter: 9
+sequence: 536
 type: phrase
 headword: ser vs estar
 gloss: the two "to be" verbs, contrasted — essence vs state

--- a/code/learning/human-languages/spanish/lessons/ES-C09-ser.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C09-ser.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C09-ser
 chapter: 9
+sequence: 534
 type: word
 headword: ser
 gloss: to be (identity — permanent, essential)

--- a/code/learning/human-languages/spanish/lessons/ES-C09-soy-de.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C09-soy-de.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C09-soy-de
 chapter: 9
+sequence: 538
 type: phrase
 headword: soy de…
 gloss: "I'm from…" — origin and identity take ser

--- a/code/learning/human-languages/spanish/lessons/ES-C10-ir-a-futuro.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C10-ir-a-futuro.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C10-ir-a-futuro
 chapter: 10
+sequence: 546
 type: phrase
 headword: voy a + infinitive
 gloss: the near future — "I'm going to…"

--- a/code/learning/human-languages/spanish/lessons/ES-C10-ir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C10-ir.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C10-ir
 chapter: 10
+sequence: 544
 type: word
 headword: ir
 gloss: to go (the most irregular Spanish verb — three Latin verbs in one)

--- a/code/learning/human-languages/spanish/lessons/ES-C10-mi-tu-su.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C10-mi-tu-su.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C10-mi-tu-su
 chapter: 10
+sequence: 548
 type: word
 headword: mi, tu, su
 gloss: my, your, his/her/your-formal (the possessives)

--- a/code/learning/human-languages/spanish/lessons/ES-C10-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C10-practice.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C10-practice
 chapter: 10
+sequence: 550
 type: practice-mix
 headword: (practice)
 gloss: going places, the near future, and whose things

--- a/code/learning/human-languages/spanish/lessons/ES-C11-nuestro.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C11-nuestro.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C11-nuestro
 chapter: 11
+sequence: 558
 type: word
 headword: nuestro
 gloss: our (and vuestro, "your"-plural) — the possessive that agrees fully

--- a/code/learning/human-languages/spanish/lessons/ES-C11-poder.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C11-poder.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C11-poder
 chapter: 11
+sequence: 554
 type: word
 headword: poder
 gloss: to be able / can — a stem-changing verb, o→ue

--- a/code/learning/human-languages/spanish/lessons/ES-C11-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C11-practice.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C11-practice
 chapter: 11
+sequence: 560
 type: practice-mix
 headword: (practice)
 gloss: wanting, being able, and the stem-change boot

--- a/code/learning/human-languages/spanish/lessons/ES-C11-querer.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C11-querer.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C11-querer
 chapter: 11
+sequence: 552
 type: word
 headword: querer
 gloss: to want (and to love) — a stem-changing verb, e→ie

--- a/code/learning/human-languages/spanish/lessons/ES-C11-stem-changes.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C11-stem-changes.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C11-stem-changes
 chapter: 11
+sequence: 556
 type: phrase
 headword: e→ie, o→ue
 gloss: the stem-change patterns, side by side — the "boot"

--- a/code/learning/human-languages/spanish/lessons/ES-C12-decir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C12-decir.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C12-decir
 chapter: 12
+sequence: 564
 type: word
 headword: decir
 gloss: to say / to tell — doubly irregular, digo + e→i

--- a/code/learning/human-languages/spanish/lessons/ES-C12-hacer.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C12-hacer.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C12-hacer
 chapter: 12
+sequence: 562
 type: word
 headword: hacer
 gloss: to do / to make — an irregular yo-form, hago

--- a/code/learning/human-languages/spanish/lessons/ES-C12-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C12-practice.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C12-practice
 chapter: 12
+sequence: 568
 type: practice-mix
 headword: (practice)
 gloss: doing, making, saying — hacer, decir, and the -go club

--- a/code/learning/human-languages/spanish/lessons/ES-C12-yo-go.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C12-yo-go.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C12-yo-go
 chapter: 12
+sequence: 566
 type: phrase
 headword: -go
 gloss: the "-go" verbs — a small club whose yo-form ends in -go

--- a/code/learning/human-languages/spanish/lessons/ES-C13-poner.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C13-poner.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C13-poner
 chapter: 13
+sequence: 570
 type: word
 headword: poner
 gloss: to put / to place — a -go yo-form, pongo

--- a/code/learning/human-languages/spanish/lessons/ES-C13-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C13-practice.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C13-practice
 chapter: 13
+sequence: 576
 type: practice-mix
 headword: (practice)
 gloss: the whole -go club, complete — tengo, hago, digo, pongo, salgo, vengo

--- a/code/learning/human-languages/spanish/lessons/ES-C13-salir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C13-salir.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C13-salir
 chapter: 13
+sequence: 572
 type: word
 headword: salir
 gloss: to leave / to go out — a -go yo-form, salgo, from a root that means "to leap"

--- a/code/learning/human-languages/spanish/lessons/ES-C13-venir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C13-venir.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C13-venir
 chapter: 13
+sequence: 574
 type: word
 headword: venir
 gloss: to come — doubly irregular, vengo + e→ie, completing the -go club

--- a/code/learning/human-languages/spanish/lessons/ES-C14-hablar-preterite.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C14-hablar-preterite.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C14-hablar-preterite
 chapter: 14
+sequence: 580
 type: word
 headword: hablé
 gloss: the regular -ar preterite — hablé, hablaste, habló — and why the accent matters

--- a/code/learning/human-languages/spanish/lessons/ES-C14-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C14-practice.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C14-practice
 chapter: 14
+sequence: 582
 type: practice-mix
 headword: (practice)
 gloss: past vs present — fui, hablé, and the forms that look the same

--- a/code/learning/human-languages/spanish/lessons/ES-C14-ser-ir-preterite.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C14-ser-ir-preterite.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C14-ser-ir-preterite
 chapter: 14
+sequence: 578
 type: word
 headword: fui
 gloss: the preterite (past) — and the astonishing fact that "I was" and "I went" are the same word

--- a/code/learning/human-languages/spanish/lessons/ES-C15-comer-vivir-preterite.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C15-comer-vivir-preterite.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C15-comer-vivir-preterite
 chapter: 15
+sequence: 584
 type: word
 headword: comí, viví
 gloss: the regular -er/-ir preterite — where two conjugations collapse into one

--- a/code/learning/human-languages/spanish/lessons/ES-C15-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C15-practice.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C15-practice
 chapter: 15
+sequence: 588
 type: practice-mix
 headword: (practice)
 gloss: the whole preterite — -ar, -er/-ir, and strong, told apart by where the stress lands

--- a/code/learning/human-languages/spanish/lessons/ES-C15-preterite-fuertes.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C15-preterite-fuertes.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C15-preterite-fuertes
 chapter: 15
+sequence: 586
 type: word
 headword: tuve, hice, estuve
 gloss: the strong preterites — where the stress moves off the ending and the accent disappears

--- a/code/learning/human-languages/spanish/lessons/ES-C16-imperfecto.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C16-imperfecto.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C16-imperfecto
 chapter: 16
+sequence: 590
 type: word
 headword: hablaba, comía
 gloss: the imperfect — the past that kept going, and the most regular tense in Spanish

--- a/code/learning/human-languages/spanish/lessons/ES-C16-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C16-practice.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C16-practice
 chapter: 16
+sequence: 594
 type: practice-mix
 headword: (practice)
 gloss: preterite vs imperfect — the distinction English doesn't grammatically make

--- a/code/learning/human-languages/spanish/lessons/ES-C16-tres-irregulares.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C16-tres-irregulares.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C16-tres-irregulares
 chapter: 16
+sequence: 592
 type: word
 headword: era, iba, veía
 gloss: the only three irregular imperfects in the entire language

--- a/code/learning/human-languages/spanish/lessons/ES-C17-condicional.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C17-condicional.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C17-condicional
 chapter: 17
+sequence: 598
 type: word
 headword: hablaría
 gloss: the conditional — the same weld, using the imperfect of haber instead

--- a/code/learning/human-languages/spanish/lessons/ES-C17-future-guessing.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C17-future-guessing.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C17-future-guessing
 chapter: 17
+sequence: 602
 type: grammar
 headword: serán las tres
 gloss: the future can express a present guess, and the conditional can express a past guess

--- a/code/learning/human-languages/spanish/lessons/ES-C17-futuro.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C17-futuro.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C17-futuro
 chapter: 17
+sequence: 596
 type: word
 headword: hablaré
 gloss: the future — a compound tense that welded itself shut

--- a/code/learning/human-languages/spanish/lessons/ES-C17-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C17-practice.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C17-practice
 chapter: 17
+sequence: 600
 type: practice-mix
 headword: (practice)
 gloss: the ten irregular stems that serve both future and conditional

--- a/code/learning/human-languages/spanish/lessons/ES-C18-inherited-subjunctive-stems.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-inherited-subjunctive-stems.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C18-inherited-subjunctive-stems
 chapter: 18
+sequence: 606
 type: grammar
 headword: tenga, diga, haga; quiera, pueda
 gloss: irregular yo stems and stressed stem changes carry into the subjunctive automatically

--- a/code/learning/human-languages/spanish/lessons/ES-C18-ojala.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-ojala.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C18-ojala
 chapter: 18
+sequence: 616
 type: etymology
 headword: ojalá
 gloss: a wish-word borrowed from Andalusi Arabic that triggers the subjunctive without que or a main verb

--- a/code/learning/human-languages/spanish/lessons/ES-C18-practice-mood.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-practice-mood.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C18-practice-mood
 chapter: 18
+sequence: 622
 type: practice-mix
 headword: fact or wish?
 gloss: choosing indicative versus subjunctive and hearing the opposite-vowel contrast

--- a/code/learning/human-languages/spanish/lessons/ES-C18-practice-subjects.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-practice-subjects.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C18-practice-subjects
 chapter: 18
+sequence: 620
 type: practice-mix
 headword: one subject or two?
 gloss: choosing infinitive versus que plus subjunctive after wanting

--- a/code/learning/human-languages/spanish/lessons/ES-C18-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-practice.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C18-practice
 chapter: 18
+sequence: 618
 type: practice-mix
 headword: "Chapter 18 practice"
 gloss: "drilling the vowel flip and inherited stems"

--- a/code/learning/human-languages/spanish/lessons/ES-C18-quiero-que.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-quiero-que.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C18-quiero-que
 chapter: 18
+sequence: 612
 type: phrase
 headword: quiero que…
 gloss: "what triggers the subjunctive — one subject wanting another to act"

--- a/code/learning/human-languages/spanish/lessons/ES-C18-subjunctive-name.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-subjunctive-name.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C18-subjunctive-name
 chapter: 18
+sequence: 610
 type: etymology
 headword: subjuntivo
 gloss: joined underneath — a mood named for its grammatical position in a subordinate clause

--- a/code/learning/human-languages/spanish/lessons/ES-C18-subjunctive-outliers.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-subjunctive-outliers.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C18-subjunctive-outliers
 chapter: 18
+sequence: 608
 type: grammar
 headword: sea, vaya, sepa, haya; esté
 gloss: four forms must be learned outright, while estar keeps a regular stem with exceptional stress

--- a/code/learning/human-languages/spanish/lessons/ES-C18-subjuntivo.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-subjuntivo.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C18-subjuntivo
 chapter: 18
+sequence: 604
 type: word
 headword: hable, coma, viva
 gloss: "the regular present subjunctive — built from the yo form, with the vowel flipped"

--- a/code/learning/human-languages/spanish/lessons/ES-C18-wanting-clause-trap.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-wanting-clause-trap.md
@@ -1,6 +1,7 @@
 ---
 id: ES-C18-wanting-clause-trap
 chapter: 18
+sequence: 614
 type: grammar
 headword: quiero que hables / quiero hablarte
 gloss: Spanish requires a full clause for a second subject after wanting, but permits object plus infinitive with perception and causation

--- a/code/learning/human-languages/spanish/narration/ch08.json
+++ b/code/learning/human-languages/spanish/narration/ch08.json
@@ -4,142 +4,11 @@
   "chapter": 8,
   "title": "Chapter 8",
   "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:aa8faca659cd6608",
+  "sourceHash": "fnv1a64:f96b7bbd0ab4daba",
   "lessons": [
     {
-      "id": "ES-C08-cuantos-anos",
-      "sequence": null,
-      "title": "¿Cuántos años tienes? — \"how old are you?\"",
-      "headword": "¿Cuántos años tienes?",
-      "romanization": "¿Cuántos años tienes?",
-      "gloss": "how old are you? (literally \"how many years do you have?\")",
-      "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:66597346c145929f",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "With tener and your numbers, you can ask and give age — and Spanish does it in a way English doesn't: you don't be a number of years old, you have them."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "etymology",
-          "title": "The phrase, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "¿Cuántos años tienes? = \"How old are you?\" literally: \"How many years do you have?\""
-            },
-            {
-              "kind": "speech",
-              "text": "cuántos = \"how many,\" from Latin quantus, \"how much/great\" becomes English quantity, quantum, quantify. (It's the qu- question family — qué, cómo, dónde, cuántos.) It agrees: cuántos años (masc. pl.)."
-            },
-            {
-              "kind": "speech",
-              "text": "años = \"years,\" from Latin annus — and look, the ñ is back (the doubled-nn of annus becomes añ, your writing lesson). annus also gives English annual, anniversary, biennial."
-            },
-            {
-              "kind": "speech",
-              "text": "tienes = \"you have\" (the tener you just learned)."
-            },
-            {
-              "kind": "speech",
-              "text": "Age is had, not been."
-            },
-            {
-              "kind": "speech",
-              "text": "This is a real difference to internalize: Spanish counts age with tener (\"have\"), not ser/estar (\"be\")."
-            },
-            {
-              "kind": "speech",
-              "text": "— ¿Cuántos años tienes? — Tengo veinte años. (\"I have twenty years.\")"
-            },
-            {
-              "kind": "speech",
-              "text": "Saying \"soy veinte\" (\"I am twenty\") is simply wrong in Spanish. You possess your years; you don't equal them. (French and Italian do the same — j'ai vingt ans, ho vent'anni, all \"I have.\")"
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"¿Cuántos años tienes?\" — KWAN-tos AN-yos TYE-nes",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"¿Cuántos años tienes?\" — *KWAN-tos AN-yos TYE-nes*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "answer — \"Tengo ___ años\" with your own number",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: answer — \"Tengo ___ años\" with your own number]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "never \"soy ___\"; always \"tengo ___ años\" — age is had",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: never \"soy ___\"; always \"tengo ___ años\" — age is *had*]"
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does ¿Cuántos años tienes? literally ask? (\"How many years do you have?\") Which verb gives age in Spanish — ser or tener? (tener — you have your years.) What letter does años bring back, and from what? (The ñ, from Latin annus's doubled nn.) Next: put counting and age together in practice."
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "ES-C08-numeros-1-5",
-      "sequence": null,
+      "sequence": 524,
       "title": "uno, dos, tres, cuatro, cinco — counting to five",
       "headword": "uno, dos, tres, cuatro, cinco",
       "romanization": "uno, dos, tres, cuatro, cinco",
@@ -150,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:4aa6da54f52285e5",
+      "sourceHash": "fnv1a64:d0ad0f4bf00e9dd5",
       "notice": null,
       "blocks": [
         {
@@ -285,7 +154,7 @@
     },
     {
       "id": "ES-C08-numeros-6-10",
-      "sequence": null,
+      "sequence": 526,
       "title": "seis, siete, ocho, nueve, diez — and the calendar's secret",
       "headword": "seis, siete, ocho, nueve, diez",
       "romanization": "seis, siete, ocho, nueve, diez",
@@ -296,7 +165,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e992fae36b1dfcbf",
+      "sourceHash": "fnv1a64:31bbfdae30ea5829",
       "notice": null,
       "blocks": [
         {
@@ -438,8 +307,297 @@
       ]
     },
     {
+      "id": "ES-C08-tener",
+      "sequence": 528,
+      "title": "tener — \"to have,\" your first irregular verb",
+      "headword": "tener",
+      "romanization": "tener",
+      "gloss": "to have (your first irregular / stem-changing verb)",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:d7ac3ca77bc32f7f",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Every verb so far has been regular — hablo, como, vivo, all tidy. tener (\"to have\") is your first irregular one, and it breaks the rule in the two ways Spanish verbs most often do. Meet the exceptions now; you'll see them again and again."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "diphthong-ie — the stem grows a -ie-: tienes = TYE-nes."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "tener comes from Latin tenēre, \"to hold, to keep, to grasp.\" Having is, at root, holding. That root has a firm grip on English:"
+            },
+            {
+              "kind": "speech",
+              "text": "tenant (one who holds land), tenure, tenacious (holding on), tenable, tenet (a held belief)."
+            },
+            {
+              "kind": "speech",
+              "text": "with prefixes: contain (\"hold together\"), retain (\"hold back\"), maintain (\"hold in hand\"), sustain (\"hold up\"), detain, obtain."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: the two irregularities",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "tener misbehaves in exactly the two classic Spanish ways:"
+            },
+            {
+              "kind": "speech",
+              "text": "The yo form is odd: not \"teno\" but tengo (a -g- appears). Several common verbs do this (hago, pongo, salgo, vengo)."
+            },
+            {
+              "kind": "speech",
+              "text": "The stem vowel breaks e becomes ie in the stressed forms — a stem-changer:"
+            },
+            {
+              "kind": "table",
+              "headers": [],
+              "columns": 3,
+              "rowCount": 5,
+              "utterances": [
+                "yo, tengo, (the -go form).",
+                "tú, tienes, (e becomes ie).",
+                "él/ella/usted, tiene, (e becomes ie).",
+                "nosotros, tenemos, (back to e — unstressed).",
+                "ellos/ustedes, tienen, (e becomes ie)."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Notice tenemos keeps the plain e — the vowel only cracks to ie when it's stressed. That \"boot\" pattern (all forms but nosotros/vosotros) is the single most common irregularity in Spanish; tener is your model for it."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"tener\" — te-NER",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"tener\" — *te-NER*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"tengo, tienes, tiene, tenemos, tienen\" — hear the ie crack in, and drop out for tenemos",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"tengo, tienes, tiene, tenemos, tienen\" — hear the *ie* crack in, and drop out for *tenemos*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"tener\" then English \"tenant, retain, contain\" — the hold family",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"tener\" then English \"tenant, retain, contain\" — the *hold* family]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What Latin verb is tener from, and its English cousins? (tenēre, \"to hold\" — tenant, retain, contain.) Its two irregularities? (The -go yo-form tengo; the e becomes ie stem-change tienes/tiene/tienen.) Which form keeps the plain e? (tenemos — it's unstressed.) Next: use it to give your age."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C08-cuantos-anos",
+      "sequence": 530,
+      "title": "¿Cuántos años tienes? — \"how old are you?\"",
+      "headword": "¿Cuántos años tienes?",
+      "romanization": "¿Cuántos años tienes?",
+      "gloss": "how old are you? (literally \"how many years do you have?\")",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:fcb5f16ab501160a",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "With tener and your numbers, you can ask and give age — and Spanish does it in a way English doesn't: you don't be a number of years old, you have them."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "etymology",
+          "title": "The phrase, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "¿Cuántos años tienes? = \"How old are you?\" literally: \"How many years do you have?\""
+            },
+            {
+              "kind": "speech",
+              "text": "cuántos = \"how many,\" from Latin quantus, \"how much/great\" becomes English quantity, quantum, quantify. (It's the qu- question family — qué, cómo, dónde, cuántos.) It agrees: cuántos años (masc. pl.)."
+            },
+            {
+              "kind": "speech",
+              "text": "años = \"years,\" from Latin annus — and look, the ñ is back (the doubled-nn of annus becomes añ, your writing lesson). annus also gives English annual, anniversary, biennial."
+            },
+            {
+              "kind": "speech",
+              "text": "tienes = \"you have\" (the tener you just learned)."
+            },
+            {
+              "kind": "speech",
+              "text": "Age is had, not been."
+            },
+            {
+              "kind": "speech",
+              "text": "This is a real difference to internalize: Spanish counts age with tener (\"have\"), not ser/estar (\"be\")."
+            },
+            {
+              "kind": "speech",
+              "text": "— ¿Cuántos años tienes? — Tengo veinte años. (\"I have twenty years.\")"
+            },
+            {
+              "kind": "speech",
+              "text": "Saying \"soy veinte\" (\"I am twenty\") is simply wrong in Spanish. You possess your years; you don't equal them. (French and Italian do the same — j'ai vingt ans, ho vent'anni, all \"I have.\")"
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"¿Cuántos años tienes?\" — KWAN-tos AN-yos TYE-nes",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"¿Cuántos años tienes?\" — *KWAN-tos AN-yos TYE-nes*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "answer — \"Tengo ___ años\" with your own number",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: answer — \"Tengo ___ años\" with your own number]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "never \"soy ___\"; always \"tengo ___ años\" — age is had",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: never \"soy ___\"; always \"tengo ___ años\" — age is *had*]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does ¿Cuántos años tienes? literally ask? (\"How many years do you have?\") Which verb gives age in Spanish — ser or tener? (tener — you have your years.) What letter does años bring back, and from what? (The ñ, from Latin annus's doubled nn.) Next: put counting and age together in practice."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "ES-C08-practice",
-      "sequence": null,
+      "sequence": 532,
       "title": "Practice — numbers, having, and age",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -450,7 +608,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:f877552a7e8bd113",
+      "sourceHash": "fnv1a64:6c650d67ce5cb460",
       "notice": null,
       "blocks": [
         {
@@ -593,164 +751,6 @@
             {
               "kind": "speech",
               "text": "Count to five. (Uno … cinco.) Give the yo and tú of tener, and name its two irregularities. (Tengo / tienes; the -go yo-form and the e becomes ie stem-change.) How does Spanish give age? (With tener — \"I have X years.\") Next chapter: ser vs estar head-on — the two \"to be\" verbs, sorted for good."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ES-C08-tener",
-      "sequence": null,
-      "title": "tener — \"to have,\" your first irregular verb",
-      "headword": "tener",
-      "romanization": "tener",
-      "gloss": "to have (your first irregular / stem-changing verb)",
-      "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:25fe3250fd9cbc5b",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Every verb so far has been regular — hablo, como, vivo, all tidy. tener (\"to have\") is your first irregular one, and it breaks the rule in the two ways Spanish verbs most often do. Meet the exceptions now; you'll see them again and again."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "pronunciation",
-          "title": "Sounds you'll need",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "diphthong-ie — the stem grows a -ie-: tienes = TYE-nes."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "tener comes from Latin tenēre, \"to hold, to keep, to grasp.\" Having is, at root, holding. That root has a firm grip on English:"
-            },
-            {
-              "kind": "speech",
-              "text": "tenant (one who holds land), tenure, tenacious (holding on), tenable, tenet (a held belief)."
-            },
-            {
-              "kind": "speech",
-              "text": "with prefixes: contain (\"hold together\"), retain (\"hold back\"), maintain (\"hold in hand\"), sustain (\"hold up\"), detain, obtain."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: the two irregularities",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "tener misbehaves in exactly the two classic Spanish ways:"
-            },
-            {
-              "kind": "speech",
-              "text": "The yo form is odd: not \"teno\" but tengo (a -g- appears). Several common verbs do this (hago, pongo, salgo, vengo)."
-            },
-            {
-              "kind": "speech",
-              "text": "The stem vowel breaks e becomes ie in the stressed forms — a stem-changer:"
-            },
-            {
-              "kind": "table",
-              "headers": [],
-              "columns": 3,
-              "rowCount": 5,
-              "utterances": [
-                "yo, tengo, (the -go form).",
-                "tú, tienes, (e becomes ie).",
-                "él/ella/usted, tiene, (e becomes ie).",
-                "nosotros, tenemos, (back to e — unstressed).",
-                "ellos/ustedes, tienen, (e becomes ie)."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "Notice tenemos keeps the plain e — the vowel only cracks to ie when it's stressed. That \"boot\" pattern (all forms but nosotros/vosotros) is the single most common irregularity in Spanish; tener is your model for it."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"tener\" — te-NER",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"tener\" — *te-NER*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"tengo, tienes, tiene, tenemos, tienen\" — hear the ie crack in, and drop out for tenemos",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"tengo, tienes, tiene, tenemos, tienen\" — hear the *ie* crack in, and drop out for *tenemos*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"tener\" then English \"tenant, retain, contain\" — the hold family",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"tener\" then English \"tenant, retain, contain\" — the *hold* family]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What Latin verb is tener from, and its English cousins? (tenēre, \"to hold\" — tenant, retain, contain.) Its two irregularities? (The -go yo-form tengo; the e becomes ie stem-change tienes/tiene/tienen.) Which form keeps the plain e? (tenemos — it's unstressed.) Next: use it to give your age."
             }
           ]
         }

--- a/code/learning/human-languages/spanish/narration/ch08.txt
+++ b/code/learning/human-languages/spanish/narration/ch08.txt
@@ -3,37 +3,6 @@ Spanish, chapter 8: Chapter 8.
 
 
 Lesson 1 of 5.
-¿Cuántos años tienes? — "how old are you?"
-
-Warm-up.
-[pause 2 seconds]
-With tener and your numbers, you can ask and give age — and Spanish does it in a way English doesn't: you don't be a number of years old, you have them.
-
-The phrase, taken apart.
-¿Cuántos años tienes? = "How old are you?" literally: "How many years do you have?"
-cuántos = "how many," from Latin quantus, "how much/great" becomes English quantity, quantum, quantify. (It's the qu- question family — qué, cómo, dónde, cuántos.) It agrees: cuántos años (masc. pl.).
-años = "years," from Latin annus — and look, the ñ is back (the doubled-nn of annus becomes añ, your writing lesson). annus also gives English annual, anniversary, biennial.
-tienes = "you have" (the tener you just learned).
-Age is had, not been.
-This is a real difference to internalize: Spanish counts age with tener ("have"), not ser/estar ("be").
-— ¿Cuántos años tienes? — Tengo veinte años. ("I have twenty years.")
-Saying "soy veinte" ("I am twenty") is simply wrong in Spanish. You possess your years; you don't equal them. (French and Italian do the same — j'ai vingt ans, ho vent'anni, all "I have.")
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "¿Cuántos años tienes?" — KWAN-tos AN-yos TYE-nes]
-[pause 8 seconds for the answer]
-[your turn — say: answer — "Tengo ___ años" with your own number]
-[pause 8 seconds for the answer]
-[your turn — say: never "soy ___"; always "tengo ___ años" — age is had]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What does ¿Cuántos años tienes? literally ask? ("How many years do you have?") Which verb gives age in Spanish — ser or tener? (tener — you have your years.) What letter does años bring back, and from what? (The ñ, from Latin annus's doubled nn.) Next: put counting and age together in practice.
-
-
-Lesson 2 of 5.
 uno, dos, tres, cuatro, cinco — counting to five.
 
 Warm-up.
@@ -70,7 +39,7 @@ Wrap-up Recall.
 Give 1–5 in Spanish. (Uno, dos, tres, cuatro, cinco.) What English word is cinco the cousin of, and why does it look different? (Quintet — Latin quīnque's qu- became Spanish c-.) What two things does un/una mean? ("One" and "a/an.") Next: 6–10.
 
 
-Lesson 3 of 5.
+Lesson 2 of 5.
 seis, siete, ocho, nueve, diez — and the calendar's secret.
 
 Warm-up.
@@ -109,45 +78,7 @@ Wrap-up Recall.
 Give 6–10. (Seis, siete, ocho, nueve, diez.) Why is December Latin for "ten"? (The Roman year started in March, so the 10th month was December.) How do you make 16, and what English word matches? (diez y seis becomes dieciséis; sixteen.) Next: the verb for having — tener.
 
 
-Lesson 4 of 5.
-Practice — numbers, having, and age.
-
-Warm-up.
-[pause 2 seconds]
-Two new powers this chapter: you can count and you can talk about what you have (including your years). Drill the numbers and the irregular tener until both are automatic.
-
-Count and conjugate.
-[pause 1 second]
-Count up: uno, dos, tres, cuatro, cinco, seis, siete, ocho, nueve, diez.
-tener, all forms: tengo, tienes, tiene, tenemos, tienen (mind the tengo and the e becomes ie crack).
-
-Say something real.
-— Hola. ¿Cómo te llamas? — Me llamo Ana. ¿Y cuántos años tienes? — Tengo veintiuno. ¿Y tú? — Tengo diecinueve. — Un café, por favor. ¿Cuánto es? — Dos euros.
-
-What you've built this chapter.
-numbers 1–10 ( from ūnus … decem; cinco/quintet, diez/December), and the teen fusion diez y seis becomes dieciséis (= sixteen).
-tener — "to have" ( from tenēre "hold"; tenant/retain/contain), your first irregular / stem-changing verb: tengo, and e becomes ie (tienes).
-¿Cuántos años tienes? — age with tener ("have your years," not "be"); años from annus (the ñ).
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: count 1–10 up and back down]
-[pause 8 seconds for the answer]
-[your turn — say: conjugate tener through all five forms]
-[pause 8 seconds for the answer]
-[your turn — say: ask and answer age about yourself and a friend — "Tengo … años"]
-[pause 8 seconds for the answer]
-[your turn — say: order "dos cafés, por favor" and ask "¿Cuánto es?"]
-[pause 8 seconds for the answer]
-[repeat that twice]
-"¿Cuántos años tienes? — Tengo … años."
-
-Wrap-up Recall.
-[pause 3 seconds]
-Count to five. (Uno … cinco.) Give the yo and tú of tener, and name its two irregularities. (Tengo / tienes; the -go yo-form and the e becomes ie stem-change.) How does Spanish give age? (With tener — "I have X years.") Next chapter: ser vs estar head-on — the two "to be" verbs, sorted for good.
-
-
-Lesson 5 of 5.
+Lesson 3 of 5.
 tener — "to have," your first irregular verb.
 
 Warm-up.
@@ -186,3 +117,72 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 What Latin verb is tener from, and its English cousins? (tenēre, "to hold" — tenant, retain, contain.) Its two irregularities? (The -go yo-form tengo; the e becomes ie stem-change tienes/tiene/tienen.) Which form keeps the plain e? (tenemos — it's unstressed.) Next: use it to give your age.
+
+
+Lesson 4 of 5.
+¿Cuántos años tienes? — "how old are you?"
+
+Warm-up.
+[pause 2 seconds]
+With tener and your numbers, you can ask and give age — and Spanish does it in a way English doesn't: you don't be a number of years old, you have them.
+
+The phrase, taken apart.
+¿Cuántos años tienes? = "How old are you?" literally: "How many years do you have?"
+cuántos = "how many," from Latin quantus, "how much/great" becomes English quantity, quantum, quantify. (It's the qu- question family — qué, cómo, dónde, cuántos.) It agrees: cuántos años (masc. pl.).
+años = "years," from Latin annus — and look, the ñ is back (the doubled-nn of annus becomes añ, your writing lesson). annus also gives English annual, anniversary, biennial.
+tienes = "you have" (the tener you just learned).
+Age is had, not been.
+This is a real difference to internalize: Spanish counts age with tener ("have"), not ser/estar ("be").
+— ¿Cuántos años tienes? — Tengo veinte años. ("I have twenty years.")
+Saying "soy veinte" ("I am twenty") is simply wrong in Spanish. You possess your years; you don't equal them. (French and Italian do the same — j'ai vingt ans, ho vent'anni, all "I have.")
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "¿Cuántos años tienes?" — KWAN-tos AN-yos TYE-nes]
+[pause 8 seconds for the answer]
+[your turn — say: answer — "Tengo ___ años" with your own number]
+[pause 8 seconds for the answer]
+[your turn — say: never "soy ___"; always "tengo ___ años" — age is had]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does ¿Cuántos años tienes? literally ask? ("How many years do you have?") Which verb gives age in Spanish — ser or tener? (tener — you have your years.) What letter does años bring back, and from what? (The ñ, from Latin annus's doubled nn.) Next: put counting and age together in practice.
+
+
+Lesson 5 of 5.
+Practice — numbers, having, and age.
+
+Warm-up.
+[pause 2 seconds]
+Two new powers this chapter: you can count and you can talk about what you have (including your years). Drill the numbers and the irregular tener until both are automatic.
+
+Count and conjugate.
+[pause 1 second]
+Count up: uno, dos, tres, cuatro, cinco, seis, siete, ocho, nueve, diez.
+tener, all forms: tengo, tienes, tiene, tenemos, tienen (mind the tengo and the e becomes ie crack).
+
+Say something real.
+— Hola. ¿Cómo te llamas? — Me llamo Ana. ¿Y cuántos años tienes? — Tengo veintiuno. ¿Y tú? — Tengo diecinueve. — Un café, por favor. ¿Cuánto es? — Dos euros.
+
+What you've built this chapter.
+numbers 1–10 ( from ūnus … decem; cinco/quintet, diez/December), and the teen fusion diez y seis becomes dieciséis (= sixteen).
+tener — "to have" ( from tenēre "hold"; tenant/retain/contain), your first irregular / stem-changing verb: tengo, and e becomes ie (tienes).
+¿Cuántos años tienes? — age with tener ("have your years," not "be"); años from annus (the ñ).
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: count 1–10 up and back down]
+[pause 8 seconds for the answer]
+[your turn — say: conjugate tener through all five forms]
+[pause 8 seconds for the answer]
+[your turn — say: ask and answer age about yourself and a friend — "Tengo … años"]
+[pause 8 seconds for the answer]
+[your turn — say: order "dos cafés, por favor" and ask "¿Cuánto es?"]
+[pause 8 seconds for the answer]
+[repeat that twice]
+"¿Cuántos años tienes? — Tengo … años."
+
+Wrap-up Recall.
+[pause 3 seconds]
+Count to five. (Uno … cinco.) Give the yo and tú of tener, and name its two irregularities. (Tengo / tienes; the -go yo-form and the e becomes ie stem-change.) How does Spanish give age? (With tener — "I have X years.") Next chapter: ser vs estar head-on — the two "to be" verbs, sorted for good.

--- a/code/learning/human-languages/spanish/narration/ch09.json
+++ b/code/learning/human-languages/spanish/narration/ch09.json
@@ -3,12 +3,503 @@
   "language": "spanish",
   "chapter": 9,
   "title": "Chapter 9",
-  "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:0f128ec69fedf560",
+  "drivablePrefix": 1,
+  "sourceHash": "fnv1a64:a145296a95911d1d",
   "lessons": [
     {
+      "id": "ES-C09-ser",
+      "sequence": 534,
+      "title": "ser — \"to be,\" the essential kind",
+      "headword": "ser",
+      "romanization": "ser",
+      "gloss": "to be (identity — permanent, essential)",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:06810f2823517346",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Back in Chapter 4 you met estar — the temporary to-be ( from stāre, \"to stand\"): how you are right now, and where. It always came with a promise: Spanish has two be-verbs, and here's the other. ser is the permanent one — what a thing essentially is. It's also your second irregular verb, and its irregularity is spectacular."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "r-tap — ser ends in one soft tap of the tongue: SER."
+            },
+            {
+              "kind": "speech",
+              "text": "No propping e here (unlike es-tar): ser already starts with its own vowel."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ser comes from Latin esse, \"to be\" — the plainest, oldest verb there is. (Vulgar Latin actually rebuilt the infinitive as essere, and even folded in a second verb, sedēre \"to sit,\" which is why a few forms look like they wandered in from elsewhere.) That root es- reaches deep into English:"
+            },
+            {
+              "kind": "speech",
+              "text": "essence, essential, entity, is, am, are — all the way down, this is the PIE root h₁es- \"to be.\" When you say es, you are saying a cousin of English is."
+            },
+            {
+              "kind": "speech",
+              "text": "with prefixes: present (prae-esse, \"to be before/at hand\"), absent (ab-esse, \"to be away\"), interest (inter-esse, \"to be between\")."
+            },
+            {
+              "kind": "speech",
+              "text": "So ser isn't just a word to memorize — it's the same ancient \"be\" that English carries in is / am / are."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: the most irregular verb in Spanish",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ser is suppletive — its forms come from different Latin words fused into one verb, so you can't derive them from the infinitive. You simply learn them:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "person",
+                "form",
+                "Latin source"
+              ],
+              "columns": 3,
+              "rowCount": 5,
+              "utterances": [
+                "person: yo. form: soy. Latin source: from sum (\"I am\"); the -y is the same odd tail as in estoy/voy/doy.",
+                "person: tú. form: eres. Latin source: from eris (\"you will be\" — a future form drafted into the present!)",
+                "person: él/ella/usted. form: es. Latin source: from est — literally cognate with English is.",
+                "person: nosotros. form: somos. Latin source: from sumus.",
+                "person: ellos/ustedes. form: son. Latin source: from sunt — cognate with English are-in-plural."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Say them as a set: soy, eres, es, somos, son. Notice how es and son sit right next to English is and (Latin) sunt — you already half-knew this verb."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ser\" — SER, one tap",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ser\" — *SER*, one tap]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"soy, eres, es, somos, son\" — the whole suppletive set, twice",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"soy, eres, es, somos, son\" — the whole suppletive set, twice]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"es\" then English \"is\"; \"son\" then Latin \"sunt\" — hear the family",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"es\" then English \"is\"; \"son\" then Latin \"sunt\" — hear the family]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What Latin verb is ser from, and one English cousin? (esse — essence / essential / present.) Why can't you predict its forms? (It's suppletive — built from sum, eris, est, sumus, sunt.) Give all five present forms. (Soy, eres, es, somos, son.) Next: the big one — when to use ser and when estar."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C09-ser-vs-estar",
+      "sequence": 536,
+      "title": "ser vs estar — essence vs state",
+      "headword": "ser vs estar",
+      "romanization": "ser vs estar",
+      "gloss": "the two \"to be\" verbs, contrasted — essence vs state",
+      "script": "latin",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "wide-table"
+      ],
+      "sourceHash": "fnv1a64:2e697cd43b1008d8",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes for one table that cannot be read aloud"
+        ],
+        "waitUntilStopped": [
+          "The rule, from the roots"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called The rule, from the roots until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "This is the lesson every Spanish learner waits for and dreads. Two verbs, one English word (\"to be\"). But the choice isn't arbitrary — it's written into the etymology you already learned. Get the roots, and the rule follows."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "The rule, from the roots",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "You met both verbs by their Latin sources. That's the whole key:"
+            },
+            {
+              "kind": "table-skipped",
+              "reason": "too-wide",
+              "columns": 4,
+              "rowCount": 2,
+              "headers": [
+                "verb",
+                "root",
+                "picture",
+                "used for"
+              ],
+              "text": "There is a table here I cannot read to you — 4 columns and 2 rows, and it has more columns than can be held in the ear at once. Its columns are: verb, root, picture, used for. Come back and look at it when you have stopped."
+            },
+            {
+              "kind": "speech",
+              "text": "The mnemonic writes itself: ser = essence, estar = estado (Spanish for \"state,\" the very word estar built). Permanent, defining truth becomes ser. Passing state or where-you-are becomes estar."
+            },
+            {
+              "kind": "speech",
+              "text": "Soy alto. — \"I am tall.\" (a defining trait becomes ser)."
+            },
+            {
+              "kind": "speech",
+              "text": "Estoy cansado. — \"I am tired.\" (a passing state becomes estar)."
+            },
+            {
+              "kind": "speech",
+              "text": "Es médico. — \"She is a doctor.\" (identity becomes ser)."
+            },
+            {
+              "kind": "speech",
+              "text": "Está en casa. — \"She is at home.\" (location becomes estar, always)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: minimal pairs that FLIP the meaning",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Here's the proof that the split is real, not decoration. Swap ser for estar on the same adjective and the meaning changes — because essence and state are genuinely different claims:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "with ser (essence)",
+                "with estar (state)"
+              ],
+              "columns": 2,
+              "rowCount": 4,
+              "utterances": [
+                "with ser (essence): es aburrido — \"he is boring\" (his nature). with estar (state): está aburrido — \"he is bored\" (right now).",
+                "with ser (essence): es listo — \"she is clever\" (a trait). with estar (state): está lista — \"she is ready\" (this moment).",
+                "with ser (essence): es rico — \"he is rich\" (wealth). with estar (state): está rico — \"it tastes delicious\" (this dish, now).",
+                "with ser (essence): es verde — \"it is green\" (its colour). with estar (state): está verde — \"it's unripe\" (its current state)."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Same adjective, two verbs, two worlds. A boring person is (ser) boring; a bored person merely stands (estar) bored today. This is why Spanish keeps two verbs English merged into one — it can say things English needs extra words for."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the mnemonic — \"ser = essence, estar = estado (state)\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the mnemonic — \"ser = essence, estar = estado (state)\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "each minimal pair aloud — \"es aburrido / está aburrido,\" and gloss each: \"is boring / is bored\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: each minimal pair aloud — \"es aburrido / está aburrido,\" and gloss each: \"is boring / is bored\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "sort five quick ones — tall (ser), tired (estar), a doctor (ser), at home (estar), from Spain (ser)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: sort five quick ones — tall (ser), tired (estar), a doctor (ser), at home (estar), from Spain (ser)]"
+            },
+            {
+              "kind": "repeat",
+              "times": 2,
+              "source": "[REPEAT x2]"
+            },
+            {
+              "kind": "speech",
+              "text": "\"ser = who/what it IS; estar = how/where it IS right now.\""
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Which verb for a permanent trait, which for a passing state? (ser / estar.) What does está aburrido mean vs es aburrido? (\"is bored\" vs \"is boring.\") Give the estar reading of está rico. (\"it tastes delicious.\") Next: the two workhorses of the split — soy de… (origin) and está en… (location)."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C09-soy-de",
+      "sequence": 538,
+      "title": "soy de… — saying where you're from",
+      "headword": "soy de…",
+      "romanization": "soy de…",
+      "gloss": "\"I'm from…\" — origin and identity take ser",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:9d827a379647bb01",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You have ser. Now aim it. Where you're from and what you do are treated as essence in Spanish — they define you — so both take ser, not estar. This is where the split starts paying rent."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "The little word: de",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "de = \"from / of,\" straight from Latin dē (\"down from, about\"). It's one of the most common words in Spanish, and its English children are everywhere as the prefix de-: deduct, depart, descend, describe — all carry the \"from / down-from\" of dē."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "unknown",
+          "title": "The pattern: soy de + place",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Origin is a permanent fact about you, so it's ser + de:"
+            },
+            {
+              "kind": "speech",
+              "text": "Soy de México. — \"I'm from Mexico.\" Eres de España. — \"You're from Spain.\" Es de Colombia. — \"She's from Colombia.\""
+            },
+            {
+              "kind": "speech",
+              "text": "And to ask it, Spanish fronts the de:"
+            },
+            {
+              "kind": "speech",
+              "text": "¿De dónde eres? — literally \"From where are-you?\" (dónde, \"where,\" you met in Ch.7; here it rides with de to mean from where.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Note it is eres, not estás — even though dónde usually pairs with estar for location. Origin isn't where you are standing; it's what you are. Essence becomes ser."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "unknown",
+          "title": "Same verb, your identity: profession and nationality",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Because these define you, they're ser too — and they take no article:"
+            },
+            {
+              "kind": "speech",
+              "text": "Soy profesor. — \"I'm a teacher.\" (no un — Spanish drops it with bare professions) Soy español. — \"I'm Spanish.\" (there's español again, from Ch.6, from Hispania) Somos estudiantes. — \"We're students.\""
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Soy de…\" + your city — soy deh …",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Soy de…\" + your city — *soy deh …*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "ask and answer — \"¿De dónde eres? — Soy de México.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: ask and answer — \"¿De dónde eres? — Soy de México.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "identity with ser — \"Soy profesor,\" \"Soy español\" (no un/una)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: identity with ser — \"Soy profesor,\" \"Soy español\" (no *un*/*una*)]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Which be-verb for where you're from, and why? (ser — origin is an essence, not a location you stand in.) What does de mean, and one English cousin? (\"from/of\"; depart/deduct.) How do you ask \"where are you from\"? (¿De dónde eres?) Next: the other workhorse — está en…, location, which is pure estar."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "ES-C09-esta-en",
-      "sequence": null,
+      "sequence": 540,
       "title": "está en… — saying where something is",
       "headword": "está en…",
       "romanization": "está en…",
@@ -19,7 +510,7 @@
       "modalityReasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:4ef4d041e2fb8044",
+      "sourceHash": "fnv1a64:c4741a1391c9dd4e",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -170,7 +661,7 @@
     },
     {
       "id": "ES-C09-practice",
-      "sequence": null,
+      "sequence": 542,
       "title": "Practice — ser or estar?",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -181,7 +672,7 @@
       "modalityReasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:8670e97fe19667a6",
+      "sourceHash": "fnv1a64:bb563dc466711e9c",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -373,497 +864,6 @@
             {
               "kind": "speech",
               "text": "Name the rule in three words. (Essence becomes ser; state becomes estar.) Give the five forms of ser. (Soy, eres, es, somos, son.) What flips between es rico and está rico? (\"is rich\" becomes \"tastes delicious.\") Next chapter: the near future — ir a + infinitive, \"going to…\" — and possessives."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ES-C09-ser",
-      "sequence": null,
-      "title": "ser — \"to be,\" the essential kind",
-      "headword": "ser",
-      "romanization": "ser",
-      "gloss": "to be (identity — permanent, essential)",
-      "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:a82cd4ab00b99923",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Back in Chapter 4 you met estar — the temporary to-be ( from stāre, \"to stand\"): how you are right now, and where. It always came with a promise: Spanish has two be-verbs, and here's the other. ser is the permanent one — what a thing essentially is. It's also your second irregular verb, and its irregularity is spectacular."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "pronunciation",
-          "title": "Sounds you'll need",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "r-tap — ser ends in one soft tap of the tongue: SER."
-            },
-            {
-              "kind": "speech",
-              "text": "No propping e here (unlike es-tar): ser already starts with its own vowel."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ser comes from Latin esse, \"to be\" — the plainest, oldest verb there is. (Vulgar Latin actually rebuilt the infinitive as essere, and even folded in a second verb, sedēre \"to sit,\" which is why a few forms look like they wandered in from elsewhere.) That root es- reaches deep into English:"
-            },
-            {
-              "kind": "speech",
-              "text": "essence, essential, entity, is, am, are — all the way down, this is the PIE root h₁es- \"to be.\" When you say es, you are saying a cousin of English is."
-            },
-            {
-              "kind": "speech",
-              "text": "with prefixes: present (prae-esse, \"to be before/at hand\"), absent (ab-esse, \"to be away\"), interest (inter-esse, \"to be between\")."
-            },
-            {
-              "kind": "speech",
-              "text": "So ser isn't just a word to memorize — it's the same ancient \"be\" that English carries in is / am / are."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: the most irregular verb in Spanish",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ser is suppletive — its forms come from different Latin words fused into one verb, so you can't derive them from the infinitive. You simply learn them:"
-            },
-            {
-              "kind": "table",
-              "headers": [
-                "person",
-                "form",
-                "Latin source"
-              ],
-              "columns": 3,
-              "rowCount": 5,
-              "utterances": [
-                "person: yo. form: soy. Latin source: from sum (\"I am\"); the -y is the same odd tail as in estoy/voy/doy.",
-                "person: tú. form: eres. Latin source: from eris (\"you will be\" — a future form drafted into the present!)",
-                "person: él/ella/usted. form: es. Latin source: from est — literally cognate with English is.",
-                "person: nosotros. form: somos. Latin source: from sumus.",
-                "person: ellos/ustedes. form: son. Latin source: from sunt — cognate with English are-in-plural."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "Say them as a set: soy, eres, es, somos, son. Notice how es and son sit right next to English is and (Latin) sunt — you already half-knew this verb."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"ser\" — SER, one tap",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"ser\" — *SER*, one tap]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"soy, eres, es, somos, son\" — the whole suppletive set, twice",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"soy, eres, es, somos, son\" — the whole suppletive set, twice]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"es\" then English \"is\"; \"son\" then Latin \"sunt\" — hear the family",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"es\" then English \"is\"; \"son\" then Latin \"sunt\" — hear the family]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What Latin verb is ser from, and one English cousin? (esse — essence / essential / present.) Why can't you predict its forms? (It's suppletive — built from sum, eris, est, sumus, sunt.) Give all five present forms. (Soy, eres, es, somos, son.) Next: the big one — when to use ser and when estar."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ES-C09-ser-vs-estar",
-      "sequence": null,
-      "title": "ser vs estar — essence vs state",
-      "headword": "ser vs estar",
-      "romanization": "ser vs estar",
-      "gloss": "the two \"to be\" verbs, contrasted — essence vs state",
-      "script": "latin",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "wide-table"
-      ],
-      "sourceHash": "fnv1a64:0b147a09ef97b4b9",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes for one table that cannot be read aloud"
-        ],
-        "waitUntilStopped": [
-          "The rule, from the roots"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called The rule, from the roots until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "This is the lesson every Spanish learner waits for and dreads. Two verbs, one English word (\"to be\"). But the choice isn't arbitrary — it's written into the etymology you already learned. Get the roots, and the rule follows."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "The rule, from the roots",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "You met both verbs by their Latin sources. That's the whole key:"
-            },
-            {
-              "kind": "table-skipped",
-              "reason": "too-wide",
-              "columns": 4,
-              "rowCount": 2,
-              "headers": [
-                "verb",
-                "root",
-                "picture",
-                "used for"
-              ],
-              "text": "There is a table here I cannot read to you — 4 columns and 2 rows, and it has more columns than can be held in the ear at once. Its columns are: verb, root, picture, used for. Come back and look at it when you have stopped."
-            },
-            {
-              "kind": "speech",
-              "text": "The mnemonic writes itself: ser = essence, estar = estado (Spanish for \"state,\" the very word estar built). Permanent, defining truth becomes ser. Passing state or where-you-are becomes estar."
-            },
-            {
-              "kind": "speech",
-              "text": "Soy alto. — \"I am tall.\" (a defining trait becomes ser)."
-            },
-            {
-              "kind": "speech",
-              "text": "Estoy cansado. — \"I am tired.\" (a passing state becomes estar)."
-            },
-            {
-              "kind": "speech",
-              "text": "Es médico. — \"She is a doctor.\" (identity becomes ser)."
-            },
-            {
-              "kind": "speech",
-              "text": "Está en casa. — \"She is at home.\" (location becomes estar, always)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "grammar",
-          "title": "Grammar Lens: minimal pairs that FLIP the meaning",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Here's the proof that the split is real, not decoration. Swap ser for estar on the same adjective and the meaning changes — because essence and state are genuinely different claims:"
-            },
-            {
-              "kind": "table",
-              "headers": [
-                "with ser (essence)",
-                "with estar (state)"
-              ],
-              "columns": 2,
-              "rowCount": 4,
-              "utterances": [
-                "with ser (essence): es aburrido — \"he is boring\" (his nature). with estar (state): está aburrido — \"he is bored\" (right now).",
-                "with ser (essence): es listo — \"she is clever\" (a trait). with estar (state): está lista — \"she is ready\" (this moment).",
-                "with ser (essence): es rico — \"he is rich\" (wealth). with estar (state): está rico — \"it tastes delicious\" (this dish, now).",
-                "with ser (essence): es verde — \"it is green\" (its colour). with estar (state): está verde — \"it's unripe\" (its current state)."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "Same adjective, two verbs, two worlds. A boring person is (ser) boring; a bored person merely stands (estar) bored today. This is why Spanish keeps two verbs English merged into one — it can say things English needs extra words for."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the mnemonic — \"ser = essence, estar = estado (state)\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the mnemonic — \"ser = essence, estar = estado (state)\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "each minimal pair aloud — \"es aburrido / está aburrido,\" and gloss each: \"is boring / is bored\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: each minimal pair aloud — \"es aburrido / está aburrido,\" and gloss each: \"is boring / is bored\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "sort five quick ones — tall (ser), tired (estar), a doctor (ser), at home (estar), from Spain (ser)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: sort five quick ones — tall (ser), tired (estar), a doctor (ser), at home (estar), from Spain (ser)]"
-            },
-            {
-              "kind": "repeat",
-              "times": 2,
-              "source": "[REPEAT x2]"
-            },
-            {
-              "kind": "speech",
-              "text": "\"ser = who/what it IS; estar = how/where it IS right now.\""
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Which verb for a permanent trait, which for a passing state? (ser / estar.) What does está aburrido mean vs es aburrido? (\"is bored\" vs \"is boring.\") Give the estar reading of está rico. (\"it tastes delicious.\") Next: the two workhorses of the split — soy de… (origin) and está en… (location)."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ES-C09-soy-de",
-      "sequence": null,
-      "title": "soy de… — saying where you're from",
-      "headword": "soy de…",
-      "romanization": "soy de…",
-      "gloss": "\"I'm from…\" — origin and identity take ser",
-      "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:e104e762179e9172",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "You have ser. Now aim it. Where you're from and what you do are treated as essence in Spanish — they define you — so both take ser, not estar. This is where the split starts paying rent."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "The little word: de",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "de = \"from / of,\" straight from Latin dē (\"down from, about\"). It's one of the most common words in Spanish, and its English children are everywhere as the prefix de-: deduct, depart, descend, describe — all carry the \"from / down-from\" of dē."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "unknown",
-          "title": "The pattern: soy de + place",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Origin is a permanent fact about you, so it's ser + de:"
-            },
-            {
-              "kind": "speech",
-              "text": "Soy de México. — \"I'm from Mexico.\" Eres de España. — \"You're from Spain.\" Es de Colombia. — \"She's from Colombia.\""
-            },
-            {
-              "kind": "speech",
-              "text": "And to ask it, Spanish fronts the de:"
-            },
-            {
-              "kind": "speech",
-              "text": "¿De dónde eres? — literally \"From where are-you?\" (dónde, \"where,\" you met in Ch.7; here it rides with de to mean from where.)"
-            },
-            {
-              "kind": "speech",
-              "text": "Note it is eres, not estás — even though dónde usually pairs with estar for location. Origin isn't where you are standing; it's what you are. Essence becomes ser."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "unknown",
-          "title": "Same verb, your identity: profession and nationality",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Because these define you, they're ser too — and they take no article:"
-            },
-            {
-              "kind": "speech",
-              "text": "Soy profesor. — \"I'm a teacher.\" (no un — Spanish drops it with bare professions) Soy español. — \"I'm Spanish.\" (there's español again, from Ch.6, from Hispania) Somos estudiantes. — \"We're students.\""
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"Soy de…\" + your city — soy deh …",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"Soy de…\" + your city — *soy deh …*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "ask and answer — \"¿De dónde eres? — Soy de México.\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: ask and answer — \"¿De dónde eres? — Soy de México.\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "identity with ser — \"Soy profesor,\" \"Soy español\" (no un/una)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: identity with ser — \"Soy profesor,\" \"Soy español\" (no *un*/*una*)]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Which be-verb for where you're from, and why? (ser — origin is an essence, not a location you stand in.) What does de mean, and one English cousin? (\"from/of\"; depart/deduct.) How do you ask \"where are you from\"? (¿De dónde eres?) Next: the other workhorse — está en…, location, which is pure estar."
             }
           ]
         }

--- a/code/learning/human-languages/spanish/narration/ch09.txt
+++ b/code/learning/human-languages/spanish/narration/ch09.txt
@@ -1,8 +1,127 @@
 Spanish, chapter 9: Chapter 9.
-5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+5 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
 
 
 Lesson 1 of 5.
+ser — "to be," the essential kind.
+
+Warm-up.
+[pause 2 seconds]
+Back in Chapter 4 you met estar — the temporary to-be ( from stāre, "to stand"): how you are right now, and where. It always came with a promise: Spanish has two be-verbs, and here's the other. ser is the permanent one — what a thing essentially is. It's also your second irregular verb, and its irregularity is spectacular.
+
+Sounds you'll need.
+r-tap — ser ends in one soft tap of the tongue: SER.
+No propping e here (unlike es-tar): ser already starts with its own vowel.
+
+The word, taken apart.
+ser comes from Latin esse, "to be" — the plainest, oldest verb there is. (Vulgar Latin actually rebuilt the infinitive as essere, and even folded in a second verb, sedēre "to sit," which is why a few forms look like they wandered in from elsewhere.) That root es- reaches deep into English:
+essence, essential, entity, is, am, are — all the way down, this is the PIE root h₁es- "to be." When you say es, you are saying a cousin of English is.
+with prefixes: present (prae-esse, "to be before/at hand"), absent (ab-esse, "to be away"), interest (inter-esse, "to be between").
+So ser isn't just a word to memorize — it's the same ancient "be" that English carries in is / am / are.
+
+Grammar Lens: the most irregular verb in Spanish.
+ser is suppletive — its forms come from different Latin words fused into one verb, so you can't derive them from the infinitive. You simply learn them:
+[a table of 5 rows, read aloud]
+person: yo. form: soy. Latin source: from sum ("I am"); the -y is the same odd tail as in estoy/voy/doy.
+person: tú. form: eres. Latin source: from eris ("you will be" — a future form drafted into the present!)
+person: él/ella/usted. form: es. Latin source: from est — literally cognate with English is.
+person: nosotros. form: somos. Latin source: from sumus.
+person: ellos/ustedes. form: son. Latin source: from sunt — cognate with English are-in-plural.
+Say them as a set: soy, eres, es, somos, son. Notice how es and son sit right next to English is and (Latin) sunt — you already half-knew this verb.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "ser" — SER, one tap]
+[pause 8 seconds for the answer]
+[your turn — say: "soy, eres, es, somos, son" — the whole suppletive set, twice]
+[pause 8 seconds for the answer]
+[your turn — say: "es" then English "is"; "son" then Latin "sunt" — hear the family]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What Latin verb is ser from, and one English cousin? (esse — essence / essential / present.) Why can't you predict its forms? (It's suppletive — built from sum, eris, est, sumus, sunt.) Give all five present forms. (Soy, eres, es, somos, son.) Next: the big one — when to use ser and when estar.
+
+
+Lesson 2 of 5.
+ser vs estar — essence vs state.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called The rule, from the roots until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+This is the lesson every Spanish learner waits for and dreads. Two verbs, one English word ("to be"). But the choice isn't arbitrary — it's written into the etymology you already learned. Get the roots, and the rule follows.
+
+The rule, from the roots.
+You met both verbs by their Latin sources. That's the whole key:
+There is a table here I cannot read to you — 4 columns and 2 rows, and it has more columns than can be held in the ear at once. Its columns are: verb, root, picture, used for. Come back and look at it when you have stopped.
+The mnemonic writes itself: ser = essence, estar = estado (Spanish for "state," the very word estar built). Permanent, defining truth becomes ser. Passing state or where-you-are becomes estar.
+Soy alto. — "I am tall." (a defining trait becomes ser).
+Estoy cansado. — "I am tired." (a passing state becomes estar).
+Es médico. — "She is a doctor." (identity becomes ser).
+Está en casa. — "She is at home." (location becomes estar, always).
+
+Grammar Lens: minimal pairs that FLIP the meaning.
+Here's the proof that the split is real, not decoration. Swap ser for estar on the same adjective and the meaning changes — because essence and state are genuinely different claims:
+[a table of 4 rows, read aloud]
+with ser (essence): es aburrido — "he is boring" (his nature). with estar (state): está aburrido — "he is bored" (right now).
+with ser (essence): es listo — "she is clever" (a trait). with estar (state): está lista — "she is ready" (this moment).
+with ser (essence): es rico — "he is rich" (wealth). with estar (state): está rico — "it tastes delicious" (this dish, now).
+with ser (essence): es verde — "it is green" (its colour). with estar (state): está verde — "it's unripe" (its current state).
+Same adjective, two verbs, two worlds. A boring person is (ser) boring; a bored person merely stands (estar) bored today. This is why Spanish keeps two verbs English merged into one — it can say things English needs extra words for.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: the mnemonic — "ser = essence, estar = estado (state)"]
+[pause 8 seconds for the answer]
+[your turn — say: each minimal pair aloud — "es aburrido / está aburrido," and gloss each: "is boring / is bored"]
+[pause 8 seconds for the answer]
+[your turn — say: sort five quick ones — tall (ser), tired (estar), a doctor (ser), at home (estar), from Spain (ser)]
+[pause 8 seconds for the answer]
+[repeat that twice]
+"ser = who/what it IS; estar = how/where it IS right now."
+
+Wrap-up Recall.
+[pause 3 seconds]
+Which verb for a permanent trait, which for a passing state? (ser / estar.) What does está aburrido mean vs es aburrido? ("is bored" vs "is boring.") Give the estar reading of está rico. ("it tastes delicious.") Next: the two workhorses of the split — soy de… (origin) and está en… (location).
+
+
+Lesson 3 of 5.
+soy de… — saying where you're from.
+
+Warm-up.
+[pause 2 seconds]
+You have ser. Now aim it. Where you're from and what you do are treated as essence in Spanish — they define you — so both take ser, not estar. This is where the split starts paying rent.
+
+The little word: de.
+de = "from / of," straight from Latin dē ("down from, about"). It's one of the most common words in Spanish, and its English children are everywhere as the prefix de-: deduct, depart, descend, describe — all carry the "from / down-from" of dē.
+
+The pattern: soy de + place.
+Origin is a permanent fact about you, so it's ser + de:
+Soy de México. — "I'm from Mexico." Eres de España. — "You're from Spain." Es de Colombia. — "She's from Colombia."
+And to ask it, Spanish fronts the de:
+¿De dónde eres? — literally "From where are-you?" (dónde, "where," you met in Ch.7; here it rides with de to mean from where.)
+Note it is eres, not estás — even though dónde usually pairs with estar for location. Origin isn't where you are standing; it's what you are. Essence becomes ser.
+
+Same verb, your identity: profession and nationality.
+Because these define you, they're ser too — and they take no article:
+Soy profesor. — "I'm a teacher." (no un — Spanish drops it with bare professions) Soy español. — "I'm Spanish." (there's español again, from Ch.6, from Hispania) Somos estudiantes. — "We're students."
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "Soy de…" + your city — soy deh …]
+[pause 8 seconds for the answer]
+[your turn — say: ask and answer — "¿De dónde eres? — Soy de México."]
+[pause 8 seconds for the answer]
+[your turn — say: identity with ser — "Soy profesor," "Soy español" (no un/una)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Which be-verb for where you're from, and why? (ser — origin is an essence, not a location you stand in.) What does de mean, and one English cousin? ("from/of"; depart/deduct.) How do you ask "where are you from"? (¿De dónde eres?) Next: the other workhorse — está en…, location, which is pure estar.
+
+
+Lesson 4 of 5.
 está en… — saying where something is.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped.
@@ -41,7 +160,7 @@ Wrap-up Recall.
 Which be-verb for physical location, and its Latin root's picture? (estar — stāre, "to stand": where a thing stands.) What does en mean, and its English twin? ("in/on/at"; English in.) Contrast ¿De dónde eres? with ¿Dónde estás? (origin/ser vs location/estar.) Next: practice — drill the whole split.
 
 
-Lesson 2 of 5.
+Lesson 5 of 5.
 Practice — ser or estar?
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped.
@@ -89,122 +208,3 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 Name the rule in three words. (Essence becomes ser; state becomes estar.) Give the five forms of ser. (Soy, eres, es, somos, son.) What flips between es rico and está rico? ("is rich" becomes "tastes delicious.") Next chapter: the near future — ir a + infinitive, "going to…" — and possessives.
-
-
-Lesson 3 of 5.
-ser — "to be," the essential kind.
-
-Warm-up.
-[pause 2 seconds]
-Back in Chapter 4 you met estar — the temporary to-be ( from stāre, "to stand"): how you are right now, and where. It always came with a promise: Spanish has two be-verbs, and here's the other. ser is the permanent one — what a thing essentially is. It's also your second irregular verb, and its irregularity is spectacular.
-
-Sounds you'll need.
-r-tap — ser ends in one soft tap of the tongue: SER.
-No propping e here (unlike es-tar): ser already starts with its own vowel.
-
-The word, taken apart.
-ser comes from Latin esse, "to be" — the plainest, oldest verb there is. (Vulgar Latin actually rebuilt the infinitive as essere, and even folded in a second verb, sedēre "to sit," which is why a few forms look like they wandered in from elsewhere.) That root es- reaches deep into English:
-essence, essential, entity, is, am, are — all the way down, this is the PIE root h₁es- "to be." When you say es, you are saying a cousin of English is.
-with prefixes: present (prae-esse, "to be before/at hand"), absent (ab-esse, "to be away"), interest (inter-esse, "to be between").
-So ser isn't just a word to memorize — it's the same ancient "be" that English carries in is / am / are.
-
-Grammar Lens: the most irregular verb in Spanish.
-ser is suppletive — its forms come from different Latin words fused into one verb, so you can't derive them from the infinitive. You simply learn them:
-[a table of 5 rows, read aloud]
-person: yo. form: soy. Latin source: from sum ("I am"); the -y is the same odd tail as in estoy/voy/doy.
-person: tú. form: eres. Latin source: from eris ("you will be" — a future form drafted into the present!)
-person: él/ella/usted. form: es. Latin source: from est — literally cognate with English is.
-person: nosotros. form: somos. Latin source: from sumus.
-person: ellos/ustedes. form: son. Latin source: from sunt — cognate with English are-in-plural.
-Say them as a set: soy, eres, es, somos, son. Notice how es and son sit right next to English is and (Latin) sunt — you already half-knew this verb.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "ser" — SER, one tap]
-[pause 8 seconds for the answer]
-[your turn — say: "soy, eres, es, somos, son" — the whole suppletive set, twice]
-[pause 8 seconds for the answer]
-[your turn — say: "es" then English "is"; "son" then Latin "sunt" — hear the family]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What Latin verb is ser from, and one English cousin? (esse — essence / essential / present.) Why can't you predict its forms? (It's suppletive — built from sum, eris, est, sumus, sunt.) Give all five present forms. (Soy, eres, es, somos, son.) Next: the big one — when to use ser and when estar.
-
-
-Lesson 4 of 5.
-ser vs estar — essence vs state.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called The rule, from the roots until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-This is the lesson every Spanish learner waits for and dreads. Two verbs, one English word ("to be"). But the choice isn't arbitrary — it's written into the etymology you already learned. Get the roots, and the rule follows.
-
-The rule, from the roots.
-You met both verbs by their Latin sources. That's the whole key:
-There is a table here I cannot read to you — 4 columns and 2 rows, and it has more columns than can be held in the ear at once. Its columns are: verb, root, picture, used for. Come back and look at it when you have stopped.
-The mnemonic writes itself: ser = essence, estar = estado (Spanish for "state," the very word estar built). Permanent, defining truth becomes ser. Passing state or where-you-are becomes estar.
-Soy alto. — "I am tall." (a defining trait becomes ser).
-Estoy cansado. — "I am tired." (a passing state becomes estar).
-Es médico. — "She is a doctor." (identity becomes ser).
-Está en casa. — "She is at home." (location becomes estar, always).
-
-Grammar Lens: minimal pairs that FLIP the meaning.
-Here's the proof that the split is real, not decoration. Swap ser for estar on the same adjective and the meaning changes — because essence and state are genuinely different claims:
-[a table of 4 rows, read aloud]
-with ser (essence): es aburrido — "he is boring" (his nature). with estar (state): está aburrido — "he is bored" (right now).
-with ser (essence): es listo — "she is clever" (a trait). with estar (state): está lista — "she is ready" (this moment).
-with ser (essence): es rico — "he is rich" (wealth). with estar (state): está rico — "it tastes delicious" (this dish, now).
-with ser (essence): es verde — "it is green" (its colour). with estar (state): está verde — "it's unripe" (its current state).
-Same adjective, two verbs, two worlds. A boring person is (ser) boring; a bored person merely stands (estar) bored today. This is why Spanish keeps two verbs English merged into one — it can say things English needs extra words for.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: the mnemonic — "ser = essence, estar = estado (state)"]
-[pause 8 seconds for the answer]
-[your turn — say: each minimal pair aloud — "es aburrido / está aburrido," and gloss each: "is boring / is bored"]
-[pause 8 seconds for the answer]
-[your turn — say: sort five quick ones — tall (ser), tired (estar), a doctor (ser), at home (estar), from Spain (ser)]
-[pause 8 seconds for the answer]
-[repeat that twice]
-"ser = who/what it IS; estar = how/where it IS right now."
-
-Wrap-up Recall.
-[pause 3 seconds]
-Which verb for a permanent trait, which for a passing state? (ser / estar.) What does está aburrido mean vs es aburrido? ("is bored" vs "is boring.") Give the estar reading of está rico. ("it tastes delicious.") Next: the two workhorses of the split — soy de… (origin) and está en… (location).
-
-
-Lesson 5 of 5.
-soy de… — saying where you're from.
-
-Warm-up.
-[pause 2 seconds]
-You have ser. Now aim it. Where you're from and what you do are treated as essence in Spanish — they define you — so both take ser, not estar. This is where the split starts paying rent.
-
-The little word: de.
-de = "from / of," straight from Latin dē ("down from, about"). It's one of the most common words in Spanish, and its English children are everywhere as the prefix de-: deduct, depart, descend, describe — all carry the "from / down-from" of dē.
-
-The pattern: soy de + place.
-Origin is a permanent fact about you, so it's ser + de:
-Soy de México. — "I'm from Mexico." Eres de España. — "You're from Spain." Es de Colombia. — "She's from Colombia."
-And to ask it, Spanish fronts the de:
-¿De dónde eres? — literally "From where are-you?" (dónde, "where," you met in Ch.7; here it rides with de to mean from where.)
-Note it is eres, not estás — even though dónde usually pairs with estar for location. Origin isn't where you are standing; it's what you are. Essence becomes ser.
-
-Same verb, your identity: profession and nationality.
-Because these define you, they're ser too — and they take no article:
-Soy profesor. — "I'm a teacher." (no un — Spanish drops it with bare professions) Soy español. — "I'm Spanish." (there's español again, from Ch.6, from Hispania) Somos estudiantes. — "We're students."
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "Soy de…" + your city — soy deh …]
-[pause 8 seconds for the answer]
-[your turn — say: ask and answer — "¿De dónde eres? — Soy de México."]
-[pause 8 seconds for the answer]
-[your turn — say: identity with ser — "Soy profesor," "Soy español" (no un/una)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Which be-verb for where you're from, and why? (ser — origin is an essence, not a location you stand in.) What does de mean, and one English cousin? ("from/of"; depart/deduct.) How do you ask "where are you from"? (¿De dónde eres?) Next: the other workhorse — está en…, location, which is pure estar.

--- a/code/learning/human-languages/spanish/narration/ch10.json
+++ b/code/learning/human-languages/spanish/narration/ch10.json
@@ -4,11 +4,11 @@
   "chapter": 10,
   "title": "Chapter 10",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:60c303e5299f5fd7",
+  "sourceHash": "fnv1a64:3341e73c1c7419bf",
   "lessons": [
     {
       "id": "ES-C10-ir",
-      "sequence": null,
+      "sequence": 544,
       "title": "ir — \"to go,\" stitched from three verbs",
       "headword": "ir",
       "romanization": "ir",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:8625b52e5ef33af5",
+      "sourceHash": "fnv1a64:a112992448d98155",
       "notice": null,
       "blocks": [
         {
@@ -181,7 +181,7 @@
     },
     {
       "id": "ES-C10-ir-a-futuro",
-      "sequence": null,
+      "sequence": 546,
       "title": "voy a + infinitive — the \"going-to\" future",
       "headword": "voy a + infinitive",
       "romanization": "voy a + infinitive",
@@ -192,7 +192,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e4484f041a323695",
+      "sourceHash": "fnv1a64:593eb56d09a903d9",
       "notice": null,
       "blocks": [
         {
@@ -316,7 +316,7 @@
     },
     {
       "id": "ES-C10-mi-tu-su",
-      "sequence": null,
+      "sequence": 548,
       "title": "mi, tu, su — my, your, his/her",
       "headword": "mi, tu, su",
       "romanization": "mi, tu, su",
@@ -327,7 +327,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:6331a08eb76e60e3",
+      "sourceHash": "fnv1a64:9e0132e713e2e689",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -478,7 +478,7 @@
     },
     {
       "id": "ES-C10-practice",
-      "sequence": null,
+      "sequence": 550,
       "title": "Practice — ir, the near future, and possessives",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -489,7 +489,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:a9c77a572314fc48",
+      "sourceHash": "fnv1a64:6e9314985eb5ba8d",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch11.json
+++ b/code/learning/human-languages/spanish/narration/ch11.json
@@ -4,22 +4,22 @@
   "chapter": 11,
   "title": "Chapter 11",
   "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:a4622dd6cae2c8a2",
+  "sourceHash": "fnv1a64:1845998478b152fa",
   "lessons": [
     {
-      "id": "ES-C11-nuestro",
-      "sequence": null,
-      "title": "nuestro — \"our,\" the possessive that agrees fully",
-      "headword": "nuestro",
-      "romanization": "nuestro",
-      "gloss": "our (and vuestro, \"your\"-plural) — the possessive that agrees fully",
+      "id": "ES-C11-querer",
+      "sequence": 552,
+      "title": "querer — \"to want,\" and the e becomes ie crack again",
+      "headword": "querer",
+      "romanization": "querer",
+      "gloss": "to want (and to love) — a stem-changing verb, e becomes ie",
       "script": "latin",
       "modality": "voice",
       "derivedModality": "voice",
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e999d3414412ed9e",
+      "sourceHash": "fnv1a64:5431d0644d171e4a",
       "notice": null,
       "blocks": [
         {
@@ -35,56 +35,74 @@
             },
             {
               "kind": "speech",
-              "text": "In Chapter 10 you met mi/tu/su — possessives that change only for number (mis, tus, sus). nuestro (\"our\") is different: it agrees in both gender and number, like an ordinary -o/-a adjective. It's the fullest-flexing of the possessives."
+              "text": "Back in Chapter 8, tener cracked its stem: tienes, with the vowel breaking e becomes ie. That wasn't a one-off — it's a whole class of Spanish verbs. Here's the most useful of them: querer, \"to want\" (and, of a person, \"to love\")."
             }
           ]
         },
         {
           "index": 1,
-          "type": "etymology",
-          "title": "The word, taken apart",
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
           "segments": [
             {
               "kind": "speech",
-              "text": "nuestro comes from Latin noster, \"our.\" You've heard it without knowing: the Paternoster is the \"Our Father,\" and a nostrum is literally \"our thing\" (a quack's secret remedy). Its partner vuestro (\"your,\" to a group) is from voster/vester."
-            },
-            {
-              "kind": "speech",
-              "text": "Notice the stem-change fossil: noster becomes nuestro shows the same o becomes ue break you just learned (short stressed o becomes ue). The possessive cracks exactly like puerta and puedo."
+              "text": "diphthong-ie — the stem breaks to -ie- under stress: quiero = KYE-ro."
             }
           ]
         },
         {
           "index": 2,
-          "type": "grammar",
-          "title": "Grammar Lens: four forms, agreeing like -o/-a",
+          "type": "etymology",
+          "title": "The word, taken apart",
           "segments": [
             {
               "kind": "speech",
-              "text": "Where mi had two forms (mi/mis), nuestro has four — masculine/feminine × singular/plural:"
-            },
-            {
-              "kind": "table",
-              "headers": [
-                "",
-                "singular",
-                "plural"
-              ],
-              "columns": 3,
-              "rowCount": 2,
-              "utterances": [
-                "masc. singular: nuestro libro. plural: nuestros libros.",
-                "fem. singular: nuestra casa. plural: nuestras casas."
-              ]
+              "text": "querer comes from Latin quaerere, \"to seek, to ask, to want.\" Seeking and wanting are the same impulse at the root — and that root is a treasure-house of English:"
             },
             {
               "kind": "speech",
-              "text": "So it's nuestro coche (\"our car,\" masc.) but nuestra casa (\"our house,\" fem.) — you match the noun in both gender and number, just like bueno/buena/buenos/buenas. vuestro does the same (vuestro/vuestra/vuestros/vuestras)."
+              "text": "query, quest, question — a seeking."
+            },
+            {
+              "kind": "speech",
+              "text": "with prefixes: inquire (in- \"into\"), require (re- \"back\"), acquire (ad- \"toward\"), conquer (con- \"thoroughly seek/win\"), exquisite (\"sought out\"), quorum (\"of whom\" the seeking needs enough)."
+            },
+            {
+              "kind": "speech",
+              "text": "So when you say quiero, you're using the same \"seek\" root as question and conquer."
             }
           ]
         },
         {
           "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: the e becomes ie stem-change (the \"boot\")",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "querer is a stem-changing verb: when the stem vowel e is stressed, it breaks to ie — exactly the pattern tener showed you."
+            },
+            {
+              "kind": "table",
+              "headers": [],
+              "columns": 3,
+              "rowCount": 5,
+              "utterances": [
+                "yo, quiero, (e becomes ie).",
+                "tú, quieres, (e becomes ie).",
+                "él/ella/usted, quiere, (e becomes ie).",
+                "nosotros, queremos, (plain e — unstressed).",
+                "ellos/ustedes, quieren, (e becomes ie)."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Only queremos keeps the plain e, because there the stress falls on the ending, not the stem. Shade in the forms that change — yo/tú/él…/ellos — and they draw a boot shape around the nosotros/vosotros gap. That \"boot\" is the signature of every stem-changer."
+            }
+          ]
+        },
+        {
+          "index": 4,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -97,34 +115,34 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"nuestro, nuestra, nuestros, nuestras\" — the full set",
+              "instruction": "\"querer\" then the set — \"quiero, quieres, quiere, queremos, quieren\" — hear the ie crack in, and drop out for queremos",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"nuestro, nuestra, nuestros, nuestras\" — the full set]"
+              "source": "[YOU SAY: \"querer\" then the set — \"quiero, quieres, quiere, queremos, quieren\" — hear the *ie* crack in, and drop out for *queremos*]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "match a noun — \"nuestro coche, nuestra casa, nuestros amigos\"",
+              "instruction": "\"Quiero un café\" (\"I want a coffee\"); \"Quiero café, por favor\"",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: match a noun — \"nuestro coche, nuestra casa, nuestros amigos\"]"
+              "source": "[YOU SAY: \"Quiero un café\" (\"I want a coffee\"); \"Quiero café, por favor\"]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"nuestro\" then \"Paternoster / nostrum\" — the noster \"our\" family",
+              "instruction": "\"querer\" then English \"query, quest, conquer\" — the seek-family",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"nuestro\" then \"Paternoster / nostrum\" — the *noster* \"our\" family]"
+              "source": "[YOU SAY: \"querer\" then English \"query, quest, conquer\" — the seek-family]"
             }
           ]
         },
         {
-          "index": 4,
+          "index": 5,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -136,7 +154,7 @@
             },
             {
               "kind": "speech",
-              "text": "What Latin word is nuestro from, and one English echo? (noster \"our\"; Paternoster / nostrum.) How does nuestro differ from mi/tu/su? (It agrees in gender and number — four forms — not just number.) Give \"our house\" and \"our car.\" (Nuestra casa; nuestro coche.) Next: practice — pull the chapter together."
+              "text": "What Latin verb is querer from, and two English cousins? (quaerere \"to seek\"; query/quest/conquer.) Give its five present forms. (Quiero, quieres, quiere, queremos, quieren.) Which form keeps the plain e, and why? (Queremos — the stress is on the ending, not the stem.) Next: poder, with a different crack, o becomes ue."
             }
           ]
         }
@@ -144,7 +162,7 @@
     },
     {
       "id": "ES-C11-poder",
-      "sequence": null,
+      "sequence": 554,
       "title": "poder — \"to be able,\" and the o becomes ue crack",
       "headword": "poder",
       "romanization": "poder",
@@ -155,7 +173,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:fc28c84739b62d76",
+      "sourceHash": "fnv1a64:2d66abfcc957b70d",
       "notice": null,
       "blocks": [
         {
@@ -316,8 +334,295 @@
       ]
     },
     {
+      "id": "ES-C11-stem-changes",
+      "sequence": 556,
+      "title": "e becomes ie and o becomes ue — one rule, two vowels",
+      "headword": "e→ie, o→ue",
+      "romanization": "e→ie, o→ue",
+      "gloss": "the stem-change patterns, side by side — the \"boot\"",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:c7b9e4b8437c58d5",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You've now seen both stem-changes: querer becomes quiero (e becomes ie) and poder becomes puedo (o becomes ue). They aren't two random quirks — they're one sound-law, and knowing it turns a \"memorize each verb\" chore into a pattern you can predict."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "The rule: stressed short vowels broke",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "In the leap from Latin to Spanish, a short, stressed e broke into ie, and a short, stressed o broke into ue. It happened in ordinary nouns too, not just verbs:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "Latin",
+                "Spanish",
+                "break"
+              ],
+              "columns": 3,
+              "rowCount": 4,
+              "utterances": [
+                "Latin: terra. Spanish: tierra (\"earth\"). break: e becomes ie.",
+                "Latin: septem. Spanish: siete (\"seven\"). break: e becomes ie.",
+                "Latin: porta. Spanish: puerta (\"door\"). break: o becomes ue.",
+                "Latin: novem. Spanish: nueve (\"nine\"). break: o becomes ue."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "(You already met siete and nueve in the numbers — now you know why they have that glide.) In verbs, the stem vowel is stressed in the \"boot\" forms and unstressed in nosotros/vosotros — so it breaks in the boot and stays plain outside it."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "unknown",
+          "title": "The boot, for both patterns",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                "e becomes ie (querer)",
+                "o becomes ue (poder)"
+              ],
+              "columns": 3,
+              "rowCount": 5,
+              "utterances": [
+                "yo. e becomes ie (querer): quiero. o becomes ue (poder): puedo.",
+                "tú. e becomes ie (querer): quieres. o becomes ue (poder): puedes.",
+                "él/ella/ud. e becomes ie (querer): quiere. o becomes ue (poder): puede.",
+                "nosotros. e becomes ie (querer): queremos. o becomes ue (poder): podemos.",
+                "ellos/uds. e becomes ie (querer): quieren. o becomes ue (poder): pueden."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Same shape both times: the four \"corner\" forms crack, the nosotros form stays plain — the boot. tener ( becomes tienes), from Chapter 8, was your first taste; now you own the whole rule."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the pairs — \"querer/quiero (e becomes ie), poder/puedo (o becomes ue)\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the pairs — \"querer/quiero (e→ie), poder/puedo (o→ue)\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the noun echoes — \"terra becomes tierra, porta becomes puerta\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the noun echoes — \"terra→tierra, porta→puerta\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "conjugate both boots, noticing queremos/podemos stay plain",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: conjugate both boots, noticing *queremos*/*podemos* stay plain]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What single sound-law lies behind e becomes ie and o becomes ue? (Short stressed Latin e and o broke into ie and ue.) Which persons crack, and which stays plain? (The \"boot\" — all but nosotros/vosotros.) Give a noun that shows each break. (tierra from terra; puerta from porta.) Next: nuestro — \"our.\""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C11-nuestro",
+      "sequence": 558,
+      "title": "nuestro — \"our,\" the possessive that agrees fully",
+      "headword": "nuestro",
+      "romanization": "nuestro",
+      "gloss": "our (and vuestro, \"your\"-plural) — the possessive that agrees fully",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:7a0ac7c6de92c18d",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "In Chapter 10 you met mi/tu/su — possessives that change only for number (mis, tus, sus). nuestro (\"our\") is different: it agrees in both gender and number, like an ordinary -o/-a adjective. It's the fullest-flexing of the possessives."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "nuestro comes from Latin noster, \"our.\" You've heard it without knowing: the Paternoster is the \"Our Father,\" and a nostrum is literally \"our thing\" (a quack's secret remedy). Its partner vuestro (\"your,\" to a group) is from voster/vester."
+            },
+            {
+              "kind": "speech",
+              "text": "Notice the stem-change fossil: noster becomes nuestro shows the same o becomes ue break you just learned (short stressed o becomes ue). The possessive cracks exactly like puerta and puedo."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: four forms, agreeing like -o/-a",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Where mi had two forms (mi/mis), nuestro has four — masculine/feminine × singular/plural:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                "singular",
+                "plural"
+              ],
+              "columns": 3,
+              "rowCount": 2,
+              "utterances": [
+                "masc. singular: nuestro libro. plural: nuestros libros.",
+                "fem. singular: nuestra casa. plural: nuestras casas."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "So it's nuestro coche (\"our car,\" masc.) but nuestra casa (\"our house,\" fem.) — you match the noun in both gender and number, just like bueno/buena/buenos/buenas. vuestro does the same (vuestro/vuestra/vuestros/vuestras)."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"nuestro, nuestra, nuestros, nuestras\" — the full set",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"nuestro, nuestra, nuestros, nuestras\" — the full set]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "match a noun — \"nuestro coche, nuestra casa, nuestros amigos\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: match a noun — \"nuestro coche, nuestra casa, nuestros amigos\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"nuestro\" then \"Paternoster / nostrum\" — the noster \"our\" family",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"nuestro\" then \"Paternoster / nostrum\" — the *noster* \"our\" family]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What Latin word is nuestro from, and one English echo? (noster \"our\"; Paternoster / nostrum.) How does nuestro differ from mi/tu/su? (It agrees in gender and number — four forms — not just number.) Give \"our house\" and \"our car.\" (Nuestra casa; nuestro coche.) Next: practice — pull the chapter together."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "ES-C11-practice",
-      "sequence": null,
+      "sequence": 560,
       "title": "Practice — querer, poder, and the boot",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -328,7 +633,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:7036de4d6ec16687",
+      "sourceHash": "fnv1a64:76a65b2d1bd68da7",
       "notice": null,
       "blocks": [
         {
@@ -493,311 +798,6 @@
             {
               "kind": "speech",
               "text": "Give the yo of querer and poder. (Quiero, puedo.) Which form of each stays plain, and why? (Queremos/podemos — the stress is on the ending.) How does nuestro agree, versus mi/tu/su? (Gender and number — four forms.) Next chapter carries the grammar forward — the course now runs on rules."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ES-C11-querer",
-      "sequence": null,
-      "title": "querer — \"to want,\" and the e becomes ie crack again",
-      "headword": "querer",
-      "romanization": "querer",
-      "gloss": "to want (and to love) — a stem-changing verb, e becomes ie",
-      "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:36fd4b2201539f9f",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Back in Chapter 8, tener cracked its stem: tienes, with the vowel breaking e becomes ie. That wasn't a one-off — it's a whole class of Spanish verbs. Here's the most useful of them: querer, \"to want\" (and, of a person, \"to love\")."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "pronunciation",
-          "title": "Sounds you'll need",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "diphthong-ie — the stem breaks to -ie- under stress: quiero = KYE-ro."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "querer comes from Latin quaerere, \"to seek, to ask, to want.\" Seeking and wanting are the same impulse at the root — and that root is a treasure-house of English:"
-            },
-            {
-              "kind": "speech",
-              "text": "query, quest, question — a seeking."
-            },
-            {
-              "kind": "speech",
-              "text": "with prefixes: inquire (in- \"into\"), require (re- \"back\"), acquire (ad- \"toward\"), conquer (con- \"thoroughly seek/win\"), exquisite (\"sought out\"), quorum (\"of whom\" the seeking needs enough)."
-            },
-            {
-              "kind": "speech",
-              "text": "So when you say quiero, you're using the same \"seek\" root as question and conquer."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: the e becomes ie stem-change (the \"boot\")",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "querer is a stem-changing verb: when the stem vowel e is stressed, it breaks to ie — exactly the pattern tener showed you."
-            },
-            {
-              "kind": "table",
-              "headers": [],
-              "columns": 3,
-              "rowCount": 5,
-              "utterances": [
-                "yo, quiero, (e becomes ie).",
-                "tú, quieres, (e becomes ie).",
-                "él/ella/usted, quiere, (e becomes ie).",
-                "nosotros, queremos, (plain e — unstressed).",
-                "ellos/ustedes, quieren, (e becomes ie)."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "Only queremos keeps the plain e, because there the stress falls on the ending, not the stem. Shade in the forms that change — yo/tú/él…/ellos — and they draw a boot shape around the nosotros/vosotros gap. That \"boot\" is the signature of every stem-changer."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"querer\" then the set — \"quiero, quieres, quiere, queremos, quieren\" — hear the ie crack in, and drop out for queremos",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"querer\" then the set — \"quiero, quieres, quiere, queremos, quieren\" — hear the *ie* crack in, and drop out for *queremos*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"Quiero un café\" (\"I want a coffee\"); \"Quiero café, por favor\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"Quiero un café\" (\"I want a coffee\"); \"Quiero café, por favor\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"querer\" then English \"query, quest, conquer\" — the seek-family",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"querer\" then English \"query, quest, conquer\" — the seek-family]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What Latin verb is querer from, and two English cousins? (quaerere \"to seek\"; query/quest/conquer.) Give its five present forms. (Quiero, quieres, quiere, queremos, quieren.) Which form keeps the plain e, and why? (Queremos — the stress is on the ending, not the stem.) Next: poder, with a different crack, o becomes ue."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ES-C11-stem-changes",
-      "sequence": null,
-      "title": "e becomes ie and o becomes ue — one rule, two vowels",
-      "headword": "e→ie, o→ue",
-      "romanization": "e→ie, o→ue",
-      "gloss": "the stem-change patterns, side by side — the \"boot\"",
-      "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:5d977c3e12affbb0",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "You've now seen both stem-changes: querer becomes quiero (e becomes ie) and poder becomes puedo (o becomes ue). They aren't two random quirks — they're one sound-law, and knowing it turns a \"memorize each verb\" chore into a pattern you can predict."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "The rule: stressed short vowels broke",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "In the leap from Latin to Spanish, a short, stressed e broke into ie, and a short, stressed o broke into ue. It happened in ordinary nouns too, not just verbs:"
-            },
-            {
-              "kind": "table",
-              "headers": [
-                "Latin",
-                "Spanish",
-                "break"
-              ],
-              "columns": 3,
-              "rowCount": 4,
-              "utterances": [
-                "Latin: terra. Spanish: tierra (\"earth\"). break: e becomes ie.",
-                "Latin: septem. Spanish: siete (\"seven\"). break: e becomes ie.",
-                "Latin: porta. Spanish: puerta (\"door\"). break: o becomes ue.",
-                "Latin: novem. Spanish: nueve (\"nine\"). break: o becomes ue."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "(You already met siete and nueve in the numbers — now you know why they have that glide.) In verbs, the stem vowel is stressed in the \"boot\" forms and unstressed in nosotros/vosotros — so it breaks in the boot and stays plain outside it."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "unknown",
-          "title": "The boot, for both patterns",
-          "segments": [
-            {
-              "kind": "table",
-              "headers": [
-                "",
-                "e becomes ie (querer)",
-                "o becomes ue (poder)"
-              ],
-              "columns": 3,
-              "rowCount": 5,
-              "utterances": [
-                "yo. e becomes ie (querer): quiero. o becomes ue (poder): puedo.",
-                "tú. e becomes ie (querer): quieres. o becomes ue (poder): puedes.",
-                "él/ella/ud. e becomes ie (querer): quiere. o becomes ue (poder): puede.",
-                "nosotros. e becomes ie (querer): queremos. o becomes ue (poder): podemos.",
-                "ellos/uds. e becomes ie (querer): quieren. o becomes ue (poder): pueden."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "Same shape both times: the four \"corner\" forms crack, the nosotros form stays plain — the boot. tener ( becomes tienes), from Chapter 8, was your first taste; now you own the whole rule."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the pairs — \"querer/quiero (e becomes ie), poder/puedo (o becomes ue)\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the pairs — \"querer/quiero (e→ie), poder/puedo (o→ue)\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the noun echoes — \"terra becomes tierra, porta becomes puerta\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the noun echoes — \"terra→tierra, porta→puerta\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "conjugate both boots, noticing queremos/podemos stay plain",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: conjugate both boots, noticing *queremos*/*podemos* stay plain]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What single sound-law lies behind e becomes ie and o becomes ue? (Short stressed Latin e and o broke into ie and ue.) Which persons crack, and which stays plain? (The \"boot\" — all but nosotros/vosotros.) Give a noun that shows each break. (tierra from terra; puerta from porta.) Next: nuestro — \"our.\""
             }
           ]
         }

--- a/code/learning/human-languages/spanish/narration/ch11.txt
+++ b/code/learning/human-languages/spanish/narration/ch11.txt
@@ -3,35 +3,43 @@ Spanish, chapter 11: Chapter 11.
 
 
 Lesson 1 of 5.
-nuestro — "our," the possessive that agrees fully.
+querer — "to want," and the e becomes ie crack again.
 
 Warm-up.
 [pause 2 seconds]
-In Chapter 10 you met mi/tu/su — possessives that change only for number (mis, tus, sus). nuestro ("our") is different: it agrees in both gender and number, like an ordinary -o/-a adjective. It's the fullest-flexing of the possessives.
+Back in Chapter 8, tener cracked its stem: tienes, with the vowel breaking e becomes ie. That wasn't a one-off — it's a whole class of Spanish verbs. Here's the most useful of them: querer, "to want" (and, of a person, "to love").
+
+Sounds you'll need.
+diphthong-ie — the stem breaks to -ie- under stress: quiero = KYE-ro.
 
 The word, taken apart.
-nuestro comes from Latin noster, "our." You've heard it without knowing: the Paternoster is the "Our Father," and a nostrum is literally "our thing" (a quack's secret remedy). Its partner vuestro ("your," to a group) is from voster/vester.
-Notice the stem-change fossil: noster becomes nuestro shows the same o becomes ue break you just learned (short stressed o becomes ue). The possessive cracks exactly like puerta and puedo.
+querer comes from Latin quaerere, "to seek, to ask, to want." Seeking and wanting are the same impulse at the root — and that root is a treasure-house of English:
+query, quest, question — a seeking.
+with prefixes: inquire (in- "into"), require (re- "back"), acquire (ad- "toward"), conquer (con- "thoroughly seek/win"), exquisite ("sought out"), quorum ("of whom" the seeking needs enough).
+So when you say quiero, you're using the same "seek" root as question and conquer.
 
-Grammar Lens: four forms, agreeing like -o/-a.
-Where mi had two forms (mi/mis), nuestro has four — masculine/feminine × singular/plural:
-[a table of 2 rows, read aloud]
-masc. singular: nuestro libro. plural: nuestros libros.
-fem. singular: nuestra casa. plural: nuestras casas.
-So it's nuestro coche ("our car," masc.) but nuestra casa ("our house," fem.) — you match the noun in both gender and number, just like bueno/buena/buenos/buenas. vuestro does the same (vuestro/vuestra/vuestros/vuestras).
+Grammar Lens: the e becomes ie stem-change (the "boot").
+querer is a stem-changing verb: when the stem vowel e is stressed, it breaks to ie — exactly the pattern tener showed you.
+[a table of 5 rows, read aloud]
+yo, quiero, (e becomes ie).
+tú, quieres, (e becomes ie).
+él/ella/usted, quiere, (e becomes ie).
+nosotros, queremos, (plain e — unstressed).
+ellos/ustedes, quieren, (e becomes ie).
+Only queremos keeps the plain e, because there the stress falls on the ending, not the stem. Shade in the forms that change — yo/tú/él…/ellos — and they draw a boot shape around the nosotros/vosotros gap. That "boot" is the signature of every stem-changer.
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: "nuestro, nuestra, nuestros, nuestras" — the full set]
+[your turn — say: "querer" then the set — "quiero, quieres, quiere, queremos, quieren" — hear the ie crack in, and drop out for queremos]
 [pause 8 seconds for the answer]
-[your turn — say: match a noun — "nuestro coche, nuestra casa, nuestros amigos"]
+[your turn — say: "Quiero un café" ("I want a coffee"); "Quiero café, por favor"]
 [pause 8 seconds for the answer]
-[your turn — say: "nuestro" then "Paternoster / nostrum" — the noster "our" family]
+[your turn — say: "querer" then English "query, quest, conquer" — the seek-family]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-What Latin word is nuestro from, and one English echo? (noster "our"; Paternoster / nostrum.) How does nuestro differ from mi/tu/su? (It agrees in gender and number — four forms — not just number.) Give "our house" and "our car." (Nuestra casa; nuestro coche.) Next: practice — pull the chapter together.
+What Latin verb is querer from, and two English cousins? (quaerere "to seek"; query/quest/conquer.) Give its five present forms. (Quiero, quieres, quiere, queremos, quieren.) Which form keeps the plain e, and why? (Queremos — the stress is on the ending, not the stem.) Next: poder, with a different crack, o becomes ue.
 
 
 Lesson 2 of 5.
@@ -80,6 +88,77 @@ What Latin verb is poder from, and its English twin? (potēre "to be able"; powe
 
 
 Lesson 3 of 5.
+e becomes ie and o becomes ue — one rule, two vowels.
+
+Warm-up.
+[pause 2 seconds]
+You've now seen both stem-changes: querer becomes quiero (e becomes ie) and poder becomes puedo (o becomes ue). They aren't two random quirks — they're one sound-law, and knowing it turns a "memorize each verb" chore into a pattern you can predict.
+
+The rule: stressed short vowels broke.
+In the leap from Latin to Spanish, a short, stressed e broke into ie, and a short, stressed o broke into ue. It happened in ordinary nouns too, not just verbs:
+[a table of 4 rows, read aloud]
+Latin: terra. Spanish: tierra ("earth"). break: e becomes ie.
+Latin: septem. Spanish: siete ("seven"). break: e becomes ie.
+Latin: porta. Spanish: puerta ("door"). break: o becomes ue.
+Latin: novem. Spanish: nueve ("nine"). break: o becomes ue.
+(You already met siete and nueve in the numbers — now you know why they have that glide.) In verbs, the stem vowel is stressed in the "boot" forms and unstressed in nosotros/vosotros — so it breaks in the boot and stays plain outside it.
+
+The boot, for both patterns.
+[a table of 5 rows, read aloud]
+yo. e becomes ie (querer): quiero. o becomes ue (poder): puedo.
+tú. e becomes ie (querer): quieres. o becomes ue (poder): puedes.
+él/ella/ud. e becomes ie (querer): quiere. o becomes ue (poder): puede.
+nosotros. e becomes ie (querer): queremos. o becomes ue (poder): podemos.
+ellos/uds. e becomes ie (querer): quieren. o becomes ue (poder): pueden.
+Same shape both times: the four "corner" forms crack, the nosotros form stays plain — the boot. tener ( becomes tienes), from Chapter 8, was your first taste; now you own the whole rule.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: the pairs — "querer/quiero (e becomes ie), poder/puedo (o becomes ue)"]
+[pause 8 seconds for the answer]
+[your turn — say: the noun echoes — "terra becomes tierra, porta becomes puerta"]
+[pause 8 seconds for the answer]
+[your turn — say: conjugate both boots, noticing queremos/podemos stay plain]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What single sound-law lies behind e becomes ie and o becomes ue? (Short stressed Latin e and o broke into ie and ue.) Which persons crack, and which stays plain? (The "boot" — all but nosotros/vosotros.) Give a noun that shows each break. (tierra from terra; puerta from porta.) Next: nuestro — "our."
+
+
+Lesson 4 of 5.
+nuestro — "our," the possessive that agrees fully.
+
+Warm-up.
+[pause 2 seconds]
+In Chapter 10 you met mi/tu/su — possessives that change only for number (mis, tus, sus). nuestro ("our") is different: it agrees in both gender and number, like an ordinary -o/-a adjective. It's the fullest-flexing of the possessives.
+
+The word, taken apart.
+nuestro comes from Latin noster, "our." You've heard it without knowing: the Paternoster is the "Our Father," and a nostrum is literally "our thing" (a quack's secret remedy). Its partner vuestro ("your," to a group) is from voster/vester.
+Notice the stem-change fossil: noster becomes nuestro shows the same o becomes ue break you just learned (short stressed o becomes ue). The possessive cracks exactly like puerta and puedo.
+
+Grammar Lens: four forms, agreeing like -o/-a.
+Where mi had two forms (mi/mis), nuestro has four — masculine/feminine × singular/plural:
+[a table of 2 rows, read aloud]
+masc. singular: nuestro libro. plural: nuestros libros.
+fem. singular: nuestra casa. plural: nuestras casas.
+So it's nuestro coche ("our car," masc.) but nuestra casa ("our house," fem.) — you match the noun in both gender and number, just like bueno/buena/buenos/buenas. vuestro does the same (vuestro/vuestra/vuestros/vuestras).
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "nuestro, nuestra, nuestros, nuestras" — the full set]
+[pause 8 seconds for the answer]
+[your turn — say: match a noun — "nuestro coche, nuestra casa, nuestros amigos"]
+[pause 8 seconds for the answer]
+[your turn — say: "nuestro" then "Paternoster / nostrum" — the noster "our" family]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What Latin word is nuestro from, and one English echo? (noster "our"; Paternoster / nostrum.) How does nuestro differ from mi/tu/su? (It agrees in gender and number — four forms — not just number.) Give "our house" and "our car." (Nuestra casa; nuestro coche.) Next: practice — pull the chapter together.
+
+
+Lesson 5 of 5.
 Practice — querer, poder, and the boot.
 
 Warm-up.
@@ -120,82 +199,3 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 Give the yo of querer and poder. (Quiero, puedo.) Which form of each stays plain, and why? (Queremos/podemos — the stress is on the ending.) How does nuestro agree, versus mi/tu/su? (Gender and number — four forms.) Next chapter carries the grammar forward — the course now runs on rules.
-
-
-Lesson 4 of 5.
-querer — "to want," and the e becomes ie crack again.
-
-Warm-up.
-[pause 2 seconds]
-Back in Chapter 8, tener cracked its stem: tienes, with the vowel breaking e becomes ie. That wasn't a one-off — it's a whole class of Spanish verbs. Here's the most useful of them: querer, "to want" (and, of a person, "to love").
-
-Sounds you'll need.
-diphthong-ie — the stem breaks to -ie- under stress: quiero = KYE-ro.
-
-The word, taken apart.
-querer comes from Latin quaerere, "to seek, to ask, to want." Seeking and wanting are the same impulse at the root — and that root is a treasure-house of English:
-query, quest, question — a seeking.
-with prefixes: inquire (in- "into"), require (re- "back"), acquire (ad- "toward"), conquer (con- "thoroughly seek/win"), exquisite ("sought out"), quorum ("of whom" the seeking needs enough).
-So when you say quiero, you're using the same "seek" root as question and conquer.
-
-Grammar Lens: the e becomes ie stem-change (the "boot").
-querer is a stem-changing verb: when the stem vowel e is stressed, it breaks to ie — exactly the pattern tener showed you.
-[a table of 5 rows, read aloud]
-yo, quiero, (e becomes ie).
-tú, quieres, (e becomes ie).
-él/ella/usted, quiere, (e becomes ie).
-nosotros, queremos, (plain e — unstressed).
-ellos/ustedes, quieren, (e becomes ie).
-Only queremos keeps the plain e, because there the stress falls on the ending, not the stem. Shade in the forms that change — yo/tú/él…/ellos — and they draw a boot shape around the nosotros/vosotros gap. That "boot" is the signature of every stem-changer.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "querer" then the set — "quiero, quieres, quiere, queremos, quieren" — hear the ie crack in, and drop out for queremos]
-[pause 8 seconds for the answer]
-[your turn — say: "Quiero un café" ("I want a coffee"); "Quiero café, por favor"]
-[pause 8 seconds for the answer]
-[your turn — say: "querer" then English "query, quest, conquer" — the seek-family]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What Latin verb is querer from, and two English cousins? (quaerere "to seek"; query/quest/conquer.) Give its five present forms. (Quiero, quieres, quiere, queremos, quieren.) Which form keeps the plain e, and why? (Queremos — the stress is on the ending, not the stem.) Next: poder, with a different crack, o becomes ue.
-
-
-Lesson 5 of 5.
-e becomes ie and o becomes ue — one rule, two vowels.
-
-Warm-up.
-[pause 2 seconds]
-You've now seen both stem-changes: querer becomes quiero (e becomes ie) and poder becomes puedo (o becomes ue). They aren't two random quirks — they're one sound-law, and knowing it turns a "memorize each verb" chore into a pattern you can predict.
-
-The rule: stressed short vowels broke.
-In the leap from Latin to Spanish, a short, stressed e broke into ie, and a short, stressed o broke into ue. It happened in ordinary nouns too, not just verbs:
-[a table of 4 rows, read aloud]
-Latin: terra. Spanish: tierra ("earth"). break: e becomes ie.
-Latin: septem. Spanish: siete ("seven"). break: e becomes ie.
-Latin: porta. Spanish: puerta ("door"). break: o becomes ue.
-Latin: novem. Spanish: nueve ("nine"). break: o becomes ue.
-(You already met siete and nueve in the numbers — now you know why they have that glide.) In verbs, the stem vowel is stressed in the "boot" forms and unstressed in nosotros/vosotros — so it breaks in the boot and stays plain outside it.
-
-The boot, for both patterns.
-[a table of 5 rows, read aloud]
-yo. e becomes ie (querer): quiero. o becomes ue (poder): puedo.
-tú. e becomes ie (querer): quieres. o becomes ue (poder): puedes.
-él/ella/ud. e becomes ie (querer): quiere. o becomes ue (poder): puede.
-nosotros. e becomes ie (querer): queremos. o becomes ue (poder): podemos.
-ellos/uds. e becomes ie (querer): quieren. o becomes ue (poder): pueden.
-Same shape both times: the four "corner" forms crack, the nosotros form stays plain — the boot. tener ( becomes tienes), from Chapter 8, was your first taste; now you own the whole rule.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: the pairs — "querer/quiero (e becomes ie), poder/puedo (o becomes ue)"]
-[pause 8 seconds for the answer]
-[your turn — say: the noun echoes — "terra becomes tierra, porta becomes puerta"]
-[pause 8 seconds for the answer]
-[your turn — say: conjugate both boots, noticing queremos/podemos stay plain]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What single sound-law lies behind e becomes ie and o becomes ue? (Short stressed Latin e and o broke into ie and ue.) Which persons crack, and which stays plain? (The "boot" — all but nosotros/vosotros.) Give a noun that shows each break. (tierra from terra; puerta from porta.) Next: nuestro — "our."

--- a/code/learning/human-languages/spanish/narration/ch12.json
+++ b/code/learning/human-languages/spanish/narration/ch12.json
@@ -3,174 +3,12 @@
   "language": "spanish",
   "chapter": 12,
   "title": "Chapter 12",
-  "drivablePrefix": 3,
-  "sourceHash": "fnv1a64:5f72f74488786bf2",
+  "drivablePrefix": 2,
+  "sourceHash": "fnv1a64:1e748551bb813072",
   "lessons": [
     {
-      "id": "ES-C12-decir",
-      "sequence": null,
-      "title": "decir — \"to say,\" the verb with two irregularities at once",
-      "headword": "decir",
-      "romanization": "decir",
-      "gloss": "to say / to tell — doubly irregular, digo + e becomes i",
-      "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:b70e553d669e1c90",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "decir (\"to say / to tell\") is the trickiest verb yet — and the most instructive, because it stacks two patterns you already know onto one word: the -go yo-form from hacer/tener, and a stem-change from Chapter 11. Learn decir and the whole system clicks together."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "pronunciation",
-          "title": "Sounds you'll need",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "diphthong-none-i — here the stressed stem e does not break to ie; instead it closes to i: digo, dices, dice. A third kind of stem-change."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "decir comes from Latin dīcere, \"to say, to tell, to point out\" — and its root dic-/dict- (\"say\") runs straight through English:"
-            },
-            {
-              "kind": "speech",
-              "text": "dictate, diction, dictionary, dictaphone — all about saying."
-            },
-            {
-              "kind": "speech",
-              "text": "with prefixes: predict (\"say beforehand\"), contradict (\"say against\"), verdict (\"a true saying\"), indicate (\"point out\"), dedicate, edict, index."
-            },
-            {
-              "kind": "speech",
-              "text": "So decir is the \"say\" root behind dictionary itself — the book of what words say."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: two irregularities stacked",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(1) The -go yo-form. Like hago and tengo, the yo-form grows a g: digo."
-            },
-            {
-              "kind": "speech",
-              "text": "(2) The e becomes i stem-change. In the stressed forms, the stem e closes to i — not the ie of querer, but a tighter shift to plain i:"
-            },
-            {
-              "kind": "table",
-              "headers": [],
-              "columns": 3,
-              "rowCount": 5,
-              "utterances": [
-                "yo, digo, (-go form; stem also becomes i).",
-                "tú, dices, (e becomes i).",
-                "él/ella/usted, dice, (e becomes i).",
-                "nosotros, decimos, (plain e — unstressed).",
-                "ellos/ustedes, dicen, (e becomes i)."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "The boot shape returns: decimos alone keeps the plain e, because the stress falls on the ending. Everything inside the boot shifts to i; the yo corner also carries the -go."
-            },
-            {
-              "kind": "speech",
-              "text": "The everyday payoff: ¿Cómo se dice…? — \"How do you say…?\", the single most useful question a learner owns. And dime (\"tell me\")."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"decir\" then the set — \"digo, dices, dice, decimos, dicen\" — the g in digo, the i through the boot, the plain e in decimos",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"decir\" then the set — \"**digo**, dices, dice, decimos, dicen\" — the *g* in *digo*, the *i* through the boot, the plain *e* in *decimos*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"¿Cómo se dice 'coffee' en español?\" — \"Se dice 'café'.\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"¿Cómo se dice 'coffee' en español?\" — \"Se dice 'café'.\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"decir\" then English \"dictate, predict, verdict\" — the say-family",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"decir\" then English \"dictate, predict, verdict\" — the say-family]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What Latin verb is decir from, and three English cousins? (dīcere; dictate/diction/predict/verdict — any three.) Name its two irregularities. (The -go yo-form digo, and the e becomes i stem-change.) Which form keeps the plain e, and why? (decimos — stress on the ending, outside the boot.) How do you ask \"How do you say…?\" (¿Cómo se dice…?) Next: the whole -go family, side by side."
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "ES-C12-hacer",
-      "sequence": null,
+      "sequence": 562,
       "title": "hacer — \"to do / to make,\" and the yo-form that grows a g",
       "headword": "hacer",
       "romanization": "hacer",
@@ -181,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:8af16bd2e1a9ced7",
+      "sourceHash": "fnv1a64:4eaa4375ddf5ddc9",
       "notice": null,
       "blocks": [
         {
@@ -332,8 +170,310 @@
       ]
     },
     {
+      "id": "ES-C12-decir",
+      "sequence": 564,
+      "title": "decir — \"to say,\" the verb with two irregularities at once",
+      "headword": "decir",
+      "romanization": "decir",
+      "gloss": "to say / to tell — doubly irregular, digo + e becomes i",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:72edb388d5667454",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "decir (\"to say / to tell\") is the trickiest verb yet — and the most instructive, because it stacks two patterns you already know onto one word: the -go yo-form from hacer/tener, and a stem-change from Chapter 11. Learn decir and the whole system clicks together."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "diphthong-none-i — here the stressed stem e does not break to ie; instead it closes to i: digo, dices, dice. A third kind of stem-change."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "decir comes from Latin dīcere, \"to say, to tell, to point out\" — and its root dic-/dict- (\"say\") runs straight through English:"
+            },
+            {
+              "kind": "speech",
+              "text": "dictate, diction, dictionary, dictaphone — all about saying."
+            },
+            {
+              "kind": "speech",
+              "text": "with prefixes: predict (\"say beforehand\"), contradict (\"say against\"), verdict (\"a true saying\"), indicate (\"point out\"), dedicate, edict, index."
+            },
+            {
+              "kind": "speech",
+              "text": "So decir is the \"say\" root behind dictionary itself — the book of what words say."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: two irregularities stacked",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(1) The -go yo-form. Like hago and tengo, the yo-form grows a g: digo."
+            },
+            {
+              "kind": "speech",
+              "text": "(2) The e becomes i stem-change. In the stressed forms, the stem e closes to i — not the ie of querer, but a tighter shift to plain i:"
+            },
+            {
+              "kind": "table",
+              "headers": [],
+              "columns": 3,
+              "rowCount": 5,
+              "utterances": [
+                "yo, digo, (-go form; stem also becomes i).",
+                "tú, dices, (e becomes i).",
+                "él/ella/usted, dice, (e becomes i).",
+                "nosotros, decimos, (plain e — unstressed).",
+                "ellos/ustedes, dicen, (e becomes i)."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "The boot shape returns: decimos alone keeps the plain e, because the stress falls on the ending. Everything inside the boot shifts to i; the yo corner also carries the -go."
+            },
+            {
+              "kind": "speech",
+              "text": "The everyday payoff: ¿Cómo se dice…? — \"How do you say…?\", the single most useful question a learner owns. And dime (\"tell me\")."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"decir\" then the set — \"digo, dices, dice, decimos, dicen\" — the g in digo, the i through the boot, the plain e in decimos",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"decir\" then the set — \"**digo**, dices, dice, decimos, dicen\" — the *g* in *digo*, the *i* through the boot, the plain *e* in *decimos*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"¿Cómo se dice 'coffee' en español?\" — \"Se dice 'café'.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"¿Cómo se dice 'coffee' en español?\" — \"Se dice 'café'.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"decir\" then English \"dictate, predict, verdict\" — the say-family",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"decir\" then English \"dictate, predict, verdict\" — the say-family]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What Latin verb is decir from, and three English cousins? (dīcere; dictate/diction/predict/verdict — any three.) Name its two irregularities. (The -go yo-form digo, and the e becomes i stem-change.) Which form keeps the plain e, and why? (decimos — stress on the ending, outside the boot.) How do you ask \"How do you say…?\" (¿Cómo se dice…?) Next: the whole -go family, side by side."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C12-yo-go",
+      "sequence": 566,
+      "title": "The \"-go\" club — one irregular corner, many verbs",
+      "headword": "-go",
+      "romanization": "-go",
+      "gloss": "the \"-go\" verbs — a small club whose yo-form ends in -go",
+      "script": "latin",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "wide-table"
+      ],
+      "sourceHash": "fnv1a64:676f366bba630168",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes for one table that cannot be read aloud"
+        ],
+        "waitUntilStopped": [
+          "The pattern"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called The pattern until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You have now met three verbs whose yo-form ends in a surprising -go: tener becomes tengo, hacer becomes hago, decir becomes digo. That is not three coincidences — it is a club. Learn the membership and you never have to re-learn the shape."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "The pattern",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Most Spanish verbs build a tidy yo-form (hablo, como, vivo). But a small set of very common verbs grow a hard g in the yo-form only — the rest of the present tense behaves normally. You have two members already; here is the core club:"
+            },
+            {
+              "kind": "table-skipped",
+              "reason": "too-wide",
+              "columns": 4,
+              "rowCount": 6,
+              "headers": [
+                "verb",
+                "meaning",
+                "yo-form",
+                "you've met it?"
+              ],
+              "text": "There is a table here I cannot read to you — 4 columns and 6 rows, and it has more columns than can be held in the ear at once. Its columns are: verb, meaning, yo-form, you've met it?. Come back and look at it when you have stopped."
+            },
+            {
+              "kind": "speech",
+              "text": "Three you know, three to come — and every one follows the same rule: -go in the yo-form, regular elsewhere (with any stem-change stacked on top, as in digo)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "unknown",
+          "title": "Why the g? (a Latin fossil)",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The g is an inheritance. Latin's first-person forms and old sound-laws left a velar (a back-of-the-mouth g/k) clinging to these particular verbs; Spanish regularized it into a clean -go. You do not need the history to use them — but it explains why the club is closed and old: these are among the most-used verbs in the language, and the oldest, most-used words are exactly the ones that keep their irregularities (like English am/was, go/went)."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the three you know — \"tengo, hago, digo\" — feel the shared -go",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the three you know — \"**tengo, hago, digo**\" — feel the shared *-go*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the three to come — \"pongo, salgo, vengo\" — same ending",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the three to come — \"**pongo, salgo, vengo**\" — same ending]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "a mixed drill — \"yo tengo, yo hago, yo digo\" then \"tú tienes, tú haces, tú dices\" — the -go is yo-only",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: a mixed drill — \"yo tengo, yo hago, yo digo\" then \"tú tienes, tú haces, tú dices\" — the *-go* is *yo*-only]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What do tengo, hago, and digo share, and in which form only? (A -go ending, in the yo-form only.) Name three more members of the club. (pongo, salgo, vengo — from poner, salir, venir.) Are these verbs irregular everywhere? (No — just the yo-form; the rest is regular, plus any stem-change.) Why is the club old and closed? (These are the most-used, oldest verbs — the ones that keep their fossils.) Next: practice — put hacer, decir, and the -go club to work."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "ES-C12-practice",
-      "sequence": null,
+      "sequence": 568,
       "title": "Practice — hacer, decir, and the -go club",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -344,7 +484,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:1004de0cf5190d97",
+      "sourceHash": "fnv1a64:5cd89031d88c7419",
       "notice": null,
       "blocks": [
         {
@@ -500,146 +640,6 @@
             {
               "kind": "speech",
               "text": "Give the yo-forms of hacer, decir, and tener. (hago, digo, tengo — the -go club.) In decir, which form escapes the e becomes i boot, and why? (decimos — stress on the ending.) How does Spanish say \"it's hot\"? (Hace calor.) You can now do, make, and say in Spanish — and you have seen that its most irregular verbs are its most-used, oldest words."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ES-C12-yo-go",
-      "sequence": null,
-      "title": "The \"-go\" club — one irregular corner, many verbs",
-      "headword": "-go",
-      "romanization": "-go",
-      "gloss": "the \"-go\" verbs — a small club whose yo-form ends in -go",
-      "script": "latin",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "wide-table"
-      ],
-      "sourceHash": "fnv1a64:ca7f98d41616fea8",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes for one table that cannot be read aloud"
-        ],
-        "waitUntilStopped": [
-          "The pattern"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called The pattern until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "You have now met three verbs whose yo-form ends in a surprising -go: tener becomes tengo, hacer becomes hago, decir becomes digo. That is not three coincidences — it is a club. Learn the membership and you never have to re-learn the shape."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "The pattern",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Most Spanish verbs build a tidy yo-form (hablo, como, vivo). But a small set of very common verbs grow a hard g in the yo-form only — the rest of the present tense behaves normally. You have two members already; here is the core club:"
-            },
-            {
-              "kind": "table-skipped",
-              "reason": "too-wide",
-              "columns": 4,
-              "rowCount": 6,
-              "headers": [
-                "verb",
-                "meaning",
-                "yo-form",
-                "you've met it?"
-              ],
-              "text": "There is a table here I cannot read to you — 4 columns and 6 rows, and it has more columns than can be held in the ear at once. Its columns are: verb, meaning, yo-form, you've met it?. Come back and look at it when you have stopped."
-            },
-            {
-              "kind": "speech",
-              "text": "Three you know, three to come — and every one follows the same rule: -go in the yo-form, regular elsewhere (with any stem-change stacked on top, as in digo)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "unknown",
-          "title": "Why the g? (a Latin fossil)",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "The g is an inheritance. Latin's first-person forms and old sound-laws left a velar (a back-of-the-mouth g/k) clinging to these particular verbs; Spanish regularized it into a clean -go. You do not need the history to use them — but it explains why the club is closed and old: these are among the most-used verbs in the language, and the oldest, most-used words are exactly the ones that keep their irregularities (like English am/was, go/went)."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the three you know — \"tengo, hago, digo\" — feel the shared -go",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the three you know — \"**tengo, hago, digo**\" — feel the shared *-go*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the three to come — \"pongo, salgo, vengo\" — same ending",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the three to come — \"**pongo, salgo, vengo**\" — same ending]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "a mixed drill — \"yo tengo, yo hago, yo digo\" then \"tú tienes, tú haces, tú dices\" — the -go is yo-only",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: a mixed drill — \"yo tengo, yo hago, yo digo\" then \"tú tienes, tú haces, tú dices\" — the *-go* is *yo*-only]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What do tengo, hago, and digo share, and in which form only? (A -go ending, in the yo-form only.) Name three more members of the club. (pongo, salgo, vengo — from poner, salir, venir.) Are these verbs irregular everywhere? (No — just the yo-form; the rest is regular, plus any stem-change.) Why is the club old and closed? (These are the most-used, oldest verbs — the ones that keep their fossils.) Next: practice — put hacer, decir, and the -go club to work."
             }
           ]
         }

--- a/code/learning/human-languages/spanish/narration/ch12.txt
+++ b/code/learning/human-languages/spanish/narration/ch12.txt
@@ -1,50 +1,8 @@
 Spanish, chapter 12: Chapter 12.
-4 lessons. You can do the first 3 of them in the car; after that you will want to have stopped.
+4 lessons. You can do the first 2 of them in the car; after that you will want to have stopped.
 
 
 Lesson 1 of 4.
-decir — "to say," the verb with two irregularities at once.
-
-Warm-up.
-[pause 2 seconds]
-decir ("to say / to tell") is the trickiest verb yet — and the most instructive, because it stacks two patterns you already know onto one word: the -go yo-form from hacer/tener, and a stem-change from Chapter 11. Learn decir and the whole system clicks together.
-
-Sounds you'll need.
-diphthong-none-i — here the stressed stem e does not break to ie; instead it closes to i: digo, dices, dice. A third kind of stem-change.
-
-The word, taken apart.
-decir comes from Latin dīcere, "to say, to tell, to point out" — and its root dic-/dict- ("say") runs straight through English:
-dictate, diction, dictionary, dictaphone — all about saying.
-with prefixes: predict ("say beforehand"), contradict ("say against"), verdict ("a true saying"), indicate ("point out"), dedicate, edict, index.
-So decir is the "say" root behind dictionary itself — the book of what words say.
-
-Grammar Lens: two irregularities stacked.
-(1) The -go yo-form. Like hago and tengo, the yo-form grows a g: digo.
-(2) The e becomes i stem-change. In the stressed forms, the stem e closes to i — not the ie of querer, but a tighter shift to plain i:
-[a table of 5 rows, read aloud]
-yo, digo, (-go form; stem also becomes i).
-tú, dices, (e becomes i).
-él/ella/usted, dice, (e becomes i).
-nosotros, decimos, (plain e — unstressed).
-ellos/ustedes, dicen, (e becomes i).
-The boot shape returns: decimos alone keeps the plain e, because the stress falls on the ending. Everything inside the boot shifts to i; the yo corner also carries the -go.
-The everyday payoff: ¿Cómo se dice…? — "How do you say…?", the single most useful question a learner owns. And dime ("tell me").
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "decir" then the set — "digo, dices, dice, decimos, dicen" — the g in digo, the i through the boot, the plain e in decimos]
-[pause 8 seconds for the answer]
-[your turn — say: "¿Cómo se dice 'coffee' en español?" — "Se dice 'café'."]
-[pause 8 seconds for the answer]
-[your turn — say: "decir" then English "dictate, predict, verdict" — the say-family]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What Latin verb is decir from, and three English cousins? (dīcere; dictate/diction/predict/verdict — any three.) Name its two irregularities. (The -go yo-form digo, and the e becomes i stem-change.) Which form keeps the plain e, and why? (decimos — stress on the ending, outside the boot.) How do you ask "How do you say…?" (¿Cómo se dice…?) Next: the whole -go family, side by side.
-
-
-Lesson 2 of 4.
 hacer — "to do / to make," and the yo-form that grows a g.
 
 Warm-up.
@@ -86,7 +44,80 @@ Wrap-up Recall.
 What two English verbs does hacer cover? ("do" and "make.") What Latin root, and two English cousins? (facere; fact/factory/perfect.) Give the yo-form, and the other verb it echoes. (hago — the -go club, like tengo.) How does Spanish say "it's hot"? (Hace calor — "it makes heat.") Next: decir, "to say" — a verb that cracks and grows a g.
 
 
+Lesson 2 of 4.
+decir — "to say," the verb with two irregularities at once.
+
+Warm-up.
+[pause 2 seconds]
+decir ("to say / to tell") is the trickiest verb yet — and the most instructive, because it stacks two patterns you already know onto one word: the -go yo-form from hacer/tener, and a stem-change from Chapter 11. Learn decir and the whole system clicks together.
+
+Sounds you'll need.
+diphthong-none-i — here the stressed stem e does not break to ie; instead it closes to i: digo, dices, dice. A third kind of stem-change.
+
+The word, taken apart.
+decir comes from Latin dīcere, "to say, to tell, to point out" — and its root dic-/dict- ("say") runs straight through English:
+dictate, diction, dictionary, dictaphone — all about saying.
+with prefixes: predict ("say beforehand"), contradict ("say against"), verdict ("a true saying"), indicate ("point out"), dedicate, edict, index.
+So decir is the "say" root behind dictionary itself — the book of what words say.
+
+Grammar Lens: two irregularities stacked.
+(1) The -go yo-form. Like hago and tengo, the yo-form grows a g: digo.
+(2) The e becomes i stem-change. In the stressed forms, the stem e closes to i — not the ie of querer, but a tighter shift to plain i:
+[a table of 5 rows, read aloud]
+yo, digo, (-go form; stem also becomes i).
+tú, dices, (e becomes i).
+él/ella/usted, dice, (e becomes i).
+nosotros, decimos, (plain e — unstressed).
+ellos/ustedes, dicen, (e becomes i).
+The boot shape returns: decimos alone keeps the plain e, because the stress falls on the ending. Everything inside the boot shifts to i; the yo corner also carries the -go.
+The everyday payoff: ¿Cómo se dice…? — "How do you say…?", the single most useful question a learner owns. And dime ("tell me").
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "decir" then the set — "digo, dices, dice, decimos, dicen" — the g in digo, the i through the boot, the plain e in decimos]
+[pause 8 seconds for the answer]
+[your turn — say: "¿Cómo se dice 'coffee' en español?" — "Se dice 'café'."]
+[pause 8 seconds for the answer]
+[your turn — say: "decir" then English "dictate, predict, verdict" — the say-family]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What Latin verb is decir from, and three English cousins? (dīcere; dictate/diction/predict/verdict — any three.) Name its two irregularities. (The -go yo-form digo, and the e becomes i stem-change.) Which form keeps the plain e, and why? (decimos — stress on the ending, outside the boot.) How do you ask "How do you say…?" (¿Cómo se dice…?) Next: the whole -go family, side by side.
+
+
 Lesson 3 of 4.
+The "-go" club — one irregular corner, many verbs.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called The pattern until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+You have now met three verbs whose yo-form ends in a surprising -go: tener becomes tengo, hacer becomes hago, decir becomes digo. That is not three coincidences — it is a club. Learn the membership and you never have to re-learn the shape.
+
+The pattern.
+Most Spanish verbs build a tidy yo-form (hablo, como, vivo). But a small set of very common verbs grow a hard g in the yo-form only — the rest of the present tense behaves normally. You have two members already; here is the core club:
+There is a table here I cannot read to you — 4 columns and 6 rows, and it has more columns than can be held in the ear at once. Its columns are: verb, meaning, yo-form, you've met it?. Come back and look at it when you have stopped.
+Three you know, three to come — and every one follows the same rule: -go in the yo-form, regular elsewhere (with any stem-change stacked on top, as in digo).
+
+Why the g? (a Latin fossil).
+The g is an inheritance. Latin's first-person forms and old sound-laws left a velar (a back-of-the-mouth g/k) clinging to these particular verbs; Spanish regularized it into a clean -go. You do not need the history to use them — but it explains why the club is closed and old: these are among the most-used verbs in the language, and the oldest, most-used words are exactly the ones that keep their irregularities (like English am/was, go/went).
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: the three you know — "tengo, hago, digo" — feel the shared -go]
+[pause 8 seconds for the answer]
+[your turn — say: the three to come — "pongo, salgo, vengo" — same ending]
+[pause 8 seconds for the answer]
+[your turn — say: a mixed drill — "yo tengo, yo hago, yo digo" then "tú tienes, tú haces, tú dices" — the -go is yo-only]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What do tengo, hago, and digo share, and in which form only? (A -go ending, in the yo-form only.) Name three more members of the club. (pongo, salgo, vengo — from poner, salir, venir.) Are these verbs irregular everywhere? (No — just the yo-form; the rest is regular, plus any stem-change.) Why is the club old and closed? (These are the most-used, oldest verbs — the ones that keep their fossils.) Next: practice — put hacer, decir, and the -go club to work.
+
+
+Lesson 4 of 4.
 Practice — hacer, decir, and the -go club.
 
 Warm-up.
@@ -125,34 +156,3 @@ decir from dīcere becomes? (dictate / diction / predict / verdict — any.)
 Wrap-up Recall.
 [pause 3 seconds]
 Give the yo-forms of hacer, decir, and tener. (hago, digo, tengo — the -go club.) In decir, which form escapes the e becomes i boot, and why? (decimos — stress on the ending.) How does Spanish say "it's hot"? (Hace calor.) You can now do, make, and say in Spanish — and you have seen that its most irregular verbs are its most-used, oldest words.
-
-
-Lesson 4 of 4.
-The "-go" club — one irregular corner, many verbs.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called The pattern until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-You have now met three verbs whose yo-form ends in a surprising -go: tener becomes tengo, hacer becomes hago, decir becomes digo. That is not three coincidences — it is a club. Learn the membership and you never have to re-learn the shape.
-
-The pattern.
-Most Spanish verbs build a tidy yo-form (hablo, como, vivo). But a small set of very common verbs grow a hard g in the yo-form only — the rest of the present tense behaves normally. You have two members already; here is the core club:
-There is a table here I cannot read to you — 4 columns and 6 rows, and it has more columns than can be held in the ear at once. Its columns are: verb, meaning, yo-form, you've met it?. Come back and look at it when you have stopped.
-Three you know, three to come — and every one follows the same rule: -go in the yo-form, regular elsewhere (with any stem-change stacked on top, as in digo).
-
-Why the g? (a Latin fossil).
-The g is an inheritance. Latin's first-person forms and old sound-laws left a velar (a back-of-the-mouth g/k) clinging to these particular verbs; Spanish regularized it into a clean -go. You do not need the history to use them — but it explains why the club is closed and old: these are among the most-used verbs in the language, and the oldest, most-used words are exactly the ones that keep their irregularities (like English am/was, go/went).
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: the three you know — "tengo, hago, digo" — feel the shared -go]
-[pause 8 seconds for the answer]
-[your turn — say: the three to come — "pongo, salgo, vengo" — same ending]
-[pause 8 seconds for the answer]
-[your turn — say: a mixed drill — "yo tengo, yo hago, yo digo" then "tú tienes, tú haces, tú dices" — the -go is yo-only]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What do tengo, hago, and digo share, and in which form only? (A -go ending, in the yo-form only.) Name three more members of the club. (pongo, salgo, vengo — from poner, salir, venir.) Are these verbs irregular everywhere? (No — just the yo-form; the rest is regular, plus any stem-change.) Why is the club old and closed? (These are the most-used, oldest verbs — the ones that keep their fossils.) Next: practice — put hacer, decir, and the -go club to work.

--- a/code/learning/human-languages/spanish/narration/ch13.json
+++ b/code/learning/human-languages/spanish/narration/ch13.json
@@ -4,11 +4,11 @@
   "chapter": 13,
   "title": "Chapter 13",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:fd74e6b6faccb060",
+  "sourceHash": "fnv1a64:a4e20b412d6537ba",
   "lessons": [
     {
       "id": "ES-C13-poner",
-      "sequence": null,
+      "sequence": 570,
       "title": "poner — \"to put,\" and the club gains a member",
       "headword": "poner",
       "romanization": "poner",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:853daae9f3657b07",
+      "sourceHash": "fnv1a64:4a6d21b6e5842518",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -168,8 +168,312 @@
       ]
     },
     {
+      "id": "ES-C13-salir",
+      "sequence": 572,
+      "title": "salir — \"to go out,\" from a verb that meant \"to leap\"",
+      "headword": "salir",
+      "romanization": "salir",
+      "gloss": "to leave / to go out — a -go yo-form, salgo, from a root that means \"to leap\"",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:6e1368dae4cebfe2",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The second -go verb: salir (\"to leave, to go out\"). Same story as poner — regular -ir everywhere but the yo-form, which grows the g: salgo. But its origin is a delight: salir comes from a Latin verb for leaping."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "salir comes from Latin salīre, \"to leap, to jump, to spring\" — and over time \"leaping out\" softened into simply \"going out.\" The leap survives across English:"
+            },
+            {
+              "kind": "speech",
+              "text": "salient (\"leaping out,\" so: prominent, sticking out), sally (\"a sudden rush out\"), somersault (sopra + saltus, \"a leap over\")."
+            },
+            {
+              "kind": "speech",
+              "text": "with prefixes: assail / assault (\"leap at\"), resilient (\"leap back\"), result (\"leap back out\"), insult (\"leap upon\")."
+            },
+            {
+              "kind": "speech",
+              "text": "and the salmon — salīre gave Latin salmō, \"the leaper,\" for the fish that leaps upstream."
+            },
+            {
+              "kind": "speech",
+              "text": "So every time you say salgo (\"I go out\"), you are using the old \"leap\" verb behind salient and salmon."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: the -go yo-form",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [],
+              "columns": 3,
+              "rowCount": 5,
+              "utterances": [
+                "yo, salgo, (-go, like pongo/tengo).",
+                "tú, sales, (regular).",
+                "él/ella/usted, sale, (regular).",
+                "nosotros, salimos, (regular).",
+                "ellos/ustedes, salen, (regular)."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "The everyday payoff: salir de casa (\"to leave the house\"), salir con alguien (\"to go out with someone\" — to date), and la salida (\"the exit\" — the sign you'll read at every station). Note: English exit is from a different Latin verb, exīre (\"go out\"); Spanish chose the leaping one."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"salir\" then the set — \"salgo, sales, sale, salimos, salen\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"salir\" then the set — \"**salgo**, sales, sale, salimos, salen\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Salgo de casa\" (\"I leave the house\"); \"la salida\" (\"the exit\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Salgo de casa\" (\"I leave the house\"); \"la salida\" (\"the exit\")]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"salir\" then English \"salient, salmon, somersault\" — the leap-family",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"salir\" then English \"salient, salmon, somersault\" — the leap-family]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What did salir's Latin root salīre originally mean? (\"To leap / jump.\") Name two English cousins. (salient/sally/somersault/salmon — any two.) Give the yo-form and the sign it hides. (salgo; la salida = the exit.) Next: venir — the last -go verb, and the trickiest, because it also cracks its stem."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C13-venir",
+      "sequence": 574,
+      "title": "venir — \"to come,\" the last club member, cracked and g-grown",
+      "headword": "venir",
+      "romanization": "venir",
+      "gloss": "to come — doubly irregular, vengo + e becomes ie, completing the -go club",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:aabd87fb7c1c7eae",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The sixth and final member of the -go club: venir (\"to come\"). And like decir back in Chapter 12, it is doubly irregular — it stacks the -go yo-form and a stem-change. Learn venir and the whole system you've been building since tener clicks shut."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "g-hard — the -go of vengo."
+            },
+            {
+              "kind": "speech",
+              "text": "diphthong-ie — the stressed stem e breaks to ie: vienes = vee-EH-nes."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "venir comes from Latin venīre, \"to come\" — a root ven-/vent- that comes toward English from every direction:"
+            },
+            {
+              "kind": "speech",
+              "text": "adventure (ad-venīre, \"what comes to you\"), event (\"what comes out\"), convene / convention (\"come together\"), invent (\"come upon\"), prevent (\"come before\"), intervene, revenue (\"what comes back\"), avenue (\"a coming-toward\"), and souvenir (French, \"a thing that comes to mind\")."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: two irregularities at once",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(1) The -go yo-form, like pongo/salgo/tengo: vengo. (2) The e becomes ie stem-change, like querer/tener: the stressed stem breaks to ie — the \"boot\" again."
+            },
+            {
+              "kind": "table",
+              "headers": [],
+              "columns": 3,
+              "rowCount": 5,
+              "utterances": [
+                "yo, vengo, (-go form).",
+                "tú, vienes, (e becomes ie).",
+                "él/ella/usted, viene, (e becomes ie).",
+                "nosotros, venimos, (plain e — unstressed).",
+                "ellos/ustedes, vienen, (e becomes ie)."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Venimos alone keeps the plain e (stress on the ending), drawing the boot; everything inside it cracks to ie, and the yo corner carries the -go. This is the exact shape of tener (tengo / tienes) — venir is its mirror twin."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "unknown",
+          "title": "The club is complete",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "You have now met all six: tengo, hago, digo, pongo, salgo, vengo. Three plain -go (poner, salir, hacer), one -go + e becomes i (decir), two -go + e becomes ie (tener, venir). The corner is closed."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"venir\" then the set — \"vengo, vienes, viene, venimos, vienen\" — the g in vengo, the ie through the boot, plain e in venimos",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"venir\" then the set — \"**vengo**, vienes, viene, venimos, vienen\" — the *g* in *vengo*, the *ie* through the boot, plain *e* in *venimos*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Vengo de España\" (\"I come from Spain\"); \"¿Vienes?\" (\"Are you coming?\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Vengo de España\" (\"I come from Spain\"); \"¿Vienes?\" (\"Are you coming?\")]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"venir\" then English \"adventure, convene, event\" — the come-family",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"venir\" then English \"adventure, convene, event\" — the come-family]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Name venir's two irregularities. (The -go yo-form vengo, and the e becomes ie stem-change.) Which form escapes the boot, and why? (venimos — stress on the ending.) What Latin verb, and two English cousins? (venīre; adventure/event/convene — any two.) Which earlier verb is venir's exact twin? (tener — tengo/tienes = vengo/vienes.) Next: practice — the whole -go club at once."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "ES-C13-practice",
-      "sequence": null,
+      "sequence": 576,
       "title": "Practice — the -go club, complete",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -180,7 +484,7 @@
       "modalityReasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:d957576393e1d909",
+      "sourceHash": "fnv1a64:c38441962b855240",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -376,310 +680,6 @@
             {
               "kind": "speech",
               "text": "Recite the six yo-forms of the club. (tengo, hago, digo, pongo, salgo, vengo.) Which two are the e becomes ie \"boot\" twins? (tener and venir.) Which single verb is -go and e becomes i? (decir — digo/dices.) You now hold the whole irregular -go corner of Spanish — its oldest, most-used verbs, mastered as one pattern."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ES-C13-salir",
-      "sequence": null,
-      "title": "salir — \"to go out,\" from a verb that meant \"to leap\"",
-      "headword": "salir",
-      "romanization": "salir",
-      "gloss": "to leave / to go out — a -go yo-form, salgo, from a root that means \"to leap\"",
-      "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:a12d1080b1f174d9",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The second -go verb: salir (\"to leave, to go out\"). Same story as poner — regular -ir everywhere but the yo-form, which grows the g: salgo. But its origin is a delight: salir comes from a Latin verb for leaping."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "salir comes from Latin salīre, \"to leap, to jump, to spring\" — and over time \"leaping out\" softened into simply \"going out.\" The leap survives across English:"
-            },
-            {
-              "kind": "speech",
-              "text": "salient (\"leaping out,\" so: prominent, sticking out), sally (\"a sudden rush out\"), somersault (sopra + saltus, \"a leap over\")."
-            },
-            {
-              "kind": "speech",
-              "text": "with prefixes: assail / assault (\"leap at\"), resilient (\"leap back\"), result (\"leap back out\"), insult (\"leap upon\")."
-            },
-            {
-              "kind": "speech",
-              "text": "and the salmon — salīre gave Latin salmō, \"the leaper,\" for the fish that leaps upstream."
-            },
-            {
-              "kind": "speech",
-              "text": "So every time you say salgo (\"I go out\"), you are using the old \"leap\" verb behind salient and salmon."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "grammar",
-          "title": "Grammar Lens: the -go yo-form",
-          "segments": [
-            {
-              "kind": "table",
-              "headers": [],
-              "columns": 3,
-              "rowCount": 5,
-              "utterances": [
-                "yo, salgo, (-go, like pongo/tengo).",
-                "tú, sales, (regular).",
-                "él/ella/usted, sale, (regular).",
-                "nosotros, salimos, (regular).",
-                "ellos/ustedes, salen, (regular)."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "The everyday payoff: salir de casa (\"to leave the house\"), salir con alguien (\"to go out with someone\" — to date), and la salida (\"the exit\" — the sign you'll read at every station). Note: English exit is from a different Latin verb, exīre (\"go out\"); Spanish chose the leaping one."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"salir\" then the set — \"salgo, sales, sale, salimos, salen\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"salir\" then the set — \"**salgo**, sales, sale, salimos, salen\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"Salgo de casa\" (\"I leave the house\"); \"la salida\" (\"the exit\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"Salgo de casa\" (\"I leave the house\"); \"la salida\" (\"the exit\")]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"salir\" then English \"salient, salmon, somersault\" — the leap-family",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"salir\" then English \"salient, salmon, somersault\" — the leap-family]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What did salir's Latin root salīre originally mean? (\"To leap / jump.\") Name two English cousins. (salient/sally/somersault/salmon — any two.) Give the yo-form and the sign it hides. (salgo; la salida = the exit.) Next: venir — the last -go verb, and the trickiest, because it also cracks its stem."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ES-C13-venir",
-      "sequence": null,
-      "title": "venir — \"to come,\" the last club member, cracked and g-grown",
-      "headword": "venir",
-      "romanization": "venir",
-      "gloss": "to come — doubly irregular, vengo + e becomes ie, completing the -go club",
-      "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:43d46c297f5ac8ef",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The sixth and final member of the -go club: venir (\"to come\"). And like decir back in Chapter 12, it is doubly irregular — it stacks the -go yo-form and a stem-change. Learn venir and the whole system you've been building since tener clicks shut."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "pronunciation",
-          "title": "Sounds you'll need",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "g-hard — the -go of vengo."
-            },
-            {
-              "kind": "speech",
-              "text": "diphthong-ie — the stressed stem e breaks to ie: vienes = vee-EH-nes."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "venir comes from Latin venīre, \"to come\" — a root ven-/vent- that comes toward English from every direction:"
-            },
-            {
-              "kind": "speech",
-              "text": "adventure (ad-venīre, \"what comes to you\"), event (\"what comes out\"), convene / convention (\"come together\"), invent (\"come upon\"), prevent (\"come before\"), intervene, revenue (\"what comes back\"), avenue (\"a coming-toward\"), and souvenir (French, \"a thing that comes to mind\")."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: two irregularities at once",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(1) The -go yo-form, like pongo/salgo/tengo: vengo. (2) The e becomes ie stem-change, like querer/tener: the stressed stem breaks to ie — the \"boot\" again."
-            },
-            {
-              "kind": "table",
-              "headers": [],
-              "columns": 3,
-              "rowCount": 5,
-              "utterances": [
-                "yo, vengo, (-go form).",
-                "tú, vienes, (e becomes ie).",
-                "él/ella/usted, viene, (e becomes ie).",
-                "nosotros, venimos, (plain e — unstressed).",
-                "ellos/ustedes, vienen, (e becomes ie)."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "Venimos alone keeps the plain e (stress on the ending), drawing the boot; everything inside it cracks to ie, and the yo corner carries the -go. This is the exact shape of tener (tengo / tienes) — venir is its mirror twin."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "unknown",
-          "title": "The club is complete",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "You have now met all six: tengo, hago, digo, pongo, salgo, vengo. Three plain -go (poner, salir, hacer), one -go + e becomes i (decir), two -go + e becomes ie (tener, venir). The corner is closed."
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"venir\" then the set — \"vengo, vienes, viene, venimos, vienen\" — the g in vengo, the ie through the boot, plain e in venimos",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"venir\" then the set — \"**vengo**, vienes, viene, venimos, vienen\" — the *g* in *vengo*, the *ie* through the boot, plain *e* in *venimos*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"Vengo de España\" (\"I come from Spain\"); \"¿Vienes?\" (\"Are you coming?\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"Vengo de España\" (\"I come from Spain\"); \"¿Vienes?\" (\"Are you coming?\")]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"venir\" then English \"adventure, convene, event\" — the come-family",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"venir\" then English \"adventure, convene, event\" — the come-family]"
-            }
-          ]
-        },
-        {
-          "index": 6,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Name venir's two irregularities. (The -go yo-form vengo, and the e becomes ie stem-change.) Which form escapes the boot, and why? (venimos — stress on the ending.) What Latin verb, and two English cousins? (venīre; adventure/event/convene — any two.) Which earlier verb is venir's exact twin? (tener — tengo/tienes = vengo/vienes.) Next: practice — the whole -go club at once."
             }
           ]
         }

--- a/code/learning/human-languages/spanish/narration/ch13.txt
+++ b/code/learning/human-languages/spanish/narration/ch13.txt
@@ -45,6 +45,85 @@ What Latin verb is poner from, and two English cousins? (pōnere "to place"; pos
 
 
 Lesson 2 of 4.
+salir — "to go out," from a verb that meant "to leap".
+
+Warm-up.
+[pause 2 seconds]
+The second -go verb: salir ("to leave, to go out"). Same story as poner — regular -ir everywhere but the yo-form, which grows the g: salgo. But its origin is a delight: salir comes from a Latin verb for leaping.
+
+The word, taken apart.
+salir comes from Latin salīre, "to leap, to jump, to spring" — and over time "leaping out" softened into simply "going out." The leap survives across English:
+salient ("leaping out," so: prominent, sticking out), sally ("a sudden rush out"), somersault (sopra + saltus, "a leap over").
+with prefixes: assail / assault ("leap at"), resilient ("leap back"), result ("leap back out"), insult ("leap upon").
+and the salmon — salīre gave Latin salmō, "the leaper," for the fish that leaps upstream.
+So every time you say salgo ("I go out"), you are using the old "leap" verb behind salient and salmon.
+
+Grammar Lens: the -go yo-form.
+[a table of 5 rows, read aloud]
+yo, salgo, (-go, like pongo/tengo).
+tú, sales, (regular).
+él/ella/usted, sale, (regular).
+nosotros, salimos, (regular).
+ellos/ustedes, salen, (regular).
+The everyday payoff: salir de casa ("to leave the house"), salir con alguien ("to go out with someone" — to date), and la salida ("the exit" — the sign you'll read at every station). Note: English exit is from a different Latin verb, exīre ("go out"); Spanish chose the leaping one.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "salir" then the set — "salgo, sales, sale, salimos, salen"]
+[pause 8 seconds for the answer]
+[your turn — say: "Salgo de casa" ("I leave the house"); "la salida" ("the exit")]
+[pause 8 seconds for the answer]
+[your turn — say: "salir" then English "salient, salmon, somersault" — the leap-family]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What did salir's Latin root salīre originally mean? ("To leap / jump.") Name two English cousins. (salient/sally/somersault/salmon — any two.) Give the yo-form and the sign it hides. (salgo; la salida = the exit.) Next: venir — the last -go verb, and the trickiest, because it also cracks its stem.
+
+
+Lesson 3 of 4.
+venir — "to come," the last club member, cracked and g-grown.
+
+Warm-up.
+[pause 2 seconds]
+The sixth and final member of the -go club: venir ("to come"). And like decir back in Chapter 12, it is doubly irregular — it stacks the -go yo-form and a stem-change. Learn venir and the whole system you've been building since tener clicks shut.
+
+Sounds you'll need.
+g-hard — the -go of vengo.
+diphthong-ie — the stressed stem e breaks to ie: vienes = vee-EH-nes.
+
+The word, taken apart.
+venir comes from Latin venīre, "to come" — a root ven-/vent- that comes toward English from every direction:
+adventure (ad-venīre, "what comes to you"), event ("what comes out"), convene / convention ("come together"), invent ("come upon"), prevent ("come before"), intervene, revenue ("what comes back"), avenue ("a coming-toward"), and souvenir (French, "a thing that comes to mind").
+
+Grammar Lens: two irregularities at once.
+(1) The -go yo-form, like pongo/salgo/tengo: vengo. (2) The e becomes ie stem-change, like querer/tener: the stressed stem breaks to ie — the "boot" again.
+[a table of 5 rows, read aloud]
+yo, vengo, (-go form).
+tú, vienes, (e becomes ie).
+él/ella/usted, viene, (e becomes ie).
+nosotros, venimos, (plain e — unstressed).
+ellos/ustedes, vienen, (e becomes ie).
+Venimos alone keeps the plain e (stress on the ending), drawing the boot; everything inside it cracks to ie, and the yo corner carries the -go. This is the exact shape of tener (tengo / tienes) — venir is its mirror twin.
+
+The club is complete.
+You have now met all six: tengo, hago, digo, pongo, salgo, vengo. Three plain -go (poner, salir, hacer), one -go + e becomes i (decir), two -go + e becomes ie (tener, venir). The corner is closed.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "venir" then the set — "vengo, vienes, viene, venimos, vienen" — the g in vengo, the ie through the boot, plain e in venimos]
+[pause 8 seconds for the answer]
+[your turn — say: "Vengo de España" ("I come from Spain"); "¿Vienes?" ("Are you coming?")]
+[pause 8 seconds for the answer]
+[your turn — say: "venir" then English "adventure, convene, event" — the come-family]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Name venir's two irregularities. (The -go yo-form vengo, and the e becomes ie stem-change.) Which form escapes the boot, and why? (venimos — stress on the ending.) What Latin verb, and two English cousins? (venīre; adventure/event/convene — any two.) Which earlier verb is venir's exact twin? (tener — tengo/tienes = vengo/vienes.) Next: practice — the whole -go club at once.
+
+
+Lesson 4 of 4.
 Practice — the -go club, complete.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped.
@@ -93,82 +172,3 @@ venir from venīre becomes? (adventure / event / convene.)
 Wrap-up Recall.
 [pause 3 seconds]
 Recite the six yo-forms of the club. (tengo, hago, digo, pongo, salgo, vengo.) Which two are the e becomes ie "boot" twins? (tener and venir.) Which single verb is -go and e becomes i? (decir — digo/dices.) You now hold the whole irregular -go corner of Spanish — its oldest, most-used verbs, mastered as one pattern.
-
-
-Lesson 3 of 4.
-salir — "to go out," from a verb that meant "to leap".
-
-Warm-up.
-[pause 2 seconds]
-The second -go verb: salir ("to leave, to go out"). Same story as poner — regular -ir everywhere but the yo-form, which grows the g: salgo. But its origin is a delight: salir comes from a Latin verb for leaping.
-
-The word, taken apart.
-salir comes from Latin salīre, "to leap, to jump, to spring" — and over time "leaping out" softened into simply "going out." The leap survives across English:
-salient ("leaping out," so: prominent, sticking out), sally ("a sudden rush out"), somersault (sopra + saltus, "a leap over").
-with prefixes: assail / assault ("leap at"), resilient ("leap back"), result ("leap back out"), insult ("leap upon").
-and the salmon — salīre gave Latin salmō, "the leaper," for the fish that leaps upstream.
-So every time you say salgo ("I go out"), you are using the old "leap" verb behind salient and salmon.
-
-Grammar Lens: the -go yo-form.
-[a table of 5 rows, read aloud]
-yo, salgo, (-go, like pongo/tengo).
-tú, sales, (regular).
-él/ella/usted, sale, (regular).
-nosotros, salimos, (regular).
-ellos/ustedes, salen, (regular).
-The everyday payoff: salir de casa ("to leave the house"), salir con alguien ("to go out with someone" — to date), and la salida ("the exit" — the sign you'll read at every station). Note: English exit is from a different Latin verb, exīre ("go out"); Spanish chose the leaping one.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "salir" then the set — "salgo, sales, sale, salimos, salen"]
-[pause 8 seconds for the answer]
-[your turn — say: "Salgo de casa" ("I leave the house"); "la salida" ("the exit")]
-[pause 8 seconds for the answer]
-[your turn — say: "salir" then English "salient, salmon, somersault" — the leap-family]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What did salir's Latin root salīre originally mean? ("To leap / jump.") Name two English cousins. (salient/sally/somersault/salmon — any two.) Give the yo-form and the sign it hides. (salgo; la salida = the exit.) Next: venir — the last -go verb, and the trickiest, because it also cracks its stem.
-
-
-Lesson 4 of 4.
-venir — "to come," the last club member, cracked and g-grown.
-
-Warm-up.
-[pause 2 seconds]
-The sixth and final member of the -go club: venir ("to come"). And like decir back in Chapter 12, it is doubly irregular — it stacks the -go yo-form and a stem-change. Learn venir and the whole system you've been building since tener clicks shut.
-
-Sounds you'll need.
-g-hard — the -go of vengo.
-diphthong-ie — the stressed stem e breaks to ie: vienes = vee-EH-nes.
-
-The word, taken apart.
-venir comes from Latin venīre, "to come" — a root ven-/vent- that comes toward English from every direction:
-adventure (ad-venīre, "what comes to you"), event ("what comes out"), convene / convention ("come together"), invent ("come upon"), prevent ("come before"), intervene, revenue ("what comes back"), avenue ("a coming-toward"), and souvenir (French, "a thing that comes to mind").
-
-Grammar Lens: two irregularities at once.
-(1) The -go yo-form, like pongo/salgo/tengo: vengo. (2) The e becomes ie stem-change, like querer/tener: the stressed stem breaks to ie — the "boot" again.
-[a table of 5 rows, read aloud]
-yo, vengo, (-go form).
-tú, vienes, (e becomes ie).
-él/ella/usted, viene, (e becomes ie).
-nosotros, venimos, (plain e — unstressed).
-ellos/ustedes, vienen, (e becomes ie).
-Venimos alone keeps the plain e (stress on the ending), drawing the boot; everything inside it cracks to ie, and the yo corner carries the -go. This is the exact shape of tener (tengo / tienes) — venir is its mirror twin.
-
-The club is complete.
-You have now met all six: tengo, hago, digo, pongo, salgo, vengo. Three plain -go (poner, salir, hacer), one -go + e becomes i (decir), two -go + e becomes ie (tener, venir). The corner is closed.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "venir" then the set — "vengo, vienes, viene, venimos, vienen" — the g in vengo, the ie through the boot, plain e in venimos]
-[pause 8 seconds for the answer]
-[your turn — say: "Vengo de España" ("I come from Spain"); "¿Vienes?" ("Are you coming?")]
-[pause 8 seconds for the answer]
-[your turn — say: "venir" then English "adventure, convene, event" — the come-family]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Name venir's two irregularities. (The -go yo-form vengo, and the e becomes ie stem-change.) Which form escapes the boot, and why? (venimos — stress on the ending.) What Latin verb, and two English cousins? (venīre; adventure/event/convene — any two.) Which earlier verb is venir's exact twin? (tener — tengo/tienes = vengo/vienes.) Next: practice — the whole -go club at once.

--- a/code/learning/human-languages/spanish/narration/ch14.json
+++ b/code/learning/human-languages/spanish/narration/ch14.json
@@ -4,11 +4,164 @@
   "chapter": 14,
   "title": "Chapter 14",
   "drivablePrefix": 3,
-  "sourceHash": "fnv1a64:6bfd206207773458",
+  "sourceHash": "fnv1a64:7b5d1287654f2e62",
   "lessons": [
     {
+      "id": "ES-C14-ser-ir-preterite",
+      "sequence": 578,
+      "title": "fui — the past tense arrives, and two verbs become one",
+      "headword": "fui",
+      "romanization": "fui",
+      "gloss": "the preterite (past) — and the astonishing fact that \"I was\" and \"I went\" are the same word",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:5cb98853f54215d7",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "A big moment: your first past tense. Spanish's everyday past is the preterite — \"I spoke, I went, I was.\" And it opens with the strangest, most memorable fact in the whole language: the verbs ser (\"to be\") and ir (\"to go\") have the exact same preterite. Fui means both \"I was\" and \"I went.\""
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "stress-final — the preterite loves the final syllable: fui, fue (one-syllable), then fuiste, fuimos, fueron."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "unknown",
+          "title": "The shared forms",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                "ser / ir (same!)"
+              ],
+              "columns": 2,
+              "rowCount": 5,
+              "utterances": [
+                "yo. ser / ir (same!): fui.",
+                "tú. ser / ir (same!): fuiste.",
+                "él/ella/usted. ser / ir (same!): fue.",
+                "nosotros. ser / ir (same!): fuimos.",
+                "ellos/ustedes. ser / ir (same!): fueron."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "One set of forms, two verbs. There is no separate past for \"to go\" — Spanish just reuses \"to be.\""
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "unknown",
+          "title": "Why? A tale of two \"be\" verbs",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "fui comes from Latin fuī, \"I have been\" — but here is the twist: Latin had two roots for \"to be.\" The present sum/es/est ( becomes soy/eres/es) came from PIE es-; the perfect fuī came from a different root, PIE bʰuH-, \"to grow, become\" — the very root of English be, been, and (through Greek and Latin) future and physics. Spanish stitched the two roots into one verb — that's suppletion, like English go/went."
+            },
+            {
+              "kind": "speech",
+              "text": "Then ir (\"to go\") borrowed fuī too, because Latin's own past of īre had worn away. So \"to be\" and \"to go\" merged in the past — and only context tells them apart:"
+            },
+            {
+              "kind": "speech",
+              "text": "Fui a Madrid. — \"I went to Madrid.\" (movement becomes ir)."
+            },
+            {
+              "kind": "speech",
+              "text": "Fui profesor. — \"I was a teacher.\" (state becomes ser)."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the set — \"fui, fuiste, fue, fuimos, fueron\" — stress the end",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the set — \"fui, fuiste, fue, fuimos, fueron\" — stress the end]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the two meanings — \"Fui a casa\" (I went) vs \"Fui feliz\" (I was happy)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the two meanings — \"Fui a casa\" (I went) vs \"Fui feliz\" (I was happy)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"same form, context decides — ser and ir share one past\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"same form, context decides — ser and ir share one past\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What tense is fui, and which two verbs does it belong to? (The preterite — both ser and ir.) Give all five forms. (Fui, fuiste, fue, fuimos, fueron.) In \"Fui a España,\" is it ser or ir, and how do you know? (Ir — \"I went\"; the a + place signals movement.) Next: the regular -ar preterite — hablé, hablaste."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "ES-C14-hablar-preterite",
-      "sequence": null,
+      "sequence": 580,
       "title": "hablé — the regular past, built on an accent",
       "headword": "hablé",
       "romanization": "hablé",
@@ -19,7 +172,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:6b93bb30072baaa4",
+      "sourceHash": "fnv1a64:99d2ac9cf71ade02",
       "notice": null,
       "blocks": [
         {
@@ -161,7 +314,7 @@
     },
     {
       "id": "ES-C14-practice",
-      "sequence": null,
+      "sequence": 582,
       "title": "Practice — the preterite, past against present",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -172,7 +325,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:528631b16e43cd5c",
+      "sourceHash": "fnv1a64:eefb1d965f836b28",
       "notice": null,
       "blocks": [
         {
@@ -328,159 +481,6 @@
             {
               "kind": "speech",
               "text": "Which two verbs share the preterite fui/fue? (ser and ir.) How does the accent change hablo into habló? (It moves the stress to the end — present becomes preterite.) In \"Fui a casa,\" be/go? (Go — ir.) You can now speak in the past — the course has crossed from \"what is\" to \"what happened.\""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ES-C14-ser-ir-preterite",
-      "sequence": null,
-      "title": "fui — the past tense arrives, and two verbs become one",
-      "headword": "fui",
-      "romanization": "fui",
-      "gloss": "the preterite (past) — and the astonishing fact that \"I was\" and \"I went\" are the same word",
-      "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:e940d842f1a80dd8",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "A big moment: your first past tense. Spanish's everyday past is the preterite — \"I spoke, I went, I was.\" And it opens with the strangest, most memorable fact in the whole language: the verbs ser (\"to be\") and ir (\"to go\") have the exact same preterite. Fui means both \"I was\" and \"I went.\""
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "pronunciation",
-          "title": "Sounds you'll need",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "stress-final — the preterite loves the final syllable: fui, fue (one-syllable), then fuiste, fuimos, fueron."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "unknown",
-          "title": "The shared forms",
-          "segments": [
-            {
-              "kind": "table",
-              "headers": [
-                "",
-                "ser / ir (same!)"
-              ],
-              "columns": 2,
-              "rowCount": 5,
-              "utterances": [
-                "yo. ser / ir (same!): fui.",
-                "tú. ser / ir (same!): fuiste.",
-                "él/ella/usted. ser / ir (same!): fue.",
-                "nosotros. ser / ir (same!): fuimos.",
-                "ellos/ustedes. ser / ir (same!): fueron."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "One set of forms, two verbs. There is no separate past for \"to go\" — Spanish just reuses \"to be.\""
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "unknown",
-          "title": "Why? A tale of two \"be\" verbs",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "fui comes from Latin fuī, \"I have been\" — but here is the twist: Latin had two roots for \"to be.\" The present sum/es/est ( becomes soy/eres/es) came from PIE es-; the perfect fuī came from a different root, PIE bʰuH-, \"to grow, become\" — the very root of English be, been, and (through Greek and Latin) future and physics. Spanish stitched the two roots into one verb — that's suppletion, like English go/went."
-            },
-            {
-              "kind": "speech",
-              "text": "Then ir (\"to go\") borrowed fuī too, because Latin's own past of īre had worn away. So \"to be\" and \"to go\" merged in the past — and only context tells them apart:"
-            },
-            {
-              "kind": "speech",
-              "text": "Fui a Madrid. — \"I went to Madrid.\" (movement becomes ir)."
-            },
-            {
-              "kind": "speech",
-              "text": "Fui profesor. — \"I was a teacher.\" (state becomes ser)."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the set — \"fui, fuiste, fue, fuimos, fueron\" — stress the end",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the set — \"fui, fuiste, fue, fuimos, fueron\" — stress the end]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the two meanings — \"Fui a casa\" (I went) vs \"Fui feliz\" (I was happy)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the two meanings — \"Fui a casa\" (I went) vs \"Fui feliz\" (I was happy)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"same form, context decides — ser and ir share one past\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"same form, context decides — ser and ir share one past\"]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What tense is fui, and which two verbs does it belong to? (The preterite — both ser and ir.) Give all five forms. (Fui, fuiste, fue, fuimos, fueron.) In \"Fui a España,\" is it ser or ir, and how do you know? (Ir — \"I went\"; the a + place signals movement.) Next: the regular -ar preterite — hablé, hablaste."
             }
           ]
         }

--- a/code/learning/human-languages/spanish/narration/ch14.txt
+++ b/code/learning/human-languages/spanish/narration/ch14.txt
@@ -3,6 +3,45 @@ Spanish, chapter 14: Chapter 14.
 
 
 Lesson 1 of 3.
+fui — the past tense arrives, and two verbs become one.
+
+Warm-up.
+[pause 2 seconds]
+A big moment: your first past tense. Spanish's everyday past is the preterite — "I spoke, I went, I was." And it opens with the strangest, most memorable fact in the whole language: the verbs ser ("to be") and ir ("to go") have the exact same preterite. Fui means both "I was" and "I went."
+
+Sounds you'll need.
+stress-final — the preterite loves the final syllable: fui, fue (one-syllable), then fuiste, fuimos, fueron.
+
+The shared forms.
+[a table of 5 rows, read aloud]
+yo. ser / ir (same!): fui.
+tú. ser / ir (same!): fuiste.
+él/ella/usted. ser / ir (same!): fue.
+nosotros. ser / ir (same!): fuimos.
+ellos/ustedes. ser / ir (same!): fueron.
+One set of forms, two verbs. There is no separate past for "to go" — Spanish just reuses "to be."
+
+Why? A tale of two "be" verbs.
+fui comes from Latin fuī, "I have been" — but here is the twist: Latin had two roots for "to be." The present sum/es/est ( becomes soy/eres/es) came from PIE es-; the perfect fuī came from a different root, PIE bʰuH-, "to grow, become" — the very root of English be, been, and (through Greek and Latin) future and physics. Spanish stitched the two roots into one verb — that's suppletion, like English go/went.
+Then ir ("to go") borrowed fuī too, because Latin's own past of īre had worn away. So "to be" and "to go" merged in the past — and only context tells them apart:
+Fui a Madrid. — "I went to Madrid." (movement becomes ir).
+Fui profesor. — "I was a teacher." (state becomes ser).
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: the set — "fui, fuiste, fue, fuimos, fueron" — stress the end]
+[pause 8 seconds for the answer]
+[your turn — say: the two meanings — "Fui a casa" (I went) vs "Fui feliz" (I was happy)]
+[pause 8 seconds for the answer]
+[your turn — say: "same form, context decides — ser and ir share one past"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What tense is fui, and which two verbs does it belong to? (The preterite — both ser and ir.) Give all five forms. (Fui, fuiste, fue, fuimos, fueron.) In "Fui a España," is it ser or ir, and how do you know? (Ir — "I went"; the a + place signals movement.) Next: the regular -ar preterite — hablé, hablaste.
+
+
+Lesson 2 of 3.
 hablé — the regular past, built on an accent.
 
 Warm-up.
@@ -42,7 +81,7 @@ Wrap-up Recall.
 Give the -ar preterite of hablar. (Hablé, hablaste, habló, hablamos, hablaron.) What single feature separates hablo (present) from habló (preterite)? (The accent — where the stress falls.) Which form is identical in present and preterite, and what disambiguates it? (Hablamos — context / a time-word like ayer.) Next: practice — past vs present, side by side.
 
 
-Lesson 2 of 3.
+Lesson 3 of 3.
 Practice — the preterite, past against present.
 
 Warm-up.
@@ -81,42 +120,3 @@ Say each out loud:
 Wrap-up Recall.
 [pause 3 seconds]
 Which two verbs share the preterite fui/fue? (ser and ir.) How does the accent change hablo into habló? (It moves the stress to the end — present becomes preterite.) In "Fui a casa," be/go? (Go — ir.) You can now speak in the past — the course has crossed from "what is" to "what happened."
-
-
-Lesson 3 of 3.
-fui — the past tense arrives, and two verbs become one.
-
-Warm-up.
-[pause 2 seconds]
-A big moment: your first past tense. Spanish's everyday past is the preterite — "I spoke, I went, I was." And it opens with the strangest, most memorable fact in the whole language: the verbs ser ("to be") and ir ("to go") have the exact same preterite. Fui means both "I was" and "I went."
-
-Sounds you'll need.
-stress-final — the preterite loves the final syllable: fui, fue (one-syllable), then fuiste, fuimos, fueron.
-
-The shared forms.
-[a table of 5 rows, read aloud]
-yo. ser / ir (same!): fui.
-tú. ser / ir (same!): fuiste.
-él/ella/usted. ser / ir (same!): fue.
-nosotros. ser / ir (same!): fuimos.
-ellos/ustedes. ser / ir (same!): fueron.
-One set of forms, two verbs. There is no separate past for "to go" — Spanish just reuses "to be."
-
-Why? A tale of two "be" verbs.
-fui comes from Latin fuī, "I have been" — but here is the twist: Latin had two roots for "to be." The present sum/es/est ( becomes soy/eres/es) came from PIE es-; the perfect fuī came from a different root, PIE bʰuH-, "to grow, become" — the very root of English be, been, and (through Greek and Latin) future and physics. Spanish stitched the two roots into one verb — that's suppletion, like English go/went.
-Then ir ("to go") borrowed fuī too, because Latin's own past of īre had worn away. So "to be" and "to go" merged in the past — and only context tells them apart:
-Fui a Madrid. — "I went to Madrid." (movement becomes ir).
-Fui profesor. — "I was a teacher." (state becomes ser).
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: the set — "fui, fuiste, fue, fuimos, fueron" — stress the end]
-[pause 8 seconds for the answer]
-[your turn — say: the two meanings — "Fui a casa" (I went) vs "Fui feliz" (I was happy)]
-[pause 8 seconds for the answer]
-[your turn — say: "same form, context decides — ser and ir share one past"]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What tense is fui, and which two verbs does it belong to? (The preterite — both ser and ir.) Give all five forms. (Fui, fuiste, fue, fuimos, fueron.) In "Fui a España," is it ser or ir, and how do you know? (Ir — "I went"; the a + place signals movement.) Next: the regular -ar preterite — hablé, hablaste.

--- a/code/learning/human-languages/spanish/narration/ch15.json
+++ b/code/learning/human-languages/spanish/narration/ch15.json
@@ -4,11 +4,11 @@
   "chapter": 15,
   "title": "Chapter 15",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:8749ab0a4a2c672b",
+  "sourceHash": "fnv1a64:bf95b4776eb920c1",
   "lessons": [
     {
       "id": "ES-C15-comer-vivir-preterite",
-      "sequence": null,
+      "sequence": 584,
       "title": "comí, viví — two conjugations become one",
       "headword": "comí, viví",
       "romanization": "comí, viví",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:16ca99df1a1c073e",
+      "sourceHash": "fnv1a64:c4492b031d93a760",
       "notice": null,
       "blocks": [
         {
@@ -166,8 +166,198 @@
       ]
     },
     {
+      "id": "ES-C15-preterite-fuertes",
+      "sequence": 586,
+      "title": "tuve, hice, estuve — the strong preterites",
+      "headword": "tuve, hice, estuve",
+      "romanization": "tuve, hice, estuve",
+      "gloss": "the strong preterites — where the stress moves off the ending and the accent disappears",
+      "script": "latin",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "wide-table"
+      ],
+      "sourceHash": "fnv1a64:1bf08f09f5512a0b",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes for 2 tables that cannot be read aloud"
+        ],
+        "waitUntilStopped": [
+          "Three of them, all verbs you know",
+          "The accent rule, inverted"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for 2 tables that cannot be read aloud. You can listen to everything else now — leave the sections called Three of them, all verbs you know and The accent rule, inverted until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Everything so far pushed the stress to the end: hablÉ, comÍ, comIÓ. Now meet the verbs that do the opposite. They pull the stress back into the stem — and so they lose their accent marks entirely. Spanish calls them pretéritos fuertes, \"strong\" preterites: strong because the stem carries the weight."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "Three of them, all verbs you know",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The stem changes, then one shared set of endings: -e, -iste, -o, -imos, -ieron."
+            },
+            {
+              "kind": "table-skipped",
+              "reason": "too-wide",
+              "columns": 4,
+              "rowCount": 5,
+              "headers": [
+                "",
+                "tener becomes tuv-",
+                "hacer becomes hic-",
+                "estar becomes estuv-"
+              ],
+              "text": "There is a table here I cannot read to you — 4 columns and 5 rows, and it has more columns than can be held in the ear at once. Its columns are: one with no heading, tener becomes tuv-, hacer becomes hic-, estar becomes estuv-. Come back and look at it when you have stopped."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "unknown",
+          "title": "The accent rule, inverted",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Compare the yo and él forms across the three families:"
+            },
+            {
+              "kind": "table-skipped",
+              "reason": "too-wide",
+              "columns": 5,
+              "rowCount": 3,
+              "headers": [
+                "family",
+                "yo",
+                "él/ella",
+                "stressed syllable",
+                "accent?"
+              ],
+              "text": "There is a table here I cannot read to you — 5 columns and 3 rows, and it has more columns than can be held in the ear at once. Its columns are: family, yo, él/ella, stressed syllable, accent?. Come back and look at it when you have stopped."
+            },
+            {
+              "kind": "speech",
+              "text": "Say them out loud back to back: hablÓ … TUvo. The written accent isn't decoration — it's telling you where the stress went. No accent on a strong preterite because the stress never left the stem."
+            },
+            {
+              "kind": "speech",
+              "text": "Note the yo ending too: -e, not -é (tuve, not tuvé)."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "unknown",
+          "title": "One spelling swerve",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Hacer gives hizo, not hico — Spanish swaps c becomes z before o to keep the sound the same. The letter changes so the pronunciation won't."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "unknown",
+          "title": "Why these are irregular",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Because they're old. Latin had two ways to build a perfect, and these verbs kept the \"strong\" one, inherited whole rather than rebuilt: tenuī becomes tuve, fēcī becomes hice, stetī/stāre becomes estuve. The regular -ar/-er/-ir patterns are the tidy replacements that spread later; the strong verbs are the most-used ones, worn smooth by frequency and never re-made. Notice tuv- and estuv- even share the same -uv- shape."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"tuve, tuviste, tuvo, tuvimos, tuvieron\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"tuve, tuviste, tuvo, tuvimos, tuvieron\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"hice, hiciste, hizo\" — hear the z",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"hice, hiciste, hizo\" — hear the **z**]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the contrast pair — \"hablÓ … TUvo\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the contrast pair — \"hablÓ … TUvo\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Ayer estuve en casa\" (\"Yesterday I was at home\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Ayer estuve en casa\" (\"Yesterday I was at home\")]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Why \"strong\"? (The stem carries the stress.) So why no accent marks? (Because the stress never reaches the ending — the accent only ever marked that.) What's the yo ending? (-e, not -é.) Why hizo and not hico? (c becomes z before o, to protect the sound.) Where do they come from? (Latin's strong perfects — tenuī, fēcī — inherited, not rebuilt.) Next: all three families side by side."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "ES-C15-practice",
-      "sequence": null,
+      "sequence": 588,
       "title": "Practice — three families, one question",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -178,7 +368,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:f60f008428500914",
+      "sourceHash": "fnv1a64:84f421ddf990bd02",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -351,196 +541,6 @@
             {
               "kind": "speech",
               "text": "Which two rows are identical? (-er and -ir.) Which forms take a written accent? (Yo and él/ella of the regular verbs only.) What single test separates regular from strong? (Where the stress lands — ending vs stem.) Which form means both \"I was\" and \"I went\"? (Fui.) Which nosotros forms are tense-ambiguous? (Hablamos, vivimos — but not comimos.) Next chapter: talking about the past that kept going — the imperfect."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ES-C15-preterite-fuertes",
-      "sequence": null,
-      "title": "tuve, hice, estuve — the strong preterites",
-      "headword": "tuve, hice, estuve",
-      "romanization": "tuve, hice, estuve",
-      "gloss": "the strong preterites — where the stress moves off the ending and the accent disappears",
-      "script": "latin",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "wide-table"
-      ],
-      "sourceHash": "fnv1a64:51b0f34d77b634bd",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes for 2 tables that cannot be read aloud"
-        ],
-        "waitUntilStopped": [
-          "Three of them, all verbs you know",
-          "The accent rule, inverted"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for 2 tables that cannot be read aloud. You can listen to everything else now — leave the sections called Three of them, all verbs you know and The accent rule, inverted until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Everything so far pushed the stress to the end: hablÉ, comÍ, comIÓ. Now meet the verbs that do the opposite. They pull the stress back into the stem — and so they lose their accent marks entirely. Spanish calls them pretéritos fuertes, \"strong\" preterites: strong because the stem carries the weight."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "Three of them, all verbs you know",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "The stem changes, then one shared set of endings: -e, -iste, -o, -imos, -ieron."
-            },
-            {
-              "kind": "table-skipped",
-              "reason": "too-wide",
-              "columns": 4,
-              "rowCount": 5,
-              "headers": [
-                "",
-                "tener becomes tuv-",
-                "hacer becomes hic-",
-                "estar becomes estuv-"
-              ],
-              "text": "There is a table here I cannot read to you — 4 columns and 5 rows, and it has more columns than can be held in the ear at once. Its columns are: one with no heading, tener becomes tuv-, hacer becomes hic-, estar becomes estuv-. Come back and look at it when you have stopped."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "unknown",
-          "title": "The accent rule, inverted",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Compare the yo and él forms across the three families:"
-            },
-            {
-              "kind": "table-skipped",
-              "reason": "too-wide",
-              "columns": 5,
-              "rowCount": 3,
-              "headers": [
-                "family",
-                "yo",
-                "él/ella",
-                "stressed syllable",
-                "accent?"
-              ],
-              "text": "There is a table here I cannot read to you — 5 columns and 3 rows, and it has more columns than can be held in the ear at once. Its columns are: family, yo, él/ella, stressed syllable, accent?. Come back and look at it when you have stopped."
-            },
-            {
-              "kind": "speech",
-              "text": "Say them out loud back to back: hablÓ … TUvo. The written accent isn't decoration — it's telling you where the stress went. No accent on a strong preterite because the stress never left the stem."
-            },
-            {
-              "kind": "speech",
-              "text": "Note the yo ending too: -e, not -é (tuve, not tuvé)."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "unknown",
-          "title": "One spelling swerve",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Hacer gives hizo, not hico — Spanish swaps c becomes z before o to keep the sound the same. The letter changes so the pronunciation won't."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "unknown",
-          "title": "Why these are irregular",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Because they're old. Latin had two ways to build a perfect, and these verbs kept the \"strong\" one, inherited whole rather than rebuilt: tenuī becomes tuve, fēcī becomes hice, stetī/stāre becomes estuve. The regular -ar/-er/-ir patterns are the tidy replacements that spread later; the strong verbs are the most-used ones, worn smooth by frequency and never re-made. Notice tuv- and estuv- even share the same -uv- shape."
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"tuve, tuviste, tuvo, tuvimos, tuvieron\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"tuve, tuviste, tuvo, tuvimos, tuvieron\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"hice, hiciste, hizo\" — hear the z",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"hice, hiciste, hizo\" — hear the **z**]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the contrast pair — \"hablÓ … TUvo\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the contrast pair — \"hablÓ … TUvo\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"Ayer estuve en casa\" (\"Yesterday I was at home\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"Ayer estuve en casa\" (\"Yesterday I was at home\")]"
-            }
-          ]
-        },
-        {
-          "index": 6,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Why \"strong\"? (The stem carries the stress.) So why no accent marks? (Because the stress never reaches the ending — the accent only ever marked that.) What's the yo ending? (-e, not -é.) Why hizo and not hico? (c becomes z before o, to protect the sound.) Where do they come from? (Latin's strong perfects — tenuī, fēcī — inherited, not rebuilt.) Next: all three families side by side."
             }
           ]
         }

--- a/code/learning/human-languages/spanish/narration/ch15.txt
+++ b/code/learning/human-languages/spanish/narration/ch15.txt
@@ -43,6 +43,47 @@ Give the five -er/-ir preterite endings. (-í, -iste, -ió, -imos, -ieron.) What
 
 
 Lesson 2 of 3.
+tuve, hice, estuve — the strong preterites.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for 2 tables that cannot be read aloud. You can listen to everything else now — leave the sections called Three of them, all verbs you know and The accent rule, inverted until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Everything so far pushed the stress to the end: hablÉ, comÍ, comIÓ. Now meet the verbs that do the opposite. They pull the stress back into the stem — and so they lose their accent marks entirely. Spanish calls them pretéritos fuertes, "strong" preterites: strong because the stem carries the weight.
+
+Three of them, all verbs you know.
+The stem changes, then one shared set of endings: -e, -iste, -o, -imos, -ieron.
+There is a table here I cannot read to you — 4 columns and 5 rows, and it has more columns than can be held in the ear at once. Its columns are: one with no heading, tener becomes tuv-, hacer becomes hic-, estar becomes estuv-. Come back and look at it when you have stopped.
+
+The accent rule, inverted.
+Compare the yo and él forms across the three families:
+There is a table here I cannot read to you — 5 columns and 3 rows, and it has more columns than can be held in the ear at once. Its columns are: family, yo, él/ella, stressed syllable, accent?. Come back and look at it when you have stopped.
+Say them out loud back to back: hablÓ … TUvo. The written accent isn't decoration — it's telling you where the stress went. No accent on a strong preterite because the stress never left the stem.
+Note the yo ending too: -e, not -é (tuve, not tuvé).
+
+One spelling swerve.
+Hacer gives hizo, not hico — Spanish swaps c becomes z before o to keep the sound the same. The letter changes so the pronunciation won't.
+
+Why these are irregular.
+Because they're old. Latin had two ways to build a perfect, and these verbs kept the "strong" one, inherited whole rather than rebuilt: tenuī becomes tuve, fēcī becomes hice, stetī/stāre becomes estuve. The regular -ar/-er/-ir patterns are the tidy replacements that spread later; the strong verbs are the most-used ones, worn smooth by frequency and never re-made. Notice tuv- and estuv- even share the same -uv- shape.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "tuve, tuviste, tuvo, tuvimos, tuvieron"]
+[pause 8 seconds for the answer]
+[your turn — say: "hice, hiciste, hizo" — hear the z]
+[pause 8 seconds for the answer]
+[your turn — say: the contrast pair — "hablÓ … TUvo"]
+[pause 8 seconds for the answer]
+[your turn — say: "Ayer estuve en casa" ("Yesterday I was at home")]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Why "strong"? (The stem carries the stress.) So why no accent marks? (Because the stress never reaches the ending — the accent only ever marked that.) What's the yo ending? (-e, not -é.) Why hizo and not hico? (c becomes z before o, to protect the sound.) Where do they come from? (Latin's strong perfects — tenuī, fēcī — inherited, not rebuilt.) Next: all three families side by side.
+
+
+Lesson 3 of 3.
 Practice — three families, one question.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called The whole map until you have stopped, and I will say so again when we reach it.
@@ -84,44 +125,3 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 Which two rows are identical? (-er and -ir.) Which forms take a written accent? (Yo and él/ella of the regular verbs only.) What single test separates regular from strong? (Where the stress lands — ending vs stem.) Which form means both "I was" and "I went"? (Fui.) Which nosotros forms are tense-ambiguous? (Hablamos, vivimos — but not comimos.) Next chapter: talking about the past that kept going — the imperfect.
-
-
-Lesson 3 of 3.
-tuve, hice, estuve — the strong preterites.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for 2 tables that cannot be read aloud. You can listen to everything else now — leave the sections called Three of them, all verbs you know and The accent rule, inverted until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Everything so far pushed the stress to the end: hablÉ, comÍ, comIÓ. Now meet the verbs that do the opposite. They pull the stress back into the stem — and so they lose their accent marks entirely. Spanish calls them pretéritos fuertes, "strong" preterites: strong because the stem carries the weight.
-
-Three of them, all verbs you know.
-The stem changes, then one shared set of endings: -e, -iste, -o, -imos, -ieron.
-There is a table here I cannot read to you — 4 columns and 5 rows, and it has more columns than can be held in the ear at once. Its columns are: one with no heading, tener becomes tuv-, hacer becomes hic-, estar becomes estuv-. Come back and look at it when you have stopped.
-
-The accent rule, inverted.
-Compare the yo and él forms across the three families:
-There is a table here I cannot read to you — 5 columns and 3 rows, and it has more columns than can be held in the ear at once. Its columns are: family, yo, él/ella, stressed syllable, accent?. Come back and look at it when you have stopped.
-Say them out loud back to back: hablÓ … TUvo. The written accent isn't decoration — it's telling you where the stress went. No accent on a strong preterite because the stress never left the stem.
-Note the yo ending too: -e, not -é (tuve, not tuvé).
-
-One spelling swerve.
-Hacer gives hizo, not hico — Spanish swaps c becomes z before o to keep the sound the same. The letter changes so the pronunciation won't.
-
-Why these are irregular.
-Because they're old. Latin had two ways to build a perfect, and these verbs kept the "strong" one, inherited whole rather than rebuilt: tenuī becomes tuve, fēcī becomes hice, stetī/stāre becomes estuve. The regular -ar/-er/-ir patterns are the tidy replacements that spread later; the strong verbs are the most-used ones, worn smooth by frequency and never re-made. Notice tuv- and estuv- even share the same -uv- shape.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "tuve, tuviste, tuvo, tuvimos, tuvieron"]
-[pause 8 seconds for the answer]
-[your turn — say: "hice, hiciste, hizo" — hear the z]
-[pause 8 seconds for the answer]
-[your turn — say: the contrast pair — "hablÓ … TUvo"]
-[pause 8 seconds for the answer]
-[your turn — say: "Ayer estuve en casa" ("Yesterday I was at home")]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Why "strong"? (The stem carries the stress.) So why no accent marks? (Because the stress never reaches the ending — the accent only ever marked that.) What's the yo ending? (-e, not -é.) Why hizo and not hico? (c becomes z before o, to protect the sound.) Where do they come from? (Latin's strong perfects — tenuī, fēcī — inherited, not rebuilt.) Next: all three families side by side.

--- a/code/learning/human-languages/spanish/narration/ch16.json
+++ b/code/learning/human-languages/spanish/narration/ch16.json
@@ -3,12 +3,12 @@
   "language": "spanish",
   "chapter": 16,
   "title": "Chapter 16",
-  "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:afadfe166aa49a8a",
+  "drivablePrefix": 1,
+  "sourceHash": "fnv1a64:30eaac9352ed3655",
   "lessons": [
     {
       "id": "ES-C16-imperfecto",
-      "sequence": null,
+      "sequence": 590,
       "title": "hablaba, comía — the past that kept going",
       "headword": "hablaba, comía",
       "romanization": "hablaba, comía",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:b01d70df596dd3f8",
+      "sourceHash": "fnv1a64:a7934411170c064f",
       "notice": null,
       "blocks": [
         {
@@ -194,8 +194,191 @@
       ]
     },
     {
+      "id": "ES-C16-tres-irregulares",
+      "sequence": 592,
+      "title": "era, iba, veía — all three of them",
+      "headword": "era, iba, veía",
+      "romanization": "era, iba, veía",
+      "gloss": "the only three irregular imperfects in the entire language",
+      "script": "latin",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "wide-table"
+      ],
+      "sourceHash": "fnv1a64:f0aeca46b35f7ba0",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes for one table that cannot be read aloud"
+        ],
+        "waitUntilStopped": [
+          "The complete list"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called The complete list until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Chapter 15 handed you a pile of strong preterites to memorise. Here is the compensation: the imperfect has three irregular verbs. Not three families — three verbs, in the whole language."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "The complete list",
+          "segments": [
+            {
+              "kind": "table-skipped",
+              "reason": "too-wide",
+              "columns": 4,
+              "rowCount": 5,
+              "headers": [
+                "",
+                "ser becomes era",
+                "ir becomes iba",
+                "ver becomes veía"
+              ],
+              "text": "There is a table here I cannot read to you — 4 columns and 5 rows, and it has more columns than can be held in the ear at once. Its columns are: one with no heading, ser becomes era, ir becomes iba, ver becomes veía. Come back and look at it when you have stopped."
+            },
+            {
+              "kind": "speech",
+              "text": "That is the entire irregular inventory. Every other verb in Spanish — thousands of them — takes the regular endings from the last lesson."
+            },
+            {
+              "kind": "speech",
+              "text": "Ver barely counts: it just keeps an extra -e- from its older form veer, then conjugates normally (ve- + -ía)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "unknown",
+          "title": "ir's third Latin verb",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Now the best thing in the chapter. Track where ir's tenses come from:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "tense",
+                "form",
+                "from Latin verb"
+              ],
+              "columns": 3,
+              "rowCount": 3,
+              "utterances": [
+                "tense: present. form: voy, vas, va. from Latin verb: vādere \"to advance\" (Ch. 10).",
+                "tense: preterite. form: fui, fuiste, fue. from Latin verb: fuī, from esse (Ch. 14).",
+                "tense: imperfect. form: iba, ibas, iba. from Latin verb: īre — its own infinitive."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Spanish ir is stitched together from three different Latin verbs, and the imperfect is the one place the original īre survives conjugated. The infinitive ir and the imperfect iba are the last two pieces of the real verb; everything else was borrowed from elsewhere."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "unknown",
+          "title": "era",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "era from Latin eram, from the same es- root as ser, soy, es — and as English is and are (Chapter 9). So ser uses that ancient root in the present and the imperfect, but jumps to fuī in the preterite: era vs fue."
+            },
+            {
+              "kind": "speech",
+              "text": "Note the accents: éramos, íbamos — stress three syllables back, exactly like hablábamos."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"era, eras, era, éramos, eran\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"era, eras, era, éramos, eran\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"iba, ibas, iba, íbamos, iban\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"iba, ibas, iba, íbamos, iban\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Cuando era niño, iba a la escuela\" (\"When I was a child, I used to go to school\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Cuando era niño, iba a la escuela\" (\"When I was a child, I used to go to school\")]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the three sources — \"voy from vādere, fui from fuī, iba from īre\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the three sources — \"voy ← *vādere* · fui ← *fuī* · iba ← *īre*\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "How many irregular imperfects are there? (Three — ser, ir, ver.) Which one hardly counts, and why? (Ver — it just keeps an extra -e- from veer.) Where does iba come from? (Latin īre — ir's own verb, and the only tense that kept it.) So how many Latin verbs is ir built from? (Three — vādere, fuī, īre.) Which two forms take a written accent? (Éramos, íbamos — stress three back.) Next: choosing between the two pasts."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "ES-C16-practice",
-      "sequence": null,
+      "sequence": 594,
       "title": "Practice — two pasts, one choice",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -206,7 +389,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:f2d5ad9eb96e32c1",
+      "sourceHash": "fnv1a64:8ea9920b4d1ad6c4",
       "notice": null,
       "blocks": [
         {
@@ -398,189 +581,6 @@
             {
               "kind": "speech",
               "text": "Preterite or imperfect for a habit? (Imperfect.) Which tense sets the background, and which interrupts it? (Imperfect sets, preterite interrupts.) What's the difference between conocía and conocí? (\"I knew someone\" vs \"I met them.\") How many irregular imperfects were there? (Three.) Give the one-word test. (\"Line or point?\") Next chapter: talking about what will happen."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ES-C16-tres-irregulares",
-      "sequence": null,
-      "title": "era, iba, veía — all three of them",
-      "headword": "era, iba, veía",
-      "romanization": "era, iba, veía",
-      "gloss": "the only three irregular imperfects in the entire language",
-      "script": "latin",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "wide-table"
-      ],
-      "sourceHash": "fnv1a64:02ca95b17070bfad",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes for one table that cannot be read aloud"
-        ],
-        "waitUntilStopped": [
-          "The complete list"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called The complete list until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Chapter 15 handed you a pile of strong preterites to memorise. Here is the compensation: the imperfect has three irregular verbs. Not three families — three verbs, in the whole language."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "The complete list",
-          "segments": [
-            {
-              "kind": "table-skipped",
-              "reason": "too-wide",
-              "columns": 4,
-              "rowCount": 5,
-              "headers": [
-                "",
-                "ser becomes era",
-                "ir becomes iba",
-                "ver becomes veía"
-              ],
-              "text": "There is a table here I cannot read to you — 4 columns and 5 rows, and it has more columns than can be held in the ear at once. Its columns are: one with no heading, ser becomes era, ir becomes iba, ver becomes veía. Come back and look at it when you have stopped."
-            },
-            {
-              "kind": "speech",
-              "text": "That is the entire irregular inventory. Every other verb in Spanish — thousands of them — takes the regular endings from the last lesson."
-            },
-            {
-              "kind": "speech",
-              "text": "Ver barely counts: it just keeps an extra -e- from its older form veer, then conjugates normally (ve- + -ía)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "unknown",
-          "title": "ir's third Latin verb",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Now the best thing in the chapter. Track where ir's tenses come from:"
-            },
-            {
-              "kind": "table",
-              "headers": [
-                "tense",
-                "form",
-                "from Latin verb"
-              ],
-              "columns": 3,
-              "rowCount": 3,
-              "utterances": [
-                "tense: present. form: voy, vas, va. from Latin verb: vādere \"to advance\" (Ch. 10).",
-                "tense: preterite. form: fui, fuiste, fue. from Latin verb: fuī, from esse (Ch. 14).",
-                "tense: imperfect. form: iba, ibas, iba. from Latin verb: īre — its own infinitive."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "Spanish ir is stitched together from three different Latin verbs, and the imperfect is the one place the original īre survives conjugated. The infinitive ir and the imperfect iba are the last two pieces of the real verb; everything else was borrowed from elsewhere."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "unknown",
-          "title": "era",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "era from Latin eram, from the same es- root as ser, soy, es — and as English is and are (Chapter 9). So ser uses that ancient root in the present and the imperfect, but jumps to fuī in the preterite: era vs fue."
-            },
-            {
-              "kind": "speech",
-              "text": "Note the accents: éramos, íbamos — stress three syllables back, exactly like hablábamos."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"era, eras, era, éramos, eran\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"era, eras, era, éramos, eran\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"iba, ibas, iba, íbamos, iban\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"iba, ibas, iba, íbamos, iban\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"Cuando era niño, iba a la escuela\" (\"When I was a child, I used to go to school\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"Cuando era niño, iba a la escuela\" (\"When I was a child, I used to go to school\")]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the three sources — \"voy from vādere, fui from fuī, iba from īre\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the three sources — \"voy ← *vādere* · fui ← *fuī* · iba ← *īre*\"]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "How many irregular imperfects are there? (Three — ser, ir, ver.) Which one hardly counts, and why? (Ver — it just keeps an extra -e- from veer.) Where does iba come from? (Latin īre — ir's own verb, and the only tense that kept it.) So how many Latin verbs is ir built from? (Three — vādere, fuī, īre.) Which two forms take a written accent? (Éramos, íbamos — stress three back.) Next: choosing between the two pasts."
             }
           ]
         }

--- a/code/learning/human-languages/spanish/narration/ch16.txt
+++ b/code/learning/human-languages/spanish/narration/ch16.txt
@@ -1,5 +1,5 @@
 Spanish, chapter 16: Chapter 16.
-3 lessons. You can do the first 2 of them in the car; after that you will want to have stopped.
+3 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
 
 
 Lesson 1 of 3.
@@ -50,6 +50,48 @@ What does the imperfect express? (A past action going on or habitual — "was do
 
 
 Lesson 2 of 3.
+era, iba, veía — all three of them.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called The complete list until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Chapter 15 handed you a pile of strong preterites to memorise. Here is the compensation: the imperfect has three irregular verbs. Not three families — three verbs, in the whole language.
+
+The complete list.
+There is a table here I cannot read to you — 4 columns and 5 rows, and it has more columns than can be held in the ear at once. Its columns are: one with no heading, ser becomes era, ir becomes iba, ver becomes veía. Come back and look at it when you have stopped.
+That is the entire irregular inventory. Every other verb in Spanish — thousands of them — takes the regular endings from the last lesson.
+Ver barely counts: it just keeps an extra -e- from its older form veer, then conjugates normally (ve- + -ía).
+
+ir's third Latin verb.
+Now the best thing in the chapter. Track where ir's tenses come from:
+[a table of 3 rows, read aloud]
+tense: present. form: voy, vas, va. from Latin verb: vādere "to advance" (Ch. 10).
+tense: preterite. form: fui, fuiste, fue. from Latin verb: fuī, from esse (Ch. 14).
+tense: imperfect. form: iba, ibas, iba. from Latin verb: īre — its own infinitive.
+Spanish ir is stitched together from three different Latin verbs, and the imperfect is the one place the original īre survives conjugated. The infinitive ir and the imperfect iba are the last two pieces of the real verb; everything else was borrowed from elsewhere.
+
+era.
+era from Latin eram, from the same es- root as ser, soy, es — and as English is and are (Chapter 9). So ser uses that ancient root in the present and the imperfect, but jumps to fuī in the preterite: era vs fue.
+Note the accents: éramos, íbamos — stress three syllables back, exactly like hablábamos.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "era, eras, era, éramos, eran"]
+[pause 8 seconds for the answer]
+[your turn — say: "iba, ibas, iba, íbamos, iban"]
+[pause 8 seconds for the answer]
+[your turn — say: "Cuando era niño, iba a la escuela" ("When I was a child, I used to go to school")]
+[pause 8 seconds for the answer]
+[your turn — say: the three sources — "voy from vādere, fui from fuī, iba from īre"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+How many irregular imperfects are there? (Three — ser, ir, ver.) Which one hardly counts, and why? (Ver — it just keeps an extra -e- from veer.) Where does iba come from? (Latin īre — ir's own verb, and the only tense that kept it.) So how many Latin verbs is ir built from? (Three — vādere, fuī, īre.) Which two forms take a written accent? (Éramos, íbamos — stress three back.) Next: choosing between the two pasts.
+
+
+Lesson 3 of 3.
 Practice — two pasts, one choice.
 
 Warm-up.
@@ -101,45 +143,3 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 Preterite or imperfect for a habit? (Imperfect.) Which tense sets the background, and which interrupts it? (Imperfect sets, preterite interrupts.) What's the difference between conocía and conocí? ("I knew someone" vs "I met them.") How many irregular imperfects were there? (Three.) Give the one-word test. ("Line or point?") Next chapter: talking about what will happen.
-
-
-Lesson 3 of 3.
-era, iba, veía — all three of them.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called The complete list until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Chapter 15 handed you a pile of strong preterites to memorise. Here is the compensation: the imperfect has three irregular verbs. Not three families — three verbs, in the whole language.
-
-The complete list.
-There is a table here I cannot read to you — 4 columns and 5 rows, and it has more columns than can be held in the ear at once. Its columns are: one with no heading, ser becomes era, ir becomes iba, ver becomes veía. Come back and look at it when you have stopped.
-That is the entire irregular inventory. Every other verb in Spanish — thousands of them — takes the regular endings from the last lesson.
-Ver barely counts: it just keeps an extra -e- from its older form veer, then conjugates normally (ve- + -ía).
-
-ir's third Latin verb.
-Now the best thing in the chapter. Track where ir's tenses come from:
-[a table of 3 rows, read aloud]
-tense: present. form: voy, vas, va. from Latin verb: vādere "to advance" (Ch. 10).
-tense: preterite. form: fui, fuiste, fue. from Latin verb: fuī, from esse (Ch. 14).
-tense: imperfect. form: iba, ibas, iba. from Latin verb: īre — its own infinitive.
-Spanish ir is stitched together from three different Latin verbs, and the imperfect is the one place the original īre survives conjugated. The infinitive ir and the imperfect iba are the last two pieces of the real verb; everything else was borrowed from elsewhere.
-
-era.
-era from Latin eram, from the same es- root as ser, soy, es — and as English is and are (Chapter 9). So ser uses that ancient root in the present and the imperfect, but jumps to fuī in the preterite: era vs fue.
-Note the accents: éramos, íbamos — stress three syllables back, exactly like hablábamos.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "era, eras, era, éramos, eran"]
-[pause 8 seconds for the answer]
-[your turn — say: "iba, ibas, iba, íbamos, iban"]
-[pause 8 seconds for the answer]
-[your turn — say: "Cuando era niño, iba a la escuela" ("When I was a child, I used to go to school")]
-[pause 8 seconds for the answer]
-[your turn — say: the three sources — "voy from vādere, fui from fuī, iba from īre"]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-How many irregular imperfects are there? (Three — ser, ir, ver.) Which one hardly counts, and why? (Ver — it just keeps an extra -e- from veer.) Where does iba come from? (Latin īre — ir's own verb, and the only tense that kept it.) So how many Latin verbs is ir built from? (Three — vādere, fuī, īre.) Which two forms take a written accent? (Éramos, íbamos — stress three back.) Next: choosing between the two pasts.

--- a/code/learning/human-languages/spanish/narration/ch17.json
+++ b/code/learning/human-languages/spanish/narration/ch17.json
@@ -3,329 +3,12 @@
   "language": "spanish",
   "chapter": 17,
   "title": "Chapter 17",
-  "drivablePrefix": 3,
-  "sourceHash": "fnv1a64:f2cd4347daa28b7a",
+  "drivablePrefix": 2,
+  "sourceHash": "fnv1a64:e4705d94e1f467da",
   "lessons": [
     {
-      "id": "ES-C17-condicional",
-      "sequence": null,
-      "title": "hablaría — the same weld, one tense over",
-      "headword": "hablaría",
-      "romanization": "hablaría",
-      "gloss": "the conditional — the same weld, using the imperfect of haber instead",
-      "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:42b4d39476b7e46c",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "If you understood the last lesson, this one is nearly free. Same machine, one part swapped."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "The forms",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Whole infinitive again, new endings:"
-            },
-            {
-              "kind": "table",
-              "headers": [
-                "",
-                ""
-              ],
-              "columns": 2,
-              "rowCount": 5,
-              "utterances": [
-                "yo, hablaría.",
-                "tú, hablarías.",
-                "él/ella/usted, hablaría.",
-                "nosotros, hablaríamos.",
-                "ellos/ustedes, hablarían."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "Look hard at those endings. You already know them. They are exactly the -er/-ir imperfect endings from Chapter 16: comía, comías, comíamos, comían."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "unknown",
-          "title": "Why they're the same",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Because they are the same. The future welded the infinitive to the present of haber; the conditional welds it to the imperfect of haber:"
-            },
-            {
-              "kind": "table",
-              "headers": [
-                "tense",
-                "infinitive +",
-                "result"
-              ],
-              "columns": 3,
-              "rowCount": 2,
-              "utterances": [
-                "tense: future. infinitive +: haber present (he, has, ha…) result: hablaré.",
-                "tense: conditional. infinitive +: haber imperfect (había, habías…) result: hablaría."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "(Strictly, what fused was the older, shorter avía — which is why you get hablaría and not hablarhabía. The modern había is the same word, un-worn.)"
-            },
-            {
-              "kind": "speech",
-              "text": "One trick, two tenses of the same auxiliary. That is the whole chapter."
-            },
-            {
-              "kind": "speech",
-              "text": "And the accent does the job Chapter 16 taught: it breaks the diphthong, so hablar-í-a is separate syllables."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "unknown",
-          "title": "What it's for",
-          "segments": [
-            {
-              "kind": "table",
-              "headers": [
-                "use",
-                "example"
-              ],
-              "columns": 2,
-              "rowCount": 3,
-              "utterances": [
-                "use: would — hypothetical. example: Hablaría con él. \"I would speak with him.\"",
-                "use: politeness — softening. example: ¿Podrías ayudarme? \"Could you help me?\"",
-                "use: future-in-the-past. example: Dijo que hablaría. \"He said he would speak.\""
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "That last one is neat: from a point in the past, the conditional is the future. Which makes sense if you remember the imperfect is inside it."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"hablaría, hablarías, hablaría, hablaríamos, hablarían\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"hablaría, hablarías, hablaría, hablaríamos, hablarían\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the echo — \"comía … hablaría\" — same endings",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the echo — \"com**ía** … hablar**ía**\" — same endings]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"Me gustaría…\" (\"I would like…\") — the politest thing in Spanish",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"Me gustaría…\" (\"I would like…\") — the politest thing in Spanish]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the pair — \"hablar + he … hablar + ía\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the pair — \"hablar + he … hablar + ía\"]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What do the conditional endings attach to? (The whole infinitive, as in the future.) Where have you seen -ía/-ías/-íamos before? (The Ch.16 imperfect of -er/-ir verbs.) Why are they identical? (Because the conditional is the infinitive + the imperfect of haber.) So what's the one-line summary of this chapter? (Infinitive + haber — present gives the future, imperfect gives the conditional.) Next: the nine verbs that bend the infinitive first."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ES-C17-future-guessing",
-      "sequence": null,
-      "title": "serán las tres — future form, present guess",
-      "headword": "serán las tres",
-      "romanization": "serán las tres",
-      "gloss": "the future can express a present guess, and the conditional can express a past guess",
-      "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:8ad1c9c2cc752b7f",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "unknown",
-          "title": "Guessing now",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Spanish uses the future to express a present conjecture:"
-            },
-            {
-              "kind": "table",
-              "headers": [
-                "Spanish",
-                "natural meaning"
-              ],
-              "columns": 2,
-              "rowCount": 3,
-              "utterances": [
-                "Spanish: ¿Dónde estará Juan? natural meaning: Where can Juan be? (now).",
-                "Spanish: Serán las tres. natural meaning: It must be three o'clock.",
-                "Spanish: ¿Quién será? natural meaning: Who could that be?"
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "The verb's form is future, but the uncertain situation is present."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "Guessing about the past",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "The conditional moves the same conjecture backward:"
-            },
-            {
-              "kind": "speech",
-              "text": "Serían las tres cuando llegó. — It must have been three when he arrived."
-            },
-            {
-              "kind": "speech",
-              "text": "These tenses grew from constructions with haber, \"have.\" The semantic path from \"have to\" toward obligation and likelihood helps the guessing use feel less arbitrary."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"¿Dónde estará?\" — where can he be?",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"¿Dónde estará?\" — where can he be?]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"Serán las tres\" — it must be three",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"Serán las tres\" — it must be three]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"Serían las tres\" — it must have been three",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"Serían las tres\" — it must have been three]"
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Does serán las tres necessarily refer to later? (No — it can guess the time now.) Which form guesses about the past? (Conditional: serían.) What older meaning helps connect future form to likelihood? (The construction with haber, \"have to.\")"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "ES-C17-futuro",
-      "sequence": null,
+      "sequence": 596,
       "title": "hablaré — the future, welded shut",
       "headword": "hablaré",
       "romanization": "hablaré",
@@ -336,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c666ac55ceac5ba0",
+      "sourceHash": "fnv1a64:2a1bea9375fca1f7",
       "notice": null,
       "blocks": [
         {
@@ -536,8 +219,202 @@
       ]
     },
     {
+      "id": "ES-C17-condicional",
+      "sequence": 598,
+      "title": "hablaría — the same weld, one tense over",
+      "headword": "hablaría",
+      "romanization": "hablaría",
+      "gloss": "the conditional — the same weld, using the imperfect of haber instead",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:b700b8e082384c9b",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "If you understood the last lesson, this one is nearly free. Same machine, one part swapped."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "The forms",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Whole infinitive again, new endings:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                ""
+              ],
+              "columns": 2,
+              "rowCount": 5,
+              "utterances": [
+                "yo, hablaría.",
+                "tú, hablarías.",
+                "él/ella/usted, hablaría.",
+                "nosotros, hablaríamos.",
+                "ellos/ustedes, hablarían."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Look hard at those endings. You already know them. They are exactly the -er/-ir imperfect endings from Chapter 16: comía, comías, comíamos, comían."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "unknown",
+          "title": "Why they're the same",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Because they are the same. The future welded the infinitive to the present of haber; the conditional welds it to the imperfect of haber:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "tense",
+                "infinitive +",
+                "result"
+              ],
+              "columns": 3,
+              "rowCount": 2,
+              "utterances": [
+                "tense: future. infinitive +: haber present (he, has, ha…) result: hablaré.",
+                "tense: conditional. infinitive +: haber imperfect (había, habías…) result: hablaría."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "(Strictly, what fused was the older, shorter avía — which is why you get hablaría and not hablarhabía. The modern había is the same word, un-worn.)"
+            },
+            {
+              "kind": "speech",
+              "text": "One trick, two tenses of the same auxiliary. That is the whole chapter."
+            },
+            {
+              "kind": "speech",
+              "text": "And the accent does the job Chapter 16 taught: it breaks the diphthong, so hablar-í-a is separate syllables."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "unknown",
+          "title": "What it's for",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "use",
+                "example"
+              ],
+              "columns": 2,
+              "rowCount": 3,
+              "utterances": [
+                "use: would — hypothetical. example: Hablaría con él. \"I would speak with him.\"",
+                "use: politeness — softening. example: ¿Podrías ayudarme? \"Could you help me?\"",
+                "use: future-in-the-past. example: Dijo que hablaría. \"He said he would speak.\""
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "That last one is neat: from a point in the past, the conditional is the future. Which makes sense if you remember the imperfect is inside it."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"hablaría, hablarías, hablaría, hablaríamos, hablarían\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"hablaría, hablarías, hablaría, hablaríamos, hablarían\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the echo — \"comía … hablaría\" — same endings",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the echo — \"com**ía** … hablar**ía**\" — same endings]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Me gustaría…\" (\"I would like…\") — the politest thing in Spanish",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Me gustaría…\" (\"I would like…\") — the politest thing in Spanish]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the pair — \"hablar + he … hablar + ía\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the pair — \"hablar + he … hablar + ía\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What do the conditional endings attach to? (The whole infinitive, as in the future.) Where have you seen -ía/-ías/-íamos before? (The Ch.16 imperfect of -er/-ir verbs.) Why are they identical? (Because the conditional is the infinitive + the imperfect of haber.) So what's the one-line summary of this chapter? (Infinitive + haber — present gives the future, imperfect gives the conditional.) Next: the nine verbs that bend the infinitive first."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "ES-C17-practice",
-      "sequence": null,
+      "sequence": 600,
       "title": "Practice — ten stems, two tenses",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -548,7 +425,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:4dd06dd0cdb60b2a",
+      "sourceHash": "fnv1a64:2b4102bf168727e5",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -713,6 +590,129 @@
             {
               "kind": "speech",
               "text": "Do the irregulars change the endings or the stem? (The stem only.) Why does tener become tendr-? (Dropping the vowel squeezed -n'r- together, and a d wedged in to fix it — medieval Spanish also tried terné.) How do the -go club verbs fare here? (All six are irregular — four take the -dr-, and hacer/decir chop instead.) Which two verbs chop hardest? (Decir becomes diré, hacer becomes haré.) Do irregular stems change the endings? (No.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C17-future-guessing",
+      "sequence": 602,
+      "title": "serán las tres — future form, present guess",
+      "headword": "serán las tres",
+      "romanization": "serán las tres",
+      "gloss": "the future can express a present guess, and the conditional can express a past guess",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:5527b162c3ab4fe8",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "unknown",
+          "title": "Guessing now",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Spanish uses the future to express a present conjecture:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "Spanish",
+                "natural meaning"
+              ],
+              "columns": 2,
+              "rowCount": 3,
+              "utterances": [
+                "Spanish: ¿Dónde estará Juan? natural meaning: Where can Juan be? (now).",
+                "Spanish: Serán las tres. natural meaning: It must be three o'clock.",
+                "Spanish: ¿Quién será? natural meaning: Who could that be?"
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "The verb's form is future, but the uncertain situation is present."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "Guessing about the past",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The conditional moves the same conjecture backward:"
+            },
+            {
+              "kind": "speech",
+              "text": "Serían las tres cuando llegó. — It must have been three when he arrived."
+            },
+            {
+              "kind": "speech",
+              "text": "These tenses grew from constructions with haber, \"have.\" The semantic path from \"have to\" toward obligation and likelihood helps the guessing use feel less arbitrary."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"¿Dónde estará?\" — where can he be?",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"¿Dónde estará?\" — where can he be?]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Serán las tres\" — it must be three",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Serán las tres\" — it must be three]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Serían las tres\" — it must have been three",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Serían las tres\" — it must have been three]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Does serán las tres necessarily refer to later? (No — it can guess the time now.) Which form guesses about the past? (Conditional: serían.) What older meaning helps connect future form to likelihood? (The construction with haber, \"have to.\")"
             }
           ]
         }

--- a/code/learning/human-languages/spanish/narration/ch17.txt
+++ b/code/learning/human-languages/spanish/narration/ch17.txt
@@ -1,87 +1,8 @@
 Spanish, chapter 17: Chapter 17.
-4 lessons. You can do the first 3 of them in the car; after that you will want to have stopped.
+4 lessons. You can do the first 2 of them in the car; after that you will want to have stopped.
 
 
 Lesson 1 of 4.
-hablaría — the same weld, one tense over.
-
-Warm-up.
-[pause 2 seconds]
-If you understood the last lesson, this one is nearly free. Same machine, one part swapped.
-
-The forms.
-Whole infinitive again, new endings:
-[a table of 5 rows, read aloud]
-yo, hablaría.
-tú, hablarías.
-él/ella/usted, hablaría.
-nosotros, hablaríamos.
-ellos/ustedes, hablarían.
-Look hard at those endings. You already know them. They are exactly the -er/-ir imperfect endings from Chapter 16: comía, comías, comíamos, comían.
-
-Why they're the same.
-Because they are the same. The future welded the infinitive to the present of haber; the conditional welds it to the imperfect of haber:
-[a table of 2 rows, read aloud]
-tense: future. infinitive +: haber present (he, has, ha…) result: hablaré.
-tense: conditional. infinitive +: haber imperfect (había, habías…) result: hablaría.
-(Strictly, what fused was the older, shorter avía — which is why you get hablaría and not hablarhabía. The modern había is the same word, un-worn.)
-One trick, two tenses of the same auxiliary. That is the whole chapter.
-And the accent does the job Chapter 16 taught: it breaks the diphthong, so hablar-í-a is separate syllables.
-
-What it's for.
-[a table of 3 rows, read aloud]
-use: would — hypothetical. example: Hablaría con él. "I would speak with him."
-use: politeness — softening. example: ¿Podrías ayudarme? "Could you help me?"
-use: future-in-the-past. example: Dijo que hablaría. "He said he would speak."
-That last one is neat: from a point in the past, the conditional is the future. Which makes sense if you remember the imperfect is inside it.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "hablaría, hablarías, hablaría, hablaríamos, hablarían"]
-[pause 8 seconds for the answer]
-[your turn — say: the echo — "comía … hablaría" — same endings]
-[pause 8 seconds for the answer]
-[your turn — say: "Me gustaría…" ("I would like…") — the politest thing in Spanish]
-[pause 8 seconds for the answer]
-[your turn — say: the pair — "hablar + he … hablar + ía"]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What do the conditional endings attach to? (The whole infinitive, as in the future.) Where have you seen -ía/-ías/-íamos before? (The Ch.16 imperfect of -er/-ir verbs.) Why are they identical? (Because the conditional is the infinitive + the imperfect of haber.) So what's the one-line summary of this chapter? (Infinitive + haber — present gives the future, imperfect gives the conditional.) Next: the nine verbs that bend the infinitive first.
-
-
-Lesson 2 of 4.
-serán las tres — future form, present guess.
-
-Guessing now.
-Spanish uses the future to express a present conjecture:
-[a table of 3 rows, read aloud]
-Spanish: ¿Dónde estará Juan? natural meaning: Where can Juan be? (now).
-Spanish: Serán las tres. natural meaning: It must be three o'clock.
-Spanish: ¿Quién será? natural meaning: Who could that be?
-The verb's form is future, but the uncertain situation is present.
-
-Guessing about the past.
-The conditional moves the same conjecture backward:
-Serían las tres cuando llegó. — It must have been three when he arrived.
-These tenses grew from constructions with haber, "have." The semantic path from "have to" toward obligation and likelihood helps the guessing use feel less arbitrary.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "¿Dónde estará?" — where can he be?]
-[pause 8 seconds for the answer]
-[your turn — say: "Serán las tres" — it must be three]
-[pause 8 seconds for the answer]
-[your turn — say: "Serían las tres" — it must have been three]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Does serán las tres necessarily refer to later? (No — it can guess the time now.) Which form guesses about the past? (Conditional: serían.) What older meaning helps connect future form to likelihood? (The construction with haber, "have to.")
-
-
-Lesson 3 of 4.
 hablaré — the future, welded shut.
 
 Warm-up.
@@ -137,7 +58,56 @@ Wrap-up Recall.
 What do you add the future endings to? (The whole infinitive — you don't strip it.) What happened to Latin's own future? (It died; Romance replaced it with a phrase.) What was that phrase? (Infinitive + habēre, "I have to speak.") So what are the endings really? (The present of haber, fused on.) Which language still shows the seam? (Portuguese — falá-lo-ei.) Next: the same trick, with a different tense of haber.
 
 
-Lesson 4 of 4.
+Lesson 2 of 4.
+hablaría — the same weld, one tense over.
+
+Warm-up.
+[pause 2 seconds]
+If you understood the last lesson, this one is nearly free. Same machine, one part swapped.
+
+The forms.
+Whole infinitive again, new endings:
+[a table of 5 rows, read aloud]
+yo, hablaría.
+tú, hablarías.
+él/ella/usted, hablaría.
+nosotros, hablaríamos.
+ellos/ustedes, hablarían.
+Look hard at those endings. You already know them. They are exactly the -er/-ir imperfect endings from Chapter 16: comía, comías, comíamos, comían.
+
+Why they're the same.
+Because they are the same. The future welded the infinitive to the present of haber; the conditional welds it to the imperfect of haber:
+[a table of 2 rows, read aloud]
+tense: future. infinitive +: haber present (he, has, ha…) result: hablaré.
+tense: conditional. infinitive +: haber imperfect (había, habías…) result: hablaría.
+(Strictly, what fused was the older, shorter avía — which is why you get hablaría and not hablarhabía. The modern había is the same word, un-worn.)
+One trick, two tenses of the same auxiliary. That is the whole chapter.
+And the accent does the job Chapter 16 taught: it breaks the diphthong, so hablar-í-a is separate syllables.
+
+What it's for.
+[a table of 3 rows, read aloud]
+use: would — hypothetical. example: Hablaría con él. "I would speak with him."
+use: politeness — softening. example: ¿Podrías ayudarme? "Could you help me?"
+use: future-in-the-past. example: Dijo que hablaría. "He said he would speak."
+That last one is neat: from a point in the past, the conditional is the future. Which makes sense if you remember the imperfect is inside it.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "hablaría, hablarías, hablaría, hablaríamos, hablarían"]
+[pause 8 seconds for the answer]
+[your turn — say: the echo — "comía … hablaría" — same endings]
+[pause 8 seconds for the answer]
+[your turn — say: "Me gustaría…" ("I would like…") — the politest thing in Spanish]
+[pause 8 seconds for the answer]
+[your turn — say: the pair — "hablar + he … hablar + ía"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What do the conditional endings attach to? (The whole infinitive, as in the future.) Where have you seen -ía/-ías/-íamos before? (The Ch.16 imperfect of -er/-ir verbs.) Why are they identical? (Because the conditional is the infinitive + the imperfect of haber.) So what's the one-line summary of this chapter? (Infinitive + haber — present gives the future, imperfect gives the conditional.) Next: the nine verbs that bend the infinitive first.
+
+
+Lesson 3 of 4.
 Practice — ten stems, two tenses.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for 2 tables that cannot be read aloud. You can listen to everything else now — leave the section called The ten, in three families until you have stopped, and I will say so again when we reach it.
@@ -174,3 +144,33 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 Do the irregulars change the endings or the stem? (The stem only.) Why does tener become tendr-? (Dropping the vowel squeezed -n'r- together, and a d wedged in to fix it — medieval Spanish also tried terné.) How do the -go club verbs fare here? (All six are irregular — four take the -dr-, and hacer/decir chop instead.) Which two verbs chop hardest? (Decir becomes diré, hacer becomes haré.) Do irregular stems change the endings? (No.)
+
+
+Lesson 4 of 4.
+serán las tres — future form, present guess.
+
+Guessing now.
+Spanish uses the future to express a present conjecture:
+[a table of 3 rows, read aloud]
+Spanish: ¿Dónde estará Juan? natural meaning: Where can Juan be? (now).
+Spanish: Serán las tres. natural meaning: It must be three o'clock.
+Spanish: ¿Quién será? natural meaning: Who could that be?
+The verb's form is future, but the uncertain situation is present.
+
+Guessing about the past.
+The conditional moves the same conjecture backward:
+Serían las tres cuando llegó. — It must have been three when he arrived.
+These tenses grew from constructions with haber, "have." The semantic path from "have to" toward obligation and likelihood helps the guessing use feel less arbitrary.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "¿Dónde estará?" — where can he be?]
+[pause 8 seconds for the answer]
+[your turn — say: "Serán las tres" — it must be three]
+[pause 8 seconds for the answer]
+[your turn — say: "Serían las tres" — it must have been three]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Does serán las tres necessarily refer to later? (No — it can guess the time now.) Which form guesses about the past? (Conditional: serían.) What older meaning helps connect future form to likelihood? (The construction with haber, "have to.")

--- a/code/learning/human-languages/spanish/narration/ch18.json
+++ b/code/learning/human-languages/spanish/narration/ch18.json
@@ -3,12 +3,179 @@
   "language": "spanish",
   "chapter": 18,
   "title": "Chapter 18",
-  "drivablePrefix": 8,
-  "sourceHash": "fnv1a64:4a7227413ea2a976",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:056b353dce315e5a",
   "lessons": [
     {
+      "id": "ES-C18-subjuntivo",
+      "sequence": 604,
+      "title": "hable, coma, viva — the subjunctive",
+      "headword": "hable, coma, viva",
+      "romanization": "hable, coma, viva",
+      "gloss": "the regular present subjunctive — built from the yo form, with the vowel flipped",
+      "script": "latin",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "wide-table"
+      ],
+      "sourceHash": "fnv1a64:256303072a07e4d8",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes for one table that cannot be read aloud"
+        ],
+        "waitUntilStopped": [
+          "Building it: take the yo form and flip the vowel"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called Building it: take the yo form and flip the vowel until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Every tense so far — hablo, hablé, hablaba, hablaré, hablaría — has belonged to one mood, the indicative: the mood of assertion. It states how things are, and it keeps stating even when it guesses (Chapter 17's Serán las tres, \"it must be three,\" is still an assertion — a confident one about an unknown)."
+            },
+            {
+              "kind": "speech",
+              "text": "Spanish has another mood for what is not asserted at all: things wanted, doubted, feared, hoped for. That is the subjunctive, and the good news is that you have already learned most of it without knowing."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "Building it: take the yo form and flip the vowel",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Not from the infinitive. From the yo form of the present."
+            },
+            {
+              "kind": "speech",
+              "text": "Take the yo form: hablo, como, vivo."
+            },
+            {
+              "kind": "speech",
+              "text": "Drop the -o: habl-, com-, viv-."
+            },
+            {
+              "kind": "speech",
+              "text": "Add the opposite vowel."
+            },
+            {
+              "kind": "speech",
+              "text": "\"Opposite\" is the whole trick:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "verb type",
+                "present takes…",
+                "subjunctive takes…"
+              ],
+              "columns": 3,
+              "rowCount": 2,
+              "utterances": [
+                "verb type: -ar. present takes…: -a- (hablas). subjunctive takes…: -e- (hables).",
+                "verb type: -er / -ir. present takes…: -e- / -i- (comes). subjunctive takes…: -a- (comas)."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "The two families swap costumes."
+            },
+            {
+              "kind": "table-skipped",
+              "reason": "too-wide",
+              "columns": 4,
+              "rowCount": 5,
+              "headers": [
+                "",
+                "hablar",
+                "comer",
+                "vivir"
+              ],
+              "text": "There is a table here I cannot read to you — 4 columns and 5 rows, and it has more columns than can be held in the ear at once. Its columns are: one with no heading, hablar, comer, vivir. Come back and look at it when you have stopped."
+            },
+            {
+              "kind": "speech",
+              "text": "Note -er and -ir are identical here — as they already were in the Ch. 15 preterite and the Ch. 16 imperfect. Outside the present tense, those two conjugations keep merging."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the recipe — \"yo form, drop the -o, flip the vowel\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the recipe — \"**yo** form, drop the **-o**, **flip the vowel**\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"hable, hables, hable, hablemos, hablen\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"hable, hables, hable, hablemos, hablen\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"coma, comas, coma, comamos, coman\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"coma, comas, coma, comamos, coman\"]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What do you build the subjunctive from? (The yo form of the present — not the infinitive.) What happens to the vowel? (It flips: -ar verbs take -e, -er/-ir take -a.) Give comer. (Coma, comas, coma, comamos, coman.) What happens to the -go club? (It transfers whole — tenga, diga, haga, ponga, salga, venga; the next step makes that inheritance explicit.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "ES-C18-inherited-subjunctive-stems",
-      "sequence": null,
+      "sequence": 606,
       "title": "tenga, diga, quiera — old irregularities come free",
       "headword": "tenga, diga, haga; quiera, pueda",
       "romanization": "tenga, diga, haga; quiera, pueda",
@@ -19,7 +186,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:f9f520e222f1fcf5",
+      "sourceHash": "fnv1a64:9406fc796546d74a",
       "notice": null,
       "blocks": [
         {
@@ -161,286 +328,80 @@
       ]
     },
     {
-      "id": "ES-C18-ojala",
-      "sequence": null,
-      "title": "ojalá — a wish borrowed whole",
-      "headword": "ojalá",
-      "romanization": "ojalá",
-      "gloss": "a wish-word borrowed from Andalusi Arabic that triggers the subjunctive without que or a main verb",
+      "id": "ES-C18-subjunctive-outliers",
+      "sequence": 608,
+      "title": "sea, vaya, sepa, haya; esté — where the shortcut stops",
+      "headword": "sea, vaya, sepa, haya; esté",
+      "romanization": "sea, vaya, sepa, haya; esté",
+      "gloss": "four forms must be learned outright, while estar keeps a regular stem with exceptional stress",
       "script": "latin",
       "modality": "voice",
       "derivedModality": "voice",
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:6cf6dfd274eb1199",
+      "sourceHash": "fnv1a64:87910704c052914f",
       "notice": null,
       "blocks": [
         {
           "index": 0,
           "type": "unknown",
-          "title": "A trigger by itself",
+          "title": "Four forms to learn",
           "segments": [
             {
               "kind": "speech",
-              "text": "Ojalá hable español. — I hope he speaks Spanish. / May he speak Spanish."
-            },
-            {
-              "kind": "speech",
-              "text": "Ojalá takes the subjunctive without que or a separate main verb. The word itself expresses the wish, so there is no factual assertion to put in the indicative."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "From Andalusi Arabic",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "The standard account derives ojalá from Andalusi Arabic law šāʾ Allāh, \"if God should will.\" The Allāh remains audible in the second half."
-            },
-            {
-              "kind": "speech",
-              "text": "Chapter 5 gave you another Arabic function word: hasta, from ḥattā. Borrowing nouns such as azúcar, aceite, and álgebra is ordinary. Borrowing grammatical tools is rarer. Spanish borrowed both a preposition and a word that selects a whole mood."
-            },
-            {
-              "kind": "speech",
-              "text": "English \"God willing\" expresses the same idea, and English has now borrowed Arabic inshallah directly as well."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"ojalá hable\" — may he speak",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"ojalá hable\" — may he speak]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"ojalá venga\" — I hope she comes",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"ojalá venga\" — I hope she comes]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"hasta / ojalá\" — two Arabic function words",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"hasta / ojalá\" — two Arabic function words]"
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Does ojalá require que? (No.) Which mood follows it? (The subjunctive.) What is its source phrase? (Andalusi Arabic law šāʾ Allāh, \"if God should will.\") Which other Arabic function word have you learned? (Hasta.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ES-C18-practice",
-      "sequence": null,
-      "title": "Chapter 18 practice — fact or wish?",
-      "headword": "Chapter 18 practice",
-      "romanization": "Chapter 18 practice",
-      "gloss": "drilling the vowel flip and inherited stems",
-      "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:0b4796f64dd3be91",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Two skills to drill, in order: build the form, then decide whether you need it."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "Drill 1 — the vowel flip",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Give the yo subjunctive. Recipe: yo form becomes drop -o becomes flip the vowel."
+              "text": "The drop-o recipe cannot start from soy, voy, sé, he:"
             },
             {
               "kind": "table",
               "headers": [
                 "verb",
                 "yo form",
-                "becomes subjunctive"
+                "subjunctive"
               ],
               "columns": 3,
-              "rowCount": 10,
+              "rowCount": 4,
               "utterances": [
-                "verb: hablar. yo form: hablo. becomes subjunctive: hable.",
-                "verb: estudiar. yo form: estudio. becomes subjunctive: estudie.",
-                "verb: comer. yo form: como. becomes subjunctive: coma.",
-                "verb: beber. yo form: bebo. becomes subjunctive: beba.",
-                "verb: vivir. yo form: vivo. becomes subjunctive: viva.",
-                "verb: tener. yo form: tengo. becomes subjunctive: tenga.",
-                "verb: hacer. yo form: hago. becomes subjunctive: haga.",
-                "verb: venir. yo form: vengo. becomes subjunctive: venga.",
-                "verb: querer. yo form: quiero. becomes subjunctive: quiera.",
-                "verb: poder. yo form: puedo. becomes subjunctive: pueda."
+                "verb: ser. yo form: soy. subjunctive: sea.",
+                "verb: ir. yo form: voy. subjunctive: vaya.",
+                "verb: saber. yo form: sé. subjunctive: sepa.",
+                "verb: haber. yo form: he. subjunctive: haya."
               ]
             },
             {
               "kind": "speech",
-              "text": "The last four are the point: you never learned a new stem. The -go and the diphthong were already in the yo form."
-            },
-            {
-              "kind": "speech",
-              "text": "Then the four with no -o to strip, which you learn outright: ser becomes sea, ir becomes vaya, saber becomes sepa, haber becomes haya."
-            },
-            {
-              "kind": "speech",
-              "text": "And estar, which looks like it belongs with them and doesn't: estoy has no strippable -o either, but take off the whole -oy and the stem est- is completely ordinary — esté, estés, esté, estemos, estén."
-            },
-            {
-              "kind": "speech",
-              "text": "Its oddity is stress, not spelling. Spanish stresses the second-to-last syllable of a word ending in a vowel, -n or -s — hablar obeys that throughout (HA-ble, ha-BLE-mos, HA-blen). Estar doesn't: es-TÉ, es-TÉS, es-TÉN all land on the last syllable, so each needs a written accent. Only es-TE-mos falls where Spanish expects, and it takes none."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Recite the recipe. (Yo form, drop the -o, flip the vowel.) Which earlier irregulars come along free? (The -go club of Ch. 12–13 and Ch. 11's stem-changers.) What's the two-subject test? (If the second verb has Ch. 11's stem-changers.) Which yo forms leave no -o to strip, and which of them is still predictable? (Soy, voy, sé, he, estoy — and estoy is the predictable one, est- + normal endings.) Where does estar's irregularity actually live? (In the stress — es-TÉ lands on the last syllable, breaking Spanish's second-to-last default, which is what the accent records.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ES-C18-practice-mood",
-      "sequence": null,
-      "title": "Practice — fact or wish?",
-      "headword": "fact or wish?",
-      "romanization": "fact or wish?",
-      "gloss": "choosing indicative versus subjunctive and hearing the opposite-vowel contrast",
-      "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:f384b514f5543593",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "unknown",
-          "title": "Report or reach",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Report the world with the indicative; reach for a different world with the subjunctive."
-            },
-            {
-              "kind": "table",
-              "headers": [
-                "",
-                ""
-              ],
-              "columns": 2,
-              "rowCount": 6,
-              "utterances": [
-                "Sé que comes aquí., I know you eat here. (fact).",
-                "Quiero que comas aquí., I want you to eat here. (wish).",
-                "Sé que está aquí., I know he is here. (fact).",
-                "Ojalá esté aquí., I hope he is here. (wish).",
-                "Dice que viene., She says she is coming. (report).",
-                "Quiero que venga., I want her to come. (wish)."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "Ojalá needs no que and no main verb. It is the wish."
+              "text": "Learn those four. Sea also recalls a fact from Chapter 9: forms of Latin sedēre, \"to sit,\" joined the history of ser. It descends from Latin sedeam."
             }
           ]
         },
         {
           "index": 1,
           "type": "unknown",
-          "title": "Hear the flip",
+          "title": "estar — regular stem, exceptional stress",
           "segments": [
             {
-              "kind": "table",
-              "headers": [
-                "indicative",
-                "subjunctive"
-              ],
-              "columns": 2,
-              "rowCount": 4,
-              "utterances": [
-                "indicative: habla. subjunctive: hable.",
-                "indicative: come. subjunctive: coma.",
-                "indicative: trabaja. subjunctive: trabaje.",
-                "indicative: vive. subjunctive: viva."
-              ]
+              "kind": "speech",
+              "text": "Remove all of -oy from estoy and the ordinary stem est- remains: esté, estés, esté, estemos, estén."
             },
             {
               "kind": "speech",
-              "text": "Also distinguish hable from hablé, and trabaje from trabajé. The written accent separates present subjunctive from \"I\" preterite."
+              "text": "The accents record final stress that breaks Spanish's default:"
+            },
+            {
+              "kind": "speech",
+              "text": "es-TÉ, es-TÉS, es-TÉN — accent required."
+            },
+            {
+              "kind": "speech",
+              "text": "es-TE-mos — default second-to-last stress, no accent."
+            },
+            {
+              "kind": "speech",
+              "text": "Dar similarly shrinks doy to d-: dé, des, dé, demos, den. The accent on one-syllable dé distinguishes the verb from preposition de; it does not move stress."
+            },
+            {
+              "kind": "speech",
+              "text": "Treat \"no -o to strip\" as a modern memory aid, not a historical cause. Sea, vaya, sepa, haya descend from Latin sedeam, vādam, sapiam, habeam."
             }
           ]
         },
@@ -458,29 +419,29 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"sé que comes / quiero que comas\"",
+              "instruction": "\"sea, vaya, sepa, haya\"",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"sé que comes / quiero que comas\"]"
+              "source": "[YOU SAY: \"sea, vaya, sepa, haya\"]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"dice que viene / quiero que venga\"",
+              "instruction": "\"esté, estés, esté, estemos, estén\"",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"dice que viene / quiero que venga\"]"
+              "source": "[YOU SAY: \"esté, estés, esté, estemos, estén\"]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"hable / hablé\"",
+              "instruction": "\"dé\" the verb versus \"de\" the preposition",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"hable / hablé\"]"
+              "source": "[YOU SAY: \"dé\" the verb versus \"de\" the preposition]"
             }
           ]
         },
@@ -497,57 +458,44 @@
             },
             {
               "kind": "speech",
-              "text": "Why is sé que comes indicative? (It reports a fact.) What does ojalá need before its subjunctive? (Nothing.) What does the accent distinguish in hable/hablé? (Present subjunctive from first-person preterite.)"
+              "text": "Which four forms are learned outright? (Sea, vaya, sepa, haya.) What is regular about estar? (Its est- stem and endings.) Why does esté need an accent but estemos does not? (Final stress breaks the default; second-to-last stress obeys it.)"
             }
           ]
         }
       ]
     },
     {
-      "id": "ES-C18-practice-subjects",
-      "sequence": null,
-      "title": "Practice — one subject or two?",
-      "headword": "one subject or two?",
-      "romanization": "one subject or two?",
-      "gloss": "choosing infinitive versus que plus subjunctive after wanting",
+      "id": "ES-C18-subjunctive-name",
+      "sequence": 610,
+      "title": "subjuntivo — \"joined underneath\"",
+      "headword": "subjuntivo",
+      "romanization": "subjuntivo",
+      "gloss": "joined underneath — a mood named for its grammatical position in a subordinate clause",
       "script": "latin",
       "modality": "voice",
       "derivedModality": "voice",
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:f996e725c8d0a48e",
+      "sourceHash": "fnv1a64:40f17ef5d07b402a",
       "notice": null,
       "blocks": [
         {
           "index": 0,
           "type": "unknown",
-          "title": "The test",
+          "title": "The name describes its grammar",
           "segments": [
             {
               "kind": "speech",
-              "text": "Does the second verb have a different subject?"
-            },
-            {
-              "kind": "table",
-              "headers": [
-                "",
-                ""
-              ],
-              "columns": 2,
-              "rowCount": 6,
-              "utterances": [
-                "I want to eat., Quiero comer. (same becomes infinitive).",
-                "I want you to eat., Quiero que comas. (two becomes clause).",
-                "We want to live here., Queremos vivir aquí.",
-                "We want them to live here., Queremos que vivan aquí.",
-                "She wants to work., Quiere trabajar.",
-                "She wants me to work., Quiere que yo trabaje."
-              ]
+              "text": "Latin subiūnctīvus means \"joined underneath\": sub- (under) + iungere (join). English join, junction, and conjunction descend from that Latin verb."
             },
             {
               "kind": "speech",
-              "text": "Say each pair back to back. English changes quietly from \"to eat\" to \"you to eat.\" Spanish marks the new subject with que and a conjugated verb."
+              "text": "English yoke and Sanskrit yoga are cousins rather than descendants. All three branches reach Proto-Indo-European yewg-, \"join\": a yoke joins oxen; yoga names a yoking; a conjunction joins clauses."
+            },
+            {
+              "kind": "speech",
+              "text": "Latin's term translated Greek hypotaktikḗ, \"subordinated.\" The name describes where the mood lives: in a clause hanging under a main clause. It does not claim that every subjunctive sentence has one single meaning."
             }
           ]
         },
@@ -565,29 +513,29 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"quiero comer / quiero que comas\"",
+              "instruction": "\"sub-\" — underneath",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"quiero comer / quiero que comas\"]"
+              "source": "[YOU SAY: \"sub-\" — underneath]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"queremos vivir / queremos que vivan\"",
+              "instruction": "\"iungere\" — to join",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"queremos vivir / queremos que vivan\"]"
+              "source": "[YOU SAY: \"iungere\" — to join]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"quiere trabajar / quiere que yo trabaje\"",
+              "instruction": "\"subjunctive\" — joined underneath",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"quiere trabajar / quiere que yo trabaje\"]"
+              "source": "[YOU SAY: \"subjunctive\" — joined underneath]"
             }
           ]
         },
@@ -604,7 +552,7 @@
             },
             {
               "kind": "speech",
-              "text": "Same subject after querer: which form? (Infinitive.) Different subject? (Que + subjunctive.) Translate \"I want to eat\" and \"I want you to eat.\" (Quiero comer / Quiero que comas.)"
+              "text": "What does subjunctive literally mean? (Joined underneath.) Which English words descend from iungere? (Join, junction, conjunction.) Which two are older cousins? (Yoke and yoga.) What does the name describe? (The mood's grammatical position.)"
             }
           ]
         }
@@ -612,7 +560,7 @@
     },
     {
       "id": "ES-C18-quiero-que",
-      "sequence": null,
+      "sequence": 612,
       "title": "quiero que… — making the subjunctive appear",
       "headword": "quiero que…",
       "romanization": "quiero que…",
@@ -623,7 +571,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:d3d46f22a51c12bc",
+      "sourceHash": "fnv1a64:5a5c6b962d384dee",
       "notice": null,
       "blocks": [
         {
@@ -783,406 +731,8 @@
       ]
     },
     {
-      "id": "ES-C18-subjunctive-name",
-      "sequence": null,
-      "title": "subjuntivo — \"joined underneath\"",
-      "headword": "subjuntivo",
-      "romanization": "subjuntivo",
-      "gloss": "joined underneath — a mood named for its grammatical position in a subordinate clause",
-      "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:f781972d2354b9c4",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "unknown",
-          "title": "The name describes its grammar",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Latin subiūnctīvus means \"joined underneath\": sub- (under) + iungere (join). English join, junction, and conjunction descend from that Latin verb."
-            },
-            {
-              "kind": "speech",
-              "text": "English yoke and Sanskrit yoga are cousins rather than descendants. All three branches reach Proto-Indo-European yewg-, \"join\": a yoke joins oxen; yoga names a yoking; a conjunction joins clauses."
-            },
-            {
-              "kind": "speech",
-              "text": "Latin's term translated Greek hypotaktikḗ, \"subordinated.\" The name describes where the mood lives: in a clause hanging under a main clause. It does not claim that every subjunctive sentence has one single meaning."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"sub-\" — underneath",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"sub-\" — underneath]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"iungere\" — to join",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"iungere\" — to join]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"subjunctive\" — joined underneath",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"subjunctive\" — joined underneath]"
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does subjunctive literally mean? (Joined underneath.) Which English words descend from iungere? (Join, junction, conjunction.) Which two are older cousins? (Yoke and yoga.) What does the name describe? (The mood's grammatical position.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ES-C18-subjunctive-outliers",
-      "sequence": null,
-      "title": "sea, vaya, sepa, haya; esté — where the shortcut stops",
-      "headword": "sea, vaya, sepa, haya; esté",
-      "romanization": "sea, vaya, sepa, haya; esté",
-      "gloss": "four forms must be learned outright, while estar keeps a regular stem with exceptional stress",
-      "script": "latin",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:291d73d20167b954",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "unknown",
-          "title": "Four forms to learn",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "The drop-o recipe cannot start from soy, voy, sé, he:"
-            },
-            {
-              "kind": "table",
-              "headers": [
-                "verb",
-                "yo form",
-                "subjunctive"
-              ],
-              "columns": 3,
-              "rowCount": 4,
-              "utterances": [
-                "verb: ser. yo form: soy. subjunctive: sea.",
-                "verb: ir. yo form: voy. subjunctive: vaya.",
-                "verb: saber. yo form: sé. subjunctive: sepa.",
-                "verb: haber. yo form: he. subjunctive: haya."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "Learn those four. Sea also recalls a fact from Chapter 9: forms of Latin sedēre, \"to sit,\" joined the history of ser. It descends from Latin sedeam."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "estar — regular stem, exceptional stress",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Remove all of -oy from estoy and the ordinary stem est- remains: esté, estés, esté, estemos, estén."
-            },
-            {
-              "kind": "speech",
-              "text": "The accents record final stress that breaks Spanish's default:"
-            },
-            {
-              "kind": "speech",
-              "text": "es-TÉ, es-TÉS, es-TÉN — accent required."
-            },
-            {
-              "kind": "speech",
-              "text": "es-TE-mos — default second-to-last stress, no accent."
-            },
-            {
-              "kind": "speech",
-              "text": "Dar similarly shrinks doy to d-: dé, des, dé, demos, den. The accent on one-syllable dé distinguishes the verb from preposition de; it does not move stress."
-            },
-            {
-              "kind": "speech",
-              "text": "Treat \"no -o to strip\" as a modern memory aid, not a historical cause. Sea, vaya, sepa, haya descend from Latin sedeam, vādam, sapiam, habeam."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"sea, vaya, sepa, haya\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"sea, vaya, sepa, haya\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"esté, estés, esté, estemos, estén\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"esté, estés, esté, estemos, estén\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"dé\" the verb versus \"de\" the preposition",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"dé\" the verb versus \"de\" the preposition]"
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Which four forms are learned outright? (Sea, vaya, sepa, haya.) What is regular about estar? (Its est- stem and endings.) Why does esté need an accent but estemos does not? (Final stress breaks the default; second-to-last stress obeys it.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "ES-C18-subjuntivo",
-      "sequence": null,
-      "title": "hable, coma, viva — the subjunctive",
-      "headword": "hable, coma, viva",
-      "romanization": "hable, coma, viva",
-      "gloss": "the regular present subjunctive — built from the yo form, with the vowel flipped",
-      "script": "latin",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "wide-table"
-      ],
-      "sourceHash": "fnv1a64:834a8361455e9a07",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes for one table that cannot be read aloud"
-        ],
-        "waitUntilStopped": [
-          "Building it: take the yo form and flip the vowel"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called Building it: take the yo form and flip the vowel until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Every tense so far — hablo, hablé, hablaba, hablaré, hablaría — has belonged to one mood, the indicative: the mood of assertion. It states how things are, and it keeps stating even when it guesses (Chapter 17's Serán las tres, \"it must be three,\" is still an assertion — a confident one about an unknown)."
-            },
-            {
-              "kind": "speech",
-              "text": "Spanish has another mood for what is not asserted at all: things wanted, doubted, feared, hoped for. That is the subjunctive, and the good news is that you have already learned most of it without knowing."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "Building it: take the yo form and flip the vowel",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Not from the infinitive. From the yo form of the present."
-            },
-            {
-              "kind": "speech",
-              "text": "Take the yo form: hablo, como, vivo."
-            },
-            {
-              "kind": "speech",
-              "text": "Drop the -o: habl-, com-, viv-."
-            },
-            {
-              "kind": "speech",
-              "text": "Add the opposite vowel."
-            },
-            {
-              "kind": "speech",
-              "text": "\"Opposite\" is the whole trick:"
-            },
-            {
-              "kind": "table",
-              "headers": [
-                "verb type",
-                "present takes…",
-                "subjunctive takes…"
-              ],
-              "columns": 3,
-              "rowCount": 2,
-              "utterances": [
-                "verb type: -ar. present takes…: -a- (hablas). subjunctive takes…: -e- (hables).",
-                "verb type: -er / -ir. present takes…: -e- / -i- (comes). subjunctive takes…: -a- (comas)."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "The two families swap costumes."
-            },
-            {
-              "kind": "table-skipped",
-              "reason": "too-wide",
-              "columns": 4,
-              "rowCount": 5,
-              "headers": [
-                "",
-                "hablar",
-                "comer",
-                "vivir"
-              ],
-              "text": "There is a table here I cannot read to you — 4 columns and 5 rows, and it has more columns than can be held in the ear at once. Its columns are: one with no heading, hablar, comer, vivir. Come back and look at it when you have stopped."
-            },
-            {
-              "kind": "speech",
-              "text": "Note -er and -ir are identical here — as they already were in the Ch. 15 preterite and the Ch. 16 imperfect. Outside the present tense, those two conjugations keep merging."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the recipe — \"yo form, drop the -o, flip the vowel\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the recipe — \"**yo** form, drop the **-o**, **flip the vowel**\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"hable, hables, hable, hablemos, hablen\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"hable, hables, hable, hablemos, hablen\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"coma, comas, coma, comamos, coman\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"coma, comas, coma, comamos, coman\"]"
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What do you build the subjunctive from? (The yo form of the present — not the infinitive.) What happens to the vowel? (It flips: -ar verbs take -e, -er/-ir take -a.) Give comer. (Coma, comas, coma, comamos, coman.) What happens to the -go club? (It transfers whole — tenga, diga, haga, ponga, salga, venga; the next step makes that inheritance explicit.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "ES-C18-wanting-clause-trap",
-      "sequence": null,
+      "sequence": 614,
       "title": "quiero que hables — do not smuggle in a subject",
       "headword": "quiero que hables / quiero hablarte",
       "romanization": "quiero que hables / quiero hablarte",
@@ -1193,7 +743,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:56bb68cc8d8dff47",
+      "sourceHash": "fnv1a64:2eedce6d8fb2c565",
       "notice": null,
       "blocks": [
         {
@@ -1285,6 +835,456 @@
             {
               "kind": "speech",
               "text": "How does Spanish say \"I want you to speak\"? (Quiero que hables.) Why is quiero hablarte different? (It has one subject; te is an object.) Name one verb family that permits object plus infinitive. (Perception or causation.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C18-ojala",
+      "sequence": 616,
+      "title": "ojalá — a wish borrowed whole",
+      "headword": "ojalá",
+      "romanization": "ojalá",
+      "gloss": "a wish-word borrowed from Andalusi Arabic that triggers the subjunctive without que or a main verb",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:7a5cbefcd831a467",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "unknown",
+          "title": "A trigger by itself",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Ojalá hable español. — I hope he speaks Spanish. / May he speak Spanish."
+            },
+            {
+              "kind": "speech",
+              "text": "Ojalá takes the subjunctive without que or a separate main verb. The word itself expresses the wish, so there is no factual assertion to put in the indicative."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "From Andalusi Arabic",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The standard account derives ojalá from Andalusi Arabic law šāʾ Allāh, \"if God should will.\" The Allāh remains audible in the second half."
+            },
+            {
+              "kind": "speech",
+              "text": "Chapter 5 gave you another Arabic function word: hasta, from ḥattā. Borrowing nouns such as azúcar, aceite, and álgebra is ordinary. Borrowing grammatical tools is rarer. Spanish borrowed both a preposition and a word that selects a whole mood."
+            },
+            {
+              "kind": "speech",
+              "text": "English \"God willing\" expresses the same idea, and English has now borrowed Arabic inshallah directly as well."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ojalá hable\" — may he speak",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ojalá hable\" — may he speak]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ojalá venga\" — I hope she comes",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ojalá venga\" — I hope she comes]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"hasta / ojalá\" — two Arabic function words",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"hasta / ojalá\" — two Arabic function words]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Does ojalá require que? (No.) Which mood follows it? (The subjunctive.) What is its source phrase? (Andalusi Arabic law šāʾ Allāh, \"if God should will.\") Which other Arabic function word have you learned? (Hasta.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C18-practice",
+      "sequence": 618,
+      "title": "Chapter 18 practice — fact or wish?",
+      "headword": "Chapter 18 practice",
+      "romanization": "Chapter 18 practice",
+      "gloss": "drilling the vowel flip and inherited stems",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:d42894546917da8b",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Two skills to drill, in order: build the form, then decide whether you need it."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "Drill 1 — the vowel flip",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Give the yo subjunctive. Recipe: yo form becomes drop -o becomes flip the vowel."
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "verb",
+                "yo form",
+                "becomes subjunctive"
+              ],
+              "columns": 3,
+              "rowCount": 10,
+              "utterances": [
+                "verb: hablar. yo form: hablo. becomes subjunctive: hable.",
+                "verb: estudiar. yo form: estudio. becomes subjunctive: estudie.",
+                "verb: comer. yo form: como. becomes subjunctive: coma.",
+                "verb: beber. yo form: bebo. becomes subjunctive: beba.",
+                "verb: vivir. yo form: vivo. becomes subjunctive: viva.",
+                "verb: tener. yo form: tengo. becomes subjunctive: tenga.",
+                "verb: hacer. yo form: hago. becomes subjunctive: haga.",
+                "verb: venir. yo form: vengo. becomes subjunctive: venga.",
+                "verb: querer. yo form: quiero. becomes subjunctive: quiera.",
+                "verb: poder. yo form: puedo. becomes subjunctive: pueda."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "The last four are the point: you never learned a new stem. The -go and the diphthong were already in the yo form."
+            },
+            {
+              "kind": "speech",
+              "text": "Then the four with no -o to strip, which you learn outright: ser becomes sea, ir becomes vaya, saber becomes sepa, haber becomes haya."
+            },
+            {
+              "kind": "speech",
+              "text": "And estar, which looks like it belongs with them and doesn't: estoy has no strippable -o either, but take off the whole -oy and the stem est- is completely ordinary — esté, estés, esté, estemos, estén."
+            },
+            {
+              "kind": "speech",
+              "text": "Its oddity is stress, not spelling. Spanish stresses the second-to-last syllable of a word ending in a vowel, -n or -s — hablar obeys that throughout (HA-ble, ha-BLE-mos, HA-blen). Estar doesn't: es-TÉ, es-TÉS, es-TÉN all land on the last syllable, so each needs a written accent. Only es-TE-mos falls where Spanish expects, and it takes none."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Recite the recipe. (Yo form, drop the -o, flip the vowel.) Which earlier irregulars come along free? (The -go club of Ch. 12–13 and Ch. 11's stem-changers.) What's the two-subject test? (If the second verb has Ch. 11's stem-changers.) Which yo forms leave no -o to strip, and which of them is still predictable? (Soy, voy, sé, he, estoy — and estoy is the predictable one, est- + normal endings.) Where does estar's irregularity actually live? (In the stress — es-TÉ lands on the last syllable, breaking Spanish's second-to-last default, which is what the accent records.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C18-practice-subjects",
+      "sequence": 620,
+      "title": "Practice — one subject or two?",
+      "headword": "one subject or two?",
+      "romanization": "one subject or two?",
+      "gloss": "choosing infinitive versus que plus subjunctive after wanting",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:e009f00a2d88fe2f",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "unknown",
+          "title": "The test",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Does the second verb have a different subject?"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                ""
+              ],
+              "columns": 2,
+              "rowCount": 6,
+              "utterances": [
+                "I want to eat., Quiero comer. (same becomes infinitive).",
+                "I want you to eat., Quiero que comas. (two becomes clause).",
+                "We want to live here., Queremos vivir aquí.",
+                "We want them to live here., Queremos que vivan aquí.",
+                "She wants to work., Quiere trabajar.",
+                "She wants me to work., Quiere que yo trabaje."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Say each pair back to back. English changes quietly from \"to eat\" to \"you to eat.\" Spanish marks the new subject with que and a conjugated verb."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"quiero comer / quiero que comas\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"quiero comer / quiero que comas\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"queremos vivir / queremos que vivan\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"queremos vivir / queremos que vivan\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"quiere trabajar / quiere que yo trabaje\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"quiere trabajar / quiere que yo trabaje\"]"
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Same subject after querer: which form? (Infinitive.) Different subject? (Que + subjunctive.) Translate \"I want to eat\" and \"I want you to eat.\" (Quiero comer / Quiero que comas.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C18-practice-mood",
+      "sequence": 622,
+      "title": "Practice — fact or wish?",
+      "headword": "fact or wish?",
+      "romanization": "fact or wish?",
+      "gloss": "choosing indicative versus subjunctive and hearing the opposite-vowel contrast",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:2bdbd831a0781532",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "unknown",
+          "title": "Report or reach",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Report the world with the indicative; reach for a different world with the subjunctive."
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                ""
+              ],
+              "columns": 2,
+              "rowCount": 6,
+              "utterances": [
+                "Sé que comes aquí., I know you eat here. (fact).",
+                "Quiero que comas aquí., I want you to eat here. (wish).",
+                "Sé que está aquí., I know he is here. (fact).",
+                "Ojalá esté aquí., I hope he is here. (wish).",
+                "Dice que viene., She says she is coming. (report).",
+                "Quiero que venga., I want her to come. (wish)."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Ojalá needs no que and no main verb. It is the wish."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "Hear the flip",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "indicative",
+                "subjunctive"
+              ],
+              "columns": 2,
+              "rowCount": 4,
+              "utterances": [
+                "indicative: habla. subjunctive: hable.",
+                "indicative: come. subjunctive: coma.",
+                "indicative: trabaja. subjunctive: trabaje.",
+                "indicative: vive. subjunctive: viva."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Also distinguish hable from hablé, and trabaje from trabajé. The written accent separates present subjunctive from \"I\" preterite."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"sé que comes / quiero que comas\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"sé que comes / quiero que comas\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"dice que viene / quiero que venga\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"dice que viene / quiero que venga\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"hable / hablé\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"hable / hablé\"]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Why is sé que comes indicative? (It reports a fact.) What does ojalá need before its subjunctive? (Nothing.) What does the accent distinguish in hable/hablé? (Present subjunctive from first-person preterite.)"
             }
           ]
         }

--- a/code/learning/human-languages/spanish/narration/ch18.txt
+++ b/code/learning/human-languages/spanish/narration/ch18.txt
@@ -1,8 +1,45 @@
 Spanish, chapter 18: Chapter 18.
-10 lessons. You can do the first 8 of them in the car; after that you will want to have stopped.
+10 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
 Lesson 1 of 10.
+hable, coma, viva — the subjunctive.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called Building it: take the yo form and flip the vowel until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Every tense so far — hablo, hablé, hablaba, hablaré, hablaría — has belonged to one mood, the indicative: the mood of assertion. It states how things are, and it keeps stating even when it guesses (Chapter 17's Serán las tres, "it must be three," is still an assertion — a confident one about an unknown).
+Spanish has another mood for what is not asserted at all: things wanted, doubted, feared, hoped for. That is the subjunctive, and the good news is that you have already learned most of it without knowing.
+
+Building it: take the yo form and flip the vowel.
+Not from the infinitive. From the yo form of the present.
+Take the yo form: hablo, como, vivo.
+Drop the -o: habl-, com-, viv-.
+Add the opposite vowel.
+"Opposite" is the whole trick:
+[a table of 2 rows, read aloud]
+verb type: -ar. present takes…: -a- (hablas). subjunctive takes…: -e- (hables).
+verb type: -er / -ir. present takes…: -e- / -i- (comes). subjunctive takes…: -a- (comas).
+The two families swap costumes.
+There is a table here I cannot read to you — 4 columns and 5 rows, and it has more columns than can be held in the ear at once. Its columns are: one with no heading, hablar, comer, vivir. Come back and look at it when you have stopped.
+Note -er and -ir are identical here — as they already were in the Ch. 15 preterite and the Ch. 16 imperfect. Outside the present tense, those two conjugations keep merging.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: the recipe — "yo form, drop the -o, flip the vowel"]
+[pause 8 seconds for the answer]
+[your turn — say: "hable, hables, hable, hablemos, hablen"]
+[pause 8 seconds for the answer]
+[your turn — say: "coma, comas, coma, comamos, coman"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What do you build the subjunctive from? (The yo form of the present — not the infinitive.) What happens to the vowel? (It flips: -ar verbs take -e, -er/-ir take -a.) Give comer. (Coma, comas, coma, comamos, coman.) What happens to the -go club? (It transfers whole — tenga, diga, haga, ponga, salga, venga; the next step makes that inheritance explicit.)
+
+
+Lesson 2 of 10.
 tenga, diga, quiera — old irregularities come free.
 
 Warm-up.
@@ -41,127 +78,63 @@ Wrap-up Recall.
 Why does tenga keep its g? (It comes from tengo.) How many new stems does the -go club require? (Zero.) Why are queramos and podamos plain? (The stem is unstressed in nosotros.)
 
 
-Lesson 2 of 10.
-ojalá — a wish borrowed whole.
+Lesson 3 of 10.
+sea, vaya, sepa, haya; esté — where the shortcut stops.
 
-A trigger by itself.
-Ojalá hable español. — I hope he speaks Spanish. / May he speak Spanish.
-Ojalá takes the subjunctive without que or a separate main verb. The word itself expresses the wish, so there is no factual assertion to put in the indicative.
+Four forms to learn.
+The drop-o recipe cannot start from soy, voy, sé, he:
+[a table of 4 rows, read aloud]
+verb: ser. yo form: soy. subjunctive: sea.
+verb: ir. yo form: voy. subjunctive: vaya.
+verb: saber. yo form: sé. subjunctive: sepa.
+verb: haber. yo form: he. subjunctive: haya.
+Learn those four. Sea also recalls a fact from Chapter 9: forms of Latin sedēre, "to sit," joined the history of ser. It descends from Latin sedeam.
 
-From Andalusi Arabic.
-The standard account derives ojalá from Andalusi Arabic law šāʾ Allāh, "if God should will." The Allāh remains audible in the second half.
-Chapter 5 gave you another Arabic function word: hasta, from ḥattā. Borrowing nouns such as azúcar, aceite, and álgebra is ordinary. Borrowing grammatical tools is rarer. Spanish borrowed both a preposition and a word that selects a whole mood.
-English "God willing" expresses the same idea, and English has now borrowed Arabic inshallah directly as well.
+estar — regular stem, exceptional stress.
+Remove all of -oy from estoy and the ordinary stem est- remains: esté, estés, esté, estemos, estén.
+The accents record final stress that breaks Spanish's default:
+es-TÉ, es-TÉS, es-TÉN — accent required.
+es-TE-mos — default second-to-last stress, no accent.
+Dar similarly shrinks doy to d-: dé, des, dé, demos, den. The accent on one-syllable dé distinguishes the verb from preposition de; it does not move stress.
+Treat "no -o to strip" as a modern memory aid, not a historical cause. Sea, vaya, sepa, haya descend from Latin sedeam, vādam, sapiam, habeam.
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: "ojalá hable" — may he speak]
+[your turn — say: "sea, vaya, sepa, haya"]
 [pause 8 seconds for the answer]
-[your turn — say: "ojalá venga" — I hope she comes]
+[your turn — say: "esté, estés, esté, estemos, estén"]
 [pause 8 seconds for the answer]
-[your turn — say: "hasta / ojalá" — two Arabic function words]
+[your turn — say: "dé" the verb versus "de" the preposition]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-Does ojalá require que? (No.) Which mood follows it? (The subjunctive.) What is its source phrase? (Andalusi Arabic law šāʾ Allāh, "if God should will.") Which other Arabic function word have you learned? (Hasta.)
-
-
-Lesson 3 of 10.
-Chapter 18 practice — fact or wish?
-
-Warm-up.
-[pause 2 seconds]
-Two skills to drill, in order: build the form, then decide whether you need it.
-
-Drill 1 — the vowel flip.
-Give the yo subjunctive. Recipe: yo form becomes drop -o becomes flip the vowel.
-[a table of 10 rows, read aloud]
-verb: hablar. yo form: hablo. becomes subjunctive: hable.
-verb: estudiar. yo form: estudio. becomes subjunctive: estudie.
-verb: comer. yo form: como. becomes subjunctive: coma.
-verb: beber. yo form: bebo. becomes subjunctive: beba.
-verb: vivir. yo form: vivo. becomes subjunctive: viva.
-verb: tener. yo form: tengo. becomes subjunctive: tenga.
-verb: hacer. yo form: hago. becomes subjunctive: haga.
-verb: venir. yo form: vengo. becomes subjunctive: venga.
-verb: querer. yo form: quiero. becomes subjunctive: quiera.
-verb: poder. yo form: puedo. becomes subjunctive: pueda.
-The last four are the point: you never learned a new stem. The -go and the diphthong were already in the yo form.
-Then the four with no -o to strip, which you learn outright: ser becomes sea, ir becomes vaya, saber becomes sepa, haber becomes haya.
-And estar, which looks like it belongs with them and doesn't: estoy has no strippable -o either, but take off the whole -oy and the stem est- is completely ordinary — esté, estés, esté, estemos, estén.
-Its oddity is stress, not spelling. Spanish stresses the second-to-last syllable of a word ending in a vowel, -n or -s — hablar obeys that throughout (HA-ble, ha-BLE-mos, HA-blen). Estar doesn't: es-TÉ, es-TÉS, es-TÉN all land on the last syllable, so each needs a written accent. Only es-TE-mos falls where Spanish expects, and it takes none.
-
-Wrap-up Recall.
-[pause 3 seconds]
-Recite the recipe. (Yo form, drop the -o, flip the vowel.) Which earlier irregulars come along free? (The -go club of Ch. 12–13 and Ch. 11's stem-changers.) What's the two-subject test? (If the second verb has Ch. 11's stem-changers.) Which yo forms leave no -o to strip, and which of them is still predictable? (Soy, voy, sé, he, estoy — and estoy is the predictable one, est- + normal endings.) Where does estar's irregularity actually live? (In the stress — es-TÉ lands on the last syllable, breaking Spanish's second-to-last default, which is what the accent records.)
+Which four forms are learned outright? (Sea, vaya, sepa, haya.) What is regular about estar? (Its est- stem and endings.) Why does esté need an accent but estemos does not? (Final stress breaks the default; second-to-last stress obeys it.)
 
 
 Lesson 4 of 10.
-Practice — fact or wish?
+subjuntivo — "joined underneath".
 
-Report or reach.
-Report the world with the indicative; reach for a different world with the subjunctive.
-[a table of 6 rows, read aloud]
-Sé que comes aquí., I know you eat here. (fact).
-Quiero que comas aquí., I want you to eat here. (wish).
-Sé que está aquí., I know he is here. (fact).
-Ojalá esté aquí., I hope he is here. (wish).
-Dice que viene., She says she is coming. (report).
-Quiero que venga., I want her to come. (wish).
-Ojalá needs no que and no main verb. It is the wish.
-
-Hear the flip.
-[a table of 4 rows, read aloud]
-indicative: habla. subjunctive: hable.
-indicative: come. subjunctive: coma.
-indicative: trabaja. subjunctive: trabaje.
-indicative: vive. subjunctive: viva.
-Also distinguish hable from hablé, and trabaje from trabajé. The written accent separates present subjunctive from "I" preterite.
+The name describes its grammar.
+Latin subiūnctīvus means "joined underneath": sub- (under) + iungere (join). English join, junction, and conjunction descend from that Latin verb.
+English yoke and Sanskrit yoga are cousins rather than descendants. All three branches reach Proto-Indo-European yewg-, "join": a yoke joins oxen; yoga names a yoking; a conjunction joins clauses.
+Latin's term translated Greek hypotaktikḗ, "subordinated." The name describes where the mood lives: in a clause hanging under a main clause. It does not claim that every subjunctive sentence has one single meaning.
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: "sé que comes / quiero que comas"]
+[your turn — say: "sub-" — underneath]
 [pause 8 seconds for the answer]
-[your turn — say: "dice que viene / quiero que venga"]
+[your turn — say: "iungere" — to join]
 [pause 8 seconds for the answer]
-[your turn — say: "hable / hablé"]
+[your turn — say: "subjunctive" — joined underneath]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-Why is sé que comes indicative? (It reports a fact.) What does ojalá need before its subjunctive? (Nothing.) What does the accent distinguish in hable/hablé? (Present subjunctive from first-person preterite.)
+What does subjunctive literally mean? (Joined underneath.) Which English words descend from iungere? (Join, junction, conjunction.) Which two are older cousins? (Yoke and yoga.) What does the name describe? (The mood's grammatical position.)
 
 
 Lesson 5 of 10.
-Practice — one subject or two?
-
-The test.
-Does the second verb have a different subject?
-[a table of 6 rows, read aloud]
-I want to eat., Quiero comer. (same becomes infinitive).
-I want you to eat., Quiero que comas. (two becomes clause).
-We want to live here., Queremos vivir aquí.
-We want them to live here., Queremos que vivan aquí.
-She wants to work., Quiere trabajar.
-She wants me to work., Quiere que yo trabaje.
-Say each pair back to back. English changes quietly from "to eat" to "you to eat." Spanish marks the new subject with que and a conjugated verb.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "quiero comer / quiero que comas"]
-[pause 8 seconds for the answer]
-[your turn — say: "queremos vivir / queremos que vivan"]
-[pause 8 seconds for the answer]
-[your turn — say: "quiere trabajar / quiere que yo trabaje"]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Same subject after querer: which form? (Infinitive.) Different subject? (Que + subjunctive.) Translate "I want to eat" and "I want you to eat." (Quiero comer / Quiero que comas.)
-
-
-Lesson 6 of 10.
 quiero que… — making the subjunctive appear.
 
 Warm-up.
@@ -202,100 +175,7 @@ Wrap-up Recall.
 What makes the subjunctive appear after querer? (Two different subjects — joined by que.) Say "I want to speak" and "I want you to speak." (Quiero hablar / Quiero que hables.) Why does Sé que hablas stay indicative? (Knowing reports a fact; wanting doesn't.) What joins the two subjects? (Que, followed by the subjunctive.)
 
 
-Lesson 7 of 10.
-subjuntivo — "joined underneath".
-
-The name describes its grammar.
-Latin subiūnctīvus means "joined underneath": sub- (under) + iungere (join). English join, junction, and conjunction descend from that Latin verb.
-English yoke and Sanskrit yoga are cousins rather than descendants. All three branches reach Proto-Indo-European yewg-, "join": a yoke joins oxen; yoga names a yoking; a conjunction joins clauses.
-Latin's term translated Greek hypotaktikḗ, "subordinated." The name describes where the mood lives: in a clause hanging under a main clause. It does not claim that every subjunctive sentence has one single meaning.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "sub-" — underneath]
-[pause 8 seconds for the answer]
-[your turn — say: "iungere" — to join]
-[pause 8 seconds for the answer]
-[your turn — say: "subjunctive" — joined underneath]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What does subjunctive literally mean? (Joined underneath.) Which English words descend from iungere? (Join, junction, conjunction.) Which two are older cousins? (Yoke and yoga.) What does the name describe? (The mood's grammatical position.)
-
-
-Lesson 8 of 10.
-sea, vaya, sepa, haya; esté — where the shortcut stops.
-
-Four forms to learn.
-The drop-o recipe cannot start from soy, voy, sé, he:
-[a table of 4 rows, read aloud]
-verb: ser. yo form: soy. subjunctive: sea.
-verb: ir. yo form: voy. subjunctive: vaya.
-verb: saber. yo form: sé. subjunctive: sepa.
-verb: haber. yo form: he. subjunctive: haya.
-Learn those four. Sea also recalls a fact from Chapter 9: forms of Latin sedēre, "to sit," joined the history of ser. It descends from Latin sedeam.
-
-estar — regular stem, exceptional stress.
-Remove all of -oy from estoy and the ordinary stem est- remains: esté, estés, esté, estemos, estén.
-The accents record final stress that breaks Spanish's default:
-es-TÉ, es-TÉS, es-TÉN — accent required.
-es-TE-mos — default second-to-last stress, no accent.
-Dar similarly shrinks doy to d-: dé, des, dé, demos, den. The accent on one-syllable dé distinguishes the verb from preposition de; it does not move stress.
-Treat "no -o to strip" as a modern memory aid, not a historical cause. Sea, vaya, sepa, haya descend from Latin sedeam, vādam, sapiam, habeam.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "sea, vaya, sepa, haya"]
-[pause 8 seconds for the answer]
-[your turn — say: "esté, estés, esté, estemos, estén"]
-[pause 8 seconds for the answer]
-[your turn — say: "dé" the verb versus "de" the preposition]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Which four forms are learned outright? (Sea, vaya, sepa, haya.) What is regular about estar? (Its est- stem and endings.) Why does esté need an accent but estemos does not? (Final stress breaks the default; second-to-last stress obeys it.)
-
-
-Lesson 9 of 10.
-hable, coma, viva — the subjunctive.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called Building it: take the yo form and flip the vowel until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Every tense so far — hablo, hablé, hablaba, hablaré, hablaría — has belonged to one mood, the indicative: the mood of assertion. It states how things are, and it keeps stating even when it guesses (Chapter 17's Serán las tres, "it must be three," is still an assertion — a confident one about an unknown).
-Spanish has another mood for what is not asserted at all: things wanted, doubted, feared, hoped for. That is the subjunctive, and the good news is that you have already learned most of it without knowing.
-
-Building it: take the yo form and flip the vowel.
-Not from the infinitive. From the yo form of the present.
-Take the yo form: hablo, como, vivo.
-Drop the -o: habl-, com-, viv-.
-Add the opposite vowel.
-"Opposite" is the whole trick:
-[a table of 2 rows, read aloud]
-verb type: -ar. present takes…: -a- (hablas). subjunctive takes…: -e- (hables).
-verb type: -er / -ir. present takes…: -e- / -i- (comes). subjunctive takes…: -a- (comas).
-The two families swap costumes.
-There is a table here I cannot read to you — 4 columns and 5 rows, and it has more columns than can be held in the ear at once. Its columns are: one with no heading, hablar, comer, vivir. Come back and look at it when you have stopped.
-Note -er and -ir are identical here — as they already were in the Ch. 15 preterite and the Ch. 16 imperfect. Outside the present tense, those two conjugations keep merging.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: the recipe — "yo form, drop the -o, flip the vowel"]
-[pause 8 seconds for the answer]
-[your turn — say: "hable, hables, hable, hablemos, hablen"]
-[pause 8 seconds for the answer]
-[your turn — say: "coma, comas, coma, comamos, coman"]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What do you build the subjunctive from? (The yo form of the present — not the infinitive.) What happens to the vowel? (It flips: -ar verbs take -e, -er/-ir take -a.) Give comer. (Coma, comas, coma, comamos, coman.) What happens to the -go club? (It transfers whole — tenga, diga, haga, ponga, salga, venga; the next step makes that inheritance explicit.)
-
-
-Lesson 10 of 10.
+Lesson 6 of 10.
 quiero que hables — do not smuggle in a subject.
 
 The English trap.
@@ -319,3 +199,123 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 How does Spanish say "I want you to speak"? (Quiero que hables.) Why is quiero hablarte different? (It has one subject; te is an object.) Name one verb family that permits object plus infinitive. (Perception or causation.)
+
+
+Lesson 7 of 10.
+ojalá — a wish borrowed whole.
+
+A trigger by itself.
+Ojalá hable español. — I hope he speaks Spanish. / May he speak Spanish.
+Ojalá takes the subjunctive without que or a separate main verb. The word itself expresses the wish, so there is no factual assertion to put in the indicative.
+
+From Andalusi Arabic.
+The standard account derives ojalá from Andalusi Arabic law šāʾ Allāh, "if God should will." The Allāh remains audible in the second half.
+Chapter 5 gave you another Arabic function word: hasta, from ḥattā. Borrowing nouns such as azúcar, aceite, and álgebra is ordinary. Borrowing grammatical tools is rarer. Spanish borrowed both a preposition and a word that selects a whole mood.
+English "God willing" expresses the same idea, and English has now borrowed Arabic inshallah directly as well.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "ojalá hable" — may he speak]
+[pause 8 seconds for the answer]
+[your turn — say: "ojalá venga" — I hope she comes]
+[pause 8 seconds for the answer]
+[your turn — say: "hasta / ojalá" — two Arabic function words]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Does ojalá require que? (No.) Which mood follows it? (The subjunctive.) What is its source phrase? (Andalusi Arabic law šāʾ Allāh, "if God should will.") Which other Arabic function word have you learned? (Hasta.)
+
+
+Lesson 8 of 10.
+Chapter 18 practice — fact or wish?
+
+Warm-up.
+[pause 2 seconds]
+Two skills to drill, in order: build the form, then decide whether you need it.
+
+Drill 1 — the vowel flip.
+Give the yo subjunctive. Recipe: yo form becomes drop -o becomes flip the vowel.
+[a table of 10 rows, read aloud]
+verb: hablar. yo form: hablo. becomes subjunctive: hable.
+verb: estudiar. yo form: estudio. becomes subjunctive: estudie.
+verb: comer. yo form: como. becomes subjunctive: coma.
+verb: beber. yo form: bebo. becomes subjunctive: beba.
+verb: vivir. yo form: vivo. becomes subjunctive: viva.
+verb: tener. yo form: tengo. becomes subjunctive: tenga.
+verb: hacer. yo form: hago. becomes subjunctive: haga.
+verb: venir. yo form: vengo. becomes subjunctive: venga.
+verb: querer. yo form: quiero. becomes subjunctive: quiera.
+verb: poder. yo form: puedo. becomes subjunctive: pueda.
+The last four are the point: you never learned a new stem. The -go and the diphthong were already in the yo form.
+Then the four with no -o to strip, which you learn outright: ser becomes sea, ir becomes vaya, saber becomes sepa, haber becomes haya.
+And estar, which looks like it belongs with them and doesn't: estoy has no strippable -o either, but take off the whole -oy and the stem est- is completely ordinary — esté, estés, esté, estemos, estén.
+Its oddity is stress, not spelling. Spanish stresses the second-to-last syllable of a word ending in a vowel, -n or -s — hablar obeys that throughout (HA-ble, ha-BLE-mos, HA-blen). Estar doesn't: es-TÉ, es-TÉS, es-TÉN all land on the last syllable, so each needs a written accent. Only es-TE-mos falls where Spanish expects, and it takes none.
+
+Wrap-up Recall.
+[pause 3 seconds]
+Recite the recipe. (Yo form, drop the -o, flip the vowel.) Which earlier irregulars come along free? (The -go club of Ch. 12–13 and Ch. 11's stem-changers.) What's the two-subject test? (If the second verb has Ch. 11's stem-changers.) Which yo forms leave no -o to strip, and which of them is still predictable? (Soy, voy, sé, he, estoy — and estoy is the predictable one, est- + normal endings.) Where does estar's irregularity actually live? (In the stress — es-TÉ lands on the last syllable, breaking Spanish's second-to-last default, which is what the accent records.)
+
+
+Lesson 9 of 10.
+Practice — one subject or two?
+
+The test.
+Does the second verb have a different subject?
+[a table of 6 rows, read aloud]
+I want to eat., Quiero comer. (same becomes infinitive).
+I want you to eat., Quiero que comas. (two becomes clause).
+We want to live here., Queremos vivir aquí.
+We want them to live here., Queremos que vivan aquí.
+She wants to work., Quiere trabajar.
+She wants me to work., Quiere que yo trabaje.
+Say each pair back to back. English changes quietly from "to eat" to "you to eat." Spanish marks the new subject with que and a conjugated verb.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "quiero comer / quiero que comas"]
+[pause 8 seconds for the answer]
+[your turn — say: "queremos vivir / queremos que vivan"]
+[pause 8 seconds for the answer]
+[your turn — say: "quiere trabajar / quiere que yo trabaje"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Same subject after querer: which form? (Infinitive.) Different subject? (Que + subjunctive.) Translate "I want to eat" and "I want you to eat." (Quiero comer / Quiero que comas.)
+
+
+Lesson 10 of 10.
+Practice — fact or wish?
+
+Report or reach.
+Report the world with the indicative; reach for a different world with the subjunctive.
+[a table of 6 rows, read aloud]
+Sé que comes aquí., I know you eat here. (fact).
+Quiero que comas aquí., I want you to eat here. (wish).
+Sé que está aquí., I know he is here. (fact).
+Ojalá esté aquí., I hope he is here. (wish).
+Dice que viene., She says she is coming. (report).
+Quiero que venga., I want her to come. (wish).
+Ojalá needs no que and no main verb. It is the wish.
+
+Hear the flip.
+[a table of 4 rows, read aloud]
+indicative: habla. subjunctive: hable.
+indicative: come. subjunctive: coma.
+indicative: trabaja. subjunctive: trabaje.
+indicative: vive. subjunctive: viva.
+Also distinguish hable from hablé, and trabaje from trabajé. The written accent separates present subjunctive from "I" preterite.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "sé que comes / quiero que comas"]
+[pause 8 seconds for the answer]
+[your turn — say: "dice que viene / quiero que venga"]
+[pause 8 seconds for the answer]
+[your turn — say: "hable / hablé"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Why is sé que comes indicative? (It reports a fact.) What does ojalá need before its subjunctive? (Nothing.) What does the accent distinguish in hable/hablé? (Present subjunctive from first-person preterite.)

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Changed — Spanish has a declared reading order (HL09 step 2)
+
+- 50 Spanish lessons across chapters 8–18 gain a `sequence:`, recovered from
+  evidence rather than invented: the `Next: …` sentence ending each lesson's
+  Wrap-up Recall, corroborated by `prerequisites:` and `reviews_of`.
+- **26 of Spanish's 31 "forward prerequisites" were never real.** With no declared
+  order the walk fell back to sorting alphabetically inside a chapter, which put
+  `beber` before `comer` and then reported `beber` as depending on a later lesson.
+  Declaring the true order removed them:
+
+      Spanish              before   after
+      no sequence              56       6
+      forward prerequisites    31       5
+      forward references      143      93
+
+  Corpus-wide: 565 → **515** unsequenced, 271 → **245** forward prerequisites,
+  331 → **300** forward reviews, 509 → **496** forward references. Atom figures are
+  unchanged, as they must be — ordering moved no content.
+- **Chapter 7's six lessons are deliberately left unsequenced.** `curriculum.json`
+  says comer → beber → qué → vivir → dónde; the prose `Next:` chain **and**
+  `ES-C07-beber`'s own `reviews_of` say comer → vivir → beber → qué → dónde. Under
+  the ledger's order, `beber` reviews a lesson that has not happened. Guessing
+  would bake a false ramp into every later measurement, so they wait for a ruling.
+  A test pins exactly which six remain, so this cannot be forgotten.
+- Chapter 18 is the weakest recovery: none of its ten lessons carries a `Next:`
+  line, so its order rests solely on `prerequisites`/`reviews_of`. Those happen to
+  form one clean chain, but with no prose corroboration.
+- **Known remainder: the numbering is cramped.** Chapters 19–33 were already
+  sequenced at 640–845, so chapters 7–18 had to fit between 510 and 640 — 129
+  integers for 56 lessons. Spacing is therefore **2**, not the intended 10, leaving
+  almost no insertion room in a track meant to grow from 146 lessons to thousands.
+  Renumbering the whole track by 10s is mechanical and should follow.
+
 ### Added — does the course have a memory of itself? (HL09 step 1)
 
 - Add `src/continuity.ts`: `measureContinuity` measures the three things a

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -116,15 +116,19 @@ import { measureContinuity, loadEverything } from "@coding-adventures/human-lang
 const { lessons } = loadEverything();
 const c = measureContinuity(lessons);
 
-c.summary.lessonsWithoutSequence;   // 565 — no declared reading order at all
+c.summary.lessonsWithoutSequence;   // 515 — no declared reading order at all
 c.summary.atomsNeverRevisited;      // 746 of 1469 (51%) taught once, never again
 c.summary.missedByWindow;           // { R1: 745, R2: 1068, R3: 649, R4: 132 }
-c.summary.forwardReferences;        // 509 uses of material a later lesson teaches
+c.summary.forwardReferences;        // 496 uses of material a later lesson teaches
 ```
 
-Order comes first: 565 lessons carry no `sequence`, so their order exists only in
+Order comes first: 515 lessons carry no `sequence`, so their order exists only in
 hand-typed LaTeX (French: **64 of 73**). A ramp whose order is unknown cannot be
 verified, so every other number is provisional until that reaches zero.
+
+Spanish is the worked example. Declaring the real order for 50 of its lessons cut
+its forward prerequisites from **31 to 5** — 26 of the 31 were never real, just
+artifacts of an alphabetical fallback sorting `beber` before `comer`.
 
 Reinforcement reads `practises.knowledge`, **never `reviews_of`** — which 144 of
 Spanish's 146 lessons set and which cannot close a window, because it names lesson

--- a/code/packages/typescript/human-language-data/src/continuity.ts
+++ b/code/packages/typescript/human-language-data/src/continuity.ts
@@ -229,7 +229,7 @@ function emphasisedRuns(body: string): string {
   for (const match of body.matchAll(/\*\*([^*]+)\*\*|\*([^*]+)\*|`([^`]+)`/g)) {
     runs.push(match[1] ?? match[2] ?? match[3] ?? "");
   }
-  return runs.join("   ").toLowerCase();
+  return runs.join("   ").toLowerCase();
 }
 
 /** Measure order integrity, reinforcement windows, and forward references. */

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -234,12 +234,12 @@ describe("the real corpus", () => {
 
     // ORDER. Until this reaches zero every other number here is provisional: a ramp
     // whose reading order is unknown cannot be verified at all.
-    expect(report.summary.lessonsWithoutSequence).toBe(565);
+    expect(report.summary.lessonsWithoutSequence).toBe(515);
     expect(report.summary.tracksWithUnorderedLessons).toBe(19);
-    expect(report.summary.forwardPrerequisites).toBe(271);
+    expect(report.summary.forwardPrerequisites).toBe(245);
 
-    // 331 lessons claim to review material the learner has not reached yet.
-    expect(report.summary.forwardReviews).toBe(331);
+    // Lessons claiming to review material the learner has not reached yet.
+    expect(report.summary.forwardReviews).toBe(300);
 
     // REINFORCEMENT. The founding promise is that the course "constantly
     // re-emphasizes what was learnt previously". Half of it is taught once.
@@ -247,21 +247,51 @@ describe("the real corpus", () => {
     expect(report.summary.atomsNeverRevisited).toBe(746);
     expect(report.summary.neverRevisitedPercent).toBe(51);
 
-    expect(report.summary.forwardReferences).toBe(509);
+    expect(report.summary.forwardReferences).toBe(496);
   });
 
-  it("reproduces the Spanish audit exactly", () => {
-    // These four numbers were measured independently in Python before this module
-    // existed. They agreeing is the evidence that the walk is the right one.
+  it("shows what a declared reading order was worth", () => {
+    // Before HL09 step 2, Spanish had 56 lessons with no `sequence` and the walk
+    // fell back to alphabetical order within a chapter. That fallback INVENTED
+    // defects: it reported 31 forward prerequisites, of which 26 were artifacts of
+    // sorting `beber` before `comer`. Declaring the real order removed them.
+    //
+    //                     before   after
+    //   no sequence           56       6   (the six chapter-7 lessons, see below)
+    //   forward prereqs       31       5
+    //   forward references   143      93
+    //
+    // The atom figures are unchanged, as they must be: ordering moved no content.
     const { lessons } = loadEverything();
     const spanish = measureContinuity(lessons).tracks.find((t) => t.language === "spanish");
     expect(spanish).toMatchObject({
       lessonCount: 146,
-      lessonsWithoutSequence: 56,
-      forwardPrerequisites: 31,
+      lessonsWithoutSequence: 6,
+      forwardPrerequisites: 5,
       atomsTaught: 182,
       atomsNeverRevisited: 93,
     });
+  });
+
+  it("leaves chapter 7 unsequenced, because its sources contradict", () => {
+    // curriculum.json says comer -> beber -> que -> vivir -> donde; the lesson prose
+    // `Next:` chain AND ES-C07-beber's own reviews_of say comer -> vivir -> beber ->
+    // que -> donde. Under the ledger's order, beber reviews a lesson that has not
+    // happened. Guessing would bake a false ramp into every later measurement, so
+    // these six stay unsequenced until the project owner rules.
+    const { lessons } = loadEverything();
+    const unsequenced = measureContinuity(lessons)
+      .order.filter((d) => d.language === "spanish" && d.kind === "no-sequence")
+      .map((d) => d.lessonId)
+      .sort();
+    expect(unsequenced).toEqual([
+      "ES-C07-beber",
+      "ES-C07-comer",
+      "ES-C07-donde",
+      "ES-C07-practice",
+      "ES-C07-que",
+      "ES-C07-vivir",
+    ]);
   });
 
   it("finds the forward references a human reviewer found by reading", () => {

--- a/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
+++ b/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
@@ -724,7 +724,12 @@ describe("corpus regression", () => {
       // Prerequisite order still costs a commuter 132 of the 965 ear-only lessons:
       // they sit behind a blocker in their own chapter and stay unreachable in the car
       // until HL-C17 reshapes the remaining wide tables.
-      drivablePrefixTotal: 655,
+      // 655 before HL09 step 2 gave 50 Spanish lessons a declared `sequence`. A
+      // chapter's drivable prefix is "how far you get by ear from its START", so it
+      // depends on ORDER — and the old alphabetical fallback happened to put
+      // eyes-needed lessons later than they really come. The real order is 10 worse,
+      // which is the measurement becoming honest, not the corpus regressing.
+      drivablePrefixTotal: 645,
       fullyDrivableChapters: 270,
       unstartableChapters: 90,
       overriddenLessons: 0,


### PR DESCRIPTION
56 of Spanish's 146 lessons carried **no `sequence`**, so their reading order existed only inside hand-typed LaTeX. A ramp whose order is unknown cannot be verified at all — which made every ramp number over Spanish provisional.

50 lessons across chapters 8–18 now declare an order, **recovered from evidence rather than invented**: the `Next: …` sentence ending each Wrap-up Recall, corroborated by `prerequisites:` and `reviews_of`.

## 26 of Spanish's 31 "forward prerequisites" were never real

With no declared order the walk fell back to sorting alphabetically inside a chapter — putting `beber` before `comer`, then reporting `beber` as depending on a later lesson.

| Spanish | before | after |
|---|---|---|
| no sequence | 56 | **6** |
| forward prerequisites | 31 | **5** |
| forward references | 143 | **99** |

Corpus-wide: 565 → **515** unsequenced, 271 → **245** forward prerequisites, 331 → **300** forward reviews. Spanish's atom figures are untouched by the ordering, as they must be — ordering moved no content.

**Every residual Spanish order defect is now confined to chapter 7.** The 50 newly-sequenced lessons introduce zero forward prerequisites and zero forward reviews; every edge in chapters 8–18 points backward.

## Chapter 7 is deliberately left unsequenced — I need your ruling

- `curriculum.json`: comer → **beber** → qué → **vivir** → dónde
- prose `Next:` chain **and** `ES-C07-beber`'s own `reviews_of`: comer → **vivir** → **beber** → qué → dónde

Under the ledger's order, `beber` reviews a lesson that hasn't happened — the exact defect you asked me to eliminate. The prose side has two independent supports; the ledger has one. But the ledger may simply be newer intent, so **I haven't picked**. Guessing would bake a false ramp into every later measurement. A test pins exactly which six remain so this can't be quietly forgotten.

(There are **six**, not five — `curriculum.json` omits `ES-C07-practice`.)

## Honest notes

- **`drivablePrefixTotal` 655 → 645** (669 after merging main). A chapter's drivable prefix is *how far you get by ear from its start*, so it depends on order — the alphabetical fallback had been flattering it. Chapter 18's prefix goes 8 → 0 because its real first lesson needs eyes. The measurement became honest.
- **Chapter 18 is the weakest recovery**: none of its ten lessons has a `Next:` line, so its order rests solely on `prerequisites`/`reviews_of`. Those form one clean chain, but with no prose corroboration.
- **Known remainder — the numbering is cramped.** Chapters 19–33 were *already* sequenced at 640–845 (my brief wrongly assumed only 1–6 were), so chapters 7–18 had to fit between 510 and 640: **129 integers for 56 lessons**. Spacing is therefore **2**, not the intended 10 — almost no insertion room in a track meant to grow to thousands. Renumbering the whole track by 10s is mechanical and should follow; review confirmed nothing consumes a sequence's absolute value, and the byte-exact `--check` CLIs would catch a stale artifact loudly.
- **Latent gap**: all 50 lessons are pre-schema-v2, so `curriculum.ts`'s duplicate-sequence and prerequisite-order gates skip them. Clean today (verified by hand), but ungated until they migrate.

Also strips a stray **NUL byte** from `continuity.ts` introduced in #10042 — runtime-benign, but it made grep and ripgrep silently return nothing for the entire file, in the module that computes these very measurements. It defeated two searches during review.

## Verification

- **369 tests pass**; modality, narration and book `--check` all clean; validator 0 errors.
- Security review: only `sequence:` lines added to lesson files (verified structurally, nothing else changed), no duplicate or inverted sequences among all 140, regenerated artifacts differ only in `sequence`/`sourceHash` and touch no other track.
- Merged `origin/main` mid-flight (a verb tranche landed on the same pins); every pin was **recomputed against the merged corpus** rather than resolved by picking a side, and main's analysis of the forward-reference move was kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)